### PR TITLE
l10n: de.po: Fix typo in German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -9279,7 +9279,7 @@ msgstr ""
 #: builtin/fetch.c:1453
 msgid "--unshallow on a complete repository does not make sense"
 msgstr ""
-"Die Option --unshallow kann nicht in einem Repository mit unvollständiger "
+"Die Option --unshallow kann nicht in einem Repository mit vollständiger "
 "Historie verwendet werden."
 
 #: builtin/fetch.c:1469


### PR DESCRIPTION
Fix translation error of "complete => "vollständig" instead of "unvollständig"

Currently: Documentation states that --unshallow can NOT be used on INcomplete projects. This is wrong;
Correct would be: --unshallow can NOT be used on complete projects.

This change fixes that error in the German translation.

See also: https://github.com/gitgitgadget/git/pull/278