### PR TITLE
Update German translation for Git 2.29.0

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2020-07-10 09:53+0800\n"
+"POT-Creation-Date: 2020-10-10 09:32+0800\n"
 "PO-Revision-Date: 2020-07-12 13:20+0100\n"
 "Last-Translator: Matthias Rüster <matthias.ruester@gmail.com>\n"
 "Language-Team: Matthias Rüster <matthias.ruester@gmail.com>\n"
@@ -23,9 +23,9 @@ msgstr ""
 msgid "Huh (%s)?"
 msgstr "Wie bitte (%s)?"
 
-#: add-interactive.c:521 add-interactive.c:822 reset.c:65 sequencer.c:3142
-#: sequencer.c:3581 sequencer.c:3723 builtin/rebase.c:1518
-#: builtin/rebase.c:1919
+#: add-interactive.c:521 add-interactive.c:822 reset.c:65 sequencer.c:3250
+#: sequencer.c:3698 sequencer.c:3840 builtin/rebase.c:1526
+#: builtin/rebase.c:1944
 msgid "could not read index"
 msgstr "Index konnte nicht gelesen werden"
 
@@ -53,7 +53,7 @@ msgstr "Aktualisieren"
 msgid "could not stage '%s'"
 msgstr "Konnte '%s' nicht zum Commit vormerken."
 
-#: add-interactive.c:695 add-interactive.c:884 reset.c:89 sequencer.c:3336
+#: add-interactive.c:695 add-interactive.c:884 reset.c:89 sequencer.c:3444
 msgid "could not write index"
 msgstr "Konnte Index nicht schreiben."
 
@@ -69,7 +69,7 @@ msgstr[1] "%d Pfade aktualisiert\n"
 msgid "note: %s is untracked now.\n"
 msgstr "Hinweis: %s ist nun unversioniert.\n"
 
-#: add-interactive.c:721 apply.c:4110 builtin/checkout.c:294
+#: add-interactive.c:721 apply.c:4127 builtin/checkout.c:295
 #: builtin/reset.c:145
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
@@ -111,21 +111,21 @@ msgstr[1] "%d Pfade hinzugefügt\n"
 msgid "ignoring unmerged: %s"
 msgstr "Ignoriere nicht zusammengeführte Datei: %s"
 
-#: add-interactive.c:929 add-patch.c:1691 git-add--interactive.perl:1368
+#: add-interactive.c:929 add-patch.c:1738 git-add--interactive.perl:1371
 #, c-format
 msgid "Only binary files changed.\n"
 msgstr "Nur Binärdateien geändert.\n"
 
-#: add-interactive.c:931 add-patch.c:1689 git-add--interactive.perl:1370
+#: add-interactive.c:931 add-patch.c:1736 git-add--interactive.perl:1373
 #, c-format
 msgid "No changes.\n"
 msgstr "Keine Änderungen.\n"
 
-#: add-interactive.c:935 git-add--interactive.perl:1378
+#: add-interactive.c:935 git-add--interactive.perl:1381
 msgid "Patch update"
 msgstr "Patch Aktualisierung"
 
-#: add-interactive.c:974 git-add--interactive.perl:1771
+#: add-interactive.c:974 git-add--interactive.perl:1794
 msgid "Review diff"
 msgstr "Diff überprüfen"
 
@@ -193,11 +193,11 @@ msgstr "Ein nummeriertes Element auswählen"
 msgid "(empty) select nothing"
 msgstr "(leer) nichts auswählen"
 
-#: add-interactive.c:1083 builtin/clean.c:816 git-add--interactive.perl:1868
+#: add-interactive.c:1083 builtin/clean.c:816 git-add--interactive.perl:1891
 msgid "*** Commands ***"
 msgstr "*** Befehle ***"
 
-#: add-interactive.c:1084 builtin/clean.c:817 git-add--interactive.perl:1865
+#: add-interactive.c:1084 builtin/clean.c:817 git-add--interactive.perl:1888
 msgid "What now"
 msgstr "Was nun"
 
@@ -209,12 +209,12 @@ msgstr "zur Staging-Area hinzugefügt"
 msgid "unstaged"
 msgstr "aus Staging-Area entfernt"
 
-#: add-interactive.c:1136 apply.c:4967 apply.c:4970 builtin/am.c:2250
-#: builtin/am.c:2253 builtin/clone.c:123 builtin/fetch.c:145
-#: builtin/merge.c:276 builtin/pull.c:190 builtin/submodule--helper.c:409
-#: builtin/submodule--helper.c:1394 builtin/submodule--helper.c:1397
-#: builtin/submodule--helper.c:1902 builtin/submodule--helper.c:1905
-#: builtin/submodule--helper.c:2148 bugreport.c:135
+#: add-interactive.c:1136 apply.c:4984 apply.c:4987 builtin/am.c:2270
+#: builtin/am.c:2273 builtin/bugreport.c:133 builtin/clone.c:123
+#: builtin/fetch.c:147 builtin/merge.c:275 builtin/pull.c:190
+#: builtin/submodule--helper.c:409 builtin/submodule--helper.c:1818
+#: builtin/submodule--helper.c:1821 builtin/submodule--helper.c:2326
+#: builtin/submodule--helper.c:2329 builtin/submodule--helper.c:2572
 #: git-add--interactive.perl:213
 msgid "path"
 msgstr "Pfad"
@@ -223,27 +223,27 @@ msgstr "Pfad"
 msgid "could not refresh index"
 msgstr "Index konnte nicht aktualisiert werden"
 
-#: add-interactive.c:1157 builtin/clean.c:781 git-add--interactive.perl:1782
+#: add-interactive.c:1157 builtin/clean.c:781 git-add--interactive.perl:1805
 #, c-format
 msgid "Bye.\n"
 msgstr "Tschüss.\n"
 
-#: add-patch.c:34 git-add--interactive.perl:1430
+#: add-patch.c:34 git-add--interactive.perl:1433
 #, c-format, perl-format
 msgid "Stage mode change [y,n,q,a,d%s,?]? "
 msgstr "Modusänderung der Staging-Area hinzufügen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:35 git-add--interactive.perl:1431
+#: add-patch.c:35 git-add--interactive.perl:1434
 #, c-format, perl-format
 msgid "Stage deletion [y,n,q,a,d%s,?]? "
 msgstr "Löschung der Staging-Area hinzufügen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:36 git-add--interactive.perl:1432
+#: add-patch.c:36 git-add--interactive.perl:1435
 #, c-format, perl-format
 msgid "Stage addition [y,n,q,a,d%s,?]? "
 msgstr "Ergänzung der Staging-Area hinzufügen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:37 git-add--interactive.perl:1433
+#: add-patch.c:37 git-add--interactive.perl:1436
 #, c-format, perl-format
 msgid "Stage this hunk [y,n,q,a,d%s,?]? "
 msgstr "Diesen Patch-Block der Staging-Area hinzufügen [y,n,q,a,d%s,?]? "
@@ -272,22 +272,22 @@ msgstr ""
 "d - diesen oder alle weiteren Patch-Blöcke in dieser Datei nicht zum Commit "
 "vormerken\n"
 
-#: add-patch.c:56 git-add--interactive.perl:1436
+#: add-patch.c:56 git-add--interactive.perl:1439
 #, c-format, perl-format
 msgid "Stash mode change [y,n,q,a,d%s,?]? "
 msgstr "Modusänderung stashen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:57 git-add--interactive.perl:1437
+#: add-patch.c:57 git-add--interactive.perl:1440
 #, c-format, perl-format
 msgid "Stash deletion [y,n,q,a,d%s,?]? "
 msgstr "Löschung stashen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:58 git-add--interactive.perl:1438
+#: add-patch.c:58 git-add--interactive.perl:1441
 #, c-format, perl-format
 msgid "Stash addition [y,n,q,a,d%s,?]? "
 msgstr "Ergänzung stashen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:59 git-add--interactive.perl:1439
+#: add-patch.c:59 git-add--interactive.perl:1442
 #, c-format, perl-format
 msgid "Stash this hunk [y,n,q,a,d%s,?]? "
 msgstr "Diesen Patch-Block stashen [y,n,q,a,d%s,?]? "
@@ -314,22 +314,22 @@ msgstr ""
 "a - diesen und alle weiteren Patch-Blöcke dieser Datei stashen\n"
 "d - diesen oder alle weiteren Patch-Blöcke dieser Datei nicht stashen\n"
 
-#: add-patch.c:80 git-add--interactive.perl:1442
+#: add-patch.c:80 git-add--interactive.perl:1445
 #, c-format, perl-format
 msgid "Unstage mode change [y,n,q,a,d%s,?]? "
 msgstr "Modusänderung aus der Staging-Area entfernen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:81 git-add--interactive.perl:1443
+#: add-patch.c:81 git-add--interactive.perl:1446
 #, c-format, perl-format
 msgid "Unstage deletion [y,n,q,a,d%s,?]? "
 msgstr "Löschung aus der Staging-Area entfernen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:82 git-add--interactive.perl:1444
+#: add-patch.c:82 git-add--interactive.perl:1447
 #, c-format, perl-format
 msgid "Unstage addition [y,n,q,a,d%s,?]? "
 msgstr "Ergänzung aus der Staging-Area entfernen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:83 git-add--interactive.perl:1445
+#: add-patch.c:83 git-add--interactive.perl:1448
 #, c-format, perl-format
 msgid "Unstage this hunk [y,n,q,a,d%s,?]? "
 msgstr "Diesen Patch-Block aus der Staging-Area entfernen [y,n,q,a,d%s,?]? "
@@ -359,22 +359,22 @@ msgstr ""
 "d - diesen oder alle weiteren Patch-Blöcke dieser Datei nicht aus Staging-"
 "Area entfernen\n"
 
-#: add-patch.c:103 git-add--interactive.perl:1448
+#: add-patch.c:103 git-add--interactive.perl:1451
 #, c-format, perl-format
 msgid "Apply mode change to index [y,n,q,a,d%s,?]? "
 msgstr "Modusänderung auf Index anwenden [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:104 git-add--interactive.perl:1449
+#: add-patch.c:104 git-add--interactive.perl:1452
 #, c-format, perl-format
 msgid "Apply deletion to index [y,n,q,a,d%s,?]? "
 msgstr "Löschung auf Index anwenden [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:105 git-add--interactive.perl:1450
+#: add-patch.c:105 git-add--interactive.perl:1453
 #, c-format, perl-format
 msgid "Apply addition to index [y,n,q,a,d%s,?]? "
 msgstr "Ergänzung auf Index anwenden [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:106 git-add--interactive.perl:1451
+#: add-patch.c:106 git-add--interactive.perl:1454
 #, c-format, perl-format
 msgid "Apply this hunk to index [y,n,q,a,d%s,?]? "
 msgstr "Diesen Patch-Block auf Index anwenden [y,n,q,a,d%s,?]? "
@@ -404,26 +404,26 @@ msgstr ""
 "d - diesen oder alle weiteren Patch-Blöcke dieser Datei nicht auf den Index "
 "anwenden\n"
 
-#: add-patch.c:126 git-add--interactive.perl:1454
-#: git-add--interactive.perl:1472
+#: add-patch.c:126 git-add--interactive.perl:1457
+#: git-add--interactive.perl:1475
 #, c-format, perl-format
 msgid "Discard mode change from worktree [y,n,q,a,d%s,?]? "
 msgstr "Modusänderung im Arbeitsverzeichnis verwerfen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:127 git-add--interactive.perl:1455
-#: git-add--interactive.perl:1473
+#: add-patch.c:127 git-add--interactive.perl:1458
+#: git-add--interactive.perl:1476
 #, c-format, perl-format
 msgid "Discard deletion from worktree [y,n,q,a,d%s,?]? "
 msgstr "Löschung im Arbeitsverzeichnis verwerfen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:128 git-add--interactive.perl:1456
-#: git-add--interactive.perl:1474
+#: add-patch.c:128 git-add--interactive.perl:1459
+#: git-add--interactive.perl:1477
 #, c-format, perl-format
 msgid "Discard addition from worktree [y,n,q,a,d%s,?]? "
 msgstr "Ergänzung im Arbeitsverzeichnis verwerfen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:129 git-add--interactive.perl:1457
-#: git-add--interactive.perl:1475
+#: add-patch.c:129 git-add--interactive.perl:1460
+#: git-add--interactive.perl:1478
 #, c-format, perl-format
 msgid "Discard this hunk from worktree [y,n,q,a,d%s,?]? "
 msgstr "Diesen Patch-Block im Arbeitsverzeichnis verwerfen [y,n,q,a,d%s,?]? "
@@ -453,23 +453,23 @@ msgstr ""
 "d - diesen oder alle weiteren Patch-Blöcke dieser Datei nicht im "
 "Arbeitsverzeichnis verwerfen\n"
 
-#: add-patch.c:149 add-patch.c:194 git-add--interactive.perl:1460
+#: add-patch.c:149 add-patch.c:194 git-add--interactive.perl:1463
 #, c-format, perl-format
 msgid "Discard mode change from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Modusänderung vom Index und Arbeitsverzeichnis verwerfen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:150 add-patch.c:195 git-add--interactive.perl:1461
+#: add-patch.c:150 add-patch.c:195 git-add--interactive.perl:1464
 #, c-format, perl-format
 msgid "Discard deletion from index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Löschung vom Index und Arbeitsverzeichnis verwerfen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:151 add-patch.c:196 git-add--interactive.perl:1462
-#,  c-format, perl-format
+#: add-patch.c:151 add-patch.c:196 git-add--interactive.perl:1465
+#, c-format, perl-format
 msgid "Discard addition from index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Ergänzung im Index und Arbeitsverzeichnis verwerfen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:152 add-patch.c:197 git-add--interactive.perl:1463
+#: add-patch.c:152 add-patch.c:197 git-add--interactive.perl:1466
 #, c-format, perl-format
 msgid "Discard this hunk from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
@@ -490,23 +490,23 @@ msgstr ""
 "a - diesen und alle weiteren Patch-Blöcke in der Datei verwerfen\n"
 "d - diesen oder alle weiteren Patch-Blöcke in der Datei nicht verwerfen\n"
 
-#: add-patch.c:171 add-patch.c:216 git-add--interactive.perl:1466
+#: add-patch.c:171 add-patch.c:216 git-add--interactive.perl:1469
 #, c-format, perl-format
 msgid "Apply mode change to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Modusänderung auf Index und Arbeitsverzeichnis anwenden [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:172 add-patch.c:217 git-add--interactive.perl:1467
+#: add-patch.c:172 add-patch.c:217 git-add--interactive.perl:1470
 #, c-format, perl-format
 msgid "Apply deletion to index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Löschung auf Index und Arbeitsverzeichnis anwenden [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:173 add-patch.c:218 git-add--interactive.perl:1468
+#: add-patch.c:173 add-patch.c:218 git-add--interactive.perl:1471
 #, c-format, perl-format
 msgid "Apply addition to index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Ergänzung auf Index und Arbeitsverzeichnis anwenden [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1469
+#: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1472
 #, c-format, perl-format
 msgid "Apply this hunk to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
@@ -542,34 +542,34 @@ msgstr ""
 "a - diesen und alle weiteren Patch-Blöcke in der Datei anwenden\n"
 "d - diesen und alle weiteren Patch-Blöcke in der Datei nicht anwenden\n"
 
-#: add-patch.c:328
+#: add-patch.c:342
 #, c-format
 msgid "could not parse hunk header '%.*s'"
 msgstr "Konnte Block-Header '%.*s' nicht parsen."
 
-#: add-patch.c:347 add-patch.c:351
+#: add-patch.c:361 add-patch.c:365
 #, c-format
 msgid "could not parse colored hunk header '%.*s'"
 msgstr "Konnte farbigen Block-Header '%.*s' nicht parsen."
 
-#: add-patch.c:405
+#: add-patch.c:419
 msgid "could not parse diff"
 msgstr "Konnte Differenz nicht parsen."
 
-#: add-patch.c:424
+#: add-patch.c:438
 msgid "could not parse colored diff"
 msgstr "Konnte farbige Differenz nicht parsen."
 
-#: add-patch.c:438
+#: add-patch.c:452
 #, c-format
 msgid "failed to run '%s'"
 msgstr "'%s' konnte nicht ausgeführt werden"
 
-#: add-patch.c:602
+#: add-patch.c:611
 msgid "mismatched output from interactive.diffFilter"
 msgstr "nicht übereinstimmende Ausgabe von interactive.diffFilter"
 
-#: add-patch.c:603
+#: add-patch.c:612
 msgid ""
 "Your filter must maintain a one-to-one correspondence\n"
 "between its input and output lines."
@@ -577,7 +577,7 @@ msgstr ""
 "Der Filter muss eine Eins-zu-Eins-Beziehung\n"
 "zwischen den Ein- und Ausgabe-Zeilen einhalten."
 
-#: add-patch.c:776
+#: add-patch.c:785
 #, c-format
 msgid ""
 "expected context line #%d in\n"
@@ -586,7 +586,7 @@ msgstr ""
 "Erwartete Kontextzeile #%d in\n"
 "%.*s"
 
-#: add-patch.c:791
+#: add-patch.c:800
 #, c-format
 msgid ""
 "hunks do not overlap:\n"
@@ -599,13 +599,13 @@ msgstr ""
 "\tendet nicht mit:\n"
 "%.*s"
 
-#: add-patch.c:1067 git-add--interactive.perl:1114
+#: add-patch.c:1076 git-add--interactive.perl:1117
 msgid "Manual hunk edit mode -- see bottom for a quick guide.\n"
 msgstr ""
 "Manueller Editiermodus für Patch-Blöcke -- siehe nach unten für eine\n"
 "Kurzanleitung.\n"
 
-#: add-patch.c:1071
+#: add-patch.c:1080
 #, c-format
 msgid ""
 "---\n"
@@ -619,7 +619,7 @@ msgstr ""
 "Zeilen, die mit %c beginnen, werden entfernt.\n"
 
 #. TRANSLATORS: 'it' refers to the patch mentioned in the previous messages.
-#: add-patch.c:1085 git-add--interactive.perl:1128
+#: add-patch.c:1094 git-add--interactive.perl:1131
 msgid ""
 "If it does not apply cleanly, you will be given an opportunity to\n"
 "edit again.  If all lines of the hunk are removed, then the edit is\n"
@@ -630,11 +630,11 @@ msgstr ""
 "werden,\n"
 "wird die Bearbeitung abgebrochen und der Patch-Block bleibt unverändert.\n"
 
-#: add-patch.c:1118
+#: add-patch.c:1127
 msgid "could not parse hunk header"
 msgstr "Konnte Block-Header nicht parsen."
 
-#: add-patch.c:1163
+#: add-patch.c:1172
 msgid "'git apply --cached' failed"
 msgstr "'git apply --cached' schlug fehl."
 
@@ -650,27 +650,27 @@ msgstr "'git apply --cached' schlug fehl."
 #. Consider translating (saying "no" discards!) as
 #. (saying "n" for "no" discards!) if the translation
 #. of the word "no" does not start with n.
-#: add-patch.c:1232 git-add--interactive.perl:1241
+#: add-patch.c:1241 git-add--interactive.perl:1244
 msgid ""
 "Your edited hunk does not apply. Edit again (saying \"no\" discards!) [y/n]? "
 msgstr ""
 "Ihr bearbeiteter Patch-Block kann nicht angewendet werden.\n"
 "Erneut bearbeiten? (\"n\" verwirft Bearbeitung!) [y/n]?"
 
-#: add-patch.c:1275
+#: add-patch.c:1284
 msgid "The selected hunks do not apply to the index!"
 msgstr ""
 "Die ausgewählten Patch-Blöcke können nicht auf den Index angewendet werden!"
 
-#: add-patch.c:1276 git-add--interactive.perl:1345
+#: add-patch.c:1285 git-add--interactive.perl:1348
 msgid "Apply them to the worktree anyway? "
 msgstr "Trotzdem auf Arbeitsverzeichnis anwenden? "
 
-#: add-patch.c:1283 git-add--interactive.perl:1348
+#: add-patch.c:1292 git-add--interactive.perl:1351
 msgid "Nothing was applied.\n"
 msgstr "Nichts angewendet.\n"
 
-#: add-patch.c:1340
+#: add-patch.c:1349
 msgid ""
 "j - leave this hunk undecided, see next undecided hunk\n"
 "J - leave this hunk undecided, see next hunk\n"
@@ -694,69 +694,69 @@ msgstr ""
 "e - aktuellen Patch-Block manuell editieren\n"
 "? - Hilfe anzeigen\n"
 
-#: add-patch.c:1463 add-patch.c:1473
+#: add-patch.c:1511 add-patch.c:1521
 msgid "No previous hunk"
 msgstr "Kein vorheriger Patch-Block"
 
-#: add-patch.c:1468 add-patch.c:1478
+#: add-patch.c:1516 add-patch.c:1526
 msgid "No next hunk"
 msgstr "Kein folgender Patch-Block"
 
-#: add-patch.c:1484
+#: add-patch.c:1532
 msgid "No other hunks to goto"
 msgstr "Keine anderen Patch-Blöcke verbleibend"
 
-#: add-patch.c:1495 git-add--interactive.perl:1594
+#: add-patch.c:1543 git-add--interactive.perl:1608
 msgid "go to which hunk (<ret> to see more)? "
 msgstr "zu welchem Patch-Block springen (<Enter> für mehr Informationen)? "
 
-#: add-patch.c:1496 git-add--interactive.perl:1596
+#: add-patch.c:1544 git-add--interactive.perl:1610
 msgid "go to which hunk? "
 msgstr "zu welchem Patch-Block springen? "
 
-#: add-patch.c:1507
+#: add-patch.c:1555
 #, c-format
 msgid "Invalid number: '%s'"
 msgstr "Ungültige Nummer: '%s'"
 
-#: add-patch.c:1512
+#: add-patch.c:1560
 #, c-format
 msgid "Sorry, only %d hunk available."
 msgid_plural "Sorry, only %d hunks available."
 msgstr[0] "Entschuldigung, nur %d Patch-Block verfügbar."
 msgstr[1] "Entschuldigung, nur %d Patch-Blöcke verfügbar."
 
-#: add-patch.c:1521
+#: add-patch.c:1569
 msgid "No other hunks to search"
 msgstr "Keine anderen Patch-Blöcke zum Durchsuchen"
 
-#: add-patch.c:1527 git-add--interactive.perl:1640
+#: add-patch.c:1575 git-add--interactive.perl:1663
 msgid "search for regex? "
 msgstr "Suche nach regulärem Ausdruck? "
 
-#: add-patch.c:1542
+#: add-patch.c:1590
 #, c-format
 msgid "Malformed search regexp %s: %s"
 msgstr "Fehlerhafter regulärer Ausdruck für Suche %s: %s"
 
-#: add-patch.c:1559
+#: add-patch.c:1607
 msgid "No hunk matches the given pattern"
 msgstr "Kein Patch-Block entspricht dem angegebenen Muster"
 
-#: add-patch.c:1566
+#: add-patch.c:1614
 msgid "Sorry, cannot split this hunk"
 msgstr "Entschuldigung, kann diesen Patch-Block nicht aufteilen"
 
-#: add-patch.c:1570
+#: add-patch.c:1618
 #, c-format
 msgid "Split into %d hunks."
 msgstr "In %d Patch-Block aufgeteilt."
 
-#: add-patch.c:1574
+#: add-patch.c:1622
 msgid "Sorry, cannot edit this hunk"
 msgstr "Entschuldigung, kann diesen Patch-Block nicht bearbeiten"
 
-#: add-patch.c:1625
+#: add-patch.c:1674
 msgid "'git apply' failed"
 msgstr "'git apply' schlug fehl"
 
@@ -818,7 +818,7 @@ msgstr ""
 msgid "Exiting because of an unresolved conflict."
 msgstr "Beende wegen unaufgelöstem Konflikt."
 
-#: advice.c:278 builtin/merge.c:1353
+#: advice.c:278 builtin/merge.c:1349
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "Sie haben Ihren Merge nicht abgeschlossen (MERGE_HEAD existiert)."
 
@@ -1132,7 +1132,7 @@ msgstr "Anwendung des Patches fehlgeschlagen: %s:%ld"
 msgid "cannot checkout %s"
 msgstr "kann %s nicht auschecken"
 
-#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:61 setup.c:308
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:72 setup.c:308
 #, c-format
 msgid "failed to read %s"
 msgstr "Fehler beim Lesen von %s"
@@ -1152,7 +1152,7 @@ msgstr "Pfad %s wurde umbenannt/gelöscht"
 msgid "%s: does not exist in index"
 msgstr "%s ist nicht im Index"
 
-#: apply.c:3537 apply.c:3708
+#: apply.c:3537 apply.c:3708 apply.c:3953
 #, c-format
 msgid "%s: does not match index"
 msgstr "%s entspricht nicht der Version im Index"
@@ -1202,374 +1202,369 @@ msgstr "%s: falscher Typ"
 msgid "%s has type %o, expected %o"
 msgstr "%s ist vom Typ %o, erwartete %o"
 
-#: apply.c:3878 apply.c:3880 read-cache.c:830 read-cache.c:856
-#: read-cache.c:1325
+#: apply.c:3892 apply.c:3894 read-cache.c:832 read-cache.c:858
+#: read-cache.c:1313
 #, c-format
 msgid "invalid path '%s'"
 msgstr "Ungültiger Pfad '%s'"
 
-#: apply.c:3936
+#: apply.c:3950
 #, c-format
 msgid "%s: already exists in index"
 msgstr "%s ist bereits bereitgestellt"
 
-#: apply.c:3939
+#: apply.c:3956
 #, c-format
 msgid "%s: already exists in working directory"
 msgstr "%s existiert bereits im Arbeitsverzeichnis"
 
-#: apply.c:3959
+#: apply.c:3976
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
 msgstr "neuer Modus (%o) von %s entspricht nicht dem alten Modus (%o)"
 
-#: apply.c:3964
+#: apply.c:3981
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
 msgstr "neuer Modus (%o) von %s entspricht nicht dem alten Modus (%o) von %s"
 
-#: apply.c:3984
+#: apply.c:4001
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
 msgstr "betroffene Datei '%s' ist hinter einer symbolischen Verknüpfung"
 
-#: apply.c:3988
+#: apply.c:4005
 #, c-format
 msgid "%s: patch does not apply"
 msgstr "%s: Patch konnte nicht angewendet werden"
 
-#: apply.c:4003
+#: apply.c:4020
 #, c-format
 msgid "Checking patch %s..."
 msgstr "Prüfe Patch %s ..."
 
-#: apply.c:4095
+#: apply.c:4112
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
 msgstr "SHA-1 Information fehlt oder ist unbrauchbar für Submodul %s"
 
-#: apply.c:4102
+#: apply.c:4119
 #, c-format
 msgid "mode change for %s, which is not in current HEAD"
 msgstr "Modusänderung für %s, was sich nicht im aktuellen HEAD befindet"
 
-#: apply.c:4105
+#: apply.c:4122
 #, c-format
 msgid "sha1 information is lacking or useless (%s)."
 msgstr "SHA-1 Information fehlt oder ist unbrauchbar (%s)."
 
-#: apply.c:4114
+#: apply.c:4131
 #, c-format
 msgid "could not add %s to temporary index"
 msgstr "konnte %s nicht zum temporären Index hinzufügen"
 
-#: apply.c:4124
+#: apply.c:4141
 #, c-format
 msgid "could not write temporary index to %s"
 msgstr "konnte temporären Index nicht nach %s schreiben"
 
-#: apply.c:4262
+#: apply.c:4279
 #, c-format
 msgid "unable to remove %s from index"
 msgstr "konnte %s nicht aus dem Index entfernen"
 
-#: apply.c:4296
+#: apply.c:4313
 #, c-format
 msgid "corrupt patch for submodule %s"
 msgstr "fehlerhafter Patch für Submodul %s"
 
-#: apply.c:4302
+#: apply.c:4319
 #, c-format
 msgid "unable to stat newly created file '%s'"
 msgstr "konnte neu erstellte Datei '%s' nicht lesen"
 
-#: apply.c:4310
+#: apply.c:4327
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr "kann internen Speicher für eben erstellte Datei %s nicht erzeugen"
 
-#: apply.c:4316 apply.c:4461
+#: apply.c:4333 apply.c:4478
 #, c-format
 msgid "unable to add cache entry for %s"
 msgstr "kann für %s keinen Eintrag in den Zwischenspeicher hinzufügen"
 
-#: apply.c:4359
+#: apply.c:4376 builtin/bisect--helper.c:537
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "Fehler beim Schreiben nach '%s'"
 
-#: apply.c:4363
+#: apply.c:4380
 #, c-format
 msgid "closing file '%s'"
 msgstr "schließe Datei '%s'"
 
-#: apply.c:4433
+#: apply.c:4450
 #, c-format
 msgid "unable to write file '%s' mode %o"
 msgstr "konnte Datei '%s' mit Modus %o nicht schreiben"
 
-#: apply.c:4531
+#: apply.c:4548
 #, c-format
 msgid "Applied patch %s cleanly."
 msgstr "Patch %s sauber angewendet"
 
-#: apply.c:4539
+#: apply.c:4556
 msgid "internal error"
 msgstr "interner Fehler"
 
-#: apply.c:4542
+#: apply.c:4559
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
 msgstr[0] "Wende Patch %%s mit %d Zurückweisung an..."
 msgstr[1] "Wende Patch %%s mit %d Zurückweisungen an..."
 
-#: apply.c:4553
+#: apply.c:4570
 #, c-format
 msgid "truncating .rej filename to %.*s.rej"
 msgstr "Verkürze Name von .rej Datei zu %.*s.rej"
 
-#: apply.c:4561 builtin/fetch.c:902 builtin/fetch.c:1195
+#: apply.c:4578 builtin/fetch.c:927 builtin/fetch.c:1228
 #, c-format
 msgid "cannot open %s"
 msgstr "kann '%s' nicht öffnen"
 
-#: apply.c:4575
+#: apply.c:4592
 #, c-format
 msgid "Hunk #%d applied cleanly."
 msgstr "Patch-Bereich #%d sauber angewendet."
 
-#: apply.c:4579
+#: apply.c:4596
 #, c-format
 msgid "Rejected hunk #%d."
 msgstr "Patch-Block #%d zurückgewiesen."
 
-#: apply.c:4698
+#: apply.c:4715
 #, c-format
 msgid "Skipped patch '%s'."
 msgstr "Patch '%s' ausgelassen."
 
-#: apply.c:4706
+#: apply.c:4723
 msgid "unrecognized input"
 msgstr "nicht erkannte Eingabe"
 
-#: apply.c:4726
+#: apply.c:4743
 msgid "unable to read index file"
 msgstr "Konnte Index-Datei nicht lesen"
 
-#: apply.c:4883
+#: apply.c:4900
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr "kann Patch '%s' nicht öffnen: %s"
 
-#: apply.c:4910
+#: apply.c:4927
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "unterdrückte %d Whitespace-Fehler"
 msgstr[1] "unterdrückte %d Whitespace-Fehler"
 
-#: apply.c:4916 apply.c:4931
+#: apply.c:4933 apply.c:4948
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] "%d Zeile fügt Whitespace-Fehler hinzu."
 msgstr[1] "%d Zeilen fügen Whitespace-Fehler hinzu."
 
-#: apply.c:4924
+#: apply.c:4941
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
 msgstr[0] "%d Zeile nach Behebung von Whitespace-Fehlern angewendet."
 msgstr[1] "%d Zeilen nach Behebung von Whitespace-Fehlern angewendet."
 
-#: apply.c:4940 builtin/add.c:612 builtin/mv.c:301 builtin/rm.c:406
+#: apply.c:4957 builtin/add.c:618 builtin/mv.c:304 builtin/rm.c:406
 msgid "Unable to write new index file"
 msgstr "Konnte neue Index-Datei nicht schreiben."
 
-#: apply.c:4968
+#: apply.c:4985
 msgid "don't apply changes matching the given path"
 msgstr "keine Änderungen im angegebenen Pfad anwenden"
 
-#: apply.c:4971
+#: apply.c:4988
 msgid "apply changes matching the given path"
 msgstr "Änderungen nur im angegebenen Pfad anwenden"
 
-#: apply.c:4973 builtin/am.c:2259
+#: apply.c:4990 builtin/am.c:2279
 msgid "num"
 msgstr "Anzahl"
 
-#: apply.c:4974
+#: apply.c:4991
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr ""
 "<Anzahl> vorangestellte Schrägstriche von herkömmlichen Differenzpfaden "
 "entfernen"
 
-#: apply.c:4977
+#: apply.c:4994
 msgid "ignore additions made by the patch"
 msgstr "hinzugefügte Zeilen des Patches ignorieren"
 
-#: apply.c:4979
+#: apply.c:4996
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr ""
 "anstatt der Anwendung des Patches, den \"diffstat\" für die Eingabe "
 "ausgegeben"
 
-#: apply.c:4983
+#: apply.c:5000
 msgid "show number of added and deleted lines in decimal notation"
 msgstr ""
 "die Anzahl von hinzugefügten/entfernten Zeilen in Dezimalnotation anzeigen"
 
-#: apply.c:4985
+#: apply.c:5002
 msgid "instead of applying the patch, output a summary for the input"
 msgstr ""
 "anstatt der Anwendung des Patches, eine Zusammenfassung für die Eingabe "
 "ausgeben"
 
-#: apply.c:4987
+#: apply.c:5004
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr ""
 "anstatt der Anwendung des Patches, zeige ob Patch angewendet werden kann"
 
-#: apply.c:4989
+#: apply.c:5006
 msgid "make sure the patch is applicable to the current index"
 msgstr ""
 "sicherstellen, dass der Patch mit dem aktuellen Index angewendet werden kann"
 
-#: apply.c:4991
+#: apply.c:5008
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "neue Dateien mit `git add --intent-to-add` markieren"
 
-#: apply.c:4993
+#: apply.c:5010
 msgid "apply a patch without touching the working tree"
 msgstr "Patch anwenden, ohne Änderungen im Arbeitsverzeichnis vorzunehmen"
 
-#: apply.c:4995
+#: apply.c:5012
 msgid "accept a patch that touches outside the working area"
 msgstr ""
 "Patch anwenden, der Änderungen außerhalb des Arbeitsverzeichnisses vornimmt"
 
-#: apply.c:4998
+#: apply.c:5015
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr "Patch anwenden (Benutzung mit --stat/--summary/--check)"
 
-#: apply.c:5000
+#: apply.c:5017
 msgid "attempt three-way merge if a patch does not apply"
 msgstr "versuche 3-Wege-Merge, wenn der Patch nicht angewendet werden konnte"
 
-#: apply.c:5002
+#: apply.c:5019
 msgid "build a temporary index based on embedded index information"
 msgstr ""
 "einen temporären Index, basierend auf den integrierten Index-Informationen, "
 "erstellen"
 
-#: apply.c:5005 builtin/checkout-index.c:173 builtin/ls-files.c:525
+#: apply.c:5022 builtin/checkout-index.c:173 builtin/ls-files.c:525
 msgid "paths are separated with NUL character"
 msgstr "Pfade sind getrennt durch NUL Zeichen"
 
-#: apply.c:5007
+#: apply.c:5024
 msgid "ensure at least <n> lines of context match"
 msgstr ""
 "sicher stellen, dass mindestens <n> Zeilen des Kontextes übereinstimmen"
 
-#: apply.c:5008 builtin/am.c:2238 builtin/interpret-trailers.c:98
+#: apply.c:5025 builtin/am.c:2258 builtin/interpret-trailers.c:98
 #: builtin/interpret-trailers.c:100 builtin/interpret-trailers.c:102
-#: builtin/pack-objects.c:3530 builtin/rebase.c:1332
+#: builtin/pack-objects.c:3562 builtin/rebase.c:1340
 msgid "action"
 msgstr "Aktion"
 
-#: apply.c:5009
+#: apply.c:5026
 msgid "detect new or modified lines that have whitespace errors"
 msgstr "neue oder geänderte Zeilen, die Whitespace-Fehler haben, ermitteln"
 
-#: apply.c:5012 apply.c:5015
+#: apply.c:5029 apply.c:5032
 msgid "ignore changes in whitespace when finding context"
 msgstr "Änderungen im Whitespace bei der Suche des Kontextes ignorieren"
 
-#: apply.c:5018
+#: apply.c:5035
 msgid "apply the patch in reverse"
 msgstr "den Patch in umgekehrter Reihenfolge anwenden"
 
-#: apply.c:5020
+#: apply.c:5037
 msgid "don't expect at least one line of context"
 msgstr "keinen Kontext erwarten"
 
-#: apply.c:5022
+#: apply.c:5039
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr ""
 "zurückgewiesene Patch-Blöcke in entsprechenden *.rej Dateien hinterlassen"
 
-#: apply.c:5024
+#: apply.c:5041
 msgid "allow overlapping hunks"
 msgstr "sich überlappende Patch-Blöcke erlauben"
 
-#: apply.c:5025 builtin/add.c:323 builtin/check-ignore.c:22
-#: builtin/commit.c:1366 builtin/count-objects.c:98 builtin/fsck.c:775
-#: builtin/log.c:2186 builtin/mv.c:123 builtin/read-tree.c:128
+#: apply.c:5042 builtin/add.c:329 builtin/check-ignore.c:22
+#: builtin/commit.c:1364 builtin/count-objects.c:98 builtin/fsck.c:775
+#: builtin/log.c:2270 builtin/mv.c:123 builtin/read-tree.c:128
 msgid "be verbose"
 msgstr "erweiterte Ausgaben"
 
-#: apply.c:5027
+#: apply.c:5044
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr "fehlerhaft erkannten fehlenden Zeilenumbruch am Dateiende tolerieren"
 
-#: apply.c:5030
+#: apply.c:5047
 msgid "do not trust the line counts in the hunk headers"
 msgstr "den Zeilennummern im Kopf des Patch-Blocks nicht vertrauen"
 
-#: apply.c:5032 builtin/am.c:2247
+#: apply.c:5049 builtin/am.c:2267
 msgid "root"
 msgstr "Wurzelverzeichnis"
 
-#: apply.c:5033
+#: apply.c:5050
 msgid "prepend <root> to all filenames"
 msgstr "<Wurzelverzeichnis> vor alle Dateinamen stellen"
 
-#: archive-tar.c:125 archive-zip.c:351
+#: archive-tar.c:125 archive-zip.c:345
 #, c-format
 msgid "cannot stream blob %s"
 msgstr "Kann Blob %s nicht streamen."
 
-#: archive-tar.c:266 archive-zip.c:369
+#: archive-tar.c:265 archive-zip.c:358
 #, c-format
 msgid "unsupported file mode: 0%o (SHA1: %s)"
 msgstr "Nicht unterstützter Dateimodus: 0%o (SHA1: %s)"
 
-#: archive-tar.c:293 archive-zip.c:359
-#, c-format
-msgid "cannot read %s"
-msgstr "Kann %s nicht lesen."
-
-#: archive-tar.c:465
+#: archive-tar.c:449
 #, c-format
 msgid "unable to start '%s' filter"
 msgstr "Konnte '%s' Filter nicht starten."
 
-#: archive-tar.c:468
+#: archive-tar.c:452
 msgid "unable to redirect descriptor"
 msgstr "Konnte Descriptor nicht umleiten."
 
-#: archive-tar.c:475
+#: archive-tar.c:459
 #, c-format
 msgid "'%s' filter reported error"
 msgstr "'%s' Filter meldete Fehler."
 
-#: archive-zip.c:319
+#: archive-zip.c:318
 #, c-format
 msgid "path is not valid UTF-8: %s"
 msgstr "Pfad ist kein gültiges UTF-8: %s"
 
-#: archive-zip.c:323
+#: archive-zip.c:322
 #, c-format
 msgid "path too long (%d chars, SHA1: %s): %s"
 msgstr "Pfad zu lang (%d Zeichen, SHA1: %s): %s"
 
-#: archive-zip.c:480 builtin/pack-objects.c:243 builtin/pack-objects.c:246
+#: archive-zip.c:469 builtin/pack-objects.c:244 builtin/pack-objects.c:247
 #, c-format
 msgid "deflate error (%d)"
 msgstr "Fehler beim Komprimieren (%d)"
 
-#: archive-zip.c:615
+#: archive-zip.c:603
 #, c-format
 msgid "timestamp too large for this system: %<PRIuMAX>"
 msgstr "Timestamp zu groß für dieses System: %<PRIuMAX>"
@@ -1593,119 +1588,152 @@ msgstr ""
 msgid "git archive --remote <repo> [--exec <cmd>] --list"
 msgstr "git archive --remote <Repository> [--exec <Programm>] --list"
 
-#: archive.c:377 builtin/add.c:181 builtin/add.c:588 builtin/rm.c:315
+#: archive.c:192
+#, c-format
+msgid "cannot read %s"
+msgstr "Kann %s nicht lesen."
+
+#: archive.c:345 sequencer.c:445 sequencer.c:1706 sequencer.c:2852
+#: sequencer.c:3293 sequencer.c:3402 builtin/am.c:263 builtin/commit.c:786
+#: builtin/merge.c:1124
+#, c-format
+msgid "could not read '%s'"
+msgstr "Konnte '%s' nicht lesen"
+
+#: archive.c:430 builtin/add.c:181 builtin/add.c:594 builtin/rm.c:315
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "Pfadspezifikation '%s' stimmt mit keinen Dateien überein"
 
-#: archive.c:401
+#: archive.c:454
 #, c-format
 msgid "no such ref: %.*s"
 msgstr "Keine solche Referenz: %.*s"
 
-#: archive.c:407
+#: archive.c:460
 #, c-format
 msgid "not a valid object name: %s"
 msgstr "Kein gültiger Objektname: %s"
 
-#: archive.c:420
+#: archive.c:473
 #, c-format
 msgid "not a tree object: %s"
 msgstr "Kein Tree-Objekt: %s"
 
-#: archive.c:432
+#: archive.c:485
 msgid "current working directory is untracked"
 msgstr "Aktuelles Arbeitsverzeichnis ist unversioniert."
 
-#: archive.c:464
+#: archive.c:526
+#, fuzzy, c-format
+msgid "File not found: %s"
+msgstr "Objekt nicht gefunden: %s"
+
+#: archive.c:528
+#, fuzzy, c-format
+msgid "Not a regular file: %s"
+msgstr "Kein Reflog: %s"
+
+#: archive.c:553
 msgid "fmt"
 msgstr "Format"
 
-#: archive.c:464
+#: archive.c:553
 msgid "archive format"
 msgstr "Archivformat"
 
-#: archive.c:465 builtin/log.c:1674
+#: archive.c:554 builtin/log.c:1760
 msgid "prefix"
 msgstr "Präfix"
 
-#: archive.c:466
+#: archive.c:555
 msgid "prepend prefix to each pathname in the archive"
 msgstr "einen Präfix vor jeden Pfadnamen in dem Archiv stellen"
 
-#: archive.c:467 builtin/blame.c:861 builtin/blame.c:865 builtin/blame.c:866
-#: builtin/commit-tree.c:117 builtin/config.c:130 builtin/fast-export.c:1208
-#: builtin/fast-export.c:1210 builtin/fast-export.c:1214 builtin/grep.c:907
-#: builtin/hash-object.c:105 builtin/ls-files.c:561 builtin/ls-files.c:564
-#: builtin/notes.c:412 builtin/notes.c:578 builtin/read-tree.c:123
-#: parse-options.h:190
+#: archive.c:556 archive.c:559 builtin/blame.c:884 builtin/blame.c:888
+#: builtin/blame.c:889 builtin/commit-tree.c:117 builtin/config.c:133
+#: builtin/fast-export.c:1208 builtin/fast-export.c:1210
+#: builtin/fast-export.c:1214 builtin/grep.c:908 builtin/hash-object.c:105
+#: builtin/ls-files.c:561 builtin/ls-files.c:564 builtin/notes.c:412
+#: builtin/notes.c:578 builtin/read-tree.c:123 parse-options.h:190
 msgid "file"
 msgstr "Datei"
 
-#: archive.c:468 builtin/archive.c:90
+#: archive.c:557
+#, fuzzy
+msgid "add untracked file to archive"
+msgstr "unversionierte Dateien in Stash einbeziehen"
+
+#: archive.c:560 builtin/archive.c:90
 msgid "write the archive to this file"
 msgstr "das Archiv in diese Datei schreiben"
 
-#: archive.c:470
+#: archive.c:562
 msgid "read .gitattributes in working directory"
 msgstr ".gitattributes aus dem Arbeitsverzeichnis lesen"
 
-#: archive.c:471
+#: archive.c:563
 msgid "report archived files on stderr"
 msgstr "archivierte Dateien in der Standard-Fehlerausgabe ausgeben"
 
-#: archive.c:472
+#: archive.c:564
 msgid "store only"
 msgstr "nur speichern"
 
-#: archive.c:473
+#: archive.c:565
 msgid "compress faster"
 msgstr "schneller komprimieren"
 
-#: archive.c:481
+#: archive.c:573
 msgid "compress better"
 msgstr "besser komprimieren"
 
-#: archive.c:484
+#: archive.c:576
 msgid "list supported archive formats"
 msgstr "unterstützte Archivformate auflisten"
 
-#: archive.c:486 builtin/archive.c:91 builtin/clone.c:113 builtin/clone.c:116
-#: builtin/submodule--helper.c:1406 builtin/submodule--helper.c:1911
+#: archive.c:578 builtin/archive.c:91 builtin/clone.c:113 builtin/clone.c:116
+#: builtin/submodule--helper.c:1830 builtin/submodule--helper.c:2335
 msgid "repo"
 msgstr "Repository"
 
-#: archive.c:487 builtin/archive.c:92
+#: archive.c:579 builtin/archive.c:92
 msgid "retrieve the archive from remote repository <repo>"
 msgstr "Archiv vom Remote-Repository <Repository> abrufen"
 
-#: archive.c:488 builtin/archive.c:93 builtin/difftool.c:715
+#: archive.c:580 builtin/archive.c:93 builtin/difftool.c:715
 #: builtin/notes.c:498
 msgid "command"
 msgstr "Programm"
 
-#: archive.c:489 builtin/archive.c:94
+#: archive.c:581 builtin/archive.c:94
 msgid "path to the remote git-upload-archive command"
 msgstr "Pfad zum externen \"git-upload-archive\"-Programm"
 
-#: archive.c:496
+#: archive.c:588
 msgid "Unexpected option --remote"
 msgstr "Unerwartete Option --remote"
 
-#: archive.c:498
+#: archive.c:590
 msgid "Option --exec can only be used together with --remote"
 msgstr "Die Option --exec kann nur zusammen mit --remote verwendet werden."
 
-#: archive.c:500
+#: archive.c:592
 msgid "Unexpected option --output"
 msgstr "Unerwartete Option --output"
 
-#: archive.c:522
+#: archive.c:594
+#, fuzzy
+msgid "Options --add-file and --remote cannot be used together"
+msgstr ""
+"Die Optionen --squash und --fixup können nicht gemeinsam verwendet werden."
+
+#: archive.c:616
 #, c-format
 msgid "Unknown archive format '%s'"
 msgstr "Unbekanntes Archivformat '%s'"
 
-#: archive.c:529
+#: archive.c:623
 #, c-format
 msgid "Argument not supported for format '%s': -%d"
 msgstr "Argument für Format '%s' nicht unterstützt: -%d"
@@ -1728,22 +1756,22 @@ msgstr ""
 "Verneinende Muster werden in Git-Attributen ignoriert.\n"
 "Benutzen Sie '\\!' für führende Ausrufezeichen."
 
-#: bisect.c:468
+#: bisect.c:476
 #, c-format
 msgid "Badly quoted content in file '%s': %s"
 msgstr "Ungültiger Inhalt bzgl. Anführungszeichen in Datei '%s': %s"
 
-#: bisect.c:678
+#: bisect.c:686
 #, c-format
 msgid "We cannot bisect more!\n"
 msgstr "Keine binäre Suche mehr möglich!\n"
 
-#: bisect.c:745
+#: bisect.c:753
 #, c-format
 msgid "Not a valid commit name %s"
 msgstr "%s ist kein gültiger Commit-Name"
 
-#: bisect.c:770
+#: bisect.c:778
 #, c-format
 msgid ""
 "The merge base %s is bad.\n"
@@ -1752,7 +1780,7 @@ msgstr ""
 "Die Merge-Basis %s ist fehlerhaft.\n"
 "Das bedeutet, der Fehler wurde zwischen %s und [%s] behoben.\n"
 
-#: bisect.c:775
+#: bisect.c:783
 #, c-format
 msgid ""
 "The merge base %s is new.\n"
@@ -1761,7 +1789,7 @@ msgstr ""
 "Die Merge-Basis %s ist neu.\n"
 "Das bedeutet, die Eigenschaft hat sich zwischen %s und [%s] geändert.\n"
 
-#: bisect.c:780
+#: bisect.c:788
 #, c-format
 msgid ""
 "The merge base %s is %s.\n"
@@ -1770,7 +1798,7 @@ msgstr ""
 "Die Merge-Basis %s ist %s.\n"
 "Das bedeutet, der erste '%s' Commit befindet sich zwischen %s und [%s].\n"
 
-#: bisect.c:788
+#: bisect.c:796
 #, c-format
 msgid ""
 "Some %s revs are not ancestors of the %s rev.\n"
@@ -1781,7 +1809,7 @@ msgstr ""
 "git bisect kann in diesem Fall nicht richtig arbeiten.\n"
 "Vielleicht verwechselten Sie %s und %s Commits?\n"
 
-#: bisect.c:801
+#: bisect.c:809
 #, c-format
 msgid ""
 "the merge base between %s and [%s] must be skipped.\n"
@@ -1793,36 +1821,36 @@ msgstr ""
 "erste %s Commit zwischen %s und %s befindet.\n"
 "Es wird dennoch fortgesetzt."
 
-#: bisect.c:840
+#: bisect.c:848
 #, c-format
 msgid "Bisecting: a merge base must be tested\n"
 msgstr "binäre Suche: eine Merge-Basis muss geprüft werden\n"
 
-#: bisect.c:890
+#: bisect.c:898
 #, c-format
 msgid "a %s revision is needed"
 msgstr "ein %s Commit wird benötigt"
 
-#: bisect.c:920 builtin/notes.c:177 builtin/tag.c:255
+#: bisect.c:928 builtin/notes.c:177 builtin/tag.c:255
 #, c-format
 msgid "could not create file '%s'"
 msgstr "konnte Datei '%s' nicht erstellen"
 
-#: bisect.c:966 builtin/merge.c:151
+#: bisect.c:974 builtin/merge.c:150
 #, c-format
 msgid "could not read file '%s'"
 msgstr "Konnte Datei '%s' nicht lesen"
 
-#: bisect.c:997
+#: bisect.c:1014
 msgid "reading bisect refs failed"
 msgstr "Lesen von Referenzen für binäre Suche fehlgeschlagen"
 
-#: bisect.c:1019
+#: bisect.c:1044
 #, c-format
 msgid "%s was both %s and %s\n"
 msgstr "%s war sowohl %s als auch %s\n"
 
-#: bisect.c:1028
+#: bisect.c:1053
 #, c-format
 msgid ""
 "No testable commit found.\n"
@@ -1831,7 +1859,7 @@ msgstr ""
 "Kein testbarer Commit gefunden.\n"
 "Vielleicht starteten Sie mit falschen Pfad-Parametern?\n"
 
-#: bisect.c:1057
+#: bisect.c:1082
 #, c-format
 msgid "(roughly %d step)"
 msgid_plural "(roughly %d steps)"
@@ -1841,50 +1869,50 @@ msgstr[1] "(ungefähr %d Schritte)"
 #. TRANSLATORS: the last %s will be replaced with "(roughly %d
 #. steps)" translation.
 #.
-#: bisect.c:1063
+#: bisect.c:1088
 #, c-format
 msgid "Bisecting: %d revision left to test after this %s\n"
 msgid_plural "Bisecting: %d revisions left to test after this %s\n"
 msgstr[0] "binäre Suche: danach noch %d Commit zum Testen übrig %s\n"
 msgstr[1] "binäre Suche: danach noch %d Commits zum Testen übrig %s\n"
 
-#: blame.c:2777
+#: blame.c:2778
 msgid "--contents and --reverse do not blend well."
 msgstr "--contents und --reverse funktionieren gemeinsam nicht."
 
-#: blame.c:2791
+#: blame.c:2792
 msgid "cannot use --contents with final commit object name"
 msgstr ""
 "kann --contents nicht mit endgültigem Namen des Commit-Objektes benutzen"
 
-#: blame.c:2812
+#: blame.c:2813
 msgid "--reverse and --first-parent together require specified latest commit"
 msgstr ""
 "--reverse und --first-parent zusammen erfordern die Angabe eines "
 "endgültigen\n"
 "Commits"
 
-#: blame.c:2821 bundle.c:187 ref-filter.c:2200 remote.c:1924 sequencer.c:2018
-#: sequencer.c:4466 submodule.c:847 builtin/commit.c:1047 builtin/log.c:405
-#: builtin/log.c:1012 builtin/log.c:1541 builtin/log.c:1945 builtin/log.c:2235
-#: builtin/merge.c:415 builtin/pack-objects.c:3348 builtin/pack-objects.c:3363
-#: builtin/shortlog.c:192
+#: blame.c:2822 bundle.c:213 ref-filter.c:2264 remote.c:2020 sequencer.c:2105
+#: sequencer.c:4606 submodule.c:855 builtin/commit.c:1045 builtin/log.c:404
+#: builtin/log.c:1020 builtin/log.c:1622 builtin/log.c:2029 builtin/log.c:2319
+#: builtin/merge.c:414 builtin/pack-objects.c:3380 builtin/pack-objects.c:3395
+#: builtin/shortlog.c:320
 msgid "revision walk setup failed"
 msgstr "Einrichtung des Revisionsgangs fehlgeschlagen"
 
-#: blame.c:2839
+#: blame.c:2840
 msgid ""
 "--reverse --first-parent together require range along first-parent chain"
 msgstr ""
 "--reverse und --first-parent zusammen erfordern einen Bereich entlang der\n"
 "\"first-parent\"-Kette"
 
-#: blame.c:2850
+#: blame.c:2851
 #, c-format
 msgid "no such path %s in %s"
 msgstr "Pfad %s nicht in %s"
 
-#: blame.c:2861
+#: blame.c:2862
 #, c-format
 msgid "cannot read blob %s for path %s"
 msgstr "kann Blob %s für Pfad '%s' nicht lesen"
@@ -2031,88 +2059,104 @@ msgstr "'%s' ist bereits in '%s' ausgecheckt"
 msgid "HEAD of working tree %s is not updated"
 msgstr "HEAD des Arbeitsverzeichnisses %s ist nicht aktualisiert."
 
-#: bundle.c:47
-#, c-format
-msgid "'%s' does not look like a v2 bundle file"
+#: bundle.c:41
+#, fuzzy, c-format
+msgid "unrecognized bundle hash algorithm: %s"
+msgstr "unbekannter Hash-Algorithmus '%s'"
+
+#: bundle.c:45
+#, fuzzy, c-format
+msgid "unknown capability '%s'"
+msgstr "Unbekannte Variable '%s'"
+
+#: bundle.c:71
+#, fuzzy, c-format
+msgid "'%s' does not look like a v2 or v3 bundle file"
 msgstr "'%s' sieht nicht wie eine v2 Paketdatei aus"
 
-#: bundle.c:69
-msgid "unknown hash algorithm length"
-msgstr "unbekannte Länge des Hash-Algorithmus"
-
-#: bundle.c:84
+#: bundle.c:110
 #, c-format
 msgid "unrecognized header: %s%s (%d)"
 msgstr "nicht erkannter Kopfbereich: %s%s (%d)"
 
-#: bundle.c:110 rerere.c:480 rerere.c:690 sequencer.c:2270 sequencer.c:3034
+#: bundle.c:136 rerere.c:480 rerere.c:690 sequencer.c:2357 sequencer.c:3142
 #: builtin/commit.c:814
 #, c-format
 msgid "could not open '%s'"
 msgstr "Konnte '%s' nicht öffnen"
 
-#: bundle.c:163
+#: bundle.c:189
 msgid "Repository lacks these prerequisite commits:"
 msgstr "Dem Repository fehlen folgende vorausgesetzte Commits:"
 
-#: bundle.c:166
+#: bundle.c:192
 msgid "need a repository to verify a bundle"
 msgstr "Um ein Paket zu überprüfen wird ein Repository benötigt."
 
-#: bundle.c:217
+#: bundle.c:243
 #, c-format
 msgid "The bundle contains this ref:"
 msgid_plural "The bundle contains these %d refs:"
 msgstr[0] "Das Paket enthält diese Referenz:"
 msgstr[1] "Das Paket enthält diese %d Referenzen:"
 
-#: bundle.c:224
+#: bundle.c:250
 msgid "The bundle records a complete history."
 msgstr "Das Paket speichert eine komplette Historie."
 
-#: bundle.c:226
+#: bundle.c:252
 #, c-format
 msgid "The bundle requires this ref:"
 msgid_plural "The bundle requires these %d refs:"
 msgstr[0] "Das Paket benötigt diese Referenz:"
 msgstr[1] "Das Paket benötigt diese %d Referenzen:"
 
-#: bundle.c:293
+#: bundle.c:319
 msgid "unable to dup bundle descriptor"
 msgstr "Konnte dup für Descriptor des Pakets nicht ausführen."
 
-#: bundle.c:300
+#: bundle.c:326
 msgid "Could not spawn pack-objects"
 msgstr "Konnte Paketobjekte nicht erstellen"
 
-#: bundle.c:311
+#: bundle.c:337
 msgid "pack-objects died"
 msgstr "Erstellung der Paketobjekte abgebrochen"
 
-#: bundle.c:353
+#: bundle.c:379
 msgid "rev-list died"
 msgstr "\"rev-list\" abgebrochen"
 
-#: bundle.c:402
+#: bundle.c:428
 #, c-format
 msgid "ref '%s' is excluded by the rev-list options"
 msgstr "Referenz '%s' wird durch \"rev-list\" Optionen ausgeschlossen"
 
-#: bundle.c:481 builtin/log.c:208 builtin/log.c:1834 builtin/shortlog.c:306
+#: bundle.c:498
+#, fuzzy, c-format
+msgid "unsupported bundle version %d"
+msgstr "nicht unterstützte Index-Version %s"
+
+#: bundle.c:500
+#, c-format
+msgid "cannot write bundle version %d with algorithm %s"
+msgstr ""
+
+#: bundle.c:522 builtin/log.c:207 builtin/log.c:1918 builtin/shortlog.c:461
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr "nicht erkanntes Argument: %s"
 
-#: bundle.c:489
+#: bundle.c:530
 msgid "Refusing to create empty bundle."
 msgstr "Erstellung eines leeren Pakets zurückgewiesen."
 
-#: bundle.c:499
+#: bundle.c:540
 #, c-format
 msgid "cannot create '%s'"
 msgstr "kann '%s' nicht erstellen"
 
-#: bundle.c:524
+#: bundle.c:565
 msgid "index-pack died"
 msgstr "Erstellung der Paketindexdatei abgebrochen"
 
@@ -2121,250 +2165,246 @@ msgstr "Erstellung der Paketindexdatei abgebrochen"
 msgid "invalid color value: %.*s"
 msgstr "Ungültiger Farbwert: %.*s"
 
-#: commit-graph.c:238
+#: commit-graph.c:188 midx.c:46
+#, fuzzy
+msgid "invalid hash version"
+msgstr "ungültige Pfadspezifikation"
+
+#: commit-graph.c:246
 msgid "commit-graph file is too small"
 msgstr "Commit-Graph-Datei ist zu klein."
 
-#: commit-graph.c:303
+#: commit-graph.c:311
 #, c-format
 msgid "commit-graph signature %X does not match signature %X"
 msgstr "Commit-Graph-Signatur %X stimmt nicht mit Signatur %X überein."
 
-#: commit-graph.c:310
+#: commit-graph.c:318
 #, c-format
 msgid "commit-graph version %X does not match version %X"
 msgstr "Commit-Graph-Version %X stimmt nicht mit Version %X überein."
 
-#: commit-graph.c:317
+#: commit-graph.c:325
 #, c-format
 msgid "commit-graph hash version %X does not match version %X"
 msgstr "Hash-Version des Commit-Graph %X stimmt nicht mit Version %X überein."
 
-#: commit-graph.c:339
-msgid "commit-graph chunk lookup table entry missing; file may be incomplete"
-msgstr ""
-"fehlender Tabelleneintrag für Commit-Graph Chunk-Lookup; Datei "
-"möglicherweise unvollständig"
+#: commit-graph.c:342
+#, fuzzy, c-format
+msgid "commit-graph file is too small to hold %u chunks"
+msgstr "Commit-Graph-Datei ist zu klein."
 
-#: commit-graph.c:349
+#: commit-graph.c:361
 #, c-format
 msgid "commit-graph improper chunk offset %08x%08x"
 msgstr "Unzulässiger Commit-Graph Chunk-Offset %08x%08x"
 
-#: commit-graph.c:417
+#: commit-graph.c:433
 #, c-format
 msgid "commit-graph chunk id %08x appears multiple times"
 msgstr "Commit-Graph Chunk-Id %08x kommt mehrfach vor."
 
-#: commit-graph.c:491
+#: commit-graph.c:499
 msgid "commit-graph has no base graphs chunk"
 msgstr "Commit-Graph hat keinen Basis-Graph-Chunk"
 
-#: commit-graph.c:501
+#: commit-graph.c:509
 msgid "commit-graph chain does not match"
 msgstr "Commit-Graph Verkettung stimmt nicht überein."
 
-#: commit-graph.c:549
+#: commit-graph.c:557
 #, c-format
 msgid "invalid commit-graph chain: line '%s' not a hash"
 msgstr "Ungültige Commit-Graph Verkettung: Zeile '%s' ist kein Hash"
 
-#: commit-graph.c:573
+#: commit-graph.c:581
 msgid "unable to find all commit-graph files"
 msgstr "Konnte nicht alle Commit-Graph-Dateien finden."
 
-#: commit-graph.c:706 commit-graph.c:770
+#: commit-graph.c:721 commit-graph.c:785
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr "Ungültige Commit-Position. Commit-Graph ist wahrscheinlich beschädigt."
 
-#: commit-graph.c:727
+#: commit-graph.c:742
 #, c-format
 msgid "could not find commit %s"
 msgstr "Konnte Commit %s nicht finden."
 
-#: commit-graph.c:1009 builtin/am.c:1292
+#: commit-graph.c:1042 builtin/am.c:1306
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "Konnte Commit '%s' nicht parsen."
 
-#: commit-graph.c:1157
-msgid "Writing changed paths Bloom filters index"
-msgstr "Schreibe Index für veränderte Pfade Bloom-Filter"
-
-#: commit-graph.c:1182
-msgid "Writing changed paths Bloom filters data"
-msgstr "Schreibe Daten für veränderte Pfade Bloom-Filter"
-
-#: commit-graph.c:1221 builtin/pack-objects.c:2832
+#: commit-graph.c:1265 builtin/pack-objects.c:2864
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "Konnte Art von Objekt '%s' nicht bestimmen."
 
-#: commit-graph.c:1257
+#: commit-graph.c:1301
 msgid "Loading known commits in commit graph"
 msgstr "Lade bekannte Commits in Commit-Graph"
 
-#: commit-graph.c:1274
+#: commit-graph.c:1318
 msgid "Expanding reachable commits in commit graph"
 msgstr "Erweitere erreichbare Commits in Commit-Graph"
 
-#: commit-graph.c:1294
+#: commit-graph.c:1338
 msgid "Clearing commit marks in commit graph"
 msgstr "Lösche Commit-Markierungen in Commit-Graph"
 
-#: commit-graph.c:1313
+#: commit-graph.c:1357
 msgid "Computing commit graph generation numbers"
 msgstr "Commit-Graph Generationsnummern berechnen"
 
-#: commit-graph.c:1367
+#: commit-graph.c:1424
 msgid "Computing commit changed paths Bloom filters"
 msgstr "Berechnung der Bloom-Filter für veränderte Pfade des Commits"
 
-#: commit-graph.c:1423
+#: commit-graph.c:1501
 msgid "Collecting referenced commits"
 msgstr "Sammle referenzierte Commits"
 
-#: commit-graph.c:1447
+#: commit-graph.c:1526
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] "Suche Commits für Commit-Graph in %d Paket"
 msgstr[1] "Suche Commits für Commit-Graph in %d Paketen"
 
-#: commit-graph.c:1460
+#: commit-graph.c:1539
 #, c-format
 msgid "error adding pack %s"
 msgstr "Fehler beim Hinzufügen von Paket %s."
 
-#: commit-graph.c:1464
+#: commit-graph.c:1543
 #, c-format
 msgid "error opening index for %s"
 msgstr "Fehler beim Öffnen des Index für %s."
 
-#: commit-graph.c:1503
+#: commit-graph.c:1582
 msgid "Finding commits for commit graph among packed objects"
 msgstr "Suche Commits für Commit-Graph in gepackten Objekten"
 
-#: commit-graph.c:1518
+#: commit-graph.c:1597
 msgid "Counting distinct commits in commit graph"
 msgstr "Zähle Commits in Commit-Graph"
 
-#: commit-graph.c:1550
+#: commit-graph.c:1629
 msgid "Finding extra edges in commit graph"
 msgstr "Suche zusätzliche Ränder in Commit-Graph"
 
-#: commit-graph.c:1599
+#: commit-graph.c:1678
 msgid "failed to write correct number of base graph ids"
 msgstr "Fehler beim Schreiben der korrekten Anzahl von Basis-Graph-IDs."
 
-#: commit-graph.c:1633 midx.c:812
+#: commit-graph.c:1720 midx.c:826
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "Konnte führende Verzeichnisse von '%s' nicht erstellen."
 
-#: commit-graph.c:1646
+#: commit-graph.c:1733
 msgid "unable to create temporary graph layer"
 msgstr "konnte temporäre Graphen-Schicht nicht erstellen"
 
-#: commit-graph.c:1651
+#: commit-graph.c:1738
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "konnte geteilte Zugriffsberechtigungen für '%s' nicht ändern"
 
-#: commit-graph.c:1728
+#: commit-graph.c:1808
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "Schreibe Commit-Graph in %d Durchgang"
 msgstr[1] "Schreibe Commit-Graph in %d Durchgängen"
 
-#: commit-graph.c:1773
+#: commit-graph.c:1853
 msgid "unable to open commit-graph chain file"
 msgstr "Konnte Commit-Graph Chain-Datei nicht öffnen."
 
-#: commit-graph.c:1789
+#: commit-graph.c:1869
 msgid "failed to rename base commit-graph file"
 msgstr "Konnte Basis-Commit-Graph-Datei nicht umbenennen."
 
-#: commit-graph.c:1809
+#: commit-graph.c:1889
 msgid "failed to rename temporary commit-graph file"
 msgstr "Konnte temporäre Commit-Graph-Datei nicht umbenennen."
 
-#: commit-graph.c:1935
+#: commit-graph.c:2015
 msgid "Scanning merged commits"
 msgstr "Durchsuche zusammengeführte Commits"
 
-#: commit-graph.c:1946
+#: commit-graph.c:2026
 #, c-format
 msgid "unexpected duplicate commit id %s"
 msgstr "Unerwartete doppelte Commit-ID %s"
 
-#: commit-graph.c:1969
+#: commit-graph.c:2049
 msgid "Merging commit-graph"
 msgstr "Zusammenführen von Commit-Graph"
 
-#: commit-graph.c:2156
+#: commit-graph.c:2259
 #, c-format
 msgid "the commit graph format cannot write %d commits"
 msgstr "Das Commit-Graph Format kann nicht %d Commits schreiben."
 
-#: commit-graph.c:2167
+#: commit-graph.c:2270
 msgid "too many commits to write graph"
 msgstr "Zu viele Commits zum Schreiben des Graphen."
 
-#: commit-graph.c:2260
+#: commit-graph.c:2363
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "Die Commit-Graph-Datei hat eine falsche Prüfsumme und ist wahrscheinlich "
 "beschädigt."
 
-#: commit-graph.c:2270
+#: commit-graph.c:2373
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "Commit-Graph hat fehlerhafte OID-Reihenfolge: %s dann %s"
 
-#: commit-graph.c:2280 commit-graph.c:2295
+#: commit-graph.c:2383 commit-graph.c:2398
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr "Commit-Graph hat fehlerhaften Fanout-Wert: fanout[%d] = %u != %u"
 
-#: commit-graph.c:2287
+#: commit-graph.c:2390
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "Konnte Commit %s von Commit-Graph nicht parsen."
 
-#: commit-graph.c:2305
+#: commit-graph.c:2408
 msgid "Verifying commits in commit graph"
 msgstr "Commit in Commit-Graph überprüfen"
 
-#: commit-graph.c:2320
+#: commit-graph.c:2423
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "Fehler beim Parsen des Commits %s von Objekt-Datenbank für Commit-Graph"
 
-#: commit-graph.c:2327
+#: commit-graph.c:2430
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 "OID des Wurzelverzeichnisses für Commit %s in Commit-Graph ist %s != %s"
 
-#: commit-graph.c:2337
+#: commit-graph.c:2440
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr "Commit-Graph Vorgänger-Liste für Commit %s ist zu lang"
 
-#: commit-graph.c:2346
+#: commit-graph.c:2449
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "Commit-Graph-Vorgänger für %s ist %s != %s"
 
-#: commit-graph.c:2360
+#: commit-graph.c:2463
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr "Commit-Graph Vorgänger-Liste für Commit %s endet zu früh"
 
-#: commit-graph.c:2365
+#: commit-graph.c:2468
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2372,7 +2412,7 @@ msgstr ""
 "Commit-Graph hat Generationsnummer null für Commit %s, aber sonst ungleich "
 "null"
 
-#: commit-graph.c:2369
+#: commit-graph.c:2472
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2380,19 +2420,19 @@ msgstr ""
 "Commit-Graph hat Generationsnummer ungleich null für Commit %s, aber sonst "
 "null"
 
-#: commit-graph.c:2385
+#: commit-graph.c:2488
 #, c-format
 msgid "commit-graph generation for commit %s is %u != %u"
 msgstr "Commit-Graph Erstellung für Commit %s ist %u != %u"
 
-#: commit-graph.c:2391
+#: commit-graph.c:2494
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 "Commit-Datum für Commit %s in Commit-Graph ist %<PRIuMAX> != %<PRIuMAX>"
 
-#: commit.c:52 sequencer.c:2739 builtin/am.c:359 builtin/am.c:403
-#: builtin/am.c:1371 builtin/am.c:2013 builtin/replace.c:457
+#: commit.c:52 sequencer.c:2845 builtin/am.c:373 builtin/am.c:417
+#: builtin/am.c:1385 builtin/am.c:2031 builtin/replace.c:457
 #, c-format
 msgid "could not parse %s"
 msgstr "konnte %s nicht parsen"
@@ -2502,7 +2542,7 @@ msgstr "Schlüssel enthält keine Sektion: %s"
 msgid "key does not contain variable name: %s"
 msgstr "Schlüssel enthält keinen Variablennamen: %s"
 
-#: config.c:408 sequencer.c:2456
+#: config.c:408 sequencer.c:2547
 #, c-format
 msgid "invalid key: %s"
 msgstr "Ungültiger Schlüssel: %s"
@@ -2646,7 +2686,7 @@ msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr ""
 "Muss einer von diesen sein: nothing, matching, simple, upstream, current"
 
-#: config.c:1533 builtin/pack-objects.c:3617
+#: config.c:1533 builtin/pack-objects.c:3649
 #, c-format
 msgid "bad pack compression level %d"
 msgstr "ungültiger Komprimierungsgrad (%d) für Paketierung"
@@ -2676,106 +2716,106 @@ msgid "unable to parse command-line config"
 msgstr ""
 "Konnte die über die Befehlszeile angegebene Konfiguration nicht parsen."
 
-#: config.c:2113
+#: config.c:2122
 msgid "unknown error occurred while reading the configuration files"
 msgstr ""
 "Es trat ein unbekannter Fehler beim Lesen der Konfigurationsdateien auf."
 
-#: config.c:2283
+#: config.c:2296
 #, c-format
 msgid "Invalid %s: '%s'"
 msgstr "Ungültiger %s: '%s'"
 
-#: config.c:2328
+#: config.c:2341
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
 msgstr ""
 "Der Wert '%d' von splitIndex.maxPercentChange sollte zwischen 0 und 100 "
 "liegen."
 
-#: config.c:2374
+#: config.c:2387
 #, c-format
 msgid "unable to parse '%s' from command-line config"
 msgstr ""
 "Konnte Wert '%s' aus der über die Befehlszeile angegebenen Konfiguration\n"
 "nicht parsen."
 
-#: config.c:2376
+#: config.c:2389
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
 msgstr "ungültige Konfigurationsvariable '%s' in Datei '%s' bei Zeile %d"
 
-#: config.c:2457
+#: config.c:2470
 #, c-format
 msgid "invalid section name '%s'"
 msgstr "Ungültiger Sektionsname '%s'"
 
-#: config.c:2489
+#: config.c:2502
 #, c-format
 msgid "%s has multiple values"
 msgstr "%s hat mehrere Werte"
 
-#: config.c:2518
+#: config.c:2531
 #, c-format
 msgid "failed to write new configuration file %s"
 msgstr "Konnte neue Konfigurationsdatei '%s' nicht schreiben."
 
-#: config.c:2770 config.c:3094
+#: config.c:2783 config.c:3107
 #, c-format
 msgid "could not lock config file %s"
 msgstr "Konnte Konfigurationsdatei '%s' nicht sperren."
 
-#: config.c:2781
+#: config.c:2794
 #, c-format
 msgid "opening %s"
 msgstr "Öffne %s"
 
-#: config.c:2816 builtin/config.c:344
+#: config.c:2829 builtin/config.c:354
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "Ungültiges Muster: %s"
 
-#: config.c:2841
+#: config.c:2854
 #, c-format
 msgid "invalid config file %s"
 msgstr "Ungültige Konfigurationsdatei %s"
 
-#: config.c:2854 config.c:3107
+#: config.c:2867 config.c:3120
 #, c-format
 msgid "fstat on %s failed"
 msgstr "fstat auf %s fehlgeschlagen"
 
-#: config.c:2865
+#: config.c:2878
 #, c-format
 msgid "unable to mmap '%s'"
 msgstr "mmap für '%s' fehlgeschlagen"
 
-#: config.c:2874 config.c:3112
+#: config.c:2887 config.c:3125
 #, c-format
 msgid "chmod on %s failed"
 msgstr "chmod auf %s fehlgeschlagen"
 
-#: config.c:2959 config.c:3209
+#: config.c:2972 config.c:3222
 #, c-format
 msgid "could not write config file %s"
 msgstr "Konnte Konfigurationsdatei %s nicht schreiben."
 
-#: config.c:2993
+#: config.c:3006
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "Konnte '%s' nicht zu '%s' setzen."
 
-#: config.c:2995 builtin/remote.c:655 builtin/remote.c:849 builtin/remote.c:857
+#: config.c:3008 builtin/remote.c:656 builtin/remote.c:850 builtin/remote.c:858
 #, c-format
 msgid "could not unset '%s'"
 msgstr "Konnte '%s' nicht aufheben."
 
-#: config.c:3085
+#: config.c:3098
 #, c-format
 msgid "invalid section name: %s"
 msgstr "Ungültiger Sektionsname: %s"
 
-#: config.c:3252
+#: config.c:3265
 #, c-format
 msgid "missing value for '%s'"
 msgstr "Fehlender Wert für '%s'"
@@ -2948,23 +2988,23 @@ msgstr "SSH-Variante 'simple' unterstützt nicht das Setzen eines Ports."
 msgid "strange pathname '%s' blocked"
 msgstr "Merkwürdigen Pfadnamen '%s' blockiert."
 
-#: connect.c:1407
+#: connect.c:1408
 msgid "unable to fork"
 msgstr "Kann Prozess nicht starten."
 
-#: connected.c:109 builtin/fsck.c:209 builtin/prune.c:45
+#: connected.c:108 builtin/fsck.c:209 builtin/prune.c:45
 msgid "Checking connectivity"
 msgstr "Prüfe Konnektivität"
 
-#: connected.c:121
+#: connected.c:120
 msgid "Could not run 'git rev-list'"
 msgstr "Konnte 'git rev-list' nicht ausführen"
 
-#: connected.c:141
+#: connected.c:144
 msgid "failed write to rev-list"
 msgstr "Fehler beim Schreiben nach rev-list"
 
-#: connected.c:148
+#: connected.c:149
 msgid "failed to close rev-list's stdin"
 msgstr "Fehler beim Schließen von rev-lists Standard-Eingabe"
 
@@ -3042,40 +3082,40 @@ msgstr "Fehler beim Codieren von '%s' von %s nach %s."
 msgid "encoding '%s' from %s to %s and back is not the same"
 msgstr "Die Codierung '%s' von %s nach %s und zurück ist nicht dasselbe."
 
-#: convert.c:668
+#: convert.c:665
 #, c-format
 msgid "cannot fork to run external filter '%s'"
 msgstr "Kann externen Filter '%s' nicht starten."
 
-#: convert.c:688
+#: convert.c:685
 #, c-format
 msgid "cannot feed the input to external filter '%s'"
 msgstr "Kann Eingaben nicht an externen Filter '%s' übergeben."
 
-#: convert.c:695
+#: convert.c:692
 #, c-format
 msgid "external filter '%s' failed %d"
 msgstr "Externer Filter '%s' fehlgeschlagen %d"
 
-#: convert.c:730 convert.c:733
+#: convert.c:727 convert.c:730
 #, c-format
 msgid "read from external filter '%s' failed"
 msgstr "Lesen von externem Filter '%s' fehlgeschlagen."
 
-#: convert.c:736 convert.c:791
+#: convert.c:733 convert.c:788
 #, c-format
 msgid "external filter '%s' failed"
 msgstr "Externer Filter '%s' fehlgeschlagen."
 
-#: convert.c:840
+#: convert.c:837
 msgid "unexpected filter type"
 msgstr "Unerwartete Filterart."
 
-#: convert.c:851
+#: convert.c:848
 msgid "path name too long for external filter"
 msgstr "Pfadname zu lang für externen Filter."
 
-#: convert.c:943
+#: convert.c:940
 #, c-format
 msgid ""
 "external filter '%s' is not available anymore although not all paths have "
@@ -3083,16 +3123,16 @@ msgid ""
 msgstr ""
 "Externer Filter '%s' nicht mehr verfügbar. Nicht alle Pfade wurden gefiltert."
 
-#: convert.c:1243
+#: convert.c:1240
 msgid "true/false are no valid working-tree-encodings"
 msgstr "true/false sind keine gültigen Codierungen im Arbeitsverzeichnis."
 
-#: convert.c:1431 convert.c:1465
+#: convert.c:1428 convert.c:1462
 #, c-format
 msgid "%s: clean filter '%s' failed"
 msgstr "%s: clean-Filter '%s' fehlgeschlagen."
 
-#: convert.c:1511
+#: convert.c:1508
 #, c-format
 msgid "%s: smudge filter %s failed"
 msgstr "%s: smudge-Filter '%s' fehlgeschlagen."
@@ -3110,17 +3150,17 @@ msgstr "Weigerung, mit fehlendem Hostnamen in Zugangsdaten zu arbeiten"
 msgid "refusing to work with credential missing protocol field"
 msgstr "Weigerung, mit fehlendem Protokoll in Zugangsdaten zu arbeiten"
 
-#: credential.c:396
+#: credential.c:394
 #, c-format
 msgid "url contains a newline in its %s component: %s"
 msgstr "URL enthält Zeilenumbruch in der %s Komponente: %s"
 
-#: credential.c:440
+#: credential.c:438
 #, c-format
 msgid "url has no scheme: %s"
 msgstr "URL hat kein Schema: %s"
 
-#: credential.c:513
+#: credential.c:511
 #, c-format
 msgid "credential url cannot be parsed: %s"
 msgstr "URL mit Zugangsdaten konnte nicht geparst werden: %s"
@@ -3282,36 +3322,36 @@ msgstr ""
 "Fehler in 'diff.dirstat' Konfigurationsvariable gefunden:\n"
 "%s"
 
-#: diff.c:4243
+#: diff.c:4269
 #, c-format
 msgid "external diff died, stopping at %s"
 msgstr "externes Diff-Programm unerwartet beendet, angehalten bei %s"
 
-#: diff.c:4589
+#: diff.c:4618
 msgid "--name-only, --name-status, --check and -s are mutually exclusive"
 msgstr ""
 "--name-only, --name-status, --check und -s schließen sich gegenseitig aus"
 
-#: diff.c:4592
+#: diff.c:4621
 msgid "-G, -S and --find-object are mutually exclusive"
 msgstr "-G, -S und --find-object schließen sich gegenseitig aus"
 
-#: diff.c:4670
+#: diff.c:4699
 msgid "--follow requires exactly one pathspec"
 msgstr "--follow erfordert genau eine Pfadspezifikation"
 
-#: diff.c:4718
+#: diff.c:4747
 #, c-format
 msgid "invalid --stat value: %s"
 msgstr "Ungültiger --stat Wert: %s"
 
-#: diff.c:4723 diff.c:4728 diff.c:4733 diff.c:4738 diff.c:5250
-#: parse-options.c:197 parse-options.c:201
+#: diff.c:4752 diff.c:4757 diff.c:4762 diff.c:4767 diff.c:5279
+#: parse-options.c:197 parse-options.c:201 builtin/commit-graph.c:180
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "%s erwartet einen numerischen Wert."
 
-#: diff.c:4755
+#: diff.c:4784
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -3320,42 +3360,42 @@ msgstr ""
 "Fehler beim Parsen des --dirstat/-X Optionsparameters:\n"
 "%s"
 
-#: diff.c:4840
+#: diff.c:4869
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
 msgstr "Unbekannte Änderungsklasse '%c' in --diff-filter=%s"
 
-#: diff.c:4864
+#: diff.c:4893
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
 msgstr "Unbekannter Wert nach ws-error-highlight=%.*s"
 
-#: diff.c:4878
+#: diff.c:4907
 #, c-format
 msgid "unable to resolve '%s'"
 msgstr "konnte '%s' nicht auflösen"
 
-#: diff.c:4928 diff.c:4934
+#: diff.c:4957 diff.c:4963
 #, c-format
 msgid "%s expects <n>/<m> form"
 msgstr "%s erwartet die Form <n>/<m>"
 
-#: diff.c:4946
+#: diff.c:4975
 #, c-format
 msgid "%s expects a character, got '%s'"
 msgstr "%s erwartet ein Zeichen, '%s' bekommen"
 
-#: diff.c:4967
+#: diff.c:4996
 #, c-format
 msgid "bad --color-moved argument: %s"
 msgstr "Ungültiges --color-moved Argument: %s"
 
-#: diff.c:4986
+#: diff.c:5015
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
 msgstr "Ungültiger Modus '%s' in --color-moved-ws"
 
-#: diff.c:5026
+#: diff.c:5055
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
@@ -3363,152 +3403,152 @@ msgstr ""
 "Option diff-algorithm akzeptiert: \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
 
-#: diff.c:5062 diff.c:5082
+#: diff.c:5091 diff.c:5111
 #, c-format
 msgid "invalid argument to %s"
 msgstr "Ungültiges Argument für %s"
 
-#: diff.c:5219
+#: diff.c:5248
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
 msgstr "Fehler beim Parsen des --submodule Optionsparameters: '%s'"
 
-#: diff.c:5275
+#: diff.c:5304
 #, c-format
 msgid "bad --word-diff argument: %s"
 msgstr "Ungültiges --word-diff Argument: %s"
 
-#: diff.c:5298
+#: diff.c:5327
 msgid "Diff output format options"
 msgstr "Diff-Optionen zu Ausgabeformaten"
 
-#: diff.c:5300 diff.c:5306
+#: diff.c:5329 diff.c:5335
 msgid "generate patch"
 msgstr "Erzeuge Patch"
 
-#: diff.c:5303 builtin/log.c:177
+#: diff.c:5332 builtin/log.c:176
 msgid "suppress diff output"
 msgstr "Ausgabe der Unterschiede unterdrücken"
 
-#: diff.c:5308 diff.c:5422 diff.c:5429
+#: diff.c:5337 diff.c:5451 diff.c:5458
 msgid "<n>"
 msgstr "<n>"
 
-#: diff.c:5309 diff.c:5312
+#: diff.c:5338 diff.c:5341
 msgid "generate diffs with <n> lines context"
 msgstr "Erstelle Unterschiede mit <n> Zeilen des Kontextes"
 
-#: diff.c:5314
+#: diff.c:5343
 msgid "generate the diff in raw format"
 msgstr "Erstelle Unterschiede im Rohformat"
 
-#: diff.c:5317
+#: diff.c:5346
 msgid "synonym for '-p --raw'"
 msgstr "Synonym für '-p --raw'"
 
-#: diff.c:5321
+#: diff.c:5350
 msgid "synonym for '-p --stat'"
 msgstr "Synonym für '-p --stat'"
 
-#: diff.c:5325
+#: diff.c:5354
 msgid "machine friendly --stat"
 msgstr "maschinenlesbare Ausgabe von --stat"
 
-#: diff.c:5328
+#: diff.c:5357
 msgid "output only the last line of --stat"
 msgstr "nur die letzte Zeile von --stat ausgeben"
 
-#: diff.c:5330 diff.c:5338
+#: diff.c:5359 diff.c:5367
 msgid "<param1,param2>..."
 msgstr "<Parameter1,Parameter2>..."
 
-#: diff.c:5331
+#: diff.c:5360
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr ""
 "Gebe die Verteilung des relativen Umfangs der Änderungen für jedes "
 "Unterverzeichnis aus"
 
-#: diff.c:5335
+#: diff.c:5364
 msgid "synonym for --dirstat=cumulative"
 msgstr "Synonym für --dirstat=cumulative"
 
-#: diff.c:5339
+#: diff.c:5368
 msgid "synonym for --dirstat=files,param1,param2..."
 msgstr "Synonym für --dirstat=files,Parameter1,Parameter2..."
 
-#: diff.c:5343
+#: diff.c:5372
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
 "Warnen, wenn Änderungen Konfliktmarker oder Whitespace-Fehler einbringen"
 
-#: diff.c:5346
+#: diff.c:5375
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr ""
 "Gekürzte Zusammenfassung, wie z.B. Erstellungen, Umbenennungen und "
 "Änderungen der Datei-Rechte"
 
-#: diff.c:5349
+#: diff.c:5378
 msgid "show only names of changed files"
 msgstr "nur Dateinamen der geänderten Dateien anzeigen"
 
-#: diff.c:5352
+#: diff.c:5381
 msgid "show only names and status of changed files"
 msgstr "nur Dateinamen und Status der geänderten Dateien anzeigen"
 
-#: diff.c:5354
+#: diff.c:5383
 msgid "<width>[,<name-width>[,<count>]]"
 msgstr "<Breite>[,<Namens-Breite>[,<Anzahl>]]"
 
-#: diff.c:5355
+#: diff.c:5384
 msgid "generate diffstat"
 msgstr "Generiere Zusammenfassung der Unterschiede"
 
-#: diff.c:5357 diff.c:5360 diff.c:5363
+#: diff.c:5386 diff.c:5389 diff.c:5392
 msgid "<width>"
 msgstr "<Breite>"
 
-#: diff.c:5358
+#: diff.c:5387
 msgid "generate diffstat with a given width"
 msgstr "Erzeuge Zusammenfassung der Unterschiede mit gegebener Breite"
 
-#: diff.c:5361
+#: diff.c:5390
 msgid "generate diffstat with a given name width"
 msgstr "Erzeuge Zusammenfassung der Unterschiede mit gegebener Namens-Breite"
 
-#: diff.c:5364
+#: diff.c:5393
 msgid "generate diffstat with a given graph width"
 msgstr "Erzeuge Zusammenfassung der Unterschiede mit gegebener Graph-Breite"
 
-#: diff.c:5366
+#: diff.c:5395
 msgid "<count>"
 msgstr "<Anzahl>"
 
-#: diff.c:5367
+#: diff.c:5396
 msgid "generate diffstat with limited lines"
 msgstr "Erzeuge Zusammenfassung der Unterschiede mit begrenzten Zeilen"
 
-#: diff.c:5370
+#: diff.c:5399
 msgid "generate compact summary in diffstat"
 msgstr "Erzeuge kompakte Zusammenstellung in Zusammenfassung der Unterschiede"
 
-#: diff.c:5373
+#: diff.c:5402
 msgid "output a binary diff that can be applied"
 msgstr "Gebe eine binäre Differenz aus, dass angewendet werden kann"
 
-#: diff.c:5376
+#: diff.c:5405
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr "Zeige vollständige Objekt-Namen in den \"index\"-Zeilen"
 
-#: diff.c:5378
+#: diff.c:5407
 msgid "show colored diff"
 msgstr "Zeige farbige Unterschiede"
 
-#: diff.c:5379
+#: diff.c:5408
 msgid "<kind>"
 msgstr "<Art>"
 
-#: diff.c:5380
+#: diff.c:5409
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
@@ -3516,7 +3556,7 @@ msgstr ""
 "Hebe Whitespace-Fehler in den Zeilen 'context', 'old' oder 'new' bei den "
 "Unterschieden hervor"
 
-#: diff.c:5383
+#: diff.c:5412
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
@@ -3524,91 +3564,91 @@ msgstr ""
 "Verschleiere nicht die Pfadnamen und nutze NUL-Zeichen als Schlusszeichen in "
 "Ausgabefeldern bei --raw oder --numstat"
 
-#: diff.c:5386 diff.c:5389 diff.c:5392 diff.c:5498
+#: diff.c:5415 diff.c:5418 diff.c:5421 diff.c:5527
 msgid "<prefix>"
 msgstr "<Präfix>"
 
-#: diff.c:5387
+#: diff.c:5416
 msgid "show the given source prefix instead of \"a/\""
 msgstr "Zeige den gegebenen Quell-Präfix statt \"a/\""
 
-#: diff.c:5390
+#: diff.c:5419
 msgid "show the given destination prefix instead of \"b/\""
 msgstr "Zeige den gegebenen Ziel-Präfix statt \"b/\""
 
-#: diff.c:5393
+#: diff.c:5422
 msgid "prepend an additional prefix to every line of output"
 msgstr "Stelle einen zusätzlichen Präfix bei jeder Ausgabezeile voran"
 
-#: diff.c:5396
+#: diff.c:5425
 msgid "do not show any source or destination prefix"
 msgstr "Zeige keine Quell- oder Ziel-Präfixe an"
 
-#: diff.c:5399
+#: diff.c:5428
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
 "Zeige Kontext zwischen Unterschied-Blöcken bis zur angegebenen Anzahl von "
 "Zeilen."
 
-#: diff.c:5403 diff.c:5408 diff.c:5413
+#: diff.c:5432 diff.c:5437 diff.c:5442
 msgid "<char>"
 msgstr "<Zeichen>"
 
-#: diff.c:5404
+#: diff.c:5433
 msgid "specify the character to indicate a new line instead of '+'"
 msgstr "Das Zeichen festlegen, das eine neue Zeile kennzeichnet (statt '+')"
 
-#: diff.c:5409
+#: diff.c:5438
 msgid "specify the character to indicate an old line instead of '-'"
 msgstr "Das Zeichen festlegen, das eine alte Zeile kennzeichnet (statt '-')"
 
-#: diff.c:5414
+#: diff.c:5443
 msgid "specify the character to indicate a context instead of ' '"
 msgstr "Das Zeichen festlegen, das den Kontext kennzeichnet (statt ' ')"
 
-#: diff.c:5417
+#: diff.c:5446
 msgid "Diff rename options"
 msgstr "Diff-Optionen zur Umbenennung"
 
-#: diff.c:5418
+#: diff.c:5447
 msgid "<n>[/<m>]"
 msgstr "<n>[/<m>]"
 
-#: diff.c:5419
+#: diff.c:5448
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr ""
 "Teile komplette Rewrite-Änderungen in Änderungen mit \"löschen\" und "
 "\"erstellen\""
 
-#: diff.c:5423
+#: diff.c:5452
 msgid "detect renames"
 msgstr "Umbenennungen erkennen"
 
-#: diff.c:5427
+#: diff.c:5456
 msgid "omit the preimage for deletes"
 msgstr "Preimage für Löschungen weglassen."
 
-#: diff.c:5430
+#: diff.c:5459
 msgid "detect copies"
 msgstr "Kopien erkennen"
 
-#: diff.c:5434
+#: diff.c:5463
 msgid "use unmodified files as source to find copies"
 msgstr "Nutze ungeänderte Dateien als Quelle zum Finden von Kopien"
 
-#: diff.c:5436
+#: diff.c:5465
 msgid "disable rename detection"
 msgstr "Erkennung von Umbenennungen deaktivieren"
 
-#: diff.c:5439
+#: diff.c:5468
 msgid "use empty blobs as rename source"
 msgstr "Nutze leere Blobs als Quelle von Umbennungen"
 
-#: diff.c:5441
+#: diff.c:5470
 msgid "continue listing the history of a file beyond renames"
 msgstr "Fortführen der Auflistung der Historie einer Datei nach Umbennung"
 
-#: diff.c:5444
+#: diff.c:5473
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
@@ -3616,159 +3656,159 @@ msgstr ""
 "Verhindere die Erkennung von Umbennungen und Kopien, wenn die Anzahl der "
 "Ziele für Umbennungen und Kopien das gegebene Limit überschreitet"
 
-#: diff.c:5446
+#: diff.c:5475
 msgid "Diff algorithm options"
 msgstr "Diff Algorithmus-Optionen"
 
-#: diff.c:5448
+#: diff.c:5477
 msgid "produce the smallest possible diff"
 msgstr "Erzeuge die kleinstmöglichen Änderungen"
 
-#: diff.c:5451
+#: diff.c:5480
 msgid "ignore whitespace when comparing lines"
 msgstr "Whitespace-Änderungen beim Vergleich von Zeilen ignorieren"
 
-#: diff.c:5454
+#: diff.c:5483
 msgid "ignore changes in amount of whitespace"
 msgstr "Änderungen bei der Anzahl von Whitespace ignorieren"
 
-#: diff.c:5457
+#: diff.c:5486
 msgid "ignore changes in whitespace at EOL"
 msgstr "Whitespace-Änderungen am Zeilenende ignorieren"
 
-#: diff.c:5460
+#: diff.c:5489
 msgid "ignore carrier-return at the end of line"
 msgstr "Ignoriere den Zeilenumbruch am Ende der Zeile"
 
-#: diff.c:5463
+#: diff.c:5492
 msgid "ignore changes whose lines are all blank"
 msgstr "Ignoriere Änderungen in leeren Zeilen"
 
-#: diff.c:5466
+#: diff.c:5495
 msgid "heuristic to shift diff hunk boundaries for easy reading"
 msgstr ""
 "Heuristik, um Grenzen der Änderungsblöcke für bessere Lesbarkeit zu "
 "verschieben"
 
-#: diff.c:5469
+#: diff.c:5498
 msgid "generate diff using the \"patience diff\" algorithm"
 msgstr "Erzeuge Änderungen durch Nutzung des Algorithmus \"Patience Diff\""
 
-#: diff.c:5473
+#: diff.c:5502
 msgid "generate diff using the \"histogram diff\" algorithm"
 msgstr "Erzeuge Änderungen durch Nutzung des Algorithmus \"Histogram Diff\""
 
-#: diff.c:5475
+#: diff.c:5504
 msgid "<algorithm>"
 msgstr "<Algorithmus>"
 
-#: diff.c:5476
+#: diff.c:5505
 msgid "choose a diff algorithm"
 msgstr "Ein Algorithmus für Änderungen wählen"
 
-#: diff.c:5478
+#: diff.c:5507
 msgid "<text>"
 msgstr "<Text>"
 
-#: diff.c:5479
+#: diff.c:5508
 msgid "generate diff using the \"anchored diff\" algorithm"
 msgstr "Erzeuge Änderungen durch Nutzung des Algorithmus \"Anchored Diff\""
 
-#: diff.c:5481 diff.c:5490 diff.c:5493
+#: diff.c:5510 diff.c:5519 diff.c:5522
 msgid "<mode>"
 msgstr "<Modus>"
 
-#: diff.c:5482
+#: diff.c:5511
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr "Zeige Wort-Änderungen, nutze <Modus>, um Wörter abzugrenzen"
 
-#: diff.c:5484 diff.c:5487 diff.c:5532
+#: diff.c:5513 diff.c:5516 diff.c:5561
 msgid "<regex>"
 msgstr "<Regex>"
 
-#: diff.c:5485
+#: diff.c:5514
 msgid "use <regex> to decide what a word is"
 msgstr "Nutze <Regex>, um zu entscheiden, was ein Wort ist"
 
-#: diff.c:5488
+#: diff.c:5517
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
 msgstr "Entsprechend wie --word-diff=color --word-diff-regex=<Regex>"
 
-#: diff.c:5491
+#: diff.c:5520
 msgid "moved lines of code are colored differently"
 msgstr "Verschobene Codezeilen sind andersfarbig"
 
-#: diff.c:5494
+#: diff.c:5523
 msgid "how white spaces are ignored in --color-moved"
 msgstr "Wie Whitespaces in --color-moved ignoriert werden"
 
-#: diff.c:5497
+#: diff.c:5526
 msgid "Other diff options"
 msgstr "Andere Diff-Optionen"
 
-#: diff.c:5499
+#: diff.c:5528
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
 "Wenn vom Unterverzeichnis aufgerufen, schließe Änderungen außerhalb aus und "
 "zeige relative Pfade an"
 
-#: diff.c:5503
+#: diff.c:5532
 msgid "treat all files as text"
 msgstr "alle Dateien als Text behandeln"
 
-#: diff.c:5505
+#: diff.c:5534
 msgid "swap two inputs, reverse the diff"
 msgstr "Vertausche die beiden Eingaben und drehe die Änderungen um"
 
-#: diff.c:5507
+#: diff.c:5536
 msgid "exit with 1 if there were differences, 0 otherwise"
 msgstr ""
 "Beende mit Exit-Status 1, wenn Änderungen vorhanden sind, andernfalls mit 0"
 
-#: diff.c:5509
+#: diff.c:5538
 msgid "disable all output of the program"
 msgstr "Keine Ausgaben vom Programm"
 
-#: diff.c:5511
+#: diff.c:5540
 msgid "allow an external diff helper to be executed"
 msgstr "Erlaube die Ausführung eines externes Programms für Änderungen"
 
-#: diff.c:5513
+#: diff.c:5542
 msgid "run external text conversion filters when comparing binary files"
 msgstr ""
 "Führe externe Text-Konvertierungsfilter aus, wenn binäre Dateien vergleicht "
 "werden"
 
-#: diff.c:5515
+#: diff.c:5544
 msgid "<when>"
 msgstr "<wann>"
 
-#: diff.c:5516
+#: diff.c:5545
 msgid "ignore changes to submodules in the diff generation"
 msgstr ""
 "Änderungen in Submodulen während der Erstellung der Unterschiede ignorieren"
 
-#: diff.c:5519
+#: diff.c:5548
 msgid "<format>"
 msgstr "<Format>"
 
-#: diff.c:5520
+#: diff.c:5549
 msgid "specify how differences in submodules are shown"
 msgstr "Angeben, wie Unterschiede in Submodulen gezeigt werden"
 
-#: diff.c:5524
+#: diff.c:5553
 msgid "hide 'git add -N' entries from the index"
 msgstr "verstecke 'git add -N' Einträge vom Index"
 
-#: diff.c:5527
+#: diff.c:5556
 msgid "treat 'git add -N' entries as real in the index"
 msgstr "Behandle 'git add -N' Einträge im Index als echt"
 
-#: diff.c:5529
+#: diff.c:5558
 msgid "<string>"
 msgstr "<Zeichenkette>"
 
-#: diff.c:5530
+#: diff.c:5559
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
@@ -3776,7 +3816,7 @@ msgstr ""
 "Suche nach Unterschieden, welche die Anzahl des Vorkommens der angegebenen "
 "Zeichenkette verändern"
 
-#: diff.c:5533
+#: diff.c:5562
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
@@ -3784,25 +3824,25 @@ msgstr ""
 "Suche nach Unterschieden, welche die Anzahl des Vorkommens des angegebenen "
 "regulären Ausdrucks verändern"
 
-#: diff.c:5536
+#: diff.c:5565
 msgid "show all changes in the changeset with -S or -G"
 msgstr "zeige alle Änderungen im Changeset mit -S oder -G"
 
-#: diff.c:5539
+#: diff.c:5568
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr ""
 "behandle <Zeichenkette> bei -S als erweiterten POSIX regulären Ausdruck"
 
-#: diff.c:5542
+#: diff.c:5571
 msgid "control the order in which files appear in the output"
 msgstr ""
 "kontrolliere die Reihenfolge, in der die Dateien in der Ausgabe erscheinen"
 
-#: diff.c:5543
+#: diff.c:5572
 msgid "<object-id>"
 msgstr "<Objekt-ID>"
 
-#: diff.c:5544
+#: diff.c:5573
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
@@ -3810,33 +3850,33 @@ msgstr ""
 "Suche nach Unterschieden, welche die Anzahl des Vorkommens des angegebenen "
 "Objektes verändern"
 
-#: diff.c:5546
+#: diff.c:5575
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "[(A|C|D|M|R|T|U|X|B)...[*]]"
 
-#: diff.c:5547
+#: diff.c:5576
 msgid "select files by diff type"
 msgstr "Wähle Dateien anhand der Art der Änderung"
 
-#: diff.c:5549
+#: diff.c:5578
 msgid "<file>"
 msgstr "<Datei>"
 
-#: diff.c:5550
+#: diff.c:5579
 msgid "Output to a specific file"
 msgstr "Ausgabe zu einer bestimmten Datei"
 
-#: diff.c:6205
+#: diff.c:6236
 msgid "inexact rename detection was skipped due to too many files."
 msgstr ""
 "Ungenaue Erkennung für Umbenennungen wurde aufgrund zu vieler Dateien\n"
 "übersprungen."
 
-#: diff.c:6208
+#: diff.c:6239
 msgid "only found copies from modified paths due to too many files."
 msgstr "nur Kopien von geänderten Pfaden, aufgrund zu vieler Dateien, gefunden"
 
-#: diff.c:6211
+#: diff.c:6242
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
@@ -3853,64 +3893,64 @@ msgstr "Fehler beim Lesen der Reihenfolgedatei '%s'."
 msgid "Performing inexact rename detection"
 msgstr "Führe Erkennung für ungenaue Umbenennung aus"
 
-#: dir.c:573
+#: dir.c:578
 #, c-format
 msgid "pathspec '%s' did not match any file(s) known to git"
 msgstr ""
 "Pfadspezifikation '%s' stimmt mit keinen git-bekannten Dateien überein."
 
-#: dir.c:713 dir.c:742 dir.c:755
+#: dir.c:718 dir.c:747 dir.c:760
 #, c-format
 msgid "unrecognized pattern: '%s'"
 msgstr "Unbekanntes Muster: '%s'"
 
-#: dir.c:772 dir.c:786
+#: dir.c:777 dir.c:791
 #, c-format
 msgid "unrecognized negative pattern: '%s'"
 msgstr "Unbekanntes verneinendes Muster: '%s'"
 
-#: dir.c:804
+#: dir.c:809
 #, c-format
 msgid "your sparse-checkout file may have issues: pattern '%s' is repeated"
 msgstr ""
 "Ihre Datei für den partiellen Checkout hat eventuell Probleme:\n"
 "Muster '%s' wiederholt sich."
 
-#: dir.c:814
+#: dir.c:819
 msgid "disabling cone pattern matching"
 msgstr "Deaktiviere Cone-Muster-Übereinstimmung"
 
-#: dir.c:1191
+#: dir.c:1198
 #, c-format
 msgid "cannot use %s as an exclude file"
 msgstr "Kann %s nicht als exclude-Filter benutzen."
 
-#: dir.c:2296
+#: dir.c:2305
 #, c-format
 msgid "could not open directory '%s'"
 msgstr "Konnte Verzeichnis '%s' nicht öffnen."
 
-#: dir.c:2596
+#: dir.c:2605
 msgid "failed to get kernel name and information"
 msgstr "Fehler beim Sammeln von Namen und Informationen zum Kernel"
 
-#: dir.c:2720
+#: dir.c:2729
 msgid "untracked cache is disabled on this system or location"
 msgstr ""
 "Cache für unversionierte Dateien ist auf diesem System oder\n"
 "für dieses Verzeichnis deaktiviert."
 
-#: dir.c:3502
+#: dir.c:3520
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "Index-Datei in Repository %s beschädigt."
 
-#: dir.c:3547 dir.c:3552
+#: dir.c:3565 dir.c:3570
 #, c-format
 msgid "could not create directories for %s"
 msgstr "Konnte Verzeichnisse für '%s' nicht erstellen."
 
-#: dir.c:3581
+#: dir.c:3599
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "Konnte Git-Verzeichnis nicht von '%s' nach '%s' migrieren."
@@ -3944,245 +3984,245 @@ msgstr "Konnte GIT_DIR nicht zu '%s' setzen."
 msgid "too many args to run %s"
 msgstr "Zu viele Argumente angegeben, um %s auszuführen."
 
-#: fetch-pack.c:152
+#: fetch-pack.c:176
 msgid "git fetch-pack: expected shallow list"
 msgstr "git fetch-pack: erwartete shallow-Liste"
 
-#: fetch-pack.c:155
+#: fetch-pack.c:179
 msgid "git fetch-pack: expected a flush packet after shallow list"
 msgstr "git fetch-pack: erwartete ein Flush-Paket nach der shallow-Liste"
 
-#: fetch-pack.c:166
+#: fetch-pack.c:190
 msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
 msgstr "git fetch-pack: ACK/NAK erwartet, Flush-Paket bekommen"
 
-#: fetch-pack.c:186
+#: fetch-pack.c:210
 #, c-format
 msgid "git fetch-pack: expected ACK/NAK, got '%s'"
 msgstr "git fetch-pack: ACK/NAK erwartet, '%s' bekommen"
 
-#: fetch-pack.c:197
+#: fetch-pack.c:221
 msgid "unable to write to remote"
 msgstr "konnte nicht zum Remote schreiben"
 
-#: fetch-pack.c:259
+#: fetch-pack.c:282
 msgid "--stateless-rpc requires multi_ack_detailed"
 msgstr "--stateless-rpc benötigt multi_ack_detailed"
 
-#: fetch-pack.c:358 fetch-pack.c:1408
+#: fetch-pack.c:375 fetch-pack.c:1397
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "Ungültige shallow-Zeile: %s"
 
-#: fetch-pack.c:364 fetch-pack.c:1414
+#: fetch-pack.c:381 fetch-pack.c:1403
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "Ungültige unshallow-Zeile: %s"
 
-#: fetch-pack.c:366 fetch-pack.c:1416
+#: fetch-pack.c:383 fetch-pack.c:1405
 #, c-format
 msgid "object not found: %s"
 msgstr "Objekt nicht gefunden: %s"
 
-#: fetch-pack.c:369 fetch-pack.c:1419
+#: fetch-pack.c:386 fetch-pack.c:1408
 #, c-format
 msgid "error in object: %s"
 msgstr "Fehler in Objekt: %s"
 
-#: fetch-pack.c:371 fetch-pack.c:1421
+#: fetch-pack.c:388 fetch-pack.c:1410
 #, c-format
 msgid "no shallow found: %s"
 msgstr "Kein shallow-Objekt gefunden: %s"
 
-#: fetch-pack.c:374 fetch-pack.c:1425
+#: fetch-pack.c:391 fetch-pack.c:1414
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "shallow/unshallow erwartet, %s bekommen"
 
-#: fetch-pack.c:416
+#: fetch-pack.c:431
 #, c-format
 msgid "got %s %d %s"
 msgstr "%s %d %s bekommen"
 
-#: fetch-pack.c:433
+#: fetch-pack.c:448
 #, c-format
 msgid "invalid commit %s"
 msgstr "Ungültiger Commit %s"
 
-#: fetch-pack.c:464
+#: fetch-pack.c:479
 msgid "giving up"
 msgstr "Gebe auf"
 
-#: fetch-pack.c:477 progress.c:336
+#: fetch-pack.c:492 progress.c:339
 msgid "done"
 msgstr "Fertig"
 
-#: fetch-pack.c:489
+#: fetch-pack.c:504
 #, c-format
 msgid "got %s (%d) %s"
 msgstr "%s (%d) %s bekommen"
 
-#: fetch-pack.c:535
+#: fetch-pack.c:540
 #, c-format
 msgid "Marking %s as complete"
 msgstr "Markiere %s als vollständig"
 
-#: fetch-pack.c:756
+#: fetch-pack.c:755
 #, c-format
 msgid "already have %s (%s)"
 msgstr "habe %s (%s) bereits"
 
-#: fetch-pack.c:821
+#: fetch-pack.c:824
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-pack: Fehler beim Starten des sideband demultiplexer"
 
-#: fetch-pack.c:829
+#: fetch-pack.c:832
 msgid "protocol error: bad pack header"
 msgstr "Protokollfehler: ungültiger Pack-Header"
 
-#: fetch-pack.c:910
+#: fetch-pack.c:916
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-pack: konnte %s nicht starten"
 
-#: fetch-pack.c:927
+#: fetch-pack.c:933
 #, c-format
 msgid "%s failed"
 msgstr "%s fehlgeschlagen"
 
-#: fetch-pack.c:929
+#: fetch-pack.c:935
 msgid "error in sideband demultiplexer"
 msgstr "Fehler in sideband demultiplexer"
 
-#: fetch-pack.c:976
+#: fetch-pack.c:978
 #, c-format
 msgid "Server version is %.*s"
 msgstr "Server-Version ist %.*s"
 
-#: fetch-pack.c:981 fetch-pack.c:987 fetch-pack.c:990 fetch-pack.c:996
-#: fetch-pack.c:1000 fetch-pack.c:1004 fetch-pack.c:1008 fetch-pack.c:1012
-#: fetch-pack.c:1016 fetch-pack.c:1020 fetch-pack.c:1024 fetch-pack.c:1028
-#: fetch-pack.c:1034 fetch-pack.c:1040 fetch-pack.c:1045 fetch-pack.c:1050
+#: fetch-pack.c:983 fetch-pack.c:989 fetch-pack.c:992 fetch-pack.c:998
+#: fetch-pack.c:1002 fetch-pack.c:1006 fetch-pack.c:1010 fetch-pack.c:1014
+#: fetch-pack.c:1018 fetch-pack.c:1022 fetch-pack.c:1026 fetch-pack.c:1030
+#: fetch-pack.c:1036 fetch-pack.c:1042 fetch-pack.c:1047 fetch-pack.c:1052
 #, c-format
 msgid "Server supports %s"
 msgstr "Server unterstützt %s"
 
-#: fetch-pack.c:983
+#: fetch-pack.c:985
 msgid "Server does not support shallow clients"
 msgstr "Server unterstützt keine shallow-Clients"
 
-#: fetch-pack.c:1043
+#: fetch-pack.c:1045
 msgid "Server does not support --shallow-since"
 msgstr "Server unterstützt kein --shallow-since"
 
-#: fetch-pack.c:1048
+#: fetch-pack.c:1050
 msgid "Server does not support --shallow-exclude"
 msgstr "Server unterstützt kein --shallow-exclude"
 
-#: fetch-pack.c:1052
+#: fetch-pack.c:1054
 msgid "Server does not support --deepen"
 msgstr "Server unterstützt kein --deepen"
 
-#: fetch-pack.c:1054
+#: fetch-pack.c:1056
 msgid "Server does not support this repository's object format"
 msgstr "Server unterstützt das Objekt-Format dieses Repositories nicht"
 
-#: fetch-pack.c:1071
+#: fetch-pack.c:1069
 msgid "no common commits"
 msgstr "keine gemeinsamen Commits"
 
-#: fetch-pack.c:1083 fetch-pack.c:1639
+#: fetch-pack.c:1081 fetch-pack.c:1619
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack: Abholen fehlgeschlagen."
 
-#: fetch-pack.c:1211
+#: fetch-pack.c:1205
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "Algorithmen stimmen nicht überein: Client %s; Server %s"
 
-#: fetch-pack.c:1215
+#: fetch-pack.c:1209
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "der Server unterstützt Algorithmus '%s' nicht"
 
-#: fetch-pack.c:1235
+#: fetch-pack.c:1229
 msgid "Server does not support shallow requests"
 msgstr "Server unterstützt keine shallow-Anfragen"
 
-#: fetch-pack.c:1242
+#: fetch-pack.c:1236
 msgid "Server supports filter"
 msgstr "Server unterstützt Filter"
 
-#: fetch-pack.c:1286
+#: fetch-pack.c:1275
 msgid "unable to write request to remote"
 msgstr "konnte Anfrage nicht zum Remote schreiben"
 
-#: fetch-pack.c:1304
+#: fetch-pack.c:1293
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "Fehler beim Lesen von Sektionskopf '%s'."
 
-#: fetch-pack.c:1310
+#: fetch-pack.c:1299
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "'%s' erwartet, '%s' empfangen"
 
-#: fetch-pack.c:1371
+#: fetch-pack.c:1360
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "Unerwartete Acknowledgment-Zeile: '%s'"
 
-#: fetch-pack.c:1376
+#: fetch-pack.c:1365
 #, c-format
 msgid "error processing acks: %d"
 msgstr "Fehler beim Verarbeiten von ACKS: %d"
 
-#: fetch-pack.c:1386
+#: fetch-pack.c:1375
 msgid "expected packfile to be sent after 'ready'"
 msgstr "Erwartete Versand einer Packdatei nach 'ready'."
 
-#: fetch-pack.c:1388
+#: fetch-pack.c:1377
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr "Erwartete keinen Versand einer anderen Sektion ohne 'ready'."
 
-#: fetch-pack.c:1430
+#: fetch-pack.c:1419
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "Fehler beim Verarbeiten von Shallow-Informationen: %d"
 
-#: fetch-pack.c:1477
+#: fetch-pack.c:1466
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "wanted-ref erwartet, '%s' bekommen"
 
-#: fetch-pack.c:1482
+#: fetch-pack.c:1471
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "unerwartetes wanted-ref: '%s'"
 
-#: fetch-pack.c:1487
+#: fetch-pack.c:1476
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "Fehler beim Verarbeiten von wanted-refs: %d"
 
-#: fetch-pack.c:1517
+#: fetch-pack.c:1506
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: Antwort-Endpaket erwartet"
 
-#: fetch-pack.c:1921
+#: fetch-pack.c:1887
 msgid "no matching remote head"
 msgstr "kein übereinstimmender Remote-Branch"
 
-#: fetch-pack.c:1944 builtin/clone.c:692
+#: fetch-pack.c:1910 builtin/clone.c:692
 msgid "remote did not send all necessary objects"
 msgstr "Remote-Repository hat nicht alle erforderlichen Objekte gesendet"
 
-#: fetch-pack.c:1971
+#: fetch-pack.c:1937
 #, c-format
 msgid "no such remote ref %s"
 msgstr "keine solche Remote-Referenz %s"
 
-#: fetch-pack.c:1974
+#: fetch-pack.c:1940
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Der Server lehnt Anfrage nach nicht angebotenem Objekt %s ab."
@@ -4281,43 +4321,44 @@ msgstr "Systembefehle / Repositories synchronisieren"
 msgid "Low-level Commands / Internal Helpers"
 msgstr "Systembefehle / Interne Hilfsbefehle"
 
-#: help.c:298
+#: help.c:300
 #, c-format
 msgid "available git commands in '%s'"
 msgstr "Vorhandene Git-Befehle in '%s'"
 
-#: help.c:305
+#: help.c:307
 msgid "git commands available from elsewhere on your $PATH"
 msgstr "Vorhandene Git-Befehle anderswo in Ihrem $PATH"
 
-#: help.c:314
+#: help.c:316
 msgid "These are common Git commands used in various situations:"
 msgstr "Allgemeine Git-Befehle, verwendet in verschiedenen Situationen:"
 
-#: help.c:363 git.c:99
+#: help.c:365 git.c:99
 #, c-format
 msgid "unsupported command listing type '%s'"
 msgstr "Nicht unterstützte Art zur Befehlsauflistung '%s'."
 
-#: help.c:403
-msgid "The common Git guides are:"
+#: help.c:405
+#, fuzzy
+msgid "The Git concept guides are:"
 msgstr "Die allgemeinen Git-Anleitungen sind:"
 
-#: help.c:427
+#: help.c:429
 msgid "See 'git help <command>' to read about a specific subcommand"
 msgstr ""
 "Siehe 'git help <Befehl>', um mehr über einen spezifischen Unterbefehl zu "
 "lesen."
 
-#: help.c:432
+#: help.c:434
 msgid "External commands"
 msgstr "Externe Befehle"
 
-#: help.c:447
+#: help.c:449
 msgid "Command aliases"
 msgstr "Alias-Befehle"
 
-#: help.c:511
+#: help.c:513
 #, c-format
 msgid ""
 "'%s' appears to be a git command, but we were not\n"
@@ -4326,32 +4367,32 @@ msgstr ""
 "'%s' scheint ein git-Befehl zu sein, konnte aber\n"
 "nicht ausgeführt werden. Vielleicht ist git-%s fehlerhaft?"
 
-#: help.c:570
+#: help.c:572
 msgid "Uh oh. Your system reports no Git commands at all."
 msgstr "Uh oh. Keine Git-Befehle auf Ihrem System vorhanden."
 
-#: help.c:592
+#: help.c:594
 #, c-format
 msgid "WARNING: You called a Git command named '%s', which does not exist."
 msgstr ""
 "WARNUNG: Sie haben Git-Befehl '%s' ausgeführt, welcher nicht existiert."
 
-#: help.c:597
+#: help.c:599
 #, c-format
 msgid "Continuing under the assumption that you meant '%s'."
 msgstr "Setze fort unter der Annahme, dass Sie '%s' meinten."
 
-#: help.c:602
+#: help.c:604
 #, c-format
 msgid "Continuing in %0.1f seconds, assuming that you meant '%s'."
 msgstr "Setze in %0.1f Sekunden fort unter der Annahme, dass Sie '%s' meinten."
 
-#: help.c:610
+#: help.c:612
 #, c-format
 msgid "git: '%s' is not a git command. See 'git --help'."
 msgstr "git: '%s' ist kein Git-Befehl. Siehe 'git --help'."
 
-#: help.c:614
+#: help.c:616
 msgid ""
 "\n"
 "The most similar command is"
@@ -4365,16 +4406,16 @@ msgstr[1] ""
 "\n"
 "Die ähnlichsten Befehle sind"
 
-#: help.c:654
+#: help.c:656
 msgid "git version [<options>]"
 msgstr "git version [<Optionen>]"
 
-#: help.c:709
+#: help.c:711
 #, c-format
 msgid "%s: %s - %s"
 msgstr "%s: %s - %s"
 
-#: help.c:713
+#: help.c:715
 msgid ""
 "\n"
 "Did you mean this?"
@@ -4388,7 +4429,15 @@ msgstr[1] ""
 "\n"
 "Haben Sie eines von diesen gemeint?"
 
-#: ident.c:349
+#: ident.c:353
+msgid "Author identity unknown\n"
+msgstr ""
+
+#: ident.c:356
+msgid "Committer identity unknown\n"
+msgstr ""
+
+#: ident.c:362
 msgid ""
 "\n"
 "*** Please tell me who you are.\n"
@@ -4414,66 +4463,66 @@ msgstr ""
 "Lassen Sie die Option \"--global\" weg, um die Identität nur\n"
 "für dieses Repository zu setzen.\n"
 
-#: ident.c:379
+#: ident.c:397
 msgid "no email was given and auto-detection is disabled"
 msgstr "keine E-Mail angegeben und automatische Erkennung ist deaktiviert"
 
-#: ident.c:384
+#: ident.c:402
 #, c-format
 msgid "unable to auto-detect email address (got '%s')"
 msgstr "Konnte die E-Mail-Adresse nicht automatisch erkennen ('%s' erhalten)"
 
-#: ident.c:401
+#: ident.c:419
 msgid "no name was given and auto-detection is disabled"
 msgstr "kein Name angegeben und automatische Erkennung ist deaktiviert"
 
-#: ident.c:407
+#: ident.c:425
 #, c-format
 msgid "unable to auto-detect name (got '%s')"
 msgstr "konnte Namen nicht automatisch erkennen ('%s' erhalten)"
 
-#: ident.c:415
+#: ident.c:433
 #, c-format
 msgid "empty ident name (for <%s>) not allowed"
 msgstr "Leerer Name in Identifikation (für <%s>) nicht erlaubt."
 
-#: ident.c:421
+#: ident.c:439
 #, c-format
 msgid "name consists only of disallowed characters: %s"
 msgstr "Name besteht nur aus nicht erlaubten Zeichen: %s"
 
-#: ident.c:436 builtin/commit.c:634
+#: ident.c:454 builtin/commit.c:634
 #, c-format
 msgid "invalid date format: %s"
 msgstr "Ungültiges Datumsformat: %s"
 
-#: list-objects-filter-options.c:58
+#: list-objects-filter-options.c:81
 msgid "expected 'tree:<depth>'"
 msgstr "'tree:<Tiefe>' erwartet"
 
-#: list-objects-filter-options.c:73
+#: list-objects-filter-options.c:96
 msgid "sparse:path filters support has been dropped"
 msgstr "Keine Unterstützung für sparse:path Filter mehr"
 
-#: list-objects-filter-options.c:86
+#: list-objects-filter-options.c:109
 #, c-format
 msgid "invalid filter-spec '%s'"
 msgstr "Ungültige filter-spec '%s'"
 
-#: list-objects-filter-options.c:102
+#: list-objects-filter-options.c:125
 #, c-format
 msgid "must escape char in sub-filter-spec: '%c'"
 msgstr "Zeichen in sub-filter-spec muss maskiert werden: '%c'"
 
-#: list-objects-filter-options.c:144
+#: list-objects-filter-options.c:167
 msgid "expected something after combine:"
 msgstr "erwartete etwas nach 'combine:'"
 
-#: list-objects-filter-options.c:226
+#: list-objects-filter-options.c:249
 msgid "multiple filter-specs cannot be combined"
 msgstr "mehrere filter-specs können nicht kombiniert werden"
 
-#: list-objects-filter-options.c:330
+#: list-objects-filter-options.c:361
 msgid "unable to upgrade repository format to support partial clone"
 msgstr ""
 "Repository-Format konnte nicht erweitert werden, um partielles Klonen zu "
@@ -4857,7 +4906,7 @@ msgstr "hinzufügen/hinzufügen"
 msgid "Skipped %s (merged same as existing)"
 msgstr "%s ausgelassen (Ergebnis des Merges existiert bereits)"
 
-#: merge-recursive.c:3101 git-submodule.sh:959
+#: merge-recursive.c:3101
 msgid "submodule"
 msgstr "Submodul"
 
@@ -4947,22 +4996,22 @@ msgstr "Bereits aktuell!"
 msgid "merging of trees %s and %s failed"
 msgstr "Zusammenführen der \"Tree\"-Objekte %s und %s fehlgeschlagen"
 
-#: merge-recursive.c:3549
+#: merge-recursive.c:3550
 msgid "Merging:"
 msgstr "Merge:"
 
-#: merge-recursive.c:3562
+#: merge-recursive.c:3563
 #, c-format
 msgid "found %u common ancestor:"
 msgid_plural "found %u common ancestors:"
 msgstr[0] "%u gemeinsamen Vorgänger-Commit gefunden"
 msgstr[1] "%u gemeinsame Vorgänger-Commits gefunden"
 
-#: merge-recursive.c:3612
+#: merge-recursive.c:3613
 msgid "merge returned no commit"
 msgstr "Merge hat keinen Commit zurückgegeben"
 
-#: merge-recursive.c:3671
+#: merge-recursive.c:3672
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -4972,12 +5021,12 @@ msgstr ""
 "überschrieben werden:\n"
 "  %s"
 
-#: merge-recursive.c:3768
+#: merge-recursive.c:3769
 #, c-format
 msgid "Could not parse object '%s'"
 msgstr "Konnte Objekt '%s' nicht parsen."
 
-#: merge-recursive.c:3786 builtin/merge.c:705 builtin/merge.c:885
+#: merge-recursive.c:3787 builtin/merge.c:702 builtin/merge.c:881
 msgid "Unable to write index."
 msgstr "Konnte Index nicht schreiben."
 
@@ -4985,118 +5034,123 @@ msgstr "Konnte Index nicht schreiben."
 msgid "failed to read the cache"
 msgstr "Lesen des Zwischenspeichers fehlgeschlagen"
 
-#: merge.c:108 rerere.c:720 builtin/am.c:1878 builtin/am.c:1912
-#: builtin/checkout.c:559 builtin/checkout.c:822 builtin/clone.c:816
+#: merge.c:109 rerere.c:720 builtin/am.c:1896 builtin/am.c:1930
+#: builtin/checkout.c:560 builtin/checkout.c:816 builtin/clone.c:816
 #: builtin/stash.c:265
 msgid "unable to write new index file"
 msgstr "Konnte neue Index-Datei nicht schreiben."
 
-#: midx.c:68
+#: midx.c:79
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "multi-pack-index-Datei %s ist zu klein."
 
-#: midx.c:84
+#: midx.c:95
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr ""
 "multi-pack-index-Signatur 0x%08x stimmt nicht mit Signatur 0x%08x überein."
 
-#: midx.c:89
+#: midx.c:100
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "multi-pack-index-Version %d nicht erkannt."
 
-#: midx.c:94
-#, c-format
-msgid "hash version %u does not match"
-msgstr "Hash-Version %u stimmt nicht überein."
+#: midx.c:105
+#, fuzzy, c-format
+msgid "multi-pack-index hash version %u does not match version %u"
+msgstr "Hash-Version des Commit-Graph %X stimmt nicht mit Version %X überein."
 
-#: midx.c:108
+#: midx.c:122
 msgid "invalid chunk offset (too large)"
 msgstr "Ungültiger Chunk-Offset (zu groß)"
 
-#: midx.c:132
+#: midx.c:146
 msgid "terminating multi-pack-index chunk id appears earlier than expected"
 msgstr "Abschließende multi-pack-index Chunk-Id erscheint eher als erwartet."
 
-#: midx.c:145
+#: midx.c:159
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "multi-pack-index fehlt erforderlicher pack-name Chunk."
 
-#: midx.c:147
+#: midx.c:161
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "multi-pack-index fehlt erforderlicher OID fanout Chunk."
 
-#: midx.c:149
+#: midx.c:163
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr "multi-pack-index fehlt erforderlicher OID lookup Chunk."
 
-#: midx.c:151
+#: midx.c:165
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr "multi-pack-index fehlt erforderlicher object offset Chunk."
 
-#: midx.c:165
+#: midx.c:179
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr "Falsche Reihenfolge bei multi-pack-index Pack-Namen: '%s' vor '%s'"
 
-#: midx.c:208
+#: midx.c:222
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr "Ungültige pack-int-id: %u (%u Pakete insgesamt)"
 
-#: midx.c:258
+#: midx.c:272
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr ""
 "multi-pack-index speichert einen 64-Bit Offset, aber off_t ist zu klein."
 
-#: midx.c:286
+#: midx.c:300
 msgid "error preparing packfile from multi-pack-index"
 msgstr "Fehler bei Vorbereitung der Packdatei aus multi-pack-index."
 
-#: midx.c:470
+#: midx.c:485
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "Fehler beim Hinzufügen von Packdatei '%s'."
 
-#: midx.c:476
+#: midx.c:491
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "Fehler beim Öffnen von pack-index '%s'"
 
-#: midx.c:536
+#: midx.c:551
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "Fehler beim Lokalisieren von Objekt %d in Packdatei."
 
-#: midx.c:840
+#: midx.c:853
 msgid "Adding packfiles to multi-pack-index"
 msgstr "Packdateien zum multi-pack-index hinzufügen"
 
-#: midx.c:873
+#: midx.c:886
 #, c-format
 msgid "did not see pack-file %s to drop"
 msgstr "Pack-Datei %s zum Weglassen nicht gefunden"
 
-#: midx.c:925
+#: midx.c:938
 msgid "no pack files to index."
 msgstr "keine Packdateien zum Indizieren."
 
-#: midx.c:977
+#: midx.c:990
 msgid "Writing chunks to multi-pack-index"
 msgstr "Chunks zum multi-pack-index schreiben"
 
-#: midx.c:1056
+#: midx.c:1068
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "Fehler beim Löschen des multi-pack-index bei %s"
 
-#: midx.c:1112
+#: midx.c:1124
+#, fuzzy
+msgid "multi-pack-index file exists, but failed to parse"
+msgstr "multi-pack-index-Datei %s ist zu klein."
+
+#: midx.c:1132
 msgid "Looking for referenced packfiles"
 msgstr "Suche nach referenzierten Pack-Dateien"
 
-#: midx.c:1127
+#: midx.c:1147
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
@@ -5104,55 +5158,55 @@ msgstr ""
 "Ungültige oid fanout Reihenfolge: fanout[%d] = %<PRIx32> > %<PRIx32> = "
 "fanout[%d]"
 
-#: midx.c:1132
+#: midx.c:1152
 msgid "the midx contains no oid"
 msgstr "das midx enthält keine oid"
 
-#: midx.c:1141
+#: midx.c:1161
 msgid "Verifying OID order in multi-pack-index"
 msgstr "Verifiziere OID-Reihenfolge im multi-pack-index"
 
-#: midx.c:1150
+#: midx.c:1170
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr "Ungültige oid lookup Reihenfolge: oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1170
+#: midx.c:1190
 msgid "Sorting objects by packfile"
 msgstr "Sortiere Objekte nach Pack-Datei"
 
-#: midx.c:1177
+#: midx.c:1197
 msgid "Verifying object offsets"
 msgstr "Überprüfe Objekt-Offsets"
 
-#: midx.c:1193
+#: midx.c:1213
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "Fehler beim Laden des Pack-Eintrags für oid[%d] = %s"
 
-#: midx.c:1199
+#: midx.c:1219
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "Fehler beim Laden des Pack-Index für Packdatei %s"
 
-#: midx.c:1208
+#: midx.c:1228
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr "Falscher Objekt-Offset für oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#: midx.c:1233
+#: midx.c:1253
 msgid "Counting referenced objects"
 msgstr "Referenzierte Objekte zählen"
 
-#: midx.c:1243
+#: midx.c:1263
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "Suchen und Löschen von unreferenzierten Pack-Dateien"
 
-#: midx.c:1433
+#: midx.c:1454
 msgid "could not start pack-objects"
 msgstr "Konnte 'pack-objects' nicht ausführen"
 
-#: midx.c:1452
+#: midx.c:1474
 msgid "could not finish pack-objects"
 msgstr "Konnte 'pack-objects' nicht beenden"
 
@@ -5241,7 +5295,7 @@ msgstr "Konnte Objekt '%s' nicht parsen."
 msgid "hash mismatch %s"
 msgstr "Hash stimmt nicht mit %s überein."
 
-#: pack-bitmap.c:815 pack-bitmap.c:821 builtin/pack-objects.c:2184
+#: pack-bitmap.c:815 pack-bitmap.c:821 builtin/pack-objects.c:2216
 #, c-format
 msgid "unable to get size of %s"
 msgstr "Konnte Größe von %s nicht bestimmen."
@@ -5250,12 +5304,12 @@ msgstr "Konnte Größe von %s nicht bestimmen."
 msgid "offset before end of packfile (broken .idx?)"
 msgstr "Offset vor Ende der Packdatei (fehlerhafte Indexdatei?)"
 
-#: packfile.c:1900
+#: packfile.c:1922
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr "Offset vor Beginn des Pack-Index für %s (beschädigter Index?)"
 
-#: packfile.c:1904
+#: packfile.c:1926
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr "Offset hinter Ende des Pack-Index für %s (abgeschnittener Index?)"
@@ -5275,7 +5329,7 @@ msgstr "Fehlerhaftes Ablaufdatum '%s'"
 msgid "option `%s' expects \"always\", \"auto\", or \"never\""
 msgstr "Option `%s' erwartet \"always\", \"auto\" oder \"never\"."
 
-#: parse-options-cb.c:130 parse-options-cb.c:147
+#: parse-options-cb.c:132 parse-options-cb.c:149
 #, c-format
 msgid "malformed object name '%s'"
 msgstr "fehlerhafter Objekt-Name '%s'"
@@ -5322,31 +5376,31 @@ msgstr "Mehrdeutige Option: %s (kann --%s%s oder --%s%s sein)"
 msgid "did you mean `--%s` (with two dashes)?"
 msgstr "Meinten Sie `--%s` (mit zwei Strichen)?"
 
-#: parse-options.c:663 parse-options.c:963
+#: parse-options.c:666 parse-options.c:971
 #, c-format
 msgid "alias of --%s"
 msgstr "Alias für --%s"
 
-#: parse-options.c:854
+#: parse-options.c:862
 #, c-format
 msgid "unknown option `%s'"
 msgstr "Unbekannte Option: `%s'"
 
-#: parse-options.c:856
+#: parse-options.c:864
 #, c-format
 msgid "unknown switch `%c'"
 msgstr "Unbekannter Schalter `%c'"
 
-#: parse-options.c:858
+#: parse-options.c:866
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
 msgstr "Unbekannte nicht-Ascii Option in String: `%s'"
 
-#: parse-options.c:882
+#: parse-options.c:890
 msgid "..."
 msgstr "..."
 
-#: parse-options.c:901
+#: parse-options.c:909
 #, c-format
 msgid "usage: %s"
 msgstr "Verwendung: %s"
@@ -5354,17 +5408,17 @@ msgstr "Verwendung: %s"
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
 #.
-#: parse-options.c:907
+#: parse-options.c:915
 #, c-format
 msgid "   or: %s"
 msgstr "      oder: %s"
 
-#: parse-options.c:910
+#: parse-options.c:918
 #, c-format
 msgid "    %s"
 msgstr "    %s"
 
-#: parse-options.c:949
+#: parse-options.c:957
 msgid "-NUM"
 msgstr "-NUM"
 
@@ -5505,7 +5559,7 @@ msgstr "Protokollfehler: ungültiges Zeichen für Zeilenlänge: %.4s"
 msgid "protocol error: bad line length %d"
 msgstr "Protokollfehler: ungültige Zeilenlänge %d"
 
-#: pkt-line.c:373
+#: pkt-line.c:373 sideband.c:150
 #, c-format
 msgid "remote error: %s"
 msgstr "Fehler am anderen Ende: %s"
@@ -5519,15 +5573,23 @@ msgstr "Aktualisiere Index"
 msgid "unable to create threaded lstat: %s"
 msgstr "Kann Thread für lstat nicht erzeugen: %s"
 
-#: pretty.c:982
+#: pretty.c:983
 msgid "unable to parse --pretty format"
 msgstr "Konnte --pretty Format nicht parsen."
 
-#: promisor-remote.c:23
-msgid "Remote with no URL"
-msgstr "Remote-Repository ohne URL"
+#: promisor-remote.c:30
+msgid "promisor-remote: unable to fork off fetch subprocess"
+msgstr ""
 
-#: promisor-remote.c:58
+#: promisor-remote.c:35 promisor-remote.c:37
+msgid "promisor-remote: could not write to fetch subprocess"
+msgstr ""
+
+#: promisor-remote.c:41
+msgid "promisor-remote: could not close stdin to fetch subprocess"
+msgstr ""
+
+#: promisor-remote.c:53
 #, c-format
 msgid "promisor remote name cannot begin with '/': %s"
 msgstr "Promisor-Remote-Name kann nicht mit '/' beginnen: %s"
@@ -5544,7 +5606,7 @@ msgstr "Konnte `log` nicht starten."
 msgid "could not read `log` output"
 msgstr "Konnte Ausgabe von `log` nicht lesen."
 
-#: range-diff.c:98 sequencer.c:5143
+#: range-diff.c:98 sequencer.c:5283
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr "Konnte Commit '%s' nicht parsen."
@@ -5572,53 +5634,53 @@ msgstr "Fehler beim Generieren des Diffs."
 msgid "could not parse log for '%s'"
 msgstr "Konnte Log für '%s' nicht parsen."
 
-#: read-cache.c:680
+#: read-cache.c:682
 #, c-format
 msgid "will not add file alias '%s' ('%s' already exists in index)"
 msgstr ""
 "Dateialias '%s' wird nicht hinzugefügt ('%s' existiert bereits im Index)."
 
-#: read-cache.c:696
+#: read-cache.c:698
 msgid "cannot create an empty blob in the object database"
 msgstr "Kann keinen leeren Blob in die Objektdatenbank schreiben."
 
-#: read-cache.c:718
+#: read-cache.c:720
 #, c-format
 msgid "%s: can only add regular files, symbolic links or git-directories"
 msgstr ""
 "%s: Kann nur reguläre Dateien, symbolische Links oder Git-Verzeichnisse "
 "hinzufügen."
 
-#: read-cache.c:723
+#: read-cache.c:725
 #, c-format
 msgid "'%s' does not have a commit checked out"
 msgstr "'%s' hat keinen Commit ausgecheckt"
 
-#: read-cache.c:775
+#: read-cache.c:777
 #, c-format
 msgid "unable to index file '%s'"
 msgstr "Konnte Datei '%s' nicht indizieren."
 
-#: read-cache.c:794
+#: read-cache.c:796
 #, c-format
 msgid "unable to add '%s' to index"
 msgstr "Konnte '%s' nicht dem Index hinzufügen."
 
-#: read-cache.c:805
+#: read-cache.c:807
 #, c-format
 msgid "unable to stat '%s'"
 msgstr "Konnte '%s' nicht lesen."
 
-#: read-cache.c:1330
+#: read-cache.c:1318
 #, c-format
 msgid "'%s' appears as both a file and as a directory"
 msgstr "'%s' scheint eine Datei und ein Verzeichnis zu sein."
 
-#: read-cache.c:1536
+#: read-cache.c:1524
 msgid "Refresh index"
 msgstr "Aktualisiere Index"
 
-#: read-cache.c:1651
+#: read-cache.c:1639
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -5627,7 +5689,7 @@ msgstr ""
 "index.version gesetzt, aber Wert ungültig.\n"
 "Verwende Version %i"
 
-#: read-cache.c:1661
+#: read-cache.c:1649
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -5636,139 +5698,139 @@ msgstr ""
 "GIT_INDEX_VERSION gesetzt, aber Wert ungültig.\n"
 "Verwende Version %i"
 
-#: read-cache.c:1717
+#: read-cache.c:1705
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr "Ungültige Signatur 0x%08x"
 
-#: read-cache.c:1720
+#: read-cache.c:1708
 #, c-format
 msgid "bad index version %d"
 msgstr "Ungültige Index-Version %d"
 
-#: read-cache.c:1729
+#: read-cache.c:1717
 msgid "bad index file sha1 signature"
 msgstr "Ungültige SHA1-Signatur der Index-Datei."
 
-#: read-cache.c:1759
+#: read-cache.c:1747
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr "Index verwendet Erweiterung %.4s, welche wir nicht unterstützen."
 
-#: read-cache.c:1761
+#: read-cache.c:1749
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr "Ignoriere Erweiterung %.4s"
 
-#: read-cache.c:1798
+#: read-cache.c:1786
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr "Unbekanntes Format für Index-Eintrag 0x%08x"
 
-#: read-cache.c:1814
+#: read-cache.c:1802
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "Ungültiges Namensfeld im Index, in der Nähe von Pfad '%s'."
 
-#: read-cache.c:1871
+#: read-cache.c:1859
 msgid "unordered stage entries in index"
 msgstr "Ungeordnete Stage-Einträge im Index."
 
-#: read-cache.c:1874
+#: read-cache.c:1862
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr "Mehrere Stage-Einträge für zusammengeführte Datei '%s'."
 
-#: read-cache.c:1877
+#: read-cache.c:1865
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr "Ungeordnete Stage-Einträge für '%s'."
 
-#: read-cache.c:1983 read-cache.c:2271 rerere.c:565 rerere.c:599 rerere.c:1111
-#: submodule.c:1619 builtin/add.c:532 builtin/check-ignore.c:181
-#: builtin/checkout.c:488 builtin/checkout.c:674 builtin/clean.c:991
+#: read-cache.c:1971 read-cache.c:2262 rerere.c:565 rerere.c:599 rerere.c:1111
+#: submodule.c:1628 builtin/add.c:538 builtin/check-ignore.c:181
+#: builtin/checkout.c:489 builtin/checkout.c:675 builtin/clean.c:991
 #: builtin/commit.c:364 builtin/diff-tree.c:121 builtin/grep.c:507
-#: builtin/mv.c:145 builtin/reset.c:247 builtin/rm.c:290
+#: builtin/mv.c:146 builtin/reset.c:247 builtin/rm.c:290
 #: builtin/submodule--helper.c:332
 msgid "index file corrupt"
 msgstr "Index-Datei beschädigt"
 
-#: read-cache.c:2124
+#: read-cache.c:2115
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr "Kann Thread für load_cache_entries nicht erzeugen: %s"
 
-#: read-cache.c:2137
+#: read-cache.c:2128
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr "Kann Thread für load_cache_entries nicht erzeugen: %s"
 
-#: read-cache.c:2170
+#: read-cache.c:2161
 #, c-format
 msgid "%s: index file open failed"
 msgstr "%s: Öffnen der Index-Datei fehlgeschlagen."
 
-#: read-cache.c:2174
+#: read-cache.c:2165
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr "%s: Kann geöffneten Index nicht lesen."
 
-#: read-cache.c:2178
+#: read-cache.c:2169
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr "%s: Index-Datei ist kleiner als erwartet."
 
-#: read-cache.c:2182
+#: read-cache.c:2173
 #, c-format
 msgid "%s: unable to map index file"
 msgstr "%s: Konnte Index-Datei nicht einlesen."
 
-#: read-cache.c:2224
+#: read-cache.c:2215
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr "Kann Thread für load_index_extensions nicht erzeugen: %s"
 
-#: read-cache.c:2251
+#: read-cache.c:2242
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr "Kann Thread für load_index_extensions nicht beitreten: %s"
 
-#: read-cache.c:2283
+#: read-cache.c:2274
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr "Konnte geteilten Index '%s' nicht aktualisieren."
 
-#: read-cache.c:2330
+#: read-cache.c:2321
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr "Fehlerhafter Index. Erwartete %s in %s, erhielt %s."
 
-#: read-cache.c:3026 strbuf.c:1171 wrapper.c:630 builtin/merge.c:1130
+#: read-cache.c:3017 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1126
 #, c-format
 msgid "could not close '%s'"
 msgstr "Konnte '%s' nicht schließen."
 
-#: read-cache.c:3129 sequencer.c:2355 sequencer.c:4066
+#: read-cache.c:3120 sequencer.c:2446 sequencer.c:4185
 #, c-format
 msgid "could not stat '%s'"
 msgstr "Konnte '%s' nicht lesen."
 
-#: read-cache.c:3142
+#: read-cache.c:3133
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "konnte Git-Verzeichnis nicht öffnen: %s"
 
-#: read-cache.c:3154
+#: read-cache.c:3145
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "Konnte '%s' nicht entfernen."
 
-#: read-cache.c:3179
+#: read-cache.c:3170
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr "Konnte Zugriffsberechtigung auf '%s' nicht setzen."
 
-#: read-cache.c:3328
+#: read-cache.c:3319
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr "%s: Kann nicht auf Stufe #0 wechseln."
@@ -5843,7 +5905,7 @@ msgid_plural "Rebase %s onto %s (%d commands)"
 msgstr[0] "Rebase von %s auf %s (%d Kommando)"
 msgstr[1] "Rebase von %s auf %s (%d Kommandos)"
 
-#: rebase-interactive.c:72 git-rebase--preserve-merges.sh:228
+#: rebase-interactive.c:72 git-rebase--preserve-merges.sh:218
 msgid ""
 "\n"
 "Do not remove any line. Use 'drop' explicitly to remove a commit.\n"
@@ -5852,7 +5914,7 @@ msgstr ""
 "Keine Zeile entfernen. Benutzen Sie 'drop', um explizit einen Commit zu\n"
 "entfernen.\n"
 
-#: rebase-interactive.c:75 git-rebase--preserve-merges.sh:232
+#: rebase-interactive.c:75 git-rebase--preserve-merges.sh:222
 msgid ""
 "\n"
 "If you remove a line here THAT COMMIT WILL BE LOST.\n"
@@ -5860,7 +5922,7 @@ msgstr ""
 "\n"
 "Wenn Sie hier eine Zeile entfernen, wird DIESER COMMIT VERLOREN GEHEN.\n"
 
-#: rebase-interactive.c:81 git-rebase--preserve-merges.sh:871
+#: rebase-interactive.c:81 git-rebase--preserve-merges.sh:861
 msgid ""
 "\n"
 "You are editing the todo file of an ongoing interactive rebase.\n"
@@ -5874,7 +5936,7 @@ msgstr ""
 "    git rebase --continue\n"
 "\n"
 
-#: rebase-interactive.c:86 git-rebase--preserve-merges.sh:948
+#: rebase-interactive.c:86 git-rebase--preserve-merges.sh:938
 msgid ""
 "\n"
 "However, if you remove everything, the rebase will be aborted.\n"
@@ -5884,14 +5946,14 @@ msgstr ""
 "Wenn Sie jedoch alles löschen, wird der Rebase abgebrochen.\n"
 "\n"
 
-#: rebase-interactive.c:110 rerere.c:485 rerere.c:692 sequencer.c:3463
-#: sequencer.c:3489 sequencer.c:5248 builtin/fsck.c:347 builtin/rebase.c:258
+#: rebase-interactive.c:110 rerere.c:485 rerere.c:692 sequencer.c:3571
+#: sequencer.c:3597 sequencer.c:5389 builtin/fsck.c:347 builtin/rebase.c:264
 #, c-format
 msgid "could not write '%s'"
 msgstr "Konnte '%s' nicht schreiben."
 
-#: rebase-interactive.c:116 builtin/rebase.c:190 builtin/rebase.c:216
-#: builtin/rebase.c:240
+#: rebase-interactive.c:116 builtin/rebase.c:196 builtin/rebase.c:222
+#: builtin/rebase.c:246
 #, c-format
 msgid "could not write '%s'."
 msgstr "Konnte '%s' nicht schreiben."
@@ -5922,14 +5984,14 @@ msgstr ""
 "Warnungen zu ändern.\n"
 "Die möglichen Verhaltensweisen sind: ignore, warn, error.\n"
 
-#: rebase-interactive.c:233 rebase-interactive.c:238 sequencer.c:2274
-#: builtin/rebase.c:176 builtin/rebase.c:201 builtin/rebase.c:227
-#: builtin/rebase.c:252
+#: rebase-interactive.c:233 rebase-interactive.c:238 sequencer.c:2361
+#: builtin/rebase.c:182 builtin/rebase.c:207 builtin/rebase.c:233
+#: builtin/rebase.c:258
 #, c-format
 msgid "could not read '%s'."
 msgstr "Konnte '%s' nicht lesen."
 
-#: ref-filter.c:42 wt-status.c:1977
+#: ref-filter.c:42 wt-status.c:1973
 msgid "gone"
 msgstr "entfernt"
 
@@ -5948,238 +6010,233 @@ msgstr "%d hinterher"
 msgid "ahead %d, behind %d"
 msgstr "%d voraus, %d hinterher"
 
-#: ref-filter.c:165
+#: ref-filter.c:169
 #, c-format
 msgid "expected format: %%(color:<color>)"
 msgstr "Erwartetes Format: %%(color:<Farbe>)"
 
-#: ref-filter.c:167
+#: ref-filter.c:171
 #, c-format
 msgid "unrecognized color: %%(color:%s)"
 msgstr "nicht erkannte Farbe: %%(color:%s)"
 
-#: ref-filter.c:189
+#: ref-filter.c:193
 #, c-format
 msgid "Integer value expected refname:lstrip=%s"
 msgstr "Positiver Wert erwartet refname:lstrip=%s"
 
-#: ref-filter.c:193
+#: ref-filter.c:197
 #, c-format
 msgid "Integer value expected refname:rstrip=%s"
 msgstr "Positiver Wert erwartet refname:rstrip=%s"
 
-#: ref-filter.c:195
+#: ref-filter.c:199
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
 msgstr "nicht erkanntes %%(%s) Argument: %s"
 
-#: ref-filter.c:250
+#: ref-filter.c:254
 #, c-format
 msgid "%%(objecttype) does not take arguments"
 msgstr "%%(objecttype) akzeptiert keine Argumente"
 
-#: ref-filter.c:272
+#: ref-filter.c:276
 #, c-format
 msgid "unrecognized %%(objectsize) argument: %s"
 msgstr "nicht erkanntes %%(objectsize) Argument: %s"
 
-#: ref-filter.c:280
+#: ref-filter.c:284
 #, c-format
 msgid "%%(deltabase) does not take arguments"
 msgstr "%%(deltabase) akzeptiert keine Argumente"
 
-#: ref-filter.c:292
+#: ref-filter.c:296
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr "%%(body) akzeptiert keine Argumente"
 
-#: ref-filter.c:301
-#, c-format
-msgid "%%(subject) does not take arguments"
-msgstr "%%(subject) akzeptiert keine Argumente"
+#: ref-filter.c:309
+#, fuzzy, c-format
+msgid "unrecognized %%(subject) argument: %s"
+msgstr "nicht erkanntes %%(objectsize) Argument: %s"
 
-#: ref-filter.c:323
+#: ref-filter.c:330
 #, c-format
 msgid "unknown %%(trailers) argument: %s"
 msgstr "unbekanntes %%(trailers) Argument: %s"
 
-#: ref-filter.c:352
+#: ref-filter.c:363
 #, c-format
 msgid "positive value expected contents:lines=%s"
 msgstr "Positiver Wert erwartet contents:lines=%s"
 
-#: ref-filter.c:354
+#: ref-filter.c:365
 #, c-format
 msgid "unrecognized %%(contents) argument: %s"
 msgstr "nicht erkanntes %%(contents) Argument: %s"
 
-#: ref-filter.c:369
-#, c-format
-msgid "positive value expected objectname:short=%s"
-msgstr "Positiver Wert erwartet objectname:short=%s"
+#: ref-filter.c:380
+#, fuzzy, c-format
+msgid "positive value expected '%s' in %%(%s)"
+msgstr "Positiver Wert erwartet contents:lines=%s"
 
-#: ref-filter.c:373
-#, c-format
-msgid "unrecognized %%(objectname) argument: %s"
-msgstr "nicht erkanntes %%(objectname) Argument: %s"
+#: ref-filter.c:384
+#, fuzzy, c-format
+msgid "unrecognized argument '%s' in %%(%s)"
+msgstr "nicht erkanntes Argument: %s"
 
-#: ref-filter.c:403
+#: ref-filter.c:398
+#, fuzzy, c-format
+msgid "unrecognized email option: %s"
+msgstr "Nicht erkannte Position: '%s'"
+
+#: ref-filter.c:428
 #, c-format
 msgid "expected format: %%(align:<width>,<position>)"
 msgstr "Erwartetes Format: %%(align:<Breite>,<Position>)"
 
-#: ref-filter.c:415
+#: ref-filter.c:440
 #, c-format
 msgid "unrecognized position:%s"
 msgstr "nicht erkannte Position:%s"
 
-#: ref-filter.c:422
+#: ref-filter.c:447
 #, c-format
 msgid "unrecognized width:%s"
 msgstr "nicht erkannte Breite:%s"
 
-#: ref-filter.c:431
+#: ref-filter.c:456
 #, c-format
 msgid "unrecognized %%(align) argument: %s"
 msgstr "nicht erkanntes %%(align) Argument: %s"
 
-#: ref-filter.c:439
+#: ref-filter.c:464
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr "Positive Breitenangabe für %%(align) erwartet"
 
-#: ref-filter.c:457
+#: ref-filter.c:482
 #, c-format
 msgid "unrecognized %%(if) argument: %s"
 msgstr "nicht erkanntes %%(if) Argument: %s"
 
-#: ref-filter.c:559
+#: ref-filter.c:584
 #, c-format
 msgid "malformed field name: %.*s"
 msgstr "Fehlerhafter Feldname: %.*s"
 
-#: ref-filter.c:586
+#: ref-filter.c:611
 #, c-format
 msgid "unknown field name: %.*s"
 msgstr "Unbekannter Feldname: %.*s"
 
-#: ref-filter.c:590
+#: ref-filter.c:615
 #, c-format
 msgid ""
 "not a git repository, but the field '%.*s' requires access to object data"
 msgstr ""
 "Kein Git-Repository, aber das Feld '%.*s' erfordert Zugriff auf Objektdaten."
 
-#: ref-filter.c:714
+#: ref-filter.c:739
 #, c-format
 msgid "format: %%(if) atom used without a %%(then) atom"
 msgstr "format: %%(if) Atom ohne ein %%(then) Atom verwendet"
 
-#: ref-filter.c:777
+#: ref-filter.c:802
 #, c-format
 msgid "format: %%(then) atom used without an %%(if) atom"
 msgstr "format: %%(then) Atom ohne ein %%(if) Atom verwendet"
 
-#: ref-filter.c:779
+#: ref-filter.c:804
 #, c-format
 msgid "format: %%(then) atom used more than once"
 msgstr "format: %%(then) Atom mehr als einmal verwendet"
 
-#: ref-filter.c:781
+#: ref-filter.c:806
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr "format: %%(then) Atom nach %%(else) verwendet"
 
-#: ref-filter.c:809
+#: ref-filter.c:834
 #, c-format
 msgid "format: %%(else) atom used without an %%(if) atom"
 msgstr "format: %%(else) Atom ohne ein %%(if) Atom verwendet"
 
-#: ref-filter.c:811
+#: ref-filter.c:836
 #, c-format
 msgid "format: %%(else) atom used without a %%(then) atom"
 msgstr "Format: %%(else) Atom ohne ein %%(then) Atom verwendet"
 
-#: ref-filter.c:813
+#: ref-filter.c:838
 #, c-format
 msgid "format: %%(else) atom used more than once"
 msgstr "Format: %%(end) Atom mehr als einmal verwendet"
 
-#: ref-filter.c:828
+#: ref-filter.c:853
 #, c-format
 msgid "format: %%(end) atom used without corresponding atom"
 msgstr "Format: %%(end) Atom ohne zugehöriges Atom verwendet"
 
-#: ref-filter.c:885
+#: ref-filter.c:910
 #, c-format
 msgid "malformed format string %s"
 msgstr "Fehlerhafter Formatierungsstring %s"
 
-#: ref-filter.c:1486
+#: ref-filter.c:1541
 #, c-format
 msgid "no branch, rebasing %s"
 msgstr "kein Branch, Rebase von %s"
 
-#: ref-filter.c:1489
+#: ref-filter.c:1544
 #, c-format
 msgid "no branch, rebasing detached HEAD %s"
 msgstr "kein Branch, Rebase von losgelöstem HEAD %s"
 
-#: ref-filter.c:1492
+#: ref-filter.c:1547
 #, c-format
 msgid "no branch, bisect started on %s"
 msgstr "kein Branch, binäre Suche begonnen bei %s"
 
-#: ref-filter.c:1502
+#: ref-filter.c:1557
 msgid "no branch"
 msgstr "kein Branch"
 
-#: ref-filter.c:1538 ref-filter.c:1747
+#: ref-filter.c:1591 ref-filter.c:1800
 #, c-format
 msgid "missing object %s for %s"
 msgstr "Objekt %s fehlt für %s"
 
-#: ref-filter.c:1548
+#: ref-filter.c:1601
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr "parse_object_buffer bei %s für %s fehlgeschlagen"
 
-#: ref-filter.c:2001
+#: ref-filter.c:2054
 #, c-format
 msgid "malformed object at '%s'"
 msgstr "fehlerhaftes Objekt bei '%s'"
 
-#: ref-filter.c:2090
+#: ref-filter.c:2143
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr "Ignoriere Referenz mit fehlerhaftem Namen %s"
 
-#: ref-filter.c:2095 refs.c:657
+#: ref-filter.c:2148 refs.c:657
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "Ignoriere fehlerhafte Referenz %s"
 
-#: ref-filter.c:2395
+#: ref-filter.c:2464
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "Format: %%(end) Atom fehlt"
 
-#: ref-filter.c:2495
-#, c-format
-msgid "option `%s' is incompatible with --merged"
-msgstr "die Option `%s' ist inkompatibel mit --merged"
-
-#: ref-filter.c:2498
-#, c-format
-msgid "option `%s' is incompatible with --no-merged"
-msgstr "die Option `%s' ist inkompatibel mit --no-merged"
-
-#: ref-filter.c:2508
+#: ref-filter.c:2563
 #, c-format
 msgid "malformed object name %s"
 msgstr "missgebildeter Objektname %s"
 
-#: ref-filter.c:2513
+#: ref-filter.c:2568
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "die Option `%s' muss auf einen Commit zeigen"
@@ -6204,161 +6261,123 @@ msgstr "ungültiger Branchname: %s = %s"
 msgid "ignoring dangling symref %s"
 msgstr "Ignoriere unreferenzierte symbolische Referenz %s"
 
-#: refs.c:792
-#, c-format
-msgid "could not open '%s' for writing: %s"
-msgstr "Konnte '%s' nicht zum Schreiben öffnen: %s"
-
-#: refs.c:802 refs.c:853
-#, c-format
-msgid "could not read ref '%s'"
-msgstr "Konnte Referenz '%s' nicht lesen."
-
-#: refs.c:808
-#, c-format
-msgid "ref '%s' already exists"
-msgstr "Referenz '%s' existiert bereits."
-
-#: refs.c:813
-#, c-format
-msgid "unexpected object ID when writing '%s'"
-msgstr "Unerwartete Objekt-ID beim Schreiben von '%s'."
-
-#: refs.c:821 sequencer.c:408 sequencer.c:2721 sequencer.c:2925
-#: sequencer.c:2939 sequencer.c:3195 sequencer.c:5159 strbuf.c:1168
-#: wrapper.c:628
-#, c-format
-msgid "could not write to '%s'"
-msgstr "Konnte nicht nach '%s' schreiben."
-
-#: refs.c:848 strbuf.c:1166 wrapper.c:196 wrapper.c:366 builtin/am.c:719
-#: builtin/rebase.c:852
-#, c-format
-msgid "could not open '%s' for writing"
-msgstr "Konnte '%s' nicht zum Schreiben öffnen."
-
-#: refs.c:855
-#, c-format
-msgid "unexpected object ID when deleting '%s'"
-msgstr "Unerwartete Objekt-ID beim Löschen von '%s'."
-
-#: refs.c:986
+#: refs.c:892
 #, c-format
 msgid "log for ref %s has gap after %s"
 msgstr "Log für Referenz %s hat eine Lücke nach %s."
 
-#: refs.c:992
+#: refs.c:898
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
 msgstr "Log für Referenz %s unerwartet bei %s beendet."
 
-#: refs.c:1051
+#: refs.c:957
 #, c-format
 msgid "log for %s is empty"
 msgstr "Log für %s ist leer."
 
-#: refs.c:1143
+#: refs.c:1049
 #, c-format
 msgid "refusing to update ref with bad name '%s'"
 msgstr "verweigere Aktualisierung einer Referenz mit fehlerhaftem Namen '%s'"
 
-#: refs.c:1219
+#: refs.c:1120
 #, c-format
 msgid "update_ref failed for ref '%s': %s"
 msgstr "update_ref für Referenz '%s' fehlgeschlagen: %s"
 
-#: refs.c:2011
+#: refs.c:1944
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "mehrere Aktualisierungen für Referenz '%s' nicht erlaubt"
 
-#: refs.c:2098
+#: refs.c:2024
 msgid "ref updates forbidden inside quarantine environment"
 msgstr ""
 "Aktualisierungen von Referenzen ist innerhalb der Quarantäne-Umgebung "
 "verboten"
 
-#: refs.c:2109
+#: refs.c:2035
 msgid "ref updates aborted by hook"
 msgstr "Aktualisierungen von Referenzen durch Hook abgebrochen"
 
-#: refs.c:2209 refs.c:2239
+#: refs.c:2135 refs.c:2165
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "'%s' existiert; kann '%s' nicht erstellen"
 
-#: refs.c:2215 refs.c:2250
+#: refs.c:2141 refs.c:2176
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "kann '%s' und '%s' nicht zur selben Zeit verarbeiten"
 
-#: refs/files-backend.c:1233
+#: refs/files-backend.c:1228
 #, c-format
 msgid "could not remove reference %s"
 msgstr "konnte Referenz %s nicht löschen"
 
-#: refs/files-backend.c:1247 refs/packed-backend.c:1541
-#: refs/packed-backend.c:1551
+#: refs/files-backend.c:1242 refs/packed-backend.c:1542
+#: refs/packed-backend.c:1552
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr "konnte Referenz %s nicht entfernen: %s"
 
-#: refs/files-backend.c:1250 refs/packed-backend.c:1554
+#: refs/files-backend.c:1245 refs/packed-backend.c:1555
 #, c-format
 msgid "could not delete references: %s"
 msgstr "konnte Referenzen nicht entfernen: %s"
 
-#: refspec.c:137
+#: refspec.c:167
 #, c-format
 msgid "invalid refspec '%s'"
 msgstr "ungültige Refspec '%s'"
 
-#: remote.c:355
+#: remote.c:351
 #, c-format
 msgid "config remote shorthand cannot begin with '/': %s"
 msgstr ""
 "Kürzel für Remote-Repository in der Konfiguration kann nicht mit '/' "
 "beginnen: %s"
 
-#: remote.c:403
+#: remote.c:399
 msgid "more than one receivepack given, using the first"
 msgstr "Mehr als ein receivepack-Befehl angegeben, benutze den ersten."
 
-#: remote.c:411
+#: remote.c:407
 msgid "more than one uploadpack given, using the first"
 msgstr "Mehr als ein uploadpack-Befehl angegeben, benutze den ersten."
 
-#: remote.c:594
+#: remote.c:590
 #, c-format
 msgid "Cannot fetch both %s and %s to %s"
 msgstr "Kann 'fetch' nicht für sowohl %s als auch %s nach %s ausführen."
 
-#: remote.c:598
+#: remote.c:594
 #, c-format
 msgid "%s usually tracks %s, not %s"
 msgstr "%s folgt üblicherweise %s, nicht %s"
 
-#: remote.c:602
+#: remote.c:598
 #, c-format
 msgid "%s tracks both %s and %s"
 msgstr "%s folgt sowohl %s als auch %s"
 
-#: remote.c:670
+#: remote.c:666
 #, c-format
 msgid "key '%s' of pattern had no '*'"
 msgstr "Schlüssel '%s' des Musters hatte kein '*'."
 
-#: remote.c:680
+#: remote.c:676
 #, c-format
 msgid "value '%s' of pattern has no '*'"
 msgstr "Wert '%s' des Musters hat kein '*'."
 
-#: remote.c:986
+#: remote.c:1073
 #, c-format
 msgid "src refspec %s does not match any"
 msgstr "Src-Refspec %s entspricht keiner Referenz."
 
-#: remote.c:991
+#: remote.c:1078
 #, c-format
 msgid "src refspec %s matches more than one"
 msgstr "Src-Refspec %s entspricht mehr als einer Referenz."
@@ -6367,7 +6386,7 @@ msgstr "Src-Refspec %s entspricht mehr als einer Referenz."
 #. <remote> <src>:<dst>" push, and "being pushed ('%s')" is
 #. the <src>.
 #.
-#: remote.c:1006
+#: remote.c:1093
 #, c-format
 msgid ""
 "The destination you provided is not a full refname (i.e.,\n"
@@ -6394,7 +6413,7 @@ msgstr ""
 "Keines hat funktioniert, sodass wir aufgegeben haben. Sie müssen die\n"
 "Referenz mit vollqualifizierten Namen angeben."
 
-#: remote.c:1026
+#: remote.c:1113
 #, c-format
 msgid ""
 "The <src> part of the refspec is a commit object.\n"
@@ -6405,7 +6424,7 @@ msgstr ""
 "Meinten Sie, einen neuen Branch mittels Push nach\n"
 "'%s:refs/heads/%s' zu erstellen?"
 
-#: remote.c:1031
+#: remote.c:1118
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tag object.\n"
@@ -6416,7 +6435,7 @@ msgstr ""
 "Meinten Sie, einen neuen Tag mittels Push nach\n"
 "'%s:refs/tags/%s' zu erstellen?"
 
-#: remote.c:1036
+#: remote.c:1123
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tree object.\n"
@@ -6427,7 +6446,7 @@ msgstr ""
 "Meinten Sie, einen Tag für ein neues Tree-Objekt\n"
 "mittels Push nach '%s:refs/tags/'%s' zu erstellen?"
 
-#: remote.c:1041
+#: remote.c:1128
 #, c-format
 msgid ""
 "The <src> part of the refspec is a blob object.\n"
@@ -6438,117 +6457,117 @@ msgstr ""
 "Meinten Sie, einen Tag für ein neues Blob-Objekt\n"
 "mittels Push nach '%s:refs/tags/%s' zu erstellen?"
 
-#: remote.c:1077
+#: remote.c:1164
 #, c-format
 msgid "%s cannot be resolved to branch"
 msgstr "%s kann nicht zu Branch aufgelöst werden."
 
-#: remote.c:1088
+#: remote.c:1175
 #, c-format
 msgid "unable to delete '%s': remote ref does not exist"
 msgstr "Konnte '%s' nicht löschen: Remote-Referenz existiert nicht."
 
-#: remote.c:1100
+#: remote.c:1187
 #, c-format
 msgid "dst refspec %s matches more than one"
 msgstr "Dst-Refspec %s entspricht mehr als einer Referenz."
 
-#: remote.c:1107
+#: remote.c:1194
 #, c-format
 msgid "dst ref %s receives from more than one src"
 msgstr "Dst-Referenz %s empfängt von mehr als einer Quelle"
 
-#: remote.c:1610 remote.c:1711
+#: remote.c:1703 remote.c:1804
 msgid "HEAD does not point to a branch"
 msgstr "HEAD zeigt auf keinen Branch"
 
-#: remote.c:1619
+#: remote.c:1712
 #, c-format
 msgid "no such branch: '%s'"
 msgstr "Kein solcher Branch: '%s'"
 
-#: remote.c:1622
+#: remote.c:1715
 #, c-format
 msgid "no upstream configured for branch '%s'"
 msgstr "Kein Upstream-Branch für Branch '%s' konfiguriert."
 
-#: remote.c:1628
+#: remote.c:1721
 #, c-format
 msgid "upstream branch '%s' not stored as a remote-tracking branch"
 msgstr "Upstream-Branch '%s' nicht als Remote-Tracking-Branch gespeichert"
 
-#: remote.c:1643
+#: remote.c:1736
 #, c-format
 msgid "push destination '%s' on remote '%s' has no local tracking branch"
 msgstr ""
 "Ziel für \"push\" '%s' auf Remote-Repository '%s' hat keinen lokal gefolgten "
 "Branch"
 
-#: remote.c:1655
+#: remote.c:1748
 #, c-format
 msgid "branch '%s' has no remote for pushing"
 msgstr "Branch '%s' hat keinen Upstream-Branch gesetzt"
 
-#: remote.c:1665
+#: remote.c:1758
 #, c-format
 msgid "push refspecs for '%s' do not include '%s'"
 msgstr "Push-Refspecs für '%s' beinhalten nicht '%s'"
 
-#: remote.c:1678
+#: remote.c:1771
 msgid "push has no destination (push.default is 'nothing')"
 msgstr "kein Ziel für \"push\" (push.default ist 'nothing')"
 
-#: remote.c:1700
+#: remote.c:1793
 msgid "cannot resolve 'simple' push to a single destination"
 msgstr "kann einzelnes Ziel für \"push\" im Modus 'simple' nicht auflösen"
 
-#: remote.c:1826
+#: remote.c:1922
 #, c-format
 msgid "couldn't find remote ref %s"
 msgstr "Konnte Remote-Referenz %s nicht finden."
 
-#: remote.c:1839
+#: remote.c:1935
 #, c-format
 msgid "* Ignoring funny ref '%s' locally"
 msgstr "* Ignoriere sonderbare Referenz '%s' lokal"
 
-#: remote.c:2002
+#: remote.c:2098
 #, c-format
 msgid "Your branch is based on '%s', but the upstream is gone.\n"
 msgstr ""
 "Ihr Branch basiert auf '%s', aber der Upstream-Branch wurde entfernt.\n"
 
-#: remote.c:2006
+#: remote.c:2102
 msgid "  (use \"git branch --unset-upstream\" to fixup)\n"
 msgstr "  (benutzen Sie \"git branch --unset-upstream\" zum Beheben)\n"
 
-#: remote.c:2009
+#: remote.c:2105
 #, c-format
 msgid "Your branch is up to date with '%s'.\n"
 msgstr "Ihr Branch ist auf demselben Stand wie '%s'.\n"
 
-#: remote.c:2013
+#: remote.c:2109
 #, c-format
 msgid "Your branch and '%s' refer to different commits.\n"
 msgstr "Ihr Branch und '%s' zeigen auf unterschiedliche Commits.\n"
 
-#: remote.c:2016
+#: remote.c:2112
 #, c-format
 msgid "  (use \"%s\" for details)\n"
 msgstr "  (benutzen Sie \"%s\" für Details)\n"
 
-#: remote.c:2020
+#: remote.c:2116
 #, c-format
 msgid "Your branch is ahead of '%s' by %d commit.\n"
 msgid_plural "Your branch is ahead of '%s' by %d commits.\n"
 msgstr[0] "Ihr Branch ist %2$d Commit vor '%1$s'.\n"
 msgstr[1] "Ihr Branch ist %2$d Commits vor '%1$s'.\n"
 
-#: remote.c:2026
+#: remote.c:2122
 msgid "  (use \"git push\" to publish your local commits)\n"
 msgstr "  (benutzen Sie \"git push\", um lokale Commits zu publizieren)\n"
 
-#: remote.c:2029
+#: remote.c:2125
 #, c-format
 msgid "Your branch is behind '%s' by %d commit, and can be fast-forwarded.\n"
 msgid_plural ""
@@ -6558,12 +6577,12 @@ msgstr[0] ""
 msgstr[1] ""
 "Ihr Branch ist %2$d Commits hinter '%1$s', und kann vorgespult werden.\n"
 
-#: remote.c:2037
+#: remote.c:2133
 msgid "  (use \"git pull\" to update your local branch)\n"
 msgstr ""
 "  (benutzen Sie \"git pull\", um Ihren lokalen Branch zu aktualisieren)\n"
 
-#: remote.c:2040
+#: remote.c:2136
 #, c-format
 msgid ""
 "Your branch and '%s' have diverged,\n"
@@ -6578,13 +6597,13 @@ msgstr[1] ""
 "Ihr Branch und '%s' sind divergiert,\n"
 "und haben jeweils %d und %d unterschiedliche Commits.\n"
 
-#: remote.c:2050
+#: remote.c:2146
 msgid "  (use \"git pull\" to merge the remote branch into yours)\n"
 msgstr ""
 "  (benutzen Sie \"git pull\", um Ihren Branch mit dem Remote-Branch "
 "zusammenzuführen)\n"
 
-#: remote.c:2241
+#: remote.c:2337
 #, c-format
 msgid "cannot parse expected object name '%s'"
 msgstr "Kann erwarteten Objektnamen '%s' nicht parsen."
@@ -6603,11 +6622,6 @@ msgstr "doppelte ersetzende Referenz: %s"
 #, c-format
 msgid "replace depth too high for object %s"
 msgstr "Ersetzungstiefe zu hoch für Objekt %s"
-
-#: repository.c:94 builtin/init-db.c:188
-#, c-format
-msgid "The hash algorithm %s is not supported in this build."
-msgstr "Der Hash-Algorithmus %s ist nicht in dieser Version unterstützt."
 
 #: rerere.c:217 rerere.c:226 rerere.c:229
 msgid "corrupt MERGE_RR"
@@ -6667,8 +6681,8 @@ msgstr "Kann '%s' nicht löschen."
 msgid "Recorded preimage for '%s'"
 msgstr "Preimage für '%s' aufgezeichnet."
 
-#: rerere.c:881 submodule.c:2078 builtin/log.c:1891
-#: builtin/submodule--helper.c:1454 builtin/submodule--helper.c:1466
+#: rerere.c:881 submodule.c:2082 builtin/log.c:1975
+#: builtin/submodule--helper.c:1878 builtin/submodule--helper.c:1890
 #, c-format
 msgid "could not create directory '%s'"
 msgstr "Konnte Verzeichnis '%s' nicht erstellen."
@@ -6706,25 +6720,31 @@ msgstr "Konnte rr-cache Verzeichnis nicht öffnen."
 msgid "could not determine HEAD revision"
 msgstr "Konnte HEAD-Commit nicht bestimmen."
 
-#: reset.c:70 reset.c:76 sequencer.c:3318
+#: reset.c:70 reset.c:76 sequencer.c:3426
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "Fehler beim Finden des \"Tree\"-Objektes von %s."
 
-#: revision.c:2661
+#: revision.c:2344
+#, fuzzy
+msgid "--unpacked=<packfile> no longer supported"
+msgstr "git-over-rsync wird nicht länger unterstützt."
+
+#: revision.c:2364
+#, fuzzy, c-format
+msgid "unknown value for --diff-merges: %s"
+msgstr "Unbekannter Wert für Konfiguration '%s': %s"
+
+#: revision.c:2702
 msgid "your current branch appears to be broken"
 msgstr "Ihr aktueller Branch scheint fehlerhaft zu sein."
 
-#: revision.c:2664
+#: revision.c:2705
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
 msgstr "Ihr aktueller Branch '%s' hat noch keine Commits."
 
-#: revision.c:2873
-msgid "--first-parent is incompatible with --bisect"
-msgstr "Die Optionen --first-parent und --bisect sind inkompatibel."
-
-#: revision.c:2877
+#: revision.c:2915
 msgid "-L does not yet support diff formats besides -p and -s"
 msgstr "-L unterstützt noch keine anderen Diff-Formate außer -p und -s"
 
@@ -6732,12 +6752,12 @@ msgstr "-L unterstützt noch keine anderen Diff-Formate außer -p und -s"
 msgid "open /dev/null failed"
 msgstr "Öffnen von /dev/null fehlgeschlagen"
 
-#: run-command.c:1269
+#: run-command.c:1270
 #, c-format
 msgid "cannot create async thread: %s"
 msgstr "Konnte Thread für async nicht erzeugen: %s"
 
-#: run-command.c:1333
+#: run-command.c:1334
 #, c-format
 msgid ""
 "The '%s' hook was ignored because it's not set as executable.\n"
@@ -6761,21 +6781,21 @@ msgstr "Konnte Status des Entpackens der Gegenseite nicht parsen: %s"
 msgid "remote unpack failed: %s"
 msgstr "Entpacken auf der Gegenseite fehlgeschlagen: %s"
 
-#: send-pack.c:308
+#: send-pack.c:372
 msgid "failed to sign the push certificate"
 msgstr "Fehler beim Signieren des \"push\"-Zertifikates"
 
-#: send-pack.c:394
+#: send-pack.c:460
 msgid "the receiving end does not support this repository's hash algorithm"
 msgstr ""
 "die Gegenseite unterstützt nicht den Hash-Algorithmus dieses Repositories"
 
-#: send-pack.c:403
+#: send-pack.c:469
 msgid "the receiving end does not support --signed push"
 msgstr ""
 "die Gegenseite unterstützt keinen signierten Versand (\"--signed push\")"
 
-#: send-pack.c:405
+#: send-pack.c:471
 msgid ""
 "not sending a push certificate since the receiving end does not support --"
 "signed push"
@@ -6783,47 +6803,47 @@ msgstr ""
 "kein Versand des \"push\"-Zertifikates, da die Gegenseite keinen signierten\n"
 "Versand (\"--signed push\") unterstützt"
 
-#: send-pack.c:417
+#: send-pack.c:483
 msgid "the receiving end does not support --atomic push"
 msgstr "die Gegenseite unterstützt keinen atomaren Versand (\"--atomic push\")"
 
-#: send-pack.c:422
+#: send-pack.c:488
 msgid "the receiving end does not support push options"
 msgstr "die Gegenseite unterstützt keine Push-Optionen"
 
-#: sequencer.c:192
+#: sequencer.c:194
 #, c-format
 msgid "invalid commit message cleanup mode '%s'"
 msgstr "Ungültiger \"cleanup\"-Modus '%s' für Commit-Beschreibungen."
 
-#: sequencer.c:297
+#: sequencer.c:308
 #, c-format
 msgid "could not delete '%s'"
 msgstr "Konnte '%s' nicht löschen."
 
-#: sequencer.c:316 builtin/rebase.c:743 builtin/rebase.c:1582 builtin/rm.c:385
+#: sequencer.c:329 builtin/rebase.c:749 builtin/rebase.c:1590 builtin/rm.c:385
 #, c-format
 msgid "could not remove '%s'"
 msgstr "Konnte '%s' nicht löschen"
 
-#: sequencer.c:326
+#: sequencer.c:339
 msgid "revert"
 msgstr "Revert"
 
-#: sequencer.c:328
+#: sequencer.c:341
 msgid "cherry-pick"
 msgstr "Cherry-Pick"
 
-#: sequencer.c:330
+#: sequencer.c:343
 msgid "rebase"
 msgstr "Rebase"
 
-#: sequencer.c:332
+#: sequencer.c:345
 #, c-format
 msgid "unknown action: %d"
 msgstr "Unbekannte Aktion: %d"
 
-#: sequencer.c:390
+#: sequencer.c:404
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'"
@@ -6831,7 +6851,7 @@ msgstr ""
 "nach Auflösung der Konflikte markieren Sie die korrigierten Pfade\n"
 "mit 'git add <Pfade>' oder 'git rm <Pfade>'"
 
-#: sequencer.c:393
+#: sequencer.c:407
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'\n"
@@ -6841,44 +6861,44 @@ msgstr ""
 "mit 'git add <Pfade>' oder 'git rm <Pfade>' und tragen Sie das Ergebnis mit\n"
 "'git commit' ein"
 
-#: sequencer.c:406 sequencer.c:2921
+#: sequencer.c:420 sequencer.c:3028
 #, c-format
 msgid "could not lock '%s'"
 msgstr "Konnte '%s' nicht sperren"
 
-#: sequencer.c:413
+#: sequencer.c:422 sequencer.c:2827 sequencer.c:3032 sequencer.c:3046
+#: sequencer.c:3303 sequencer.c:5299 strbuf.c:1168 wrapper.c:631
+#, c-format
+msgid "could not write to '%s'"
+msgstr "Konnte nicht nach '%s' schreiben."
+
+#: sequencer.c:427
 #, c-format
 msgid "could not write eol to '%s'"
 msgstr "Konnte EOL nicht nach '%s' schreiben."
 
-#: sequencer.c:418 sequencer.c:2726 sequencer.c:2927 sequencer.c:2941
-#: sequencer.c:3203
+#: sequencer.c:432 sequencer.c:2832 sequencer.c:3034 sequencer.c:3048
+#: sequencer.c:3311
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "Fehler beim Fertigstellen von '%s'."
 
-#: sequencer.c:431 sequencer.c:1620 sequencer.c:2746 sequencer.c:3185
-#: sequencer.c:3294 builtin/am.c:249 builtin/commit.c:786 builtin/merge.c:1128
-#, c-format
-msgid "could not read '%s'"
-msgstr "Konnte '%s' nicht lesen"
-
-#: sequencer.c:457
+#: sequencer.c:471
 #, c-format
 msgid "your local changes would be overwritten by %s."
 msgstr "Ihre lokalen Änderungen würden durch den %s überschrieben werden."
 
-#: sequencer.c:461
+#: sequencer.c:475
 msgid "commit your changes or stash them to proceed."
 msgstr ""
 "Committen Sie Ihre Änderungen oder benutzen Sie \"stash\", um fortzufahren."
 
-#: sequencer.c:493
+#: sequencer.c:507
 #, c-format
 msgid "%s: fast-forward"
 msgstr "%s: Vorspulen"
 
-#: sequencer.c:532 builtin/tag.c:566
+#: sequencer.c:546 builtin/tag.c:566
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Ungültiger \"cleanup\" Modus %s"
@@ -6886,65 +6906,65 @@ msgstr "Ungültiger \"cleanup\" Modus %s"
 #. TRANSLATORS: %s will be "revert", "cherry-pick" or
 #. "rebase".
 #.
-#: sequencer.c:626
+#: sequencer.c:640
 #, c-format
 msgid "%s: Unable to write new index file"
 msgstr "%s: Konnte neue Index-Datei nicht schreiben"
 
-#: sequencer.c:643
+#: sequencer.c:657
 msgid "unable to update cache tree"
 msgstr "Konnte Cache-Verzeichnis nicht aktualisieren."
 
-#: sequencer.c:657
+#: sequencer.c:671
 msgid "could not resolve HEAD commit"
 msgstr "Konnte HEAD-Commit nicht auflösen."
 
-#: sequencer.c:737
+#: sequencer.c:751
 #, c-format
 msgid "no key present in '%.*s'"
 msgstr "Kein Schlüssel in '%.*s' vorhanden."
 
-#: sequencer.c:748
+#: sequencer.c:762
 #, c-format
 msgid "unable to dequote value of '%s'"
 msgstr "Konnte Anführungszeichen von '%s' nicht entfernen."
 
-#: sequencer.c:785 wrapper.c:198 wrapper.c:368 builtin/am.c:710
-#: builtin/am.c:802 builtin/merge.c:1125 builtin/rebase.c:896
+#: sequencer.c:799 wrapper.c:201 wrapper.c:371 builtin/am.c:724
+#: builtin/am.c:816 builtin/merge.c:1121 builtin/rebase.c:902
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "Konnte '%s' nicht zum Lesen öffnen."
 
-#: sequencer.c:795
+#: sequencer.c:809
 msgid "'GIT_AUTHOR_NAME' already given"
 msgstr "'GIT_AUTHOR_NAME' bereits angegeben."
 
-#: sequencer.c:800
+#: sequencer.c:814
 msgid "'GIT_AUTHOR_EMAIL' already given"
 msgstr "'GIT_AUTHOR_EMAIL' bereits angegeben."
 
-#: sequencer.c:805
+#: sequencer.c:819
 msgid "'GIT_AUTHOR_DATE' already given"
 msgstr "'GIT_AUTHOR_DATE' bereits angegeben."
 
-#: sequencer.c:809
+#: sequencer.c:823
 #, c-format
 msgid "unknown variable '%s'"
 msgstr "Unbekannte Variable '%s'"
 
-#: sequencer.c:814
+#: sequencer.c:828
 msgid "missing 'GIT_AUTHOR_NAME'"
 msgstr "'GIT_AUTHOR_NAME' fehlt."
 
-#: sequencer.c:816
+#: sequencer.c:830
 msgid "missing 'GIT_AUTHOR_EMAIL'"
 msgstr "'GIT_AUTHOR_EMAIL' fehlt."
 
-#: sequencer.c:818
+#: sequencer.c:832
 msgid "missing 'GIT_AUTHOR_DATE'"
 msgstr "'GIT_AUTHOR_DATE' fehlt."
 
-#: sequencer.c:867
+#: sequencer.c:897
 #, c-format
 msgid ""
 "you have staged changes in your working tree\n"
@@ -6975,11 +6995,11 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:1141
+#: sequencer.c:1178
 msgid "'prepare-commit-msg' hook failed"
 msgstr "'prepare-commit-msg' Hook fehlgeschlagen."
 
-#: sequencer.c:1147
+#: sequencer.c:1184
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7007,7 +7027,7 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1160
+#: sequencer.c:1197
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7033,331 +7053,340 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1202
+#: sequencer.c:1239
 msgid "couldn't look up newly created commit"
 msgstr "Konnte neu erstellten Commit nicht nachschlagen."
 
-#: sequencer.c:1204
+#: sequencer.c:1241
 msgid "could not parse newly created commit"
 msgstr "Konnte neu erstellten Commit nicht analysieren."
 
-#: sequencer.c:1250
+#: sequencer.c:1287
 msgid "unable to resolve HEAD after creating commit"
 msgstr "Konnte HEAD nicht auflösen, nachdem der Commit erstellt wurde."
 
-#: sequencer.c:1252
+#: sequencer.c:1289
 msgid "detached HEAD"
 msgstr "losgelöster HEAD"
 
-#: sequencer.c:1256
+#: sequencer.c:1293
 msgid " (root-commit)"
 msgstr " (Root-Commit)"
 
-#: sequencer.c:1277
+#: sequencer.c:1314
 msgid "could not parse HEAD"
 msgstr "Konnte HEAD nicht parsen."
 
-#: sequencer.c:1279
+#: sequencer.c:1316
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "HEAD %s ist kein Commit!"
 
-#: sequencer.c:1283 sequencer.c:1357 builtin/commit.c:1579
+#: sequencer.c:1320 sequencer.c:1395 builtin/commit.c:1577
 msgid "could not parse HEAD commit"
 msgstr "Konnte Commit von HEAD nicht analysieren."
 
-#: sequencer.c:1335 sequencer.c:1980
+#: sequencer.c:1373 sequencer.c:2067
 msgid "unable to parse commit author"
 msgstr "Konnte Commit-Autor nicht parsen."
 
-#: sequencer.c:1346 builtin/am.c:1566 builtin/merge.c:695
+#: sequencer.c:1384 builtin/am.c:1580 builtin/merge.c:692
 msgid "git write-tree failed to write a tree"
 msgstr "\"git write-tree\" schlug beim Schreiben eines \"Tree\"-Objektes fehl"
 
-#: sequencer.c:1379 sequencer.c:1450
+#: sequencer.c:1417 sequencer.c:1535
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "Konnte Commit-Beschreibung von '%s' nicht lesen."
 
-#: sequencer.c:1406 builtin/am.c:1588 builtin/commit.c:1680 builtin/merge.c:894
-#: builtin/merge.c:919
+#: sequencer.c:1446 sequencer.c:1478
+#, fuzzy, c-format
+msgid "invalid author identity '%s'"
+msgstr "Ungültiger Pfad '%s'"
+
+#: sequencer.c:1452
+msgid "corrupt author: missing date information"
+msgstr ""
+
+#: sequencer.c:1491 builtin/am.c:1606 builtin/commit.c:1678 builtin/merge.c:890
+#: builtin/merge.c:915
 msgid "failed to write commit object"
 msgstr "Fehler beim Schreiben des Commit-Objektes."
 
-#: sequencer.c:1433 sequencer.c:4118
+#: sequencer.c:1518 sequencer.c:4237
 #, c-format
 msgid "could not update %s"
 msgstr "Konnte %s nicht aktualisieren."
 
-#: sequencer.c:1481
+#: sequencer.c:1567
 #, c-format
 msgid "could not parse commit %s"
 msgstr "Konnte Commit %s nicht parsen."
 
-#: sequencer.c:1486
+#: sequencer.c:1572
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "Konnte Eltern-Commit %s nicht parsen."
 
-#: sequencer.c:1569 sequencer.c:1680
+#: sequencer.c:1655 sequencer.c:1766
 #, c-format
 msgid "unknown command: %d"
 msgstr "Unbekannter Befehl: %d"
 
-#: sequencer.c:1627 sequencer.c:1652
+#: sequencer.c:1713 sequencer.c:1738
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr "Das ist eine Kombination aus %d Commits."
 
-#: sequencer.c:1637
+#: sequencer.c:1723
 msgid "need a HEAD to fixup"
 msgstr "benötige HEAD für fixup"
 
-#: sequencer.c:1639 sequencer.c:3230
+#: sequencer.c:1725 sequencer.c:3338
 msgid "could not read HEAD"
 msgstr "Konnte HEAD nicht lesen"
 
-#: sequencer.c:1641
+#: sequencer.c:1727
 msgid "could not read HEAD's commit message"
 msgstr "Konnte Commit-Beschreibung von HEAD nicht lesen"
 
-#: sequencer.c:1647
+#: sequencer.c:1733
 #, c-format
 msgid "cannot write '%s'"
 msgstr "kann '%s' nicht schreiben"
 
-#: sequencer.c:1654 git-rebase--preserve-merges.sh:496
+#: sequencer.c:1740 git-rebase--preserve-merges.sh:486
 msgid "This is the 1st commit message:"
 msgstr "Das ist die erste Commit-Beschreibung:"
 
-#: sequencer.c:1662
+#: sequencer.c:1748
 #, c-format
 msgid "could not read commit message of %s"
 msgstr "Konnte Commit-Beschreibung von %s nicht lesen."
 
-#: sequencer.c:1669
+#: sequencer.c:1755
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "Das ist Commit-Beschreibung #%d:"
 
-#: sequencer.c:1675
+#: sequencer.c:1761
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "Die Commit-Beschreibung #%d wird ausgelassen:"
 
-#: sequencer.c:1763
+#: sequencer.c:1849
 msgid "your index file is unmerged."
 msgstr "Ihre Index-Datei ist nicht zusammengeführt."
 
-#: sequencer.c:1770
+#: sequencer.c:1856
 msgid "cannot fixup root commit"
 msgstr "kann fixup nicht auf Root-Commit anwenden"
 
-#: sequencer.c:1789
+#: sequencer.c:1875
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "Commit %s ist ein Merge, aber die Option -m wurde nicht angegeben."
 
-#: sequencer.c:1797 sequencer.c:1805
+#: sequencer.c:1883 sequencer.c:1891
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "Commit %s hat keinen Eltern-Commit %d"
 
-#: sequencer.c:1811
+#: sequencer.c:1897
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "Kann keine Commit-Beschreibung für %s bekommen."
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:1830
+#: sequencer.c:1916
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: kann Eltern-Commit %s nicht parsen"
 
-#: sequencer.c:1895
+#: sequencer.c:1981
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "Konnte '%s' nicht zu '%s' umbenennen."
 
-#: sequencer.c:1952
+#: sequencer.c:2038
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "Konnte \"revert\" nicht auf %s... (%s) ausführen"
 
-#: sequencer.c:1953
+#: sequencer.c:2039
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "Konnte %s... (%s) nicht anwenden"
 
-#: sequencer.c:1972
+#: sequencer.c:2059
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr "Weglassen von %s %s -- Patch-Inhalte sind bereits im Upstream-Branch\n"
 
-#: sequencer.c:2030
+#: sequencer.c:2117
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: Fehler beim Lesen des Index"
 
-#: sequencer.c:2037
+#: sequencer.c:2124
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: Fehler beim Aktualisieren des Index"
 
-#: sequencer.c:2114
+#: sequencer.c:2201
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "%s akzeptiert keine Argumente: '%s'"
 
-#: sequencer.c:2123
+#: sequencer.c:2210
 #, c-format
 msgid "missing arguments for %s"
 msgstr "Fehlende Argumente für %s."
 
-#: sequencer.c:2154
+#: sequencer.c:2241
 #, c-format
 msgid "could not parse '%s'"
 msgstr "Konnte '%s' nicht parsen."
 
-#: sequencer.c:2215
+#: sequencer.c:2302
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "Ungültige Zeile %d: %.*s"
 
-#: sequencer.c:2226
+#: sequencer.c:2313
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "Kann '%s' nicht ohne vorherigen Commit ausführen"
 
-#: sequencer.c:2310
+#: sequencer.c:2399
 msgid "cancelling a cherry picking in progress"
 msgstr "Abbrechen eines laufenden \"cherry-pick\""
 
-#: sequencer.c:2317
+#: sequencer.c:2408
 msgid "cancelling a revert in progress"
 msgstr "Abbrechen eines laufenden \"revert\""
 
-#: sequencer.c:2361
+#: sequencer.c:2452
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr ""
 "Bitte beheben Sie dieses, indem Sie 'git rebase --edit-todo' ausführen."
 
-#: sequencer.c:2363
+#: sequencer.c:2454
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "Unbenutzbares Instruktionsblatt: '%s'"
 
-#: sequencer.c:2368
+#: sequencer.c:2459
 msgid "no commits parsed."
 msgstr "Keine Commits geparst."
 
-#: sequencer.c:2379
+#: sequencer.c:2470
 msgid "cannot cherry-pick during a revert."
 msgstr "Kann Cherry-Pick nicht während eines Reverts ausführen."
 
-#: sequencer.c:2381
+#: sequencer.c:2472
 msgid "cannot revert during a cherry-pick."
 msgstr "Kann Revert nicht während eines Cherry-Picks ausführen."
 
-#: sequencer.c:2459
+#: sequencer.c:2550
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr "Ungültiger Wert für %s: %s"
 
-#: sequencer.c:2556
+#: sequencer.c:2657
 msgid "unusable squash-onto"
 msgstr "Unbenutzbares squash-onto."
 
-#: sequencer.c:2576
+#: sequencer.c:2677
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "Fehlerhaftes Optionsblatt: '%s'"
 
-#: sequencer.c:2664 sequencer.c:4469
+#: sequencer.c:2769 sequencer.c:4609
 msgid "empty commit set passed"
 msgstr "leere Menge von Commits übergeben"
 
-#: sequencer.c:2680
+#: sequencer.c:2786
 msgid "revert is already in progress"
 msgstr "\"revert\" ist bereits im Gange"
 
-#: sequencer.c:2682
+#: sequencer.c:2788
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr "Versuchen Sie \"git revert (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:2685
+#: sequencer.c:2791
 msgid "cherry-pick is already in progress"
 msgstr "\"cherry-pick\" wird bereits durchgeführt"
 
-#: sequencer.c:2687
+#: sequencer.c:2793
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr "Versuchen Sie \"git cherry-pick (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:2701
+#: sequencer.c:2807
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr "Konnte \"sequencer\"-Verzeichnis '%s' nicht erstellen."
 
-#: sequencer.c:2716
+#: sequencer.c:2822
 msgid "could not lock HEAD"
 msgstr "Konnte HEAD nicht sperren"
 
-#: sequencer.c:2776 sequencer.c:4206
+#: sequencer.c:2882 sequencer.c:4325
 msgid "no cherry-pick or revert in progress"
 msgstr "kein \"cherry-pick\" oder \"revert\" im Gange"
 
-#: sequencer.c:2778 sequencer.c:2789
+#: sequencer.c:2884 sequencer.c:2895
 msgid "cannot resolve HEAD"
 msgstr "kann HEAD nicht auflösen"
 
-#: sequencer.c:2780 sequencer.c:2824
+#: sequencer.c:2886 sequencer.c:2930
 msgid "cannot abort from a branch yet to be born"
 msgstr "kann nicht abbrechen: bin auf einem Branch, der noch nicht geboren ist"
 
-#: sequencer.c:2810 builtin/grep.c:744
+#: sequencer.c:2916 builtin/grep.c:745
 #, c-format
 msgid "cannot open '%s'"
 msgstr "kann '%s' nicht öffnen"
 
-#: sequencer.c:2812
+#: sequencer.c:2918
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "Kann '%s' nicht lesen: %s"
 
-#: sequencer.c:2813
+#: sequencer.c:2919
 msgid "unexpected end of file"
 msgstr "Unerwartetes Dateiende"
 
-#: sequencer.c:2819
+#: sequencer.c:2925
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr "gespeicherte \"pre-cherry-pick\" HEAD Datei '%s' ist beschädigt"
 
-#: sequencer.c:2830
+#: sequencer.c:2936
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr ""
 "Sie scheinen HEAD verändert zu haben. Keine Rückspulung, prüfen Sie HEAD."
 
-#: sequencer.c:2871
+#: sequencer.c:2977
 msgid "no revert in progress"
 msgstr "Kein Revert im Gange"
 
-#: sequencer.c:2879
+#: sequencer.c:2986
 msgid "no cherry-pick in progress"
 msgstr "kein \"cherry-pick\" im Gange"
 
-#: sequencer.c:2889
+#: sequencer.c:2996
 msgid "failed to skip the commit"
 msgstr "Überspringen des Commits fehlgeschlagen"
 
-#: sequencer.c:2896
+#: sequencer.c:3003
 msgid "there is nothing to skip"
 msgstr "Nichts zum Überspringen vorhanden"
 
-#: sequencer.c:2899
+#: sequencer.c:3006
 #, c-format
 msgid ""
 "have you committed already?\n"
@@ -7366,16 +7395,16 @@ msgstr ""
 "Haben Sie bereits committet?\n"
 "Versuchen Sie \"git %s --continue\""
 
-#: sequencer.c:3060 sequencer.c:4098
+#: sequencer.c:3168 sequencer.c:4217
 msgid "cannot read HEAD"
 msgstr "Kann HEAD nicht lesen"
 
-#: sequencer.c:3077
+#: sequencer.c:3185
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "Konnte '%s' nicht nach '%s' kopieren."
 
-#: sequencer.c:3085
+#: sequencer.c:3193
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -7394,27 +7423,27 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:3095
+#: sequencer.c:3203
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "Konnte %s... (%.*s) nicht anwenden"
 
-#: sequencer.c:3102
+#: sequencer.c:3210
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "Konnte \"%.*s\" nicht zusammenführen."
 
-#: sequencer.c:3116 sequencer.c:3120 builtin/difftool.c:641
+#: sequencer.c:3224 sequencer.c:3228 builtin/difftool.c:641
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "Konnte '%s' nicht nach '%s' kopieren."
 
-#: sequencer.c:3132
+#: sequencer.c:3240
 #, c-format
 msgid "Executing: %s\n"
 msgstr "Führe aus: %s\n"
 
-#: sequencer.c:3147
+#: sequencer.c:3255
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -7430,11 +7459,11 @@ msgstr ""
 "\n"
 "ausführen.\n"
 
-#: sequencer.c:3153
+#: sequencer.c:3261
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "Der Index und/oder das Arbeitsverzeichnis wurde geändert.\n"
 
-#: sequencer.c:3159
+#: sequencer.c:3267
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -7452,91 +7481,91 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3220
+#: sequencer.c:3328
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "Unerlaubter Beschriftungsname: '%.*s'"
 
-#: sequencer.c:3274
+#: sequencer.c:3382
 msgid "writing fake root commit"
 msgstr "unechten Root-Commit schreiben"
 
-#: sequencer.c:3279
+#: sequencer.c:3387
 msgid "writing squash-onto"
 msgstr "squash-onto schreiben"
 
-#: sequencer.c:3363
+#: sequencer.c:3471
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "Konnte '%s' nicht auflösen."
 
-#: sequencer.c:3394
+#: sequencer.c:3502
 msgid "cannot merge without a current revision"
 msgstr "Kann nicht ohne einen aktuellen Commit mergen."
 
-#: sequencer.c:3416
+#: sequencer.c:3524
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "Konnte '%.*s' nicht parsen."
 
-#: sequencer.c:3425
+#: sequencer.c:3533
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "Nichts zum Zusammenführen: '%.*s'"
 
-#: sequencer.c:3437
+#: sequencer.c:3545
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr ""
 "Oktopus-Merge kann nicht auf Basis von [neuem Root-Commit] ausgeführt werden."
 
-#: sequencer.c:3453
+#: sequencer.c:3561
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "Konnte keine Commit-Beschreibung von '%s' bekommen."
 
-#: sequencer.c:3613
+#: sequencer.c:3730
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "Konnte nicht einmal versuchen '%.*s' zu mergen."
 
-#: sequencer.c:3629
+#: sequencer.c:3746
 msgid "merge: Unable to write new index file"
 msgstr "merge: Konnte neue Index-Datei nicht schreiben."
 
-#: sequencer.c:3703
+#: sequencer.c:3820
 msgid "Cannot autostash"
 msgstr "Kann automatischen Stash nicht erzeugen."
 
-#: sequencer.c:3706
+#: sequencer.c:3823
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Unerwartete 'stash'-Antwort: '%s'"
 
-#: sequencer.c:3712
+#: sequencer.c:3829
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "Konnte Verzeichnis für '%s' nicht erstellen."
 
-#: sequencer.c:3715
+#: sequencer.c:3832
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "Automatischen Stash erzeugt: %s\n"
 
-#: sequencer.c:3719
+#: sequencer.c:3836
 msgid "could not reset --hard"
 msgstr "Konnte 'reset --hard' nicht ausführen."
 
-#: sequencer.c:3744
+#: sequencer.c:3861
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "Automatischen Stash angewendet.\n"
 
-#: sequencer.c:3756
+#: sequencer.c:3873
 #, c-format
 msgid "cannot store %s"
 msgstr "kann %s nicht speichern"
 
-#: sequencer.c:3759
+#: sequencer.c:3876
 #, c-format
 msgid ""
 "%s\n"
@@ -7547,34 +7576,34 @@ msgstr ""
 "Ihre Änderungen sind im Stash sicher.\n"
 "Sie können jederzeit \"git stash pop\" oder \"git stash drop\" ausführen.\n"
 
-#: sequencer.c:3764
+#: sequencer.c:3881
 msgid "Applying autostash resulted in conflicts."
 msgstr "Beim Anwenden des automatischen Stash traten Konflikte auf."
 
-#: sequencer.c:3765
+#: sequencer.c:3882
 msgid "Autostash exists; creating a new stash entry."
 msgstr "Automatischer Stash existiert; ein neuer Stash-Eintrag wird erstellt."
 
-#: sequencer.c:3857
+#: sequencer.c:3974
 #, c-format
 msgid "%s: not a valid OID"
 msgstr "%s: keine gültige OID"
 
-#: sequencer.c:3862 git-rebase--preserve-merges.sh:779
+#: sequencer.c:3979 git-rebase--preserve-merges.sh:769
 msgid "could not detach HEAD"
 msgstr "Konnte HEAD nicht loslösen"
 
-#: sequencer.c:3877
+#: sequencer.c:3994
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Angehalten bei HEAD\n"
 
-#: sequencer.c:3879
+#: sequencer.c:3996
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Angehalten bei %s\n"
 
-#: sequencer.c:3887
+#: sequencer.c:4004
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -7596,60 +7625,60 @@ msgstr ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:3931
+#: sequencer.c:4050
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr "Rebase (%d/%d)%s"
 
-#: sequencer.c:3976
+#: sequencer.c:4095
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Angehalten bei %s... %.*s\n"
 
-#: sequencer.c:4047
+#: sequencer.c:4166
 #, c-format
 msgid "unknown command %d"
 msgstr "Unbekannter Befehl %d"
 
-#: sequencer.c:4106
+#: sequencer.c:4225
 msgid "could not read orig-head"
 msgstr "Konnte orig-head nicht lesen."
 
-#: sequencer.c:4111
+#: sequencer.c:4230
 msgid "could not read 'onto'"
 msgstr "Konnte 'onto' nicht lesen."
 
-#: sequencer.c:4125
+#: sequencer.c:4244
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "Konnte HEAD nicht auf %s aktualisieren."
 
-#: sequencer.c:4185
+#: sequencer.c:4304
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr "Erfolgreich Rebase ausgeführt und %s aktualisiert.\n"
 
-#: sequencer.c:4218
+#: sequencer.c:4337
 msgid "cannot rebase: You have unstaged changes."
 msgstr ""
 "Rebase nicht möglich: Sie haben Änderungen, die nicht zum Commit\n"
 "vorgemerkt sind."
 
-#: sequencer.c:4227
+#: sequencer.c:4346
 msgid "cannot amend non-existing commit"
 msgstr "Kann nicht existierenden Commit nicht nachbessern."
 
-#: sequencer.c:4229
+#: sequencer.c:4348
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "Ungültige Datei: '%s'"
 
-#: sequencer.c:4231
+#: sequencer.c:4350
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "Ungültige Inhalte: '%s'"
 
-#: sequencer.c:4234
+#: sequencer.c:4353
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -7660,50 +7689,55 @@ msgstr ""
 "committen Sie diese zuerst und führen Sie dann 'git rebase --continue'\n"
 "erneut aus."
 
-#: sequencer.c:4270 sequencer.c:4309
+#: sequencer.c:4389 sequencer.c:4428
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "Konnte Datei nicht schreiben: '%s'"
 
-#: sequencer.c:4324
+#: sequencer.c:4444
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "Konnte CHERRY_PICK_HEAD nicht löschen."
 
-#: sequencer.c:4331
+#: sequencer.c:4451
 msgid "could not commit staged changes."
 msgstr "Konnte Änderungen aus der Staging-Area nicht committen."
 
-#: sequencer.c:4446
+#: sequencer.c:4477
+#, fuzzy, c-format
+msgid "invalid committer '%s'"
+msgstr "Ungültiger Commit %s"
+
+#: sequencer.c:4586
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: %s kann nicht in \"cherry-pick\" benutzt werden"
 
-#: sequencer.c:4450
+#: sequencer.c:4590
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: ungültiger Commit"
 
-#: sequencer.c:4485
+#: sequencer.c:4625
 msgid "can't revert as initial commit"
 msgstr "Kann nicht als allerersten Commit einen Revert ausführen."
 
-#: sequencer.c:4962
+#: sequencer.c:5102
 msgid "make_script: unhandled options"
 msgstr "make_script: unbehandelte Optionen"
 
-#: sequencer.c:4965
+#: sequencer.c:5105
 msgid "make_script: error preparing revisions"
 msgstr "make_script: Fehler beim Vorbereiten der Commits"
 
-#: sequencer.c:5206 sequencer.c:5223
+#: sequencer.c:5347 sequencer.c:5364
 msgid "nothing to do"
 msgstr "Nichts zu tun."
 
-#: sequencer.c:5242
+#: sequencer.c:5383
 msgid "could not skip unnecessary pick commands"
 msgstr "Konnte unnötige \"pick\"-Befehle nicht auslassen."
 
-#: sequencer.c:5336
+#: sequencer.c:5480
 msgid "the script was already rearranged."
 msgstr "Das Script wurde bereits umgeordnet."
 
@@ -7760,84 +7794,89 @@ msgstr ""
 msgid "this operation must be run in a work tree"
 msgstr "Diese Operation muss in einem Arbeitsverzeichnis ausgeführt werden."
 
-#: setup.c:604
+#: setup.c:661
 #, c-format
 msgid "Expected git repo version <= %d, found %d"
 msgstr "Erwartete Git-Repository-Version <= %d, %d gefunden"
 
-#: setup.c:612
+#: setup.c:669
 msgid "unknown repository extensions found:"
 msgstr "Unbekannte Repository-Erweiterungen gefunden:"
 
-#: setup.c:631
+#: setup.c:681
+#, fuzzy
+msgid "repo version is 0, but v1-only extensions found:"
+msgstr "Unbekannte Repository-Erweiterungen gefunden:"
+
+#: setup.c:700
 #, c-format
 msgid "error opening '%s'"
 msgstr "Fehler beim Öffnen von '%s'."
 
-#: setup.c:633
+#: setup.c:702
 #, c-format
 msgid "too large to be a .git file: '%s'"
 msgstr "Zu groß, um eine .git-Datei zu sein: '%s'"
 
-#: setup.c:635
+#: setup.c:704
 #, c-format
 msgid "error reading %s"
 msgstr "Fehler beim Lesen von '%s'."
 
-#: setup.c:637
+#: setup.c:706
 #, c-format
 msgid "invalid gitfile format: %s"
 msgstr "Ungültiges gitfile-Format: %s"
 
-#: setup.c:639
+#: setup.c:708
 #, c-format
 msgid "no path in gitfile: %s"
 msgstr "Kein Pfad in gitfile: %s"
 
-#: setup.c:641
+#: setup.c:710
 #, c-format
 msgid "not a git repository: %s"
 msgstr "Kein Git-Repository: %s"
 
-#: setup.c:743
+#: setup.c:812
 #, c-format
 msgid "'$%s' too big"
 msgstr "'$%s' zu groß"
 
-#: setup.c:757
+#: setup.c:826
 #, c-format
 msgid "not a git repository: '%s'"
 msgstr "Kein Git-Repository: '%s'"
 
-#: setup.c:786 setup.c:788 setup.c:819
+#: setup.c:855 setup.c:857 setup.c:888
 #, c-format
 msgid "cannot chdir to '%s'"
 msgstr "Kann nicht in Verzeichnis '%s' wechseln."
 
-#: setup.c:791 setup.c:847 setup.c:857 setup.c:896 setup.c:904
+#: setup.c:860 setup.c:916 setup.c:926 setup.c:965 setup.c:973
 msgid "cannot come back to cwd"
 msgstr "Kann nicht zum aktuellen Arbeitsverzeichnis zurückwechseln."
 
-#: setup.c:918
+#: setup.c:987
 #, c-format
 msgid "failed to stat '%*s%s%s'"
 msgstr "Konnte '%*s%s%s' nicht lesen."
 
-#: setup.c:1156
+#: setup.c:1225
 msgid "Unable to read current working directory"
 msgstr "Konnte aktuelles Arbeitsverzeichnis nicht lesen."
 
-#: setup.c:1165 setup.c:1171
+#: setup.c:1234 setup.c:1240
 #, c-format
 msgid "cannot change to '%s'"
 msgstr "Kann nicht nach '%s' wechseln."
 
-#: setup.c:1176
+#: setup.c:1245
 #, c-format
 msgid "not a git repository (or any of the parent directories): %s"
 msgstr "Kein Git-Repository (oder irgendeines der Elternverzeichnisse): %s"
 
-#: setup.c:1182
+#: setup.c:1251
 #, c-format
 msgid ""
 "not a git repository (or any parent up to mount point %s)\n"
@@ -7847,7 +7886,7 @@ msgstr ""
 "%s)\n"
 "Stoppe bei Dateisystemgrenze (GIT_DISCOVERY_ACROSS_FILESYSTEM nicht gesetzt)."
 
-#: setup.c:1293
+#: setup.c:1362
 #, c-format
 msgid ""
 "problem with core.sharedRepository filemode value (0%.3o).\n"
@@ -7856,15 +7895,15 @@ msgstr ""
 "Problem mit Wert für Dateimodus (0%.3o) von core.sharedRepository.\n"
 "Der Besitzer der Dateien muss immer Lese- und Schreibrechte haben."
 
-#: setup.c:1340
+#: setup.c:1409
 msgid "open /dev/null or dup failed"
 msgstr "Öffnen von /dev/null oder dup fehlgeschlagen."
 
-#: setup.c:1355
+#: setup.c:1424
 msgid "fork failed"
 msgstr "fork fehlgeschlagen"
 
-#: setup.c:1360
+#: setup.c:1429
 msgid "setsid failed"
 msgstr "setsid fehlgeschlagen"
 
@@ -7950,12 +7989,12 @@ msgstr "mmap fehlgeschlagen"
 msgid "object file %s is empty"
 msgstr "Objektdatei %s ist leer."
 
-#: sha1-file.c:1274 sha1-file.c:2454
+#: sha1-file.c:1274 sha1-file.c:2467
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr "Fehlerhaftes loses Objekt '%s'."
 
-#: sha1-file.c:1276 sha1-file.c:2458
+#: sha1-file.c:1276 sha1-file.c:2471
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr "Nutzlose Daten am Ende von losem Objekt '%s'."
@@ -7984,148 +8023,148 @@ msgstr "Konnte %s Kopfbereich mit --allow-unknown-type nicht parsen."
 msgid "unable to parse %s header"
 msgstr "Konnte %s Kopfbereich nicht parsen."
 
-#: sha1-file.c:1640
+#: sha1-file.c:1641
 #, c-format
 msgid "failed to read object %s"
 msgstr "Konnte Objekt %s nicht lesen."
 
-#: sha1-file.c:1644
+#: sha1-file.c:1645
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr "Ersetzung %s für %s nicht gefunden."
 
-#: sha1-file.c:1648
+#: sha1-file.c:1649
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr "Loses Objekt %s (gespeichert in %s) ist beschädigt."
 
-#: sha1-file.c:1652
+#: sha1-file.c:1653
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr "Gepacktes Objekt %s (gespeichert in %s) ist beschädigt."
 
-#: sha1-file.c:1757
+#: sha1-file.c:1758
 #, c-format
 msgid "unable to write file %s"
 msgstr "Konnte Datei %s nicht schreiben."
 
-#: sha1-file.c:1764
+#: sha1-file.c:1765
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr "Konnte Zugriffsberechtigung auf '%s' nicht setzen."
 
-#: sha1-file.c:1771
+#: sha1-file.c:1772
 msgid "file write error"
 msgstr "Fehler beim Schreiben einer Datei."
 
-#: sha1-file.c:1791
+#: sha1-file.c:1792
 msgid "error when closing loose object file"
 msgstr "Fehler beim Schließen der Datei für lose Objekte."
 
-#: sha1-file.c:1856
+#: sha1-file.c:1857
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 "Unzureichende Berechtigung zum Hinzufügen eines Objektes zur Repository-"
 "Datenbank %s"
 
-#: sha1-file.c:1858
+#: sha1-file.c:1859
 msgid "unable to create temporary file"
 msgstr "Konnte temporäre Datei nicht erstellen."
 
-#: sha1-file.c:1882
+#: sha1-file.c:1883
 msgid "unable to write loose object file"
 msgstr "Fehler beim Schreiben der Datei für lose Objekte."
 
-#: sha1-file.c:1888
+#: sha1-file.c:1889
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr "Konnte neues Objekt %s (%d) nicht komprimieren."
 
-#: sha1-file.c:1892
+#: sha1-file.c:1893
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr "deflateEnd auf Objekt %s fehlgeschlagen (%d)"
 
-#: sha1-file.c:1896
+#: sha1-file.c:1897
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr "Fehler wegen instabilen Objektquelldaten für %s"
 
-#: sha1-file.c:1906 builtin/pack-objects.c:1085
+#: sha1-file.c:1907 builtin/pack-objects.c:1086
 #, c-format
 msgid "failed utime() on %s"
 msgstr "Fehler beim Aufruf von utime() auf '%s'."
 
-#: sha1-file.c:1983
+#: sha1-file.c:1984
 #, c-format
 msgid "cannot read object for %s"
 msgstr "Kann Objekt für %s nicht lesen."
 
-#: sha1-file.c:2022
+#: sha1-file.c:2035
 msgid "corrupt commit"
 msgstr "fehlerhafter Commit"
 
-#: sha1-file.c:2030
+#: sha1-file.c:2043
 msgid "corrupt tag"
 msgstr "fehlerhaftes Tag"
 
-#: sha1-file.c:2130
+#: sha1-file.c:2143
 #, c-format
 msgid "read error while indexing %s"
 msgstr "Lesefehler beim Indizieren von '%s'."
 
-#: sha1-file.c:2133
+#: sha1-file.c:2146
 #, c-format
 msgid "short read while indexing %s"
 msgstr "read() zu kurz beim Indizieren von '%s'."
 
-#: sha1-file.c:2206 sha1-file.c:2216
+#: sha1-file.c:2219 sha1-file.c:2229
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr "%s: Fehler beim Einfügen in die Datenbank"
 
-#: sha1-file.c:2222
+#: sha1-file.c:2235
 #, c-format
 msgid "%s: unsupported file type"
 msgstr "%s: nicht unterstützte Dateiart"
 
-#: sha1-file.c:2246
+#: sha1-file.c:2259
 #, c-format
 msgid "%s is not a valid object"
 msgstr "%s ist kein gültiges Objekt"
 
-#: sha1-file.c:2248
+#: sha1-file.c:2261
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr "%s ist kein gültiges '%s' Objekt"
 
-#: sha1-file.c:2275 builtin/index-pack.c:155
+#: sha1-file.c:2288 builtin/index-pack.c:192
 #, c-format
 msgid "unable to open %s"
 msgstr "kann %s nicht öffnen"
 
-#: sha1-file.c:2465 sha1-file.c:2518
+#: sha1-file.c:2478 sha1-file.c:2531
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
 msgstr "Hash für %s stimmt nicht überein (%s erwartet)."
 
-#: sha1-file.c:2489
+#: sha1-file.c:2502
 #, c-format
 msgid "unable to mmap %s"
 msgstr "Konnte mmap nicht auf %s ausführen."
 
-#: sha1-file.c:2494
+#: sha1-file.c:2507
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr "Konnte Kopfbereich von %s nicht entpacken."
 
-#: sha1-file.c:2500
+#: sha1-file.c:2513
 #, c-format
 msgid "unable to parse header of %s"
 msgstr "Konnte Kopfbereich von %s nicht parsen."
 
-#: sha1-file.c:2511
+#: sha1-file.c:2524
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr "Konnte Inhalt von %s nicht entpacken."
@@ -8174,12 +8213,12 @@ msgstr "Log für '%.*s' geht nur bis %s zurück"
 msgid "log for '%.*s' only has %d entries"
 msgstr "Log für '%.*s' hat nur %d Einträge"
 
-#: sha1-name.c:1689
+#: sha1-name.c:1702
 #, c-format
 msgid "path '%s' exists on disk, but not in '%.*s'"
 msgstr "Pfad '%s' befindet sich im Dateisystem, aber nicht in '%.*s'"
 
-#: sha1-name.c:1695
+#: sha1-name.c:1708
 #, c-format
 msgid ""
 "path '%s' exists, but not '%s'\n"
@@ -8188,12 +8227,12 @@ msgstr ""
 "Pfad '%s' existiert, aber nicht '%s'\n"
 "Hinweis: Meinten Sie '%.*s:%s' auch bekannt als '%.*s:./%s'?"
 
-#: sha1-name.c:1704
+#: sha1-name.c:1717
 #, c-format
 msgid "path '%s' does not exist in '%.*s'"
 msgstr "Pfad '%s' existiert nicht in '%.*s'"
 
-#: sha1-name.c:1732
+#: sha1-name.c:1745
 #, c-format
 msgid ""
 "path '%s' is in the index, but not at stage %d\n"
@@ -8202,7 +8241,7 @@ msgstr ""
 "Pfad '%s' ist im Index, aber nicht in Stufe %d\n"
 "Hinweis: Meinten Sie ':%d:%s'?"
 
-#: sha1-name.c:1748
+#: sha1-name.c:1761
 #, c-format
 msgid ""
 "path '%s' is in the index, but not '%s'\n"
@@ -8211,23 +8250,23 @@ msgstr ""
 "Pfad '%s' ist im Index, aber nicht '%s'\n"
 "Hinweis: Meinten Sie ':%d:%s' auch bekannt als ':%d:./%s'?"
 
-#: sha1-name.c:1756
+#: sha1-name.c:1769
 #, c-format
 msgid "path '%s' exists on disk, but not in the index"
 msgstr "Pfad '%s' existiert im Dateisystem, aber nicht im Index"
 
-#: sha1-name.c:1758
+#: sha1-name.c:1771
 #, c-format
 msgid "path '%s' does not exist (neither on disk nor in the index)"
 msgstr "Pfad '%s' existiert nicht (weder im Dateisystem noch im Index)"
 
-#: sha1-name.c:1771
+#: sha1-name.c:1784
 msgid "relative path syntax can't be used outside working tree"
 msgstr ""
 "Die Syntax für relative Pfade kann nicht außerhalb des Arbeitsverzeichnisses "
 "benutzt werden."
 
-#: sha1-name.c:1909
+#: sha1-name.c:1922
 #, c-format
 msgid "invalid object name '%.*s'."
 msgstr "ungültiger Objektname '%.*s'."
@@ -8283,6 +8322,12 @@ msgid "%u byte/s"
 msgid_plural "%u bytes/s"
 msgstr[0] "%u Byte/s"
 msgstr[1] "%u Bytes/s"
+
+#: strbuf.c:1166 wrapper.c:199 wrapper.c:369 builtin/am.c:733
+#: builtin/rebase.c:858
+#, c-format
+msgid "could not open '%s' for writing"
+msgstr "Konnte '%s' nicht zum Schreiben öffnen."
 
 #: strbuf.c:1175
 #, c-format
@@ -8350,7 +8395,7 @@ msgstr "Pfadspezifikation '%s' befindet sich in Submodul '%.*s'"
 msgid "bad --ignore-submodules argument: %s"
 msgstr "ungültiges --ignore-submodules Argument: %s"
 
-#: submodule.c:815
+#: submodule.c:816
 #, c-format
 msgid ""
 "Submodule in commit %s at path: '%s' collides with a submodule named the "
@@ -8359,12 +8404,12 @@ msgstr ""
 "Submodul in Commit %s beim Pfad: '%s' hat den gleichen Namen wie ein "
 "Submodul. Wird übersprungen."
 
-#: submodule.c:910
+#: submodule.c:919
 #, c-format
 msgid "submodule entry '%s' (%s) is a %s, not a commit"
 msgstr "Submodul-Eintrag '%s' (%s) ist ein %s, kein Commit."
 
-#: submodule.c:995
+#: submodule.c:1004
 #, c-format
 msgid ""
 "Could not run 'git rev-list <commits> --not --remotes -n 1' command in "
@@ -8373,36 +8418,36 @@ msgstr ""
 "Konnte 'git rev-list <Commits> --not --remotes -n 1' nicht in Submodul '%s' "
 "ausführen."
 
-#: submodule.c:1118
+#: submodule.c:1127
 #, c-format
 msgid "process for submodule '%s' failed"
 msgstr "Prozess für Submodul '%s' fehlgeschlagen"
 
-#: submodule.c:1147 builtin/branch.c:678 builtin/submodule--helper.c:2045
+#: submodule.c:1156 builtin/branch.c:678 builtin/submodule--helper.c:2469
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "Konnte HEAD nicht als gültige Referenz auflösen."
 
-#: submodule.c:1158
+#: submodule.c:1167
 #, c-format
 msgid "Pushing submodule '%s'\n"
 msgstr "Pushe Submodul '%s'\n"
 
-#: submodule.c:1161
+#: submodule.c:1170
 #, c-format
 msgid "Unable to push submodule '%s'\n"
 msgstr "Kann Push für Submodul '%s' nicht ausführen\n"
 
-#: submodule.c:1453
+#: submodule.c:1462
 #, c-format
 msgid "Fetching submodule %s%s\n"
 msgstr "Anfordern des Submoduls %s%s\n"
 
-#: submodule.c:1483
+#: submodule.c:1492
 #, c-format
 msgid "Could not access submodule '%s'\n"
 msgstr "Konnte nicht auf Submodul '%s' zugreifen\n"
 
-#: submodule.c:1637
+#: submodule.c:1646
 #, c-format
 msgid ""
 "Errors during submodule fetch:\n"
@@ -8411,62 +8456,62 @@ msgstr ""
 "Fehler während des Anforderns der Submodule:\n"
 "%s"
 
-#: submodule.c:1662
+#: submodule.c:1671
 #, c-format
 msgid "'%s' not recognized as a git repository"
 msgstr "'%s' nicht als Git-Repository erkannt"
 
-#: submodule.c:1679
+#: submodule.c:1688
 #, c-format
 msgid "Could not run 'git status --porcelain=2' in submodule %s"
 msgstr "Konnte 'git status --porcelain=2' nicht in Submodul %s ausführen"
 
-#: submodule.c:1720
+#: submodule.c:1729
 #, c-format
 msgid "'git status --porcelain=2' failed in submodule %s"
 msgstr "'git status --porcelain=2' ist in Submodul %s fehlgeschlagen"
 
-#: submodule.c:1800
+#: submodule.c:1804
 #, c-format
 msgid "could not start 'git status' in submodule '%s'"
 msgstr "Konnte 'git status' in Submodul '%s' nicht starten."
 
-#: submodule.c:1813
+#: submodule.c:1817
 #, c-format
 msgid "could not run 'git status' in submodule '%s'"
 msgstr "Konnte 'git status' in Submodul '%s' nicht ausführen."
 
-#: submodule.c:1828
+#: submodule.c:1832
 #, c-format
 msgid "Could not unset core.worktree setting in submodule '%s'"
 msgstr "Konnte core.worktree Einstellung in Submodul '%s' nicht aufheben."
 
-#: submodule.c:1855 submodule.c:2165
+#: submodule.c:1859 submodule.c:2169
 #, c-format
 msgid "could not recurse into submodule '%s'"
 msgstr "Fehler bei Rekursion in Submodul-Pfad '%s'"
 
-#: submodule.c:1876
+#: submodule.c:1880
 msgid "could not reset submodule index"
 msgstr "konnte Index des Submoduls nicht zurücksetzen"
 
-#: submodule.c:1918
+#: submodule.c:1922
 #, c-format
 msgid "submodule '%s' has dirty index"
 msgstr "Submodul '%s' hat einen geänderten Index."
 
-#: submodule.c:1970
+#: submodule.c:1974
 #, c-format
 msgid "Submodule '%s' could not be updated."
 msgstr "Submodule '%s' konnte nicht aktualisiert werden."
 
-#: submodule.c:2038
+#: submodule.c:2042
 #, c-format
 msgid "submodule git dir '%s' is inside git dir '%.*s'"
 msgstr ""
 "Git-Verzeichnis des Submoduls '%s' ist im Git-Verzeichnis '%.*s' enthalten."
 
-#: submodule.c:2059
+#: submodule.c:2063
 #, c-format
 msgid ""
 "relocate_gitdir for submodule '%s' with more than one worktree not supported"
@@ -8474,17 +8519,17 @@ msgstr ""
 "relocate_gitdir für Submodul '%s' mit mehr als einem Arbeitsverzeichnis\n"
 "wird nicht unterstützt"
 
-#: submodule.c:2071 submodule.c:2130
+#: submodule.c:2075 submodule.c:2134
 #, c-format
 msgid "could not lookup name for submodule '%s'"
 msgstr "Konnte Name für Submodul '%s' nicht nachschlagen."
 
-#: submodule.c:2075
+#: submodule.c:2079
 #, c-format
 msgid "refusing to move '%s' into an existing git dir"
 msgstr "Verschieben von '%s' in ein existierendes Git-Verzeichnis verweigert."
 
-#: submodule.c:2082
+#: submodule.c:2086
 #, c-format
 msgid ""
 "Migrating git directory of '%s%s' from\n"
@@ -8495,65 +8540,65 @@ msgstr ""
 "'%s' nach\n"
 "'%s'\n"
 
-#: submodule.c:2210
+#: submodule.c:2214
 msgid "could not start ls-files in .."
 msgstr "Konnte 'ls-files' nicht in .. starten"
 
-#: submodule.c:2250
+#: submodule.c:2254
 #, c-format
 msgid "ls-tree returned unexpected return code %d"
 msgstr "ls-tree mit unerwartetem Rückgabewert %d beendet"
 
-#: trailer.c:238
+#: trailer.c:236
 #, c-format
 msgid "running trailer command '%s' failed"
 msgstr "Ausführen des Anhang-Befehls '%s' fehlgeschlagen"
 
-#: trailer.c:485 trailer.c:490 trailer.c:495 trailer.c:549 trailer.c:553
-#: trailer.c:557
+#: trailer.c:483 trailer.c:488 trailer.c:493 trailer.c:547 trailer.c:551
+#: trailer.c:555
 #, c-format
 msgid "unknown value '%s' for key '%s'"
 msgstr "unbekannter Wert '%s' für Schlüssel %s"
 
-#: trailer.c:539 trailer.c:544 builtin/remote.c:298 builtin/remote.c:323
+#: trailer.c:537 trailer.c:542 builtin/remote.c:298 builtin/remote.c:323
 #, c-format
 msgid "more than one %s"
 msgstr "mehr als ein %s"
 
-#: trailer.c:730
+#: trailer.c:728
 #, c-format
 msgid "empty trailer token in trailer '%.*s'"
 msgstr "leerer Anhang-Token in Anhang '%.*s'"
 
-#: trailer.c:750
+#: trailer.c:748
 #, c-format
 msgid "could not read input file '%s'"
 msgstr "Konnte Eingabe-Datei '%s' nicht lesen"
 
-#: trailer.c:753
+#: trailer.c:751
 msgid "could not read from stdin"
 msgstr "konnte nicht von der Standard-Eingabe lesen"
 
-#: trailer.c:1011 wrapper.c:673
+#: trailer.c:1009 wrapper.c:676
 #, c-format
 msgid "could not stat %s"
 msgstr "Konnte '%s' nicht lesen"
 
-#: trailer.c:1013
+#: trailer.c:1011
 #, c-format
 msgid "file %s is not a regular file"
 msgstr "Datei '%s' ist keine reguläre Datei"
 
-#: trailer.c:1015
+#: trailer.c:1013
 #, c-format
 msgid "file %s is not writable by user"
 msgstr "Datei %s ist vom Benutzer nicht beschreibbar."
 
-#: trailer.c:1027
+#: trailer.c:1025
 msgid "could not open temporary file"
 msgstr "konnte temporäre Datei '%s' nicht öffnen"
 
-#: trailer.c:1067
+#: trailer.c:1065
 #, c-format
 msgid "could not rename temporary file to %s"
 msgstr "konnte temporäre Datei nicht zu %s umbenennen"
@@ -8604,7 +8649,7 @@ msgstr "Konnte \"fast-import\" nicht ausführen."
 msgid "error while running fast-import"
 msgstr "Fehler beim Ausführen von 'fast-import'."
 
-#: transport-helper.c:549 transport-helper.c:1156
+#: transport-helper.c:549 transport-helper.c:1226
 #, c-format
 msgid "could not read ref %s"
 msgstr "Konnte Referenz %s nicht lesen."
@@ -8623,7 +8668,7 @@ msgstr ""
 msgid "invalid remote service path"
 msgstr "Ungültiger Remote-Service Pfad."
 
-#: transport-helper.c:661 transport.c:1347
+#: transport-helper.c:661 transport.c:1428
 msgid "operation not supported by protocol"
 msgstr "Die Operation wird von dem Protokoll nicht unterstützt."
 
@@ -8632,59 +8677,63 @@ msgstr "Die Operation wird von dem Protokoll nicht unterstützt."
 msgid "can't connect to subservice %s"
 msgstr "Kann keine Verbindung zu Subservice %s herstellen."
 
-#: transport-helper.c:740
+#: transport-helper.c:745
+msgid "'option' without a matching 'ok/error' directive"
+msgstr ""
+
+#: transport-helper.c:788
 #, c-format
 msgid "expected ok/error, helper said '%s'"
 msgstr "Erwartete ok/error, Remote-Helper gab '%s' aus."
 
-#: transport-helper.c:793
+#: transport-helper.c:841
 #, c-format
 msgid "helper reported unexpected status of %s"
 msgstr "Remote-Helper meldete unerwarteten Status von %s."
 
-#: transport-helper.c:854
+#: transport-helper.c:924
 #, c-format
 msgid "helper %s does not support dry-run"
 msgstr "Remote-Helper %s unterstützt kein Trockenlauf."
 
-#: transport-helper.c:857
+#: transport-helper.c:927
 #, c-format
 msgid "helper %s does not support --signed"
 msgstr "Remote-Helper %s unterstützt kein --signed."
 
-#: transport-helper.c:860
+#: transport-helper.c:930
 #, c-format
 msgid "helper %s does not support --signed=if-asked"
 msgstr "Remote-Helper %s unterstützt kein --signed=if-asked."
 
-#: transport-helper.c:865
+#: transport-helper.c:935
 #, c-format
 msgid "helper %s does not support --atomic"
 msgstr "Remote-Helper %s unterstützt kein --atomic."
 
-#: transport-helper.c:871
+#: transport-helper.c:941
 #, c-format
 msgid "helper %s does not support 'push-option'"
 msgstr "Remote-Helper %s unterstützt nicht 'push-option'."
 
-#: transport-helper.c:970
+#: transport-helper.c:1040
 msgid "remote-helper doesn't support push; refspec needed"
 msgstr "Remote-Helper unterstützt kein Push; Refspec benötigt"
 
-#: transport-helper.c:975
+#: transport-helper.c:1045
 #, c-format
 msgid "helper %s does not support 'force'"
 msgstr "Remote-Helper %s unterstützt kein 'force'."
 
-#: transport-helper.c:1022
+#: transport-helper.c:1092
 msgid "couldn't run fast-export"
 msgstr "Konnte \"fast-export\" nicht ausführen."
 
-#: transport-helper.c:1027
+#: transport-helper.c:1097
 msgid "error while running fast-export"
 msgstr "Fehler beim Ausführen von \"fast-export\"."
 
-#: transport-helper.c:1052
+#: transport-helper.c:1122
 #, c-format
 msgid ""
 "No refs in common and none specified; doing nothing.\n"
@@ -8693,52 +8742,52 @@ msgstr ""
 "Keine gemeinsamen Referenzen und nichts spezifiziert; keine Ausführung.\n"
 "Vielleicht sollten Sie einen Branch angeben.\n"
 
-#: transport-helper.c:1133
+#: transport-helper.c:1203
 #, c-format
 msgid "unsupported object format '%s'"
 msgstr "nicht unterstütztes Objekt-Format '%s'"
 
-#: transport-helper.c:1142
+#: transport-helper.c:1212
 #, c-format
 msgid "malformed response in ref list: %s"
 msgstr "Ungültige Antwort in Referenzliste: %s"
 
-#: transport-helper.c:1294
+#: transport-helper.c:1364
 #, c-format
 msgid "read(%s) failed"
 msgstr "Lesen von %s fehlgeschlagen."
 
-#: transport-helper.c:1321
+#: transport-helper.c:1391
 #, c-format
 msgid "write(%s) failed"
 msgstr "Schreiben von %s fehlgeschlagen."
 
-#: transport-helper.c:1370
+#: transport-helper.c:1440
 #, c-format
 msgid "%s thread failed"
 msgstr "Thread %s fehlgeschlagen."
 
-#: transport-helper.c:1374
+#: transport-helper.c:1444
 #, c-format
 msgid "%s thread failed to join: %s"
 msgstr "Fehler beim Beitreten zu Thread %s: %s"
 
-#: transport-helper.c:1393 transport-helper.c:1397
+#: transport-helper.c:1463 transport-helper.c:1467
 #, c-format
 msgid "can't start thread for copying data: %s"
 msgstr "Kann Thread zum Kopieren von Daten nicht starten: %s"
 
-#: transport-helper.c:1434
+#: transport-helper.c:1504
 #, c-format
 msgid "%s process failed to wait"
 msgstr "Fehler beim Warten von Prozess %s."
 
-#: transport-helper.c:1438
+#: transport-helper.c:1508
 #, c-format
 msgid "%s process failed"
 msgstr "Prozess %s fehlgeschlagen"
 
-#: transport-helper.c:1456 transport-helper.c:1465
+#: transport-helper.c:1526 transport-helper.c:1535
 msgid "can't start thread for copying data"
 msgstr "Kann Thread zum Kopieren von Daten nicht starten."
 
@@ -8757,37 +8806,37 @@ msgstr "Konnte Paket '%s' nicht lesen."
 msgid "transport: invalid depth option '%s'"
 msgstr "transport: ungültige --depth Option '%s'"
 
-#: transport.c:272
+#: transport.c:269
 msgid "see protocol.version in 'git help config' for more details"
 msgstr "Siehe protocol.version in 'git help config' für weitere Informationen"
 
-#: transport.c:273
+#: transport.c:270
 msgid "server options require protocol version 2 or later"
 msgstr "Server-Optionen benötigen Protokoll-Version 2 oder höher"
 
-#: transport.c:631
+#: transport.c:712
 msgid "could not parse transport.color.* config"
 msgstr "Konnte transport.color.* Konfiguration nicht parsen."
 
-#: transport.c:704
+#: transport.c:785
 msgid "support for protocol v2 not implemented yet"
 msgstr "Unterstützung für Protokoll v2 noch nicht implementiert."
 
-#: transport.c:838
+#: transport.c:919
 #, c-format
 msgid "unknown value for config '%s': %s"
 msgstr "Unbekannter Wert für Konfiguration '%s': %s"
 
-#: transport.c:904
+#: transport.c:985
 #, c-format
 msgid "transport '%s' not allowed"
 msgstr "Übertragungsart '%s' nicht erlaubt."
 
-#: transport.c:957
+#: transport.c:1038
 msgid "git-over-rsync is no longer supported"
 msgstr "git-over-rsync wird nicht länger unterstützt."
 
-#: transport.c:1059
+#: transport.c:1140
 #, c-format
 msgid ""
 "The following submodule paths contain changes that can\n"
@@ -8796,7 +8845,7 @@ msgstr ""
 "Die folgenden Submodul-Pfade enthalten Änderungen, die in keinem\n"
 "Remote-Repository gefunden wurden:\n"
 
-#: transport.c:1063
+#: transport.c:1144
 #, c-format
 msgid ""
 "\n"
@@ -8823,11 +8872,11 @@ msgstr ""
 "zum Versenden zu einem Remote-Repository.\n"
 "\n"
 
-#: transport.c:1071
+#: transport.c:1152
 msgid "Aborting."
 msgstr "Abbruch."
 
-#: transport.c:1216
+#: transport.c:1297
 msgid "failed to push all needed submodules"
 msgstr "Fehler beim Versand aller erforderlichen Submodule."
 
@@ -9121,7 +9170,7 @@ msgstr ""
 msgid "Updating index flags"
 msgstr "Aktualisiere Index-Markierungen"
 
-#: upload-pack.c:1415
+#: upload-pack.c:1516
 msgid "expected flush after fetch arguments"
 msgstr "erwartete Flush nach Abrufen der Argumente"
 
@@ -9158,47 +9207,89 @@ msgstr "ungültiges '..' Pfadsegment"
 msgid "Fetching objects"
 msgstr "Anfordern der Objekte"
 
-#: worktree.c:248 builtin/am.c:2098
+#: worktree.c:236 builtin/am.c:2116
 #, c-format
 msgid "failed to read '%s'"
 msgstr "Fehler beim Lesen von '%s'"
 
-#: worktree.c:295
+#: worktree.c:283
 #, c-format
 msgid "'%s' at main working tree is not the repository directory"
 msgstr "'%s' im Hauptarbeitsverzeichnis ist nicht das Repository-Verzeichnis."
 
-#: worktree.c:306
+#: worktree.c:294
 #, c-format
 msgid "'%s' file does not contain absolute path to the working tree location"
 msgstr "'%s' Datei enthält nicht den absoluten Pfad zum Arbeitsverzeichnis."
 
-#: worktree.c:318
+#: worktree.c:306
 #, c-format
 msgid "'%s' does not exist"
 msgstr "'%s' existiert nicht."
 
-#: worktree.c:324
+#: worktree.c:312
 #, c-format
 msgid "'%s' is not a .git file, error code %d"
 msgstr "'%s' ist keine .git-Datei, Fehlercode %d"
 
-#: worktree.c:333
+#: worktree.c:321
 #, c-format
 msgid "'%s' does not point back to '%s'"
 msgstr "'%s' zeigt nicht zurück auf '%s'"
 
-#: wrapper.c:194 wrapper.c:364
+#: worktree.c:587
+#, fuzzy
+msgid "not a directory"
+msgstr "kein gültiges Verzeichnis"
+
+#: worktree.c:596
+#, fuzzy
+msgid ".git is not a file"
+msgstr "git show %s: ungültige Datei"
+
+#: worktree.c:598
+msgid ".git file broken"
+msgstr ""
+
+#: worktree.c:600
+#, fuzzy
+msgid ".git file incorrect"
+msgstr "Index-Datei beschädigt"
+
+#: worktree.c:670
+#, fuzzy
+msgid "not a valid path"
+msgstr "kein gültiges Verzeichnis"
+
+#: worktree.c:676
+#, fuzzy
+msgid "unable to locate repository; .git is not a file"
+msgstr "Konnte temporäre Datei nicht erstellen."
+
+#: worktree.c:679
+#, fuzzy
+msgid "unable to locate repository; .git file broken"
+msgstr "Konnte temporäre Datei nicht erstellen."
+
+#: worktree.c:685
+msgid "gitdir unreadable"
+msgstr ""
+
+#: worktree.c:689
+msgid "gitdir incorrect"
+msgstr ""
+
+#: wrapper.c:197 wrapper.c:367
 #, c-format
 msgid "could not open '%s' for reading and writing"
 msgstr "Konnte '%s' nicht zum Lesen und Schreiben öffnen."
 
-#: wrapper.c:395 wrapper.c:596
+#: wrapper.c:398 wrapper.c:599
 #, c-format
 msgid "unable to access '%s'"
 msgstr "konnte nicht auf '%s' zugreifen"
 
-#: wrapper.c:604
+#: wrapper.c:607
 msgid "unable to get current working directory"
 msgstr "Konnte aktuelles Arbeitsverzeichnis nicht bekommen."
 
@@ -9241,11 +9332,11 @@ msgid "  (use \"git rm <file>...\" to mark resolution)"
 msgstr ""
 "  (benutzen Sie \"git add/rm <Datei>...\", um die Auflösung zu markieren)"
 
-#: wt-status.c:211 wt-status.c:1072
+#: wt-status.c:211 wt-status.c:1070
 msgid "Changes to be committed:"
 msgstr "Zum Commit vorgemerkte Änderungen:"
 
-#: wt-status.c:234 wt-status.c:1081
+#: wt-status.c:234 wt-status.c:1079
 msgid "Changes not staged for commit:"
 msgstr "Änderungen, die nicht zum Commit vorgemerkt sind:"
 
@@ -9281,94 +9372,94 @@ msgstr ""
 "  (benutzen Sie \"git %s <Datei>...\", um die Änderungen zum Commit "
 "vorzumerken)"
 
-#: wt-status.c:268
+#: wt-status.c:266
 msgid "both deleted:"
 msgstr "beide gelöscht:"
 
-#: wt-status.c:270
+#: wt-status.c:268
 msgid "added by us:"
 msgstr "von uns hinzugefügt:"
 
-#: wt-status.c:272
+#: wt-status.c:270
 msgid "deleted by them:"
 msgstr "von denen gelöscht:"
 
-#: wt-status.c:274
+#: wt-status.c:272
 msgid "added by them:"
 msgstr "von denen hinzugefügt:"
 
-#: wt-status.c:276
+#: wt-status.c:274
 msgid "deleted by us:"
 msgstr "von uns gelöscht:"
 
-#: wt-status.c:278
+#: wt-status.c:276
 msgid "both added:"
 msgstr "von beiden hinzugefügt:"
 
-#: wt-status.c:280
+#: wt-status.c:278
 msgid "both modified:"
 msgstr "von beiden geändert:"
 
-#: wt-status.c:290
+#: wt-status.c:288
 msgid "new file:"
 msgstr "neue Datei:"
 
-#: wt-status.c:292
+#: wt-status.c:290
 msgid "copied:"
 msgstr "kopiert:"
 
-#: wt-status.c:294
+#: wt-status.c:292
 msgid "deleted:"
 msgstr "gelöscht:"
 
-#: wt-status.c:296
+#: wt-status.c:294
 msgid "modified:"
 msgstr "geändert:"
 
-#: wt-status.c:298
+#: wt-status.c:296
 msgid "renamed:"
 msgstr "umbenannt:"
 
-#: wt-status.c:300
+#: wt-status.c:298
 msgid "typechange:"
 msgstr "Typänderung:"
 
-#: wt-status.c:302
+#: wt-status.c:300
 msgid "unknown:"
 msgstr "unbekannt:"
 
-#: wt-status.c:304
+#: wt-status.c:302
 msgid "unmerged:"
 msgstr "nicht gemerged:"
 
-#: wt-status.c:384
+#: wt-status.c:382
 msgid "new commits, "
 msgstr "neue Commits, "
 
-#: wt-status.c:386
+#: wt-status.c:384
 msgid "modified content, "
 msgstr "geänderter Inhalt, "
 
-#: wt-status.c:388
+#: wt-status.c:386
 msgid "untracked content, "
 msgstr "unversionierter Inhalt, "
 
-#: wt-status.c:904
+#: wt-status.c:903
 #, c-format
 msgid "Your stash currently has %d entry"
 msgid_plural "Your stash currently has %d entries"
 msgstr[0] "Ihr Stash hat gerade %d Eintrag"
 msgstr[1] "Ihr Stash hat gerade %d Einträge"
 
-#: wt-status.c:936
+#: wt-status.c:934
 msgid "Submodules changed but not updated:"
 msgstr "Submodule geändert, aber nicht aktualisiert:"
 
-#: wt-status.c:938
+#: wt-status.c:936
 msgid "Submodule changes to be committed:"
 msgstr "Änderungen in Submodul zum Committen:"
 
-#: wt-status.c:1020
+#: wt-status.c:1018
 msgid ""
 "Do not modify or remove the line above.\n"
 "Everything below it will be ignored."
@@ -9376,7 +9467,7 @@ msgstr ""
 "Ändern oder entfernen Sie nicht die obige Zeile.\n"
 "Alles unterhalb von ihr wird ignoriert."
 
-#: wt-status.c:1112
+#: wt-status.c:1110
 #, c-format
 msgid ""
 "\n"
@@ -9388,114 +9479,114 @@ msgstr ""
 "berechnen.\n"
 "Sie können '--no-ahead-behind' benutzen, um das zu verhindern.\n"
 
-#: wt-status.c:1142
+#: wt-status.c:1140
 msgid "You have unmerged paths."
 msgstr "Sie haben nicht zusammengeführte Pfade."
 
-#: wt-status.c:1145
+#: wt-status.c:1143
 msgid "  (fix conflicts and run \"git commit\")"
 msgstr "  (beheben Sie die Konflikte und führen Sie \"git commit\" aus)"
 
-#: wt-status.c:1147
+#: wt-status.c:1145
 msgid "  (use \"git merge --abort\" to abort the merge)"
 msgstr "  (benutzen Sie \"git merge --abort\", um den Merge abzubrechen)"
 
-#: wt-status.c:1151
+#: wt-status.c:1149
 msgid "All conflicts fixed but you are still merging."
 msgstr "Alle Konflikte sind behoben, aber Sie sind immer noch beim Merge."
 
-#: wt-status.c:1154
+#: wt-status.c:1152
 msgid "  (use \"git commit\" to conclude merge)"
 msgstr "  (benutzen Sie \"git commit\", um den Merge abzuschließen)"
 
-#: wt-status.c:1163
+#: wt-status.c:1161
 msgid "You are in the middle of an am session."
 msgstr "Eine \"am\"-Sitzung ist im Gange."
 
-#: wt-status.c:1166
+#: wt-status.c:1164
 msgid "The current patch is empty."
 msgstr "Der aktuelle Patch ist leer."
 
-#: wt-status.c:1170
+#: wt-status.c:1168
 msgid "  (fix conflicts and then run \"git am --continue\")"
 msgstr ""
 "  (beheben Sie die Konflikte und führen Sie dann \"git am --continue\" aus)"
 
-#: wt-status.c:1172
+#: wt-status.c:1170
 msgid "  (use \"git am --skip\" to skip this patch)"
 msgstr "  (benutzen Sie \"git am --skip\", um diesen Patch auszulassen)"
 
-#: wt-status.c:1174
+#: wt-status.c:1172
 msgid "  (use \"git am --abort\" to restore the original branch)"
 msgstr ""
 "  (benutzen Sie \"git am --abort\", um den ursprünglichen Branch "
 "wiederherzustellen)"
 
-#: wt-status.c:1307
+#: wt-status.c:1305
 msgid "git-rebase-todo is missing."
 msgstr "git-rebase-todo fehlt."
 
-#: wt-status.c:1309
+#: wt-status.c:1307
 msgid "No commands done."
 msgstr "Keine Befehle ausgeführt."
 
-#: wt-status.c:1312
+#: wt-status.c:1310
 #, c-format
 msgid "Last command done (%d command done):"
 msgid_plural "Last commands done (%d commands done):"
 msgstr[0] "Zuletzt ausgeführter Befehl (%d Befehl ausgeführt):"
 msgstr[1] "Zuletzt ausgeführte Befehle (%d Befehle ausgeführt):"
 
-#: wt-status.c:1323
+#: wt-status.c:1321
 #, c-format
 msgid "  (see more in file %s)"
 msgstr "  (mehr Informationen in Datei %s)"
 
-#: wt-status.c:1328
+#: wt-status.c:1326
 msgid "No commands remaining."
 msgstr "Keine Befehle verbleibend."
 
-#: wt-status.c:1331
+#: wt-status.c:1329
 #, c-format
 msgid "Next command to do (%d remaining command):"
 msgid_plural "Next commands to do (%d remaining commands):"
 msgstr[0] "Nächster auszuführender Befehl (%d Befehle verbleibend):"
 msgstr[1] "Nächste auszuführende Befehle (%d Befehle verbleibend):"
 
-#: wt-status.c:1339
+#: wt-status.c:1337
 msgid "  (use \"git rebase --edit-todo\" to view and edit)"
 msgstr "  (benutzen Sie \"git rebase --edit-todo\" zum Ansehen und Bearbeiten)"
 
-#: wt-status.c:1351
+#: wt-status.c:1349
 #, c-format
 msgid "You are currently rebasing branch '%s' on '%s'."
 msgstr "Sie sind gerade beim Rebase von Branch '%s' auf '%s'."
 
-#: wt-status.c:1356
+#: wt-status.c:1354
 msgid "You are currently rebasing."
 msgstr "Sie sind gerade beim Rebase."
 
-#: wt-status.c:1369
+#: wt-status.c:1367
 msgid "  (fix conflicts and then run \"git rebase --continue\")"
 msgstr ""
 "  (beheben Sie die Konflikte und führen Sie dann \"git rebase --continue\" "
 "aus)"
 
-#: wt-status.c:1371
+#: wt-status.c:1369
 msgid "  (use \"git rebase --skip\" to skip this patch)"
 msgstr "  (benutzen Sie \"git rebase --skip\", um diesen Patch auszulassen)"
 
-#: wt-status.c:1373
+#: wt-status.c:1371
 msgid "  (use \"git rebase --abort\" to check out the original branch)"
 msgstr ""
 "  (benutzen Sie \"git rebase --abort\", um den ursprünglichen Branch "
 "auszuchecken)"
 
-#: wt-status.c:1380
+#: wt-status.c:1378
 msgid "  (all conflicts fixed: run \"git rebase --continue\")"
 msgstr "  (alle Konflikte behoben: führen Sie \"git rebase --continue\" aus)"
 
-#: wt-status.c:1384
+#: wt-status.c:1382
 #, c-format
 msgid ""
 "You are currently splitting a commit while rebasing branch '%s' on '%s'."
@@ -9503,162 +9594,162 @@ msgstr ""
 "Sie teilen gerade einen Commit auf, während ein Rebase von Branch '%s' auf "
 "'%s' im Gange ist."
 
-#: wt-status.c:1389
+#: wt-status.c:1387
 msgid "You are currently splitting a commit during a rebase."
 msgstr "Sie teilen gerade einen Commit während eines Rebase auf."
 
-#: wt-status.c:1392
+#: wt-status.c:1390
 msgid "  (Once your working directory is clean, run \"git rebase --continue\")"
 msgstr ""
 "  (Sobald Ihr Arbeitsverzeichnis unverändert ist, führen Sie \"git rebase --"
 "continue\" aus)"
 
-#: wt-status.c:1396
+#: wt-status.c:1394
 #, c-format
 msgid "You are currently editing a commit while rebasing branch '%s' on '%s'."
 msgstr ""
 "Sie editieren gerade einen Commit während eines Rebase von Branch '%s' auf "
 "'%s'."
 
-#: wt-status.c:1401
+#: wt-status.c:1399
 msgid "You are currently editing a commit during a rebase."
 msgstr "Sie editieren gerade einen Commit während eines Rebase."
 
-#: wt-status.c:1404
+#: wt-status.c:1402
 msgid "  (use \"git commit --amend\" to amend the current commit)"
 msgstr ""
 "  (benutzen Sie \"git commit --amend\", um den aktuellen Commit "
 "nachzubessern)"
 
-#: wt-status.c:1406
+#: wt-status.c:1404
 msgid ""
 "  (use \"git rebase --continue\" once you are satisfied with your changes)"
 msgstr ""
 "  (benutzen Sie \"git rebase --continue\" sobald Ihre Änderungen "
 "abgeschlossen sind)"
 
-#: wt-status.c:1417
+#: wt-status.c:1415
 msgid "Cherry-pick currently in progress."
 msgstr "Cherry-pick zurzeit im Gange."
 
-#: wt-status.c:1420
+#: wt-status.c:1418
 #, c-format
 msgid "You are currently cherry-picking commit %s."
 msgstr "Sie führen gerade \"cherry-pick\" von Commit %s aus."
 
-#: wt-status.c:1427
+#: wt-status.c:1425
 msgid "  (fix conflicts and run \"git cherry-pick --continue\")"
 msgstr ""
 "  (beheben Sie die Konflikte und führen Sie dann \"git cherry-pick --continue"
 "\" aus)"
 
-#: wt-status.c:1430
+#: wt-status.c:1428
 msgid "  (run \"git cherry-pick --continue\" to continue)"
 msgstr "  (Führen Sie \"git cherry-pick --continue\" aus, um weiterzumachen)"
 
-#: wt-status.c:1433
+#: wt-status.c:1431
 msgid "  (all conflicts fixed: run \"git cherry-pick --continue\")"
 msgstr ""
 "  (alle Konflikte behoben: führen Sie \"git cherry-pick --continue\" aus)"
 
-#: wt-status.c:1435
+#: wt-status.c:1433
 msgid "  (use \"git cherry-pick --skip\" to skip this patch)"
 msgstr ""
 "  (benutzen Sie \"git cherry-pick --skip\", um diesen Patch auszulassen)"
 
-#: wt-status.c:1437
+#: wt-status.c:1435
 msgid "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)"
 msgstr ""
 "  (benutzen Sie \"git cherry-pick --abort\", um die Cherry-Pick-Operation "
 "abzubrechen)"
 
-#: wt-status.c:1447
+#: wt-status.c:1445
 msgid "Revert currently in progress."
 msgstr "Revert zurzeit im Gange."
 
-#: wt-status.c:1450
+#: wt-status.c:1448
 #, c-format
 msgid "You are currently reverting commit %s."
 msgstr "Sie sind gerade beim Revert von Commit '%s'."
 
-#: wt-status.c:1456
+#: wt-status.c:1454
 msgid "  (fix conflicts and run \"git revert --continue\")"
 msgstr ""
 "  (beheben Sie die Konflikte und führen Sie dann \"git revert --continue\" "
 "aus)"
 
-#: wt-status.c:1459
+#: wt-status.c:1457
 msgid "  (run \"git revert --continue\" to continue)"
 msgstr "  (Führen Sie \"git revert --continue\", um weiterzumachen)"
 
-#: wt-status.c:1462
+#: wt-status.c:1460
 msgid "  (all conflicts fixed: run \"git revert --continue\")"
 msgstr "  (alle Konflikte behoben: führen Sie \"git revert --continue\" aus)"
 
-#: wt-status.c:1464
+#: wt-status.c:1462
 msgid "  (use \"git revert --skip\" to skip this patch)"
 msgstr "  (benutzen Sie \"git revert --skip\", um diesen Patch auszulassen)"
 
-#: wt-status.c:1466
+#: wt-status.c:1464
 msgid "  (use \"git revert --abort\" to cancel the revert operation)"
 msgstr ""
 "  (benutzen Sie \"git revert --abort\", um die Revert-Operation abzubrechen)"
 
-#: wt-status.c:1476
+#: wt-status.c:1474
 #, c-format
 msgid "You are currently bisecting, started from branch '%s'."
 msgstr "Sie sind gerade bei einer binären Suche, gestartet von Branch '%s'."
 
-#: wt-status.c:1480
+#: wt-status.c:1478
 msgid "You are currently bisecting."
 msgstr "Sie sind gerade bei einer binären Suche."
 
-#: wt-status.c:1483
+#: wt-status.c:1481
 msgid "  (use \"git bisect reset\" to get back to the original branch)"
 msgstr ""
 "  (benutzen Sie \"git bisect reset\", um zum ursprünglichen Branch "
 "zurückzukehren)"
 
-#: wt-status.c:1494
+#: wt-status.c:1492
 #, c-format
 msgid "You are in a sparse checkout with %d%% of tracked files present."
 msgstr ""
 "Sie sind in einem partiellen Checkout mit %d%% vorhandenen versionierten "
 "Dateien."
 
-#: wt-status.c:1733
+#: wt-status.c:1731
 msgid "On branch "
 msgstr "Auf Branch "
 
-#: wt-status.c:1740
+#: wt-status.c:1738
 msgid "interactive rebase in progress; onto "
 msgstr "interaktives Rebase im Gange; auf "
 
-#: wt-status.c:1742
+#: wt-status.c:1740
 msgid "rebase in progress; onto "
 msgstr "Rebase im Gange; auf "
 
-#: wt-status.c:1752
+#: wt-status.c:1750
 msgid "Not currently on any branch."
 msgstr "Im Moment auf keinem Branch."
 
-#: wt-status.c:1769
+#: wt-status.c:1767
 msgid "Initial commit"
 msgstr "Initialer Commit"
 
-#: wt-status.c:1770
+#: wt-status.c:1768
 msgid "No commits yet"
 msgstr "Noch keine Commits"
 
-#: wt-status.c:1784
+#: wt-status.c:1782
 msgid "Untracked files"
 msgstr "Unversionierte Dateien"
 
-#: wt-status.c:1786
+#: wt-status.c:1784
 msgid "Ignored files"
 msgstr "Ignorierte Dateien"
 
-#: wt-status.c:1790
+#: wt-status.c:1788
 #, c-format
 msgid ""
 "It took %.2f seconds to enumerate untracked files. 'status -uno'\n"
@@ -9669,27 +9760,27 @@ msgstr ""
 "'status -uno' könnte das beschleunigen, aber Sie müssen darauf achten,\n"
 "neue Dateien selbstständig hinzuzufügen (siehe 'git help status')."
 
-#: wt-status.c:1796
+#: wt-status.c:1794
 #, c-format
 msgid "Untracked files not listed%s"
 msgstr "Unversionierte Dateien nicht aufgelistet%s"
 
-#: wt-status.c:1798
+#: wt-status.c:1796
 msgid " (use -u option to show untracked files)"
 msgstr " (benutzen Sie die Option -u, um unversionierte Dateien anzuzeigen)"
 
-#: wt-status.c:1804
+#: wt-status.c:1802
 msgid "No changes"
 msgstr "Keine Änderungen"
 
-#: wt-status.c:1809
+#: wt-status.c:1807
 #, c-format
 msgid "no changes added to commit (use \"git add\" and/or \"git commit -a\")\n"
 msgstr ""
 "keine Änderungen zum Commit vorgemerkt (benutzen Sie \"git add\" und/oder "
 "\"git commit -a\")\n"
 
-#: wt-status.c:1812
+#: wt-status.c:1811
 #, c-format
 msgid "no changes added to commit\n"
 msgstr "keine Änderungen zum Commit vorgemerkt\n"
@@ -9703,67 +9794,67 @@ msgstr ""
 "nichts zum Commit vorgemerkt, aber es gibt unversionierte Dateien\n"
 "(benutzen Sie \"git add\" zum Versionieren)\n"
 
-#: wt-status.c:1818
+#: wt-status.c:1819
 #, c-format
 msgid "nothing added to commit but untracked files present\n"
 msgstr "nichts zum Commit vorgemerkt, aber es gibt unversionierte Dateien\n"
 
-#: wt-status.c:1821
+#: wt-status.c:1823
 #, c-format
 msgid "nothing to commit (create/copy files and use \"git add\" to track)\n"
 msgstr ""
 "nichts zu committen (erstellen/kopieren Sie Dateien und benutzen\n"
 "Sie \"git add\" zum Versionieren)\n"
 
-#: wt-status.c:1824 wt-status.c:1829
+#: wt-status.c:1827 wt-status.c:1833
 #, c-format
 msgid "nothing to commit\n"
 msgstr "nichts zu committen\n"
 
-#: wt-status.c:1827
+#: wt-status.c:1830
 #, c-format
 msgid "nothing to commit (use -u to show untracked files)\n"
 msgstr ""
 "nichts zu committen (benutzen Sie die Option -u, um unversionierte Dateien "
 "anzuzeigen)\n"
 
-#: wt-status.c:1831
+#: wt-status.c:1835
 #, c-format
 msgid "nothing to commit, working tree clean\n"
 msgstr "nichts zu committen, Arbeitsverzeichnis unverändert\n"
 
-#: wt-status.c:1944
+#: wt-status.c:1940
 msgid "No commits yet on "
 msgstr "Noch keine Commits in "
 
-#: wt-status.c:1948
+#: wt-status.c:1944
 msgid "HEAD (no branch)"
 msgstr "HEAD (kein Branch)"
 
-#: wt-status.c:1979
+#: wt-status.c:1975
 msgid "different"
 msgstr "unterschiedlich"
 
-#: wt-status.c:1981 wt-status.c:1989
+#: wt-status.c:1977 wt-status.c:1985
 msgid "behind "
 msgstr "hinterher "
 
-#: wt-status.c:1984 wt-status.c:1987
+#: wt-status.c:1980 wt-status.c:1983
 msgid "ahead "
 msgstr "voraus "
 
 #. TRANSLATORS: the action is e.g. "pull with rebase"
-#: wt-status.c:2509
+#: wt-status.c:2505
 #, c-format
 msgid "cannot %s: You have unstaged changes."
 msgstr ""
 "%s nicht möglich: Sie haben Änderungen, die nicht zum Commit vorgemerkt sind."
 
-#: wt-status.c:2515
+#: wt-status.c:2511
 msgid "additionally, your index contains uncommitted changes."
 msgstr "Zusätzlich enthält die Staging-Area nicht committete Änderungen."
 
-#: wt-status.c:2517
+#: wt-status.c:2513
 #, c-format
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr ""
@@ -9797,115 +9888,115 @@ msgid "Unstaged changes after refreshing the index:"
 msgstr ""
 "Nicht zum Commit vorgemerkte Änderungen nach Aktualisierung der Staging-Area:"
 
-#: builtin/add.c:266 builtin/rev-parse.c:904
+#: builtin/add.c:272 builtin/rev-parse.c:904
 msgid "Could not read the index"
 msgstr "Konnte den Index nicht lesen"
 
-#: builtin/add.c:277
+#: builtin/add.c:283
 #, c-format
 msgid "Could not open '%s' for writing."
 msgstr "Konnte '%s' nicht zum Schreiben öffnen."
 
-#: builtin/add.c:281
+#: builtin/add.c:287
 msgid "Could not write patch"
 msgstr "Konnte Patch nicht schreiben"
 
-#: builtin/add.c:284
+#: builtin/add.c:290
 msgid "editing patch failed"
 msgstr "Bearbeitung des Patches fehlgeschlagen"
 
-#: builtin/add.c:287
+#: builtin/add.c:293
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "Konnte Verzeichnis '%s' nicht lesen"
 
-#: builtin/add.c:289
+#: builtin/add.c:295
 msgid "Empty patch. Aborted."
 msgstr "Leerer Patch. Abgebrochen."
 
-#: builtin/add.c:294
+#: builtin/add.c:300
 #, c-format
 msgid "Could not apply '%s'"
 msgstr "Konnte '%s' nicht anwenden."
 
-#: builtin/add.c:302
+#: builtin/add.c:308
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr ""
 "Die folgenden Pfade werden durch eine Ihrer \".gitignore\" Dateien "
 "ignoriert:\n"
 
-#: builtin/add.c:322 builtin/clean.c:904 builtin/fetch.c:164 builtin/mv.c:124
-#: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:548
-#: builtin/remote.c:1421 builtin/rm.c:242 builtin/send-pack.c:165
+#: builtin/add.c:328 builtin/clean.c:904 builtin/fetch.c:166 builtin/mv.c:124
+#: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:538
+#: builtin/remote.c:1422 builtin/rm.c:242 builtin/send-pack.c:184
 msgid "dry run"
 msgstr "Probelauf"
 
-#: builtin/add.c:325
+#: builtin/add.c:331
 msgid "interactive picking"
 msgstr "interaktives Auswählen"
 
-#: builtin/add.c:326 builtin/checkout.c:1533 builtin/reset.c:308
+#: builtin/add.c:332 builtin/checkout.c:1529 builtin/reset.c:308
 msgid "select hunks interactively"
 msgstr "Blöcke interaktiv auswählen"
 
-#: builtin/add.c:327
+#: builtin/add.c:333
 msgid "edit current diff and apply"
 msgstr "aktuelle Unterschiede editieren und anwenden"
 
-#: builtin/add.c:328
+#: builtin/add.c:334
 msgid "allow adding otherwise ignored files"
 msgstr "das Hinzufügen andernfalls ignorierter Dateien erlauben"
 
-#: builtin/add.c:329
+#: builtin/add.c:335
 msgid "update tracked files"
 msgstr "versionierte Dateien aktualisieren"
 
-#: builtin/add.c:330
+#: builtin/add.c:336
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr ""
 "erneutes Normalisieren der Zeilenenden von versionierten Dateien (impliziert "
 "-u)"
 
-#: builtin/add.c:331
+#: builtin/add.c:337
 msgid "record only the fact that the path will be added later"
 msgstr "nur speichern, dass der Pfad später hinzugefügt werden soll"
 
-#: builtin/add.c:332
+#: builtin/add.c:338
 msgid "add changes from all tracked and untracked files"
 msgstr ""
 "Änderungen von allen versionierten und unversionierten Dateien hinzufügen"
 
-#: builtin/add.c:335
+#: builtin/add.c:341
 msgid "ignore paths removed in the working tree (same as --no-all)"
 msgstr "gelöschte Pfade im Arbeitsverzeichnis ignorieren (genau wie --no-all)"
 
-#: builtin/add.c:337
+#: builtin/add.c:343
 msgid "don't add, only refresh the index"
 msgstr "nichts hinzufügen, nur den Index aktualisieren"
 
-#: builtin/add.c:338
+#: builtin/add.c:344
 msgid "just skip files which cannot be added because of errors"
 msgstr ""
 "Dateien überspringen, die aufgrund von Fehlern nicht hinzugefügt werden "
 "konnten"
 
-#: builtin/add.c:339
+#: builtin/add.c:345
 msgid "check if - even missing - files are ignored in dry run"
 msgstr "prüfen ob - auch fehlende - Dateien im Probelauf ignoriert werden"
 
-#: builtin/add.c:341 builtin/update-index.c:1004
+#: builtin/add.c:347 builtin/update-index.c:1004
 msgid "override the executable bit of the listed files"
 msgstr "das \"ausführbar\"-Bit der aufgelisteten Dateien überschreiben"
 
-#: builtin/add.c:343
+#: builtin/add.c:349
 msgid "warn when adding an embedded repository"
 msgstr "warnen wenn eingebettetes Repository hinzugefügt wird"
 
-#: builtin/add.c:345
+#: builtin/add.c:351
 msgid "backend for `git stash -p`"
 msgstr "Backend für `git stash -p`"
 
-#: builtin/add.c:363
+#: builtin/add.c:369
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -9939,12 +10030,12 @@ msgstr ""
 "\n"
 "Siehe \"git help submodule\" für weitere Informationen."
 
-#: builtin/add.c:391
+#: builtin/add.c:397
 #, c-format
 msgid "adding embedded git repository: %s"
 msgstr "Füge eingebettetes Repository hinzu: %s"
 
-#: builtin/add.c:410
+#: builtin/add.c:416
 msgid ""
 "Use -f if you really want to add them.\n"
 "Turn this message off by running\n"
@@ -9954,52 +10045,52 @@ msgstr ""
 "Um diese Meldung abzuschalten, führen Sie folgenden Befehl aus:\n"
 "\"git config advice.addIgnoredFile false\""
 
-#: builtin/add.c:419
+#: builtin/add.c:425
 msgid "adding files failed"
 msgstr "Hinzufügen von Dateien fehlgeschlagen"
 
-#: builtin/add.c:447 builtin/commit.c:345
+#: builtin/add.c:453 builtin/commit.c:345
 msgid "--pathspec-from-file is incompatible with --interactive/--patch"
 msgstr ""
 "Die Optionen --pathspec-from-file und --interactive/--patch sind "
 "inkompatibel."
 
-#: builtin/add.c:464
+#: builtin/add.c:470
 msgid "--pathspec-from-file is incompatible with --edit"
 msgstr "Die Optionen --pathspec-from-file und --edit sind inkompatibel."
 
-#: builtin/add.c:476
+#: builtin/add.c:482
 msgid "-A and -u are mutually incompatible"
 msgstr "Die Optionen -A und -u sind zueinander inkompatibel."
 
-#: builtin/add.c:479
+#: builtin/add.c:485
 msgid "Option --ignore-missing can only be used together with --dry-run"
 msgstr ""
 "Die Option --ignore-missing kann nur zusammen mit --dry-run verwendet werden."
 
-#: builtin/add.c:483
+#: builtin/add.c:489
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "--chmod Parameter '%s' muss entweder -x oder +x sein"
 
-#: builtin/add.c:501 builtin/checkout.c:1701 builtin/commit.c:351
-#: builtin/reset.c:328 builtin/rm.c:272 builtin/stash.c:1506
+#: builtin/add.c:507 builtin/checkout.c:1697 builtin/commit.c:351
+#: builtin/reset.c:328 builtin/rm.c:272 builtin/stash.c:1503
 msgid "--pathspec-from-file is incompatible with pathspec arguments"
 msgstr ""
 "Die Option --pathspec-from-file ist inkompatibel mit\n"
 "Pfadspezifikation-Argumenten."
 
-#: builtin/add.c:508 builtin/checkout.c:1713 builtin/commit.c:357
-#: builtin/reset.c:334 builtin/rm.c:278 builtin/stash.c:1512
+#: builtin/add.c:514 builtin/checkout.c:1709 builtin/commit.c:357
+#: builtin/reset.c:334 builtin/rm.c:278 builtin/stash.c:1509
 msgid "--pathspec-file-nul requires --pathspec-from-file"
 msgstr "Die Option --pathspec-file-nul benötigt --pathspec-from-file"
 
-#: builtin/add.c:512
+#: builtin/add.c:518
 #, c-format
 msgid "Nothing specified, nothing added.\n"
 msgstr "Nichts spezifiziert, nichts hinzugefügt.\n"
 
-#: builtin/add.c:514
+#: builtin/add.c:520
 msgid ""
 "Maybe you wanted to say 'git add .'?\n"
 "Turn this message off by running\n"
@@ -10009,116 +10100,121 @@ msgstr ""
 "Um diese Meldung abzuschalten, führen Sie folgenden Befehl aus:\n"
 "\"git config advice.addEmptyPathspec false\""
 
-#: builtin/am.c:352
+#: builtin/am.c:160
+#, fuzzy, c-format
+msgid "invalid committer: %s"
+msgstr "Ungültiger Commit %s"
+
+#: builtin/am.c:366
 msgid "could not parse author script"
 msgstr "konnte Autor-Skript nicht parsen"
 
-#: builtin/am.c:436
+#: builtin/am.c:450
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
 msgstr "'%s' wurde durch den applypatch-msg Hook entfernt"
 
-#: builtin/am.c:478
+#: builtin/am.c:492
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr "Fehlerhafte Eingabezeile: '%s'."
 
-#: builtin/am.c:516
+#: builtin/am.c:530
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
 msgstr "Fehler beim Kopieren der Notizen von '%s' nach '%s'"
 
-#: builtin/am.c:542
+#: builtin/am.c:556
 msgid "fseek failed"
 msgstr "\"fseek\" fehlgeschlagen"
 
-#: builtin/am.c:730
+#: builtin/am.c:744
 #, c-format
 msgid "could not parse patch '%s'"
 msgstr "konnte Patch '%s' nicht parsen"
 
-#: builtin/am.c:795
+#: builtin/am.c:809
 msgid "Only one StGIT patch series can be applied at once"
 msgstr "Es kann nur eine StGIT Patch-Serie auf einmal angewendet werden."
 
-#: builtin/am.c:843
+#: builtin/am.c:857
 msgid "invalid timestamp"
 msgstr "ungültiger Zeitstempel"
 
-#: builtin/am.c:848 builtin/am.c:860
+#: builtin/am.c:862 builtin/am.c:874
 msgid "invalid Date line"
 msgstr "Ungültige \"Date\"-Zeile"
 
-#: builtin/am.c:855
+#: builtin/am.c:869
 msgid "invalid timezone offset"
 msgstr "Ungültiger Offset in der Zeitzone"
 
-#: builtin/am.c:948
+#: builtin/am.c:962
 msgid "Patch format detection failed."
 msgstr "Patch-Formaterkennung fehlgeschlagen."
 
-#: builtin/am.c:953 builtin/clone.c:409
+#: builtin/am.c:967 builtin/clone.c:409
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "Fehler beim Erstellen von Verzeichnis '%s'"
 
-#: builtin/am.c:958
+#: builtin/am.c:972
 msgid "Failed to split patches."
 msgstr "Fehler beim Aufteilen der Patches."
 
-#: builtin/am.c:1089
+#: builtin/am.c:1103
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\"."
 msgstr ""
 "Wenn Sie das Problem aufgelöst haben, führen Sie \"%s --continue\" aus."
 
-#: builtin/am.c:1090
+#: builtin/am.c:1104
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
 msgstr ""
 "Falls Sie diesen Patch auslassen möchten, führen Sie stattdessen \"%s --skip"
 "\" aus."
 
-#: builtin/am.c:1091
+#: builtin/am.c:1105
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr ""
 "Um den ursprünglichen Branch wiederherzustellen und die Anwendung der "
 "Patches abzubrechen, führen Sie \"%s --abort\" aus."
 
-#: builtin/am.c:1174
+#: builtin/am.c:1188
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
 "Patch mit format=flowed versendet; Leerzeichen am Ende von Zeilen könnte "
 "verloren gehen."
 
-#: builtin/am.c:1202
+#: builtin/am.c:1216
 msgid "Patch is empty."
 msgstr "Patch ist leer."
 
-#: builtin/am.c:1267
+#: builtin/am.c:1281
 #, c-format
 msgid "missing author line in commit %s"
 msgstr "Autor-Zeile fehlt in Commit %s"
 
-#: builtin/am.c:1270
+#: builtin/am.c:1284
 #, c-format
 msgid "invalid ident line: %.*s"
 msgstr "Ungültige Identifikationszeile: %.*s"
 
-#: builtin/am.c:1489
+#: builtin/am.c:1503
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
 "Dem Repository fehlen notwendige Blobs um auf einen 3-Wege-Merge "
 "zurückzufallen."
 
-#: builtin/am.c:1491
+#: builtin/am.c:1505
 msgid "Using index info to reconstruct a base tree..."
 msgstr ""
 "Verwende Informationen aus der Staging-Area, um ein Basisverzeichnis "
 "nachzustellen ..."
 
-#: builtin/am.c:1510
+#: builtin/am.c:1524
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
@@ -10126,24 +10222,24 @@ msgstr ""
 "Haben Sie den Patch per Hand editiert?\n"
 "Er kann nicht auf die Blobs in seiner 'index' Zeile angewendet werden."
 
-#: builtin/am.c:1516
+#: builtin/am.c:1530
 msgid "Falling back to patching base and 3-way merge..."
 msgstr "Falle zurück zum Patchen der Basis und zum 3-Wege-Merge ..."
 
-#: builtin/am.c:1542
+#: builtin/am.c:1556
 msgid "Failed to merge in the changes."
 msgstr "Merge der Änderungen fehlgeschlagen."
 
-#: builtin/am.c:1574
+#: builtin/am.c:1588
 msgid "applying to an empty history"
 msgstr "auf leere Historie anwenden"
 
-#: builtin/am.c:1621 builtin/am.c:1625
+#: builtin/am.c:1639 builtin/am.c:1643
 #, c-format
 msgid "cannot resume: %s does not exist."
 msgstr "Kann nicht fortsetzen: %s existiert nicht"
 
-#: builtin/am.c:1643
+#: builtin/am.c:1661
 msgid "Commit Body is:"
 msgstr "Commit-Beschreibung ist:"
 
@@ -10151,41 +10247,41 @@ msgstr "Commit-Beschreibung ist:"
 #. in your translation. The program will only accept English
 #. input at this point.
 #.
-#: builtin/am.c:1653
+#: builtin/am.c:1671
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr "Anwenden? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 
-#: builtin/am.c:1699 builtin/commit.c:395
+#: builtin/am.c:1717 builtin/commit.c:395
 msgid "unable to write index file"
 msgstr "Konnte Index-Datei nicht schreiben."
 
-#: builtin/am.c:1703
+#: builtin/am.c:1721
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
 msgstr "Geänderter Index: kann Patches nicht anwenden (geändert: %s)"
 
-#: builtin/am.c:1743 builtin/am.c:1811
+#: builtin/am.c:1761 builtin/am.c:1829
 #, c-format
 msgid "Applying: %.*s"
 msgstr "Wende an: %.*s"
 
-#: builtin/am.c:1760
+#: builtin/am.c:1778
 msgid "No changes -- Patch already applied."
 msgstr "Keine Änderungen -- Patches bereits angewendet."
 
-#: builtin/am.c:1766
+#: builtin/am.c:1784
 #, c-format
 msgid "Patch failed at %s %.*s"
 msgstr "Anwendung des Patches fehlgeschlagen bei %s %.*s"
 
-#: builtin/am.c:1770
+#: builtin/am.c:1788
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr ""
 "Benutzen Sie 'git am --show-current-patch=diff', um den\n"
 "fehlgeschlagenen Patch zu sehen"
 
-#: builtin/am.c:1814
+#: builtin/am.c:1832
 msgid ""
 "No changes - did you forget to use 'git add'?\n"
 "If there is nothing left to stage, chances are that something else\n"
@@ -10196,7 +10292,7 @@ msgstr ""
 "diese bereits anderweitig eingefügt worden sein; Sie könnten diesen Patch\n"
 "auslassen."
 
-#: builtin/am.c:1821
+#: builtin/am.c:1839
 msgid ""
 "You still have unmerged paths in your index.\n"
 "You should 'git add' each file with resolved conflicts to mark them as "
@@ -10209,17 +10305,17 @@ msgstr ""
 "Sie können 'git rm' auf Dateien ausführen, um \"von denen gelöscht\" für\n"
 "diese zu akzeptieren."
 
-#: builtin/am.c:1928 builtin/am.c:1932 builtin/am.c:1944 builtin/reset.c:347
+#: builtin/am.c:1946 builtin/am.c:1950 builtin/am.c:1962 builtin/reset.c:347
 #: builtin/reset.c:355
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "Konnte Objekt '%s' nicht parsen."
 
-#: builtin/am.c:1980
+#: builtin/am.c:1998
 msgid "failed to clean index"
 msgstr "Fehler beim Bereinigen des Index"
 
-#: builtin/am.c:2024
+#: builtin/am.c:2042
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
@@ -10227,156 +10323,156 @@ msgstr ""
 "Sie scheinen seit dem letzten gescheiterten 'am' HEAD geändert zu haben.\n"
 "Keine Zurücksetzung zu ORIG_HEAD."
 
-#: builtin/am.c:2131
+#: builtin/am.c:2149
 #, c-format
 msgid "Invalid value for --patch-format: %s"
 msgstr "Ungültiger Wert für --patch-format: %s"
 
-#: builtin/am.c:2171
+#: builtin/am.c:2191
 #, c-format
 msgid "Invalid value for --show-current-patch: %s"
 msgstr "Ungültiger Wert für --show-current-patch: %s"
 
-#: builtin/am.c:2175
+#: builtin/am.c:2195
 #, c-format
 msgid "--show-current-patch=%s is incompatible with --show-current-patch=%s"
 msgstr "--show-current-patch=%s ist inkombatibel mit --show-current-patch=%s"
 
-#: builtin/am.c:2206
+#: builtin/am.c:2226
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
 msgstr "git am [<Optionen>] [(<mbox> | <E-Mail-Verzeichnis>)...]"
 
-#: builtin/am.c:2207
+#: builtin/am.c:2227
 msgid "git am [<options>] (--continue | --skip | --abort)"
 msgstr "git am [<Optionen>] (--continue | --skip | --abort)"
 
-#: builtin/am.c:2213
+#: builtin/am.c:2233
 msgid "run interactively"
 msgstr "interaktiv ausführen"
 
-#: builtin/am.c:2215
+#: builtin/am.c:2235
 msgid "historical option -- no-op"
 msgstr "historische Option -- kein Effekt"
 
-#: builtin/am.c:2217
+#: builtin/am.c:2237
 msgid "allow fall back on 3way merging if needed"
 msgstr "erlaube, falls notwendig, das Zurückfallen auf einen 3-Wege-Merge"
 
-#: builtin/am.c:2218 builtin/init-db.c:559 builtin/prune-packed.c:16
-#: builtin/repack.c:306 builtin/stash.c:816
+#: builtin/am.c:2238 builtin/init-db.c:558 builtin/prune-packed.c:16
+#: builtin/repack.c:309 builtin/stash.c:816
 msgid "be quiet"
 msgstr "weniger Ausgaben"
 
-#: builtin/am.c:2220
+#: builtin/am.c:2240
 msgid "add a Signed-off-by line to the commit message"
 msgstr "der Commit-Beschreibung eine Signed-off-by Zeile hinzufügen"
 
-#: builtin/am.c:2223
+#: builtin/am.c:2243
 msgid "recode into utf8 (default)"
 msgstr "nach UTF-8 umkodieren (Standard)"
 
-#: builtin/am.c:2225
+#: builtin/am.c:2245
 msgid "pass -k flag to git-mailinfo"
 msgstr "-k an git-mailinfo übergeben"
 
-#: builtin/am.c:2227
+#: builtin/am.c:2247
 msgid "pass -b flag to git-mailinfo"
 msgstr "-b an git-mailinfo übergeben"
 
-#: builtin/am.c:2229
+#: builtin/am.c:2249
 msgid "pass -m flag to git-mailinfo"
 msgstr "-m an git-mailinfo übergeben"
 
-#: builtin/am.c:2231
+#: builtin/am.c:2251
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
 msgstr "--keep-cr an git-mailsplit für mbox-Format übergeben"
 
-#: builtin/am.c:2234
+#: builtin/am.c:2254
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr "kein --keep-cr an git-mailsplit übergeben, unabhängig von am.keepcr"
 
-#: builtin/am.c:2237
+#: builtin/am.c:2257
 msgid "strip everything before a scissors line"
 msgstr "alles vor einer Scheren-Zeile entfernen"
 
-#: builtin/am.c:2239 builtin/am.c:2242 builtin/am.c:2245 builtin/am.c:2248
-#: builtin/am.c:2251 builtin/am.c:2254 builtin/am.c:2257 builtin/am.c:2260
-#: builtin/am.c:2266
+#: builtin/am.c:2259 builtin/am.c:2262 builtin/am.c:2265 builtin/am.c:2268
+#: builtin/am.c:2271 builtin/am.c:2274 builtin/am.c:2277 builtin/am.c:2280
+#: builtin/am.c:2286
 msgid "pass it through git-apply"
 msgstr "an git-apply übergeben"
 
-#: builtin/am.c:2256 builtin/commit.c:1397 builtin/fmt-merge-msg.c:17
-#: builtin/fmt-merge-msg.c:20 builtin/grep.c:891 builtin/merge.c:252
+#: builtin/am.c:2276 builtin/commit.c:1395 builtin/fmt-merge-msg.c:17
+#: builtin/fmt-merge-msg.c:20 builtin/grep.c:892 builtin/merge.c:251
 #: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
-#: builtin/rebase.c:1329 builtin/repack.c:317 builtin/repack.c:321
-#: builtin/repack.c:323 builtin/show-branch.c:650 builtin/show-ref.c:172
+#: builtin/rebase.c:1335 builtin/repack.c:320 builtin/repack.c:324
+#: builtin/repack.c:326 builtin/show-branch.c:650 builtin/show-ref.c:172
 #: builtin/tag.c:404 parse-options.h:154 parse-options.h:175
 #: parse-options.h:316
 msgid "n"
 msgstr "Anzahl"
 
-#: builtin/am.c:2262 builtin/branch.c:659 builtin/for-each-ref.c:38
-#: builtin/replace.c:556 builtin/tag.c:438 builtin/verify-tag.c:38
-#: bugreport.c:137
+#: builtin/am.c:2282 builtin/branch.c:659 builtin/bugreport.c:135
+#: builtin/for-each-ref.c:38 builtin/replace.c:556 builtin/tag.c:438
+#: builtin/verify-tag.c:38
 msgid "format"
 msgstr "Format"
 
-#: builtin/am.c:2263
+#: builtin/am.c:2283
 msgid "format the patch(es) are in"
 msgstr "Patch-Format"
 
-#: builtin/am.c:2269
+#: builtin/am.c:2289
 msgid "override error message when patch failure occurs"
 msgstr "Meldung bei fehlerhafter Patch-Anwendung überschreiben"
 
-#: builtin/am.c:2271
+#: builtin/am.c:2291
 msgid "continue applying patches after resolving a conflict"
 msgstr "Anwendung der Patches nach Auflösung eines Konfliktes fortsetzen"
 
-#: builtin/am.c:2274
+#: builtin/am.c:2294
 msgid "synonyms for --continue"
 msgstr "Synonyme für --continue"
 
-#: builtin/am.c:2277
+#: builtin/am.c:2297
 msgid "skip the current patch"
 msgstr "den aktuellen Patch auslassen"
 
-#: builtin/am.c:2280
+#: builtin/am.c:2300
 msgid "restore the original branch and abort the patching operation."
 msgstr ""
 "ursprünglichen Branch wiederherstellen und Anwendung der Patches abbrechen"
 
-#: builtin/am.c:2283
+#: builtin/am.c:2303
 msgid "abort the patching operation but keep HEAD where it is."
 msgstr "Patch-Operation abbrechen, aber HEAD an aktueller Stelle belassen"
 
-#: builtin/am.c:2287
+#: builtin/am.c:2307
 msgid "show the patch being applied"
 msgstr "den Patch, der gerade angewendet wird, anzeigen"
 
-#: builtin/am.c:2292
+#: builtin/am.c:2312
 msgid "lie about committer date"
 msgstr "Autor-Datum als Commit-Datum verwenden"
 
-#: builtin/am.c:2294
+#: builtin/am.c:2314
 msgid "use current timestamp for author date"
 msgstr "aktuellen Zeitstempel als Autor-Datum verwenden"
 
-#: builtin/am.c:2296 builtin/commit-tree.c:120 builtin/commit.c:1517
-#: builtin/merge.c:289 builtin/pull.c:175 builtin/rebase.c:524
-#: builtin/rebase.c:1380 builtin/revert.c:117 builtin/tag.c:419
+#: builtin/am.c:2316 builtin/commit-tree.c:120 builtin/commit.c:1515
+#: builtin/merge.c:288 builtin/pull.c:175 builtin/rebase.c:530
+#: builtin/rebase.c:1388 builtin/revert.c:117 builtin/tag.c:419
 msgid "key-id"
 msgstr "GPG-Schlüsselkennung"
 
-#: builtin/am.c:2297 builtin/rebase.c:525 builtin/rebase.c:1381
+#: builtin/am.c:2317 builtin/rebase.c:531 builtin/rebase.c:1389
 msgid "GPG-sign commits"
 msgstr "Commits mit GPG signieren"
 
-#: builtin/am.c:2300
+#: builtin/am.c:2320
 msgid "(internal use for git-rebase)"
 msgstr "(intern für git-rebase verwendet)"
 
-#: builtin/am.c:2318
+#: builtin/am.c:2338
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
@@ -10384,16 +10480,16 @@ msgstr ""
 "Die -b/--binary Option hat seit Langem keinen Effekt und wird\n"
 "entfernt. Bitte verwenden Sie diese nicht mehr."
 
-#: builtin/am.c:2325
+#: builtin/am.c:2345
 msgid "failed to read the index"
 msgstr "Fehler beim Lesen des Index"
 
-#: builtin/am.c:2340
+#: builtin/am.c:2360
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr "Vorheriges Rebase-Verzeichnis %s existiert noch, aber mbox gegeben."
 
-#: builtin/am.c:2364
+#: builtin/am.c:2384
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
@@ -10402,11 +10498,11 @@ msgstr ""
 "Stray %s Verzeichnis gefunden.\n"
 "Benutzen Sie \"git am --abort\", um es zu entfernen."
 
-#: builtin/am.c:2370
+#: builtin/am.c:2390
 msgid "Resolve operation not in progress, we are not resuming."
 msgstr "Es ist keine Auflösung im Gange, es wird nicht fortgesetzt."
 
-#: builtin/am.c:2380
+#: builtin/am.c:2400
 msgid "interactive mode requires patches on the command line"
 msgstr "Interaktiver Modus benötigt Patches über die Kommandozeile"
 
@@ -10444,23 +10540,24 @@ msgstr "git archive: Protokollfehler"
 msgid "git archive: expected a flush"
 msgstr "git archive: erwartete eine Spülung (flush)"
 
-#: builtin/bisect--helper.c:22
-msgid "git bisect--helper --next-all [--no-checkout]"
+#: builtin/bisect--helper.c:23
+#, fuzzy
+msgid "git bisect--helper --next-all"
 msgstr "git bisect--helper --next-all [--no-checkout]"
 
-#: builtin/bisect--helper.c:23
+#: builtin/bisect--helper.c:24
 msgid "git bisect--helper --write-terms <bad_term> <good_term>"
 msgstr "git bisect--helper --write-terms <bad_term> <good_term>"
 
-#: builtin/bisect--helper.c:24
+#: builtin/bisect--helper.c:25
 msgid "git bisect--helper --bisect-clean-state"
 msgstr "git bisect--helper --bisect-clean-state"
 
-#: builtin/bisect--helper.c:25
+#: builtin/bisect--helper.c:26
 msgid "git bisect--helper --bisect-reset [<commit>]"
 msgstr "git bisect--helper --bisect-reset [<Commit>]"
 
-#: builtin/bisect--helper.c:26
+#: builtin/bisect--helper.c:27
 msgid ""
 "git bisect--helper --bisect-write [--no-log] <state> <revision> <good_term> "
 "<bad_term>"
@@ -10468,7 +10565,7 @@ msgstr ""
 "git bisect--helper --bisect-write [--no-log] <Zustand> <Revision> "
 "<Begriff_gut> <Begriff_schlecht>"
 
-#: builtin/bisect--helper.c:27
+#: builtin/bisect--helper.c:28
 msgid ""
 "git bisect--helper --bisect-check-and-set-terms <command> <good_term> "
 "<bad_term>"
@@ -10476,13 +10573,13 @@ msgstr ""
 "git bisect--helper --bisect-check-and-set-terms <Befehl> <Begriff_gut> "
 "<Begriff_schlecht>"
 
-#: builtin/bisect--helper.c:28
+#: builtin/bisect--helper.c:29
 msgid "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
 msgstr ""
 "git bisect--helper --bisect-next-check <Begriff_gut> <Begriff_schlecht> "
 "[<Begriff>]"
 
-#: builtin/bisect--helper.c:29
+#: builtin/bisect--helper.c:30
 msgid ""
 "git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
 "term-new]"
@@ -10490,48 +10587,71 @@ msgstr ""
 "git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
 "term-new]"
 
-#: builtin/bisect--helper.c:30
+#: builtin/bisect--helper.c:31
+#, fuzzy
 msgid ""
-"git bisect--helper --bisect-start [--term-{old,good}=<term> --term-{new,bad}"
-"=<term>][--no-checkout] [<bad> [<good>...]] [--] [<paths>...]"
+"git bisect--helper --bisect-start [--term-{new,bad}=<term> --term-{old,good}"
+"=<term>] [--no-checkout] [--first-parent] [<bad> [<good>...]] [--] "
+"[<paths>...]"
 msgstr ""
 "git bisect--helper --bisect-start [--term-{old,good}=<Begriff> --term-{new,"
 "bad}=<Begriff>][--no-checkout] [<schlecht> [<gut>...]] [--] [<Pfade>...]"
 
-#: builtin/bisect--helper.c:86
+#: builtin/bisect--helper.c:33
+#, fuzzy
+msgid "git bisect--helper --bisect-next"
+msgstr "git bisect--helper --bisect-clean-state"
+
+#: builtin/bisect--helper.c:34
+#, fuzzy
+msgid "git bisect--helper --bisect-auto-next"
+msgstr "git bisect--helper --bisect-clean-state"
+
+#: builtin/bisect--helper.c:35
+#, fuzzy
+msgid "git bisect--helper --bisect-autostart"
+msgstr "git bisect--helper --bisect-clean-state"
+
+#: builtin/bisect--helper.c:97
+#, fuzzy, c-format
+msgid "cannot open file '%s' in mode '%s'"
+msgstr "kann '%s' nicht nach '%s' kopieren"
+
+#: builtin/bisect--helper.c:104
+#, fuzzy, c-format
+msgid "could not write to file '%s'"
+msgstr "Konnte Datei nicht schreiben: '%s'"
+
+#: builtin/bisect--helper.c:143
 #, c-format
 msgid "'%s' is not a valid term"
 msgstr "'%s' ist kein gültiger Begriff."
 
-#: builtin/bisect--helper.c:90
+#: builtin/bisect--helper.c:147
 #, c-format
 msgid "can't use the builtin command '%s' as a term"
 msgstr "Kann den eingebauten Befehl '%s' nicht als Begriff verwenden."
 
-#: builtin/bisect--helper.c:100
+#: builtin/bisect--helper.c:157
 #, c-format
 msgid "can't change the meaning of the term '%s'"
 msgstr "Kann die Bedeutung von dem Begriff '%s' nicht ändern."
 
-#: builtin/bisect--helper.c:111
+#: builtin/bisect--helper.c:167
 msgid "please use two different terms"
 msgstr "Bitte verwenden Sie zwei verschiedene Begriffe."
 
-#: builtin/bisect--helper.c:118
-msgid "could not open the file BISECT_TERMS"
-msgstr "Konnte die Datei BISECT_TERMS nicht öffnen."
-
-#: builtin/bisect--helper.c:155
+#: builtin/bisect--helper.c:207
 #, c-format
 msgid "We are not bisecting.\n"
 msgstr "Keine binäre Suche im Gange.\n"
 
-#: builtin/bisect--helper.c:163
+#: builtin/bisect--helper.c:215
 #, c-format
 msgid "'%s' is not a valid commit"
 msgstr "'%s' ist kein gültiger Commit."
 
-#: builtin/bisect--helper.c:172
+#: builtin/bisect--helper.c:224
 #, c-format
 msgid ""
 "could not check out original HEAD '%s'. Try 'git bisect reset <commit>'."
@@ -10539,27 +10659,27 @@ msgstr ""
 "Konnte den ursprünglichen HEAD '%s' nicht auschecken.\n"
 "Versuchen Sie 'git bisect reset <Commit>'."
 
-#: builtin/bisect--helper.c:216
+#: builtin/bisect--helper.c:268
 #, c-format
 msgid "Bad bisect_write argument: %s"
 msgstr "Ungültiges \"bisect_write\" Argument: %s"
 
-#: builtin/bisect--helper.c:221
+#: builtin/bisect--helper.c:273
 #, c-format
 msgid "couldn't get the oid of the rev '%s'"
 msgstr "Konnte die OID der Revision '%s' nicht erhalten."
 
-#: builtin/bisect--helper.c:233
+#: builtin/bisect--helper.c:285
 #, c-format
 msgid "couldn't open the file '%s'"
 msgstr "Konnte die Datei '%s' nicht öffnen."
 
-#: builtin/bisect--helper.c:259
+#: builtin/bisect--helper.c:311
 #, c-format
 msgid "Invalid command: you're currently in a %s/%s bisect"
 msgstr "Ungültiger Befehl: Sie sind gerade bei einer binären %s/%s Suche."
 
-#: builtin/bisect--helper.c:286
+#: builtin/bisect--helper.c:338
 #, c-format
 msgid ""
 "You need to give me at least one %s and %s revision.\n"
@@ -10568,7 +10688,7 @@ msgstr ""
 "Sie müssen mindestens einen \"%s\" und einen \"%s\" Commit angeben.\n"
 "Sie können dafür \"git bisect %s\" und \"git bisect %s\" benutzen."
 
-#: builtin/bisect--helper.c:290
+#: builtin/bisect--helper.c:342
 #, c-format
 msgid ""
 "You need to start by \"git bisect start\".\n"
@@ -10579,7 +10699,7 @@ msgstr ""
 "Danach müssen Sie mindestens einen \"%s\" und einen \"%s\" Commit angeben.\n"
 "Sie können dafür \"git bisect %s\" und \"git bisect %s\" benutzen."
 
-#: builtin/bisect--helper.c:310
+#: builtin/bisect--helper.c:362
 #, c-format
 msgid "bisecting only with a %s commit"
 msgstr "Binäre Suche nur mit einem %s Commit."
@@ -10588,15 +10708,15 @@ msgstr "Binäre Suche nur mit einem %s Commit."
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:318
+#: builtin/bisect--helper.c:370
 msgid "Are you sure [Y/n]? "
 msgstr "Sind Sie sicher [Y/n]? "
 
-#: builtin/bisect--helper.c:379
+#: builtin/bisect--helper.c:431
 msgid "no terms defined"
 msgstr "Keine Begriffe definiert."
 
-#: builtin/bisect--helper.c:382
+#: builtin/bisect--helper.c:434
 #, c-format
 msgid ""
 "Your current terms are %s for the old state\n"
@@ -10605,7 +10725,7 @@ msgstr ""
 "Ihre aktuellen Begriffe sind %s für den alten Zustand\n"
 "und %s für den neuen Zustand.\n"
 
-#: builtin/bisect--helper.c:392
+#: builtin/bisect--helper.c:444
 #, c-format
 msgid ""
 "invalid argument %s for 'git bisect terms'.\n"
@@ -10614,272 +10734,320 @@ msgstr ""
 "Ungültiges Argument %s für 'git bisect terms'.\n"
 "Unterstützte Optionen sind: --term-good|--term-old und --term-bad|--term-new."
 
-#: builtin/bisect--helper.c:460 builtin/bisect--helper.c:473
+#: builtin/bisect--helper.c:511
+#, fuzzy
+msgid "revision walk setup failed\n"
+msgstr "Einrichtung des Revisionsgangs fehlgeschlagen"
+
+#: builtin/bisect--helper.c:533
+#, fuzzy, c-format
+msgid "could not open '%s' for appending"
+msgstr "Konnte '%s' nicht zum Lesen öffnen."
+
+#: builtin/bisect--helper.c:651 builtin/bisect--helper.c:664
 msgid "'' is not a valid term"
 msgstr "'' ist kein gültiger Begriff"
 
-#: builtin/bisect--helper.c:483
+#: builtin/bisect--helper.c:674
 #, c-format
 msgid "unrecognized option: '%s'"
 msgstr "Nicht erkannte Position: '%s'"
 
-#: builtin/bisect--helper.c:487
+#: builtin/bisect--helper.c:678
 #, c-format
 msgid "'%s' does not appear to be a valid revision"
 msgstr "'%s' scheint kein gültiger Commit zu sein."
 
-#: builtin/bisect--helper.c:519
+#: builtin/bisect--helper.c:709
 msgid "bad HEAD - I need a HEAD"
 msgstr "Ungültiger HEAD - HEAD wird benötigt."
 
-#: builtin/bisect--helper.c:534
+#: builtin/bisect--helper.c:724
 #, c-format
 msgid "checking out '%s' failed. Try 'git bisect start <valid-branch>'."
 msgstr ""
 "Auschecken von '%s' fehlgeschlagen. Versuchen Sie 'git bisect start "
 "<gültiger-Branch>'."
 
-#: builtin/bisect--helper.c:555
+#: builtin/bisect--helper.c:745
 msgid "won't bisect on cg-seek'ed tree"
 msgstr ""
 "binäre Suche auf einem durch 'cg-seek' geändertem Verzeichnis nicht möglich"
 
-#: builtin/bisect--helper.c:558
+#: builtin/bisect--helper.c:748
 msgid "bad HEAD - strange symbolic ref"
 msgstr "Ungültiger HEAD - merkwürdige symbolische Referenz."
 
-#: builtin/bisect--helper.c:582
+#: builtin/bisect--helper.c:775
 #, c-format
 msgid "invalid ref: '%s'"
 msgstr "Ungültige Referenz: '%s'"
 
-#: builtin/bisect--helper.c:638
+#: builtin/bisect--helper.c:827
+#, fuzzy
+msgid "You need to start by \"git bisect start\"\n"
+msgstr "Sie müssen mit \"git bisect start\" beginnen."
+
+#. TRANSLATORS: Make sure to include [Y] and [n] in your
+#. translation. The program will only accept English input
+#. at this point.
+#.
+#: builtin/bisect--helper.c:838
+msgid "Do you want me to do it for you [Y/n]? "
+msgstr "Wollen Sie, dass ich es für Sie mache [Y/n]? "
+
+#: builtin/bisect--helper.c:866
 msgid "perform 'git bisect next'"
 msgstr "'git bisect next' ausführen"
 
-#: builtin/bisect--helper.c:640
+#: builtin/bisect--helper.c:868
 msgid "write the terms to .git/BISECT_TERMS"
 msgstr "die Begriffe nach .git/BISECT_TERMS schreiben"
 
-#: builtin/bisect--helper.c:642
+#: builtin/bisect--helper.c:870
 msgid "cleanup the bisection state"
 msgstr "den Zustand der binären Suche aufräumen"
 
-#: builtin/bisect--helper.c:644
+#: builtin/bisect--helper.c:872
 msgid "check for expected revs"
 msgstr "auf erwartete Commits prüfen"
 
-#: builtin/bisect--helper.c:646
+#: builtin/bisect--helper.c:874
 msgid "reset the bisection state"
 msgstr "den Zustand der binären Suche zurücksetzen"
 
-#: builtin/bisect--helper.c:648
+#: builtin/bisect--helper.c:876
 msgid "write out the bisection state in BISECT_LOG"
 msgstr "den Zustand der binären Suche nach BISECT_LOG schreiben"
 
-#: builtin/bisect--helper.c:650
+#: builtin/bisect--helper.c:878
 msgid "check and set terms in a bisection state"
 msgstr "Begriffe innerhalb einer binären Suche prüfen und setzen"
 
-#: builtin/bisect--helper.c:652
+#: builtin/bisect--helper.c:880
 msgid "check whether bad or good terms exist"
 msgstr "prüfen, ob Begriffe für gute und schlechte Commits existieren"
 
-#: builtin/bisect--helper.c:654
+#: builtin/bisect--helper.c:882
 msgid "print out the bisect terms"
 msgstr "die Begriffe für die binäre Suche ausgeben"
 
-#: builtin/bisect--helper.c:656
+#: builtin/bisect--helper.c:884
 msgid "start the bisect session"
 msgstr "Sitzung für binäre Suche starten"
 
-#: builtin/bisect--helper.c:658
-msgid "update BISECT_HEAD instead of checking out the current commit"
-msgstr "BISECT_HEAD aktualisieren, anstatt den aktuellen Commit auszuchecken"
+#: builtin/bisect--helper.c:886
+#, fuzzy
+msgid "find the next bisection commit"
+msgstr "Kann nicht existierenden Commit nicht nachbessern."
 
-#: builtin/bisect--helper.c:660
+#: builtin/bisect--helper.c:888
+msgid "verify the next bisection state then checkout the next bisection commit"
+msgstr ""
+
+#: builtin/bisect--helper.c:890
+msgid "start the bisection if it has not yet been started"
+msgstr ""
+
+#: builtin/bisect--helper.c:892
 msgid "no log for BISECT_WRITE"
 msgstr "kein Log für BISECT_WRITE"
 
-#: builtin/bisect--helper.c:678
+#: builtin/bisect--helper.c:910
 msgid "--write-terms requires two arguments"
 msgstr "--write-terms benötigt zwei Argumente."
 
-#: builtin/bisect--helper.c:682
+#: builtin/bisect--helper.c:914
 msgid "--bisect-clean-state requires no arguments"
 msgstr "--bisect-clean-state erwartet keine Argumente."
 
-#: builtin/bisect--helper.c:689
+#: builtin/bisect--helper.c:921
 msgid "--bisect-reset requires either no argument or a commit"
 msgstr "--bisect-reset benötigt entweder kein Argument oder ein Commit."
 
-#: builtin/bisect--helper.c:693
+#: builtin/bisect--helper.c:925
 msgid "--bisect-write requires either 4 or 5 arguments"
 msgstr "--bisect-write benötigt entweder 4 oder 5 Argumente."
 
-#: builtin/bisect--helper.c:699
+#: builtin/bisect--helper.c:931
 msgid "--check-and-set-terms requires 3 arguments"
 msgstr "--check-and-set-terms benötigt 3 Argumente."
 
-#: builtin/bisect--helper.c:705
+#: builtin/bisect--helper.c:937
 msgid "--bisect-next-check requires 2 or 3 arguments"
 msgstr "--bisect-next-check benötigt 2 oder 3 Argumente."
 
-#: builtin/bisect--helper.c:711
+#: builtin/bisect--helper.c:943
 msgid "--bisect-terms requires 0 or 1 argument"
 msgstr "--bisect-terms benötigt 0 oder 1 Argument."
 
-#: builtin/blame.c:31
+#: builtin/bisect--helper.c:952
+#, fuzzy
+msgid "--bisect-next requires 0 arguments"
+msgstr "--bisect-next-check benötigt 2 oder 3 Argumente."
+
+#: builtin/bisect--helper.c:958
+#, fuzzy
+msgid "--bisect-auto-next requires 0 arguments"
+msgstr "--bisect-terms benötigt 0 oder 1 Argument."
+
+#: builtin/bisect--helper.c:964
+#, fuzzy
+msgid "--bisect-autostart does not accept arguments"
+msgstr "--bisect-clean-state erwartet keine Argumente."
+
+#: builtin/blame.c:32
 msgid "git blame [<options>] [<rev-opts>] [<rev>] [--] <file>"
 msgstr "git blame [<Optionen>] [<rev-opts>] [<Commit>] [--] <Datei>"
 
-#: builtin/blame.c:36
+#: builtin/blame.c:37
 msgid "<rev-opts> are documented in git-rev-list(1)"
 msgstr "<rev-opts> sind dokumentiert in git-rev-list(1)"
 
-#: builtin/blame.c:409
+#: builtin/blame.c:410
 #, c-format
 msgid "expecting a color: %s"
 msgstr "Erwarte eine Farbe: %s"
 
-#: builtin/blame.c:416
+#: builtin/blame.c:417
 msgid "must end with a color"
 msgstr "Muss mit einer Farbe enden."
 
-#: builtin/blame.c:729
+#: builtin/blame.c:730
 #, c-format
 msgid "invalid color '%s' in color.blame.repeatedLines"
 msgstr "Ungültige Farbe '%s' in color.blame.repeatedLines."
 
-#: builtin/blame.c:747
+#: builtin/blame.c:748
 msgid "invalid value for blame.coloring"
 msgstr "Ungültiger Wert für blame.coloring."
 
-#: builtin/blame.c:822
+#: builtin/blame.c:845
 #, c-format
 msgid "cannot find revision %s to ignore"
 msgstr "Konnte Commit %s zum Ignorieren nicht finden"
 
-#: builtin/blame.c:844
+#: builtin/blame.c:867
 msgid "Show blame entries as we find them, incrementally"
 msgstr "\"blame\"-Einträge schrittweise anzeigen, während wir sie generieren"
 
-#: builtin/blame.c:845
-msgid "Show blank SHA-1 for boundary commits (Default: off)"
+#: builtin/blame.c:868
+#, fuzzy
+msgid "Do not show object names of boundary commits (Default: off)"
 msgstr "leere SHA-1 für Grenz-Commits anzeigen (Standard: aus)"
 
-#: builtin/blame.c:846
+#: builtin/blame.c:869
 msgid "Do not treat root commits as boundaries (Default: off)"
 msgstr "Root-Commits nicht als Grenzen behandeln (Standard: aus)"
 
-#: builtin/blame.c:847
+#: builtin/blame.c:870
 msgid "Show work cost statistics"
 msgstr "Statistiken zum Arbeitsaufwand anzeigen"
 
-#: builtin/blame.c:848
+#: builtin/blame.c:871
 msgid "Force progress reporting"
 msgstr "Fortschrittsanzeige erzwingen"
 
-#: builtin/blame.c:849
+#: builtin/blame.c:872
 msgid "Show output score for blame entries"
 msgstr "Ausgabebewertung für \"blame\"-Einträge anzeigen"
 
-#: builtin/blame.c:850
+#: builtin/blame.c:873
 msgid "Show original filename (Default: auto)"
 msgstr "ursprünglichen Dateinamen anzeigen (Standard: auto)"
 
-#: builtin/blame.c:851
+#: builtin/blame.c:874
 msgid "Show original linenumber (Default: off)"
 msgstr "ursprüngliche Zeilennummer anzeigen (Standard: aus)"
 
-#: builtin/blame.c:852
+#: builtin/blame.c:875
 msgid "Show in a format designed for machine consumption"
 msgstr "Anzeige in einem Format für maschinelle Auswertung"
 
-#: builtin/blame.c:853
+#: builtin/blame.c:876
 msgid "Show porcelain format with per-line commit information"
 msgstr ""
 "Anzeige in Format für Fremdprogramme mit Commit-Informationen pro Zeile"
 
-#: builtin/blame.c:854
+#: builtin/blame.c:877
 msgid "Use the same output mode as git-annotate (Default: off)"
 msgstr ""
 "Den gleichen Ausgabemodus benutzen wie \"git-annotate\" (Standard: aus)"
 
-#: builtin/blame.c:855
+#: builtin/blame.c:878
 msgid "Show raw timestamp (Default: off)"
 msgstr "Unbearbeiteten Zeitstempel anzeigen (Standard: aus)"
 
-#: builtin/blame.c:856
+#: builtin/blame.c:879
 msgid "Show long commit SHA1 (Default: off)"
 msgstr "Langen Commit-SHA1 anzeigen (Standard: aus)"
 
-#: builtin/blame.c:857
+#: builtin/blame.c:880
 msgid "Suppress author name and timestamp (Default: off)"
 msgstr "Den Namen des Autors und den Zeitstempel unterdrücken (Standard: aus)"
 
-#: builtin/blame.c:858
+#: builtin/blame.c:881
 msgid "Show author email instead of name (Default: off)"
 msgstr ""
 "Anstatt des Namens die E-Mail-Adresse des Autors anzeigen (Standard: aus)"
 
-#: builtin/blame.c:859
+#: builtin/blame.c:882
 msgid "Ignore whitespace differences"
 msgstr "Unterschiede im Whitespace ignorieren"
 
-#: builtin/blame.c:860 builtin/log.c:1721
+#: builtin/blame.c:883 builtin/log.c:1808
 msgid "rev"
 msgstr "Commit"
 
-#: builtin/blame.c:860
+#: builtin/blame.c:883
 msgid "Ignore <rev> when blaming"
 msgstr "Ignoriere <rev> beim Ausführen von 'blame'"
 
-#: builtin/blame.c:861
+#: builtin/blame.c:884
 msgid "Ignore revisions from <file>"
 msgstr "Ignoriere Commits aus <Datei>"
 
-#: builtin/blame.c:862
+#: builtin/blame.c:885
 msgid "color redundant metadata from previous line differently"
 msgstr "redundante Metadaten der vorherigen Zeile unterschiedlich einfärben"
 
-#: builtin/blame.c:863
+#: builtin/blame.c:886
 msgid "color lines by age"
 msgstr "Zeilen nach Alter einfärben"
 
-#: builtin/blame.c:864
+#: builtin/blame.c:887
 msgid "Spend extra cycles to find better match"
 msgstr "Länger arbeiten, um bessere Übereinstimmungen zu finden"
 
-#: builtin/blame.c:865
+#: builtin/blame.c:888
 msgid "Use revisions from <file> instead of calling git-rev-list"
 msgstr "Commits von <Datei> benutzen, anstatt \"git-rev-list\" aufzurufen"
 
-#: builtin/blame.c:866
+#: builtin/blame.c:889
 msgid "Use <file>'s contents as the final image"
 msgstr "Inhalte der <Datei>en als endgültiges Abbild benutzen"
 
-#: builtin/blame.c:867 builtin/blame.c:868
+#: builtin/blame.c:890 builtin/blame.c:891
 msgid "score"
 msgstr "Bewertung"
 
-#: builtin/blame.c:867
+#: builtin/blame.c:890
 msgid "Find line copies within and across files"
 msgstr "kopierte Zeilen innerhalb oder zwischen Dateien finden"
 
-#: builtin/blame.c:868
+#: builtin/blame.c:891
 msgid "Find line movements within and across files"
 msgstr "verschobene Zeilen innerhalb oder zwischen Dateien finden"
 
-#: builtin/blame.c:869
+#: builtin/blame.c:892
 msgid "n,m"
 msgstr "n,m"
 
-#: builtin/blame.c:869
+#: builtin/blame.c:892
 msgid "Process only line range n,m, counting from 1"
 msgstr "nur Zeilen im Bereich n,m verarbeiten, gezählt von 1"
 
-#: builtin/blame.c:921
+#: builtin/blame.c:944
 msgid "--progress can't be used with --incremental or porcelain formats"
 msgstr ""
 "--progress kann nicht mit --incremental oder Formaten für Fremdprogramme\n"
@@ -10893,23 +11061,24 @@ msgstr ""
 #. your language may need more or fewer display
 #. columns.
 #.
-#: builtin/blame.c:972
+#: builtin/blame.c:995
 msgid "4 years, 11 months ago"
 msgstr "vor 4 Jahren und 11 Monaten"
 
-#: builtin/blame.c:1087
+#: builtin/blame.c:1110
 #, c-format
 msgid "file %s has only %lu line"
 msgid_plural "file %s has only %lu lines"
 msgstr[0] "Datei %s hat nur %lu Zeile"
 msgstr[1] "Datei %s hat nur %lu Zeilen"
 
-#: builtin/blame.c:1133
+#: builtin/blame.c:1156
 msgid "Blaming lines"
 msgstr "Verarbeite Zeilen"
 
 #: builtin/branch.c:29
-msgid "git branch [<options>] [-r | -a] [--merged | --no-merged]"
+#, fuzzy
+msgid "git branch [<options>] [-r | -a] [--merged] [--no-merged]"
 msgstr "git branch [<Optionen>] [-r | -a] [--merged | --no-merged]"
 
 #: builtin/branch.c:30
@@ -11121,7 +11290,7 @@ msgstr "Modus zum Folgen von Branches einstellen (siehe git-pull(1))"
 msgid "do not use"
 msgstr "nicht verwenden"
 
-#: builtin/branch.c:626 builtin/rebase.c:520
+#: builtin/branch.c:626 builtin/rebase.c:526
 msgid "upstream"
 msgstr "Upstream"
 
@@ -11327,6 +11496,104 @@ msgstr ""
 "Die '--set-upstream' Option wird nicht länger unterstützt.\n"
 "Bitte benutzen Sie stattdessen '--track' oder '--set-upstream-to'."
 
+#: builtin/bugreport.c:15
+msgid "git version:\n"
+msgstr "git Version:\n"
+
+#: builtin/bugreport.c:21
+#, c-format
+msgid "uname() failed with error '%s' (%d)\n"
+msgstr "uname() ist fehlgeschlagen mit Fehler '%s' (%d)\n"
+
+#: builtin/bugreport.c:31
+msgid "compiler info: "
+msgstr "Compiler Info: "
+
+#: builtin/bugreport.c:34
+msgid "libc info: "
+msgstr "libc Info: "
+
+#: builtin/bugreport.c:80
+msgid "not run from a git repository - no hooks to show\n"
+msgstr "nicht in einem Git-Repository ausgeführt - keine Hooks zum Anzeigen\n"
+
+#: builtin/bugreport.c:90
+msgid "git bugreport [-o|--output-directory <file>] [-s|--suffix <format>]"
+msgstr "git bugreport [-o|--output-directory <Datei>] [-s|--suffix <Format>]"
+
+#: builtin/bugreport.c:97
+msgid ""
+"Thank you for filling out a Git bug report!\n"
+"Please answer the following questions to help us understand your issue.\n"
+"\n"
+"What did you do before the bug happened? (Steps to reproduce your issue)\n"
+"\n"
+"What did you expect to happen? (Expected behavior)\n"
+"\n"
+"What happened instead? (Actual behavior)\n"
+"\n"
+"What's different between what you expected and what actually happened?\n"
+"\n"
+"Anything else you want to add:\n"
+"\n"
+"Please review the rest of the bug report below.\n"
+"You can delete any lines you don't wish to share.\n"
+msgstr ""
+"Vielen Dank für das Ausfüllen eines Git-Fehlerberichts!\n"
+"Bitte antworten Sie auf die folgenden Fragen, um uns dabei zu helfen, Ihr\n"
+"Problem zu verstehen.\n"
+"\n"
+"Was haben Sie gemacht, bevor der Fehler auftrat? (Schritte, um Ihr Fehler\n"
+"zu reproduzieren)\n"
+"\n"
+"Was haben Sie erwartet, was passieren soll? (Erwartetes Verhalten)\n"
+"\n"
+"Was ist stattdessen passiert? (Wirkliches Verhalten)\n"
+"\n"
+"Was ist der Unterschied zwischen dem, was Sie erwartet haben und was\n"
+"wirklich passiert ist?\n"
+"\n"
+"Sonstige Anmerkungen, die Sie hinzufügen möchten:\n"
+"\n"
+"Bitte überprüfen Sie den restlichen Teil des Fehlerberichts unten.\n"
+"Sie können jede Zeile löschen, die Sie nicht mitteilen möchten.\n"
+
+#: builtin/bugreport.c:134
+msgid "specify a destination for the bugreport file"
+msgstr "Speicherort für die Datei des Fehlerberichts angeben"
+
+#: builtin/bugreport.c:136
+msgid "specify a strftime format suffix for the filename"
+msgstr "Dateiendung im strftime-Format für den Dateinamen angeben"
+
+#: builtin/bugreport.c:158
+#, c-format
+msgid "could not create leading directories for '%s'"
+msgstr "konnte vorangehende Verzeichnisse für '%s' nicht erstellen"
+
+#: builtin/bugreport.c:165
+msgid "System Info"
+msgstr "System Info"
+
+#: builtin/bugreport.c:168
+msgid "Enabled Hooks"
+msgstr "Aktivierte Hooks"
+
+#: builtin/bugreport.c:175
+#, c-format
+msgid "couldn't create a new file at '%s'"
+msgstr "konnte keine neue Datei unter '%s' erstellen"
+
+#: builtin/bugreport.c:178
+#, c-format
+msgid "unable to write to %s"
+msgstr "konnte nicht nach %s schreiben"
+
+#: builtin/bugreport.c:188
+#, c-format
+msgid "Created new report at '%s'.\n"
+msgstr "Neuer Bericht unter '%s' erstellt.\n"
+
 #: builtin/bundle.c:15 builtin/bundle.c:23
 msgid "git bundle create [<options>] <file> <git-rev-list args>"
 msgstr "git bundle create [<Optionen>] <Datei> <git-rev-list Argumente>"
@@ -11343,44 +11610,48 @@ msgstr "git bundle list-heads <Datei> [<Referenzname>...]"
 msgid "git bundle unbundle <file> [<refname>...]"
 msgstr "git bundle unbundle <Datei> [<Referenzname>...]"
 
-#: builtin/bundle.c:66 builtin/pack-objects.c:3448
+#: builtin/bundle.c:67 builtin/pack-objects.c:3480
 msgid "do not show progress meter"
 msgstr "keine Fortschrittsanzeige anzeigen"
 
-#: builtin/bundle.c:68 builtin/pack-objects.c:3450
+#: builtin/bundle.c:69 builtin/pack-objects.c:3482
 msgid "show progress meter"
 msgstr "Fortschrittsanzeige anzeigen"
 
-#: builtin/bundle.c:70 builtin/pack-objects.c:3452
+#: builtin/bundle.c:71 builtin/pack-objects.c:3484
 msgid "show progress meter during object writing phase"
 msgstr "Forschrittsanzeige während des Schreibens von Objekten anzeigen"
 
-#: builtin/bundle.c:73 builtin/pack-objects.c:3455
+#: builtin/bundle.c:74 builtin/pack-objects.c:3487
 msgid "similar to --all-progress when progress meter is shown"
 msgstr "ähnlich zu --all-progress wenn Fortschrittsanzeige darstellt wird"
 
-#: builtin/bundle.c:93
+#: builtin/bundle.c:76
+msgid "specify bundle format version"
+msgstr ""
+
+#: builtin/bundle.c:96
 msgid "Need a repository to create a bundle."
 msgstr "Um ein Paket zu erstellen wird ein Repository benötigt."
 
-#: builtin/bundle.c:104
+#: builtin/bundle.c:107
 msgid "do not show bundle details"
 msgstr "Keine Bundle-Details anzeigen"
 
-#: builtin/bundle.c:119
+#: builtin/bundle.c:122
 #, c-format
 msgid "%s is okay\n"
 msgstr "%s ist in Ordnung\n"
 
-#: builtin/bundle.c:160
+#: builtin/bundle.c:163
 msgid "Need a repository to unbundle."
 msgstr "Zum Entpacken wird ein Repository benötigt."
 
-#: builtin/bundle.c:168 builtin/remote.c:1686
+#: builtin/bundle.c:171 builtin/remote.c:1687
 msgid "be verbose; must be placed before a subcommand"
 msgstr "erweiterte Ausgaben; muss vor einem Unterbefehl angegeben werden"
 
-#: builtin/bundle.c:190 builtin/remote.c:1717
+#: builtin/bundle.c:193 builtin/remote.c:1718
 #, c-format
 msgid "Unknown subcommand: %s"
 msgstr "Unbekannter Unterbefehl: %s"
@@ -11433,7 +11704,7 @@ msgstr "eine Textkonvertierung auf den Inhalt von Blob-Objekten ausführen"
 msgid "for blob objects, run filters on object's content"
 msgstr "für Blob-Objekte, Filter auf Objekt-Inhalte ausführen"
 
-#: builtin/cat-file.c:648 git-submodule.sh:958
+#: builtin/cat-file.c:648
 msgid "blob"
 msgstr "Blob"
 
@@ -11498,7 +11769,7 @@ msgstr "Dateinamen von der Standard-Eingabe lesen"
 msgid "terminate input and output records by a NUL character"
 msgstr "Einträge von Ein- und Ausgabe mit NUL-Zeichen abschließen"
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1486 builtin/gc.c:537
+#: builtin/check-ignore.c:21 builtin/checkout.c:1482 builtin/gc.c:538
 #: builtin/worktree.c:561
 msgid "suppress progress reporting"
 msgstr "Fortschrittsanzeige unterdrücken"
@@ -11592,8 +11863,8 @@ msgid "write the content to temporary files"
 msgstr "den Inhalt in temporäre Dateien schreiben"
 
 #: builtin/checkout-index.c:178 builtin/column.c:31
-#: builtin/submodule--helper.c:1400 builtin/submodule--helper.c:1403
-#: builtin/submodule--helper.c:1411 builtin/submodule--helper.c:1909
+#: builtin/submodule--helper.c:1824 builtin/submodule--helper.c:1827
+#: builtin/submodule--helper.c:1835 builtin/submodule--helper.c:2333
 #: builtin/worktree.c:754
 msgid "string"
 msgstr "Zeichenkette"
@@ -11638,84 +11909,84 @@ msgstr "Pfad '%s' hat nicht deren Version."
 msgid "path '%s' does not have all necessary versions"
 msgstr "Pfad '%s' hat nicht alle notwendigen Versionen."
 
-#: builtin/checkout.c:256
+#: builtin/checkout.c:258
 #, c-format
 msgid "path '%s' does not have necessary versions"
 msgstr "Pfad '%s' hat nicht die notwendigen Versionen."
 
-#: builtin/checkout.c:274
+#: builtin/checkout.c:275
 #, c-format
 msgid "path '%s': cannot merge"
 msgstr "Pfad '%s': kann nicht zusammenführen"
 
-#: builtin/checkout.c:290
+#: builtin/checkout.c:291
 #, c-format
 msgid "Unable to add merge result for '%s'"
 msgstr "Konnte Merge-Ergebnis von '%s' nicht hinzufügen."
 
-#: builtin/checkout.c:395
+#: builtin/checkout.c:396
 #, c-format
 msgid "Recreated %d merge conflict"
 msgid_plural "Recreated %d merge conflicts"
 msgstr[0] "%d Merge-Konflikt wieder erstellt"
 msgstr[1] "%d Merge-Konflikte wieder erstellt"
 
-#: builtin/checkout.c:400
+#: builtin/checkout.c:401
 #, c-format
 msgid "Updated %d path from %s"
 msgid_plural "Updated %d paths from %s"
 msgstr[0] "%d Pfad von %s aktualisiert"
 msgstr[1] "%d Pfade von %s aktualisiert"
 
-#: builtin/checkout.c:407
+#: builtin/checkout.c:408
 #, c-format
 msgid "Updated %d path from the index"
 msgid_plural "Updated %d paths from the index"
 msgstr[0] "%d Pfad vom Index aktualisiert"
 msgstr[1] "%d Pfade vom Index aktualisiert"
 
-#: builtin/checkout.c:430 builtin/checkout.c:433 builtin/checkout.c:436
-#: builtin/checkout.c:440
+#: builtin/checkout.c:431 builtin/checkout.c:434 builtin/checkout.c:437
+#: builtin/checkout.c:441
 #, c-format
 msgid "'%s' cannot be used with updating paths"
 msgstr "'%s' kann nicht mit der Aktualisierung von Pfaden verwendet werden"
 
-#: builtin/checkout.c:443 builtin/checkout.c:446
+#: builtin/checkout.c:444 builtin/checkout.c:447
 #, c-format
 msgid "'%s' cannot be used with %s"
 msgstr "'%s' kann nicht mit '%s' verwendet werden"
 
-#: builtin/checkout.c:450
+#: builtin/checkout.c:451
 #, c-format
 msgid "Cannot update paths and switch to branch '%s' at the same time."
 msgstr ""
 "Kann nicht gleichzeitig Pfade aktualisieren und zu Branch '%s' wechseln"
 
-#: builtin/checkout.c:454
+#: builtin/checkout.c:455
 #, c-format
 msgid "neither '%s' or '%s' is specified"
 msgstr "Weder '%s' noch '%s' ist angegeben"
 
-#: builtin/checkout.c:458
+#: builtin/checkout.c:459
 #, c-format
 msgid "'%s' must be used when '%s' is not specified"
 msgstr "'%s' kann nur genutzt werden, wenn '%s' nicht verwendet wird"
 
-#: builtin/checkout.c:463 builtin/checkout.c:468
+#: builtin/checkout.c:464 builtin/checkout.c:469
 #, c-format
 msgid "'%s' or '%s' cannot be used with %s"
 msgstr "'%s' oder '%s' kann nicht mit %s verwendet werden"
 
-#: builtin/checkout.c:527 builtin/checkout.c:534
+#: builtin/checkout.c:528 builtin/checkout.c:535
 #, c-format
 msgid "path '%s' is unmerged"
 msgstr "Pfad '%s' ist nicht zusammengeführt."
 
-#: builtin/checkout.c:702
+#: builtin/checkout.c:703
 msgid "you need to resolve your current index first"
 msgstr "Sie müssen zuerst die Konflikte in Ihrem aktuellen Index auflösen."
 
-#: builtin/checkout.c:756
+#: builtin/checkout.c:757
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -11724,50 +11995,50 @@ msgstr ""
 "Kann nicht mit vorgemerkten Änderungen in folgenden Dateien fortsetzen:\n"
 "%s"
 
-#: builtin/checkout.c:859
+#: builtin/checkout.c:853
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Kann \"reflog\" für '%s' nicht durchführen: %s\n"
 
-#: builtin/checkout.c:901
+#: builtin/checkout.c:895
 msgid "HEAD is now at"
 msgstr "HEAD ist jetzt bei"
 
-#: builtin/checkout.c:905 builtin/clone.c:720
+#: builtin/checkout.c:899 builtin/clone.c:720
 msgid "unable to update HEAD"
 msgstr "Konnte HEAD nicht aktualisieren."
 
-#: builtin/checkout.c:909
+#: builtin/checkout.c:903
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Setze Branch '%s' neu\n"
 
-#: builtin/checkout.c:912
+#: builtin/checkout.c:906
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Bereits auf '%s'\n"
 
-#: builtin/checkout.c:916
+#: builtin/checkout.c:910
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Zu umgesetztem Branch '%s' gewechselt\n"
 
-#: builtin/checkout.c:918 builtin/checkout.c:1342
+#: builtin/checkout.c:912 builtin/checkout.c:1338
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Zu neuem Branch '%s' gewechselt\n"
 
-#: builtin/checkout.c:920
+#: builtin/checkout.c:914
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Zu Branch '%s' gewechselt\n"
 
-#: builtin/checkout.c:971
+#: builtin/checkout.c:965
 #, c-format
 msgid " ... and %d more.\n"
 msgstr " ... und %d weitere.\n"
 
-#: builtin/checkout.c:977
+#: builtin/checkout.c:971
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -11790,7 +12061,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:996
+#: builtin/checkout.c:990
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -11817,19 +12088,19 @@ msgstr[1] ""
 " git branch <neuer-Branchname> %s\n"
 "\n"
 
-#: builtin/checkout.c:1031
+#: builtin/checkout.c:1025
 msgid "internal error in revision walk"
 msgstr "interner Fehler im Revisionsgang"
 
-#: builtin/checkout.c:1035
+#: builtin/checkout.c:1029
 msgid "Previous HEAD position was"
 msgstr "Vorherige Position von HEAD war"
 
-#: builtin/checkout.c:1075 builtin/checkout.c:1337
+#: builtin/checkout.c:1069 builtin/checkout.c:1333
 msgid "You are on a branch yet to be born"
 msgstr "Sie sind auf einem Branch, der noch nicht geboren ist"
 
-#: builtin/checkout.c:1150
+#: builtin/checkout.c:1146
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
@@ -11839,7 +12110,7 @@ msgstr ""
 "Bitte benutzen Sie -- (und optional --no-guess), um diese\n"
 "eindeutig voneinander zu unterscheiden."
 
-#: builtin/checkout.c:1157
+#: builtin/checkout.c:1153
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -11862,51 +12133,51 @@ msgstr ""
 "bevorzugen möchten, z.B. 'origin', können Sie die Einstellung\n"
 "checkout.defaultRemote=origin in Ihrer Konfiguration setzen."
 
-#: builtin/checkout.c:1167
+#: builtin/checkout.c:1163
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "'%s' entspricht mehreren (%d) Remote-Tracking-Branches"
 
-#: builtin/checkout.c:1233
+#: builtin/checkout.c:1229
 msgid "only one reference expected"
 msgstr "nur eine Referenz erwartet"
 
-#: builtin/checkout.c:1250
+#: builtin/checkout.c:1246
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "nur eine Referenz erwartet, %d gegeben."
 
-#: builtin/checkout.c:1296 builtin/worktree.c:342 builtin/worktree.c:510
+#: builtin/checkout.c:1292 builtin/worktree.c:342 builtin/worktree.c:510
 #, c-format
 msgid "invalid reference: %s"
 msgstr "Ungültige Referenz: %s"
 
-#: builtin/checkout.c:1309 builtin/checkout.c:1675
+#: builtin/checkout.c:1305 builtin/checkout.c:1671
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "Referenz ist kein \"Tree\"-Objekt: %s"
 
-#: builtin/checkout.c:1356
+#: builtin/checkout.c:1352
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "Ein Branch wird erwartet, Tag '%s' bekommen"
 
-#: builtin/checkout.c:1358
+#: builtin/checkout.c:1354
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "Ein Branch wird erwartet, Remote-Branch '%s' bekommen"
 
-#: builtin/checkout.c:1359 builtin/checkout.c:1367
+#: builtin/checkout.c:1355 builtin/checkout.c:1363
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "Ein Branch wird erwartet, '%s' bekommen"
 
-#: builtin/checkout.c:1362
+#: builtin/checkout.c:1358
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "Ein Branch wird erwartet, Commit '%s' bekommen"
 
-#: builtin/checkout.c:1378
+#: builtin/checkout.c:1374
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -11914,7 +12185,7 @@ msgstr ""
 "Der Branch kann nicht während eines Merges gewechselt werden.\n"
 "Ziehen Sie \"git merge --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1382
+#: builtin/checkout.c:1378
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
@@ -11923,7 +12194,7 @@ msgstr ""
 "werden.\n"
 "Ziehen Sie \"git am --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1386
+#: builtin/checkout.c:1382
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
@@ -11932,7 +12203,7 @@ msgstr ""
 "werden.\n"
 "Ziehen Sie \"git rebase --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1390
+#: builtin/checkout.c:1386
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
@@ -11941,7 +12212,7 @@ msgstr ""
 "gewechselt werden.\n"
 "Ziehen Sie \"git cherry-pick --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1394
+#: builtin/checkout.c:1390
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -11950,147 +12221,147 @@ msgstr ""
 "werden.\n"
 "Ziehen Sie \"git revert --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1398
+#: builtin/checkout.c:1394
 msgid "you are switching branch while bisecting"
 msgstr "Sie wechseln den Branch während einer binären Suche"
 
-#: builtin/checkout.c:1405
+#: builtin/checkout.c:1401
 msgid "paths cannot be used with switching branches"
 msgstr "Pfade können nicht beim Wechseln von Branches verwendet werden"
 
-#: builtin/checkout.c:1408 builtin/checkout.c:1412 builtin/checkout.c:1416
+#: builtin/checkout.c:1404 builtin/checkout.c:1408 builtin/checkout.c:1412
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "'%s' kann nicht beim Wechseln von Branches verwendet werden"
 
-#: builtin/checkout.c:1420 builtin/checkout.c:1423 builtin/checkout.c:1426
-#: builtin/checkout.c:1431 builtin/checkout.c:1436
+#: builtin/checkout.c:1416 builtin/checkout.c:1419 builtin/checkout.c:1422
+#: builtin/checkout.c:1427 builtin/checkout.c:1432
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "'%s' kann nicht mit '%s' verwendet werden"
 
-#: builtin/checkout.c:1433
+#: builtin/checkout.c:1429
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "'%s' kann nicht <Startpunkt> bekommen"
 
-#: builtin/checkout.c:1441
+#: builtin/checkout.c:1437
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "Kann Branch nicht zu Nicht-Commit '%s' wechseln"
 
-#: builtin/checkout.c:1448
+#: builtin/checkout.c:1444
 msgid "missing branch or commit argument"
 msgstr "Branch- oder Commit-Argument fehlt"
 
-#: builtin/checkout.c:1490 builtin/clone.c:91 builtin/commit-graph.c:82
-#: builtin/commit-graph.c:189 builtin/fetch.c:168 builtin/merge.c:288
-#: builtin/multi-pack-index.c:27 builtin/pull.c:119 builtin/push.c:561
-#: builtin/send-pack.c:173
+#: builtin/checkout.c:1486 builtin/clone.c:91 builtin/commit-graph.c:84
+#: builtin/commit-graph.c:222 builtin/fetch.c:172 builtin/merge.c:287
+#: builtin/multi-pack-index.c:27 builtin/pull.c:119 builtin/push.c:551
+#: builtin/send-pack.c:192
 msgid "force progress reporting"
 msgstr "Fortschrittsanzeige erzwingen"
 
-#: builtin/checkout.c:1491
+#: builtin/checkout.c:1487
 msgid "perform a 3-way merge with the new branch"
 msgstr "einen 3-Wege-Merge mit dem neuen Branch ausführen"
 
-#: builtin/checkout.c:1492 builtin/log.c:1709 parse-options.h:322
+#: builtin/checkout.c:1488 builtin/log.c:1795 parse-options.h:322
 msgid "style"
 msgstr "Stil"
 
-#: builtin/checkout.c:1493
+#: builtin/checkout.c:1489
 msgid "conflict style (merge or diff3)"
 msgstr "Konfliktstil (merge oder diff3)"
 
-#: builtin/checkout.c:1505 builtin/worktree.c:558
+#: builtin/checkout.c:1501 builtin/worktree.c:558
 msgid "detach HEAD at named commit"
 msgstr "HEAD bei benanntem Commit loslösen"
 
-#: builtin/checkout.c:1506
+#: builtin/checkout.c:1502
 msgid "set upstream info for new branch"
 msgstr "Informationen zum Upstream-Branch für den neuen Branch setzen"
 
-#: builtin/checkout.c:1508
+#: builtin/checkout.c:1504
 msgid "force checkout (throw away local modifications)"
 msgstr "Auschecken erzwingen (verwirft lokale Änderungen)"
 
-#: builtin/checkout.c:1510
+#: builtin/checkout.c:1506
 msgid "new-branch"
 msgstr "neuer Branch"
 
-#: builtin/checkout.c:1510
+#: builtin/checkout.c:1506
 msgid "new unparented branch"
 msgstr "neuer Branch ohne Eltern-Commit"
 
-#: builtin/checkout.c:1512 builtin/merge.c:292
+#: builtin/checkout.c:1508 builtin/merge.c:291
 msgid "update ignored files (default)"
 msgstr "ignorierte Dateien aktualisieren (Standard)"
 
-#: builtin/checkout.c:1515
+#: builtin/checkout.c:1511
 msgid "do not check if another worktree is holding the given ref"
 msgstr ""
 "Prüfung, ob die Referenz bereits in einem anderen Arbeitsverzeichnis "
 "ausgecheckt wurde, deaktivieren"
 
-#: builtin/checkout.c:1528
+#: builtin/checkout.c:1524
 msgid "checkout our version for unmerged files"
 msgstr "unsere Variante für nicht zusammengeführte Dateien auschecken"
 
-#: builtin/checkout.c:1531
+#: builtin/checkout.c:1527
 msgid "checkout their version for unmerged files"
 msgstr "ihre Variante für nicht zusammengeführte Dateien auschecken"
 
-#: builtin/checkout.c:1535
+#: builtin/checkout.c:1531
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "keine Einschränkung bei Pfadspezifikationen zum partiellen Auschecken"
 
-#: builtin/checkout.c:1590
+#: builtin/checkout.c:1586
 #, c-format
 msgid "-%c, -%c and --orphan are mutually exclusive"
 msgstr "die Optionen -%c, -%c und --orphan schließen sich gegenseitig aus"
 
-#: builtin/checkout.c:1594
+#: builtin/checkout.c:1590
 msgid "-p and --overlay are mutually exclusive"
 msgstr "-p und --overlay schließen sich gegenseitig aus."
 
-#: builtin/checkout.c:1631
+#: builtin/checkout.c:1627
 msgid "--track needs a branch name"
 msgstr "Bei der Option --track muss ein Branchname angegeben werden."
 
-#: builtin/checkout.c:1636
+#: builtin/checkout.c:1632
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "kein Branchname; versuchen Sie -%c"
 
-#: builtin/checkout.c:1668
+#: builtin/checkout.c:1664
 #, c-format
 msgid "could not resolve %s"
 msgstr "Konnte %s nicht auflösen."
 
-#: builtin/checkout.c:1684
+#: builtin/checkout.c:1680
 msgid "invalid path specification"
 msgstr "ungültige Pfadspezifikation"
 
-#: builtin/checkout.c:1691
+#: builtin/checkout.c:1687
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr ""
 "'%s' ist kein Commit und es kann kein Branch '%s' aus diesem erstellt werden."
 
-#: builtin/checkout.c:1695
+#: builtin/checkout.c:1691
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach nimmt kein Pfad-Argument '%s'"
 
-#: builtin/checkout.c:1704
+#: builtin/checkout.c:1700
 msgid "--pathspec-from-file is incompatible with --detach"
 msgstr "Die Optionen --pathspec-from-file und --detach sind inkompatibel."
 
-#: builtin/checkout.c:1707 builtin/reset.c:325 builtin/stash.c:1503
+#: builtin/checkout.c:1703 builtin/reset.c:325 builtin/stash.c:1500
 msgid "--pathspec-from-file is incompatible with --patch"
 msgstr "Die Optionen --pathspec-from-file und --patch sind inkompatibel."
 
-#: builtin/checkout.c:1718
+#: builtin/checkout.c:1716
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -12098,70 +12369,70 @@ msgstr ""
 "git checkout: --ours/--theirs, --force und --merge sind inkompatibel wenn\n"
 "Sie aus dem Index auschecken."
 
-#: builtin/checkout.c:1723
+#: builtin/checkout.c:1721
 msgid "you must specify path(s) to restore"
 msgstr "Sie müssen Pfad(e) zur Wiederherstellung angeben."
 
-#: builtin/checkout.c:1749 builtin/checkout.c:1751 builtin/checkout.c:1800
-#: builtin/checkout.c:1802 builtin/clone.c:121 builtin/remote.c:170
-#: builtin/remote.c:172 builtin/submodule--helper.c:2295 builtin/worktree.c:554
+#: builtin/checkout.c:1747 builtin/checkout.c:1749 builtin/checkout.c:1798
+#: builtin/checkout.c:1800 builtin/clone.c:121 builtin/remote.c:170
+#: builtin/remote.c:172 builtin/submodule--helper.c:2719 builtin/worktree.c:554
 #: builtin/worktree.c:556
 msgid "branch"
 msgstr "Branch"
 
-#: builtin/checkout.c:1750
+#: builtin/checkout.c:1748
 msgid "create and checkout a new branch"
 msgstr "einen neuen Branch erzeugen und auschecken"
 
-#: builtin/checkout.c:1752
+#: builtin/checkout.c:1750
 msgid "create/reset and checkout a branch"
 msgstr "einen Branch erstellen/umsetzen und auschecken"
 
-#: builtin/checkout.c:1753
+#: builtin/checkout.c:1751
 msgid "create reflog for new branch"
 msgstr "das Reflog für den neuen Branch erzeugen"
 
-#: builtin/checkout.c:1755
+#: builtin/checkout.c:1753
 msgid "second guess 'git checkout <no-such-branch>' (default)"
 msgstr "Zweite Vermutung 'git checkout <kein-solcher-Branch>' (Standard)"
 
-#: builtin/checkout.c:1756
+#: builtin/checkout.c:1754
 msgid "use overlay mode (default)"
 msgstr "benutze Overlay-Modus (Standard)"
 
-#: builtin/checkout.c:1801
+#: builtin/checkout.c:1799
 msgid "create and switch to a new branch"
 msgstr "einen neuen Branch erzeugen und dahin wechseln"
 
-#: builtin/checkout.c:1803
+#: builtin/checkout.c:1801
 msgid "create/reset and switch to a branch"
 msgstr "einen Branch erstellen/umsetzen und dahin wechseln"
 
-#: builtin/checkout.c:1805
+#: builtin/checkout.c:1803
 msgid "second guess 'git switch <no-such-branch>'"
 msgstr "Zweite Vermutung 'git switch <kein-solcher-Branch>'"
 
-#: builtin/checkout.c:1807
+#: builtin/checkout.c:1805
 msgid "throw away local modifications"
 msgstr "lokale Änderungen verwerfen"
 
-#: builtin/checkout.c:1841
+#: builtin/checkout.c:1839
 msgid "which tree-ish to checkout from"
 msgstr "Von welcher Commit-Referenz ausgecheckt werden soll"
 
-#: builtin/checkout.c:1843
+#: builtin/checkout.c:1841
 msgid "restore the index"
 msgstr "Index wiederherstellen"
 
-#: builtin/checkout.c:1845
+#: builtin/checkout.c:1843
 msgid "restore the working tree (default)"
 msgstr "das Arbeitsverzeichnis wiederherstellen (Standard)"
 
-#: builtin/checkout.c:1847
+#: builtin/checkout.c:1845
 msgid "ignore unmerged entries"
 msgstr "ignoriere nicht zusammengeführte Einträge"
 
-#: builtin/checkout.c:1848
+#: builtin/checkout.c:1846
 msgid "use overlay mode"
 msgstr "benutze Overlay-Modus"
 
@@ -12306,7 +12577,7 @@ msgid "remove whole directories"
 msgstr "ganze Verzeichnisse löschen"
 
 #: builtin/clean.c:909 builtin/describe.c:565 builtin/describe.c:567
-#: builtin/grep.c:909 builtin/log.c:182 builtin/log.c:184
+#: builtin/grep.c:910 builtin/log.c:181 builtin/log.c:183
 #: builtin/ls-files.c:558 builtin/name-rev.c:526 builtin/name-rev.c:528
 #: builtin/show-ref.c:179
 msgid "pattern"
@@ -12352,7 +12623,7 @@ msgstr "git clone [<Optionen>] [--] <Repository> [<Verzeichnis>]"
 msgid "don't create a checkout"
 msgstr "kein Auschecken"
 
-#: builtin/clone.c:94 builtin/clone.c:96 builtin/init-db.c:554
+#: builtin/clone.c:94 builtin/clone.c:96 builtin/init-db.c:553
 msgid "create a bare repository"
 msgstr "ein Bare-Repository erstellen"
 
@@ -12384,26 +12655,26 @@ msgstr "Submodule im Klon initialisieren"
 msgid "number of submodules cloned in parallel"
 msgstr "Anzahl der parallel zu klonenden Submodule"
 
-#: builtin/clone.c:111 builtin/init-db.c:551
+#: builtin/clone.c:111 builtin/init-db.c:550
 msgid "template-directory"
 msgstr "Vorlagenverzeichnis"
 
-#: builtin/clone.c:112 builtin/init-db.c:552
+#: builtin/clone.c:112 builtin/init-db.c:551
 msgid "directory from which templates will be used"
 msgstr "Verzeichnis, von welchem die Vorlagen verwendet werden"
 
-#: builtin/clone.c:114 builtin/clone.c:116 builtin/submodule--helper.c:1407
-#: builtin/submodule--helper.c:1912
+#: builtin/clone.c:114 builtin/clone.c:116 builtin/submodule--helper.c:1831
+#: builtin/submodule--helper.c:2336
 msgid "reference repository"
 msgstr "Repository referenzieren"
 
-#: builtin/clone.c:118 builtin/submodule--helper.c:1409
-#: builtin/submodule--helper.c:1914
+#: builtin/clone.c:118 builtin/submodule--helper.c:1833
+#: builtin/submodule--helper.c:2338
 msgid "use --reference only while cloning"
 msgstr "--reference nur während des Klonens benutzen"
 
-#: builtin/clone.c:119 builtin/column.c:27 builtin/init-db.c:562
-#: builtin/merge-file.c:46 builtin/pack-objects.c:3514 builtin/repack.c:329
+#: builtin/clone.c:119 builtin/column.c:27 builtin/init-db.c:561
+#: builtin/merge-file.c:46 builtin/pack-objects.c:3546 builtin/repack.c:332
 msgid "name"
 msgstr "Name"
 
@@ -12419,7 +12690,7 @@ msgstr "<Branch> auschecken, anstatt HEAD des Remote-Repositories"
 msgid "path to git-upload-pack on the remote"
 msgstr "Pfad zu \"git-upload-pack\" auf der Gegenseite"
 
-#: builtin/clone.c:125 builtin/fetch.c:169 builtin/grep.c:848
+#: builtin/clone.c:125 builtin/fetch.c:173 builtin/grep.c:849
 #: builtin/pull.c:208
 msgid "depth"
 msgstr "Tiefe"
@@ -12429,7 +12700,7 @@ msgid "create a shallow clone of that depth"
 msgstr ""
 "einen Klon mit unvollständiger Historie (shallow) in dieser Tiefe erstellen"
 
-#: builtin/clone.c:127 builtin/fetch.c:171 builtin/pack-objects.c:3503
+#: builtin/clone.c:127 builtin/fetch.c:175 builtin/pack-objects.c:3535
 #: builtin/pull.c:211
 msgid "time"
 msgstr "Zeit"
@@ -12441,19 +12712,19 @@ msgstr ""
 "Zeit\n"
 "erstellen"
 
-#: builtin/clone.c:129 builtin/fetch.c:173 builtin/fetch.c:196
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1304
+#: builtin/clone.c:129 builtin/fetch.c:177 builtin/fetch.c:200
+#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1311
 msgid "revision"
 msgstr "Commit"
 
-#: builtin/clone.c:130 builtin/fetch.c:174 builtin/pull.c:215
+#: builtin/clone.c:130 builtin/fetch.c:178 builtin/pull.c:215
 msgid "deepen history of shallow clone, excluding rev"
 msgstr ""
 "die Historie eines Klons mit unvollständiger Historie (shallow) mittels\n"
 "Ausschluss eines Commits vertiefen"
 
-#: builtin/clone.c:132 builtin/submodule--helper.c:1419
-#: builtin/submodule--helper.c:1928
+#: builtin/clone.c:132 builtin/submodule--helper.c:1843
+#: builtin/submodule--helper.c:2352
 msgid "clone only one branch, HEAD or --branch"
 msgstr "nur einen Branch klonen, HEAD oder --branch"
 
@@ -12465,11 +12736,11 @@ msgstr "keine Tags klonen, und auch bei späteren Abrufen nicht beachten"
 msgid "any cloned submodules will be shallow"
 msgstr "jedes geklonte Submodul mit unvollständiger Historie (shallow)"
 
-#: builtin/clone.c:137 builtin/init-db.c:560
+#: builtin/clone.c:137 builtin/init-db.c:559
 msgid "gitdir"
 msgstr ".git-Verzeichnis"
 
-#: builtin/clone.c:138 builtin/init-db.c:561
+#: builtin/clone.c:138 builtin/init-db.c:560
 msgid "separate git dir from working tree"
 msgstr "Git-Verzeichnis vom Arbeitsverzeichnis separieren"
 
@@ -12481,23 +12752,23 @@ msgstr "Schlüssel=Wert"
 msgid "set config inside the new repository"
 msgstr "Konfiguration innerhalb des neuen Repositories setzen"
 
-#: builtin/clone.c:142 builtin/fetch.c:191 builtin/ls-remote.c:76
-#: builtin/pull.c:230 builtin/push.c:570 builtin/send-pack.c:171
+#: builtin/clone.c:142 builtin/fetch.c:195 builtin/ls-remote.c:76
+#: builtin/pull.c:230 builtin/push.c:560 builtin/send-pack.c:190
 msgid "server-specific"
 msgstr "serverspezifisch"
 
-#: builtin/clone.c:142 builtin/fetch.c:191 builtin/ls-remote.c:76
-#: builtin/pull.c:231 builtin/push.c:570 builtin/send-pack.c:172
+#: builtin/clone.c:142 builtin/fetch.c:195 builtin/ls-remote.c:76
+#: builtin/pull.c:231 builtin/push.c:560 builtin/send-pack.c:191
 msgid "option to transmit"
 msgstr "Option übertragen"
 
-#: builtin/clone.c:143 builtin/fetch.c:192 builtin/pull.c:234
-#: builtin/push.c:571
+#: builtin/clone.c:143 builtin/fetch.c:196 builtin/pull.c:234
+#: builtin/push.c:561
 msgid "use IPv4 addresses only"
 msgstr "nur IPv4-Adressen benutzen"
 
-#: builtin/clone.c:145 builtin/fetch.c:194 builtin/pull.c:237
-#: builtin/push.c:573
+#: builtin/clone.c:145 builtin/fetch.c:198 builtin/pull.c:237
+#: builtin/push.c:563
 msgid "use IPv6 addresses only"
 msgstr "nur IPv6-Adressen benutzen"
 
@@ -12600,65 +12871,70 @@ msgstr "Kann \"repack\" zum Aufräumen nicht aufrufen"
 msgid "cannot unlink temporary alternates file"
 msgstr "Kann temporäre \"alternates\"-Datei nicht entfernen"
 
-#: builtin/clone.c:971 builtin/receive-pack.c:1982
+#: builtin/clone.c:970 builtin/receive-pack.c:2434
 msgid "Too many arguments."
 msgstr "Zu viele Argumente."
 
-#: builtin/clone.c:975
+#: builtin/clone.c:974
 msgid "You must specify a repository to clone."
 msgstr "Sie müssen ein Repository zum Klonen angeben."
 
-#: builtin/clone.c:988
+#: builtin/clone.c:987
 #, c-format
 msgid "--bare and --origin %s options are incompatible."
 msgstr "Die Optionen --bare und --origin %s sind inkompatibel."
 
-#: builtin/clone.c:991
+#: builtin/clone.c:990
 msgid "--bare and --separate-git-dir are incompatible."
 msgstr "Die Optionen --bare und --separate-git-dir sind inkompatibel."
 
-#: builtin/clone.c:1007
+#: builtin/clone.c:1006
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "Repository '%s' existiert nicht."
 
-#: builtin/clone.c:1011 builtin/fetch.c:1794
+#: builtin/clone.c:1010 builtin/fetch.c:1841
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "Tiefe %s ist keine positive Zahl"
 
-#: builtin/clone.c:1021
+#: builtin/clone.c:1020
 #, c-format
 msgid "destination path '%s' already exists and is not an empty directory."
 msgstr "Zielpfad '%s' existiert bereits und ist kein leeres Verzeichnis."
 
-#: builtin/clone.c:1033
+#: builtin/clone.c:1026
+#, fuzzy, c-format
+msgid "repository path '%s' already exists and is not an empty directory."
+msgstr "Zielpfad '%s' existiert bereits und ist kein leeres Verzeichnis."
+
+#: builtin/clone.c:1040
 #, c-format
 msgid "working tree '%s' already exists."
 msgstr "Arbeitsverzeichnis '%s' existiert bereits."
 
-#: builtin/clone.c:1048 builtin/clone.c:1069 builtin/difftool.c:271
-#: builtin/log.c:1886 builtin/worktree.c:354 builtin/worktree.c:386
+#: builtin/clone.c:1055 builtin/clone.c:1076 builtin/difftool.c:271
+#: builtin/log.c:1970 builtin/worktree.c:354 builtin/worktree.c:386
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "Konnte führende Verzeichnisse von '%s' nicht erstellen."
 
-#: builtin/clone.c:1053
+#: builtin/clone.c:1060
 #, c-format
 msgid "could not create work tree dir '%s'"
 msgstr "Konnte Arbeitsverzeichnis '%s' nicht erstellen"
 
-#: builtin/clone.c:1073
+#: builtin/clone.c:1080
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
 msgstr "Klone in Bare-Repository '%s' ...\n"
 
-#: builtin/clone.c:1075
+#: builtin/clone.c:1082
 #, c-format
 msgid "Cloning into '%s'...\n"
 msgstr "Klone nach '%s' ...\n"
 
-#: builtin/clone.c:1099
+#: builtin/clone.c:1106
 msgid ""
 "clone --recursive is not compatible with both --reference and --reference-if-"
 "able"
@@ -12666,45 +12942,45 @@ msgstr ""
 "'clone --recursive' ist nicht kompatibel mit --reference und --reference-if-"
 "able"
 
-#: builtin/clone.c:1164
+#: builtin/clone.c:1170
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr ""
 "Die Option --depth wird in lokalen Klonen ignoriert; benutzen Sie "
 "stattdessen file://"
 
-#: builtin/clone.c:1166
+#: builtin/clone.c:1172
 msgid "--shallow-since is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-since wird in lokalen Klonen ignoriert; benutzen Sie stattdessen "
 "file://"
 
-#: builtin/clone.c:1168
+#: builtin/clone.c:1174
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-exclude wird in lokalen Klonen ignoriert; benutzen Sie stattdessen "
 "file://"
 
-#: builtin/clone.c:1170
+#: builtin/clone.c:1176
 msgid "--filter is ignored in local clones; use file:// instead."
 msgstr ""
 "--filter wird in lokalen Klonen ignoriert; benutzen Sie stattdessen file://"
 
-#: builtin/clone.c:1173
+#: builtin/clone.c:1179
 msgid "source repository is shallow, ignoring --local"
 msgstr ""
 "Quelle ist ein Repository mit unvollständiger Historie (shallow),\n"
 "ignoriere --local"
 
-#: builtin/clone.c:1178
+#: builtin/clone.c:1184
 msgid "--local is ignored"
 msgstr "--local wird ignoriert"
 
-#: builtin/clone.c:1262 builtin/clone.c:1270
+#: builtin/clone.c:1268 builtin/clone.c:1276
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "Remote-Branch %s nicht im Upstream-Repository %s gefunden"
 
-#: builtin/clone.c:1273
+#: builtin/clone.c:1279
 msgid "You appear to have cloned an empty repository."
 msgstr "Sie scheinen ein leeres Repository geklont zu haben."
 
@@ -12740,110 +13016,116 @@ msgstr "Abstand zwischen Spalten"
 msgid "--command must be the first argument"
 msgstr "Die Option --command muss an erster Stelle stehen."
 
-#: builtin/commit-graph.c:13 builtin/commit-graph.c:21
+#: builtin/commit-graph.c:13 builtin/commit-graph.c:22
 msgid ""
 "git commit-graph verify [--object-dir <objdir>] [--shallow] [--[no-]progress]"
 msgstr ""
 "git commit-graph verify [--object-dir <Objektverzeichnis>] [--shallow] [--"
 "[no-]progress]"
 
-#: builtin/commit-graph.c:14 builtin/commit-graph.c:26
+#: builtin/commit-graph.c:14 builtin/commit-graph.c:27
+#, fuzzy
 msgid ""
 "git commit-graph write [--object-dir <objdir>] [--append] [--"
 "split[=<strategy>]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
-"paths] [--[no-]progress] <split options>"
+"paths] [--[no-]max-new-filters <n>] [--[no-]progress] <split options>"
 msgstr ""
 "git commit-graph write [--object-dir <Objektverzeichnis>] [--append] [--"
 "split[=<Strategie>]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
 "paths] [--[no-]progress] <Split-Optionen>"
 
-#: builtin/commit-graph.c:62
+#: builtin/commit-graph.c:64
 #, c-format
 msgid "could not find object directory matching %s"
 msgstr "konnte Objekt-Verzeichnis nicht finden, dass '%s' entsprechen soll"
 
-#: builtin/commit-graph.c:78 builtin/commit-graph.c:177
-#: builtin/commit-graph.c:276 builtin/fetch.c:180 builtin/log.c:1678
+#: builtin/commit-graph.c:80 builtin/commit-graph.c:210
+#: builtin/commit-graph.c:316 builtin/fetch.c:184 builtin/log.c:1764
 msgid "dir"
 msgstr "Verzeichnis"
 
-#: builtin/commit-graph.c:79 builtin/commit-graph.c:178
-#: builtin/commit-graph.c:277
+#: builtin/commit-graph.c:81 builtin/commit-graph.c:211
+#: builtin/commit-graph.c:317
 msgid "The object directory to store the graph"
 msgstr "Das Objektverzeichnis zum Speichern des Graphen."
 
-#: builtin/commit-graph.c:81
+#: builtin/commit-graph.c:83
 msgid "if the commit-graph is split, only verify the tip file"
 msgstr ""
 "Wenn der Commit-Graph aufgeteilt ist, nur die Datei an der Spitze überprüfen"
 
-#: builtin/commit-graph.c:104
+#: builtin/commit-graph.c:106
 #, c-format
 msgid "Could not open commit-graph '%s'"
 msgstr "Konnte Commit-Graph '%s' nicht öffnen."
 
-#: builtin/commit-graph.c:138
+#: builtin/commit-graph.c:142
 #, c-format
 msgid "unrecognized --split argument, %s"
 msgstr "nicht erkanntes --split Argument, %s"
 
-#: builtin/commit-graph.c:151
+#: builtin/commit-graph.c:155
 #, c-format
 msgid "unexpected non-hex object ID: %s"
 msgstr "unerwartete nicht-hexadezimale Objekt-ID: %s"
 
-#: builtin/commit-graph.c:156
+#: builtin/commit-graph.c:160
 #, c-format
 msgid "invalid object: %s"
 msgstr "ungültiges Objekt: %s"
 
-#: builtin/commit-graph.c:180
+#: builtin/commit-graph.c:213
 msgid "start walk at all refs"
 msgstr "Durchlauf auf allen Referenzen beginnen"
 
-#: builtin/commit-graph.c:182
+#: builtin/commit-graph.c:215
 msgid "scan pack-indexes listed by stdin for commits"
 msgstr "durch Standard-Eingabe gelistete Pack-Indexe nach Commits scannen"
 
-#: builtin/commit-graph.c:184
+#: builtin/commit-graph.c:217
 msgid "start walk at commits listed by stdin"
 msgstr "Lauf bei Commits beginnen, die über die Standard-Eingabe gelistet sind"
 
-#: builtin/commit-graph.c:186
+#: builtin/commit-graph.c:219
 msgid "include all commits already in the commit-graph file"
 msgstr ""
 "alle Commits einschließen, die sich bereits in der Commit-Graph-Datei "
 "befinden"
 
-#: builtin/commit-graph.c:188
+#: builtin/commit-graph.c:221
 msgid "enable computation for changed paths"
 msgstr "Berechnung für veränderte Pfade aktivieren"
 
-#: builtin/commit-graph.c:191
+#: builtin/commit-graph.c:224
 msgid "allow writing an incremental commit-graph file"
 msgstr "Erlaube das Schreiben einer inkrementellen Commit-Graph-Datei"
 
-#: builtin/commit-graph.c:195
+#: builtin/commit-graph.c:228
 msgid "maximum number of commits in a non-base split commit-graph"
 msgstr ""
 "Maximale Anzahl von Commits in einem aufgeteilten Commit-Graph ohne Basis"
 
-#: builtin/commit-graph.c:197
+#: builtin/commit-graph.c:230
 msgid "maximum ratio between two levels of a split commit-graph"
 msgstr ""
 "Maximales Verhältnis zwischen zwei Ebenen eines aufgeteilten Commit-Graph"
 
-#: builtin/commit-graph.c:199
+#: builtin/commit-graph.c:232
 msgid "only expire files older than a given date-time"
 msgstr "nur Objekte älter als angegebene Zeit verfallen lassen"
 
-#: builtin/commit-graph.c:215
+#: builtin/commit-graph.c:234
+#, fuzzy
+msgid "maximum number of changed-path Bloom filters to compute"
+msgstr "Schreibe Daten für veränderte Pfade Bloom-Filter"
+
+#: builtin/commit-graph.c:255
 msgid "use at most one of --reachable, --stdin-commits, or --stdin-packs"
 msgstr ""
 "Benutzen Sie mindestens eins von --reachable, --stdin-commits, oder --stdin-"
 "packs."
 
-#: builtin/commit-graph.c:245
+#: builtin/commit-graph.c:287
 msgid "Collecting commits from input"
 msgstr "Sammle Commits von der Standard-Eingabe"
 
@@ -12860,7 +13142,7 @@ msgstr ""
 msgid "duplicate parent %s ignored"
 msgstr "doppelter Vorgänger %s ignoriert"
 
-#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:547
+#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:546
 #, c-format
 msgid "not a valid object name %s"
 msgstr "Kein gültiger Objektname: %s"
@@ -12888,13 +13170,13 @@ msgstr "Eltern-Commit"
 msgid "id of a parent commit object"
 msgstr "ID eines Eltern-Commit-Objektes."
 
-#: builtin/commit-tree.c:114 builtin/commit.c:1506 builtin/merge.c:273
-#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1474
+#: builtin/commit-tree.c:114 builtin/commit.c:1504 builtin/merge.c:272
+#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1471
 #: builtin/tag.c:413
 msgid "message"
 msgstr "Beschreibung"
 
-#: builtin/commit-tree.c:115 builtin/commit.c:1506
+#: builtin/commit-tree.c:115 builtin/commit.c:1504
 msgid "commit message"
 msgstr "Commit-Beschreibung"
 
@@ -12902,7 +13184,7 @@ msgstr "Commit-Beschreibung"
 msgid "read commit log message from file"
 msgstr "Commit-Beschreibung von Datei lesen"
 
-#: builtin/commit-tree.c:121 builtin/commit.c:1518 builtin/merge.c:290
+#: builtin/commit-tree.c:121 builtin/commit.c:1516 builtin/merge.c:289
 #: builtin/pull.c:176 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "Commit mit GPG signieren"
@@ -13053,12 +13335,12 @@ msgstr ""
 "Konnte kein Kommentar-Zeichen auswählen, das nicht in\n"
 "der aktuellen Commit-Beschreibung verwendet wird."
 
-#: builtin/commit.c:717 builtin/commit.c:750 builtin/commit.c:1099
+#: builtin/commit.c:717 builtin/commit.c:750 builtin/commit.c:1097
 #, c-format
 msgid "could not lookup commit %s"
 msgstr "Konnte Commit %s nicht nachschlagen"
 
-#: builtin/commit.c:729 builtin/shortlog.c:319
+#: builtin/commit.c:729 builtin/shortlog.c:478
 #, c-format
 msgid "(reading log message from standard input)\n"
 msgstr "(lese Log-Nachricht von Standard-Eingabe)\n"
@@ -13084,13 +13366,13 @@ msgstr "Konnte MERGE_MSG nicht lesen"
 msgid "could not write commit template"
 msgstr "Konnte Commit-Vorlage nicht schreiben"
 
-#: builtin/commit.c:852
-#, c-format
+#: builtin/commit.c:853
+#, fuzzy
 msgid ""
 "\n"
 "It looks like you may be committing a merge.\n"
-"If this is not correct, please remove the file\n"
-"\t%s\n"
+"If this is not correct, please run\n"
+"\tgit update-ref -d MERGE_HEAD\n"
 "and try again.\n"
 msgstr ""
 "\n"
@@ -13099,13 +13381,13 @@ msgstr ""
 "\t%s\n"
 "und versuchen Sie es erneut.\n"
 
-#: builtin/commit.c:857
-#, c-format
+#: builtin/commit.c:858
+#, fuzzy
 msgid ""
 "\n"
 "It looks like you may be committing a cherry-pick.\n"
-"If this is not correct, please remove the file\n"
-"\t%s\n"
+"If this is not correct, please run\n"
+"\tgit update-ref -d CHERRY_PICK_HEAD\n"
 "and try again.\n"
 msgstr ""
 "\n"
@@ -13114,7 +13396,7 @@ msgstr ""
 "\t%s\n"
 "und versuchen Sie es erneut.\n"
 
-#: builtin/commit.c:870
+#: builtin/commit.c:868
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13124,7 +13406,7 @@ msgstr ""
 "die mit '%c' beginnen, werden ignoriert, und eine leere Beschreibung\n"
 "bricht den Commit ab.\n"
 
-#: builtin/commit.c:878
+#: builtin/commit.c:876
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13137,153 +13419,153 @@ msgstr ""
 "entfernen.\n"
 "Eine leere Beschreibung bricht den Commit ab.\n"
 
-#: builtin/commit.c:895
+#: builtin/commit.c:893
 #, c-format
 msgid "%sAuthor:    %.*s <%.*s>"
 msgstr "%sAutor:           %.*s <%.*s>"
 
-#: builtin/commit.c:903
+#: builtin/commit.c:901
 #, c-format
 msgid "%sDate:      %s"
 msgstr "%sDatum:            %s"
 
-#: builtin/commit.c:910
+#: builtin/commit.c:908
 #, c-format
 msgid "%sCommitter: %.*s <%.*s>"
 msgstr "%sCommit-Ersteller: %.*s <%.*s>"
 
-#: builtin/commit.c:928
+#: builtin/commit.c:926
 msgid "Cannot read index"
 msgstr "Kann Index nicht lesen"
 
-#: builtin/commit.c:999
+#: builtin/commit.c:997
 msgid "Error building trees"
 msgstr "Fehler beim Erzeugen der \"Tree\"-Objekte"
 
-#: builtin/commit.c:1013 builtin/tag.c:276
+#: builtin/commit.c:1011 builtin/tag.c:276
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr ""
 "Bitte liefern Sie eine Beschreibung entweder mit der Option -m oder -F.\n"
 
-#: builtin/commit.c:1057
+#: builtin/commit.c:1055
 #, c-format
 msgid "--author '%s' is not 'Name <email>' and matches no existing author"
 msgstr ""
 "--author '%s' ist nicht im Format 'Name <E-Mail>' und stimmt mit keinem "
 "vorhandenen Autor überein"
 
-#: builtin/commit.c:1071
+#: builtin/commit.c:1069
 #, c-format
 msgid "Invalid ignored mode '%s'"
 msgstr "Ungültiger ignored-Modus '%s'."
 
-#: builtin/commit.c:1089 builtin/commit.c:1333
+#: builtin/commit.c:1087 builtin/commit.c:1331
 #, c-format
 msgid "Invalid untracked files mode '%s'"
 msgstr "Ungültiger Modus '%s' für unversionierte Dateien"
 
-#: builtin/commit.c:1129
+#: builtin/commit.c:1127
 msgid "--long and -z are incompatible"
 msgstr "Die Optionen --long und -z sind inkompatibel."
 
-#: builtin/commit.c:1173
+#: builtin/commit.c:1171
 msgid "Using both --reset-author and --author does not make sense"
 msgstr ""
 "Die Optionen --reset-author und --author können nicht gemeinsam verwendet "
 "werden."
 
-#: builtin/commit.c:1182
+#: builtin/commit.c:1180
 msgid "You have nothing to amend."
 msgstr "Sie haben nichts für \"--amend\"."
 
-#: builtin/commit.c:1185
+#: builtin/commit.c:1183
 msgid "You are in the middle of a merge -- cannot amend."
 msgstr "Ein Merge ist im Gange -- kann \"--amend\" nicht ausführen."
 
-#: builtin/commit.c:1187
+#: builtin/commit.c:1185
 msgid "You are in the middle of a cherry-pick -- cannot amend."
 msgstr "\"cherry-pick\" ist im Gange -- kann \"--amend\" nicht ausführen."
 
-#: builtin/commit.c:1189
+#: builtin/commit.c:1187
 msgid "You are in the middle of a rebase -- cannot amend."
 msgstr "Ein Rebase ist im Gange -- kann \"--amend\" nicht ausführen."
 
-#: builtin/commit.c:1192
+#: builtin/commit.c:1190
 msgid "Options --squash and --fixup cannot be used together"
 msgstr ""
 "Die Optionen --squash und --fixup können nicht gemeinsam verwendet werden."
 
-#: builtin/commit.c:1202
+#: builtin/commit.c:1200
 msgid "Only one of -c/-C/-F/--fixup can be used."
 msgstr "Es kann nur eine Option von -c/-C/-F/--fixup verwendet werden."
 
-#: builtin/commit.c:1204
+#: builtin/commit.c:1202
 msgid "Option -m cannot be combined with -c/-C/-F."
 msgstr "Die Option -m kann nicht mit -c/-C/-F kombiniert werden."
 
-#: builtin/commit.c:1213
+#: builtin/commit.c:1211
 msgid "--reset-author can be used only with -C, -c or --amend."
 msgstr ""
 "Die Option --reset--author kann nur mit -C, -c oder --amend verwendet werden."
 
-#: builtin/commit.c:1231
+#: builtin/commit.c:1229
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
 msgstr ""
 "Es kann nur eine Option von --include/--only/--all/--interactive/--patch "
 "verwendet werden."
 
-#: builtin/commit.c:1237
+#: builtin/commit.c:1235
 #, c-format
 msgid "paths '%s ...' with -a does not make sense"
 msgstr "Pfade '%s ...' mit -a sind nicht sinnvoll"
 
-#: builtin/commit.c:1368 builtin/commit.c:1529
+#: builtin/commit.c:1366 builtin/commit.c:1527
 msgid "show status concisely"
 msgstr "Status im Kurzformat anzeigen"
 
-#: builtin/commit.c:1370 builtin/commit.c:1531
+#: builtin/commit.c:1368 builtin/commit.c:1529
 msgid "show branch information"
 msgstr "Branchinformationen anzeigen"
 
-#: builtin/commit.c:1372
+#: builtin/commit.c:1370
 msgid "show stash information"
 msgstr "Stashinformationen anzeigen"
 
-#: builtin/commit.c:1374 builtin/commit.c:1533
+#: builtin/commit.c:1372 builtin/commit.c:1531
 msgid "compute full ahead/behind values"
 msgstr "voraus/hinterher-Werte berechnen"
 
-#: builtin/commit.c:1376
+#: builtin/commit.c:1374
 msgid "version"
 msgstr "Version"
 
-#: builtin/commit.c:1376 builtin/commit.c:1535 builtin/push.c:549
+#: builtin/commit.c:1374 builtin/commit.c:1533 builtin/push.c:539
 #: builtin/worktree.c:722
 msgid "machine-readable output"
 msgstr "maschinenlesbare Ausgabe"
 
-#: builtin/commit.c:1379 builtin/commit.c:1537
+#: builtin/commit.c:1377 builtin/commit.c:1535
 msgid "show status in long format (default)"
 msgstr "Status im Langformat anzeigen (Standard)"
 
-#: builtin/commit.c:1382 builtin/commit.c:1540
+#: builtin/commit.c:1380 builtin/commit.c:1538
 msgid "terminate entries with NUL"
 msgstr "Einträge mit NUL-Zeichen abschließen"
 
-#: builtin/commit.c:1384 builtin/commit.c:1388 builtin/commit.c:1543
+#: builtin/commit.c:1382 builtin/commit.c:1386 builtin/commit.c:1541
 #: builtin/fast-export.c:1199 builtin/fast-export.c:1202
-#: builtin/fast-export.c:1205 builtin/rebase.c:1392 parse-options.h:336
+#: builtin/fast-export.c:1205 builtin/rebase.c:1400 parse-options.h:336
 msgid "mode"
 msgstr "Modus"
 
-#: builtin/commit.c:1385 builtin/commit.c:1543
+#: builtin/commit.c:1383 builtin/commit.c:1541
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
 "unversionierte Dateien anzeigen, optionale Modi: all, normal, no. (Standard: "
 "all)"
 
-#: builtin/commit.c:1389
+#: builtin/commit.c:1387
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
@@ -13291,11 +13573,11 @@ msgstr ""
 "ignorierte Dateien anzeigen, optionale Modi: traditional, matching, no. "
 "(Standard: traditional)"
 
-#: builtin/commit.c:1391 parse-options.h:192
+#: builtin/commit.c:1389 parse-options.h:192
 msgid "when"
 msgstr "wann"
 
-#: builtin/commit.c:1392
+#: builtin/commit.c:1390
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
@@ -13303,174 +13585,174 @@ msgstr ""
 "Änderungen in Submodulen ignorieren, optional wenn: all, dirty, untracked. "
 "(Standard: all)"
 
-#: builtin/commit.c:1394
+#: builtin/commit.c:1392
 msgid "list untracked files in columns"
 msgstr "unversionierte Dateien in Spalten auflisten"
 
-#: builtin/commit.c:1395
+#: builtin/commit.c:1393
 msgid "do not detect renames"
 msgstr "keine Umbenennungen ermitteln"
 
-#: builtin/commit.c:1397
+#: builtin/commit.c:1395
 msgid "detect renames, optionally set similarity index"
 msgstr "Umbenennungen erkennen, optional Index für Gleichheit setzen"
 
-#: builtin/commit.c:1417
+#: builtin/commit.c:1415
 msgid "Unsupported combination of ignored and untracked-files arguments"
 msgstr ""
 "Nicht unterstützte Kombination von ignored und untracked-files Argumenten."
 
-#: builtin/commit.c:1499
+#: builtin/commit.c:1497
 msgid "suppress summary after successful commit"
 msgstr "Zusammenfassung nach erfolgreichem Commit unterdrücken"
 
-#: builtin/commit.c:1500
+#: builtin/commit.c:1498
 msgid "show diff in commit message template"
 msgstr "Unterschiede in Commit-Beschreibungsvorlage anzeigen"
 
-#: builtin/commit.c:1502
+#: builtin/commit.c:1500
 msgid "Commit message options"
 msgstr "Optionen für Commit-Beschreibung"
 
-#: builtin/commit.c:1503 builtin/merge.c:277 builtin/tag.c:415
+#: builtin/commit.c:1501 builtin/merge.c:276 builtin/tag.c:415
 msgid "read message from file"
 msgstr "Beschreibung von Datei lesen"
 
-#: builtin/commit.c:1504
+#: builtin/commit.c:1502
 msgid "author"
 msgstr "Autor"
 
-#: builtin/commit.c:1504
+#: builtin/commit.c:1502
 msgid "override author for commit"
 msgstr "Autor eines Commits überschreiben"
 
-#: builtin/commit.c:1505 builtin/gc.c:538
+#: builtin/commit.c:1503 builtin/gc.c:539
 msgid "date"
 msgstr "Datum"
 
-#: builtin/commit.c:1505
+#: builtin/commit.c:1503
 msgid "override date for commit"
 msgstr "Datum eines Commits überschreiben"
 
-#: builtin/commit.c:1507 builtin/commit.c:1508 builtin/commit.c:1509
-#: builtin/commit.c:1510 parse-options.h:328 ref-filter.h:92
+#: builtin/commit.c:1505 builtin/commit.c:1506 builtin/commit.c:1507
+#: builtin/commit.c:1508 parse-options.h:328 ref-filter.h:87
 msgid "commit"
 msgstr "Commit"
 
-#: builtin/commit.c:1507
+#: builtin/commit.c:1505
 msgid "reuse and edit message from specified commit"
 msgstr "Beschreibung des angegebenen Commits wiederverwenden und editieren"
 
-#: builtin/commit.c:1508
+#: builtin/commit.c:1506
 msgid "reuse message from specified commit"
 msgstr "Beschreibung des angegebenen Commits wiederverwenden"
 
-#: builtin/commit.c:1509
+#: builtin/commit.c:1507
 msgid "use autosquash formatted message to fixup specified commit"
 msgstr ""
 "eine automatisch zusammengesetzte Beschreibung zum Nachbessern des "
 "angegebenen Commits verwenden"
 
-#: builtin/commit.c:1510
+#: builtin/commit.c:1508
 msgid "use autosquash formatted message to squash specified commit"
 msgstr ""
 "eine automatisch zusammengesetzte Beschreibung beim \"squash\" des "
 "angegebenen Commits verwenden"
 
-#: builtin/commit.c:1511
+#: builtin/commit.c:1509
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr "Sie als Autor des Commits setzen (verwendet mit -C/-c/--amend)"
 
-#: builtin/commit.c:1512 builtin/log.c:1655 builtin/merge.c:293
+#: builtin/commit.c:1510 builtin/log.c:1741 builtin/merge.c:292
 #: builtin/pull.c:145 builtin/revert.c:110
 msgid "add Signed-off-by:"
 msgstr "'Signed-off-by:'-Zeile hinzufügen"
 
-#: builtin/commit.c:1513
+#: builtin/commit.c:1511
 msgid "use specified template file"
 msgstr "angegebene Vorlagendatei verwenden"
 
-#: builtin/commit.c:1514
+#: builtin/commit.c:1512
 msgid "force edit of commit"
 msgstr "Bearbeitung des Commits erzwingen"
 
-#: builtin/commit.c:1516
+#: builtin/commit.c:1514
 msgid "include status in commit message template"
 msgstr "Status in die Commit-Beschreibungsvorlage einfügen"
 
-#: builtin/commit.c:1521
+#: builtin/commit.c:1519
 msgid "Commit contents options"
 msgstr "Optionen für Commit-Inhalt"
 
-#: builtin/commit.c:1522
+#: builtin/commit.c:1520
 msgid "commit all changed files"
 msgstr "alle geänderten Dateien committen"
 
-#: builtin/commit.c:1523
+#: builtin/commit.c:1521
 msgid "add specified files to index for commit"
 msgstr "die angegebenen Dateien zusätzlich zum Commit vormerken"
 
-#: builtin/commit.c:1524
+#: builtin/commit.c:1522
 msgid "interactively add files"
 msgstr "interaktives Hinzufügen von Dateien"
 
-#: builtin/commit.c:1525
+#: builtin/commit.c:1523
 msgid "interactively add changes"
 msgstr "interaktives Hinzufügen von Änderungen"
 
-#: builtin/commit.c:1526
+#: builtin/commit.c:1524
 msgid "commit only specified files"
 msgstr "nur die angegebenen Dateien committen"
 
-#: builtin/commit.c:1527
+#: builtin/commit.c:1525
 msgid "bypass pre-commit and commit-msg hooks"
 msgstr "Hooks pre-commit und commit-msg umgehen"
 
-#: builtin/commit.c:1528
+#: builtin/commit.c:1526
 msgid "show what would be committed"
 msgstr "anzeigen, was committet werden würde"
 
-#: builtin/commit.c:1541
+#: builtin/commit.c:1539
 msgid "amend previous commit"
 msgstr "vorherigen Commit ändern"
 
-#: builtin/commit.c:1542
+#: builtin/commit.c:1540
 msgid "bypass post-rewrite hook"
 msgstr "\"post-rewrite hook\" umgehen"
 
-#: builtin/commit.c:1549
+#: builtin/commit.c:1547
 msgid "ok to record an empty change"
 msgstr "Aufzeichnung einer leeren Änderung erlauben"
 
-#: builtin/commit.c:1551
+#: builtin/commit.c:1549
 msgid "ok to record a change with an empty message"
 msgstr "Aufzeichnung einer Änderung mit einer leeren Beschreibung erlauben"
 
-#: builtin/commit.c:1624
+#: builtin/commit.c:1622
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
 msgstr "Beschädigte MERGE_HEAD-Datei (%s)"
 
-#: builtin/commit.c:1631
+#: builtin/commit.c:1629
 msgid "could not read MERGE_MODE"
 msgstr "Konnte MERGE_MODE nicht lesen"
 
-#: builtin/commit.c:1652
+#: builtin/commit.c:1650
 #, c-format
 msgid "could not read commit message: %s"
 msgstr "Konnte Commit-Beschreibung nicht lesen: %s"
 
-#: builtin/commit.c:1659
+#: builtin/commit.c:1657
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
 msgstr "Commit aufgrund leerer Beschreibung abgebrochen.\n"
 
-#: builtin/commit.c:1664
+#: builtin/commit.c:1662
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
 msgstr "Commit abgebrochen; Sie haben die Beschreibung nicht editiert.\n"
 
-#: builtin/commit.c:1698
+#: builtin/commit.c:1696
 msgid ""
 "repository has been updated, but unable to write\n"
 "new_index file. Check that disk is not full and quota is\n"
@@ -13485,214 +13767,219 @@ msgstr ""
 msgid "git config [<options>]"
 msgstr "git config [<Optionen>]"
 
-#: builtin/config.c:104 builtin/env--helper.c:23
+#: builtin/config.c:107 builtin/env--helper.c:27
 #, c-format
 msgid "unrecognized --type argument, %s"
 msgstr "nicht erkanntes --type Argument, %s"
 
-#: builtin/config.c:116
+#: builtin/config.c:119
 msgid "only one type at a time"
 msgstr "nur ein Typ erlaubt"
 
-#: builtin/config.c:125
+#: builtin/config.c:128
 msgid "Config file location"
 msgstr "Ort der Konfigurationsdatei"
 
-#: builtin/config.c:126
+#: builtin/config.c:129
 msgid "use global config file"
 msgstr "globale Konfigurationsdatei verwenden"
 
-#: builtin/config.c:127
+#: builtin/config.c:130
 msgid "use system config file"
 msgstr "systemweite Konfigurationsdatei verwenden"
 
-#: builtin/config.c:128
+#: builtin/config.c:131
 msgid "use repository config file"
 msgstr "Konfigurationsdatei des Repositories verwenden"
 
-#: builtin/config.c:129
+#: builtin/config.c:132
 msgid "use per-worktree config file"
 msgstr "Konfigurationsdatei pro Arbeitsverzeichnis verwenden"
 
-#: builtin/config.c:130
+#: builtin/config.c:133
 msgid "use given config file"
 msgstr "die angegebene Konfigurationsdatei verwenden"
 
-#: builtin/config.c:131
+#: builtin/config.c:134
 msgid "blob-id"
 msgstr "Blob-Id"
 
-#: builtin/config.c:131
+#: builtin/config.c:134
 msgid "read config from given blob object"
 msgstr "Konfiguration von angegebenem Blob-Objekt lesen"
 
-#: builtin/config.c:132
+#: builtin/config.c:135
 msgid "Action"
 msgstr "Aktion"
 
-#: builtin/config.c:133
+#: builtin/config.c:136
 msgid "get value: name [value-regex]"
 msgstr "Wert zurückgeben: Name [Wert-regex]"
 
-#: builtin/config.c:134
+#: builtin/config.c:137
 msgid "get all values: key [value-regex]"
 msgstr "alle Werte zurückgeben: Schlüssel [Wert-regex]"
 
-#: builtin/config.c:135
+#: builtin/config.c:138
 msgid "get values for regexp: name-regex [value-regex]"
 msgstr "Werte für den regulären Ausdruck zurückgeben: Name-regex [Wert-regex]"
 
-#: builtin/config.c:136
+#: builtin/config.c:139
 msgid "get value specific for the URL: section[.var] URL"
 msgstr "Wert spezifisch für eine URL zurückgeben: section[.var] URL"
 
-#: builtin/config.c:137
+#: builtin/config.c:140
 msgid "replace all matching variables: name value [value_regex]"
 msgstr "alle passenden Variablen ersetzen: Name Wert [Wert-regex] "
 
-#: builtin/config.c:138
+#: builtin/config.c:141
 msgid "add a new variable: name value"
 msgstr "neue Variable hinzufügen: Name Wert"
 
-#: builtin/config.c:139
+#: builtin/config.c:142
 msgid "remove a variable: name [value-regex]"
 msgstr "eine Variable entfernen: Name [Wert-regex]"
 
-#: builtin/config.c:140
+#: builtin/config.c:143
 msgid "remove all matches: name [value-regex]"
 msgstr "alle Übereinstimmungen entfernen: Name [Wert-regex]"
 
-#: builtin/config.c:141
+#: builtin/config.c:144
 msgid "rename section: old-name new-name"
 msgstr "eine Sektion umbenennen: alter-Name neuer-Name"
 
-#: builtin/config.c:142
+#: builtin/config.c:145
 msgid "remove a section: name"
 msgstr "eine Sektion entfernen: Name"
 
-#: builtin/config.c:143
+#: builtin/config.c:146
 msgid "list all"
 msgstr "alles auflisten"
 
-#: builtin/config.c:144
+#: builtin/config.c:147
 msgid "open an editor"
 msgstr "einen Editor öffnen"
 
-#: builtin/config.c:145
+#: builtin/config.c:148
 msgid "find the color configured: slot [default]"
 msgstr "die konfigurierte Farbe finden: Slot [Standard]"
 
-#: builtin/config.c:146
+#: builtin/config.c:149
 msgid "find the color setting: slot [stdout-is-tty]"
 msgstr "die Farbeinstellung finden: Slot [Standard-Ausgabe-ist-Terminal]"
 
-#: builtin/config.c:147
+#: builtin/config.c:150
 msgid "Type"
 msgstr "Typ"
 
-#: builtin/config.c:148 builtin/env--helper.c:38
+#: builtin/config.c:151 builtin/env--helper.c:43
 msgid "value is given this type"
 msgstr "Wert ist mit diesem Typ angegeben"
 
-#: builtin/config.c:149
+#: builtin/config.c:152
 msgid "value is \"true\" or \"false\""
 msgstr "Wert ist \"true\" oder \"false\""
 
-#: builtin/config.c:150
+#: builtin/config.c:153
 msgid "value is decimal number"
 msgstr "Wert ist eine Dezimalzahl"
 
-#: builtin/config.c:151
+#: builtin/config.c:154
 msgid "value is --bool or --int"
 msgstr "Wert ist --bool oder --int"
 
-#: builtin/config.c:152
+#: builtin/config.c:155
+#, fuzzy
+msgid "value is --bool or string"
+msgstr "Wert ist --bool oder --int"
+
+#: builtin/config.c:156
 msgid "value is a path (file or directory name)"
 msgstr "Wert ist ein Pfad (Datei oder Verzeichnisname)"
 
-#: builtin/config.c:153
+#: builtin/config.c:157
 msgid "value is an expiry date"
 msgstr "Wert ist ein Verfallsdatum"
 
-#: builtin/config.c:154
+#: builtin/config.c:158
 msgid "Other"
 msgstr "Sonstiges"
 
-#: builtin/config.c:155
+#: builtin/config.c:159
 msgid "terminate values with NUL byte"
 msgstr "schließt Werte mit NUL-Byte ab"
 
-#: builtin/config.c:156
+#: builtin/config.c:160
 msgid "show variable names only"
 msgstr "nur Variablennamen anzeigen"
 
-#: builtin/config.c:157
+#: builtin/config.c:161
 msgid "respect include directives on lookup"
 msgstr "beachtet \"include\"-Direktiven beim Nachschlagen"
 
-#: builtin/config.c:158
+#: builtin/config.c:162
 msgid "show origin of config (file, standard input, blob, command line)"
 msgstr ""
 "Ursprung der Konfiguration anzeigen (Datei, Standard-Eingabe, Blob, "
 "Befehlszeile)"
 
-#: builtin/config.c:159
+#: builtin/config.c:163
 msgid "show scope of config (worktree, local, global, system, command)"
 msgstr ""
 "Zeige Geltungsbereich der Konfiguration (Arbeitsverzeichnis, lokal, global, "
 "systemweit, Befehl)"
 
-#: builtin/config.c:160 builtin/env--helper.c:40
+#: builtin/config.c:164 builtin/env--helper.c:45
 msgid "value"
 msgstr "Wert"
 
-#: builtin/config.c:160
+#: builtin/config.c:164
 msgid "with --get, use default value when missing entry"
 msgstr "mit --get, benutze den Standardwert, wenn der Eintrag fehlt"
 
-#: builtin/config.c:174
+#: builtin/config.c:178
 #, c-format
 msgid "wrong number of arguments, should be %d"
 msgstr "Falsche Anzahl von Argumenten - sollte %d sein."
 
-#: builtin/config.c:176
+#: builtin/config.c:180
 #, c-format
 msgid "wrong number of arguments, should be from %d to %d"
 msgstr "Falsche Anzahl von Argumenten - sollte zwischen %d und %d sein."
 
-#: builtin/config.c:324
+#: builtin/config.c:334
 #, c-format
 msgid "invalid key pattern: %s"
 msgstr "Ungültiges Schlüsselmuster: %s"
 
-#: builtin/config.c:360
+#: builtin/config.c:370
 #, c-format
 msgid "failed to format default config value: %s"
 msgstr "Fehler beim Formatieren des Standardkonfigurationswertes: %s"
 
-#: builtin/config.c:417
+#: builtin/config.c:434
 #, c-format
 msgid "cannot parse color '%s'"
 msgstr "Kann Farbe '%s' nicht parsen."
 
-#: builtin/config.c:459
+#: builtin/config.c:476
 msgid "unable to parse default color value"
 msgstr "konnte Standard-Farbwert nicht parsen"
 
-#: builtin/config.c:512 builtin/config.c:768
+#: builtin/config.c:529 builtin/config.c:789
 msgid "not in a git directory"
 msgstr "Nicht in einem Git-Repository."
 
-#: builtin/config.c:515
+#: builtin/config.c:532
 msgid "writing to stdin is not supported"
 msgstr "Das Schreiben in die Standard-Eingabe wird nicht unterstützt."
 
-#: builtin/config.c:518
+#: builtin/config.c:535
 msgid "writing config blobs is not supported"
 msgstr ""
 "Das Schreiben von Blob-Objekten für Konfigurationen wird nicht unterstützt."
 
-#: builtin/config.c:603
+#: builtin/config.c:620
 #, c-format
 msgid ""
 "# This is Git's per-user configuration file.\n"
@@ -13707,23 +13994,28 @@ msgstr ""
 "#\tname = %s\n"
 "#\temail = %s\n"
 
-#: builtin/config.c:627
+#: builtin/config.c:644
 msgid "only one config file at a time"
 msgstr "Nur eine Konfigurationsdatei zu einer Zeit möglich."
 
-#: builtin/config.c:632
+#: builtin/config.c:650
 msgid "--local can only be used inside a git repository"
 msgstr "--local kann nur innerhalb eines Git-Repositories verwendet werden."
 
-#: builtin/config.c:635
+#: builtin/config.c:652
 msgid "--blob can only be used inside a git repository"
 msgstr "--blob kann nur innerhalb eines Git-Repositories verwendet werden."
 
-#: builtin/config.c:655
+#: builtin/config.c:654
+#, fuzzy
+msgid "--worktree can only be used inside a git repository"
+msgstr "--blob kann nur innerhalb eines Git-Repositories verwendet werden."
+
+#: builtin/config.c:676
 msgid "$HOME not set"
 msgstr "$HOME nicht gesetzt."
 
-#: builtin/config.c:679
+#: builtin/config.c:700
 msgid ""
 "--worktree cannot be used with multiple working trees unless the config\n"
 "extension worktreeConfig is enabled. Please read \"CONFIGURATION FILE\"\n"
@@ -13734,52 +14026,52 @@ msgstr ""
 "lesen Sie die Sektion \"CONFIGURATION_FILE\" in \"git help worktree\" für "
 "Details"
 
-#: builtin/config.c:714
+#: builtin/config.c:735
 msgid "--get-color and variable type are incoherent"
 msgstr "Angabe von --get-color und Variablentyp sind ungültig."
 
-#: builtin/config.c:719
+#: builtin/config.c:740
 msgid "only one action at a time"
 msgstr "Nur eine Aktion erlaubt."
 
-#: builtin/config.c:732
+#: builtin/config.c:753
 msgid "--name-only is only applicable to --list or --get-regexp"
 msgstr "--name-only ist nur anwendbar auf --list oder --get-regexp"
 
-#: builtin/config.c:738
+#: builtin/config.c:759
 msgid ""
 "--show-origin is only applicable to --get, --get-all, --get-regexp, and --"
 "list"
 msgstr ""
 "--show-origin ist nur anwendbar auf --get, --get-all, --get-regexp und --list"
 
-#: builtin/config.c:744
+#: builtin/config.c:765
 msgid "--default is only applicable to --get"
 msgstr "--default ist nur anwendbar auf --get"
 
-#: builtin/config.c:757
+#: builtin/config.c:778
 #, c-format
 msgid "unable to read config file '%s'"
 msgstr "Konnte Konfigurationsdatei '%s' nicht lesen."
 
-#: builtin/config.c:760
+#: builtin/config.c:781
 msgid "error processing config file(s)"
 msgstr "Fehler beim Verarbeiten der Konfigurationsdatei(en)."
 
-#: builtin/config.c:770
+#: builtin/config.c:791
 msgid "editing stdin is not supported"
 msgstr "Das Bearbeiten der Standard-Eingabe wird nicht unterstützt."
 
-#: builtin/config.c:772
+#: builtin/config.c:793
 msgid "editing blobs is not supported"
 msgstr "Das Bearbeiten von Blobs wird nicht unterstützt."
 
-#: builtin/config.c:786
+#: builtin/config.c:807
 #, c-format
 msgid "cannot create configuration file %s"
 msgstr "Konnte Konfigurationsdatei '%s' nicht erstellen."
 
-#: builtin/config.c:799
+#: builtin/config.c:820
 #, c-format
 msgid ""
 "cannot overwrite multiple values with a single value\n"
@@ -13789,7 +14081,7 @@ msgstr ""
 "       Benutzen Sie einen regulären Ausdruck, --add oder --replace, um %s\n"
 "       zu ändern."
 
-#: builtin/config.c:873 builtin/config.c:884
+#: builtin/config.c:894 builtin/config.c:905
 #, c-format
 msgid "no such section: %s"
 msgstr "Keine solche Sektion: %s"
@@ -13801,6 +14093,34 @@ msgstr "git count-objects [-v] [-H | --human-readable]"
 #: builtin/count-objects.c:100
 msgid "print sizes in human readable format"
 msgstr "gibt Größenangaben in menschenlesbaren Format aus"
+
+#: builtin/credential-cache--daemon.c:226
+#, c-format
+msgid ""
+"The permissions on your socket directory are too loose; other\n"
+"users may be able to read your cached credentials. Consider running:\n"
+"\n"
+"\tchmod 0700 %s"
+msgstr ""
+"Die Berechtigungen auf Ihr Socket-Verzeichnis sind zu schwach; andere\n"
+"Nutzer könnten Ihre zwischengespeicherten Anmeldeinformationen lesen.\n"
+"Ziehen Sie in Betracht\n"
+"\n"
+"\tchmod 0700 %s\n"
+"\n"
+"auszuführen."
+
+#: builtin/credential-cache--daemon.c:275
+msgid "print debugging messages to stderr"
+msgstr "Meldungen zur Fehlersuche in Standard-Fehlerausgabe ausgeben"
+
+#: builtin/credential-cache--daemon.c:315
+msgid "credential-cache--daemon unavailable; no unix socket support"
+msgstr ""
+
+#: builtin/credential-cache.c:154
+msgid "credential-cache unavailable; no unix socket support"
+msgstr ""
 
 #: builtin/describe.c:26
 msgid "git describe [<options>] [<commit-ish>...]"
@@ -13976,36 +14296,36 @@ msgstr "Die Option --broken kann nicht mit Commits verwendet werden."
 msgid "'%s': not a regular file or symlink"
 msgstr "'%s': keine reguläre Datei oder symbolische Verknüpfung"
 
-#: builtin/diff.c:242
+#: builtin/diff.c:241
 #, c-format
 msgid "invalid option: %s"
 msgstr "Ungültige Option: %s"
 
-#: builtin/diff.c:359
+#: builtin/diff.c:358
 #, c-format
 msgid "%s...%s: no merge base"
 msgstr "%s...%s: keine Merge-Basis"
 
-#: builtin/diff.c:469
+#: builtin/diff.c:468
 msgid "Not a git repository"
 msgstr "Kein Git-Repository"
 
-#: builtin/diff.c:514
+#: builtin/diff.c:513
 #, c-format
 msgid "invalid object '%s' given."
 msgstr "Objekt '%s' ist ungültig."
 
-#: builtin/diff.c:525
+#: builtin/diff.c:524
 #, c-format
 msgid "more than two blobs given: '%s'"
 msgstr "Mehr als zwei Blobs angegeben: '%s'"
 
-#: builtin/diff.c:530
+#: builtin/diff.c:529
 #, c-format
 msgid "unhandled object '%s' given."
 msgstr "unbehandeltes Objekt '%s' angegeben"
 
-#: builtin/diff.c:564
+#: builtin/diff.c:563
 #, c-format
 msgid "%s...%s: multiple merge bases, using %s"
 msgstr "%s...%s: mehrere Merge-Basen, nutze %s"
@@ -14130,26 +14450,26 @@ msgstr "kein <Programm> für --extcmd=<Programm> angegeben"
 msgid "git env--helper --type=[bool|ulong] <options> <env-var>"
 msgstr "git env--helper --type=[bool|ulong] <Optionen> <Umgebungsvariable>"
 
-#: builtin/env--helper.c:37 builtin/hash-object.c:98
+#: builtin/env--helper.c:42 builtin/hash-object.c:98
 msgid "type"
 msgstr "Art"
 
-#: builtin/env--helper.c:41
+#: builtin/env--helper.c:46
 msgid "default for git_env_*(...) to fall back on"
 msgstr "Standard für git_env_*(...), um darauf zurückzugreifen"
 
-#: builtin/env--helper.c:43
+#: builtin/env--helper.c:48
 msgid "be quiet only use git_env_*() value as exit code"
 msgstr "Ausgaben unterdrücken; nur git_env_*() Werte als Exit-Code verwenden"
 
-#: builtin/env--helper.c:62
+#: builtin/env--helper.c:67
 #, c-format
 msgid "option `--default' expects a boolean value with `--type=bool`, not `%s`"
 msgstr ""
 "Option `--default' erwartet einen booleschen Wert bei `--type=bool', nicht `"
 "%s`"
 
-#: builtin/env--helper.c:77
+#: builtin/env--helper.c:82
 #, c-format
 msgid ""
 "option `--default' expects an unsigned long value with `--type=ulong`, not `"
@@ -14217,7 +14537,7 @@ msgstr "die \"done\"-Funktion benutzen, um den Datenstrom abzuschließen"
 msgid "Skip output of blob data"
 msgstr "Ausgabe von Blob-Daten überspringen"
 
-#: builtin/fast-export.c:1223 builtin/log.c:1724
+#: builtin/fast-export.c:1223 builtin/log.c:1811
 msgid "refspec"
 msgstr "Refspec"
 
@@ -14261,7 +14581,36 @@ msgstr ""
 "--import-marks und --import-marks-if-exists können nicht zusammen "
 "weitergegeben werden"
 
-#: builtin/fetch-pack.c:245
+#: builtin/fast-import.c:3086
+#, c-format
+msgid "Missing from marks for submodule '%s'"
+msgstr "Fehlende 'from'-Markierungen für Submodul '%s'"
+
+#: builtin/fast-import.c:3088
+#, c-format
+msgid "Missing to marks for submodule '%s'"
+msgstr "Fehlende 'to'-Markierungen für Submodul '%s'"
+
+#: builtin/fast-import.c:3223
+#, c-format
+msgid "Expected 'mark' command, got %s"
+msgstr "'mark' Befehl erwartet, '%s' bekommen"
+
+#: builtin/fast-import.c:3228
+#, c-format
+msgid "Expected 'to' command, got %s"
+msgstr "'to' Befehl erwartet, '%s' bekommen"
+
+#: builtin/fast-import.c:3320
+msgid "Expected format name:filename for submodule rewrite option"
+msgstr "Format 'Name:Dateiname' für Submodul-Rewrite-Option erwartet"
+
+#: builtin/fast-import.c:3374
+#, c-format
+msgid "feature '%s' forbidden in input without --allow-unsafe-features"
+msgstr "Feature '%s' verboten in Eingabe ohne Option --allow-unsafe-features"
+
+#: builtin/fetch-pack.c:241
 #, c-format
 msgid "Lockfile created but not reported: %s"
 msgstr "Lock-Datei erstellt, aber nicht gemeldet: %s"
@@ -14282,96 +14631,101 @@ msgstr "git fetch --multiple [<Optionen>] [(<Repository> | <Gruppe>)...]"
 msgid "git fetch --all [<options>]"
 msgstr "git fetch --all [<Optionen>]"
 
-#: builtin/fetch.c:117
+#: builtin/fetch.c:119
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel kann nicht negativ sein"
 
-#: builtin/fetch.c:140 builtin/pull.c:185
+#: builtin/fetch.c:142 builtin/pull.c:185
 msgid "fetch from all remotes"
 msgstr "fordert von allen Remote-Repositories an"
 
-#: builtin/fetch.c:142 builtin/pull.c:245
+#: builtin/fetch.c:144 builtin/pull.c:245
 msgid "set upstream for git pull/fetch"
 msgstr "Upstream für \"git pull/fetch\" setzen"
 
-#: builtin/fetch.c:144 builtin/pull.c:188
+#: builtin/fetch.c:146 builtin/pull.c:188
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "an .git/FETCH_HEAD anhängen, anstatt zu überschreiben"
 
-#: builtin/fetch.c:146 builtin/pull.c:191
+#: builtin/fetch.c:148 builtin/pull.c:191
 msgid "path to upload pack on remote end"
 msgstr "Pfad des Programms zum Hochladen von Paketen auf der Gegenseite"
 
-#: builtin/fetch.c:147
+#: builtin/fetch.c:149
 msgid "force overwrite of local reference"
 msgstr "das Überschreiben einer lokalen Referenz erzwingen"
 
-#: builtin/fetch.c:149
+#: builtin/fetch.c:151
 msgid "fetch from multiple remotes"
 msgstr "von mehreren Remote-Repositories anfordern"
 
-#: builtin/fetch.c:151 builtin/pull.c:195
+#: builtin/fetch.c:153 builtin/pull.c:195
 msgid "fetch all tags and associated objects"
 msgstr "alle Tags und verbundene Objekte anfordern"
 
-#: builtin/fetch.c:153
+#: builtin/fetch.c:155
 msgid "do not fetch all tags (--no-tags)"
 msgstr "nicht alle Tags anfordern (--no-tags)"
 
-#: builtin/fetch.c:155
+#: builtin/fetch.c:157
 msgid "number of submodules fetched in parallel"
 msgstr "Anzahl der parallel anzufordernden Submodule"
 
-#: builtin/fetch.c:157 builtin/pull.c:198
+#: builtin/fetch.c:159 builtin/pull.c:198
 msgid "prune remote-tracking branches no longer on remote"
 msgstr ""
 "Remote-Tracking-Branches entfernen, die sich nicht mehr im Remote-Repository "
 "befinden"
 
-#: builtin/fetch.c:159
+#: builtin/fetch.c:161
 msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr ""
 "lokale Tags entfernen, die sich nicht mehr im Remote-Repository befinden, "
 "und geänderte Tags aktualisieren"
 
-#: builtin/fetch.c:160 builtin/fetch.c:183 builtin/pull.c:122
+#: builtin/fetch.c:162 builtin/fetch.c:187 builtin/pull.c:122
 msgid "on-demand"
 msgstr "bei-Bedarf"
 
-#: builtin/fetch.c:161
+#: builtin/fetch.c:163
 msgid "control recursive fetching of submodules"
 msgstr "rekursive Anforderungen von Submodulen kontrollieren"
 
-#: builtin/fetch.c:165 builtin/pull.c:206
+#: builtin/fetch.c:168
+#, fuzzy
+msgid "write fetched references to the FETCH_HEAD file"
+msgstr "das Archiv in diese Datei schreiben"
+
+#: builtin/fetch.c:169 builtin/pull.c:206
 msgid "keep downloaded pack"
 msgstr "heruntergeladenes Paket behalten"
 
-#: builtin/fetch.c:167
+#: builtin/fetch.c:171
 msgid "allow updating of HEAD ref"
 msgstr "Aktualisierung der \"HEAD\"-Referenz erlauben"
 
-#: builtin/fetch.c:170 builtin/fetch.c:176 builtin/pull.c:209
+#: builtin/fetch.c:174 builtin/fetch.c:180 builtin/pull.c:209
 #: builtin/pull.c:218
 msgid "deepen history of shallow clone"
 msgstr ""
 "die Historie eines Klons mit unvollständiger Historie (shallow) vertiefen"
 
-#: builtin/fetch.c:172 builtin/pull.c:212
+#: builtin/fetch.c:176 builtin/pull.c:212
 msgid "deepen history of shallow repository based on time"
 msgstr ""
 "die Historie eines Klons mit unvollständiger Historie (shallow) auf "
 "Zeitbasis\n"
 "vertiefen"
 
-#: builtin/fetch.c:178 builtin/pull.c:221
+#: builtin/fetch.c:182 builtin/pull.c:221
 msgid "convert to a complete repository"
 msgstr "zu einem vollständigen Repository konvertieren"
 
-#: builtin/fetch.c:181
+#: builtin/fetch.c:185
 msgid "prepend this to submodule path output"
 msgstr "dies an die Ausgabe der Submodul-Pfade voranstellen"
 
-#: builtin/fetch.c:184
+#: builtin/fetch.c:188
 msgid ""
 "default for recursive fetching of submodules (lower priority than config "
 "files)"
@@ -14379,96 +14733,102 @@ msgstr ""
 "Standard für die rekursive Anforderung von Submodulen (geringere Priorität\n"
 "als Konfigurationsdateien)"
 
-#: builtin/fetch.c:188 builtin/pull.c:224
+#: builtin/fetch.c:192 builtin/pull.c:224
 msgid "accept refs that update .git/shallow"
 msgstr "Referenzen, die .git/shallow aktualisieren, akzeptieren"
 
-#: builtin/fetch.c:189 builtin/pull.c:226
+#: builtin/fetch.c:193 builtin/pull.c:226
 msgid "refmap"
 msgstr "Refmap"
 
-#: builtin/fetch.c:190 builtin/pull.c:227
+#: builtin/fetch.c:194 builtin/pull.c:227
 msgid "specify fetch refmap"
 msgstr "Refmap für 'fetch' angeben"
 
-#: builtin/fetch.c:197 builtin/pull.c:240
+#: builtin/fetch.c:201 builtin/pull.c:240
 msgid "report that we have only objects reachable from this object"
 msgstr ""
 "ausgeben, dass wir nur Objekte haben, die von diesem Objekt aus erreichbar "
 "sind"
 
-#: builtin/fetch.c:200
-msgid "run 'gc --auto' after fetching"
+#: builtin/fetch.c:204 builtin/fetch.c:206
+#, fuzzy
+msgid "run 'maintenance --auto' after fetching"
 msgstr "Führe 'gc --auto' nach \"fetch\" aus"
 
-#: builtin/fetch.c:202 builtin/pull.c:243
+#: builtin/fetch.c:208 builtin/pull.c:243
 msgid "check for forced-updates on all updated branches"
 msgstr "Prüfe auf erzwungene Aktualisierungen in allen aktualisierten Branches"
 
-#: builtin/fetch.c:204
+#: builtin/fetch.c:210
 msgid "write the commit-graph after fetching"
 msgstr "Schreibe den Commit-Graph nach \"fetch\""
 
-#: builtin/fetch.c:514
+#: builtin/fetch.c:212
+#, fuzzy
+msgid "accept refspecs from stdin"
+msgstr "Referenzen von der Standard-Eingabe lesen"
+
+#: builtin/fetch.c:523
 msgid "Couldn't find remote ref HEAD"
 msgstr "Konnte Remote-Referenz von HEAD nicht finden."
 
-#: builtin/fetch.c:654
+#: builtin/fetch.c:677
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "Konfiguration fetch.output enthält ungültigen Wert %s"
 
-#: builtin/fetch.c:752
+#: builtin/fetch.c:775
 #, c-format
 msgid "object %s not found"
 msgstr "Objekt %s nicht gefunden"
 
-#: builtin/fetch.c:756
+#: builtin/fetch.c:779
 msgid "[up to date]"
 msgstr "[aktuell]"
 
-#: builtin/fetch.c:769 builtin/fetch.c:785 builtin/fetch.c:857
+#: builtin/fetch.c:792 builtin/fetch.c:808 builtin/fetch.c:880
 msgid "[rejected]"
 msgstr "[zurückgewiesen]"
 
-#: builtin/fetch.c:770
+#: builtin/fetch.c:793
 msgid "can't fetch in current branch"
 msgstr "kann \"fetch\" im aktuellen Branch nicht ausführen"
 
-#: builtin/fetch.c:780
+#: builtin/fetch.c:803
 msgid "[tag update]"
 msgstr "[Tag Aktualisierung]"
 
-#: builtin/fetch.c:781 builtin/fetch.c:818 builtin/fetch.c:840
-#: builtin/fetch.c:852
+#: builtin/fetch.c:804 builtin/fetch.c:841 builtin/fetch.c:863
+#: builtin/fetch.c:875
 msgid "unable to update local ref"
 msgstr "kann lokale Referenz nicht aktualisieren"
 
-#: builtin/fetch.c:785
+#: builtin/fetch.c:808
 msgid "would clobber existing tag"
 msgstr "würde bestehende Tags verändern"
 
-#: builtin/fetch.c:807
+#: builtin/fetch.c:830
 msgid "[new tag]"
 msgstr "[neues Tag]"
 
-#: builtin/fetch.c:810
+#: builtin/fetch.c:833
 msgid "[new branch]"
 msgstr "[neuer Branch]"
 
-#: builtin/fetch.c:813
+#: builtin/fetch.c:836
 msgid "[new ref]"
 msgstr "[neue Referenz]"
 
-#: builtin/fetch.c:852
+#: builtin/fetch.c:875
 msgid "forced update"
 msgstr "Aktualisierung erzwungen"
 
-#: builtin/fetch.c:857
+#: builtin/fetch.c:880
 msgid "non-fast-forward"
 msgstr "kein Vorspulen"
 
-#: builtin/fetch.c:878
+#: builtin/fetch.c:901
 msgid ""
 "Fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled. To re-enable, use '--show-forced-updates'\n"
@@ -14479,7 +14839,7 @@ msgstr ""
 "aktivieren, nutzen Sie die Option '--show-forced-updated' oder führen\n"
 "Sie 'git config fetch.showForcedUpdates true' aus."
 
-#: builtin/fetch.c:882
+#: builtin/fetch.c:905
 #, c-format
 msgid ""
 "It took %.2f seconds to check forced updates. You can use\n"
@@ -14492,12 +14852,12 @@ msgstr ""
 "'git config fetch.showForcedUpdates false' ausführen, um diese Überprüfung\n"
 "zu umgehen.\n"
 
-#: builtin/fetch.c:914
+#: builtin/fetch.c:939
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s hat nicht alle erforderlichen Objekte gesendet\n"
 
-#: builtin/fetch.c:935
+#: builtin/fetch.c:960
 #, c-format
 msgid "reject %s because shallow roots are not allowed to be updated"
 msgstr ""
@@ -14505,12 +14865,12 @@ msgstr ""
 "unvollständiger\n"
 "Historie (shallow) nicht aktualisiert werden dürfen."
 
-#: builtin/fetch.c:1020 builtin/fetch.c:1158
+#: builtin/fetch.c:1053 builtin/fetch.c:1191
 #, c-format
 msgid "From %.*s\n"
 msgstr "Von %.*s\n"
 
-#: builtin/fetch.c:1031
+#: builtin/fetch.c:1064
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -14519,58 +14879,58 @@ msgstr ""
 "Einige lokale Referenzen konnten nicht aktualisiert werden; versuchen Sie\n"
 "'git remote prune %s', um jeden älteren, widersprüchlichen Branch zu löschen."
 
-#: builtin/fetch.c:1128
+#: builtin/fetch.c:1161
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s wird unreferenziert)"
 
-#: builtin/fetch.c:1129
+#: builtin/fetch.c:1162
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s wurde unreferenziert)"
 
-#: builtin/fetch.c:1161
+#: builtin/fetch.c:1194
 msgid "[deleted]"
 msgstr "[gelöscht]"
 
-#: builtin/fetch.c:1162 builtin/remote.c:1112
+#: builtin/fetch.c:1195 builtin/remote.c:1113
 msgid "(none)"
 msgstr "(nichts)"
 
-#: builtin/fetch.c:1185
+#: builtin/fetch.c:1218
 #, c-format
 msgid "Refusing to fetch into current branch %s of non-bare repository"
 msgstr ""
 "Der \"fetch\" in den aktuellen Branch %s von einem Nicht-Bare-Repository "
 "wurde verweigert."
 
-#: builtin/fetch.c:1204
+#: builtin/fetch.c:1237
 #, c-format
 msgid "Option \"%s\" value \"%s\" is not valid for %s"
 msgstr "Option \"%s\" Wert \"%s\" ist nicht gültig für %s"
 
-#: builtin/fetch.c:1207
+#: builtin/fetch.c:1240
 #, c-format
 msgid "Option \"%s\" is ignored for %s\n"
 msgstr "Option \"%s\" wird ignoriert für %s\n"
 
-#: builtin/fetch.c:1415
+#: builtin/fetch.c:1448
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "Mehrere Branches erkannt, inkompatibel mit --set-upstream"
 
-#: builtin/fetch.c:1430
+#: builtin/fetch.c:1463
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "Setze keinen Upstream für einen entfernten Remote-Tracking-Branch."
 
-#: builtin/fetch.c:1432
+#: builtin/fetch.c:1465
 msgid "not setting upstream for a remote tag"
 msgstr "Setze keinen Upstream für einen Tag eines Remote-Repositories."
 
-#: builtin/fetch.c:1434
+#: builtin/fetch.c:1467
 msgid "unknown branch type"
 msgstr "Unbekannter Branch-Typ"
 
-#: builtin/fetch.c:1436
+#: builtin/fetch.c:1469
 msgid ""
 "no source branch found.\n"
 "you need to specify exactly one branch with the --set-upstream option."
@@ -14578,22 +14938,22 @@ msgstr ""
 "Keinen Quell-Branch gefunden.\n"
 "Sie müssen bei der Option --set-upstream genau einen Branch angeben."
 
-#: builtin/fetch.c:1562 builtin/fetch.c:1625
+#: builtin/fetch.c:1598 builtin/fetch.c:1661
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Fordere an von %s\n"
 
-#: builtin/fetch.c:1572 builtin/fetch.c:1627 builtin/remote.c:101
+#: builtin/fetch.c:1608 builtin/fetch.c:1663 builtin/remote.c:101
 #, c-format
 msgid "Could not fetch %s"
 msgstr "Konnte nicht von %s anfordern"
 
-#: builtin/fetch.c:1584
+#: builtin/fetch.c:1620
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "Konnte '%s' nicht anfordern (Exit-Code: %d)\n"
 
-#: builtin/fetch.c:1687
+#: builtin/fetch.c:1724
 msgid ""
 "No remote repository specified.  Please, specify either a URL or a\n"
 "remote name from which new revisions should be fetched."
@@ -14602,55 +14962,60 @@ msgstr ""
 "oder den Namen des Remote-Repositories an, von welchem neue\n"
 "Commits angefordert werden sollen."
 
-#: builtin/fetch.c:1724
+#: builtin/fetch.c:1760
 msgid "You need to specify a tag name."
 msgstr "Sie müssen den Namen des Tags angeben."
 
-#: builtin/fetch.c:1778
+#: builtin/fetch.c:1825
 msgid "Negative depth in --deepen is not supported"
 msgstr "Negative Tiefe wird von --deepen nicht unterstützt."
 
-#: builtin/fetch.c:1780
+#: builtin/fetch.c:1827
 msgid "--deepen and --depth are mutually exclusive"
 msgstr "--deepen und --depth schließen sich gegenseitig aus"
 
-#: builtin/fetch.c:1785
+#: builtin/fetch.c:1832
 msgid "--depth and --unshallow cannot be used together"
 msgstr ""
 "Die Optionen --depth und --unshallow können nicht gemeinsam verwendet werden."
 
-#: builtin/fetch.c:1787
+#: builtin/fetch.c:1834
 msgid "--unshallow on a complete repository does not make sense"
 msgstr ""
 "Die Option --unshallow kann nicht in einem Repository mit vollständiger "
 "Historie verwendet werden."
 
-#: builtin/fetch.c:1800
+#: builtin/fetch.c:1851
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all akzeptiert kein Repository als Argument"
 
-#: builtin/fetch.c:1802
+#: builtin/fetch.c:1853
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all kann nicht mit Refspecs verwendet werden."
 
-#: builtin/fetch.c:1811
+#: builtin/fetch.c:1862
 #, c-format
 msgid "No such remote or remote group: %s"
 msgstr "Kein Remote-Repository (einzeln oder Gruppe): %s"
 
-#: builtin/fetch.c:1818
+#: builtin/fetch.c:1869
 msgid "Fetching a group and specifying refspecs does not make sense"
 msgstr ""
 "Das Abholen einer Gruppe von Remote-Repositories kann nicht mit der Angabe\n"
 "von Refspecs verwendet werden."
 
-#: builtin/fetch.c:1836
+#: builtin/fetch.c:1887
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
 msgstr ""
 "--filter kann nur mit den Remote-Repositories verwendet werden,\n"
 "die in core.partialClone konfiguriert sind."
+
+#: builtin/fetch.c:1891
+#, fuzzy
+msgid "--stdin can only be used when fetching from one remote"
+msgstr "Die Option --exec kann nur zusammen mit --remote verwendet werden."
 
 #: builtin/fmt-merge-msg.c:7
 msgid ""
@@ -14688,7 +15053,8 @@ msgid "git for-each-ref [--points-at <object>]"
 msgstr "git for-each-ref [--points-at <Objekt>]"
 
 #: builtin/for-each-ref.c:12
-msgid "git for-each-ref [(--merged | --no-merged) [<commit>]]"
+#, fuzzy
+msgid "git for-each-ref [--merged [<commit>]] [--no-merged [<commit>]]"
 msgstr "git for-each-ref [(--merged | --no-merged) [<Commit>]]"
 
 #: builtin/for-each-ref.c:13
@@ -14883,7 +15249,7 @@ msgstr "Prüfe Objekt-Verzeichnisse"
 msgid "Checking %s link"
 msgstr "Prüfe %s Verknüpfung"
 
-#: builtin/fsck.c:696 builtin/index-pack.c:843
+#: builtin/fsck.c:696 builtin/index-pack.c:865
 #, c-format
 msgid "invalid %s"
 msgstr "Ungültiger Objekt-Typ %s"
@@ -14968,7 +15334,7 @@ msgstr "Fortschrittsanzeige anzeigen"
 msgid "show verbose names for reachable objects"
 msgstr "ausführliche Namen für erreichbare Objekte anzeigen"
 
-#: builtin/fsck.c:847 builtin/index-pack.c:225
+#: builtin/fsck.c:847 builtin/index-pack.c:261
 msgid "Checking objects"
 msgstr "Prüfe Objekte"
 
@@ -14982,31 +15348,31 @@ msgstr "%s: Objekt nicht vorhanden"
 msgid "invalid parameter: expected sha1, got '%s'"
 msgstr "Ungültiger Parameter: SHA-1 erwartet, '%s' bekommen"
 
-#: builtin/gc.c:35
+#: builtin/gc.c:36
 msgid "git gc [<options>]"
 msgstr "git gc [<Optionen>]"
 
-#: builtin/gc.c:90
+#: builtin/gc.c:91
 #, c-format
 msgid "Failed to fstat %s: %s"
 msgstr "Konnte '%s' nicht lesen: %s"
 
-#: builtin/gc.c:126
+#: builtin/gc.c:127
 #, c-format
 msgid "failed to parse '%s' value '%s'"
 msgstr "Fehler beim Parsen von '%s' mit dem Wert '%s'"
 
-#: builtin/gc.c:475 builtin/init-db.c:57
+#: builtin/gc.c:476 builtin/init-db.c:58
 #, c-format
 msgid "cannot stat '%s'"
 msgstr "Kann '%s' nicht lesen"
 
-#: builtin/gc.c:484 builtin/notes.c:240 builtin/tag.c:530
+#: builtin/gc.c:485 builtin/notes.c:240 builtin/tag.c:530
 #, c-format
 msgid "cannot read '%s'"
 msgstr "kann '%s' nicht lesen"
 
-#: builtin/gc.c:491
+#: builtin/gc.c:492
 #, c-format
 msgid ""
 "The last gc run reported the following. Please correct the root cause\n"
@@ -15022,58 +15388,58 @@ msgstr ""
 "\n"
 "%s"
 
-#: builtin/gc.c:539
+#: builtin/gc.c:540
 msgid "prune unreferenced objects"
 msgstr "unreferenzierte Objekte entfernen"
 
-#: builtin/gc.c:541
+#: builtin/gc.c:542
 msgid "be more thorough (increased runtime)"
 msgstr "mehr Gründlichkeit (erhöht Laufzeit)"
 
-#: builtin/gc.c:542
+#: builtin/gc.c:543
 msgid "enable auto-gc mode"
 msgstr "\"auto-gc\" Modus aktivieren"
 
-#: builtin/gc.c:545
+#: builtin/gc.c:546
 msgid "force running gc even if there may be another gc running"
 msgstr ""
 "Ausführung von \"git gc\" erzwingen, selbst wenn ein anderes\n"
 "\"git gc\" bereits ausgeführt wird"
 
-#: builtin/gc.c:548
+#: builtin/gc.c:549
 msgid "repack all other packs except the largest pack"
 msgstr "alle anderen Pakete, außer das größte Paket, neu packen"
 
-#: builtin/gc.c:565
+#: builtin/gc.c:566
 #, c-format
 msgid "failed to parse gc.logexpiry value %s"
 msgstr "Fehler beim Parsen des Wertes '%s' von gc.logexpiry."
 
-#: builtin/gc.c:576
+#: builtin/gc.c:577
 #, c-format
 msgid "failed to parse prune expiry value %s"
 msgstr "Fehler beim Parsen des \"prune expiry\" Wertes %s"
 
-#: builtin/gc.c:596
+#: builtin/gc.c:597
 #, c-format
 msgid "Auto packing the repository in background for optimum performance.\n"
 msgstr ""
 "Die Datenbank des Repositories wird für eine optimale Performance im\n"
 "Hintergrund komprimiert.\n"
 
-#: builtin/gc.c:598
+#: builtin/gc.c:599
 #, c-format
 msgid "Auto packing the repository for optimum performance.\n"
 msgstr ""
 "Die Datenbank des Projektarchivs wird für eine optimale Performance "
 "komprimiert.\n"
 
-#: builtin/gc.c:599
+#: builtin/gc.c:600
 #, c-format
 msgid "See \"git help gc\" for manual housekeeping.\n"
 msgstr "Siehe \"git help gc\" für manuelles Aufräumen.\n"
 
-#: builtin/gc.c:639
+#: builtin/gc.c:640
 #, c-format
 msgid ""
 "gc is already running on machine '%s' pid %<PRIuMAX> (use --force if not)"
@@ -15081,12 +15447,68 @@ msgstr ""
 "\"git gc\" wird bereits auf Maschine '%s' pid %<PRIuMAX> ausgeführt\n"
 "(benutzen Sie --force falls nicht)"
 
-#: builtin/gc.c:694
+#: builtin/gc.c:695
 msgid ""
 "There are too many unreachable loose objects; run 'git prune' to remove them."
 msgstr ""
 "Es gibt zu viele unerreichbare lose Objekte; führen Sie 'git prune' aus, um "
 "diese zu löschen."
+
+#: builtin/gc.c:705
+msgid "git maintenance run [--auto] [--[no-]quiet] [--task=<task>]"
+msgstr ""
+
+#: builtin/gc.c:812
+#, fuzzy
+msgid "failed to write commit-graph"
+msgstr "Fehler beim Schreiben des Commit-Objektes."
+
+#: builtin/gc.c:905
+#, c-format
+msgid "lock file '%s' exists, skipping maintenance"
+msgstr ""
+
+#: builtin/gc.c:932
+#, fuzzy, c-format
+msgid "task '%s' failed"
+msgstr "Schreiben von '%s' fehlgeschlagen."
+
+#: builtin/gc.c:979
+#, fuzzy, c-format
+msgid "'%s' is not a valid task"
+msgstr "'%s' ist kein gültiger Begriff."
+
+#: builtin/gc.c:984
+#, fuzzy, c-format
+msgid "task '%s' cannot be selected multiple times"
+msgstr "'%s' kann nicht mit '%s' verwendet werden"
+
+#: builtin/gc.c:999
+msgid "run tasks based on the state of the repository"
+msgstr ""
+
+#: builtin/gc.c:1001
+msgid "do not report progress or other information over stderr"
+msgstr ""
+
+#: builtin/gc.c:1002
+msgid "task"
+msgstr ""
+
+#: builtin/gc.c:1003
+#, fuzzy
+msgid "run a specific task"
+msgstr "kein Pfad angegeben"
+
+#: builtin/gc.c:1026
+#, fuzzy
+msgid "git maintenance run [<options>]"
+msgstr "git notes prune [<Optionen>]"
+
+#: builtin/gc.c:1037
+#, fuzzy, c-format
+msgid "invalid subcommand: %s"
+msgstr "Ungültiger Commit %s"
 
 #: builtin/grep.c:30
 msgid "git grep [<options>] [-e] <pattern> [<rev>...] [[--] <path>...]"
@@ -15106,8 +15528,8 @@ msgstr "ungültige Anzahl von Threads (%d) für %s angegeben"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:287 builtin/index-pack.c:1537 builtin/index-pack.c:1727
-#: builtin/pack-objects.c:2904
+#: builtin/grep.c:287 builtin/index-pack.c:1576 builtin/index-pack.c:1766
+#: builtin/pack-objects.c:2936
 #, c-format
 msgid "no threads support, ignoring %s"
 msgstr "keine Unterstützung von Threads, '%s' wird ignoriert"
@@ -15122,250 +15544,250 @@ msgstr "konnte \"Tree\"-Objekt (%s) nicht lesen"
 msgid "unable to grep from object of type %s"
 msgstr "kann \"grep\" nicht mit Objekten des Typs %s durchführen"
 
-#: builtin/grep.c:724
+#: builtin/grep.c:725
 #, c-format
 msgid "switch `%c' expects a numerical value"
 msgstr "Schalter '%c' erwartet einen numerischen Wert"
 
-#: builtin/grep.c:823
+#: builtin/grep.c:824
 msgid "search in index instead of in the work tree"
 msgstr "im Index anstatt im Arbeitsverzeichnis suchen"
 
-#: builtin/grep.c:825
+#: builtin/grep.c:826
 msgid "find in contents not managed by git"
 msgstr "auch in Inhalten finden, die nicht von Git verwaltet werden"
 
-#: builtin/grep.c:827
+#: builtin/grep.c:828
 msgid "search in both tracked and untracked files"
 msgstr "in versionierten und unversionierten Dateien suchen"
 
-#: builtin/grep.c:829
+#: builtin/grep.c:830
 msgid "ignore files specified via '.gitignore'"
 msgstr "Dateien, die über '.gitignore' angegeben sind, ignorieren"
 
-#: builtin/grep.c:831
+#: builtin/grep.c:832
 msgid "recursively search in each submodule"
 msgstr "rekursive Suche in jedem Submodul"
 
-#: builtin/grep.c:834
+#: builtin/grep.c:835
 msgid "show non-matching lines"
 msgstr "Zeilen ohne Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:836
+#: builtin/grep.c:837
 msgid "case insensitive matching"
 msgstr "Übereinstimmungen unabhängig von Groß- und Kleinschreibung finden"
 
-#: builtin/grep.c:838
+#: builtin/grep.c:839
 msgid "match patterns only at word boundaries"
 msgstr "nur ganze Wörter suchen"
 
-#: builtin/grep.c:840
+#: builtin/grep.c:841
 msgid "process binary files as text"
 msgstr "binäre Dateien als Text verarbeiten"
 
-#: builtin/grep.c:842
+#: builtin/grep.c:843
 msgid "don't match patterns in binary files"
 msgstr "keine Muster in Binärdateien finden"
 
-#: builtin/grep.c:845
+#: builtin/grep.c:846
 msgid "process binary files with textconv filters"
 msgstr "binäre Dateien mit \"textconv\"-Filtern verarbeiten"
 
-#: builtin/grep.c:847
+#: builtin/grep.c:848
 msgid "search in subdirectories (default)"
 msgstr "in Unterverzeichnissen suchen (Standard)"
 
-#: builtin/grep.c:849
+#: builtin/grep.c:850
 msgid "descend at most <depth> levels"
 msgstr "höchstens <Tiefe> Ebenen durchlaufen"
 
-#: builtin/grep.c:853
+#: builtin/grep.c:854
 msgid "use extended POSIX regular expressions"
 msgstr "erweiterte reguläre Ausdrücke aus POSIX verwenden"
 
-#: builtin/grep.c:856
+#: builtin/grep.c:857
 msgid "use basic POSIX regular expressions (default)"
 msgstr "grundlegende reguläre Ausdrücke aus POSIX verwenden (Standard)"
 
-#: builtin/grep.c:859
+#: builtin/grep.c:860
 msgid "interpret patterns as fixed strings"
 msgstr "Muster als feste Zeichenketten interpretieren"
 
-#: builtin/grep.c:862
+#: builtin/grep.c:863
 msgid "use Perl-compatible regular expressions"
 msgstr "Perl-kompatible reguläre Ausdrücke verwenden"
 
-#: builtin/grep.c:865
+#: builtin/grep.c:866
 msgid "show line numbers"
 msgstr "Zeilennummern anzeigen"
 
-#: builtin/grep.c:866
+#: builtin/grep.c:867
 msgid "show column number of first match"
 msgstr "Nummer der Spalte des ersten Treffers anzeigen"
 
-#: builtin/grep.c:867
+#: builtin/grep.c:868
 msgid "don't show filenames"
 msgstr "keine Dateinamen anzeigen"
 
-#: builtin/grep.c:868
+#: builtin/grep.c:869
 msgid "show filenames"
 msgstr "Dateinamen anzeigen"
 
-#: builtin/grep.c:870
+#: builtin/grep.c:871
 msgid "show filenames relative to top directory"
 msgstr "Dateinamen relativ zum Projektverzeichnis anzeigen"
 
-#: builtin/grep.c:872
+#: builtin/grep.c:873
 msgid "show only filenames instead of matching lines"
 msgstr "nur Dateinamen anzeigen anstatt übereinstimmende Zeilen"
 
-#: builtin/grep.c:874
+#: builtin/grep.c:875
 msgid "synonym for --files-with-matches"
 msgstr "Synonym für --files-with-matches"
 
-#: builtin/grep.c:877
+#: builtin/grep.c:878
 msgid "show only the names of files without match"
 msgstr "nur die Dateinamen ohne Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:879
+#: builtin/grep.c:880
 msgid "print NUL after filenames"
 msgstr "NUL-Zeichen nach Dateinamen ausgeben"
 
-#: builtin/grep.c:882
+#: builtin/grep.c:883
 msgid "show only matching parts of a line"
 msgstr "nur übereinstimmende Teile der Zeile anzeigen"
 
-#: builtin/grep.c:884
+#: builtin/grep.c:885
 msgid "show the number of matches instead of matching lines"
 msgstr "anstatt der Zeilen, die Anzahl der übereinstimmenden Zeilen anzeigen"
 
-#: builtin/grep.c:885
+#: builtin/grep.c:886
 msgid "highlight matches"
 msgstr "Übereinstimmungen hervorheben"
 
-#: builtin/grep.c:887
+#: builtin/grep.c:888
 msgid "print empty line between matches from different files"
 msgstr ""
 "eine Leerzeile zwischen Übereinstimmungen in verschiedenen Dateien ausgeben"
 
-#: builtin/grep.c:889
+#: builtin/grep.c:890
 msgid "show filename only once above matches from same file"
 msgstr ""
 "den Dateinamen nur einmal oberhalb der Übereinstimmungen aus dieser Datei "
 "anzeigen"
 
-#: builtin/grep.c:892
+#: builtin/grep.c:893
 msgid "show <n> context lines before and after matches"
 msgstr "<n> Zeilen vor und nach den Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:895
+#: builtin/grep.c:896
 msgid "show <n> context lines before matches"
 msgstr "<n> Zeilen vor den Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:897
+#: builtin/grep.c:898
 msgid "show <n> context lines after matches"
 msgstr "<n> Zeilen nach den Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:899
+#: builtin/grep.c:900
 msgid "use <n> worker threads"
 msgstr "<n> Threads benutzen"
 
-#: builtin/grep.c:900
+#: builtin/grep.c:901
 msgid "shortcut for -C NUM"
 msgstr "Kurzform für -C NUM"
 
-#: builtin/grep.c:903
+#: builtin/grep.c:904
 msgid "show a line with the function name before matches"
 msgstr "eine Zeile mit dem Funktionsnamen vor Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:905
+#: builtin/grep.c:906
 msgid "show the surrounding function"
 msgstr "die umgebende Funktion anzeigen"
 
-#: builtin/grep.c:908
+#: builtin/grep.c:909
 msgid "read patterns from file"
 msgstr "Muster von einer Datei lesen"
 
-#: builtin/grep.c:910
+#: builtin/grep.c:911
 msgid "match <pattern>"
 msgstr "<Muster> finden"
 
-#: builtin/grep.c:912
+#: builtin/grep.c:913
 msgid "combine patterns specified with -e"
 msgstr "Muster kombinieren, die mit -e angegeben wurden"
 
-#: builtin/grep.c:924
+#: builtin/grep.c:925
 msgid "indicate hit with exit status without output"
 msgstr "Übereinstimmungen nur durch Beendigungsstatus anzeigen"
 
-#: builtin/grep.c:926
+#: builtin/grep.c:927
 msgid "show only matches from files that match all patterns"
 msgstr ""
 "nur Übereinstimmungen von Dateien anzeigen, die allen Mustern entsprechen"
 
-#: builtin/grep.c:928
+#: builtin/grep.c:929
 msgid "show parse tree for grep expression"
 msgstr "geparstes Verzeichnis für \"grep\"-Ausdruck anzeigen"
 
-#: builtin/grep.c:932
+#: builtin/grep.c:933
 msgid "pager"
 msgstr "Anzeigeprogramm"
 
-#: builtin/grep.c:932
+#: builtin/grep.c:933
 msgid "show matching files in the pager"
 msgstr "Dateien mit Übereinstimmungen im Anzeigeprogramm anzeigen"
 
-#: builtin/grep.c:936
+#: builtin/grep.c:937
 msgid "allow calling of grep(1) (ignored by this build)"
 msgstr "den Aufruf von grep(1) erlauben (von dieser Programmversion ignoriert)"
 
-#: builtin/grep.c:1003
+#: builtin/grep.c:1004
 msgid "no pattern given"
 msgstr "Kein Muster angegeben."
 
-#: builtin/grep.c:1039
+#: builtin/grep.c:1040
 msgid "--no-index or --untracked cannot be used with revs"
 msgstr "--no-index oder --untracked können nicht mit Commits verwendet werden"
 
-#: builtin/grep.c:1047
+#: builtin/grep.c:1048
 #, c-format
 msgid "unable to resolve revision: %s"
 msgstr "Konnte Commit nicht auflösen: %s"
 
-#: builtin/grep.c:1077
+#: builtin/grep.c:1078
 msgid "--untracked not supported with --recurse-submodules"
 msgstr "--untracked zusammen mit --recurse-submodules wird nicht unterstützt"
 
-#: builtin/grep.c:1081
+#: builtin/grep.c:1082
 msgid "invalid option combination, ignoring --threads"
 msgstr "Ungültige Kombination von Optionen, --threads wird ignoriert."
 
-#: builtin/grep.c:1084 builtin/pack-objects.c:3623
+#: builtin/grep.c:1085 builtin/pack-objects.c:3655
 msgid "no threads support, ignoring --threads"
 msgstr "Keine Unterstützung für Threads, --threads wird ignoriert."
 
-#: builtin/grep.c:1087 builtin/index-pack.c:1534 builtin/pack-objects.c:2901
+#: builtin/grep.c:1088 builtin/index-pack.c:1573 builtin/pack-objects.c:2933
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "ungültige Anzahl von Threads angegeben (%d)"
 
-#: builtin/grep.c:1121
+#: builtin/grep.c:1122
 msgid "--open-files-in-pager only works on the worktree"
 msgstr ""
 "Die Option --open-files-in-pager kann nur innerhalb des "
 "Arbeitsverzeichnisses verwendet werden."
 
-#: builtin/grep.c:1147
+#: builtin/grep.c:1148
 msgid "--cached or --untracked cannot be used with --no-index"
 msgstr "--cached und --untracked können nicht mit --no-index verwendet werden."
 
-#: builtin/grep.c:1153
+#: builtin/grep.c:1154
 msgid "--[no-]exclude-standard cannot be used for tracked contents"
 msgstr ""
 "--[no-]exclude-standard kann nicht mit versionierten Inhalten verwendet "
 "werden."
 
-#: builtin/grep.c:1161
+#: builtin/grep.c:1162
 msgid "both --cached and trees are given"
 msgstr "--cached und \"Tree\"-Objekte angegeben"
 
@@ -15503,7 +15925,7 @@ msgstr "kein Informations-Betrachter konnte mit dieser Anfrage umgehen"
 msgid "'%s' is aliased to '%s'"
 msgstr "Für '%s' wurde der Alias '%s' angelegt."
 
-#: builtin/help.c:534 git.c:367
+#: builtin/help.c:534 git.c:369
 #, c-format
 msgid "bad alias.%s string: %s"
 msgstr "Ungültiger alias.%s String: %s"
@@ -15517,393 +15939,393 @@ msgstr "Verwendung: %s%s"
 msgid "'git help config' for more information"
 msgstr "'git help config' für weitere Informationen"
 
-#: builtin/index-pack.c:185
+#: builtin/index-pack.c:221
 #, c-format
 msgid "object type mismatch at %s"
 msgstr "Objekt-Typen passen bei %s nicht zusammen"
 
-#: builtin/index-pack.c:205
+#: builtin/index-pack.c:241
 #, c-format
 msgid "did not receive expected object %s"
 msgstr "konnte erwartetes Objekt %s nicht empfangen"
 
-#: builtin/index-pack.c:208
+#: builtin/index-pack.c:244
 #, c-format
 msgid "object %s: expected type %s, found %s"
 msgstr "Objekt %s: erwarteter Typ %s, %s gefunden"
 
-#: builtin/index-pack.c:258
+#: builtin/index-pack.c:294
 #, c-format
 msgid "cannot fill %d byte"
 msgid_plural "cannot fill %d bytes"
 msgstr[0] "kann %d Byte nicht lesen"
 msgstr[1] "kann %d Bytes nicht lesen"
 
-#: builtin/index-pack.c:268
+#: builtin/index-pack.c:304
 msgid "early EOF"
 msgstr "zu frühes Dateiende"
 
-#: builtin/index-pack.c:269
+#: builtin/index-pack.c:305
 msgid "read error on input"
 msgstr "Fehler beim Lesen der Eingabe"
 
-#: builtin/index-pack.c:281
+#: builtin/index-pack.c:317
 msgid "used more bytes than were available"
 msgstr "verwendete mehr Bytes als verfügbar waren"
 
-#: builtin/index-pack.c:288 builtin/pack-objects.c:618
+#: builtin/index-pack.c:324 builtin/pack-objects.c:619
 msgid "pack too large for current definition of off_t"
 msgstr "Paket ist zu groß für die aktuelle Definition von off_t"
 
-#: builtin/index-pack.c:291 builtin/unpack-objects.c:95
+#: builtin/index-pack.c:327 builtin/unpack-objects.c:95
 msgid "pack exceeds maximum allowed size"
 msgstr "Paket überschreitet die maximal erlaubte Größe"
 
-#: builtin/index-pack.c:306 builtin/repack.c:250
+#: builtin/index-pack.c:342 builtin/repack.c:254
 #, c-format
 msgid "unable to create '%s'"
 msgstr "konnte '%s' nicht erstellen"
 
-#: builtin/index-pack.c:312
+#: builtin/index-pack.c:348
 #, c-format
 msgid "cannot open packfile '%s'"
 msgstr "Kann Paketdatei '%s' nicht öffnen"
 
-#: builtin/index-pack.c:326
+#: builtin/index-pack.c:362
 msgid "pack signature mismatch"
 msgstr "Paketsignatur stimmt nicht überein"
 
-#: builtin/index-pack.c:328
+#: builtin/index-pack.c:364
 #, c-format
 msgid "pack version %<PRIu32> unsupported"
 msgstr "Paketversion %<PRIu32> nicht unterstützt"
 
-#: builtin/index-pack.c:346
+#: builtin/index-pack.c:382
 #, c-format
 msgid "pack has bad object at offset %<PRIuMAX>: %s"
 msgstr "Paket hat ein ungültiges Objekt bei Versatz %<PRIuMAX>: %s"
 
-#: builtin/index-pack.c:466
+#: builtin/index-pack.c:488
 #, c-format
 msgid "inflate returned %d"
 msgstr "Dekomprimierung gab %d zurück"
 
-#: builtin/index-pack.c:515
+#: builtin/index-pack.c:537
 msgid "offset value overflow for delta base object"
 msgstr "Wert für Versatz bei Differenzobjekt übergelaufen"
 
-#: builtin/index-pack.c:523
+#: builtin/index-pack.c:545
 msgid "delta base offset is out of bound"
 msgstr ""
 "Wert für Versatz bei Differenzobjekt liegt außerhalb des gültigen Bereichs"
 
-#: builtin/index-pack.c:531
+#: builtin/index-pack.c:553
 #, c-format
 msgid "unknown object type %d"
 msgstr "Unbekannter Objekt-Typ %d"
 
-#: builtin/index-pack.c:562
+#: builtin/index-pack.c:584
 msgid "cannot pread pack file"
 msgstr "Kann Paketdatei %s nicht lesen"
 
-#: builtin/index-pack.c:564
+#: builtin/index-pack.c:586
 #, c-format
 msgid "premature end of pack file, %<PRIuMAX> byte missing"
 msgid_plural "premature end of pack file, %<PRIuMAX> bytes missing"
 msgstr[0] "frühzeitiges Ende der Paketdatei, vermisse %<PRIuMAX> Byte"
 msgstr[1] "frühzeitiges Ende der Paketdatei, vermisse %<PRIuMAX> Bytes"
 
-#: builtin/index-pack.c:590
+#: builtin/index-pack.c:612
 msgid "serious inflate inconsistency"
 msgstr "ernsthafte Inkonsistenz nach Dekomprimierung"
 
-#: builtin/index-pack.c:735 builtin/index-pack.c:741 builtin/index-pack.c:765
-#: builtin/index-pack.c:804 builtin/index-pack.c:813
+#: builtin/index-pack.c:757 builtin/index-pack.c:763 builtin/index-pack.c:787
+#: builtin/index-pack.c:826 builtin/index-pack.c:835
 #, c-format
 msgid "SHA1 COLLISION FOUND WITH %s !"
 msgstr "SHA1 KOLLISION MIT %s GEFUNDEN !"
 
-#: builtin/index-pack.c:738 builtin/pack-objects.c:170
-#: builtin/pack-objects.c:230 builtin/pack-objects.c:325
+#: builtin/index-pack.c:760 builtin/pack-objects.c:171
+#: builtin/pack-objects.c:231 builtin/pack-objects.c:326
 #, c-format
 msgid "unable to read %s"
 msgstr "kann %s nicht lesen"
 
-#: builtin/index-pack.c:802
+#: builtin/index-pack.c:824
 #, c-format
 msgid "cannot read existing object info %s"
 msgstr "Kann existierende Informationen zu Objekt %s nicht lesen."
 
-#: builtin/index-pack.c:810
+#: builtin/index-pack.c:832
 #, c-format
 msgid "cannot read existing object %s"
 msgstr "Kann existierendes Objekt %s nicht lesen."
 
-#: builtin/index-pack.c:824
+#: builtin/index-pack.c:846
 #, c-format
 msgid "invalid blob object %s"
 msgstr "ungültiges Blob-Objekt %s"
 
-#: builtin/index-pack.c:827 builtin/index-pack.c:846
+#: builtin/index-pack.c:849 builtin/index-pack.c:868
 msgid "fsck error in packed object"
 msgstr "fsck Fehler in gepacktem Objekt"
 
-#: builtin/index-pack.c:848
+#: builtin/index-pack.c:870
 #, c-format
 msgid "Not all child objects of %s are reachable"
 msgstr "Nicht alle Kind-Objekte von %s sind erreichbar"
 
-#: builtin/index-pack.c:920 builtin/index-pack.c:951
+#: builtin/index-pack.c:931 builtin/index-pack.c:978
 msgid "failed to apply delta"
 msgstr "Konnte Dateiunterschied nicht anwenden"
 
-#: builtin/index-pack.c:1121
+#: builtin/index-pack.c:1161
 msgid "Receiving objects"
 msgstr "Empfange Objekte"
 
-#: builtin/index-pack.c:1121
+#: builtin/index-pack.c:1161
 msgid "Indexing objects"
 msgstr "Indiziere Objekte"
 
-#: builtin/index-pack.c:1155
+#: builtin/index-pack.c:1195
 msgid "pack is corrupted (SHA1 mismatch)"
 msgstr "Paket ist beschädigt (SHA1 unterschiedlich)"
 
-#: builtin/index-pack.c:1160
+#: builtin/index-pack.c:1200
 msgid "cannot fstat packfile"
 msgstr "kann Paketdatei nicht lesen"
 
-#: builtin/index-pack.c:1163
+#: builtin/index-pack.c:1203
 msgid "pack has junk at the end"
 msgstr "Paketende enthält nicht verwendbaren Inhalt"
 
-#: builtin/index-pack.c:1175
+#: builtin/index-pack.c:1215
 msgid "confusion beyond insanity in parse_pack_objects()"
 msgstr "Fehler beim Ausführen von \"parse_pack_objects()\""
 
-#: builtin/index-pack.c:1198
+#: builtin/index-pack.c:1238
 msgid "Resolving deltas"
 msgstr "Löse Unterschiede auf"
 
-#: builtin/index-pack.c:1208 builtin/pack-objects.c:2665
+#: builtin/index-pack.c:1249 builtin/pack-objects.c:2697
 #, c-format
 msgid "unable to create thread: %s"
 msgstr "kann Thread nicht erzeugen: %s"
 
-#: builtin/index-pack.c:1249
+#: builtin/index-pack.c:1282
 msgid "confusion beyond insanity"
 msgstr "Fehler beim Auflösen der Unterschiede"
 
-#: builtin/index-pack.c:1255
+#: builtin/index-pack.c:1288
 #, c-format
 msgid "completed with %d local object"
 msgid_plural "completed with %d local objects"
 msgstr[0] "abgeschlossen mit %d lokalem Objekt"
 msgstr[1] "abgeschlossen mit %d lokalen Objekten"
 
-#: builtin/index-pack.c:1267
+#: builtin/index-pack.c:1300
 #, c-format
 msgid "Unexpected tail checksum for %s (disk corruption?)"
 msgstr "Unerwartete Prüfsumme für %s (Festplattenfehler?)"
 
-#: builtin/index-pack.c:1271
+#: builtin/index-pack.c:1304
 #, c-format
 msgid "pack has %d unresolved delta"
 msgid_plural "pack has %d unresolved deltas"
 msgstr[0] "Paket hat %d unaufgelösten Unterschied"
 msgstr[1] "Paket hat %d unaufgelöste Unterschiede"
 
-#: builtin/index-pack.c:1295
+#: builtin/index-pack.c:1328
 #, c-format
 msgid "unable to deflate appended object (%d)"
 msgstr "Konnte angehängtes Objekt (%d) nicht komprimieren"
 
-#: builtin/index-pack.c:1391
+#: builtin/index-pack.c:1424
 #, c-format
 msgid "local object %s is corrupt"
 msgstr "lokales Objekt %s ist beschädigt"
 
-#: builtin/index-pack.c:1405
+#: builtin/index-pack.c:1444
 #, c-format
 msgid "packfile name '%s' does not end with '.pack'"
 msgstr "Name der Paketdatei '%s' endet nicht mit '.pack'"
 
-#: builtin/index-pack.c:1430
+#: builtin/index-pack.c:1469
 #, c-format
 msgid "cannot write %s file '%s'"
 msgstr "Kann %s Datei '%s' nicht schreiben."
 
-#: builtin/index-pack.c:1438
+#: builtin/index-pack.c:1477
 #, c-format
 msgid "cannot close written %s file '%s'"
 msgstr "Kann eben geschriebene %s Datei '%s' nicht schließen."
 
-#: builtin/index-pack.c:1462
+#: builtin/index-pack.c:1501
 msgid "error while closing pack file"
 msgstr "Fehler beim Schließen der Paketdatei"
 
-#: builtin/index-pack.c:1476
+#: builtin/index-pack.c:1515
 msgid "cannot store pack file"
 msgstr "Kann Paketdatei nicht speichern"
 
-#: builtin/index-pack.c:1484
+#: builtin/index-pack.c:1523
 msgid "cannot store index file"
 msgstr "Kann Indexdatei nicht speichern"
 
-#: builtin/index-pack.c:1528 builtin/pack-objects.c:2912
+#: builtin/index-pack.c:1567 builtin/pack-objects.c:2944
 #, c-format
 msgid "bad pack.indexversion=%<PRIu32>"
 msgstr "\"pack.indexversion=%<PRIu32>\" ist ungültig"
 
-#: builtin/index-pack.c:1592
+#: builtin/index-pack.c:1631
 #, c-format
 msgid "Cannot open existing pack file '%s'"
 msgstr "Kann existierende Paketdatei '%s' nicht öffnen"
 
-#: builtin/index-pack.c:1594
+#: builtin/index-pack.c:1633
 #, c-format
 msgid "Cannot open existing pack idx file for '%s'"
 msgstr "Kann existierende Indexdatei für Paket '%s' nicht öffnen"
 
-#: builtin/index-pack.c:1642
+#: builtin/index-pack.c:1681
 #, c-format
 msgid "non delta: %d object"
 msgid_plural "non delta: %d objects"
 msgstr[0] "kein Unterschied: %d Objekt"
 msgstr[1] "kein Unterschied: %d Objekte"
 
-#: builtin/index-pack.c:1649
+#: builtin/index-pack.c:1688
 #, c-format
 msgid "chain length = %d: %lu object"
 msgid_plural "chain length = %d: %lu objects"
 msgstr[0] "Länge der Objekt-Liste = %d: %lu Objekt"
 msgstr[1] "Länge der Objekt-Liste = %d: %lu Objekte"
 
-#: builtin/index-pack.c:1689
+#: builtin/index-pack.c:1728
 msgid "Cannot come back to cwd"
 msgstr "Kann nicht zurück zum Arbeitsverzeichnis wechseln"
 
-#: builtin/index-pack.c:1738 builtin/index-pack.c:1741
-#: builtin/index-pack.c:1757 builtin/index-pack.c:1761
+#: builtin/index-pack.c:1777 builtin/index-pack.c:1780
+#: builtin/index-pack.c:1796 builtin/index-pack.c:1800
 #, c-format
 msgid "bad %s"
 msgstr "%s ist ungültig"
 
-#: builtin/index-pack.c:1767 builtin/init-db.c:392 builtin/init-db.c:621
+#: builtin/index-pack.c:1806 builtin/init-db.c:391 builtin/init-db.c:623
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "unbekannter Hash-Algorithmus '%s'"
 
-#: builtin/index-pack.c:1782
+#: builtin/index-pack.c:1821
 msgid "--fix-thin cannot be used without --stdin"
 msgstr "Die Option --fix-thin kann nicht ohne --stdin verwendet werden."
 
-#: builtin/index-pack.c:1784
+#: builtin/index-pack.c:1823
 msgid "--stdin requires a git repository"
 msgstr "--stdin erfordert ein Git-Repository"
 
-#: builtin/index-pack.c:1786
+#: builtin/index-pack.c:1825
 msgid "--object-format cannot be used with --stdin"
 msgstr "Die Option --object-format kann nicht mit --stdin verwendet werden."
 
-#: builtin/index-pack.c:1792
+#: builtin/index-pack.c:1831
 msgid "--verify with no packfile name given"
 msgstr "Die Option --verify wurde ohne Namen der Paketdatei angegeben."
 
-#: builtin/index-pack.c:1840 builtin/unpack-objects.c:582
+#: builtin/index-pack.c:1892 builtin/unpack-objects.c:582
 msgid "fsck error in pack objects"
 msgstr "fsck Fehler beim Packen von Objekten"
 
-#: builtin/init-db.c:63
+#: builtin/init-db.c:64
 #, c-format
 msgid "cannot stat template '%s'"
 msgstr "kann Vorlage '%s' nicht lesen"
 
-#: builtin/init-db.c:68
+#: builtin/init-db.c:69
 #, c-format
 msgid "cannot opendir '%s'"
 msgstr "kann Verzeichnis '%s' nicht öffnen"
 
-#: builtin/init-db.c:80
+#: builtin/init-db.c:81
 #, c-format
 msgid "cannot readlink '%s'"
 msgstr "kann Verweis '%s' nicht lesen"
 
-#: builtin/init-db.c:82
+#: builtin/init-db.c:83
 #, c-format
 msgid "cannot symlink '%s' '%s'"
 msgstr "kann symbolische Verknüpfung '%s' auf '%s' nicht erstellen"
 
-#: builtin/init-db.c:88
+#: builtin/init-db.c:89
 #, c-format
 msgid "cannot copy '%s' to '%s'"
 msgstr "kann '%s' nicht nach '%s' kopieren"
 
-#: builtin/init-db.c:92
+#: builtin/init-db.c:93
 #, c-format
 msgid "ignoring template %s"
 msgstr "ignoriere Vorlage %s"
 
-#: builtin/init-db.c:123
+#: builtin/init-db.c:124
 #, c-format
 msgid "templates not found in %s"
 msgstr "Keine Vorlagen in %s gefunden."
 
-#: builtin/init-db.c:138
+#: builtin/init-db.c:139
 #, c-format
 msgid "not copying templates from '%s': %s"
 msgstr "kopiere keine Vorlagen von '%s': %s"
 
-#: builtin/init-db.c:276
+#: builtin/init-db.c:274
 #, c-format
 msgid "invalid initial branch name: '%s'"
 msgstr "ungültiger initialer Branchname: '%s'"
 
-#: builtin/init-db.c:368
+#: builtin/init-db.c:366
 #, c-format
 msgid "unable to handle file type %d"
 msgstr "kann nicht mit Dateityp %d umgehen"
 
-#: builtin/init-db.c:371
+#: builtin/init-db.c:369
 #, c-format
 msgid "unable to move %s to %s"
 msgstr "Konnte %s nicht nach %s verschieben"
 
-#: builtin/init-db.c:386
+#: builtin/init-db.c:385
 msgid "attempt to reinitialize repository with different hash"
 msgstr "Versuch, das Repository mit einem anderen Hash zu reinitialisieren"
 
-#: builtin/init-db.c:410 builtin/init-db.c:413
+#: builtin/init-db.c:409 builtin/init-db.c:412
 #, c-format
 msgid "%s already exists"
 msgstr "%s existiert bereits"
 
-#: builtin/init-db.c:444
+#: builtin/init-db.c:443
 #, c-format
 msgid "re-init: ignored --initial-branch=%s"
 msgstr "Neu-Initialisierung: --initial-branch=%s ignoriert"
 
-#: builtin/init-db.c:475
+#: builtin/init-db.c:474
 #, c-format
 msgid "Reinitialized existing shared Git repository in %s%s\n"
 msgstr "Bestehendes verteiltes Git-Repository in %s%s neuinitialisiert\n"
 
-#: builtin/init-db.c:476
+#: builtin/init-db.c:475
 #, c-format
 msgid "Reinitialized existing Git repository in %s%s\n"
 msgstr "Bestehendes Git-Repository in %s%s neuinitialisiert\n"
 
-#: builtin/init-db.c:480
+#: builtin/init-db.c:479
 #, c-format
 msgid "Initialized empty shared Git repository in %s%s\n"
 msgstr "Leeres verteiltes Git-Repository in %s%s initialisiert\n"
 
-#: builtin/init-db.c:481
+#: builtin/init-db.c:480
 #, c-format
 msgid "Initialized empty Git repository in %s%s\n"
 msgstr "Leeres Git-Repository in %s%s initialisiert\n"
 
-#: builtin/init-db.c:530
+#: builtin/init-db.c:529
 msgid ""
 "git init [-q | --quiet] [--bare] [--template=<template-directory>] [--"
 "shared[=<permissions>]] [<directory>]"
@@ -15911,37 +16333,42 @@ msgstr ""
 "git init [-q | --quiet] [--bare] [--template=<Vorlagenverzeichnis>] [--"
 "shared[=<Berechtigungen>]] [<Verzeichnis>]"
 
-#: builtin/init-db.c:556
+#: builtin/init-db.c:555
 msgid "permissions"
 msgstr "Berechtigungen"
 
-#: builtin/init-db.c:557
+#: builtin/init-db.c:556
 msgid "specify that the git repository is to be shared amongst several users"
 msgstr "angeben, dass das Git-Repository mit mehreren Benutzern geteilt wird"
 
-#: builtin/init-db.c:563
+#: builtin/init-db.c:562
 msgid "override the name of the initial branch"
 msgstr "den Namen des initialen Branches überschreiben"
 
-#: builtin/init-db.c:564
+#: builtin/init-db.c:563 builtin/verify-pack.c:74
 msgid "hash"
 msgstr "Hash"
 
-#: builtin/init-db.c:565 builtin/show-index.c:22
+#: builtin/init-db.c:564 builtin/show-index.c:22 builtin/verify-pack.c:75
 msgid "specify the hash algorithm to use"
 msgstr "den zu verwendenen Hash-Algorithmus angeben"
 
-#: builtin/init-db.c:598 builtin/init-db.c:603
+#: builtin/init-db.c:571
+#, fuzzy
+msgid "--separate-git-dir and --bare are mutually exclusive"
+msgstr "--deepen und --depth schließen sich gegenseitig aus"
+
+#: builtin/init-db.c:600 builtin/init-db.c:605
 #, c-format
 msgid "cannot mkdir %s"
 msgstr "kann Verzeichnis %s nicht erstellen"
 
-#: builtin/init-db.c:607
+#: builtin/init-db.c:609 builtin/init-db.c:664
 #, c-format
 msgid "cannot chdir to %s"
 msgstr "kann nicht in Verzeichnis %s wechseln"
 
-#: builtin/init-db.c:634
+#: builtin/init-db.c:636
 #, c-format
 msgid ""
 "%s (or --work-tree=<directory>) not allowed without specifying %s (or --git-"
@@ -15950,10 +16377,15 @@ msgstr ""
 "%s (oder --work-tree=<Verzeichnis>) nicht erlaubt ohne Spezifizierung von %s "
 "(oder --git-dir=<Verzeichnis>)"
 
-#: builtin/init-db.c:662
+#: builtin/init-db.c:688
 #, c-format
 msgid "Cannot access work tree '%s'"
 msgstr "Kann nicht auf Arbeitsverzeichnis '%s' zugreifen."
+
+#: builtin/init-db.c:693
+#, fuzzy
+msgid "--separate-git-dir incompatible with bare repository"
+msgstr "Die Optionen --first-parent und --bisect sind inkompatibel."
 
 #: builtin/interpret-trailers.c:16
 msgid ""
@@ -16021,127 +16453,127 @@ msgstr ""
 msgid "no input file given for in-place editing"
 msgstr "keine Datei zur direkten Bearbeitung angegeben"
 
-#: builtin/log.c:57
+#: builtin/log.c:56
 msgid "git log [<options>] [<revision-range>] [[--] <path>...]"
 msgstr "git log [<Optionen>] [<Commitbereich>] [[--] <Pfad>...]"
 
-#: builtin/log.c:58
+#: builtin/log.c:57
 msgid "git show [<options>] <object>..."
 msgstr "git show [<Optionen>] <Objekt>..."
 
-#: builtin/log.c:111
+#: builtin/log.c:110
 #, c-format
 msgid "invalid --decorate option: %s"
 msgstr "Ungültige Option für --decorate: %s"
 
-#: builtin/log.c:178
+#: builtin/log.c:177
 msgid "show source"
 msgstr "Quelle anzeigen"
 
-#: builtin/log.c:179
+#: builtin/log.c:178
 msgid "Use mail map file"
 msgstr "\"mailmap\"-Datei verwenden"
 
-#: builtin/log.c:182
+#: builtin/log.c:181
 msgid "only decorate refs that match <pattern>"
 msgstr "\"decorate\" nur bei Referenzen anwenden, die <Muster> entsprechen"
 
-#: builtin/log.c:184
+#: builtin/log.c:183
 msgid "do not decorate refs that match <pattern>"
 msgstr "\"decorate\" nicht bei Referenzen anwenden, die <Muster> entsprechen"
 
-#: builtin/log.c:185
+#: builtin/log.c:184
 msgid "decorate options"
 msgstr "decorate-Optionen"
 
-#: builtin/log.c:188
+#: builtin/log.c:187
 msgid "Process line range n,m in file, counting from 1"
 msgstr "Verarbeitet nur Zeilen im Bereich n,m in der Datei, gezählt von 1"
 
-#: builtin/log.c:298
+#: builtin/log.c:297
 #, c-format
 msgid "Final output: %d %s\n"
 msgstr "letzte Ausgabe: %d %s\n"
 
-#: builtin/log.c:556
+#: builtin/log.c:555
 #, c-format
 msgid "git show %s: bad file"
 msgstr "git show %s: ungültige Datei"
 
-#: builtin/log.c:571 builtin/log.c:666
+#: builtin/log.c:570 builtin/log.c:665
 #, c-format
 msgid "could not read object %s"
 msgstr "Konnte Objekt %s nicht lesen."
 
-#: builtin/log.c:691
+#: builtin/log.c:690
 #, c-format
 msgid "unknown type: %d"
 msgstr "Unbekannter Typ: %d"
 
-#: builtin/log.c:835
+#: builtin/log.c:839
 #, c-format
 msgid "%s: invalid cover from description mode"
 msgstr ""
 "%s: Ungültiger Modus für Erstellung des Deckblattes aus der Beschreibung"
 
-#: builtin/log.c:842
+#: builtin/log.c:846
 msgid "format.headers without value"
 msgstr "format.headers ohne Wert"
 
-#: builtin/log.c:957
+#: builtin/log.c:965
 msgid "name of output directory is too long"
 msgstr "Name des Ausgabeverzeichnisses ist zu lang."
 
-#: builtin/log.c:973
+#: builtin/log.c:981
 #, c-format
 msgid "cannot open patch file %s"
 msgstr "Kann Patch-Datei %s nicht öffnen"
 
-#: builtin/log.c:990
+#: builtin/log.c:998
 msgid "need exactly one range"
 msgstr "Brauche genau einen Commit-Bereich."
 
-#: builtin/log.c:1000
+#: builtin/log.c:1008
 msgid "not a range"
 msgstr "Kein Commit-Bereich."
 
-#: builtin/log.c:1164
+#: builtin/log.c:1172
 msgid "cover letter needs email format"
 msgstr "Anschreiben benötigt E-Mail-Format"
 
-#: builtin/log.c:1170
+#: builtin/log.c:1178
 msgid "failed to create cover-letter file"
 msgstr "Fehler beim Erstellen der Datei für das Anschreiben."
 
-#: builtin/log.c:1249
+#: builtin/log.c:1259
 #, c-format
 msgid "insane in-reply-to: %s"
 msgstr "ungültiges in-reply-to: %s"
 
-#: builtin/log.c:1276
+#: builtin/log.c:1286
 msgid "git format-patch [<options>] [<since> | <revision-range>]"
 msgstr "git format-patch [<Optionen>] [<seit> | <Commitbereich>]"
 
-#: builtin/log.c:1334
+#: builtin/log.c:1344
 msgid "two output directories?"
 msgstr "Zwei Ausgabeverzeichnisse?"
 
-#: builtin/log.c:1445 builtin/log.c:2217 builtin/log.c:2219 builtin/log.c:2231
+#: builtin/log.c:1495 builtin/log.c:2301 builtin/log.c:2303 builtin/log.c:2315
 #, c-format
 msgid "unknown commit %s"
 msgstr "Unbekannter Commit %s"
 
-#: builtin/log.c:1455 builtin/replace.c:58 builtin/replace.c:207
+#: builtin/log.c:1506 builtin/replace.c:58 builtin/replace.c:207
 #: builtin/replace.c:210
 #, c-format
 msgid "failed to resolve '%s' as a valid ref"
 msgstr "Konnte '%s' nicht als gültige Referenz auflösen."
 
-#: builtin/log.c:1460
+#: builtin/log.c:1515
 msgid "could not find exact merge base"
 msgstr "Konnte keine exakte Merge-Basis finden."
 
-#: builtin/log.c:1464
+#: builtin/log.c:1525
 msgid ""
 "failed to get upstream, if you want to record base commit automatically,\n"
 "please use git branch --set-upstream-to to track a remote branch.\n"
@@ -16152,281 +16584,287 @@ msgstr ""
 "'git branch --set-upstream-to', um einem Remote-Branch zu folgen.\n"
 "Oder geben Sie den Basis-Commit mit '--base=<Basis-Commit-Id>' manuell an."
 
-#: builtin/log.c:1484
+#: builtin/log.c:1548
 msgid "failed to find exact merge base"
 msgstr "Fehler beim Finden einer exakten Merge-Basis."
 
-#: builtin/log.c:1495
+#: builtin/log.c:1565
 msgid "base commit should be the ancestor of revision list"
 msgstr "Basis-Commit sollte der Vorgänger der Revisionsliste sein."
 
-#: builtin/log.c:1499
+#: builtin/log.c:1575
 msgid "base commit shouldn't be in revision list"
 msgstr "Basis-Commit sollte nicht in der Revisionsliste enthalten sein."
 
-#: builtin/log.c:1552
+#: builtin/log.c:1633
 msgid "cannot get patch id"
 msgstr "kann Patch-Id nicht lesen"
 
-#: builtin/log.c:1604
-msgid "failed to infer range-diff ranges"
+#: builtin/log.c:1690
+#, fuzzy
+msgid "failed to infer range-diff origin of current series"
 msgstr "Fehler beim Ableiten des range-diff-Bereichs."
 
-#: builtin/log.c:1650
+#: builtin/log.c:1692
+#, c-format
+msgid "using '%s' as range-diff origin of current series"
+msgstr ""
+
+#: builtin/log.c:1736
 msgid "use [PATCH n/m] even with a single patch"
 msgstr "[PATCH n/m] auch mit einzelnem Patch verwenden"
 
-#: builtin/log.c:1653
+#: builtin/log.c:1739
 msgid "use [PATCH] even with multiple patches"
 msgstr "[PATCH] auch mit mehreren Patches verwenden"
 
-#: builtin/log.c:1657
+#: builtin/log.c:1743
 msgid "print patches to standard out"
 msgstr "Ausgabe der Patches in Standard-Ausgabe"
 
-#: builtin/log.c:1659
+#: builtin/log.c:1745
 msgid "generate a cover letter"
 msgstr "ein Deckblatt erzeugen"
 
-#: builtin/log.c:1661
+#: builtin/log.c:1747
 msgid "use simple number sequence for output file names"
 msgstr "einfache Nummernfolge für die Namen der Ausgabedateien verwenden"
 
-#: builtin/log.c:1662
+#: builtin/log.c:1748
 msgid "sfx"
 msgstr "Dateiendung"
 
-#: builtin/log.c:1663
+#: builtin/log.c:1749
 msgid "use <sfx> instead of '.patch'"
 msgstr "<Dateiendung> anstatt '.patch' verwenden"
 
-#: builtin/log.c:1665
+#: builtin/log.c:1751
 msgid "start numbering patches at <n> instead of 1"
 msgstr "die Nummerierung der Patches bei <n> anstatt bei 1 beginnen"
 
-#: builtin/log.c:1667
+#: builtin/log.c:1753
 msgid "mark the series as Nth re-roll"
 msgstr "die Serie als n-te Fassung kennzeichnen"
 
-#: builtin/log.c:1669
+#: builtin/log.c:1755
 msgid "Use [RFC PATCH] instead of [PATCH]"
 msgstr "[RFC PATCH] anstatt [PATCH] verwenden"
 
-#: builtin/log.c:1672
+#: builtin/log.c:1758
 msgid "cover-from-description-mode"
 msgstr "Modus für Erstellung des Deckblattes aus der Beschreibung"
 
-#: builtin/log.c:1673
+#: builtin/log.c:1759
 msgid "generate parts of a cover letter based on a branch's description"
 msgstr ""
 "Erzeuge Teile des Deckblattes basierend auf der Beschreibung des Branches"
 
-#: builtin/log.c:1675
+#: builtin/log.c:1761
 msgid "Use [<prefix>] instead of [PATCH]"
 msgstr "Nutze [<Präfix>] statt [PATCH]"
 
-#: builtin/log.c:1678
+#: builtin/log.c:1764
 msgid "store resulting files in <dir>"
 msgstr "erzeugte Dateien in <Verzeichnis> speichern"
 
-#: builtin/log.c:1681
+#: builtin/log.c:1767
 msgid "don't strip/add [PATCH]"
 msgstr "[PATCH] nicht entfernen/hinzufügen"
 
-#: builtin/log.c:1684
+#: builtin/log.c:1770
 msgid "don't output binary diffs"
 msgstr "keine binären Unterschiede ausgeben"
 
-#: builtin/log.c:1686
+#: builtin/log.c:1772
 msgid "output all-zero hash in From header"
 msgstr "Hash mit Nullen in \"From\"-Header ausgeben"
 
-#: builtin/log.c:1688
+#: builtin/log.c:1774
 msgid "don't include a patch matching a commit upstream"
 msgstr ""
 "keine Patches einschließen, die einem Commit im Upstream-Branch entsprechen"
 
-#: builtin/log.c:1690
+#: builtin/log.c:1776
 msgid "show patch format instead of default (patch + stat)"
 msgstr "Patchformat anstatt des Standards anzeigen (Patch + Zusammenfassung)"
 
-#: builtin/log.c:1692
+#: builtin/log.c:1778
 msgid "Messaging"
 msgstr "E-Mail-Einstellungen"
 
-#: builtin/log.c:1693
+#: builtin/log.c:1779
 msgid "header"
 msgstr "Header"
 
-#: builtin/log.c:1694
+#: builtin/log.c:1780
 msgid "add email header"
 msgstr "E-Mail-Header hinzufügen"
 
-#: builtin/log.c:1695 builtin/log.c:1696
+#: builtin/log.c:1781 builtin/log.c:1782
 msgid "email"
 msgstr "E-Mail"
 
-#: builtin/log.c:1695
+#: builtin/log.c:1781
 msgid "add To: header"
 msgstr "\"To:\"-Header hinzufügen"
 
-#: builtin/log.c:1696
+#: builtin/log.c:1782
 msgid "add Cc: header"
 msgstr "\"Cc:\"-Header hinzufügen"
 
-#: builtin/log.c:1697
+#: builtin/log.c:1783
 msgid "ident"
 msgstr "Ident"
 
-#: builtin/log.c:1698
+#: builtin/log.c:1784
 msgid "set From address to <ident> (or committer ident if absent)"
 msgstr ""
 "\"From\"-Adresse auf <Ident> setzen (oder Ident des Commit-Erstellers, wenn "
 "fehlend)"
 
-#: builtin/log.c:1700
+#: builtin/log.c:1786
 msgid "message-id"
 msgstr "message-id"
 
-#: builtin/log.c:1701
+#: builtin/log.c:1787
 msgid "make first mail a reply to <message-id>"
 msgstr "aus erster E-Mail eine Antwort zu <message-id> machen"
 
-#: builtin/log.c:1702 builtin/log.c:1705
+#: builtin/log.c:1788 builtin/log.c:1791
 msgid "boundary"
 msgstr "Grenze"
 
-#: builtin/log.c:1703
+#: builtin/log.c:1789
 msgid "attach the patch"
 msgstr "den Patch anhängen"
 
-#: builtin/log.c:1706
+#: builtin/log.c:1792
 msgid "inline the patch"
 msgstr "den Patch direkt in die Nachricht einfügen"
 
-#: builtin/log.c:1710
+#: builtin/log.c:1796
 msgid "enable message threading, styles: shallow, deep"
 msgstr "Nachrichtenverkettung aktivieren, Stile: shallow, deep"
 
-#: builtin/log.c:1712
+#: builtin/log.c:1798
 msgid "signature"
 msgstr "Signatur"
 
-#: builtin/log.c:1713
+#: builtin/log.c:1799
 msgid "add a signature"
 msgstr "eine Signatur hinzufügen"
 
-#: builtin/log.c:1714
+#: builtin/log.c:1800
 msgid "base-commit"
 msgstr "Basis-Commit"
 
-#: builtin/log.c:1715
+#: builtin/log.c:1801
 msgid "add prerequisite tree info to the patch series"
 msgstr "erforderliche Revisions-Informationen der Patch-Serie hinzufügen"
 
-#: builtin/log.c:1717
+#: builtin/log.c:1804
 msgid "add a signature from a file"
 msgstr "eine Signatur aus einer Datei hinzufügen"
 
-#: builtin/log.c:1718
+#: builtin/log.c:1805
 msgid "don't print the patch filenames"
 msgstr "keine Dateinamen der Patches anzeigen"
 
-#: builtin/log.c:1720
+#: builtin/log.c:1807
 msgid "show progress while generating patches"
 msgstr "Forschrittsanzeige während der Erzeugung der Patches"
 
-#: builtin/log.c:1722
+#: builtin/log.c:1809
 msgid "show changes against <rev> in cover letter or single patch"
 msgstr ""
 "Änderungen gegenüber <Commit> im Deckblatt oder einzelnem Patch anzeigen"
 
-#: builtin/log.c:1725
+#: builtin/log.c:1812
 msgid "show changes against <refspec> in cover letter or single patch"
 msgstr ""
 "Änderungen gegenüber <Refspec> im Deckblatt oder einzelnem Patch anzeigen"
 
-#: builtin/log.c:1727
+#: builtin/log.c:1814
 msgid "percentage by which creation is weighted"
 msgstr "Prozentsatz mit welchem Erzeugung gewichtet wird"
 
-#: builtin/log.c:1812
+#: builtin/log.c:1896
 #, c-format
 msgid "invalid ident line: %s"
 msgstr "Ungültige Identifikationszeile: %s"
 
-#: builtin/log.c:1827
+#: builtin/log.c:1911
 msgid "-n and -k are mutually exclusive"
 msgstr "-n und -k schließen sich gegenseitig aus."
 
-#: builtin/log.c:1829
+#: builtin/log.c:1913
 msgid "--subject-prefix/--rfc and -k are mutually exclusive"
 msgstr "--subject-prefix/--rfc und -k schließen sich gegenseitig aus."
 
-#: builtin/log.c:1837
+#: builtin/log.c:1921
 msgid "--name-only does not make sense"
 msgstr "Die Option --name-only kann nicht verwendet werden."
 
-#: builtin/log.c:1839
+#: builtin/log.c:1923
 msgid "--name-status does not make sense"
 msgstr "Die Option --name-status kann nicht verwendet werden."
 
-#: builtin/log.c:1841
+#: builtin/log.c:1925
 msgid "--check does not make sense"
 msgstr "Die Option --check kann nicht verwendet werden."
 
-#: builtin/log.c:1874
+#: builtin/log.c:1958
 msgid "standard output, or directory, which one?"
 msgstr "Standard-Ausgabe oder Verzeichnis, welches von beidem?"
 
-#: builtin/log.c:1978
+#: builtin/log.c:2062
 msgid "--interdiff requires --cover-letter or single patch"
 msgstr "--interdiff erfordert --cover-letter oder einzelnen Patch."
 
-#: builtin/log.c:1982
+#: builtin/log.c:2066
 msgid "Interdiff:"
 msgstr "Interdiff:"
 
-#: builtin/log.c:1983
+#: builtin/log.c:2067
 #, c-format
 msgid "Interdiff against v%d:"
 msgstr "Interdiff gegen v%d:"
 
-#: builtin/log.c:1989
+#: builtin/log.c:2073
 msgid "--creation-factor requires --range-diff"
 msgstr "--creation-factor erfordert --range-diff"
 
-#: builtin/log.c:1993
+#: builtin/log.c:2077
 msgid "--range-diff requires --cover-letter or single patch"
 msgstr "--range-diff erfordert --cover-letter oder einzelnen Patch."
 
-#: builtin/log.c:2001
+#: builtin/log.c:2085
 msgid "Range-diff:"
 msgstr "Range-Diff:"
 
-#: builtin/log.c:2002
+#: builtin/log.c:2086
 #, c-format
 msgid "Range-diff against v%d:"
 msgstr "Range-Diff gegen v%d:"
 
-#: builtin/log.c:2013
+#: builtin/log.c:2097
 #, c-format
 msgid "unable to read signature file '%s'"
 msgstr "Konnte Signatur-Datei '%s' nicht lesen"
 
-#: builtin/log.c:2049
+#: builtin/log.c:2133
 msgid "Generating patches"
 msgstr "Erzeuge Patches"
 
-#: builtin/log.c:2093
+#: builtin/log.c:2177
 msgid "failed to create output files"
 msgstr "Fehler beim Erstellen der Ausgabedateien."
 
-#: builtin/log.c:2152
+#: builtin/log.c:2236
 msgid "git cherry [-v] [<upstream> [<head> [<limit>]]]"
 msgstr "git cherry [-v] [<Upstream> [<Branch> [<Limit>]]]"
 
-#: builtin/log.c:2206
+#: builtin/log.c:2290
 #, c-format
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> manually.\n"
@@ -16557,7 +16995,7 @@ msgstr ""
 msgid "do not print remote URL"
 msgstr "URL des Remote-Repositories nicht ausgeben"
 
-#: builtin/ls-remote.c:60 builtin/ls-remote.c:62 builtin/rebase.c:1384
+#: builtin/ls-remote.c:60 builtin/ls-remote.c:62 builtin/rebase.c:1392
 msgid "exec"
 msgstr "Programm"
 
@@ -16757,182 +17195,182 @@ msgstr "git merge --abort"
 msgid "git merge --continue"
 msgstr "git merge --continue"
 
-#: builtin/merge.c:121
+#: builtin/merge.c:120
 msgid "switch `m' requires a value"
 msgstr "Schalter 'm' erfordert einen Wert."
 
-#: builtin/merge.c:144
+#: builtin/merge.c:143
 #, c-format
 msgid "option `%s' requires a value"
 msgstr "Option `%s' erfordert einen Wert."
 
-#: builtin/merge.c:190
+#: builtin/merge.c:189
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
 msgstr "Konnte Merge-Strategie '%s' nicht finden.\n"
 
-#: builtin/merge.c:191
+#: builtin/merge.c:190
 #, c-format
 msgid "Available strategies are:"
 msgstr "Verfügbare Strategien sind:"
 
-#: builtin/merge.c:196
+#: builtin/merge.c:195
 #, c-format
 msgid "Available custom strategies are:"
 msgstr "Verfügbare benutzerdefinierte Strategien sind:"
 
-#: builtin/merge.c:247 builtin/pull.c:133
+#: builtin/merge.c:246 builtin/pull.c:133
 msgid "do not show a diffstat at the end of the merge"
 msgstr "keine Zusammenfassung der Unterschiede am Schluss des Merges anzeigen"
 
-#: builtin/merge.c:250 builtin/pull.c:136
+#: builtin/merge.c:249 builtin/pull.c:136
 msgid "show a diffstat at the end of the merge"
 msgstr "eine Zusammenfassung der Unterschiede am Schluss des Merges anzeigen"
 
-#: builtin/merge.c:251 builtin/pull.c:139
+#: builtin/merge.c:250 builtin/pull.c:139
 msgid "(synonym to --stat)"
 msgstr "(Synonym für --stat)"
 
-#: builtin/merge.c:253 builtin/pull.c:142
+#: builtin/merge.c:252 builtin/pull.c:142
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "(höchstens <n>) Einträge von \"shortlog\" zur Beschreibung des Merge-Commits "
 "hinzufügen"
 
-#: builtin/merge.c:256 builtin/pull.c:148
+#: builtin/merge.c:255 builtin/pull.c:148
 msgid "create a single commit instead of doing a merge"
 msgstr "einen einzelnen Commit anstatt eines Merges erzeugen"
 
-#: builtin/merge.c:258 builtin/pull.c:151
+#: builtin/merge.c:257 builtin/pull.c:151
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "einen Commit durchführen, wenn der Merge erfolgreich war (Standard)"
 
-#: builtin/merge.c:260 builtin/pull.c:154
+#: builtin/merge.c:259 builtin/pull.c:154
 msgid "edit message before committing"
 msgstr "Bearbeitung der Beschreibung vor dem Commit"
 
-#: builtin/merge.c:262
+#: builtin/merge.c:261
 msgid "allow fast-forward (default)"
 msgstr "Vorspulen erlauben (Standard)"
 
-#: builtin/merge.c:264 builtin/pull.c:161
+#: builtin/merge.c:263 builtin/pull.c:161
 msgid "abort if fast-forward is not possible"
 msgstr "abbrechen, wenn kein Vorspulen möglich ist"
 
-#: builtin/merge.c:268 builtin/pull.c:164
+#: builtin/merge.c:267 builtin/pull.c:164
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "den genannten Commit auf eine gültige GPG-Signatur überprüfen"
 
-#: builtin/merge.c:269 builtin/notes.c:787 builtin/pull.c:168
-#: builtin/rebase.c:527 builtin/rebase.c:1398 builtin/revert.c:114
+#: builtin/merge.c:268 builtin/notes.c:787 builtin/pull.c:168
+#: builtin/rebase.c:533 builtin/rebase.c:1406 builtin/revert.c:114
 msgid "strategy"
 msgstr "Strategie"
 
-#: builtin/merge.c:270 builtin/pull.c:169
+#: builtin/merge.c:269 builtin/pull.c:169
 msgid "merge strategy to use"
 msgstr "zu verwendende Merge-Strategie"
 
-#: builtin/merge.c:271 builtin/pull.c:172
+#: builtin/merge.c:270 builtin/pull.c:172
 msgid "option=value"
 msgstr "Option=Wert"
 
-#: builtin/merge.c:272 builtin/pull.c:173
+#: builtin/merge.c:271 builtin/pull.c:173
 msgid "option for selected merge strategy"
 msgstr "Option für ausgewählte Merge-Strategie"
 
-#: builtin/merge.c:274
+#: builtin/merge.c:273
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr ""
 "Commit-Beschreibung zusammenführen (für einen Merge, der kein Vorspulen war)"
 
-#: builtin/merge.c:281
+#: builtin/merge.c:280
 msgid "abort the current in-progress merge"
 msgstr "den sich im Gange befindlichen Merge abbrechen"
 
-#: builtin/merge.c:283
+#: builtin/merge.c:282
 msgid "--abort but leave index and working tree alone"
 msgstr "--abort, aber Index und Arbeitsverzeichnis unverändert lassen"
 
-#: builtin/merge.c:285
+#: builtin/merge.c:284
 msgid "continue the current in-progress merge"
 msgstr "den sich im Gange befindlichen Merge fortsetzen"
 
-#: builtin/merge.c:287 builtin/pull.c:180
+#: builtin/merge.c:286 builtin/pull.c:180
 msgid "allow merging unrelated histories"
 msgstr "erlaube das Zusammenführen von nicht zusammenhängenden Historien"
 
-#: builtin/merge.c:294
+#: builtin/merge.c:293
 msgid "bypass pre-merge-commit and commit-msg hooks"
 msgstr "Hooks pre-merge-commit und commit-msg umgehen"
 
-#: builtin/merge.c:311
+#: builtin/merge.c:310
 msgid "could not run stash."
 msgstr "Konnte \"stash\" nicht ausführen."
 
-#: builtin/merge.c:316
+#: builtin/merge.c:315
 msgid "stash failed"
 msgstr "\"stash\" fehlgeschlagen"
 
-#: builtin/merge.c:321
+#: builtin/merge.c:320
 #, c-format
 msgid "not a valid object: %s"
 msgstr "kein gültiges Objekt: %s"
 
-#: builtin/merge.c:343 builtin/merge.c:360
+#: builtin/merge.c:342 builtin/merge.c:359
 msgid "read-tree failed"
 msgstr "read-tree fehlgeschlagen"
 
-#: builtin/merge.c:390
+#: builtin/merge.c:389
 msgid " (nothing to squash)"
 msgstr " (nichts zu quetschen)"
 
-#: builtin/merge.c:401
+#: builtin/merge.c:400
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
 msgstr "Quetsche Commit -- HEAD wird nicht aktualisiert\n"
 
-#: builtin/merge.c:451
+#: builtin/merge.c:450
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
 msgstr "Keine Merge-Commit-Beschreibung -- HEAD wird nicht aktualisiert\n"
 
-#: builtin/merge.c:502
+#: builtin/merge.c:501
 #, c-format
 msgid "'%s' does not point to a commit"
 msgstr "'%s' zeigt auf keinen Commit"
 
-#: builtin/merge.c:589
+#: builtin/merge.c:588
 #, c-format
 msgid "Bad branch.%s.mergeoptions string: %s"
 msgstr "Ungültiger branch.%s.mergeoptions String: %s"
 
-#: builtin/merge.c:716
+#: builtin/merge.c:713
 msgid "Not handling anything other than two heads merge."
 msgstr "Es wird nur der Merge von zwei Branches behandelt."
 
-#: builtin/merge.c:730
+#: builtin/merge.c:726
 #, c-format
 msgid "Unknown option for merge-recursive: -X%s"
 msgstr "Unbekannte Option für merge-recursive: -X%s"
 
-#: builtin/merge.c:745
+#: builtin/merge.c:741
 #, c-format
 msgid "unable to write %s"
 msgstr "konnte %s nicht schreiben"
 
-#: builtin/merge.c:797
+#: builtin/merge.c:793
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "konnte nicht von '%s' lesen"
 
-#: builtin/merge.c:806
+#: builtin/merge.c:802
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
 "Merge wurde nicht committet; benutzen Sie 'git commit', um den Merge "
 "abzuschließen.\n"
 
-#: builtin/merge.c:812
+#: builtin/merge.c:808
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
@@ -16943,11 +17381,11 @@ msgstr ""
 "Upstream-Branch mit einem Thema-Branch zusammenführt.\n"
 "\n"
 
-#: builtin/merge.c:817
+#: builtin/merge.c:813
 msgid "An empty message aborts the commit.\n"
 msgstr "Eine leere Commit-Beschreibung bricht den Commit ab.\n"
 
-#: builtin/merge.c:820
+#: builtin/merge.c:816
 #, c-format
 msgid ""
 "Lines starting with '%c' will be ignored, and an empty message aborts\n"
@@ -16956,75 +17394,75 @@ msgstr ""
 "Zeilen, die mit '%c' beginnen, werden ignoriert,\n"
 "und eine leere Beschreibung bricht den Commit ab.\n"
 
-#: builtin/merge.c:873
+#: builtin/merge.c:869
 msgid "Empty commit message."
 msgstr "Leere Commit-Beschreibung"
 
-#: builtin/merge.c:888
+#: builtin/merge.c:884
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Wunderbar.\n"
 
-#: builtin/merge.c:949
+#: builtin/merge.c:945
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
 "Automatischer Merge fehlgeschlagen; beheben Sie die Konflikte und committen "
 "Sie dann das Ergebnis.\n"
 
-#: builtin/merge.c:988
+#: builtin/merge.c:984
 msgid "No current branch."
 msgstr "Sie befinden sich auf keinem Branch."
 
-#: builtin/merge.c:990
+#: builtin/merge.c:986
 msgid "No remote for the current branch."
 msgstr "Kein Remote-Repository für den aktuellen Branch."
 
-#: builtin/merge.c:992
+#: builtin/merge.c:988
 msgid "No default upstream defined for the current branch."
 msgstr ""
 "Es ist kein Standard-Upstream-Branch für den aktuellen Branch definiert."
 
-#: builtin/merge.c:997
+#: builtin/merge.c:993
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "Kein Remote-Tracking-Branch für %s von %s"
 
-#: builtin/merge.c:1054
+#: builtin/merge.c:1050
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Fehlerhafter Wert '%s' in Umgebungsvariable '%s'"
 
-#: builtin/merge.c:1157
+#: builtin/merge.c:1153
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "nichts was wir in %s zusammenführen können: %s"
 
-#: builtin/merge.c:1191
+#: builtin/merge.c:1187
 msgid "not something we can merge"
 msgstr "nichts was wir zusammenführen können"
 
-#: builtin/merge.c:1295
+#: builtin/merge.c:1291
 msgid "--abort expects no arguments"
 msgstr "--abort akzeptiert keine Argumente"
 
-#: builtin/merge.c:1299
+#: builtin/merge.c:1295
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr "Es gibt keinen Merge abzubrechen (MERGE_HEAD fehlt)"
 
-#: builtin/merge.c:1317
+#: builtin/merge.c:1313
 msgid "--quit expects no arguments"
 msgstr "--quit erwartet keine Argumente"
 
-#: builtin/merge.c:1330
+#: builtin/merge.c:1326
 msgid "--continue expects no arguments"
 msgstr "--continue erwartet keine Argumente"
 
-#: builtin/merge.c:1334
+#: builtin/merge.c:1330
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "Es ist kein Merge im Gange (MERGE_HEAD fehlt)."
 
-#: builtin/merge.c:1350
+#: builtin/merge.c:1346
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17032,7 +17470,7 @@ msgstr ""
 "Sie haben Ihren Merge nicht abgeschlossen (MERGE_HEAD existiert).\n"
 "Bitte committen Sie Ihre Änderungen, bevor Sie den Merge ausführen."
 
-#: builtin/merge.c:1357
+#: builtin/merge.c:1353
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17040,100 +17478,100 @@ msgstr ""
 "Sie haben \"cherry-pick\" nicht abgeschlossen (CHERRY_PICK_HEAD existiert).\n"
 "Bitte committen Sie Ihre Änderungen, bevor Sie den Merge ausführen."
 
-#: builtin/merge.c:1360
+#: builtin/merge.c:1356
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr ""
 "Sie haben \"cherry-pick\" nicht abgeschlossen (CHERRY_PICK_HEAD existiert)."
 
-#: builtin/merge.c:1374
+#: builtin/merge.c:1370
 msgid "You cannot combine --squash with --no-ff."
 msgstr "Sie können --squash nicht mit --no-ff kombinieren."
 
-#: builtin/merge.c:1376
+#: builtin/merge.c:1372
 msgid "You cannot combine --squash with --commit."
 msgstr "Sie können --squash nicht mit --commit kombinieren."
 
-#: builtin/merge.c:1392
+#: builtin/merge.c:1388
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr "Kein Commit angegeben und merge.defaultToUpstream ist nicht gesetzt."
 
-#: builtin/merge.c:1409
+#: builtin/merge.c:1405
 msgid "Squash commit into empty head not supported yet"
 msgstr ""
 "Bin auf einem Commit, der noch geboren wird; kann \"squash\" nicht ausführen."
 
-#: builtin/merge.c:1411
+#: builtin/merge.c:1407
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr ""
 "Nicht vorzuspulender Commit kann nicht in einem leeren Branch verwendet "
 "werden."
 
-#: builtin/merge.c:1416
+#: builtin/merge.c:1412
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "%s - nichts was wir zusammenführen können"
 
-#: builtin/merge.c:1418
+#: builtin/merge.c:1414
 msgid "Can merge only exactly one commit into empty head"
 msgstr "Kann nur exakt einen Commit in einem leeren Branch zusammenführen."
 
-#: builtin/merge.c:1499
+#: builtin/merge.c:1495
 msgid "refusing to merge unrelated histories"
 msgstr "Verweigere den Merge von nicht zusammenhängenden Historien."
 
-#: builtin/merge.c:1508
+#: builtin/merge.c:1504
 msgid "Already up to date."
 msgstr "Bereits aktuell."
 
-#: builtin/merge.c:1518
+#: builtin/merge.c:1514
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "Aktualisiere %s..%s\n"
 
-#: builtin/merge.c:1564
+#: builtin/merge.c:1560
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "Probiere wirklich trivialen \"in-index\"-Merge ...\n"
 
-#: builtin/merge.c:1571
+#: builtin/merge.c:1567
 #, c-format
 msgid "Nope.\n"
 msgstr "Nein.\n"
 
-#: builtin/merge.c:1596
+#: builtin/merge.c:1592
 msgid "Already up to date. Yeeah!"
 msgstr "Bereits aktuell."
 
-#: builtin/merge.c:1602
+#: builtin/merge.c:1598
 msgid "Not possible to fast-forward, aborting."
 msgstr "Vorspulen nicht möglich, breche ab."
 
-#: builtin/merge.c:1630 builtin/merge.c:1695
+#: builtin/merge.c:1626 builtin/merge.c:1691
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "Rücklauf des Verzeichnisses bis zum Ursprung ...\n"
 
-#: builtin/merge.c:1634
+#: builtin/merge.c:1630
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Probiere Merge-Strategie %s ...\n"
 
-#: builtin/merge.c:1686
+#: builtin/merge.c:1682
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Keine Merge-Strategie behandelt diesen Merge.\n"
 
-#: builtin/merge.c:1688
+#: builtin/merge.c:1684
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "Merge mit Strategie %s fehlgeschlagen.\n"
 
-#: builtin/merge.c:1697
+#: builtin/merge.c:1693
 #, c-format
 msgid "Using the %s to prepare resolving by hand.\n"
 msgstr "Benutzen Sie \"%s\", um die Auflösung per Hand vorzubereiten.\n"
 
-#: builtin/merge.c:1711
+#: builtin/merge.c:1707
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
@@ -17218,68 +17656,72 @@ msgstr "Verschieben/Umbenennen erzwingen, auch wenn das Ziel existiert"
 msgid "skip move/rename errors"
 msgstr "Fehler beim Verschieben oder Umbenennen überspringen"
 
-#: builtin/mv.c:169
+#: builtin/mv.c:170
 #, c-format
 msgid "destination '%s' is not a directory"
 msgstr "Ziel '%s' ist kein Verzeichnis"
 
-#: builtin/mv.c:180
+#: builtin/mv.c:181
 #, c-format
 msgid "Checking rename of '%s' to '%s'\n"
 msgstr "Prüfe Umbenennung von '%s' nach '%s'\n"
 
-#: builtin/mv.c:184
+#: builtin/mv.c:185
 msgid "bad source"
 msgstr "ungültige Quelle"
 
-#: builtin/mv.c:187
+#: builtin/mv.c:188
 msgid "can not move directory into itself"
 msgstr "kann Verzeichnis nicht in sich selbst verschieben"
 
-#: builtin/mv.c:190
+#: builtin/mv.c:191
 msgid "cannot move directory over file"
 msgstr "kann Verzeichnis nicht über Datei verschieben"
 
-#: builtin/mv.c:199
+#: builtin/mv.c:200
 msgid "source directory is empty"
 msgstr "Quellverzeichnis ist leer"
 
-#: builtin/mv.c:224
+#: builtin/mv.c:225
 msgid "not under version control"
 msgstr "nicht unter Versionskontrolle"
 
 #: builtin/mv.c:227
+msgid "conflicted"
+msgstr ""
+
+#: builtin/mv.c:230
 msgid "destination exists"
 msgstr "Ziel existiert bereits"
 
-#: builtin/mv.c:235
+#: builtin/mv.c:238
 #, c-format
 msgid "overwriting '%s'"
 msgstr "überschreibe '%s'"
 
-#: builtin/mv.c:238
+#: builtin/mv.c:241
 msgid "Cannot overwrite"
 msgstr "Kann nicht überschreiben"
 
-#: builtin/mv.c:241
+#: builtin/mv.c:244
 msgid "multiple sources for the same target"
 msgstr "mehrere Quellen für dasselbe Ziel"
 
-#: builtin/mv.c:243
+#: builtin/mv.c:246
 msgid "destination directory does not exist"
 msgstr "Zielverzeichnis existiert nicht"
 
-#: builtin/mv.c:250
+#: builtin/mv.c:253
 #, c-format
 msgid "%s, source=%s, destination=%s"
 msgstr "%s, Quelle=%s, Ziel=%s"
 
-#: builtin/mv.c:271
+#: builtin/mv.c:274
 #, c-format
 msgid "Renaming %s to %s\n"
 msgstr "Benenne %s nach %s um\n"
 
-#: builtin/mv.c:277 builtin/remote.c:781 builtin/repack.c:520
+#: builtin/mv.c:280 builtin/remote.c:782 builtin/repack.c:518
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "Umbenennung von '%s' fehlgeschlagen"
@@ -17297,8 +17739,9 @@ msgid "git name-rev [<options>] --stdin"
 msgstr "git name-rev [<Optionen>] --stdin"
 
 #: builtin/name-rev.c:524
-msgid "print only names (no SHA-1)"
-msgstr "nur Namen anzeigen (keine SHA-1)"
+#, fuzzy
+msgid "print only ref-based names (no object names)"
+msgstr "nur Branches von diesem Objekt ausgeben"
 
 #: builtin/name-rev.c:525
 msgid "only use tags to name the commits"
@@ -17746,125 +18189,125 @@ msgstr "Notiz-Referenz"
 msgid "use notes from <notes-ref>"
 msgstr "Notizen von <Notiz-Referenz> verwenden"
 
-#: builtin/notes.c:1034 builtin/stash.c:1608
+#: builtin/notes.c:1034 builtin/stash.c:1605
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr "Unbekannter Unterbefehl: %s"
 
-#: builtin/pack-objects.c:53
+#: builtin/pack-objects.c:54
 msgid ""
 "git pack-objects --stdout [<options>...] [< <ref-list> | < <object-list>]"
 msgstr ""
 "git pack-objects --stdout [<Optionen>...] [< <Referenzliste> | < "
 "<Objektliste>]"
 
-#: builtin/pack-objects.c:54
+#: builtin/pack-objects.c:55
 msgid ""
 "git pack-objects [<options>...] <base-name> [< <ref-list> | < <object-list>]"
 msgstr ""
 "git pack-objects [<Optionen>...] <Basis-Name> [< <Referenzliste> | < "
 "<Objektliste>]"
 
-#: builtin/pack-objects.c:442
+#: builtin/pack-objects.c:443
 #, c-format
 msgid "bad packed object CRC for %s"
 msgstr "Ungültiges CRC für gepacktes Objekt %s."
 
-#: builtin/pack-objects.c:453
+#: builtin/pack-objects.c:454
 #, c-format
 msgid "corrupt packed object for %s"
 msgstr "Fehlerhaftes gepacktes Objekt für %s."
 
-#: builtin/pack-objects.c:584
+#: builtin/pack-objects.c:585
 #, c-format
 msgid "recursive delta detected for object %s"
 msgstr "Rekursiver Unterschied für Objekt %s festgestellt."
 
-#: builtin/pack-objects.c:795
+#: builtin/pack-objects.c:796
 #, c-format
 msgid "ordered %u objects, expected %<PRIu32>"
 msgstr "%u Objekte geordnet, %<PRIu32> erwartet."
 
-#: builtin/pack-objects.c:1003
+#: builtin/pack-objects.c:1004
 msgid "disabling bitmap writing, packs are split due to pack.packSizeLimit"
 msgstr ""
 "Deaktiviere Schreiben der Bitmap, Pakete wurden durch pack.packSizeLimit\n"
 "aufgetrennt."
 
-#: builtin/pack-objects.c:1016
+#: builtin/pack-objects.c:1017
 msgid "Writing objects"
 msgstr "Schreibe Objekte"
 
-#: builtin/pack-objects.c:1077 builtin/update-index.c:90
+#: builtin/pack-objects.c:1078 builtin/update-index.c:90
 #, c-format
 msgid "failed to stat %s"
 msgstr "Konnte '%s' nicht lesen"
 
-#: builtin/pack-objects.c:1130
+#: builtin/pack-objects.c:1131
 #, c-format
 msgid "wrote %<PRIu32> objects while expecting %<PRIu32>"
 msgstr "Schrieb %<PRIu32> Objekte während %<PRIu32> erwartet waren."
 
-#: builtin/pack-objects.c:1347
+#: builtin/pack-objects.c:1348
 msgid "disabling bitmap writing, as some objects are not being packed"
 msgstr ""
 "Deaktiviere Schreiben der Bitmap, da einige Objekte nicht in eine Pack-"
 "Datei\n"
 "geschrieben wurden."
 
-#: builtin/pack-objects.c:1774
+#: builtin/pack-objects.c:1796
 #, c-format
 msgid "delta base offset overflow in pack for %s"
 msgstr "\"delta base offset\" Überlauf in Paket für %s"
 
-#: builtin/pack-objects.c:1783
+#: builtin/pack-objects.c:1805
 #, c-format
 msgid "delta base offset out of bound for %s"
 msgstr "\"delta base offset\" liegt außerhalb des gültigen Bereichs für %s"
 
-#: builtin/pack-objects.c:2054
+#: builtin/pack-objects.c:2086
 msgid "Counting objects"
 msgstr "Zähle Objekte"
 
-#: builtin/pack-objects.c:2199
+#: builtin/pack-objects.c:2231
 #, c-format
 msgid "unable to parse object header of %s"
 msgstr "Konnte Kopfbereich von Objekt '%s' nicht parsen."
 
-#: builtin/pack-objects.c:2269 builtin/pack-objects.c:2285
-#: builtin/pack-objects.c:2295
+#: builtin/pack-objects.c:2301 builtin/pack-objects.c:2317
+#: builtin/pack-objects.c:2327
 #, c-format
 msgid "object %s cannot be read"
 msgstr "Objekt %s kann nicht gelesen werden."
 
-#: builtin/pack-objects.c:2272 builtin/pack-objects.c:2299
+#: builtin/pack-objects.c:2304 builtin/pack-objects.c:2331
 #, c-format
 msgid "object %s inconsistent object length (%<PRIuMAX> vs %<PRIuMAX>)"
 msgstr "Inkonsistente Objektlänge bei Objekt %s (%<PRIuMAX> vs %<PRIuMAX>)"
 
-#: builtin/pack-objects.c:2309
+#: builtin/pack-objects.c:2341
 msgid "suboptimal pack - out of memory"
 msgstr "ungünstiges Packet - Speicher voll"
 
-#: builtin/pack-objects.c:2624
+#: builtin/pack-objects.c:2656
 #, c-format
 msgid "Delta compression using up to %d threads"
 msgstr "Delta-Kompression verwendet bis zu %d Threads."
 
-#: builtin/pack-objects.c:2763
+#: builtin/pack-objects.c:2795
 #, c-format
 msgid "unable to pack objects reachable from tag %s"
 msgstr "Konnte keine Objekte packen, die von Tag %s erreichbar sind."
 
-#: builtin/pack-objects.c:2851
+#: builtin/pack-objects.c:2883
 msgid "Compressing objects"
 msgstr "Komprimiere Objekte"
 
-#: builtin/pack-objects.c:2857
+#: builtin/pack-objects.c:2889
 msgid "inconsistency with delta count"
 msgstr "Inkonsistenz mit der Anzahl von Deltas"
 
-#: builtin/pack-objects.c:2929
+#: builtin/pack-objects.c:2961
 #, c-format
 msgid ""
 "value of uploadpack.blobpackfileuri must be of the form '<object-hash> <pack-"
@@ -17873,7 +18316,7 @@ msgstr ""
 "Wert für uploadpack.blobpackfileuri muss in der Form '<Objekt-Hash> <Pack-"
 "Hash> <URI>' vorliegen ('%s' erhalten)"
 
-#: builtin/pack-objects.c:2932
+#: builtin/pack-objects.c:2964
 #, c-format
 msgid ""
 "object already configured in another uploadpack.blobpackfileuri (got '%s')"
@@ -17881,7 +18324,7 @@ msgstr ""
 "Objekt bereits in einem anderen uploadpack.blobpackfileuri konfiguriert "
 "('%s' erhalten)"
 
-#: builtin/pack-objects.c:2961
+#: builtin/pack-objects.c:2993
 #, c-format
 msgid ""
 "expected edge object ID, got garbage:\n"
@@ -17890,7 +18333,7 @@ msgstr ""
 "erwartete Randobjekt-ID, erhielt nutzlose Daten:\n"
 " %s"
 
-#: builtin/pack-objects.c:2967
+#: builtin/pack-objects.c:2999
 #, c-format
 msgid ""
 "expected object ID, got garbage:\n"
@@ -17899,250 +18342,250 @@ msgstr ""
 "erwartete Objekt-ID, erhielt nutzlose Daten:\n"
 " %s"
 
-#: builtin/pack-objects.c:3065
+#: builtin/pack-objects.c:3097
 msgid "invalid value for --missing"
 msgstr "ungültiger Wert für --missing"
 
-#: builtin/pack-objects.c:3124 builtin/pack-objects.c:3232
+#: builtin/pack-objects.c:3156 builtin/pack-objects.c:3264
 msgid "cannot open pack index"
 msgstr "kann Paketindex nicht öffnen"
 
-#: builtin/pack-objects.c:3155
+#: builtin/pack-objects.c:3187
 #, c-format
 msgid "loose object at %s could not be examined"
 msgstr "loses Objekt bei %s konnte nicht untersucht werden"
 
-#: builtin/pack-objects.c:3240
+#: builtin/pack-objects.c:3272
 msgid "unable to force loose object"
 msgstr "konnte loses Objekt nicht erzwingen"
 
-#: builtin/pack-objects.c:3333
+#: builtin/pack-objects.c:3365
 #, c-format
 msgid "not a rev '%s'"
 msgstr "'%s' ist kein Commit"
 
-#: builtin/pack-objects.c:3336
+#: builtin/pack-objects.c:3368
 #, c-format
 msgid "bad revision '%s'"
 msgstr "ungültiger Commit '%s'"
 
-#: builtin/pack-objects.c:3361
+#: builtin/pack-objects.c:3393
 msgid "unable to add recent objects"
 msgstr "konnte neuere Objekte nicht hinzufügen"
 
-#: builtin/pack-objects.c:3414
+#: builtin/pack-objects.c:3446
 #, c-format
 msgid "unsupported index version %s"
 msgstr "nicht unterstützte Index-Version %s"
 
-#: builtin/pack-objects.c:3418
+#: builtin/pack-objects.c:3450
 #, c-format
 msgid "bad index version '%s'"
 msgstr "ungültige Index-Version '%s'"
 
-#: builtin/pack-objects.c:3456
+#: builtin/pack-objects.c:3488
 msgid "<version>[,<offset>]"
 msgstr "<Version>[,<Offset>]"
 
-#: builtin/pack-objects.c:3457
+#: builtin/pack-objects.c:3489
 msgid "write the pack index file in the specified idx format version"
 msgstr ""
 "die Index-Datei des Paketes in der angegebenen Indexformat-Version schreiben"
 
-#: builtin/pack-objects.c:3460
+#: builtin/pack-objects.c:3492
 msgid "maximum size of each output pack file"
 msgstr "maximale Größe für jede ausgegebene Paketdatei"
 
-#: builtin/pack-objects.c:3462
+#: builtin/pack-objects.c:3494
 msgid "ignore borrowed objects from alternate object store"
 msgstr "geliehene Objekte von alternativem Objektspeicher ignorieren"
 
-#: builtin/pack-objects.c:3464
+#: builtin/pack-objects.c:3496
 msgid "ignore packed objects"
 msgstr "gepackte Objekte ignorieren"
 
-#: builtin/pack-objects.c:3466
+#: builtin/pack-objects.c:3498
 msgid "limit pack window by objects"
 msgstr "Paketfenster durch Objekte begrenzen"
 
-#: builtin/pack-objects.c:3468
+#: builtin/pack-objects.c:3500
 msgid "limit pack window by memory in addition to object limit"
 msgstr ""
 "Paketfenster, zusätzlich zur Objektbegrenzung, durch Speicher begrenzen"
 
-#: builtin/pack-objects.c:3470
+#: builtin/pack-objects.c:3502
 msgid "maximum length of delta chain allowed in the resulting pack"
 msgstr ""
 "maximale Länge der erlaubten Differenzverkettung im resultierenden Paket"
 
-#: builtin/pack-objects.c:3472
+#: builtin/pack-objects.c:3504
 msgid "reuse existing deltas"
 msgstr "existierende Unterschiede wiederverwenden"
 
-#: builtin/pack-objects.c:3474
+#: builtin/pack-objects.c:3506
 msgid "reuse existing objects"
 msgstr "existierende Objekte wiederverwenden"
 
-#: builtin/pack-objects.c:3476
+#: builtin/pack-objects.c:3508
 msgid "use OFS_DELTA objects"
 msgstr "OFS_DELTA Objekte verwenden"
 
-#: builtin/pack-objects.c:3478
+#: builtin/pack-objects.c:3510
 msgid "use threads when searching for best delta matches"
 msgstr ""
 "Threads bei der Suche nach den besten Übereinstimmungen bei Unterschieden "
 "verwenden"
 
-#: builtin/pack-objects.c:3480
+#: builtin/pack-objects.c:3512
 msgid "do not create an empty pack output"
 msgstr "keine leeren Pakete erzeugen"
 
-#: builtin/pack-objects.c:3482
+#: builtin/pack-objects.c:3514
 msgid "read revision arguments from standard input"
 msgstr "Argumente bezüglich Commits von der Standard-Eingabe lesen"
 
-#: builtin/pack-objects.c:3484
+#: builtin/pack-objects.c:3516
 msgid "limit the objects to those that are not yet packed"
 msgstr "die Objekte zu solchen, die noch nicht gepackt wurden, begrenzen"
 
-#: builtin/pack-objects.c:3487
+#: builtin/pack-objects.c:3519
 msgid "include objects reachable from any reference"
 msgstr "Objekte einschließen, die von jeder Referenz erreichbar sind"
 
-#: builtin/pack-objects.c:3490
+#: builtin/pack-objects.c:3522
 msgid "include objects referred by reflog entries"
 msgstr ""
 "Objekte einschließen, die von Einträgen des Reflogs referenziert werden"
 
-#: builtin/pack-objects.c:3493
+#: builtin/pack-objects.c:3525
 msgid "include objects referred to by the index"
 msgstr "Objekte einschließen, die vom Index referenziert werden"
 
-#: builtin/pack-objects.c:3496
+#: builtin/pack-objects.c:3528
 msgid "output pack to stdout"
 msgstr "Paket in die Standard-Ausgabe schreiben"
 
-#: builtin/pack-objects.c:3498
+#: builtin/pack-objects.c:3530
 msgid "include tag objects that refer to objects to be packed"
 msgstr "Tag-Objekte einschließen, die auf gepackte Objekte referenzieren"
 
-#: builtin/pack-objects.c:3500
+#: builtin/pack-objects.c:3532
 msgid "keep unreachable objects"
 msgstr "nicht erreichbare Objekte behalten"
 
-#: builtin/pack-objects.c:3502
+#: builtin/pack-objects.c:3534
 msgid "pack loose unreachable objects"
 msgstr "nicht erreichbare lose Objekte packen"
 
-#: builtin/pack-objects.c:3504
+#: builtin/pack-objects.c:3536
 msgid "unpack unreachable objects newer than <time>"
 msgstr "nicht erreichbare Objekte entpacken, die neuer als <Zeit> sind"
 
-#: builtin/pack-objects.c:3507
+#: builtin/pack-objects.c:3539
 msgid "use the sparse reachability algorithm"
 msgstr "den \"sparse\" Algorithmus zur Bestimmung der Erreichbarkeit benutzen"
 
-#: builtin/pack-objects.c:3509
+#: builtin/pack-objects.c:3541
 msgid "create thin packs"
 msgstr "dünnere Pakete erzeugen"
 
-#: builtin/pack-objects.c:3511
+#: builtin/pack-objects.c:3543
 msgid "create packs suitable for shallow fetches"
 msgstr ""
 "Pakete geeignet für Abholung mit unvollständiger Historie (shallow) erzeugen"
 
-#: builtin/pack-objects.c:3513
+#: builtin/pack-objects.c:3545
 msgid "ignore packs that have companion .keep file"
 msgstr "Pakete ignorieren, die .keep Dateien haben"
 
-#: builtin/pack-objects.c:3515
+#: builtin/pack-objects.c:3547
 msgid "ignore this pack"
 msgstr "dieses Paket ignorieren"
 
-#: builtin/pack-objects.c:3517
+#: builtin/pack-objects.c:3549
 msgid "pack compression level"
 msgstr "Komprimierungsgrad für Paketierung"
 
-#: builtin/pack-objects.c:3519
+#: builtin/pack-objects.c:3551
 msgid "do not hide commits by grafts"
 msgstr "keine künstlichen Vorgänger-Commits (\"grafts\") verbergen"
 
-#: builtin/pack-objects.c:3521
+#: builtin/pack-objects.c:3553
 msgid "use a bitmap index if available to speed up counting objects"
 msgstr ""
 "Bitmap-Index (falls verfügbar) zur Optimierung der Objektzählung benutzen"
 
-#: builtin/pack-objects.c:3523
+#: builtin/pack-objects.c:3555
 msgid "write a bitmap index together with the pack index"
 msgstr "Bitmap-Index zusammen mit Pack-Index schreiben"
 
-#: builtin/pack-objects.c:3527
+#: builtin/pack-objects.c:3559
 msgid "write a bitmap index if possible"
 msgstr "Bitmap-Index schreiben, wenn möglich"
 
-#: builtin/pack-objects.c:3531
+#: builtin/pack-objects.c:3563
 msgid "handling for missing objects"
 msgstr "Behandlung für fehlende Objekte"
 
-#: builtin/pack-objects.c:3534
+#: builtin/pack-objects.c:3566
 msgid "do not pack objects in promisor packfiles"
 msgstr ""
 "keine Objekte aus Packdateien von partiell geklonten Remote-Repositories "
 "packen"
 
-#: builtin/pack-objects.c:3536
+#: builtin/pack-objects.c:3568
 msgid "respect islands during delta compression"
 msgstr "Delta-Islands bei Delta-Kompression beachten"
 
-#: builtin/pack-objects.c:3538
+#: builtin/pack-objects.c:3570
 msgid "protocol"
 msgstr "Protokoll"
 
-#: builtin/pack-objects.c:3539
+#: builtin/pack-objects.c:3571
 msgid "exclude any configured uploadpack.blobpackfileuri with this protocol"
 msgstr ""
 "jegliche konfigurierte uploadpack.blobpackfileuri für dieses Protkoll "
 "ausschließen"
 
-#: builtin/pack-objects.c:3568
+#: builtin/pack-objects.c:3600
 #, c-format
 msgid "delta chain depth %d is too deep, forcing %d"
 msgstr "Tiefe für Verkettung von Unterschieden %d ist zu tief, erzwinge %d"
 
-#: builtin/pack-objects.c:3573
+#: builtin/pack-objects.c:3605
 #, c-format
 msgid "pack.deltaCacheLimit is too high, forcing %d"
 msgstr "pack.deltaCacheLimit ist zu hoch, erzwinge %d"
 
-#: builtin/pack-objects.c:3627
+#: builtin/pack-objects.c:3659
 msgid "--max-pack-size cannot be used to build a pack for transfer"
 msgstr ""
 "--max-pack-size kann nicht für die Erstellung eines Pakets für eine "
 "Übertragung\n"
 "benutzt werden."
 
-#: builtin/pack-objects.c:3629
+#: builtin/pack-objects.c:3661
 msgid "minimum pack size limit is 1 MiB"
 msgstr "Minimales Limit für die Paketgröße ist 1 MiB."
 
-#: builtin/pack-objects.c:3634
+#: builtin/pack-objects.c:3666
 msgid "--thin cannot be used to build an indexable pack"
 msgstr ""
 "--thin kann nicht benutzt werden, um ein indizierbares Paket zu erstellen."
 
-#: builtin/pack-objects.c:3637
+#: builtin/pack-objects.c:3669
 msgid "--keep-unreachable and --unpack-unreachable are incompatible"
 msgstr "--keep-unreachable und --unpack-unreachable sind inkompatibel"
 
-#: builtin/pack-objects.c:3643
+#: builtin/pack-objects.c:3675
 msgid "cannot use --filter without --stdout"
 msgstr "Kann --filter nicht ohne --stdout benutzen."
 
-#: builtin/pack-objects.c:3703
+#: builtin/pack-objects.c:3735
 msgid "Enumerating objects"
 msgstr "Objekte aufzählen"
 
-#: builtin/pack-objects.c:3734
+#: builtin/pack-objects.c:3766
 #, c-format
 msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
@@ -18210,7 +18653,7 @@ msgstr "Optionen bezogen auf Merge"
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "Integration von Änderungen durch Rebase statt Merge"
 
-#: builtin/pull.c:158 builtin/rebase.c:478 builtin/revert.c:126
+#: builtin/pull.c:158 builtin/rebase.c:484 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "Vorspulen erlauben"
 
@@ -18235,7 +18678,7 @@ msgstr "Anzahl der parallel mit 'pull' zu verarbeitenden Submodule"
 msgid "Invalid value for pull.ff: %s"
 msgstr "Ungültiger Wert für pull.ff: %s"
 
-#: builtin/pull.c:349
+#: builtin/pull.c:348
 msgid ""
 "Pulling without specifying how to reconcile divergent branches is\n"
 "discouraged. You can squelch this message by running one of the following\n"
@@ -18265,7 +18708,7 @@ msgstr ""
 "Option --rebase, --no-rebase oder --ff-only auf der Kommandozeile nutzen,\n"
 "um das konfigurierte Standardverhalten pro Aufruf zu überschreiben.\n"
 
-#: builtin/pull.c:459
+#: builtin/pull.c:458
 msgid ""
 "There is no candidate for rebasing against among the refs that you just "
 "fetched."
@@ -18273,14 +18716,14 @@ msgstr ""
 "Es gibt keinen Kandidaten für Rebase innerhalb der Referenzen, die eben "
 "angefordert wurden."
 
-#: builtin/pull.c:461
+#: builtin/pull.c:460
 msgid ""
 "There are no candidates for merging among the refs that you just fetched."
 msgstr ""
 "Es gibt keine Kandidaten für Merge innerhalb der Referenzen, die eben "
 "angefordert wurden."
 
-#: builtin/pull.c:462
+#: builtin/pull.c:461
 msgid ""
 "Generally this means that you provided a wildcard refspec which had no\n"
 "matches on the remote end."
@@ -18288,7 +18731,7 @@ msgstr ""
 "Im Allgemeinen bedeutet das, dass Sie einen Refspec mit Wildcards angegeben\n"
 "haben, der auf der Gegenseite mit keinen Referenzen übereinstimmt."
 
-#: builtin/pull.c:465
+#: builtin/pull.c:464
 #, c-format
 msgid ""
 "You asked to pull from the remote '%s', but did not specify\n"
@@ -18300,39 +18743,39 @@ msgstr ""
 "Repository für den aktuellen Branch ist, müssen Sie einen Branch auf\n"
 "der Befehlszeile angeben."
 
-#: builtin/pull.c:470 builtin/rebase.c:1234 git-parse-remote.sh:73
+#: builtin/pull.c:469 builtin/rebase.c:1240 git-parse-remote.sh:73
 msgid "You are not currently on a branch."
 msgstr "Im Moment auf keinem Branch."
 
-#: builtin/pull.c:472 builtin/pull.c:487 git-parse-remote.sh:79
+#: builtin/pull.c:471 builtin/pull.c:486 git-parse-remote.sh:79
 msgid "Please specify which branch you want to rebase against."
 msgstr ""
 "Bitte geben Sie den Branch an, gegen welchen Sie \"rebase\" ausführen "
 "möchten."
 
-#: builtin/pull.c:474 builtin/pull.c:489 git-parse-remote.sh:82
+#: builtin/pull.c:473 builtin/pull.c:488 git-parse-remote.sh:82
 msgid "Please specify which branch you want to merge with."
 msgstr "Bitte geben Sie den Branch an, welchen Sie zusammenführen möchten."
 
-#: builtin/pull.c:475 builtin/pull.c:490
+#: builtin/pull.c:474 builtin/pull.c:489
 msgid "See git-pull(1) for details."
 msgstr "Siehe git-pull(1) für weitere Details."
 
-#: builtin/pull.c:477 builtin/pull.c:483 builtin/pull.c:492
-#: builtin/rebase.c:1240 git-parse-remote.sh:64
+#: builtin/pull.c:476 builtin/pull.c:482 builtin/pull.c:491
+#: builtin/rebase.c:1246 git-parse-remote.sh:64
 msgid "<remote>"
 msgstr "<Remote-Repository>"
 
-#: builtin/pull.c:477 builtin/pull.c:492 builtin/pull.c:497
+#: builtin/pull.c:476 builtin/pull.c:491 builtin/pull.c:496
 #: git-parse-remote.sh:65
 msgid "<branch>"
 msgstr "<Branch>"
 
-#: builtin/pull.c:485 builtin/rebase.c:1232 git-parse-remote.sh:75
+#: builtin/pull.c:484 builtin/rebase.c:1238 git-parse-remote.sh:75
 msgid "There is no tracking information for the current branch."
 msgstr "Es gibt keine Tracking-Informationen für den aktuellen Branch."
 
-#: builtin/pull.c:494 git-parse-remote.sh:95
+#: builtin/pull.c:493 git-parse-remote.sh:95
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:"
 msgstr ""
@@ -18340,7 +18783,7 @@ msgstr ""
 "Sie\n"
 "dies tun mit:"
 
-#: builtin/pull.c:499
+#: builtin/pull.c:498
 #, c-format
 msgid ""
 "Your configuration specifies to merge with the ref '%s'\n"
@@ -18350,30 +18793,30 @@ msgstr ""
 "des Remote-Repositories durchzuführen, aber diese Referenz\n"
 "wurde nicht angefordert."
 
-#: builtin/pull.c:610
+#: builtin/pull.c:609
 #, c-format
 msgid "unable to access commit %s"
 msgstr "Konnte nicht auf Commit '%s' zugreifen."
 
-#: builtin/pull.c:895
+#: builtin/pull.c:894
 msgid "ignoring --verify-signatures for rebase"
 msgstr "Ignoriere --verify-signatures für Rebase"
 
-#: builtin/pull.c:955
+#: builtin/pull.c:954
 msgid "Updating an unborn branch with changes added to the index."
 msgstr ""
 "Aktualisiere einen ungeborenen Branch mit Änderungen, die zum Commit "
 "vorgemerkt sind."
 
-#: builtin/pull.c:959
+#: builtin/pull.c:958
 msgid "pull with rebase"
 msgstr "Pull mit Rebase"
 
-#: builtin/pull.c:960
+#: builtin/pull.c:959
 msgid "please commit or stash them."
 msgstr "Bitte committen Sie die Änderungen oder benutzen Sie \"stash\"."
 
-#: builtin/pull.c:985
+#: builtin/pull.c:984
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -18383,7 +18826,7 @@ msgstr ""
 "\"fetch\" aktualisierte die Spitze des aktuellen Branches.\n"
 "Spule Ihr Arbeitsverzeichnis von Commit %s vor."
 
-#: builtin/pull.c:991
+#: builtin/pull.c:990
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -18400,15 +18843,15 @@ msgstr ""
 "$ git reset --hard\n"
 "zur Wiederherstellung aus."
 
-#: builtin/pull.c:1006
+#: builtin/pull.c:1005
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Kann nicht mehrere Branches in einen leeren Branch zusammenführen."
 
-#: builtin/pull.c:1010
+#: builtin/pull.c:1009
 msgid "Cannot rebase onto multiple branches."
 msgstr "Kann Rebase nicht auf mehrere Branches ausführen."
 
-#: builtin/pull.c:1018
+#: builtin/pull.c:1017
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "Kann Rebase nicht mit lokal aufgezeichneten Änderungen in Submodulen "
@@ -18418,15 +18861,15 @@ msgstr ""
 msgid "git push [<options>] [<repository> [<refspec>...]]"
 msgstr "git push [<Optionen>] [<Repository> [<Refspec>...]]"
 
-#: builtin/push.c:112
+#: builtin/push.c:111
 msgid "tag shorthand without <tag>"
 msgstr "Kurzschrift für Tag ohne <Tag>"
 
-#: builtin/push.c:122
+#: builtin/push.c:119
 msgid "--delete only accepts plain target ref names"
 msgstr "Die Option --delete akzeptiert nur reine Referenznamen als Ziel."
 
-#: builtin/push.c:168
+#: builtin/push.c:164
 msgid ""
 "\n"
 "To choose either option permanently, see push.default in 'git help config'."
@@ -18435,7 +18878,7 @@ msgstr ""
 "Um eine Variante permanent zu verwenden, siehe push.default in 'git help "
 "config'."
 
-#: builtin/push.c:171
+#: builtin/push.c:167
 #, c-format
 msgid ""
 "The upstream branch of your current branch does not match\n"
@@ -18461,7 +18904,7 @@ msgstr ""
 "    git push %s HEAD\n"
 "%s"
 
-#: builtin/push.c:186
+#: builtin/push.c:182
 #, c-format
 msgid ""
 "You are not currently on a branch.\n"
@@ -18476,7 +18919,7 @@ msgstr ""
 "\n"
 "    git push %s HEAD:<Name-des-Remote-Branches>\n"
 
-#: builtin/push.c:200
+#: builtin/push.c:194
 #, c-format
 msgid ""
 "The current branch %s has no upstream branch.\n"
@@ -18490,13 +18933,13 @@ msgstr ""
 "\n"
 "    git push --set-upstream %s %s\n"
 
-#: builtin/push.c:208
+#: builtin/push.c:202
 #, c-format
 msgid "The current branch %s has multiple upstream branches, refusing to push."
 msgstr ""
 "Der aktuelle Branch %s hat mehrere Upstream-Branches, \"push\" verweigert."
 
-#: builtin/push.c:211
+#: builtin/push.c:205
 #, c-format
 msgid ""
 "You are pushing to remote '%s', which is not the upstream of\n"
@@ -18507,14 +18950,14 @@ msgstr ""
 "Branches '%s' ist, ohne anzugeben, was versendet werden soll, um welchen\n"
 "Remote-Branch zu aktualisieren."
 
-#: builtin/push.c:270
+#: builtin/push.c:260
 msgid ""
 "You didn't specify any refspecs to push, and push.default is \"nothing\"."
 msgstr ""
 "Sie haben keine Refspec für \"push\" angegeben, und push.default ist "
 "\"nothing\"."
 
-#: builtin/push.c:277
+#: builtin/push.c:267
 msgid ""
 "Updates were rejected because the tip of your current branch is behind\n"
 "its remote counterpart. Integrate the remote changes (e.g.\n"
@@ -18528,7 +18971,7 @@ msgstr ""
 "Siehe auch die Sektion 'Note about fast-forwards' in 'git push --help'\n"
 "für weitere Details."
 
-#: builtin/push.c:283
+#: builtin/push.c:273
 msgid ""
 "Updates were rejected because a pushed branch tip is behind its remote\n"
 "counterpart. Check out this branch and integrate the remote changes\n"
@@ -18542,7 +18985,7 @@ msgstr ""
 "Siehe auch die Sektion 'Note about fast-forwards' in 'git push --help'\n"
 "für weitere Details."
 
-#: builtin/push.c:289
+#: builtin/push.c:279
 msgid ""
 "Updates were rejected because the remote contains work that you do\n"
 "not have locally. This is usually caused by another repository pushing\n"
@@ -18561,13 +19004,13 @@ msgstr ""
 "Siehe auch die Sektion 'Note about fast-forwards' in 'git push --help'\n"
 "für weitere Details."
 
-#: builtin/push.c:296
+#: builtin/push.c:286
 msgid "Updates were rejected because the tag already exists in the remote."
 msgstr ""
 "Aktualisierungen wurden zurückgewiesen, weil das Tag bereits\n"
 "im Remote-Repository existiert."
 
-#: builtin/push.c:299
+#: builtin/push.c:289
 msgid ""
 "You cannot update a remote ref that points at a non-commit object,\n"
 "or update a remote ref to make it point at a non-commit object,\n"
@@ -18577,99 +19020,99 @@ msgstr ""
 "das kein Commit ist, oder es auf ein solches Objekt zeigen lassen, ohne\n"
 "die Option '--force' zu verwenden.\n"
 
-#: builtin/push.c:361
+#: builtin/push.c:351
 #, c-format
 msgid "Pushing to %s\n"
 msgstr "Push nach %s\n"
 
-#: builtin/push.c:368
+#: builtin/push.c:358
 #, c-format
 msgid "failed to push some refs to '%s'"
 msgstr "Fehler beim Versenden einiger Referenzen nach '%s'"
 
-#: builtin/push.c:542
+#: builtin/push.c:532
 msgid "repository"
 msgstr "Repository"
 
-#: builtin/push.c:543 builtin/send-pack.c:164
+#: builtin/push.c:533 builtin/send-pack.c:183
 msgid "push all refs"
 msgstr "alle Referenzen versenden"
 
-#: builtin/push.c:544 builtin/send-pack.c:166
+#: builtin/push.c:534 builtin/send-pack.c:185
 msgid "mirror all refs"
 msgstr "alle Referenzen spiegeln"
 
-#: builtin/push.c:546
+#: builtin/push.c:536
 msgid "delete refs"
 msgstr "Referenzen löschen"
 
-#: builtin/push.c:547
+#: builtin/push.c:537
 msgid "push tags (can't be used with --all or --mirror)"
 msgstr "Tags versenden (kann nicht mit --all oder --mirror verwendet werden)"
 
-#: builtin/push.c:550 builtin/send-pack.c:167
+#: builtin/push.c:540 builtin/send-pack.c:186
 msgid "force updates"
 msgstr "Aktualisierung erzwingen"
 
-#: builtin/push.c:551 builtin/send-pack.c:179
+#: builtin/push.c:541 builtin/send-pack.c:198
 msgid "<refname>:<expect>"
 msgstr "<Referenzname>:<Erwartungswert>"
 
-#: builtin/push.c:552 builtin/send-pack.c:180
+#: builtin/push.c:542 builtin/send-pack.c:199
 msgid "require old value of ref to be at this value"
 msgstr "Referenz muss sich auf dem angegebenen Wert befinden"
 
-#: builtin/push.c:555
+#: builtin/push.c:545
 msgid "control recursive pushing of submodules"
 msgstr "rekursiven \"push\" von Submodulen steuern"
 
-#: builtin/push.c:556 builtin/send-pack.c:174
+#: builtin/push.c:546 builtin/send-pack.c:193
 msgid "use thin pack"
 msgstr "kleinere Pakete verwenden"
 
-#: builtin/push.c:557 builtin/push.c:558 builtin/send-pack.c:161
-#: builtin/send-pack.c:162
+#: builtin/push.c:547 builtin/push.c:548 builtin/send-pack.c:180
+#: builtin/send-pack.c:181
 msgid "receive pack program"
 msgstr "'receive pack' Programm"
 
-#: builtin/push.c:559
+#: builtin/push.c:549
 msgid "set upstream for git pull/status"
 msgstr "Upstream für \"git pull/status\" setzen"
 
-#: builtin/push.c:562
+#: builtin/push.c:552
 msgid "prune locally removed refs"
 msgstr "lokal gelöschte Referenzen entfernen"
 
-#: builtin/push.c:564
+#: builtin/push.c:554
 msgid "bypass pre-push hook"
 msgstr "\"pre-push hook\" umgehen"
 
-#: builtin/push.c:565
+#: builtin/push.c:555
 msgid "push missing but relevant tags"
 msgstr "fehlende, aber relevante Tags versenden"
 
-#: builtin/push.c:567 builtin/send-pack.c:168
+#: builtin/push.c:557 builtin/send-pack.c:187
 msgid "GPG sign the push"
 msgstr "signiert \"push\" mit GPG"
 
-#: builtin/push.c:569 builtin/send-pack.c:175
+#: builtin/push.c:559 builtin/send-pack.c:194
 msgid "request atomic transaction on remote side"
 msgstr "Referenzen atomar versenden"
 
-#: builtin/push.c:587
+#: builtin/push.c:577
 msgid "--delete is incompatible with --all, --mirror and --tags"
 msgstr "Die Option --delete ist inkompatibel mit --all, --mirror und --tags."
 
-#: builtin/push.c:589
+#: builtin/push.c:579
 msgid "--delete doesn't make sense without any refs"
 msgstr "Die Option --delete kann nur mit Referenzen verwendet werden."
 
-#: builtin/push.c:609
+#: builtin/push.c:599
 #, c-format
 msgid "bad repository '%s'"
 msgstr "ungültiges Repository '%s'"
 
-#: builtin/push.c:610
+#: builtin/push.c:600
 msgid ""
 "No configured push destination.\n"
 "Either specify the URL from the command-line or configure a remote "
@@ -18691,27 +19134,27 @@ msgstr ""
 "\n"
 "    git push <Name>\n"
 
-#: builtin/push.c:625
+#: builtin/push.c:615
 msgid "--all and --tags are incompatible"
 msgstr "Die Optionen --all und --tags sind inkompatibel."
 
-#: builtin/push.c:627
+#: builtin/push.c:617
 msgid "--all can't be combined with refspecs"
 msgstr "Die Option --all kann nicht mit Refspecs kombiniert werden."
 
-#: builtin/push.c:631
+#: builtin/push.c:621
 msgid "--mirror and --tags are incompatible"
 msgstr "Die Optionen --mirror und --tags sind inkompatibel."
 
-#: builtin/push.c:633
+#: builtin/push.c:623
 msgid "--mirror can't be combined with refspecs"
 msgstr "Die Option --mirror kann nicht mit Refspecs kombiniert werden."
 
-#: builtin/push.c:636
+#: builtin/push.c:626
 msgid "--all and --mirror are incompatible"
 msgstr "Die Optionen --all und --mirror sind inkompatibel."
 
-#: builtin/push.c:640
+#: builtin/push.c:630
 msgid "push options must not have new line characters"
 msgstr "Push-Optionen dürfen keine Zeilenvorschubzeichen haben"
 
@@ -18860,194 +19303,194 @@ msgstr ""
 msgid "git rebase --continue | --abort | --skip | --edit-todo"
 msgstr "git rebase --continue | --abort | --skip | --edit-todo"
 
-#: builtin/rebase.c:181 builtin/rebase.c:205 builtin/rebase.c:232
+#: builtin/rebase.c:187 builtin/rebase.c:211 builtin/rebase.c:238
 #, c-format
 msgid "unusable todo list: '%s'"
 msgstr "Unbenutzbare TODO-Liste: '%s'"
 
-#: builtin/rebase.c:298
+#: builtin/rebase.c:304
 #, c-format
 msgid "could not create temporary %s"
 msgstr "Konnte temporäres Verzeichnis '%s' nicht erstellen."
 
-#: builtin/rebase.c:304
+#: builtin/rebase.c:310
 msgid "could not mark as interactive"
 msgstr "Markierung auf interaktiven Rebase fehlgeschlagen."
 
-#: builtin/rebase.c:358
+#: builtin/rebase.c:364
 msgid "could not generate todo list"
 msgstr "Konnte TODO-Liste nicht erzeugen."
 
-#: builtin/rebase.c:399
+#: builtin/rebase.c:405
 msgid "a base commit must be provided with --upstream or --onto"
 msgstr "Ein Basis-Commit muss mit --upstream oder --onto angegeben werden."
 
-#: builtin/rebase.c:468
+#: builtin/rebase.c:474
 msgid "git rebase--interactive [<options>]"
 msgstr "git rebase--interactive [<Optionen>]"
 
-#: builtin/rebase.c:481 builtin/rebase.c:1374
+#: builtin/rebase.c:487 builtin/rebase.c:1382
 msgid "keep commits which start empty"
 msgstr "behalte Commits, die leer beginnen"
 
-#: builtin/rebase.c:485 builtin/revert.c:128
+#: builtin/rebase.c:491 builtin/revert.c:128
 msgid "allow commits with empty messages"
 msgstr "Commits mit leerer Beschreibung erlauben"
 
-#: builtin/rebase.c:487
+#: builtin/rebase.c:493
 msgid "rebase merge commits"
 msgstr "Rebase auf Merge-Commits ausführen"
 
-#: builtin/rebase.c:489
+#: builtin/rebase.c:495
 msgid "keep original branch points of cousins"
 msgstr "originale Branch-Punkte der Cousins behalten"
 
-#: builtin/rebase.c:491
+#: builtin/rebase.c:497
 msgid "move commits that begin with squash!/fixup!"
 msgstr "Commits verschieben, die mit squash!/fixup! beginnen"
 
-#: builtin/rebase.c:492
+#: builtin/rebase.c:498
 msgid "sign commits"
 msgstr "Commits signieren"
 
-#: builtin/rebase.c:494 builtin/rebase.c:1314
+#: builtin/rebase.c:500 builtin/rebase.c:1321
 msgid "display a diffstat of what changed upstream"
 msgstr ""
 "Zusammenfassung der Unterschiede gegenüber dem Upstream-Branch anzeigen"
 
-#: builtin/rebase.c:496
+#: builtin/rebase.c:502
 msgid "continue rebase"
 msgstr "Rebase fortsetzen"
 
-#: builtin/rebase.c:498
+#: builtin/rebase.c:504
 msgid "skip commit"
 msgstr "Commit auslassen"
 
-#: builtin/rebase.c:499
+#: builtin/rebase.c:505
 msgid "edit the todo list"
 msgstr "die TODO-Liste bearbeiten"
 
-#: builtin/rebase.c:501
+#: builtin/rebase.c:507
 msgid "show the current patch"
 msgstr "den aktuellen Patch anzeigen"
 
-#: builtin/rebase.c:504
+#: builtin/rebase.c:510
 msgid "shorten commit ids in the todo list"
 msgstr "Commit-IDs in der TODO-Liste verkürzen"
 
-#: builtin/rebase.c:506
+#: builtin/rebase.c:512
 msgid "expand commit ids in the todo list"
 msgstr "Commit-IDs in der TODO-Liste erweitern"
 
-#: builtin/rebase.c:508
+#: builtin/rebase.c:514
 msgid "check the todo list"
 msgstr "die TODO-Liste prüfen"
 
-#: builtin/rebase.c:510
+#: builtin/rebase.c:516
 msgid "rearrange fixup/squash lines"
 msgstr "fixup/squash-Zeilen umordnen"
 
-#: builtin/rebase.c:512
+#: builtin/rebase.c:518
 msgid "insert exec commands in todo list"
 msgstr "\"exec\"-Befehle in TODO-Liste einfügen"
 
-#: builtin/rebase.c:513
+#: builtin/rebase.c:519
 msgid "onto"
 msgstr "auf"
 
-#: builtin/rebase.c:516
+#: builtin/rebase.c:522
 msgid "restrict-revision"
 msgstr "Begrenzungscommit"
 
-#: builtin/rebase.c:516
+#: builtin/rebase.c:522
 msgid "restrict revision"
 msgstr "Begrenzungscommit"
 
-#: builtin/rebase.c:518
+#: builtin/rebase.c:524
 msgid "squash-onto"
 msgstr "squash-onto"
 
-#: builtin/rebase.c:519
+#: builtin/rebase.c:525
 msgid "squash onto"
 msgstr "squash onto"
 
-#: builtin/rebase.c:521
+#: builtin/rebase.c:527
 msgid "the upstream commit"
 msgstr "der Upstream-Commit"
 
-#: builtin/rebase.c:523
+#: builtin/rebase.c:529
 msgid "head-name"
 msgstr "head-Name"
 
-#: builtin/rebase.c:523
+#: builtin/rebase.c:529
 msgid "head name"
 msgstr "head-Name"
 
-#: builtin/rebase.c:528
+#: builtin/rebase.c:534
 msgid "rebase strategy"
 msgstr "Rebase-Strategie"
 
-#: builtin/rebase.c:529
+#: builtin/rebase.c:535
 msgid "strategy-opts"
 msgstr "Strategie-Optionen"
 
-#: builtin/rebase.c:530
+#: builtin/rebase.c:536
 msgid "strategy options"
 msgstr "Strategie-Optionen"
 
-#: builtin/rebase.c:531
+#: builtin/rebase.c:537
 msgid "switch-to"
 msgstr "wechseln zu"
 
-#: builtin/rebase.c:532
+#: builtin/rebase.c:538
 msgid "the branch or commit to checkout"
 msgstr "der Branch oder Commit zum Auschecken"
 
-#: builtin/rebase.c:533
+#: builtin/rebase.c:539
 msgid "onto-name"
 msgstr "onto-Name"
 
-#: builtin/rebase.c:533
+#: builtin/rebase.c:539
 msgid "onto name"
 msgstr "onto-Name"
 
-#: builtin/rebase.c:534
+#: builtin/rebase.c:540
 msgid "cmd"
 msgstr "Befehl"
 
-#: builtin/rebase.c:534
+#: builtin/rebase.c:540
 msgid "the command to run"
 msgstr "auszuführender Befehl"
 
-#: builtin/rebase.c:537 builtin/rebase.c:1407
+#: builtin/rebase.c:543 builtin/rebase.c:1415
 msgid "automatically re-schedule any `exec` that fails"
 msgstr "jeden fehlgeschlagenen `exec`-Befehl neu ansetzen"
 
-#: builtin/rebase.c:553
+#: builtin/rebase.c:559
 msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
 msgstr "--[no-]rebase-cousins hat ohne --rebase-merges keine Auswirkung"
 
-#: builtin/rebase.c:569
+#: builtin/rebase.c:575
 #, c-format
 msgid "%s requires the merge backend"
 msgstr "%s erfordert das Merge-Backend"
 
-#: builtin/rebase.c:612
+#: builtin/rebase.c:618
 #, c-format
 msgid "could not get 'onto': '%s'"
 msgstr "Konnte 'onto' nicht bestimmen: '%s'"
 
-#: builtin/rebase.c:629
+#: builtin/rebase.c:635
 #, c-format
 msgid "invalid orig-head: '%s'"
 msgstr "Ungültiges orig-head: '%s'"
 
-#: builtin/rebase.c:654
+#: builtin/rebase.c:660
 #, c-format
 msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
 msgstr "Ignoriere ungültiges allow_rerere_autoupdate: '%s'"
 
-#: builtin/rebase.c:799 git-rebase--preserve-merges.sh:81
+#: builtin/rebase.c:805 git-rebase--preserve-merges.sh:81
 msgid ""
 "Resolve all conflicts manually, mark them as resolved with\n"
 "\"git add/rm <conflicted_files>\", then run \"git rebase --continue\".\n"
@@ -19063,7 +19506,7 @@ msgstr ""
 "Um abzubrechen und zurück zum Zustand vor \"git rebase\" zu gelangen,\n"
 "führen Sie \"git rebase --abort\" aus."
 
-#: builtin/rebase.c:882
+#: builtin/rebase.c:888
 #, c-format
 msgid ""
 "\n"
@@ -19083,7 +19526,7 @@ msgstr ""
 "Infolge dessen kann Git auf diesen Revisionen Rebase nicht\n"
 "ausführen."
 
-#: builtin/rebase.c:1208
+#: builtin/rebase.c:1214
 #, c-format
 msgid ""
 "unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and \"ask"
@@ -19092,7 +19535,7 @@ msgstr ""
 "nicht erkannter leerer Typ '%s'; Gültige Werte sind \"drop\", \"keep\", und "
 "\"ask\"."
 
-#: builtin/rebase.c:1226
+#: builtin/rebase.c:1232
 #, c-format
 msgid ""
 "%s\n"
@@ -19110,7 +19553,7 @@ msgstr ""
 "    git rebase '<Branch>'\n"
 "\n"
 
-#: builtin/rebase.c:1242
+#: builtin/rebase.c:1248
 #, c-format
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:\n"
@@ -19124,142 +19567,157 @@ msgstr ""
 "    git branch --set-upstream-to=%s/<Branch> %s\n"
 "\n"
 
-#: builtin/rebase.c:1272
+#: builtin/rebase.c:1278
 msgid "exec commands cannot contain newlines"
 msgstr "\"exec\"-Befehle können keine neuen Zeilen enthalten"
 
-#: builtin/rebase.c:1276
+#: builtin/rebase.c:1282
 msgid "empty exec command"
 msgstr "Leerer \"exec\"-Befehl."
 
-#: builtin/rebase.c:1305
+#: builtin/rebase.c:1312
 msgid "rebase onto given branch instead of upstream"
 msgstr "Rebase auf angegebenen Branch anstelle des Upstream-Branches ausführen"
 
-#: builtin/rebase.c:1307
+#: builtin/rebase.c:1314
 msgid "use the merge-base of upstream and branch as the current base"
 msgstr "Nutze die Merge-Basis von Upstream und Branch als die aktuelle Basis"
 
-#: builtin/rebase.c:1309
+#: builtin/rebase.c:1316
 msgid "allow pre-rebase hook to run"
 msgstr "Ausführung des pre-rebase-Hooks erlauben"
 
-#: builtin/rebase.c:1311
+#: builtin/rebase.c:1318
 msgid "be quiet. implies --no-stat"
 msgstr "weniger Ausgaben (impliziert --no-stat)"
 
-#: builtin/rebase.c:1317
+#: builtin/rebase.c:1324
 msgid "do not show diffstat of what changed upstream"
 msgstr ""
 "Zusammenfassung der Unterschiede gegenüber dem Upstream-Branch verbergen"
 
-#: builtin/rebase.c:1320
+#: builtin/rebase.c:1327
 msgid "add a Signed-off-by: line to each commit"
 msgstr "eine \"Signed-off-by:\"-Zeile zu jedem Commit hinzufügen"
 
-#: builtin/rebase.c:1322 builtin/rebase.c:1326 builtin/rebase.c:1328
-msgid "passed to 'git am'"
-msgstr "an 'git am' übergeben"
+#: builtin/rebase.c:1330
+#, fuzzy
+msgid "make committer date match author date"
+msgstr "über Commit-Ersteller anstatt Autor gruppieren"
 
-#: builtin/rebase.c:1330 builtin/rebase.c:1332
+#: builtin/rebase.c:1332
+msgid "ignore author date and use current date"
+msgstr ""
+
+#: builtin/rebase.c:1334
+#, fuzzy
+msgid "synonym of --reset-author-date"
+msgstr "Synonym für --files-with-matches"
+
+#: builtin/rebase.c:1336 builtin/rebase.c:1340
 msgid "passed to 'git apply'"
 msgstr "an 'git apply' übergeben"
 
-#: builtin/rebase.c:1334 builtin/rebase.c:1337
+#: builtin/rebase.c:1338
+#, fuzzy
+msgid "ignore changes in whitespace"
+msgstr "Whitespace-Änderungen am Zeilenende ignorieren"
+
+#: builtin/rebase.c:1342 builtin/rebase.c:1345
 msgid "cherry-pick all commits, even if unchanged"
 msgstr ""
 "Cherry-Pick auf alle Commits ausführen, auch wenn diese unverändert sind"
 
-#: builtin/rebase.c:1339
+#: builtin/rebase.c:1347
 msgid "continue"
 msgstr "fortsetzen"
 
-#: builtin/rebase.c:1342
+#: builtin/rebase.c:1350
 msgid "skip current patch and continue"
 msgstr "den aktuellen Patch auslassen und fortfahren"
 
-#: builtin/rebase.c:1344
+#: builtin/rebase.c:1352
 msgid "abort and check out the original branch"
 msgstr "abbrechen und den ursprünglichen Branch auschecken"
 
-#: builtin/rebase.c:1347
+#: builtin/rebase.c:1355
 msgid "abort but keep HEAD where it is"
 msgstr "abbrechen, aber HEAD an aktueller Stelle belassen"
 
-#: builtin/rebase.c:1348
+#: builtin/rebase.c:1356
 msgid "edit the todo list during an interactive rebase"
 msgstr "TODO-Liste während eines interaktiven Rebase bearbeiten"
 
-#: builtin/rebase.c:1351
+#: builtin/rebase.c:1359
 msgid "show the patch file being applied or merged"
 msgstr "den Patch, der gerade angewendet oder zusammengeführt wird, anzeigen"
 
-#: builtin/rebase.c:1354
+#: builtin/rebase.c:1362
 msgid "use apply strategies to rebase"
 msgstr "Strategien von 'git am' bei Rebase verwenden"
 
-#: builtin/rebase.c:1358
+#: builtin/rebase.c:1366
 msgid "use merging strategies to rebase"
 msgstr "Merge-Strategien beim Rebase verwenden"
 
-#: builtin/rebase.c:1362
+#: builtin/rebase.c:1370
 msgid "let the user edit the list of commits to rebase"
 msgstr "den Benutzer die Liste der Commits für den Rebase bearbeiten lassen"
 
-#: builtin/rebase.c:1366
+#: builtin/rebase.c:1374
 msgid "(DEPRECATED) try to recreate merges instead of ignoring them"
 msgstr ""
 "(VERALTET) Versuche, Merges wiederherzustellen anstatt sie zu ignorieren"
 
-#: builtin/rebase.c:1371
+#: builtin/rebase.c:1379
 msgid "how to handle commits that become empty"
 msgstr "wie sollen Commits behandelt werden, die leer werden"
 
-#: builtin/rebase.c:1378
+#: builtin/rebase.c:1386
 msgid "move commits that begin with squash!/fixup! under -i"
 msgstr "bei -i Commits verschieben, die mit squash!/fixup! beginnen"
 
-#: builtin/rebase.c:1385
+#: builtin/rebase.c:1393
 msgid "add exec lines after each commit of the editable list"
 msgstr "exec-Zeilen nach jedem Commit der editierbaren Liste hinzufügen"
 
-#: builtin/rebase.c:1389
+#: builtin/rebase.c:1397
 msgid "allow rebasing commits with empty messages"
 msgstr "Rebase von Commits mit leerer Beschreibung erlauben"
 
-#: builtin/rebase.c:1393
+#: builtin/rebase.c:1401
 msgid "try to rebase merges instead of skipping them"
 msgstr ""
 "versuchen, Rebase mit Merges auszuführen, anstatt diese zu überspringen"
 
-#: builtin/rebase.c:1396
+#: builtin/rebase.c:1404
 msgid "use 'merge-base --fork-point' to refine upstream"
 msgstr ""
 "'git merge-base --fork-point' benutzen, um Upstream-Branch zu bestimmen"
 
-#: builtin/rebase.c:1398
+#: builtin/rebase.c:1406
 msgid "use the given merge strategy"
 msgstr "angegebene Merge-Strategie verwenden"
 
-#: builtin/rebase.c:1400 builtin/revert.c:115
+#: builtin/rebase.c:1408 builtin/revert.c:115
 msgid "option"
 msgstr "Option"
 
-#: builtin/rebase.c:1401
+#: builtin/rebase.c:1409
 msgid "pass the argument through to the merge strategy"
 msgstr "Argument zur Merge-Strategie durchreichen"
 
-#: builtin/rebase.c:1404
+#: builtin/rebase.c:1412
 msgid "rebase all reachable commits up to the root(s)"
 msgstr "Rebase auf alle erreichbaren Commits bis zum Root-Commit ausführen"
 
-#: builtin/rebase.c:1409
+#: builtin/rebase.c:1417
 msgid "apply all changes, even those already present upstream"
 msgstr ""
 "alle Änderungen anwenden, auch jene, die bereits im Upstream-Branch "
 "vorhanden sind"
 
-#: builtin/rebase.c:1426
+#: builtin/rebase.c:1434
 msgid ""
 "the rebase.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -19267,44 +19725,44 @@ msgstr ""
 "Die Unterstützung für rebase.useBuiltin wurde entfernt!\n"
 "Siehe dessen Eintrag in 'git help config' für Details."
 
-#: builtin/rebase.c:1432
+#: builtin/rebase.c:1440
 msgid "It looks like 'git am' is in progress. Cannot rebase."
 msgstr "'git-am' scheint im Gange zu sein. Kann Rebase nicht durchführen."
 
-#: builtin/rebase.c:1473
+#: builtin/rebase.c:1481
 msgid ""
 "git rebase --preserve-merges is deprecated. Use --rebase-merges instead."
 msgstr ""
 "'git rebase --preserve-merges' ist veraltet. Benutzen Sie stattdessen '--"
 "rebase-merges'."
 
-#: builtin/rebase.c:1478
+#: builtin/rebase.c:1486
 msgid "cannot combine '--keep-base' with '--onto'"
 msgstr "'--keep-base' kann nicht mit '--onto' kombiniert werden"
 
-#: builtin/rebase.c:1480
+#: builtin/rebase.c:1488
 msgid "cannot combine '--keep-base' with '--root'"
 msgstr "'--keep-base' kann nicht mit '--root' kombiniert werden"
 
-#: builtin/rebase.c:1484
+#: builtin/rebase.c:1492
 msgid "cannot combine '--root' with '--fork-point'"
 msgstr "'--root' kann nicht mit '--fork-point' kombiniert werden"
 
-#: builtin/rebase.c:1487
+#: builtin/rebase.c:1495
 msgid "No rebase in progress?"
 msgstr "Kein Rebase im Gange?"
 
-#: builtin/rebase.c:1491
+#: builtin/rebase.c:1499
 msgid "The --edit-todo action can only be used during interactive rebase."
 msgstr ""
 "Die --edit-todo Aktion kann nur während eines interaktiven Rebase verwendet "
 "werden."
 
-#: builtin/rebase.c:1514
+#: builtin/rebase.c:1522
 msgid "Cannot read HEAD"
 msgstr "Kann HEAD nicht lesen"
 
-#: builtin/rebase.c:1526
+#: builtin/rebase.c:1534
 msgid ""
 "You must edit all merge conflicts and then\n"
 "mark them as resolved using git add"
@@ -19312,16 +19770,16 @@ msgstr ""
 "Sie müssen alle Merge-Konflikte editieren und diese dann\n"
 "mittels \"git add\" als aufgelöst markieren"
 
-#: builtin/rebase.c:1545
+#: builtin/rebase.c:1553
 msgid "could not discard worktree changes"
 msgstr "Konnte Änderungen im Arbeitsverzeichnis nicht verwerfen."
 
-#: builtin/rebase.c:1564
+#: builtin/rebase.c:1572
 #, c-format
 msgid "could not move back to %s"
 msgstr "Konnte nicht zu %s zurückgehen."
 
-#: builtin/rebase.c:1610
+#: builtin/rebase.c:1618
 #, c-format
 msgid ""
 "It seems that there is already a %s directory, and\n"
@@ -19342,138 +19800,138 @@ msgstr ""
 "und führen Sie diesen Befehl nochmal aus. Es wird angehalten, falls noch\n"
 "etwas Schützenswertes vorhanden ist.\n"
 
-#: builtin/rebase.c:1638
+#: builtin/rebase.c:1646
 msgid "switch `C' expects a numerical value"
 msgstr "Schalter `C' erwartet einen numerischen Wert."
 
-#: builtin/rebase.c:1680
+#: builtin/rebase.c:1688
 #, c-format
 msgid "Unknown mode: %s"
 msgstr "Unbekannter Modus: %s"
 
-#: builtin/rebase.c:1702
+#: builtin/rebase.c:1727
 msgid "--strategy requires --merge or --interactive"
 msgstr "--strategy erfordert --merge oder --interactive"
 
-#: builtin/rebase.c:1732
+#: builtin/rebase.c:1757
 msgid "cannot combine apply options with merge options"
 msgstr ""
 "Optionen für \"am\" können nicht mit Optionen für \"merge\" kombiniert "
 "werden."
 
-#: builtin/rebase.c:1745
+#: builtin/rebase.c:1770
 #, c-format
 msgid "Unknown rebase backend: %s"
 msgstr "Unbekanntes Rebase-Backend: %s"
 
-#: builtin/rebase.c:1770
+#: builtin/rebase.c:1795
 msgid "--reschedule-failed-exec requires --exec or --interactive"
 msgstr "--reschedule-failed-exec erfordert --exec oder --interactive"
 
-#: builtin/rebase.c:1790
+#: builtin/rebase.c:1815
 msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
 msgstr ""
 "'--preserve-merges' kann nicht mit '--rebase-merges' kombiniert werden."
 
-#: builtin/rebase.c:1794
+#: builtin/rebase.c:1819
 msgid ""
 "error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
 msgstr ""
 "Fehler: '--preserve-merges' kann nicht mit '--reschedule-failed-exec' "
 "kombiniert werden."
 
-#: builtin/rebase.c:1818
+#: builtin/rebase.c:1843
 #, c-format
 msgid "invalid upstream '%s'"
 msgstr "Ungültiger Upstream '%s'"
 
-#: builtin/rebase.c:1824
+#: builtin/rebase.c:1849
 msgid "Could not create new root commit"
 msgstr "Konnte neuen Root-Commit nicht erstellen."
 
-#: builtin/rebase.c:1850
+#: builtin/rebase.c:1875
 #, c-format
 msgid "'%s': need exactly one merge base with branch"
 msgstr "'%s': benötige genau eine Merge-Basis mit dem Branch"
 
-#: builtin/rebase.c:1853
+#: builtin/rebase.c:1878
 #, c-format
 msgid "'%s': need exactly one merge base"
 msgstr "'%s': benötige genau eine Merge-Basis"
 
-#: builtin/rebase.c:1861
+#: builtin/rebase.c:1886
 #, c-format
 msgid "Does not point to a valid commit '%s'"
 msgstr "'%s' zeigt auf keinen gültigen Commit."
 
-#: builtin/rebase.c:1887
+#: builtin/rebase.c:1912
 #, c-format
 msgid "fatal: no such branch/commit '%s'"
 msgstr "fatal: Branch/Commit '%s' nicht gefunden"
 
-#: builtin/rebase.c:1895 builtin/submodule--helper.c:40
-#: builtin/submodule--helper.c:1990
+#: builtin/rebase.c:1920 builtin/submodule--helper.c:40
+#: builtin/submodule--helper.c:2414
 #, c-format
 msgid "No such ref: %s"
 msgstr "Referenz nicht gefunden: %s"
 
-#: builtin/rebase.c:1906
+#: builtin/rebase.c:1931
 msgid "Could not resolve HEAD to a revision"
 msgstr "Konnte HEAD zu keinem Commit auflösen."
 
-#: builtin/rebase.c:1927
+#: builtin/rebase.c:1952
 msgid "Please commit or stash them."
 msgstr "Bitte committen Sie die Änderungen oder benutzen Sie \"stash\"."
 
-#: builtin/rebase.c:1963
+#: builtin/rebase.c:1988
 #, c-format
 msgid "could not switch to %s"
 msgstr "Konnte nicht zu %s wechseln."
 
-#: builtin/rebase.c:1974
+#: builtin/rebase.c:1999
 msgid "HEAD is up to date."
 msgstr "HEAD ist aktuell."
 
-#: builtin/rebase.c:1976
+#: builtin/rebase.c:2001
 #, c-format
 msgid "Current branch %s is up to date.\n"
 msgstr "Aktueller Branch %s ist auf dem neuesten Stand.\n"
 
-#: builtin/rebase.c:1984
+#: builtin/rebase.c:2009
 msgid "HEAD is up to date, rebase forced."
 msgstr "HEAD ist aktuell, Rebase erzwungen."
 
-#: builtin/rebase.c:1986
+#: builtin/rebase.c:2011
 #, c-format
 msgid "Current branch %s is up to date, rebase forced.\n"
 msgstr "Aktueller Branch %s ist auf dem neuesten Stand, Rebase erzwungen.\n"
 
-#: builtin/rebase.c:1994
+#: builtin/rebase.c:2019
 msgid "The pre-rebase hook refused to rebase."
 msgstr "Der \"pre-rebase hook\" hat den Rebase zurückgewiesen."
 
-#: builtin/rebase.c:2001
+#: builtin/rebase.c:2026
 #, c-format
 msgid "Changes to %s:\n"
 msgstr "Änderungen zu %s:\n"
 
-#: builtin/rebase.c:2004
+#: builtin/rebase.c:2029
 #, c-format
 msgid "Changes from %s to %s:\n"
 msgstr "Änderungen von %s zu %s:\n"
 
-#: builtin/rebase.c:2029
+#: builtin/rebase.c:2054
 #, c-format
 msgid "First, rewinding head to replay your work on top of it...\n"
 msgstr ""
 "Zunächst wird der Branch zurückgespult, um Ihre Änderungen darauf neu "
 "anzuwenden...\n"
 
-#: builtin/rebase.c:2038
+#: builtin/rebase.c:2063
 msgid "Could not detach HEAD"
 msgstr "Konnte HEAD nicht loslösen."
 
-#: builtin/rebase.c:2047
+#: builtin/rebase.c:2072
 #, c-format
 msgid "Fast-forwarded %s to %s.\n"
 msgstr "Spule %s vor zu %s.\n"
@@ -19482,7 +19940,7 @@ msgstr "Spule %s vor zu %s.\n"
 msgid "git receive-pack <git-dir>"
 msgstr "git receive-pack <Git-Verzeichnis>"
 
-#: builtin/receive-pack.c:844
+#: builtin/receive-pack.c:1224
 msgid ""
 "By default, updating the current branch in a non-bare repository\n"
 "is denied, because it will make the index and work tree inconsistent\n"
@@ -19514,7 +19972,7 @@ msgstr ""
 "setzen Sie die Konfigurationsvariable 'receive.denyCurrentBranch' auf\n"
 "'refuse'."
 
-#: builtin/receive-pack.c:864
+#: builtin/receive-pack.c:1244
 msgid ""
 "By default, deleting the current branch is denied, because the next\n"
 "'git clone' won't result in any file checked out, causing confusion.\n"
@@ -19535,11 +19993,11 @@ msgstr ""
 "\n"
 "Um diese Meldung zu unterdrücken, setzen Sie die Variable auf 'refuse'."
 
-#: builtin/receive-pack.c:1970
+#: builtin/receive-pack.c:2422
 msgid "quiet"
 msgstr "weniger Ausgaben"
 
-#: builtin/receive-pack.c:1984
+#: builtin/receive-pack.c:2436
 msgid "You must specify a directory."
 msgstr "Sie müssen ein Repository angeben."
 
@@ -19741,12 +20199,12 @@ msgstr ""
 "Die Angabe von zu folgenden Branches kann nur mit dem Anfordern von "
 "Spiegelarchiven verwendet werden."
 
-#: builtin/remote.c:195 builtin/remote.c:696
+#: builtin/remote.c:195 builtin/remote.c:697
 #, c-format
 msgid "remote %s already exists."
 msgstr "externes Repository %s existiert bereits"
 
-#: builtin/remote.c:199 builtin/remote.c:700
+#: builtin/remote.c:199 builtin/remote.c:701
 #, c-format
 msgid "'%s' is not a valid remote name"
 msgstr "'%s' ist kein gültiger Name für ein Remote-Repository"
@@ -19769,12 +20227,12 @@ msgstr "(übereinstimmend)"
 msgid "(delete)"
 msgstr "(lösche)"
 
-#: builtin/remote.c:653
+#: builtin/remote.c:654
 #, c-format
 msgid "could not set '%s'"
 msgstr "konnte '%s' nicht setzen"
 
-#: builtin/remote.c:658
+#: builtin/remote.c:659
 #, c-format
 msgid ""
 "The %s configuration remote.pushDefault in:\n"
@@ -19785,17 +20243,17 @@ msgstr ""
 "\t%s:%d\n"
 "benennt jetzt das nicht existierende Remote-Repository '%s'"
 
-#: builtin/remote.c:689 builtin/remote.c:832 builtin/remote.c:940
+#: builtin/remote.c:690 builtin/remote.c:833 builtin/remote.c:941
 #, c-format
 msgid "No such remote: '%s'"
 msgstr "Kein solches Remote-Repository: '%s'"
 
-#: builtin/remote.c:706
+#: builtin/remote.c:707
 #, c-format
 msgid "Could not rename config section '%s' to '%s'"
 msgstr "Konnte Sektion '%s' in Konfiguration nicht nach '%s' umbenennen"
 
-#: builtin/remote.c:726
+#: builtin/remote.c:727
 #, c-format
 msgid ""
 "Not updating non-default fetch refspec\n"
@@ -19806,17 +20264,17 @@ msgstr ""
 "\t%s\n"
 "\tBitte aktualisieren Sie, falls notwendig, die Konfiguration manuell."
 
-#: builtin/remote.c:766
+#: builtin/remote.c:767
 #, c-format
 msgid "deleting '%s' failed"
 msgstr "Konnte '%s' nicht löschen"
 
-#: builtin/remote.c:800
+#: builtin/remote.c:801
 #, c-format
 msgid "creating '%s' failed"
 msgstr "Konnte '%s' nicht erstellen"
 
-#: builtin/remote.c:876
+#: builtin/remote.c:877
 msgid ""
 "Note: A branch outside the refs/remotes/ hierarchy was not removed;\n"
 "to delete it, use:"
@@ -19832,118 +20290,118 @@ msgstr[1] ""
 "entfernt;\n"
 "um diese zu entfernen, benutzen Sie:"
 
-#: builtin/remote.c:890
+#: builtin/remote.c:891
 #, c-format
 msgid "Could not remove config section '%s'"
 msgstr "Konnte Sektion '%s' nicht aus Konfiguration entfernen"
 
-#: builtin/remote.c:993
+#: builtin/remote.c:994
 #, c-format
 msgid " new (next fetch will store in remotes/%s)"
 msgstr " neu (wird bei nächstem \"fetch\" in remotes/%s gespeichert)"
 
-#: builtin/remote.c:996
+#: builtin/remote.c:997
 msgid " tracked"
 msgstr " gefolgt"
 
-#: builtin/remote.c:998
+#: builtin/remote.c:999
 msgid " stale (use 'git remote prune' to remove)"
 msgstr " veraltet (benutzen Sie 'git remote prune' zum Löschen)"
 
-#: builtin/remote.c:1000
+#: builtin/remote.c:1001
 msgid " ???"
 msgstr " ???"
 
-#: builtin/remote.c:1041
+#: builtin/remote.c:1042
 #, c-format
 msgid "invalid branch.%s.merge; cannot rebase onto > 1 branch"
 msgstr "ungültiges branch.%s.merge; kann Rebase nicht auf > 1 Branch ausführen"
 
-#: builtin/remote.c:1050
+#: builtin/remote.c:1051
 #, c-format
 msgid "rebases interactively onto remote %s"
 msgstr "interaktiver Rebase auf Remote-Branch %s"
 
-#: builtin/remote.c:1052
+#: builtin/remote.c:1053
 #, c-format
 msgid "rebases interactively (with merges) onto remote %s"
 msgstr "interaktiver Rebase (mit Merges) auf Remote-Branch %s"
 
-#: builtin/remote.c:1055
+#: builtin/remote.c:1056
 #, c-format
 msgid "rebases onto remote %s"
 msgstr "Rebase auf Remote-Branch %s"
 
-#: builtin/remote.c:1059
+#: builtin/remote.c:1060
 #, c-format
 msgid " merges with remote %s"
 msgstr " führt mit Remote-Branch %s zusammen"
 
-#: builtin/remote.c:1062
+#: builtin/remote.c:1063
 #, c-format
 msgid "merges with remote %s"
 msgstr "führt mit Remote-Branch %s zusammen"
 
-#: builtin/remote.c:1065
+#: builtin/remote.c:1066
 #, c-format
 msgid "%-*s    and with remote %s\n"
 msgstr "%-*s    und mit Remote-Branch %s\n"
 
-#: builtin/remote.c:1108
+#: builtin/remote.c:1109
 msgid "create"
 msgstr "erstellt"
 
-#: builtin/remote.c:1111
+#: builtin/remote.c:1112
 msgid "delete"
 msgstr "gelöscht"
 
-#: builtin/remote.c:1115
+#: builtin/remote.c:1116
 msgid "up to date"
 msgstr "aktuell"
 
-#: builtin/remote.c:1118
+#: builtin/remote.c:1119
 msgid "fast-forwardable"
 msgstr "vorspulbar"
 
-#: builtin/remote.c:1121
+#: builtin/remote.c:1122
 msgid "local out of date"
 msgstr "lokal nicht aktuell"
 
-#: builtin/remote.c:1128
+#: builtin/remote.c:1129
 #, c-format
 msgid "    %-*s forces to %-*s (%s)"
 msgstr "    %-*s erzwingt Versandt nach %-*s (%s)"
 
-#: builtin/remote.c:1131
+#: builtin/remote.c:1132
 #, c-format
 msgid "    %-*s pushes to %-*s (%s)"
 msgstr "    %-*s versendet nach %-*s (%s)"
 
-#: builtin/remote.c:1135
+#: builtin/remote.c:1136
 #, c-format
 msgid "    %-*s forces to %s"
 msgstr "    %-*s erzwingt Versand nach %s"
 
-#: builtin/remote.c:1138
+#: builtin/remote.c:1139
 #, c-format
 msgid "    %-*s pushes to %s"
 msgstr "    %-*s versendet nach %s"
 
-#: builtin/remote.c:1206
+#: builtin/remote.c:1207
 msgid "do not query remotes"
 msgstr "keine Abfrage von Remote-Repositories"
 
-#: builtin/remote.c:1233
+#: builtin/remote.c:1234
 #, c-format
 msgid "* remote %s"
 msgstr "* Remote-Repository %s"
 
-#: builtin/remote.c:1234
+#: builtin/remote.c:1235
 #, c-format
 msgid "  Fetch URL: %s"
 msgstr "  URL zum Abholen: %s"
 
-#: builtin/remote.c:1235 builtin/remote.c:1251 builtin/remote.c:1390
+#: builtin/remote.c:1236 builtin/remote.c:1252 builtin/remote.c:1391
 msgid "(no URL)"
 msgstr "(keine URL)"
 
@@ -19951,25 +20409,25 @@ msgstr "(keine URL)"
 #. with the one in " Fetch URL: %s"
 #. translation.
 #.
-#: builtin/remote.c:1249 builtin/remote.c:1251
+#: builtin/remote.c:1250 builtin/remote.c:1252
 #, c-format
 msgid "  Push  URL: %s"
 msgstr "  URL zum Versenden: %s"
 
-#: builtin/remote.c:1253 builtin/remote.c:1255 builtin/remote.c:1257
+#: builtin/remote.c:1254 builtin/remote.c:1256 builtin/remote.c:1258
 #, c-format
 msgid "  HEAD branch: %s"
 msgstr "  Hauptbranch: %s"
 
-#: builtin/remote.c:1253
+#: builtin/remote.c:1254
 msgid "(not queried)"
 msgstr "(nicht abgefragt)"
 
-#: builtin/remote.c:1255
+#: builtin/remote.c:1256
 msgid "(unknown)"
 msgstr "(unbekannt)"
 
-#: builtin/remote.c:1259
+#: builtin/remote.c:1260
 #, c-format
 msgid ""
 "  HEAD branch (remote HEAD is ambiguous, may be one of the following):\n"
@@ -19977,155 +20435,155 @@ msgstr ""
 "  Hauptbranch (externer HEAD ist mehrdeutig, könnte einer der folgenden "
 "sein):\n"
 
-#: builtin/remote.c:1271
+#: builtin/remote.c:1272
 #, c-format
 msgid "  Remote branch:%s"
 msgid_plural "  Remote branches:%s"
 msgstr[0] "  Remote-Branch:%s"
 msgstr[1] "  Remote-Branches:%s"
 
-#: builtin/remote.c:1274 builtin/remote.c:1300
+#: builtin/remote.c:1275 builtin/remote.c:1301
 msgid " (status not queried)"
 msgstr " (Zustand nicht abgefragt)"
 
-#: builtin/remote.c:1283
+#: builtin/remote.c:1284
 msgid "  Local branch configured for 'git pull':"
 msgid_plural "  Local branches configured for 'git pull':"
 msgstr[0] "  Lokaler Branch konfiguriert für 'git pull':"
 msgstr[1] "  Lokale Branches konfiguriert für 'git pull':"
 
-#: builtin/remote.c:1291
+#: builtin/remote.c:1292
 msgid "  Local refs will be mirrored by 'git push'"
 msgstr "  Lokale Referenzen werden von 'git push' gespiegelt"
 
-#: builtin/remote.c:1297
+#: builtin/remote.c:1298
 #, c-format
 msgid "  Local ref configured for 'git push'%s:"
 msgid_plural "  Local refs configured for 'git push'%s:"
 msgstr[0] "  Lokale Referenz konfiguriert für 'git push'%s:"
 msgstr[1] "  Lokale Referenzen konfiguriert für 'git push'%s:"
 
-#: builtin/remote.c:1318
+#: builtin/remote.c:1319
 msgid "set refs/remotes/<name>/HEAD according to remote"
 msgstr "setzt refs/remotes/<Name>/HEAD gemäß dem Remote-Repository"
 
-#: builtin/remote.c:1320
+#: builtin/remote.c:1321
 msgid "delete refs/remotes/<name>/HEAD"
 msgstr "entfernt refs/remotes/<Name>/HEAD"
 
-#: builtin/remote.c:1335
+#: builtin/remote.c:1336
 msgid "Cannot determine remote HEAD"
 msgstr "Kann HEAD des Remote-Repositories nicht bestimmen"
 
-#: builtin/remote.c:1337
+#: builtin/remote.c:1338
 msgid "Multiple remote HEAD branches. Please choose one explicitly with:"
 msgstr ""
 "Mehrere Hauptbranches im Remote-Repository. Bitte wählen Sie explizit einen "
 "aus mit:"
 
-#: builtin/remote.c:1347
+#: builtin/remote.c:1348
 #, c-format
 msgid "Could not delete %s"
 msgstr "Konnte %s nicht entfernen"
 
-#: builtin/remote.c:1355
+#: builtin/remote.c:1356
 #, c-format
 msgid "Not a valid ref: %s"
 msgstr "keine gültige Referenz: %s"
 
-#: builtin/remote.c:1357
+#: builtin/remote.c:1358
 #, c-format
 msgid "Could not setup %s"
 msgstr "Konnte %s nicht einrichten"
 
-#: builtin/remote.c:1375
+#: builtin/remote.c:1376
 #, c-format
 msgid " %s will become dangling!"
 msgstr " %s wird unreferenziert!"
 
-#: builtin/remote.c:1376
+#: builtin/remote.c:1377
 #, c-format
 msgid " %s has become dangling!"
 msgstr " %s wurde unreferenziert!"
 
-#: builtin/remote.c:1386
+#: builtin/remote.c:1387
 #, c-format
 msgid "Pruning %s"
 msgstr "entferne veraltete Branches von %s"
 
-#: builtin/remote.c:1387
+#: builtin/remote.c:1388
 #, c-format
 msgid "URL: %s"
 msgstr "URL: %s"
 
-#: builtin/remote.c:1403
+#: builtin/remote.c:1404
 #, c-format
 msgid " * [would prune] %s"
 msgstr " * [würde veralteten Branch entfernen] %s"
 
-#: builtin/remote.c:1406
+#: builtin/remote.c:1407
 #, c-format
 msgid " * [pruned] %s"
 msgstr "* [veralteten Branch entfernt] %s"
 
-#: builtin/remote.c:1451
+#: builtin/remote.c:1452
 msgid "prune remotes after fetching"
 msgstr "entferne veraltete Branches im Remote-Repository nach \"fetch\""
 
-#: builtin/remote.c:1514 builtin/remote.c:1568 builtin/remote.c:1636
+#: builtin/remote.c:1515 builtin/remote.c:1569 builtin/remote.c:1637
 #, c-format
 msgid "No such remote '%s'"
 msgstr "Kein solches Remote-Repository '%s'"
 
-#: builtin/remote.c:1530
+#: builtin/remote.c:1531
 msgid "add branch"
 msgstr "Branch hinzufügen"
 
-#: builtin/remote.c:1537
+#: builtin/remote.c:1538
 msgid "no remote specified"
 msgstr "kein Remote-Repository angegeben"
 
-#: builtin/remote.c:1554
+#: builtin/remote.c:1555
 msgid "query push URLs rather than fetch URLs"
 msgstr "nur URLs für Push ausgeben"
 
-#: builtin/remote.c:1556
+#: builtin/remote.c:1557
 msgid "return all URLs"
 msgstr "alle URLs ausgeben"
 
-#: builtin/remote.c:1584
+#: builtin/remote.c:1585
 #, c-format
 msgid "no URLs configured for remote '%s'"
 msgstr "Keine URLs für Remote-Repository '%s' konfiguriert."
 
-#: builtin/remote.c:1610
+#: builtin/remote.c:1611
 msgid "manipulate push URLs"
 msgstr "URLs für \"push\" manipulieren"
 
-#: builtin/remote.c:1612
+#: builtin/remote.c:1613
 msgid "add URL"
 msgstr "URL hinzufügen"
 
-#: builtin/remote.c:1614
+#: builtin/remote.c:1615
 msgid "delete URLs"
 msgstr "URLs löschen"
 
-#: builtin/remote.c:1621
+#: builtin/remote.c:1622
 msgid "--add --delete doesn't make sense"
 msgstr ""
 "Die Optionen --add und --delete können nicht gemeinsam verwendet werden."
 
-#: builtin/remote.c:1660
+#: builtin/remote.c:1661
 #, c-format
 msgid "Invalid old URL pattern: %s"
 msgstr "ungültiges altes URL Format: %s"
 
-#: builtin/remote.c:1668
+#: builtin/remote.c:1669
 #, c-format
 msgid "No such URL found: %s"
 msgstr "Keine solche URL gefunden: %s"
 
-#: builtin/remote.c:1670
+#: builtin/remote.c:1671
 msgid "Will not delete all non-push URLs"
 msgstr "Werde keine URLs entfernen, die nicht für \"push\" bestimmt sind"
 
@@ -20142,119 +20600,119 @@ msgstr ""
 "--no-write-bitmap-index oder deaktivieren Sie die pack.writebitmaps\n"
 "Konfiguration."
 
-#: builtin/repack.c:193
+#: builtin/repack.c:197
 msgid "could not start pack-objects to repack promisor objects"
 msgstr ""
 "Konnte 'pack-objects' für das Neupacken von Objekten aus partiell geklonten\n"
 "Remote-Repositories nicht starten."
 
-#: builtin/repack.c:232 builtin/repack.c:418
+#: builtin/repack.c:236 builtin/repack.c:421
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
 msgstr ""
 "repack: Erwarte Zeilen mit vollständiger Hex-Objekt-ID nur von pack-objects."
 
-#: builtin/repack.c:256
+#: builtin/repack.c:260
 msgid "could not finish pack-objects to repack promisor objects"
 msgstr ""
 "Konnte 'pack-objects' für das Neupacken von Objekten aus partiell geklonten\n"
 "Remote-Repositories nicht abschließen."
 
-#: builtin/repack.c:294
+#: builtin/repack.c:297
 msgid "pack everything in a single pack"
 msgstr "alles in eine einzige Pack-Datei packen"
 
-#: builtin/repack.c:296
+#: builtin/repack.c:299
 msgid "same as -a, and turn unreachable objects loose"
 msgstr "genau wie -a, unerreichbare Objekte werden aber nicht gelöscht"
 
-#: builtin/repack.c:299
+#: builtin/repack.c:302
 msgid "remove redundant packs, and run git-prune-packed"
 msgstr "redundante Pakete entfernen und \"git-prune-packed\" ausführen"
 
-#: builtin/repack.c:301
+#: builtin/repack.c:304
 msgid "pass --no-reuse-delta to git-pack-objects"
 msgstr "--no-reuse-delta an git-pack-objects übergeben"
 
-#: builtin/repack.c:303
+#: builtin/repack.c:306
 msgid "pass --no-reuse-object to git-pack-objects"
 msgstr "--no-reuse-object an git-pack-objects übergeben"
 
-#: builtin/repack.c:305
+#: builtin/repack.c:308
 msgid "do not run git-update-server-info"
 msgstr "git-update-server-info nicht ausführen"
 
-#: builtin/repack.c:308
+#: builtin/repack.c:311
 msgid "pass --local to git-pack-objects"
 msgstr "--local an git-pack-objects übergeben"
 
-#: builtin/repack.c:310
+#: builtin/repack.c:313
 msgid "write bitmap index"
 msgstr "Bitmap-Index schreiben"
 
-#: builtin/repack.c:312
+#: builtin/repack.c:315
 msgid "pass --delta-islands to git-pack-objects"
 msgstr "--delta-islands an git-pack-objects übergeben"
 
-#: builtin/repack.c:313
+#: builtin/repack.c:316
 msgid "approxidate"
 msgstr "Datumsangabe"
 
-#: builtin/repack.c:314
+#: builtin/repack.c:317
 msgid "with -A, do not loosen objects older than this"
 msgstr "mit -A, keine Objekte älter als dieses Datum löschen"
 
-#: builtin/repack.c:316
+#: builtin/repack.c:319
 msgid "with -a, repack unreachable objects"
 msgstr "mit -a, nicht erreichbare Objekte neu packen"
 
-#: builtin/repack.c:318
+#: builtin/repack.c:321
 msgid "size of the window used for delta compression"
 msgstr "Größe des Fensters für die Delta-Kompression"
 
-#: builtin/repack.c:319 builtin/repack.c:325
+#: builtin/repack.c:322 builtin/repack.c:328
 msgid "bytes"
 msgstr "Bytes"
 
-#: builtin/repack.c:320
+#: builtin/repack.c:323
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr ""
 "gleiches wie oben, aber die Speichergröße anstatt der\n"
 "Anzahl der Einträge limitieren"
 
-#: builtin/repack.c:322
+#: builtin/repack.c:325
 msgid "limits the maximum delta depth"
 msgstr "die maximale Delta-Tiefe limitieren"
 
-#: builtin/repack.c:324
+#: builtin/repack.c:327
 msgid "limits the maximum number of threads"
 msgstr "maximale Anzahl von Threads limitieren"
 
-#: builtin/repack.c:326
+#: builtin/repack.c:329
 msgid "maximum size of each packfile"
 msgstr "maximale Größe für jede Paketdatei"
 
-#: builtin/repack.c:328
+#: builtin/repack.c:331
 msgid "repack objects in packs marked with .keep"
 msgstr ""
 "Objekte umpacken, die sich in mit .keep markierten Pack-Dateien befinden"
 
-#: builtin/repack.c:330
+#: builtin/repack.c:333
 msgid "do not repack this pack"
 msgstr "dieses Paket nicht neu packen"
 
-#: builtin/repack.c:340
+#: builtin/repack.c:343
 msgid "cannot delete packs in a precious-objects repo"
 msgstr "kann Pack-Dateien in precious-objects Repository nicht löschen"
 
-#: builtin/repack.c:344
+#: builtin/repack.c:347
 msgid "--keep-unreachable and -A are incompatible"
 msgstr "--keep-unreachable und -A sind inkompatibel"
 
-#: builtin/repack.c:427
+#: builtin/repack.c:430
 msgid "Nothing new to pack."
 msgstr "Nichts Neues zum Packen."
 
-#: builtin/repack.c:488
+#: builtin/repack.c:486
 #, c-format
 msgid ""
 "WARNING: Some packs in use have been renamed by\n"
@@ -20273,7 +20731,7 @@ msgstr ""
 "WARNUNG: ebenfalls fehl.\n"
 "WARNUNG: Bitte benennen Sie diese manuell nach %s um:\n"
 
-#: builtin/repack.c:536
+#: builtin/repack.c:534
 #, c-format
 msgid "failed to remove '%s'"
 msgstr "Fehler beim Löschen von '%s'"
@@ -20932,55 +21390,78 @@ msgstr ""
 "  --all und die explizite Angabe einer <Referenz> schließen sich gegenseitig "
 "aus."
 
-#: builtin/send-pack.c:163
+#: builtin/send-pack.c:182
 msgid "remote name"
 msgstr "Name des Remote-Repositories"
 
-#: builtin/send-pack.c:176
+#: builtin/send-pack.c:195
 msgid "use stateless RPC protocol"
 msgstr "zustandsloses RPC-Protokoll verwenden"
 
-#: builtin/send-pack.c:177
+#: builtin/send-pack.c:196
 msgid "read refs from stdin"
 msgstr "Referenzen von der Standard-Eingabe lesen"
 
-#: builtin/send-pack.c:178
+#: builtin/send-pack.c:197
 msgid "print status from remote helper"
 msgstr "Status des Remote-Helpers ausgeben"
 
-#: builtin/shortlog.c:14
+#: builtin/shortlog.c:15
 msgid "git shortlog [<options>] [<revision-range>] [[--] <path>...]"
 msgstr "git shortlog [<Optionen>] [<Commitbereich>] [[--] <Pfad>...]"
 
-#: builtin/shortlog.c:15
+#: builtin/shortlog.c:16
 msgid "git log --pretty=short | git shortlog [<options>]"
 msgstr "git log --pretty=short | git shortlog [<Optionen>]"
 
-#: builtin/shortlog.c:264
+#: builtin/shortlog.c:134
+#, fuzzy
+msgid "using multiple --group options with stdin is not supported"
+msgstr "Das Schreiben in die Standard-Eingabe wird nicht unterstützt."
+
+#: builtin/shortlog.c:144
+#, fuzzy
+msgid "using --group=trailer with stdin is not supported"
+msgstr "Das Schreiben in die Standard-Eingabe wird nicht unterstützt."
+
+#: builtin/shortlog.c:388
+#, fuzzy, c-format
+msgid "unknown group type: %s"
+msgstr "Unbekannter Typ: %d"
+
+#: builtin/shortlog.c:416
 msgid "Group by committer rather than author"
 msgstr "über Commit-Ersteller anstatt Autor gruppieren"
 
-#: builtin/shortlog.c:266
+#: builtin/shortlog.c:419
 msgid "sort output according to the number of commits per author"
 msgstr "die Ausgabe entsprechend der Anzahl von Commits pro Autor sortieren"
 
-#: builtin/shortlog.c:268
+#: builtin/shortlog.c:421
 msgid "Suppress commit descriptions, only provides commit count"
 msgstr "Commit-Beschreibungen unterdrücken, nur Anzahl der Commits liefern"
 
-#: builtin/shortlog.c:270
+#: builtin/shortlog.c:423
 msgid "Show the email address of each author"
 msgstr "die E-Mail-Adresse von jedem Autor anzeigen"
 
-#: builtin/shortlog.c:271
+#: builtin/shortlog.c:424
 msgid "<w>[,<i1>[,<i2>]]"
 msgstr "<w>[,<i1>[,<i2>]]"
 
-#: builtin/shortlog.c:272
+#: builtin/shortlog.c:425
 msgid "Linewrap output"
 msgstr "Ausgabe mit Zeilenumbrüchen"
 
-#: builtin/shortlog.c:301
+#: builtin/shortlog.c:427
+msgid "field"
+msgstr ""
+
+#: builtin/shortlog.c:428
+msgid "Group by field"
+msgstr ""
+
+#: builtin/shortlog.c:456
 msgid "too many arguments given outside repository"
 msgstr "zu viele Argumente außerhalb des Repositories angegeben"
 
@@ -21181,64 +21662,79 @@ msgstr ""
 msgid "git sparse-checkout (init|list|set|add|reapply|disable) <options>"
 msgstr "git sparse-checkout (init|list|set|add|reapply|disable) <Optionen>"
 
-#: builtin/sparse-checkout.c:64
+#: builtin/sparse-checkout.c:50
+#, fuzzy
+msgid "git sparse-checkout list"
+msgstr "git sparse-checkout init [--cone]"
+
+#: builtin/sparse-checkout.c:76
 msgid "this worktree is not sparse (sparse-checkout file may not exist)"
 msgstr ""
 "dieses Arbeitsverzeichnis ist nicht partiell (Datei für partieller Checkout "
 "existiert eventuell nicht)"
 
-#: builtin/sparse-checkout.c:216
+#: builtin/sparse-checkout.c:228
 msgid "failed to create directory for sparse-checkout file"
 msgstr ""
 "Fehler beim Erstellen eines Verzeichnisses für Datei eines partiellen "
 "Checkouts"
 
-#: builtin/sparse-checkout.c:257
+#: builtin/sparse-checkout.c:269
 msgid "unable to upgrade repository format to enable worktreeConfig"
 msgstr ""
 "Repository-Format konnte nicht erweitert werden, um worktreeConfig zu "
 "aktivieren"
 
-#: builtin/sparse-checkout.c:259
+#: builtin/sparse-checkout.c:271
 msgid "failed to set extensions.worktreeConfig setting"
 msgstr "Einstellung für extensions.worktreeConfig konnte nicht gesetzt werden"
 
-#: builtin/sparse-checkout.c:276
+#: builtin/sparse-checkout.c:288
 msgid "git sparse-checkout init [--cone]"
 msgstr "git sparse-checkout init [--cone]"
 
-#: builtin/sparse-checkout.c:295
+#: builtin/sparse-checkout.c:307
 msgid "initialize the sparse-checkout in cone mode"
 msgstr "initialisiere den partiellen Checkout im Cone-Modus"
 
-#: builtin/sparse-checkout.c:332
+#: builtin/sparse-checkout.c:344
 #, c-format
 msgid "failed to open '%s'"
 msgstr "Fehler beim Öffnen von '%s'"
 
-#: builtin/sparse-checkout.c:389
+#: builtin/sparse-checkout.c:401
 #, c-format
 msgid "could not normalize path %s"
 msgstr "konnte Pfad '%s' nicht normalisieren"
 
-#: builtin/sparse-checkout.c:401
+#: builtin/sparse-checkout.c:413
 msgid "git sparse-checkout (set|add) (--stdin | <patterns>)"
 msgstr "git sparse-checkout (set|add) (--stdin | <Muster>)"
 
-#: builtin/sparse-checkout.c:426
+#: builtin/sparse-checkout.c:438
 #, c-format
 msgid "unable to unquote C-style string '%s'"
 msgstr "konnte Anführungszeichen von C-Style Zeichenkette '%s' nicht entfernen"
 
-#: builtin/sparse-checkout.c:480 builtin/sparse-checkout.c:504
+#: builtin/sparse-checkout.c:492 builtin/sparse-checkout.c:516
 msgid "unable to load existing sparse-checkout patterns"
 msgstr "konnte die existierenden Muster des partiellen Checkouts nicht laden"
 
-#: builtin/sparse-checkout.c:549
+#: builtin/sparse-checkout.c:561
 msgid "read patterns from standard in"
 msgstr "Muster von der Standard-Eingabe lesen"
 
-#: builtin/sparse-checkout.c:586
+#: builtin/sparse-checkout.c:576
+#, fuzzy
+msgid "git sparse-checkout reapply"
+msgstr "git sparse-checkout init [--cone]"
+
+#: builtin/sparse-checkout.c:595
+#, fuzzy
+msgid "git sparse-checkout disable"
+msgstr "git sparse-checkout init [--cone]"
+
+#: builtin/sparse-checkout.c:623
 msgid "error while refreshing working directory"
 msgstr "Fehler während der Aktualisierung des Arbeitsverzeichnisses."
 
@@ -21395,7 +21891,7 @@ msgstr "Kein Branchname spezifiziert"
 msgid "Cannot update %s with %s"
 msgstr "Kann nicht %s mit %s aktualisieren."
 
-#: builtin/stash.c:818 builtin/stash.c:1475 builtin/stash.c:1540
+#: builtin/stash.c:818 builtin/stash.c:1472 builtin/stash.c:1537
 msgid "stash message"
 msgstr "Stash-Beschreibung"
 
@@ -21403,81 +21899,81 @@ msgstr "Stash-Beschreibung"
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "\"git stash store\" erwartet ein Argument <Commit>"
 
-#: builtin/stash.c:1046
+#: builtin/stash.c:1043
 msgid "No changes selected"
 msgstr "Keine Änderungen ausgewählt"
 
-#: builtin/stash.c:1146
+#: builtin/stash.c:1143
 msgid "You do not have the initial commit yet"
 msgstr "Sie haben bisher noch keinen initialen Commit"
 
-#: builtin/stash.c:1173
+#: builtin/stash.c:1170
 msgid "Cannot save the current index state"
 msgstr "Kann den aktuellen Zustand des Index nicht speichern"
 
-#: builtin/stash.c:1182
+#: builtin/stash.c:1179
 msgid "Cannot save the untracked files"
 msgstr "Kann die unversionierten Dateien nicht speichern"
 
-#: builtin/stash.c:1193 builtin/stash.c:1202
+#: builtin/stash.c:1190 builtin/stash.c:1199
 msgid "Cannot save the current worktree state"
 msgstr "Kann den aktuellen Zustand des Arbeitsverzeichnisses nicht speichern"
 
-#: builtin/stash.c:1230
+#: builtin/stash.c:1227
 msgid "Cannot record working tree state"
 msgstr "Kann Zustand des Arbeitsverzeichnisses nicht aufzeichnen"
 
-#: builtin/stash.c:1279
+#: builtin/stash.c:1276
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr ""
 "Kann nicht gleichzeitig --patch und --include-untracked oder --all verwenden"
 
-#: builtin/stash.c:1295
+#: builtin/stash.c:1292
 msgid "Did you forget to 'git add'?"
 msgstr "Haben Sie vielleicht 'git add' vergessen?"
 
-#: builtin/stash.c:1310
+#: builtin/stash.c:1307
 msgid "No local changes to save"
 msgstr "Keine lokalen Änderungen zum Speichern"
 
-#: builtin/stash.c:1317
+#: builtin/stash.c:1314
 msgid "Cannot initialize stash"
 msgstr "Kann \"stash\" nicht initialisieren"
 
-#: builtin/stash.c:1332
+#: builtin/stash.c:1329
 msgid "Cannot save the current status"
 msgstr "Kann den aktuellen Status nicht speichern"
 
-#: builtin/stash.c:1337
+#: builtin/stash.c:1334
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "Arbeitsverzeichnis und Index-Status %s gespeichert."
 
-#: builtin/stash.c:1427
+#: builtin/stash.c:1424
 msgid "Cannot remove worktree changes"
 msgstr "Kann Änderungen im Arbeitsverzeichnis nicht löschen"
 
-#: builtin/stash.c:1466 builtin/stash.c:1531
+#: builtin/stash.c:1463 builtin/stash.c:1528
 msgid "keep index"
 msgstr "behalte Index"
 
-#: builtin/stash.c:1468 builtin/stash.c:1533
+#: builtin/stash.c:1465 builtin/stash.c:1530
 msgid "stash in patch mode"
 msgstr "Stash in Patch-Modus"
 
-#: builtin/stash.c:1469 builtin/stash.c:1534
+#: builtin/stash.c:1466 builtin/stash.c:1531
 msgid "quiet mode"
 msgstr "weniger Ausgaben"
 
-#: builtin/stash.c:1471 builtin/stash.c:1536
+#: builtin/stash.c:1468 builtin/stash.c:1533
 msgid "include untracked files in stash"
 msgstr "unversionierte Dateien in Stash einbeziehen"
 
-#: builtin/stash.c:1473 builtin/stash.c:1538
+#: builtin/stash.c:1470 builtin/stash.c:1535
 msgid "include ignore files"
 msgstr "ignorierte Dateien einbeziehen"
 
-#: builtin/stash.c:1573
+#: builtin/stash.c:1570
 msgid ""
 "the stash.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -21503,7 +21999,7 @@ msgstr ""
 msgid "prepend comment character and space to each line"
 msgstr "Kommentarzeichen mit Leerzeichen an jede Zeile voranstellen"
 
-#: builtin/submodule--helper.c:47 builtin/submodule--helper.c:1999
+#: builtin/submodule--helper.c:47 builtin/submodule--helper.c:2423
 #, c-format
 msgid "Expecting a full ref name, got %s"
 msgstr "Vollständiger Referenzname erwartet, %s erhalten"
@@ -21517,7 +22013,7 @@ msgstr "'submodule--helper print-default-remote' erwartet keine Argumente."
 msgid "cannot strip one component off url '%s'"
 msgstr "Kann eine Komponente von URL '%s' nicht extrahieren"
 
-#: builtin/submodule--helper.c:410 builtin/submodule--helper.c:1395
+#: builtin/submodule--helper.c:410 builtin/submodule--helper.c:1819
 msgid "alternative anchor for relative paths"
 msgstr "Alternativer Anker für relative Pfade"
 
@@ -21525,8 +22021,8 @@ msgstr "Alternativer Anker für relative Pfade"
 msgid "git submodule--helper list [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper list [--prefix=<Pfad>] [<Pfad>...]"
 
-#: builtin/submodule--helper.c:472 builtin/submodule--helper.c:630
-#: builtin/submodule--helper.c:653
+#: builtin/submodule--helper.c:472 builtin/submodule--helper.c:629
+#: builtin/submodule--helper.c:652
 #, c-format
 msgid "No url found for submodule path '%s' in .gitmodules"
 msgstr "Keine URL für Submodul-Pfad '%s' in .gitmodules gefunden"
@@ -21563,7 +22059,7 @@ msgstr ""
 "Ausgaben beim Betreten und der Befehlsausführung in einem Submodul "
 "unterdrücken"
 
-#: builtin/submodule--helper.c:567 builtin/submodule--helper.c:1063
+#: builtin/submodule--helper.c:567 builtin/submodule--helper.c:1487
 msgid "Recurse into nested submodules"
 msgstr "Rekursion in verschachtelte Submodule durchführen"
 
@@ -21580,104 +22076,165 @@ msgstr ""
 "Konnte Konfiguration '%s' nicht nachschlagen. Nehme an, dass dieses\n"
 "Repository sein eigenes verbindliches Upstream-Repository ist."
 
-#: builtin/submodule--helper.c:667
+#: builtin/submodule--helper.c:666
 #, c-format
 msgid "Failed to register url for submodule path '%s'"
 msgstr ""
 "Fehler beim Eintragen der URL für Submodul-Pfad '%s' in die Konfiguration."
 
-#: builtin/submodule--helper.c:671
+#: builtin/submodule--helper.c:670
 #, c-format
 msgid "Submodule '%s' (%s) registered for path '%s'\n"
 msgstr "Submodul '%s' (%s) für Pfad '%s' in die Konfiguration eingetragen.\n"
 
-#: builtin/submodule--helper.c:681
+#: builtin/submodule--helper.c:680
 #, c-format
 msgid "warning: command update mode suggested for submodule '%s'\n"
 msgstr "Warnung: 'update'-Modus für Submodul '%s' vorgeschlagen\n"
 
-#: builtin/submodule--helper.c:688
+#: builtin/submodule--helper.c:687
 #, c-format
 msgid "Failed to register update mode for submodule path '%s'"
 msgstr ""
 "Fehler bei Änderung des Aktualisierungsmodus für Submodul-Pfad '%s' in der\n"
 "Konfiguration."
 
-#: builtin/submodule--helper.c:710
+#: builtin/submodule--helper.c:709
 msgid "Suppress output for initializing a submodule"
 msgstr "Ausgaben bei Initialisierung eines Submoduls unterdrücken"
 
-#: builtin/submodule--helper.c:715
+#: builtin/submodule--helper.c:714
 msgid "git submodule--helper init [<options>] [<path>]"
 msgstr "git submodule--helper init [<Optionen>] [<Pfad>]"
 
-#: builtin/submodule--helper.c:789 builtin/submodule--helper.c:924
+#: builtin/submodule--helper.c:787 builtin/submodule--helper.c:922
 #, c-format
 msgid "no submodule mapping found in .gitmodules for path '%s'"
 msgstr "Keine Submodul-Zuordnung in .gitmodules für Pfad '%s' gefunden"
 
-#: builtin/submodule--helper.c:837
+#: builtin/submodule--helper.c:835
 #, c-format
 msgid "could not resolve HEAD ref inside the submodule '%s'"
 msgstr "Konnte HEAD-Referenz nicht innerhalb des Submodul-Pfads '%s' auflösen."
 
-#: builtin/submodule--helper.c:864 builtin/submodule--helper.c:1033
+#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1457
 #, c-format
 msgid "failed to recurse into submodule '%s'"
 msgstr "Fehler bei Rekursion in Submodul '%s'."
 
-#: builtin/submodule--helper.c:888 builtin/submodule--helper.c:1199
+#: builtin/submodule--helper.c:886 builtin/submodule--helper.c:1623
 msgid "Suppress submodule status output"
 msgstr "Ausgabe über Submodul-Status unterdrücken"
 
-#: builtin/submodule--helper.c:889
+#: builtin/submodule--helper.c:887
 msgid ""
 "Use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
 msgstr ""
 "Benutze den Commit, der im Index gespeichert ist, statt den im Submodul HEAD"
 
-#: builtin/submodule--helper.c:890
+#: builtin/submodule--helper.c:888
 msgid "recurse into nested submodules"
 msgstr "Rekursion in verschachtelte Submodule durchführen"
 
-#: builtin/submodule--helper.c:895
+#: builtin/submodule--helper.c:893
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
 msgstr "git submodule status [--quiet] [--cached] [--recursive] [<Pfad>...]"
 
-#: builtin/submodule--helper.c:919
+#: builtin/submodule--helper.c:917
 msgid "git submodule--helper name <path>"
 msgstr "git submodule--helper name <Pfad>"
 
-#: builtin/submodule--helper.c:983
+#: builtin/submodule--helper.c:989
+#, c-format
+msgid "* %s %s(blob)->%s(submodule)"
+msgstr ""
+
+#: builtin/submodule--helper.c:992
+#, c-format
+msgid "* %s %s(submodule)->%s(blob)"
+msgstr ""
+
+#: builtin/submodule--helper.c:1005
+#, c-format
+msgid "%s"
+msgstr ""
+
+#: builtin/submodule--helper.c:1055
+#, fuzzy, c-format
+msgid "couldn't hash object from '%s'"
+msgstr "Konnte Objekt '%s' nicht parsen."
+
+#: builtin/submodule--helper.c:1059
+#, fuzzy, c-format
+msgid "unexpected mode %o\n"
+msgstr "unerwarteter Modus $mod_dst"
+
+#: builtin/submodule--helper.c:1300
+#, fuzzy
+msgid "use the commit stored in the index instead of the submodule HEAD"
+msgstr ""
+"Benutze den Commit, der im Index gespeichert ist, statt den im Submodul HEAD"
+
+#: builtin/submodule--helper.c:1302
+#, fuzzy
+msgid "to compare the commit in the index with that in the submodule HEAD"
+msgstr ""
+"Benutze den Commit, der im Index gespeichert ist, statt den im Submodul HEAD"
+
+#: builtin/submodule--helper.c:1304
+msgid "skip submodules with 'ignore_config' value set to 'all'"
+msgstr ""
+
+#: builtin/submodule--helper.c:1306
+#, fuzzy
+msgid "limit the summary size"
+msgstr "auf Branches einschränken"
+
+#: builtin/submodule--helper.c:1311
+#, fuzzy
+msgid "git submodule--helper summary [<options>] [<commit>] [--] [<path>]"
+msgstr "git submodule--helper init [<Optionen>] [<Pfad>]"
+
+#: builtin/submodule--helper.c:1335
+#, fuzzy
+msgid "could not fetch a revision for HEAD"
+msgstr "Konnte HEAD nicht loslösen"
+
+#: builtin/submodule--helper.c:1340
+#, fuzzy
+msgid "--cached and --files are mutually exclusive"
+msgstr "--branch und --default schließen sich gegenseitig aus"
+
+#: builtin/submodule--helper.c:1407
 #, c-format
 msgid "Synchronizing submodule url for '%s'\n"
 msgstr "Synchronisiere Submodul-URL für '%s'\n"
 
-#: builtin/submodule--helper.c:989
+#: builtin/submodule--helper.c:1413
 #, c-format
 msgid "failed to register url for submodule path '%s'"
 msgstr "Fehler beim Registrieren der URL für Submodul-Pfad '%s'."
 
-#: builtin/submodule--helper.c:1003
+#: builtin/submodule--helper.c:1427
 #, c-format
 msgid "failed to get the default remote for submodule '%s'"
 msgstr "Fehler beim Lesen des Standard-Remote-Repositories für Submodul '%s'."
 
-#: builtin/submodule--helper.c:1014
+#: builtin/submodule--helper.c:1438
 #, c-format
 msgid "failed to update remote for submodule '%s'"
 msgstr "Fehler beim Aktualisieren des Remote-Repositories für Submodul '%s'."
 
-#: builtin/submodule--helper.c:1061
+#: builtin/submodule--helper.c:1485
 msgid "Suppress output of synchronizing submodule url"
 msgstr "Ausgaben bei der Synchronisierung der Submodul-URLs unterdrücken"
 
-#: builtin/submodule--helper.c:1068
+#: builtin/submodule--helper.c:1492
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
 msgstr "git submodule--helper sync [--quiet] [--recursive] [<Pfad>]"
 
-#: builtin/submodule--helper.c:1122
+#: builtin/submodule--helper.c:1546
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains a .git directory (use 'rm -rf' if you "
@@ -21687,7 +22244,7 @@ msgstr ""
 "(benutzen Sie 'rm -rf', wenn Sie dieses wirklich mitsamt seiner Historie\n"
 "löschen möchten)"
 
-#: builtin/submodule--helper.c:1134
+#: builtin/submodule--helper.c:1558
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
@@ -21696,49 +22253,49 @@ msgstr ""
 "Arbeitsverzeichnis von Submodul in '%s' enthält lokale Änderungen;\n"
 "verwenden Sie '-f', um diese zu verwerfen."
 
-#: builtin/submodule--helper.c:1142
+#: builtin/submodule--helper.c:1566
 #, c-format
 msgid "Cleared directory '%s'\n"
 msgstr "Verzeichnis '%s' bereinigt.\n"
 
-#: builtin/submodule--helper.c:1144
+#: builtin/submodule--helper.c:1568
 #, c-format
 msgid "Could not remove submodule work tree '%s'\n"
 msgstr "Konnte Arbeitsverzeichnis des Submoduls in '%s' nicht löschen.\n"
 
-#: builtin/submodule--helper.c:1155
+#: builtin/submodule--helper.c:1579
 #, c-format
 msgid "could not create empty submodule directory %s"
 msgstr "Konnte kein leeres Verzeichnis für Submodul in '%s' erstellen."
 
-#: builtin/submodule--helper.c:1171
+#: builtin/submodule--helper.c:1595
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "Submodul '%s' (%s) für Pfad '%s' ausgetragen.\n"
 
-#: builtin/submodule--helper.c:1200
+#: builtin/submodule--helper.c:1624
 msgid "Remove submodule working trees even if they contain local changes"
 msgstr ""
 "Arbeitsverzeichnisse von Submodulen löschen, auch wenn lokale Änderungen "
 "vorliegen"
 
-#: builtin/submodule--helper.c:1201
+#: builtin/submodule--helper.c:1625
 msgid "Unregister all submodules"
 msgstr "alle Submodule austragen"
 
-#: builtin/submodule--helper.c:1206
+#: builtin/submodule--helper.c:1630
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<Pfad>...]]"
 
-#: builtin/submodule--helper.c:1220
+#: builtin/submodule--helper.c:1644
 msgid "Use '--all' if you really want to deinitialize all submodules"
 msgstr ""
 "Verwenden Sie '--all', wenn Sie wirklich alle Submodule deinitialisieren\n"
 "möchten."
 
-#: builtin/submodule--helper.c:1289
+#: builtin/submodule--helper.c:1713
 msgid ""
 "An alternate computed from a superproject's alternate is invalid.\n"
 "To allow Git to clone without an alternate in such a case, set\n"
@@ -21751,46 +22308,46 @@ msgstr ""
 "submodule.alternateErrorStrategy auf 'info' oder klone mit der Option\n"
 "'--reference-if-able' statt '--reference'."
 
-#: builtin/submodule--helper.c:1328 builtin/submodule--helper.c:1331
+#: builtin/submodule--helper.c:1752 builtin/submodule--helper.c:1755
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
 msgstr "Submodul '%s' kann Alternative nicht hinzufügen: %s"
 
-#: builtin/submodule--helper.c:1367
+#: builtin/submodule--helper.c:1791
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
 msgstr "Wert '%s' für submodule.alternateErrorStrategy wird nicht erkannt"
 
-#: builtin/submodule--helper.c:1374
+#: builtin/submodule--helper.c:1798
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
 msgstr "Wert '%s' für submodule.alternateLocation wird nicht erkannt."
 
-#: builtin/submodule--helper.c:1398
+#: builtin/submodule--helper.c:1822
 msgid "where the new submodule will be cloned to"
 msgstr "Pfad für neues Submodul"
 
-#: builtin/submodule--helper.c:1401
+#: builtin/submodule--helper.c:1825
 msgid "name of the new submodule"
 msgstr "Name des neuen Submoduls"
 
-#: builtin/submodule--helper.c:1404
+#: builtin/submodule--helper.c:1828
 msgid "url where to clone the submodule from"
 msgstr "URL von der das Submodul geklont wird"
 
-#: builtin/submodule--helper.c:1412
+#: builtin/submodule--helper.c:1836
 msgid "depth for shallow clones"
 msgstr "Tiefe des Klons mit unvollständiger Historie (shallow)"
 
-#: builtin/submodule--helper.c:1415 builtin/submodule--helper.c:1924
+#: builtin/submodule--helper.c:1839 builtin/submodule--helper.c:2348
 msgid "force cloning progress"
 msgstr "Fortschrittsanzeige beim Klonen erzwingen"
 
-#: builtin/submodule--helper.c:1417 builtin/submodule--helper.c:1926
+#: builtin/submodule--helper.c:1841 builtin/submodule--helper.c:2350
 msgid "disallow cloning into non-empty directory"
 msgstr "Klonen in ein nicht leeres Verzeichnis verbieten"
 
-#: builtin/submodule--helper.c:1424
+#: builtin/submodule--helper.c:1848
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
 "<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
@@ -21800,111 +22357,111 @@ msgstr ""
 "<Repository>] [--name <Name>] [--depth <Tiefe>] [--single-branch] --url "
 "<URL> --path <Pfad>"
 
-#: builtin/submodule--helper.c:1449
+#: builtin/submodule--helper.c:1873
 #, c-format
 msgid "refusing to create/use '%s' in another submodule's git dir"
 msgstr ""
 "Erstellung/Benutzung von '%s' in einem anderen Submodul-Git-Verzeichnis\n"
 "verweigert."
 
-#: builtin/submodule--helper.c:1460
+#: builtin/submodule--helper.c:1884
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
 msgstr "Klonen von '%s' in Submodul-Pfad '%s' fehlgeschlagen."
 
-#: builtin/submodule--helper.c:1464
+#: builtin/submodule--helper.c:1888
 #, c-format
 msgid "directory not empty: '%s'"
 msgstr "Verzeichnis ist nicht leer: '%s'"
 
-#: builtin/submodule--helper.c:1476
+#: builtin/submodule--helper.c:1900
 #, c-format
 msgid "could not get submodule directory for '%s'"
 msgstr "Konnte Submodul-Verzeichnis '%s' nicht finden."
 
-#: builtin/submodule--helper.c:1512
+#: builtin/submodule--helper.c:1936
 #, c-format
 msgid "Invalid update mode '%s' for submodule path '%s'"
 msgstr "Ungültiger Aktualisierungsmodus '%s' für Submodul-Pfad '%s'."
 
-#: builtin/submodule--helper.c:1516
+#: builtin/submodule--helper.c:1940
 #, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
 msgstr ""
 "Ungültiger Aktualisierungsmodus '%s' für Submodul-Pfad '%s' konfiguriert."
 
-#: builtin/submodule--helper.c:1617
+#: builtin/submodule--helper.c:2041
 #, c-format
 msgid "Submodule path '%s' not initialized"
 msgstr "Submodul-Pfad '%s' nicht initialisiert"
 
-#: builtin/submodule--helper.c:1621
+#: builtin/submodule--helper.c:2045
 msgid "Maybe you want to use 'update --init'?"
 msgstr "Meinten Sie vielleicht 'update --init'?"
 
-#: builtin/submodule--helper.c:1651
+#: builtin/submodule--helper.c:2075
 #, c-format
 msgid "Skipping unmerged submodule %s"
 msgstr "Überspringe nicht zusammengeführtes Submodul %s"
 
-#: builtin/submodule--helper.c:1680
+#: builtin/submodule--helper.c:2104
 #, c-format
 msgid "Skipping submodule '%s'"
 msgstr "Überspringe Submodul '%s'"
 
-#: builtin/submodule--helper.c:1830
+#: builtin/submodule--helper.c:2254
 #, c-format
 msgid "Failed to clone '%s'. Retry scheduled"
 msgstr "Fehler beim Klonen von '%s'. Weiterer Versuch geplant"
 
-#: builtin/submodule--helper.c:1841
+#: builtin/submodule--helper.c:2265
 #, c-format
 msgid "Failed to clone '%s' a second time, aborting"
 msgstr "Zweiter Versuch '%s' zu klonen fehlgeschlagen, breche ab."
 
-#: builtin/submodule--helper.c:1903 builtin/submodule--helper.c:2149
+#: builtin/submodule--helper.c:2327 builtin/submodule--helper.c:2573
 msgid "path into the working tree"
 msgstr "Pfad zum Arbeitsverzeichnis"
 
-#: builtin/submodule--helper.c:1906
+#: builtin/submodule--helper.c:2330
 msgid "path into the working tree, across nested submodule boundaries"
 msgstr ""
 "Pfad zum Arbeitsverzeichnis, über verschachtelte Submodul-Grenzen hinweg"
 
-#: builtin/submodule--helper.c:1910
+#: builtin/submodule--helper.c:2334
 msgid "rebase, merge, checkout or none"
 msgstr "rebase, merge, checkout oder none"
 
-#: builtin/submodule--helper.c:1916
+#: builtin/submodule--helper.c:2340
 msgid "Create a shallow clone truncated to the specified number of revisions"
 msgstr ""
 "Erstellung eines Klons mit unvollständiger Historie (shallow), abgeschnitten "
 "bei\n"
 "der angegebenen Anzahl von Commits."
 
-#: builtin/submodule--helper.c:1919
+#: builtin/submodule--helper.c:2343
 msgid "parallel jobs"
 msgstr "Parallele Ausführungen"
 
-#: builtin/submodule--helper.c:1921
+#: builtin/submodule--helper.c:2345
 msgid "whether the initial clone should follow the shallow recommendation"
 msgstr ""
 "ob das initiale Klonen den Empfehlungen für eine unvollständige\n"
 "Historie (shallow) folgen soll"
 
-#: builtin/submodule--helper.c:1922
+#: builtin/submodule--helper.c:2346
 msgid "don't print cloning progress"
 msgstr "keine Fortschrittsanzeige beim Klonen"
 
-#: builtin/submodule--helper.c:1933
+#: builtin/submodule--helper.c:2357
 msgid "git submodule--helper update-clone [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper update-clone [--prefix=<Pfad>] [<Pfad>...]"
 
-#: builtin/submodule--helper.c:1946
+#: builtin/submodule--helper.c:2370
 msgid "bad value for update parameter"
 msgstr "Fehlerhafter Wert für --update Parameter"
 
-#: builtin/submodule--helper.c:1994
+#: builtin/submodule--helper.c:2418
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
@@ -21913,86 +22470,86 @@ msgstr ""
 "Branch von Submodul (%s) ist konfiguriert, den Branch des Hauptprojektes\n"
 "zu erben, aber das Hauptprojekt befindet sich auf keinem Branch."
 
-#: builtin/submodule--helper.c:2117
+#: builtin/submodule--helper.c:2541
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
 msgstr "Konnte kein Repository-Handle für Submodul '%s' erhalten."
 
-#: builtin/submodule--helper.c:2150
+#: builtin/submodule--helper.c:2574
 msgid "recurse into submodules"
 msgstr "Rekursion in Submodule durchführen"
 
-#: builtin/submodule--helper.c:2156
+#: builtin/submodule--helper.c:2580
 msgid "git submodule--helper absorb-git-dirs [<options>] [<path>...]"
 msgstr "git submodule--helper absorb-git-dirs [<Optionen>] [<Pfad>...]"
 
-#: builtin/submodule--helper.c:2212
+#: builtin/submodule--helper.c:2636
 msgid "check if it is safe to write to the .gitmodules file"
 msgstr "prüfen, ob es sicher ist, in die Datei .gitmodules zu schreiben"
 
-#: builtin/submodule--helper.c:2215
+#: builtin/submodule--helper.c:2639
 msgid "unset the config in the .gitmodules file"
 msgstr "Konfiguration in der .gitmodules-Datei entfernen"
 
-#: builtin/submodule--helper.c:2220
+#: builtin/submodule--helper.c:2644
 msgid "git submodule--helper config <name> [<value>]"
 msgstr "git submodule--helper config <name> [<Wert>]"
 
-#: builtin/submodule--helper.c:2221
+#: builtin/submodule--helper.c:2645
 msgid "git submodule--helper config --unset <name>"
 msgstr "git submodule--helper config --unset <Name>"
 
-#: builtin/submodule--helper.c:2222
+#: builtin/submodule--helper.c:2646
 msgid "git submodule--helper config --check-writeable"
 msgstr "git submodule--helper config --check-writeable"
 
-#: builtin/submodule--helper.c:2241 git-submodule.sh:176
+#: builtin/submodule--helper.c:2665 git-submodule.sh:151
 #, sh-format
 msgid "please make sure that the .gitmodules file is in the working tree"
 msgstr ""
 "Bitte stellen Sie sicher, dass sich die Datei .gitmodules im "
 "Arbeitsverzeichnis befindet."
 
-#: builtin/submodule--helper.c:2257
+#: builtin/submodule--helper.c:2681
 msgid "Suppress output for setting url of a submodule"
 msgstr "Ausgaben beim Setzen der URL eines Submoduls unterdrücken"
 
-#: builtin/submodule--helper.c:2261
+#: builtin/submodule--helper.c:2685
 msgid "git submodule--helper set-url [--quiet] <path> <newurl>"
 msgstr "git submodule--helper set-url [--quiet] <Pfad> <neue URL>"
 
-#: builtin/submodule--helper.c:2294
+#: builtin/submodule--helper.c:2718
 msgid "set the default tracking branch to master"
 msgstr "Standard-Tracking-Branch auf master setzen"
 
-#: builtin/submodule--helper.c:2296
+#: builtin/submodule--helper.c:2720
 msgid "set the default tracking branch"
 msgstr "Standard-Tracking-Branch setzen"
 
-#: builtin/submodule--helper.c:2300
+#: builtin/submodule--helper.c:2724
 msgid "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
 msgstr "git submodule--helper set-branch [-q|--quiet] (-d|--default) [<Pfad>]"
 
-#: builtin/submodule--helper.c:2301
+#: builtin/submodule--helper.c:2725
 msgid ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
 msgstr ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <Branch> <Pfad>"
 
-#: builtin/submodule--helper.c:2308
+#: builtin/submodule--helper.c:2732
 msgid "--branch or --default required"
 msgstr "Option --branch oder --default erforderlich"
 
-#: builtin/submodule--helper.c:2311
+#: builtin/submodule--helper.c:2735
 msgid "--branch and --default are mutually exclusive"
 msgstr "--branch und --default schließen sich gegenseitig aus"
 
-#: builtin/submodule--helper.c:2367 git.c:436 git.c:683
+#: builtin/submodule--helper.c:2792 git.c:438 git.c:710
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s unterstützt kein --super-prefix"
 
-#: builtin/submodule--helper.c:2373
+#: builtin/submodule--helper.c:2798
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
 msgstr "'%s' ist kein gültiger Unterbefehl von submodule--helper"
@@ -22039,10 +22596,12 @@ msgid "git tag -d <tagname>..."
 msgstr "git tag -d <Tagname>..."
 
 #: builtin/tag.c:28
+#, fuzzy
 msgid ""
 "git tag -l [-n[<num>]] [--contains <commit>] [--no-contains <commit>] [--"
 "points-at <object>]\n"
-"\t\t[--format=<format>] [--[no-]merged [<commit>]] [<pattern>...]"
+"\t\t[--format=<format>] [--merged <commit>] [--no-merged <commit>] "
+"[<pattern>...]"
 msgstr ""
 "git tag -l [-n[<Nummer>]] [--contains <Commit>] [--no-contains <Commit>] [--"
 "points-at <Objekt>]\n"
@@ -22600,15 +23159,15 @@ msgstr "Commit-Inhalte ausgeben"
 msgid "print raw gpg status output"
 msgstr "unbearbeitete Ausgabe des Status von gpg ausgeben"
 
-#: builtin/verify-pack.c:55
+#: builtin/verify-pack.c:59
 msgid "git verify-pack [-v | --verbose] [-s | --stat-only] <pack>..."
 msgstr "git verify-pack [-v | --verbose] [-s | --stat-only] <Paket>..."
 
-#: builtin/verify-pack.c:65
+#: builtin/verify-pack.c:70
 msgid "verbose"
 msgstr "erweiterte Ausgaben"
 
-#: builtin/verify-pack.c:67
+#: builtin/verify-pack.c:72
 msgid "show statistics only"
 msgstr "nur Statistiken anzeigen"
 
@@ -22648,7 +23207,7 @@ msgstr "git worktree remove [<Optionen>] <Arbeitsverzeichnis>"
 msgid "git worktree unlock <path>"
 msgstr "git worktree unlock <Pfad>"
 
-#: builtin/worktree.c:60 builtin/worktree.c:972
+#: builtin/worktree.c:60 builtin/worktree.c:970
 #, c-format
 msgid "failed to delete '%s'"
 msgstr "Fehler beim Löschen von '%s'"
@@ -22793,7 +23352,7 @@ msgid "reason for locking"
 msgstr "Sperrgrund"
 
 #: builtin/worktree.c:767 builtin/worktree.c:800 builtin/worktree.c:874
-#: builtin/worktree.c:1000
+#: builtin/worktree.c:998
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr "'%s' ist kein Arbeitsverzeichnis"
@@ -22829,7 +23388,7 @@ msgstr ""
 "Verschieben erzwingen, auch wenn das Arbeitsverzeichnis geändert oder "
 "gesperrt ist"
 
-#: builtin/worktree.c:876 builtin/worktree.c:1002
+#: builtin/worktree.c:876 builtin/worktree.c:1000
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr "'%s' ist ein Hauptarbeitsverzeichnis"
@@ -22868,30 +23427,30 @@ msgstr "Validierung fehlgeschlagen, kann Arbeitszeichnis nicht verschieben: %s"
 msgid "failed to move '%s' to '%s'"
 msgstr "Fehler beim Verschieben von '%s' nach '%s'"
 
-#: builtin/worktree.c:952
+#: builtin/worktree.c:950
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr "Fehler beim Ausführen von 'git status' auf '%s'"
 
-#: builtin/worktree.c:956
+#: builtin/worktree.c:954
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
 "'%s' enthält geänderte oder nicht versionierte Dateien, benutzen Sie --force "
 "zum Löschen"
 
-#: builtin/worktree.c:961
+#: builtin/worktree.c:959
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr "Fehler beim Ausführen von 'git status' auf '%s'. Code: %d"
 
-#: builtin/worktree.c:984
+#: builtin/worktree.c:982
 msgid "force removal even if worktree is dirty or locked"
 msgstr ""
 "Löschen erzwingen, auch wenn das Arbeitsverzeichnis geändert oder gesperrt "
 "ist"
 
-#: builtin/worktree.c:1007
+#: builtin/worktree.c:1005
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
@@ -22901,7 +23460,7 @@ msgstr ""
 "Benutzen Sie 'remove -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:1009
+#: builtin/worktree.c:1007
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
@@ -22910,10 +23469,20 @@ msgstr ""
 "Benutzen Sie 'remove -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:1012
+#: builtin/worktree.c:1010
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr "Validierung fehlgeschlagen, kann Arbeitsverzeichnis nicht löschen: %s"
+
+#: builtin/worktree.c:1034
+#, fuzzy, c-format
+msgid "repair: %s: %s"
+msgstr "Ungültiger %s: '%s'"
+
+#: builtin/worktree.c:1037
+#, fuzzy, c-format
+msgid "error: %s: %s"
+msgstr "Fehler in %s %s: %s"
 
 #: builtin/write-tree.c:15
 msgid "git write-tree [--missing-ok] [--prefix=<prefix>/]"
@@ -22931,164 +23500,22 @@ msgstr "das Tree-Objekt für ein Unterverzeichnis <Präfix> schreiben"
 msgid "only useful for debugging"
 msgstr "nur nützlich für Fehlersuche"
 
-#: bugreport.c:15
-msgid "git version:\n"
-msgstr "git Version:\n"
-
-#: bugreport.c:21
-#, c-format
-msgid "uname() failed with error '%s' (%d)\n"
-msgstr "uname() ist fehlgeschlagen mit Fehler '%s' (%d)\n"
-
-#: bugreport.c:31
-msgid "compiler info: "
-msgstr "Compiler Info: "
-
-#: bugreport.c:34
-msgid "libc info: "
-msgstr "libc Info: "
-
-#: bugreport.c:80
-msgid "not run from a git repository - no hooks to show\n"
-msgstr "nicht in einem Git-Repository ausgeführt - keine Hooks zum Anzeigen\n"
-
-#: bugreport.c:90
-msgid "git bugreport [-o|--output-directory <file>] [-s|--suffix <format>]"
-msgstr "git bugreport [-o|--output-directory <Datei>] [-s|--suffix <Format>]"
-
-#: bugreport.c:97
-msgid ""
-"Thank you for filling out a Git bug report!\n"
-"Please answer the following questions to help us understand your issue.\n"
-"\n"
-"What did you do before the bug happened? (Steps to reproduce your issue)\n"
-"\n"
-"What did you expect to happen? (Expected behavior)\n"
-"\n"
-"What happened instead? (Actual behavior)\n"
-"\n"
-"What's different between what you expected and what actually happened?\n"
-"\n"
-"Anything else you want to add:\n"
-"\n"
-"Please review the rest of the bug report below.\n"
-"You can delete any lines you don't wish to share.\n"
-msgstr ""
-"Vielen Dank für das Ausfüllen eines Git-Fehlerberichts!\n"
-"Bitte antworten Sie auf die folgenden Fragen, um uns dabei zu helfen, Ihr\n"
-"Problem zu verstehen.\n"
-"\n"
-"Was haben Sie gemacht, bevor der Fehler auftrat? (Schritte, um Ihr Fehler\n"
-"zu reproduzieren)\n"
-"\n"
-"Was haben Sie erwartet, was passieren soll? (Erwartetes Verhalten)\n"
-"\n"
-"Was ist stattdessen passiert? (Wirkliches Verhalten)\n"
-"\n"
-"Was ist der Unterschied zwischen dem, was Sie erwartet haben und was\n"
-"wirklich passiert ist?\n"
-"\n"
-"Sonstige Anmerkungen, die Sie hinzufügen möchten:\n"
-"\n"
-"Bitte überprüfen Sie den restlichen Teil des Fehlerberichts unten.\n"
-"Sie können jede Zeile löschen, die Sie nicht mitteilen möchten.\n"
-
-#: bugreport.c:136
-msgid "specify a destination for the bugreport file"
-msgstr "Speicherort für die Datei des Fehlerberichts angeben"
-
-#: bugreport.c:138
-msgid "specify a strftime format suffix for the filename"
-msgstr "Dateiendung im strftime-Format für den Dateinamen angeben"
-
-#: bugreport.c:162
-#, c-format
-msgid "could not create leading directories for '%s'"
-msgstr "konnte vorangehende Verzeichnisse für '%s' nicht erstellen"
-
-#: bugreport.c:169
-msgid "System Info"
-msgstr "System Info"
-
-#: bugreport.c:172
-msgid "Enabled Hooks"
-msgstr "Aktivierte Hooks"
-
-#: bugreport.c:180
-#, c-format
-msgid "couldn't create a new file at '%s'"
-msgstr "konnte keine neue Datei unter '%s' erstellen"
-
-#: bugreport.c:184
-#, c-format
-msgid "unable to write to %s"
-msgstr "konnte nicht nach %s schreiben"
-
-#: bugreport.c:194
-#, c-format
-msgid "Created new report at '%s'.\n"
-msgstr "Neuer Bericht unter '%s' erstellt.\n"
-
-#: fast-import.c:3100
-#, c-format
-msgid "Missing from marks for submodule '%s'"
-msgstr "Fehlende 'from'-Markierungen für Submodul '%s'"
-
-#: fast-import.c:3102
-#, c-format
-msgid "Missing to marks for submodule '%s'"
-msgstr "Fehlende 'to'-Markierungen für Submodul '%s'"
-
-#: fast-import.c:3237
-#, c-format
-msgid "Expected 'mark' command, got %s"
-msgstr "'mark' Befehl erwartet, '%s' bekommen"
-
-#: fast-import.c:3242
-#, c-format
-msgid "Expected 'to' command, got %s"
-msgstr "'to' Befehl erwartet, '%s' bekommen"
-
-#: fast-import.c:3334
-msgid "Expected format name:filename for submodule rewrite option"
-msgstr "Format 'Name:Dateiname' für Submodul-Rewrite-Option erwartet"
-
-#: fast-import.c:3388
-#, c-format
-msgid "feature '%s' forbidden in input without --allow-unsafe-features"
-msgstr "Feature '%s' verboten in Eingabe ohne Option --allow-unsafe-features"
-
-#: http-fetch.c:111
+#: http-fetch.c:114
 #, c-format
 msgid "argument to --packfile must be a valid hash (got '%s')"
 msgstr "Argument für --packfile muss ein gültiger Hash sein ('%s' erhalten)"
 
-#: credential-cache--daemon.c:223
-#, c-format
-msgid ""
-"The permissions on your socket directory are too loose; other\n"
-"users may be able to read your cached credentials. Consider running:\n"
-"\n"
-"\tchmod 0700 %s"
-msgstr ""
-"Die Berechtigungen auf Ihr Socket-Verzeichnis sind zu schwach; andere\n"
-"Nutzer könnten Ihre zwischengespeicherten Anmeldeinformationen lesen.\n"
-"Ziehen Sie in Betracht\n"
-"\n"
-"\tchmod 0700 %s\n"
-"\n"
-"auszuführen."
+#: http-fetch.c:122
+#, fuzzy
+msgid "not a git repository"
+msgstr "Kein Git-Repository"
 
-#: credential-cache--daemon.c:272
-msgid "print debugging messages to stderr"
-msgstr "Meldungen zur Fehlersuche in Standard-Fehlerausgabe ausgeben"
-
-#: t/helper/test-reach.c:152
+#: t/helper/test-reach.c:154
 #, c-format
 msgid "commit %s is not marked reachable"
 msgstr "Commit %s ist nicht als erreichbar gekennzeichnet."
 
-#: t/helper/test-reach.c:162
+#: t/helper/test-reach.c:164
 msgid "too many commits marked reachable"
 msgstr "Zu viele Commits als erreichbar gekennzeichnet."
 
@@ -23164,12 +23591,12 @@ msgstr "Kein Verzeichnis für -C angegeben.\n"
 msgid "unknown option: %s\n"
 msgstr "Unbekannte Option: %s\n"
 
-#: git.c:362
+#: git.c:364
 #, c-format
 msgid "while expanding alias '%s': '%s'"
 msgstr "beim Erweitern von Alias '%s': '%s'"
 
-#: git.c:371
+#: git.c:373
 #, c-format
 msgid ""
 "alias '%s' changes environment variables.\n"
@@ -23178,39 +23605,39 @@ msgstr ""
 "Alias '%s' ändert Umgebungsvariablen.\n"
 "Sie können '!git' im Alias benutzen, um dies zu tun."
 
-#: git.c:378
+#: git.c:380
 #, c-format
 msgid "empty alias for %s"
 msgstr "leerer Alias für %s"
 
-#: git.c:381
+#: git.c:383
 #, c-format
 msgid "recursive alias: %s"
 msgstr "rekursiver Alias: %s"
 
-#: git.c:463
+#: git.c:465
 msgid "write failure on standard output"
 msgstr "Fehler beim Schreiben in die Standard-Ausgabe."
 
-#: git.c:465
+#: git.c:467
 msgid "unknown write failure on standard output"
 msgstr "Unbekannter Fehler beim Schreiben in die Standard-Ausgabe."
 
-#: git.c:467
+#: git.c:469
 msgid "close failed on standard output"
 msgstr "Fehler beim Schließen der Standard-Ausgabe."
 
-#: git.c:792
+#: git.c:819
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr "Alias-Schleife erkannt: Erweiterung von '%s' schließt nicht ab:%s"
 
-#: git.c:842
+#: git.c:869
 #, c-format
 msgid "cannot handle %s as a builtin"
 msgstr "Kann %s nicht als eingebauten Befehl behandeln."
 
-#: git.c:855
+#: git.c:882
 #, c-format
 msgid ""
 "usage: %s\n"
@@ -23219,12 +23646,12 @@ msgstr ""
 "Verwendung: %s\n"
 "\n"
 
-#: git.c:875
+#: git.c:902
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr "Erweiterung von Alias '%s' fehlgeschlagen; '%s' ist kein Git-Befehl.\n"
 
-#: git.c:887
+#: git.c:914
 #, c-format
 msgid "failed to run command '%s': %s\n"
 msgstr "Fehler beim Ausführen von Befehl '%s': %s\n"
@@ -23279,136 +23706,136 @@ msgstr ""
 "  gefragt nach: %s\n"
 "    umgeleitet: %s"
 
-#: remote-curl.c:168
+#: remote-curl.c:174
 #, c-format
 msgid "invalid quoting in push-option value: '%s'"
 msgstr "Ungültiges Quoting beim \"push-option\"-Wert: '%s'"
 
-#: remote-curl.c:295
+#: remote-curl.c:298
 #, c-format
 msgid "%sinfo/refs not valid: is this a git repository?"
 msgstr "%sinfo/refs nicht gültig: Ist das ein Git-Repository?"
 
-#: remote-curl.c:396
+#: remote-curl.c:399
 msgid "invalid server response; expected service, got flush packet"
 msgstr "Ungültige Antwort des Servers. Service erwartet, Flush-Paket bekommen"
 
-#: remote-curl.c:427
+#: remote-curl.c:430
 #, c-format
 msgid "invalid server response; got '%s'"
 msgstr "Ungültige Serverantwort; '%s' bekommen"
 
-#: remote-curl.c:487
+#: remote-curl.c:490
 #, c-format
 msgid "repository '%s' not found"
 msgstr "Repository '%s' nicht gefunden."
 
-#: remote-curl.c:491
+#: remote-curl.c:494
 #, c-format
 msgid "Authentication failed for '%s'"
 msgstr "Authentifizierung fehlgeschlagen für '%s'"
 
-#: remote-curl.c:495
+#: remote-curl.c:498
 #, c-format
 msgid "unable to access '%s': %s"
 msgstr "konnte nicht auf '%s' zugreifen: %s"
 
-#: remote-curl.c:501
+#: remote-curl.c:504
 #, c-format
 msgid "redirecting to %s"
 msgstr "Umleitung nach %s"
 
-#: remote-curl.c:630
+#: remote-curl.c:633
 msgid "shouldn't have EOF when not gentle on EOF"
 msgstr "sollte kein EOF haben, wenn nicht behutsam mit EOF"
 
-#: remote-curl.c:642
+#: remote-curl.c:645
 msgid "remote server sent stateless separator"
 msgstr "Server sendete zustandslosen Separator"
 
-#: remote-curl.c:712
+#: remote-curl.c:715
 msgid "unable to rewind rpc post data - try increasing http.postBuffer"
 msgstr ""
 "konnte nicht RPC-POST-Daten zurückspulen - Versuchen Sie http.postBuffer zu "
 "erhöhen"
 
-#: remote-curl.c:742
+#: remote-curl.c:745
 #, c-format
 msgid "remote-curl: bad line length character: %.4s"
 msgstr "remote-curl: ungültiges Zeichen für Zeilenlänge: %.4s"
 
-#: remote-curl.c:744
+#: remote-curl.c:747
 msgid "remote-curl: unexpected response end packet"
 msgstr "remote-curl: unerwartetes Antwort-Endpaket"
 
-#: remote-curl.c:820
+#: remote-curl.c:823
 #, c-format
 msgid "RPC failed; %s"
 msgstr "RPC fehlgeschlagen; %s"
 
-#: remote-curl.c:860
+#: remote-curl.c:863
 msgid "cannot handle pushes this big"
 msgstr "Kann solche großen Übertragungen nicht verarbeiten."
 
-#: remote-curl.c:975
+#: remote-curl.c:978
 #, c-format
 msgid "cannot deflate request; zlib deflate error %d"
 msgstr "Kann Request nicht komprimieren; \"zlib deflate\"-Fehler %d"
 
-#: remote-curl.c:979
+#: remote-curl.c:982
 #, c-format
 msgid "cannot deflate request; zlib end error %d"
 msgstr "Kann Request nicht komprimieren; \"zlib end\"-Fehler %d"
 
-#: remote-curl.c:1029
+#: remote-curl.c:1032
 #, c-format
 msgid "%d bytes of length header were received"
 msgstr "%d Bytes des Längen-Headers wurden empfangen"
 
-#: remote-curl.c:1031
+#: remote-curl.c:1034
 #, c-format
 msgid "%d bytes of body are still expected"
 msgstr "%d Bytes des Bodys werden noch erwartet"
 
-#: remote-curl.c:1120
+#: remote-curl.c:1123
 msgid "dumb http transport does not support shallow capabilities"
 msgstr "Dumb HTTP-Transport unterstützt keine shallow-Funktionen"
 
-#: remote-curl.c:1135
+#: remote-curl.c:1138
 msgid "fetch failed."
 msgstr "\"fetch\" fehlgeschlagen."
 
-#: remote-curl.c:1183
+#: remote-curl.c:1184
 msgid "cannot fetch by sha1 over smart http"
 msgstr "Kann SHA-1 nicht über Smart-HTTP anfordern"
 
-#: remote-curl.c:1227 remote-curl.c:1233
+#: remote-curl.c:1228 remote-curl.c:1234
 #, c-format
 msgid "protocol error: expected sha/ref, got '%s'"
 msgstr "Protokollfehler: SHA-1/Referenz erwartet, '%s' bekommen"
 
-#: remote-curl.c:1245 remote-curl.c:1360
+#: remote-curl.c:1246 remote-curl.c:1361
 #, c-format
 msgid "http transport does not support %s"
 msgstr "HTTP-Transport unterstützt nicht %s"
 
-#: remote-curl.c:1281
+#: remote-curl.c:1282
 msgid "git-http-push failed"
 msgstr "\"git-http-push\" fehlgeschlagen"
 
-#: remote-curl.c:1466
+#: remote-curl.c:1467
 msgid "remote-curl: usage: git remote-curl <remote> [<url>]"
 msgstr "remote-curl: Verwendung: git remote-curl <Remote-Repository> [<URL>]"
 
-#: remote-curl.c:1498
+#: remote-curl.c:1499
 msgid "remote-curl: error reading command stream from git"
 msgstr "remote-curl: Fehler beim Lesen des Kommando-Streams von Git"
 
-#: remote-curl.c:1505
+#: remote-curl.c:1506
 msgid "remote-curl: fetch attempted without a local repo"
 msgstr "remote-curl: \"fetch\" ohne lokales Repository versucht"
 
-#: remote-curl.c:1546
+#: remote-curl.c:1547
 #, c-format
 msgid "remote-curl: unknown command '%s' from git"
 msgstr "remote-curl: Unbekannter Befehl '%s' von Git"
@@ -23421,11 +23848,11 @@ msgstr "keine Compiler-Information verfügbar\n"
 msgid "no libc information available\n"
 msgstr "keine libc Informationen verfügbar\n"
 
-#: list-objects-filter-options.h:85
+#: list-objects-filter-options.h:91
 msgid "args"
 msgstr "Argumente"
 
-#: list-objects-filter-options.h:86
+#: list-objects-filter-options.h:92
 msgid "object filtering"
 msgstr "Filtern nach Objekten"
 
@@ -23446,7 +23873,8 @@ msgid "be more quiet"
 msgstr "weniger Ausgaben"
 
 #: parse-options.h:317
-msgid "use <n> digits to display SHA-1s"
+#, fuzzy
+msgid "use <n> digits to display object names"
 msgstr "benutze <n> Ziffern zur Anzeige von SHA-1s"
 
 #: parse-options.h:336
@@ -23464,11 +23892,11 @@ msgid ""
 msgstr ""
 "Mit der Option --pathspec-from-file sind Pfade durch NUL-Zeichen getrennt"
 
-#: ref-filter.h:101
+#: ref-filter.h:96
 msgid "key"
 msgstr "Schüssel"
 
-#: ref-filter.h:101
+#: ref-filter.h:96
 msgid "field name to sort on"
 msgstr "sortiere nach diesem Feld"
 
@@ -23796,443 +24224,444 @@ msgid "Simple UNIX mbox splitter program"
 msgstr "einfaches UNIX mbox Splitter-Programm"
 
 #: command-list.h:122
+msgid "Run tasks to optimize Git repository data"
+msgstr ""
+
+#: command-list.h:123
 msgid "Join two or more development histories together"
 msgstr "zwei oder mehr Entwicklungszweige zusammenführen"
 
-#: command-list.h:123
+#: command-list.h:124
 msgid "Find as good common ancestors as possible for a merge"
 msgstr "möglichst besten gemeinsamen Vorgänger-Commit für einen Merge finden"
 
-#: command-list.h:124
+#: command-list.h:125
 msgid "Run a three-way file merge"
 msgstr "einen 3-Wege-Datei-Merge ausführen"
 
-#: command-list.h:125
+#: command-list.h:126
 msgid "Run a merge for files needing merging"
 msgstr "einen Merge für zusammenzuführende Dateien ausführen"
 
-#: command-list.h:126
+#: command-list.h:127
 msgid "The standard helper program to use with git-merge-index"
 msgstr "das Standard-Hilfsprogramm für die Verwendung mit git-merge-index"
 
-#: command-list.h:127
+#: command-list.h:128
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
 msgstr ""
 "Ausführen von Tools zur Auflösung von Merge-Konflikten zur Behebung dieser"
 
-#: command-list.h:128
+#: command-list.h:129
 msgid "Show three-way merge without touching index"
 msgstr "3-Wege-Merge anzeigen ohne den Index zu verändern"
 
-#: command-list.h:129
+#: command-list.h:130
 msgid "Write and verify multi-pack-indexes"
 msgstr "multi-pack-indexes schreiben und überprüfen"
 
-#: command-list.h:130
+#: command-list.h:131
 msgid "Creates a tag object"
 msgstr "ein Tag-Objekt erstellen"
 
-#: command-list.h:131
+#: command-list.h:132
 msgid "Build a tree-object from ls-tree formatted text"
 msgstr "Tree-Objekt aus ls-tree formattiertem Text erzeugen"
 
-#: command-list.h:132
+#: command-list.h:133
 msgid "Move or rename a file, a directory, or a symlink"
 msgstr ""
 "eine Datei, ein Verzeichnis, oder eine symbolische Verknüpfung verschieben "
 "oder umbenennen"
 
-#: command-list.h:133
+#: command-list.h:134
 msgid "Find symbolic names for given revs"
 msgstr "symbolische Namen für die gegebenen Commits finden"
 
-#: command-list.h:134
+#: command-list.h:135
 msgid "Add or inspect object notes"
 msgstr "Objekt-Notizen hinzufügen oder überprüfen"
 
-#: command-list.h:135
+#: command-list.h:136
 msgid "Import from and submit to Perforce repositories"
 msgstr "von Perforce Repositories importieren und nach diese senden"
 
-#: command-list.h:136
+#: command-list.h:137
 msgid "Create a packed archive of objects"
 msgstr "ein gepacktes Archiv von Objekten erstellen"
 
-#: command-list.h:137
+#: command-list.h:138
 msgid "Find redundant pack files"
 msgstr "redundante Paketdateien finden"
 
-#: command-list.h:138
+#: command-list.h:139
 msgid "Pack heads and tags for efficient repository access"
 msgstr "Branches und Tags für effizienten Zugriff auf das Repository packen"
 
-#: command-list.h:139
+#: command-list.h:140
 msgid "Routines to help parsing remote repository access parameters"
 msgstr ""
 "Routinen als Hilfe zum Parsen von Zugriffsparametern von Remote-Repositories"
 
-#: command-list.h:140
+#: command-list.h:141
 msgid "Compute unique ID for a patch"
 msgstr "eindeutige ID für einen Patch berechnen"
 
-#: command-list.h:141
+#: command-list.h:142
 msgid "Prune all unreachable objects from the object database"
 msgstr "alle nicht erreichbaren Objekte von der Objektdatenbank entfernen"
 
-#: command-list.h:142
+#: command-list.h:143
 msgid "Remove extra objects that are already in pack files"
 msgstr ""
 "zusätzliche Objekte, die sich bereits in Paketdateien befinden, entfernen"
 
-#: command-list.h:143
+#: command-list.h:144
 msgid "Fetch from and integrate with another repository or a local branch"
 msgstr ""
 "Objekte von einem externen Repository anfordern und sie mit einem anderen "
 "Repository oder einem lokalen Branch zusammenführen"
 
-#: command-list.h:144
+#: command-list.h:145
 msgid "Update remote refs along with associated objects"
 msgstr "Remote-Referenzen mitsamt den verbundenen Objekten aktualisieren"
 
-#: command-list.h:145
+#: command-list.h:146
 msgid "Applies a quilt patchset onto the current branch"
 msgstr "Patches aus quilt auf aktuellen Branch anwenden"
 
-#: command-list.h:146
+#: command-list.h:147
 msgid "Compare two commit ranges (e.g. two versions of a branch)"
 msgstr "zwei Commit-Bereiche vergleichen (zwei Versionen eines Branches)"
 
-#: command-list.h:147
+#: command-list.h:148
 msgid "Reads tree information into the index"
 msgstr "Verzeichnisinformationen in den Index einlesen"
 
-#: command-list.h:148
+#: command-list.h:149
 msgid "Reapply commits on top of another base tip"
 msgstr "Wiederholtes Anwenden von Commits auf anderem Basis-Commit"
 
-#: command-list.h:149
+#: command-list.h:150
 msgid "Receive what is pushed into the repository"
 msgstr "Empfangen was in das Repository übertragen wurde"
 
-#: command-list.h:150
+#: command-list.h:151
 msgid "Manage reflog information"
 msgstr "Reflog Informationen verwalten"
 
-#: command-list.h:151
+#: command-list.h:152
 msgid "Manage set of tracked repositories"
 msgstr "Menge von hinterlegten Repositories verwalten"
 
-#: command-list.h:152
+#: command-list.h:153
 msgid "Pack unpacked objects in a repository"
 msgstr "ungepackte Objekte in einem Repository packen"
 
-#: command-list.h:153
+#: command-list.h:154
 msgid "Create, list, delete refs to replace objects"
 msgstr "Referenzen für ersetzende Objekte erstellen, auflisten, löschen"
 
-#: command-list.h:154
+#: command-list.h:155
 msgid "Generates a summary of pending changes"
 msgstr "eine Übersicht über ausstehende Änderungen generieren"
 
-#: command-list.h:155
+#: command-list.h:156
 msgid "Reuse recorded resolution of conflicted merges"
 msgstr "aufgezeichnete Auflösung von Merge-Konflikten wiederverwenden"
 
-#: command-list.h:156
+#: command-list.h:157
 msgid "Reset current HEAD to the specified state"
 msgstr "aktuellen HEAD zu einem spezifizierten Zustand setzen"
 
-#: command-list.h:157
+#: command-list.h:158
 msgid "Restore working tree files"
 msgstr "Dateien im Arbeitsverzeichnis wiederherstellen"
 
-#: command-list.h:158
+#: command-list.h:159
 msgid "Revert some existing commits"
 msgstr "einige bestehende Commits rückgängig machen"
 
-#: command-list.h:159
+#: command-list.h:160
 msgid "Lists commit objects in reverse chronological order"
 msgstr "Commit-Objekte in umgekehrter chronologischer Ordnung auflisten"
 
-#: command-list.h:160
+#: command-list.h:161
 msgid "Pick out and massage parameters"
 msgstr "Parameter herauspicken und ändern"
 
-#: command-list.h:161
+#: command-list.h:162
 msgid "Remove files from the working tree and from the index"
 msgstr "Dateien im Arbeitsverzeichnis und vom Index löschen"
 
-#: command-list.h:162
+#: command-list.h:163
 msgid "Send a collection of patches as emails"
 msgstr "eine Sammlung von Patches als E-Mails versenden"
 
-#: command-list.h:163
+#: command-list.h:164
 msgid "Push objects over Git protocol to another repository"
 msgstr "Objekte über das Git Protokoll zu einem anderen Repository übertragen"
 
-#: command-list.h:164
+#: command-list.h:165
 msgid "Restricted login shell for Git-only SSH access"
 msgstr "Login-Shell beschränkt für Nur-Git SSH-Zugriff"
 
-#: command-list.h:165
+#: command-list.h:166
 msgid "Summarize 'git log' output"
 msgstr "Ausgabe von 'git log' zusammenfassen"
 
-#: command-list.h:166
+#: command-list.h:167
 msgid "Show various types of objects"
 msgstr "verschiedene Arten von Objekten anzeigen"
 
-#: command-list.h:167
+#: command-list.h:168
 msgid "Show branches and their commits"
 msgstr "Branches und ihre Commits ausgeben"
 
-#: command-list.h:168
+#: command-list.h:169
 msgid "Show packed archive index"
 msgstr "gepackten Archiv-Index anzeigen"
 
-#: command-list.h:169
+#: command-list.h:170
 msgid "List references in a local repository"
 msgstr "Referenzen in einem lokales Repository auflisten"
 
-#: command-list.h:170
+#: command-list.h:171
 msgid "Git's i18n setup code for shell scripts"
 msgstr "Gits i18n-Konfigurationscode für Shell-Skripte"
 
-#: command-list.h:171
+#: command-list.h:172
 msgid "Common Git shell script setup code"
 msgstr "allgemeiner Git Shell-Skript Konfigurationscode"
 
-#: command-list.h:172
+#: command-list.h:173
 msgid "Initialize and modify the sparse-checkout"
 msgstr "Initialisiere und verändere den partiellen Checkout"
 
-#: command-list.h:173
+#: command-list.h:174
 msgid "Stash the changes in a dirty working directory away"
 msgstr "Änderungen in einem Arbeitsverzeichnis aufbewahren"
 
-#: command-list.h:174
+#: command-list.h:175
 msgid "Add file contents to the staging area"
 msgstr "Dateiinhalte der Staging-Area hinzufügen"
 
-#: command-list.h:175
+#: command-list.h:176
 msgid "Show the working tree status"
 msgstr "den Zustand des Arbeitsverzeichnisses anzeigen"
 
-#: command-list.h:176
+#: command-list.h:177
 msgid "Remove unnecessary whitespace"
 msgstr "nicht erforderlichen Whitespace entfernen"
 
-#: command-list.h:177
+#: command-list.h:178
 msgid "Initialize, update or inspect submodules"
 msgstr "Submodule initialisieren, aktualisieren oder inspizieren"
 
-#: command-list.h:178
+#: command-list.h:179
 msgid "Bidirectional operation between a Subversion repository and Git"
 msgstr ""
 "Bidirektionale Operationen zwischen einem Subversion Repository und Git"
 
-#: command-list.h:179
+#: command-list.h:180
 msgid "Switch branches"
 msgstr "Branches wechseln"
 
-#: command-list.h:180
+#: command-list.h:181
 msgid "Read, modify and delete symbolic refs"
 msgstr "symbolische Referenzen lesen, ändern und löschen"
 
-#: command-list.h:181
+#: command-list.h:182
 msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr ""
 "ein mit GPG signiertes Tag-Objekt erzeugen, auflisten, löschen oder "
 "verifizieren."
 
-#: command-list.h:182
+#: command-list.h:183
 msgid "Creates a temporary file with a blob's contents"
 msgstr "eine temporäre Datei mit den Inhalten eines Blobs erstellen"
 
-#: command-list.h:183
+#: command-list.h:184
 msgid "Unpack objects from a packed archive"
 msgstr "Objekte von einem gepackten Archiv entpacken"
 
-#: command-list.h:184
+#: command-list.h:185
 msgid "Register file contents in the working tree to the index"
 msgstr "Dateiinhalte aus dem Arbeitsverzeichnis im Index registrieren"
 
-#: command-list.h:185
+#: command-list.h:186
 msgid "Update the object name stored in a ref safely"
 msgstr ""
 "den Objektnamen, der in einer Referenz gespeichert ist, sicher aktualisieren"
 
-#: command-list.h:186
+#: command-list.h:187
 msgid "Update auxiliary info file to help dumb servers"
 msgstr "Hilfsinformationsdatei zur Hilfe von einfachen Servern aktualisieren"
 
-#: command-list.h:187
+#: command-list.h:188
 msgid "Send archive back to git-archive"
 msgstr "Archiv zurück zu git-archive senden"
 
-#: command-list.h:188
+#: command-list.h:189
 msgid "Send objects packed back to git-fetch-pack"
 msgstr "Objekte gepackt zurück an git-fetch-pack senden"
 
-#: command-list.h:189
+#: command-list.h:190
 msgid "Show a Git logical variable"
 msgstr "eine logische Variable von Git anzeigen"
 
-#: command-list.h:190
+#: command-list.h:191
 msgid "Check the GPG signature of commits"
 msgstr "die GPG-Signatur von Commits prüfen"
 
-#: command-list.h:191
+#: command-list.h:192
 msgid "Validate packed Git archive files"
 msgstr "gepackte Git-Archivdateien validieren"
 
-#: command-list.h:192
+#: command-list.h:193
 msgid "Check the GPG signature of tags"
 msgstr "die GPG-Signatur von Tags prüfen"
 
-#: command-list.h:193
+#: command-list.h:194
 msgid "Git web interface (web frontend to Git repositories)"
 msgstr "Git Web Interface (Web-Frontend für Git-Repositories)"
 
-#: command-list.h:194
+#: command-list.h:195
 msgid "Show logs with difference each commit introduces"
 msgstr "Logs mit dem Unterschied, den jeder Commit einführt, anzeigen"
 
-#: command-list.h:195
+#: command-list.h:196
 msgid "Manage multiple working trees"
 msgstr "mehrere Arbeitsverzeichnisse verwalten"
 
-#: command-list.h:196
+#: command-list.h:197
 msgid "Create a tree object from the current index"
 msgstr "Tree-Objekt vom aktuellen Index erstellen"
 
-#: command-list.h:197
+#: command-list.h:198
 msgid "Defining attributes per path"
 msgstr "Definition von Attributen pro Pfad"
 
-#: command-list.h:198
+#: command-list.h:199
 msgid "Git command-line interface and conventions"
 msgstr "Git Kommandozeilenschnittstelle und Konventionen"
 
-#: command-list.h:199
+#: command-list.h:200
 msgid "A Git core tutorial for developers"
 msgstr "eine Git Anleitung für Entwickler"
 
-#: command-list.h:200
+#: command-list.h:201
+msgid "Providing usernames and passwords to Git"
+msgstr ""
+
+#: command-list.h:202
 msgid "Git for CVS users"
 msgstr "Git für CVS Benutzer"
 
-#: command-list.h:201
+#: command-list.h:203
 msgid "Tweaking diff output"
 msgstr "Diff-Ausgabe optimieren"
 
-#: command-list.h:202
+#: command-list.h:204
 msgid "A useful minimum set of commands for Everyday Git"
 msgstr ""
 "ein kleine, nützliche Menge von Befehlen für die tägliche Verwendung von Git"
 
-#: command-list.h:203
+#: command-list.h:205
 msgid "Frequently asked questions about using Git"
 msgstr "Häufig gestellte Fragen über die Nutzung von Git"
 
-#: command-list.h:204
+#: command-list.h:206
 msgid "A Git Glossary"
 msgstr "ein Git-Glossar"
 
-#: command-list.h:205
+#: command-list.h:207
 msgid "Hooks used by Git"
 msgstr "von Git verwendete Hooks"
 
-#: command-list.h:206
+#: command-list.h:208
 msgid "Specifies intentionally untracked files to ignore"
 msgstr "Spezifikation von bewusst ignorierten, unversionierten Dateien"
 
-#: command-list.h:207
+#: command-list.h:209
 msgid "Defining submodule properties"
 msgstr "Definition von Submodul-Eigenschaften"
 
-#: command-list.h:208
+#: command-list.h:210
 msgid "Git namespaces"
 msgstr "Git Namensbereiche"
 
-#: command-list.h:209
+#: command-list.h:211
+msgid "Helper programs to interact with remote repositories"
+msgstr ""
+
+#: command-list.h:212
 msgid "Git Repository Layout"
 msgstr "Git Repository Aufbau"
 
-#: command-list.h:210
+#: command-list.h:213
 msgid "Specifying revisions and ranges for Git"
 msgstr "Spezifikation von Commits und Bereichen für Git"
 
-#: command-list.h:211
+#: command-list.h:214
 msgid "Mounting one repository inside another"
 msgstr "Einbinden eines Repositories in ein anderes"
 
-#: command-list.h:212
+#: command-list.h:215
 msgid "A tutorial introduction to Git: part two"
 msgstr "eine einführende Anleitung zu Git: Teil zwei"
 
-#: command-list.h:213
+#: command-list.h:216
 msgid "A tutorial introduction to Git"
 msgstr "eine einführende Anleitung zu Git"
 
-#: command-list.h:214
+#: command-list.h:217
 msgid "An overview of recommended workflows with Git"
 msgstr "Eine Übersicht über empfohlene Arbeitsabläufe mit Git"
 
-#: git-bisect.sh:54
-msgid "You need to start by \"git bisect start\""
-msgstr "Sie müssen mit \"git bisect start\" beginnen."
-
-#. TRANSLATORS: Make sure to include [Y] and [n] in your
-#. translation. The program will only accept English input
-#. at this point.
-#: git-bisect.sh:60
-msgid "Do you want me to do it for you [Y/n]? "
-msgstr "Wollen Sie, dass ich es für Sie mache [Y/n]? "
-
-#: git-bisect.sh:101
+#: git-bisect.sh:79
 #, sh-format
 msgid "Bad rev input: $arg"
 msgstr "Ungültige Referenz-Eingabe: $arg"
 
-#: git-bisect.sh:121
+#: git-bisect.sh:99
 #, sh-format
 msgid "Bad rev input: $bisected_head"
 msgstr "Ungültige Referenz-Eingabe: $bisected_head"
 
-#: git-bisect.sh:130
+#: git-bisect.sh:108
 #, sh-format
 msgid "Bad rev input: $rev"
 msgstr "Ungültige Referenz-Eingabe: $rev"
 
-#: git-bisect.sh:139
+#: git-bisect.sh:117
 #, sh-format
 msgid "'git bisect $TERM_BAD' can take only one argument."
 msgstr "'git bisect $TERM_BAD' kann nur ein Argument entgegennehmen."
 
-#: git-bisect.sh:209
+#: git-bisect.sh:149
 msgid "No logfile given"
 msgstr "Keine Log-Datei gegeben"
 
-#: git-bisect.sh:210
+#: git-bisect.sh:150
 #, sh-format
 msgid "cannot read $file for replaying"
 msgstr "kann $file nicht für das Abspielen lesen"
 
-#: git-bisect.sh:233
+#: git-bisect.sh:173
 msgid "?? what are you talking about?"
 msgstr "?? Was reden Sie da?"
 
-#: git-bisect.sh:243
+#: git-bisect.sh:183
 msgid "bisect run failed: no command provided."
 msgstr "'bisect run' fehlgeschlagen: kein Befehl angegeben."
 
-#: git-bisect.sh:248
+#: git-bisect.sh:188
 #, sh-format
 msgid "running $command"
 msgstr "führe $command aus"
 
-#: git-bisect.sh:255
+#: git-bisect.sh:195
 #, sh-format
 msgid ""
 "bisect run failed:\n"
@@ -24241,11 +24670,11 @@ msgstr ""
 "'bisect run' fehlgeschlagen:\n"
 "Exit-Code $res von '$command' ist < 0 oder >= 128"
 
-#: git-bisect.sh:281
+#: git-bisect.sh:221
 msgid "bisect run cannot continue any more"
 msgstr "'bisect run' kann nicht mehr fortgesetzt werden"
 
-#: git-bisect.sh:287
+#: git-bisect.sh:227
 #, sh-format
 msgid ""
 "bisect run failed:\n"
@@ -24254,11 +24683,11 @@ msgstr ""
 "'bisect run' fehlgeschlagen:\n"
 "'bisect_state $state' wurde mit Fehlerwert $res beendet"
 
-#: git-bisect.sh:294
+#: git-bisect.sh:234
 msgid "bisect run success"
 msgstr "'bisect run' erfolgreich ausgeführt"
 
-#: git-bisect.sh:302
+#: git-bisect.sh:242
 msgid "We are not bisecting."
 msgstr "keine binäre Suche im Gange"
 
@@ -24303,50 +24732,50 @@ msgstr "Versuche einfachen Merge mit $pretty_name"
 msgid "Simple merge did not work, trying automatic merge."
 msgstr "Einfacher Merge hat nicht funktioniert, versuche automatischen Merge."
 
-#: git-submodule.sh:205
+#: git-submodule.sh:180
 msgid "Relative path can only be used from the toplevel of the working tree"
 msgstr ""
 "Relative Pfade können nur von der obersten Ebene des Arbeitsverzeichnisses "
 "benutzt werden."
 
-#: git-submodule.sh:215
+#: git-submodule.sh:190
 #, sh-format
 msgid "repo URL: '$repo' must be absolute or begin with ./|../"
 msgstr "repo URL: '$repo' muss absolut sein oder mit ./|../ beginnen"
 
-#: git-submodule.sh:234
+#: git-submodule.sh:209
 #, sh-format
 msgid "'$sm_path' already exists in the index"
 msgstr "'$sm_path' ist bereits zum Commit vorgemerkt"
 
-#: git-submodule.sh:237
+#: git-submodule.sh:212
 #, sh-format
 msgid "'$sm_path' already exists in the index and is not a submodule"
 msgstr "'$sm_path' ist bereits zum Commit vorgemerkt und ist kein Submodul"
 
-#: git-submodule.sh:244
+#: git-submodule.sh:219
 #, sh-format
 msgid "'$sm_path' does not have a commit checked out"
 msgstr "'$sm_path' hat keinen Commit ausgecheckt"
 
-#: git-submodule.sh:275
+#: git-submodule.sh:250
 #, sh-format
 msgid "Adding existing repo at '$sm_path' to the index"
 msgstr "Füge existierendes Repository in '$sm_path' dem Index hinzu."
 
-#: git-submodule.sh:277
+#: git-submodule.sh:252
 #, sh-format
 msgid "'$sm_path' already exists and is not a valid git repo"
 msgstr "'$sm_path' existiert bereits und ist kein gültiges Git-Repository"
 
-#: git-submodule.sh:285
+#: git-submodule.sh:260
 #, sh-format
 msgid "A git directory for '$sm_name' is found locally with remote(s):"
 msgstr ""
 "Ein Git-Verzeichnis für '$sm_name' wurde lokal gefunden mit den Remote-"
 "Repositories:"
 
-#: git-submodule.sh:287
+#: git-submodule.sh:262
 #, sh-format
 msgid ""
 "If you want to reuse this local git directory instead of cloning again from\n"
@@ -24364,37 +24793,37 @@ msgstr ""
 "nicht das korrekte Repository ist oder Sie unsicher sind, was das bedeutet,\n"
 "wählen Sie einen anderen Namen mit der Option '--name'."
 
-#: git-submodule.sh:293
+#: git-submodule.sh:268
 #, sh-format
 msgid "Reactivating local git directory for submodule '$sm_name'."
 msgstr "Reaktiviere lokales Git-Verzeichnis für Submodul '$sm_name'."
 
-#: git-submodule.sh:305
+#: git-submodule.sh:280
 #, sh-format
 msgid "Unable to checkout submodule '$sm_path'"
 msgstr "Kann Submodul '$sm_path' nicht auschecken"
 
-#: git-submodule.sh:310
+#: git-submodule.sh:285
 #, sh-format
 msgid "Failed to add submodule '$sm_path'"
 msgstr "Hinzufügen von Submodul '$sm_path' fehlgeschlagen"
 
-#: git-submodule.sh:319
+#: git-submodule.sh:294
 #, sh-format
 msgid "Failed to register submodule '$sm_path'"
 msgstr "Fehler beim Eintragen von Submodul '$sm_path' in die Konfiguration."
 
-#: git-submodule.sh:592
+#: git-submodule.sh:567
 #, sh-format
 msgid "Unable to find current revision in submodule path '$displaypath'"
 msgstr "Konnte aktuellen Commit in Submodul-Pfad '$displaypath' nicht finden."
 
-#: git-submodule.sh:602
+#: git-submodule.sh:577
 #, sh-format
 msgid "Unable to fetch in submodule path '$sm_path'"
 msgstr "Konnte \"fetch\" in Submodul-Pfad '$sm_path' nicht ausführen"
 
-#: git-submodule.sh:607
+#: git-submodule.sh:582
 #, sh-format
 msgid ""
 "Unable to find current ${remote_name}/${branch} revision in submodule path "
@@ -24403,7 +24832,7 @@ msgstr ""
 "Konnte aktuellen Commit von ${remote_name}/${branch} in Submodul-Pfad\n"
 "'$sm_path' nicht finden."
 
-#: git-submodule.sh:625
+#: git-submodule.sh:600
 #, sh-format
 msgid ""
 "Unable to fetch in submodule path '$displaypath'; trying to directly fetch "
@@ -24412,7 +24841,7 @@ msgstr ""
 "Konnte \"fetch\" in Submodul-Pfad '$displaypath' nicht ausführen. Versuche "
 "$sha1 direkt anzufordern:"
 
-#: git-submodule.sh:631
+#: git-submodule.sh:606
 #, sh-format
 msgid ""
 "Fetched in submodule path '$displaypath', but it did not contain $sha1. "
@@ -24421,78 +24850,52 @@ msgstr ""
 "\"fetch\" in Submodul-Pfad '$displaypath' ausgeführt, aber $sha1 nicht\n"
 "enthalten. Direktes Anfordern dieses Commits ist fehlgeschlagen."
 
-#: git-submodule.sh:638
+#: git-submodule.sh:613
 #, sh-format
 msgid "Unable to checkout '$sha1' in submodule path '$displaypath'"
 msgstr "Konnte '$sha1' in Submodul-Pfad '$displaypath' nicht auschecken."
 
-#: git-submodule.sh:639
+#: git-submodule.sh:614
 #, sh-format
 msgid "Submodule path '$displaypath': checked out '$sha1'"
 msgstr "Submodul-Pfad: '$displaypath': '$sha1' ausgecheckt"
 
-#: git-submodule.sh:643
+#: git-submodule.sh:618
 #, sh-format
 msgid "Unable to rebase '$sha1' in submodule path '$displaypath'"
 msgstr "Rebase auf '$sha1' in Submodul-Pfad '$displaypath' nicht möglich"
 
-#: git-submodule.sh:644
+#: git-submodule.sh:619
 #, sh-format
 msgid "Submodule path '$displaypath': rebased into '$sha1'"
 msgstr "Submodul-Pfad '$displaypath': Rebase auf '$sha1'"
 
-#: git-submodule.sh:649
+#: git-submodule.sh:624
 #, sh-format
 msgid "Unable to merge '$sha1' in submodule path '$displaypath'"
 msgstr "Merge von '$sha1' in Submodul-Pfad '$displaypath' fehlgeschlagen"
 
-#: git-submodule.sh:650
+#: git-submodule.sh:625
 #, sh-format
 msgid "Submodule path '$displaypath': merged in '$sha1'"
 msgstr "Submodul-Pfad '$displaypath': zusammengeführt in '$sha1'"
 
-#: git-submodule.sh:655
+#: git-submodule.sh:630
 #, sh-format
 msgid "Execution of '$command $sha1' failed in submodule path '$displaypath'"
 msgstr ""
 "Ausführung von '$command $sha1' in Submodul-Pfad '$displaypath' "
 "fehlgeschlagen"
 
-#: git-submodule.sh:656
+#: git-submodule.sh:631
 #, sh-format
 msgid "Submodule path '$displaypath': '$command $sha1'"
 msgstr "Submodul-Pfad '$displaypath': '$command $sha1'"
 
-#: git-submodule.sh:687
+#: git-submodule.sh:662
 #, sh-format
 msgid "Failed to recurse into submodule path '$displaypath'"
 msgstr "Fehler bei Rekursion in Submodul-Pfad '$displaypath'"
-
-#: git-submodule.sh:852
-msgid "The --cached option cannot be used with the --files option"
-msgstr ""
-"Die Optionen --cached und --files können nicht gemeinsam verwendet werden."
-
-#: git-submodule.sh:904
-#, sh-format
-msgid "unexpected mode $mod_dst"
-msgstr "unerwarteter Modus $mod_dst"
-
-#: git-submodule.sh:924
-#, sh-format
-msgid "  Warn: $display_name doesn't contain commit $sha1_src"
-msgstr "  Warnung: $display_name beinhaltet nicht Commit $sha1_src"
-
-#: git-submodule.sh:927
-#, sh-format
-msgid "  Warn: $display_name doesn't contain commit $sha1_dst"
-msgstr "  Warnung: $display_name beinhaltet nicht Commit $sha1_dst"
-
-#: git-submodule.sh:930
-#, sh-format
-msgid "  Warn: $display_name doesn't contain commits $sha1_src and $sha1_dst"
-msgstr ""
-"  Warnung: $display_name beinhaltet nicht die Commits $sha1_src und $sha1_dst"
 
 #: git-parse-remote.sh:89
 #, sh-format
@@ -24523,7 +24926,7 @@ msgstr ""
 msgid "Rebasing ($new_count/$total)"
 msgstr "Führe Rebase aus ($new_count/$total)"
 
-#: git-rebase--preserve-merges.sh:207
+#: git-rebase--preserve-merges.sh:197
 msgid ""
 "\n"
 "Commands:\n"
@@ -24565,7 +24968,7 @@ msgstr ""
 "Diese Zeilen können umsortiert werden; Sie werden von oben nach unten\n"
 "ausgeführt.\n"
 
-#: git-rebase--preserve-merges.sh:270
+#: git-rebase--preserve-merges.sh:260
 #, sh-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -24584,83 +24987,83 @@ msgstr ""
 "\n"
 "\tgit rebase --continue"
 
-#: git-rebase--preserve-merges.sh:295
+#: git-rebase--preserve-merges.sh:285
 #, sh-format
 msgid "$sha1: not a commit that can be picked"
 msgstr "$sha1: kein Commit der gepickt werden kann"
 
-#: git-rebase--preserve-merges.sh:334
+#: git-rebase--preserve-merges.sh:324
 #, sh-format
 msgid "Invalid commit name: $sha1"
 msgstr "Ungültiger Commit-Name: $sha1"
 
-#: git-rebase--preserve-merges.sh:364
+#: git-rebase--preserve-merges.sh:354
 msgid "Cannot write current commit's replacement sha1"
 msgstr "Kann ersetzenden SHA-1 des aktuellen Commits nicht schreiben"
 
-#: git-rebase--preserve-merges.sh:415
+#: git-rebase--preserve-merges.sh:405
 #, sh-format
 msgid "Fast-forward to $sha1"
 msgstr "Spule vor zu $sha1"
 
-#: git-rebase--preserve-merges.sh:417
+#: git-rebase--preserve-merges.sh:407
 #, sh-format
 msgid "Cannot fast-forward to $sha1"
 msgstr "Kann nicht zu $sha1 vorspulen"
 
-#: git-rebase--preserve-merges.sh:426
+#: git-rebase--preserve-merges.sh:416
 #, sh-format
 msgid "Cannot move HEAD to $first_parent"
 msgstr "Kann HEAD nicht auf $first_parent setzen"
 
-#: git-rebase--preserve-merges.sh:431
+#: git-rebase--preserve-merges.sh:421
 #, sh-format
 msgid "Refusing to squash a merge: $sha1"
 msgstr "\"squash\" eines Merges ($sha1) zurückgewiesen."
 
-#: git-rebase--preserve-merges.sh:449
+#: git-rebase--preserve-merges.sh:439
 #, sh-format
 msgid "Error redoing merge $sha1"
 msgstr "Fehler beim Wiederholen des Merges von $sha1"
 
-#: git-rebase--preserve-merges.sh:458
+#: git-rebase--preserve-merges.sh:448
 #, sh-format
 msgid "Could not pick $sha1"
 msgstr "Konnte $sha1 nicht picken"
 
-#: git-rebase--preserve-merges.sh:467
+#: git-rebase--preserve-merges.sh:457
 #, sh-format
 msgid "This is the commit message #${n}:"
 msgstr "Das ist Commit-Beschreibung #${n}:"
 
-#: git-rebase--preserve-merges.sh:472
+#: git-rebase--preserve-merges.sh:462
 #, sh-format
 msgid "The commit message #${n} will be skipped:"
 msgstr "Commit-Beschreibung #${n} wird ausgelassen:"
 
-#: git-rebase--preserve-merges.sh:483
+#: git-rebase--preserve-merges.sh:473
 #, sh-format
 msgid "This is a combination of $count commit."
 msgid_plural "This is a combination of $count commits."
 msgstr[0] "Das ist eine Kombination aus $count Commit."
 msgstr[1] "Das ist eine Kombination aus $count Commits."
 
-#: git-rebase--preserve-merges.sh:492
+#: git-rebase--preserve-merges.sh:482
 #, sh-format
 msgid "Cannot write $fixup_msg"
 msgstr "Kann $fixup_msg nicht schreiben"
 
-#: git-rebase--preserve-merges.sh:495
+#: git-rebase--preserve-merges.sh:485
 msgid "This is a combination of 2 commits."
 msgstr "Das ist eine Kombination aus 2 Commits."
 
-#: git-rebase--preserve-merges.sh:536 git-rebase--preserve-merges.sh:579
-#: git-rebase--preserve-merges.sh:582
+#: git-rebase--preserve-merges.sh:526 git-rebase--preserve-merges.sh:569
+#: git-rebase--preserve-merges.sh:572
 #, sh-format
 msgid "Could not apply $sha1... $rest"
 msgstr "Konnte $sha1... ($rest) nicht anwenden"
 
-#: git-rebase--preserve-merges.sh:611
+#: git-rebase--preserve-merges.sh:601
 #, sh-format
 msgid ""
 "Could not amend commit after successfully picking $sha1... $rest\n"
@@ -24677,31 +25080,31 @@ msgstr ""
 "sollten Sie das Problem beheben, bevor Sie die Commit-Beschreibung ändern "
 "können."
 
-#: git-rebase--preserve-merges.sh:626
+#: git-rebase--preserve-merges.sh:616
 #, sh-format
 msgid "Stopped at $sha1_abbrev... $rest"
 msgstr "Angehalten bei $sha1_abbrev... $rest"
 
-#: git-rebase--preserve-merges.sh:641
+#: git-rebase--preserve-merges.sh:631
 #, sh-format
 msgid "Cannot '$squash_style' without a previous commit"
 msgstr "Kann nicht '$squash_style' ohne vorherigen Commit"
 
-#: git-rebase--preserve-merges.sh:683
+#: git-rebase--preserve-merges.sh:673
 #, sh-format
 msgid "Executing: $rest"
 msgstr "Führe aus: $rest"
 
-#: git-rebase--preserve-merges.sh:691
+#: git-rebase--preserve-merges.sh:681
 #, sh-format
 msgid "Execution failed: $rest"
 msgstr "Ausführung fehlgeschlagen: $rest"
 
-#: git-rebase--preserve-merges.sh:693
+#: git-rebase--preserve-merges.sh:683
 msgid "and made changes to the index and/or the working tree"
 msgstr "Der Index und/oder das Arbeitsverzeichnis wurde geändert."
 
-#: git-rebase--preserve-merges.sh:695
+#: git-rebase--preserve-merges.sh:685
 msgid ""
 "You can fix the problem, and then run\n"
 "\n"
@@ -24714,7 +25117,7 @@ msgstr ""
 "ausführen."
 
 #. TRANSLATORS: after these lines is a command to be issued by the user
-#: git-rebase--preserve-merges.sh:708
+#: git-rebase--preserve-merges.sh:698
 #, sh-format
 msgid ""
 "Execution succeeded: $rest\n"
@@ -24730,25 +25133,25 @@ msgstr ""
 "\n"
 "\tgit rebase --continue"
 
-#: git-rebase--preserve-merges.sh:719
+#: git-rebase--preserve-merges.sh:709
 #, sh-format
 msgid "Unknown command: $command $sha1 $rest"
 msgstr "Unbekannter Befehl: $command $sha1 $rest"
 
-#: git-rebase--preserve-merges.sh:720
+#: git-rebase--preserve-merges.sh:710
 msgid "Please fix this using 'git rebase --edit-todo'."
 msgstr "Bitte beheben Sie das, indem Sie 'git rebase --edit-todo' ausführen."
 
-#: git-rebase--preserve-merges.sh:755
+#: git-rebase--preserve-merges.sh:745
 #, sh-format
 msgid "Successfully rebased and updated $head_name."
 msgstr "Erfolgreich Rebase ausgeführt und $head_name aktualisiert."
 
-#: git-rebase--preserve-merges.sh:812
+#: git-rebase--preserve-merges.sh:802
 msgid "Could not remove CHERRY_PICK_HEAD"
 msgstr "Konnte CHERRY_PICK_HEAD nicht löschen"
 
-#: git-rebase--preserve-merges.sh:817
+#: git-rebase--preserve-merges.sh:807
 #, sh-format
 msgid ""
 "You have staged changes in your working tree.\n"
@@ -24780,13 +25183,13 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: git-rebase--preserve-merges.sh:834
+#: git-rebase--preserve-merges.sh:824
 msgid "Error trying to find the author identity to amend commit"
 msgstr ""
 "Fehler beim Versuch die Identität des Authors zum Verbessern des Commits zu\n"
 "finden"
 
-#: git-rebase--preserve-merges.sh:839
+#: git-rebase--preserve-merges.sh:829
 msgid ""
 "You have uncommitted changes in your working tree. Please commit them\n"
 "first and then run 'git rebase --continue' again."
@@ -24796,44 +25199,44 @@ msgstr ""
 "erneut\n"
 "aus."
 
-#: git-rebase--preserve-merges.sh:844 git-rebase--preserve-merges.sh:848
+#: git-rebase--preserve-merges.sh:834 git-rebase--preserve-merges.sh:838
 msgid "Could not commit staged changes."
 msgstr "Konnte Änderungen aus der Staging-Area nicht committen."
 
-#: git-rebase--preserve-merges.sh:879 git-rebase--preserve-merges.sh:965
+#: git-rebase--preserve-merges.sh:869 git-rebase--preserve-merges.sh:955
 msgid "Could not execute editor"
 msgstr "Konnte Editor nicht ausführen."
 
-#: git-rebase--preserve-merges.sh:900
+#: git-rebase--preserve-merges.sh:890
 #, sh-format
 msgid "Could not checkout $switch_to"
 msgstr "Konnte $switch_to nicht auschecken."
 
-#: git-rebase--preserve-merges.sh:907
+#: git-rebase--preserve-merges.sh:897
 msgid "No HEAD?"
 msgstr "Kein HEAD?"
 
-#: git-rebase--preserve-merges.sh:908
+#: git-rebase--preserve-merges.sh:898
 #, sh-format
 msgid "Could not create temporary $state_dir"
 msgstr "Konnte temporäres Verzeichnis $state_dir nicht erstellen."
 
-#: git-rebase--preserve-merges.sh:911
+#: git-rebase--preserve-merges.sh:901
 msgid "Could not mark as interactive"
 msgstr "Konnte nicht als interaktiven Rebase markieren."
 
-#: git-rebase--preserve-merges.sh:943
+#: git-rebase--preserve-merges.sh:933
 #, sh-format
 msgid "Rebase $shortrevisions onto $shortonto ($todocount command)"
 msgid_plural "Rebase $shortrevisions onto $shortonto ($todocount commands)"
 msgstr[0] "Rebase von $shortrevisions auf $shortonto ($todocount Kommando)"
 msgstr[1] "Rebase von $shortrevisions auf $shortonto ($todocount Kommandos)"
 
-#: git-rebase--preserve-merges.sh:955
+#: git-rebase--preserve-merges.sh:945
 msgid "Note that empty commits are commented out"
 msgstr "Leere Commits sind auskommentiert."
 
-#: git-rebase--preserve-merges.sh:997 git-rebase--preserve-merges.sh:1002
+#: git-rebase--preserve-merges.sh:987 git-rebase--preserve-merges.sh:992
 msgid "Could not init rewritten commits"
 msgstr "Konnte neu geschriebene Commits nicht initialisieren."
 
@@ -24927,7 +25330,7 @@ msgid_plural "touched %d paths\n"
 msgstr[0] "%d Pfad angefasst\n"
 msgstr[1] "%d Pfade angefasst\n"
 
-#: git-add--interactive.perl:1055
+#: git-add--interactive.perl:1058
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for staging."
@@ -24935,7 +25338,7 @@ msgstr ""
 "Wenn der Patch sauber angewendet werden kann, wird der bearbeitete\n"
 "Patch-Block direkt zum Hinzufügen zur Staging-Area markiert."
 
-#: git-add--interactive.perl:1058
+#: git-add--interactive.perl:1061
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for stashing."
@@ -24943,7 +25346,7 @@ msgstr ""
 "Wenn der Patch sauber angewendet werden kann, wird der bearbeitete\n"
 "Patch-Block direkt zum Hinzufügen zum Stash markiert."
 
-#: git-add--interactive.perl:1061
+#: git-add--interactive.perl:1064
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for unstaging."
@@ -24951,8 +25354,8 @@ msgstr ""
 "Wenn der Patch sauber angewendet werden kann, wird der bearbeitete\n"
 "Patch-Block direkt zum Entfernen aus der Staging-Area markiert."
 
-#: git-add--interactive.perl:1064 git-add--interactive.perl:1073
-#: git-add--interactive.perl:1079
+#: git-add--interactive.perl:1067 git-add--interactive.perl:1076
+#: git-add--interactive.perl:1082
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for applying."
@@ -24960,8 +25363,8 @@ msgstr ""
 "Wenn der Patch sauber angewendet werden kann, wird der bearbeitete\n"
 "Patch-Block direkt zum Anwenden markiert."
 
-#: git-add--interactive.perl:1067 git-add--interactive.perl:1070
-#: git-add--interactive.perl:1076
+#: git-add--interactive.perl:1070 git-add--interactive.perl:1073
+#: git-add--interactive.perl:1079
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for discarding."
@@ -24969,13 +25372,13 @@ msgstr ""
 "Wenn der Patch sauber angewendet werden kann, wird der bearbeitete\n"
 "Patch-Block direkt zum Verwerfen markiert."
 
-#: git-add--interactive.perl:1113
+#: git-add--interactive.perl:1116
 #, perl-format
 msgid "failed to open hunk edit file for writing: %s"
 msgstr ""
 "Fehler beim Öffnen von Editier-Datei eines Patch-Blocks zum Schreiben: %s"
 
-#: git-add--interactive.perl:1120
+#: git-add--interactive.perl:1123
 #, perl-format
 msgid ""
 "---\n"
@@ -24988,12 +25391,12 @@ msgstr ""
 "Um '%s' Zeilen zu entfernen, löschen Sie diese.\n"
 "Zeilen, die mit %s beginnen, werden entfernt.\n"
 
-#: git-add--interactive.perl:1142
+#: git-add--interactive.perl:1145
 #, perl-format
 msgid "failed to open hunk edit file for reading: %s"
 msgstr "Fehler beim Öffnen von Editier-Datei eines Patch-Blocks zum Lesen: %s"
 
-#: git-add--interactive.perl:1250
+#: git-add--interactive.perl:1253
 msgid ""
 "y - stage this hunk\n"
 "n - do not stage this hunk\n"
@@ -25009,7 +25412,7 @@ msgstr ""
 "d - diesen oder alle weiteren Patch-Blöcke in dieser Datei nicht zum Commit "
 "vormerken"
 
-#: git-add--interactive.perl:1256
+#: git-add--interactive.perl:1259
 msgid ""
 "y - stash this hunk\n"
 "n - do not stash this hunk\n"
@@ -25023,7 +25426,7 @@ msgstr ""
 "a - diesen und alle weiteren Patch-Blöcke dieser Datei stashen\n"
 "d - diesen oder alle weiteren Patch-Blöcke dieser Datei nicht stashen"
 
-#: git-add--interactive.perl:1262
+#: git-add--interactive.perl:1265
 msgid ""
 "y - unstage this hunk\n"
 "n - do not unstage this hunk\n"
@@ -25037,7 +25440,7 @@ msgstr ""
 "a - diesen und alle weiteren Patch-Blöcke dieser Datei unstashen\n"
 "d - diesen oder alle weiteren Patch-Blöcke dieser Datei nicht unstashen"
 
-#: git-add--interactive.perl:1268
+#: git-add--interactive.perl:1271
 msgid ""
 "y - apply this hunk to index\n"
 "n - do not apply this hunk to index\n"
@@ -25054,7 +25457,7 @@ msgstr ""
 "d - diesen oder alle weiteren Patch-Blöcke dieser Datei nicht auf den Index "
 "anwenden"
 
-#: git-add--interactive.perl:1274 git-add--interactive.perl:1292
+#: git-add--interactive.perl:1277 git-add--interactive.perl:1295
 msgid ""
 "y - discard this hunk from worktree\n"
 "n - do not discard this hunk from worktree\n"
@@ -25071,7 +25474,7 @@ msgstr ""
 "d - diesen oder alle weiteren Patch-Blöcke dieser Datei nicht im "
 "Arbeitsverzeichnis verwerfen"
 
-#: git-add--interactive.perl:1280
+#: git-add--interactive.perl:1283
 msgid ""
 "y - discard this hunk from index and worktree\n"
 "n - do not discard this hunk from index and worktree\n"
@@ -25086,7 +25489,7 @@ msgstr ""
 "a - diesen und alle weiteren Patch-Blöcke in der Datei verwerfen\n"
 "d - diesen oder alle weiteren Patch-Blöcke in der Datei nicht verwerfen"
 
-#: git-add--interactive.perl:1286
+#: git-add--interactive.perl:1289
 msgid ""
 "y - apply this hunk to index and worktree\n"
 "n - do not apply this hunk to index and worktree\n"
@@ -25100,7 +25503,7 @@ msgstr ""
 "a - diesen und alle weiteren Patch-Blöcke in der Datei anwenden\n"
 "d - diesen oder alle weiteren Patch-Blöcke in der Datei nicht anwenden"
 
-#: git-add--interactive.perl:1298
+#: git-add--interactive.perl:1301
 msgid ""
 "y - apply this hunk to worktree\n"
 "n - do not apply this hunk to worktree\n"
@@ -25114,7 +25517,7 @@ msgstr ""
 "a - diesen und alle weiteren Patch-Blöcke in der Datei anwenden\n"
 "d - diesen und alle weiteren Patch-Blöcke in der Datei nicht anwenden"
 
-#: git-add--interactive.perl:1313
+#: git-add--interactive.perl:1316
 msgid ""
 "g - select a hunk to go to\n"
 "/ - search for a hunk matching the given regex\n"
@@ -25138,92 +25541,92 @@ msgstr ""
 "e - aktuellen Patch-Block manuell editieren\n"
 "? - Hilfe anzeigen\n"
 
-#: git-add--interactive.perl:1344
+#: git-add--interactive.perl:1347
 msgid "The selected hunks do not apply to the index!\n"
 msgstr ""
 "Die ausgewählten Patch-Blöcke können nicht auf den Index angewendet werden!\n"
 
-#: git-add--interactive.perl:1359
+#: git-add--interactive.perl:1362
 #, perl-format
 msgid "ignoring unmerged: %s\n"
 msgstr "ignoriere nicht zusammengeführte Datei: %s\n"
 
-#: git-add--interactive.perl:1478
+#: git-add--interactive.perl:1481
 #, perl-format
 msgid "Apply mode change to worktree [y,n,q,a,d%s,?]? "
 msgstr "Modusänderung auf Arbeitsverzeichnis anwenden [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1479
+#: git-add--interactive.perl:1482
 #, perl-format
 msgid "Apply deletion to worktree [y,n,q,a,d%s,?]? "
 msgstr "Löschung auf Arbeitsverzeichnis anwenden [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1480
+#: git-add--interactive.perl:1483
 #, perl-format
 msgid "Apply addition to worktree [y,n,q,a,d%s,?]? "
 msgstr "Ergänzung auf Arbeitsverzeichnis anwenden [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1481
+#: git-add--interactive.perl:1484
 #, perl-format
 msgid "Apply this hunk to worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Diesen Patch-Block auf das Arbeitsverzeichnis anwenden [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1587
+#: git-add--interactive.perl:1601
 msgid "No other hunks to goto\n"
 msgstr "Keine anderen Patch-Blöcke verbleibend\n"
 
-#: git-add--interactive.perl:1605
+#: git-add--interactive.perl:1619
 #, perl-format
 msgid "Invalid number: '%s'\n"
 msgstr "Ungültige Nummer: '%s'\n"
 
-#: git-add--interactive.perl:1610
+#: git-add--interactive.perl:1624
 #, perl-format
 msgid "Sorry, only %d hunk available.\n"
 msgid_plural "Sorry, only %d hunks available.\n"
 msgstr[0] "Entschuldigung, nur %d Patch-Block verfügbar.\n"
 msgstr[1] "Entschuldigung, nur %d Patch-Blöcke verfügbar.\n"
 
-#: git-add--interactive.perl:1636
+#: git-add--interactive.perl:1659
 msgid "No other hunks to search\n"
 msgstr "Keine anderen Patch-Blöcke zum Durchsuchen\n"
 
-#: git-add--interactive.perl:1653
+#: git-add--interactive.perl:1676
 #, perl-format
 msgid "Malformed search regexp %s: %s\n"
 msgstr "Fehlerhafter regulärer Ausdruck für Suche %s: %s\n"
 
-#: git-add--interactive.perl:1663
+#: git-add--interactive.perl:1686
 msgid "No hunk matches the given pattern\n"
 msgstr "Kein Patch-Block entspricht dem angegebenen Muster\n"
 
-#: git-add--interactive.perl:1675 git-add--interactive.perl:1697
+#: git-add--interactive.perl:1698 git-add--interactive.perl:1720
 msgid "No previous hunk\n"
 msgstr "Kein vorheriger Patch-Block\n"
 
-#: git-add--interactive.perl:1684 git-add--interactive.perl:1703
+#: git-add--interactive.perl:1707 git-add--interactive.perl:1726
 msgid "No next hunk\n"
 msgstr "Kein folgender Patch-Block\n"
 
-#: git-add--interactive.perl:1709
+#: git-add--interactive.perl:1732
 msgid "Sorry, cannot split this hunk\n"
 msgstr "Entschuldigung, kann diesen Patch-Block nicht aufteilen.\n"
 
-#: git-add--interactive.perl:1715
+#: git-add--interactive.perl:1738
 #, perl-format
 msgid "Split into %d hunk.\n"
 msgid_plural "Split into %d hunks.\n"
 msgstr[0] "In %d Patch-Block aufgeteilt.\n"
 msgstr[1] "In %d Patch-Blöcke aufgeteilt.\n"
 
-#: git-add--interactive.perl:1725
+#: git-add--interactive.perl:1748
 msgid "Sorry, cannot edit this hunk\n"
 msgstr "Entschuldigung, kann diesen Patch-Block nicht bearbeiten.\n"
 
 #. TRANSLATORS: please do not translate the command names
 #. 'status', 'update', 'revert', etc.
-#: git-add--interactive.perl:1790
+#: git-add--interactive.perl:1813
 msgid ""
 "status        - show paths with changes\n"
 "update        - add working tree state to the staged set of changes\n"
@@ -25242,19 +25645,19 @@ msgstr ""
 "diff          - Unterschiede zwischen HEAD und Index anzeigen\n"
 "add untracked - Inhalte von unversionierten Dateien zum Commit vormerken\n"
 
-#: git-add--interactive.perl:1807 git-add--interactive.perl:1812
-#: git-add--interactive.perl:1815 git-add--interactive.perl:1822
-#: git-add--interactive.perl:1825 git-add--interactive.perl:1832
-#: git-add--interactive.perl:1836 git-add--interactive.perl:1842
+#: git-add--interactive.perl:1830 git-add--interactive.perl:1835
+#: git-add--interactive.perl:1838 git-add--interactive.perl:1845
+#: git-add--interactive.perl:1848 git-add--interactive.perl:1855
+#: git-add--interactive.perl:1859 git-add--interactive.perl:1865
 msgid "missing --"
 msgstr "-- fehlt"
 
-#: git-add--interactive.perl:1838
+#: git-add--interactive.perl:1861
 #, perl-format
 msgid "unknown --patch mode: %s"
 msgstr "Unbekannter --patch Modus: %s"
 
-#: git-add--interactive.perl:1844 git-add--interactive.perl:1850
+#: git-add--interactive.perl:1867 git-add--interactive.perl:1873
 #, perl-format
 msgid "invalid argument %s, expecting --"
 msgstr "ungültiges Argument %s, erwarte --"
@@ -25272,28 +25675,35 @@ msgstr "lokaler Zeit-Offset größer oder gleich 24 Stunden\n"
 msgid "the editor exited uncleanly, aborting everything"
 msgstr "Der Editor wurde unsauber beendet, breche alles ab."
 
-#: git-send-email.perl:310
+#: git-send-email.perl:312
 #, perl-format
 msgid ""
 "'%s' contains an intermediate version of the email you were composing.\n"
 msgstr ""
 "'%s' enthält eine Zwischenversion der E-Mail, die Sie gerade verfassen.\n"
 
-#: git-send-email.perl:315
+#: git-send-email.perl:317
 #, perl-format
 msgid "'%s.final' contains the composed email.\n"
 msgstr "'%s.final' enthält die verfasste E-Mail.\n"
 
-#: git-send-email.perl:408
+#: git-send-email.perl:410
 msgid "--dump-aliases incompatible with other options\n"
 msgstr "--dump-aliases ist mit anderen Optionen inkompatibel\n"
 
-#: git-send-email.perl:481 git-send-email.perl:683
+#: git-send-email.perl:484
+msgid ""
+"fatal: found configuration options for 'sendmail'\n"
+"git-send-email is configured with the sendemail.* options - note the 'e'.\n"
+"Set sendemail.forbidSendmailVariables to false to disable this check.\n"
+msgstr ""
+
+#: git-send-email.perl:489 git-send-email.perl:691
 msgid "Cannot run git format-patch from outside a repository\n"
 msgstr ""
 "Kann 'git format-patch' nicht außerhalb eines Repositories ausführen.\n"
 
-#: git-send-email.perl:484
+#: git-send-email.perl:492
 msgid ""
 "`batch-size` and `relogin` must be specified together (via command-line or "
 "configuration option)\n"
@@ -25302,38 +25712,38 @@ msgstr ""
 "Kommandozeile\n"
 "oder Konfigurationsoption)\n"
 
-#: git-send-email.perl:497
+#: git-send-email.perl:505
 #, perl-format
 msgid "Unknown --suppress-cc field: '%s'\n"
 msgstr "Unbekanntes --suppress-cc Feld: '%s'\n"
 
-#: git-send-email.perl:528
+#: git-send-email.perl:536
 #, perl-format
 msgid "Unknown --confirm setting: '%s'\n"
 msgstr "Unbekannte --confirm Einstellung: '%s'\n"
 
-#: git-send-email.perl:556
+#: git-send-email.perl:564
 #, perl-format
 msgid "warning: sendmail alias with quotes is not supported: %s\n"
 msgstr ""
 "Warnung: sendemail-Alias mit Anführungszeichen wird nicht unterstützt: %s\n"
 
-#: git-send-email.perl:558
+#: git-send-email.perl:566
 #, perl-format
 msgid "warning: `:include:` not supported: %s\n"
 msgstr "Warnung: `:include:` wird nicht unterstützt: %s\n"
 
-#: git-send-email.perl:560
+#: git-send-email.perl:568
 #, perl-format
 msgid "warning: `/file` or `|pipe` redirection not supported: %s\n"
 msgstr "Warnung: `/file` oder `|pipe` Umleitung wird nicht unterstützt: %s\n"
 
-#: git-send-email.perl:565
+#: git-send-email.perl:573
 #, perl-format
 msgid "warning: sendmail line is not recognized: %s\n"
 msgstr "Warnung: sendmail Zeile wird nicht erkannt: %s\n"
 
-#: git-send-email.perl:649
+#: git-send-email.perl:657
 #, perl-format
 msgid ""
 "File '%s' exists but it could also be the range of commits\n"
@@ -25350,12 +25760,12 @@ msgstr ""
 "    * die Option --format-patch angeben, wenn Sie einen Commit-Bereich "
 "meinen\n"
 
-#: git-send-email.perl:670
+#: git-send-email.perl:678
 #, perl-format
 msgid "Failed to opendir %s: %s"
 msgstr "Fehler beim Öffnen von %s: %s"
 
-#: git-send-email.perl:694
+#: git-send-email.perl:702
 #, perl-format
 msgid ""
 "fatal: %s: %s\n"
@@ -25364,7 +25774,7 @@ msgstr ""
 "fatal: %s: %s\n"
 "Warnung: Es wurden keine Patches versendet.\n"
 
-#: git-send-email.perl:705
+#: git-send-email.perl:713
 msgid ""
 "\n"
 "No patch files specified!\n"
@@ -25374,17 +25784,17 @@ msgstr ""
 "keine Patch-Dateien angegeben!\n"
 "\n"
 
-#: git-send-email.perl:718
+#: git-send-email.perl:726
 #, perl-format
 msgid "No subject line in %s?"
 msgstr "Keine Betreffzeile in %s?"
 
-#: git-send-email.perl:728
+#: git-send-email.perl:736
 #, perl-format
 msgid "Failed to open for writing %s: %s"
 msgstr "Fehler beim Öffnen von '%s' zum Schreiben: %s"
 
-#: git-send-email.perl:739
+#: git-send-email.perl:747
 msgid ""
 "Lines beginning in \"GIT:\" will be removed.\n"
 "Consider including an overall diffstat or table of contents\n"
@@ -25399,27 +25809,27 @@ msgstr ""
 "Leeren Sie den Inhalt des Bodys, wenn Sie keine Zusammenfassung senden "
 "möchten.\n"
 
-#: git-send-email.perl:763
+#: git-send-email.perl:771
 #, perl-format
 msgid "Failed to open %s: %s"
 msgstr "Fehler beim Öffnen von %s: %s"
 
-#: git-send-email.perl:780
+#: git-send-email.perl:788
 #, perl-format
 msgid "Failed to open %s.final: %s"
 msgstr "Fehler beim Öffnen von %s.final: %s"
 
-#: git-send-email.perl:823
+#: git-send-email.perl:831
 msgid "Summary email is empty, skipping it\n"
 msgstr "E-Mail mit Zusammenfassung ist leer, wird ausgelassen\n"
 
 #. TRANSLATORS: please keep [y/N] as is.
-#: git-send-email.perl:858
+#: git-send-email.perl:866
 #, perl-format
 msgid "Are you sure you want to use <%s> [y/N]? "
 msgstr "Sind Sie sich sicher, <%s> zu benutzen [y/N]? "
 
-#: git-send-email.perl:913
+#: git-send-email.perl:921
 msgid ""
 "The following files are 8bit, but do not declare a Content-Transfer-"
 "Encoding.\n"
@@ -25427,11 +25837,11 @@ msgstr ""
 "Die folgenden Dateien sind 8-Bit, aber deklarieren kein\n"
 "Content-Transfer-Encoding.\n"
 
-#: git-send-email.perl:918
+#: git-send-email.perl:926
 msgid "Which 8bit encoding should I declare [UTF-8]? "
 msgstr "Welches 8-Bit-Encoding soll deklariert werden [UTF-8]? "
 
-#: git-send-email.perl:926
+#: git-send-email.perl:934
 #, perl-format
 msgid ""
 "Refusing to send because the patch\n"
@@ -25445,22 +25855,22 @@ msgstr ""
 "an,\n"
 "wenn Sie den Patch wirklich versenden wollen.\n"
 
-#: git-send-email.perl:945
+#: git-send-email.perl:953
 msgid "To whom should the emails be sent (if anyone)?"
 msgstr "An wen sollen die E-Mails versendet werden (wenn überhaupt jemand)?"
 
-#: git-send-email.perl:963
+#: git-send-email.perl:971
 #, perl-format
 msgid "fatal: alias '%s' expands to itself\n"
 msgstr "fatal: Alias '%s' erweitert sich zu sich selbst\n"
 
-#: git-send-email.perl:975
+#: git-send-email.perl:983
 msgid "Message-ID to be used as In-Reply-To for the first email (if any)? "
 msgstr ""
 "Message-ID zur Verwendung als In-Reply-To für die erste E-Mail (wenn eine "
 "existiert)? "
 
-#: git-send-email.perl:1033 git-send-email.perl:1041
+#: git-send-email.perl:1041 git-send-email.perl:1049
 #, perl-format
 msgid "error: unable to extract a valid address from: %s\n"
 msgstr "Fehler: konnte keine gültige Adresse aus %s extrahieren\n"
@@ -25468,18 +25878,18 @@ msgstr "Fehler: konnte keine gültige Adresse aus %s extrahieren\n"
 #. TRANSLATORS: Make sure to include [q] [d] [e] in your
 #. translation. The program will only accept English input
 #. at this point.
-#: git-send-email.perl:1045
+#: git-send-email.perl:1053
 msgid "What to do with this address? ([q]uit|[d]rop|[e]dit): "
 msgstr ""
 "Was soll mit dieser Adresse geschehen? (Beenden [q]|Löschen [d]|Bearbeiten "
 "[e]): "
 
-#: git-send-email.perl:1362
+#: git-send-email.perl:1370
 #, perl-format
 msgid "CA path \"%s\" does not exist"
 msgstr "CA Pfad \"%s\" existiert nicht"
 
-#: git-send-email.perl:1445
+#: git-send-email.perl:1453
 msgid ""
 "    The Cc list above has been expanded by additional\n"
 "    addresses found in the patch commit message. By default\n"
@@ -25508,133 +25918,133 @@ msgstr ""
 #. TRANSLATORS: Make sure to include [y] [n] [e] [q] [a] in your
 #. translation. The program will only accept English input
 #. at this point.
-#: git-send-email.perl:1460
+#: git-send-email.perl:1468
 msgid "Send this email? ([y]es|[n]o|[e]dit|[q]uit|[a]ll): "
 msgstr ""
 "Diese E-Mail versenden? (Ja [y]|Nein [n]|Bearbeiten [e]|Beenden [q]|Alle "
 "[a]): "
 
-#: git-send-email.perl:1463
+#: git-send-email.perl:1471
 msgid "Send this email reply required"
 msgstr "Zum Versenden dieser E-Mail ist eine Antwort erforderlich."
 
-#: git-send-email.perl:1491
+#: git-send-email.perl:1499
 msgid "The required SMTP server is not properly defined."
 msgstr "Der erforderliche SMTP-Server ist nicht korrekt definiert."
 
-#: git-send-email.perl:1538
+#: git-send-email.perl:1546
 #, perl-format
 msgid "Server does not support STARTTLS! %s"
 msgstr "Server unterstützt kein STARTTLS! %s"
 
-#: git-send-email.perl:1543 git-send-email.perl:1547
+#: git-send-email.perl:1551 git-send-email.perl:1555
 #, perl-format
 msgid "STARTTLS failed! %s"
 msgstr "STARTTLS fehlgeschlagen! %s"
 
-#: git-send-email.perl:1556
+#: git-send-email.perl:1564
 msgid "Unable to initialize SMTP properly. Check config and use --smtp-debug."
 msgstr ""
 "Konnte SMTP nicht korrekt initialisieren. Bitte prüfen Sie Ihre "
 "Konfiguration\n"
 "und benutzen Sie --smtp-debug."
 
-#: git-send-email.perl:1574
+#: git-send-email.perl:1582
 #, perl-format
 msgid "Failed to send %s\n"
 msgstr "Fehler beim Senden %s\n"
 
-#: git-send-email.perl:1577
+#: git-send-email.perl:1585
 #, perl-format
 msgid "Dry-Sent %s\n"
 msgstr "Probeversand %s\n"
 
-#: git-send-email.perl:1577
+#: git-send-email.perl:1585
 #, perl-format
 msgid "Sent %s\n"
 msgstr "%s gesendet\n"
 
-#: git-send-email.perl:1579
+#: git-send-email.perl:1587
 msgid "Dry-OK. Log says:\n"
 msgstr "Probeversand OK. Log enthält:\n"
 
-#: git-send-email.perl:1579
+#: git-send-email.perl:1587
 msgid "OK. Log says:\n"
 msgstr "OK. Log enthält:\n"
 
-#: git-send-email.perl:1591
+#: git-send-email.perl:1599
 msgid "Result: "
 msgstr "Ergebnis: "
 
-#: git-send-email.perl:1594
+#: git-send-email.perl:1602
 msgid "Result: OK\n"
 msgstr "Ergebnis: OK\n"
 
-#: git-send-email.perl:1612
+#: git-send-email.perl:1620
 #, perl-format
 msgid "can't open file %s"
 msgstr "Kann Datei %s nicht öffnen"
 
-#: git-send-email.perl:1659 git-send-email.perl:1679
+#: git-send-email.perl:1667 git-send-email.perl:1687
 #, perl-format
 msgid "(mbox) Adding cc: %s from line '%s'\n"
 msgstr "(mbox) Füge cc: hinzu: %s von Zeile '%s'\n"
 
-#: git-send-email.perl:1665
+#: git-send-email.perl:1673
 #, perl-format
 msgid "(mbox) Adding to: %s from line '%s'\n"
 msgstr "(mbox) Füge to: hinzu: %s von Zeile '%s'\n"
 
-#: git-send-email.perl:1722
+#: git-send-email.perl:1730
 #, perl-format
 msgid "(non-mbox) Adding cc: %s from line '%s'\n"
 msgstr "(non-mbox) Füge cc: hinzu: %s von Zeile '%s'\n"
 
-#: git-send-email.perl:1757
+#: git-send-email.perl:1765
 #, perl-format
 msgid "(body) Adding cc: %s from line '%s'\n"
 msgstr "(body) Füge cc: hinzu: %s von Zeile '%s'\n"
 
-#: git-send-email.perl:1868
+#: git-send-email.perl:1876
 #, perl-format
 msgid "(%s) Could not execute '%s'"
 msgstr "(%s) Konnte '%s' nicht ausführen"
 
-#: git-send-email.perl:1875
+#: git-send-email.perl:1883
 #, perl-format
 msgid "(%s) Adding %s: %s from: '%s'\n"
 msgstr "(%s) Füge %s: %s hinzu von: '%s'\n"
 
-#: git-send-email.perl:1879
+#: git-send-email.perl:1887
 #, perl-format
 msgid "(%s) failed to close pipe to '%s'"
 msgstr "(%s) Fehler beim Schließen der Pipe nach '%s'"
 
-#: git-send-email.perl:1909
+#: git-send-email.perl:1917
 msgid "cannot send message as 7bit"
 msgstr "Kann Nachricht nicht als 7bit versenden."
 
-#: git-send-email.perl:1917
+#: git-send-email.perl:1925
 msgid "invalid transfer encoding"
 msgstr "Ungültiges Transfer-Encoding"
 
-#: git-send-email.perl:1958 git-send-email.perl:2010 git-send-email.perl:2020
+#: git-send-email.perl:1966 git-send-email.perl:2018 git-send-email.perl:2028
 #, perl-format
 msgid "unable to open %s: %s\n"
 msgstr "konnte %s nicht öffnen: %s\n"
 
-#: git-send-email.perl:1961
+#: git-send-email.perl:1969
 #, perl-format
 msgid "%s: patch contains a line longer than 998 characters"
 msgstr "%s: Patch enthält eine Zeile, die länger als 998 Zeichen ist"
 
-#: git-send-email.perl:1978
+#: git-send-email.perl:1986
 #, perl-format
 msgid "Skipping %s with backup suffix '%s'.\n"
 msgstr "Lasse %s mit Backup-Suffix '%s' aus.\n"
 
 #. TRANSLATORS: please keep "[y|N]" as is.
-#: git-send-email.perl:1982
+#: git-send-email.perl:1990
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Wollen Sie %s wirklich versenden? [y|N]: "

--- a/po/de.po
+++ b/po/de.po
@@ -1625,14 +1625,14 @@ msgid "current working directory is untracked"
 msgstr "Aktuelles Arbeitsverzeichnis ist unversioniert."
 
 #: archive.c:526
-#, fuzzy, c-format
+#, c-format
 msgid "File not found: %s"
-msgstr "Objekt nicht gefunden: %s"
+msgstr "Datei nicht gefunden: %s"
 
 #: archive.c:528
-#, fuzzy, c-format
+#, c-format
 msgid "Not a regular file: %s"
-msgstr "Kein Reflog: %s"
+msgstr "Keine reguläre Datei: %s"
 
 #: archive.c:553
 msgid "fmt"
@@ -1660,9 +1660,8 @@ msgid "file"
 msgstr "Datei"
 
 #: archive.c:557
-#, fuzzy
 msgid "add untracked file to archive"
-msgstr "unversionierte Dateien in Stash einbeziehen"
+msgstr "unversionierte Datei zum Archiv hinzufügen"
 
 #: archive.c:560 builtin/archive.c:90
 msgid "write the archive to this file"
@@ -1723,10 +1722,9 @@ msgid "Unexpected option --output"
 msgstr "Unerwartete Option --output"
 
 #: archive.c:594
-#, fuzzy
 msgid "Options --add-file and --remote cannot be used together"
 msgstr ""
-"Die Optionen --squash und --fixup können nicht gemeinsam verwendet werden."
+"Die Optionen --add-file und --remote können nicht gemeinsam verwendet werden."
 
 #: archive.c:616
 #, c-format
@@ -2060,19 +2058,19 @@ msgid "HEAD of working tree %s is not updated"
 msgstr "HEAD des Arbeitsverzeichnisses %s ist nicht aktualisiert."
 
 #: bundle.c:41
-#, fuzzy, c-format
+#, c-format
 msgid "unrecognized bundle hash algorithm: %s"
-msgstr "unbekannter Hash-Algorithmus '%s'"
+msgstr "unbekannter Paket-Hash-Algorithmus: %s"
 
 #: bundle.c:45
-#, fuzzy, c-format
+#, c-format
 msgid "unknown capability '%s'"
-msgstr "Unbekannte Variable '%s'"
+msgstr "unbekannte Fähigkeit '%s'"
 
 #: bundle.c:71
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' does not look like a v2 or v3 bundle file"
-msgstr "'%s' sieht nicht wie eine v2 Paketdatei aus"
+msgstr "'%s' sieht nicht wie eine v2 oder v3 Paketdatei aus"
 
 #: bundle.c:110
 #, c-format
@@ -2133,14 +2131,14 @@ msgid "ref '%s' is excluded by the rev-list options"
 msgstr "Referenz '%s' wird durch \"rev-list\" Optionen ausgeschlossen"
 
 #: bundle.c:498
-#, fuzzy, c-format
+#, c-format
 msgid "unsupported bundle version %d"
-msgstr "nicht unterstützte Index-Version %s"
+msgstr "nicht unterstützte Paket-Version %d"
 
 #: bundle.c:500
 #, c-format
 msgid "cannot write bundle version %d with algorithm %s"
-msgstr ""
+msgstr "kann Paket-Version %d nicht mit Algorithmus %s schreiben"
 
 #: bundle.c:522 builtin/log.c:207 builtin/log.c:1918 builtin/shortlog.c:461
 #, c-format
@@ -2166,9 +2164,8 @@ msgid "invalid color value: %.*s"
 msgstr "Ungültiger Farbwert: %.*s"
 
 #: commit-graph.c:188 midx.c:46
-#, fuzzy
 msgid "invalid hash version"
-msgstr "ungültige Pfadspezifikation"
+msgstr "ungültige Hash-Version"
 
 #: commit-graph.c:246
 msgid "commit-graph file is too small"
@@ -2190,9 +2187,9 @@ msgid "commit-graph hash version %X does not match version %X"
 msgstr "Hash-Version des Commit-Graph %X stimmt nicht mit Version %X überein."
 
 #: commit-graph.c:342
-#, fuzzy, c-format
+#, c-format
 msgid "commit-graph file is too small to hold %u chunks"
-msgstr "Commit-Graph-Datei ist zu klein."
+msgstr "Commit-Graph-Datei ist zu klein, um %u Chunks zu enthalten"
 
 #: commit-graph.c:361
 #, c-format
@@ -4340,9 +4337,8 @@ msgid "unsupported command listing type '%s'"
 msgstr "Nicht unterstützte Art zur Befehlsauflistung '%s'."
 
 #: help.c:405
-#, fuzzy
 msgid "The Git concept guides are:"
-msgstr "Die allgemeinen Git-Anleitungen sind:"
+msgstr "Die Git-Konzeptanleitungen sind:"
 
 #: help.c:429
 msgid "See 'git help <command>' to read about a specific subcommand"
@@ -4431,11 +4427,11 @@ msgstr[1] ""
 
 #: ident.c:353
 msgid "Author identity unknown\n"
-msgstr ""
+msgstr "Identität des Autors unbekannt\n"
 
 #: ident.c:356
 msgid "Committer identity unknown\n"
-msgstr ""
+msgstr "Identität des Commit-Erstellers unbekannt\n"
 
 #: ident.c:362
 msgid ""
@@ -5057,9 +5053,10 @@ msgid "multi-pack-index version %d not recognized"
 msgstr "multi-pack-index-Version %d nicht erkannt."
 
 #: midx.c:105
-#, fuzzy, c-format
+#, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
-msgstr "Hash-Version des Commit-Graph %X stimmt nicht mit Version %X überein."
+msgstr ""
+"Hash-Version %u des multi-pack-index stimmt nicht mit Version %u überein"
 
 #: midx.c:122
 msgid "invalid chunk offset (too large)"
@@ -5142,9 +5139,8 @@ msgid "failed to clear multi-pack-index at %s"
 msgstr "Fehler beim Löschen des multi-pack-index bei %s"
 
 #: midx.c:1124
-#, fuzzy
 msgid "multi-pack-index file exists, but failed to parse"
-msgstr "multi-pack-index-Datei %s ist zu klein."
+msgstr "multi-pack-index-Datei existiert, aber das Parsen schlug fehl"
 
 #: midx.c:1132
 msgid "Looking for referenced packfiles"
@@ -5579,15 +5575,17 @@ msgstr "Konnte --pretty Format nicht parsen."
 
 #: promisor-remote.c:30
 msgid "promisor-remote: unable to fork off fetch subprocess"
-msgstr ""
+msgstr "Promisor-Remote: konnte Fetch-Subprozess nicht abspalten"
 
 #: promisor-remote.c:35 promisor-remote.c:37
 msgid "promisor-remote: could not write to fetch subprocess"
-msgstr ""
+msgstr "Promisor-Remote: konnte nicht zum Fetch-Subprozess schreiben"
 
 #: promisor-remote.c:41
 msgid "promisor-remote: could not close stdin to fetch subprocess"
 msgstr ""
+"Promisor-Remote: konnte Standard-Eingabe des Fetch-Subprozesses nicht "
+"schließen"
 
 #: promisor-remote.c:53
 #, c-format
@@ -6056,9 +6054,9 @@ msgid "%%(body) does not take arguments"
 msgstr "%%(body) akzeptiert keine Argumente"
 
 #: ref-filter.c:309
-#, fuzzy, c-format
+#, c-format
 msgid "unrecognized %%(subject) argument: %s"
-msgstr "nicht erkanntes %%(objectsize) Argument: %s"
+msgstr "nicht erkanntes %%(subject) Argument: %s"
 
 #: ref-filter.c:330
 #, c-format
@@ -6076,24 +6074,24 @@ msgid "unrecognized %%(contents) argument: %s"
 msgstr "nicht erkanntes %%(contents) Argument: %s"
 
 #: ref-filter.c:380
-#, fuzzy, c-format
+#, c-format
 msgid "positive value expected '%s' in %%(%s)"
-msgstr "Positiver Wert erwartet contents:lines=%s"
+msgstr "positiver Wert erwartet '%s' in %%(%s)"
 
 #: ref-filter.c:384
-#, fuzzy, c-format
+#, c-format
 msgid "unrecognized argument '%s' in %%(%s)"
-msgstr "nicht erkanntes Argument: %s"
+msgstr "nicht erkanntes Argument '%s' in %%(%s)"
 
 #: ref-filter.c:398
-#, fuzzy, c-format
+#, c-format
 msgid "unrecognized email option: %s"
-msgstr "Nicht erkannte Position: '%s'"
+msgstr "nicht erkannte E-Mail Option: %s"
 
 #: ref-filter.c:428
 #, c-format
 msgid "expected format: %%(align:<width>,<position>)"
-msgstr "Erwartetes Format: %%(align:<Breite>,<Position>)"
+msgstr "erwartetes Format: %%(align:<Breite>,<Position>)"
 
 #: ref-filter.c:440
 #, c-format
@@ -6726,14 +6724,13 @@ msgid "failed to find tree of %s"
 msgstr "Fehler beim Finden des \"Tree\"-Objektes von %s."
 
 #: revision.c:2344
-#, fuzzy
 msgid "--unpacked=<packfile> no longer supported"
-msgstr "git-over-rsync wird nicht länger unterstützt."
+msgstr "--unpacked=<Pack-Datei> wird nicht länger unterstützt"
 
 #: revision.c:2364
-#, fuzzy, c-format
+#, c-format
 msgid "unknown value for --diff-merges: %s"
-msgstr "Unbekannter Wert für Konfiguration '%s': %s"
+msgstr "unbekannter Wert für --diff-merges: %s"
 
 #: revision.c:2702
 msgid "your current branch appears to be broken"
@@ -7100,13 +7097,13 @@ msgid "unable to read commit message from '%s'"
 msgstr "Konnte Commit-Beschreibung von '%s' nicht lesen."
 
 #: sequencer.c:1446 sequencer.c:1478
-#, fuzzy, c-format
+#, c-format
 msgid "invalid author identity '%s'"
-msgstr "Ungültiger Pfad '%s'"
+msgstr "ungültige Autor-Identität '%s'"
 
 #: sequencer.c:1452
 msgid "corrupt author: missing date information"
-msgstr ""
+msgstr "unbrauchbarer Autor: Datumsinformationen fehlen"
 
 #: sequencer.c:1491 builtin/am.c:1606 builtin/commit.c:1678 builtin/merge.c:890
 #: builtin/merge.c:915
@@ -7703,9 +7700,9 @@ msgid "could not commit staged changes."
 msgstr "Konnte Änderungen aus der Staging-Area nicht committen."
 
 #: sequencer.c:4477
-#, fuzzy, c-format
+#, c-format
 msgid "invalid committer '%s'"
-msgstr "Ungültiger Commit %s"
+msgstr "ungültiger Commit-Ersteller '%s'"
 
 #: sequencer.c:4586
 #, c-format
@@ -7804,9 +7801,8 @@ msgid "unknown repository extensions found:"
 msgstr "Unbekannte Repository-Erweiterungen gefunden:"
 
 #: setup.c:681
-#, fuzzy
 msgid "repo version is 0, but v1-only extensions found:"
-msgstr "Unbekannte Repository-Erweiterungen gefunden:"
+msgstr "Repository-Version ist 0, aber Erweiterungen nur für v1 gefunden:"
 
 #: setup.c:700
 #, c-format
@@ -8679,7 +8675,7 @@ msgstr "Kann keine Verbindung zu Subservice %s herstellen."
 
 #: transport-helper.c:745
 msgid "'option' without a matching 'ok/error' directive"
-msgstr ""
+msgstr "'option' ohne passende 'ok/error' Direktive"
 
 #: transport-helper.c:788
 #, c-format
@@ -9238,51 +9234,45 @@ msgid "'%s' does not point back to '%s'"
 msgstr "'%s' zeigt nicht zurück auf '%s'"
 
 #: worktree.c:587
-#, fuzzy
 msgid "not a directory"
-msgstr "kein gültiges Verzeichnis"
+msgstr "kein Verzeichnis"
 
 #: worktree.c:596
-#, fuzzy
 msgid ".git is not a file"
-msgstr "git show %s: ungültige Datei"
+msgstr ".git ist keine Datei"
 
 #: worktree.c:598
 msgid ".git file broken"
-msgstr ""
+msgstr ".git-Datei kaputt"
 
 #: worktree.c:600
-#, fuzzy
 msgid ".git file incorrect"
-msgstr "Index-Datei beschädigt"
+msgstr ".git-Datei fehlerhaft"
 
 #: worktree.c:670
-#, fuzzy
 msgid "not a valid path"
-msgstr "kein gültiges Verzeichnis"
+msgstr "kein gültiger Pfad"
 
 #: worktree.c:676
-#, fuzzy
 msgid "unable to locate repository; .git is not a file"
-msgstr "Konnte temporäre Datei nicht erstellen."
+msgstr "Konnte Repository nicht finden; .git ist keine Datei"
 
 #: worktree.c:679
-#, fuzzy
 msgid "unable to locate repository; .git file broken"
-msgstr "Konnte temporäre Datei nicht erstellen."
+msgstr "Konnte Repository nicht finden; .git-Datei ist kaputt"
 
 #: worktree.c:685
 msgid "gitdir unreadable"
-msgstr ""
+msgstr "gitdir nicht lesbar""
 
 #: worktree.c:689
 msgid "gitdir incorrect"
-msgstr ""
+msgstr "gitdir fehlerhaft"
 
 #: wrapper.c:197 wrapper.c:367
 #, c-format
 msgid "could not open '%s' for reading and writing"
-msgstr "Konnte '%s' nicht zum Lesen und Schreiben öffnen."
+msgstr "konnte '%s' nicht zum Lesen und Schreiben öffnen"
 
 #: wrapper.c:398 wrapper.c:599
 #, c-format
@@ -9291,7 +9281,7 @@ msgstr "konnte nicht auf '%s' zugreifen"
 
 #: wrapper.c:607
 msgid "unable to get current working directory"
-msgstr "Konnte aktuelles Arbeitsverzeichnis nicht bekommen."
+msgstr "konnte aktuelles Arbeitsverzeichnis nicht bekommen"
 
 #: wt-status.c:158
 msgid "Unmerged paths:"
@@ -10101,9 +10091,9 @@ msgstr ""
 "\"git config advice.addEmptyPathspec false\""
 
 #: builtin/am.c:160
-#, fuzzy, c-format
+#, c-format
 msgid "invalid committer: %s"
-msgstr "Ungültiger Commit %s"
+msgstr "ungültiger Commit-Ersteller: %s"
 
 #: builtin/am.c:366
 msgid "could not parse author script"
@@ -10541,9 +10531,8 @@ msgid "git archive: expected a flush"
 msgstr "git archive: erwartete eine Spülung (flush)"
 
 #: builtin/bisect--helper.c:23
-#, fuzzy
 msgid "git bisect--helper --next-all"
-msgstr "git bisect--helper --next-all [--no-checkout]"
+msgstr "git bisect--helper --next-all"
 
 #: builtin/bisect--helper.c:24
 msgid "git bisect--helper --write-terms <bad_term> <good_term>"
@@ -10588,58 +10577,55 @@ msgstr ""
 "term-new]"
 
 #: builtin/bisect--helper.c:31
-#, fuzzy
 msgid ""
 "git bisect--helper --bisect-start [--term-{new,bad}=<term> --term-{old,good}"
 "=<term>] [--no-checkout] [--first-parent] [<bad> [<good>...]] [--] "
 "[<paths>...]"
 msgstr ""
-"git bisect--helper --bisect-start [--term-{old,good}=<Begriff> --term-{new,"
-"bad}=<Begriff>][--no-checkout] [<schlecht> [<gut>...]] [--] [<Pfade>...]"
+"git bisect--helper --bisect-start [--term-{new,bad}=<Begriff> --term-{old,
+good}=<Begriff>] [--no-checkout] [--first-parent] [<schlecht> [<gut>...]] "
+"[--] [<Pfade>...]"
 
 #: builtin/bisect--helper.c:33
-#, fuzzy
 msgid "git bisect--helper --bisect-next"
-msgstr "git bisect--helper --bisect-clean-state"
+msgstr "git bisect--helper --bisect-next"
 
 #: builtin/bisect--helper.c:34
-#, fuzzy
 msgid "git bisect--helper --bisect-auto-next"
-msgstr "git bisect--helper --bisect-clean-state"
+msgstr "git bisect--helper --bisect-auto-next"
 
 #: builtin/bisect--helper.c:35
-#, fuzzy
 msgid "git bisect--helper --bisect-autostart"
-msgstr "git bisect--helper --bisect-clean-state"
+msgstr "git bisect--helper --bisect-autostart"
 
 #: builtin/bisect--helper.c:97
-#, fuzzy, c-format
+#, c-format
 msgid "cannot open file '%s' in mode '%s'"
-msgstr "kann '%s' nicht nach '%s' kopieren"
+msgstr "kann Datei '%s' nicht im Modus '%s' öffnen"
 
 #: builtin/bisect--helper.c:104
-#, fuzzy, c-format
+#, c-format
 msgid "could not write to file '%s'"
-msgstr "Konnte Datei nicht schreiben: '%s'"
+msgstr "konnte nicht in Datei '%s' schreiben"
 
 #: builtin/bisect--helper.c:143
 #, c-format
 msgid "'%s' is not a valid term"
-msgstr "'%s' ist kein gültiger Begriff."
+msgstr "'%s' ist kein gültiger Begriff"
 
 #: builtin/bisect--helper.c:147
 #, c-format
 msgid "can't use the builtin command '%s' as a term"
-msgstr "Kann den eingebauten Befehl '%s' nicht als Begriff verwenden."
+msgstr "kann den eingebauten Befehl '%s' nicht als Begriff verwenden"
 
 #: builtin/bisect--helper.c:157
 #, c-format
 msgid "can't change the meaning of the term '%s'"
-msgstr "Kann die Bedeutung von dem Begriff '%s' nicht ändern."
+msgstr "kann die Bedeutung von dem Begriff '%s' nicht ändern"
 
 #: builtin/bisect--helper.c:167
 msgid "please use two different terms"
-msgstr "Bitte verwenden Sie zwei verschiedene Begriffe."
+msgstr "bitte verwenden Sie zwei verschiedene Begriffe"
 
 #: builtin/bisect--helper.c:207
 #, c-format
@@ -10649,7 +10635,7 @@ msgstr "Keine binäre Suche im Gange.\n"
 #: builtin/bisect--helper.c:215
 #, c-format
 msgid "'%s' is not a valid commit"
-msgstr "'%s' ist kein gültiger Commit."
+msgstr "'%s' ist kein gültiger Commit"
 
 #: builtin/bisect--helper.c:224
 #, c-format
@@ -10735,14 +10721,13 @@ msgstr ""
 "Unterstützte Optionen sind: --term-good|--term-old und --term-bad|--term-new."
 
 #: builtin/bisect--helper.c:511
-#, fuzzy
 msgid "revision walk setup failed\n"
-msgstr "Einrichtung des Revisionsgangs fehlgeschlagen"
+msgstr "Einrichtung des Revisionsgangs fehlgeschlagen\n"
 
 #: builtin/bisect--helper.c:533
-#, fuzzy, c-format
+#, c-format
 msgid "could not open '%s' for appending"
-msgstr "Konnte '%s' nicht zum Lesen öffnen."
+msgstr "konnte '%s' nicht zum Anhängen öffnen"
 
 #: builtin/bisect--helper.c:651 builtin/bisect--helper.c:664
 msgid "'' is not a valid term"
@@ -10751,16 +10736,16 @@ msgstr "'' ist kein gültiger Begriff"
 #: builtin/bisect--helper.c:674
 #, c-format
 msgid "unrecognized option: '%s'"
-msgstr "Nicht erkannte Position: '%s'"
+msgstr "nicht erkannte Option: '%s'"
 
 #: builtin/bisect--helper.c:678
 #, c-format
 msgid "'%s' does not appear to be a valid revision"
-msgstr "'%s' scheint kein gültiger Commit zu sein."
+msgstr "'%s' scheint kein gültiger Commit zu sein"
 
 #: builtin/bisect--helper.c:709
 msgid "bad HEAD - I need a HEAD"
-msgstr "Ungültiger HEAD - HEAD wird benötigt."
+msgstr "ungültiger HEAD - HEAD wird benötigt"
 
 #: builtin/bisect--helper.c:724
 #, c-format
@@ -10776,17 +10761,16 @@ msgstr ""
 
 #: builtin/bisect--helper.c:748
 msgid "bad HEAD - strange symbolic ref"
-msgstr "Ungültiger HEAD - merkwürdige symbolische Referenz."
+msgstr "ungültiger HEAD - merkwürdige symbolische Referenz"
 
 #: builtin/bisect--helper.c:775
 #, c-format
 msgid "invalid ref: '%s'"
-msgstr "Ungültige Referenz: '%s'"
+msgstr "ungültige Referenz: '%s'"
 
 #: builtin/bisect--helper.c:827
-#, fuzzy
 msgid "You need to start by \"git bisect start\"\n"
-msgstr "Sie müssen mit \"git bisect start\" beginnen."
+msgstr "Sie müssen mit \"git bisect start\" beginnen\n"
 
 #. TRANSLATORS: Make sure to include [Y] and [n] in your
 #. translation. The program will only accept English input
@@ -10837,17 +10821,18 @@ msgid "start the bisect session"
 msgstr "Sitzung für binäre Suche starten"
 
 #: builtin/bisect--helper.c:886
-#, fuzzy
 msgid "find the next bisection commit"
-msgstr "Kann nicht existierenden Commit nicht nachbessern."
+msgstr "nächsten Commit für die binäre Suche finden"
 
 #: builtin/bisect--helper.c:888
 msgid "verify the next bisection state then checkout the next bisection commit"
 msgstr ""
+"überprüfe den nächsten Zustand der binären Suche, checke dann den nächsten "
+"Commit der binären Suche aus"
 
 #: builtin/bisect--helper.c:890
 msgid "start the bisection if it has not yet been started"
-msgstr ""
+msgstr "starte die binäre Suche, wenn diese noch nicht begonnen hat"
 
 #: builtin/bisect--helper.c:892
 msgid "no log for BISECT_WRITE"
@@ -10855,46 +10840,43 @@ msgstr "kein Log für BISECT_WRITE"
 
 #: builtin/bisect--helper.c:910
 msgid "--write-terms requires two arguments"
-msgstr "--write-terms benötigt zwei Argumente."
+msgstr "--write-terms benötigt zwei Argumente"
 
 #: builtin/bisect--helper.c:914
 msgid "--bisect-clean-state requires no arguments"
-msgstr "--bisect-clean-state erwartet keine Argumente."
+msgstr "--bisect-clean-state erwartet keine Argumente"
 
 #: builtin/bisect--helper.c:921
 msgid "--bisect-reset requires either no argument or a commit"
-msgstr "--bisect-reset benötigt entweder kein Argument oder ein Commit."
+msgstr "--bisect-reset benötigt entweder kein Argument oder ein Commit"
 
 #: builtin/bisect--helper.c:925
 msgid "--bisect-write requires either 4 or 5 arguments"
-msgstr "--bisect-write benötigt entweder 4 oder 5 Argumente."
+msgstr "--bisect-write benötigt entweder 4 oder 5 Argumente"
 
 #: builtin/bisect--helper.c:931
 msgid "--check-and-set-terms requires 3 arguments"
-msgstr "--check-and-set-terms benötigt 3 Argumente."
+msgstr "--check-and-set-terms benötigt 3 Argumente"
 
 #: builtin/bisect--helper.c:937
 msgid "--bisect-next-check requires 2 or 3 arguments"
-msgstr "--bisect-next-check benötigt 2 oder 3 Argumente."
+msgstr "--bisect-next-check benötigt 2 oder 3 Argumente"
 
 #: builtin/bisect--helper.c:943
 msgid "--bisect-terms requires 0 or 1 argument"
-msgstr "--bisect-terms benötigt 0 oder 1 Argument."
+msgstr "--bisect-terms benötigt 0 oder 1 Argument"
 
 #: builtin/bisect--helper.c:952
-#, fuzzy
 msgid "--bisect-next requires 0 arguments"
-msgstr "--bisect-next-check benötigt 2 oder 3 Argumente."
+msgstr "--bisect-next benötigt 0 Argumente"
 
 #: builtin/bisect--helper.c:958
-#, fuzzy
 msgid "--bisect-auto-next requires 0 arguments"
-msgstr "--bisect-terms benötigt 0 oder 1 Argument."
+msgstr "--bisect-auto-next benötigt 0 Argumente"
 
 #: builtin/bisect--helper.c:964
-#, fuzzy
 msgid "--bisect-autostart does not accept arguments"
-msgstr "--bisect-clean-state erwartet keine Argumente."
+msgstr "--bisect-autostart erwartet keine Argumente"
 
 #: builtin/blame.c:32
 msgid "git blame [<options>] [<rev-opts>] [<rev>] [--] <file>"
@@ -10907,34 +10889,33 @@ msgstr "<rev-opts> sind dokumentiert in git-rev-list(1)"
 #: builtin/blame.c:410
 #, c-format
 msgid "expecting a color: %s"
-msgstr "Erwarte eine Farbe: %s"
+msgstr "erwarte eine Farbe: %s"
 
 #: builtin/blame.c:417
 msgid "must end with a color"
-msgstr "Muss mit einer Farbe enden."
+msgstr "muss mit einer Farbe enden"
 
 #: builtin/blame.c:730
 #, c-format
 msgid "invalid color '%s' in color.blame.repeatedLines"
-msgstr "Ungültige Farbe '%s' in color.blame.repeatedLines."
+msgstr "ungültige Farbe '%s' in color.blame.repeatedLines"
 
 #: builtin/blame.c:748
 msgid "invalid value for blame.coloring"
-msgstr "Ungültiger Wert für blame.coloring."
+msgstr "ungültiger Wert für blame.coloring"
 
 #: builtin/blame.c:845
 #, c-format
 msgid "cannot find revision %s to ignore"
-msgstr "Konnte Commit %s zum Ignorieren nicht finden"
+msgstr "konnte Commit %s zum Ignorieren nicht finden"
 
 #: builtin/blame.c:867
 msgid "Show blame entries as we find them, incrementally"
 msgstr "\"blame\"-Einträge schrittweise anzeigen, während wir sie generieren"
 
 #: builtin/blame.c:868
-#, fuzzy
 msgid "Do not show object names of boundary commits (Default: off)"
-msgstr "leere SHA-1 für Grenz-Commits anzeigen (Standard: aus)"
+msgstr "Zeige keine Objektnamen für Grenz-Commits an (Standard: aus)"
 
 #: builtin/blame.c:869
 msgid "Do not treat root commits as boundaries (Default: off)"
@@ -11077,9 +11058,8 @@ msgid "Blaming lines"
 msgstr "Verarbeite Zeilen"
 
 #: builtin/branch.c:29
-#, fuzzy
 msgid "git branch [<options>] [-r | -a] [--merged] [--no-merged]"
-msgstr "git branch [<Optionen>] [-r | -a] [--merged | --no-merged]"
+msgstr "git branch [<Optionen>] [-r | -a] [--merged] [--no-merged]"
 
 #: builtin/branch.c:30
 msgid "git branch [<options>] [-l] [-f] <branch-name> [<start-point>]"
@@ -11628,7 +11608,7 @@ msgstr "ähnlich zu --all-progress wenn Fortschrittsanzeige darstellt wird"
 
 #: builtin/bundle.c:76
 msgid "specify bundle format version"
-msgstr ""
+msgstr "Version des Paket-Formats angeben"
 
 #: builtin/bundle.c:96
 msgid "Need a repository to create a bundle."
@@ -12904,9 +12884,10 @@ msgid "destination path '%s' already exists and is not an empty directory."
 msgstr "Zielpfad '%s' existiert bereits und ist kein leeres Verzeichnis."
 
 #: builtin/clone.c:1026
-#, fuzzy, c-format
+#, c-format
 msgid "repository path '%s' already exists and is not an empty directory."
-msgstr "Zielpfad '%s' existiert bereits und ist kein leeres Verzeichnis."
+msgstr ""
+"Pfad des Repositories '%s' existiert bereits und ist kein leeres Verzeichnis."
 
 #: builtin/clone.c:1040
 #, c-format
@@ -13024,7 +13005,6 @@ msgstr ""
 "[no-]progress]"
 
 #: builtin/commit-graph.c:14 builtin/commit-graph.c:27
-#, fuzzy
 msgid ""
 "git commit-graph write [--object-dir <objdir>] [--append] [--"
 "split[=<strategy>]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
@@ -13032,7 +13012,7 @@ msgid ""
 msgstr ""
 "git commit-graph write [--object-dir <Objektverzeichnis>] [--append] [--"
 "split[=<Strategie>]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
-"paths] [--[no-]progress] <Split-Optionen>"
+"paths] [--[no-]max-new-filters <Anzahl>] [--[no-]progress] <Split-Optionen>"
 
 #: builtin/commit-graph.c:64
 #, c-format
@@ -13098,32 +13078,31 @@ msgstr "Berechnung für veränderte Pfade aktivieren"
 
 #: builtin/commit-graph.c:224
 msgid "allow writing an incremental commit-graph file"
-msgstr "Erlaube das Schreiben einer inkrementellen Commit-Graph-Datei"
+msgstr "erlaube das Schreiben einer inkrementellen Commit-Graph-Datei"
 
 #: builtin/commit-graph.c:228
 msgid "maximum number of commits in a non-base split commit-graph"
 msgstr ""
-"Maximale Anzahl von Commits in einem aufgeteilten Commit-Graph ohne Basis"
+"maximale Anzahl von Commits in einem aufgeteilten Commit-Graph ohne Basis"
 
 #: builtin/commit-graph.c:230
 msgid "maximum ratio between two levels of a split commit-graph"
 msgstr ""
-"Maximales Verhältnis zwischen zwei Ebenen eines aufgeteilten Commit-Graph"
+"maximales Verhältnis zwischen zwei Ebenen eines aufgeteilten Commit-Graph"
 
 #: builtin/commit-graph.c:232
 msgid "only expire files older than a given date-time"
 msgstr "nur Objekte älter als angegebene Zeit verfallen lassen"
 
 #: builtin/commit-graph.c:234
-#, fuzzy
 msgid "maximum number of changed-path Bloom filters to compute"
-msgstr "Schreibe Daten für veränderte Pfade Bloom-Filter"
+msgstr "maximale Anzahl der zu berechnenden Bloom-Filter für veränderte Pfade"
 
 #: builtin/commit-graph.c:255
 msgid "use at most one of --reachable, --stdin-commits, or --stdin-packs"
 msgstr ""
-"Benutzen Sie mindestens eins von --reachable, --stdin-commits, oder --stdin-"
-"packs."
+"benutzen Sie mindestens eine der folgenden Optionen: --reachable, "
+"--stdin-commits, oder --stdin-packs"
 
 #: builtin/commit-graph.c:287
 msgid "Collecting commits from input"
@@ -13367,7 +13346,6 @@ msgid "could not write commit template"
 msgstr "Konnte Commit-Vorlage nicht schreiben"
 
 #: builtin/commit.c:853
-#, fuzzy
 msgid ""
 "\n"
 "It looks like you may be committing a merge.\n"
@@ -13377,12 +13355,11 @@ msgid ""
 msgstr ""
 "\n"
 "Es sieht so aus, als committen Sie einen Merge.\n"
-"Falls das nicht korrekt ist, löschen Sie bitte die Datei\n"
-"\t%s\n"
-"und versuchen Sie es erneut.\n"
+"Falls das nicht korrekt ist, führen Sie bitte\n"
+"\tgit update-ref -d MERGE_HEAD\n"
+"aus und versuchen Sie es erneut.\n"
 
 #: builtin/commit.c:858
-#, fuzzy
 msgid ""
 "\n"
 "It looks like you may be committing a cherry-pick.\n"
@@ -13392,9 +13369,9 @@ msgid ""
 msgstr ""
 "\n"
 "Es sieht so aus, als committen Sie einen \"cherry-pick\".\n"
-"Falls das nicht korrekt ist, löschen Sie bitte die Datei\n"
-"\t%s\n"
-"und versuchen Sie es erneut.\n"
+"Falls das nicht korrekt ist, führen Sie bitte\n"
+"\tgit update-ref -d CHERRY_PICK_HEAD\n"
+"aus und versuchen Sie es erneut.\n"
 
 #: builtin/commit.c:868
 #, c-format
@@ -13889,9 +13866,8 @@ msgid "value is --bool or --int"
 msgstr "Wert ist --bool oder --int"
 
 #: builtin/config.c:155
-#, fuzzy
 msgid "value is --bool or string"
-msgstr "Wert ist --bool oder --int"
+msgstr "Wert ist --bool oder string"
 
 #: builtin/config.c:156
 msgid "value is a path (file or directory name)"
@@ -13945,7 +13921,7 @@ msgstr "Falsche Anzahl von Argumenten - sollte %d sein."
 #: builtin/config.c:180
 #, c-format
 msgid "wrong number of arguments, should be from %d to %d"
-msgstr "Falsche Anzahl von Argumenten - sollte zwischen %d und %d sein."
+msgstr "falsche Anzahl von Argumenten - sollte zwischen %d und %d sein"
 
 #: builtin/config.c:334
 #, c-format
@@ -13960,7 +13936,7 @@ msgstr "Fehler beim Formatieren des Standardkonfigurationswertes: %s"
 #: builtin/config.c:434
 #, c-format
 msgid "cannot parse color '%s'"
-msgstr "Kann Farbe '%s' nicht parsen."
+msgstr "nann Farbe '%s' nicht parsen"
 
 #: builtin/config.c:476
 msgid "unable to parse default color value"
@@ -13968,16 +13944,16 @@ msgstr "konnte Standard-Farbwert nicht parsen"
 
 #: builtin/config.c:529 builtin/config.c:789
 msgid "not in a git directory"
-msgstr "Nicht in einem Git-Repository."
+msgstr "nicht in einem Git-Repository"
 
 #: builtin/config.c:532
 msgid "writing to stdin is not supported"
-msgstr "Das Schreiben in die Standard-Eingabe wird nicht unterstützt."
+msgstr "das Schreiben in die Standard-Eingabe wird nicht unterstützt"
 
 #: builtin/config.c:535
 msgid "writing config blobs is not supported"
 msgstr ""
-"Das Schreiben von Blob-Objekten für Konfigurationen wird nicht unterstützt."
+"das Schreiben von Blob-Objekten für Konfigurationen wird nicht unterstützt"
 
 #: builtin/config.c:620
 #, c-format
@@ -13996,24 +13972,23 @@ msgstr ""
 
 #: builtin/config.c:644
 msgid "only one config file at a time"
-msgstr "Nur eine Konfigurationsdatei zu einer Zeit möglich."
+msgstr "nur eine Konfigurationsdatei zu einer Zeit möglich"
 
 #: builtin/config.c:650
 msgid "--local can only be used inside a git repository"
-msgstr "--local kann nur innerhalb eines Git-Repositories verwendet werden."
+msgstr "--local kann nur innerhalb eines Git-Repositories verwendet werden"
 
 #: builtin/config.c:652
 msgid "--blob can only be used inside a git repository"
-msgstr "--blob kann nur innerhalb eines Git-Repositories verwendet werden."
+msgstr "--blob kann nur innerhalb eines Git-Repositories verwendet werden"
 
 #: builtin/config.c:654
-#, fuzzy
 msgid "--worktree can only be used inside a git repository"
-msgstr "--blob kann nur innerhalb eines Git-Repositories verwendet werden."
+msgstr "--worktree kann nur innerhalb eines Git-Repositories verwendet werden"
 
 #: builtin/config.c:676
 msgid "$HOME not set"
-msgstr "$HOME nicht gesetzt."
+msgstr "$HOME nicht gesetzt"
 
 #: builtin/config.c:700
 msgid ""
@@ -14117,10 +14092,11 @@ msgstr "Meldungen zur Fehlersuche in Standard-Fehlerausgabe ausgeben"
 #: builtin/credential-cache--daemon.c:315
 msgid "credential-cache--daemon unavailable; no unix socket support"
 msgstr ""
+"credential-cache--daemon nicht verfügbar; Unix-Socket wird nicht unterstüzt"
 
 #: builtin/credential-cache.c:154
 msgid "credential-cache unavailable; no unix socket support"
-msgstr ""
+msgstr "credential-cache nicht verfügbar; Unix-Socket wird nicht unterstüzt"
 
 #: builtin/describe.c:26
 msgid "git describe [<options>] [<commit-ish>...]"
@@ -14692,9 +14668,8 @@ msgid "control recursive fetching of submodules"
 msgstr "rekursive Anforderungen von Submodulen kontrollieren"
 
 #: builtin/fetch.c:168
-#, fuzzy
 msgid "write fetched references to the FETCH_HEAD file"
-msgstr "das Archiv in diese Datei schreiben"
+msgstr "schreibe angeforderte Referenzen in die FETCH_HEAD-Datei"
 
 #: builtin/fetch.c:169 builtin/pull.c:206
 msgid "keep downloaded pack"
@@ -14752,9 +14727,8 @@ msgstr ""
 "sind"
 
 #: builtin/fetch.c:204 builtin/fetch.c:206
-#, fuzzy
 msgid "run 'maintenance --auto' after fetching"
-msgstr "Führe 'gc --auto' nach \"fetch\" aus"
+msgstr "führe 'maintenance --auto' nach \"fetch\" aus"
 
 #: builtin/fetch.c:208 builtin/pull.c:243
 msgid "check for forced-updates on all updated branches"
@@ -14765,9 +14739,8 @@ msgid "write the commit-graph after fetching"
 msgstr "Schreibe den Commit-Graph nach \"fetch\""
 
 #: builtin/fetch.c:212
-#, fuzzy
 msgid "accept refspecs from stdin"
-msgstr "Referenzen von der Standard-Eingabe lesen"
+msgstr "akzeptiere Refspecs von der Standard-Eingabe"
 
 #: builtin/fetch.c:523
 msgid "Couldn't find remote ref HEAD"
@@ -15010,12 +14983,13 @@ msgid ""
 "partialclone"
 msgstr ""
 "--filter kann nur mit den Remote-Repositories verwendet werden,\n"
-"die in core.partialClone konfiguriert sind."
+"die in extensions.partialclone konfiguriert sind"
 
 #: builtin/fetch.c:1891
-#, fuzzy
 msgid "--stdin can only be used when fetching from one remote"
-msgstr "Die Option --exec kann nur zusammen mit --remote verwendet werden."
+msgstr ""
+"die Option --stdin kann nur verwendet werden, wenn von einem Remote-\n"
+"Repository abgefragt wird"
 
 #: builtin/fmt-merge-msg.c:7
 msgid ""
@@ -15053,9 +15027,8 @@ msgid "git for-each-ref [--points-at <object>]"
 msgstr "git for-each-ref [--points-at <Objekt>]"
 
 #: builtin/for-each-ref.c:12
-#, fuzzy
 msgid "git for-each-ref [--merged [<commit>]] [--no-merged [<commit>]]"
-msgstr "git for-each-ref [(--merged | --no-merged) [<Commit>]]"
+msgstr "git for-each-ref [--merged [<Commit>]] [--no-merged [<Commit>]]"
 
 #: builtin/for-each-ref.c:13
 msgid "git for-each-ref [--contains [<commit>]] [--no-contains [<commit>]]"
@@ -15456,59 +15429,56 @@ msgstr ""
 
 #: builtin/gc.c:705
 msgid "git maintenance run [--auto] [--[no-]quiet] [--task=<task>]"
-msgstr ""
+msgstr "git maintenance run [--auto] [--[no-]quiet] [--task=<Aufgabe>]"
 
 #: builtin/gc.c:812
-#, fuzzy
 msgid "failed to write commit-graph"
-msgstr "Fehler beim Schreiben des Commit-Objektes."
+msgstr "Fehler beim Schreiben des Commit-Graph"
 
 #: builtin/gc.c:905
 #, c-format
 msgid "lock file '%s' exists, skipping maintenance"
-msgstr ""
+msgstr "Sperrdatei '%s' existiert, Wartung wird übersprungen"
 
 #: builtin/gc.c:932
-#, fuzzy, c-format
+#, c-format
 msgid "task '%s' failed"
-msgstr "Schreiben von '%s' fehlgeschlagen."
+msgstr "Aufgabe '%s' fehlgeschlagen"
 
 #: builtin/gc.c:979
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not a valid task"
-msgstr "'%s' ist kein gültiger Begriff."
+msgstr "'%s' ist keine gültige Aufgabe"
 
 #: builtin/gc.c:984
-#, fuzzy, c-format
+#, c-format
 msgid "task '%s' cannot be selected multiple times"
-msgstr "'%s' kann nicht mit '%s' verwendet werden"
+msgstr "Aufgabe '%s' kann nicht mehrfach ausgewählt werden"
 
 #: builtin/gc.c:999
 msgid "run tasks based on the state of the repository"
-msgstr ""
+msgstr "Aufgaben abhängig vom Zustand des Repositories ausführen"
 
 #: builtin/gc.c:1001
 msgid "do not report progress or other information over stderr"
-msgstr ""
+msgstr "zeige keinen Fortschritt oder andere Informationen über stderr"
 
 #: builtin/gc.c:1002
 msgid "task"
-msgstr ""
+msgstr "Aufgabe"
 
 #: builtin/gc.c:1003
-#, fuzzy
 msgid "run a specific task"
-msgstr "kein Pfad angegeben"
+msgstr "eine bestimmte Aufgabe ausführen"
 
 #: builtin/gc.c:1026
-#, fuzzy
 msgid "git maintenance run [<options>]"
-msgstr "git notes prune [<Optionen>]"
+msgstr "git maintenance run [<Optionen>]"
 
 #: builtin/gc.c:1037
-#, fuzzy, c-format
+#, c-format
 msgid "invalid subcommand: %s"
-msgstr "Ungültiger Commit %s"
+msgstr "ungültiger Unterbefehl: %s"
 
 #: builtin/grep.c:30
 msgid "git grep [<options>] [-e] <pattern> [<rev>...] [[--] <path>...]"
@@ -16354,9 +16324,8 @@ msgid "specify the hash algorithm to use"
 msgstr "den zu verwendenen Hash-Algorithmus angeben"
 
 #: builtin/init-db.c:571
-#, fuzzy
 msgid "--separate-git-dir and --bare are mutually exclusive"
-msgstr "--deepen und --depth schließen sich gegenseitig aus"
+msgstr "--separate-git-dir und --bare schließen sich gegenseitig aus"
 
 #: builtin/init-db.c:600 builtin/init-db.c:605
 #, c-format
@@ -16383,9 +16352,8 @@ msgid "Cannot access work tree '%s'"
 msgstr "Kann nicht auf Arbeitsverzeichnis '%s' zugreifen."
 
 #: builtin/init-db.c:693
-#, fuzzy
 msgid "--separate-git-dir incompatible with bare repository"
-msgstr "Die Optionen --first-parent und --bisect sind inkompatibel."
+msgstr "--separate-git-dir nicht kompatibel mit Bare-Repository"
 
 #: builtin/interpret-trailers.c:16
 msgid ""
@@ -16601,14 +16569,13 @@ msgid "cannot get patch id"
 msgstr "kann Patch-Id nicht lesen"
 
 #: builtin/log.c:1690
-#, fuzzy
 msgid "failed to infer range-diff origin of current series"
-msgstr "Fehler beim Ableiten des range-diff-Bereichs."
+msgstr "Fehler beim Ableiten des range-diff Ursprungs der aktuellen Serie"
 
 #: builtin/log.c:1692
 #, c-format
 msgid "using '%s' as range-diff origin of current series"
-msgstr ""
+msgstr "nutze '%s' als range-diff Ursprung der aktuellen Serie"
 
 #: builtin/log.c:1736
 msgid "use [PATCH n/m] even with a single patch"
@@ -17688,7 +17655,7 @@ msgstr "nicht unter Versionskontrolle"
 
 #: builtin/mv.c:227
 msgid "conflicted"
-msgstr ""
+msgstr "in Konflikt"
 
 #: builtin/mv.c:230
 msgid "destination exists"
@@ -17739,9 +17706,8 @@ msgid "git name-rev [<options>] --stdin"
 msgstr "git name-rev [<Optionen>] --stdin"
 
 #: builtin/name-rev.c:524
-#, fuzzy
 msgid "print only ref-based names (no object names)"
-msgstr "nur Branches von diesem Objekt ausgeben"
+msgstr "nur Referenzen-basierte Namen ausgeben (keine Objektnamen)"
 
 #: builtin/name-rev.c:525
 msgid "only use tags to name the commits"
@@ -19601,27 +19567,24 @@ msgid "add a Signed-off-by: line to each commit"
 msgstr "eine \"Signed-off-by:\"-Zeile zu jedem Commit hinzufügen"
 
 #: builtin/rebase.c:1330
-#, fuzzy
 msgid "make committer date match author date"
-msgstr "über Commit-Ersteller anstatt Autor gruppieren"
+msgstr "Datum des Commit-Erstellers soll mit Datum des Autors übereinstimmen"
 
 #: builtin/rebase.c:1332
 msgid "ignore author date and use current date"
-msgstr ""
+msgstr "ignoriere Autor-Datum und nutze aktuelles Datum"
 
 #: builtin/rebase.c:1334
-#, fuzzy
 msgid "synonym of --reset-author-date"
-msgstr "Synonym für --files-with-matches"
+msgstr "Synonym für --reset-author-date"
 
 #: builtin/rebase.c:1336 builtin/rebase.c:1340
 msgid "passed to 'git apply'"
 msgstr "an 'git apply' übergeben"
 
 #: builtin/rebase.c:1338
-#, fuzzy
 msgid "ignore changes in whitespace"
-msgstr "Whitespace-Änderungen am Zeilenende ignorieren"
+msgstr "Whitespace-Änderungen ignorieren"
 
 #: builtin/rebase.c:1342 builtin/rebase.c:1345
 msgid "cherry-pick all commits, even if unchanged"
@@ -21415,19 +21378,18 @@ msgid "git log --pretty=short | git shortlog [<options>]"
 msgstr "git log --pretty=short | git shortlog [<Optionen>]"
 
 #: builtin/shortlog.c:134
-#, fuzzy
 msgid "using multiple --group options with stdin is not supported"
-msgstr "Das Schreiben in die Standard-Eingabe wird nicht unterstützt."
+msgstr "mehrere Optionen --group mit Standard-Eingabe wird nicht unterstützt"
 
 #: builtin/shortlog.c:144
-#, fuzzy
 msgid "using --group=trailer with stdin is not supported"
-msgstr "Das Schreiben in die Standard-Eingabe wird nicht unterstützt."
+msgstr ""
+"Nutzung von --group=trailer mit Standard-Eingabe wird nicht unterstützt"
 
 #: builtin/shortlog.c:388
-#, fuzzy, c-format
+#, c-format
 msgid "unknown group type: %s"
-msgstr "Unbekannter Typ: %d"
+msgstr "unbekannter Gruppen-Typ: %s"
 
 #: builtin/shortlog.c:416
 msgid "Group by committer rather than author"
@@ -21455,11 +21417,11 @@ msgstr "Ausgabe mit Zeilenumbrüchen"
 
 #: builtin/shortlog.c:427
 msgid "field"
-msgstr ""
+msgstr "Feld"
 
 #: builtin/shortlog.c:428
 msgid "Group by field"
-msgstr ""
+msgstr "Gruppieren über Feld"
 
 #: builtin/shortlog.c:456
 msgid "too many arguments given outside repository"
@@ -21663,9 +21625,8 @@ msgid "git sparse-checkout (init|list|set|add|reapply|disable) <options>"
 msgstr "git sparse-checkout (init|list|set|add|reapply|disable) <Optionen>"
 
 #: builtin/sparse-checkout.c:50
-#, fuzzy
 msgid "git sparse-checkout list"
-msgstr "git sparse-checkout init [--cone]"
+msgstr "git sparse-checkout list"
 
 #: builtin/sparse-checkout.c:76
 msgid "this worktree is not sparse (sparse-checkout file may not exist)"
@@ -21725,14 +21686,12 @@ msgid "read patterns from standard in"
 msgstr "Muster von der Standard-Eingabe lesen"
 
 #: builtin/sparse-checkout.c:576
-#, fuzzy
 msgid "git sparse-checkout reapply"
-msgstr "git sparse-checkout init [--cone]"
+msgstr "git sparse-checkout reapply"
 
 #: builtin/sparse-checkout.c:595
-#, fuzzy
 msgid "git sparse-checkout disable"
-msgstr "git sparse-checkout init [--cone]"
+msgstr "git sparse-checkout disable"
 
 #: builtin/sparse-checkout.c:623
 msgid "error while refreshing working directory"
@@ -22148,63 +22107,57 @@ msgstr "git submodule--helper name <Pfad>"
 #: builtin/submodule--helper.c:989
 #, c-format
 msgid "* %s %s(blob)->%s(submodule)"
-msgstr ""
+msgstr "* %s %s(blob)->%s(submodule)"
 
 #: builtin/submodule--helper.c:992
 #, c-format
 msgid "* %s %s(submodule)->%s(blob)"
-msgstr ""
+msgstr "* %s %s(submodule)->%s(blob)"
 
 #: builtin/submodule--helper.c:1005
 #, c-format
 msgid "%s"
-msgstr ""
+msgstr "%s"
 
 #: builtin/submodule--helper.c:1055
-#, fuzzy, c-format
+#, c-format
 msgid "couldn't hash object from '%s'"
-msgstr "Konnte Objekt '%s' nicht parsen."
+msgstr "konnte Hash nicht vom Objekt '%s' erzeugen"
 
 #: builtin/submodule--helper.c:1059
-#, fuzzy, c-format
+#, c-format
 msgid "unexpected mode %o\n"
-msgstr "unerwarteter Modus $mod_dst"
+msgstr "unerwarteter Modus %o\n"
 
 #: builtin/submodule--helper.c:1300
-#, fuzzy
 msgid "use the commit stored in the index instead of the submodule HEAD"
 msgstr ""
-"Benutze den Commit, der im Index gespeichert ist, statt den im Submodul HEAD"
+"benutze den Commit, der im Index gespeichert ist, statt vom Submodul HEAD"
 
 #: builtin/submodule--helper.c:1302
-#, fuzzy
 msgid "to compare the commit in the index with that in the submodule HEAD"
-msgstr ""
-"Benutze den Commit, der im Index gespeichert ist, statt den im Submodul HEAD"
+msgstr "um den Commit aus dem Index mit dem im Submodul HEAD zu vergleichen"
 
 #: builtin/submodule--helper.c:1304
 msgid "skip submodules with 'ignore_config' value set to 'all'"
 msgstr ""
+"überspringe Submodule, wo der 'ignore_config' Wert auf 'all' gesetzt ist"
 
 #: builtin/submodule--helper.c:1306
-#, fuzzy
 msgid "limit the summary size"
-msgstr "auf Branches einschränken"
+msgstr "Größe der Zusammenfassung begrenzen"
 
 #: builtin/submodule--helper.c:1311
-#, fuzzy
 msgid "git submodule--helper summary [<options>] [<commit>] [--] [<path>]"
-msgstr "git submodule--helper init [<Optionen>] [<Pfad>]"
+msgstr "git submodule--helper summary [<Optionen>] [<Commit>] [--] [<Pfad>]"
 
 #: builtin/submodule--helper.c:1335
-#, fuzzy
 msgid "could not fetch a revision for HEAD"
-msgstr "Konnte HEAD nicht loslösen"
+msgstr "konnte keinen Commit für HEAD holen"
 
 #: builtin/submodule--helper.c:1340
-#, fuzzy
 msgid "--cached and --files are mutually exclusive"
-msgstr "--branch und --default schließen sich gegenseitig aus"
+msgstr "--cached und --files schließen sich gegenseitig aus"
 
 #: builtin/submodule--helper.c:1407
 #, c-format
@@ -22214,17 +22167,17 @@ msgstr "Synchronisiere Submodul-URL für '%s'\n"
 #: builtin/submodule--helper.c:1413
 #, c-format
 msgid "failed to register url for submodule path '%s'"
-msgstr "Fehler beim Registrieren der URL für Submodul-Pfad '%s'."
+msgstr "Fehler beim Registrieren der URL für Submodul-Pfad '%s'"
 
 #: builtin/submodule--helper.c:1427
 #, c-format
 msgid "failed to get the default remote for submodule '%s'"
-msgstr "Fehler beim Lesen des Standard-Remote-Repositories für Submodul '%s'."
+msgstr "Fehler beim Lesen des Standard-Remote-Repositories für Submodul '%s'"
 
 #: builtin/submodule--helper.c:1438
 #, c-format
 msgid "failed to update remote for submodule '%s'"
-msgstr "Fehler beim Aktualisieren des Remote-Repositories für Submodul '%s'."
+msgstr "Fehler beim Aktualisieren des Remote-Repositories für Submodul '%s'"
 
 #: builtin/submodule--helper.c:1485
 msgid "Suppress output of synchronizing submodule url"
@@ -22596,7 +22549,6 @@ msgid "git tag -d <tagname>..."
 msgstr "git tag -d <Tagname>..."
 
 #: builtin/tag.c:28
-#, fuzzy
 msgid ""
 "git tag -l [-n[<num>]] [--contains <commit>] [--no-contains <commit>] [--"
 "points-at <object>]\n"
@@ -22605,7 +22557,8 @@ msgid ""
 msgstr ""
 "git tag -l [-n[<Nummer>]] [--contains <Commit>] [--no-contains <Commit>] [--"
 "points-at <Objekt>]\n"
-"\t\t[--format=<Muster>] [--[no-]merged [<Commit>]] [<Muster>...]"
+"\t\t[--format=<format>] [--merged <Commit>] [--no-merged <Commit>] "
+"[<Muster>...]"
 
 #: builtin/tag.c:30
 msgid "git tag -v [--format=<format>] <tagname>..."
@@ -23475,14 +23428,14 @@ msgid "validation failed, cannot remove working tree: %s"
 msgstr "Validierung fehlgeschlagen, kann Arbeitsverzeichnis nicht löschen: %s"
 
 #: builtin/worktree.c:1034
-#, fuzzy, c-format
+#, c-format
 msgid "repair: %s: %s"
-msgstr "Ungültiger %s: '%s'"
+msgstr "repariere: %s: %s"
 
 #: builtin/worktree.c:1037
-#, fuzzy, c-format
+#, c-format
 msgid "error: %s: %s"
-msgstr "Fehler in %s %s: %s"
+msgstr "Fehler: %s: %s"
 
 #: builtin/write-tree.c:15
 msgid "git write-tree [--missing-ok] [--prefix=<prefix>/]"
@@ -23506,9 +23459,8 @@ msgid "argument to --packfile must be a valid hash (got '%s')"
 msgstr "Argument für --packfile muss ein gültiger Hash sein ('%s' erhalten)"
 
 #: http-fetch.c:122
-#, fuzzy
 msgid "not a git repository"
-msgstr "Kein Git-Repository"
+msgstr "kein Git-Repository"
 
 #: t/helper/test-reach.c:154
 #, c-format
@@ -23873,9 +23825,8 @@ msgid "be more quiet"
 msgstr "weniger Ausgaben"
 
 #: parse-options.h:317
-#, fuzzy
 msgid "use <n> digits to display object names"
-msgstr "benutze <n> Ziffern zur Anzeige von SHA-1s"
+msgstr "benutze <Anzahl> Ziffern zur Anzeige von Objektnamen"
 
 #: parse-options.h:336
 msgid "how to strip spaces and #comments from message"
@@ -24225,7 +24176,7 @@ msgstr "einfaches UNIX mbox Splitter-Programm"
 
 #: command-list.h:122
 msgid "Run tasks to optimize Git repository data"
-msgstr ""
+msgstr "Aufgaben ausführen, um Git-Repository-Daten zu optimieren"
 
 #: command-list.h:123
 msgid "Join two or more development histories together"
@@ -24552,7 +24503,7 @@ msgstr "eine Git Anleitung für Entwickler"
 
 #: command-list.h:201
 msgid "Providing usernames and passwords to Git"
-msgstr ""
+msgstr "Bereitstellung von Benutzernamen und Passwörtern für Git"
 
 #: command-list.h:202
 msgid "Git for CVS users"
@@ -24593,7 +24544,7 @@ msgstr "Git Namensbereiche"
 
 #: command-list.h:211
 msgid "Helper programs to interact with remote repositories"
-msgstr ""
+msgstr "Hilfsprogramme zur Interaktion mit Remote-Repositories"
 
 #: command-list.h:212
 msgid "Git Repository Layout"
@@ -25697,6 +25648,11 @@ msgid ""
 "git-send-email is configured with the sendemail.* options - note the 'e'.\n"
 "Set sendemail.forbidSendmailVariables to false to disable this check.\n"
 msgstr ""
+"fatal: Konfigurations-Optionen für 'sendmail' gefunden\n"
+"git-send-email wird über die Optionen sendemail.* konfiguriert - beachten "
+"Sie das 'e'.\n"
+"Setze sendemail.forbidSendmailVariables auf 'false', um diese Prüfung "
+"zu deaktivieren."
 
 #: git-send-email.perl:489 git-send-email.perl:691
 msgid "Cannot run git format-patch from outside a repository\n"

--- a/po/de.po
+++ b/po/de.po
@@ -5055,8 +5055,7 @@ msgstr "multi-pack-index-Version %d nicht erkannt."
 #: midx.c:105
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
-msgstr ""
-"Hash-Version %u des multi-pack-index stimmt nicht mit Version %u überein"
+msgstr "multi-pack-index Hash-Version %u stimmt nicht mit Version %u überein"
 
 #: midx.c:122
 msgid "invalid chunk offset (too large)"
@@ -13936,7 +13935,7 @@ msgstr "Fehler beim Formatieren des Standardkonfigurationswertes: %s"
 #: builtin/config.c:434
 #, c-format
 msgid "cannot parse color '%s'"
-msgstr "nann Farbe '%s' nicht parsen"
+msgstr "kann Farbe '%s' nicht parsen"
 
 #: builtin/config.c:476
 msgid "unable to parse default color value"
@@ -14092,11 +14091,11 @@ msgstr "Meldungen zur Fehlersuche in Standard-Fehlerausgabe ausgeben"
 #: builtin/credential-cache--daemon.c:315
 msgid "credential-cache--daemon unavailable; no unix socket support"
 msgstr ""
-"credential-cache--daemon nicht verfügbar; Unix-Socket wird nicht unterstüzt"
+"credential-cache--daemon nicht verfügbar; Unix-Socket wird nicht unterstützt"
 
 #: builtin/credential-cache.c:154
 msgid "credential-cache unavailable; no unix socket support"
-msgstr "credential-cache nicht verfügbar; Unix-Socket wird nicht unterstüzt"
+msgstr "credential-cache nicht verfügbar; Unix-Socket wird nicht unterstützt"
 
 #: builtin/describe.c:26
 msgid "git describe [<options>] [<commit-ish>...]"
@@ -14988,7 +14987,7 @@ msgstr ""
 #: builtin/fetch.c:1891
 msgid "--stdin can only be used when fetching from one remote"
 msgstr ""
-"die Option --stdin kann nur verwendet werden, wenn von einem Remote-\n"
+"die Option --stdin kann nur verwendet werden, wenn nur von einem Remote-\n"
 "Repository abgefragt wird"
 
 #: builtin/fmt-merge-msg.c:7
@@ -22122,7 +22121,7 @@ msgstr "%s"
 #: builtin/submodule--helper.c:1055
 #, c-format
 msgid "couldn't hash object from '%s'"
-msgstr "konnte Hash nicht vom Objekt '%s' erzeugen"
+msgstr "Hash eines Objektes von '%s' konnte nicht erzeugt werden"
 
 #: builtin/submodule--helper.c:1059
 #, c-format
@@ -25651,7 +25650,7 @@ msgstr ""
 "fatal: Konfigurations-Optionen für 'sendmail' gefunden\n"
 "git-send-email wird über die Optionen sendemail.* konfiguriert - beachten "
 "Sie das 'e'.\n"
-"Setze sendemail.forbidSendmailVariables auf 'false', um diese Prüfung "
+"Setzen Sie sendemail.forbidSendmailVariables auf 'false', um diese Prüfung "
 "zu deaktivieren."
 
 #: git-send-email.perl:489 git-send-email.perl:691


### PR DESCRIPTION
@ralfth and @PhillipSz: please have a look at my suggestions for the German translation of Git 2.29.0. Only the commit 523df53dfb needs to be reviewed, the other commit is the automatically generated one to update the po file.