### PR TITLE
 Update German translation for Git 2.30.0

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -6267,6 +6267,18 @@ msgid ""
 "\n"
 "\tgit branch -m <name>\n"
 msgstr ""
+"Als Name für den initialen Branch wurde '%s' benutzt. Dieser\n"
+"Standard-Branchname kann sich ändern. Um den Namen des initialen Branches\n"
+"zu konfigurieren, der in allen neuen Repositories verwendet werden soll und\n"
+"um diese Warnung zu unterdrücken, führen Sie aus:\n"
+"\n"
+"\tgit config --global init.defaultBranch <Name>\n"
+"\n"
+"Häufig gewählte Namen statt 'master' sind 'main', 'trunk' und\n"
+"'development'. Der gerade erstellte Branch kann mit diesem Befehl\n"
+"umbenannt werden:\n"
+"\n"
+"\tgit branch -m <Name>\n"
 
 #: refs.c:588
 #, c-format
@@ -26120,9 +26132,3 @@ msgstr "Lasse %s mit Backup-Suffix '%s' aus.\n"
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Wollen Sie %s wirklich versenden? [y|N]: "
-
-#~ msgid "Counting distinct commits in commit graph"
-#~ msgstr "Zähle Commits in Commit-Graph"
-
-#~ msgid "the commit graph format cannot write %d commits"
-#~ msgstr "das Commit-Graph Format kann nicht %d Commits schreiben"

--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
 "POT-Creation-Date: 2020-12-15 16:27+0800\n"
-"PO-Revision-Date: 2020-10-15 19:16+0200\n"
+"PO-Revision-Date: 2020-12-19 14:01+0100\n"
 "Last-Translator: Matthias Rüster <matthias.ruester@gmail.com>\n"
 "Language-Team: Matthias Rüster <matthias.ruester@gmail.com>\n"
 "Language: de\n"
@@ -1676,9 +1676,8 @@ msgid "report archived files on stderr"
 msgstr "archivierte Dateien in der Standard-Fehlerausgabe ausgeben"
 
 #: archive.c:567
-#, fuzzy
 msgid "set compression level"
-msgstr "Komprimierungsgrad für Paketierung"
+msgstr "Komprimierungsgrad setzen"
 
 #: archive.c:570
 msgid "list supported archive formats"
@@ -2310,15 +2309,15 @@ msgstr[1] "Schreibe Commit-Graph in %d Durchgängen"
 
 #: commit-graph.c:1853
 msgid "unable to open commit-graph chain file"
-msgstr "Konnte Commit-Graph Chain-Datei nicht öffnen."
+msgstr "konnte Commit-Graph Chain-Datei nicht öffnen"
 
 #: commit-graph.c:1869
 msgid "failed to rename base commit-graph file"
-msgstr "Konnte Basis-Commit-Graph-Datei nicht umbenennen."
+msgstr "konnte Basis-Commit-Graph-Datei nicht umbenennen"
 
 #: commit-graph.c:1889
 msgid "failed to rename temporary commit-graph file"
-msgstr "Konnte temporäre Commit-Graph-Datei nicht umbenennen."
+msgstr "konnte temporäre Commit-Graph-Datei nicht umbenennen"
 
 #: commit-graph.c:2015
 msgid "Scanning merged commits"
@@ -2331,21 +2330,23 @@ msgstr "Zusammenführen von Commit-Graph"
 #: commit-graph.c:2165
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
+"versuche einen Commit-Graph zu schreiben, aber 'core.commitGraph' ist "
+"deaktiviert"
 
 #: commit-graph.c:2274
 #, c-format
 msgid "the commit graph format cannot write %d commits"
-msgstr "Das Commit-Graph Format kann nicht %d Commits schreiben."
+msgstr "das Commit-Graph Format kann nicht %d Commits schreiben"
 
 #: commit-graph.c:2285
 msgid "too many commits to write graph"
-msgstr "Zu viele Commits zum Schreiben des Graphen."
+msgstr "zu viele Commits zum Schreiben des Graphen"
 
 #: commit-graph.c:2378
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
-"Die Commit-Graph-Datei hat eine falsche Prüfsumme und ist wahrscheinlich "
-"beschädigt."
+"die Commit-Graph-Datei hat eine falsche Prüfsumme und ist wahrscheinlich "
+"beschädigt"
 
 #: commit-graph.c:2388
 #, c-format
@@ -2360,7 +2361,7 @@ msgstr "Commit-Graph hat fehlerhaften Fanout-Wert: fanout[%d] = %u != %u"
 #: commit-graph.c:2405
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
-msgstr "Konnte Commit %s von Commit-Graph nicht parsen."
+msgstr "konnte Commit %s von Commit-Graph nicht parsen"
 
 #: commit-graph.c:2423
 msgid "Verifying commits in commit graph"
@@ -3241,8 +3242,8 @@ msgstr ""
 #, c-format
 msgid "island regex from config has too many capture groups (max=%d)"
 msgstr ""
-"Regulärer Ausdruck des Delta-Island aus Konfiguration hat zu\n"
-"viele Capture-Gruppen (maximal %d)."
+"regulärer Ausdruck des Delta-Island aus Konfiguration hat zu\n"
+"viele Capture-Gruppen (maximal %d)"
 
 #: delta-islands.c:467
 #, c-format
@@ -3251,26 +3252,23 @@ msgstr "%d Delta-Islands markiert, fertig.\n"
 
 #: diff-lib.c:534
 msgid "--merge-base does not work with ranges"
-msgstr ""
+msgstr "--merge-base funktioniert nicht mit Bereichen"
 
 #: diff-lib.c:536
 msgid "--merge-base only works with commits"
-msgstr ""
+msgstr "--merge-base funktioniert nur mit Commits"
 
 #: diff-lib.c:553
-#, fuzzy
 msgid "unable to get HEAD"
-msgstr "Konnte HEAD nicht aktualisieren."
+msgstr "konnte HEAD nicht bekommen"
 
 #: diff-lib.c:560
-#, fuzzy
 msgid "no merge base found"
-msgstr "%s...%s: keine Merge-Basis"
+msgstr "keine Merge-Basis gefunden"
 
 #: diff-lib.c:562
-#, fuzzy
 msgid "multiple merge bases found"
-msgstr "%s...%s: mehrere Merge-Basen, nutze %s"
+msgstr "mehrere Merge-Basen gefunden"
 
 #: diff-no-index.c:238
 msgid "git diff --no-index [<options>] <path> <path>"
@@ -3375,12 +3373,12 @@ msgstr ""
 #: diff.c:4876
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
-msgstr "Unbekannte Änderungsklasse '%c' in --diff-filter=%s"
+msgstr "unbekannte Änderungsklasse '%c' in --diff-filter=%s"
 
 #: diff.c:4900
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
-msgstr "Unbekannter Wert nach ws-error-highlight=%.*s"
+msgstr "unbekannter Wert nach ws-error-highlight=%.*s"
 
 #: diff.c:4914
 #, c-format
@@ -3400,12 +3398,12 @@ msgstr "%s erwartet ein Zeichen, '%s' bekommen"
 #: diff.c:5003
 #, c-format
 msgid "bad --color-moved argument: %s"
-msgstr "Ungültiges --color-moved Argument: %s"
+msgstr "ungültiges --color-moved Argument: %s"
 
 #: diff.c:5022
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
-msgstr "Ungültiger Modus '%s' in --color-moved-ws"
+msgstr "ungültiger Modus '%s' in --color-moved-ws"
 
 #: diff.c:5062
 msgid ""
@@ -3418,12 +3416,12 @@ msgstr ""
 #: diff.c:5098 diff.c:5118
 #, c-format
 msgid "invalid argument to %s"
-msgstr "Ungültiges Argument für %s"
+msgstr "ungültiges Argument für %s"
 
 #: diff.c:5222
-#, fuzzy, c-format
+#, c-format
 msgid "invalid regex given to -I: '%s'"
-msgstr "Ungültiges Argument für %s"
+msgstr "ungültiger regulärer Ausdruck für -I gegeben: '%s'"
 
 #: diff.c:5271
 #, c-format
@@ -3433,7 +3431,7 @@ msgstr "Fehler beim Parsen des --submodule Optionsparameters: '%s'"
 #: diff.c:5327
 #, c-format
 msgid "bad --word-diff argument: %s"
-msgstr "Ungültiges --word-diff Argument: %s"
+msgstr "ungültiges --word-diff Argument: %s"
 
 #: diff.c:5350
 msgid "Diff output format options"
@@ -3441,7 +3439,7 @@ msgstr "Diff-Optionen zu Ausgabeformaten"
 
 #: diff.c:5352 diff.c:5358
 msgid "generate patch"
-msgstr "Erzeuge Patch"
+msgstr "Patch erzeugen"
 
 #: diff.c:5355 builtin/log.c:178
 msgid "suppress diff output"
@@ -3453,11 +3451,11 @@ msgstr "<n>"
 
 #: diff.c:5361 diff.c:5364
 msgid "generate diffs with <n> lines context"
-msgstr "Erstelle Unterschiede mit <n> Zeilen des Kontextes"
+msgstr "Unterschiede mit <n> Zeilen des Kontextes erstellen"
 
 #: diff.c:5366
 msgid "generate the diff in raw format"
-msgstr "Erstelle Unterschiede im Rohformat"
+msgstr "Unterschiede im Rohformat erstellen"
 
 #: diff.c:5369
 msgid "synonym for '-p --raw'"
@@ -3483,8 +3481,8 @@ msgstr "<Parameter1,Parameter2>..."
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr ""
-"Gebe die Verteilung des relativen Umfangs der Änderungen für jedes "
-"Unterverzeichnis aus"
+"die Verteilung des relativen Umfangs der Änderungen für jedes "
+"Unterverzeichnis ausgeben"
 
 #: diff.c:5387
 msgid "synonym for --dirstat=cumulative"
@@ -3497,12 +3495,12 @@ msgstr "Synonym für --dirstat=files,Parameter1,Parameter2..."
 #: diff.c:5395
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
-"Warnen, wenn Änderungen Konfliktmarker oder Whitespace-Fehler einbringen"
+"warnen, wenn Änderungen Konfliktmarker oder Whitespace-Fehler einbringen"
 
 #: diff.c:5398
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr ""
-"Gekürzte Zusammenfassung, wie z.B. Erstellungen, Umbenennungen und "
+"gekürzte Zusammenfassung, wie z.B. Erstellungen, Umbenennungen und "
 "Änderungen der Datei-Rechte"
 
 #: diff.c:5401
@@ -3519,7 +3517,7 @@ msgstr "<Breite>[,<Namens-Breite>[,<Anzahl>]]"
 
 #: diff.c:5407
 msgid "generate diffstat"
-msgstr "Generiere Zusammenfassung der Unterschiede"
+msgstr "Zusammenfassung der Unterschiede erzeugen"
 
 #: diff.c:5409 diff.c:5412 diff.c:5415
 msgid "<width>"
@@ -3527,15 +3525,15 @@ msgstr "<Breite>"
 
 #: diff.c:5410
 msgid "generate diffstat with a given width"
-msgstr "Erzeuge Zusammenfassung der Unterschiede mit gegebener Breite"
+msgstr "Zusammenfassung der Unterschiede mit gegebener Breite erzeugen"
 
 #: diff.c:5413
 msgid "generate diffstat with a given name width"
-msgstr "Erzeuge Zusammenfassung der Unterschiede mit gegebener Namens-Breite"
+msgstr "Zusammenfassung der Unterschiede mit gegebener Namens-Breite erzeugen"
 
 #: diff.c:5416
 msgid "generate diffstat with a given graph width"
-msgstr "Erzeuge Zusammenfassung der Unterschiede mit gegebener Graph-Breite"
+msgstr "Zusammenfassung der Unterschiede mit gegebener Graph-Breite erzeugen"
 
 #: diff.c:5418
 msgid "<count>"
@@ -3543,23 +3541,23 @@ msgstr "<Anzahl>"
 
 #: diff.c:5419
 msgid "generate diffstat with limited lines"
-msgstr "Erzeuge Zusammenfassung der Unterschiede mit begrenzten Zeilen"
+msgstr "Zusammenfassung der Unterschiede mit begrenzten Zeilen erzeugen"
 
 #: diff.c:5422
 msgid "generate compact summary in diffstat"
-msgstr "Erzeuge kompakte Zusammenstellung in Zusammenfassung der Unterschiede"
+msgstr "kompakte Zusammenstellung in Zusammenfassung der Unterschiede erzeugen"
 
 #: diff.c:5425
 msgid "output a binary diff that can be applied"
-msgstr "Gebe eine binäre Differenz aus, dass angewendet werden kann"
+msgstr "eine binäre Differenz ausgeben, dass angewendet werden kann"
 
 #: diff.c:5428
 msgid "show full pre- and post-image object names on the \"index\" lines"
-msgstr "Zeige vollständige Objekt-Namen in den \"index\"-Zeilen"
+msgstr "vollständige Objekt-Namen in den \"index\"-Zeilen anzeigen"
 
 #: diff.c:5430
 msgid "show colored diff"
-msgstr "Zeige farbige Unterschiede"
+msgstr "farbige Unterschiede anzeigen"
 
 #: diff.c:5431
 msgid "<kind>"
@@ -3570,16 +3568,16 @@ msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
 msgstr ""
-"Hebe Whitespace-Fehler in den Zeilen 'context', 'old' oder 'new' bei den "
-"Unterschieden hervor"
+"Whitespace-Fehler in den Zeilen 'context', 'old' oder 'new' bei den "
+"Unterschieden hervorheben"
 
 #: diff.c:5435
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
 msgstr ""
-"Verschleiere nicht die Pfadnamen und nutze NUL-Zeichen als Schlusszeichen in "
-"Ausgabefeldern bei --raw oder --numstat"
+"die Pfadnamen nicht verschleiern und NUL-Zeichen als Schlusszeichen in "
+"Ausgabefeldern bei --raw oder --numstat nutzen"
 
 #: diff.c:5438 diff.c:5441 diff.c:5444 diff.c:5553
 msgid "<prefix>"
@@ -3587,25 +3585,25 @@ msgstr "<Präfix>"
 
 #: diff.c:5439
 msgid "show the given source prefix instead of \"a/\""
-msgstr "Zeige den gegebenen Quell-Präfix statt \"a/\""
+msgstr "den gegebenen Quell-Präfix statt \"a/\" anzeigen"
 
 #: diff.c:5442
 msgid "show the given destination prefix instead of \"b/\""
-msgstr "Zeige den gegebenen Ziel-Präfix statt \"b/\""
+msgstr "den gegebenen Ziel-Präfix statt \"b/\" anzeigen"
 
 #: diff.c:5445
 msgid "prepend an additional prefix to every line of output"
-msgstr "Stelle einen zusätzlichen Präfix bei jeder Ausgabezeile voran"
+msgstr "einen zusätzlichen Präfix bei jeder Ausgabezeile voranstellen"
 
 #: diff.c:5448
 msgid "do not show any source or destination prefix"
-msgstr "Zeige keine Quell- oder Ziel-Präfixe an"
+msgstr "keine Quell- oder Ziel-Präfixe anzeigen"
 
 #: diff.c:5451
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
-"Zeige Kontext zwischen Unterschied-Blöcken bis zur angegebenen Anzahl von "
-"Zeilen."
+"Kontext zwischen Unterschied-Blöcken bis zur angegebenen Anzahl von Zeilen "
+"anzeigen"
 
 #: diff.c:5455 diff.c:5460 diff.c:5465
 msgid "<char>"
@@ -3613,15 +3611,15 @@ msgstr "<Zeichen>"
 
 #: diff.c:5456
 msgid "specify the character to indicate a new line instead of '+'"
-msgstr "Das Zeichen festlegen, das eine neue Zeile kennzeichnet (statt '+')"
+msgstr "das Zeichen festlegen, das eine neue Zeile kennzeichnet (statt '+')"
 
 #: diff.c:5461
 msgid "specify the character to indicate an old line instead of '-'"
-msgstr "Das Zeichen festlegen, das eine alte Zeile kennzeichnet (statt '-')"
+msgstr "das Zeichen festlegen, das eine alte Zeile kennzeichnet (statt '-')"
 
 #: diff.c:5466
 msgid "specify the character to indicate a context instead of ' '"
-msgstr "Das Zeichen festlegen, das den Kontext kennzeichnet (statt ' ')"
+msgstr "das Zeichen festlegen, das den Kontext kennzeichnet (statt ' ')"
 
 #: diff.c:5469
 msgid "Diff rename options"
@@ -3634,7 +3632,7 @@ msgstr "<n>[/<m>]"
 #: diff.c:5471
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr ""
-"Teile komplette Rewrite-Änderungen in Änderungen mit \"löschen\" und "
+"teile komplette Rewrite-Änderungen in Änderungen mit \"löschen\" und "
 "\"erstellen\""
 
 #: diff.c:5475
@@ -3643,7 +3641,7 @@ msgstr "Umbenennungen erkennen"
 
 #: diff.c:5479
 msgid "omit the preimage for deletes"
-msgstr "Preimage für Löschungen weglassen."
+msgstr "Preimage für Löschungen weglassen"
 
 #: diff.c:5482
 msgid "detect copies"
@@ -3651,7 +3649,7 @@ msgstr "Kopien erkennen"
 
 #: diff.c:5486
 msgid "use unmodified files as source to find copies"
-msgstr "Nutze ungeänderte Dateien als Quelle zum Finden von Kopien"
+msgstr "ungeänderte Dateien als Quelle zum Finden von Kopien nutzen"
 
 #: diff.c:5488
 msgid "disable rename detection"
@@ -3659,19 +3657,19 @@ msgstr "Erkennung von Umbenennungen deaktivieren"
 
 #: diff.c:5491
 msgid "use empty blobs as rename source"
-msgstr "Nutze leere Blobs als Quelle von Umbennungen"
+msgstr "leere Blobs als Quelle von Umbenennungen nutzen"
 
 #: diff.c:5493
 msgid "continue listing the history of a file beyond renames"
-msgstr "Fortführen der Auflistung der Historie einer Datei nach Umbennung"
+msgstr "Auflistung der Historie einer Datei nach Umbenennung fortführen"
 
 #: diff.c:5496
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
 msgstr ""
-"Verhindere die Erkennung von Umbennungen und Kopien, wenn die Anzahl der "
-"Ziele für Umbennungen und Kopien das gegebene Limit überschreitet"
+"Erkennung von Umbenennungen und Kopien verhindern, wenn die Anzahl der "
+"Ziele für Umbenennungen und Kopien das gegebene Limit überschreitet"
 
 #: diff.c:5498
 msgid "Diff algorithm options"
@@ -3679,7 +3677,7 @@ msgstr "Diff Algorithmus-Optionen"
 
 #: diff.c:5500
 msgid "produce the smallest possible diff"
-msgstr "Erzeuge die kleinstmöglichen Änderungen"
+msgstr "die kleinstmöglichen Änderungen erzeugen"
 
 #: diff.c:5503
 msgid "ignore whitespace when comparing lines"
@@ -3695,20 +3693,20 @@ msgstr "Whitespace-Änderungen am Zeilenende ignorieren"
 
 #: diff.c:5512
 msgid "ignore carrier-return at the end of line"
-msgstr "Ignoriere den Zeilenumbruch am Ende der Zeile"
+msgstr "den Zeilenumbruch am Ende der Zeile ignorieren"
 
 #: diff.c:5515
 msgid "ignore changes whose lines are all blank"
-msgstr "Ignoriere Änderungen in leeren Zeilen"
+msgstr "Änderungen in leeren Zeilen ignorieren"
 
 #: diff.c:5517 diff.c:5539 diff.c:5542 diff.c:5587
 msgid "<regex>"
 msgstr "<Regex>"
 
 #: diff.c:5518
-#, fuzzy
 msgid "ignore changes whose all lines match <regex>"
-msgstr "Ignoriere Änderungen in leeren Zeilen"
+msgstr ""
+"Änderungen ignorieren, bei denen alle Zeilen mit <Regex> übereinstimmen"
 
 #: diff.c:5521
 msgid "heuristic to shift diff hunk boundaries for easy reading"
@@ -3718,11 +3716,11 @@ msgstr ""
 
 #: diff.c:5524
 msgid "generate diff using the \"patience diff\" algorithm"
-msgstr "Erzeuge Änderungen durch Nutzung des Algorithmus \"Patience Diff\""
+msgstr "Änderungen durch Nutzung des Algorithmus \"Patience Diff\" erzeugen"
 
 #: diff.c:5528
 msgid "generate diff using the \"histogram diff\" algorithm"
-msgstr "Erzeuge Änderungen durch Nutzung des Algorithmus \"Histogram Diff\""
+msgstr "Änderungen durch Nutzung des Algorithmus \"Histogram Diff\" erzeugen"
 
 #: diff.c:5530
 msgid "<algorithm>"
@@ -3730,7 +3728,7 @@ msgstr "<Algorithmus>"
 
 #: diff.c:5531
 msgid "choose a diff algorithm"
-msgstr "Ein Algorithmus für Änderungen wählen"
+msgstr "einen Algorithmus für Änderungen wählen"
 
 #: diff.c:5533
 msgid "<text>"
@@ -3738,7 +3736,7 @@ msgstr "<Text>"
 
 #: diff.c:5534
 msgid "generate diff using the \"anchored diff\" algorithm"
-msgstr "Erzeuge Änderungen durch Nutzung des Algorithmus \"Anchored Diff\""
+msgstr "Änderungen durch Nutzung des Algorithmus \"Anchored Diff\" erzeugen"
 
 #: diff.c:5536 diff.c:5545 diff.c:5548
 msgid "<mode>"
@@ -3746,23 +3744,23 @@ msgstr "<Modus>"
 
 #: diff.c:5537
 msgid "show word diff, using <mode> to delimit changed words"
-msgstr "Zeige Wort-Änderungen, nutze <Modus>, um Wörter abzugrenzen"
+msgstr "Wort-Änderungen zeigen, nutze <Modus>, um Wörter abzugrenzen"
 
 #: diff.c:5540
 msgid "use <regex> to decide what a word is"
-msgstr "Nutze <Regex>, um zu entscheiden, was ein Wort ist"
+msgstr "<Regex> nutzen, um zu entscheiden, was ein Wort ist"
 
 #: diff.c:5543
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
-msgstr "Entsprechend wie --word-diff=color --word-diff-regex=<Regex>"
+msgstr "entsprechend wie --word-diff=color --word-diff-regex=<Regex>"
 
 #: diff.c:5546
 msgid "moved lines of code are colored differently"
-msgstr "Verschobene Codezeilen sind andersfarbig"
+msgstr "verschobene Codezeilen sind andersfarbig"
 
 #: diff.c:5549
 msgid "how white spaces are ignored in --color-moved"
-msgstr "Wie Whitespaces in --color-moved ignoriert werden"
+msgstr "wie Whitespaces in --color-moved ignoriert werden"
 
 #: diff.c:5552
 msgid "Other diff options"
@@ -3771,7 +3769,7 @@ msgstr "Andere Diff-Optionen"
 #: diff.c:5554
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
-"Wenn vom Unterverzeichnis aufgerufen, schließe Änderungen außerhalb aus und "
+"wenn vom Unterverzeichnis aufgerufen, schließe Änderungen außerhalb aus und "
 "zeige relative Pfade an"
 
 #: diff.c:5558
@@ -3780,20 +3778,20 @@ msgstr "alle Dateien als Text behandeln"
 
 #: diff.c:5560
 msgid "swap two inputs, reverse the diff"
-msgstr "Vertausche die beiden Eingaben und drehe die Änderungen um"
+msgstr "die beiden Eingaben vertauschen und die Änderungen umkehren"
 
 #: diff.c:5562
 msgid "exit with 1 if there were differences, 0 otherwise"
 msgstr ""
-"Beende mit Exit-Status 1, wenn Änderungen vorhanden sind, andernfalls mit 0"
+"mit Exit-Status 1 beenden, wenn Änderungen vorhanden sind, andernfalls mit 0"
 
 #: diff.c:5564
 msgid "disable all output of the program"
-msgstr "Keine Ausgaben vom Programm"
+msgstr "alle Ausgaben vom Programm deaktivieren"
 
 #: diff.c:5566
 msgid "allow an external diff helper to be executed"
-msgstr "Erlaube die Ausführung eines externes Programms für Änderungen"
+msgstr "erlaube die Ausführung eines externes Programms für Änderungen"
 
 #: diff.c:5568
 msgid "run external text conversion filters when comparing binary files"
@@ -3816,15 +3814,15 @@ msgstr "<Format>"
 
 #: diff.c:5575
 msgid "specify how differences in submodules are shown"
-msgstr "Angeben, wie Unterschiede in Submodulen gezeigt werden"
+msgstr "angeben, wie Unterschiede in Submodulen gezeigt werden"
 
 #: diff.c:5579
 msgid "hide 'git add -N' entries from the index"
-msgstr "verstecke 'git add -N' Einträge vom Index"
+msgstr "'git add -N' Einträge vom Index verstecken"
 
 #: diff.c:5582
 msgid "treat 'git add -N' entries as real in the index"
-msgstr "Behandle 'git add -N' Einträge im Index als echt"
+msgstr "'git add -N' Einträge im Index als echt behandeln"
 
 #: diff.c:5584
 msgid "<string>"
@@ -3835,7 +3833,7 @@ msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
 msgstr ""
-"Suche nach Unterschieden, welche die Anzahl des Vorkommens der angegebenen "
+"nach Unterschieden suchen, welche die Anzahl des Vorkommens der angegebenen "
 "Zeichenkette verändern"
 
 #: diff.c:5588
@@ -3843,22 +3841,22 @@ msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
 msgstr ""
-"Suche nach Unterschieden, welche die Anzahl des Vorkommens des angegebenen "
+"nach Unterschieden suchen, welche die Anzahl des Vorkommens des angegebenen "
 "regulären Ausdrucks verändern"
 
 #: diff.c:5591
 msgid "show all changes in the changeset with -S or -G"
-msgstr "zeige alle Änderungen im Changeset mit -S oder -G"
+msgstr "alle Änderungen im Changeset mit -S oder -G anzeigen"
 
 #: diff.c:5594
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr ""
-"behandle <Zeichenkette> bei -S als erweiterten POSIX regulären Ausdruck"
+"<Zeichenkette> bei -S als erweiterten POSIX regulären Ausdruck behandeln"
 
 #: diff.c:5597
 msgid "control the order in which files appear in the output"
 msgstr ""
-"kontrolliere die Reihenfolge, in der die Dateien in der Ausgabe erscheinen"
+"die Reihenfolge kontrollieren, in der die Dateien in der Ausgabe erscheinen"
 
 #: diff.c:5598
 msgid "<object-id>"
@@ -3869,7 +3867,7 @@ msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
 msgstr ""
-"Suche nach Unterschieden, welche die Anzahl des Vorkommens des angegebenen "
+"nach Unterschieden suchen, welche die Anzahl des Vorkommens des angegebenen "
 "Objektes verändern"
 
 #: diff.c:5601
@@ -3878,7 +3876,7 @@ msgstr "[(A|C|D|M|R|T|U|X|B)...[*]]"
 
 #: diff.c:5602
 msgid "select files by diff type"
-msgstr "Wähle Dateien anhand der Art der Änderung"
+msgstr "Dateien anhand der Art der Änderung wählen"
 
 #: diff.c:5604
 msgid "<file>"
@@ -3891,7 +3889,7 @@ msgstr "Ausgabe zu einer bestimmten Datei"
 #: diff.c:6262
 msgid "inexact rename detection was skipped due to too many files."
 msgstr ""
-"Ungenaue Erkennung für Umbenennungen wurde aufgrund zu vieler Dateien\n"
+"ungenaue Erkennung für Umbenennungen wurde aufgrund zu vieler Dateien\n"
 "übersprungen."
 
 #: diff.c:6265
@@ -3909,7 +3907,7 @@ msgstr ""
 #: diffcore-order.c:24
 #, c-format
 msgid "failed to read orderfile '%s'"
-msgstr "Fehler beim Lesen der Reihenfolgedatei '%s'."
+msgstr "Fehler beim Lesen der Reihenfolgedatei '%s'"
 
 #: diffcore-rename.c:592
 msgid "Performing inexact rename detection"
@@ -3919,17 +3917,17 @@ msgstr "Führe Erkennung für ungenaue Umbenennung aus"
 #, c-format
 msgid "pathspec '%s' did not match any file(s) known to git"
 msgstr ""
-"Pfadspezifikation '%s' stimmt mit keinen git-bekannten Dateien überein."
+"Pfadspezifikation '%s' stimmt mit keinen git-bekannten Dateien überein"
 
 #: dir.c:718 dir.c:747 dir.c:760
 #, c-format
 msgid "unrecognized pattern: '%s'"
-msgstr "Unbekanntes Muster: '%s'"
+msgstr "unbekanntes Muster: '%s'"
 
 #: dir.c:777 dir.c:791
 #, c-format
 msgid "unrecognized negative pattern: '%s'"
-msgstr "Unbekanntes verneinendes Muster: '%s'"
+msgstr "unbekanntes verneinendes Muster: '%s'"
 
 #: dir.c:809
 #, c-format
@@ -3940,17 +3938,17 @@ msgstr ""
 
 #: dir.c:819
 msgid "disabling cone pattern matching"
-msgstr "Deaktiviere Cone-Muster-Übereinstimmung"
+msgstr "deaktiviere Cone-Muster-Übereinstimmung"
 
 #: dir.c:1198
 #, c-format
 msgid "cannot use %s as an exclude file"
-msgstr "Kann %s nicht als exclude-Filter benutzen."
+msgstr "kann %s nicht als exclude-Filter benutzen"
 
 #: dir.c:2305
 #, c-format
 msgid "could not open directory '%s'"
-msgstr "Konnte Verzeichnis '%s' nicht öffnen."
+msgstr "konnte Verzeichnis '%s' nicht öffnen"
 
 #: dir.c:2605
 msgid "failed to get kernel name and information"
@@ -3960,22 +3958,22 @@ msgstr "Fehler beim Sammeln von Namen und Informationen zum Kernel"
 msgid "untracked cache is disabled on this system or location"
 msgstr ""
 "Cache für unversionierte Dateien ist auf diesem System oder\n"
-"für dieses Verzeichnis deaktiviert."
+"für dieses Verzeichnis deaktiviert"
 
 #: dir.c:3520
 #, c-format
 msgid "index file corrupt in repo %s"
-msgstr "Index-Datei in Repository %s beschädigt."
+msgstr "Index-Datei in Repository %s beschädigt"
 
 #: dir.c:3565 dir.c:3570
 #, c-format
 msgid "could not create directories for %s"
-msgstr "Konnte Verzeichnisse für '%s' nicht erstellen."
+msgstr "Konnte Verzeichnisse für '%s' nicht erstellen"
 
 #: dir.c:3599
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
-msgstr "Konnte Git-Verzeichnis nicht von '%s' nach '%s' migrieren."
+msgstr "Konnte Git-Verzeichnis nicht von '%s' nach '%s' migrieren"
 
 #: editor.c:74
 #, c-format
@@ -3989,22 +3987,22 @@ msgstr "Filtere Inhalt"
 #: entry.c:478
 #, c-format
 msgid "could not stat file '%s'"
-msgstr "Konnte Datei '%s' nicht lesen."
+msgstr "konnte Datei '%s' nicht lesen"
 
 #: environment.c:150
 #, c-format
 msgid "bad git namespace path \"%s\""
-msgstr "Ungültiger Git-Namespace-Pfad \"%s\""
+msgstr "ungültiger Git-Namespace-Pfad \"%s\""
 
 #: environment.c:337
 #, c-format
 msgid "could not set GIT_DIR to '%s'"
-msgstr "Konnte GIT_DIR nicht zu '%s' setzen."
+msgstr "konnte GIT_DIR nicht zu '%s' setzen"
 
 #: exec-cmd.c:363
 #, c-format
 msgid "too many args to run %s"
-msgstr "Zu viele Argumente angegeben, um %s auszuführen."
+msgstr "zu viele Argumente angegeben, um %s auszuführen"
 
 #: fetch-pack.c:177
 msgid "git fetch-pack: expected shallow list"
@@ -4034,12 +4032,12 @@ msgstr "--stateless-rpc benötigt multi_ack_detailed"
 #: fetch-pack.c:378 fetch-pack.c:1406
 #, c-format
 msgid "invalid shallow line: %s"
-msgstr "Ungültige shallow-Zeile: %s"
+msgstr "ungültige shallow-Zeile: %s"
 
 #: fetch-pack.c:384 fetch-pack.c:1412
 #, c-format
 msgid "invalid unshallow line: %s"
-msgstr "Ungültige unshallow-Zeile: %s"
+msgstr "ungültige unshallow-Zeile: %s"
 
 #: fetch-pack.c:386 fetch-pack.c:1414
 #, c-format
@@ -4054,7 +4052,7 @@ msgstr "Fehler in Objekt: %s"
 #: fetch-pack.c:391 fetch-pack.c:1419
 #, c-format
 msgid "no shallow found: %s"
-msgstr "Kein shallow-Objekt gefunden: %s"
+msgstr "kein shallow-Objekt gefunden: %s"
 
 #: fetch-pack.c:394 fetch-pack.c:1423
 #, c-format
@@ -4069,15 +4067,15 @@ msgstr "%s %d %s bekommen"
 #: fetch-pack.c:451
 #, c-format
 msgid "invalid commit %s"
-msgstr "Ungültiger Commit %s"
+msgstr "ungültiger Commit %s"
 
 #: fetch-pack.c:482
 msgid "giving up"
-msgstr "Gebe auf"
+msgstr "gebe auf"
 
 #: fetch-pack.c:495 progress.c:339
 msgid "done"
-msgstr "Fertig"
+msgstr "fertig"
 
 #: fetch-pack.c:507
 #, c-format
@@ -8650,7 +8648,7 @@ msgstr "%s sperrte auch %s"
 
 #: transport-helper.c:497
 msgid "couldn't run fast-import"
-msgstr "Konnte \"fast-import\" nicht ausführen."
+msgstr "konnte \"fast-import\" nicht ausführen"
 
 #: transport-helper.c:520
 msgid "error while running fast-import"
@@ -8659,30 +8657,30 @@ msgstr "Fehler beim Ausführen von 'fast-import'."
 #: transport-helper.c:549 transport-helper.c:1236
 #, c-format
 msgid "could not read ref %s"
-msgstr "Konnte Referenz %s nicht lesen."
+msgstr "konnte Referenz %s nicht lesen"
 
 #: transport-helper.c:594
 #, c-format
 msgid "unknown response to connect: %s"
-msgstr "Unbekannte Antwort auf 'connect': %s"
+msgstr "unbekannte Antwort auf 'connect': %s"
 
 #: transport-helper.c:616
 msgid "setting remote service path not supported by protocol"
 msgstr ""
-"Setzen des Remote-Service Pfads wird von dem Protokoll nicht unterstützt."
+"Setzen des Remote-Service Pfads wird von dem Protokoll nicht unterstützt"
 
 #: transport-helper.c:618
 msgid "invalid remote service path"
-msgstr "Ungültiger Remote-Service Pfad."
+msgstr "ungültiger Remote-Service Pfad."
 
 #: transport-helper.c:661 transport.c:1446
 msgid "operation not supported by protocol"
-msgstr "Die Operation wird von dem Protokoll nicht unterstützt."
+msgstr "die Operation wird von dem Protokoll nicht unterstützt"
 
 #: transport-helper.c:664
 #, c-format
 msgid "can't connect to subservice %s"
-msgstr "Kann keine Verbindung zu Subservice %s herstellen."
+msgstr "kann keine Verbindung zu Subservice %s herstellen"
 
 #: transport-helper.c:745
 msgid "'option' without a matching 'ok/error' directive"
@@ -8691,42 +8689,42 @@ msgstr "'option' ohne passende 'ok/error' Direktive"
 #: transport-helper.c:788
 #, c-format
 msgid "expected ok/error, helper said '%s'"
-msgstr "Erwartete ok/error, Remote-Helper gab '%s' aus."
+msgstr "erwartete ok/error, Remote-Helper gab '%s' aus"
 
 #: transport-helper.c:845
 #, c-format
 msgid "helper reported unexpected status of %s"
-msgstr "Remote-Helper meldete unerwarteten Status von %s."
+msgstr "Remote-Helper meldete unerwarteten Status von %s"
 
 #: transport-helper.c:928
 #, c-format
 msgid "helper %s does not support dry-run"
-msgstr "Remote-Helper %s unterstützt kein Trockenlauf."
+msgstr "Remote-Helper %s unterstützt kein Trockenlauf"
 
 #: transport-helper.c:931
 #, c-format
 msgid "helper %s does not support --signed"
-msgstr "Remote-Helper %s unterstützt kein --signed."
+msgstr "Remote-Helper %s unterstützt kein --signed"
 
 #: transport-helper.c:934
 #, c-format
 msgid "helper %s does not support --signed=if-asked"
-msgstr "Remote-Helper %s unterstützt kein --signed=if-asked."
+msgstr "Remote-Helper %s unterstützt kein --signed=if-asked"
 
 #: transport-helper.c:939
 #, c-format
 msgid "helper %s does not support --atomic"
-msgstr "Remote-Helper %s unterstützt kein --atomic."
+msgstr "Remote-Helper %s unterstützt kein --atomic"
 
 #: transport-helper.c:943
-#, fuzzy, c-format
+#, c-format
 msgid "helper %s does not support --%s"
-msgstr "Remote-Helper %s unterstützt kein --signed."
+msgstr "Remote-Helper %s unterstützt kein --%s"
 
 #: transport-helper.c:950
 #, c-format
 msgid "helper %s does not support 'push-option'"
-msgstr "Remote-Helper %s unterstützt nicht 'push-option'."
+msgstr "Remote-Helper %s unterstützt nicht 'push-option'"
 
 #: transport-helper.c:1050
 msgid "remote-helper doesn't support push; refspec needed"
@@ -10365,9 +10363,8 @@ msgid "be quiet"
 msgstr "weniger Ausgaben"
 
 #: builtin/am.c:2227
-#, fuzzy
 msgid "add a Signed-off-by trailer to the commit message"
-msgstr "der Commit-Beschreibung eine Signed-off-by Zeile hinzufügen"
+msgstr "eine Signed-off-by Zeile der Commit-Beschreibung hinzufügen"
 
 #: builtin/am.c:2230
 msgid "recode into utf8 (default)"
@@ -10595,14 +10592,12 @@ msgid "git bisect--helper --bisect-auto-next"
 msgstr "git bisect--helper --bisect-auto-next"
 
 #: builtin/bisect--helper.c:32
-#, fuzzy
 msgid "git bisect--helper --bisect-state (bad|new) [<rev>]"
-msgstr "git bisect--helper --bisect-reset [<Commit>]"
+msgstr "git bisect--helper --bisect-state (bad|new) [<Commit>]"
 
 #: builtin/bisect--helper.c:33
-#, fuzzy
 msgid "git bisect--helper --bisect-state (good|old) [<rev>...]"
-msgstr "git bisect--helper --bisect-reset [<Commit>]"
+msgstr "git bisect--helper --bisect-state (good|old) [<Commit>...]"
 
 #: builtin/bisect--helper.c:108
 #, c-format
@@ -10788,17 +10783,17 @@ msgstr "Wollen Sie, dass ich es für Sie mache [Y/n]? "
 
 #: builtin/bisect--helper.c:843
 msgid "Please call `--bisect-state` with at least one argument"
-msgstr ""
+msgstr "Bitte führen Sie `--bisect-state` mit mindestens einem Argument aus"
 
 #: builtin/bisect--helper.c:856
-#, fuzzy, c-format
+#, c-format
 msgid "'git bisect %s' can take only one argument."
-msgstr "'git bisect $TERM_BAD' kann nur ein Argument entgegennehmen."
+msgstr "'git bisect %s' kann nur ein Argument entgegennehmen."
 
 #: builtin/bisect--helper.c:868 builtin/bisect--helper.c:879
-#, fuzzy, c-format
+#, c-format
 msgid "Bad rev input: %s"
-msgstr "Ungültige Referenz-Eingabe: $arg"
+msgstr "Ungültige Referenz-Eingabe: %s"
 
 #: builtin/bisect--helper.c:924
 msgid "reset the bisection state"
@@ -10836,7 +10831,7 @@ msgstr ""
 
 #: builtin/bisect--helper.c:940
 msgid "mark the state of ref (or refs)"
-msgstr ""
+msgstr "den Status der Referenz(en) markieren"
 
 #: builtin/bisect--helper.c:942
 msgid "no log for BISECT_WRITE"
@@ -10974,7 +10969,7 @@ msgstr "Commit"
 
 #: builtin/blame.c:885
 msgid "Ignore <rev> when blaming"
-msgstr "Ignoriere <rev> beim Ausführen von 'blame'"
+msgstr "Ignoriere <Commit> beim Ausführen von 'blame'"
 
 #: builtin/blame.c:886
 msgid "Ignore revisions from <file>"
@@ -11013,14 +11008,14 @@ msgid "Find line movements within and across files"
 msgstr "verschobene Zeilen innerhalb oder zwischen Dateien finden"
 
 #: builtin/blame.c:894
-#, fuzzy
 msgid "range"
-msgstr "Kein Commit-Bereich."
+msgstr "Bereich"
 
 #: builtin/blame.c:895
-#, fuzzy
 msgid "Process only line range <start>,<end> or function :<funcname>"
-msgstr "nur Zeilen im Bereich n,m verarbeiten, gezählt von 1"
+msgstr ""
+"Nur Zeilen im Bereich <Start>,<Ende> oder Funktion :<Funktionsname> "
+"verarbeiten"
 
 #: builtin/blame.c:947
 msgid "--progress can't be used with --incremental or porcelain formats"
@@ -13641,9 +13636,8 @@ msgstr "Sie als Autor des Commits setzen (verwendet mit -C/-c/--amend)"
 
 #: builtin/commit.c:1510 builtin/log.c:1744 builtin/merge.c:301
 #: builtin/pull.c:145 builtin/revert.c:110
-#, fuzzy
 msgid "add a Signed-off-by trailer"
-msgstr "'Signed-off-by:'-Zeile hinzufügen"
+msgstr "eine Signed-off-by Zeile hinzufügen"
 
 #: builtin/commit.c:1511
 msgid "use specified template file"
@@ -13790,42 +13784,36 @@ msgid "Action"
 msgstr "Aktion"
 
 #: builtin/config.c:138
-#, fuzzy
 msgid "get value: name [value-pattern]"
-msgstr "Wert zurückgeben: Name [Wert-regex]"
+msgstr "Wert zurückgeben: Name [Wert-Muster]"
 
 #: builtin/config.c:139
-#, fuzzy
 msgid "get all values: key [value-pattern]"
-msgstr "alle Werte zurückgeben: Schlüssel [Wert-regex]"
+msgstr "alle Werte zurückgeben: Schlüssel [Wert-Muster]"
 
 #: builtin/config.c:140
-#, fuzzy
 msgid "get values for regexp: name-regex [value-pattern]"
-msgstr "Werte für den regulären Ausdruck zurückgeben: Name-regex [Wert-regex]"
+msgstr "Werte für den regulären Ausdruck zurückgeben: Name-Regex [Wert-Muster]"
 
 #: builtin/config.c:141
 msgid "get value specific for the URL: section[.var] URL"
 msgstr "Wert spezifisch für eine URL zurückgeben: section[.var] URL"
 
 #: builtin/config.c:142
-#, fuzzy
 msgid "replace all matching variables: name value [value-pattern]"
-msgstr "alle passenden Variablen ersetzen: Name Wert [Wert-regex] "
+msgstr "alle passenden Variablen ersetzen: Name Wert [Wert-Muster] "
 
 #: builtin/config.c:143
 msgid "add a new variable: name value"
 msgstr "neue Variable hinzufügen: Name Wert"
 
 #: builtin/config.c:144
-#, fuzzy
 msgid "remove a variable: name [value-pattern]"
-msgstr "eine Variable entfernen: Name [Wert-regex]"
+msgstr "eine Variable entfernen: Name [Wert-Muster]"
 
 #: builtin/config.c:145
-#, fuzzy
 msgid "remove all matches: name [value-pattern]"
-msgstr "alle Übereinstimmungen entfernen: Name [Wert-regex]"
+msgstr "alle Übereinstimmungen entfernen: Name [Wert-Muster]"
 
 #: builtin/config.c:146
 msgid "rename section: old-name new-name"
@@ -13842,6 +13830,7 @@ msgstr "alles auflisten"
 #: builtin/config.c:149
 msgid "use string equality when comparing values to 'value-pattern'"
 msgstr ""
+"nutze String-Gleichheit beim Vergleich von Werten mit dem 'Wert-Muster'"
 
 #: builtin/config.c:150
 msgid "open an editor"
@@ -14036,7 +14025,7 @@ msgstr "--default ist nur anwendbar auf --get"
 
 #: builtin/config.c:806
 msgid "--fixed-value only applies with 'value-pattern'"
-msgstr ""
+msgstr "--fixed-value wird nur zusammen mit 'Wert-Muster' angewendet"
 
 #: builtin/config.c:822
 #, c-format
@@ -14113,9 +14102,9 @@ msgid "credential-cache unavailable; no unix socket support"
 msgstr "credential-cache nicht verfügbar; Unix-Socket wird nicht unterstützt"
 
 #: builtin/credential-store.c:66
-#, fuzzy, c-format
+#, c-format
 msgid "unable to get credential storage lock in %d ms"
-msgstr "konnte aktuelles Arbeitsverzeichnis nicht bekommen"
+msgstr "konnte Sperre für Zugangsdatenspeicher nicht in %d ms bekommen"
 
 #: builtin/describe.c:26
 msgid "git describe [<options>] [<commit-ish>...]"
@@ -14287,13 +14276,12 @@ msgid "--broken is incompatible with commit-ishes"
 msgstr "Die Option --broken kann nicht mit Commits verwendet werden."
 
 #: builtin/diff-tree.c:155
-#, fuzzy
 msgid "--stdin and --merge-base are mutually exclusive"
-msgstr "-p und --overlay schließen sich gegenseitig aus."
+msgstr "--stdin und --merge-base schließen sich gegenseitig aus"
 
 #: builtin/diff-tree.c:157
 msgid "--merge-base only works with two commits"
-msgstr ""
+msgstr "--merge-base funktioniert nur mit zwei Commits"
 
 #: builtin/diff.c:91
 #, c-format
@@ -15108,20 +15096,19 @@ msgstr "nur Referenzen ausgeben, die diesen Commit nicht enthalten"
 
 #: builtin/for-each-repo.c:9
 msgid "git for-each-repo --config=<config> <command-args>"
-msgstr ""
+msgstr "git for-each-repo --config=<Konfiguration> <Befehlsargumente>"
 
 #: builtin/for-each-repo.c:37
-#, fuzzy
 msgid "config"
-msgstr "in Konflikt"
+msgstr "Konfiguration"
 
 #: builtin/for-each-repo.c:38
 msgid "config key storing a list of repository paths"
-msgstr ""
+msgstr "Konfigurationsschlüssel für eine Liste von Repository-Pfaden"
 
 #: builtin/for-each-repo.c:46
 msgid "missing --config=<config>"
-msgstr ""
+msgstr "Option --config=<Konfiguration> fehlt"
 
 #: builtin/fsck.c:69 builtin/fsck.c:148 builtin/fsck.c:149
 msgid "unknown"
@@ -15142,11 +15129,11 @@ msgstr "Warnung in %s %s: %s"
 #: builtin/fsck.c:144 builtin/fsck.c:147
 #, c-format
 msgid "broken link from %7s %s"
-msgstr "Fehlerhafte Verknüpfung von %7s %s"
+msgstr "fehlerhafte Verknüpfung von %7s %s"
 
 #: builtin/fsck.c:156
 msgid "wrong object type in link"
-msgstr "Falscher Objekttyp in Verknüpfung."
+msgstr "falscher Objekttyp in Verknüpfung"
 
 #: builtin/fsck.c:172
 #, c-format
@@ -15154,7 +15141,7 @@ msgid ""
 "broken link from %7s %s\n"
 "              to %7s %s"
 msgstr ""
-"Fehlerhafte Verknüpfung von %7s %s\n"
+"fehlerhafte Verknüpfung von %7s %s\n"
 "                       nach %7s %s"
 
 #: builtin/fsck.c:283
@@ -15473,58 +15460,54 @@ msgstr ""
 "diese zu löschen."
 
 #: builtin/gc.c:708
-#, fuzzy
 msgid ""
 "git maintenance run [--auto] [--[no-]quiet] [--task=<task>] [--schedule]"
-msgstr "git maintenance run [--auto] [--[no-]quiet] [--task=<Aufgabe>]"
+msgstr ""
+"git maintenance run [--auto] [--[no-]quiet] [--task=<Aufgabe>] [--schedule]"
 
 #: builtin/gc.c:738
 msgid "--no-schedule is not allowed"
-msgstr ""
+msgstr "--no-schedule ist nicht erlaubt"
 
 #: builtin/gc.c:743
-#, fuzzy, c-format
+#, c-format
 msgid "unrecognized --schedule argument '%s'"
-msgstr "nicht erkanntes --split Argument, %s"
+msgstr "nicht erkanntes --schedule Argument '%s'"
 
 #: builtin/gc.c:862
 msgid "failed to write commit-graph"
 msgstr "Fehler beim Schreiben des Commit-Graph"
 
 #: builtin/gc.c:901
-#, fuzzy
 msgid "failed to fill remotes"
-msgstr "Fehler beim Löschen von %s"
+msgstr "Fehler beim Eintragen der Remote-Repositories"
 
 #: builtin/gc.c:1024
-#, fuzzy
 msgid "failed to start 'git pack-objects' process"
-msgstr "Konnte 'pack-objects' nicht ausführen"
+msgstr "konnte 'git pack-objects' Prozess nicht starten"
 
 #: builtin/gc.c:1041
-#, fuzzy
 msgid "failed to finish 'git pack-objects' process"
-msgstr "Konnte 'pack-objects' nicht beenden"
+msgstr "konnte 'git pack-objects' Prozess nicht beenden"
 
 #: builtin/gc.c:1093
-#, fuzzy
 msgid "failed to write multi-pack-index"
-msgstr "Fehler beim Löschen des multi-pack-index bei %s"
+msgstr "Fehler beim Schreiben des multi-pack-index"
 
 #: builtin/gc.c:1111
-#, fuzzy
 msgid "'git multi-pack-index expire' failed"
-msgstr "multi-pack-index-Datei existiert, aber das Parsen schlug fehl"
+msgstr "Fehler beim Ausführen von 'git multi-pack-index expire'"
 
 #: builtin/gc.c:1172
-#, fuzzy
 msgid "'git multi-pack-index repack' failed"
-msgstr "Fehler beim Laden des Pack-Index für Packdatei %s"
+msgstr "Fehler beim Ausführen von 'git multi-pack-index repack'"
 
 #: builtin/gc.c:1181
 msgid ""
 "skipping incremental-repack task because core.multiPackIndex is disabled"
 msgstr ""
+"Überspringen der Aufgabe 'incremental-repack', weil core.multiPackIndex "
+"deaktiviert ist"
 
 #: builtin/gc.c:1279
 #, c-format
@@ -15552,12 +15535,11 @@ msgstr "Aufgaben abhängig vom Zustand des Repositories ausführen"
 
 #: builtin/gc.c:1410
 msgid "frequency"
-msgstr ""
+msgstr "Häufigkeit"
 
 #: builtin/gc.c:1411
-#, fuzzy
 msgid "run tasks based on frequency"
-msgstr "Aufgaben abhängig vom Zustand des Repositories ausführen"
+msgstr "Aufgaben abhängig von der Häufigkeit ausführen"
 
 #: builtin/gc.c:1414
 msgid "do not report progress or other information over stderr"
@@ -15574,42 +15556,43 @@ msgstr "eine bestimmte Aufgabe ausführen"
 #: builtin/gc.c:1433
 msgid "use at most one of --auto and --schedule=<frequency>"
 msgstr ""
+"nutzen Sie höchstens eine der Optionen --auto oder --schedule=<Häufigkeit>"
 
 #: builtin/gc.c:1467
-#, fuzzy
 msgid "failed to run 'git config'"
-msgstr "Fehler beim Ausführen von 'git status' auf '%s'"
+msgstr "Fehler beim Ausführen von 'git config'"
 
 #: builtin/gc.c:1512
 msgid "another process is scheduling background maintenance"
-msgstr ""
+msgstr "ein anderer Prozess plant die Hintergrundwartung"
 
 #: builtin/gc.c:1525
 msgid "failed to run 'crontab -l'; your system might not support 'cron'"
 msgstr ""
+"Fehler beim Ausführen von 'crontab -l'; Ihr System unterstützt eventuell "
+"'cron' nicht"
 
 #: builtin/gc.c:1544
 msgid "failed to run 'crontab'; your system might not support 'cron'"
 msgstr ""
+"Fehler beim Ausführen von 'crontab'; Ihr System unterstützt eventuell "
+"'cron' nicht"
 
 #: builtin/gc.c:1550
-#, fuzzy
 msgid "failed to open stdin of 'crontab'"
-msgstr "Fehler beim Öffnen von '%s'"
+msgstr "Fehler beim Öffnen der Standard-Eingabe von 'crontab'"
 
 #: builtin/gc.c:1592
 msgid "'crontab' died"
-msgstr ""
+msgstr "'crontab' abgebrochen"
 
 #: builtin/gc.c:1605
-#, fuzzy
 msgid "failed to add repo to global config"
-msgstr "Fehler beim Hinzufügen von Packdatei '%s'."
+msgstr "Repository konnte nicht zur globalen Konfiguration hinzugefügt werden"
 
 #: builtin/gc.c:1615
-#, fuzzy
 msgid "git maintenance <subcommand> [<options>]"
-msgstr "git maintenance run [<Optionen>]"
+msgstr "git maintenance <Unterbefehl> [<Optionen>]"
 
 #: builtin/gc.c:1634
 #, c-format
@@ -16232,7 +16215,7 @@ msgstr[1] "abgeschlossen mit %d lokalen Objekten"
 #: builtin/index-pack.c:1300
 #, c-format
 msgid "Unexpected tail checksum for %s (disk corruption?)"
-msgstr "Unerwartete Prüfsumme für %s (Festplattenfehler?)"
+msgstr "unerwartete Prüfsumme für %s (Festplattenfehler?)"
 
 #: builtin/index-pack.c:1304
 #, c-format
@@ -16595,11 +16578,12 @@ msgid ""
 "Trace the evolution of line range <start>,<end> or function :<funcname> in "
 "<file>"
 msgstr ""
+"Entwicklung der Zeilen vom Bereich <Start>,<Ende> oder Funktion "
+":<Funktionsname> in <Datei> verfolgen"
 
 #: builtin/log.c:212
-#, fuzzy
 msgid "-L<range>:<file> cannot be used with pathspec"
-msgstr "%s: %s kann nicht mit %s verwendet werden"
+msgstr "-L<Bereich>:<Datei> kann nicht mit Pfadspezifikation verwendet werden"
 
 #: builtin/log.c:302
 #, c-format
@@ -16753,9 +16737,8 @@ msgid "mark the series as Nth re-roll"
 msgstr "die Serie als n-te Fassung kennzeichnen"
 
 #: builtin/log.c:1758
-#, fuzzy
 msgid "max length of output filename"
-msgstr "maximale Größe für jede ausgegebene Paketdatei"
+msgstr "maximale Länge des Dateinamens für die Ausgabe"
 
 #: builtin/log.c:1760
 msgid "Use [RFC PATCH] instead of [PATCH]"
@@ -16906,32 +16889,32 @@ msgstr "Ungültige Identifikationszeile: %s"
 
 #: builtin/log.c:1920
 msgid "-n and -k are mutually exclusive"
-msgstr "-n und -k schließen sich gegenseitig aus."
+msgstr "-n und -k schließen sich gegenseitig aus"
 
 #: builtin/log.c:1922
 msgid "--subject-prefix/--rfc and -k are mutually exclusive"
-msgstr "--subject-prefix/--rfc und -k schließen sich gegenseitig aus."
+msgstr "--subject-prefix/--rfc und -k schließen sich gegenseitig aus"
 
 #: builtin/log.c:1930
 msgid "--name-only does not make sense"
-msgstr "Die Option --name-only kann nicht verwendet werden."
+msgstr "die Option --name-only kann nicht verwendet werden"
 
 #: builtin/log.c:1932
 msgid "--name-status does not make sense"
-msgstr "Die Option --name-status kann nicht verwendet werden."
+msgstr "die Option --name-status kann nicht verwendet werden"
 
 #: builtin/log.c:1934
 msgid "--check does not make sense"
-msgstr "Die Option --check kann nicht verwendet werden."
+msgstr "die Option --check kann nicht verwendet werden"
 
 #: builtin/log.c:1956
-#, fuzzy
 msgid "--stdout, --output, and --output-directory are mutually exclusive"
-msgstr "-b, -B und --detach schließen sich gegenseitig aus"
+msgstr ""
+"--stdout, --output und --output-directory schließen sich gegenseitig aus"
 
 #: builtin/log.c:2079
 msgid "--interdiff requires --cover-letter or single patch"
-msgstr "--interdiff erfordert --cover-letter oder einzelnen Patch."
+msgstr "--interdiff erfordert --cover-letter oder einzelnen Patch"
 
 #: builtin/log.c:2083
 msgid "Interdiff:"
@@ -19131,19 +19114,16 @@ msgstr ""
 "die Option '--force' zu verwenden.\n"
 
 #: builtin/push.c:294
-#, fuzzy
 msgid ""
 "Updates were rejected because the tip of the remote-tracking\n"
 "branch has been updated since the last checkout. You may want\n"
 "to integrate those changes locally (e.g., 'git pull ...')\n"
 "before forcing an update.\n"
 msgstr ""
-"Aktualisierungen wurden zurückgewiesen, weil die Spitze Ihres aktuellen\n"
-"Branches hinter seinem externen Gegenstück zurückgefallen ist. Führen Sie\n"
-"die externen Änderungen zusammen (z. B. 'git pull ...') bevor Sie \"push\"\n"
-"erneut ausführen.\n"
-"Siehe auch die Sektion 'Note about fast-forwards' in 'git push --help'\n"
-"für weitere Details."
+"Aktualisierungen wurden zurückgewiesen, weil die Spitze des Remote-\n"
+"Tracking-Branches seit dem letzen Checkout aktualisiert wurde. Sie möchten\n"
+"diese Änderungen vielleicht lokal integrieren (z. B. 'git pull ...') bevor\n"
+"Sie die Änderungen erzwingen.\n"
 
 #: builtin/push.c:364
 #, c-format
@@ -19189,7 +19169,7 @@ msgstr "Referenz muss sich auf dem angegebenen Wert befinden"
 
 #: builtin/push.c:566 builtin/send-pack.c:208
 msgid "require remote updates to be integrated locally"
-msgstr ""
+msgstr "Aktualisierungen des Remote müssen lokal integriert werden"
 
 #: builtin/push.c:569
 msgid "control recursive pushing of submodules"
@@ -19726,9 +19706,8 @@ msgstr ""
 "Zusammenfassung der Unterschiede gegenüber dem Upstream-Branch verbergen"
 
 #: builtin/rebase.c:1333
-#, fuzzy
 msgid "add a Signed-off-by trailer to each commit"
-msgstr "eine \"Signed-off-by:\"-Zeile zu jedem Commit hinzufügen"
+msgstr "eine Signed-off-by Zeile zu jedem Commit hinzufügen"
 
 #: builtin/rebase.c:1336
 msgid "make committer date match author date"
@@ -20835,14 +20814,14 @@ msgid "Nothing new to pack."
 msgstr "Nichts Neues zum Packen."
 
 #: builtin/repack.c:486
-#, fuzzy, c-format
+#, c-format
 msgid "missing required file: %s"
-msgstr "Fehlende Argumente für %s."
+msgstr "benötigte Datei fehlt: %s"
 
 #: builtin/repack.c:488
-#, fuzzy, c-format
+#, c-format
 msgid "could not unlink: %s"
-msgstr "Konnte '%s' nicht sperren"
+msgstr "konnte nicht löschen: %s"
 
 #: builtin/replace.c:22
 msgid "git replace [-f] <object> <replacement>"
@@ -21941,7 +21920,6 @@ msgid "could not generate diff %s^!."
 msgstr "Konnte keinen Diff erzeugen %s^!."
 
 #: builtin/stash.c:422
-#, fuzzy
 msgid "conflicts in index. Try without --index."
 msgstr "Konflikte im Index. Versuchen Sie es ohne --index."
 
@@ -23609,14 +23587,12 @@ msgid "not a git repository"
 msgstr "kein Git-Repository"
 
 #: t/helper/test-fast-rebase.c:141
-#, fuzzy
 msgid "unhandled options"
-msgstr "make_script: unbehandelte Optionen"
+msgstr "unbehandelte Optionen"
 
 #: t/helper/test-fast-rebase.c:146
-#, fuzzy
 msgid "error preparing revisions"
-msgstr "make_script: Fehler beim Vorbereiten der Commits"
+msgstr "Fehler beim Vorbereiten der Commits"
 
 #: t/helper/test-reach.c:154
 #, c-format
@@ -24230,9 +24206,8 @@ msgid "Output information on each ref"
 msgstr "Informationen für jede Referenz ausgeben"
 
 #: command-list.h:99
-#, fuzzy
 msgid "Run a Git command on a list of repositories"
-msgstr "Aufgaben abhängig vom Zustand des Repositories ausführen"
+msgstr "Einen Git-Befehl für mehrere Repositories ausführen"
 
 #: command-list.h:100
 msgid "Prepare patches for e-mail submission"
@@ -24767,13 +24742,13 @@ msgid "bisect run cannot continue any more"
 msgstr "'bisect run' kann nicht mehr fortgesetzt werden"
 
 #: git-bisect.sh:158
-#, fuzzy, sh-format
+#, sh-format
 msgid ""
 "bisect run failed:\n"
 "'bisect-state $state' exited with error code $res"
 msgstr ""
 "'bisect run' fehlgeschlagen:\n"
-"'bisect_state $state' wurde mit Fehlerwert $res beendet"
+"'bisect-state $state' wurde mit Fehlerwert $res beendet"
 
 #: git-bisect.sh:165
 msgid "bisect run success"
@@ -24781,7 +24756,7 @@ msgstr "'bisect run' erfolgreich ausgeführt"
 
 #: git-bisect.sh:173
 msgid "We are not bisecting."
-msgstr "keine binäre Suche im Gange"
+msgstr "Keine binäre Suche im Gange."
 
 #: git-merge-octopus.sh:46
 msgid ""
@@ -26140,109 +26115,3 @@ msgstr "Lasse %s mit Backup-Suffix '%s' aus.\n"
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Wollen Sie %s wirklich versenden? [y|N]: "
-
-#~ msgid "store only"
-#~ msgstr "nur speichern"
-
-#~ msgid "compress faster"
-#~ msgstr "schneller komprimieren"
-
-#~ msgid "compress better"
-#~ msgstr "besser komprimieren"
-
-#~ msgid "unexpected duplicate commit id %s"
-#~ msgstr "Unerwartete doppelte Commit-ID %s"
-
-#~ msgid "error preparing packfile from multi-pack-index"
-#~ msgstr "Fehler bei Vorbereitung der Packdatei aus multi-pack-index."
-
-#~ msgid "%s: not a valid OID"
-#~ msgstr "%s: keine gültige OID"
-
-#~ msgid "invalid committer '%s'"
-#~ msgstr "ungültiger Commit-Ersteller '%s'"
-
-#~ msgid "invalid committer: %s"
-#~ msgstr "ungültiger Commit-Ersteller: %s"
-
-#~ msgid "git bisect--helper --next-all"
-#~ msgstr "git bisect--helper --next-all"
-
-#~ msgid "git bisect--helper --write-terms <bad_term> <good_term>"
-#~ msgstr "git bisect--helper --write-terms <bad_term> <good_term>"
-
-#~ msgid "git bisect--helper --bisect-clean-state"
-#~ msgstr "git bisect--helper --bisect-clean-state"
-
-#~ msgid "git bisect--helper --bisect-autostart"
-#~ msgstr "git bisect--helper --bisect-autostart"
-
-#~ msgid "perform 'git bisect next'"
-#~ msgstr "'git bisect next' ausführen"
-
-#~ msgid "write the terms to .git/BISECT_TERMS"
-#~ msgstr "die Begriffe nach .git/BISECT_TERMS schreiben"
-
-#~ msgid "cleanup the bisection state"
-#~ msgstr "den Zustand der binären Suche aufräumen"
-
-#~ msgid "check for expected revs"
-#~ msgstr "auf erwartete Commits prüfen"
-
-#~ msgid "start the bisection if it has not yet been started"
-#~ msgstr "starte die binäre Suche, wenn diese noch nicht begonnen hat"
-
-#~ msgid "--write-terms requires two arguments"
-#~ msgstr "--write-terms benötigt zwei Argumente"
-
-#~ msgid "--bisect-clean-state requires no arguments"
-#~ msgstr "--bisect-clean-state erwartet keine Argumente"
-
-#~ msgid "--bisect-autostart does not accept arguments"
-#~ msgstr "--bisect-autostart erwartet keine Argumente"
-
-#~ msgid "n,m"
-#~ msgstr "n,m"
-
-#~ msgid "Process line range n,m in file, counting from 1"
-#~ msgstr "Verarbeitet nur Zeilen im Bereich n,m in der Datei, gezählt von 1"
-
-#~ msgid "name of output directory is too long"
-#~ msgstr "Name des Ausgabeverzeichnisses ist zu lang."
-
-#~ msgid "standard output, or directory, which one?"
-#~ msgstr "Standard-Ausgabe oder Verzeichnis, welches von beidem?"
-
-#~ msgid ""
-#~ "WARNING: Some packs in use have been renamed by\n"
-#~ "WARNING: prefixing old- to their name, in order to\n"
-#~ "WARNING: replace them with the new version of the\n"
-#~ "WARNING: file.  But the operation failed, and the\n"
-#~ "WARNING: attempt to rename them back to their\n"
-#~ "WARNING: original names also failed.\n"
-#~ "WARNING: Please rename them in %s manually:\n"
-#~ msgstr ""
-#~ "WARNUNG: Einige in Verwendung befindliche Pakete wurden\n"
-#~ "WARNUNG: umbenannt, indem 'old-' an deren Namen vorrangestellt\n"
-#~ "WARNUNG: wurde, um diese mit der neuen Dateiversion zu ersetzen.\n"
-#~ "WARNUNG: Diese Operation ist fehlgeschlagen. Der Versuch, die\n"
-#~ "WARNUNG: Datei zu ihrem ursprünglichen Namen umzubenennen, schlug\n"
-#~ "WARNUNG: ebenfalls fehl.\n"
-#~ "WARNUNG: Bitte benennen Sie diese manuell nach %s um:\n"
-
-#~ msgid "failed to remove '%s'"
-#~ msgstr "Fehler beim Löschen von '%s'"
-
-#~ msgid "Routines to help parsing remote repository access parameters"
-#~ msgstr ""
-#~ "Routinen als Hilfe zum Parsen von Zugriffsparametern von Remote-"
-#~ "Repositories"
-
-#~ msgid "Bad rev input: $bisected_head"
-#~ msgstr "Ungültige Referenz-Eingabe: $bisected_head"
-
-#~ msgid "Bad rev input: $rev"
-#~ msgstr "Ungültige Referenz-Eingabe: $rev"
-
-#~ msgid "See git-${cmd}(1) for details."
-#~ msgstr "Siehe git-${cmd}(1) für weitere Details."

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2020-10-10 09:32+0800\n"
+"POT-Creation-Date: 2020-12-15 16:27+0800\n"
 "PO-Revision-Date: 2020-10-15 19:16+0200\n"
 "Last-Translator: Matthias Rüster <matthias.ruester@gmail.com>\n"
 "Language-Team: Matthias Rüster <matthias.ruester@gmail.com>\n"
@@ -18,200 +18,200 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 
-#: add-interactive.c:368
+#: add-interactive.c:376
 #, c-format
 msgid "Huh (%s)?"
 msgstr "Wie bitte (%s)?"
 
-#: add-interactive.c:521 add-interactive.c:822 reset.c:65 sequencer.c:3250
-#: sequencer.c:3698 sequencer.c:3840 builtin/rebase.c:1526
-#: builtin/rebase.c:1944
+#: add-interactive.c:529 add-interactive.c:830 reset.c:65 sequencer.c:3284
+#: sequencer.c:3735 sequencer.c:3890 builtin/rebase.c:1532
+#: builtin/rebase.c:1955
 msgid "could not read index"
 msgstr "Index konnte nicht gelesen werden"
 
-#: add-interactive.c:576 git-add--interactive.perl:269
+#: add-interactive.c:584 git-add--interactive.perl:269
 #: git-add--interactive.perl:294
 msgid "binary"
 msgstr "Binär"
 
-#: add-interactive.c:634 git-add--interactive.perl:278
+#: add-interactive.c:642 git-add--interactive.perl:278
 #: git-add--interactive.perl:332
 msgid "nothing"
 msgstr "Nichts"
 
-#: add-interactive.c:635 git-add--interactive.perl:314
+#: add-interactive.c:643 git-add--interactive.perl:314
 #: git-add--interactive.perl:329
 msgid "unchanged"
 msgstr "unverändert"
 
-#: add-interactive.c:672 git-add--interactive.perl:643
+#: add-interactive.c:680 git-add--interactive.perl:641
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: add-interactive.c:689 add-interactive.c:877
+#: add-interactive.c:697 add-interactive.c:885
 #, c-format
 msgid "could not stage '%s'"
 msgstr "Konnte '%s' nicht zum Commit vormerken."
 
-#: add-interactive.c:695 add-interactive.c:884 reset.c:89 sequencer.c:3444
+#: add-interactive.c:703 add-interactive.c:892 reset.c:89 sequencer.c:3478
 msgid "could not write index"
 msgstr "Konnte Index nicht schreiben."
 
-#: add-interactive.c:698 git-add--interactive.perl:628
+#: add-interactive.c:706 git-add--interactive.perl:626
 #, c-format, perl-format
 msgid "updated %d path\n"
 msgid_plural "updated %d paths\n"
 msgstr[0] "%d Pfad aktualisiert\n"
 msgstr[1] "%d Pfade aktualisiert\n"
 
-#: add-interactive.c:716 git-add--interactive.perl:678
+#: add-interactive.c:724 git-add--interactive.perl:676
 #, c-format, perl-format
 msgid "note: %s is untracked now.\n"
 msgstr "Hinweis: %s ist nun unversioniert.\n"
 
-#: add-interactive.c:721 apply.c:4127 builtin/checkout.c:295
+#: add-interactive.c:729 apply.c:4127 builtin/checkout.c:295
 #: builtin/reset.c:145
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
 msgstr "make_cache_entry für Pfad '%s' fehlgeschlagen"
 
-#: add-interactive.c:751 git-add--interactive.perl:655
+#: add-interactive.c:759 git-add--interactive.perl:653
 msgid "Revert"
 msgstr "Revert"
 
-#: add-interactive.c:767
+#: add-interactive.c:775
 msgid "Could not parse HEAD^{tree}"
 msgstr "Konnte HEAD^{tree} nicht parsen."
 
-#: add-interactive.c:805 git-add--interactive.perl:631
+#: add-interactive.c:813 git-add--interactive.perl:629
 #, c-format, perl-format
 msgid "reverted %d path\n"
 msgid_plural "reverted %d paths\n"
 msgstr[0] "%d Pfad wiederhergestellt\n"
 msgstr[1] "%d Pfade wiederhergestellt\n"
 
-#: add-interactive.c:856 git-add--interactive.perl:695
+#: add-interactive.c:864 git-add--interactive.perl:693
 #, c-format
 msgid "No untracked files.\n"
 msgstr "Keine unversionierten Dateien.\n"
 
-#: add-interactive.c:860 git-add--interactive.perl:689
+#: add-interactive.c:868 git-add--interactive.perl:687
 msgid "Add untracked"
 msgstr "unversionierte Dateien hinzufügen"
 
-#: add-interactive.c:887 git-add--interactive.perl:625
+#: add-interactive.c:895 git-add--interactive.perl:623
 #, c-format, perl-format
 msgid "added %d path\n"
 msgid_plural "added %d paths\n"
 msgstr[0] "%d Pfad hinzugefügt\n"
 msgstr[1] "%d Pfade hinzugefügt\n"
 
-#: add-interactive.c:917
+#: add-interactive.c:925
 #, c-format
 msgid "ignoring unmerged: %s"
 msgstr "Ignoriere nicht zusammengeführte Datei: %s"
 
-#: add-interactive.c:929 add-patch.c:1738 git-add--interactive.perl:1371
+#: add-interactive.c:937 add-patch.c:1751 git-add--interactive.perl:1369
 #, c-format
 msgid "Only binary files changed.\n"
 msgstr "Nur Binärdateien geändert.\n"
 
-#: add-interactive.c:931 add-patch.c:1736 git-add--interactive.perl:1373
+#: add-interactive.c:939 add-patch.c:1749 git-add--interactive.perl:1371
 #, c-format
 msgid "No changes.\n"
 msgstr "Keine Änderungen.\n"
 
-#: add-interactive.c:935 git-add--interactive.perl:1381
+#: add-interactive.c:943 git-add--interactive.perl:1379
 msgid "Patch update"
 msgstr "Patch Aktualisierung"
 
-#: add-interactive.c:974 git-add--interactive.perl:1794
+#: add-interactive.c:982 git-add--interactive.perl:1792
 msgid "Review diff"
 msgstr "Diff überprüfen"
 
-#: add-interactive.c:1002
+#: add-interactive.c:1010
 msgid "show paths with changes"
 msgstr "Zeige Pfade mit Änderungen"
 
-#: add-interactive.c:1004
+#: add-interactive.c:1012
 msgid "add working tree state to the staged set of changes"
 msgstr "Zustand des Arbeitsverzeichnisses zum Commit vormerken"
 
-#: add-interactive.c:1006
+#: add-interactive.c:1014
 msgid "revert staged set of changes back to the HEAD version"
 msgstr "Zum Commit vorgemerkte Änderungen auf HEAD-Version zurücksetzen"
 
-#: add-interactive.c:1008
+#: add-interactive.c:1016
 msgid "pick hunks and update selectively"
 msgstr "Blöcke und Änderung gezielt auswählen"
 
-#: add-interactive.c:1010
+#: add-interactive.c:1018
 msgid "view diff between HEAD and index"
 msgstr "Differenz zwischen HEAD und Index ansehen"
 
-#: add-interactive.c:1012
+#: add-interactive.c:1020
 msgid "add contents of untracked files to the staged set of changes"
 msgstr "Inhalte von unversionierten Dateien zum Commit vormerken"
 
-#: add-interactive.c:1020 add-interactive.c:1069
+#: add-interactive.c:1028 add-interactive.c:1077
 msgid "Prompt help:"
 msgstr "Hilfe für Eingaben:"
 
-#: add-interactive.c:1022
+#: add-interactive.c:1030
 msgid "select a single item"
 msgstr "Ein einzelnes Element auswählen"
 
-#: add-interactive.c:1024
+#: add-interactive.c:1032
 msgid "select a range of items"
 msgstr "Eine Reihe von Elementen auswählen"
 
-#: add-interactive.c:1026
+#: add-interactive.c:1034
 msgid "select multiple ranges"
 msgstr "Mehrere Reihen auswählen"
 
-#: add-interactive.c:1028 add-interactive.c:1073
+#: add-interactive.c:1036 add-interactive.c:1081
 msgid "select item based on unique prefix"
 msgstr "Element basierend auf eindeutigen Präfix auswählen"
 
-#: add-interactive.c:1030
+#: add-interactive.c:1038
 msgid "unselect specified items"
 msgstr "Angegebene Elemente abwählen"
 
-#: add-interactive.c:1032
+#: add-interactive.c:1040
 msgid "choose all items"
 msgstr "Alle Elemente auswählen"
 
-#: add-interactive.c:1034
+#: add-interactive.c:1042
 msgid "(empty) finish selecting"
 msgstr "(leer) Auswählen beenden"
 
-#: add-interactive.c:1071
+#: add-interactive.c:1079
 msgid "select a numbered item"
 msgstr "Ein nummeriertes Element auswählen"
 
-#: add-interactive.c:1075
+#: add-interactive.c:1083
 msgid "(empty) select nothing"
 msgstr "(leer) nichts auswählen"
 
-#: add-interactive.c:1083 builtin/clean.c:816 git-add--interactive.perl:1891
+#: add-interactive.c:1091 builtin/clean.c:816 git-add--interactive.perl:1896
 msgid "*** Commands ***"
 msgstr "*** Befehle ***"
 
-#: add-interactive.c:1084 builtin/clean.c:817 git-add--interactive.perl:1888
+#: add-interactive.c:1092 builtin/clean.c:817 git-add--interactive.perl:1893
 msgid "What now"
 msgstr "Was nun"
 
-#: add-interactive.c:1136 git-add--interactive.perl:213
+#: add-interactive.c:1144 git-add--interactive.perl:213
 msgid "staged"
 msgstr "zur Staging-Area hinzugefügt"
 
-#: add-interactive.c:1136 git-add--interactive.perl:213
+#: add-interactive.c:1144 git-add--interactive.perl:213
 msgid "unstaged"
 msgstr "aus Staging-Area entfernt"
 
-#: add-interactive.c:1136 apply.c:4984 apply.c:4987 builtin/am.c:2270
-#: builtin/am.c:2273 builtin/bugreport.c:133 builtin/clone.c:123
-#: builtin/fetch.c:147 builtin/merge.c:275 builtin/pull.c:190
+#: add-interactive.c:1144 apply.c:4989 apply.c:4992 builtin/am.c:2257
+#: builtin/am.c:2260 builtin/bugreport.c:134 builtin/clone.c:124
+#: builtin/fetch.c:147 builtin/merge.c:284 builtin/pull.c:190
 #: builtin/submodule--helper.c:409 builtin/submodule--helper.c:1818
 #: builtin/submodule--helper.c:1821 builtin/submodule--helper.c:2326
 #: builtin/submodule--helper.c:2329 builtin/submodule--helper.c:2572
@@ -219,31 +219,31 @@ msgstr "aus Staging-Area entfernt"
 msgid "path"
 msgstr "Pfad"
 
-#: add-interactive.c:1143
+#: add-interactive.c:1151
 msgid "could not refresh index"
 msgstr "Index konnte nicht aktualisiert werden"
 
-#: add-interactive.c:1157 builtin/clean.c:781 git-add--interactive.perl:1805
+#: add-interactive.c:1165 builtin/clean.c:781 git-add--interactive.perl:1803
 #, c-format
 msgid "Bye.\n"
 msgstr "Tschüss.\n"
 
-#: add-patch.c:34 git-add--interactive.perl:1433
+#: add-patch.c:34 git-add--interactive.perl:1431
 #, c-format, perl-format
 msgid "Stage mode change [y,n,q,a,d%s,?]? "
 msgstr "Modusänderung der Staging-Area hinzufügen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:35 git-add--interactive.perl:1434
+#: add-patch.c:35 git-add--interactive.perl:1432
 #, c-format, perl-format
 msgid "Stage deletion [y,n,q,a,d%s,?]? "
 msgstr "Löschung der Staging-Area hinzufügen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:36 git-add--interactive.perl:1435
+#: add-patch.c:36 git-add--interactive.perl:1433
 #, c-format, perl-format
 msgid "Stage addition [y,n,q,a,d%s,?]? "
 msgstr "Ergänzung der Staging-Area hinzufügen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:37 git-add--interactive.perl:1436
+#: add-patch.c:37 git-add--interactive.perl:1434
 #, c-format, perl-format
 msgid "Stage this hunk [y,n,q,a,d%s,?]? "
 msgstr "Diesen Patch-Block der Staging-Area hinzufügen [y,n,q,a,d%s,?]? "
@@ -272,22 +272,22 @@ msgstr ""
 "d - diesen oder alle weiteren Patch-Blöcke in dieser Datei nicht zum Commit "
 "vormerken\n"
 
-#: add-patch.c:56 git-add--interactive.perl:1439
+#: add-patch.c:56 git-add--interactive.perl:1437
 #, c-format, perl-format
 msgid "Stash mode change [y,n,q,a,d%s,?]? "
 msgstr "Modusänderung stashen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:57 git-add--interactive.perl:1440
+#: add-patch.c:57 git-add--interactive.perl:1438
 #, c-format, perl-format
 msgid "Stash deletion [y,n,q,a,d%s,?]? "
 msgstr "Löschung stashen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:58 git-add--interactive.perl:1441
+#: add-patch.c:58 git-add--interactive.perl:1439
 #, c-format, perl-format
 msgid "Stash addition [y,n,q,a,d%s,?]? "
 msgstr "Ergänzung stashen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:59 git-add--interactive.perl:1442
+#: add-patch.c:59 git-add--interactive.perl:1440
 #, c-format, perl-format
 msgid "Stash this hunk [y,n,q,a,d%s,?]? "
 msgstr "Diesen Patch-Block stashen [y,n,q,a,d%s,?]? "
@@ -314,22 +314,22 @@ msgstr ""
 "a - diesen und alle weiteren Patch-Blöcke dieser Datei stashen\n"
 "d - diesen oder alle weiteren Patch-Blöcke dieser Datei nicht stashen\n"
 
-#: add-patch.c:80 git-add--interactive.perl:1445
+#: add-patch.c:80 git-add--interactive.perl:1443
 #, c-format, perl-format
 msgid "Unstage mode change [y,n,q,a,d%s,?]? "
 msgstr "Modusänderung aus der Staging-Area entfernen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:81 git-add--interactive.perl:1446
+#: add-patch.c:81 git-add--interactive.perl:1444
 #, c-format, perl-format
 msgid "Unstage deletion [y,n,q,a,d%s,?]? "
 msgstr "Löschung aus der Staging-Area entfernen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:82 git-add--interactive.perl:1447
+#: add-patch.c:82 git-add--interactive.perl:1445
 #, c-format, perl-format
 msgid "Unstage addition [y,n,q,a,d%s,?]? "
 msgstr "Ergänzung aus der Staging-Area entfernen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:83 git-add--interactive.perl:1448
+#: add-patch.c:83 git-add--interactive.perl:1446
 #, c-format, perl-format
 msgid "Unstage this hunk [y,n,q,a,d%s,?]? "
 msgstr "Diesen Patch-Block aus der Staging-Area entfernen [y,n,q,a,d%s,?]? "
@@ -359,22 +359,22 @@ msgstr ""
 "d - diesen oder alle weiteren Patch-Blöcke dieser Datei nicht aus Staging-"
 "Area entfernen\n"
 
-#: add-patch.c:103 git-add--interactive.perl:1451
+#: add-patch.c:103 git-add--interactive.perl:1449
 #, c-format, perl-format
 msgid "Apply mode change to index [y,n,q,a,d%s,?]? "
 msgstr "Modusänderung auf Index anwenden [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:104 git-add--interactive.perl:1452
+#: add-patch.c:104 git-add--interactive.perl:1450
 #, c-format, perl-format
 msgid "Apply deletion to index [y,n,q,a,d%s,?]? "
 msgstr "Löschung auf Index anwenden [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:105 git-add--interactive.perl:1453
+#: add-patch.c:105 git-add--interactive.perl:1451
 #, c-format, perl-format
 msgid "Apply addition to index [y,n,q,a,d%s,?]? "
 msgstr "Ergänzung auf Index anwenden [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:106 git-add--interactive.perl:1454
+#: add-patch.c:106 git-add--interactive.perl:1452
 #, c-format, perl-format
 msgid "Apply this hunk to index [y,n,q,a,d%s,?]? "
 msgstr "Diesen Patch-Block auf Index anwenden [y,n,q,a,d%s,?]? "
@@ -404,26 +404,26 @@ msgstr ""
 "d - diesen oder alle weiteren Patch-Blöcke dieser Datei nicht auf den Index "
 "anwenden\n"
 
-#: add-patch.c:126 git-add--interactive.perl:1457
-#: git-add--interactive.perl:1475
+#: add-patch.c:126 git-add--interactive.perl:1455
+#: git-add--interactive.perl:1473
 #, c-format, perl-format
 msgid "Discard mode change from worktree [y,n,q,a,d%s,?]? "
 msgstr "Modusänderung im Arbeitsverzeichnis verwerfen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:127 git-add--interactive.perl:1458
-#: git-add--interactive.perl:1476
+#: add-patch.c:127 git-add--interactive.perl:1456
+#: git-add--interactive.perl:1474
 #, c-format, perl-format
 msgid "Discard deletion from worktree [y,n,q,a,d%s,?]? "
 msgstr "Löschung im Arbeitsverzeichnis verwerfen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:128 git-add--interactive.perl:1459
-#: git-add--interactive.perl:1477
+#: add-patch.c:128 git-add--interactive.perl:1457
+#: git-add--interactive.perl:1475
 #, c-format, perl-format
 msgid "Discard addition from worktree [y,n,q,a,d%s,?]? "
 msgstr "Ergänzung im Arbeitsverzeichnis verwerfen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:129 git-add--interactive.perl:1460
-#: git-add--interactive.perl:1478
+#: add-patch.c:129 git-add--interactive.perl:1458
+#: git-add--interactive.perl:1476
 #, c-format, perl-format
 msgid "Discard this hunk from worktree [y,n,q,a,d%s,?]? "
 msgstr "Diesen Patch-Block im Arbeitsverzeichnis verwerfen [y,n,q,a,d%s,?]? "
@@ -453,23 +453,23 @@ msgstr ""
 "d - diesen oder alle weiteren Patch-Blöcke dieser Datei nicht im "
 "Arbeitsverzeichnis verwerfen\n"
 
-#: add-patch.c:149 add-patch.c:194 git-add--interactive.perl:1463
+#: add-patch.c:149 add-patch.c:194 git-add--interactive.perl:1461
 #, c-format, perl-format
 msgid "Discard mode change from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Modusänderung vom Index und Arbeitsverzeichnis verwerfen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:150 add-patch.c:195 git-add--interactive.perl:1464
+#: add-patch.c:150 add-patch.c:195 git-add--interactive.perl:1462
 #, c-format, perl-format
 msgid "Discard deletion from index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Löschung vom Index und Arbeitsverzeichnis verwerfen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:151 add-patch.c:196 git-add--interactive.perl:1465
+#: add-patch.c:151 add-patch.c:196 git-add--interactive.perl:1463
 #, c-format, perl-format
 msgid "Discard addition from index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Ergänzung im Index und Arbeitsverzeichnis verwerfen [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:152 add-patch.c:197 git-add--interactive.perl:1466
+#: add-patch.c:152 add-patch.c:197 git-add--interactive.perl:1464
 #, c-format, perl-format
 msgid "Discard this hunk from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
@@ -490,23 +490,23 @@ msgstr ""
 "a - diesen und alle weiteren Patch-Blöcke in der Datei verwerfen\n"
 "d - diesen oder alle weiteren Patch-Blöcke in der Datei nicht verwerfen\n"
 
-#: add-patch.c:171 add-patch.c:216 git-add--interactive.perl:1469
+#: add-patch.c:171 add-patch.c:216 git-add--interactive.perl:1467
 #, c-format, perl-format
 msgid "Apply mode change to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Modusänderung auf Index und Arbeitsverzeichnis anwenden [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:172 add-patch.c:217 git-add--interactive.perl:1470
+#: add-patch.c:172 add-patch.c:217 git-add--interactive.perl:1468
 #, c-format, perl-format
 msgid "Apply deletion to index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Löschung auf Index und Arbeitsverzeichnis anwenden [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:173 add-patch.c:218 git-add--interactive.perl:1471
+#: add-patch.c:173 add-patch.c:218 git-add--interactive.perl:1469
 #, c-format, perl-format
 msgid "Apply addition to index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Ergänzung auf Index und Arbeitsverzeichnis anwenden [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1472
+#: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1470
 #, c-format, perl-format
 msgid "Apply this hunk to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
@@ -577,7 +577,7 @@ msgstr ""
 "Der Filter muss eine Eins-zu-Eins-Beziehung\n"
 "zwischen den Ein- und Ausgabe-Zeilen einhalten."
 
-#: add-patch.c:785
+#: add-patch.c:790
 #, c-format
 msgid ""
 "expected context line #%d in\n"
@@ -586,7 +586,7 @@ msgstr ""
 "Erwartete Kontextzeile #%d in\n"
 "%.*s"
 
-#: add-patch.c:800
+#: add-patch.c:805
 #, c-format
 msgid ""
 "hunks do not overlap:\n"
@@ -599,13 +599,13 @@ msgstr ""
 "\tendet nicht mit:\n"
 "%.*s"
 
-#: add-patch.c:1076 git-add--interactive.perl:1117
+#: add-patch.c:1081 git-add--interactive.perl:1115
 msgid "Manual hunk edit mode -- see bottom for a quick guide.\n"
 msgstr ""
 "Manueller Editiermodus für Patch-Blöcke -- siehe nach unten für eine\n"
 "Kurzanleitung.\n"
 
-#: add-patch.c:1080
+#: add-patch.c:1085
 #, c-format
 msgid ""
 "---\n"
@@ -619,7 +619,7 @@ msgstr ""
 "Zeilen, die mit %c beginnen, werden entfernt.\n"
 
 #. TRANSLATORS: 'it' refers to the patch mentioned in the previous messages.
-#: add-patch.c:1094 git-add--interactive.perl:1131
+#: add-patch.c:1099 git-add--interactive.perl:1129
 msgid ""
 "If it does not apply cleanly, you will be given an opportunity to\n"
 "edit again.  If all lines of the hunk are removed, then the edit is\n"
@@ -630,11 +630,11 @@ msgstr ""
 "werden,\n"
 "wird die Bearbeitung abgebrochen und der Patch-Block bleibt unverändert.\n"
 
-#: add-patch.c:1127
+#: add-patch.c:1132
 msgid "could not parse hunk header"
 msgstr "Konnte Block-Header nicht parsen."
 
-#: add-patch.c:1172
+#: add-patch.c:1177
 msgid "'git apply --cached' failed"
 msgstr "'git apply --cached' schlug fehl."
 
@@ -650,27 +650,27 @@ msgstr "'git apply --cached' schlug fehl."
 #. Consider translating (saying "no" discards!) as
 #. (saying "n" for "no" discards!) if the translation
 #. of the word "no" does not start with n.
-#: add-patch.c:1241 git-add--interactive.perl:1244
+#: add-patch.c:1246 git-add--interactive.perl:1242
 msgid ""
 "Your edited hunk does not apply. Edit again (saying \"no\" discards!) [y/n]? "
 msgstr ""
 "Ihr bearbeiteter Patch-Block kann nicht angewendet werden.\n"
 "Erneut bearbeiten? (\"n\" verwirft Bearbeitung!) [y/n]?"
 
-#: add-patch.c:1284
+#: add-patch.c:1289
 msgid "The selected hunks do not apply to the index!"
 msgstr ""
 "Die ausgewählten Patch-Blöcke können nicht auf den Index angewendet werden!"
 
-#: add-patch.c:1285 git-add--interactive.perl:1348
+#: add-patch.c:1290 git-add--interactive.perl:1346
 msgid "Apply them to the worktree anyway? "
 msgstr "Trotzdem auf Arbeitsverzeichnis anwenden? "
 
-#: add-patch.c:1292 git-add--interactive.perl:1351
+#: add-patch.c:1297 git-add--interactive.perl:1349
 msgid "Nothing was applied.\n"
 msgstr "Nichts angewendet.\n"
 
-#: add-patch.c:1349
+#: add-patch.c:1354
 msgid ""
 "j - leave this hunk undecided, see next undecided hunk\n"
 "J - leave this hunk undecided, see next hunk\n"
@@ -694,73 +694,73 @@ msgstr ""
 "e - aktuellen Patch-Block manuell editieren\n"
 "? - Hilfe anzeigen\n"
 
-#: add-patch.c:1511 add-patch.c:1521
+#: add-patch.c:1516 add-patch.c:1526
 msgid "No previous hunk"
 msgstr "Kein vorheriger Patch-Block"
 
-#: add-patch.c:1516 add-patch.c:1526
+#: add-patch.c:1521 add-patch.c:1531
 msgid "No next hunk"
 msgstr "Kein folgender Patch-Block"
 
-#: add-patch.c:1532
+#: add-patch.c:1537
 msgid "No other hunks to goto"
 msgstr "Keine anderen Patch-Blöcke verbleibend"
 
-#: add-patch.c:1543 git-add--interactive.perl:1608
+#: add-patch.c:1548 git-add--interactive.perl:1606
 msgid "go to which hunk (<ret> to see more)? "
 msgstr "zu welchem Patch-Block springen (<Enter> für mehr Informationen)? "
 
-#: add-patch.c:1544 git-add--interactive.perl:1610
+#: add-patch.c:1549 git-add--interactive.perl:1608
 msgid "go to which hunk? "
 msgstr "zu welchem Patch-Block springen? "
 
-#: add-patch.c:1555
+#: add-patch.c:1560
 #, c-format
 msgid "Invalid number: '%s'"
 msgstr "Ungültige Nummer: '%s'"
 
-#: add-patch.c:1560
+#: add-patch.c:1565
 #, c-format
 msgid "Sorry, only %d hunk available."
 msgid_plural "Sorry, only %d hunks available."
 msgstr[0] "Entschuldigung, nur %d Patch-Block verfügbar."
 msgstr[1] "Entschuldigung, nur %d Patch-Blöcke verfügbar."
 
-#: add-patch.c:1569
+#: add-patch.c:1574
 msgid "No other hunks to search"
 msgstr "Keine anderen Patch-Blöcke zum Durchsuchen"
 
-#: add-patch.c:1575 git-add--interactive.perl:1663
+#: add-patch.c:1580 git-add--interactive.perl:1661
 msgid "search for regex? "
 msgstr "Suche nach regulärem Ausdruck? "
 
-#: add-patch.c:1590
+#: add-patch.c:1595
 #, c-format
 msgid "Malformed search regexp %s: %s"
 msgstr "Fehlerhafter regulärer Ausdruck für Suche %s: %s"
 
-#: add-patch.c:1607
+#: add-patch.c:1612
 msgid "No hunk matches the given pattern"
 msgstr "Kein Patch-Block entspricht dem angegebenen Muster"
 
-#: add-patch.c:1614
+#: add-patch.c:1619
 msgid "Sorry, cannot split this hunk"
 msgstr "Entschuldigung, kann diesen Patch-Block nicht aufteilen"
 
-#: add-patch.c:1618
+#: add-patch.c:1623
 #, c-format
 msgid "Split into %d hunks."
 msgstr "In %d Patch-Block aufgeteilt."
 
-#: add-patch.c:1622
+#: add-patch.c:1627
 msgid "Sorry, cannot edit this hunk"
 msgstr "Entschuldigung, kann diesen Patch-Block nicht bearbeiten"
 
-#: add-patch.c:1674
+#: add-patch.c:1679
 msgid "'git apply' failed"
 msgstr "'git apply' schlug fehl"
 
-#: advice.c:140
+#: advice.c:143
 #, c-format
 msgid ""
 "\n"
@@ -769,43 +769,43 @@ msgstr ""
 "\n"
 "Deaktivieren Sie diese Nachricht mit \"git config advice.%s false\""
 
-#: advice.c:156
+#: advice.c:159
 #, c-format
 msgid "%shint: %.*s%s\n"
 msgstr "%sHinweis: %.*s%s\n"
 
-#: advice.c:247
+#: advice.c:250
 msgid "Cherry-picking is not possible because you have unmerged files."
 msgstr ""
 "Cherry-Picken ist nicht möglich, weil Sie nicht zusammengeführte Dateien "
 "haben."
 
-#: advice.c:249
+#: advice.c:252
 msgid "Committing is not possible because you have unmerged files."
 msgstr ""
 "Committen ist nicht möglich, weil Sie nicht zusammengeführte Dateien haben."
 
-#: advice.c:251
+#: advice.c:254
 msgid "Merging is not possible because you have unmerged files."
 msgstr ""
 "Mergen ist nicht möglich, weil Sie nicht zusammengeführte Dateien haben."
 
-#: advice.c:253
+#: advice.c:256
 msgid "Pulling is not possible because you have unmerged files."
 msgstr ""
 "Pullen ist nicht möglich, weil Sie nicht zusammengeführte Dateien haben."
 
-#: advice.c:255
+#: advice.c:258
 msgid "Reverting is not possible because you have unmerged files."
 msgstr ""
 "Reverten ist nicht möglich, weil Sie nicht zusammengeführte Dateien haben."
 
-#: advice.c:257
+#: advice.c:260
 #, c-format
 msgid "It is not possible to %s because you have unmerged files."
 msgstr "%s ist nicht möglich, weil Sie nicht zusammengeführte Dateien haben."
 
-#: advice.c:265
+#: advice.c:268
 msgid ""
 "Fix them up in the work tree, and then use 'git add/rm <file>'\n"
 "as appropriate to mark resolution and make a commit."
@@ -814,23 +814,23 @@ msgstr ""
 "dann 'git add/rm <Datei>', um die Auflösung entsprechend zu markieren\n"
 "und zu committen."
 
-#: advice.c:273
+#: advice.c:276
 msgid "Exiting because of an unresolved conflict."
 msgstr "Beende wegen unaufgelöstem Konflikt."
 
-#: advice.c:278 builtin/merge.c:1349
+#: advice.c:281 builtin/merge.c:1369
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "Sie haben Ihren Merge nicht abgeschlossen (MERGE_HEAD existiert)."
 
-#: advice.c:280
+#: advice.c:283
 msgid "Please, commit your changes before merging."
 msgstr "Bitte committen Sie Ihre Änderungen, bevor Sie mergen."
 
-#: advice.c:281
+#: advice.c:284
 msgid "Exiting because of unfinished merge."
 msgstr "Beende wegen nicht abgeschlossenem Merge."
 
-#: advice.c:287
+#: advice.c:290
 #, c-format
 msgid ""
 "Note: switching to '%s'.\n"
@@ -1132,7 +1132,7 @@ msgstr "Anwendung des Patches fehlgeschlagen: %s:%ld"
 msgid "cannot checkout %s"
 msgstr "kann %s nicht auschecken"
 
-#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:72 setup.c:308
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:73 setup.c:308
 #, c-format
 msgid "failed to read %s"
 msgstr "Fehler beim Lesen von %s"
@@ -1293,7 +1293,7 @@ msgstr "kann internen Speicher für eben erstellte Datei %s nicht erzeugen"
 msgid "unable to add cache entry for %s"
 msgstr "kann für %s keinen Eintrag in den Zwischenspeicher hinzufügen"
 
-#: apply.c:4376 builtin/bisect--helper.c:537
+#: apply.c:4376 builtin/bisect--helper.c:524
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "Fehler beim Schreiben nach '%s'"
@@ -1344,184 +1344,184 @@ msgstr "Patch-Bereich #%d sauber angewendet."
 msgid "Rejected hunk #%d."
 msgstr "Patch-Block #%d zurückgewiesen."
 
-#: apply.c:4715
+#: apply.c:4720
 #, c-format
 msgid "Skipped patch '%s'."
 msgstr "Patch '%s' ausgelassen."
 
-#: apply.c:4723
+#: apply.c:4728
 msgid "unrecognized input"
 msgstr "nicht erkannte Eingabe"
 
-#: apply.c:4743
+#: apply.c:4748
 msgid "unable to read index file"
 msgstr "Konnte Index-Datei nicht lesen"
 
-#: apply.c:4900
+#: apply.c:4905
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr "kann Patch '%s' nicht öffnen: %s"
 
-#: apply.c:4927
+#: apply.c:4932
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "unterdrückte %d Whitespace-Fehler"
 msgstr[1] "unterdrückte %d Whitespace-Fehler"
 
-#: apply.c:4933 apply.c:4948
+#: apply.c:4938 apply.c:4953
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] "%d Zeile fügt Whitespace-Fehler hinzu."
 msgstr[1] "%d Zeilen fügen Whitespace-Fehler hinzu."
 
-#: apply.c:4941
+#: apply.c:4946
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
 msgstr[0] "%d Zeile nach Behebung von Whitespace-Fehlern angewendet."
 msgstr[1] "%d Zeilen nach Behebung von Whitespace-Fehlern angewendet."
 
-#: apply.c:4957 builtin/add.c:618 builtin/mv.c:304 builtin/rm.c:406
+#: apply.c:4962 builtin/add.c:618 builtin/mv.c:304 builtin/rm.c:406
 msgid "Unable to write new index file"
 msgstr "Konnte neue Index-Datei nicht schreiben."
 
-#: apply.c:4985
+#: apply.c:4990
 msgid "don't apply changes matching the given path"
 msgstr "keine Änderungen im angegebenen Pfad anwenden"
 
-#: apply.c:4988
+#: apply.c:4993
 msgid "apply changes matching the given path"
 msgstr "Änderungen nur im angegebenen Pfad anwenden"
 
-#: apply.c:4990 builtin/am.c:2279
+#: apply.c:4995 builtin/am.c:2266
 msgid "num"
 msgstr "Anzahl"
 
-#: apply.c:4991
+#: apply.c:4996
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr ""
 "<Anzahl> vorangestellte Schrägstriche von herkömmlichen Differenzpfaden "
 "entfernen"
 
-#: apply.c:4994
+#: apply.c:4999
 msgid "ignore additions made by the patch"
 msgstr "hinzugefügte Zeilen des Patches ignorieren"
 
-#: apply.c:4996
+#: apply.c:5001
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr ""
 "anstatt der Anwendung des Patches, den \"diffstat\" für die Eingabe "
 "ausgegeben"
 
-#: apply.c:5000
+#: apply.c:5005
 msgid "show number of added and deleted lines in decimal notation"
 msgstr ""
 "die Anzahl von hinzugefügten/entfernten Zeilen in Dezimalnotation anzeigen"
 
-#: apply.c:5002
+#: apply.c:5007
 msgid "instead of applying the patch, output a summary for the input"
 msgstr ""
 "anstatt der Anwendung des Patches, eine Zusammenfassung für die Eingabe "
 "ausgeben"
 
-#: apply.c:5004
+#: apply.c:5009
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr ""
 "anstatt der Anwendung des Patches, zeige ob Patch angewendet werden kann"
 
-#: apply.c:5006
+#: apply.c:5011
 msgid "make sure the patch is applicable to the current index"
 msgstr ""
 "sicherstellen, dass der Patch mit dem aktuellen Index angewendet werden kann"
 
-#: apply.c:5008
+#: apply.c:5013
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "neue Dateien mit `git add --intent-to-add` markieren"
 
-#: apply.c:5010
+#: apply.c:5015
 msgid "apply a patch without touching the working tree"
 msgstr "Patch anwenden, ohne Änderungen im Arbeitsverzeichnis vorzunehmen"
 
-#: apply.c:5012
+#: apply.c:5017
 msgid "accept a patch that touches outside the working area"
 msgstr ""
 "Patch anwenden, der Änderungen außerhalb des Arbeitsverzeichnisses vornimmt"
 
-#: apply.c:5015
+#: apply.c:5020
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr "Patch anwenden (Benutzung mit --stat/--summary/--check)"
 
-#: apply.c:5017
+#: apply.c:5022
 msgid "attempt three-way merge if a patch does not apply"
 msgstr "versuche 3-Wege-Merge, wenn der Patch nicht angewendet werden konnte"
 
-#: apply.c:5019
+#: apply.c:5024
 msgid "build a temporary index based on embedded index information"
 msgstr ""
 "einen temporären Index, basierend auf den integrierten Index-Informationen, "
 "erstellen"
 
-#: apply.c:5022 builtin/checkout-index.c:173 builtin/ls-files.c:525
+#: apply.c:5027 builtin/checkout-index.c:182 builtin/ls-files.c:525
 msgid "paths are separated with NUL character"
 msgstr "Pfade sind getrennt durch NUL Zeichen"
 
-#: apply.c:5024
+#: apply.c:5029
 msgid "ensure at least <n> lines of context match"
 msgstr ""
 "sicher stellen, dass mindestens <n> Zeilen des Kontextes übereinstimmen"
 
-#: apply.c:5025 builtin/am.c:2258 builtin/interpret-trailers.c:98
+#: apply.c:5030 builtin/am.c:2245 builtin/interpret-trailers.c:98
 #: builtin/interpret-trailers.c:100 builtin/interpret-trailers.c:102
-#: builtin/pack-objects.c:3562 builtin/rebase.c:1340
+#: builtin/pack-objects.c:3562 builtin/rebase.c:1346
 msgid "action"
 msgstr "Aktion"
 
-#: apply.c:5026
+#: apply.c:5031
 msgid "detect new or modified lines that have whitespace errors"
 msgstr "neue oder geänderte Zeilen, die Whitespace-Fehler haben, ermitteln"
 
-#: apply.c:5029 apply.c:5032
+#: apply.c:5034 apply.c:5037
 msgid "ignore changes in whitespace when finding context"
 msgstr "Änderungen im Whitespace bei der Suche des Kontextes ignorieren"
 
-#: apply.c:5035
+#: apply.c:5040
 msgid "apply the patch in reverse"
 msgstr "den Patch in umgekehrter Reihenfolge anwenden"
 
-#: apply.c:5037
+#: apply.c:5042
 msgid "don't expect at least one line of context"
 msgstr "keinen Kontext erwarten"
 
-#: apply.c:5039
+#: apply.c:5044
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr ""
 "zurückgewiesene Patch-Blöcke in entsprechenden *.rej Dateien hinterlassen"
 
-#: apply.c:5041
+#: apply.c:5046
 msgid "allow overlapping hunks"
 msgstr "sich überlappende Patch-Blöcke erlauben"
 
-#: apply.c:5042 builtin/add.c:329 builtin/check-ignore.c:22
+#: apply.c:5047 builtin/add.c:329 builtin/check-ignore.c:22
 #: builtin/commit.c:1364 builtin/count-objects.c:98 builtin/fsck.c:775
-#: builtin/log.c:2270 builtin/mv.c:123 builtin/read-tree.c:128
+#: builtin/log.c:2287 builtin/mv.c:123 builtin/read-tree.c:128
 msgid "be verbose"
 msgstr "erweiterte Ausgaben"
 
-#: apply.c:5044
+#: apply.c:5049
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr "fehlerhaft erkannten fehlenden Zeilenumbruch am Dateiende tolerieren"
 
-#: apply.c:5047
+#: apply.c:5052
 msgid "do not trust the line counts in the hunk headers"
 msgstr "den Zeilennummern im Kopf des Patch-Blocks nicht vertrauen"
 
-#: apply.c:5049 builtin/am.c:2267
+#: apply.c:5054 builtin/am.c:2254
 msgid "root"
 msgstr "Wurzelverzeichnis"
 
-#: apply.c:5050
+#: apply.c:5055
 msgid "prepend <root> to all filenames"
 msgstr "<Wurzelverzeichnis> vor alle Dateinamen stellen"
 
@@ -1535,16 +1535,16 @@ msgstr "Kann Blob %s nicht streamen."
 msgid "unsupported file mode: 0%o (SHA1: %s)"
 msgstr "Nicht unterstützter Dateimodus: 0%o (SHA1: %s)"
 
-#: archive-tar.c:449
+#: archive-tar.c:450
 #, c-format
 msgid "unable to start '%s' filter"
 msgstr "Konnte '%s' Filter nicht starten."
 
-#: archive-tar.c:452
+#: archive-tar.c:453
 msgid "unable to redirect descriptor"
 msgstr "Konnte Descriptor nicht umleiten."
 
-#: archive-tar.c:459
+#: archive-tar.c:460
 #, c-format
 msgid "'%s' filter reported error"
 msgstr "'%s' Filter meldete Fehler."
@@ -1593,9 +1593,9 @@ msgstr "git archive --remote <Repository> [--exec <Programm>] --list"
 msgid "cannot read %s"
 msgstr "Kann %s nicht lesen."
 
-#: archive.c:345 sequencer.c:445 sequencer.c:1706 sequencer.c:2852
-#: sequencer.c:3293 sequencer.c:3402 builtin/am.c:263 builtin/commit.c:786
-#: builtin/merge.c:1124
+#: archive.c:345 sequencer.c:459 sequencer.c:1736 sequencer.c:2886
+#: sequencer.c:3327 sequencer.c:3436 builtin/am.c:249 builtin/commit.c:786
+#: builtin/merge.c:1138
 #, c-format
 msgid "could not read '%s'"
 msgstr "Konnte '%s' nicht lesen"
@@ -1634,119 +1634,112 @@ msgstr "Datei nicht gefunden: %s"
 msgid "Not a regular file: %s"
 msgstr "Keine reguläre Datei: %s"
 
-#: archive.c:553
+#: archive.c:555
 msgid "fmt"
 msgstr "Format"
 
-#: archive.c:553
+#: archive.c:555
 msgid "archive format"
 msgstr "Archivformat"
 
-#: archive.c:554 builtin/log.c:1760
+#: archive.c:556 builtin/log.c:1765
 msgid "prefix"
 msgstr "Präfix"
 
-#: archive.c:555
+#: archive.c:557
 msgid "prepend prefix to each pathname in the archive"
 msgstr "einen Präfix vor jeden Pfadnamen in dem Archiv stellen"
 
-#: archive.c:556 archive.c:559 builtin/blame.c:884 builtin/blame.c:888
-#: builtin/blame.c:889 builtin/commit-tree.c:117 builtin/config.c:133
+#: archive.c:558 archive.c:561 builtin/blame.c:886 builtin/blame.c:890
+#: builtin/blame.c:891 builtin/commit-tree.c:117 builtin/config.c:135
 #: builtin/fast-export.c:1208 builtin/fast-export.c:1210
-#: builtin/fast-export.c:1214 builtin/grep.c:908 builtin/hash-object.c:105
+#: builtin/fast-export.c:1214 builtin/grep.c:919 builtin/hash-object.c:105
 #: builtin/ls-files.c:561 builtin/ls-files.c:564 builtin/notes.c:412
 #: builtin/notes.c:578 builtin/read-tree.c:123 parse-options.h:190
 msgid "file"
 msgstr "Datei"
 
-#: archive.c:557
+#: archive.c:559
 msgid "add untracked file to archive"
 msgstr "unversionierte Datei zum Archiv hinzufügen"
 
-#: archive.c:560 builtin/archive.c:90
+#: archive.c:562 builtin/archive.c:90
 msgid "write the archive to this file"
 msgstr "das Archiv in diese Datei schreiben"
 
-#: archive.c:562
+#: archive.c:564
 msgid "read .gitattributes in working directory"
 msgstr ".gitattributes aus dem Arbeitsverzeichnis lesen"
 
-#: archive.c:563
+#: archive.c:565
 msgid "report archived files on stderr"
 msgstr "archivierte Dateien in der Standard-Fehlerausgabe ausgeben"
 
-#: archive.c:564
-msgid "store only"
-msgstr "nur speichern"
+#: archive.c:567
+#, fuzzy
+msgid "set compression level"
+msgstr "Komprimierungsgrad für Paketierung"
 
-#: archive.c:565
-msgid "compress faster"
-msgstr "schneller komprimieren"
-
-#: archive.c:573
-msgid "compress better"
-msgstr "besser komprimieren"
-
-#: archive.c:576
+#: archive.c:570
 msgid "list supported archive formats"
 msgstr "unterstützte Archivformate auflisten"
 
-#: archive.c:578 builtin/archive.c:91 builtin/clone.c:113 builtin/clone.c:116
+#: archive.c:572 builtin/archive.c:91 builtin/clone.c:114 builtin/clone.c:117
 #: builtin/submodule--helper.c:1830 builtin/submodule--helper.c:2335
 msgid "repo"
 msgstr "Repository"
 
-#: archive.c:579 builtin/archive.c:92
+#: archive.c:573 builtin/archive.c:92
 msgid "retrieve the archive from remote repository <repo>"
 msgstr "Archiv vom Remote-Repository <Repository> abrufen"
 
-#: archive.c:580 builtin/archive.c:93 builtin/difftool.c:715
+#: archive.c:574 builtin/archive.c:93 builtin/difftool.c:714
 #: builtin/notes.c:498
 msgid "command"
 msgstr "Programm"
 
-#: archive.c:581 builtin/archive.c:94
+#: archive.c:575 builtin/archive.c:94
 msgid "path to the remote git-upload-archive command"
 msgstr "Pfad zum externen \"git-upload-archive\"-Programm"
 
-#: archive.c:588
+#: archive.c:582
 msgid "Unexpected option --remote"
 msgstr "Unerwartete Option --remote"
 
-#: archive.c:590
+#: archive.c:584
 msgid "Option --exec can only be used together with --remote"
 msgstr "Die Option --exec kann nur zusammen mit --remote verwendet werden."
 
-#: archive.c:592
+#: archive.c:586
 msgid "Unexpected option --output"
 msgstr "Unerwartete Option --output"
 
-#: archive.c:594
+#: archive.c:588
 msgid "Options --add-file and --remote cannot be used together"
 msgstr ""
 "Die Optionen --add-file und --remote können nicht gemeinsam verwendet werden."
 
-#: archive.c:616
+#: archive.c:610
 #, c-format
 msgid "Unknown archive format '%s'"
 msgstr "Unbekanntes Archivformat '%s'"
 
-#: archive.c:623
+#: archive.c:619
 #, c-format
 msgid "Argument not supported for format '%s': -%d"
 msgstr "Argument für Format '%s' nicht unterstützt: -%d"
 
-#: attr.c:212
+#: attr.c:202
 #, c-format
 msgid "%.*s is not a valid attribute name"
 msgstr "%.*s ist kein gültiger Attributname"
 
-#: attr.c:369
+#: attr.c:359
 #, c-format
 msgid "%s not allowed: %s:%d"
 msgstr "%s nicht erlaubt: %s:%d"
 
-#: attr.c:409
+#: attr.c:399
 msgid ""
 "Negative patterns are ignored in git attributes\n"
 "Use '\\!' for literal leading exclamation."
@@ -1754,22 +1747,22 @@ msgstr ""
 "Verneinende Muster werden in Git-Attributen ignoriert.\n"
 "Benutzen Sie '\\!' für führende Ausrufezeichen."
 
-#: bisect.c:476
+#: bisect.c:489
 #, c-format
 msgid "Badly quoted content in file '%s': %s"
 msgstr "Ungültiger Inhalt bzgl. Anführungszeichen in Datei '%s': %s"
 
-#: bisect.c:686
+#: bisect.c:699
 #, c-format
 msgid "We cannot bisect more!\n"
 msgstr "Keine binäre Suche mehr möglich!\n"
 
-#: bisect.c:753
+#: bisect.c:766
 #, c-format
 msgid "Not a valid commit name %s"
 msgstr "%s ist kein gültiger Commit-Name"
 
-#: bisect.c:778
+#: bisect.c:791
 #, c-format
 msgid ""
 "The merge base %s is bad.\n"
@@ -1778,7 +1771,7 @@ msgstr ""
 "Die Merge-Basis %s ist fehlerhaft.\n"
 "Das bedeutet, der Fehler wurde zwischen %s und [%s] behoben.\n"
 
-#: bisect.c:783
+#: bisect.c:796
 #, c-format
 msgid ""
 "The merge base %s is new.\n"
@@ -1787,7 +1780,7 @@ msgstr ""
 "Die Merge-Basis %s ist neu.\n"
 "Das bedeutet, die Eigenschaft hat sich zwischen %s und [%s] geändert.\n"
 
-#: bisect.c:788
+#: bisect.c:801
 #, c-format
 msgid ""
 "The merge base %s is %s.\n"
@@ -1796,7 +1789,7 @@ msgstr ""
 "Die Merge-Basis %s ist %s.\n"
 "Das bedeutet, der erste '%s' Commit befindet sich zwischen %s und [%s].\n"
 
-#: bisect.c:796
+#: bisect.c:809
 #, c-format
 msgid ""
 "Some %s revs are not ancestors of the %s rev.\n"
@@ -1807,7 +1800,7 @@ msgstr ""
 "git bisect kann in diesem Fall nicht richtig arbeiten.\n"
 "Vielleicht verwechselten Sie %s und %s Commits?\n"
 
-#: bisect.c:809
+#: bisect.c:822
 #, c-format
 msgid ""
 "the merge base between %s and [%s] must be skipped.\n"
@@ -1819,36 +1812,36 @@ msgstr ""
 "erste %s Commit zwischen %s und %s befindet.\n"
 "Es wird dennoch fortgesetzt."
 
-#: bisect.c:848
+#: bisect.c:861
 #, c-format
 msgid "Bisecting: a merge base must be tested\n"
 msgstr "binäre Suche: eine Merge-Basis muss geprüft werden\n"
 
-#: bisect.c:898
+#: bisect.c:911
 #, c-format
 msgid "a %s revision is needed"
 msgstr "ein %s Commit wird benötigt"
 
-#: bisect.c:928 builtin/notes.c:177 builtin/tag.c:255
+#: bisect.c:941 builtin/notes.c:177 builtin/tag.c:255
 #, c-format
 msgid "could not create file '%s'"
 msgstr "konnte Datei '%s' nicht erstellen"
 
-#: bisect.c:974 builtin/merge.c:150
+#: bisect.c:987 builtin/merge.c:152
 #, c-format
 msgid "could not read file '%s'"
 msgstr "Konnte Datei '%s' nicht lesen"
 
-#: bisect.c:1014
+#: bisect.c:1027
 msgid "reading bisect refs failed"
 msgstr "Lesen von Referenzen für binäre Suche fehlgeschlagen"
 
-#: bisect.c:1044
+#: bisect.c:1057
 #, c-format
 msgid "%s was both %s and %s\n"
 msgstr "%s war sowohl %s als auch %s\n"
 
-#: bisect.c:1053
+#: bisect.c:1066
 #, c-format
 msgid ""
 "No testable commit found.\n"
@@ -1857,7 +1850,7 @@ msgstr ""
 "Kein testbarer Commit gefunden.\n"
 "Vielleicht starteten Sie mit falschen Pfad-Parametern?\n"
 
-#: bisect.c:1082
+#: bisect.c:1095
 #, c-format
 msgid "(roughly %d step)"
 msgid_plural "(roughly %d steps)"
@@ -1867,50 +1860,50 @@ msgstr[1] "(ungefähr %d Schritte)"
 #. TRANSLATORS: the last %s will be replaced with "(roughly %d
 #. steps)" translation.
 #.
-#: bisect.c:1088
+#: bisect.c:1101
 #, c-format
 msgid "Bisecting: %d revision left to test after this %s\n"
 msgid_plural "Bisecting: %d revisions left to test after this %s\n"
 msgstr[0] "binäre Suche: danach noch %d Commit zum Testen übrig %s\n"
 msgstr[1] "binäre Suche: danach noch %d Commits zum Testen übrig %s\n"
 
-#: blame.c:2778
+#: blame.c:2777
 msgid "--contents and --reverse do not blend well."
 msgstr "--contents und --reverse funktionieren gemeinsam nicht."
 
-#: blame.c:2792
+#: blame.c:2791
 msgid "cannot use --contents with final commit object name"
 msgstr ""
 "kann --contents nicht mit endgültigem Namen des Commit-Objektes benutzen"
 
-#: blame.c:2813
+#: blame.c:2812
 msgid "--reverse and --first-parent together require specified latest commit"
 msgstr ""
 "--reverse und --first-parent zusammen erfordern die Angabe eines "
 "endgültigen\n"
 "Commits"
 
-#: blame.c:2822 bundle.c:213 ref-filter.c:2264 remote.c:2020 sequencer.c:2105
-#: sequencer.c:4606 submodule.c:855 builtin/commit.c:1045 builtin/log.c:404
-#: builtin/log.c:1020 builtin/log.c:1622 builtin/log.c:2029 builtin/log.c:2319
-#: builtin/merge.c:414 builtin/pack-objects.c:3380 builtin/pack-objects.c:3395
-#: builtin/shortlog.c:320
+#: blame.c:2821 bundle.c:213 ref-filter.c:2272 remote.c:2031 sequencer.c:2138
+#: sequencer.c:4633 submodule.c:855 builtin/commit.c:1045 builtin/log.c:409
+#: builtin/log.c:1023 builtin/log.c:1625 builtin/log.c:2046 builtin/log.c:2336
+#: builtin/merge.c:423 builtin/pack-objects.c:3380 builtin/pack-objects.c:3395
+#: builtin/shortlog.c:267
 msgid "revision walk setup failed"
 msgstr "Einrichtung des Revisionsgangs fehlgeschlagen"
 
-#: blame.c:2840
+#: blame.c:2839
 msgid ""
 "--reverse --first-parent together require range along first-parent chain"
 msgstr ""
 "--reverse und --first-parent zusammen erfordern einen Bereich entlang der\n"
 "\"first-parent\"-Kette"
 
-#: blame.c:2851
+#: blame.c:2850
 #, c-format
 msgid "no such path %s in %s"
 msgstr "Pfad %s nicht in %s"
 
-#: blame.c:2862
+#: blame.c:2861
 #, c-format
 msgid "cannot read blob %s for path %s"
 msgstr "kann Blob %s für Pfad '%s' nicht lesen"
@@ -2077,7 +2070,7 @@ msgstr "'%s' sieht nicht wie eine v2 oder v3 Paketdatei aus"
 msgid "unrecognized header: %s%s (%d)"
 msgstr "nicht erkannter Kopfbereich: %s%s (%d)"
 
-#: bundle.c:136 rerere.c:480 rerere.c:690 sequencer.c:2357 sequencer.c:3142
+#: bundle.c:136 rerere.c:480 rerere.c:690 sequencer.c:2390 sequencer.c:3176
 #: builtin/commit.c:814
 #, c-format
 msgid "could not open '%s'"
@@ -2140,7 +2133,7 @@ msgstr "nicht unterstützte Paket-Version %d"
 msgid "cannot write bundle version %d with algorithm %s"
 msgstr "kann Paket-Version %d nicht mit Algorithmus %s schreiben"
 
-#: bundle.c:522 builtin/log.c:207 builtin/log.c:1918 builtin/shortlog.c:461
+#: bundle.c:522 builtin/log.c:209 builtin/log.c:1927 builtin/shortlog.c:408
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr "nicht erkanntes Argument: %s"
@@ -2163,7 +2156,7 @@ msgstr "Erstellung der Paketindexdatei abgebrochen"
 msgid "invalid color value: %.*s"
 msgstr "Ungültiger Farbwert: %.*s"
 
-#: commit-graph.c:188 midx.c:46
+#: commit-graph.c:188 midx.c:47
 msgid "invalid hash version"
 msgstr "ungültige Hash-Version"
 
@@ -2227,7 +2220,7 @@ msgstr "Ungültige Commit-Position. Commit-Graph ist wahrscheinlich beschädigt.
 msgid "could not find commit %s"
 msgstr "Konnte Commit %s nicht finden."
 
-#: commit-graph.c:1042 builtin/am.c:1306
+#: commit-graph.c:1042 builtin/am.c:1292
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "Konnte Commit '%s' nicht parsen."
@@ -2294,7 +2287,7 @@ msgstr "Suche zusätzliche Ränder in Commit-Graph"
 msgid "failed to write correct number of base graph ids"
 msgstr "Fehler beim Schreiben der korrekten Anzahl von Basis-Graph-IDs."
 
-#: commit-graph.c:1720 midx.c:826
+#: commit-graph.c:1720 midx.c:819
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "Konnte führende Verzeichnisse von '%s' nicht erstellen."
@@ -2331,77 +2324,76 @@ msgstr "Konnte temporäre Commit-Graph-Datei nicht umbenennen."
 msgid "Scanning merged commits"
 msgstr "Durchsuche zusammengeführte Commits"
 
-#: commit-graph.c:2026
-#, c-format
-msgid "unexpected duplicate commit id %s"
-msgstr "Unerwartete doppelte Commit-ID %s"
-
-#: commit-graph.c:2049
+#: commit-graph.c:2059
 msgid "Merging commit-graph"
 msgstr "Zusammenführen von Commit-Graph"
 
-#: commit-graph.c:2259
+#: commit-graph.c:2165
+msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
+msgstr ""
+
+#: commit-graph.c:2274
 #, c-format
 msgid "the commit graph format cannot write %d commits"
 msgstr "Das Commit-Graph Format kann nicht %d Commits schreiben."
 
-#: commit-graph.c:2270
+#: commit-graph.c:2285
 msgid "too many commits to write graph"
 msgstr "Zu viele Commits zum Schreiben des Graphen."
 
-#: commit-graph.c:2363
+#: commit-graph.c:2378
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "Die Commit-Graph-Datei hat eine falsche Prüfsumme und ist wahrscheinlich "
 "beschädigt."
 
-#: commit-graph.c:2373
+#: commit-graph.c:2388
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "Commit-Graph hat fehlerhafte OID-Reihenfolge: %s dann %s"
 
-#: commit-graph.c:2383 commit-graph.c:2398
+#: commit-graph.c:2398 commit-graph.c:2413
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr "Commit-Graph hat fehlerhaften Fanout-Wert: fanout[%d] = %u != %u"
 
-#: commit-graph.c:2390
+#: commit-graph.c:2405
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "Konnte Commit %s von Commit-Graph nicht parsen."
 
-#: commit-graph.c:2408
+#: commit-graph.c:2423
 msgid "Verifying commits in commit graph"
 msgstr "Commit in Commit-Graph überprüfen"
 
-#: commit-graph.c:2423
+#: commit-graph.c:2438
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "Fehler beim Parsen des Commits %s von Objekt-Datenbank für Commit-Graph"
 
-#: commit-graph.c:2430
+#: commit-graph.c:2445
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 "OID des Wurzelverzeichnisses für Commit %s in Commit-Graph ist %s != %s"
 
-#: commit-graph.c:2440
+#: commit-graph.c:2455
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr "Commit-Graph Vorgänger-Liste für Commit %s ist zu lang"
 
-#: commit-graph.c:2449
+#: commit-graph.c:2464
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "Commit-Graph-Vorgänger für %s ist %s != %s"
 
-#: commit-graph.c:2463
+#: commit-graph.c:2478
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr "Commit-Graph Vorgänger-Liste für Commit %s endet zu früh"
 
-#: commit-graph.c:2468
+#: commit-graph.c:2483
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2409,7 +2401,7 @@ msgstr ""
 "Commit-Graph hat Generationsnummer null für Commit %s, aber sonst ungleich "
 "null"
 
-#: commit-graph.c:2472
+#: commit-graph.c:2487
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2417,19 +2409,19 @@ msgstr ""
 "Commit-Graph hat Generationsnummer ungleich null für Commit %s, aber sonst "
 "null"
 
-#: commit-graph.c:2488
+#: commit-graph.c:2503
 #, c-format
 msgid "commit-graph generation for commit %s is %u != %u"
 msgstr "Commit-Graph Erstellung für Commit %s ist %u != %u"
 
-#: commit-graph.c:2494
+#: commit-graph.c:2509
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 "Commit-Datum für Commit %s in Commit-Graph ist %<PRIuMAX> != %<PRIuMAX>"
 
-#: commit.c:52 sequencer.c:2845 builtin/am.c:373 builtin/am.c:417
-#: builtin/am.c:1385 builtin/am.c:2031 builtin/replace.c:457
+#: commit.c:52 sequencer.c:2879 builtin/am.c:359 builtin/am.c:403
+#: builtin/am.c:1371 builtin/am.c:2018 builtin/replace.c:457
 #, c-format
 msgid "could not parse %s"
 msgstr "konnte %s nicht parsen"
@@ -2539,7 +2531,7 @@ msgstr "Schlüssel enthält keine Sektion: %s"
 msgid "key does not contain variable name: %s"
 msgstr "Schlüssel enthält keinen Variablennamen: %s"
 
-#: config.c:408 sequencer.c:2547
+#: config.c:408 sequencer.c:2580
 #, c-format
 msgid "invalid key: %s"
 msgstr "Ungültiger Schlüssel: %s"
@@ -2742,77 +2734,77 @@ msgstr ""
 msgid "bad config variable '%s' in file '%s' at line %d"
 msgstr "ungültige Konfigurationsvariable '%s' in Datei '%s' bei Zeile %d"
 
-#: config.c:2470
+#: config.c:2473
 #, c-format
 msgid "invalid section name '%s'"
 msgstr "Ungültiger Sektionsname '%s'"
 
-#: config.c:2502
+#: config.c:2505
 #, c-format
 msgid "%s has multiple values"
 msgstr "%s hat mehrere Werte"
 
-#: config.c:2531
+#: config.c:2534
 #, c-format
 msgid "failed to write new configuration file %s"
 msgstr "Konnte neue Konfigurationsdatei '%s' nicht schreiben."
 
-#: config.c:2783 config.c:3107
+#: config.c:2786 config.c:3112
 #, c-format
 msgid "could not lock config file %s"
 msgstr "Konnte Konfigurationsdatei '%s' nicht sperren."
 
-#: config.c:2794
+#: config.c:2797
 #, c-format
 msgid "opening %s"
 msgstr "Öffne %s"
 
-#: config.c:2829 builtin/config.c:354
+#: config.c:2834 builtin/config.c:361
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "Ungültiges Muster: %s"
 
-#: config.c:2854
+#: config.c:2859
 #, c-format
 msgid "invalid config file %s"
 msgstr "Ungültige Konfigurationsdatei %s"
 
-#: config.c:2867 config.c:3120
+#: config.c:2872 config.c:3125
 #, c-format
 msgid "fstat on %s failed"
 msgstr "fstat auf %s fehlgeschlagen"
 
-#: config.c:2878
+#: config.c:2883
 #, c-format
 msgid "unable to mmap '%s'"
 msgstr "mmap für '%s' fehlgeschlagen"
 
-#: config.c:2887 config.c:3125
+#: config.c:2892 config.c:3130
 #, c-format
 msgid "chmod on %s failed"
 msgstr "chmod auf %s fehlgeschlagen"
 
-#: config.c:2972 config.c:3222
+#: config.c:2977 config.c:3227
 #, c-format
 msgid "could not write config file %s"
 msgstr "Konnte Konfigurationsdatei %s nicht schreiben."
 
-#: config.c:3006
+#: config.c:3011
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "Konnte '%s' nicht zu '%s' setzen."
 
-#: config.c:3008 builtin/remote.c:656 builtin/remote.c:850 builtin/remote.c:858
+#: config.c:3013 builtin/remote.c:657 builtin/remote.c:855 builtin/remote.c:863
 #, c-format
 msgid "could not unset '%s'"
 msgstr "Konnte '%s' nicht aufheben."
 
-#: config.c:3098
+#: config.c:3103
 #, c-format
 msgid "invalid section name: %s"
 msgstr "Ungültiger Sektionsname: %s"
 
-#: config.c:3265
+#: config.c:3270
 #, c-format
 msgid "missing value for '%s'"
 msgstr "Fehlender Wert für '%s'"
@@ -3257,6 +3249,29 @@ msgstr ""
 msgid "Marked %d islands, done.\n"
 msgstr "%d Delta-Islands markiert, fertig.\n"
 
+#: diff-lib.c:534
+msgid "--merge-base does not work with ranges"
+msgstr ""
+
+#: diff-lib.c:536
+msgid "--merge-base only works with commits"
+msgstr ""
+
+#: diff-lib.c:553
+#, fuzzy
+msgid "unable to get HEAD"
+msgstr "Konnte HEAD nicht aktualisieren."
+
+#: diff-lib.c:560
+#, fuzzy
+msgid "no merge base found"
+msgstr "%s...%s: keine Merge-Basis"
+
+#: diff-lib.c:562
+#, fuzzy
+msgid "multiple merge bases found"
+msgstr "%s...%s: mehrere Merge-Basen, nutze %s"
+
 #: diff-no-index.c:238
 msgid "git diff --no-index [<options>] <path> <path>"
 msgstr "git diff --no-index [<Optionen>] <Pfad> <Pfad>"
@@ -3319,36 +3334,36 @@ msgstr ""
 "Fehler in 'diff.dirstat' Konfigurationsvariable gefunden:\n"
 "%s"
 
-#: diff.c:4269
+#: diff.c:4276
 #, c-format
 msgid "external diff died, stopping at %s"
 msgstr "externes Diff-Programm unerwartet beendet, angehalten bei %s"
 
-#: diff.c:4618
+#: diff.c:4625
 msgid "--name-only, --name-status, --check and -s are mutually exclusive"
 msgstr ""
 "--name-only, --name-status, --check und -s schließen sich gegenseitig aus"
 
-#: diff.c:4621
+#: diff.c:4628
 msgid "-G, -S and --find-object are mutually exclusive"
 msgstr "-G, -S und --find-object schließen sich gegenseitig aus"
 
-#: diff.c:4699
+#: diff.c:4706
 msgid "--follow requires exactly one pathspec"
 msgstr "--follow erfordert genau eine Pfadspezifikation"
 
-#: diff.c:4747
+#: diff.c:4754
 #, c-format
 msgid "invalid --stat value: %s"
 msgstr "Ungültiger --stat Wert: %s"
 
-#: diff.c:4752 diff.c:4757 diff.c:4762 diff.c:4767 diff.c:5279
+#: diff.c:4759 diff.c:4764 diff.c:4769 diff.c:4774 diff.c:5302
 #: parse-options.c:197 parse-options.c:201 builtin/commit-graph.c:180
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "%s erwartet einen numerischen Wert."
 
-#: diff.c:4784
+#: diff.c:4791
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -3357,42 +3372,42 @@ msgstr ""
 "Fehler beim Parsen des --dirstat/-X Optionsparameters:\n"
 "%s"
 
-#: diff.c:4869
+#: diff.c:4876
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
 msgstr "Unbekannte Änderungsklasse '%c' in --diff-filter=%s"
 
-#: diff.c:4893
+#: diff.c:4900
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
 msgstr "Unbekannter Wert nach ws-error-highlight=%.*s"
 
-#: diff.c:4907
+#: diff.c:4914
 #, c-format
 msgid "unable to resolve '%s'"
 msgstr "konnte '%s' nicht auflösen"
 
-#: diff.c:4957 diff.c:4963
+#: diff.c:4964 diff.c:4970
 #, c-format
 msgid "%s expects <n>/<m> form"
 msgstr "%s erwartet die Form <n>/<m>"
 
-#: diff.c:4975
+#: diff.c:4982
 #, c-format
 msgid "%s expects a character, got '%s'"
 msgstr "%s erwartet ein Zeichen, '%s' bekommen"
 
-#: diff.c:4996
+#: diff.c:5003
 #, c-format
 msgid "bad --color-moved argument: %s"
 msgstr "Ungültiges --color-moved Argument: %s"
 
-#: diff.c:5015
+#: diff.c:5022
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
 msgstr "Ungültiger Modus '%s' in --color-moved-ws"
 
-#: diff.c:5055
+#: diff.c:5062
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
@@ -3400,152 +3415,157 @@ msgstr ""
 "Option diff-algorithm akzeptiert: \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
 
-#: diff.c:5091 diff.c:5111
+#: diff.c:5098 diff.c:5118
 #, c-format
 msgid "invalid argument to %s"
 msgstr "Ungültiges Argument für %s"
 
-#: diff.c:5248
+#: diff.c:5222
+#, fuzzy, c-format
+msgid "invalid regex given to -I: '%s'"
+msgstr "Ungültiges Argument für %s"
+
+#: diff.c:5271
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
 msgstr "Fehler beim Parsen des --submodule Optionsparameters: '%s'"
 
-#: diff.c:5304
+#: diff.c:5327
 #, c-format
 msgid "bad --word-diff argument: %s"
 msgstr "Ungültiges --word-diff Argument: %s"
 
-#: diff.c:5327
+#: diff.c:5350
 msgid "Diff output format options"
 msgstr "Diff-Optionen zu Ausgabeformaten"
 
-#: diff.c:5329 diff.c:5335
+#: diff.c:5352 diff.c:5358
 msgid "generate patch"
 msgstr "Erzeuge Patch"
 
-#: diff.c:5332 builtin/log.c:176
+#: diff.c:5355 builtin/log.c:178
 msgid "suppress diff output"
 msgstr "Ausgabe der Unterschiede unterdrücken"
 
-#: diff.c:5337 diff.c:5451 diff.c:5458
+#: diff.c:5360 diff.c:5474 diff.c:5481
 msgid "<n>"
 msgstr "<n>"
 
-#: diff.c:5338 diff.c:5341
+#: diff.c:5361 diff.c:5364
 msgid "generate diffs with <n> lines context"
 msgstr "Erstelle Unterschiede mit <n> Zeilen des Kontextes"
 
-#: diff.c:5343
+#: diff.c:5366
 msgid "generate the diff in raw format"
 msgstr "Erstelle Unterschiede im Rohformat"
 
-#: diff.c:5346
+#: diff.c:5369
 msgid "synonym for '-p --raw'"
 msgstr "Synonym für '-p --raw'"
 
-#: diff.c:5350
+#: diff.c:5373
 msgid "synonym for '-p --stat'"
 msgstr "Synonym für '-p --stat'"
 
-#: diff.c:5354
+#: diff.c:5377
 msgid "machine friendly --stat"
 msgstr "maschinenlesbare Ausgabe von --stat"
 
-#: diff.c:5357
+#: diff.c:5380
 msgid "output only the last line of --stat"
 msgstr "nur die letzte Zeile von --stat ausgeben"
 
-#: diff.c:5359 diff.c:5367
+#: diff.c:5382 diff.c:5390
 msgid "<param1,param2>..."
 msgstr "<Parameter1,Parameter2>..."
 
-#: diff.c:5360
+#: diff.c:5383
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr ""
 "Gebe die Verteilung des relativen Umfangs der Änderungen für jedes "
 "Unterverzeichnis aus"
 
-#: diff.c:5364
+#: diff.c:5387
 msgid "synonym for --dirstat=cumulative"
 msgstr "Synonym für --dirstat=cumulative"
 
-#: diff.c:5368
+#: diff.c:5391
 msgid "synonym for --dirstat=files,param1,param2..."
 msgstr "Synonym für --dirstat=files,Parameter1,Parameter2..."
 
-#: diff.c:5372
+#: diff.c:5395
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
 "Warnen, wenn Änderungen Konfliktmarker oder Whitespace-Fehler einbringen"
 
-#: diff.c:5375
+#: diff.c:5398
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr ""
 "Gekürzte Zusammenfassung, wie z.B. Erstellungen, Umbenennungen und "
 "Änderungen der Datei-Rechte"
 
-#: diff.c:5378
+#: diff.c:5401
 msgid "show only names of changed files"
 msgstr "nur Dateinamen der geänderten Dateien anzeigen"
 
-#: diff.c:5381
+#: diff.c:5404
 msgid "show only names and status of changed files"
 msgstr "nur Dateinamen und Status der geänderten Dateien anzeigen"
 
-#: diff.c:5383
+#: diff.c:5406
 msgid "<width>[,<name-width>[,<count>]]"
 msgstr "<Breite>[,<Namens-Breite>[,<Anzahl>]]"
 
-#: diff.c:5384
+#: diff.c:5407
 msgid "generate diffstat"
 msgstr "Generiere Zusammenfassung der Unterschiede"
 
-#: diff.c:5386 diff.c:5389 diff.c:5392
+#: diff.c:5409 diff.c:5412 diff.c:5415
 msgid "<width>"
 msgstr "<Breite>"
 
-#: diff.c:5387
+#: diff.c:5410
 msgid "generate diffstat with a given width"
 msgstr "Erzeuge Zusammenfassung der Unterschiede mit gegebener Breite"
 
-#: diff.c:5390
+#: diff.c:5413
 msgid "generate diffstat with a given name width"
 msgstr "Erzeuge Zusammenfassung der Unterschiede mit gegebener Namens-Breite"
 
-#: diff.c:5393
+#: diff.c:5416
 msgid "generate diffstat with a given graph width"
 msgstr "Erzeuge Zusammenfassung der Unterschiede mit gegebener Graph-Breite"
 
-#: diff.c:5395
+#: diff.c:5418
 msgid "<count>"
 msgstr "<Anzahl>"
 
-#: diff.c:5396
+#: diff.c:5419
 msgid "generate diffstat with limited lines"
 msgstr "Erzeuge Zusammenfassung der Unterschiede mit begrenzten Zeilen"
 
-#: diff.c:5399
+#: diff.c:5422
 msgid "generate compact summary in diffstat"
 msgstr "Erzeuge kompakte Zusammenstellung in Zusammenfassung der Unterschiede"
 
-#: diff.c:5402
+#: diff.c:5425
 msgid "output a binary diff that can be applied"
 msgstr "Gebe eine binäre Differenz aus, dass angewendet werden kann"
 
-#: diff.c:5405
+#: diff.c:5428
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr "Zeige vollständige Objekt-Namen in den \"index\"-Zeilen"
 
-#: diff.c:5407
+#: diff.c:5430
 msgid "show colored diff"
 msgstr "Zeige farbige Unterschiede"
 
-#: diff.c:5408
+#: diff.c:5431
 msgid "<kind>"
 msgstr "<Art>"
 
-#: diff.c:5409
+#: diff.c:5432
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
@@ -3553,7 +3573,7 @@ msgstr ""
 "Hebe Whitespace-Fehler in den Zeilen 'context', 'old' oder 'new' bei den "
 "Unterschieden hervor"
 
-#: diff.c:5412
+#: diff.c:5435
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
@@ -3561,91 +3581,91 @@ msgstr ""
 "Verschleiere nicht die Pfadnamen und nutze NUL-Zeichen als Schlusszeichen in "
 "Ausgabefeldern bei --raw oder --numstat"
 
-#: diff.c:5415 diff.c:5418 diff.c:5421 diff.c:5527
+#: diff.c:5438 diff.c:5441 diff.c:5444 diff.c:5553
 msgid "<prefix>"
 msgstr "<Präfix>"
 
-#: diff.c:5416
+#: diff.c:5439
 msgid "show the given source prefix instead of \"a/\""
 msgstr "Zeige den gegebenen Quell-Präfix statt \"a/\""
 
-#: diff.c:5419
+#: diff.c:5442
 msgid "show the given destination prefix instead of \"b/\""
 msgstr "Zeige den gegebenen Ziel-Präfix statt \"b/\""
 
-#: diff.c:5422
+#: diff.c:5445
 msgid "prepend an additional prefix to every line of output"
 msgstr "Stelle einen zusätzlichen Präfix bei jeder Ausgabezeile voran"
 
-#: diff.c:5425
+#: diff.c:5448
 msgid "do not show any source or destination prefix"
 msgstr "Zeige keine Quell- oder Ziel-Präfixe an"
 
-#: diff.c:5428
+#: diff.c:5451
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
 "Zeige Kontext zwischen Unterschied-Blöcken bis zur angegebenen Anzahl von "
 "Zeilen."
 
-#: diff.c:5432 diff.c:5437 diff.c:5442
+#: diff.c:5455 diff.c:5460 diff.c:5465
 msgid "<char>"
 msgstr "<Zeichen>"
 
-#: diff.c:5433
+#: diff.c:5456
 msgid "specify the character to indicate a new line instead of '+'"
 msgstr "Das Zeichen festlegen, das eine neue Zeile kennzeichnet (statt '+')"
 
-#: diff.c:5438
+#: diff.c:5461
 msgid "specify the character to indicate an old line instead of '-'"
 msgstr "Das Zeichen festlegen, das eine alte Zeile kennzeichnet (statt '-')"
 
-#: diff.c:5443
+#: diff.c:5466
 msgid "specify the character to indicate a context instead of ' '"
 msgstr "Das Zeichen festlegen, das den Kontext kennzeichnet (statt ' ')"
 
-#: diff.c:5446
+#: diff.c:5469
 msgid "Diff rename options"
 msgstr "Diff-Optionen zur Umbenennung"
 
-#: diff.c:5447
+#: diff.c:5470
 msgid "<n>[/<m>]"
 msgstr "<n>[/<m>]"
 
-#: diff.c:5448
+#: diff.c:5471
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr ""
 "Teile komplette Rewrite-Änderungen in Änderungen mit \"löschen\" und "
 "\"erstellen\""
 
-#: diff.c:5452
+#: diff.c:5475
 msgid "detect renames"
 msgstr "Umbenennungen erkennen"
 
-#: diff.c:5456
+#: diff.c:5479
 msgid "omit the preimage for deletes"
 msgstr "Preimage für Löschungen weglassen."
 
-#: diff.c:5459
+#: diff.c:5482
 msgid "detect copies"
 msgstr "Kopien erkennen"
 
-#: diff.c:5463
+#: diff.c:5486
 msgid "use unmodified files as source to find copies"
 msgstr "Nutze ungeänderte Dateien als Quelle zum Finden von Kopien"
 
-#: diff.c:5465
+#: diff.c:5488
 msgid "disable rename detection"
 msgstr "Erkennung von Umbenennungen deaktivieren"
 
-#: diff.c:5468
+#: diff.c:5491
 msgid "use empty blobs as rename source"
 msgstr "Nutze leere Blobs als Quelle von Umbennungen"
 
-#: diff.c:5470
+#: diff.c:5493
 msgid "continue listing the history of a file beyond renames"
 msgstr "Fortführen der Auflistung der Historie einer Datei nach Umbennung"
 
-#: diff.c:5473
+#: diff.c:5496
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
@@ -3653,159 +3673,164 @@ msgstr ""
 "Verhindere die Erkennung von Umbennungen und Kopien, wenn die Anzahl der "
 "Ziele für Umbennungen und Kopien das gegebene Limit überschreitet"
 
-#: diff.c:5475
+#: diff.c:5498
 msgid "Diff algorithm options"
 msgstr "Diff Algorithmus-Optionen"
 
-#: diff.c:5477
+#: diff.c:5500
 msgid "produce the smallest possible diff"
 msgstr "Erzeuge die kleinstmöglichen Änderungen"
 
-#: diff.c:5480
+#: diff.c:5503
 msgid "ignore whitespace when comparing lines"
 msgstr "Whitespace-Änderungen beim Vergleich von Zeilen ignorieren"
 
-#: diff.c:5483
+#: diff.c:5506
 msgid "ignore changes in amount of whitespace"
 msgstr "Änderungen bei der Anzahl von Whitespace ignorieren"
 
-#: diff.c:5486
+#: diff.c:5509
 msgid "ignore changes in whitespace at EOL"
 msgstr "Whitespace-Änderungen am Zeilenende ignorieren"
 
-#: diff.c:5489
+#: diff.c:5512
 msgid "ignore carrier-return at the end of line"
 msgstr "Ignoriere den Zeilenumbruch am Ende der Zeile"
 
-#: diff.c:5492
+#: diff.c:5515
 msgid "ignore changes whose lines are all blank"
 msgstr "Ignoriere Änderungen in leeren Zeilen"
 
-#: diff.c:5495
+#: diff.c:5517 diff.c:5539 diff.c:5542 diff.c:5587
+msgid "<regex>"
+msgstr "<Regex>"
+
+#: diff.c:5518
+#, fuzzy
+msgid "ignore changes whose all lines match <regex>"
+msgstr "Ignoriere Änderungen in leeren Zeilen"
+
+#: diff.c:5521
 msgid "heuristic to shift diff hunk boundaries for easy reading"
 msgstr ""
 "Heuristik, um Grenzen der Änderungsblöcke für bessere Lesbarkeit zu "
 "verschieben"
 
-#: diff.c:5498
+#: diff.c:5524
 msgid "generate diff using the \"patience diff\" algorithm"
 msgstr "Erzeuge Änderungen durch Nutzung des Algorithmus \"Patience Diff\""
 
-#: diff.c:5502
+#: diff.c:5528
 msgid "generate diff using the \"histogram diff\" algorithm"
 msgstr "Erzeuge Änderungen durch Nutzung des Algorithmus \"Histogram Diff\""
 
-#: diff.c:5504
+#: diff.c:5530
 msgid "<algorithm>"
 msgstr "<Algorithmus>"
 
-#: diff.c:5505
+#: diff.c:5531
 msgid "choose a diff algorithm"
 msgstr "Ein Algorithmus für Änderungen wählen"
 
-#: diff.c:5507
+#: diff.c:5533
 msgid "<text>"
 msgstr "<Text>"
 
-#: diff.c:5508
+#: diff.c:5534
 msgid "generate diff using the \"anchored diff\" algorithm"
 msgstr "Erzeuge Änderungen durch Nutzung des Algorithmus \"Anchored Diff\""
 
-#: diff.c:5510 diff.c:5519 diff.c:5522
+#: diff.c:5536 diff.c:5545 diff.c:5548
 msgid "<mode>"
 msgstr "<Modus>"
 
-#: diff.c:5511
+#: diff.c:5537
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr "Zeige Wort-Änderungen, nutze <Modus>, um Wörter abzugrenzen"
 
-#: diff.c:5513 diff.c:5516 diff.c:5561
-msgid "<regex>"
-msgstr "<Regex>"
-
-#: diff.c:5514
+#: diff.c:5540
 msgid "use <regex> to decide what a word is"
 msgstr "Nutze <Regex>, um zu entscheiden, was ein Wort ist"
 
-#: diff.c:5517
+#: diff.c:5543
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
 msgstr "Entsprechend wie --word-diff=color --word-diff-regex=<Regex>"
 
-#: diff.c:5520
+#: diff.c:5546
 msgid "moved lines of code are colored differently"
 msgstr "Verschobene Codezeilen sind andersfarbig"
 
-#: diff.c:5523
+#: diff.c:5549
 msgid "how white spaces are ignored in --color-moved"
 msgstr "Wie Whitespaces in --color-moved ignoriert werden"
 
-#: diff.c:5526
+#: diff.c:5552
 msgid "Other diff options"
 msgstr "Andere Diff-Optionen"
 
-#: diff.c:5528
+#: diff.c:5554
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
 "Wenn vom Unterverzeichnis aufgerufen, schließe Änderungen außerhalb aus und "
 "zeige relative Pfade an"
 
-#: diff.c:5532
+#: diff.c:5558
 msgid "treat all files as text"
 msgstr "alle Dateien als Text behandeln"
 
-#: diff.c:5534
+#: diff.c:5560
 msgid "swap two inputs, reverse the diff"
 msgstr "Vertausche die beiden Eingaben und drehe die Änderungen um"
 
-#: diff.c:5536
+#: diff.c:5562
 msgid "exit with 1 if there were differences, 0 otherwise"
 msgstr ""
 "Beende mit Exit-Status 1, wenn Änderungen vorhanden sind, andernfalls mit 0"
 
-#: diff.c:5538
+#: diff.c:5564
 msgid "disable all output of the program"
 msgstr "Keine Ausgaben vom Programm"
 
-#: diff.c:5540
+#: diff.c:5566
 msgid "allow an external diff helper to be executed"
 msgstr "Erlaube die Ausführung eines externes Programms für Änderungen"
 
-#: diff.c:5542
+#: diff.c:5568
 msgid "run external text conversion filters when comparing binary files"
 msgstr ""
 "Führe externe Text-Konvertierungsfilter aus, wenn binäre Dateien vergleicht "
 "werden"
 
-#: diff.c:5544
+#: diff.c:5570
 msgid "<when>"
 msgstr "<wann>"
 
-#: diff.c:5545
+#: diff.c:5571
 msgid "ignore changes to submodules in the diff generation"
 msgstr ""
 "Änderungen in Submodulen während der Erstellung der Unterschiede ignorieren"
 
-#: diff.c:5548
+#: diff.c:5574
 msgid "<format>"
 msgstr "<Format>"
 
-#: diff.c:5549
+#: diff.c:5575
 msgid "specify how differences in submodules are shown"
 msgstr "Angeben, wie Unterschiede in Submodulen gezeigt werden"
 
-#: diff.c:5553
+#: diff.c:5579
 msgid "hide 'git add -N' entries from the index"
 msgstr "verstecke 'git add -N' Einträge vom Index"
 
-#: diff.c:5556
+#: diff.c:5582
 msgid "treat 'git add -N' entries as real in the index"
 msgstr "Behandle 'git add -N' Einträge im Index als echt"
 
-#: diff.c:5558
+#: diff.c:5584
 msgid "<string>"
 msgstr "<Zeichenkette>"
 
-#: diff.c:5559
+#: diff.c:5585
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
@@ -3813,7 +3838,7 @@ msgstr ""
 "Suche nach Unterschieden, welche die Anzahl des Vorkommens der angegebenen "
 "Zeichenkette verändern"
 
-#: diff.c:5562
+#: diff.c:5588
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
@@ -3821,25 +3846,25 @@ msgstr ""
 "Suche nach Unterschieden, welche die Anzahl des Vorkommens des angegebenen "
 "regulären Ausdrucks verändern"
 
-#: diff.c:5565
+#: diff.c:5591
 msgid "show all changes in the changeset with -S or -G"
 msgstr "zeige alle Änderungen im Changeset mit -S oder -G"
 
-#: diff.c:5568
+#: diff.c:5594
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr ""
 "behandle <Zeichenkette> bei -S als erweiterten POSIX regulären Ausdruck"
 
-#: diff.c:5571
+#: diff.c:5597
 msgid "control the order in which files appear in the output"
 msgstr ""
 "kontrolliere die Reihenfolge, in der die Dateien in der Ausgabe erscheinen"
 
-#: diff.c:5572
+#: diff.c:5598
 msgid "<object-id>"
 msgstr "<Objekt-ID>"
 
-#: diff.c:5573
+#: diff.c:5599
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
@@ -3847,33 +3872,33 @@ msgstr ""
 "Suche nach Unterschieden, welche die Anzahl des Vorkommens des angegebenen "
 "Objektes verändern"
 
-#: diff.c:5575
+#: diff.c:5601
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "[(A|C|D|M|R|T|U|X|B)...[*]]"
 
-#: diff.c:5576
+#: diff.c:5602
 msgid "select files by diff type"
 msgstr "Wähle Dateien anhand der Art der Änderung"
 
-#: diff.c:5578
+#: diff.c:5604
 msgid "<file>"
 msgstr "<Datei>"
 
-#: diff.c:5579
+#: diff.c:5605
 msgid "Output to a specific file"
 msgstr "Ausgabe zu einer bestimmten Datei"
 
-#: diff.c:6236
+#: diff.c:6262
 msgid "inexact rename detection was skipped due to too many files."
 msgstr ""
 "Ungenaue Erkennung für Umbenennungen wurde aufgrund zu vieler Dateien\n"
 "übersprungen."
 
-#: diff.c:6239
+#: diff.c:6265
 msgid "only found copies from modified paths due to too many files."
 msgstr "nur Kopien von geänderten Pfaden, aufgrund zu vieler Dateien, gefunden"
 
-#: diff.c:6242
+#: diff.c:6268
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
@@ -3981,245 +4006,245 @@ msgstr "Konnte GIT_DIR nicht zu '%s' setzen."
 msgid "too many args to run %s"
 msgstr "Zu viele Argumente angegeben, um %s auszuführen."
 
-#: fetch-pack.c:176
+#: fetch-pack.c:177
 msgid "git fetch-pack: expected shallow list"
 msgstr "git fetch-pack: erwartete shallow-Liste"
 
-#: fetch-pack.c:179
+#: fetch-pack.c:180
 msgid "git fetch-pack: expected a flush packet after shallow list"
 msgstr "git fetch-pack: erwartete ein Flush-Paket nach der shallow-Liste"
 
-#: fetch-pack.c:190
+#: fetch-pack.c:191
 msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
 msgstr "git fetch-pack: ACK/NAK erwartet, Flush-Paket bekommen"
 
-#: fetch-pack.c:210
+#: fetch-pack.c:211
 #, c-format
 msgid "git fetch-pack: expected ACK/NAK, got '%s'"
 msgstr "git fetch-pack: ACK/NAK erwartet, '%s' bekommen"
 
-#: fetch-pack.c:221
+#: fetch-pack.c:222
 msgid "unable to write to remote"
 msgstr "konnte nicht zum Remote schreiben"
 
-#: fetch-pack.c:282
+#: fetch-pack.c:283
 msgid "--stateless-rpc requires multi_ack_detailed"
 msgstr "--stateless-rpc benötigt multi_ack_detailed"
 
-#: fetch-pack.c:375 fetch-pack.c:1397
+#: fetch-pack.c:378 fetch-pack.c:1406
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "Ungültige shallow-Zeile: %s"
 
-#: fetch-pack.c:381 fetch-pack.c:1403
+#: fetch-pack.c:384 fetch-pack.c:1412
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "Ungültige unshallow-Zeile: %s"
 
-#: fetch-pack.c:383 fetch-pack.c:1405
+#: fetch-pack.c:386 fetch-pack.c:1414
 #, c-format
 msgid "object not found: %s"
 msgstr "Objekt nicht gefunden: %s"
 
-#: fetch-pack.c:386 fetch-pack.c:1408
+#: fetch-pack.c:389 fetch-pack.c:1417
 #, c-format
 msgid "error in object: %s"
 msgstr "Fehler in Objekt: %s"
 
-#: fetch-pack.c:388 fetch-pack.c:1410
+#: fetch-pack.c:391 fetch-pack.c:1419
 #, c-format
 msgid "no shallow found: %s"
 msgstr "Kein shallow-Objekt gefunden: %s"
 
-#: fetch-pack.c:391 fetch-pack.c:1414
+#: fetch-pack.c:394 fetch-pack.c:1423
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "shallow/unshallow erwartet, %s bekommen"
 
-#: fetch-pack.c:431
+#: fetch-pack.c:434
 #, c-format
 msgid "got %s %d %s"
 msgstr "%s %d %s bekommen"
 
-#: fetch-pack.c:448
+#: fetch-pack.c:451
 #, c-format
 msgid "invalid commit %s"
 msgstr "Ungültiger Commit %s"
 
-#: fetch-pack.c:479
+#: fetch-pack.c:482
 msgid "giving up"
 msgstr "Gebe auf"
 
-#: fetch-pack.c:492 progress.c:339
+#: fetch-pack.c:495 progress.c:339
 msgid "done"
 msgstr "Fertig"
 
-#: fetch-pack.c:504
+#: fetch-pack.c:507
 #, c-format
 msgid "got %s (%d) %s"
 msgstr "%s (%d) %s bekommen"
 
-#: fetch-pack.c:540
+#: fetch-pack.c:543
 #, c-format
 msgid "Marking %s as complete"
 msgstr "Markiere %s als vollständig"
 
-#: fetch-pack.c:755
+#: fetch-pack.c:758
 #, c-format
 msgid "already have %s (%s)"
 msgstr "habe %s (%s) bereits"
 
-#: fetch-pack.c:824
+#: fetch-pack.c:827
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-pack: Fehler beim Starten des sideband demultiplexer"
 
-#: fetch-pack.c:832
+#: fetch-pack.c:835
 msgid "protocol error: bad pack header"
 msgstr "Protokollfehler: ungültiger Pack-Header"
 
-#: fetch-pack.c:916
+#: fetch-pack.c:919
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-pack: konnte %s nicht starten"
 
-#: fetch-pack.c:933
+#: fetch-pack.c:937
 #, c-format
 msgid "%s failed"
 msgstr "%s fehlgeschlagen"
 
-#: fetch-pack.c:935
+#: fetch-pack.c:939
 msgid "error in sideband demultiplexer"
 msgstr "Fehler in sideband demultiplexer"
 
-#: fetch-pack.c:978
+#: fetch-pack.c:982
 #, c-format
 msgid "Server version is %.*s"
 msgstr "Server-Version ist %.*s"
 
-#: fetch-pack.c:983 fetch-pack.c:989 fetch-pack.c:992 fetch-pack.c:998
-#: fetch-pack.c:1002 fetch-pack.c:1006 fetch-pack.c:1010 fetch-pack.c:1014
-#: fetch-pack.c:1018 fetch-pack.c:1022 fetch-pack.c:1026 fetch-pack.c:1030
-#: fetch-pack.c:1036 fetch-pack.c:1042 fetch-pack.c:1047 fetch-pack.c:1052
+#: fetch-pack.c:990 fetch-pack.c:996 fetch-pack.c:999 fetch-pack.c:1005
+#: fetch-pack.c:1009 fetch-pack.c:1013 fetch-pack.c:1017 fetch-pack.c:1021
+#: fetch-pack.c:1025 fetch-pack.c:1029 fetch-pack.c:1033 fetch-pack.c:1037
+#: fetch-pack.c:1043 fetch-pack.c:1049 fetch-pack.c:1054 fetch-pack.c:1059
 #, c-format
 msgid "Server supports %s"
 msgstr "Server unterstützt %s"
 
-#: fetch-pack.c:985
+#: fetch-pack.c:992
 msgid "Server does not support shallow clients"
 msgstr "Server unterstützt keine shallow-Clients"
 
-#: fetch-pack.c:1045
+#: fetch-pack.c:1052
 msgid "Server does not support --shallow-since"
 msgstr "Server unterstützt kein --shallow-since"
 
-#: fetch-pack.c:1050
+#: fetch-pack.c:1057
 msgid "Server does not support --shallow-exclude"
 msgstr "Server unterstützt kein --shallow-exclude"
 
-#: fetch-pack.c:1054
+#: fetch-pack.c:1061
 msgid "Server does not support --deepen"
 msgstr "Server unterstützt kein --deepen"
 
-#: fetch-pack.c:1056
+#: fetch-pack.c:1063
 msgid "Server does not support this repository's object format"
 msgstr "Server unterstützt das Objekt-Format dieses Repositories nicht"
 
-#: fetch-pack.c:1069
+#: fetch-pack.c:1076
 msgid "no common commits"
 msgstr "keine gemeinsamen Commits"
 
-#: fetch-pack.c:1081 fetch-pack.c:1619
+#: fetch-pack.c:1088 fetch-pack.c:1628
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack: Abholen fehlgeschlagen."
 
-#: fetch-pack.c:1205
+#: fetch-pack.c:1214
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "Algorithmen stimmen nicht überein: Client %s; Server %s"
 
-#: fetch-pack.c:1209
+#: fetch-pack.c:1218
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "der Server unterstützt Algorithmus '%s' nicht"
 
-#: fetch-pack.c:1229
+#: fetch-pack.c:1238
 msgid "Server does not support shallow requests"
 msgstr "Server unterstützt keine shallow-Anfragen"
 
-#: fetch-pack.c:1236
+#: fetch-pack.c:1245
 msgid "Server supports filter"
 msgstr "Server unterstützt Filter"
 
-#: fetch-pack.c:1275
+#: fetch-pack.c:1284
 msgid "unable to write request to remote"
 msgstr "konnte Anfrage nicht zum Remote schreiben"
 
-#: fetch-pack.c:1293
+#: fetch-pack.c:1302
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "Fehler beim Lesen von Sektionskopf '%s'."
 
-#: fetch-pack.c:1299
+#: fetch-pack.c:1308
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "'%s' erwartet, '%s' empfangen"
 
-#: fetch-pack.c:1360
+#: fetch-pack.c:1369
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "Unerwartete Acknowledgment-Zeile: '%s'"
 
-#: fetch-pack.c:1365
+#: fetch-pack.c:1374
 #, c-format
 msgid "error processing acks: %d"
 msgstr "Fehler beim Verarbeiten von ACKS: %d"
 
-#: fetch-pack.c:1375
+#: fetch-pack.c:1384
 msgid "expected packfile to be sent after 'ready'"
 msgstr "Erwartete Versand einer Packdatei nach 'ready'."
 
-#: fetch-pack.c:1377
+#: fetch-pack.c:1386
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr "Erwartete keinen Versand einer anderen Sektion ohne 'ready'."
 
-#: fetch-pack.c:1419
+#: fetch-pack.c:1428
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "Fehler beim Verarbeiten von Shallow-Informationen: %d"
 
-#: fetch-pack.c:1466
+#: fetch-pack.c:1475
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "wanted-ref erwartet, '%s' bekommen"
 
-#: fetch-pack.c:1471
+#: fetch-pack.c:1480
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "unerwartetes wanted-ref: '%s'"
 
-#: fetch-pack.c:1476
+#: fetch-pack.c:1485
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "Fehler beim Verarbeiten von wanted-refs: %d"
 
-#: fetch-pack.c:1506
+#: fetch-pack.c:1515
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: Antwort-Endpaket erwartet"
 
-#: fetch-pack.c:1887
+#: fetch-pack.c:1897
 msgid "no matching remote head"
 msgstr "kein übereinstimmender Remote-Branch"
 
-#: fetch-pack.c:1910 builtin/clone.c:692
+#: fetch-pack.c:1920 builtin/clone.c:693
 msgid "remote did not send all necessary objects"
 msgstr "Remote-Repository hat nicht alle erforderlichen Objekte gesendet"
 
-#: fetch-pack.c:1937
+#: fetch-pack.c:1947
 #, c-format
 msgid "no such remote ref %s"
 msgstr "keine solche Remote-Referenz %s"
 
-#: fetch-pack.c:1940
+#: fetch-pack.c:1950
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Der Server lehnt Anfrage nach nicht angebotenem Objekt %s ab."
@@ -4242,7 +4267,7 @@ msgstr "gpg beim Signieren der Daten fehlgeschlagen"
 msgid "ignore invalid color '%.*s' in log.graphColors"
 msgstr "Ignoriere ungültige Farbe '%.*s' in log.graphColors"
 
-#: grep.c:668
+#: grep.c:640
 msgid ""
 "given pattern contains NULL byte (via -f <file>). This is only supported "
 "with -P under PCRE v2"
@@ -4250,18 +4275,18 @@ msgstr ""
 "Angegebenes Muster enthält NULL Byte (über -f <Datei>). Das wird nur mit -"
 "Punter PCRE v2 unterstützt."
 
-#: grep.c:2128
+#: grep.c:2100
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr "'%s': konnte %s nicht lesen"
 
-#: grep.c:2145 setup.c:176 builtin/clone.c:411 builtin/diff.c:89
+#: grep.c:2117 setup.c:176 builtin/clone.c:412 builtin/diff.c:89
 #: builtin/rm.c:135
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "Konnte '%s' nicht lesen"
 
-#: grep.c:2156
+#: grep.c:2128
 #, c-format
 msgid "'%s': short read"
 msgstr "'%s': read() zu kurz"
@@ -4354,7 +4379,7 @@ msgstr "Externe Befehle"
 msgid "Command aliases"
 msgstr "Alias-Befehle"
 
-#: help.c:513
+#: help.c:527
 #, c-format
 msgid ""
 "'%s' appears to be a git command, but we were not\n"
@@ -4363,32 +4388,32 @@ msgstr ""
 "'%s' scheint ein git-Befehl zu sein, konnte aber\n"
 "nicht ausgeführt werden. Vielleicht ist git-%s fehlerhaft?"
 
-#: help.c:572
+#: help.c:543 help.c:631
+#, c-format
+msgid "git: '%s' is not a git command. See 'git --help'."
+msgstr "git: '%s' ist kein Git-Befehl. Siehe 'git --help'."
+
+#: help.c:591
 msgid "Uh oh. Your system reports no Git commands at all."
 msgstr "Uh oh. Keine Git-Befehle auf Ihrem System vorhanden."
 
-#: help.c:594
+#: help.c:613
 #, c-format
 msgid "WARNING: You called a Git command named '%s', which does not exist."
 msgstr ""
 "WARNUNG: Sie haben Git-Befehl '%s' ausgeführt, welcher nicht existiert."
 
-#: help.c:599
+#: help.c:618
 #, c-format
 msgid "Continuing under the assumption that you meant '%s'."
 msgstr "Setze fort unter der Annahme, dass Sie '%s' meinten."
 
-#: help.c:604
+#: help.c:623
 #, c-format
 msgid "Continuing in %0.1f seconds, assuming that you meant '%s'."
 msgstr "Setze in %0.1f Sekunden fort unter der Annahme, dass Sie '%s' meinten."
 
-#: help.c:612
-#, c-format
-msgid "git: '%s' is not a git command. See 'git --help'."
-msgstr "git: '%s' ist kein Git-Befehl. Siehe 'git --help'."
-
-#: help.c:616
+#: help.c:635
 msgid ""
 "\n"
 "The most similar command is"
@@ -4402,16 +4427,16 @@ msgstr[1] ""
 "\n"
 "Die ähnlichsten Befehle sind"
 
-#: help.c:656
+#: help.c:675
 msgid "git version [<options>]"
 msgstr "git version [<Optionen>]"
 
-#: help.c:711
+#: help.c:730
 #, c-format
 msgid "%s: %s - %s"
 msgstr "%s: %s - %s"
 
-#: help.c:715
+#: help.c:734
 msgid ""
 "\n"
 "Did you mean this?"
@@ -4578,6 +4603,21 @@ msgstr "Konnte '%s.lock' nicht erstellen: %s"
 #: ls-refs.c:109
 msgid "expected flush after ls-refs arguments"
 msgstr "erwartete Flush nach Argumenten für die Auflistung der Referenzen"
+
+#: merge-ort-wrappers.c:13 merge-recursive.c:3672
+#, c-format
+msgid ""
+"Your local changes to the following files would be overwritten by merge:\n"
+"  %s"
+msgstr ""
+"Ihre lokalen Änderungen in den folgenden Dateien würden durch den Merge\n"
+"überschrieben werden:\n"
+"  %s"
+
+#: merge-ort-wrappers.c:33 merge-recursive.c:3436
+#, c-format
+msgid "Already up to date!"
+msgstr "Bereits aktuell!"
 
 #: merge-recursive.c:356
 msgid "(bad commit)\n"
@@ -4983,10 +5023,6 @@ msgstr "Füge %s hinzu"
 msgid "CONFLICT (add/add): Merge conflict in %s"
 msgstr "KONFLIKT (hinzufügen/hinzufügen): Merge-Konflikt in %s"
 
-#: merge-recursive.c:3436
-msgid "Already up to date!"
-msgstr "Bereits aktuell!"
-
 #: merge-recursive.c:3445
 #, c-format
 msgid "merging of trees %s and %s failed"
@@ -5007,22 +5043,12 @@ msgstr[1] "%u gemeinsame Vorgänger-Commits gefunden"
 msgid "merge returned no commit"
 msgstr "Merge hat keinen Commit zurückgegeben"
 
-#: merge-recursive.c:3672
-#, c-format
-msgid ""
-"Your local changes to the following files would be overwritten by merge:\n"
-"  %s"
-msgstr ""
-"Ihre lokalen Änderungen in den folgenden Dateien würden durch den Merge\n"
-"überschrieben werden:\n"
-"  %s"
-
 #: merge-recursive.c:3769
 #, c-format
 msgid "Could not parse object '%s'"
 msgstr "Konnte Objekt '%s' nicht parsen."
 
-#: merge-recursive.c:3787 builtin/merge.c:702 builtin/merge.c:881
+#: merge-recursive.c:3787 builtin/merge.c:711 builtin/merge.c:895
 msgid "Unable to write index."
 msgstr "Konnte Index nicht schreiben."
 
@@ -5030,122 +5056,118 @@ msgstr "Konnte Index nicht schreiben."
 msgid "failed to read the cache"
 msgstr "Lesen des Zwischenspeichers fehlgeschlagen"
 
-#: merge.c:109 rerere.c:720 builtin/am.c:1896 builtin/am.c:1930
-#: builtin/checkout.c:560 builtin/checkout.c:816 builtin/clone.c:816
+#: merge.c:109 rerere.c:720 builtin/am.c:1883 builtin/am.c:1917
+#: builtin/checkout.c:573 builtin/checkout.c:829 builtin/clone.c:817
 #: builtin/stash.c:265
 msgid "unable to write new index file"
 msgstr "Konnte neue Index-Datei nicht schreiben."
 
-#: midx.c:79
+#: midx.c:80
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "multi-pack-index-Datei %s ist zu klein."
 
-#: midx.c:95
+#: midx.c:96
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr ""
 "multi-pack-index-Signatur 0x%08x stimmt nicht mit Signatur 0x%08x überein."
 
-#: midx.c:100
+#: midx.c:101
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "multi-pack-index-Version %d nicht erkannt."
 
-#: midx.c:105
+#: midx.c:106
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr "multi-pack-index Hash-Version %u stimmt nicht mit Version %u überein"
 
-#: midx.c:122
+#: midx.c:123
 msgid "invalid chunk offset (too large)"
 msgstr "Ungültiger Chunk-Offset (zu groß)"
 
-#: midx.c:146
+#: midx.c:147
 msgid "terminating multi-pack-index chunk id appears earlier than expected"
 msgstr "Abschließende multi-pack-index Chunk-Id erscheint eher als erwartet."
 
-#: midx.c:159
+#: midx.c:160
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "multi-pack-index fehlt erforderlicher pack-name Chunk."
 
-#: midx.c:161
+#: midx.c:162
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "multi-pack-index fehlt erforderlicher OID fanout Chunk."
 
-#: midx.c:163
+#: midx.c:164
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr "multi-pack-index fehlt erforderlicher OID lookup Chunk."
 
-#: midx.c:165
+#: midx.c:166
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr "multi-pack-index fehlt erforderlicher object offset Chunk."
 
-#: midx.c:179
+#: midx.c:180
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr "Falsche Reihenfolge bei multi-pack-index Pack-Namen: '%s' vor '%s'"
 
-#: midx.c:222
+#: midx.c:223
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr "Ungültige pack-int-id: %u (%u Pakete insgesamt)"
 
-#: midx.c:272
+#: midx.c:273
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr ""
 "multi-pack-index speichert einen 64-Bit Offset, aber off_t ist zu klein."
 
-#: midx.c:300
-msgid "error preparing packfile from multi-pack-index"
-msgstr "Fehler bei Vorbereitung der Packdatei aus multi-pack-index."
-
-#: midx.c:485
+#: midx.c:480
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "Fehler beim Hinzufügen von Packdatei '%s'."
 
-#: midx.c:491
+#: midx.c:486
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "Fehler beim Öffnen von pack-index '%s'"
 
-#: midx.c:551
+#: midx.c:546
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "Fehler beim Lokalisieren von Objekt %d in Packdatei."
 
-#: midx.c:853
+#: midx.c:846
 msgid "Adding packfiles to multi-pack-index"
 msgstr "Packdateien zum multi-pack-index hinzufügen"
 
-#: midx.c:886
+#: midx.c:879
 #, c-format
 msgid "did not see pack-file %s to drop"
 msgstr "Pack-Datei %s zum Weglassen nicht gefunden"
 
-#: midx.c:938
+#: midx.c:931
 msgid "no pack files to index."
 msgstr "keine Packdateien zum Indizieren."
 
-#: midx.c:990
+#: midx.c:982
 msgid "Writing chunks to multi-pack-index"
 msgstr "Chunks zum multi-pack-index schreiben"
 
-#: midx.c:1068
+#: midx.c:1060
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "Fehler beim Löschen des multi-pack-index bei %s"
 
-#: midx.c:1124
+#: midx.c:1116
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr "multi-pack-index-Datei existiert, aber das Parsen schlug fehl"
 
-#: midx.c:1132
+#: midx.c:1124
 msgid "Looking for referenced packfiles"
 msgstr "Suche nach referenzierten Pack-Dateien"
 
-#: midx.c:1147
+#: midx.c:1139
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
@@ -5153,55 +5175,55 @@ msgstr ""
 "Ungültige oid fanout Reihenfolge: fanout[%d] = %<PRIx32> > %<PRIx32> = "
 "fanout[%d]"
 
-#: midx.c:1152
+#: midx.c:1144
 msgid "the midx contains no oid"
 msgstr "das midx enthält keine oid"
 
-#: midx.c:1161
+#: midx.c:1153
 msgid "Verifying OID order in multi-pack-index"
 msgstr "Verifiziere OID-Reihenfolge im multi-pack-index"
 
-#: midx.c:1170
+#: midx.c:1162
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr "Ungültige oid lookup Reihenfolge: oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1190
+#: midx.c:1182
 msgid "Sorting objects by packfile"
 msgstr "Sortiere Objekte nach Pack-Datei"
 
-#: midx.c:1197
+#: midx.c:1189
 msgid "Verifying object offsets"
 msgstr "Überprüfe Objekt-Offsets"
 
-#: midx.c:1213
+#: midx.c:1205
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "Fehler beim Laden des Pack-Eintrags für oid[%d] = %s"
 
-#: midx.c:1219
+#: midx.c:1211
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "Fehler beim Laden des Pack-Index für Packdatei %s"
 
-#: midx.c:1228
+#: midx.c:1220
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr "Falscher Objekt-Offset für oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#: midx.c:1253
+#: midx.c:1245
 msgid "Counting referenced objects"
 msgstr "Referenzierte Objekte zählen"
 
-#: midx.c:1263
+#: midx.c:1255
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "Suchen und Löschen von unreferenzierten Pack-Dateien"
 
-#: midx.c:1454
+#: midx.c:1446
 msgid "could not start pack-objects"
 msgstr "Konnte 'pack-objects' nicht ausführen"
 
-#: midx.c:1474
+#: midx.c:1466
 msgid "could not finish pack-objects"
 msgstr "Konnte 'pack-objects' nicht beenden"
 
@@ -5295,16 +5317,16 @@ msgstr "Hash stimmt nicht mit %s überein."
 msgid "unable to get size of %s"
 msgstr "Konnte Größe von %s nicht bestimmen."
 
-#: packfile.c:630
+#: packfile.c:615
 msgid "offset before end of packfile (broken .idx?)"
 msgstr "Offset vor Ende der Packdatei (fehlerhafte Indexdatei?)"
 
-#: packfile.c:1922
+#: packfile.c:1907
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr "Offset vor Beginn des Pack-Index für %s (beschädigter Index?)"
 
-#: packfile.c:1926
+#: packfile.c:1911
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr "Offset hinter Ende des Pack-Index für %s (abgeschnittener Index?)"
@@ -5554,7 +5576,7 @@ msgstr "Protokollfehler: ungültiges Zeichen für Zeilenlänge: %.4s"
 msgid "protocol error: bad line length %d"
 msgstr "Protokollfehler: ungültige Zeilenlänge %d"
 
-#: pkt-line.c:373 sideband.c:150
+#: pkt-line.c:373 sideband.c:165
 #, c-format
 msgid "remote error: %s"
 msgstr "Fehler am anderen Ende: %s"
@@ -5603,7 +5625,7 @@ msgstr "Konnte `log` nicht starten."
 msgid "could not read `log` output"
 msgstr "Konnte Ausgabe von `log` nicht lesen."
 
-#: range-diff.c:98 sequencer.c:5283
+#: range-diff.c:98 sequencer.c:5310
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr "Konnte Commit '%s' nicht parsen."
@@ -5622,11 +5644,11 @@ msgstr ""
 msgid "could not parse git header '%.*s'"
 msgstr "Konnte Git-Header '%.*s' nicht parsen."
 
-#: range-diff.c:301
+#: range-diff.c:299
 msgid "failed to generate diff"
 msgstr "Fehler beim Generieren des Diffs."
 
-#: range-diff.c:534 range-diff.c:536
+#: range-diff.c:532 range-diff.c:534
 #, c-format
 msgid "could not parse log for '%s'"
 msgstr "Konnte Log für '%s' nicht parsen."
@@ -5745,8 +5767,8 @@ msgstr "Ungeordnete Stage-Einträge für '%s'."
 
 #: read-cache.c:1971 read-cache.c:2262 rerere.c:565 rerere.c:599 rerere.c:1111
 #: submodule.c:1628 builtin/add.c:538 builtin/check-ignore.c:181
-#: builtin/checkout.c:489 builtin/checkout.c:675 builtin/clean.c:991
-#: builtin/commit.c:364 builtin/diff-tree.c:121 builtin/grep.c:507
+#: builtin/checkout.c:502 builtin/checkout.c:688 builtin/clean.c:991
+#: builtin/commit.c:364 builtin/diff-tree.c:122 builtin/grep.c:507
 #: builtin/mv.c:146 builtin/reset.c:247 builtin/rm.c:290
 #: builtin/submodule--helper.c:332
 msgid "index file corrupt"
@@ -5802,12 +5824,12 @@ msgstr "Konnte geteilten Index '%s' nicht aktualisieren."
 msgid "broken index, expect %s in %s, got %s"
 msgstr "Fehlerhafter Index. Erwartete %s in %s, erhielt %s."
 
-#: read-cache.c:3017 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1126
+#: read-cache.c:3017 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1140
 #, c-format
 msgid "could not close '%s'"
 msgstr "Konnte '%s' nicht schließen."
 
-#: read-cache.c:3120 sequencer.c:2446 sequencer.c:4185
+#: read-cache.c:3120 sequencer.c:2479 sequencer.c:4231
 #, c-format
 msgid "could not stat '%s'"
 msgstr "Konnte '%s' nicht lesen."
@@ -5943,14 +5965,14 @@ msgstr ""
 "Wenn Sie jedoch alles löschen, wird der Rebase abgebrochen.\n"
 "\n"
 
-#: rebase-interactive.c:110 rerere.c:485 rerere.c:692 sequencer.c:3571
-#: sequencer.c:3597 sequencer.c:5389 builtin/fsck.c:347 builtin/rebase.c:264
+#: rebase-interactive.c:110 rerere.c:485 rerere.c:692 sequencer.c:3607
+#: sequencer.c:3633 sequencer.c:5416 builtin/fsck.c:347 builtin/rebase.c:270
 #, c-format
 msgid "could not write '%s'"
 msgstr "Konnte '%s' nicht schreiben."
 
-#: rebase-interactive.c:116 builtin/rebase.c:196 builtin/rebase.c:222
-#: builtin/rebase.c:246
+#: rebase-interactive.c:116 builtin/rebase.c:202 builtin/rebase.c:228
+#: builtin/rebase.c:252
 #, c-format
 msgid "could not write '%s'."
 msgstr "Konnte '%s' nicht schreiben."
@@ -5981,9 +6003,9 @@ msgstr ""
 "Warnungen zu ändern.\n"
 "Die möglichen Verhaltensweisen sind: ignore, warn, error.\n"
 
-#: rebase-interactive.c:233 rebase-interactive.c:238 sequencer.c:2361
-#: builtin/rebase.c:182 builtin/rebase.c:207 builtin/rebase.c:233
-#: builtin/rebase.c:258
+#: rebase-interactive.c:233 rebase-interactive.c:238 sequencer.c:2394
+#: builtin/rebase.c:188 builtin/rebase.c:213 builtin/rebase.c:239
+#: builtin/rebase.c:264
 #, c-format
 msgid "could not read '%s'."
 msgstr "Konnte '%s' nicht lesen."
@@ -6179,61 +6201,61 @@ msgstr "Format: %%(end) Atom ohne zugehöriges Atom verwendet"
 msgid "malformed format string %s"
 msgstr "Fehlerhafter Formatierungsstring %s"
 
-#: ref-filter.c:1541
+#: ref-filter.c:1549
 #, c-format
 msgid "no branch, rebasing %s"
 msgstr "kein Branch, Rebase von %s"
 
-#: ref-filter.c:1544
+#: ref-filter.c:1552
 #, c-format
 msgid "no branch, rebasing detached HEAD %s"
 msgstr "kein Branch, Rebase von losgelöstem HEAD %s"
 
-#: ref-filter.c:1547
+#: ref-filter.c:1555
 #, c-format
 msgid "no branch, bisect started on %s"
 msgstr "kein Branch, binäre Suche begonnen bei %s"
 
-#: ref-filter.c:1557
+#: ref-filter.c:1565
 msgid "no branch"
 msgstr "kein Branch"
 
-#: ref-filter.c:1591 ref-filter.c:1800
+#: ref-filter.c:1599 ref-filter.c:1808
 #, c-format
 msgid "missing object %s for %s"
 msgstr "Objekt %s fehlt für %s"
 
-#: ref-filter.c:1601
+#: ref-filter.c:1609
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr "parse_object_buffer bei %s für %s fehlgeschlagen"
 
-#: ref-filter.c:2054
+#: ref-filter.c:2062
 #, c-format
 msgid "malformed object at '%s'"
 msgstr "fehlerhaftes Objekt bei '%s'"
 
-#: ref-filter.c:2143
+#: ref-filter.c:2151
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr "Ignoriere Referenz mit fehlerhaftem Namen %s"
 
-#: ref-filter.c:2148 refs.c:657
+#: ref-filter.c:2156 refs.c:660
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "Ignoriere fehlerhafte Referenz %s"
 
-#: ref-filter.c:2464
+#: ref-filter.c:2472
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "Format: %%(end) Atom fehlt"
 
-#: ref-filter.c:2563
+#: ref-filter.c:2571
 #, c-format
 msgid "malformed object name %s"
 msgstr "missgebildeter Objektname %s"
 
-#: ref-filter.c:2568
+#: ref-filter.c:2576
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "die Option `%s' muss auf einen Commit zeigen"
@@ -6243,67 +6265,67 @@ msgstr "die Option `%s' muss auf einen Commit zeigen"
 msgid "%s does not point to a valid object!"
 msgstr "%s zeigt auf kein gültiges Objekt!"
 
-#: refs.c:572
+#: refs.c:575
 #, c-format
 msgid "could not retrieve `%s`"
 msgstr "konnte `%s` nicht abrufen"
 
-#: refs.c:579
+#: refs.c:582
 #, c-format
 msgid "invalid branch name: %s = %s"
 msgstr "ungültiger Branchname: %s = %s"
 
-#: refs.c:655
+#: refs.c:658
 #, c-format
 msgid "ignoring dangling symref %s"
 msgstr "Ignoriere unreferenzierte symbolische Referenz %s"
 
-#: refs.c:892
+#: refs.c:895
 #, c-format
 msgid "log for ref %s has gap after %s"
 msgstr "Log für Referenz %s hat eine Lücke nach %s."
 
-#: refs.c:898
+#: refs.c:901
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
 msgstr "Log für Referenz %s unerwartet bei %s beendet."
 
-#: refs.c:957
+#: refs.c:960
 #, c-format
 msgid "log for %s is empty"
 msgstr "Log für %s ist leer."
 
-#: refs.c:1049
+#: refs.c:1052
 #, c-format
 msgid "refusing to update ref with bad name '%s'"
 msgstr "verweigere Aktualisierung einer Referenz mit fehlerhaftem Namen '%s'"
 
-#: refs.c:1120
+#: refs.c:1123
 #, c-format
 msgid "update_ref failed for ref '%s': %s"
 msgstr "update_ref für Referenz '%s' fehlgeschlagen: %s"
 
-#: refs.c:1944
+#: refs.c:1947
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "mehrere Aktualisierungen für Referenz '%s' nicht erlaubt"
 
-#: refs.c:2024
+#: refs.c:2027
 msgid "ref updates forbidden inside quarantine environment"
 msgstr ""
 "Aktualisierungen von Referenzen ist innerhalb der Quarantäne-Umgebung "
 "verboten"
 
-#: refs.c:2035
+#: refs.c:2038
 msgid "ref updates aborted by hook"
 msgstr "Aktualisierungen von Referenzen durch Hook abgebrochen"
 
-#: refs.c:2135 refs.c:2165
+#: refs.c:2138 refs.c:2168
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "'%s' existiert; kann '%s' nicht erstellen"
 
-#: refs.c:2141 refs.c:2176
+#: refs.c:2144 refs.c:2179
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "kann '%s' und '%s' nicht zur selben Zeit verarbeiten"
@@ -6324,7 +6346,7 @@ msgstr "konnte Referenz %s nicht entfernen: %s"
 msgid "could not delete references: %s"
 msgstr "konnte Referenzen nicht entfernen: %s"
 
-#: refspec.c:167
+#: refspec.c:170
 #, c-format
 msgid "invalid refspec '%s'"
 msgstr "ungültige Refspec '%s'"
@@ -6474,97 +6496,97 @@ msgstr "Dst-Refspec %s entspricht mehr als einer Referenz."
 msgid "dst ref %s receives from more than one src"
 msgstr "Dst-Referenz %s empfängt von mehr als einer Quelle"
 
-#: remote.c:1703 remote.c:1804
+#: remote.c:1714 remote.c:1815
 msgid "HEAD does not point to a branch"
 msgstr "HEAD zeigt auf keinen Branch"
 
-#: remote.c:1712
+#: remote.c:1723
 #, c-format
 msgid "no such branch: '%s'"
 msgstr "Kein solcher Branch: '%s'"
 
-#: remote.c:1715
+#: remote.c:1726
 #, c-format
 msgid "no upstream configured for branch '%s'"
 msgstr "Kein Upstream-Branch für Branch '%s' konfiguriert."
 
-#: remote.c:1721
+#: remote.c:1732
 #, c-format
 msgid "upstream branch '%s' not stored as a remote-tracking branch"
 msgstr "Upstream-Branch '%s' nicht als Remote-Tracking-Branch gespeichert"
 
-#: remote.c:1736
+#: remote.c:1747
 #, c-format
 msgid "push destination '%s' on remote '%s' has no local tracking branch"
 msgstr ""
 "Ziel für \"push\" '%s' auf Remote-Repository '%s' hat keinen lokal gefolgten "
 "Branch"
 
-#: remote.c:1748
+#: remote.c:1759
 #, c-format
 msgid "branch '%s' has no remote for pushing"
 msgstr "Branch '%s' hat keinen Upstream-Branch gesetzt"
 
-#: remote.c:1758
+#: remote.c:1769
 #, c-format
 msgid "push refspecs for '%s' do not include '%s'"
 msgstr "Push-Refspecs für '%s' beinhalten nicht '%s'"
 
-#: remote.c:1771
+#: remote.c:1782
 msgid "push has no destination (push.default is 'nothing')"
 msgstr "kein Ziel für \"push\" (push.default ist 'nothing')"
 
-#: remote.c:1793
+#: remote.c:1804
 msgid "cannot resolve 'simple' push to a single destination"
 msgstr "kann einzelnes Ziel für \"push\" im Modus 'simple' nicht auflösen"
 
-#: remote.c:1922
+#: remote.c:1933
 #, c-format
 msgid "couldn't find remote ref %s"
 msgstr "Konnte Remote-Referenz %s nicht finden."
 
-#: remote.c:1935
+#: remote.c:1946
 #, c-format
 msgid "* Ignoring funny ref '%s' locally"
 msgstr "* Ignoriere sonderbare Referenz '%s' lokal"
 
-#: remote.c:2098
+#: remote.c:2109
 #, c-format
 msgid "Your branch is based on '%s', but the upstream is gone.\n"
 msgstr ""
 "Ihr Branch basiert auf '%s', aber der Upstream-Branch wurde entfernt.\n"
 
-#: remote.c:2102
+#: remote.c:2113
 msgid "  (use \"git branch --unset-upstream\" to fixup)\n"
 msgstr "  (benutzen Sie \"git branch --unset-upstream\" zum Beheben)\n"
 
-#: remote.c:2105
+#: remote.c:2116
 #, c-format
 msgid "Your branch is up to date with '%s'.\n"
 msgstr "Ihr Branch ist auf demselben Stand wie '%s'.\n"
 
-#: remote.c:2109
+#: remote.c:2120
 #, c-format
 msgid "Your branch and '%s' refer to different commits.\n"
 msgstr "Ihr Branch und '%s' zeigen auf unterschiedliche Commits.\n"
 
-#: remote.c:2112
+#: remote.c:2123
 #, c-format
 msgid "  (use \"%s\" for details)\n"
 msgstr "  (benutzen Sie \"%s\" für Details)\n"
 
-#: remote.c:2116
+#: remote.c:2127
 #, c-format
 msgid "Your branch is ahead of '%s' by %d commit.\n"
 msgid_plural "Your branch is ahead of '%s' by %d commits.\n"
 msgstr[0] "Ihr Branch ist %2$d Commit vor '%1$s'.\n"
 msgstr[1] "Ihr Branch ist %2$d Commits vor '%1$s'.\n"
 
-#: remote.c:2122
+#: remote.c:2133
 msgid "  (use \"git push\" to publish your local commits)\n"
 msgstr "  (benutzen Sie \"git push\", um lokale Commits zu publizieren)\n"
 
-#: remote.c:2125
+#: remote.c:2136
 #, c-format
 msgid "Your branch is behind '%s' by %d commit, and can be fast-forwarded.\n"
 msgid_plural ""
@@ -6574,12 +6596,12 @@ msgstr[0] ""
 msgstr[1] ""
 "Ihr Branch ist %2$d Commits hinter '%1$s', und kann vorgespult werden.\n"
 
-#: remote.c:2133
+#: remote.c:2144
 msgid "  (use \"git pull\" to update your local branch)\n"
 msgstr ""
 "  (benutzen Sie \"git pull\", um Ihren lokalen Branch zu aktualisieren)\n"
 
-#: remote.c:2136
+#: remote.c:2147
 #, c-format
 msgid ""
 "Your branch and '%s' have diverged,\n"
@@ -6594,13 +6616,13 @@ msgstr[1] ""
 "Ihr Branch und '%s' sind divergiert,\n"
 "und haben jeweils %d und %d unterschiedliche Commits.\n"
 
-#: remote.c:2146
+#: remote.c:2157
 msgid "  (use \"git pull\" to merge the remote branch into yours)\n"
 msgstr ""
 "  (benutzen Sie \"git pull\", um Ihren Branch mit dem Remote-Branch "
 "zusammenzuführen)\n"
 
-#: remote.c:2337
+#: remote.c:2348
 #, c-format
 msgid "cannot parse expected object name '%s'"
 msgstr "Kann erwarteten Objektnamen '%s' nicht parsen."
@@ -6678,7 +6700,7 @@ msgstr "Kann '%s' nicht löschen."
 msgid "Recorded preimage for '%s'"
 msgstr "Preimage für '%s' aufgezeichnet."
 
-#: rerere.c:881 submodule.c:2082 builtin/log.c:1975
+#: rerere.c:881 submodule.c:2082 builtin/log.c:1992
 #: builtin/submodule--helper.c:1878 builtin/submodule--helper.c:1890
 #, c-format
 msgid "could not create directory '%s'"
@@ -6717,43 +6739,43 @@ msgstr "Konnte rr-cache Verzeichnis nicht öffnen."
 msgid "could not determine HEAD revision"
 msgstr "Konnte HEAD-Commit nicht bestimmen."
 
-#: reset.c:70 reset.c:76 sequencer.c:3426
+#: reset.c:70 reset.c:76 sequencer.c:3460
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "Fehler beim Finden des \"Tree\"-Objektes von %s."
 
-#: revision.c:2344
+#: revision.c:2336
 msgid "--unpacked=<packfile> no longer supported"
 msgstr "--unpacked=<Pack-Datei> wird nicht länger unterstützt"
 
-#: revision.c:2364
+#: revision.c:2356
 #, c-format
 msgid "unknown value for --diff-merges: %s"
 msgstr "unbekannter Wert für --diff-merges: %s"
 
-#: revision.c:2702
+#: revision.c:2694
 msgid "your current branch appears to be broken"
 msgstr "Ihr aktueller Branch scheint fehlerhaft zu sein."
 
-#: revision.c:2705
+#: revision.c:2697
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
 msgstr "Ihr aktueller Branch '%s' hat noch keine Commits."
 
-#: revision.c:2915
+#: revision.c:2907
 msgid "-L does not yet support diff formats besides -p and -s"
 msgstr "-L unterstützt noch keine anderen Diff-Formate außer -p und -s"
 
-#: run-command.c:763
+#: run-command.c:764
 msgid "open /dev/null failed"
 msgstr "Öffnen von /dev/null fehlgeschlagen"
 
-#: run-command.c:1270
+#: run-command.c:1271
 #, c-format
 msgid "cannot create async thread: %s"
 msgstr "Konnte Thread für async nicht erzeugen: %s"
 
-#: run-command.c:1334
+#: run-command.c:1335
 #, c-format
 msgid ""
 "The '%s' hook was ignored because it's not set as executable.\n"
@@ -6763,35 +6785,35 @@ msgstr ""
 "Sie können diese Warnung mit `git config advice.ignoredHook false` "
 "deaktivieren."
 
-#: send-pack.c:145
+#: send-pack.c:146
 msgid "unexpected flush packet while reading remote unpack status"
 msgstr "Unerwartetes Flush-Paket beim Lesen des Remote-Unpack-Status."
 
-#: send-pack.c:147
+#: send-pack.c:148
 #, c-format
 msgid "unable to parse remote unpack status: %s"
 msgstr "Konnte Status des Entpackens der Gegenseite nicht parsen: %s"
 
-#: send-pack.c:149
+#: send-pack.c:150
 #, c-format
 msgid "remote unpack failed: %s"
 msgstr "Entpacken auf der Gegenseite fehlgeschlagen: %s"
 
-#: send-pack.c:372
+#: send-pack.c:374
 msgid "failed to sign the push certificate"
 msgstr "Fehler beim Signieren des \"push\"-Zertifikates"
 
-#: send-pack.c:460
+#: send-pack.c:467
 msgid "the receiving end does not support this repository's hash algorithm"
 msgstr ""
 "die Gegenseite unterstützt nicht den Hash-Algorithmus dieses Repositories"
 
-#: send-pack.c:469
+#: send-pack.c:476
 msgid "the receiving end does not support --signed push"
 msgstr ""
 "die Gegenseite unterstützt keinen signierten Versand (\"--signed push\")"
 
-#: send-pack.c:471
+#: send-pack.c:478
 msgid ""
 "not sending a push certificate since the receiving end does not support --"
 "signed push"
@@ -6799,47 +6821,47 @@ msgstr ""
 "kein Versand des \"push\"-Zertifikates, da die Gegenseite keinen signierten\n"
 "Versand (\"--signed push\") unterstützt"
 
-#: send-pack.c:483
+#: send-pack.c:490
 msgid "the receiving end does not support --atomic push"
 msgstr "die Gegenseite unterstützt keinen atomaren Versand (\"--atomic push\")"
 
-#: send-pack.c:488
+#: send-pack.c:495
 msgid "the receiving end does not support push options"
 msgstr "die Gegenseite unterstützt keine Push-Optionen"
 
-#: sequencer.c:194
+#: sequencer.c:195
 #, c-format
 msgid "invalid commit message cleanup mode '%s'"
 msgstr "Ungültiger \"cleanup\"-Modus '%s' für Commit-Beschreibungen."
 
-#: sequencer.c:308
+#: sequencer.c:323
 #, c-format
 msgid "could not delete '%s'"
 msgstr "Konnte '%s' nicht löschen."
 
-#: sequencer.c:329 builtin/rebase.c:749 builtin/rebase.c:1590 builtin/rm.c:385
+#: sequencer.c:343 builtin/rebase.c:755 builtin/rebase.c:1596 builtin/rm.c:385
 #, c-format
 msgid "could not remove '%s'"
 msgstr "Konnte '%s' nicht löschen"
 
-#: sequencer.c:339
+#: sequencer.c:353
 msgid "revert"
 msgstr "Revert"
 
-#: sequencer.c:341
+#: sequencer.c:355
 msgid "cherry-pick"
 msgstr "Cherry-Pick"
 
-#: sequencer.c:343
+#: sequencer.c:357
 msgid "rebase"
 msgstr "Rebase"
 
-#: sequencer.c:345
+#: sequencer.c:359
 #, c-format
 msgid "unknown action: %d"
 msgstr "Unbekannte Aktion: %d"
 
-#: sequencer.c:404
+#: sequencer.c:418
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'"
@@ -6847,7 +6869,7 @@ msgstr ""
 "nach Auflösung der Konflikte markieren Sie die korrigierten Pfade\n"
 "mit 'git add <Pfade>' oder 'git rm <Pfade>'"
 
-#: sequencer.c:407
+#: sequencer.c:421
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'\n"
@@ -6857,44 +6879,44 @@ msgstr ""
 "mit 'git add <Pfade>' oder 'git rm <Pfade>' und tragen Sie das Ergebnis mit\n"
 "'git commit' ein"
 
-#: sequencer.c:420 sequencer.c:3028
+#: sequencer.c:434 sequencer.c:3062
 #, c-format
 msgid "could not lock '%s'"
 msgstr "Konnte '%s' nicht sperren"
 
-#: sequencer.c:422 sequencer.c:2827 sequencer.c:3032 sequencer.c:3046
-#: sequencer.c:3303 sequencer.c:5299 strbuf.c:1168 wrapper.c:631
+#: sequencer.c:436 sequencer.c:2861 sequencer.c:3066 sequencer.c:3080
+#: sequencer.c:3337 sequencer.c:5326 strbuf.c:1168 wrapper.c:631
 #, c-format
 msgid "could not write to '%s'"
 msgstr "Konnte nicht nach '%s' schreiben."
 
-#: sequencer.c:427
+#: sequencer.c:441
 #, c-format
 msgid "could not write eol to '%s'"
 msgstr "Konnte EOL nicht nach '%s' schreiben."
 
-#: sequencer.c:432 sequencer.c:2832 sequencer.c:3034 sequencer.c:3048
-#: sequencer.c:3311
+#: sequencer.c:446 sequencer.c:2866 sequencer.c:3068 sequencer.c:3082
+#: sequencer.c:3345
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "Fehler beim Fertigstellen von '%s'."
 
-#: sequencer.c:471
+#: sequencer.c:485
 #, c-format
 msgid "your local changes would be overwritten by %s."
 msgstr "Ihre lokalen Änderungen würden durch den %s überschrieben werden."
 
-#: sequencer.c:475
+#: sequencer.c:489
 msgid "commit your changes or stash them to proceed."
 msgstr ""
 "Committen Sie Ihre Änderungen oder benutzen Sie \"stash\", um fortzufahren."
 
-#: sequencer.c:507
+#: sequencer.c:521
 #, c-format
 msgid "%s: fast-forward"
 msgstr "%s: Vorspulen"
 
-#: sequencer.c:546 builtin/tag.c:566
+#: sequencer.c:560 builtin/tag.c:566
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Ungültiger \"cleanup\" Modus %s"
@@ -6902,65 +6924,65 @@ msgstr "Ungültiger \"cleanup\" Modus %s"
 #. TRANSLATORS: %s will be "revert", "cherry-pick" or
 #. "rebase".
 #.
-#: sequencer.c:640
+#: sequencer.c:670
 #, c-format
 msgid "%s: Unable to write new index file"
 msgstr "%s: Konnte neue Index-Datei nicht schreiben"
 
-#: sequencer.c:657
+#: sequencer.c:687
 msgid "unable to update cache tree"
 msgstr "Konnte Cache-Verzeichnis nicht aktualisieren."
 
-#: sequencer.c:671
+#: sequencer.c:701
 msgid "could not resolve HEAD commit"
 msgstr "Konnte HEAD-Commit nicht auflösen."
 
-#: sequencer.c:751
+#: sequencer.c:781
 #, c-format
 msgid "no key present in '%.*s'"
 msgstr "Kein Schlüssel in '%.*s' vorhanden."
 
-#: sequencer.c:762
+#: sequencer.c:792
 #, c-format
 msgid "unable to dequote value of '%s'"
 msgstr "Konnte Anführungszeichen von '%s' nicht entfernen."
 
-#: sequencer.c:799 wrapper.c:201 wrapper.c:371 builtin/am.c:724
-#: builtin/am.c:816 builtin/merge.c:1121 builtin/rebase.c:902
+#: sequencer.c:829 wrapper.c:201 wrapper.c:371 builtin/am.c:710
+#: builtin/am.c:802 builtin/merge.c:1135 builtin/rebase.c:908
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "Konnte '%s' nicht zum Lesen öffnen."
 
-#: sequencer.c:809
+#: sequencer.c:839
 msgid "'GIT_AUTHOR_NAME' already given"
 msgstr "'GIT_AUTHOR_NAME' bereits angegeben."
 
-#: sequencer.c:814
+#: sequencer.c:844
 msgid "'GIT_AUTHOR_EMAIL' already given"
 msgstr "'GIT_AUTHOR_EMAIL' bereits angegeben."
 
-#: sequencer.c:819
+#: sequencer.c:849
 msgid "'GIT_AUTHOR_DATE' already given"
 msgstr "'GIT_AUTHOR_DATE' bereits angegeben."
 
-#: sequencer.c:823
+#: sequencer.c:853
 #, c-format
 msgid "unknown variable '%s'"
 msgstr "Unbekannte Variable '%s'"
 
-#: sequencer.c:828
+#: sequencer.c:858
 msgid "missing 'GIT_AUTHOR_NAME'"
 msgstr "'GIT_AUTHOR_NAME' fehlt."
 
-#: sequencer.c:830
+#: sequencer.c:860
 msgid "missing 'GIT_AUTHOR_EMAIL'"
 msgstr "'GIT_AUTHOR_EMAIL' fehlt."
 
-#: sequencer.c:832
+#: sequencer.c:862
 msgid "missing 'GIT_AUTHOR_DATE'"
 msgstr "'GIT_AUTHOR_DATE' fehlt."
 
-#: sequencer.c:897
+#: sequencer.c:927
 #, c-format
 msgid ""
 "you have staged changes in your working tree\n"
@@ -6991,11 +7013,11 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:1178
+#: sequencer.c:1208
 msgid "'prepare-commit-msg' hook failed"
 msgstr "'prepare-commit-msg' Hook fehlgeschlagen."
 
-#: sequencer.c:1184
+#: sequencer.c:1214
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7023,7 +7045,7 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1197
+#: sequencer.c:1227
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7049,340 +7071,340 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1239
+#: sequencer.c:1269
 msgid "couldn't look up newly created commit"
 msgstr "Konnte neu erstellten Commit nicht nachschlagen."
 
-#: sequencer.c:1241
+#: sequencer.c:1271
 msgid "could not parse newly created commit"
 msgstr "Konnte neu erstellten Commit nicht analysieren."
 
-#: sequencer.c:1287
+#: sequencer.c:1317
 msgid "unable to resolve HEAD after creating commit"
 msgstr "Konnte HEAD nicht auflösen, nachdem der Commit erstellt wurde."
 
-#: sequencer.c:1289
+#: sequencer.c:1319
 msgid "detached HEAD"
 msgstr "losgelöster HEAD"
 
-#: sequencer.c:1293
+#: sequencer.c:1323
 msgid " (root-commit)"
 msgstr " (Root-Commit)"
 
-#: sequencer.c:1314
+#: sequencer.c:1344
 msgid "could not parse HEAD"
 msgstr "Konnte HEAD nicht parsen."
 
-#: sequencer.c:1316
+#: sequencer.c:1346
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "HEAD %s ist kein Commit!"
 
-#: sequencer.c:1320 sequencer.c:1395 builtin/commit.c:1577
+#: sequencer.c:1350 sequencer.c:1425 builtin/commit.c:1577
 msgid "could not parse HEAD commit"
 msgstr "Konnte Commit von HEAD nicht analysieren."
 
-#: sequencer.c:1373 sequencer.c:2067
+#: sequencer.c:1403 sequencer.c:2100
 msgid "unable to parse commit author"
 msgstr "Konnte Commit-Autor nicht parsen."
 
-#: sequencer.c:1384 builtin/am.c:1580 builtin/merge.c:692
+#: sequencer.c:1414 builtin/am.c:1566 builtin/merge.c:701
 msgid "git write-tree failed to write a tree"
 msgstr "\"git write-tree\" schlug beim Schreiben eines \"Tree\"-Objektes fehl"
 
-#: sequencer.c:1417 sequencer.c:1535
+#: sequencer.c:1447 sequencer.c:1565
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "Konnte Commit-Beschreibung von '%s' nicht lesen."
 
-#: sequencer.c:1446 sequencer.c:1478
+#: sequencer.c:1476 sequencer.c:1508
 #, c-format
 msgid "invalid author identity '%s'"
 msgstr "ungültige Autor-Identität '%s'"
 
-#: sequencer.c:1452
+#: sequencer.c:1482
 msgid "corrupt author: missing date information"
 msgstr "unbrauchbarer Autor: Datumsinformationen fehlen"
 
-#: sequencer.c:1491 builtin/am.c:1606 builtin/commit.c:1678 builtin/merge.c:890
-#: builtin/merge.c:915
+#: sequencer.c:1521 builtin/am.c:1593 builtin/commit.c:1678 builtin/merge.c:904
+#: builtin/merge.c:929 t/helper/test-fast-rebase.c:78
 msgid "failed to write commit object"
 msgstr "Fehler beim Schreiben des Commit-Objektes."
 
-#: sequencer.c:1518 sequencer.c:4237
+#: sequencer.c:1548 sequencer.c:4283 t/helper/test-fast-rebase.c:198
 #, c-format
 msgid "could not update %s"
 msgstr "Konnte %s nicht aktualisieren."
 
-#: sequencer.c:1567
+#: sequencer.c:1597
 #, c-format
 msgid "could not parse commit %s"
 msgstr "Konnte Commit %s nicht parsen."
 
-#: sequencer.c:1572
+#: sequencer.c:1602
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "Konnte Eltern-Commit %s nicht parsen."
 
-#: sequencer.c:1655 sequencer.c:1766
+#: sequencer.c:1685 sequencer.c:1796
 #, c-format
 msgid "unknown command: %d"
 msgstr "Unbekannter Befehl: %d"
 
-#: sequencer.c:1713 sequencer.c:1738
+#: sequencer.c:1743 sequencer.c:1768
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr "Das ist eine Kombination aus %d Commits."
 
-#: sequencer.c:1723
+#: sequencer.c:1753
 msgid "need a HEAD to fixup"
 msgstr "benötige HEAD für fixup"
 
-#: sequencer.c:1725 sequencer.c:3338
+#: sequencer.c:1755 sequencer.c:3372
 msgid "could not read HEAD"
 msgstr "Konnte HEAD nicht lesen"
 
-#: sequencer.c:1727
+#: sequencer.c:1757
 msgid "could not read HEAD's commit message"
 msgstr "Konnte Commit-Beschreibung von HEAD nicht lesen"
 
-#: sequencer.c:1733
+#: sequencer.c:1763
 #, c-format
 msgid "cannot write '%s'"
 msgstr "kann '%s' nicht schreiben"
 
-#: sequencer.c:1740 git-rebase--preserve-merges.sh:486
+#: sequencer.c:1770 git-rebase--preserve-merges.sh:486
 msgid "This is the 1st commit message:"
 msgstr "Das ist die erste Commit-Beschreibung:"
 
-#: sequencer.c:1748
+#: sequencer.c:1778
 #, c-format
 msgid "could not read commit message of %s"
 msgstr "Konnte Commit-Beschreibung von %s nicht lesen."
 
-#: sequencer.c:1755
+#: sequencer.c:1785
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "Das ist Commit-Beschreibung #%d:"
 
-#: sequencer.c:1761
+#: sequencer.c:1791
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "Die Commit-Beschreibung #%d wird ausgelassen:"
 
-#: sequencer.c:1849
+#: sequencer.c:1879
 msgid "your index file is unmerged."
 msgstr "Ihre Index-Datei ist nicht zusammengeführt."
 
-#: sequencer.c:1856
+#: sequencer.c:1886
 msgid "cannot fixup root commit"
 msgstr "kann fixup nicht auf Root-Commit anwenden"
 
-#: sequencer.c:1875
+#: sequencer.c:1905
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "Commit %s ist ein Merge, aber die Option -m wurde nicht angegeben."
 
-#: sequencer.c:1883 sequencer.c:1891
+#: sequencer.c:1913 sequencer.c:1921
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "Commit %s hat keinen Eltern-Commit %d"
 
-#: sequencer.c:1897
+#: sequencer.c:1927
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "Kann keine Commit-Beschreibung für %s bekommen."
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:1916
+#: sequencer.c:1946
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: kann Eltern-Commit %s nicht parsen"
 
-#: sequencer.c:1981
+#: sequencer.c:2011
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "Konnte '%s' nicht zu '%s' umbenennen."
 
-#: sequencer.c:2038
+#: sequencer.c:2071
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "Konnte \"revert\" nicht auf %s... (%s) ausführen"
 
-#: sequencer.c:2039
+#: sequencer.c:2072
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "Konnte %s... (%s) nicht anwenden"
 
-#: sequencer.c:2059
+#: sequencer.c:2092
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr "Weglassen von %s %s -- Patch-Inhalte sind bereits im Upstream-Branch\n"
 
-#: sequencer.c:2117
+#: sequencer.c:2150
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: Fehler beim Lesen des Index"
 
-#: sequencer.c:2124
+#: sequencer.c:2157
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: Fehler beim Aktualisieren des Index"
 
-#: sequencer.c:2201
+#: sequencer.c:2234
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "%s akzeptiert keine Argumente: '%s'"
 
-#: sequencer.c:2210
+#: sequencer.c:2243
 #, c-format
 msgid "missing arguments for %s"
 msgstr "Fehlende Argumente für %s."
 
-#: sequencer.c:2241
+#: sequencer.c:2274
 #, c-format
 msgid "could not parse '%s'"
 msgstr "Konnte '%s' nicht parsen."
 
-#: sequencer.c:2302
+#: sequencer.c:2335
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "Ungültige Zeile %d: %.*s"
 
-#: sequencer.c:2313
+#: sequencer.c:2346
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "Kann '%s' nicht ohne vorherigen Commit ausführen"
 
-#: sequencer.c:2399
+#: sequencer.c:2432
 msgid "cancelling a cherry picking in progress"
 msgstr "Abbrechen eines laufenden \"cherry-pick\""
 
-#: sequencer.c:2408
+#: sequencer.c:2441
 msgid "cancelling a revert in progress"
 msgstr "Abbrechen eines laufenden \"revert\""
 
-#: sequencer.c:2452
+#: sequencer.c:2485
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr ""
 "Bitte beheben Sie dieses, indem Sie 'git rebase --edit-todo' ausführen."
 
-#: sequencer.c:2454
+#: sequencer.c:2487
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "Unbenutzbares Instruktionsblatt: '%s'"
 
-#: sequencer.c:2459
+#: sequencer.c:2492
 msgid "no commits parsed."
 msgstr "Keine Commits geparst."
 
-#: sequencer.c:2470
+#: sequencer.c:2503
 msgid "cannot cherry-pick during a revert."
 msgstr "Kann Cherry-Pick nicht während eines Reverts ausführen."
 
-#: sequencer.c:2472
+#: sequencer.c:2505
 msgid "cannot revert during a cherry-pick."
 msgstr "Kann Revert nicht während eines Cherry-Picks ausführen."
 
-#: sequencer.c:2550
+#: sequencer.c:2583
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr "Ungültiger Wert für %s: %s"
 
-#: sequencer.c:2657
+#: sequencer.c:2690
 msgid "unusable squash-onto"
 msgstr "Unbenutzbares squash-onto."
 
-#: sequencer.c:2677
+#: sequencer.c:2710
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "Fehlerhaftes Optionsblatt: '%s'"
 
-#: sequencer.c:2769 sequencer.c:4609
+#: sequencer.c:2803 sequencer.c:4636
 msgid "empty commit set passed"
 msgstr "leere Menge von Commits übergeben"
 
-#: sequencer.c:2786
+#: sequencer.c:2820
 msgid "revert is already in progress"
 msgstr "\"revert\" ist bereits im Gange"
 
-#: sequencer.c:2788
+#: sequencer.c:2822
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr "Versuchen Sie \"git revert (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:2791
+#: sequencer.c:2825
 msgid "cherry-pick is already in progress"
 msgstr "\"cherry-pick\" wird bereits durchgeführt"
 
-#: sequencer.c:2793
+#: sequencer.c:2827
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr "Versuchen Sie \"git cherry-pick (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:2807
+#: sequencer.c:2841
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr "Konnte \"sequencer\"-Verzeichnis '%s' nicht erstellen."
 
-#: sequencer.c:2822
+#: sequencer.c:2856
 msgid "could not lock HEAD"
 msgstr "Konnte HEAD nicht sperren"
 
-#: sequencer.c:2882 sequencer.c:4325
+#: sequencer.c:2916 sequencer.c:4371
 msgid "no cherry-pick or revert in progress"
 msgstr "kein \"cherry-pick\" oder \"revert\" im Gange"
 
-#: sequencer.c:2884 sequencer.c:2895
+#: sequencer.c:2918 sequencer.c:2929
 msgid "cannot resolve HEAD"
 msgstr "kann HEAD nicht auflösen"
 
-#: sequencer.c:2886 sequencer.c:2930
+#: sequencer.c:2920 sequencer.c:2964
 msgid "cannot abort from a branch yet to be born"
 msgstr "kann nicht abbrechen: bin auf einem Branch, der noch nicht geboren ist"
 
-#: sequencer.c:2916 builtin/grep.c:745
+#: sequencer.c:2950 builtin/grep.c:756
 #, c-format
 msgid "cannot open '%s'"
 msgstr "kann '%s' nicht öffnen"
 
-#: sequencer.c:2918
+#: sequencer.c:2952
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "Kann '%s' nicht lesen: %s"
 
-#: sequencer.c:2919
+#: sequencer.c:2953
 msgid "unexpected end of file"
 msgstr "Unerwartetes Dateiende"
 
-#: sequencer.c:2925
+#: sequencer.c:2959
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr "gespeicherte \"pre-cherry-pick\" HEAD Datei '%s' ist beschädigt"
 
-#: sequencer.c:2936
+#: sequencer.c:2970
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr ""
 "Sie scheinen HEAD verändert zu haben. Keine Rückspulung, prüfen Sie HEAD."
 
-#: sequencer.c:2977
+#: sequencer.c:3011
 msgid "no revert in progress"
 msgstr "Kein Revert im Gange"
 
-#: sequencer.c:2986
+#: sequencer.c:3020
 msgid "no cherry-pick in progress"
 msgstr "kein \"cherry-pick\" im Gange"
 
-#: sequencer.c:2996
+#: sequencer.c:3030
 msgid "failed to skip the commit"
 msgstr "Überspringen des Commits fehlgeschlagen"
 
-#: sequencer.c:3003
+#: sequencer.c:3037
 msgid "there is nothing to skip"
 msgstr "Nichts zum Überspringen vorhanden"
 
-#: sequencer.c:3006
+#: sequencer.c:3040
 #, c-format
 msgid ""
 "have you committed already?\n"
@@ -7391,16 +7413,16 @@ msgstr ""
 "Haben Sie bereits committet?\n"
 "Versuchen Sie \"git %s --continue\""
 
-#: sequencer.c:3168 sequencer.c:4217
+#: sequencer.c:3202 sequencer.c:4263
 msgid "cannot read HEAD"
 msgstr "Kann HEAD nicht lesen"
 
-#: sequencer.c:3185
+#: sequencer.c:3219
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "Konnte '%s' nicht nach '%s' kopieren."
 
-#: sequencer.c:3193
+#: sequencer.c:3227
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -7419,27 +7441,27 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:3203
+#: sequencer.c:3237
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "Konnte %s... (%.*s) nicht anwenden"
 
-#: sequencer.c:3210
+#: sequencer.c:3244
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "Konnte \"%.*s\" nicht zusammenführen."
 
-#: sequencer.c:3224 sequencer.c:3228 builtin/difftool.c:641
+#: sequencer.c:3258 sequencer.c:3262 builtin/difftool.c:640
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "Konnte '%s' nicht nach '%s' kopieren."
 
-#: sequencer.c:3240
+#: sequencer.c:3274
 #, c-format
 msgid "Executing: %s\n"
 msgstr "Führe aus: %s\n"
 
-#: sequencer.c:3255
+#: sequencer.c:3289
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -7455,11 +7477,11 @@ msgstr ""
 "\n"
 "ausführen.\n"
 
-#: sequencer.c:3261
+#: sequencer.c:3295
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "Der Index und/oder das Arbeitsverzeichnis wurde geändert.\n"
 
-#: sequencer.c:3267
+#: sequencer.c:3301
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -7477,91 +7499,91 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3328
+#: sequencer.c:3362
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "Unerlaubter Beschriftungsname: '%.*s'"
 
-#: sequencer.c:3382
+#: sequencer.c:3416
 msgid "writing fake root commit"
 msgstr "unechten Root-Commit schreiben"
 
-#: sequencer.c:3387
+#: sequencer.c:3421
 msgid "writing squash-onto"
 msgstr "squash-onto schreiben"
 
-#: sequencer.c:3471
+#: sequencer.c:3505
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "Konnte '%s' nicht auflösen."
 
-#: sequencer.c:3502
+#: sequencer.c:3538
 msgid "cannot merge without a current revision"
 msgstr "Kann nicht ohne einen aktuellen Commit mergen."
 
-#: sequencer.c:3524
+#: sequencer.c:3560
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "Konnte '%.*s' nicht parsen."
 
-#: sequencer.c:3533
+#: sequencer.c:3569
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "Nichts zum Zusammenführen: '%.*s'"
 
-#: sequencer.c:3545
+#: sequencer.c:3581
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr ""
 "Oktopus-Merge kann nicht auf Basis von [neuem Root-Commit] ausgeführt werden."
 
-#: sequencer.c:3561
+#: sequencer.c:3597
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "Konnte keine Commit-Beschreibung von '%s' bekommen."
 
-#: sequencer.c:3730
+#: sequencer.c:3780
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "Konnte nicht einmal versuchen '%.*s' zu mergen."
 
-#: sequencer.c:3746
+#: sequencer.c:3796
 msgid "merge: Unable to write new index file"
 msgstr "merge: Konnte neue Index-Datei nicht schreiben."
 
-#: sequencer.c:3820
+#: sequencer.c:3870
 msgid "Cannot autostash"
 msgstr "Kann automatischen Stash nicht erzeugen."
 
-#: sequencer.c:3823
+#: sequencer.c:3873
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Unerwartete 'stash'-Antwort: '%s'"
 
-#: sequencer.c:3829
+#: sequencer.c:3879
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "Konnte Verzeichnis für '%s' nicht erstellen."
 
-#: sequencer.c:3832
+#: sequencer.c:3882
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "Automatischen Stash erzeugt: %s\n"
 
-#: sequencer.c:3836
+#: sequencer.c:3886
 msgid "could not reset --hard"
 msgstr "Konnte 'reset --hard' nicht ausführen."
 
-#: sequencer.c:3861
+#: sequencer.c:3911
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "Automatischen Stash angewendet.\n"
 
-#: sequencer.c:3873
+#: sequencer.c:3923
 #, c-format
 msgid "cannot store %s"
 msgstr "kann %s nicht speichern"
 
-#: sequencer.c:3876
+#: sequencer.c:3926
 #, c-format
 msgid ""
 "%s\n"
@@ -7572,34 +7594,29 @@ msgstr ""
 "Ihre Änderungen sind im Stash sicher.\n"
 "Sie können jederzeit \"git stash pop\" oder \"git stash drop\" ausführen.\n"
 
-#: sequencer.c:3881
+#: sequencer.c:3931
 msgid "Applying autostash resulted in conflicts."
 msgstr "Beim Anwenden des automatischen Stash traten Konflikte auf."
 
-#: sequencer.c:3882
+#: sequencer.c:3932
 msgid "Autostash exists; creating a new stash entry."
 msgstr "Automatischer Stash existiert; ein neuer Stash-Eintrag wird erstellt."
 
-#: sequencer.c:3974
-#, c-format
-msgid "%s: not a valid OID"
-msgstr "%s: keine gültige OID"
-
-#: sequencer.c:3979 git-rebase--preserve-merges.sh:769
+#: sequencer.c:4025 git-rebase--preserve-merges.sh:769
 msgid "could not detach HEAD"
 msgstr "Konnte HEAD nicht loslösen"
 
-#: sequencer.c:3994
+#: sequencer.c:4040
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Angehalten bei HEAD\n"
 
-#: sequencer.c:3996
+#: sequencer.c:4042
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Angehalten bei %s\n"
 
-#: sequencer.c:4004
+#: sequencer.c:4050
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -7621,60 +7638,60 @@ msgstr ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:4050
+#: sequencer.c:4096
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr "Rebase (%d/%d)%s"
 
-#: sequencer.c:4095
+#: sequencer.c:4141
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Angehalten bei %s... %.*s\n"
 
-#: sequencer.c:4166
+#: sequencer.c:4212
 #, c-format
 msgid "unknown command %d"
 msgstr "Unbekannter Befehl %d"
 
-#: sequencer.c:4225
+#: sequencer.c:4271
 msgid "could not read orig-head"
 msgstr "Konnte orig-head nicht lesen."
 
-#: sequencer.c:4230
+#: sequencer.c:4276
 msgid "could not read 'onto'"
 msgstr "Konnte 'onto' nicht lesen."
 
-#: sequencer.c:4244
+#: sequencer.c:4290
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "Konnte HEAD nicht auf %s aktualisieren."
 
-#: sequencer.c:4304
+#: sequencer.c:4350
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr "Erfolgreich Rebase ausgeführt und %s aktualisiert.\n"
 
-#: sequencer.c:4337
+#: sequencer.c:4383
 msgid "cannot rebase: You have unstaged changes."
 msgstr ""
 "Rebase nicht möglich: Sie haben Änderungen, die nicht zum Commit\n"
 "vorgemerkt sind."
 
-#: sequencer.c:4346
+#: sequencer.c:4392
 msgid "cannot amend non-existing commit"
 msgstr "Kann nicht existierenden Commit nicht nachbessern."
 
-#: sequencer.c:4348
+#: sequencer.c:4394
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "Ungültige Datei: '%s'"
 
-#: sequencer.c:4350
+#: sequencer.c:4396
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "Ungültige Inhalte: '%s'"
 
-#: sequencer.c:4353
+#: sequencer.c:4399
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -7685,55 +7702,50 @@ msgstr ""
 "committen Sie diese zuerst und führen Sie dann 'git rebase --continue'\n"
 "erneut aus."
 
-#: sequencer.c:4389 sequencer.c:4428
+#: sequencer.c:4435 sequencer.c:4474
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "Konnte Datei nicht schreiben: '%s'"
 
-#: sequencer.c:4444
+#: sequencer.c:4490
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "Konnte CHERRY_PICK_HEAD nicht löschen."
 
-#: sequencer.c:4451
+#: sequencer.c:4497
 msgid "could not commit staged changes."
 msgstr "Konnte Änderungen aus der Staging-Area nicht committen."
 
-#: sequencer.c:4477
-#, c-format
-msgid "invalid committer '%s'"
-msgstr "ungültiger Commit-Ersteller '%s'"
-
-#: sequencer.c:4586
+#: sequencer.c:4613
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: %s kann nicht in \"cherry-pick\" benutzt werden"
 
-#: sequencer.c:4590
+#: sequencer.c:4617
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: ungültiger Commit"
 
-#: sequencer.c:4625
+#: sequencer.c:4652
 msgid "can't revert as initial commit"
 msgstr "Kann nicht als allerersten Commit einen Revert ausführen."
 
-#: sequencer.c:5102
+#: sequencer.c:5129
 msgid "make_script: unhandled options"
 msgstr "make_script: unbehandelte Optionen"
 
-#: sequencer.c:5105
+#: sequencer.c:5132
 msgid "make_script: error preparing revisions"
 msgstr "make_script: Fehler beim Vorbereiten der Commits"
 
-#: sequencer.c:5347 sequencer.c:5364
+#: sequencer.c:5374 sequencer.c:5391
 msgid "nothing to do"
 msgstr "Nichts zu tun."
 
-#: sequencer.c:5383
+#: sequencer.c:5410
 msgid "could not skip unnecessary pick commands"
 msgstr "Konnte unnötige \"pick\"-Befehle nicht auslassen."
 
-#: sequencer.c:5480
+#: sequencer.c:5504
 msgid "the script was already rearranged."
 msgstr "Das Script wurde bereits umgeordnet."
 
@@ -7902,264 +7914,264 @@ msgstr "fork fehlgeschlagen"
 msgid "setsid failed"
 msgstr "setsid fehlgeschlagen"
 
-#: sha1-file.c:470
+#: sha1-file.c:480
 #, c-format
 msgid "object directory %s does not exist; check .git/objects/info/alternates"
 msgstr ""
 "Objektverzeichnis %s existiert nicht; prüfe .git/objects/info/alternates"
 
-#: sha1-file.c:521
+#: sha1-file.c:531
 #, c-format
 msgid "unable to normalize alternate object path: %s"
 msgstr "Konnte alternativen Objektpfad '%s' nicht normalisieren."
 
-#: sha1-file.c:593
+#: sha1-file.c:603
 #, c-format
 msgid "%s: ignoring alternate object stores, nesting too deep"
 msgstr "%s: ignoriere alternative Objektspeicher - Verschachtelung zu tief"
 
-#: sha1-file.c:600
+#: sha1-file.c:610
 #, c-format
 msgid "unable to normalize object directory: %s"
 msgstr "Konnte Objektverzeichnis '%s' nicht normalisieren."
 
-#: sha1-file.c:643
+#: sha1-file.c:653
 msgid "unable to fdopen alternates lockfile"
 msgstr "Konnte fdopen nicht auf Lock-Datei für \"alternates\" aufrufen."
 
-#: sha1-file.c:661
+#: sha1-file.c:671
 msgid "unable to read alternates file"
 msgstr "Konnte \"alternates\"-Datei nicht lesen."
 
-#: sha1-file.c:668
+#: sha1-file.c:678
 msgid "unable to move new alternates file into place"
 msgstr "Konnte neue \"alternates\"-Datei nicht übernehmen."
 
-#: sha1-file.c:703
+#: sha1-file.c:713
 #, c-format
 msgid "path '%s' does not exist"
 msgstr "Pfad '%s' existiert nicht"
 
-#: sha1-file.c:724
+#: sha1-file.c:734
 #, c-format
 msgid "reference repository '%s' as a linked checkout is not supported yet."
 msgstr ""
 "Referenziertes Repository '%s' wird noch nicht als verknüpftes\n"
 "Arbeitsverzeichnis unterstützt."
 
-#: sha1-file.c:730
+#: sha1-file.c:740
 #, c-format
 msgid "reference repository '%s' is not a local repository."
 msgstr "Referenziertes Repository '%s' ist kein lokales Repository."
 
-#: sha1-file.c:736
+#: sha1-file.c:746
 #, c-format
 msgid "reference repository '%s' is shallow"
 msgstr ""
 "Referenziertes Repository '%s' hat eine unvollständige Historie (shallow)."
 
-#: sha1-file.c:744
+#: sha1-file.c:754
 #, c-format
 msgid "reference repository '%s' is grafted"
 msgstr ""
 "Referenziertes Repository '%s' ist mit künstlichen Vorgängern (\"grafts\") "
 "eingehängt."
 
-#: sha1-file.c:804
+#: sha1-file.c:814
 #, c-format
 msgid "invalid line while parsing alternate refs: %s"
 msgstr "Ungültige Zeile beim Parsen alternativer Referenzen: %s"
 
-#: sha1-file.c:954
+#: sha1-file.c:964
 #, c-format
 msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
 msgstr "Versuche mmap %<PRIuMAX> über Limit %<PRIuMAX>."
 
-#: sha1-file.c:975
+#: sha1-file.c:985
 msgid "mmap failed"
 msgstr "mmap fehlgeschlagen"
 
-#: sha1-file.c:1139
+#: sha1-file.c:1149
 #, c-format
 msgid "object file %s is empty"
 msgstr "Objektdatei %s ist leer."
 
-#: sha1-file.c:1274 sha1-file.c:2467
+#: sha1-file.c:1284 sha1-file.c:2477
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr "Fehlerhaftes loses Objekt '%s'."
 
-#: sha1-file.c:1276 sha1-file.c:2471
+#: sha1-file.c:1286 sha1-file.c:2481
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr "Nutzlose Daten am Ende von losem Objekt '%s'."
 
-#: sha1-file.c:1318
+#: sha1-file.c:1328
 msgid "invalid object type"
 msgstr "ungültiger Objekt-Typ"
 
-#: sha1-file.c:1402
+#: sha1-file.c:1412
 #, c-format
 msgid "unable to unpack %s header with --allow-unknown-type"
 msgstr "Konnte %s Kopfbereich nicht mit --allow-unknown-type entpacken."
 
-#: sha1-file.c:1405
+#: sha1-file.c:1415
 #, c-format
 msgid "unable to unpack %s header"
 msgstr "Konnte %s Kopfbereich nicht entpacken."
 
-#: sha1-file.c:1411
+#: sha1-file.c:1421
 #, c-format
 msgid "unable to parse %s header with --allow-unknown-type"
 msgstr "Konnte %s Kopfbereich mit --allow-unknown-type nicht parsen."
 
-#: sha1-file.c:1414
+#: sha1-file.c:1424
 #, c-format
 msgid "unable to parse %s header"
 msgstr "Konnte %s Kopfbereich nicht parsen."
 
-#: sha1-file.c:1641
+#: sha1-file.c:1651
 #, c-format
 msgid "failed to read object %s"
 msgstr "Konnte Objekt %s nicht lesen."
 
-#: sha1-file.c:1645
+#: sha1-file.c:1655
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr "Ersetzung %s für %s nicht gefunden."
 
-#: sha1-file.c:1649
+#: sha1-file.c:1659
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr "Loses Objekt %s (gespeichert in %s) ist beschädigt."
 
-#: sha1-file.c:1653
+#: sha1-file.c:1663
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr "Gepacktes Objekt %s (gespeichert in %s) ist beschädigt."
 
-#: sha1-file.c:1758
+#: sha1-file.c:1768
 #, c-format
 msgid "unable to write file %s"
 msgstr "Konnte Datei %s nicht schreiben."
 
-#: sha1-file.c:1765
+#: sha1-file.c:1775
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr "Konnte Zugriffsberechtigung auf '%s' nicht setzen."
 
-#: sha1-file.c:1772
+#: sha1-file.c:1782
 msgid "file write error"
 msgstr "Fehler beim Schreiben einer Datei."
 
-#: sha1-file.c:1792
+#: sha1-file.c:1802
 msgid "error when closing loose object file"
 msgstr "Fehler beim Schließen der Datei für lose Objekte."
 
-#: sha1-file.c:1857
+#: sha1-file.c:1867
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 "Unzureichende Berechtigung zum Hinzufügen eines Objektes zur Repository-"
 "Datenbank %s"
 
-#: sha1-file.c:1859
+#: sha1-file.c:1869
 msgid "unable to create temporary file"
 msgstr "Konnte temporäre Datei nicht erstellen."
 
-#: sha1-file.c:1883
+#: sha1-file.c:1893
 msgid "unable to write loose object file"
 msgstr "Fehler beim Schreiben der Datei für lose Objekte."
 
-#: sha1-file.c:1889
+#: sha1-file.c:1899
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr "Konnte neues Objekt %s (%d) nicht komprimieren."
 
-#: sha1-file.c:1893
+#: sha1-file.c:1903
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr "deflateEnd auf Objekt %s fehlgeschlagen (%d)"
 
-#: sha1-file.c:1897
+#: sha1-file.c:1907
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr "Fehler wegen instabilen Objektquelldaten für %s"
 
-#: sha1-file.c:1907 builtin/pack-objects.c:1086
+#: sha1-file.c:1917 builtin/pack-objects.c:1086
 #, c-format
 msgid "failed utime() on %s"
 msgstr "Fehler beim Aufruf von utime() auf '%s'."
 
-#: sha1-file.c:1984
+#: sha1-file.c:1994
 #, c-format
 msgid "cannot read object for %s"
 msgstr "Kann Objekt für %s nicht lesen."
 
-#: sha1-file.c:2035
+#: sha1-file.c:2045
 msgid "corrupt commit"
 msgstr "fehlerhafter Commit"
 
-#: sha1-file.c:2043
+#: sha1-file.c:2053
 msgid "corrupt tag"
 msgstr "fehlerhaftes Tag"
 
-#: sha1-file.c:2143
+#: sha1-file.c:2153
 #, c-format
 msgid "read error while indexing %s"
 msgstr "Lesefehler beim Indizieren von '%s'."
 
-#: sha1-file.c:2146
+#: sha1-file.c:2156
 #, c-format
 msgid "short read while indexing %s"
 msgstr "read() zu kurz beim Indizieren von '%s'."
 
-#: sha1-file.c:2219 sha1-file.c:2229
+#: sha1-file.c:2229 sha1-file.c:2239
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr "%s: Fehler beim Einfügen in die Datenbank"
 
-#: sha1-file.c:2235
+#: sha1-file.c:2245
 #, c-format
 msgid "%s: unsupported file type"
 msgstr "%s: nicht unterstützte Dateiart"
 
-#: sha1-file.c:2259
+#: sha1-file.c:2269
 #, c-format
 msgid "%s is not a valid object"
 msgstr "%s ist kein gültiges Objekt"
 
-#: sha1-file.c:2261
+#: sha1-file.c:2271
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr "%s ist kein gültiges '%s' Objekt"
 
-#: sha1-file.c:2288 builtin/index-pack.c:192
+#: sha1-file.c:2298 builtin/index-pack.c:192
 #, c-format
 msgid "unable to open %s"
 msgstr "kann %s nicht öffnen"
 
-#: sha1-file.c:2478 sha1-file.c:2531
+#: sha1-file.c:2488 sha1-file.c:2541
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
 msgstr "Hash für %s stimmt nicht überein (%s erwartet)."
 
-#: sha1-file.c:2502
+#: sha1-file.c:2512
 #, c-format
 msgid "unable to mmap %s"
 msgstr "Konnte mmap nicht auf %s ausführen."
 
-#: sha1-file.c:2507
+#: sha1-file.c:2517
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr "Konnte Kopfbereich von %s nicht entpacken."
 
-#: sha1-file.c:2513
+#: sha1-file.c:2523
 #, c-format
 msgid "unable to parse header of %s"
 msgstr "Konnte Kopfbereich von %s nicht parsen."
 
-#: sha1-file.c:2524
+#: sha1-file.c:2534
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr "Konnte Inhalt von %s nicht entpacken."
@@ -8318,8 +8330,8 @@ msgid_plural "%u bytes/s"
 msgstr[0] "%u Byte/s"
 msgstr[1] "%u Bytes/s"
 
-#: strbuf.c:1166 wrapper.c:199 wrapper.c:369 builtin/am.c:733
-#: builtin/rebase.c:858
+#: strbuf.c:1166 wrapper.c:199 wrapper.c:369 builtin/am.c:719
+#: builtin/rebase.c:864
 #, c-format
 msgid "could not open '%s' for writing"
 msgstr "Konnte '%s' nicht zum Schreiben öffnen."
@@ -8555,7 +8567,7 @@ msgstr "Ausführen des Anhang-Befehls '%s' fehlgeschlagen"
 msgid "unknown value '%s' for key '%s'"
 msgstr "unbekannter Wert '%s' für Schlüssel %s"
 
-#: trailer.c:537 trailer.c:542 builtin/remote.c:298 builtin/remote.c:323
+#: trailer.c:537 trailer.c:542 builtin/remote.c:299 builtin/remote.c:324
 #, c-format
 msgid "more than one %s"
 msgstr "mehr als ein %s"
@@ -8644,7 +8656,7 @@ msgstr "Konnte \"fast-import\" nicht ausführen."
 msgid "error while running fast-import"
 msgstr "Fehler beim Ausführen von 'fast-import'."
 
-#: transport-helper.c:549 transport-helper.c:1226
+#: transport-helper.c:549 transport-helper.c:1236
 #, c-format
 msgid "could not read ref %s"
 msgstr "Konnte Referenz %s nicht lesen."
@@ -8663,7 +8675,7 @@ msgstr ""
 msgid "invalid remote service path"
 msgstr "Ungültiger Remote-Service Pfad."
 
-#: transport-helper.c:661 transport.c:1428
+#: transport-helper.c:661 transport.c:1446
 msgid "operation not supported by protocol"
 msgstr "Die Operation wird von dem Protokoll nicht unterstützt."
 
@@ -8681,54 +8693,59 @@ msgstr "'option' ohne passende 'ok/error' Direktive"
 msgid "expected ok/error, helper said '%s'"
 msgstr "Erwartete ok/error, Remote-Helper gab '%s' aus."
 
-#: transport-helper.c:841
+#: transport-helper.c:845
 #, c-format
 msgid "helper reported unexpected status of %s"
 msgstr "Remote-Helper meldete unerwarteten Status von %s."
 
-#: transport-helper.c:924
+#: transport-helper.c:928
 #, c-format
 msgid "helper %s does not support dry-run"
 msgstr "Remote-Helper %s unterstützt kein Trockenlauf."
 
-#: transport-helper.c:927
+#: transport-helper.c:931
 #, c-format
 msgid "helper %s does not support --signed"
 msgstr "Remote-Helper %s unterstützt kein --signed."
 
-#: transport-helper.c:930
+#: transport-helper.c:934
 #, c-format
 msgid "helper %s does not support --signed=if-asked"
 msgstr "Remote-Helper %s unterstützt kein --signed=if-asked."
 
-#: transport-helper.c:935
+#: transport-helper.c:939
 #, c-format
 msgid "helper %s does not support --atomic"
 msgstr "Remote-Helper %s unterstützt kein --atomic."
 
-#: transport-helper.c:941
+#: transport-helper.c:943
+#, fuzzy, c-format
+msgid "helper %s does not support --%s"
+msgstr "Remote-Helper %s unterstützt kein --signed."
+
+#: transport-helper.c:950
 #, c-format
 msgid "helper %s does not support 'push-option'"
 msgstr "Remote-Helper %s unterstützt nicht 'push-option'."
 
-#: transport-helper.c:1040
+#: transport-helper.c:1050
 msgid "remote-helper doesn't support push; refspec needed"
 msgstr "Remote-Helper unterstützt kein Push; Refspec benötigt"
 
-#: transport-helper.c:1045
+#: transport-helper.c:1055
 #, c-format
 msgid "helper %s does not support 'force'"
 msgstr "Remote-Helper %s unterstützt kein 'force'."
 
-#: transport-helper.c:1092
+#: transport-helper.c:1102
 msgid "couldn't run fast-export"
 msgstr "Konnte \"fast-export\" nicht ausführen."
 
-#: transport-helper.c:1097
+#: transport-helper.c:1107
 msgid "error while running fast-export"
 msgstr "Fehler beim Ausführen von \"fast-export\"."
 
-#: transport-helper.c:1122
+#: transport-helper.c:1132
 #, c-format
 msgid ""
 "No refs in common and none specified; doing nothing.\n"
@@ -8737,52 +8754,52 @@ msgstr ""
 "Keine gemeinsamen Referenzen und nichts spezifiziert; keine Ausführung.\n"
 "Vielleicht sollten Sie einen Branch angeben.\n"
 
-#: transport-helper.c:1203
+#: transport-helper.c:1213
 #, c-format
 msgid "unsupported object format '%s'"
 msgstr "nicht unterstütztes Objekt-Format '%s'"
 
-#: transport-helper.c:1212
+#: transport-helper.c:1222
 #, c-format
 msgid "malformed response in ref list: %s"
 msgstr "Ungültige Antwort in Referenzliste: %s"
 
-#: transport-helper.c:1364
+#: transport-helper.c:1374
 #, c-format
 msgid "read(%s) failed"
 msgstr "Lesen von %s fehlgeschlagen."
 
-#: transport-helper.c:1391
+#: transport-helper.c:1401
 #, c-format
 msgid "write(%s) failed"
 msgstr "Schreiben von %s fehlgeschlagen."
 
-#: transport-helper.c:1440
+#: transport-helper.c:1450
 #, c-format
 msgid "%s thread failed"
 msgstr "Thread %s fehlgeschlagen."
 
-#: transport-helper.c:1444
+#: transport-helper.c:1454
 #, c-format
 msgid "%s thread failed to join: %s"
 msgstr "Fehler beim Beitreten zu Thread %s: %s"
 
-#: transport-helper.c:1463 transport-helper.c:1467
+#: transport-helper.c:1473 transport-helper.c:1477
 #, c-format
 msgid "can't start thread for copying data: %s"
 msgstr "Kann Thread zum Kopieren von Daten nicht starten: %s"
 
-#: transport-helper.c:1504
+#: transport-helper.c:1514
 #, c-format
 msgid "%s process failed to wait"
 msgstr "Fehler beim Warten von Prozess %s."
 
-#: transport-helper.c:1508
+#: transport-helper.c:1518
 #, c-format
 msgid "%s process failed"
 msgstr "Prozess %s fehlgeschlagen"
 
-#: transport-helper.c:1526 transport-helper.c:1535
+#: transport-helper.c:1536 transport-helper.c:1545
 msgid "can't start thread for copying data"
 msgstr "Kann Thread zum Kopieren von Daten nicht starten."
 
@@ -8809,29 +8826,29 @@ msgstr "Siehe protocol.version in 'git help config' für weitere Informationen"
 msgid "server options require protocol version 2 or later"
 msgstr "Server-Optionen benötigen Protokoll-Version 2 oder höher"
 
-#: transport.c:712
+#: transport.c:727
 msgid "could not parse transport.color.* config"
 msgstr "Konnte transport.color.* Konfiguration nicht parsen."
 
-#: transport.c:785
+#: transport.c:802
 msgid "support for protocol v2 not implemented yet"
 msgstr "Unterstützung für Protokoll v2 noch nicht implementiert."
 
-#: transport.c:919
+#: transport.c:936
 #, c-format
 msgid "unknown value for config '%s': %s"
 msgstr "Unbekannter Wert für Konfiguration '%s': %s"
 
-#: transport.c:985
+#: transport.c:1002
 #, c-format
 msgid "transport '%s' not allowed"
 msgstr "Übertragungsart '%s' nicht erlaubt."
 
-#: transport.c:1038
+#: transport.c:1055
 msgid "git-over-rsync is no longer supported"
 msgstr "git-over-rsync wird nicht länger unterstützt."
 
-#: transport.c:1140
+#: transport.c:1157
 #, c-format
 msgid ""
 "The following submodule paths contain changes that can\n"
@@ -8840,7 +8857,7 @@ msgstr ""
 "Die folgenden Submodul-Pfade enthalten Änderungen, die in keinem\n"
 "Remote-Repository gefunden wurden:\n"
 
-#: transport.c:1144
+#: transport.c:1161
 #, c-format
 msgid ""
 "\n"
@@ -8867,11 +8884,11 @@ msgstr ""
 "zum Versenden zu einem Remote-Repository.\n"
 "\n"
 
-#: transport.c:1152
+#: transport.c:1169
 msgid "Aborting."
 msgstr "Abbruch."
 
-#: transport.c:1297
+#: transport.c:1315
 msgid "failed to push all needed submodules"
 msgstr "Fehler beim Versand aller erforderlichen Submodule."
 
@@ -9165,7 +9182,7 @@ msgstr ""
 msgid "Updating index flags"
 msgstr "Aktualisiere Index-Markierungen"
 
-#: upload-pack.c:1516
+#: upload-pack.c:1550
 msgid "expected flush after fetch arguments"
 msgstr "erwartete Flush nach Abrufen der Argumente"
 
@@ -9202,7 +9219,7 @@ msgstr "ungültiges '..' Pfadsegment"
 msgid "Fetching objects"
 msgstr "Anfordern der Objekte"
 
-#: worktree.c:236 builtin/am.c:2116
+#: worktree.c:236 builtin/am.c:2103
 #, c-format
 msgid "failed to read '%s'"
 msgstr "Fehler beim Lesen von '%s'"
@@ -9849,7 +9866,7 @@ msgid "cannot %s: Your index contains uncommitted changes."
 msgstr ""
 "%s nicht möglich: Die Staging-Area enthält nicht committete Änderungen."
 
-#: compat/precompose_utf8.c:58 builtin/clone.c:456
+#: compat/precompose_utf8.c:58 builtin/clone.c:457
 #, c-format
 msgid "failed to unlink '%s'"
 msgstr "Konnte '%s' nicht entfernen."
@@ -9877,7 +9894,7 @@ msgid "Unstaged changes after refreshing the index:"
 msgstr ""
 "Nicht zum Commit vorgemerkte Änderungen nach Aktualisierung der Staging-Area:"
 
-#: builtin/add.c:272 builtin/rev-parse.c:904
+#: builtin/add.c:272 builtin/rev-parse.c:908
 msgid "Could not read the index"
 msgstr "Konnte den Index nicht lesen"
 
@@ -9915,8 +9932,8 @@ msgstr ""
 "ignoriert:\n"
 
 #: builtin/add.c:328 builtin/clean.c:904 builtin/fetch.c:166 builtin/mv.c:124
-#: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:538
-#: builtin/remote.c:1422 builtin/rm.c:242 builtin/send-pack.c:184
+#: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:559
+#: builtin/remote.c:1427 builtin/rm.c:242 builtin/send-pack.c:190
 msgid "dry run"
 msgstr "Probelauf"
 
@@ -9924,7 +9941,7 @@ msgstr "Probelauf"
 msgid "interactive picking"
 msgstr "interaktives Auswählen"
 
-#: builtin/add.c:332 builtin/checkout.c:1529 builtin/reset.c:308
+#: builtin/add.c:332 builtin/checkout.c:1547 builtin/reset.c:308
 msgid "select hunks interactively"
 msgstr "Blöcke interaktiv auswählen"
 
@@ -10062,15 +10079,15 @@ msgstr ""
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "--chmod Parameter '%s' muss entweder -x oder +x sein"
 
-#: builtin/add.c:507 builtin/checkout.c:1697 builtin/commit.c:351
-#: builtin/reset.c:328 builtin/rm.c:272 builtin/stash.c:1503
+#: builtin/add.c:507 builtin/checkout.c:1715 builtin/commit.c:351
+#: builtin/reset.c:328 builtin/rm.c:272 builtin/stash.c:1502
 msgid "--pathspec-from-file is incompatible with pathspec arguments"
 msgstr ""
 "Die Option --pathspec-from-file ist inkompatibel mit\n"
 "Pfadspezifikation-Argumenten."
 
-#: builtin/add.c:514 builtin/checkout.c:1709 builtin/commit.c:357
-#: builtin/reset.c:334 builtin/rm.c:278 builtin/stash.c:1509
+#: builtin/add.c:514 builtin/checkout.c:1727 builtin/commit.c:357
+#: builtin/reset.c:334 builtin/rm.c:278 builtin/stash.c:1508
 msgid "--pathspec-file-nul requires --pathspec-from-file"
 msgstr "Die Option --pathspec-file-nul benötigt --pathspec-from-file"
 
@@ -10089,121 +10106,116 @@ msgstr ""
 "Um diese Meldung abzuschalten, führen Sie folgenden Befehl aus:\n"
 "\"git config advice.addEmptyPathspec false\""
 
-#: builtin/am.c:160
-#, c-format
-msgid "invalid committer: %s"
-msgstr "ungültiger Commit-Ersteller: %s"
-
-#: builtin/am.c:366
+#: builtin/am.c:352
 msgid "could not parse author script"
 msgstr "konnte Autor-Skript nicht parsen"
 
-#: builtin/am.c:450
+#: builtin/am.c:436
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
 msgstr "'%s' wurde durch den applypatch-msg Hook entfernt"
 
-#: builtin/am.c:492
+#: builtin/am.c:478
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr "Fehlerhafte Eingabezeile: '%s'."
 
-#: builtin/am.c:530
+#: builtin/am.c:516
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
 msgstr "Fehler beim Kopieren der Notizen von '%s' nach '%s'"
 
-#: builtin/am.c:556
+#: builtin/am.c:542
 msgid "fseek failed"
 msgstr "\"fseek\" fehlgeschlagen"
 
-#: builtin/am.c:744
+#: builtin/am.c:730
 #, c-format
 msgid "could not parse patch '%s'"
 msgstr "konnte Patch '%s' nicht parsen"
 
-#: builtin/am.c:809
+#: builtin/am.c:795
 msgid "Only one StGIT patch series can be applied at once"
 msgstr "Es kann nur eine StGIT Patch-Serie auf einmal angewendet werden."
 
-#: builtin/am.c:857
+#: builtin/am.c:843
 msgid "invalid timestamp"
 msgstr "ungültiger Zeitstempel"
 
-#: builtin/am.c:862 builtin/am.c:874
+#: builtin/am.c:848 builtin/am.c:860
 msgid "invalid Date line"
 msgstr "Ungültige \"Date\"-Zeile"
 
-#: builtin/am.c:869
+#: builtin/am.c:855
 msgid "invalid timezone offset"
 msgstr "Ungültiger Offset in der Zeitzone"
 
-#: builtin/am.c:962
+#: builtin/am.c:948
 msgid "Patch format detection failed."
 msgstr "Patch-Formaterkennung fehlgeschlagen."
 
-#: builtin/am.c:967 builtin/clone.c:409
+#: builtin/am.c:953 builtin/clone.c:410
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "Fehler beim Erstellen von Verzeichnis '%s'"
 
-#: builtin/am.c:972
+#: builtin/am.c:958
 msgid "Failed to split patches."
 msgstr "Fehler beim Aufteilen der Patches."
 
-#: builtin/am.c:1103
+#: builtin/am.c:1089
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\"."
 msgstr ""
 "Wenn Sie das Problem aufgelöst haben, führen Sie \"%s --continue\" aus."
 
-#: builtin/am.c:1104
+#: builtin/am.c:1090
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
 msgstr ""
 "Falls Sie diesen Patch auslassen möchten, führen Sie stattdessen \"%s --skip"
 "\" aus."
 
-#: builtin/am.c:1105
+#: builtin/am.c:1091
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr ""
 "Um den ursprünglichen Branch wiederherzustellen und die Anwendung der "
 "Patches abzubrechen, führen Sie \"%s --abort\" aus."
 
-#: builtin/am.c:1188
+#: builtin/am.c:1174
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
 "Patch mit format=flowed versendet; Leerzeichen am Ende von Zeilen könnte "
 "verloren gehen."
 
-#: builtin/am.c:1216
+#: builtin/am.c:1202
 msgid "Patch is empty."
 msgstr "Patch ist leer."
 
-#: builtin/am.c:1281
+#: builtin/am.c:1267
 #, c-format
 msgid "missing author line in commit %s"
 msgstr "Autor-Zeile fehlt in Commit %s"
 
-#: builtin/am.c:1284
+#: builtin/am.c:1270
 #, c-format
 msgid "invalid ident line: %.*s"
 msgstr "Ungültige Identifikationszeile: %.*s"
 
-#: builtin/am.c:1503
+#: builtin/am.c:1489
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
 "Dem Repository fehlen notwendige Blobs um auf einen 3-Wege-Merge "
 "zurückzufallen."
 
-#: builtin/am.c:1505
+#: builtin/am.c:1491
 msgid "Using index info to reconstruct a base tree..."
 msgstr ""
 "Verwende Informationen aus der Staging-Area, um ein Basisverzeichnis "
 "nachzustellen ..."
 
-#: builtin/am.c:1524
+#: builtin/am.c:1510
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
@@ -10211,24 +10223,24 @@ msgstr ""
 "Haben Sie den Patch per Hand editiert?\n"
 "Er kann nicht auf die Blobs in seiner 'index' Zeile angewendet werden."
 
-#: builtin/am.c:1530
+#: builtin/am.c:1516
 msgid "Falling back to patching base and 3-way merge..."
 msgstr "Falle zurück zum Patchen der Basis und zum 3-Wege-Merge ..."
 
-#: builtin/am.c:1556
+#: builtin/am.c:1542
 msgid "Failed to merge in the changes."
 msgstr "Merge der Änderungen fehlgeschlagen."
 
-#: builtin/am.c:1588
+#: builtin/am.c:1574
 msgid "applying to an empty history"
 msgstr "auf leere Historie anwenden"
 
-#: builtin/am.c:1639 builtin/am.c:1643
+#: builtin/am.c:1626 builtin/am.c:1630
 #, c-format
 msgid "cannot resume: %s does not exist."
 msgstr "Kann nicht fortsetzen: %s existiert nicht"
 
-#: builtin/am.c:1661
+#: builtin/am.c:1648
 msgid "Commit Body is:"
 msgstr "Commit-Beschreibung ist:"
 
@@ -10236,41 +10248,41 @@ msgstr "Commit-Beschreibung ist:"
 #. in your translation. The program will only accept English
 #. input at this point.
 #.
-#: builtin/am.c:1671
+#: builtin/am.c:1658
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr "Anwenden? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 
-#: builtin/am.c:1717 builtin/commit.c:395
+#: builtin/am.c:1704 builtin/commit.c:395
 msgid "unable to write index file"
 msgstr "Konnte Index-Datei nicht schreiben."
 
-#: builtin/am.c:1721
+#: builtin/am.c:1708
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
 msgstr "Geänderter Index: kann Patches nicht anwenden (geändert: %s)"
 
-#: builtin/am.c:1761 builtin/am.c:1829
+#: builtin/am.c:1748 builtin/am.c:1816
 #, c-format
 msgid "Applying: %.*s"
 msgstr "Wende an: %.*s"
 
-#: builtin/am.c:1778
+#: builtin/am.c:1765
 msgid "No changes -- Patch already applied."
 msgstr "Keine Änderungen -- Patches bereits angewendet."
 
-#: builtin/am.c:1784
+#: builtin/am.c:1771
 #, c-format
 msgid "Patch failed at %s %.*s"
 msgstr "Anwendung des Patches fehlgeschlagen bei %s %.*s"
 
-#: builtin/am.c:1788
+#: builtin/am.c:1775
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr ""
 "Benutzen Sie 'git am --show-current-patch=diff', um den\n"
 "fehlgeschlagenen Patch zu sehen"
 
-#: builtin/am.c:1832
+#: builtin/am.c:1819
 msgid ""
 "No changes - did you forget to use 'git add'?\n"
 "If there is nothing left to stage, chances are that something else\n"
@@ -10281,7 +10293,7 @@ msgstr ""
 "diese bereits anderweitig eingefügt worden sein; Sie könnten diesen Patch\n"
 "auslassen."
 
-#: builtin/am.c:1839
+#: builtin/am.c:1826
 msgid ""
 "You still have unmerged paths in your index.\n"
 "You should 'git add' each file with resolved conflicts to mark them as "
@@ -10294,17 +10306,17 @@ msgstr ""
 "Sie können 'git rm' auf Dateien ausführen, um \"von denen gelöscht\" für\n"
 "diese zu akzeptieren."
 
-#: builtin/am.c:1946 builtin/am.c:1950 builtin/am.c:1962 builtin/reset.c:347
+#: builtin/am.c:1933 builtin/am.c:1937 builtin/am.c:1949 builtin/reset.c:347
 #: builtin/reset.c:355
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "Konnte Objekt '%s' nicht parsen."
 
-#: builtin/am.c:1998
+#: builtin/am.c:1985
 msgid "failed to clean index"
 msgstr "Fehler beim Bereinigen des Index"
 
-#: builtin/am.c:2042
+#: builtin/am.c:2029
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
@@ -10312,156 +10324,157 @@ msgstr ""
 "Sie scheinen seit dem letzten gescheiterten 'am' HEAD geändert zu haben.\n"
 "Keine Zurücksetzung zu ORIG_HEAD."
 
-#: builtin/am.c:2149
+#: builtin/am.c:2136
 #, c-format
 msgid "Invalid value for --patch-format: %s"
 msgstr "Ungültiger Wert für --patch-format: %s"
 
-#: builtin/am.c:2191
+#: builtin/am.c:2178
 #, c-format
 msgid "Invalid value for --show-current-patch: %s"
 msgstr "Ungültiger Wert für --show-current-patch: %s"
 
-#: builtin/am.c:2195
+#: builtin/am.c:2182
 #, c-format
 msgid "--show-current-patch=%s is incompatible with --show-current-patch=%s"
 msgstr "--show-current-patch=%s ist inkombatibel mit --show-current-patch=%s"
 
-#: builtin/am.c:2226
+#: builtin/am.c:2213
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
 msgstr "git am [<Optionen>] [(<mbox> | <E-Mail-Verzeichnis>)...]"
 
-#: builtin/am.c:2227
+#: builtin/am.c:2214
 msgid "git am [<options>] (--continue | --skip | --abort)"
 msgstr "git am [<Optionen>] (--continue | --skip | --abort)"
 
-#: builtin/am.c:2233
+#: builtin/am.c:2220
 msgid "run interactively"
 msgstr "interaktiv ausführen"
 
-#: builtin/am.c:2235
+#: builtin/am.c:2222
 msgid "historical option -- no-op"
 msgstr "historische Option -- kein Effekt"
 
-#: builtin/am.c:2237
+#: builtin/am.c:2224
 msgid "allow fall back on 3way merging if needed"
 msgstr "erlaube, falls notwendig, das Zurückfallen auf einen 3-Wege-Merge"
 
-#: builtin/am.c:2238 builtin/init-db.c:558 builtin/prune-packed.c:16
-#: builtin/repack.c:309 builtin/stash.c:816
+#: builtin/am.c:2225 builtin/init-db.c:558 builtin/prune-packed.c:16
+#: builtin/repack.c:335 builtin/stash.c:815
 msgid "be quiet"
 msgstr "weniger Ausgaben"
 
-#: builtin/am.c:2240
-msgid "add a Signed-off-by line to the commit message"
+#: builtin/am.c:2227
+#, fuzzy
+msgid "add a Signed-off-by trailer to the commit message"
 msgstr "der Commit-Beschreibung eine Signed-off-by Zeile hinzufügen"
 
-#: builtin/am.c:2243
+#: builtin/am.c:2230
 msgid "recode into utf8 (default)"
 msgstr "nach UTF-8 umkodieren (Standard)"
 
-#: builtin/am.c:2245
+#: builtin/am.c:2232
 msgid "pass -k flag to git-mailinfo"
 msgstr "-k an git-mailinfo übergeben"
 
-#: builtin/am.c:2247
+#: builtin/am.c:2234
 msgid "pass -b flag to git-mailinfo"
 msgstr "-b an git-mailinfo übergeben"
 
-#: builtin/am.c:2249
+#: builtin/am.c:2236
 msgid "pass -m flag to git-mailinfo"
 msgstr "-m an git-mailinfo übergeben"
 
-#: builtin/am.c:2251
+#: builtin/am.c:2238
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
 msgstr "--keep-cr an git-mailsplit für mbox-Format übergeben"
 
-#: builtin/am.c:2254
+#: builtin/am.c:2241
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr "kein --keep-cr an git-mailsplit übergeben, unabhängig von am.keepcr"
 
-#: builtin/am.c:2257
+#: builtin/am.c:2244
 msgid "strip everything before a scissors line"
 msgstr "alles vor einer Scheren-Zeile entfernen"
 
-#: builtin/am.c:2259 builtin/am.c:2262 builtin/am.c:2265 builtin/am.c:2268
-#: builtin/am.c:2271 builtin/am.c:2274 builtin/am.c:2277 builtin/am.c:2280
-#: builtin/am.c:2286
+#: builtin/am.c:2246 builtin/am.c:2249 builtin/am.c:2252 builtin/am.c:2255
+#: builtin/am.c:2258 builtin/am.c:2261 builtin/am.c:2264 builtin/am.c:2267
+#: builtin/am.c:2273
 msgid "pass it through git-apply"
 msgstr "an git-apply übergeben"
 
-#: builtin/am.c:2276 builtin/commit.c:1395 builtin/fmt-merge-msg.c:17
-#: builtin/fmt-merge-msg.c:20 builtin/grep.c:892 builtin/merge.c:251
+#: builtin/am.c:2263 builtin/commit.c:1395 builtin/fmt-merge-msg.c:17
+#: builtin/fmt-merge-msg.c:20 builtin/grep.c:903 builtin/merge.c:260
 #: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
-#: builtin/rebase.c:1335 builtin/repack.c:320 builtin/repack.c:324
-#: builtin/repack.c:326 builtin/show-branch.c:650 builtin/show-ref.c:172
+#: builtin/rebase.c:1341 builtin/repack.c:346 builtin/repack.c:350
+#: builtin/repack.c:352 builtin/show-branch.c:650 builtin/show-ref.c:172
 #: builtin/tag.c:404 parse-options.h:154 parse-options.h:175
 #: parse-options.h:316
 msgid "n"
 msgstr "Anzahl"
 
-#: builtin/am.c:2282 builtin/branch.c:659 builtin/bugreport.c:135
+#: builtin/am.c:2269 builtin/branch.c:659 builtin/bugreport.c:136
 #: builtin/for-each-ref.c:38 builtin/replace.c:556 builtin/tag.c:438
 #: builtin/verify-tag.c:38
 msgid "format"
 msgstr "Format"
 
-#: builtin/am.c:2283
+#: builtin/am.c:2270
 msgid "format the patch(es) are in"
 msgstr "Patch-Format"
 
-#: builtin/am.c:2289
+#: builtin/am.c:2276
 msgid "override error message when patch failure occurs"
 msgstr "Meldung bei fehlerhafter Patch-Anwendung überschreiben"
 
-#: builtin/am.c:2291
+#: builtin/am.c:2278
 msgid "continue applying patches after resolving a conflict"
 msgstr "Anwendung der Patches nach Auflösung eines Konfliktes fortsetzen"
 
-#: builtin/am.c:2294
+#: builtin/am.c:2281
 msgid "synonyms for --continue"
 msgstr "Synonyme für --continue"
 
-#: builtin/am.c:2297
+#: builtin/am.c:2284
 msgid "skip the current patch"
 msgstr "den aktuellen Patch auslassen"
 
-#: builtin/am.c:2300
+#: builtin/am.c:2287
 msgid "restore the original branch and abort the patching operation."
 msgstr ""
 "ursprünglichen Branch wiederherstellen und Anwendung der Patches abbrechen"
 
-#: builtin/am.c:2303
+#: builtin/am.c:2290
 msgid "abort the patching operation but keep HEAD where it is."
 msgstr "Patch-Operation abbrechen, aber HEAD an aktueller Stelle belassen"
 
-#: builtin/am.c:2307
+#: builtin/am.c:2294
 msgid "show the patch being applied"
 msgstr "den Patch, der gerade angewendet wird, anzeigen"
 
-#: builtin/am.c:2312
+#: builtin/am.c:2299
 msgid "lie about committer date"
 msgstr "Autor-Datum als Commit-Datum verwenden"
 
-#: builtin/am.c:2314
+#: builtin/am.c:2301
 msgid "use current timestamp for author date"
 msgstr "aktuellen Zeitstempel als Autor-Datum verwenden"
 
-#: builtin/am.c:2316 builtin/commit-tree.c:120 builtin/commit.c:1515
-#: builtin/merge.c:288 builtin/pull.c:175 builtin/rebase.c:530
-#: builtin/rebase.c:1388 builtin/revert.c:117 builtin/tag.c:419
+#: builtin/am.c:2303 builtin/commit-tree.c:120 builtin/commit.c:1515
+#: builtin/merge.c:297 builtin/pull.c:175 builtin/rebase.c:536
+#: builtin/rebase.c:1394 builtin/revert.c:117 builtin/tag.c:419
 msgid "key-id"
 msgstr "GPG-Schlüsselkennung"
 
-#: builtin/am.c:2317 builtin/rebase.c:531 builtin/rebase.c:1389
+#: builtin/am.c:2304 builtin/rebase.c:537 builtin/rebase.c:1395
 msgid "GPG-sign commits"
 msgstr "Commits mit GPG signieren"
 
-#: builtin/am.c:2320
+#: builtin/am.c:2307
 msgid "(internal use for git-rebase)"
 msgstr "(intern für git-rebase verwendet)"
 
-#: builtin/am.c:2338
+#: builtin/am.c:2325
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
@@ -10469,16 +10482,16 @@ msgstr ""
 "Die -b/--binary Option hat seit Langem keinen Effekt und wird\n"
 "entfernt. Bitte verwenden Sie diese nicht mehr."
 
-#: builtin/am.c:2345
+#: builtin/am.c:2332
 msgid "failed to read the index"
 msgstr "Fehler beim Lesen des Index"
 
-#: builtin/am.c:2360
+#: builtin/am.c:2347
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr "Vorheriges Rebase-Verzeichnis %s existiert noch, aber mbox gegeben."
 
-#: builtin/am.c:2384
+#: builtin/am.c:2371
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
@@ -10487,11 +10500,11 @@ msgstr ""
 "Stray %s Verzeichnis gefunden.\n"
 "Benutzen Sie \"git am --abort\", um es zu entfernen."
 
-#: builtin/am.c:2390
+#: builtin/am.c:2377
 msgid "Resolve operation not in progress, we are not resuming."
 msgstr "Es ist keine Auflösung im Gange, es wird nicht fortgesetzt."
 
-#: builtin/am.c:2400
+#: builtin/am.c:2387
 msgid "interactive mode requires patches on the command line"
 msgstr "Interaktiver Modus benötigt Patches über die Kommandozeile"
 
@@ -10530,22 +10543,10 @@ msgid "git archive: expected a flush"
 msgstr "git archive: erwartete eine Spülung (flush)"
 
 #: builtin/bisect--helper.c:23
-msgid "git bisect--helper --next-all"
-msgstr "git bisect--helper --next-all"
-
-#: builtin/bisect--helper.c:24
-msgid "git bisect--helper --write-terms <bad_term> <good_term>"
-msgstr "git bisect--helper --write-terms <bad_term> <good_term>"
-
-#: builtin/bisect--helper.c:25
-msgid "git bisect--helper --bisect-clean-state"
-msgstr "git bisect--helper --bisect-clean-state"
-
-#: builtin/bisect--helper.c:26
 msgid "git bisect--helper --bisect-reset [<commit>]"
 msgstr "git bisect--helper --bisect-reset [<Commit>]"
 
-#: builtin/bisect--helper.c:27
+#: builtin/bisect--helper.c:24
 msgid ""
 "git bisect--helper --bisect-write [--no-log] <state> <revision> <good_term> "
 "<bad_term>"
@@ -10553,7 +10554,7 @@ msgstr ""
 "git bisect--helper --bisect-write [--no-log] <Zustand> <Revision> "
 "<Begriff_gut> <Begriff_schlecht>"
 
-#: builtin/bisect--helper.c:28
+#: builtin/bisect--helper.c:25
 msgid ""
 "git bisect--helper --bisect-check-and-set-terms <command> <good_term> "
 "<bad_term>"
@@ -10561,13 +10562,13 @@ msgstr ""
 "git bisect--helper --bisect-check-and-set-terms <Befehl> <Begriff_gut> "
 "<Begriff_schlecht>"
 
-#: builtin/bisect--helper.c:29
+#: builtin/bisect--helper.c:26
 msgid "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
 msgstr ""
 "git bisect--helper --bisect-next-check <Begriff_gut> <Begriff_schlecht> "
 "[<Begriff>]"
 
-#: builtin/bisect--helper.c:30
+#: builtin/bisect--helper.c:27
 msgid ""
 "git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
 "term-new]"
@@ -10575,7 +10576,7 @@ msgstr ""
 "git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
 "term-new]"
 
-#: builtin/bisect--helper.c:31
+#: builtin/bisect--helper.c:28
 msgid ""
 "git bisect--helper --bisect-start [--term-{new,bad}=<term> --term-{old,good}"
 "=<term>] [--no-checkout] [--first-parent] [<bad> [<good>...]] [--] "
@@ -10585,58 +10586,64 @@ msgstr ""
 "good}=<Begriff>] [--no-checkout] [--first-parent] [<schlecht> [<gut>...]] "
 "[--] [<Pfade>...]"
 
-#: builtin/bisect--helper.c:33
+#: builtin/bisect--helper.c:30
 msgid "git bisect--helper --bisect-next"
 msgstr "git bisect--helper --bisect-next"
 
-#: builtin/bisect--helper.c:34
+#: builtin/bisect--helper.c:31
 msgid "git bisect--helper --bisect-auto-next"
 msgstr "git bisect--helper --bisect-auto-next"
 
-#: builtin/bisect--helper.c:35
-msgid "git bisect--helper --bisect-autostart"
-msgstr "git bisect--helper --bisect-autostart"
+#: builtin/bisect--helper.c:32
+#, fuzzy
+msgid "git bisect--helper --bisect-state (bad|new) [<rev>]"
+msgstr "git bisect--helper --bisect-reset [<Commit>]"
 
-#: builtin/bisect--helper.c:97
+#: builtin/bisect--helper.c:33
+#, fuzzy
+msgid "git bisect--helper --bisect-state (good|old) [<rev>...]"
+msgstr "git bisect--helper --bisect-reset [<Commit>]"
+
+#: builtin/bisect--helper.c:108
 #, c-format
 msgid "cannot open file '%s' in mode '%s'"
 msgstr "kann Datei '%s' nicht im Modus '%s' öffnen"
 
-#: builtin/bisect--helper.c:104
+#: builtin/bisect--helper.c:115
 #, c-format
 msgid "could not write to file '%s'"
 msgstr "konnte nicht in Datei '%s' schreiben"
 
-#: builtin/bisect--helper.c:143
+#: builtin/bisect--helper.c:154
 #, c-format
 msgid "'%s' is not a valid term"
 msgstr "'%s' ist kein gültiger Begriff"
 
-#: builtin/bisect--helper.c:147
+#: builtin/bisect--helper.c:158
 #, c-format
 msgid "can't use the builtin command '%s' as a term"
 msgstr "kann den eingebauten Befehl '%s' nicht als Begriff verwenden"
 
-#: builtin/bisect--helper.c:157
+#: builtin/bisect--helper.c:168
 #, c-format
 msgid "can't change the meaning of the term '%s'"
 msgstr "kann die Bedeutung von dem Begriff '%s' nicht ändern"
 
-#: builtin/bisect--helper.c:167
+#: builtin/bisect--helper.c:178
 msgid "please use two different terms"
 msgstr "bitte verwenden Sie zwei verschiedene Begriffe"
 
-#: builtin/bisect--helper.c:207
+#: builtin/bisect--helper.c:194
 #, c-format
 msgid "We are not bisecting.\n"
 msgstr "Keine binäre Suche im Gange.\n"
 
-#: builtin/bisect--helper.c:215
+#: builtin/bisect--helper.c:202
 #, c-format
 msgid "'%s' is not a valid commit"
 msgstr "'%s' ist kein gültiger Commit"
 
-#: builtin/bisect--helper.c:224
+#: builtin/bisect--helper.c:211
 #, c-format
 msgid ""
 "could not check out original HEAD '%s'. Try 'git bisect reset <commit>'."
@@ -10644,27 +10651,27 @@ msgstr ""
 "Konnte den ursprünglichen HEAD '%s' nicht auschecken.\n"
 "Versuchen Sie 'git bisect reset <Commit>'."
 
-#: builtin/bisect--helper.c:268
+#: builtin/bisect--helper.c:255
 #, c-format
 msgid "Bad bisect_write argument: %s"
 msgstr "Ungültiges \"bisect_write\" Argument: %s"
 
-#: builtin/bisect--helper.c:273
+#: builtin/bisect--helper.c:260
 #, c-format
 msgid "couldn't get the oid of the rev '%s'"
 msgstr "Konnte die OID der Revision '%s' nicht erhalten."
 
-#: builtin/bisect--helper.c:285
+#: builtin/bisect--helper.c:272
 #, c-format
 msgid "couldn't open the file '%s'"
 msgstr "Konnte die Datei '%s' nicht öffnen."
 
-#: builtin/bisect--helper.c:311
+#: builtin/bisect--helper.c:298
 #, c-format
 msgid "Invalid command: you're currently in a %s/%s bisect"
 msgstr "Ungültiger Befehl: Sie sind gerade bei einer binären %s/%s Suche."
 
-#: builtin/bisect--helper.c:338
+#: builtin/bisect--helper.c:325
 #, c-format
 msgid ""
 "You need to give me at least one %s and %s revision.\n"
@@ -10673,7 +10680,7 @@ msgstr ""
 "Sie müssen mindestens einen \"%s\" und einen \"%s\" Commit angeben.\n"
 "Sie können dafür \"git bisect %s\" und \"git bisect %s\" benutzen."
 
-#: builtin/bisect--helper.c:342
+#: builtin/bisect--helper.c:329
 #, c-format
 msgid ""
 "You need to start by \"git bisect start\".\n"
@@ -10684,7 +10691,7 @@ msgstr ""
 "Danach müssen Sie mindestens einen \"%s\" und einen \"%s\" Commit angeben.\n"
 "Sie können dafür \"git bisect %s\" und \"git bisect %s\" benutzen."
 
-#: builtin/bisect--helper.c:362
+#: builtin/bisect--helper.c:349
 #, c-format
 msgid "bisecting only with a %s commit"
 msgstr "Binäre Suche nur mit einem %s Commit."
@@ -10693,15 +10700,15 @@ msgstr "Binäre Suche nur mit einem %s Commit."
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:370
+#: builtin/bisect--helper.c:357
 msgid "Are you sure [Y/n]? "
 msgstr "Sind Sie sicher [Y/n]? "
 
-#: builtin/bisect--helper.c:431
+#: builtin/bisect--helper.c:418
 msgid "no terms defined"
 msgstr "Keine Begriffe definiert."
 
-#: builtin/bisect--helper.c:434
+#: builtin/bisect--helper.c:421
 #, c-format
 msgid ""
 "Your current terms are %s for the old state\n"
@@ -10710,7 +10717,7 @@ msgstr ""
 "Ihre aktuellen Begriffe sind %s für den alten Zustand\n"
 "und %s für den neuen Zustand.\n"
 
-#: builtin/bisect--helper.c:444
+#: builtin/bisect--helper.c:431
 #, c-format
 msgid ""
 "invalid argument %s for 'git bisect terms'.\n"
@@ -10719,55 +10726,55 @@ msgstr ""
 "Ungültiges Argument %s für 'git bisect terms'.\n"
 "Unterstützte Optionen sind: --term-good|--term-old und --term-bad|--term-new."
 
-#: builtin/bisect--helper.c:511
+#: builtin/bisect--helper.c:498
 msgid "revision walk setup failed\n"
 msgstr "Einrichtung des Revisionsgangs fehlgeschlagen\n"
 
-#: builtin/bisect--helper.c:533
+#: builtin/bisect--helper.c:520
 #, c-format
 msgid "could not open '%s' for appending"
 msgstr "konnte '%s' nicht zum Anhängen öffnen"
 
-#: builtin/bisect--helper.c:651 builtin/bisect--helper.c:664
+#: builtin/bisect--helper.c:639 builtin/bisect--helper.c:652
 msgid "'' is not a valid term"
 msgstr "'' ist kein gültiger Begriff"
 
-#: builtin/bisect--helper.c:674
+#: builtin/bisect--helper.c:662
 #, c-format
 msgid "unrecognized option: '%s'"
 msgstr "nicht erkannte Option: '%s'"
 
-#: builtin/bisect--helper.c:678
+#: builtin/bisect--helper.c:666
 #, c-format
 msgid "'%s' does not appear to be a valid revision"
 msgstr "'%s' scheint kein gültiger Commit zu sein"
 
-#: builtin/bisect--helper.c:709
+#: builtin/bisect--helper.c:697
 msgid "bad HEAD - I need a HEAD"
 msgstr "ungültiger HEAD - HEAD wird benötigt"
 
-#: builtin/bisect--helper.c:724
+#: builtin/bisect--helper.c:712
 #, c-format
 msgid "checking out '%s' failed. Try 'git bisect start <valid-branch>'."
 msgstr ""
 "Auschecken von '%s' fehlgeschlagen. Versuchen Sie 'git bisect start "
 "<gültiger-Branch>'."
 
-#: builtin/bisect--helper.c:745
+#: builtin/bisect--helper.c:733
 msgid "won't bisect on cg-seek'ed tree"
 msgstr ""
 "binäre Suche auf einem durch 'cg-seek' geändertem Verzeichnis nicht möglich"
 
-#: builtin/bisect--helper.c:748
+#: builtin/bisect--helper.c:736
 msgid "bad HEAD - strange symbolic ref"
 msgstr "ungültiger HEAD - merkwürdige symbolische Referenz"
 
-#: builtin/bisect--helper.c:775
+#: builtin/bisect--helper.c:756
 #, c-format
 msgid "invalid ref: '%s'"
 msgstr "ungültige Referenz: '%s'"
 
-#: builtin/bisect--helper.c:827
+#: builtin/bisect--helper.c:814
 msgid "You need to start by \"git bisect start\"\n"
 msgstr "Sie müssen mit \"git bisect start\" beginnen\n"
 
@@ -10775,107 +10782,93 @@ msgstr "Sie müssen mit \"git bisect start\" beginnen\n"
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:838
+#: builtin/bisect--helper.c:825
 msgid "Do you want me to do it for you [Y/n]? "
 msgstr "Wollen Sie, dass ich es für Sie mache [Y/n]? "
 
-#: builtin/bisect--helper.c:866
-msgid "perform 'git bisect next'"
-msgstr "'git bisect next' ausführen"
+#: builtin/bisect--helper.c:843
+msgid "Please call `--bisect-state` with at least one argument"
+msgstr ""
 
-#: builtin/bisect--helper.c:868
-msgid "write the terms to .git/BISECT_TERMS"
-msgstr "die Begriffe nach .git/BISECT_TERMS schreiben"
+#: builtin/bisect--helper.c:856
+#, fuzzy, c-format
+msgid "'git bisect %s' can take only one argument."
+msgstr "'git bisect $TERM_BAD' kann nur ein Argument entgegennehmen."
 
-#: builtin/bisect--helper.c:870
-msgid "cleanup the bisection state"
-msgstr "den Zustand der binären Suche aufräumen"
+#: builtin/bisect--helper.c:868 builtin/bisect--helper.c:879
+#, fuzzy, c-format
+msgid "Bad rev input: %s"
+msgstr "Ungültige Referenz-Eingabe: $arg"
 
-#: builtin/bisect--helper.c:872
-msgid "check for expected revs"
-msgstr "auf erwartete Commits prüfen"
-
-#: builtin/bisect--helper.c:874
+#: builtin/bisect--helper.c:924
 msgid "reset the bisection state"
 msgstr "den Zustand der binären Suche zurücksetzen"
 
-#: builtin/bisect--helper.c:876
+#: builtin/bisect--helper.c:926
 msgid "write out the bisection state in BISECT_LOG"
 msgstr "den Zustand der binären Suche nach BISECT_LOG schreiben"
 
-#: builtin/bisect--helper.c:878
+#: builtin/bisect--helper.c:928
 msgid "check and set terms in a bisection state"
 msgstr "Begriffe innerhalb einer binären Suche prüfen und setzen"
 
-#: builtin/bisect--helper.c:880
+#: builtin/bisect--helper.c:930
 msgid "check whether bad or good terms exist"
 msgstr "prüfen, ob Begriffe für gute und schlechte Commits existieren"
 
-#: builtin/bisect--helper.c:882
+#: builtin/bisect--helper.c:932
 msgid "print out the bisect terms"
 msgstr "die Begriffe für die binäre Suche ausgeben"
 
-#: builtin/bisect--helper.c:884
+#: builtin/bisect--helper.c:934
 msgid "start the bisect session"
 msgstr "Sitzung für binäre Suche starten"
 
-#: builtin/bisect--helper.c:886
+#: builtin/bisect--helper.c:936
 msgid "find the next bisection commit"
 msgstr "nächsten Commit für die binäre Suche finden"
 
-#: builtin/bisect--helper.c:888
+#: builtin/bisect--helper.c:938
 msgid "verify the next bisection state then checkout the next bisection commit"
 msgstr ""
 "überprüfe den nächsten Zustand der binären Suche, checke dann den nächsten "
 "Commit der binären Suche aus"
 
-#: builtin/bisect--helper.c:890
-msgid "start the bisection if it has not yet been started"
-msgstr "starte die binäre Suche, wenn diese noch nicht begonnen hat"
+#: builtin/bisect--helper.c:940
+msgid "mark the state of ref (or refs)"
+msgstr ""
 
-#: builtin/bisect--helper.c:892
+#: builtin/bisect--helper.c:942
 msgid "no log for BISECT_WRITE"
 msgstr "kein Log für BISECT_WRITE"
 
-#: builtin/bisect--helper.c:910
-msgid "--write-terms requires two arguments"
-msgstr "--write-terms benötigt zwei Argumente"
-
-#: builtin/bisect--helper.c:914
-msgid "--bisect-clean-state requires no arguments"
-msgstr "--bisect-clean-state erwartet keine Argumente"
-
-#: builtin/bisect--helper.c:921
+#: builtin/bisect--helper.c:957
 msgid "--bisect-reset requires either no argument or a commit"
 msgstr "--bisect-reset benötigt entweder kein Argument oder ein Commit"
 
-#: builtin/bisect--helper.c:925
+#: builtin/bisect--helper.c:961
 msgid "--bisect-write requires either 4 or 5 arguments"
 msgstr "--bisect-write benötigt entweder 4 oder 5 Argumente"
 
-#: builtin/bisect--helper.c:931
+#: builtin/bisect--helper.c:967
 msgid "--check-and-set-terms requires 3 arguments"
 msgstr "--check-and-set-terms benötigt 3 Argumente"
 
-#: builtin/bisect--helper.c:937
+#: builtin/bisect--helper.c:973
 msgid "--bisect-next-check requires 2 or 3 arguments"
 msgstr "--bisect-next-check benötigt 2 oder 3 Argumente"
 
-#: builtin/bisect--helper.c:943
+#: builtin/bisect--helper.c:979
 msgid "--bisect-terms requires 0 or 1 argument"
 msgstr "--bisect-terms benötigt 0 oder 1 Argument"
 
-#: builtin/bisect--helper.c:952
+#: builtin/bisect--helper.c:988
 msgid "--bisect-next requires 0 arguments"
 msgstr "--bisect-next benötigt 0 Argumente"
 
-#: builtin/bisect--helper.c:958
+#: builtin/bisect--helper.c:994
 msgid "--bisect-auto-next requires 0 arguments"
 msgstr "--bisect-auto-next benötigt 0 Argumente"
-
-#: builtin/bisect--helper.c:964
-msgid "--bisect-autostart does not accept arguments"
-msgstr "--bisect-autostart erwartet keine Argumente"
 
 #: builtin/blame.c:32
 msgid "git blame [<options>] [<rev-opts>] [<rev>] [--] <file>"
@@ -10903,131 +10896,133 @@ msgstr "ungültige Farbe '%s' in color.blame.repeatedLines"
 msgid "invalid value for blame.coloring"
 msgstr "ungültiger Wert für blame.coloring"
 
-#: builtin/blame.c:845
+#: builtin/blame.c:847
 #, c-format
 msgid "cannot find revision %s to ignore"
 msgstr "konnte Commit %s zum Ignorieren nicht finden"
 
-#: builtin/blame.c:867
+#: builtin/blame.c:869
 msgid "Show blame entries as we find them, incrementally"
 msgstr "\"blame\"-Einträge schrittweise anzeigen, während wir sie generieren"
 
-#: builtin/blame.c:868
+#: builtin/blame.c:870
 msgid "Do not show object names of boundary commits (Default: off)"
 msgstr "Zeige keine Objektnamen für Grenz-Commits an (Standard: aus)"
 
-#: builtin/blame.c:869
+#: builtin/blame.c:871
 msgid "Do not treat root commits as boundaries (Default: off)"
 msgstr "Root-Commits nicht als Grenzen behandeln (Standard: aus)"
 
-#: builtin/blame.c:870
+#: builtin/blame.c:872
 msgid "Show work cost statistics"
 msgstr "Statistiken zum Arbeitsaufwand anzeigen"
 
-#: builtin/blame.c:871
+#: builtin/blame.c:873
 msgid "Force progress reporting"
 msgstr "Fortschrittsanzeige erzwingen"
 
-#: builtin/blame.c:872
+#: builtin/blame.c:874
 msgid "Show output score for blame entries"
 msgstr "Ausgabebewertung für \"blame\"-Einträge anzeigen"
 
-#: builtin/blame.c:873
+#: builtin/blame.c:875
 msgid "Show original filename (Default: auto)"
 msgstr "ursprünglichen Dateinamen anzeigen (Standard: auto)"
 
-#: builtin/blame.c:874
+#: builtin/blame.c:876
 msgid "Show original linenumber (Default: off)"
 msgstr "ursprüngliche Zeilennummer anzeigen (Standard: aus)"
 
-#: builtin/blame.c:875
+#: builtin/blame.c:877
 msgid "Show in a format designed for machine consumption"
 msgstr "Anzeige in einem Format für maschinelle Auswertung"
 
-#: builtin/blame.c:876
+#: builtin/blame.c:878
 msgid "Show porcelain format with per-line commit information"
 msgstr ""
 "Anzeige in Format für Fremdprogramme mit Commit-Informationen pro Zeile"
 
-#: builtin/blame.c:877
+#: builtin/blame.c:879
 msgid "Use the same output mode as git-annotate (Default: off)"
 msgstr ""
 "Den gleichen Ausgabemodus benutzen wie \"git-annotate\" (Standard: aus)"
 
-#: builtin/blame.c:878
+#: builtin/blame.c:880
 msgid "Show raw timestamp (Default: off)"
 msgstr "Unbearbeiteten Zeitstempel anzeigen (Standard: aus)"
 
-#: builtin/blame.c:879
+#: builtin/blame.c:881
 msgid "Show long commit SHA1 (Default: off)"
 msgstr "Langen Commit-SHA1 anzeigen (Standard: aus)"
 
-#: builtin/blame.c:880
+#: builtin/blame.c:882
 msgid "Suppress author name and timestamp (Default: off)"
 msgstr "Den Namen des Autors und den Zeitstempel unterdrücken (Standard: aus)"
 
-#: builtin/blame.c:881
+#: builtin/blame.c:883
 msgid "Show author email instead of name (Default: off)"
 msgstr ""
 "Anstatt des Namens die E-Mail-Adresse des Autors anzeigen (Standard: aus)"
 
-#: builtin/blame.c:882
+#: builtin/blame.c:884
 msgid "Ignore whitespace differences"
 msgstr "Unterschiede im Whitespace ignorieren"
 
-#: builtin/blame.c:883 builtin/log.c:1808
+#: builtin/blame.c:885 builtin/log.c:1813
 msgid "rev"
 msgstr "Commit"
 
-#: builtin/blame.c:883
+#: builtin/blame.c:885
 msgid "Ignore <rev> when blaming"
 msgstr "Ignoriere <rev> beim Ausführen von 'blame'"
 
-#: builtin/blame.c:884
+#: builtin/blame.c:886
 msgid "Ignore revisions from <file>"
 msgstr "Ignoriere Commits aus <Datei>"
 
-#: builtin/blame.c:885
+#: builtin/blame.c:887
 msgid "color redundant metadata from previous line differently"
 msgstr "redundante Metadaten der vorherigen Zeile unterschiedlich einfärben"
 
-#: builtin/blame.c:886
+#: builtin/blame.c:888
 msgid "color lines by age"
 msgstr "Zeilen nach Alter einfärben"
 
-#: builtin/blame.c:887
+#: builtin/blame.c:889
 msgid "Spend extra cycles to find better match"
 msgstr "Länger arbeiten, um bessere Übereinstimmungen zu finden"
 
-#: builtin/blame.c:888
+#: builtin/blame.c:890
 msgid "Use revisions from <file> instead of calling git-rev-list"
 msgstr "Commits von <Datei> benutzen, anstatt \"git-rev-list\" aufzurufen"
 
-#: builtin/blame.c:889
+#: builtin/blame.c:891
 msgid "Use <file>'s contents as the final image"
 msgstr "Inhalte der <Datei>en als endgültiges Abbild benutzen"
 
-#: builtin/blame.c:890 builtin/blame.c:891
+#: builtin/blame.c:892 builtin/blame.c:893
 msgid "score"
 msgstr "Bewertung"
 
-#: builtin/blame.c:890
+#: builtin/blame.c:892
 msgid "Find line copies within and across files"
 msgstr "kopierte Zeilen innerhalb oder zwischen Dateien finden"
 
-#: builtin/blame.c:891
+#: builtin/blame.c:893
 msgid "Find line movements within and across files"
 msgstr "verschobene Zeilen innerhalb oder zwischen Dateien finden"
 
-#: builtin/blame.c:892
-msgid "n,m"
-msgstr "n,m"
+#: builtin/blame.c:894
+#, fuzzy
+msgid "range"
+msgstr "Kein Commit-Bereich."
 
-#: builtin/blame.c:892
-msgid "Process only line range n,m, counting from 1"
+#: builtin/blame.c:895
+#, fuzzy
+msgid "Process only line range <start>,<end> or function :<funcname>"
 msgstr "nur Zeilen im Bereich n,m verarbeiten, gezählt von 1"
 
-#: builtin/blame.c:944
+#: builtin/blame.c:947
 msgid "--progress can't be used with --incremental or porcelain formats"
 msgstr ""
 "--progress kann nicht mit --incremental oder Formaten für Fremdprogramme\n"
@@ -11041,18 +11036,18 @@ msgstr ""
 #. your language may need more or fewer display
 #. columns.
 #.
-#: builtin/blame.c:995
+#: builtin/blame.c:998
 msgid "4 years, 11 months ago"
 msgstr "vor 4 Jahren und 11 Monaten"
 
-#: builtin/blame.c:1110
+#: builtin/blame.c:1114
 #, c-format
 msgid "file %s has only %lu line"
 msgid_plural "file %s has only %lu lines"
 msgstr[0] "Datei %s hat nur %lu Zeile"
 msgstr[1] "Datei %s hat nur %lu Zeilen"
 
-#: builtin/blame.c:1156
+#: builtin/blame.c:1159
 msgid "Blaming lines"
 msgstr "Verarbeite Zeilen"
 
@@ -11269,7 +11264,7 @@ msgstr "Modus zum Folgen von Branches einstellen (siehe git-pull(1))"
 msgid "do not use"
 msgstr "nicht verwenden"
 
-#: builtin/branch.c:626 builtin/rebase.c:526
+#: builtin/branch.c:626 builtin/rebase.c:532
 msgid "upstream"
 msgstr "Upstream"
 
@@ -11381,7 +11376,7 @@ msgstr "Sortierung und Filterung sind unabhängig von Groß- und Kleinschreibung
 msgid "format to use for the output"
 msgstr "für die Ausgabe zu verwendendes Format"
 
-#: builtin/branch.c:682 builtin/clone.c:789
+#: builtin/branch.c:682 builtin/clone.c:790
 msgid "HEAD not found below refs/heads!"
 msgstr "HEAD wurde nicht unter \"refs/heads\" gefunden!"
 
@@ -11537,38 +11532,38 @@ msgstr ""
 "Bitte überprüfen Sie den restlichen Teil des Fehlerberichts unten.\n"
 "Sie können jede Zeile löschen, die Sie nicht mitteilen möchten.\n"
 
-#: builtin/bugreport.c:134
+#: builtin/bugreport.c:135
 msgid "specify a destination for the bugreport file"
 msgstr "Speicherort für die Datei des Fehlerberichts angeben"
 
-#: builtin/bugreport.c:136
+#: builtin/bugreport.c:137
 msgid "specify a strftime format suffix for the filename"
 msgstr "Dateiendung im strftime-Format für den Dateinamen angeben"
 
-#: builtin/bugreport.c:158
+#: builtin/bugreport.c:159
 #, c-format
 msgid "could not create leading directories for '%s'"
 msgstr "konnte vorangehende Verzeichnisse für '%s' nicht erstellen"
 
-#: builtin/bugreport.c:165
+#: builtin/bugreport.c:166
 msgid "System Info"
 msgstr "System Info"
 
-#: builtin/bugreport.c:168
+#: builtin/bugreport.c:169
 msgid "Enabled Hooks"
 msgstr "Aktivierte Hooks"
 
-#: builtin/bugreport.c:175
+#: builtin/bugreport.c:176
 #, c-format
 msgid "couldn't create a new file at '%s'"
 msgstr "konnte keine neue Datei unter '%s' erstellen"
 
-#: builtin/bugreport.c:178
+#: builtin/bugreport.c:179
 #, c-format
 msgid "unable to write to %s"
 msgstr "konnte nicht nach %s schreiben"
 
-#: builtin/bugreport.c:188
+#: builtin/bugreport.c:189
 #, c-format
 msgid "Created new report at '%s'.\n"
 msgstr "Neuer Bericht unter '%s' erstellt.\n"
@@ -11626,11 +11621,11 @@ msgstr "%s ist in Ordnung\n"
 msgid "Need a repository to unbundle."
 msgstr "Zum Entpacken wird ein Repository benötigt."
 
-#: builtin/bundle.c:171 builtin/remote.c:1687
+#: builtin/bundle.c:171 builtin/remote.c:1700
 msgid "be verbose; must be placed before a subcommand"
 msgstr "erweiterte Ausgaben; muss vor einem Unterbefehl angegeben werden"
 
-#: builtin/bundle.c:193 builtin/remote.c:1718
+#: builtin/bundle.c:193 builtin/remote.c:1731
 #, c-format
 msgid "Unknown subcommand: %s"
 msgstr "Unbekannter Unterbefehl: %s"
@@ -11748,7 +11743,7 @@ msgstr "Dateinamen von der Standard-Eingabe lesen"
 msgid "terminate input and output records by a NUL character"
 msgstr "Einträge von Ein- und Ausgabe mit NUL-Zeichen abschließen"
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1482 builtin/gc.c:538
+#: builtin/check-ignore.c:21 builtin/checkout.c:1500 builtin/gc.c:541
 #: builtin/worktree.c:561
 msgid "suppress progress reporting"
 msgstr "Fortschrittsanzeige unterdrücken"
@@ -11803,57 +11798,57 @@ msgstr "Konnte Kontakt '%s' nicht parsen."
 msgid "no contacts specified"
 msgstr "keine Kontakte angegeben"
 
-#: builtin/checkout-index.c:131
+#: builtin/checkout-index.c:139
 msgid "git checkout-index [<options>] [--] [<file>...]"
 msgstr "git checkout-index [<Optionen>] [--] [<Datei>...]"
 
-#: builtin/checkout-index.c:148
+#: builtin/checkout-index.c:156
 msgid "stage should be between 1 and 3 or all"
 msgstr "--stage sollte zwischen 1 und 3 oder 'all' sein"
 
-#: builtin/checkout-index.c:164
+#: builtin/checkout-index.c:173
 msgid "check out all files in the index"
 msgstr "alle Dateien im Index auschecken"
 
-#: builtin/checkout-index.c:165
+#: builtin/checkout-index.c:174
 msgid "force overwrite of existing files"
 msgstr "das Überschreiben bereits existierender Dateien erzwingen"
 
-#: builtin/checkout-index.c:167
+#: builtin/checkout-index.c:176
 msgid "no warning for existing files and files not in index"
 msgstr ""
 "keine Warnung für existierende Dateien, und Dateien, die sich nicht im Index "
 "befinden"
 
-#: builtin/checkout-index.c:169
+#: builtin/checkout-index.c:178
 msgid "don't checkout new files"
 msgstr "keine neuen Dateien auschecken"
 
-#: builtin/checkout-index.c:171
+#: builtin/checkout-index.c:180
 msgid "update stat information in the index file"
 msgstr "Dateiinformationen in der Index-Datei aktualisieren"
 
-#: builtin/checkout-index.c:175
+#: builtin/checkout-index.c:184
 msgid "read list of paths from the standard input"
 msgstr "eine Liste von Pfaden von der Standard-Eingabe lesen"
 
-#: builtin/checkout-index.c:177
+#: builtin/checkout-index.c:186
 msgid "write the content to temporary files"
 msgstr "den Inhalt in temporäre Dateien schreiben"
 
-#: builtin/checkout-index.c:178 builtin/column.c:31
+#: builtin/checkout-index.c:187 builtin/column.c:31
 #: builtin/submodule--helper.c:1824 builtin/submodule--helper.c:1827
 #: builtin/submodule--helper.c:1835 builtin/submodule--helper.c:2333
-#: builtin/worktree.c:754
+#: builtin/worktree.c:757
 msgid "string"
 msgstr "Zeichenkette"
 
-#: builtin/checkout-index.c:179
+#: builtin/checkout-index.c:188
 msgid "when creating files, prepend <string>"
 msgstr ""
 "wenn Dateien erzeugt werden, stelle <Zeichenkette> dem Dateinamen voran"
 
-#: builtin/checkout-index.c:181
+#: builtin/checkout-index.c:190
 msgid "copy out the files from named stage"
 msgstr "Dateien von dem benannten Stand kopieren"
 
@@ -11956,16 +11951,16 @@ msgstr "'%s' kann nur genutzt werden, wenn '%s' nicht verwendet wird"
 msgid "'%s' or '%s' cannot be used with %s"
 msgstr "'%s' oder '%s' kann nicht mit %s verwendet werden"
 
-#: builtin/checkout.c:528 builtin/checkout.c:535
+#: builtin/checkout.c:541 builtin/checkout.c:548
 #, c-format
 msgid "path '%s' is unmerged"
 msgstr "Pfad '%s' ist nicht zusammengeführt."
 
-#: builtin/checkout.c:703
+#: builtin/checkout.c:716
 msgid "you need to resolve your current index first"
 msgstr "Sie müssen zuerst die Konflikte in Ihrem aktuellen Index auflösen."
 
-#: builtin/checkout.c:757
+#: builtin/checkout.c:770
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -11974,50 +11969,50 @@ msgstr ""
 "Kann nicht mit vorgemerkten Änderungen in folgenden Dateien fortsetzen:\n"
 "%s"
 
-#: builtin/checkout.c:853
+#: builtin/checkout.c:866
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Kann \"reflog\" für '%s' nicht durchführen: %s\n"
 
-#: builtin/checkout.c:895
+#: builtin/checkout.c:908
 msgid "HEAD is now at"
 msgstr "HEAD ist jetzt bei"
 
-#: builtin/checkout.c:899 builtin/clone.c:720
+#: builtin/checkout.c:912 builtin/clone.c:721 t/helper/test-fast-rebase.c:202
 msgid "unable to update HEAD"
 msgstr "Konnte HEAD nicht aktualisieren."
 
-#: builtin/checkout.c:903
+#: builtin/checkout.c:916
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Setze Branch '%s' neu\n"
 
-#: builtin/checkout.c:906
+#: builtin/checkout.c:919
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Bereits auf '%s'\n"
 
-#: builtin/checkout.c:910
+#: builtin/checkout.c:923
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Zu umgesetztem Branch '%s' gewechselt\n"
 
-#: builtin/checkout.c:912 builtin/checkout.c:1338
+#: builtin/checkout.c:925 builtin/checkout.c:1356
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Zu neuem Branch '%s' gewechselt\n"
 
-#: builtin/checkout.c:914
+#: builtin/checkout.c:927
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Zu Branch '%s' gewechselt\n"
 
-#: builtin/checkout.c:965
+#: builtin/checkout.c:978
 #, c-format
 msgid " ... and %d more.\n"
 msgstr " ... und %d weitere.\n"
 
-#: builtin/checkout.c:971
+#: builtin/checkout.c:984
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -12040,7 +12035,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:990
+#: builtin/checkout.c:1003
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -12067,19 +12062,19 @@ msgstr[1] ""
 " git branch <neuer-Branchname> %s\n"
 "\n"
 
-#: builtin/checkout.c:1025
+#: builtin/checkout.c:1038
 msgid "internal error in revision walk"
 msgstr "interner Fehler im Revisionsgang"
 
-#: builtin/checkout.c:1029
+#: builtin/checkout.c:1042
 msgid "Previous HEAD position was"
 msgstr "Vorherige Position von HEAD war"
 
-#: builtin/checkout.c:1069 builtin/checkout.c:1333
+#: builtin/checkout.c:1082 builtin/checkout.c:1351
 msgid "You are on a branch yet to be born"
 msgstr "Sie sind auf einem Branch, der noch nicht geboren ist"
 
-#: builtin/checkout.c:1146
+#: builtin/checkout.c:1164
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
@@ -12089,7 +12084,7 @@ msgstr ""
 "Bitte benutzen Sie -- (und optional --no-guess), um diese\n"
 "eindeutig voneinander zu unterscheiden."
 
-#: builtin/checkout.c:1153
+#: builtin/checkout.c:1171
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -12112,51 +12107,51 @@ msgstr ""
 "bevorzugen möchten, z.B. 'origin', können Sie die Einstellung\n"
 "checkout.defaultRemote=origin in Ihrer Konfiguration setzen."
 
-#: builtin/checkout.c:1163
+#: builtin/checkout.c:1181
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "'%s' entspricht mehreren (%d) Remote-Tracking-Branches"
 
-#: builtin/checkout.c:1229
+#: builtin/checkout.c:1247
 msgid "only one reference expected"
 msgstr "nur eine Referenz erwartet"
 
-#: builtin/checkout.c:1246
+#: builtin/checkout.c:1264
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "nur eine Referenz erwartet, %d gegeben."
 
-#: builtin/checkout.c:1292 builtin/worktree.c:342 builtin/worktree.c:510
+#: builtin/checkout.c:1310 builtin/worktree.c:342 builtin/worktree.c:510
 #, c-format
 msgid "invalid reference: %s"
 msgstr "Ungültige Referenz: %s"
 
-#: builtin/checkout.c:1305 builtin/checkout.c:1671
+#: builtin/checkout.c:1323 builtin/checkout.c:1689
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "Referenz ist kein \"Tree\"-Objekt: %s"
 
-#: builtin/checkout.c:1352
+#: builtin/checkout.c:1370
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "Ein Branch wird erwartet, Tag '%s' bekommen"
 
-#: builtin/checkout.c:1354
+#: builtin/checkout.c:1372
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "Ein Branch wird erwartet, Remote-Branch '%s' bekommen"
 
-#: builtin/checkout.c:1355 builtin/checkout.c:1363
+#: builtin/checkout.c:1373 builtin/checkout.c:1381
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "Ein Branch wird erwartet, '%s' bekommen"
 
-#: builtin/checkout.c:1358
+#: builtin/checkout.c:1376
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "Ein Branch wird erwartet, Commit '%s' bekommen"
 
-#: builtin/checkout.c:1374
+#: builtin/checkout.c:1392
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -12164,7 +12159,7 @@ msgstr ""
 "Der Branch kann nicht während eines Merges gewechselt werden.\n"
 "Ziehen Sie \"git merge --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1378
+#: builtin/checkout.c:1396
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
@@ -12173,7 +12168,7 @@ msgstr ""
 "werden.\n"
 "Ziehen Sie \"git am --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1382
+#: builtin/checkout.c:1400
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
@@ -12182,7 +12177,7 @@ msgstr ""
 "werden.\n"
 "Ziehen Sie \"git rebase --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1386
+#: builtin/checkout.c:1404
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
@@ -12191,7 +12186,7 @@ msgstr ""
 "gewechselt werden.\n"
 "Ziehen Sie \"git cherry-pick --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1390
+#: builtin/checkout.c:1408
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -12200,147 +12195,147 @@ msgstr ""
 "werden.\n"
 "Ziehen Sie \"git revert --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1394
+#: builtin/checkout.c:1412
 msgid "you are switching branch while bisecting"
 msgstr "Sie wechseln den Branch während einer binären Suche"
 
-#: builtin/checkout.c:1401
+#: builtin/checkout.c:1419
 msgid "paths cannot be used with switching branches"
 msgstr "Pfade können nicht beim Wechseln von Branches verwendet werden"
 
-#: builtin/checkout.c:1404 builtin/checkout.c:1408 builtin/checkout.c:1412
+#: builtin/checkout.c:1422 builtin/checkout.c:1426 builtin/checkout.c:1430
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "'%s' kann nicht beim Wechseln von Branches verwendet werden"
 
-#: builtin/checkout.c:1416 builtin/checkout.c:1419 builtin/checkout.c:1422
-#: builtin/checkout.c:1427 builtin/checkout.c:1432
+#: builtin/checkout.c:1434 builtin/checkout.c:1437 builtin/checkout.c:1440
+#: builtin/checkout.c:1445 builtin/checkout.c:1450
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "'%s' kann nicht mit '%s' verwendet werden"
 
-#: builtin/checkout.c:1429
+#: builtin/checkout.c:1447
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "'%s' kann nicht <Startpunkt> bekommen"
 
-#: builtin/checkout.c:1437
+#: builtin/checkout.c:1455
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "Kann Branch nicht zu Nicht-Commit '%s' wechseln"
 
-#: builtin/checkout.c:1444
+#: builtin/checkout.c:1462
 msgid "missing branch or commit argument"
 msgstr "Branch- oder Commit-Argument fehlt"
 
-#: builtin/checkout.c:1486 builtin/clone.c:91 builtin/commit-graph.c:84
-#: builtin/commit-graph.c:222 builtin/fetch.c:172 builtin/merge.c:287
-#: builtin/multi-pack-index.c:27 builtin/pull.c:119 builtin/push.c:551
-#: builtin/send-pack.c:192
+#: builtin/checkout.c:1504 builtin/clone.c:92 builtin/commit-graph.c:84
+#: builtin/commit-graph.c:222 builtin/fetch.c:172 builtin/merge.c:296
+#: builtin/multi-pack-index.c:27 builtin/pull.c:119 builtin/push.c:575
+#: builtin/send-pack.c:198
 msgid "force progress reporting"
 msgstr "Fortschrittsanzeige erzwingen"
 
-#: builtin/checkout.c:1487
+#: builtin/checkout.c:1505
 msgid "perform a 3-way merge with the new branch"
 msgstr "einen 3-Wege-Merge mit dem neuen Branch ausführen"
 
-#: builtin/checkout.c:1488 builtin/log.c:1795 parse-options.h:322
+#: builtin/checkout.c:1506 builtin/log.c:1800 parse-options.h:322
 msgid "style"
 msgstr "Stil"
 
-#: builtin/checkout.c:1489
+#: builtin/checkout.c:1507
 msgid "conflict style (merge or diff3)"
 msgstr "Konfliktstil (merge oder diff3)"
 
-#: builtin/checkout.c:1501 builtin/worktree.c:558
+#: builtin/checkout.c:1519 builtin/worktree.c:558
 msgid "detach HEAD at named commit"
 msgstr "HEAD bei benanntem Commit loslösen"
 
-#: builtin/checkout.c:1502
+#: builtin/checkout.c:1520
 msgid "set upstream info for new branch"
 msgstr "Informationen zum Upstream-Branch für den neuen Branch setzen"
 
-#: builtin/checkout.c:1504
+#: builtin/checkout.c:1522
 msgid "force checkout (throw away local modifications)"
 msgstr "Auschecken erzwingen (verwirft lokale Änderungen)"
 
-#: builtin/checkout.c:1506
+#: builtin/checkout.c:1524
 msgid "new-branch"
 msgstr "neuer Branch"
 
-#: builtin/checkout.c:1506
+#: builtin/checkout.c:1524
 msgid "new unparented branch"
 msgstr "neuer Branch ohne Eltern-Commit"
 
-#: builtin/checkout.c:1508 builtin/merge.c:291
+#: builtin/checkout.c:1526 builtin/merge.c:300
 msgid "update ignored files (default)"
 msgstr "ignorierte Dateien aktualisieren (Standard)"
 
-#: builtin/checkout.c:1511
+#: builtin/checkout.c:1529
 msgid "do not check if another worktree is holding the given ref"
 msgstr ""
 "Prüfung, ob die Referenz bereits in einem anderen Arbeitsverzeichnis "
 "ausgecheckt wurde, deaktivieren"
 
-#: builtin/checkout.c:1524
+#: builtin/checkout.c:1542
 msgid "checkout our version for unmerged files"
 msgstr "unsere Variante für nicht zusammengeführte Dateien auschecken"
 
-#: builtin/checkout.c:1527
+#: builtin/checkout.c:1545
 msgid "checkout their version for unmerged files"
 msgstr "ihre Variante für nicht zusammengeführte Dateien auschecken"
 
-#: builtin/checkout.c:1531
+#: builtin/checkout.c:1549
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "keine Einschränkung bei Pfadspezifikationen zum partiellen Auschecken"
 
-#: builtin/checkout.c:1586
+#: builtin/checkout.c:1604
 #, c-format
 msgid "-%c, -%c and --orphan are mutually exclusive"
 msgstr "die Optionen -%c, -%c und --orphan schließen sich gegenseitig aus"
 
-#: builtin/checkout.c:1590
+#: builtin/checkout.c:1608
 msgid "-p and --overlay are mutually exclusive"
 msgstr "-p und --overlay schließen sich gegenseitig aus."
 
-#: builtin/checkout.c:1627
+#: builtin/checkout.c:1645
 msgid "--track needs a branch name"
 msgstr "Bei der Option --track muss ein Branchname angegeben werden."
 
-#: builtin/checkout.c:1632
+#: builtin/checkout.c:1650
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "kein Branchname; versuchen Sie -%c"
 
-#: builtin/checkout.c:1664
+#: builtin/checkout.c:1682
 #, c-format
 msgid "could not resolve %s"
 msgstr "Konnte %s nicht auflösen."
 
-#: builtin/checkout.c:1680
+#: builtin/checkout.c:1698
 msgid "invalid path specification"
 msgstr "ungültige Pfadspezifikation"
 
-#: builtin/checkout.c:1687
+#: builtin/checkout.c:1705
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr ""
 "'%s' ist kein Commit und es kann kein Branch '%s' aus diesem erstellt werden."
 
-#: builtin/checkout.c:1691
+#: builtin/checkout.c:1709
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach nimmt kein Pfad-Argument '%s'"
 
-#: builtin/checkout.c:1700
+#: builtin/checkout.c:1718
 msgid "--pathspec-from-file is incompatible with --detach"
 msgstr "Die Optionen --pathspec-from-file und --detach sind inkompatibel."
 
-#: builtin/checkout.c:1703 builtin/reset.c:325 builtin/stash.c:1500
+#: builtin/checkout.c:1721 builtin/reset.c:325 builtin/stash.c:1499
 msgid "--pathspec-from-file is incompatible with --patch"
 msgstr "Die Optionen --pathspec-from-file und --patch sind inkompatibel."
 
-#: builtin/checkout.c:1716
+#: builtin/checkout.c:1734
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -12348,70 +12343,70 @@ msgstr ""
 "git checkout: --ours/--theirs, --force und --merge sind inkompatibel wenn\n"
 "Sie aus dem Index auschecken."
 
-#: builtin/checkout.c:1721
+#: builtin/checkout.c:1739
 msgid "you must specify path(s) to restore"
 msgstr "Sie müssen Pfad(e) zur Wiederherstellung angeben."
 
-#: builtin/checkout.c:1747 builtin/checkout.c:1749 builtin/checkout.c:1798
-#: builtin/checkout.c:1800 builtin/clone.c:121 builtin/remote.c:170
+#: builtin/checkout.c:1765 builtin/checkout.c:1767 builtin/checkout.c:1816
+#: builtin/checkout.c:1818 builtin/clone.c:122 builtin/remote.c:170
 #: builtin/remote.c:172 builtin/submodule--helper.c:2719 builtin/worktree.c:554
 #: builtin/worktree.c:556
 msgid "branch"
 msgstr "Branch"
 
-#: builtin/checkout.c:1748
+#: builtin/checkout.c:1766
 msgid "create and checkout a new branch"
 msgstr "einen neuen Branch erzeugen und auschecken"
 
-#: builtin/checkout.c:1750
+#: builtin/checkout.c:1768
 msgid "create/reset and checkout a branch"
 msgstr "einen Branch erstellen/umsetzen und auschecken"
 
-#: builtin/checkout.c:1751
+#: builtin/checkout.c:1769
 msgid "create reflog for new branch"
 msgstr "das Reflog für den neuen Branch erzeugen"
 
-#: builtin/checkout.c:1753
+#: builtin/checkout.c:1771
 msgid "second guess 'git checkout <no-such-branch>' (default)"
 msgstr "Zweite Vermutung 'git checkout <kein-solcher-Branch>' (Standard)"
 
-#: builtin/checkout.c:1754
+#: builtin/checkout.c:1772
 msgid "use overlay mode (default)"
 msgstr "benutze Overlay-Modus (Standard)"
 
-#: builtin/checkout.c:1799
+#: builtin/checkout.c:1817
 msgid "create and switch to a new branch"
 msgstr "einen neuen Branch erzeugen und dahin wechseln"
 
-#: builtin/checkout.c:1801
+#: builtin/checkout.c:1819
 msgid "create/reset and switch to a branch"
 msgstr "einen Branch erstellen/umsetzen und dahin wechseln"
 
-#: builtin/checkout.c:1803
+#: builtin/checkout.c:1821
 msgid "second guess 'git switch <no-such-branch>'"
 msgstr "Zweite Vermutung 'git switch <kein-solcher-Branch>'"
 
-#: builtin/checkout.c:1805
+#: builtin/checkout.c:1823
 msgid "throw away local modifications"
 msgstr "lokale Änderungen verwerfen"
 
-#: builtin/checkout.c:1839
+#: builtin/checkout.c:1857
 msgid "which tree-ish to checkout from"
 msgstr "Von welcher Commit-Referenz ausgecheckt werden soll"
 
-#: builtin/checkout.c:1841
+#: builtin/checkout.c:1859
 msgid "restore the index"
 msgstr "Index wiederherstellen"
 
-#: builtin/checkout.c:1843
+#: builtin/checkout.c:1861
 msgid "restore the working tree (default)"
 msgstr "das Arbeitsverzeichnis wiederherstellen (Standard)"
 
-#: builtin/checkout.c:1845
+#: builtin/checkout.c:1863
 msgid "ignore unmerged entries"
 msgstr "ignoriere nicht zusammengeführte Einträge"
 
-#: builtin/checkout.c:1846
+#: builtin/checkout.c:1864
 msgid "use overlay mode"
 msgstr "benutze Overlay-Modus"
 
@@ -12451,7 +12446,7 @@ msgstr "Fehler beim Löschen von %s"
 msgid "could not lstat %s\n"
 msgstr "Konnte 'lstat' nicht für %s ausführen\n"
 
-#: builtin/clean.c:302 git-add--interactive.perl:595
+#: builtin/clean.c:302 git-add--interactive.perl:593
 #, c-format
 msgid ""
 "Prompt help:\n"
@@ -12464,7 +12459,7 @@ msgstr ""
 "foo        - Element anhand eines eindeutigen Präfix auswählen\n"
 "           - (leer) nichts auswählen\n"
 
-#: builtin/clean.c:306 git-add--interactive.perl:604
+#: builtin/clean.c:306 git-add--interactive.perl:602
 #, c-format
 msgid ""
 "Prompt help:\n"
@@ -12485,8 +12480,8 @@ msgstr ""
 "*          - alle Elemente auswählen\n"
 "           - (leer) Auswahl beenden\n"
 
-#: builtin/clean.c:521 git-add--interactive.perl:570
-#: git-add--interactive.perl:575
+#: builtin/clean.c:521 git-add--interactive.perl:568
+#: git-add--interactive.perl:573
 #, c-format, perl-format
 msgid "Huh (%s)?\n"
 msgstr "Wie bitte (%s)?\n"
@@ -12556,7 +12551,7 @@ msgid "remove whole directories"
 msgstr "ganze Verzeichnisse löschen"
 
 #: builtin/clean.c:909 builtin/describe.c:565 builtin/describe.c:567
-#: builtin/grep.c:910 builtin/log.c:181 builtin/log.c:183
+#: builtin/grep.c:921 builtin/log.c:183 builtin/log.c:185
 #: builtin/ls-files.c:558 builtin/name-rev.c:526 builtin/name-rev.c:528
 #: builtin/show-ref.c:179
 msgid "pattern"
@@ -12598,170 +12593,170 @@ msgstr "Die Optionen -x und -X können nicht gemeinsam verwendet werden."
 msgid "git clone [<options>] [--] <repo> [<dir>]"
 msgstr "git clone [<Optionen>] [--] <Repository> [<Verzeichnis>]"
 
-#: builtin/clone.c:93
+#: builtin/clone.c:94
 msgid "don't create a checkout"
 msgstr "kein Auschecken"
 
-#: builtin/clone.c:94 builtin/clone.c:96 builtin/init-db.c:553
+#: builtin/clone.c:95 builtin/clone.c:97 builtin/init-db.c:553
 msgid "create a bare repository"
 msgstr "ein Bare-Repository erstellen"
 
-#: builtin/clone.c:98
+#: builtin/clone.c:99
 msgid "create a mirror repository (implies bare)"
 msgstr "ein Spiegelarchiv erstellen (impliziert --bare)"
 
-#: builtin/clone.c:100
+#: builtin/clone.c:101
 msgid "to clone from a local repository"
 msgstr "von einem lokalen Repository klonen"
 
-#: builtin/clone.c:102
+#: builtin/clone.c:103
 msgid "don't use local hardlinks, always copy"
 msgstr "lokal keine harten Verweise verwenden, immer Kopien"
 
-#: builtin/clone.c:104
+#: builtin/clone.c:105
 msgid "setup as shared repository"
 msgstr "als verteiltes Repository einrichten"
 
-#: builtin/clone.c:106
+#: builtin/clone.c:107
 msgid "pathspec"
 msgstr "Pfadspezifikation"
 
-#: builtin/clone.c:106
+#: builtin/clone.c:107
 msgid "initialize submodules in the clone"
 msgstr "Submodule im Klon initialisieren"
 
-#: builtin/clone.c:110
+#: builtin/clone.c:111
 msgid "number of submodules cloned in parallel"
 msgstr "Anzahl der parallel zu klonenden Submodule"
 
-#: builtin/clone.c:111 builtin/init-db.c:550
+#: builtin/clone.c:112 builtin/init-db.c:550
 msgid "template-directory"
 msgstr "Vorlagenverzeichnis"
 
-#: builtin/clone.c:112 builtin/init-db.c:551
+#: builtin/clone.c:113 builtin/init-db.c:551
 msgid "directory from which templates will be used"
 msgstr "Verzeichnis, von welchem die Vorlagen verwendet werden"
 
-#: builtin/clone.c:114 builtin/clone.c:116 builtin/submodule--helper.c:1831
+#: builtin/clone.c:115 builtin/clone.c:117 builtin/submodule--helper.c:1831
 #: builtin/submodule--helper.c:2336
 msgid "reference repository"
 msgstr "Repository referenzieren"
 
-#: builtin/clone.c:118 builtin/submodule--helper.c:1833
+#: builtin/clone.c:119 builtin/submodule--helper.c:1833
 #: builtin/submodule--helper.c:2338
 msgid "use --reference only while cloning"
 msgstr "--reference nur während des Klonens benutzen"
 
-#: builtin/clone.c:119 builtin/column.c:27 builtin/init-db.c:561
-#: builtin/merge-file.c:46 builtin/pack-objects.c:3546 builtin/repack.c:332
+#: builtin/clone.c:120 builtin/column.c:27 builtin/init-db.c:561
+#: builtin/merge-file.c:46 builtin/pack-objects.c:3546 builtin/repack.c:358
 msgid "name"
 msgstr "Name"
 
-#: builtin/clone.c:120
+#: builtin/clone.c:121
 msgid "use <name> instead of 'origin' to track upstream"
 msgstr "<Name> statt 'origin' für Upstream-Repository verwenden"
 
-#: builtin/clone.c:122
+#: builtin/clone.c:123
 msgid "checkout <branch> instead of the remote's HEAD"
 msgstr "<Branch> auschecken, anstatt HEAD des Remote-Repositories"
 
-#: builtin/clone.c:124
+#: builtin/clone.c:125
 msgid "path to git-upload-pack on the remote"
 msgstr "Pfad zu \"git-upload-pack\" auf der Gegenseite"
 
-#: builtin/clone.c:125 builtin/fetch.c:173 builtin/grep.c:849
+#: builtin/clone.c:126 builtin/fetch.c:173 builtin/grep.c:860
 #: builtin/pull.c:208
 msgid "depth"
 msgstr "Tiefe"
 
-#: builtin/clone.c:126
+#: builtin/clone.c:127
 msgid "create a shallow clone of that depth"
 msgstr ""
 "einen Klon mit unvollständiger Historie (shallow) in dieser Tiefe erstellen"
 
-#: builtin/clone.c:127 builtin/fetch.c:175 builtin/pack-objects.c:3535
+#: builtin/clone.c:128 builtin/fetch.c:175 builtin/pack-objects.c:3535
 #: builtin/pull.c:211
 msgid "time"
 msgstr "Zeit"
 
-#: builtin/clone.c:128
+#: builtin/clone.c:129
 msgid "create a shallow clone since a specific time"
 msgstr ""
 "einen Klon mit unvollständiger Historie (shallow) seit einer bestimmten "
 "Zeit\n"
 "erstellen"
 
-#: builtin/clone.c:129 builtin/fetch.c:177 builtin/fetch.c:200
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1311
+#: builtin/clone.c:130 builtin/fetch.c:177 builtin/fetch.c:200
+#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1317
 msgid "revision"
 msgstr "Commit"
 
-#: builtin/clone.c:130 builtin/fetch.c:178 builtin/pull.c:215
+#: builtin/clone.c:131 builtin/fetch.c:178 builtin/pull.c:215
 msgid "deepen history of shallow clone, excluding rev"
 msgstr ""
 "die Historie eines Klons mit unvollständiger Historie (shallow) mittels\n"
 "Ausschluss eines Commits vertiefen"
 
-#: builtin/clone.c:132 builtin/submodule--helper.c:1843
+#: builtin/clone.c:133 builtin/submodule--helper.c:1843
 #: builtin/submodule--helper.c:2352
 msgid "clone only one branch, HEAD or --branch"
 msgstr "nur einen Branch klonen, HEAD oder --branch"
 
-#: builtin/clone.c:134
+#: builtin/clone.c:135
 msgid "don't clone any tags, and make later fetches not to follow them"
 msgstr "keine Tags klonen, und auch bei späteren Abrufen nicht beachten"
 
-#: builtin/clone.c:136
+#: builtin/clone.c:137
 msgid "any cloned submodules will be shallow"
 msgstr "jedes geklonte Submodul mit unvollständiger Historie (shallow)"
 
-#: builtin/clone.c:137 builtin/init-db.c:559
+#: builtin/clone.c:138 builtin/init-db.c:559
 msgid "gitdir"
 msgstr ".git-Verzeichnis"
 
-#: builtin/clone.c:138 builtin/init-db.c:560
+#: builtin/clone.c:139 builtin/init-db.c:560
 msgid "separate git dir from working tree"
 msgstr "Git-Verzeichnis vom Arbeitsverzeichnis separieren"
 
-#: builtin/clone.c:139
+#: builtin/clone.c:140
 msgid "key=value"
 msgstr "Schlüssel=Wert"
 
-#: builtin/clone.c:140
+#: builtin/clone.c:141
 msgid "set config inside the new repository"
 msgstr "Konfiguration innerhalb des neuen Repositories setzen"
 
-#: builtin/clone.c:142 builtin/fetch.c:195 builtin/ls-remote.c:76
-#: builtin/pull.c:230 builtin/push.c:560 builtin/send-pack.c:190
+#: builtin/clone.c:143 builtin/fetch.c:195 builtin/ls-remote.c:76
+#: builtin/pull.c:230 builtin/push.c:584 builtin/send-pack.c:196
 msgid "server-specific"
 msgstr "serverspezifisch"
 
-#: builtin/clone.c:142 builtin/fetch.c:195 builtin/ls-remote.c:76
-#: builtin/pull.c:231 builtin/push.c:560 builtin/send-pack.c:191
+#: builtin/clone.c:143 builtin/fetch.c:195 builtin/ls-remote.c:76
+#: builtin/pull.c:231 builtin/push.c:584 builtin/send-pack.c:197
 msgid "option to transmit"
 msgstr "Option übertragen"
 
-#: builtin/clone.c:143 builtin/fetch.c:196 builtin/pull.c:234
-#: builtin/push.c:561
+#: builtin/clone.c:144 builtin/fetch.c:196 builtin/pull.c:234
+#: builtin/push.c:585
 msgid "use IPv4 addresses only"
 msgstr "nur IPv4-Adressen benutzen"
 
-#: builtin/clone.c:145 builtin/fetch.c:198 builtin/pull.c:237
-#: builtin/push.c:563
+#: builtin/clone.c:146 builtin/fetch.c:198 builtin/pull.c:237
+#: builtin/push.c:587
 msgid "use IPv6 addresses only"
 msgstr "nur IPv6-Adressen benutzen"
 
-#: builtin/clone.c:149
+#: builtin/clone.c:150
 msgid "any cloned submodules will use their remote-tracking branch"
 msgstr "jedes geklonte Submodul nutzt seinen Remote-Tracking-Branch"
 
-#: builtin/clone.c:151
+#: builtin/clone.c:152
 msgid "initialize sparse-checkout file to include only files at root"
 msgstr ""
 "Initialisiere Datei für partiellen Checkout, um nur Dateien im\n"
 "Root-Verzeichnis einzubeziehen"
 
-#: builtin/clone.c:287
+#: builtin/clone.c:288
 msgid ""
 "No directory name could be guessed.\n"
 "Please specify a directory on the command line"
@@ -12769,42 +12764,42 @@ msgstr ""
 "Konnte keinen Verzeichnisnamen erraten.\n"
 "Bitte geben Sie ein Verzeichnis auf der Befehlszeile an."
 
-#: builtin/clone.c:340
+#: builtin/clone.c:341
 #, c-format
 msgid "info: Could not add alternate for '%s': %s\n"
 msgstr "info: Konnte Alternative für '%s' nicht hinzufügen: %s\n"
 
-#: builtin/clone.c:413
+#: builtin/clone.c:414
 #, c-format
 msgid "%s exists and is not a directory"
 msgstr "%s existiert und ist kein Verzeichnis"
 
-#: builtin/clone.c:431
+#: builtin/clone.c:432
 #, c-format
 msgid "failed to start iterator over '%s'"
 msgstr "Fehler beim Starten der Iteration über '%s'"
 
-#: builtin/clone.c:462
+#: builtin/clone.c:463
 #, c-format
 msgid "failed to create link '%s'"
 msgstr "Konnte Verweis '%s' nicht erstellen"
 
-#: builtin/clone.c:466
+#: builtin/clone.c:467
 #, c-format
 msgid "failed to copy file to '%s'"
 msgstr "Konnte Datei nicht nach '%s' kopieren"
 
-#: builtin/clone.c:471
+#: builtin/clone.c:472
 #, c-format
 msgid "failed to iterate over '%s'"
 msgstr "Fehler beim Iterieren über '%s'"
 
-#: builtin/clone.c:498
+#: builtin/clone.c:499
 #, c-format
 msgid "done.\n"
 msgstr "Fertig.\n"
 
-#: builtin/clone.c:512
+#: builtin/clone.c:513
 msgid ""
 "Clone succeeded, but checkout failed.\n"
 "You can inspect what was checked out with 'git status'\n"
@@ -12814,107 +12809,107 @@ msgstr ""
 "Sie können mit 'git status' prüfen, was ausgecheckt worden ist\n"
 "und das Auschecken mit 'git restore --source=HEAD :/' erneut versuchen.\n"
 
-#: builtin/clone.c:589
+#: builtin/clone.c:590
 #, c-format
 msgid "Could not find remote branch %s to clone."
 msgstr "Konnte zu klonenden Remote-Branch %s nicht finden."
 
-#: builtin/clone.c:708
+#: builtin/clone.c:709
 #, c-format
 msgid "unable to update %s"
 msgstr "kann %s nicht aktualisieren"
 
-#: builtin/clone.c:756
+#: builtin/clone.c:757
 msgid "failed to initialize sparse-checkout"
 msgstr "Fehler beim Initialisieren vom partiellen Checkout."
 
-#: builtin/clone.c:779
+#: builtin/clone.c:780
 msgid "remote HEAD refers to nonexistent ref, unable to checkout.\n"
 msgstr ""
 "Externer HEAD bezieht sich auf eine nicht existierende Referenz und kann "
 "nicht ausgecheckt werden.\n"
 
-#: builtin/clone.c:811
+#: builtin/clone.c:812
 msgid "unable to checkout working tree"
 msgstr "Arbeitsverzeichnis konnte nicht ausgecheckt werden"
 
-#: builtin/clone.c:868
+#: builtin/clone.c:887
 msgid "unable to write parameters to config file"
 msgstr "konnte Parameter nicht in Konfigurationsdatei schreiben"
 
-#: builtin/clone.c:931
+#: builtin/clone.c:950
 msgid "cannot repack to clean up"
 msgstr "Kann \"repack\" zum Aufräumen nicht aufrufen"
 
-#: builtin/clone.c:933
+#: builtin/clone.c:952
 msgid "cannot unlink temporary alternates file"
 msgstr "Kann temporäre \"alternates\"-Datei nicht entfernen"
 
-#: builtin/clone.c:970 builtin/receive-pack.c:2434
+#: builtin/clone.c:992 builtin/receive-pack.c:2493
 msgid "Too many arguments."
 msgstr "Zu viele Argumente."
 
-#: builtin/clone.c:974
+#: builtin/clone.c:996
 msgid "You must specify a repository to clone."
 msgstr "Sie müssen ein Repository zum Klonen angeben."
 
-#: builtin/clone.c:987
+#: builtin/clone.c:1009
 #, c-format
 msgid "--bare and --origin %s options are incompatible."
 msgstr "Die Optionen --bare und --origin %s sind inkompatibel."
 
-#: builtin/clone.c:990
+#: builtin/clone.c:1012
 msgid "--bare and --separate-git-dir are incompatible."
 msgstr "Die Optionen --bare und --separate-git-dir sind inkompatibel."
 
-#: builtin/clone.c:1006
+#: builtin/clone.c:1025
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "Repository '%s' existiert nicht."
 
-#: builtin/clone.c:1010 builtin/fetch.c:1841
+#: builtin/clone.c:1029 builtin/fetch.c:1841
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "Tiefe %s ist keine positive Zahl"
 
-#: builtin/clone.c:1020
+#: builtin/clone.c:1039
 #, c-format
 msgid "destination path '%s' already exists and is not an empty directory."
 msgstr "Zielpfad '%s' existiert bereits und ist kein leeres Verzeichnis."
 
-#: builtin/clone.c:1026
+#: builtin/clone.c:1045
 #, c-format
 msgid "repository path '%s' already exists and is not an empty directory."
 msgstr ""
 "Pfad des Repositories '%s' existiert bereits und ist kein leeres Verzeichnis."
 
-#: builtin/clone.c:1040
+#: builtin/clone.c:1059
 #, c-format
 msgid "working tree '%s' already exists."
 msgstr "Arbeitsverzeichnis '%s' existiert bereits."
 
-#: builtin/clone.c:1055 builtin/clone.c:1076 builtin/difftool.c:271
-#: builtin/log.c:1970 builtin/worktree.c:354 builtin/worktree.c:386
+#: builtin/clone.c:1074 builtin/clone.c:1095 builtin/difftool.c:271
+#: builtin/log.c:1987 builtin/worktree.c:354 builtin/worktree.c:386
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "Konnte führende Verzeichnisse von '%s' nicht erstellen."
 
-#: builtin/clone.c:1060
+#: builtin/clone.c:1079
 #, c-format
 msgid "could not create work tree dir '%s'"
 msgstr "Konnte Arbeitsverzeichnis '%s' nicht erstellen"
 
-#: builtin/clone.c:1080
+#: builtin/clone.c:1099
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
 msgstr "Klone in Bare-Repository '%s' ...\n"
 
-#: builtin/clone.c:1082
+#: builtin/clone.c:1101
 #, c-format
 msgid "Cloning into '%s'...\n"
 msgstr "Klone nach '%s' ...\n"
 
-#: builtin/clone.c:1106
+#: builtin/clone.c:1125
 msgid ""
 "clone --recursive is not compatible with both --reference and --reference-if-"
 "able"
@@ -12922,45 +12917,50 @@ msgstr ""
 "'clone --recursive' ist nicht kompatibel mit --reference und --reference-if-"
 "able"
 
-#: builtin/clone.c:1170
+#: builtin/clone.c:1169 builtin/remote.c:200 builtin/remote.c:705
+#, c-format
+msgid "'%s' is not a valid remote name"
+msgstr "'%s' ist kein gültiger Name für ein Remote-Repository"
+
+#: builtin/clone.c:1210
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr ""
 "Die Option --depth wird in lokalen Klonen ignoriert; benutzen Sie "
 "stattdessen file://"
 
-#: builtin/clone.c:1172
+#: builtin/clone.c:1212
 msgid "--shallow-since is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-since wird in lokalen Klonen ignoriert; benutzen Sie stattdessen "
 "file://"
 
-#: builtin/clone.c:1174
+#: builtin/clone.c:1214
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-exclude wird in lokalen Klonen ignoriert; benutzen Sie stattdessen "
 "file://"
 
-#: builtin/clone.c:1176
+#: builtin/clone.c:1216
 msgid "--filter is ignored in local clones; use file:// instead."
 msgstr ""
 "--filter wird in lokalen Klonen ignoriert; benutzen Sie stattdessen file://"
 
-#: builtin/clone.c:1179
+#: builtin/clone.c:1219
 msgid "source repository is shallow, ignoring --local"
 msgstr ""
 "Quelle ist ein Repository mit unvollständiger Historie (shallow),\n"
 "ignoriere --local"
 
-#: builtin/clone.c:1184
+#: builtin/clone.c:1224
 msgid "--local is ignored"
 msgstr "--local wird ignoriert"
 
-#: builtin/clone.c:1268 builtin/clone.c:1276
+#: builtin/clone.c:1308 builtin/clone.c:1316
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "Remote-Branch %s nicht im Upstream-Repository %s gefunden"
 
-#: builtin/clone.c:1279
+#: builtin/clone.c:1319
 msgid "You appear to have cloned an empty repository."
 msgstr "Sie scheinen ein leeres Repository geklont zu haben."
 
@@ -13019,7 +13019,7 @@ msgid "could not find object directory matching %s"
 msgstr "konnte Objekt-Verzeichnis nicht finden, dass '%s' entsprechen soll"
 
 #: builtin/commit-graph.c:80 builtin/commit-graph.c:210
-#: builtin/commit-graph.c:316 builtin/fetch.c:184 builtin/log.c:1764
+#: builtin/commit-graph.c:316 builtin/fetch.c:184 builtin/log.c:1769
 msgid "dir"
 msgstr "Verzeichnis"
 
@@ -13100,8 +13100,8 @@ msgstr "maximale Anzahl der zu berechnenden Bloom-Filter für veränderte Pfade"
 #: builtin/commit-graph.c:255
 msgid "use at most one of --reachable, --stdin-commits, or --stdin-packs"
 msgstr ""
-"benutzen Sie mindestens eine der folgenden Optionen: --reachable, "
-"--stdin-commits, oder --stdin-packs"
+"benutzen Sie mindestens eine der folgenden Optionen: --reachable, --stdin-"
+"commits, oder --stdin-packs"
 
 #: builtin/commit-graph.c:287
 msgid "Collecting commits from input"
@@ -13120,7 +13120,7 @@ msgstr ""
 msgid "duplicate parent %s ignored"
 msgstr "doppelter Vorgänger %s ignoriert"
 
-#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:546
+#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:555
 #, c-format
 msgid "not a valid object name %s"
 msgstr "Kein gültiger Objektname: %s"
@@ -13148,8 +13148,8 @@ msgstr "Eltern-Commit"
 msgid "id of a parent commit object"
 msgstr "ID eines Eltern-Commit-Objektes."
 
-#: builtin/commit-tree.c:114 builtin/commit.c:1504 builtin/merge.c:272
-#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1471
+#: builtin/commit-tree.c:114 builtin/commit.c:1504 builtin/merge.c:281
+#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1470
 #: builtin/tag.c:413
 msgid "message"
 msgstr "Beschreibung"
@@ -13162,7 +13162,7 @@ msgstr "Commit-Beschreibung"
 msgid "read commit log message from file"
 msgstr "Commit-Beschreibung von Datei lesen"
 
-#: builtin/commit-tree.c:121 builtin/commit.c:1516 builtin/merge.c:289
+#: builtin/commit-tree.c:121 builtin/commit.c:1516 builtin/merge.c:298
 #: builtin/pull.c:176 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "Commit mit GPG signieren"
@@ -13318,7 +13318,7 @@ msgstr ""
 msgid "could not lookup commit %s"
 msgstr "Konnte Commit %s nicht nachschlagen"
 
-#: builtin/commit.c:729 builtin/shortlog.c:478
+#: builtin/commit.c:729 builtin/shortlog.c:425
 #, c-format
 msgid "(reading log message from standard input)\n"
 msgstr "(lese Log-Nachricht von Standard-Eingabe)\n"
@@ -13516,8 +13516,8 @@ msgstr "voraus/hinterher-Werte berechnen"
 msgid "version"
 msgstr "Version"
 
-#: builtin/commit.c:1374 builtin/commit.c:1533 builtin/push.c:539
-#: builtin/worktree.c:722
+#: builtin/commit.c:1374 builtin/commit.c:1533 builtin/push.c:560
+#: builtin/worktree.c:725
 msgid "machine-readable output"
 msgstr "maschinenlesbare Ausgabe"
 
@@ -13531,7 +13531,7 @@ msgstr "Einträge mit NUL-Zeichen abschließen"
 
 #: builtin/commit.c:1382 builtin/commit.c:1386 builtin/commit.c:1541
 #: builtin/fast-export.c:1199 builtin/fast-export.c:1202
-#: builtin/fast-export.c:1205 builtin/rebase.c:1400 parse-options.h:336
+#: builtin/fast-export.c:1205 builtin/rebase.c:1406 parse-options.h:336
 msgid "mode"
 msgstr "Modus"
 
@@ -13590,7 +13590,7 @@ msgstr "Unterschiede in Commit-Beschreibungsvorlage anzeigen"
 msgid "Commit message options"
 msgstr "Optionen für Commit-Beschreibung"
 
-#: builtin/commit.c:1501 builtin/merge.c:276 builtin/tag.c:415
+#: builtin/commit.c:1501 builtin/merge.c:285 builtin/tag.c:415
 msgid "read message from file"
 msgstr "Beschreibung von Datei lesen"
 
@@ -13602,7 +13602,7 @@ msgstr "Autor"
 msgid "override author for commit"
 msgstr "Autor eines Commits überschreiben"
 
-#: builtin/commit.c:1503 builtin/gc.c:539
+#: builtin/commit.c:1503 builtin/gc.c:542
 msgid "date"
 msgstr "Datum"
 
@@ -13639,9 +13639,10 @@ msgstr ""
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr "Sie als Autor des Commits setzen (verwendet mit -C/-c/--amend)"
 
-#: builtin/commit.c:1510 builtin/log.c:1741 builtin/merge.c:292
+#: builtin/commit.c:1510 builtin/log.c:1744 builtin/merge.c:301
 #: builtin/pull.c:145 builtin/revert.c:110
-msgid "add Signed-off-by:"
+#, fuzzy
+msgid "add a Signed-off-by trailer"
 msgstr "'Signed-off-by:'-Zeile hinzufügen"
 
 #: builtin/commit.c:1511
@@ -13743,218 +13744,228 @@ msgstr ""
 msgid "git config [<options>]"
 msgstr "git config [<Optionen>]"
 
-#: builtin/config.c:107 builtin/env--helper.c:27
+#: builtin/config.c:109 builtin/env--helper.c:27
 #, c-format
 msgid "unrecognized --type argument, %s"
 msgstr "nicht erkanntes --type Argument, %s"
 
-#: builtin/config.c:119
+#: builtin/config.c:121
 msgid "only one type at a time"
 msgstr "nur ein Typ erlaubt"
 
-#: builtin/config.c:128
+#: builtin/config.c:130
 msgid "Config file location"
 msgstr "Ort der Konfigurationsdatei"
 
-#: builtin/config.c:129
+#: builtin/config.c:131
 msgid "use global config file"
 msgstr "globale Konfigurationsdatei verwenden"
 
-#: builtin/config.c:130
+#: builtin/config.c:132
 msgid "use system config file"
 msgstr "systemweite Konfigurationsdatei verwenden"
 
-#: builtin/config.c:131
+#: builtin/config.c:133
 msgid "use repository config file"
 msgstr "Konfigurationsdatei des Repositories verwenden"
 
-#: builtin/config.c:132
+#: builtin/config.c:134
 msgid "use per-worktree config file"
 msgstr "Konfigurationsdatei pro Arbeitsverzeichnis verwenden"
 
-#: builtin/config.c:133
+#: builtin/config.c:135
 msgid "use given config file"
 msgstr "die angegebene Konfigurationsdatei verwenden"
 
-#: builtin/config.c:134
+#: builtin/config.c:136
 msgid "blob-id"
 msgstr "Blob-Id"
 
-#: builtin/config.c:134
+#: builtin/config.c:136
 msgid "read config from given blob object"
 msgstr "Konfiguration von angegebenem Blob-Objekt lesen"
 
-#: builtin/config.c:135
+#: builtin/config.c:137
 msgid "Action"
 msgstr "Aktion"
 
-#: builtin/config.c:136
-msgid "get value: name [value-regex]"
+#: builtin/config.c:138
+#, fuzzy
+msgid "get value: name [value-pattern]"
 msgstr "Wert zurückgeben: Name [Wert-regex]"
 
-#: builtin/config.c:137
-msgid "get all values: key [value-regex]"
+#: builtin/config.c:139
+#, fuzzy
+msgid "get all values: key [value-pattern]"
 msgstr "alle Werte zurückgeben: Schlüssel [Wert-regex]"
 
-#: builtin/config.c:138
-msgid "get values for regexp: name-regex [value-regex]"
+#: builtin/config.c:140
+#, fuzzy
+msgid "get values for regexp: name-regex [value-pattern]"
 msgstr "Werte für den regulären Ausdruck zurückgeben: Name-regex [Wert-regex]"
 
-#: builtin/config.c:139
+#: builtin/config.c:141
 msgid "get value specific for the URL: section[.var] URL"
 msgstr "Wert spezifisch für eine URL zurückgeben: section[.var] URL"
 
-#: builtin/config.c:140
-msgid "replace all matching variables: name value [value_regex]"
+#: builtin/config.c:142
+#, fuzzy
+msgid "replace all matching variables: name value [value-pattern]"
 msgstr "alle passenden Variablen ersetzen: Name Wert [Wert-regex] "
 
-#: builtin/config.c:141
+#: builtin/config.c:143
 msgid "add a new variable: name value"
 msgstr "neue Variable hinzufügen: Name Wert"
 
-#: builtin/config.c:142
-msgid "remove a variable: name [value-regex]"
+#: builtin/config.c:144
+#, fuzzy
+msgid "remove a variable: name [value-pattern]"
 msgstr "eine Variable entfernen: Name [Wert-regex]"
 
-#: builtin/config.c:143
-msgid "remove all matches: name [value-regex]"
+#: builtin/config.c:145
+#, fuzzy
+msgid "remove all matches: name [value-pattern]"
 msgstr "alle Übereinstimmungen entfernen: Name [Wert-regex]"
 
-#: builtin/config.c:144
+#: builtin/config.c:146
 msgid "rename section: old-name new-name"
 msgstr "eine Sektion umbenennen: alter-Name neuer-Name"
 
-#: builtin/config.c:145
+#: builtin/config.c:147
 msgid "remove a section: name"
 msgstr "eine Sektion entfernen: Name"
 
-#: builtin/config.c:146
+#: builtin/config.c:148
 msgid "list all"
 msgstr "alles auflisten"
 
-#: builtin/config.c:147
+#: builtin/config.c:149
+msgid "use string equality when comparing values to 'value-pattern'"
+msgstr ""
+
+#: builtin/config.c:150
 msgid "open an editor"
 msgstr "einen Editor öffnen"
 
-#: builtin/config.c:148
+#: builtin/config.c:151
 msgid "find the color configured: slot [default]"
 msgstr "die konfigurierte Farbe finden: Slot [Standard]"
 
-#: builtin/config.c:149
+#: builtin/config.c:152
 msgid "find the color setting: slot [stdout-is-tty]"
 msgstr "die Farbeinstellung finden: Slot [Standard-Ausgabe-ist-Terminal]"
 
-#: builtin/config.c:150
+#: builtin/config.c:153
 msgid "Type"
 msgstr "Typ"
 
-#: builtin/config.c:151 builtin/env--helper.c:43
+#: builtin/config.c:154 builtin/env--helper.c:43
 msgid "value is given this type"
 msgstr "Wert ist mit diesem Typ angegeben"
 
-#: builtin/config.c:152
+#: builtin/config.c:155
 msgid "value is \"true\" or \"false\""
 msgstr "Wert ist \"true\" oder \"false\""
 
-#: builtin/config.c:153
+#: builtin/config.c:156
 msgid "value is decimal number"
 msgstr "Wert ist eine Dezimalzahl"
 
-#: builtin/config.c:154
+#: builtin/config.c:157
 msgid "value is --bool or --int"
 msgstr "Wert ist --bool oder --int"
 
-#: builtin/config.c:155
+#: builtin/config.c:158
 msgid "value is --bool or string"
 msgstr "Wert ist --bool oder string"
 
-#: builtin/config.c:156
+#: builtin/config.c:159
 msgid "value is a path (file or directory name)"
 msgstr "Wert ist ein Pfad (Datei oder Verzeichnisname)"
 
-#: builtin/config.c:157
+#: builtin/config.c:160
 msgid "value is an expiry date"
 msgstr "Wert ist ein Verfallsdatum"
 
-#: builtin/config.c:158
+#: builtin/config.c:161
 msgid "Other"
 msgstr "Sonstiges"
 
-#: builtin/config.c:159
+#: builtin/config.c:162
 msgid "terminate values with NUL byte"
 msgstr "schließt Werte mit NUL-Byte ab"
 
-#: builtin/config.c:160
+#: builtin/config.c:163
 msgid "show variable names only"
 msgstr "nur Variablennamen anzeigen"
 
-#: builtin/config.c:161
+#: builtin/config.c:164
 msgid "respect include directives on lookup"
 msgstr "beachtet \"include\"-Direktiven beim Nachschlagen"
 
-#: builtin/config.c:162
+#: builtin/config.c:165
 msgid "show origin of config (file, standard input, blob, command line)"
 msgstr ""
 "Ursprung der Konfiguration anzeigen (Datei, Standard-Eingabe, Blob, "
 "Befehlszeile)"
 
-#: builtin/config.c:163
+#: builtin/config.c:166
 msgid "show scope of config (worktree, local, global, system, command)"
 msgstr ""
 "Zeige Geltungsbereich der Konfiguration (Arbeitsverzeichnis, lokal, global, "
 "systemweit, Befehl)"
 
-#: builtin/config.c:164 builtin/env--helper.c:45
+#: builtin/config.c:167 builtin/env--helper.c:45
 msgid "value"
 msgstr "Wert"
 
-#: builtin/config.c:164
+#: builtin/config.c:167
 msgid "with --get, use default value when missing entry"
 msgstr "mit --get, benutze den Standardwert, wenn der Eintrag fehlt"
 
-#: builtin/config.c:178
+#: builtin/config.c:181
 #, c-format
 msgid "wrong number of arguments, should be %d"
 msgstr "Falsche Anzahl von Argumenten - sollte %d sein."
 
-#: builtin/config.c:180
+#: builtin/config.c:183
 #, c-format
 msgid "wrong number of arguments, should be from %d to %d"
 msgstr "falsche Anzahl von Argumenten - sollte zwischen %d und %d sein"
 
-#: builtin/config.c:334
+#: builtin/config.c:339
 #, c-format
 msgid "invalid key pattern: %s"
 msgstr "Ungültiges Schlüsselmuster: %s"
 
-#: builtin/config.c:370
+#: builtin/config.c:377
 #, c-format
 msgid "failed to format default config value: %s"
 msgstr "Fehler beim Formatieren des Standardkonfigurationswertes: %s"
 
-#: builtin/config.c:434
+#: builtin/config.c:441
 #, c-format
 msgid "cannot parse color '%s'"
 msgstr "kann Farbe '%s' nicht parsen"
 
-#: builtin/config.c:476
+#: builtin/config.c:483
 msgid "unable to parse default color value"
 msgstr "konnte Standard-Farbwert nicht parsen"
 
-#: builtin/config.c:529 builtin/config.c:789
+#: builtin/config.c:536 builtin/config.c:833
 msgid "not in a git directory"
 msgstr "nicht in einem Git-Repository"
 
-#: builtin/config.c:532
+#: builtin/config.c:539
 msgid "writing to stdin is not supported"
 msgstr "das Schreiben in die Standard-Eingabe wird nicht unterstützt"
 
-#: builtin/config.c:535
+#: builtin/config.c:542
 msgid "writing config blobs is not supported"
 msgstr ""
 "das Schreiben von Blob-Objekten für Konfigurationen wird nicht unterstützt"
 
-#: builtin/config.c:620
+#: builtin/config.c:627
 #, c-format
 msgid ""
 "# This is Git's per-user configuration file.\n"
@@ -13969,27 +13980,27 @@ msgstr ""
 "#\tname = %s\n"
 "#\temail = %s\n"
 
-#: builtin/config.c:644
+#: builtin/config.c:652
 msgid "only one config file at a time"
 msgstr "nur eine Konfigurationsdatei zu einer Zeit möglich"
 
-#: builtin/config.c:650
+#: builtin/config.c:658
 msgid "--local can only be used inside a git repository"
 msgstr "--local kann nur innerhalb eines Git-Repositories verwendet werden"
 
-#: builtin/config.c:652
+#: builtin/config.c:660
 msgid "--blob can only be used inside a git repository"
 msgstr "--blob kann nur innerhalb eines Git-Repositories verwendet werden"
 
-#: builtin/config.c:654
+#: builtin/config.c:662
 msgid "--worktree can only be used inside a git repository"
 msgstr "--worktree kann nur innerhalb eines Git-Repositories verwendet werden"
 
-#: builtin/config.c:676
+#: builtin/config.c:684
 msgid "$HOME not set"
 msgstr "$HOME nicht gesetzt"
 
-#: builtin/config.c:700
+#: builtin/config.c:708
 msgid ""
 "--worktree cannot be used with multiple working trees unless the config\n"
 "extension worktreeConfig is enabled. Please read \"CONFIGURATION FILE\"\n"
@@ -14000,52 +14011,56 @@ msgstr ""
 "lesen Sie die Sektion \"CONFIGURATION_FILE\" in \"git help worktree\" für "
 "Details"
 
-#: builtin/config.c:735
+#: builtin/config.c:743
 msgid "--get-color and variable type are incoherent"
 msgstr "Angabe von --get-color und Variablentyp sind ungültig."
 
-#: builtin/config.c:740
+#: builtin/config.c:748
 msgid "only one action at a time"
 msgstr "Nur eine Aktion erlaubt."
 
-#: builtin/config.c:753
+#: builtin/config.c:761
 msgid "--name-only is only applicable to --list or --get-regexp"
 msgstr "--name-only ist nur anwendbar auf --list oder --get-regexp"
 
-#: builtin/config.c:759
+#: builtin/config.c:767
 msgid ""
 "--show-origin is only applicable to --get, --get-all, --get-regexp, and --"
 "list"
 msgstr ""
 "--show-origin ist nur anwendbar auf --get, --get-all, --get-regexp und --list"
 
-#: builtin/config.c:765
+#: builtin/config.c:773
 msgid "--default is only applicable to --get"
 msgstr "--default ist nur anwendbar auf --get"
 
-#: builtin/config.c:778
+#: builtin/config.c:806
+msgid "--fixed-value only applies with 'value-pattern'"
+msgstr ""
+
+#: builtin/config.c:822
 #, c-format
 msgid "unable to read config file '%s'"
 msgstr "Konnte Konfigurationsdatei '%s' nicht lesen."
 
-#: builtin/config.c:781
+#: builtin/config.c:825
 msgid "error processing config file(s)"
 msgstr "Fehler beim Verarbeiten der Konfigurationsdatei(en)."
 
-#: builtin/config.c:791
+#: builtin/config.c:835
 msgid "editing stdin is not supported"
 msgstr "Das Bearbeiten der Standard-Eingabe wird nicht unterstützt."
 
-#: builtin/config.c:793
+#: builtin/config.c:837
 msgid "editing blobs is not supported"
 msgstr "Das Bearbeiten von Blobs wird nicht unterstützt."
 
-#: builtin/config.c:807
+#: builtin/config.c:851
 #, c-format
 msgid "cannot create configuration file %s"
 msgstr "Konnte Konfigurationsdatei '%s' nicht erstellen."
 
-#: builtin/config.c:820
+#: builtin/config.c:864
 #, c-format
 msgid ""
 "cannot overwrite multiple values with a single value\n"
@@ -14055,7 +14070,7 @@ msgstr ""
 "       Benutzen Sie einen regulären Ausdruck, --add oder --replace, um %s\n"
 "       zu ändern."
 
-#: builtin/config.c:894 builtin/config.c:905
+#: builtin/config.c:943 builtin/config.c:954
 #, c-format
 msgid "no such section: %s"
 msgstr "Keine solche Sektion: %s"
@@ -14096,6 +14111,11 @@ msgstr ""
 #: builtin/credential-cache.c:154
 msgid "credential-cache unavailable; no unix socket support"
 msgstr "credential-cache nicht verfügbar; Unix-Socket wird nicht unterstützt"
+
+#: builtin/credential-store.c:66
+#, fuzzy, c-format
+msgid "unable to get credential storage lock in %d ms"
+msgstr "konnte aktuelles Arbeitsverzeichnis nicht bekommen"
 
 #: builtin/describe.c:26
 msgid "git describe [<options>] [<commit-ish>...]"
@@ -14266,41 +14286,50 @@ msgstr "Die Option --dirty kann nicht mit Commits verwendet werden."
 msgid "--broken is incompatible with commit-ishes"
 msgstr "Die Option --broken kann nicht mit Commits verwendet werden."
 
+#: builtin/diff-tree.c:155
+#, fuzzy
+msgid "--stdin and --merge-base are mutually exclusive"
+msgstr "-p und --overlay schließen sich gegenseitig aus."
+
+#: builtin/diff-tree.c:157
+msgid "--merge-base only works with two commits"
+msgstr ""
+
 #: builtin/diff.c:91
 #, c-format
 msgid "'%s': not a regular file or symlink"
 msgstr "'%s': keine reguläre Datei oder symbolische Verknüpfung"
 
-#: builtin/diff.c:241
+#: builtin/diff.c:258
 #, c-format
 msgid "invalid option: %s"
 msgstr "Ungültige Option: %s"
 
-#: builtin/diff.c:358
+#: builtin/diff.c:375
 #, c-format
 msgid "%s...%s: no merge base"
 msgstr "%s...%s: keine Merge-Basis"
 
-#: builtin/diff.c:468
+#: builtin/diff.c:485
 msgid "Not a git repository"
 msgstr "Kein Git-Repository"
 
-#: builtin/diff.c:513
+#: builtin/diff.c:530 builtin/grep.c:681
 #, c-format
 msgid "invalid object '%s' given."
 msgstr "Objekt '%s' ist ungültig."
 
-#: builtin/diff.c:524
+#: builtin/diff.c:541
 #, c-format
 msgid "more than two blobs given: '%s'"
 msgstr "Mehr als zwei Blobs angegeben: '%s'"
 
-#: builtin/diff.c:529
+#: builtin/diff.c:546
 #, c-format
 msgid "unhandled object '%s' given."
 msgstr "unbehandeltes Objekt '%s' angegeben"
 
-#: builtin/diff.c:563
+#: builtin/diff.c:580
 #, c-format
 msgid "%s...%s: multiple merge bases, using %s"
 msgstr "%s...%s: mehrere Merge-Basen, nutze %s"
@@ -14329,7 +14358,7 @@ msgstr "Konnte Datei von symbolischer Verknüpfung '%s' nicht lesen."
 msgid "could not read object %s for symlink %s"
 msgstr "Konnte Objekt '%s' für symbolische Verknüpfung '%s' nicht lesen."
 
-#: builtin/difftool.c:413
+#: builtin/difftool.c:412
 msgid ""
 "combined diff formats('-c' and '--cc') are not supported in\n"
 "directory diff mode('-d' and '--dir-diff')."
@@ -14337,54 +14366,54 @@ msgstr ""
 "Kombinierte Diff-Formate('-c' und '--cc') werden im Verzeichnis-\n"
 "Diff-Modus('-d' und '--dir-diff') nicht unterstützt."
 
-#: builtin/difftool.c:634
+#: builtin/difftool.c:633
 #, c-format
 msgid "both files modified: '%s' and '%s'."
 msgstr "beide Dateien geändert: '%s' und '%s'."
 
-#: builtin/difftool.c:636
+#: builtin/difftool.c:635
 msgid "working tree file has been left."
 msgstr "Datei im Arbeitsverzeichnis belassen."
 
-#: builtin/difftool.c:647
+#: builtin/difftool.c:646
 #, c-format
 msgid "temporary files exist in '%s'."
 msgstr "Es existieren temporäre Dateien in '%s'."
 
-#: builtin/difftool.c:648
+#: builtin/difftool.c:647
 msgid "you may want to cleanup or recover these."
 msgstr "Sie könnten diese aufräumen oder wiederherstellen."
 
-#: builtin/difftool.c:697
+#: builtin/difftool.c:696
 msgid "use `diff.guitool` instead of `diff.tool`"
 msgstr "`diff.guitool` anstatt `diff.tool` benutzen"
 
-#: builtin/difftool.c:699
+#: builtin/difftool.c:698
 msgid "perform a full-directory diff"
 msgstr "Diff über ganzes Verzeichnis ausführen"
 
-#: builtin/difftool.c:701
+#: builtin/difftool.c:700
 msgid "do not prompt before launching a diff tool"
 msgstr "keine Eingabeaufforderung vor Ausführung eines Diff-Tools"
 
-#: builtin/difftool.c:706
+#: builtin/difftool.c:705
 msgid "use symlinks in dir-diff mode"
 msgstr "symbolische Verknüpfungen im dir-diff Modus verwenden"
 
-#: builtin/difftool.c:707
+#: builtin/difftool.c:706
 msgid "tool"
 msgstr "Tool"
 
-#: builtin/difftool.c:708
+#: builtin/difftool.c:707
 msgid "use the specified diff tool"
 msgstr "das angegebene Diff-Tool benutzen"
 
-#: builtin/difftool.c:710
+#: builtin/difftool.c:709
 msgid "print a list of diff tools that may be used with `--tool`"
 msgstr ""
 "eine Liste mit Diff-Tools darstellen, die mit `--tool` benutzt werden können"
 
-#: builtin/difftool.c:713
+#: builtin/difftool.c:712
 msgid ""
 "make 'git-difftool' exit when an invoked diff tool returns a non - zero exit "
 "code"
@@ -14393,31 +14422,31 @@ msgstr ""
 "Rückkehrwert\n"
 "verschieden 0 ausgeführt wurde"
 
-#: builtin/difftool.c:716
+#: builtin/difftool.c:715
 msgid "specify a custom command for viewing diffs"
 msgstr "eigenen Befehl zur Anzeige von Unterschieden angeben"
 
-#: builtin/difftool.c:717
+#: builtin/difftool.c:716
 msgid "passed to `diff`"
 msgstr "an 'diff' übergeben"
 
-#: builtin/difftool.c:732
+#: builtin/difftool.c:731
 msgid "difftool requires worktree or --no-index"
 msgstr "difftool benötigt Arbeitsverzeichnis oder --no-index"
 
-#: builtin/difftool.c:739
+#: builtin/difftool.c:738
 msgid "--dir-diff is incompatible with --no-index"
 msgstr "--dir-diff kann nicht mit --no-index verwendet werden"
 
-#: builtin/difftool.c:742
+#: builtin/difftool.c:741
 msgid "--gui, --tool and --extcmd are mutually exclusive"
 msgstr "--gui, --tool und --extcmd schließen sich gegenseitig aus"
 
-#: builtin/difftool.c:750
+#: builtin/difftool.c:749
 msgid "no <tool> given for --tool=<tool>"
 msgstr "kein <Tool> für --tool=<Tool> angegeben"
 
-#: builtin/difftool.c:757
+#: builtin/difftool.c:756
 msgid "no <cmd> given for --extcmd=<cmd>"
 msgstr "kein <Programm> für --extcmd=<Programm> angegeben"
 
@@ -14512,7 +14541,7 @@ msgstr "die \"done\"-Funktion benutzen, um den Datenstrom abzuschließen"
 msgid "Skip output of blob data"
 msgstr "Ausgabe von Blob-Daten überspringen"
 
-#: builtin/fast-export.c:1223 builtin/log.c:1811
+#: builtin/fast-export.c:1223 builtin/log.c:1816
 msgid "refspec"
 msgstr "Refspec"
 
@@ -14556,31 +14585,31 @@ msgstr ""
 "--import-marks und --import-marks-if-exists können nicht zusammen "
 "weitergegeben werden"
 
-#: builtin/fast-import.c:3086
+#: builtin/fast-import.c:3088
 #, c-format
 msgid "Missing from marks for submodule '%s'"
 msgstr "Fehlende 'from'-Markierungen für Submodul '%s'"
 
-#: builtin/fast-import.c:3088
+#: builtin/fast-import.c:3090
 #, c-format
 msgid "Missing to marks for submodule '%s'"
 msgstr "Fehlende 'to'-Markierungen für Submodul '%s'"
 
-#: builtin/fast-import.c:3223
+#: builtin/fast-import.c:3225
 #, c-format
 msgid "Expected 'mark' command, got %s"
 msgstr "'mark' Befehl erwartet, '%s' bekommen"
 
-#: builtin/fast-import.c:3228
+#: builtin/fast-import.c:3230
 #, c-format
 msgid "Expected 'to' command, got %s"
 msgstr "'to' Befehl erwartet, '%s' bekommen"
 
-#: builtin/fast-import.c:3320
+#: builtin/fast-import.c:3322
 msgid "Expected format name:filename for submodule rewrite option"
 msgstr "Format 'Name:Dateiname' für Submodul-Rewrite-Option erwartet"
 
-#: builtin/fast-import.c:3374
+#: builtin/fast-import.c:3377
 #, c-format
 msgid "feature '%s' forbidden in input without --allow-unsafe-features"
 msgstr "Feature '%s' verboten in Eingabe ohne Option --allow-unsafe-features"
@@ -14865,7 +14894,7 @@ msgstr "   (%s wurde unreferenziert)"
 msgid "[deleted]"
 msgstr "[gelöscht]"
 
-#: builtin/fetch.c:1195 builtin/remote.c:1113
+#: builtin/fetch.c:1195 builtin/remote.c:1118
 msgid "(none)"
 msgstr "(nichts)"
 
@@ -15076,6 +15105,23 @@ msgstr "nur Referenzen ausgeben, die diesen Commit enthalten"
 #: builtin/for-each-ref.c:47
 msgid "print only refs which don't contain the commit"
 msgstr "nur Referenzen ausgeben, die diesen Commit nicht enthalten"
+
+#: builtin/for-each-repo.c:9
+msgid "git for-each-repo --config=<config> <command-args>"
+msgstr ""
+
+#: builtin/for-each-repo.c:37
+#, fuzzy
+msgid "config"
+msgstr "in Konflikt"
+
+#: builtin/for-each-repo.c:38
+msgid "config key storing a list of repository paths"
+msgstr ""
+
+#: builtin/for-each-repo.c:46
+msgid "missing --config=<config>"
+msgstr ""
 
 #: builtin/fsck.c:69 builtin/fsck.c:148 builtin/fsck.c:149
 msgid "unknown"
@@ -15320,31 +15366,31 @@ msgstr "%s: Objekt nicht vorhanden"
 msgid "invalid parameter: expected sha1, got '%s'"
 msgstr "Ungültiger Parameter: SHA-1 erwartet, '%s' bekommen"
 
-#: builtin/gc.c:36
+#: builtin/gc.c:39
 msgid "git gc [<options>]"
 msgstr "git gc [<Optionen>]"
 
-#: builtin/gc.c:91
+#: builtin/gc.c:94
 #, c-format
 msgid "Failed to fstat %s: %s"
 msgstr "Konnte '%s' nicht lesen: %s"
 
-#: builtin/gc.c:127
+#: builtin/gc.c:130
 #, c-format
 msgid "failed to parse '%s' value '%s'"
 msgstr "Fehler beim Parsen von '%s' mit dem Wert '%s'"
 
-#: builtin/gc.c:476 builtin/init-db.c:58
+#: builtin/gc.c:479 builtin/init-db.c:58
 #, c-format
 msgid "cannot stat '%s'"
 msgstr "Kann '%s' nicht lesen"
 
-#: builtin/gc.c:485 builtin/notes.c:240 builtin/tag.c:530
+#: builtin/gc.c:488 builtin/notes.c:240 builtin/tag.c:530
 #, c-format
 msgid "cannot read '%s'"
 msgstr "kann '%s' nicht lesen"
 
-#: builtin/gc.c:492
+#: builtin/gc.c:495
 #, c-format
 msgid ""
 "The last gc run reported the following. Please correct the root cause\n"
@@ -15360,58 +15406,58 @@ msgstr ""
 "\n"
 "%s"
 
-#: builtin/gc.c:540
+#: builtin/gc.c:543
 msgid "prune unreferenced objects"
 msgstr "unreferenzierte Objekte entfernen"
 
-#: builtin/gc.c:542
+#: builtin/gc.c:545
 msgid "be more thorough (increased runtime)"
 msgstr "mehr Gründlichkeit (erhöht Laufzeit)"
 
-#: builtin/gc.c:543
+#: builtin/gc.c:546
 msgid "enable auto-gc mode"
 msgstr "\"auto-gc\" Modus aktivieren"
 
-#: builtin/gc.c:546
+#: builtin/gc.c:549
 msgid "force running gc even if there may be another gc running"
 msgstr ""
 "Ausführung von \"git gc\" erzwingen, selbst wenn ein anderes\n"
 "\"git gc\" bereits ausgeführt wird"
 
-#: builtin/gc.c:549
+#: builtin/gc.c:552
 msgid "repack all other packs except the largest pack"
 msgstr "alle anderen Pakete, außer das größte Paket, neu packen"
 
-#: builtin/gc.c:566
+#: builtin/gc.c:569
 #, c-format
 msgid "failed to parse gc.logexpiry value %s"
 msgstr "Fehler beim Parsen des Wertes '%s' von gc.logexpiry."
 
-#: builtin/gc.c:577
+#: builtin/gc.c:580
 #, c-format
 msgid "failed to parse prune expiry value %s"
 msgstr "Fehler beim Parsen des \"prune expiry\" Wertes %s"
 
-#: builtin/gc.c:597
+#: builtin/gc.c:600
 #, c-format
 msgid "Auto packing the repository in background for optimum performance.\n"
 msgstr ""
 "Die Datenbank des Repositories wird für eine optimale Performance im\n"
 "Hintergrund komprimiert.\n"
 
-#: builtin/gc.c:599
+#: builtin/gc.c:602
 #, c-format
 msgid "Auto packing the repository for optimum performance.\n"
 msgstr ""
 "Die Datenbank des Projektarchivs wird für eine optimale Performance "
 "komprimiert.\n"
 
-#: builtin/gc.c:600
+#: builtin/gc.c:603
 #, c-format
 msgid "See \"git help gc\" for manual housekeeping.\n"
 msgstr "Siehe \"git help gc\" für manuelles Aufräumen.\n"
 
-#: builtin/gc.c:640
+#: builtin/gc.c:643
 #, c-format
 msgid ""
 "gc is already running on machine '%s' pid %<PRIuMAX> (use --force if not)"
@@ -15419,62 +15465,153 @@ msgstr ""
 "\"git gc\" wird bereits auf Maschine '%s' pid %<PRIuMAX> ausgeführt\n"
 "(benutzen Sie --force falls nicht)"
 
-#: builtin/gc.c:695
+#: builtin/gc.c:698
 msgid ""
 "There are too many unreachable loose objects; run 'git prune' to remove them."
 msgstr ""
 "Es gibt zu viele unerreichbare lose Objekte; führen Sie 'git prune' aus, um "
 "diese zu löschen."
 
-#: builtin/gc.c:705
-msgid "git maintenance run [--auto] [--[no-]quiet] [--task=<task>]"
+#: builtin/gc.c:708
+#, fuzzy
+msgid ""
+"git maintenance run [--auto] [--[no-]quiet] [--task=<task>] [--schedule]"
 msgstr "git maintenance run [--auto] [--[no-]quiet] [--task=<Aufgabe>]"
 
-#: builtin/gc.c:812
+#: builtin/gc.c:738
+msgid "--no-schedule is not allowed"
+msgstr ""
+
+#: builtin/gc.c:743
+#, fuzzy, c-format
+msgid "unrecognized --schedule argument '%s'"
+msgstr "nicht erkanntes --split Argument, %s"
+
+#: builtin/gc.c:862
 msgid "failed to write commit-graph"
 msgstr "Fehler beim Schreiben des Commit-Graph"
 
-#: builtin/gc.c:905
+#: builtin/gc.c:901
+#, fuzzy
+msgid "failed to fill remotes"
+msgstr "Fehler beim Löschen von %s"
+
+#: builtin/gc.c:1024
+#, fuzzy
+msgid "failed to start 'git pack-objects' process"
+msgstr "Konnte 'pack-objects' nicht ausführen"
+
+#: builtin/gc.c:1041
+#, fuzzy
+msgid "failed to finish 'git pack-objects' process"
+msgstr "Konnte 'pack-objects' nicht beenden"
+
+#: builtin/gc.c:1093
+#, fuzzy
+msgid "failed to write multi-pack-index"
+msgstr "Fehler beim Löschen des multi-pack-index bei %s"
+
+#: builtin/gc.c:1111
+#, fuzzy
+msgid "'git multi-pack-index expire' failed"
+msgstr "multi-pack-index-Datei existiert, aber das Parsen schlug fehl"
+
+#: builtin/gc.c:1172
+#, fuzzy
+msgid "'git multi-pack-index repack' failed"
+msgstr "Fehler beim Laden des Pack-Index für Packdatei %s"
+
+#: builtin/gc.c:1181
+msgid ""
+"skipping incremental-repack task because core.multiPackIndex is disabled"
+msgstr ""
+
+#: builtin/gc.c:1279
 #, c-format
 msgid "lock file '%s' exists, skipping maintenance"
 msgstr "Sperrdatei '%s' existiert, Wartung wird übersprungen"
 
-#: builtin/gc.c:932
+#: builtin/gc.c:1309
 #, c-format
 msgid "task '%s' failed"
 msgstr "Aufgabe '%s' fehlgeschlagen"
 
-#: builtin/gc.c:979
+#: builtin/gc.c:1389
 #, c-format
 msgid "'%s' is not a valid task"
 msgstr "'%s' ist keine gültige Aufgabe"
 
-#: builtin/gc.c:984
+#: builtin/gc.c:1394
 #, c-format
 msgid "task '%s' cannot be selected multiple times"
 msgstr "Aufgabe '%s' kann nicht mehrfach ausgewählt werden"
 
-#: builtin/gc.c:999
+#: builtin/gc.c:1409
 msgid "run tasks based on the state of the repository"
 msgstr "Aufgaben abhängig vom Zustand des Repositories ausführen"
 
-#: builtin/gc.c:1001
+#: builtin/gc.c:1410
+msgid "frequency"
+msgstr ""
+
+#: builtin/gc.c:1411
+#, fuzzy
+msgid "run tasks based on frequency"
+msgstr "Aufgaben abhängig vom Zustand des Repositories ausführen"
+
+#: builtin/gc.c:1414
 msgid "do not report progress or other information over stderr"
 msgstr "zeige keinen Fortschritt oder andere Informationen über stderr"
 
-#: builtin/gc.c:1002
+#: builtin/gc.c:1415
 msgid "task"
 msgstr "Aufgabe"
 
-#: builtin/gc.c:1003
+#: builtin/gc.c:1416
 msgid "run a specific task"
 msgstr "eine bestimmte Aufgabe ausführen"
 
-#: builtin/gc.c:1026
-msgid "git maintenance run [<options>]"
+#: builtin/gc.c:1433
+msgid "use at most one of --auto and --schedule=<frequency>"
+msgstr ""
+
+#: builtin/gc.c:1467
+#, fuzzy
+msgid "failed to run 'git config'"
+msgstr "Fehler beim Ausführen von 'git status' auf '%s'"
+
+#: builtin/gc.c:1512
+msgid "another process is scheduling background maintenance"
+msgstr ""
+
+#: builtin/gc.c:1525
+msgid "failed to run 'crontab -l'; your system might not support 'cron'"
+msgstr ""
+
+#: builtin/gc.c:1544
+msgid "failed to run 'crontab'; your system might not support 'cron'"
+msgstr ""
+
+#: builtin/gc.c:1550
+#, fuzzy
+msgid "failed to open stdin of 'crontab'"
+msgstr "Fehler beim Öffnen von '%s'"
+
+#: builtin/gc.c:1592
+msgid "'crontab' died"
+msgstr ""
+
+#: builtin/gc.c:1605
+#, fuzzy
+msgid "failed to add repo to global config"
+msgstr "Fehler beim Hinzufügen von Packdatei '%s'."
+
+#: builtin/gc.c:1615
+#, fuzzy
+msgid "git maintenance <subcommand> [<options>]"
 msgstr "git maintenance run [<Optionen>]"
 
-#: builtin/gc.c:1037
+#: builtin/gc.c:1634
 #, c-format
 msgid "invalid subcommand: %s"
 msgstr "ungültiger Unterbefehl: %s"
@@ -15513,250 +15650,250 @@ msgstr "konnte \"Tree\"-Objekt (%s) nicht lesen"
 msgid "unable to grep from object of type %s"
 msgstr "kann \"grep\" nicht mit Objekten des Typs %s durchführen"
 
-#: builtin/grep.c:725
+#: builtin/grep.c:736
 #, c-format
 msgid "switch `%c' expects a numerical value"
 msgstr "Schalter '%c' erwartet einen numerischen Wert"
 
-#: builtin/grep.c:824
+#: builtin/grep.c:835
 msgid "search in index instead of in the work tree"
 msgstr "im Index anstatt im Arbeitsverzeichnis suchen"
 
-#: builtin/grep.c:826
+#: builtin/grep.c:837
 msgid "find in contents not managed by git"
 msgstr "auch in Inhalten finden, die nicht von Git verwaltet werden"
 
-#: builtin/grep.c:828
+#: builtin/grep.c:839
 msgid "search in both tracked and untracked files"
 msgstr "in versionierten und unversionierten Dateien suchen"
 
-#: builtin/grep.c:830
+#: builtin/grep.c:841
 msgid "ignore files specified via '.gitignore'"
 msgstr "Dateien, die über '.gitignore' angegeben sind, ignorieren"
 
-#: builtin/grep.c:832
+#: builtin/grep.c:843
 msgid "recursively search in each submodule"
 msgstr "rekursive Suche in jedem Submodul"
 
-#: builtin/grep.c:835
+#: builtin/grep.c:846
 msgid "show non-matching lines"
 msgstr "Zeilen ohne Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:837
+#: builtin/grep.c:848
 msgid "case insensitive matching"
 msgstr "Übereinstimmungen unabhängig von Groß- und Kleinschreibung finden"
 
-#: builtin/grep.c:839
+#: builtin/grep.c:850
 msgid "match patterns only at word boundaries"
 msgstr "nur ganze Wörter suchen"
 
-#: builtin/grep.c:841
+#: builtin/grep.c:852
 msgid "process binary files as text"
 msgstr "binäre Dateien als Text verarbeiten"
 
-#: builtin/grep.c:843
+#: builtin/grep.c:854
 msgid "don't match patterns in binary files"
 msgstr "keine Muster in Binärdateien finden"
 
-#: builtin/grep.c:846
+#: builtin/grep.c:857
 msgid "process binary files with textconv filters"
 msgstr "binäre Dateien mit \"textconv\"-Filtern verarbeiten"
 
-#: builtin/grep.c:848
+#: builtin/grep.c:859
 msgid "search in subdirectories (default)"
 msgstr "in Unterverzeichnissen suchen (Standard)"
 
-#: builtin/grep.c:850
+#: builtin/grep.c:861
 msgid "descend at most <depth> levels"
 msgstr "höchstens <Tiefe> Ebenen durchlaufen"
 
-#: builtin/grep.c:854
+#: builtin/grep.c:865
 msgid "use extended POSIX regular expressions"
 msgstr "erweiterte reguläre Ausdrücke aus POSIX verwenden"
 
-#: builtin/grep.c:857
+#: builtin/grep.c:868
 msgid "use basic POSIX regular expressions (default)"
 msgstr "grundlegende reguläre Ausdrücke aus POSIX verwenden (Standard)"
 
-#: builtin/grep.c:860
+#: builtin/grep.c:871
 msgid "interpret patterns as fixed strings"
 msgstr "Muster als feste Zeichenketten interpretieren"
 
-#: builtin/grep.c:863
+#: builtin/grep.c:874
 msgid "use Perl-compatible regular expressions"
 msgstr "Perl-kompatible reguläre Ausdrücke verwenden"
 
-#: builtin/grep.c:866
+#: builtin/grep.c:877
 msgid "show line numbers"
 msgstr "Zeilennummern anzeigen"
 
-#: builtin/grep.c:867
+#: builtin/grep.c:878
 msgid "show column number of first match"
 msgstr "Nummer der Spalte des ersten Treffers anzeigen"
 
-#: builtin/grep.c:868
+#: builtin/grep.c:879
 msgid "don't show filenames"
 msgstr "keine Dateinamen anzeigen"
 
-#: builtin/grep.c:869
+#: builtin/grep.c:880
 msgid "show filenames"
 msgstr "Dateinamen anzeigen"
 
-#: builtin/grep.c:871
+#: builtin/grep.c:882
 msgid "show filenames relative to top directory"
 msgstr "Dateinamen relativ zum Projektverzeichnis anzeigen"
 
-#: builtin/grep.c:873
+#: builtin/grep.c:884
 msgid "show only filenames instead of matching lines"
 msgstr "nur Dateinamen anzeigen anstatt übereinstimmende Zeilen"
 
-#: builtin/grep.c:875
+#: builtin/grep.c:886
 msgid "synonym for --files-with-matches"
 msgstr "Synonym für --files-with-matches"
 
-#: builtin/grep.c:878
+#: builtin/grep.c:889
 msgid "show only the names of files without match"
 msgstr "nur die Dateinamen ohne Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:880
+#: builtin/grep.c:891
 msgid "print NUL after filenames"
 msgstr "NUL-Zeichen nach Dateinamen ausgeben"
 
-#: builtin/grep.c:883
+#: builtin/grep.c:894
 msgid "show only matching parts of a line"
 msgstr "nur übereinstimmende Teile der Zeile anzeigen"
 
-#: builtin/grep.c:885
+#: builtin/grep.c:896
 msgid "show the number of matches instead of matching lines"
 msgstr "anstatt der Zeilen, die Anzahl der übereinstimmenden Zeilen anzeigen"
 
-#: builtin/grep.c:886
+#: builtin/grep.c:897
 msgid "highlight matches"
 msgstr "Übereinstimmungen hervorheben"
 
-#: builtin/grep.c:888
+#: builtin/grep.c:899
 msgid "print empty line between matches from different files"
 msgstr ""
 "eine Leerzeile zwischen Übereinstimmungen in verschiedenen Dateien ausgeben"
 
-#: builtin/grep.c:890
+#: builtin/grep.c:901
 msgid "show filename only once above matches from same file"
 msgstr ""
 "den Dateinamen nur einmal oberhalb der Übereinstimmungen aus dieser Datei "
 "anzeigen"
 
-#: builtin/grep.c:893
+#: builtin/grep.c:904
 msgid "show <n> context lines before and after matches"
 msgstr "<n> Zeilen vor und nach den Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:896
+#: builtin/grep.c:907
 msgid "show <n> context lines before matches"
 msgstr "<n> Zeilen vor den Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:898
+#: builtin/grep.c:909
 msgid "show <n> context lines after matches"
 msgstr "<n> Zeilen nach den Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:900
+#: builtin/grep.c:911
 msgid "use <n> worker threads"
 msgstr "<n> Threads benutzen"
 
-#: builtin/grep.c:901
+#: builtin/grep.c:912
 msgid "shortcut for -C NUM"
 msgstr "Kurzform für -C NUM"
 
-#: builtin/grep.c:904
+#: builtin/grep.c:915
 msgid "show a line with the function name before matches"
 msgstr "eine Zeile mit dem Funktionsnamen vor Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:906
+#: builtin/grep.c:917
 msgid "show the surrounding function"
 msgstr "die umgebende Funktion anzeigen"
 
-#: builtin/grep.c:909
+#: builtin/grep.c:920
 msgid "read patterns from file"
 msgstr "Muster von einer Datei lesen"
 
-#: builtin/grep.c:911
+#: builtin/grep.c:922
 msgid "match <pattern>"
 msgstr "<Muster> finden"
 
-#: builtin/grep.c:913
+#: builtin/grep.c:924
 msgid "combine patterns specified with -e"
 msgstr "Muster kombinieren, die mit -e angegeben wurden"
 
-#: builtin/grep.c:925
+#: builtin/grep.c:936
 msgid "indicate hit with exit status without output"
 msgstr "Übereinstimmungen nur durch Beendigungsstatus anzeigen"
 
-#: builtin/grep.c:927
+#: builtin/grep.c:938
 msgid "show only matches from files that match all patterns"
 msgstr ""
 "nur Übereinstimmungen von Dateien anzeigen, die allen Mustern entsprechen"
 
-#: builtin/grep.c:929
+#: builtin/grep.c:940
 msgid "show parse tree for grep expression"
 msgstr "geparstes Verzeichnis für \"grep\"-Ausdruck anzeigen"
 
-#: builtin/grep.c:933
+#: builtin/grep.c:944
 msgid "pager"
 msgstr "Anzeigeprogramm"
 
-#: builtin/grep.c:933
+#: builtin/grep.c:944
 msgid "show matching files in the pager"
 msgstr "Dateien mit Übereinstimmungen im Anzeigeprogramm anzeigen"
 
-#: builtin/grep.c:937
+#: builtin/grep.c:948
 msgid "allow calling of grep(1) (ignored by this build)"
 msgstr "den Aufruf von grep(1) erlauben (von dieser Programmversion ignoriert)"
 
-#: builtin/grep.c:1004
+#: builtin/grep.c:1014
 msgid "no pattern given"
 msgstr "Kein Muster angegeben."
 
-#: builtin/grep.c:1040
+#: builtin/grep.c:1050
 msgid "--no-index or --untracked cannot be used with revs"
 msgstr "--no-index oder --untracked können nicht mit Commits verwendet werden"
 
-#: builtin/grep.c:1048
+#: builtin/grep.c:1058
 #, c-format
 msgid "unable to resolve revision: %s"
 msgstr "Konnte Commit nicht auflösen: %s"
 
-#: builtin/grep.c:1078
+#: builtin/grep.c:1088
 msgid "--untracked not supported with --recurse-submodules"
 msgstr "--untracked zusammen mit --recurse-submodules wird nicht unterstützt"
 
-#: builtin/grep.c:1082
+#: builtin/grep.c:1092
 msgid "invalid option combination, ignoring --threads"
 msgstr "Ungültige Kombination von Optionen, --threads wird ignoriert."
 
-#: builtin/grep.c:1085 builtin/pack-objects.c:3655
+#: builtin/grep.c:1095 builtin/pack-objects.c:3655
 msgid "no threads support, ignoring --threads"
 msgstr "Keine Unterstützung für Threads, --threads wird ignoriert."
 
-#: builtin/grep.c:1088 builtin/index-pack.c:1573 builtin/pack-objects.c:2933
+#: builtin/grep.c:1098 builtin/index-pack.c:1573 builtin/pack-objects.c:2933
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "ungültige Anzahl von Threads angegeben (%d)"
 
-#: builtin/grep.c:1122
+#: builtin/grep.c:1132
 msgid "--open-files-in-pager only works on the worktree"
 msgstr ""
 "Die Option --open-files-in-pager kann nur innerhalb des "
 "Arbeitsverzeichnisses verwendet werden."
 
-#: builtin/grep.c:1148
+#: builtin/grep.c:1158
 msgid "--cached or --untracked cannot be used with --no-index"
 msgstr "--cached und --untracked können nicht mit --no-index verwendet werden."
 
-#: builtin/grep.c:1154
+#: builtin/grep.c:1164
 msgid "--[no-]exclude-standard cannot be used for tracked contents"
 msgstr ""
 "--[no-]exclude-standard kann nicht mit versionierten Inhalten verwendet "
 "werden."
 
-#: builtin/grep.c:1162
+#: builtin/grep.c:1172
 msgid "both --cached and trees are given"
 msgstr "--cached und \"Tree\"-Objekte angegeben"
 
@@ -15950,7 +16087,7 @@ msgstr "Paket ist zu groß für die aktuelle Definition von off_t"
 msgid "pack exceeds maximum allowed size"
 msgstr "Paket überschreitet die maximal erlaubte Größe"
 
-#: builtin/index-pack.c:342 builtin/repack.c:254
+#: builtin/index-pack.c:342 builtin/repack.c:286
 #, c-format
 msgid "unable to create '%s'"
 msgstr "konnte '%s' nicht erstellen"
@@ -16420,127 +16557,130 @@ msgstr ""
 msgid "no input file given for in-place editing"
 msgstr "keine Datei zur direkten Bearbeitung angegeben"
 
-#: builtin/log.c:56
+#: builtin/log.c:58
 msgid "git log [<options>] [<revision-range>] [[--] <path>...]"
 msgstr "git log [<Optionen>] [<Commitbereich>] [[--] <Pfad>...]"
 
-#: builtin/log.c:57
+#: builtin/log.c:59
 msgid "git show [<options>] <object>..."
 msgstr "git show [<Optionen>] <Objekt>..."
 
-#: builtin/log.c:110
+#: builtin/log.c:112
 #, c-format
 msgid "invalid --decorate option: %s"
 msgstr "Ungültige Option für --decorate: %s"
 
-#: builtin/log.c:177
+#: builtin/log.c:179
 msgid "show source"
 msgstr "Quelle anzeigen"
 
-#: builtin/log.c:178
+#: builtin/log.c:180
 msgid "Use mail map file"
 msgstr "\"mailmap\"-Datei verwenden"
 
-#: builtin/log.c:181
+#: builtin/log.c:183
 msgid "only decorate refs that match <pattern>"
 msgstr "\"decorate\" nur bei Referenzen anwenden, die <Muster> entsprechen"
 
-#: builtin/log.c:183
+#: builtin/log.c:185
 msgid "do not decorate refs that match <pattern>"
 msgstr "\"decorate\" nicht bei Referenzen anwenden, die <Muster> entsprechen"
 
-#: builtin/log.c:184
+#: builtin/log.c:186
 msgid "decorate options"
 msgstr "decorate-Optionen"
 
-#: builtin/log.c:187
-msgid "Process line range n,m in file, counting from 1"
-msgstr "Verarbeitet nur Zeilen im Bereich n,m in der Datei, gezählt von 1"
+#: builtin/log.c:189
+msgid ""
+"Trace the evolution of line range <start>,<end> or function :<funcname> in "
+"<file>"
+msgstr ""
 
-#: builtin/log.c:297
+#: builtin/log.c:212
+#, fuzzy
+msgid "-L<range>:<file> cannot be used with pathspec"
+msgstr "%s: %s kann nicht mit %s verwendet werden"
+
+#: builtin/log.c:302
 #, c-format
 msgid "Final output: %d %s\n"
 msgstr "letzte Ausgabe: %d %s\n"
 
-#: builtin/log.c:555
+#: builtin/log.c:564
 #, c-format
 msgid "git show %s: bad file"
 msgstr "git show %s: ungültige Datei"
 
-#: builtin/log.c:570 builtin/log.c:665
+#: builtin/log.c:579 builtin/log.c:674
 #, c-format
 msgid "could not read object %s"
 msgstr "Konnte Objekt %s nicht lesen."
 
-#: builtin/log.c:690
+#: builtin/log.c:699
 #, c-format
 msgid "unknown type: %d"
 msgstr "Unbekannter Typ: %d"
 
-#: builtin/log.c:839
+#: builtin/log.c:848
 #, c-format
 msgid "%s: invalid cover from description mode"
 msgstr ""
 "%s: Ungültiger Modus für Erstellung des Deckblattes aus der Beschreibung"
 
-#: builtin/log.c:846
+#: builtin/log.c:855
 msgid "format.headers without value"
 msgstr "format.headers ohne Wert"
 
-#: builtin/log.c:965
-msgid "name of output directory is too long"
-msgstr "Name des Ausgabeverzeichnisses ist zu lang."
-
-#: builtin/log.c:981
+#: builtin/log.c:984
 #, c-format
 msgid "cannot open patch file %s"
 msgstr "Kann Patch-Datei %s nicht öffnen"
 
-#: builtin/log.c:998
+#: builtin/log.c:1001
 msgid "need exactly one range"
 msgstr "Brauche genau einen Commit-Bereich."
 
-#: builtin/log.c:1008
+#: builtin/log.c:1011
 msgid "not a range"
 msgstr "Kein Commit-Bereich."
 
-#: builtin/log.c:1172
+#: builtin/log.c:1175
 msgid "cover letter needs email format"
 msgstr "Anschreiben benötigt E-Mail-Format"
 
-#: builtin/log.c:1178
+#: builtin/log.c:1181
 msgid "failed to create cover-letter file"
 msgstr "Fehler beim Erstellen der Datei für das Anschreiben."
 
-#: builtin/log.c:1259
+#: builtin/log.c:1262
 #, c-format
 msgid "insane in-reply-to: %s"
 msgstr "ungültiges in-reply-to: %s"
 
-#: builtin/log.c:1286
+#: builtin/log.c:1289
 msgid "git format-patch [<options>] [<since> | <revision-range>]"
 msgstr "git format-patch [<Optionen>] [<seit> | <Commitbereich>]"
 
-#: builtin/log.c:1344
+#: builtin/log.c:1347
 msgid "two output directories?"
 msgstr "Zwei Ausgabeverzeichnisse?"
 
-#: builtin/log.c:1495 builtin/log.c:2301 builtin/log.c:2303 builtin/log.c:2315
+#: builtin/log.c:1498 builtin/log.c:2318 builtin/log.c:2320 builtin/log.c:2332
 #, c-format
 msgid "unknown commit %s"
 msgstr "Unbekannter Commit %s"
 
-#: builtin/log.c:1506 builtin/replace.c:58 builtin/replace.c:207
+#: builtin/log.c:1509 builtin/replace.c:58 builtin/replace.c:207
 #: builtin/replace.c:210
 #, c-format
 msgid "failed to resolve '%s' as a valid ref"
 msgstr "Konnte '%s' nicht als gültige Referenz auflösen."
 
-#: builtin/log.c:1515
+#: builtin/log.c:1518
 msgid "could not find exact merge base"
 msgstr "Konnte keine exakte Merge-Basis finden."
 
-#: builtin/log.c:1525
+#: builtin/log.c:1528
 msgid ""
 "failed to get upstream, if you want to record base commit automatically,\n"
 "please use git branch --set-upstream-to to track a remote branch.\n"
@@ -16551,286 +16691,292 @@ msgstr ""
 "'git branch --set-upstream-to', um einem Remote-Branch zu folgen.\n"
 "Oder geben Sie den Basis-Commit mit '--base=<Basis-Commit-Id>' manuell an."
 
-#: builtin/log.c:1548
+#: builtin/log.c:1551
 msgid "failed to find exact merge base"
 msgstr "Fehler beim Finden einer exakten Merge-Basis."
 
-#: builtin/log.c:1565
+#: builtin/log.c:1568
 msgid "base commit should be the ancestor of revision list"
 msgstr "Basis-Commit sollte der Vorgänger der Revisionsliste sein."
 
-#: builtin/log.c:1575
+#: builtin/log.c:1578
 msgid "base commit shouldn't be in revision list"
 msgstr "Basis-Commit sollte nicht in der Revisionsliste enthalten sein."
 
-#: builtin/log.c:1633
+#: builtin/log.c:1636
 msgid "cannot get patch id"
 msgstr "kann Patch-Id nicht lesen"
 
-#: builtin/log.c:1690
+#: builtin/log.c:1693
 msgid "failed to infer range-diff origin of current series"
 msgstr "Fehler beim Ableiten des range-diff Ursprungs der aktuellen Serie"
 
-#: builtin/log.c:1692
+#: builtin/log.c:1695
 #, c-format
 msgid "using '%s' as range-diff origin of current series"
 msgstr "nutze '%s' als range-diff Ursprung der aktuellen Serie"
 
-#: builtin/log.c:1736
+#: builtin/log.c:1739
 msgid "use [PATCH n/m] even with a single patch"
 msgstr "[PATCH n/m] auch mit einzelnem Patch verwenden"
 
-#: builtin/log.c:1739
+#: builtin/log.c:1742
 msgid "use [PATCH] even with multiple patches"
 msgstr "[PATCH] auch mit mehreren Patches verwenden"
 
-#: builtin/log.c:1743
+#: builtin/log.c:1746
 msgid "print patches to standard out"
 msgstr "Ausgabe der Patches in Standard-Ausgabe"
 
-#: builtin/log.c:1745
+#: builtin/log.c:1748
 msgid "generate a cover letter"
 msgstr "ein Deckblatt erzeugen"
 
-#: builtin/log.c:1747
+#: builtin/log.c:1750
 msgid "use simple number sequence for output file names"
 msgstr "einfache Nummernfolge für die Namen der Ausgabedateien verwenden"
 
-#: builtin/log.c:1748
+#: builtin/log.c:1751
 msgid "sfx"
 msgstr "Dateiendung"
 
-#: builtin/log.c:1749
+#: builtin/log.c:1752
 msgid "use <sfx> instead of '.patch'"
 msgstr "<Dateiendung> anstatt '.patch' verwenden"
 
-#: builtin/log.c:1751
+#: builtin/log.c:1754
 msgid "start numbering patches at <n> instead of 1"
 msgstr "die Nummerierung der Patches bei <n> anstatt bei 1 beginnen"
 
-#: builtin/log.c:1753
+#: builtin/log.c:1756
 msgid "mark the series as Nth re-roll"
 msgstr "die Serie als n-te Fassung kennzeichnen"
 
-#: builtin/log.c:1755
+#: builtin/log.c:1758
+#, fuzzy
+msgid "max length of output filename"
+msgstr "maximale Größe für jede ausgegebene Paketdatei"
+
+#: builtin/log.c:1760
 msgid "Use [RFC PATCH] instead of [PATCH]"
 msgstr "[RFC PATCH] anstatt [PATCH] verwenden"
 
-#: builtin/log.c:1758
+#: builtin/log.c:1763
 msgid "cover-from-description-mode"
 msgstr "Modus für Erstellung des Deckblattes aus der Beschreibung"
 
-#: builtin/log.c:1759
+#: builtin/log.c:1764
 msgid "generate parts of a cover letter based on a branch's description"
 msgstr ""
 "Erzeuge Teile des Deckblattes basierend auf der Beschreibung des Branches"
 
-#: builtin/log.c:1761
+#: builtin/log.c:1766
 msgid "Use [<prefix>] instead of [PATCH]"
 msgstr "Nutze [<Präfix>] statt [PATCH]"
 
-#: builtin/log.c:1764
+#: builtin/log.c:1769
 msgid "store resulting files in <dir>"
 msgstr "erzeugte Dateien in <Verzeichnis> speichern"
 
-#: builtin/log.c:1767
+#: builtin/log.c:1772
 msgid "don't strip/add [PATCH]"
 msgstr "[PATCH] nicht entfernen/hinzufügen"
 
-#: builtin/log.c:1770
+#: builtin/log.c:1775
 msgid "don't output binary diffs"
 msgstr "keine binären Unterschiede ausgeben"
 
-#: builtin/log.c:1772
+#: builtin/log.c:1777
 msgid "output all-zero hash in From header"
 msgstr "Hash mit Nullen in \"From\"-Header ausgeben"
 
-#: builtin/log.c:1774
+#: builtin/log.c:1779
 msgid "don't include a patch matching a commit upstream"
 msgstr ""
 "keine Patches einschließen, die einem Commit im Upstream-Branch entsprechen"
 
-#: builtin/log.c:1776
+#: builtin/log.c:1781
 msgid "show patch format instead of default (patch + stat)"
 msgstr "Patchformat anstatt des Standards anzeigen (Patch + Zusammenfassung)"
 
-#: builtin/log.c:1778
+#: builtin/log.c:1783
 msgid "Messaging"
 msgstr "E-Mail-Einstellungen"
 
-#: builtin/log.c:1779
+#: builtin/log.c:1784
 msgid "header"
 msgstr "Header"
 
-#: builtin/log.c:1780
+#: builtin/log.c:1785
 msgid "add email header"
 msgstr "E-Mail-Header hinzufügen"
 
-#: builtin/log.c:1781 builtin/log.c:1782
+#: builtin/log.c:1786 builtin/log.c:1787
 msgid "email"
 msgstr "E-Mail"
 
-#: builtin/log.c:1781
+#: builtin/log.c:1786
 msgid "add To: header"
 msgstr "\"To:\"-Header hinzufügen"
 
-#: builtin/log.c:1782
+#: builtin/log.c:1787
 msgid "add Cc: header"
 msgstr "\"Cc:\"-Header hinzufügen"
 
-#: builtin/log.c:1783
+#: builtin/log.c:1788
 msgid "ident"
 msgstr "Ident"
 
-#: builtin/log.c:1784
+#: builtin/log.c:1789
 msgid "set From address to <ident> (or committer ident if absent)"
 msgstr ""
 "\"From\"-Adresse auf <Ident> setzen (oder Ident des Commit-Erstellers, wenn "
 "fehlend)"
 
-#: builtin/log.c:1786
+#: builtin/log.c:1791
 msgid "message-id"
 msgstr "message-id"
 
-#: builtin/log.c:1787
+#: builtin/log.c:1792
 msgid "make first mail a reply to <message-id>"
 msgstr "aus erster E-Mail eine Antwort zu <message-id> machen"
 
-#: builtin/log.c:1788 builtin/log.c:1791
+#: builtin/log.c:1793 builtin/log.c:1796
 msgid "boundary"
 msgstr "Grenze"
 
-#: builtin/log.c:1789
+#: builtin/log.c:1794
 msgid "attach the patch"
 msgstr "den Patch anhängen"
 
-#: builtin/log.c:1792
+#: builtin/log.c:1797
 msgid "inline the patch"
 msgstr "den Patch direkt in die Nachricht einfügen"
 
-#: builtin/log.c:1796
+#: builtin/log.c:1801
 msgid "enable message threading, styles: shallow, deep"
 msgstr "Nachrichtenverkettung aktivieren, Stile: shallow, deep"
 
-#: builtin/log.c:1798
+#: builtin/log.c:1803
 msgid "signature"
 msgstr "Signatur"
 
-#: builtin/log.c:1799
+#: builtin/log.c:1804
 msgid "add a signature"
 msgstr "eine Signatur hinzufügen"
 
-#: builtin/log.c:1800
+#: builtin/log.c:1805
 msgid "base-commit"
 msgstr "Basis-Commit"
 
-#: builtin/log.c:1801
+#: builtin/log.c:1806
 msgid "add prerequisite tree info to the patch series"
 msgstr "erforderliche Revisions-Informationen der Patch-Serie hinzufügen"
 
-#: builtin/log.c:1804
+#: builtin/log.c:1809
 msgid "add a signature from a file"
 msgstr "eine Signatur aus einer Datei hinzufügen"
 
-#: builtin/log.c:1805
+#: builtin/log.c:1810
 msgid "don't print the patch filenames"
 msgstr "keine Dateinamen der Patches anzeigen"
 
-#: builtin/log.c:1807
+#: builtin/log.c:1812
 msgid "show progress while generating patches"
 msgstr "Forschrittsanzeige während der Erzeugung der Patches"
 
-#: builtin/log.c:1809
+#: builtin/log.c:1814
 msgid "show changes against <rev> in cover letter or single patch"
 msgstr ""
 "Änderungen gegenüber <Commit> im Deckblatt oder einzelnem Patch anzeigen"
 
-#: builtin/log.c:1812
+#: builtin/log.c:1817
 msgid "show changes against <refspec> in cover letter or single patch"
 msgstr ""
 "Änderungen gegenüber <Refspec> im Deckblatt oder einzelnem Patch anzeigen"
 
-#: builtin/log.c:1814
+#: builtin/log.c:1819
 msgid "percentage by which creation is weighted"
 msgstr "Prozentsatz mit welchem Erzeugung gewichtet wird"
 
-#: builtin/log.c:1896
+#: builtin/log.c:1905
 #, c-format
 msgid "invalid ident line: %s"
 msgstr "Ungültige Identifikationszeile: %s"
 
-#: builtin/log.c:1911
+#: builtin/log.c:1920
 msgid "-n and -k are mutually exclusive"
 msgstr "-n und -k schließen sich gegenseitig aus."
 
-#: builtin/log.c:1913
+#: builtin/log.c:1922
 msgid "--subject-prefix/--rfc and -k are mutually exclusive"
 msgstr "--subject-prefix/--rfc und -k schließen sich gegenseitig aus."
 
-#: builtin/log.c:1921
+#: builtin/log.c:1930
 msgid "--name-only does not make sense"
 msgstr "Die Option --name-only kann nicht verwendet werden."
 
-#: builtin/log.c:1923
+#: builtin/log.c:1932
 msgid "--name-status does not make sense"
 msgstr "Die Option --name-status kann nicht verwendet werden."
 
-#: builtin/log.c:1925
+#: builtin/log.c:1934
 msgid "--check does not make sense"
 msgstr "Die Option --check kann nicht verwendet werden."
 
-#: builtin/log.c:1958
-msgid "standard output, or directory, which one?"
-msgstr "Standard-Ausgabe oder Verzeichnis, welches von beidem?"
+#: builtin/log.c:1956
+#, fuzzy
+msgid "--stdout, --output, and --output-directory are mutually exclusive"
+msgstr "-b, -B und --detach schließen sich gegenseitig aus"
 
-#: builtin/log.c:2062
+#: builtin/log.c:2079
 msgid "--interdiff requires --cover-letter or single patch"
 msgstr "--interdiff erfordert --cover-letter oder einzelnen Patch."
 
-#: builtin/log.c:2066
+#: builtin/log.c:2083
 msgid "Interdiff:"
 msgstr "Interdiff:"
 
-#: builtin/log.c:2067
+#: builtin/log.c:2084
 #, c-format
 msgid "Interdiff against v%d:"
 msgstr "Interdiff gegen v%d:"
 
-#: builtin/log.c:2073
+#: builtin/log.c:2090
 msgid "--creation-factor requires --range-diff"
 msgstr "--creation-factor erfordert --range-diff"
 
-#: builtin/log.c:2077
+#: builtin/log.c:2094
 msgid "--range-diff requires --cover-letter or single patch"
 msgstr "--range-diff erfordert --cover-letter oder einzelnen Patch."
 
-#: builtin/log.c:2085
+#: builtin/log.c:2102
 msgid "Range-diff:"
 msgstr "Range-Diff:"
 
-#: builtin/log.c:2086
+#: builtin/log.c:2103
 #, c-format
 msgid "Range-diff against v%d:"
 msgstr "Range-Diff gegen v%d:"
 
-#: builtin/log.c:2097
+#: builtin/log.c:2114
 #, c-format
 msgid "unable to read signature file '%s'"
 msgstr "Konnte Signatur-Datei '%s' nicht lesen"
 
-#: builtin/log.c:2133
+#: builtin/log.c:2150
 msgid "Generating patches"
 msgstr "Erzeuge Patches"
 
-#: builtin/log.c:2177
+#: builtin/log.c:2194
 msgid "failed to create output files"
 msgstr "Fehler beim Erstellen der Ausgabedateien."
 
-#: builtin/log.c:2236
+#: builtin/log.c:2253
 msgid "git cherry [-v] [<upstream> [<head> [<limit>]]]"
 msgstr "git cherry [-v] [<Upstream> [<Branch> [<Limit>]]]"
 
-#: builtin/log.c:2290
+#: builtin/log.c:2307
 #, c-format
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> manually.\n"
@@ -16961,7 +17107,7 @@ msgstr ""
 msgid "do not print remote URL"
 msgstr "URL des Remote-Repositories nicht ausgeben"
 
-#: builtin/ls-remote.c:60 builtin/ls-remote.c:62 builtin/rebase.c:1392
+#: builtin/ls-remote.c:60 builtin/ls-remote.c:62 builtin/rebase.c:1398
 msgid "exec"
 msgstr "Programm"
 
@@ -17149,194 +17295,194 @@ msgstr "Konnte Referenz '%s' nicht auflösen"
 msgid "Merging %s with %s\n"
 msgstr "Führe %s mit %s zusammen\n"
 
-#: builtin/merge.c:56
+#: builtin/merge.c:57
 msgid "git merge [<options>] [<commit>...]"
 msgstr "git merge [<Optionen>] [<Commit>...]"
 
-#: builtin/merge.c:57
+#: builtin/merge.c:58
 msgid "git merge --abort"
 msgstr "git merge --abort"
 
-#: builtin/merge.c:58
+#: builtin/merge.c:59
 msgid "git merge --continue"
 msgstr "git merge --continue"
 
-#: builtin/merge.c:120
+#: builtin/merge.c:122
 msgid "switch `m' requires a value"
 msgstr "Schalter 'm' erfordert einen Wert."
 
-#: builtin/merge.c:143
+#: builtin/merge.c:145
 #, c-format
 msgid "option `%s' requires a value"
 msgstr "Option `%s' erfordert einen Wert."
 
-#: builtin/merge.c:189
+#: builtin/merge.c:198
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
 msgstr "Konnte Merge-Strategie '%s' nicht finden.\n"
 
-#: builtin/merge.c:190
+#: builtin/merge.c:199
 #, c-format
 msgid "Available strategies are:"
 msgstr "Verfügbare Strategien sind:"
 
-#: builtin/merge.c:195
+#: builtin/merge.c:204
 #, c-format
 msgid "Available custom strategies are:"
 msgstr "Verfügbare benutzerdefinierte Strategien sind:"
 
-#: builtin/merge.c:246 builtin/pull.c:133
+#: builtin/merge.c:255 builtin/pull.c:133
 msgid "do not show a diffstat at the end of the merge"
 msgstr "keine Zusammenfassung der Unterschiede am Schluss des Merges anzeigen"
 
-#: builtin/merge.c:249 builtin/pull.c:136
+#: builtin/merge.c:258 builtin/pull.c:136
 msgid "show a diffstat at the end of the merge"
 msgstr "eine Zusammenfassung der Unterschiede am Schluss des Merges anzeigen"
 
-#: builtin/merge.c:250 builtin/pull.c:139
+#: builtin/merge.c:259 builtin/pull.c:139
 msgid "(synonym to --stat)"
 msgstr "(Synonym für --stat)"
 
-#: builtin/merge.c:252 builtin/pull.c:142
+#: builtin/merge.c:261 builtin/pull.c:142
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "(höchstens <n>) Einträge von \"shortlog\" zur Beschreibung des Merge-Commits "
 "hinzufügen"
 
-#: builtin/merge.c:255 builtin/pull.c:148
+#: builtin/merge.c:264 builtin/pull.c:148
 msgid "create a single commit instead of doing a merge"
 msgstr "einen einzelnen Commit anstatt eines Merges erzeugen"
 
-#: builtin/merge.c:257 builtin/pull.c:151
+#: builtin/merge.c:266 builtin/pull.c:151
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "einen Commit durchführen, wenn der Merge erfolgreich war (Standard)"
 
-#: builtin/merge.c:259 builtin/pull.c:154
+#: builtin/merge.c:268 builtin/pull.c:154
 msgid "edit message before committing"
 msgstr "Bearbeitung der Beschreibung vor dem Commit"
 
-#: builtin/merge.c:261
+#: builtin/merge.c:270
 msgid "allow fast-forward (default)"
 msgstr "Vorspulen erlauben (Standard)"
 
-#: builtin/merge.c:263 builtin/pull.c:161
+#: builtin/merge.c:272 builtin/pull.c:161
 msgid "abort if fast-forward is not possible"
 msgstr "abbrechen, wenn kein Vorspulen möglich ist"
 
-#: builtin/merge.c:267 builtin/pull.c:164
+#: builtin/merge.c:276 builtin/pull.c:164
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "den genannten Commit auf eine gültige GPG-Signatur überprüfen"
 
-#: builtin/merge.c:268 builtin/notes.c:787 builtin/pull.c:168
-#: builtin/rebase.c:533 builtin/rebase.c:1406 builtin/revert.c:114
+#: builtin/merge.c:277 builtin/notes.c:787 builtin/pull.c:168
+#: builtin/rebase.c:539 builtin/rebase.c:1412 builtin/revert.c:114
 msgid "strategy"
 msgstr "Strategie"
 
-#: builtin/merge.c:269 builtin/pull.c:169
+#: builtin/merge.c:278 builtin/pull.c:169
 msgid "merge strategy to use"
 msgstr "zu verwendende Merge-Strategie"
 
-#: builtin/merge.c:270 builtin/pull.c:172
+#: builtin/merge.c:279 builtin/pull.c:172
 msgid "option=value"
 msgstr "Option=Wert"
 
-#: builtin/merge.c:271 builtin/pull.c:173
+#: builtin/merge.c:280 builtin/pull.c:173
 msgid "option for selected merge strategy"
 msgstr "Option für ausgewählte Merge-Strategie"
 
-#: builtin/merge.c:273
+#: builtin/merge.c:282
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr ""
 "Commit-Beschreibung zusammenführen (für einen Merge, der kein Vorspulen war)"
 
-#: builtin/merge.c:280
+#: builtin/merge.c:289
 msgid "abort the current in-progress merge"
 msgstr "den sich im Gange befindlichen Merge abbrechen"
 
-#: builtin/merge.c:282
+#: builtin/merge.c:291
 msgid "--abort but leave index and working tree alone"
 msgstr "--abort, aber Index und Arbeitsverzeichnis unverändert lassen"
 
-#: builtin/merge.c:284
+#: builtin/merge.c:293
 msgid "continue the current in-progress merge"
 msgstr "den sich im Gange befindlichen Merge fortsetzen"
 
-#: builtin/merge.c:286 builtin/pull.c:180
+#: builtin/merge.c:295 builtin/pull.c:180
 msgid "allow merging unrelated histories"
 msgstr "erlaube das Zusammenführen von nicht zusammenhängenden Historien"
 
-#: builtin/merge.c:293
+#: builtin/merge.c:302
 msgid "bypass pre-merge-commit and commit-msg hooks"
 msgstr "Hooks pre-merge-commit und commit-msg umgehen"
 
-#: builtin/merge.c:310
+#: builtin/merge.c:319
 msgid "could not run stash."
 msgstr "Konnte \"stash\" nicht ausführen."
 
-#: builtin/merge.c:315
+#: builtin/merge.c:324
 msgid "stash failed"
 msgstr "\"stash\" fehlgeschlagen"
 
-#: builtin/merge.c:320
+#: builtin/merge.c:329
 #, c-format
 msgid "not a valid object: %s"
 msgstr "kein gültiges Objekt: %s"
 
-#: builtin/merge.c:342 builtin/merge.c:359
+#: builtin/merge.c:351 builtin/merge.c:368
 msgid "read-tree failed"
 msgstr "read-tree fehlgeschlagen"
 
-#: builtin/merge.c:389
+#: builtin/merge.c:398
 msgid " (nothing to squash)"
 msgstr " (nichts zu quetschen)"
 
-#: builtin/merge.c:400
+#: builtin/merge.c:409
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
 msgstr "Quetsche Commit -- HEAD wird nicht aktualisiert\n"
 
-#: builtin/merge.c:450
+#: builtin/merge.c:459
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
 msgstr "Keine Merge-Commit-Beschreibung -- HEAD wird nicht aktualisiert\n"
 
-#: builtin/merge.c:501
+#: builtin/merge.c:510
 #, c-format
 msgid "'%s' does not point to a commit"
 msgstr "'%s' zeigt auf keinen Commit"
 
-#: builtin/merge.c:588
+#: builtin/merge.c:597
 #, c-format
 msgid "Bad branch.%s.mergeoptions string: %s"
 msgstr "Ungültiger branch.%s.mergeoptions String: %s"
 
-#: builtin/merge.c:713
+#: builtin/merge.c:723
 msgid "Not handling anything other than two heads merge."
 msgstr "Es wird nur der Merge von zwei Branches behandelt."
 
-#: builtin/merge.c:726
+#: builtin/merge.c:736
 #, c-format
 msgid "Unknown option for merge-recursive: -X%s"
 msgstr "Unbekannte Option für merge-recursive: -X%s"
 
-#: builtin/merge.c:741
+#: builtin/merge.c:755 t/helper/test-fast-rebase.c:209
 #, c-format
 msgid "unable to write %s"
 msgstr "konnte %s nicht schreiben"
 
-#: builtin/merge.c:793
+#: builtin/merge.c:807
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "konnte nicht von '%s' lesen"
 
-#: builtin/merge.c:802
+#: builtin/merge.c:816
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
 "Merge wurde nicht committet; benutzen Sie 'git commit', um den Merge "
 "abzuschließen.\n"
 
-#: builtin/merge.c:808
+#: builtin/merge.c:822
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
@@ -17347,11 +17493,11 @@ msgstr ""
 "Upstream-Branch mit einem Thema-Branch zusammenführt.\n"
 "\n"
 
-#: builtin/merge.c:813
+#: builtin/merge.c:827
 msgid "An empty message aborts the commit.\n"
 msgstr "Eine leere Commit-Beschreibung bricht den Commit ab.\n"
 
-#: builtin/merge.c:816
+#: builtin/merge.c:830
 #, c-format
 msgid ""
 "Lines starting with '%c' will be ignored, and an empty message aborts\n"
@@ -17360,75 +17506,75 @@ msgstr ""
 "Zeilen, die mit '%c' beginnen, werden ignoriert,\n"
 "und eine leere Beschreibung bricht den Commit ab.\n"
 
-#: builtin/merge.c:869
+#: builtin/merge.c:883
 msgid "Empty commit message."
 msgstr "Leere Commit-Beschreibung"
 
-#: builtin/merge.c:884
+#: builtin/merge.c:898
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Wunderbar.\n"
 
-#: builtin/merge.c:945
+#: builtin/merge.c:959
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
 "Automatischer Merge fehlgeschlagen; beheben Sie die Konflikte und committen "
 "Sie dann das Ergebnis.\n"
 
-#: builtin/merge.c:984
+#: builtin/merge.c:998
 msgid "No current branch."
 msgstr "Sie befinden sich auf keinem Branch."
 
-#: builtin/merge.c:986
+#: builtin/merge.c:1000
 msgid "No remote for the current branch."
 msgstr "Kein Remote-Repository für den aktuellen Branch."
 
-#: builtin/merge.c:988
+#: builtin/merge.c:1002
 msgid "No default upstream defined for the current branch."
 msgstr ""
 "Es ist kein Standard-Upstream-Branch für den aktuellen Branch definiert."
 
-#: builtin/merge.c:993
+#: builtin/merge.c:1007
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "Kein Remote-Tracking-Branch für %s von %s"
 
-#: builtin/merge.c:1050
+#: builtin/merge.c:1064
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Fehlerhafter Wert '%s' in Umgebungsvariable '%s'"
 
-#: builtin/merge.c:1153
+#: builtin/merge.c:1167
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "nichts was wir in %s zusammenführen können: %s"
 
-#: builtin/merge.c:1187
+#: builtin/merge.c:1201
 msgid "not something we can merge"
 msgstr "nichts was wir zusammenführen können"
 
-#: builtin/merge.c:1291
+#: builtin/merge.c:1311
 msgid "--abort expects no arguments"
 msgstr "--abort akzeptiert keine Argumente"
 
-#: builtin/merge.c:1295
+#: builtin/merge.c:1315
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr "Es gibt keinen Merge abzubrechen (MERGE_HEAD fehlt)"
 
-#: builtin/merge.c:1313
+#: builtin/merge.c:1333
 msgid "--quit expects no arguments"
 msgstr "--quit erwartet keine Argumente"
 
-#: builtin/merge.c:1326
+#: builtin/merge.c:1346
 msgid "--continue expects no arguments"
 msgstr "--continue erwartet keine Argumente"
 
-#: builtin/merge.c:1330
+#: builtin/merge.c:1350
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "Es ist kein Merge im Gange (MERGE_HEAD fehlt)."
 
-#: builtin/merge.c:1346
+#: builtin/merge.c:1366
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17436,7 +17582,7 @@ msgstr ""
 "Sie haben Ihren Merge nicht abgeschlossen (MERGE_HEAD existiert).\n"
 "Bitte committen Sie Ihre Änderungen, bevor Sie den Merge ausführen."
 
-#: builtin/merge.c:1353
+#: builtin/merge.c:1373
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17444,100 +17590,100 @@ msgstr ""
 "Sie haben \"cherry-pick\" nicht abgeschlossen (CHERRY_PICK_HEAD existiert).\n"
 "Bitte committen Sie Ihre Änderungen, bevor Sie den Merge ausführen."
 
-#: builtin/merge.c:1356
+#: builtin/merge.c:1376
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr ""
 "Sie haben \"cherry-pick\" nicht abgeschlossen (CHERRY_PICK_HEAD existiert)."
 
-#: builtin/merge.c:1370
+#: builtin/merge.c:1390
 msgid "You cannot combine --squash with --no-ff."
 msgstr "Sie können --squash nicht mit --no-ff kombinieren."
 
-#: builtin/merge.c:1372
+#: builtin/merge.c:1392
 msgid "You cannot combine --squash with --commit."
 msgstr "Sie können --squash nicht mit --commit kombinieren."
 
-#: builtin/merge.c:1388
+#: builtin/merge.c:1408
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr "Kein Commit angegeben und merge.defaultToUpstream ist nicht gesetzt."
 
-#: builtin/merge.c:1405
+#: builtin/merge.c:1425
 msgid "Squash commit into empty head not supported yet"
 msgstr ""
 "Bin auf einem Commit, der noch geboren wird; kann \"squash\" nicht ausführen."
 
-#: builtin/merge.c:1407
+#: builtin/merge.c:1427
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr ""
 "Nicht vorzuspulender Commit kann nicht in einem leeren Branch verwendet "
 "werden."
 
-#: builtin/merge.c:1412
+#: builtin/merge.c:1432
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "%s - nichts was wir zusammenführen können"
 
-#: builtin/merge.c:1414
+#: builtin/merge.c:1434
 msgid "Can merge only exactly one commit into empty head"
 msgstr "Kann nur exakt einen Commit in einem leeren Branch zusammenführen."
 
-#: builtin/merge.c:1495
+#: builtin/merge.c:1515
 msgid "refusing to merge unrelated histories"
 msgstr "Verweigere den Merge von nicht zusammenhängenden Historien."
 
-#: builtin/merge.c:1504
+#: builtin/merge.c:1524
 msgid "Already up to date."
 msgstr "Bereits aktuell."
 
-#: builtin/merge.c:1514
+#: builtin/merge.c:1534
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "Aktualisiere %s..%s\n"
 
-#: builtin/merge.c:1560
+#: builtin/merge.c:1580
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "Probiere wirklich trivialen \"in-index\"-Merge ...\n"
 
-#: builtin/merge.c:1567
+#: builtin/merge.c:1587
 #, c-format
 msgid "Nope.\n"
 msgstr "Nein.\n"
 
-#: builtin/merge.c:1592
+#: builtin/merge.c:1612
 msgid "Already up to date. Yeeah!"
 msgstr "Bereits aktuell."
 
-#: builtin/merge.c:1598
+#: builtin/merge.c:1618
 msgid "Not possible to fast-forward, aborting."
 msgstr "Vorspulen nicht möglich, breche ab."
 
-#: builtin/merge.c:1626 builtin/merge.c:1691
+#: builtin/merge.c:1646 builtin/merge.c:1711
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "Rücklauf des Verzeichnisses bis zum Ursprung ...\n"
 
-#: builtin/merge.c:1630
+#: builtin/merge.c:1650
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Probiere Merge-Strategie %s ...\n"
 
-#: builtin/merge.c:1682
+#: builtin/merge.c:1702
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Keine Merge-Strategie behandelt diesen Merge.\n"
 
-#: builtin/merge.c:1684
+#: builtin/merge.c:1704
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "Merge mit Strategie %s fehlgeschlagen.\n"
 
-#: builtin/merge.c:1693
+#: builtin/merge.c:1713
 #, c-format
 msgid "Using the %s to prepare resolving by hand.\n"
 msgstr "Benutzen Sie \"%s\", um die Auflösung per Hand vorzubereiten.\n"
 
-#: builtin/merge.c:1707
+#: builtin/merge.c:1727
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
@@ -17687,7 +17833,7 @@ msgstr "%s, Quelle=%s, Ziel=%s"
 msgid "Renaming %s to %s\n"
 msgstr "Benenne %s nach %s um\n"
 
-#: builtin/mv.c:280 builtin/remote.c:782 builtin/repack.c:518
+#: builtin/mv.c:280 builtin/remote.c:785 builtin/repack.c:484
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "Umbenennung von '%s' fehlgeschlagen"
@@ -18154,7 +18300,7 @@ msgstr "Notiz-Referenz"
 msgid "use notes from <notes-ref>"
 msgstr "Notizen von <Notiz-Referenz> verwenden"
 
-#: builtin/notes.c:1034 builtin/stash.c:1605
+#: builtin/notes.c:1034 builtin/stash.c:1604
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr "Unbekannter Unterbefehl: %s"
@@ -18618,7 +18764,7 @@ msgstr "Optionen bezogen auf Merge"
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "Integration von Änderungen durch Rebase statt Merge"
 
-#: builtin/pull.c:158 builtin/rebase.c:484 builtin/revert.c:126
+#: builtin/pull.c:158 builtin/rebase.c:490 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "Vorspulen erlauben"
 
@@ -18708,17 +18854,17 @@ msgstr ""
 "Repository für den aktuellen Branch ist, müssen Sie einen Branch auf\n"
 "der Befehlszeile angeben."
 
-#: builtin/pull.c:469 builtin/rebase.c:1240 git-parse-remote.sh:73
+#: builtin/pull.c:469 builtin/rebase.c:1246
 msgid "You are not currently on a branch."
 msgstr "Im Moment auf keinem Branch."
 
-#: builtin/pull.c:471 builtin/pull.c:486 git-parse-remote.sh:79
+#: builtin/pull.c:471 builtin/pull.c:486
 msgid "Please specify which branch you want to rebase against."
 msgstr ""
 "Bitte geben Sie den Branch an, gegen welchen Sie \"rebase\" ausführen "
 "möchten."
 
-#: builtin/pull.c:473 builtin/pull.c:488 git-parse-remote.sh:82
+#: builtin/pull.c:473 builtin/pull.c:488
 msgid "Please specify which branch you want to merge with."
 msgstr "Bitte geben Sie den Branch an, welchen Sie zusammenführen möchten."
 
@@ -18727,20 +18873,19 @@ msgid "See git-pull(1) for details."
 msgstr "Siehe git-pull(1) für weitere Details."
 
 #: builtin/pull.c:476 builtin/pull.c:482 builtin/pull.c:491
-#: builtin/rebase.c:1246 git-parse-remote.sh:64
+#: builtin/rebase.c:1252
 msgid "<remote>"
 msgstr "<Remote-Repository>"
 
 #: builtin/pull.c:476 builtin/pull.c:491 builtin/pull.c:496
-#: git-parse-remote.sh:65
 msgid "<branch>"
 msgstr "<Branch>"
 
-#: builtin/pull.c:484 builtin/rebase.c:1238 git-parse-remote.sh:75
+#: builtin/pull.c:484 builtin/rebase.c:1244
 msgid "There is no tracking information for the current branch."
 msgstr "Es gibt keine Tracking-Informationen für den aktuellen Branch."
 
-#: builtin/pull.c:493 git-parse-remote.sh:95
+#: builtin/pull.c:493
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:"
 msgstr ""
@@ -18763,25 +18908,25 @@ msgstr ""
 msgid "unable to access commit %s"
 msgstr "Konnte nicht auf Commit '%s' zugreifen."
 
-#: builtin/pull.c:894
+#: builtin/pull.c:915
 msgid "ignoring --verify-signatures for rebase"
 msgstr "Ignoriere --verify-signatures für Rebase"
 
-#: builtin/pull.c:954
+#: builtin/pull.c:972
 msgid "Updating an unborn branch with changes added to the index."
 msgstr ""
 "Aktualisiere einen ungeborenen Branch mit Änderungen, die zum Commit "
 "vorgemerkt sind."
 
-#: builtin/pull.c:958
+#: builtin/pull.c:976
 msgid "pull with rebase"
 msgstr "Pull mit Rebase"
 
-#: builtin/pull.c:959
+#: builtin/pull.c:977
 msgid "please commit or stash them."
 msgstr "Bitte committen Sie die Änderungen oder benutzen Sie \"stash\"."
 
-#: builtin/pull.c:984
+#: builtin/pull.c:1002
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -18791,7 +18936,7 @@ msgstr ""
 "\"fetch\" aktualisierte die Spitze des aktuellen Branches.\n"
 "Spule Ihr Arbeitsverzeichnis von Commit %s vor."
 
-#: builtin/pull.c:990
+#: builtin/pull.c:1008
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -18808,15 +18953,15 @@ msgstr ""
 "$ git reset --hard\n"
 "zur Wiederherstellung aus."
 
-#: builtin/pull.c:1005
+#: builtin/pull.c:1023
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Kann nicht mehrere Branches in einen leeren Branch zusammenführen."
 
-#: builtin/pull.c:1009
+#: builtin/pull.c:1027
 msgid "Cannot rebase onto multiple branches."
 msgstr "Kann Rebase nicht auf mehrere Branches ausführen."
 
-#: builtin/pull.c:1017
+#: builtin/pull.c:1041
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "Kann Rebase nicht mit lokal aufgezeichneten Änderungen in Submodulen "
@@ -18985,99 +19130,118 @@ msgstr ""
 "das kein Commit ist, oder es auf ein solches Objekt zeigen lassen, ohne\n"
 "die Option '--force' zu verwenden.\n"
 
-#: builtin/push.c:351
+#: builtin/push.c:294
+#, fuzzy
+msgid ""
+"Updates were rejected because the tip of the remote-tracking\n"
+"branch has been updated since the last checkout. You may want\n"
+"to integrate those changes locally (e.g., 'git pull ...')\n"
+"before forcing an update.\n"
+msgstr ""
+"Aktualisierungen wurden zurückgewiesen, weil die Spitze Ihres aktuellen\n"
+"Branches hinter seinem externen Gegenstück zurückgefallen ist. Führen Sie\n"
+"die externen Änderungen zusammen (z. B. 'git pull ...') bevor Sie \"push\"\n"
+"erneut ausführen.\n"
+"Siehe auch die Sektion 'Note about fast-forwards' in 'git push --help'\n"
+"für weitere Details."
+
+#: builtin/push.c:364
 #, c-format
 msgid "Pushing to %s\n"
 msgstr "Push nach %s\n"
 
-#: builtin/push.c:358
+#: builtin/push.c:371
 #, c-format
 msgid "failed to push some refs to '%s'"
 msgstr "Fehler beim Versenden einiger Referenzen nach '%s'"
 
-#: builtin/push.c:532
+#: builtin/push.c:553
 msgid "repository"
 msgstr "Repository"
 
-#: builtin/push.c:533 builtin/send-pack.c:183
+#: builtin/push.c:554 builtin/send-pack.c:189
 msgid "push all refs"
 msgstr "alle Referenzen versenden"
 
-#: builtin/push.c:534 builtin/send-pack.c:185
+#: builtin/push.c:555 builtin/send-pack.c:191
 msgid "mirror all refs"
 msgstr "alle Referenzen spiegeln"
 
-#: builtin/push.c:536
+#: builtin/push.c:557
 msgid "delete refs"
 msgstr "Referenzen löschen"
 
-#: builtin/push.c:537
+#: builtin/push.c:558
 msgid "push tags (can't be used with --all or --mirror)"
 msgstr "Tags versenden (kann nicht mit --all oder --mirror verwendet werden)"
 
-#: builtin/push.c:540 builtin/send-pack.c:186
+#: builtin/push.c:561 builtin/send-pack.c:192
 msgid "force updates"
 msgstr "Aktualisierung erzwingen"
 
-#: builtin/push.c:541 builtin/send-pack.c:198
+#: builtin/push.c:562 builtin/send-pack.c:204
 msgid "<refname>:<expect>"
 msgstr "<Referenzname>:<Erwartungswert>"
 
-#: builtin/push.c:542 builtin/send-pack.c:199
+#: builtin/push.c:563 builtin/send-pack.c:205
 msgid "require old value of ref to be at this value"
 msgstr "Referenz muss sich auf dem angegebenen Wert befinden"
 
-#: builtin/push.c:545
+#: builtin/push.c:566 builtin/send-pack.c:208
+msgid "require remote updates to be integrated locally"
+msgstr ""
+
+#: builtin/push.c:569
 msgid "control recursive pushing of submodules"
 msgstr "rekursiven \"push\" von Submodulen steuern"
 
-#: builtin/push.c:546 builtin/send-pack.c:193
+#: builtin/push.c:570 builtin/send-pack.c:199
 msgid "use thin pack"
 msgstr "kleinere Pakete verwenden"
 
-#: builtin/push.c:547 builtin/push.c:548 builtin/send-pack.c:180
-#: builtin/send-pack.c:181
+#: builtin/push.c:571 builtin/push.c:572 builtin/send-pack.c:186
+#: builtin/send-pack.c:187
 msgid "receive pack program"
 msgstr "'receive pack' Programm"
 
-#: builtin/push.c:549
+#: builtin/push.c:573
 msgid "set upstream for git pull/status"
 msgstr "Upstream für \"git pull/status\" setzen"
 
-#: builtin/push.c:552
+#: builtin/push.c:576
 msgid "prune locally removed refs"
 msgstr "lokal gelöschte Referenzen entfernen"
 
-#: builtin/push.c:554
+#: builtin/push.c:578
 msgid "bypass pre-push hook"
 msgstr "\"pre-push hook\" umgehen"
 
-#: builtin/push.c:555
+#: builtin/push.c:579
 msgid "push missing but relevant tags"
 msgstr "fehlende, aber relevante Tags versenden"
 
-#: builtin/push.c:557 builtin/send-pack.c:187
+#: builtin/push.c:581 builtin/send-pack.c:193
 msgid "GPG sign the push"
 msgstr "signiert \"push\" mit GPG"
 
-#: builtin/push.c:559 builtin/send-pack.c:194
+#: builtin/push.c:583 builtin/send-pack.c:200
 msgid "request atomic transaction on remote side"
 msgstr "Referenzen atomar versenden"
 
-#: builtin/push.c:577
+#: builtin/push.c:601
 msgid "--delete is incompatible with --all, --mirror and --tags"
 msgstr "Die Option --delete ist inkompatibel mit --all, --mirror und --tags."
 
-#: builtin/push.c:579
+#: builtin/push.c:603
 msgid "--delete doesn't make sense without any refs"
 msgstr "Die Option --delete kann nur mit Referenzen verwendet werden."
 
-#: builtin/push.c:599
+#: builtin/push.c:623
 #, c-format
 msgid "bad repository '%s'"
 msgstr "ungültiges Repository '%s'"
 
-#: builtin/push.c:600
+#: builtin/push.c:624
 msgid ""
 "No configured push destination.\n"
 "Either specify the URL from the command-line or configure a remote "
@@ -19099,27 +19263,27 @@ msgstr ""
 "\n"
 "    git push <Name>\n"
 
-#: builtin/push.c:615
+#: builtin/push.c:639
 msgid "--all and --tags are incompatible"
 msgstr "Die Optionen --all und --tags sind inkompatibel."
 
-#: builtin/push.c:617
+#: builtin/push.c:641
 msgid "--all can't be combined with refspecs"
 msgstr "Die Option --all kann nicht mit Refspecs kombiniert werden."
 
-#: builtin/push.c:621
+#: builtin/push.c:645
 msgid "--mirror and --tags are incompatible"
 msgstr "Die Optionen --mirror und --tags sind inkompatibel."
 
-#: builtin/push.c:623
+#: builtin/push.c:647
 msgid "--mirror can't be combined with refspecs"
 msgstr "Die Option --mirror kann nicht mit Refspecs kombiniert werden."
 
-#: builtin/push.c:626
+#: builtin/push.c:650
 msgid "--all and --mirror are incompatible"
 msgstr "Die Optionen --all und --mirror sind inkompatibel."
 
-#: builtin/push.c:630
+#: builtin/push.c:657
 msgid "push options must not have new line characters"
 msgstr "Push-Optionen dürfen keine Zeilenvorschubzeichen haben"
 
@@ -19268,194 +19432,194 @@ msgstr ""
 msgid "git rebase --continue | --abort | --skip | --edit-todo"
 msgstr "git rebase --continue | --abort | --skip | --edit-todo"
 
-#: builtin/rebase.c:187 builtin/rebase.c:211 builtin/rebase.c:238
+#: builtin/rebase.c:193 builtin/rebase.c:217 builtin/rebase.c:244
 #, c-format
 msgid "unusable todo list: '%s'"
 msgstr "Unbenutzbare TODO-Liste: '%s'"
 
-#: builtin/rebase.c:304
+#: builtin/rebase.c:310
 #, c-format
 msgid "could not create temporary %s"
 msgstr "Konnte temporäres Verzeichnis '%s' nicht erstellen."
 
-#: builtin/rebase.c:310
+#: builtin/rebase.c:316
 msgid "could not mark as interactive"
 msgstr "Markierung auf interaktiven Rebase fehlgeschlagen."
 
-#: builtin/rebase.c:364
+#: builtin/rebase.c:369
 msgid "could not generate todo list"
 msgstr "Konnte TODO-Liste nicht erzeugen."
 
-#: builtin/rebase.c:405
+#: builtin/rebase.c:411
 msgid "a base commit must be provided with --upstream or --onto"
 msgstr "Ein Basis-Commit muss mit --upstream oder --onto angegeben werden."
 
-#: builtin/rebase.c:474
+#: builtin/rebase.c:480
 msgid "git rebase--interactive [<options>]"
 msgstr "git rebase--interactive [<Optionen>]"
 
-#: builtin/rebase.c:487 builtin/rebase.c:1382
+#: builtin/rebase.c:493 builtin/rebase.c:1388
 msgid "keep commits which start empty"
 msgstr "behalte Commits, die leer beginnen"
 
-#: builtin/rebase.c:491 builtin/revert.c:128
+#: builtin/rebase.c:497 builtin/revert.c:128
 msgid "allow commits with empty messages"
 msgstr "Commits mit leerer Beschreibung erlauben"
 
-#: builtin/rebase.c:493
+#: builtin/rebase.c:499
 msgid "rebase merge commits"
 msgstr "Rebase auf Merge-Commits ausführen"
 
-#: builtin/rebase.c:495
+#: builtin/rebase.c:501
 msgid "keep original branch points of cousins"
 msgstr "originale Branch-Punkte der Cousins behalten"
 
-#: builtin/rebase.c:497
+#: builtin/rebase.c:503
 msgid "move commits that begin with squash!/fixup!"
 msgstr "Commits verschieben, die mit squash!/fixup! beginnen"
 
-#: builtin/rebase.c:498
+#: builtin/rebase.c:504
 msgid "sign commits"
 msgstr "Commits signieren"
 
-#: builtin/rebase.c:500 builtin/rebase.c:1321
+#: builtin/rebase.c:506 builtin/rebase.c:1327
 msgid "display a diffstat of what changed upstream"
 msgstr ""
 "Zusammenfassung der Unterschiede gegenüber dem Upstream-Branch anzeigen"
 
-#: builtin/rebase.c:502
+#: builtin/rebase.c:508
 msgid "continue rebase"
 msgstr "Rebase fortsetzen"
 
-#: builtin/rebase.c:504
+#: builtin/rebase.c:510
 msgid "skip commit"
 msgstr "Commit auslassen"
 
-#: builtin/rebase.c:505
+#: builtin/rebase.c:511
 msgid "edit the todo list"
 msgstr "die TODO-Liste bearbeiten"
 
-#: builtin/rebase.c:507
+#: builtin/rebase.c:513
 msgid "show the current patch"
 msgstr "den aktuellen Patch anzeigen"
 
-#: builtin/rebase.c:510
+#: builtin/rebase.c:516
 msgid "shorten commit ids in the todo list"
 msgstr "Commit-IDs in der TODO-Liste verkürzen"
 
-#: builtin/rebase.c:512
+#: builtin/rebase.c:518
 msgid "expand commit ids in the todo list"
 msgstr "Commit-IDs in der TODO-Liste erweitern"
 
-#: builtin/rebase.c:514
+#: builtin/rebase.c:520
 msgid "check the todo list"
 msgstr "die TODO-Liste prüfen"
 
-#: builtin/rebase.c:516
+#: builtin/rebase.c:522
 msgid "rearrange fixup/squash lines"
 msgstr "fixup/squash-Zeilen umordnen"
 
-#: builtin/rebase.c:518
+#: builtin/rebase.c:524
 msgid "insert exec commands in todo list"
 msgstr "\"exec\"-Befehle in TODO-Liste einfügen"
 
-#: builtin/rebase.c:519
+#: builtin/rebase.c:525
 msgid "onto"
 msgstr "auf"
 
-#: builtin/rebase.c:522
+#: builtin/rebase.c:528
 msgid "restrict-revision"
 msgstr "Begrenzungscommit"
 
-#: builtin/rebase.c:522
+#: builtin/rebase.c:528
 msgid "restrict revision"
 msgstr "Begrenzungscommit"
 
-#: builtin/rebase.c:524
+#: builtin/rebase.c:530
 msgid "squash-onto"
 msgstr "squash-onto"
 
-#: builtin/rebase.c:525
+#: builtin/rebase.c:531
 msgid "squash onto"
 msgstr "squash onto"
 
-#: builtin/rebase.c:527
+#: builtin/rebase.c:533
 msgid "the upstream commit"
 msgstr "der Upstream-Commit"
 
-#: builtin/rebase.c:529
+#: builtin/rebase.c:535
 msgid "head-name"
 msgstr "head-Name"
 
-#: builtin/rebase.c:529
+#: builtin/rebase.c:535
 msgid "head name"
 msgstr "head-Name"
 
-#: builtin/rebase.c:534
+#: builtin/rebase.c:540
 msgid "rebase strategy"
 msgstr "Rebase-Strategie"
 
-#: builtin/rebase.c:535
+#: builtin/rebase.c:541
 msgid "strategy-opts"
 msgstr "Strategie-Optionen"
 
-#: builtin/rebase.c:536
+#: builtin/rebase.c:542
 msgid "strategy options"
 msgstr "Strategie-Optionen"
 
-#: builtin/rebase.c:537
+#: builtin/rebase.c:543
 msgid "switch-to"
 msgstr "wechseln zu"
 
-#: builtin/rebase.c:538
+#: builtin/rebase.c:544
 msgid "the branch or commit to checkout"
 msgstr "der Branch oder Commit zum Auschecken"
 
-#: builtin/rebase.c:539
+#: builtin/rebase.c:545
 msgid "onto-name"
 msgstr "onto-Name"
 
-#: builtin/rebase.c:539
+#: builtin/rebase.c:545
 msgid "onto name"
 msgstr "onto-Name"
 
-#: builtin/rebase.c:540
+#: builtin/rebase.c:546
 msgid "cmd"
 msgstr "Befehl"
 
-#: builtin/rebase.c:540
+#: builtin/rebase.c:546
 msgid "the command to run"
 msgstr "auszuführender Befehl"
 
-#: builtin/rebase.c:543 builtin/rebase.c:1415
+#: builtin/rebase.c:549 builtin/rebase.c:1421
 msgid "automatically re-schedule any `exec` that fails"
 msgstr "jeden fehlgeschlagenen `exec`-Befehl neu ansetzen"
 
-#: builtin/rebase.c:559
+#: builtin/rebase.c:565
 msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
 msgstr "--[no-]rebase-cousins hat ohne --rebase-merges keine Auswirkung"
 
-#: builtin/rebase.c:575
+#: builtin/rebase.c:581
 #, c-format
 msgid "%s requires the merge backend"
 msgstr "%s erfordert das Merge-Backend"
 
-#: builtin/rebase.c:618
+#: builtin/rebase.c:624
 #, c-format
 msgid "could not get 'onto': '%s'"
 msgstr "Konnte 'onto' nicht bestimmen: '%s'"
 
-#: builtin/rebase.c:635
+#: builtin/rebase.c:641
 #, c-format
 msgid "invalid orig-head: '%s'"
 msgstr "Ungültiges orig-head: '%s'"
 
-#: builtin/rebase.c:660
+#: builtin/rebase.c:666
 #, c-format
 msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
 msgstr "Ignoriere ungültiges allow_rerere_autoupdate: '%s'"
 
-#: builtin/rebase.c:805 git-rebase--preserve-merges.sh:81
+#: builtin/rebase.c:811 git-rebase--preserve-merges.sh:81
 msgid ""
 "Resolve all conflicts manually, mark them as resolved with\n"
 "\"git add/rm <conflicted_files>\", then run \"git rebase --continue\".\n"
@@ -19471,7 +19635,7 @@ msgstr ""
 "Um abzubrechen und zurück zum Zustand vor \"git rebase\" zu gelangen,\n"
 "führen Sie \"git rebase --abort\" aus."
 
-#: builtin/rebase.c:888
+#: builtin/rebase.c:894
 #, c-format
 msgid ""
 "\n"
@@ -19491,7 +19655,7 @@ msgstr ""
 "Infolge dessen kann Git auf diesen Revisionen Rebase nicht\n"
 "ausführen."
 
-#: builtin/rebase.c:1214
+#: builtin/rebase.c:1220
 #, c-format
 msgid ""
 "unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and \"ask"
@@ -19500,7 +19664,7 @@ msgstr ""
 "nicht erkannter leerer Typ '%s'; Gültige Werte sind \"drop\", \"keep\", und "
 "\"ask\"."
 
-#: builtin/rebase.c:1232
+#: builtin/rebase.c:1238
 #, c-format
 msgid ""
 "%s\n"
@@ -19518,7 +19682,7 @@ msgstr ""
 "    git rebase '<Branch>'\n"
 "\n"
 
-#: builtin/rebase.c:1248
+#: builtin/rebase.c:1254
 #, c-format
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:\n"
@@ -19532,154 +19696,155 @@ msgstr ""
 "    git branch --set-upstream-to=%s/<Branch> %s\n"
 "\n"
 
-#: builtin/rebase.c:1278
+#: builtin/rebase.c:1284
 msgid "exec commands cannot contain newlines"
 msgstr "\"exec\"-Befehle können keine neuen Zeilen enthalten"
 
-#: builtin/rebase.c:1282
+#: builtin/rebase.c:1288
 msgid "empty exec command"
 msgstr "Leerer \"exec\"-Befehl."
 
-#: builtin/rebase.c:1312
+#: builtin/rebase.c:1318
 msgid "rebase onto given branch instead of upstream"
 msgstr "Rebase auf angegebenen Branch anstelle des Upstream-Branches ausführen"
 
-#: builtin/rebase.c:1314
+#: builtin/rebase.c:1320
 msgid "use the merge-base of upstream and branch as the current base"
 msgstr "Nutze die Merge-Basis von Upstream und Branch als die aktuelle Basis"
 
-#: builtin/rebase.c:1316
+#: builtin/rebase.c:1322
 msgid "allow pre-rebase hook to run"
 msgstr "Ausführung des pre-rebase-Hooks erlauben"
 
-#: builtin/rebase.c:1318
+#: builtin/rebase.c:1324
 msgid "be quiet. implies --no-stat"
 msgstr "weniger Ausgaben (impliziert --no-stat)"
 
-#: builtin/rebase.c:1324
+#: builtin/rebase.c:1330
 msgid "do not show diffstat of what changed upstream"
 msgstr ""
 "Zusammenfassung der Unterschiede gegenüber dem Upstream-Branch verbergen"
 
-#: builtin/rebase.c:1327
-msgid "add a Signed-off-by: line to each commit"
+#: builtin/rebase.c:1333
+#, fuzzy
+msgid "add a Signed-off-by trailer to each commit"
 msgstr "eine \"Signed-off-by:\"-Zeile zu jedem Commit hinzufügen"
 
-#: builtin/rebase.c:1330
+#: builtin/rebase.c:1336
 msgid "make committer date match author date"
 msgstr "Datum des Commit-Erstellers soll mit Datum des Autors übereinstimmen"
 
-#: builtin/rebase.c:1332
+#: builtin/rebase.c:1338
 msgid "ignore author date and use current date"
 msgstr "ignoriere Autor-Datum und nutze aktuelles Datum"
 
-#: builtin/rebase.c:1334
+#: builtin/rebase.c:1340
 msgid "synonym of --reset-author-date"
 msgstr "Synonym für --reset-author-date"
 
-#: builtin/rebase.c:1336 builtin/rebase.c:1340
+#: builtin/rebase.c:1342 builtin/rebase.c:1346
 msgid "passed to 'git apply'"
 msgstr "an 'git apply' übergeben"
 
-#: builtin/rebase.c:1338
+#: builtin/rebase.c:1344
 msgid "ignore changes in whitespace"
 msgstr "Whitespace-Änderungen ignorieren"
 
-#: builtin/rebase.c:1342 builtin/rebase.c:1345
+#: builtin/rebase.c:1348 builtin/rebase.c:1351
 msgid "cherry-pick all commits, even if unchanged"
 msgstr ""
 "Cherry-Pick auf alle Commits ausführen, auch wenn diese unverändert sind"
 
-#: builtin/rebase.c:1347
+#: builtin/rebase.c:1353
 msgid "continue"
 msgstr "fortsetzen"
 
-#: builtin/rebase.c:1350
+#: builtin/rebase.c:1356
 msgid "skip current patch and continue"
 msgstr "den aktuellen Patch auslassen und fortfahren"
 
-#: builtin/rebase.c:1352
+#: builtin/rebase.c:1358
 msgid "abort and check out the original branch"
 msgstr "abbrechen und den ursprünglichen Branch auschecken"
 
-#: builtin/rebase.c:1355
+#: builtin/rebase.c:1361
 msgid "abort but keep HEAD where it is"
 msgstr "abbrechen, aber HEAD an aktueller Stelle belassen"
 
-#: builtin/rebase.c:1356
+#: builtin/rebase.c:1362
 msgid "edit the todo list during an interactive rebase"
 msgstr "TODO-Liste während eines interaktiven Rebase bearbeiten"
 
-#: builtin/rebase.c:1359
+#: builtin/rebase.c:1365
 msgid "show the patch file being applied or merged"
 msgstr "den Patch, der gerade angewendet oder zusammengeführt wird, anzeigen"
 
-#: builtin/rebase.c:1362
+#: builtin/rebase.c:1368
 msgid "use apply strategies to rebase"
 msgstr "Strategien von 'git am' bei Rebase verwenden"
 
-#: builtin/rebase.c:1366
+#: builtin/rebase.c:1372
 msgid "use merging strategies to rebase"
 msgstr "Merge-Strategien beim Rebase verwenden"
 
-#: builtin/rebase.c:1370
+#: builtin/rebase.c:1376
 msgid "let the user edit the list of commits to rebase"
 msgstr "den Benutzer die Liste der Commits für den Rebase bearbeiten lassen"
 
-#: builtin/rebase.c:1374
+#: builtin/rebase.c:1380
 msgid "(DEPRECATED) try to recreate merges instead of ignoring them"
 msgstr ""
 "(VERALTET) Versuche, Merges wiederherzustellen anstatt sie zu ignorieren"
 
-#: builtin/rebase.c:1379
+#: builtin/rebase.c:1385
 msgid "how to handle commits that become empty"
 msgstr "wie sollen Commits behandelt werden, die leer werden"
 
-#: builtin/rebase.c:1386
+#: builtin/rebase.c:1392
 msgid "move commits that begin with squash!/fixup! under -i"
 msgstr "bei -i Commits verschieben, die mit squash!/fixup! beginnen"
 
-#: builtin/rebase.c:1393
+#: builtin/rebase.c:1399
 msgid "add exec lines after each commit of the editable list"
 msgstr "exec-Zeilen nach jedem Commit der editierbaren Liste hinzufügen"
 
-#: builtin/rebase.c:1397
+#: builtin/rebase.c:1403
 msgid "allow rebasing commits with empty messages"
 msgstr "Rebase von Commits mit leerer Beschreibung erlauben"
 
-#: builtin/rebase.c:1401
+#: builtin/rebase.c:1407
 msgid "try to rebase merges instead of skipping them"
 msgstr ""
 "versuchen, Rebase mit Merges auszuführen, anstatt diese zu überspringen"
 
-#: builtin/rebase.c:1404
+#: builtin/rebase.c:1410
 msgid "use 'merge-base --fork-point' to refine upstream"
 msgstr ""
 "'git merge-base --fork-point' benutzen, um Upstream-Branch zu bestimmen"
 
-#: builtin/rebase.c:1406
+#: builtin/rebase.c:1412
 msgid "use the given merge strategy"
 msgstr "angegebene Merge-Strategie verwenden"
 
-#: builtin/rebase.c:1408 builtin/revert.c:115
+#: builtin/rebase.c:1414 builtin/revert.c:115
 msgid "option"
 msgstr "Option"
 
-#: builtin/rebase.c:1409
+#: builtin/rebase.c:1415
 msgid "pass the argument through to the merge strategy"
 msgstr "Argument zur Merge-Strategie durchreichen"
 
-#: builtin/rebase.c:1412
+#: builtin/rebase.c:1418
 msgid "rebase all reachable commits up to the root(s)"
 msgstr "Rebase auf alle erreichbaren Commits bis zum Root-Commit ausführen"
 
-#: builtin/rebase.c:1417
+#: builtin/rebase.c:1423
 msgid "apply all changes, even those already present upstream"
 msgstr ""
 "alle Änderungen anwenden, auch jene, die bereits im Upstream-Branch "
 "vorhanden sind"
 
-#: builtin/rebase.c:1434
+#: builtin/rebase.c:1440
 msgid ""
 "the rebase.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -19687,44 +19852,44 @@ msgstr ""
 "Die Unterstützung für rebase.useBuiltin wurde entfernt!\n"
 "Siehe dessen Eintrag in 'git help config' für Details."
 
-#: builtin/rebase.c:1440
+#: builtin/rebase.c:1446
 msgid "It looks like 'git am' is in progress. Cannot rebase."
 msgstr "'git-am' scheint im Gange zu sein. Kann Rebase nicht durchführen."
 
-#: builtin/rebase.c:1481
+#: builtin/rebase.c:1487
 msgid ""
 "git rebase --preserve-merges is deprecated. Use --rebase-merges instead."
 msgstr ""
 "'git rebase --preserve-merges' ist veraltet. Benutzen Sie stattdessen '--"
 "rebase-merges'."
 
-#: builtin/rebase.c:1486
+#: builtin/rebase.c:1492
 msgid "cannot combine '--keep-base' with '--onto'"
 msgstr "'--keep-base' kann nicht mit '--onto' kombiniert werden"
 
-#: builtin/rebase.c:1488
+#: builtin/rebase.c:1494
 msgid "cannot combine '--keep-base' with '--root'"
 msgstr "'--keep-base' kann nicht mit '--root' kombiniert werden"
 
-#: builtin/rebase.c:1492
+#: builtin/rebase.c:1498
 msgid "cannot combine '--root' with '--fork-point'"
 msgstr "'--root' kann nicht mit '--fork-point' kombiniert werden"
 
-#: builtin/rebase.c:1495
+#: builtin/rebase.c:1501
 msgid "No rebase in progress?"
 msgstr "Kein Rebase im Gange?"
 
-#: builtin/rebase.c:1499
+#: builtin/rebase.c:1505
 msgid "The --edit-todo action can only be used during interactive rebase."
 msgstr ""
 "Die --edit-todo Aktion kann nur während eines interaktiven Rebase verwendet "
 "werden."
 
-#: builtin/rebase.c:1522
+#: builtin/rebase.c:1528 t/helper/test-fast-rebase.c:123
 msgid "Cannot read HEAD"
 msgstr "Kann HEAD nicht lesen"
 
-#: builtin/rebase.c:1534
+#: builtin/rebase.c:1540
 msgid ""
 "You must edit all merge conflicts and then\n"
 "mark them as resolved using git add"
@@ -19732,16 +19897,16 @@ msgstr ""
 "Sie müssen alle Merge-Konflikte editieren und diese dann\n"
 "mittels \"git add\" als aufgelöst markieren"
 
-#: builtin/rebase.c:1553
+#: builtin/rebase.c:1559
 msgid "could not discard worktree changes"
 msgstr "Konnte Änderungen im Arbeitsverzeichnis nicht verwerfen."
 
-#: builtin/rebase.c:1572
+#: builtin/rebase.c:1578
 #, c-format
 msgid "could not move back to %s"
 msgstr "Konnte nicht zu %s zurückgehen."
 
-#: builtin/rebase.c:1618
+#: builtin/rebase.c:1624
 #, c-format
 msgid ""
 "It seems that there is already a %s directory, and\n"
@@ -19762,138 +19927,138 @@ msgstr ""
 "und führen Sie diesen Befehl nochmal aus. Es wird angehalten, falls noch\n"
 "etwas Schützenswertes vorhanden ist.\n"
 
-#: builtin/rebase.c:1646
+#: builtin/rebase.c:1652
 msgid "switch `C' expects a numerical value"
 msgstr "Schalter `C' erwartet einen numerischen Wert."
 
-#: builtin/rebase.c:1688
+#: builtin/rebase.c:1694
 #, c-format
 msgid "Unknown mode: %s"
 msgstr "Unbekannter Modus: %s"
 
-#: builtin/rebase.c:1727
+#: builtin/rebase.c:1733
 msgid "--strategy requires --merge or --interactive"
 msgstr "--strategy erfordert --merge oder --interactive"
 
-#: builtin/rebase.c:1757
+#: builtin/rebase.c:1763
 msgid "cannot combine apply options with merge options"
 msgstr ""
 "Optionen für \"am\" können nicht mit Optionen für \"merge\" kombiniert "
 "werden."
 
-#: builtin/rebase.c:1770
+#: builtin/rebase.c:1776
 #, c-format
 msgid "Unknown rebase backend: %s"
 msgstr "Unbekanntes Rebase-Backend: %s"
 
-#: builtin/rebase.c:1795
+#: builtin/rebase.c:1806
 msgid "--reschedule-failed-exec requires --exec or --interactive"
 msgstr "--reschedule-failed-exec erfordert --exec oder --interactive"
 
-#: builtin/rebase.c:1815
+#: builtin/rebase.c:1826
 msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
 msgstr ""
 "'--preserve-merges' kann nicht mit '--rebase-merges' kombiniert werden."
 
-#: builtin/rebase.c:1819
+#: builtin/rebase.c:1830
 msgid ""
 "error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
 msgstr ""
 "Fehler: '--preserve-merges' kann nicht mit '--reschedule-failed-exec' "
 "kombiniert werden."
 
-#: builtin/rebase.c:1843
+#: builtin/rebase.c:1854
 #, c-format
 msgid "invalid upstream '%s'"
 msgstr "Ungültiger Upstream '%s'"
 
-#: builtin/rebase.c:1849
+#: builtin/rebase.c:1860
 msgid "Could not create new root commit"
 msgstr "Konnte neuen Root-Commit nicht erstellen."
 
-#: builtin/rebase.c:1875
+#: builtin/rebase.c:1886
 #, c-format
 msgid "'%s': need exactly one merge base with branch"
 msgstr "'%s': benötige genau eine Merge-Basis mit dem Branch"
 
-#: builtin/rebase.c:1878
+#: builtin/rebase.c:1889
 #, c-format
 msgid "'%s': need exactly one merge base"
 msgstr "'%s': benötige genau eine Merge-Basis"
 
-#: builtin/rebase.c:1886
+#: builtin/rebase.c:1897
 #, c-format
 msgid "Does not point to a valid commit '%s'"
 msgstr "'%s' zeigt auf keinen gültigen Commit."
 
-#: builtin/rebase.c:1912
+#: builtin/rebase.c:1923
 #, c-format
 msgid "fatal: no such branch/commit '%s'"
 msgstr "fatal: Branch/Commit '%s' nicht gefunden"
 
-#: builtin/rebase.c:1920 builtin/submodule--helper.c:40
+#: builtin/rebase.c:1931 builtin/submodule--helper.c:40
 #: builtin/submodule--helper.c:2414
 #, c-format
 msgid "No such ref: %s"
 msgstr "Referenz nicht gefunden: %s"
 
-#: builtin/rebase.c:1931
+#: builtin/rebase.c:1942
 msgid "Could not resolve HEAD to a revision"
 msgstr "Konnte HEAD zu keinem Commit auflösen."
 
-#: builtin/rebase.c:1952
+#: builtin/rebase.c:1963
 msgid "Please commit or stash them."
 msgstr "Bitte committen Sie die Änderungen oder benutzen Sie \"stash\"."
 
-#: builtin/rebase.c:1988
+#: builtin/rebase.c:1999
 #, c-format
 msgid "could not switch to %s"
 msgstr "Konnte nicht zu %s wechseln."
 
-#: builtin/rebase.c:1999
+#: builtin/rebase.c:2010
 msgid "HEAD is up to date."
 msgstr "HEAD ist aktuell."
 
-#: builtin/rebase.c:2001
+#: builtin/rebase.c:2012
 #, c-format
 msgid "Current branch %s is up to date.\n"
 msgstr "Aktueller Branch %s ist auf dem neuesten Stand.\n"
 
-#: builtin/rebase.c:2009
+#: builtin/rebase.c:2020
 msgid "HEAD is up to date, rebase forced."
 msgstr "HEAD ist aktuell, Rebase erzwungen."
 
-#: builtin/rebase.c:2011
+#: builtin/rebase.c:2022
 #, c-format
 msgid "Current branch %s is up to date, rebase forced.\n"
 msgstr "Aktueller Branch %s ist auf dem neuesten Stand, Rebase erzwungen.\n"
 
-#: builtin/rebase.c:2019
+#: builtin/rebase.c:2030
 msgid "The pre-rebase hook refused to rebase."
 msgstr "Der \"pre-rebase hook\" hat den Rebase zurückgewiesen."
 
-#: builtin/rebase.c:2026
+#: builtin/rebase.c:2037
 #, c-format
 msgid "Changes to %s:\n"
 msgstr "Änderungen zu %s:\n"
 
-#: builtin/rebase.c:2029
+#: builtin/rebase.c:2040
 #, c-format
 msgid "Changes from %s to %s:\n"
 msgstr "Änderungen von %s zu %s:\n"
 
-#: builtin/rebase.c:2054
+#: builtin/rebase.c:2065
 #, c-format
 msgid "First, rewinding head to replay your work on top of it...\n"
 msgstr ""
 "Zunächst wird der Branch zurückgespult, um Ihre Änderungen darauf neu "
 "anzuwenden...\n"
 
-#: builtin/rebase.c:2063
+#: builtin/rebase.c:2074
 msgid "Could not detach HEAD"
 msgstr "Konnte HEAD nicht loslösen."
 
-#: builtin/rebase.c:2072
+#: builtin/rebase.c:2083
 #, c-format
 msgid "Fast-forwarded %s to %s.\n"
 msgstr "Spule %s vor zu %s.\n"
@@ -19902,7 +20067,7 @@ msgstr "Spule %s vor zu %s.\n"
 msgid "git receive-pack <git-dir>"
 msgstr "git receive-pack <Git-Verzeichnis>"
 
-#: builtin/receive-pack.c:1224
+#: builtin/receive-pack.c:1276
 msgid ""
 "By default, updating the current branch in a non-bare repository\n"
 "is denied, because it will make the index and work tree inconsistent\n"
@@ -19934,7 +20099,7 @@ msgstr ""
 "setzen Sie die Konfigurationsvariable 'receive.denyCurrentBranch' auf\n"
 "'refuse'."
 
-#: builtin/receive-pack.c:1244
+#: builtin/receive-pack.c:1296
 msgid ""
 "By default, deleting the current branch is denied, because the next\n"
 "'git clone' won't result in any file checked out, causing confusion.\n"
@@ -19955,11 +20120,11 @@ msgstr ""
 "\n"
 "Um diese Meldung zu unterdrücken, setzen Sie die Variable auf 'refuse'."
 
-#: builtin/receive-pack.c:2422
+#: builtin/receive-pack.c:2481
 msgid "quiet"
 msgstr "weniger Ausgaben"
 
-#: builtin/receive-pack.c:2436
+#: builtin/receive-pack.c:2495
 msgid "You must specify a directory."
 msgstr "Sie müssen ein Repository angeben."
 
@@ -20161,40 +20326,35 @@ msgstr ""
 "Die Angabe von zu folgenden Branches kann nur mit dem Anfordern von "
 "Spiegelarchiven verwendet werden."
 
-#: builtin/remote.c:195 builtin/remote.c:697
+#: builtin/remote.c:195 builtin/remote.c:700
 #, c-format
 msgid "remote %s already exists."
 msgstr "externes Repository %s existiert bereits"
 
-#: builtin/remote.c:199 builtin/remote.c:701
-#, c-format
-msgid "'%s' is not a valid remote name"
-msgstr "'%s' ist kein gültiger Name für ein Remote-Repository"
-
-#: builtin/remote.c:239
+#: builtin/remote.c:240
 #, c-format
 msgid "Could not setup master '%s'"
 msgstr "Konnte symbolische Referenz für Hauptbranch von '%s' nicht einrichten"
 
-#: builtin/remote.c:354
+#: builtin/remote.c:355
 #, c-format
 msgid "Could not get fetch map for refspec %s"
 msgstr "Konnte Fetch-Map für Refspec %s nicht bekommen"
 
-#: builtin/remote.c:453 builtin/remote.c:461
+#: builtin/remote.c:454 builtin/remote.c:462
 msgid "(matching)"
 msgstr "(übereinstimmend)"
 
-#: builtin/remote.c:465
+#: builtin/remote.c:466
 msgid "(delete)"
 msgstr "(lösche)"
 
-#: builtin/remote.c:654
+#: builtin/remote.c:655
 #, c-format
 msgid "could not set '%s'"
 msgstr "konnte '%s' nicht setzen"
 
-#: builtin/remote.c:659
+#: builtin/remote.c:660
 #, c-format
 msgid ""
 "The %s configuration remote.pushDefault in:\n"
@@ -20205,17 +20365,17 @@ msgstr ""
 "\t%s:%d\n"
 "benennt jetzt das nicht existierende Remote-Repository '%s'"
 
-#: builtin/remote.c:690 builtin/remote.c:833 builtin/remote.c:941
+#: builtin/remote.c:691 builtin/remote.c:836 builtin/remote.c:946
 #, c-format
 msgid "No such remote: '%s'"
 msgstr "Kein solches Remote-Repository: '%s'"
 
-#: builtin/remote.c:707
+#: builtin/remote.c:710
 #, c-format
 msgid "Could not rename config section '%s' to '%s'"
 msgstr "Konnte Sektion '%s' in Konfiguration nicht nach '%s' umbenennen"
 
-#: builtin/remote.c:727
+#: builtin/remote.c:730
 #, c-format
 msgid ""
 "Not updating non-default fetch refspec\n"
@@ -20226,17 +20386,17 @@ msgstr ""
 "\t%s\n"
 "\tBitte aktualisieren Sie, falls notwendig, die Konfiguration manuell."
 
-#: builtin/remote.c:767
+#: builtin/remote.c:770
 #, c-format
 msgid "deleting '%s' failed"
 msgstr "Konnte '%s' nicht löschen"
 
-#: builtin/remote.c:801
+#: builtin/remote.c:804
 #, c-format
 msgid "creating '%s' failed"
 msgstr "Konnte '%s' nicht erstellen"
 
-#: builtin/remote.c:877
+#: builtin/remote.c:882
 msgid ""
 "Note: A branch outside the refs/remotes/ hierarchy was not removed;\n"
 "to delete it, use:"
@@ -20252,118 +20412,118 @@ msgstr[1] ""
 "entfernt;\n"
 "um diese zu entfernen, benutzen Sie:"
 
-#: builtin/remote.c:891
+#: builtin/remote.c:896
 #, c-format
 msgid "Could not remove config section '%s'"
 msgstr "Konnte Sektion '%s' nicht aus Konfiguration entfernen"
 
-#: builtin/remote.c:994
+#: builtin/remote.c:999
 #, c-format
 msgid " new (next fetch will store in remotes/%s)"
 msgstr " neu (wird bei nächstem \"fetch\" in remotes/%s gespeichert)"
 
-#: builtin/remote.c:997
+#: builtin/remote.c:1002
 msgid " tracked"
 msgstr " gefolgt"
 
-#: builtin/remote.c:999
+#: builtin/remote.c:1004
 msgid " stale (use 'git remote prune' to remove)"
 msgstr " veraltet (benutzen Sie 'git remote prune' zum Löschen)"
 
-#: builtin/remote.c:1001
+#: builtin/remote.c:1006
 msgid " ???"
 msgstr " ???"
 
-#: builtin/remote.c:1042
+#: builtin/remote.c:1047
 #, c-format
 msgid "invalid branch.%s.merge; cannot rebase onto > 1 branch"
 msgstr "ungültiges branch.%s.merge; kann Rebase nicht auf > 1 Branch ausführen"
 
-#: builtin/remote.c:1051
+#: builtin/remote.c:1056
 #, c-format
 msgid "rebases interactively onto remote %s"
 msgstr "interaktiver Rebase auf Remote-Branch %s"
 
-#: builtin/remote.c:1053
+#: builtin/remote.c:1058
 #, c-format
 msgid "rebases interactively (with merges) onto remote %s"
 msgstr "interaktiver Rebase (mit Merges) auf Remote-Branch %s"
 
-#: builtin/remote.c:1056
+#: builtin/remote.c:1061
 #, c-format
 msgid "rebases onto remote %s"
 msgstr "Rebase auf Remote-Branch %s"
 
-#: builtin/remote.c:1060
+#: builtin/remote.c:1065
 #, c-format
 msgid " merges with remote %s"
 msgstr " führt mit Remote-Branch %s zusammen"
 
-#: builtin/remote.c:1063
+#: builtin/remote.c:1068
 #, c-format
 msgid "merges with remote %s"
 msgstr "führt mit Remote-Branch %s zusammen"
 
-#: builtin/remote.c:1066
+#: builtin/remote.c:1071
 #, c-format
 msgid "%-*s    and with remote %s\n"
 msgstr "%-*s    und mit Remote-Branch %s\n"
 
-#: builtin/remote.c:1109
+#: builtin/remote.c:1114
 msgid "create"
 msgstr "erstellt"
 
-#: builtin/remote.c:1112
+#: builtin/remote.c:1117
 msgid "delete"
 msgstr "gelöscht"
 
-#: builtin/remote.c:1116
+#: builtin/remote.c:1121
 msgid "up to date"
 msgstr "aktuell"
 
-#: builtin/remote.c:1119
+#: builtin/remote.c:1124
 msgid "fast-forwardable"
 msgstr "vorspulbar"
 
-#: builtin/remote.c:1122
+#: builtin/remote.c:1127
 msgid "local out of date"
 msgstr "lokal nicht aktuell"
 
-#: builtin/remote.c:1129
+#: builtin/remote.c:1134
 #, c-format
 msgid "    %-*s forces to %-*s (%s)"
 msgstr "    %-*s erzwingt Versandt nach %-*s (%s)"
 
-#: builtin/remote.c:1132
+#: builtin/remote.c:1137
 #, c-format
 msgid "    %-*s pushes to %-*s (%s)"
 msgstr "    %-*s versendet nach %-*s (%s)"
 
-#: builtin/remote.c:1136
+#: builtin/remote.c:1141
 #, c-format
 msgid "    %-*s forces to %s"
 msgstr "    %-*s erzwingt Versand nach %s"
 
-#: builtin/remote.c:1139
+#: builtin/remote.c:1144
 #, c-format
 msgid "    %-*s pushes to %s"
 msgstr "    %-*s versendet nach %s"
 
-#: builtin/remote.c:1207
+#: builtin/remote.c:1212
 msgid "do not query remotes"
 msgstr "keine Abfrage von Remote-Repositories"
 
-#: builtin/remote.c:1234
+#: builtin/remote.c:1239
 #, c-format
 msgid "* remote %s"
 msgstr "* Remote-Repository %s"
 
-#: builtin/remote.c:1235
+#: builtin/remote.c:1240
 #, c-format
 msgid "  Fetch URL: %s"
 msgstr "  URL zum Abholen: %s"
 
-#: builtin/remote.c:1236 builtin/remote.c:1252 builtin/remote.c:1391
+#: builtin/remote.c:1241 builtin/remote.c:1257 builtin/remote.c:1396
 msgid "(no URL)"
 msgstr "(keine URL)"
 
@@ -20371,25 +20531,25 @@ msgstr "(keine URL)"
 #. with the one in " Fetch URL: %s"
 #. translation.
 #.
-#: builtin/remote.c:1250 builtin/remote.c:1252
+#: builtin/remote.c:1255 builtin/remote.c:1257
 #, c-format
 msgid "  Push  URL: %s"
 msgstr "  URL zum Versenden: %s"
 
-#: builtin/remote.c:1254 builtin/remote.c:1256 builtin/remote.c:1258
+#: builtin/remote.c:1259 builtin/remote.c:1261 builtin/remote.c:1263
 #, c-format
 msgid "  HEAD branch: %s"
 msgstr "  Hauptbranch: %s"
 
-#: builtin/remote.c:1254
+#: builtin/remote.c:1259
 msgid "(not queried)"
 msgstr "(nicht abgefragt)"
 
-#: builtin/remote.c:1256
+#: builtin/remote.c:1261
 msgid "(unknown)"
 msgstr "(unbekannt)"
 
-#: builtin/remote.c:1260
+#: builtin/remote.c:1265
 #, c-format
 msgid ""
 "  HEAD branch (remote HEAD is ambiguous, may be one of the following):\n"
@@ -20397,155 +20557,155 @@ msgstr ""
 "  Hauptbranch (externer HEAD ist mehrdeutig, könnte einer der folgenden "
 "sein):\n"
 
-#: builtin/remote.c:1272
+#: builtin/remote.c:1277
 #, c-format
 msgid "  Remote branch:%s"
 msgid_plural "  Remote branches:%s"
 msgstr[0] "  Remote-Branch:%s"
 msgstr[1] "  Remote-Branches:%s"
 
-#: builtin/remote.c:1275 builtin/remote.c:1301
+#: builtin/remote.c:1280 builtin/remote.c:1306
 msgid " (status not queried)"
 msgstr " (Zustand nicht abgefragt)"
 
-#: builtin/remote.c:1284
+#: builtin/remote.c:1289
 msgid "  Local branch configured for 'git pull':"
 msgid_plural "  Local branches configured for 'git pull':"
 msgstr[0] "  Lokaler Branch konfiguriert für 'git pull':"
 msgstr[1] "  Lokale Branches konfiguriert für 'git pull':"
 
-#: builtin/remote.c:1292
+#: builtin/remote.c:1297
 msgid "  Local refs will be mirrored by 'git push'"
 msgstr "  Lokale Referenzen werden von 'git push' gespiegelt"
 
-#: builtin/remote.c:1298
+#: builtin/remote.c:1303
 #, c-format
 msgid "  Local ref configured for 'git push'%s:"
 msgid_plural "  Local refs configured for 'git push'%s:"
 msgstr[0] "  Lokale Referenz konfiguriert für 'git push'%s:"
 msgstr[1] "  Lokale Referenzen konfiguriert für 'git push'%s:"
 
-#: builtin/remote.c:1319
+#: builtin/remote.c:1324
 msgid "set refs/remotes/<name>/HEAD according to remote"
 msgstr "setzt refs/remotes/<Name>/HEAD gemäß dem Remote-Repository"
 
-#: builtin/remote.c:1321
+#: builtin/remote.c:1326
 msgid "delete refs/remotes/<name>/HEAD"
 msgstr "entfernt refs/remotes/<Name>/HEAD"
 
-#: builtin/remote.c:1336
+#: builtin/remote.c:1341
 msgid "Cannot determine remote HEAD"
 msgstr "Kann HEAD des Remote-Repositories nicht bestimmen"
 
-#: builtin/remote.c:1338
+#: builtin/remote.c:1343
 msgid "Multiple remote HEAD branches. Please choose one explicitly with:"
 msgstr ""
 "Mehrere Hauptbranches im Remote-Repository. Bitte wählen Sie explizit einen "
 "aus mit:"
 
-#: builtin/remote.c:1348
+#: builtin/remote.c:1353
 #, c-format
 msgid "Could not delete %s"
 msgstr "Konnte %s nicht entfernen"
 
-#: builtin/remote.c:1356
+#: builtin/remote.c:1361
 #, c-format
 msgid "Not a valid ref: %s"
 msgstr "keine gültige Referenz: %s"
 
-#: builtin/remote.c:1358
+#: builtin/remote.c:1363
 #, c-format
 msgid "Could not setup %s"
 msgstr "Konnte %s nicht einrichten"
 
-#: builtin/remote.c:1376
+#: builtin/remote.c:1381
 #, c-format
 msgid " %s will become dangling!"
 msgstr " %s wird unreferenziert!"
 
-#: builtin/remote.c:1377
+#: builtin/remote.c:1382
 #, c-format
 msgid " %s has become dangling!"
 msgstr " %s wurde unreferenziert!"
 
-#: builtin/remote.c:1387
+#: builtin/remote.c:1392
 #, c-format
 msgid "Pruning %s"
 msgstr "entferne veraltete Branches von %s"
 
-#: builtin/remote.c:1388
+#: builtin/remote.c:1393
 #, c-format
 msgid "URL: %s"
 msgstr "URL: %s"
 
-#: builtin/remote.c:1404
+#: builtin/remote.c:1409
 #, c-format
 msgid " * [would prune] %s"
 msgstr " * [würde veralteten Branch entfernen] %s"
 
-#: builtin/remote.c:1407
+#: builtin/remote.c:1412
 #, c-format
 msgid " * [pruned] %s"
 msgstr "* [veralteten Branch entfernt] %s"
 
-#: builtin/remote.c:1452
+#: builtin/remote.c:1457
 msgid "prune remotes after fetching"
 msgstr "entferne veraltete Branches im Remote-Repository nach \"fetch\""
 
-#: builtin/remote.c:1515 builtin/remote.c:1569 builtin/remote.c:1637
+#: builtin/remote.c:1521 builtin/remote.c:1577 builtin/remote.c:1647
 #, c-format
 msgid "No such remote '%s'"
 msgstr "Kein solches Remote-Repository '%s'"
 
-#: builtin/remote.c:1531
+#: builtin/remote.c:1539
 msgid "add branch"
 msgstr "Branch hinzufügen"
 
-#: builtin/remote.c:1538
+#: builtin/remote.c:1546
 msgid "no remote specified"
 msgstr "kein Remote-Repository angegeben"
 
-#: builtin/remote.c:1555
+#: builtin/remote.c:1563
 msgid "query push URLs rather than fetch URLs"
 msgstr "nur URLs für Push ausgeben"
 
-#: builtin/remote.c:1557
+#: builtin/remote.c:1565
 msgid "return all URLs"
 msgstr "alle URLs ausgeben"
 
-#: builtin/remote.c:1585
+#: builtin/remote.c:1595
 #, c-format
 msgid "no URLs configured for remote '%s'"
 msgstr "Keine URLs für Remote-Repository '%s' konfiguriert."
 
-#: builtin/remote.c:1611
+#: builtin/remote.c:1621
 msgid "manipulate push URLs"
 msgstr "URLs für \"push\" manipulieren"
 
-#: builtin/remote.c:1613
+#: builtin/remote.c:1623
 msgid "add URL"
 msgstr "URL hinzufügen"
 
-#: builtin/remote.c:1615
+#: builtin/remote.c:1625
 msgid "delete URLs"
 msgstr "URLs löschen"
 
-#: builtin/remote.c:1622
+#: builtin/remote.c:1632
 msgid "--add --delete doesn't make sense"
 msgstr ""
 "Die Optionen --add und --delete können nicht gemeinsam verwendet werden."
 
-#: builtin/remote.c:1661
+#: builtin/remote.c:1673
 #, c-format
 msgid "Invalid old URL pattern: %s"
 msgstr "ungültiges altes URL Format: %s"
 
-#: builtin/remote.c:1669
+#: builtin/remote.c:1681
 #, c-format
 msgid "No such URL found: %s"
 msgstr "Keine solche URL gefunden: %s"
 
-#: builtin/remote.c:1671
+#: builtin/remote.c:1683
 msgid "Will not delete all non-push URLs"
 msgstr "Werde keine URLs entfernen, die nicht für \"push\" bestimmt sind"
 
@@ -20568,135 +20728,121 @@ msgstr ""
 "Konnte 'pack-objects' für das Neupacken von Objekten aus partiell geklonten\n"
 "Remote-Repositories nicht starten."
 
-#: builtin/repack.c:236 builtin/repack.c:421
+#: builtin/repack.c:268 builtin/repack.c:447
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
 msgstr ""
 "repack: Erwarte Zeilen mit vollständiger Hex-Objekt-ID nur von pack-objects."
 
-#: builtin/repack.c:260
+#: builtin/repack.c:295
 msgid "could not finish pack-objects to repack promisor objects"
 msgstr ""
 "Konnte 'pack-objects' für das Neupacken von Objekten aus partiell geklonten\n"
 "Remote-Repositories nicht abschließen."
 
-#: builtin/repack.c:297
+#: builtin/repack.c:323
 msgid "pack everything in a single pack"
 msgstr "alles in eine einzige Pack-Datei packen"
 
-#: builtin/repack.c:299
+#: builtin/repack.c:325
 msgid "same as -a, and turn unreachable objects loose"
 msgstr "genau wie -a, unerreichbare Objekte werden aber nicht gelöscht"
 
-#: builtin/repack.c:302
+#: builtin/repack.c:328
 msgid "remove redundant packs, and run git-prune-packed"
 msgstr "redundante Pakete entfernen und \"git-prune-packed\" ausführen"
 
-#: builtin/repack.c:304
+#: builtin/repack.c:330
 msgid "pass --no-reuse-delta to git-pack-objects"
 msgstr "--no-reuse-delta an git-pack-objects übergeben"
 
-#: builtin/repack.c:306
+#: builtin/repack.c:332
 msgid "pass --no-reuse-object to git-pack-objects"
 msgstr "--no-reuse-object an git-pack-objects übergeben"
 
-#: builtin/repack.c:308
+#: builtin/repack.c:334
 msgid "do not run git-update-server-info"
 msgstr "git-update-server-info nicht ausführen"
 
-#: builtin/repack.c:311
+#: builtin/repack.c:337
 msgid "pass --local to git-pack-objects"
 msgstr "--local an git-pack-objects übergeben"
 
-#: builtin/repack.c:313
+#: builtin/repack.c:339
 msgid "write bitmap index"
 msgstr "Bitmap-Index schreiben"
 
-#: builtin/repack.c:315
+#: builtin/repack.c:341
 msgid "pass --delta-islands to git-pack-objects"
 msgstr "--delta-islands an git-pack-objects übergeben"
 
-#: builtin/repack.c:316
+#: builtin/repack.c:342
 msgid "approxidate"
 msgstr "Datumsangabe"
 
-#: builtin/repack.c:317
+#: builtin/repack.c:343
 msgid "with -A, do not loosen objects older than this"
 msgstr "mit -A, keine Objekte älter als dieses Datum löschen"
 
-#: builtin/repack.c:319
+#: builtin/repack.c:345
 msgid "with -a, repack unreachable objects"
 msgstr "mit -a, nicht erreichbare Objekte neu packen"
 
-#: builtin/repack.c:321
+#: builtin/repack.c:347
 msgid "size of the window used for delta compression"
 msgstr "Größe des Fensters für die Delta-Kompression"
 
-#: builtin/repack.c:322 builtin/repack.c:328
+#: builtin/repack.c:348 builtin/repack.c:354
 msgid "bytes"
 msgstr "Bytes"
 
-#: builtin/repack.c:323
+#: builtin/repack.c:349
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr ""
 "gleiches wie oben, aber die Speichergröße anstatt der\n"
 "Anzahl der Einträge limitieren"
 
-#: builtin/repack.c:325
+#: builtin/repack.c:351
 msgid "limits the maximum delta depth"
 msgstr "die maximale Delta-Tiefe limitieren"
 
-#: builtin/repack.c:327
+#: builtin/repack.c:353
 msgid "limits the maximum number of threads"
 msgstr "maximale Anzahl von Threads limitieren"
 
-#: builtin/repack.c:329
+#: builtin/repack.c:355
 msgid "maximum size of each packfile"
 msgstr "maximale Größe für jede Paketdatei"
 
-#: builtin/repack.c:331
+#: builtin/repack.c:357
 msgid "repack objects in packs marked with .keep"
 msgstr ""
 "Objekte umpacken, die sich in mit .keep markierten Pack-Dateien befinden"
 
-#: builtin/repack.c:333
+#: builtin/repack.c:359
 msgid "do not repack this pack"
 msgstr "dieses Paket nicht neu packen"
 
-#: builtin/repack.c:343
+#: builtin/repack.c:369
 msgid "cannot delete packs in a precious-objects repo"
 msgstr "kann Pack-Dateien in precious-objects Repository nicht löschen"
 
-#: builtin/repack.c:347
+#: builtin/repack.c:373
 msgid "--keep-unreachable and -A are incompatible"
 msgstr "--keep-unreachable und -A sind inkompatibel"
 
-#: builtin/repack.c:430
+#: builtin/repack.c:456
 msgid "Nothing new to pack."
 msgstr "Nichts Neues zum Packen."
 
 #: builtin/repack.c:486
-#, c-format
-msgid ""
-"WARNING: Some packs in use have been renamed by\n"
-"WARNING: prefixing old- to their name, in order to\n"
-"WARNING: replace them with the new version of the\n"
-"WARNING: file.  But the operation failed, and the\n"
-"WARNING: attempt to rename them back to their\n"
-"WARNING: original names also failed.\n"
-"WARNING: Please rename them in %s manually:\n"
-msgstr ""
-"WARNUNG: Einige in Verwendung befindliche Pakete wurden\n"
-"WARNUNG: umbenannt, indem 'old-' an deren Namen vorrangestellt\n"
-"WARNUNG: wurde, um diese mit der neuen Dateiversion zu ersetzen.\n"
-"WARNUNG: Diese Operation ist fehlgeschlagen. Der Versuch, die\n"
-"WARNUNG: Datei zu ihrem ursprünglichen Namen umzubenennen, schlug\n"
-"WARNUNG: ebenfalls fehl.\n"
-"WARNUNG: Bitte benennen Sie diese manuell nach %s um:\n"
+#, fuzzy, c-format
+msgid "missing required file: %s"
+msgstr "Fehlende Argumente für %s."
 
-#: builtin/repack.c:534
-#, c-format
-msgid "failed to remove '%s'"
-msgstr "Fehler beim Löschen von '%s'"
+#: builtin/repack.c:488
+#, fuzzy, c-format
+msgid "could not unlink: %s"
+msgstr "Konnte '%s' nicht sperren"
 
 #: builtin/replace.c:22
 msgid "git replace [-f] <object> <replacement>"
@@ -21028,8 +21174,8 @@ msgstr "HEAD ist jetzt bei %s"
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "Kann keinen '%s'-Reset durchführen, während ein Merge im Gange ist."
 
-#: builtin/reset.c:295 builtin/stash.c:520 builtin/stash.c:595
-#: builtin/stash.c:619
+#: builtin/reset.c:295 builtin/stash.c:520 builtin/stash.c:594
+#: builtin/stash.c:618
 msgid "be quiet, only report errors"
 msgstr "weniger Ausgaben, nur Fehler melden"
 
@@ -21241,11 +21387,11 @@ msgstr "ursprüngliche, leere Commits erhalten"
 msgid "keep redundant, empty commits"
 msgstr "redundante, leere Commits behalten"
 
-#: builtin/revert.c:232
+#: builtin/revert.c:239
 msgid "revert failed"
 msgstr "\"revert\" fehlgeschlagen"
 
-#: builtin/revert.c:245
+#: builtin/revert.c:252
 msgid "cherry-pick failed"
 msgstr "\"cherry-pick\" fehlgeschlagen"
 
@@ -21352,77 +21498,77 @@ msgstr ""
 "  --all und die explizite Angabe einer <Referenz> schließen sich gegenseitig "
 "aus."
 
-#: builtin/send-pack.c:182
+#: builtin/send-pack.c:188
 msgid "remote name"
 msgstr "Name des Remote-Repositories"
 
-#: builtin/send-pack.c:195
+#: builtin/send-pack.c:201
 msgid "use stateless RPC protocol"
 msgstr "zustandsloses RPC-Protokoll verwenden"
 
-#: builtin/send-pack.c:196
+#: builtin/send-pack.c:202
 msgid "read refs from stdin"
 msgstr "Referenzen von der Standard-Eingabe lesen"
 
-#: builtin/send-pack.c:197
+#: builtin/send-pack.c:203
 msgid "print status from remote helper"
 msgstr "Status des Remote-Helpers ausgeben"
 
-#: builtin/shortlog.c:15
+#: builtin/shortlog.c:16
 msgid "git shortlog [<options>] [<revision-range>] [[--] <path>...]"
 msgstr "git shortlog [<Optionen>] [<Commitbereich>] [[--] <Pfad>...]"
 
-#: builtin/shortlog.c:16
+#: builtin/shortlog.c:17
 msgid "git log --pretty=short | git shortlog [<options>]"
 msgstr "git log --pretty=short | git shortlog [<Optionen>]"
 
-#: builtin/shortlog.c:134
+#: builtin/shortlog.c:135
 msgid "using multiple --group options with stdin is not supported"
 msgstr "mehrere Optionen --group mit Standard-Eingabe wird nicht unterstützt"
 
-#: builtin/shortlog.c:144
+#: builtin/shortlog.c:145
 msgid "using --group=trailer with stdin is not supported"
 msgstr ""
 "Nutzung von --group=trailer mit Standard-Eingabe wird nicht unterstützt"
 
-#: builtin/shortlog.c:388
+#: builtin/shortlog.c:335
 #, c-format
 msgid "unknown group type: %s"
 msgstr "unbekannter Gruppen-Typ: %s"
 
-#: builtin/shortlog.c:416
+#: builtin/shortlog.c:363
 msgid "Group by committer rather than author"
 msgstr "über Commit-Ersteller anstatt Autor gruppieren"
 
-#: builtin/shortlog.c:419
+#: builtin/shortlog.c:366
 msgid "sort output according to the number of commits per author"
 msgstr "die Ausgabe entsprechend der Anzahl von Commits pro Autor sortieren"
 
-#: builtin/shortlog.c:421
+#: builtin/shortlog.c:368
 msgid "Suppress commit descriptions, only provides commit count"
 msgstr "Commit-Beschreibungen unterdrücken, nur Anzahl der Commits liefern"
 
-#: builtin/shortlog.c:423
+#: builtin/shortlog.c:370
 msgid "Show the email address of each author"
 msgstr "die E-Mail-Adresse von jedem Autor anzeigen"
 
-#: builtin/shortlog.c:424
+#: builtin/shortlog.c:371
 msgid "<w>[,<i1>[,<i2>]]"
 msgstr "<w>[,<i1>[,<i2>]]"
 
-#: builtin/shortlog.c:425
+#: builtin/shortlog.c:372
 msgid "Linewrap output"
 msgstr "Ausgabe mit Zeilenumbrüchen"
 
-#: builtin/shortlog.c:427
+#: builtin/shortlog.c:374
 msgid "field"
 msgstr "Feld"
 
-#: builtin/shortlog.c:428
+#: builtin/shortlog.c:375
 msgid "Group by field"
 msgstr "Gruppieren über Feld"
 
-#: builtin/shortlog.c:456
+#: builtin/shortlog.c:403
 msgid "too many arguments given outside repository"
 msgstr "zu viele Argumente außerhalb des Repositories angegeben"
 
@@ -21795,7 +21941,8 @@ msgid "could not generate diff %s^!."
 msgstr "Konnte keinen Diff erzeugen %s^!."
 
 #: builtin/stash.c:422
-msgid "conflicts in index.Try without --index."
+#, fuzzy
+msgid "conflicts in index. Try without --index."
 msgstr "Konflikte im Index. Versuchen Sie es ohne --index."
 
 #: builtin/stash.c:428
@@ -21815,123 +21962,123 @@ msgstr "Führe %s mit %s zusammen"
 msgid "Index was not unstashed."
 msgstr "Index wurde nicht aus dem Stash zurückgeladen."
 
-#: builtin/stash.c:522 builtin/stash.c:621
+#: builtin/stash.c:522 builtin/stash.c:620
 msgid "attempt to recreate the index"
 msgstr "Versuche Index wiederherzustellen."
 
-#: builtin/stash.c:555
+#: builtin/stash.c:566
 #, c-format
 msgid "Dropped %s (%s)"
 msgstr "%s (%s) gelöscht"
 
-#: builtin/stash.c:558
+#: builtin/stash.c:569
 #, c-format
 msgid "%s: Could not drop stash entry"
 msgstr "%s: Konnte Stash-Eintrag nicht löschen"
 
-#: builtin/stash.c:583
+#: builtin/stash.c:582
 #, c-format
 msgid "'%s' is not a stash reference"
 msgstr "'%s' ist keine Stash-Referenz"
 
-#: builtin/stash.c:633
+#: builtin/stash.c:632
 msgid "The stash entry is kept in case you need it again."
 msgstr ""
 "Der Stash-Eintrag wird für den Fall behalten, dass Sie diesen nochmal "
 "benötigen."
 
-#: builtin/stash.c:656
+#: builtin/stash.c:655
 msgid "No branch name specified"
 msgstr "Kein Branchname spezifiziert"
 
-#: builtin/stash.c:800 builtin/stash.c:837
+#: builtin/stash.c:799 builtin/stash.c:836
 #, c-format
 msgid "Cannot update %s with %s"
 msgstr "Kann nicht %s mit %s aktualisieren."
 
-#: builtin/stash.c:818 builtin/stash.c:1472 builtin/stash.c:1537
+#: builtin/stash.c:817 builtin/stash.c:1471 builtin/stash.c:1536
 msgid "stash message"
 msgstr "Stash-Beschreibung"
 
-#: builtin/stash.c:828
+#: builtin/stash.c:827
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "\"git stash store\" erwartet ein Argument <Commit>"
 
-#: builtin/stash.c:1043
+#: builtin/stash.c:1042
 msgid "No changes selected"
 msgstr "Keine Änderungen ausgewählt"
 
-#: builtin/stash.c:1143
+#: builtin/stash.c:1142
 msgid "You do not have the initial commit yet"
 msgstr "Sie haben bisher noch keinen initialen Commit"
 
-#: builtin/stash.c:1170
+#: builtin/stash.c:1169
 msgid "Cannot save the current index state"
 msgstr "Kann den aktuellen Zustand des Index nicht speichern"
 
-#: builtin/stash.c:1179
+#: builtin/stash.c:1178
 msgid "Cannot save the untracked files"
 msgstr "Kann die unversionierten Dateien nicht speichern"
 
-#: builtin/stash.c:1190 builtin/stash.c:1199
+#: builtin/stash.c:1189 builtin/stash.c:1198
 msgid "Cannot save the current worktree state"
 msgstr "Kann den aktuellen Zustand des Arbeitsverzeichnisses nicht speichern"
 
-#: builtin/stash.c:1227
+#: builtin/stash.c:1226
 msgid "Cannot record working tree state"
 msgstr "Kann Zustand des Arbeitsverzeichnisses nicht aufzeichnen"
 
-#: builtin/stash.c:1276
+#: builtin/stash.c:1275
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr ""
 "Kann nicht gleichzeitig --patch und --include-untracked oder --all verwenden"
 
-#: builtin/stash.c:1292
+#: builtin/stash.c:1291
 msgid "Did you forget to 'git add'?"
 msgstr "Haben Sie vielleicht 'git add' vergessen?"
 
-#: builtin/stash.c:1307
+#: builtin/stash.c:1306
 msgid "No local changes to save"
 msgstr "Keine lokalen Änderungen zum Speichern"
 
-#: builtin/stash.c:1314
+#: builtin/stash.c:1313
 msgid "Cannot initialize stash"
 msgstr "Kann \"stash\" nicht initialisieren"
 
-#: builtin/stash.c:1329
+#: builtin/stash.c:1328
 msgid "Cannot save the current status"
 msgstr "Kann den aktuellen Status nicht speichern"
 
-#: builtin/stash.c:1334
+#: builtin/stash.c:1333
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "Arbeitsverzeichnis und Index-Status %s gespeichert."
 
-#: builtin/stash.c:1424
+#: builtin/stash.c:1423
 msgid "Cannot remove worktree changes"
 msgstr "Kann Änderungen im Arbeitsverzeichnis nicht löschen"
 
-#: builtin/stash.c:1463 builtin/stash.c:1528
+#: builtin/stash.c:1462 builtin/stash.c:1527
 msgid "keep index"
 msgstr "behalte Index"
 
-#: builtin/stash.c:1465 builtin/stash.c:1530
+#: builtin/stash.c:1464 builtin/stash.c:1529
 msgid "stash in patch mode"
 msgstr "Stash in Patch-Modus"
 
-#: builtin/stash.c:1466 builtin/stash.c:1531
+#: builtin/stash.c:1465 builtin/stash.c:1530
 msgid "quiet mode"
 msgstr "weniger Ausgaben"
 
-#: builtin/stash.c:1468 builtin/stash.c:1533
+#: builtin/stash.c:1467 builtin/stash.c:1532
 msgid "include untracked files in stash"
 msgstr "unversionierte Dateien in Stash einbeziehen"
 
-#: builtin/stash.c:1470 builtin/stash.c:1535
+#: builtin/stash.c:1469 builtin/stash.c:1534
 msgid "include ignore files"
 msgstr "ignorierte Dateien einbeziehen"
 
-#: builtin/stash.c:1570
+#: builtin/stash.c:1569
 msgid ""
 "the stash.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -22455,7 +22602,7 @@ msgstr "git submodule--helper config --unset <Name>"
 msgid "git submodule--helper config --check-writeable"
 msgstr "git submodule--helper config --check-writeable"
 
-#: builtin/submodule--helper.c:2665 git-submodule.sh:151
+#: builtin/submodule--helper.c:2665 git-submodule.sh:150
 #, sh-format
 msgid "please make sure that the .gitmodules file is in the working tree"
 msgstr ""
@@ -22496,7 +22643,7 @@ msgstr "Option --branch oder --default erforderlich"
 msgid "--branch and --default are mutually exclusive"
 msgstr "--branch und --default schließen sich gegenseitig aus"
 
-#: builtin/submodule--helper.c:2792 git.c:438 git.c:710
+#: builtin/submodule--helper.c:2792 git.c:438 git.c:711
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s unterstützt kein --super-prefix"
@@ -22527,11 +22674,11 @@ msgstr "symbolische Referenzen löschen"
 msgid "shorten ref output"
 msgstr "verkürzte Ausgabe der Referenzen"
 
-#: builtin/symbolic-ref.c:43 builtin/update-ref.c:486
+#: builtin/symbolic-ref.c:43 builtin/update-ref.c:499
 msgid "reason"
 msgstr "Grund"
 
-#: builtin/symbolic-ref.c:43 builtin/update-ref.c:486
+#: builtin/symbolic-ref.c:43 builtin/update-ref.c:499
 msgid "reason of the update"
 msgstr "Grund für die Aktualisierung"
 
@@ -22680,7 +22827,7 @@ msgstr "einen anderen Schlüssel verwenden, um das Tag zu signieren"
 msgid "replace the tag if exists"
 msgstr "das Tag ersetzen, wenn es existiert"
 
-#: builtin/tag.c:422 builtin/update-ref.c:492
+#: builtin/tag.c:422 builtin/update-ref.c:505
 msgid "create a reflog"
 msgstr "Reflog erstellen"
 
@@ -23053,19 +23200,19 @@ msgstr ""
 msgid "git update-ref [<options>] --stdin [-z]"
 msgstr "git update-ref [<Optionen>] --stdin [-z]"
 
-#: builtin/update-ref.c:487
+#: builtin/update-ref.c:500
 msgid "delete the reference"
 msgstr "diese Referenz löschen"
 
-#: builtin/update-ref.c:489
+#: builtin/update-ref.c:502
 msgid "update <refname> not the one it points to"
 msgstr "<Referenzname> aktualisieren, nicht den Verweis"
 
-#: builtin/update-ref.c:490
+#: builtin/update-ref.c:503
 msgid "stdin has NUL-terminated arguments"
 msgstr "Standard-Eingabe hat durch NUL-Zeichen abgeschlossene Argumente"
 
-#: builtin/update-ref.c:491
+#: builtin/update-ref.c:504
 msgid "read updates from stdin"
 msgstr "Aktualisierungen von der Standard-Eingabe lesen"
 
@@ -23159,7 +23306,7 @@ msgstr "git worktree remove [<Optionen>] <Arbeitsverzeichnis>"
 msgid "git worktree unlock <path>"
 msgstr "git worktree unlock <Pfad>"
 
-#: builtin/worktree.c:60 builtin/worktree.c:970
+#: builtin/worktree.c:60 builtin/worktree.c:973
 #, c-format
 msgid "failed to delete '%s'"
 msgstr "Fehler beim Löschen von '%s'"
@@ -23299,58 +23446,58 @@ msgid "--[no-]track can only be used if a new branch is created"
 msgstr ""
 "--[no]-track kann nur verwendet werden, wenn ein neuer Branch erstellt wird."
 
-#: builtin/worktree.c:755
+#: builtin/worktree.c:758
 msgid "reason for locking"
 msgstr "Sperrgrund"
 
-#: builtin/worktree.c:767 builtin/worktree.c:800 builtin/worktree.c:874
-#: builtin/worktree.c:998
+#: builtin/worktree.c:770 builtin/worktree.c:803 builtin/worktree.c:877
+#: builtin/worktree.c:1001
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr "'%s' ist kein Arbeitsverzeichnis"
 
-#: builtin/worktree.c:769 builtin/worktree.c:802
+#: builtin/worktree.c:772 builtin/worktree.c:805
 msgid "The main working tree cannot be locked or unlocked"
 msgstr "Das Hauptarbeitsverzeichnis kann nicht gesperrt oder entsperrt werden."
 
-#: builtin/worktree.c:774
+#: builtin/worktree.c:777
 #, c-format
 msgid "'%s' is already locked, reason: %s"
 msgstr "'%s' ist bereits gesperrt, Grund: %s"
 
-#: builtin/worktree.c:776
+#: builtin/worktree.c:779
 #, c-format
 msgid "'%s' is already locked"
 msgstr "'%s' ist bereits gesperrt"
 
-#: builtin/worktree.c:804
+#: builtin/worktree.c:807
 #, c-format
 msgid "'%s' is not locked"
 msgstr "'%s' ist nicht gesperrt"
 
-#: builtin/worktree.c:845
+#: builtin/worktree.c:848
 msgid "working trees containing submodules cannot be moved or removed"
 msgstr ""
 "Arbeitsverzeichnisse, die Submodule enthalten, können nicht verschoben oder\n"
 "entfernt werden."
 
-#: builtin/worktree.c:853
+#: builtin/worktree.c:856
 msgid "force move even if worktree is dirty or locked"
 msgstr ""
 "Verschieben erzwingen, auch wenn das Arbeitsverzeichnis geändert oder "
 "gesperrt ist"
 
-#: builtin/worktree.c:876 builtin/worktree.c:1000
+#: builtin/worktree.c:879 builtin/worktree.c:1003
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr "'%s' ist ein Hauptarbeitsverzeichnis"
 
-#: builtin/worktree.c:881
+#: builtin/worktree.c:884
 #, c-format
 msgid "could not figure out destination name from '%s'"
 msgstr "Konnte Zielname aus '%s' nicht bestimmen."
 
-#: builtin/worktree.c:894
+#: builtin/worktree.c:897
 #, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
@@ -23360,7 +23507,7 @@ msgstr ""
 "Benutzen Sie 'move -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:896
+#: builtin/worktree.c:899
 msgid ""
 "cannot move a locked working tree;\n"
 "use 'move -f -f' to override or unlock first"
@@ -23369,40 +23516,40 @@ msgstr ""
 "Benutzen Sie 'move -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:899
+#: builtin/worktree.c:902
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
 msgstr "Validierung fehlgeschlagen, kann Arbeitszeichnis nicht verschieben: %s"
 
-#: builtin/worktree.c:904
+#: builtin/worktree.c:907
 #, c-format
 msgid "failed to move '%s' to '%s'"
 msgstr "Fehler beim Verschieben von '%s' nach '%s'"
 
-#: builtin/worktree.c:950
+#: builtin/worktree.c:953
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr "Fehler beim Ausführen von 'git status' auf '%s'"
 
-#: builtin/worktree.c:954
+#: builtin/worktree.c:957
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
 "'%s' enthält geänderte oder nicht versionierte Dateien, benutzen Sie --force "
 "zum Löschen"
 
-#: builtin/worktree.c:959
+#: builtin/worktree.c:962
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr "Fehler beim Ausführen von 'git status' auf '%s'. Code: %d"
 
-#: builtin/worktree.c:982
+#: builtin/worktree.c:985
 msgid "force removal even if worktree is dirty or locked"
 msgstr ""
 "Löschen erzwingen, auch wenn das Arbeitsverzeichnis geändert oder gesperrt "
 "ist"
 
-#: builtin/worktree.c:1005
+#: builtin/worktree.c:1008
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
@@ -23412,7 +23559,7 @@ msgstr ""
 "Benutzen Sie 'remove -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:1007
+#: builtin/worktree.c:1010
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
@@ -23421,17 +23568,17 @@ msgstr ""
 "Benutzen Sie 'remove -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:1010
+#: builtin/worktree.c:1013
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr "Validierung fehlgeschlagen, kann Arbeitsverzeichnis nicht löschen: %s"
 
-#: builtin/worktree.c:1034
+#: builtin/worktree.c:1037
 #, c-format
 msgid "repair: %s: %s"
 msgstr "repariere: %s: %s"
 
-#: builtin/worktree.c:1037
+#: builtin/worktree.c:1040
 #, c-format
 msgid "error: %s: %s"
 msgstr "Fehler: %s: %s"
@@ -23460,6 +23607,16 @@ msgstr "Argument für --packfile muss ein gültiger Hash sein ('%s' erhalten)"
 #: http-fetch.c:122
 msgid "not a git repository"
 msgstr "kein Git-Repository"
+
+#: t/helper/test-fast-rebase.c:141
+#, fuzzy
+msgid "unhandled options"
+msgstr "make_script: unbehandelte Optionen"
+
+#: t/helper/test-fast-rebase.c:146
+#, fuzzy
+msgid "error preparing revisions"
+msgstr "make_script: Fehler beim Vorbereiten der Commits"
 
 #: t/helper/test-reach.c:154
 #, c-format
@@ -23578,17 +23735,17 @@ msgstr "Unbekannter Fehler beim Schreiben in die Standard-Ausgabe."
 msgid "close failed on standard output"
 msgstr "Fehler beim Schließen der Standard-Ausgabe."
 
-#: git.c:819
+#: git.c:820
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr "Alias-Schleife erkannt: Erweiterung von '%s' schließt nicht ab:%s"
 
-#: git.c:869
+#: git.c:870
 #, c-format
 msgid "cannot handle %s as a builtin"
 msgstr "Kann %s nicht als eingebauten Befehl behandeln."
 
-#: git.c:882
+#: git.c:883
 #, c-format
 msgid ""
 "usage: %s\n"
@@ -23597,12 +23754,12 @@ msgstr ""
 "Verwendung: %s\n"
 "\n"
 
-#: git.c:902
+#: git.c:903
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr "Erweiterung von Alias '%s' fehlgeschlagen; '%s' ist kein Git-Befehl.\n"
 
-#: git.c:914
+#: git.c:915
 #, c-format
 msgid "failed to run command '%s': %s\n"
 msgstr "Fehler beim Ausführen von Befehl '%s': %s\n"
@@ -23657,136 +23814,136 @@ msgstr ""
 "  gefragt nach: %s\n"
 "    umgeleitet: %s"
 
-#: remote-curl.c:174
+#: remote-curl.c:183
 #, c-format
 msgid "invalid quoting in push-option value: '%s'"
 msgstr "Ungültiges Quoting beim \"push-option\"-Wert: '%s'"
 
-#: remote-curl.c:298
+#: remote-curl.c:307
 #, c-format
 msgid "%sinfo/refs not valid: is this a git repository?"
 msgstr "%sinfo/refs nicht gültig: Ist das ein Git-Repository?"
 
-#: remote-curl.c:399
+#: remote-curl.c:408
 msgid "invalid server response; expected service, got flush packet"
 msgstr "Ungültige Antwort des Servers. Service erwartet, Flush-Paket bekommen"
 
-#: remote-curl.c:430
+#: remote-curl.c:439
 #, c-format
 msgid "invalid server response; got '%s'"
 msgstr "Ungültige Serverantwort; '%s' bekommen"
 
-#: remote-curl.c:490
+#: remote-curl.c:499
 #, c-format
 msgid "repository '%s' not found"
 msgstr "Repository '%s' nicht gefunden."
 
-#: remote-curl.c:494
+#: remote-curl.c:503
 #, c-format
 msgid "Authentication failed for '%s'"
 msgstr "Authentifizierung fehlgeschlagen für '%s'"
 
-#: remote-curl.c:498
+#: remote-curl.c:507
 #, c-format
 msgid "unable to access '%s': %s"
 msgstr "konnte nicht auf '%s' zugreifen: %s"
 
-#: remote-curl.c:504
+#: remote-curl.c:513
 #, c-format
 msgid "redirecting to %s"
 msgstr "Umleitung nach %s"
 
-#: remote-curl.c:633
+#: remote-curl.c:642
 msgid "shouldn't have EOF when not gentle on EOF"
 msgstr "sollte kein EOF haben, wenn nicht behutsam mit EOF"
 
-#: remote-curl.c:645
+#: remote-curl.c:654
 msgid "remote server sent stateless separator"
 msgstr "Server sendete zustandslosen Separator"
 
-#: remote-curl.c:715
+#: remote-curl.c:724
 msgid "unable to rewind rpc post data - try increasing http.postBuffer"
 msgstr ""
 "konnte nicht RPC-POST-Daten zurückspulen - Versuchen Sie http.postBuffer zu "
 "erhöhen"
 
-#: remote-curl.c:745
+#: remote-curl.c:754
 #, c-format
 msgid "remote-curl: bad line length character: %.4s"
 msgstr "remote-curl: ungültiges Zeichen für Zeilenlänge: %.4s"
 
-#: remote-curl.c:747
+#: remote-curl.c:756
 msgid "remote-curl: unexpected response end packet"
 msgstr "remote-curl: unerwartetes Antwort-Endpaket"
 
-#: remote-curl.c:823
+#: remote-curl.c:832
 #, c-format
 msgid "RPC failed; %s"
 msgstr "RPC fehlgeschlagen; %s"
 
-#: remote-curl.c:863
+#: remote-curl.c:872
 msgid "cannot handle pushes this big"
 msgstr "Kann solche großen Übertragungen nicht verarbeiten."
 
-#: remote-curl.c:978
+#: remote-curl.c:987
 #, c-format
 msgid "cannot deflate request; zlib deflate error %d"
 msgstr "Kann Request nicht komprimieren; \"zlib deflate\"-Fehler %d"
 
-#: remote-curl.c:982
+#: remote-curl.c:991
 #, c-format
 msgid "cannot deflate request; zlib end error %d"
 msgstr "Kann Request nicht komprimieren; \"zlib end\"-Fehler %d"
 
-#: remote-curl.c:1032
+#: remote-curl.c:1041
 #, c-format
 msgid "%d bytes of length header were received"
 msgstr "%d Bytes des Längen-Headers wurden empfangen"
 
-#: remote-curl.c:1034
+#: remote-curl.c:1043
 #, c-format
 msgid "%d bytes of body are still expected"
 msgstr "%d Bytes des Bodys werden noch erwartet"
 
-#: remote-curl.c:1123
+#: remote-curl.c:1132
 msgid "dumb http transport does not support shallow capabilities"
 msgstr "Dumb HTTP-Transport unterstützt keine shallow-Funktionen"
 
-#: remote-curl.c:1138
+#: remote-curl.c:1147
 msgid "fetch failed."
 msgstr "\"fetch\" fehlgeschlagen."
 
-#: remote-curl.c:1184
+#: remote-curl.c:1193
 msgid "cannot fetch by sha1 over smart http"
 msgstr "Kann SHA-1 nicht über Smart-HTTP anfordern"
 
-#: remote-curl.c:1228 remote-curl.c:1234
+#: remote-curl.c:1237 remote-curl.c:1243
 #, c-format
 msgid "protocol error: expected sha/ref, got '%s'"
 msgstr "Protokollfehler: SHA-1/Referenz erwartet, '%s' bekommen"
 
-#: remote-curl.c:1246 remote-curl.c:1361
+#: remote-curl.c:1255 remote-curl.c:1373
 #, c-format
 msgid "http transport does not support %s"
 msgstr "HTTP-Transport unterstützt nicht %s"
 
-#: remote-curl.c:1282
+#: remote-curl.c:1291
 msgid "git-http-push failed"
 msgstr "\"git-http-push\" fehlgeschlagen"
 
-#: remote-curl.c:1467
+#: remote-curl.c:1479
 msgid "remote-curl: usage: git remote-curl <remote> [<url>]"
 msgstr "remote-curl: Verwendung: git remote-curl <Remote-Repository> [<URL>]"
 
-#: remote-curl.c:1499
+#: remote-curl.c:1511
 msgid "remote-curl: error reading command stream from git"
 msgstr "remote-curl: Fehler beim Lesen des Kommando-Streams von Git"
 
-#: remote-curl.c:1506
+#: remote-curl.c:1518
 msgid "remote-curl: fetch attempted without a local repo"
 msgstr "remote-curl: \"fetch\" ohne lokales Repository versucht"
 
-#: remote-curl.c:1547
+#: remote-curl.c:1559
 #, c-format
 msgid "remote-curl: unknown command '%s' from git"
 msgstr "remote-curl: Unbekannter Befehl '%s' von Git"
@@ -24073,185 +24230,185 @@ msgid "Output information on each ref"
 msgstr "Informationen für jede Referenz ausgeben"
 
 #: command-list.h:99
+#, fuzzy
+msgid "Run a Git command on a list of repositories"
+msgstr "Aufgaben abhängig vom Zustand des Repositories ausführen"
+
+#: command-list.h:100
 msgid "Prepare patches for e-mail submission"
 msgstr "Patches für E-Mail-Versand vorbereiten"
 
-#: command-list.h:100
+#: command-list.h:101
 msgid "Verifies the connectivity and validity of the objects in the database"
 msgstr ""
 "stellt die Verbundenheit und Gültigkeit der Objekte in der Datenbank sicher"
 
-#: command-list.h:101
+#: command-list.h:102
 msgid "Cleanup unnecessary files and optimize the local repository"
 msgstr "nicht benötigte Dateien entfernen und das lokale Repository optimieren"
 
-#: command-list.h:102
+#: command-list.h:103
 msgid "Extract commit ID from an archive created using git-archive"
 msgstr ""
 "Commit-ID eines Archivs extrahieren, welches mit git-archive erstellt wurde"
 
-#: command-list.h:103
+#: command-list.h:104
 msgid "Print lines matching a pattern"
 msgstr "Zeilen darstellen, die einem Muster entsprechen"
 
-#: command-list.h:104
+#: command-list.h:105
 msgid "A portable graphical interface to Git"
 msgstr "eine portable grafische Schnittstelle zu Git"
 
-#: command-list.h:105
+#: command-list.h:106
 msgid "Compute object ID and optionally creates a blob from a file"
 msgstr ""
 "von einer Datei die Objekt-ID berechnen und optional ein Blob erstellen"
 
-#: command-list.h:106
+#: command-list.h:107
 msgid "Display help information about Git"
 msgstr "Hilfsinformationen über Git anzeigen"
 
-#: command-list.h:107
+#: command-list.h:108
 msgid "Server side implementation of Git over HTTP"
 msgstr "serverseitige Implementierung von Git über HTTP"
 
-#: command-list.h:108
+#: command-list.h:109
 msgid "Download from a remote Git repository via HTTP"
 msgstr "von einem Remote-Git-Repository über HTTP herunterladen"
 
-#: command-list.h:109
+#: command-list.h:110
 msgid "Push objects over HTTP/DAV to another repository"
 msgstr "Objekte über HTTP/DAV zu einem anderen Repository übertragen"
 
-#: command-list.h:110
+#: command-list.h:111
 msgid "Send a collection of patches from stdin to an IMAP folder"
 msgstr ""
 "eine Sammlung von Patches von der Standard-Eingabe zu einem IMAP-Ordner "
 "senden"
 
-#: command-list.h:111
+#: command-list.h:112
 msgid "Build pack index file for an existing packed archive"
 msgstr "Pack-Index-Datei für ein existierendes gepacktes Archiv erzeugen"
 
-#: command-list.h:112
+#: command-list.h:113
 msgid "Create an empty Git repository or reinitialize an existing one"
 msgstr ""
 "ein leeres Git-Repository erstellen oder ein bestehendes neuinitialisieren"
 
-#: command-list.h:113
+#: command-list.h:114
 msgid "Instantly browse your working repository in gitweb"
 msgstr "Ihr aktuelles Repository sofort in gitweb betrachten"
 
-#: command-list.h:114
+#: command-list.h:115
 msgid "Add or parse structured information in commit messages"
 msgstr ""
 "Strukturierte Informationen in Commit-Beschreibungen hinzufügen oder parsen"
 
-#: command-list.h:115
+#: command-list.h:116
 msgid "The Git repository browser"
 msgstr "der Git-Repository-Browser"
 
-#: command-list.h:116
+#: command-list.h:117
 msgid "Show commit logs"
 msgstr "Commit-Historie anzeigen"
 
-#: command-list.h:117
+#: command-list.h:118
 msgid "Show information about files in the index and the working tree"
 msgstr ""
 "Informationen über Dateien in dem Index und im Arbeitsverzeichnis anzeigen"
 
-#: command-list.h:118
+#: command-list.h:119
 msgid "List references in a remote repository"
 msgstr "Referenzen in einem Remote-Repository auflisten"
 
-#: command-list.h:119
+#: command-list.h:120
 msgid "List the contents of a tree object"
 msgstr "Inhalte eines Tree-Objektes auflisten"
 
-#: command-list.h:120
+#: command-list.h:121
 msgid "Extracts patch and authorship from a single e-mail message"
 msgstr ""
 "Patch und Urheberschaft von einer einzelnen E-Mail-Nachricht extrahieren"
 
-#: command-list.h:121
+#: command-list.h:122
 msgid "Simple UNIX mbox splitter program"
 msgstr "einfaches UNIX mbox Splitter-Programm"
 
-#: command-list.h:122
+#: command-list.h:123
 msgid "Run tasks to optimize Git repository data"
 msgstr "Aufgaben ausführen, um Git-Repository-Daten zu optimieren"
 
-#: command-list.h:123
+#: command-list.h:124
 msgid "Join two or more development histories together"
 msgstr "zwei oder mehr Entwicklungszweige zusammenführen"
 
-#: command-list.h:124
+#: command-list.h:125
 msgid "Find as good common ancestors as possible for a merge"
 msgstr "möglichst besten gemeinsamen Vorgänger-Commit für einen Merge finden"
 
-#: command-list.h:125
+#: command-list.h:126
 msgid "Run a three-way file merge"
 msgstr "einen 3-Wege-Datei-Merge ausführen"
 
-#: command-list.h:126
+#: command-list.h:127
 msgid "Run a merge for files needing merging"
 msgstr "einen Merge für zusammenzuführende Dateien ausführen"
 
-#: command-list.h:127
+#: command-list.h:128
 msgid "The standard helper program to use with git-merge-index"
 msgstr "das Standard-Hilfsprogramm für die Verwendung mit git-merge-index"
 
-#: command-list.h:128
+#: command-list.h:129
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
 msgstr ""
 "Ausführen von Tools zur Auflösung von Merge-Konflikten zur Behebung dieser"
 
-#: command-list.h:129
+#: command-list.h:130
 msgid "Show three-way merge without touching index"
 msgstr "3-Wege-Merge anzeigen ohne den Index zu verändern"
 
-#: command-list.h:130
+#: command-list.h:131
 msgid "Write and verify multi-pack-indexes"
 msgstr "multi-pack-indexes schreiben und überprüfen"
 
-#: command-list.h:131
+#: command-list.h:132
 msgid "Creates a tag object"
 msgstr "ein Tag-Objekt erstellen"
 
-#: command-list.h:132
+#: command-list.h:133
 msgid "Build a tree-object from ls-tree formatted text"
 msgstr "Tree-Objekt aus ls-tree formattiertem Text erzeugen"
 
-#: command-list.h:133
+#: command-list.h:134
 msgid "Move or rename a file, a directory, or a symlink"
 msgstr ""
 "eine Datei, ein Verzeichnis, oder eine symbolische Verknüpfung verschieben "
 "oder umbenennen"
 
-#: command-list.h:134
+#: command-list.h:135
 msgid "Find symbolic names for given revs"
 msgstr "symbolische Namen für die gegebenen Commits finden"
 
-#: command-list.h:135
+#: command-list.h:136
 msgid "Add or inspect object notes"
 msgstr "Objekt-Notizen hinzufügen oder überprüfen"
 
-#: command-list.h:136
+#: command-list.h:137
 msgid "Import from and submit to Perforce repositories"
 msgstr "von Perforce Repositories importieren und nach diese senden"
 
-#: command-list.h:137
+#: command-list.h:138
 msgid "Create a packed archive of objects"
 msgstr "ein gepacktes Archiv von Objekten erstellen"
 
-#: command-list.h:138
+#: command-list.h:139
 msgid "Find redundant pack files"
 msgstr "redundante Paketdateien finden"
 
-#: command-list.h:139
+#: command-list.h:140
 msgid "Pack heads and tags for efficient repository access"
 msgstr "Branches und Tags für effizienten Zugriff auf das Repository packen"
-
-#: command-list.h:140
-msgid "Routines to help parsing remote repository access parameters"
-msgstr ""
-"Routinen als Hilfe zum Parsen von Zugriffsparametern von Remote-Repositories"
 
 #: command-list.h:141
 msgid "Compute unique ID for a patch"
@@ -24569,49 +24726,34 @@ msgstr "eine einführende Anleitung zu Git"
 msgid "An overview of recommended workflows with Git"
 msgstr "Eine Übersicht über empfohlene Arbeitsabläufe mit Git"
 
-#: git-bisect.sh:79
+#: git-bisect.sh:48
 #, sh-format
 msgid "Bad rev input: $arg"
 msgstr "Ungültige Referenz-Eingabe: $arg"
 
-#: git-bisect.sh:99
-#, sh-format
-msgid "Bad rev input: $bisected_head"
-msgstr "Ungültige Referenz-Eingabe: $bisected_head"
-
-#: git-bisect.sh:108
-#, sh-format
-msgid "Bad rev input: $rev"
-msgstr "Ungültige Referenz-Eingabe: $rev"
-
-#: git-bisect.sh:117
-#, sh-format
-msgid "'git bisect $TERM_BAD' can take only one argument."
-msgstr "'git bisect $TERM_BAD' kann nur ein Argument entgegennehmen."
-
-#: git-bisect.sh:149
+#: git-bisect.sh:82
 msgid "No logfile given"
 msgstr "Keine Log-Datei gegeben"
 
-#: git-bisect.sh:150
+#: git-bisect.sh:83
 #, sh-format
 msgid "cannot read $file for replaying"
 msgstr "kann $file nicht für das Abspielen lesen"
 
-#: git-bisect.sh:173
+#: git-bisect.sh:105
 msgid "?? what are you talking about?"
 msgstr "?? Was reden Sie da?"
 
-#: git-bisect.sh:183
+#: git-bisect.sh:115
 msgid "bisect run failed: no command provided."
 msgstr "'bisect run' fehlgeschlagen: kein Befehl angegeben."
 
-#: git-bisect.sh:188
+#: git-bisect.sh:120
 #, sh-format
 msgid "running $command"
 msgstr "führe $command aus"
 
-#: git-bisect.sh:195
+#: git-bisect.sh:127
 #, sh-format
 msgid ""
 "bisect run failed:\n"
@@ -24620,24 +24762,24 @@ msgstr ""
 "'bisect run' fehlgeschlagen:\n"
 "Exit-Code $res von '$command' ist < 0 oder >= 128"
 
-#: git-bisect.sh:221
+#: git-bisect.sh:152
 msgid "bisect run cannot continue any more"
 msgstr "'bisect run' kann nicht mehr fortgesetzt werden"
 
-#: git-bisect.sh:227
-#, sh-format
+#: git-bisect.sh:158
+#, fuzzy, sh-format
 msgid ""
 "bisect run failed:\n"
-"'bisect_state $state' exited with error code $res"
+"'bisect-state $state' exited with error code $res"
 msgstr ""
 "'bisect run' fehlgeschlagen:\n"
 "'bisect_state $state' wurde mit Fehlerwert $res beendet"
 
-#: git-bisect.sh:234
+#: git-bisect.sh:165
 msgid "bisect run success"
 msgstr "'bisect run' erfolgreich ausgeführt"
 
-#: git-bisect.sh:242
+#: git-bisect.sh:173
 msgid "We are not bisecting."
 msgstr "keine binäre Suche im Gange"
 
@@ -24682,50 +24824,50 @@ msgstr "Versuche einfachen Merge mit $pretty_name"
 msgid "Simple merge did not work, trying automatic merge."
 msgstr "Einfacher Merge hat nicht funktioniert, versuche automatischen Merge."
 
-#: git-submodule.sh:180
+#: git-submodule.sh:179
 msgid "Relative path can only be used from the toplevel of the working tree"
 msgstr ""
 "Relative Pfade können nur von der obersten Ebene des Arbeitsverzeichnisses "
 "benutzt werden."
 
-#: git-submodule.sh:190
+#: git-submodule.sh:189
 #, sh-format
 msgid "repo URL: '$repo' must be absolute or begin with ./|../"
 msgstr "repo URL: '$repo' muss absolut sein oder mit ./|../ beginnen"
 
-#: git-submodule.sh:209
+#: git-submodule.sh:208
 #, sh-format
 msgid "'$sm_path' already exists in the index"
 msgstr "'$sm_path' ist bereits zum Commit vorgemerkt"
 
-#: git-submodule.sh:212
+#: git-submodule.sh:211
 #, sh-format
 msgid "'$sm_path' already exists in the index and is not a submodule"
 msgstr "'$sm_path' ist bereits zum Commit vorgemerkt und ist kein Submodul"
 
-#: git-submodule.sh:219
+#: git-submodule.sh:218
 #, sh-format
 msgid "'$sm_path' does not have a commit checked out"
 msgstr "'$sm_path' hat keinen Commit ausgecheckt"
 
-#: git-submodule.sh:250
+#: git-submodule.sh:249
 #, sh-format
 msgid "Adding existing repo at '$sm_path' to the index"
 msgstr "Füge existierendes Repository in '$sm_path' dem Index hinzu."
 
-#: git-submodule.sh:252
+#: git-submodule.sh:251
 #, sh-format
 msgid "'$sm_path' already exists and is not a valid git repo"
 msgstr "'$sm_path' existiert bereits und ist kein gültiges Git-Repository"
 
-#: git-submodule.sh:260
+#: git-submodule.sh:259
 #, sh-format
 msgid "A git directory for '$sm_name' is found locally with remote(s):"
 msgstr ""
 "Ein Git-Verzeichnis für '$sm_name' wurde lokal gefunden mit den Remote-"
 "Repositories:"
 
-#: git-submodule.sh:262
+#: git-submodule.sh:261
 #, sh-format
 msgid ""
 "If you want to reuse this local git directory instead of cloning again from\n"
@@ -24743,37 +24885,37 @@ msgstr ""
 "nicht das korrekte Repository ist oder Sie unsicher sind, was das bedeutet,\n"
 "wählen Sie einen anderen Namen mit der Option '--name'."
 
-#: git-submodule.sh:268
+#: git-submodule.sh:267
 #, sh-format
 msgid "Reactivating local git directory for submodule '$sm_name'."
 msgstr "Reaktiviere lokales Git-Verzeichnis für Submodul '$sm_name'."
 
-#: git-submodule.sh:280
+#: git-submodule.sh:279
 #, sh-format
 msgid "Unable to checkout submodule '$sm_path'"
 msgstr "Kann Submodul '$sm_path' nicht auschecken"
 
-#: git-submodule.sh:285
+#: git-submodule.sh:284
 #, sh-format
 msgid "Failed to add submodule '$sm_path'"
 msgstr "Hinzufügen von Submodul '$sm_path' fehlgeschlagen"
 
-#: git-submodule.sh:294
+#: git-submodule.sh:293
 #, sh-format
 msgid "Failed to register submodule '$sm_path'"
 msgstr "Fehler beim Eintragen von Submodul '$sm_path' in die Konfiguration."
 
-#: git-submodule.sh:567
+#: git-submodule.sh:568
 #, sh-format
 msgid "Unable to find current revision in submodule path '$displaypath'"
 msgstr "Konnte aktuellen Commit in Submodul-Pfad '$displaypath' nicht finden."
 
-#: git-submodule.sh:577
+#: git-submodule.sh:578
 #, sh-format
 msgid "Unable to fetch in submodule path '$sm_path'"
 msgstr "Konnte \"fetch\" in Submodul-Pfad '$sm_path' nicht ausführen"
 
-#: git-submodule.sh:582
+#: git-submodule.sh:583
 #, sh-format
 msgid ""
 "Unable to find current ${remote_name}/${branch} revision in submodule path "
@@ -24782,7 +24924,7 @@ msgstr ""
 "Konnte aktuellen Commit von ${remote_name}/${branch} in Submodul-Pfad\n"
 "'$sm_path' nicht finden."
 
-#: git-submodule.sh:600
+#: git-submodule.sh:601
 #, sh-format
 msgid ""
 "Unable to fetch in submodule path '$displaypath'; trying to directly fetch "
@@ -24791,7 +24933,7 @@ msgstr ""
 "Konnte \"fetch\" in Submodul-Pfad '$displaypath' nicht ausführen. Versuche "
 "$sha1 direkt anzufordern:"
 
-#: git-submodule.sh:606
+#: git-submodule.sh:607
 #, sh-format
 msgid ""
 "Fetched in submodule path '$displaypath', but it did not contain $sha1. "
@@ -24800,57 +24942,52 @@ msgstr ""
 "\"fetch\" in Submodul-Pfad '$displaypath' ausgeführt, aber $sha1 nicht\n"
 "enthalten. Direktes Anfordern dieses Commits ist fehlgeschlagen."
 
-#: git-submodule.sh:613
+#: git-submodule.sh:614
 #, sh-format
 msgid "Unable to checkout '$sha1' in submodule path '$displaypath'"
 msgstr "Konnte '$sha1' in Submodul-Pfad '$displaypath' nicht auschecken."
 
-#: git-submodule.sh:614
+#: git-submodule.sh:615
 #, sh-format
 msgid "Submodule path '$displaypath': checked out '$sha1'"
 msgstr "Submodul-Pfad: '$displaypath': '$sha1' ausgecheckt"
 
-#: git-submodule.sh:618
+#: git-submodule.sh:619
 #, sh-format
 msgid "Unable to rebase '$sha1' in submodule path '$displaypath'"
 msgstr "Rebase auf '$sha1' in Submodul-Pfad '$displaypath' nicht möglich"
 
-#: git-submodule.sh:619
+#: git-submodule.sh:620
 #, sh-format
 msgid "Submodule path '$displaypath': rebased into '$sha1'"
 msgstr "Submodul-Pfad '$displaypath': Rebase auf '$sha1'"
 
-#: git-submodule.sh:624
+#: git-submodule.sh:625
 #, sh-format
 msgid "Unable to merge '$sha1' in submodule path '$displaypath'"
 msgstr "Merge von '$sha1' in Submodul-Pfad '$displaypath' fehlgeschlagen"
 
-#: git-submodule.sh:625
+#: git-submodule.sh:626
 #, sh-format
 msgid "Submodule path '$displaypath': merged in '$sha1'"
 msgstr "Submodul-Pfad '$displaypath': zusammengeführt in '$sha1'"
 
-#: git-submodule.sh:630
+#: git-submodule.sh:631
 #, sh-format
 msgid "Execution of '$command $sha1' failed in submodule path '$displaypath'"
 msgstr ""
 "Ausführung von '$command $sha1' in Submodul-Pfad '$displaypath' "
 "fehlgeschlagen"
 
-#: git-submodule.sh:631
+#: git-submodule.sh:632
 #, sh-format
 msgid "Submodule path '$displaypath': '$command $sha1'"
 msgstr "Submodul-Pfad '$displaypath': '$command $sha1'"
 
-#: git-submodule.sh:662
+#: git-submodule.sh:663
 #, sh-format
 msgid "Failed to recurse into submodule path '$displaypath'"
 msgstr "Fehler bei Rekursion in Submodul-Pfad '$displaypath'"
-
-#: git-parse-remote.sh:89
-#, sh-format
-msgid "See git-${cmd}(1) for details."
-msgstr "Siehe git-${cmd}(1) für weitere Details."
 
 #: git-rebase--preserve-merges.sh:109
 msgid "Applied autostash."
@@ -25273,14 +25410,14 @@ msgstr "Konnte absoluten Pfad des Git-Verzeichnisses nicht bestimmen."
 msgid "%12s %12s %s"
 msgstr "%28s %25s %s"
 
-#: git-add--interactive.perl:634
+#: git-add--interactive.perl:632
 #, perl-format
 msgid "touched %d path\n"
 msgid_plural "touched %d paths\n"
 msgstr[0] "%d Pfad angefasst\n"
 msgstr[1] "%d Pfade angefasst\n"
 
-#: git-add--interactive.perl:1058
+#: git-add--interactive.perl:1056
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for staging."
@@ -25288,7 +25425,7 @@ msgstr ""
 "Wenn der Patch sauber angewendet werden kann, wird der bearbeitete\n"
 "Patch-Block direkt zum Hinzufügen zur Staging-Area markiert."
 
-#: git-add--interactive.perl:1061
+#: git-add--interactive.perl:1059
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for stashing."
@@ -25296,7 +25433,7 @@ msgstr ""
 "Wenn der Patch sauber angewendet werden kann, wird der bearbeitete\n"
 "Patch-Block direkt zum Hinzufügen zum Stash markiert."
 
-#: git-add--interactive.perl:1064
+#: git-add--interactive.perl:1062
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for unstaging."
@@ -25304,8 +25441,8 @@ msgstr ""
 "Wenn der Patch sauber angewendet werden kann, wird der bearbeitete\n"
 "Patch-Block direkt zum Entfernen aus der Staging-Area markiert."
 
-#: git-add--interactive.perl:1067 git-add--interactive.perl:1076
-#: git-add--interactive.perl:1082
+#: git-add--interactive.perl:1065 git-add--interactive.perl:1074
+#: git-add--interactive.perl:1080
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for applying."
@@ -25313,8 +25450,8 @@ msgstr ""
 "Wenn der Patch sauber angewendet werden kann, wird der bearbeitete\n"
 "Patch-Block direkt zum Anwenden markiert."
 
-#: git-add--interactive.perl:1070 git-add--interactive.perl:1073
-#: git-add--interactive.perl:1079
+#: git-add--interactive.perl:1068 git-add--interactive.perl:1071
+#: git-add--interactive.perl:1077
 msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be\n"
 "marked for discarding."
@@ -25322,13 +25459,13 @@ msgstr ""
 "Wenn der Patch sauber angewendet werden kann, wird der bearbeitete\n"
 "Patch-Block direkt zum Verwerfen markiert."
 
-#: git-add--interactive.perl:1116
+#: git-add--interactive.perl:1114
 #, perl-format
 msgid "failed to open hunk edit file for writing: %s"
 msgstr ""
 "Fehler beim Öffnen von Editier-Datei eines Patch-Blocks zum Schreiben: %s"
 
-#: git-add--interactive.perl:1123
+#: git-add--interactive.perl:1121
 #, perl-format
 msgid ""
 "---\n"
@@ -25341,12 +25478,12 @@ msgstr ""
 "Um '%s' Zeilen zu entfernen, löschen Sie diese.\n"
 "Zeilen, die mit %s beginnen, werden entfernt.\n"
 
-#: git-add--interactive.perl:1145
+#: git-add--interactive.perl:1143
 #, perl-format
 msgid "failed to open hunk edit file for reading: %s"
 msgstr "Fehler beim Öffnen von Editier-Datei eines Patch-Blocks zum Lesen: %s"
 
-#: git-add--interactive.perl:1253
+#: git-add--interactive.perl:1251
 msgid ""
 "y - stage this hunk\n"
 "n - do not stage this hunk\n"
@@ -25362,7 +25499,7 @@ msgstr ""
 "d - diesen oder alle weiteren Patch-Blöcke in dieser Datei nicht zum Commit "
 "vormerken"
 
-#: git-add--interactive.perl:1259
+#: git-add--interactive.perl:1257
 msgid ""
 "y - stash this hunk\n"
 "n - do not stash this hunk\n"
@@ -25376,7 +25513,7 @@ msgstr ""
 "a - diesen und alle weiteren Patch-Blöcke dieser Datei stashen\n"
 "d - diesen oder alle weiteren Patch-Blöcke dieser Datei nicht stashen"
 
-#: git-add--interactive.perl:1265
+#: git-add--interactive.perl:1263
 msgid ""
 "y - unstage this hunk\n"
 "n - do not unstage this hunk\n"
@@ -25390,7 +25527,7 @@ msgstr ""
 "a - diesen und alle weiteren Patch-Blöcke dieser Datei unstashen\n"
 "d - diesen oder alle weiteren Patch-Blöcke dieser Datei nicht unstashen"
 
-#: git-add--interactive.perl:1271
+#: git-add--interactive.perl:1269
 msgid ""
 "y - apply this hunk to index\n"
 "n - do not apply this hunk to index\n"
@@ -25407,7 +25544,7 @@ msgstr ""
 "d - diesen oder alle weiteren Patch-Blöcke dieser Datei nicht auf den Index "
 "anwenden"
 
-#: git-add--interactive.perl:1277 git-add--interactive.perl:1295
+#: git-add--interactive.perl:1275 git-add--interactive.perl:1293
 msgid ""
 "y - discard this hunk from worktree\n"
 "n - do not discard this hunk from worktree\n"
@@ -25424,7 +25561,7 @@ msgstr ""
 "d - diesen oder alle weiteren Patch-Blöcke dieser Datei nicht im "
 "Arbeitsverzeichnis verwerfen"
 
-#: git-add--interactive.perl:1283
+#: git-add--interactive.perl:1281
 msgid ""
 "y - discard this hunk from index and worktree\n"
 "n - do not discard this hunk from index and worktree\n"
@@ -25439,7 +25576,7 @@ msgstr ""
 "a - diesen und alle weiteren Patch-Blöcke in der Datei verwerfen\n"
 "d - diesen oder alle weiteren Patch-Blöcke in der Datei nicht verwerfen"
 
-#: git-add--interactive.perl:1289
+#: git-add--interactive.perl:1287
 msgid ""
 "y - apply this hunk to index and worktree\n"
 "n - do not apply this hunk to index and worktree\n"
@@ -25453,7 +25590,7 @@ msgstr ""
 "a - diesen und alle weiteren Patch-Blöcke in der Datei anwenden\n"
 "d - diesen oder alle weiteren Patch-Blöcke in der Datei nicht anwenden"
 
-#: git-add--interactive.perl:1301
+#: git-add--interactive.perl:1299
 msgid ""
 "y - apply this hunk to worktree\n"
 "n - do not apply this hunk to worktree\n"
@@ -25467,7 +25604,7 @@ msgstr ""
 "a - diesen und alle weiteren Patch-Blöcke in der Datei anwenden\n"
 "d - diesen und alle weiteren Patch-Blöcke in der Datei nicht anwenden"
 
-#: git-add--interactive.perl:1316
+#: git-add--interactive.perl:1314
 msgid ""
 "g - select a hunk to go to\n"
 "/ - search for a hunk matching the given regex\n"
@@ -25491,92 +25628,92 @@ msgstr ""
 "e - aktuellen Patch-Block manuell editieren\n"
 "? - Hilfe anzeigen\n"
 
-#: git-add--interactive.perl:1347
+#: git-add--interactive.perl:1345
 msgid "The selected hunks do not apply to the index!\n"
 msgstr ""
 "Die ausgewählten Patch-Blöcke können nicht auf den Index angewendet werden!\n"
 
-#: git-add--interactive.perl:1362
+#: git-add--interactive.perl:1360
 #, perl-format
 msgid "ignoring unmerged: %s\n"
 msgstr "ignoriere nicht zusammengeführte Datei: %s\n"
 
-#: git-add--interactive.perl:1481
+#: git-add--interactive.perl:1479
 #, perl-format
 msgid "Apply mode change to worktree [y,n,q,a,d%s,?]? "
 msgstr "Modusänderung auf Arbeitsverzeichnis anwenden [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1482
+#: git-add--interactive.perl:1480
 #, perl-format
 msgid "Apply deletion to worktree [y,n,q,a,d%s,?]? "
 msgstr "Löschung auf Arbeitsverzeichnis anwenden [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1483
+#: git-add--interactive.perl:1481
 #, perl-format
 msgid "Apply addition to worktree [y,n,q,a,d%s,?]? "
 msgstr "Ergänzung auf Arbeitsverzeichnis anwenden [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1484
+#: git-add--interactive.perl:1482
 #, perl-format
 msgid "Apply this hunk to worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Diesen Patch-Block auf das Arbeitsverzeichnis anwenden [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1601
+#: git-add--interactive.perl:1599
 msgid "No other hunks to goto\n"
 msgstr "Keine anderen Patch-Blöcke verbleibend\n"
 
-#: git-add--interactive.perl:1619
+#: git-add--interactive.perl:1617
 #, perl-format
 msgid "Invalid number: '%s'\n"
 msgstr "Ungültige Nummer: '%s'\n"
 
-#: git-add--interactive.perl:1624
+#: git-add--interactive.perl:1622
 #, perl-format
 msgid "Sorry, only %d hunk available.\n"
 msgid_plural "Sorry, only %d hunks available.\n"
 msgstr[0] "Entschuldigung, nur %d Patch-Block verfügbar.\n"
 msgstr[1] "Entschuldigung, nur %d Patch-Blöcke verfügbar.\n"
 
-#: git-add--interactive.perl:1659
+#: git-add--interactive.perl:1657
 msgid "No other hunks to search\n"
 msgstr "Keine anderen Patch-Blöcke zum Durchsuchen\n"
 
-#: git-add--interactive.perl:1676
+#: git-add--interactive.perl:1674
 #, perl-format
 msgid "Malformed search regexp %s: %s\n"
 msgstr "Fehlerhafter regulärer Ausdruck für Suche %s: %s\n"
 
-#: git-add--interactive.perl:1686
+#: git-add--interactive.perl:1684
 msgid "No hunk matches the given pattern\n"
 msgstr "Kein Patch-Block entspricht dem angegebenen Muster\n"
 
-#: git-add--interactive.perl:1698 git-add--interactive.perl:1720
+#: git-add--interactive.perl:1696 git-add--interactive.perl:1718
 msgid "No previous hunk\n"
 msgstr "Kein vorheriger Patch-Block\n"
 
-#: git-add--interactive.perl:1707 git-add--interactive.perl:1726
+#: git-add--interactive.perl:1705 git-add--interactive.perl:1724
 msgid "No next hunk\n"
 msgstr "Kein folgender Patch-Block\n"
 
-#: git-add--interactive.perl:1732
+#: git-add--interactive.perl:1730
 msgid "Sorry, cannot split this hunk\n"
 msgstr "Entschuldigung, kann diesen Patch-Block nicht aufteilen.\n"
 
-#: git-add--interactive.perl:1738
+#: git-add--interactive.perl:1736
 #, perl-format
 msgid "Split into %d hunk.\n"
 msgid_plural "Split into %d hunks.\n"
 msgstr[0] "In %d Patch-Block aufgeteilt.\n"
 msgstr[1] "In %d Patch-Blöcke aufgeteilt.\n"
 
-#: git-add--interactive.perl:1748
+#: git-add--interactive.perl:1746
 msgid "Sorry, cannot edit this hunk\n"
 msgstr "Entschuldigung, kann diesen Patch-Block nicht bearbeiten.\n"
 
 #. TRANSLATORS: please do not translate the command names
 #. 'status', 'update', 'revert', etc.
-#: git-add--interactive.perl:1813
+#: git-add--interactive.perl:1811
 msgid ""
 "status        - show paths with changes\n"
 "update        - add working tree state to the staged set of changes\n"
@@ -25595,19 +25732,19 @@ msgstr ""
 "diff          - Unterschiede zwischen HEAD und Index anzeigen\n"
 "add untracked - Inhalte von unversionierten Dateien zum Commit vormerken\n"
 
-#: git-add--interactive.perl:1830 git-add--interactive.perl:1835
-#: git-add--interactive.perl:1838 git-add--interactive.perl:1845
-#: git-add--interactive.perl:1848 git-add--interactive.perl:1855
-#: git-add--interactive.perl:1859 git-add--interactive.perl:1865
+#: git-add--interactive.perl:1828 git-add--interactive.perl:1840
+#: git-add--interactive.perl:1843 git-add--interactive.perl:1850
+#: git-add--interactive.perl:1853 git-add--interactive.perl:1860
+#: git-add--interactive.perl:1864 git-add--interactive.perl:1870
 msgid "missing --"
 msgstr "-- fehlt"
 
-#: git-add--interactive.perl:1861
+#: git-add--interactive.perl:1866
 #, perl-format
 msgid "unknown --patch mode: %s"
 msgstr "Unbekannter --patch Modus: %s"
 
-#: git-add--interactive.perl:1867 git-add--interactive.perl:1873
+#: git-add--interactive.perl:1872 git-add--interactive.perl:1878
 #, perl-format
 msgid "invalid argument %s, expecting --"
 msgstr "ungültiges Argument %s, erwarte --"
@@ -26003,3 +26140,109 @@ msgstr "Lasse %s mit Backup-Suffix '%s' aus.\n"
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Wollen Sie %s wirklich versenden? [y|N]: "
+
+#~ msgid "store only"
+#~ msgstr "nur speichern"
+
+#~ msgid "compress faster"
+#~ msgstr "schneller komprimieren"
+
+#~ msgid "compress better"
+#~ msgstr "besser komprimieren"
+
+#~ msgid "unexpected duplicate commit id %s"
+#~ msgstr "Unerwartete doppelte Commit-ID %s"
+
+#~ msgid "error preparing packfile from multi-pack-index"
+#~ msgstr "Fehler bei Vorbereitung der Packdatei aus multi-pack-index."
+
+#~ msgid "%s: not a valid OID"
+#~ msgstr "%s: keine gültige OID"
+
+#~ msgid "invalid committer '%s'"
+#~ msgstr "ungültiger Commit-Ersteller '%s'"
+
+#~ msgid "invalid committer: %s"
+#~ msgstr "ungültiger Commit-Ersteller: %s"
+
+#~ msgid "git bisect--helper --next-all"
+#~ msgstr "git bisect--helper --next-all"
+
+#~ msgid "git bisect--helper --write-terms <bad_term> <good_term>"
+#~ msgstr "git bisect--helper --write-terms <bad_term> <good_term>"
+
+#~ msgid "git bisect--helper --bisect-clean-state"
+#~ msgstr "git bisect--helper --bisect-clean-state"
+
+#~ msgid "git bisect--helper --bisect-autostart"
+#~ msgstr "git bisect--helper --bisect-autostart"
+
+#~ msgid "perform 'git bisect next'"
+#~ msgstr "'git bisect next' ausführen"
+
+#~ msgid "write the terms to .git/BISECT_TERMS"
+#~ msgstr "die Begriffe nach .git/BISECT_TERMS schreiben"
+
+#~ msgid "cleanup the bisection state"
+#~ msgstr "den Zustand der binären Suche aufräumen"
+
+#~ msgid "check for expected revs"
+#~ msgstr "auf erwartete Commits prüfen"
+
+#~ msgid "start the bisection if it has not yet been started"
+#~ msgstr "starte die binäre Suche, wenn diese noch nicht begonnen hat"
+
+#~ msgid "--write-terms requires two arguments"
+#~ msgstr "--write-terms benötigt zwei Argumente"
+
+#~ msgid "--bisect-clean-state requires no arguments"
+#~ msgstr "--bisect-clean-state erwartet keine Argumente"
+
+#~ msgid "--bisect-autostart does not accept arguments"
+#~ msgstr "--bisect-autostart erwartet keine Argumente"
+
+#~ msgid "n,m"
+#~ msgstr "n,m"
+
+#~ msgid "Process line range n,m in file, counting from 1"
+#~ msgstr "Verarbeitet nur Zeilen im Bereich n,m in der Datei, gezählt von 1"
+
+#~ msgid "name of output directory is too long"
+#~ msgstr "Name des Ausgabeverzeichnisses ist zu lang."
+
+#~ msgid "standard output, or directory, which one?"
+#~ msgstr "Standard-Ausgabe oder Verzeichnis, welches von beidem?"
+
+#~ msgid ""
+#~ "WARNING: Some packs in use have been renamed by\n"
+#~ "WARNING: prefixing old- to their name, in order to\n"
+#~ "WARNING: replace them with the new version of the\n"
+#~ "WARNING: file.  But the operation failed, and the\n"
+#~ "WARNING: attempt to rename them back to their\n"
+#~ "WARNING: original names also failed.\n"
+#~ "WARNING: Please rename them in %s manually:\n"
+#~ msgstr ""
+#~ "WARNUNG: Einige in Verwendung befindliche Pakete wurden\n"
+#~ "WARNUNG: umbenannt, indem 'old-' an deren Namen vorrangestellt\n"
+#~ "WARNUNG: wurde, um diese mit der neuen Dateiversion zu ersetzen.\n"
+#~ "WARNUNG: Diese Operation ist fehlgeschlagen. Der Versuch, die\n"
+#~ "WARNUNG: Datei zu ihrem ursprünglichen Namen umzubenennen, schlug\n"
+#~ "WARNUNG: ebenfalls fehl.\n"
+#~ "WARNUNG: Bitte benennen Sie diese manuell nach %s um:\n"
+
+#~ msgid "failed to remove '%s'"
+#~ msgstr "Fehler beim Löschen von '%s'"
+
+#~ msgid "Routines to help parsing remote repository access parameters"
+#~ msgstr ""
+#~ "Routinen als Hilfe zum Parsen von Zugriffsparametern von Remote-"
+#~ "Repositories"
+
+#~ msgid "Bad rev input: $bisected_head"
+#~ msgstr "Ungültige Referenz-Eingabe: $bisected_head"
+
+#~ msgid "Bad rev input: $rev"
+#~ msgstr "Ungültige Referenz-Eingabe: $rev"
+
+#~ msgid "See git-${cmd}(1) for details."
+#~ msgstr "Siehe git-${cmd}(1) für weitere Details."

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2020-12-15 16:27+0800\n"
+"POT-Creation-Date: 2020-12-21 07:10+0800\n"
 "PO-Revision-Date: 2020-12-19 14:01+0100\n"
 "Last-Translator: Matthias Rüster <matthias.ruester@gmail.com>\n"
 "Language-Team: Matthias Rüster <matthias.ruester@gmail.com>\n"
@@ -69,7 +69,7 @@ msgstr[1] "%d Pfade aktualisiert\n"
 msgid "note: %s is untracked now.\n"
 msgstr "Hinweis: %s ist nun unversioniert.\n"
 
-#: add-interactive.c:729 apply.c:4127 builtin/checkout.c:295
+#: add-interactive.c:729 apply.c:4125 builtin/checkout.c:295
 #: builtin/reset.c:145
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
@@ -209,7 +209,7 @@ msgstr "zur Staging-Area hinzugefügt"
 msgid "unstaged"
 msgstr "aus Staging-Area entfernt"
 
-#: add-interactive.c:1144 apply.c:4989 apply.c:4992 builtin/am.c:2257
+#: add-interactive.c:1144 apply.c:4987 apply.c:4990 builtin/am.c:2257
 #: builtin/am.c:2260 builtin/bugreport.c:134 builtin/clone.c:124
 #: builtin/fetch.c:147 builtin/merge.c:284 builtin/pull.c:190
 #: builtin/submodule--helper.c:409 builtin/submodule--helper.c:1818
@@ -1152,7 +1152,7 @@ msgstr "Pfad %s wurde umbenannt/gelöscht"
 msgid "%s: does not exist in index"
 msgstr "%s ist nicht im Index"
 
-#: apply.c:3537 apply.c:3708 apply.c:3953
+#: apply.c:3537 apply.c:3708 apply.c:3952
 #, c-format
 msgid "%s: does not match index"
 msgstr "%s entspricht nicht der Version im Index"
@@ -1213,315 +1213,315 @@ msgstr "Ungültiger Pfad '%s'"
 msgid "%s: already exists in index"
 msgstr "%s ist bereits bereitgestellt"
 
-#: apply.c:3956
+#: apply.c:3954
 #, c-format
 msgid "%s: already exists in working directory"
 msgstr "%s existiert bereits im Arbeitsverzeichnis"
 
-#: apply.c:3976
+#: apply.c:3974
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
 msgstr "neuer Modus (%o) von %s entspricht nicht dem alten Modus (%o)"
 
-#: apply.c:3981
+#: apply.c:3979
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
 msgstr "neuer Modus (%o) von %s entspricht nicht dem alten Modus (%o) von %s"
 
-#: apply.c:4001
+#: apply.c:3999
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
 msgstr "betroffene Datei '%s' ist hinter einer symbolischen Verknüpfung"
 
-#: apply.c:4005
+#: apply.c:4003
 #, c-format
 msgid "%s: patch does not apply"
 msgstr "%s: Patch konnte nicht angewendet werden"
 
-#: apply.c:4020
+#: apply.c:4018
 #, c-format
 msgid "Checking patch %s..."
 msgstr "Prüfe Patch %s ..."
 
-#: apply.c:4112
+#: apply.c:4110
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
 msgstr "SHA-1 Information fehlt oder ist unbrauchbar für Submodul %s"
 
-#: apply.c:4119
+#: apply.c:4117
 #, c-format
 msgid "mode change for %s, which is not in current HEAD"
 msgstr "Modusänderung für %s, was sich nicht im aktuellen HEAD befindet"
 
-#: apply.c:4122
+#: apply.c:4120
 #, c-format
 msgid "sha1 information is lacking or useless (%s)."
 msgstr "SHA-1 Information fehlt oder ist unbrauchbar (%s)."
 
-#: apply.c:4131
+#: apply.c:4129
 #, c-format
 msgid "could not add %s to temporary index"
 msgstr "konnte %s nicht zum temporären Index hinzufügen"
 
-#: apply.c:4141
+#: apply.c:4139
 #, c-format
 msgid "could not write temporary index to %s"
 msgstr "konnte temporären Index nicht nach %s schreiben"
 
-#: apply.c:4279
+#: apply.c:4277
 #, c-format
 msgid "unable to remove %s from index"
 msgstr "konnte %s nicht aus dem Index entfernen"
 
-#: apply.c:4313
+#: apply.c:4311
 #, c-format
 msgid "corrupt patch for submodule %s"
 msgstr "fehlerhafter Patch für Submodul %s"
 
-#: apply.c:4319
+#: apply.c:4317
 #, c-format
 msgid "unable to stat newly created file '%s'"
 msgstr "konnte neu erstellte Datei '%s' nicht lesen"
 
-#: apply.c:4327
+#: apply.c:4325
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr "kann internen Speicher für eben erstellte Datei %s nicht erzeugen"
 
-#: apply.c:4333 apply.c:4478
+#: apply.c:4331 apply.c:4476
 #, c-format
 msgid "unable to add cache entry for %s"
 msgstr "kann für %s keinen Eintrag in den Zwischenspeicher hinzufügen"
 
-#: apply.c:4376 builtin/bisect--helper.c:524
+#: apply.c:4374 builtin/bisect--helper.c:524
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "Fehler beim Schreiben nach '%s'"
 
-#: apply.c:4380
+#: apply.c:4378
 #, c-format
 msgid "closing file '%s'"
 msgstr "schließe Datei '%s'"
 
-#: apply.c:4450
+#: apply.c:4448
 #, c-format
 msgid "unable to write file '%s' mode %o"
 msgstr "konnte Datei '%s' mit Modus %o nicht schreiben"
 
-#: apply.c:4548
+#: apply.c:4546
 #, c-format
 msgid "Applied patch %s cleanly."
 msgstr "Patch %s sauber angewendet"
 
-#: apply.c:4556
+#: apply.c:4554
 msgid "internal error"
 msgstr "interner Fehler"
 
-#: apply.c:4559
+#: apply.c:4557
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
 msgstr[0] "Wende Patch %%s mit %d Zurückweisung an..."
 msgstr[1] "Wende Patch %%s mit %d Zurückweisungen an..."
 
-#: apply.c:4570
+#: apply.c:4568
 #, c-format
 msgid "truncating .rej filename to %.*s.rej"
 msgstr "Verkürze Name von .rej Datei zu %.*s.rej"
 
-#: apply.c:4578 builtin/fetch.c:927 builtin/fetch.c:1228
+#: apply.c:4576 builtin/fetch.c:927 builtin/fetch.c:1228
 #, c-format
 msgid "cannot open %s"
 msgstr "kann '%s' nicht öffnen"
 
-#: apply.c:4592
+#: apply.c:4590
 #, c-format
 msgid "Hunk #%d applied cleanly."
 msgstr "Patch-Bereich #%d sauber angewendet."
 
-#: apply.c:4596
+#: apply.c:4594
 #, c-format
 msgid "Rejected hunk #%d."
 msgstr "Patch-Block #%d zurückgewiesen."
 
-#: apply.c:4720
+#: apply.c:4718
 #, c-format
 msgid "Skipped patch '%s'."
 msgstr "Patch '%s' ausgelassen."
 
-#: apply.c:4728
+#: apply.c:4726
 msgid "unrecognized input"
 msgstr "nicht erkannte Eingabe"
 
-#: apply.c:4748
+#: apply.c:4746
 msgid "unable to read index file"
 msgstr "Konnte Index-Datei nicht lesen"
 
-#: apply.c:4905
+#: apply.c:4903
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr "kann Patch '%s' nicht öffnen: %s"
 
-#: apply.c:4932
+#: apply.c:4930
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "unterdrückte %d Whitespace-Fehler"
 msgstr[1] "unterdrückte %d Whitespace-Fehler"
 
-#: apply.c:4938 apply.c:4953
+#: apply.c:4936 apply.c:4951
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] "%d Zeile fügt Whitespace-Fehler hinzu."
 msgstr[1] "%d Zeilen fügen Whitespace-Fehler hinzu."
 
-#: apply.c:4946
+#: apply.c:4944
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
 msgstr[0] "%d Zeile nach Behebung von Whitespace-Fehlern angewendet."
 msgstr[1] "%d Zeilen nach Behebung von Whitespace-Fehlern angewendet."
 
-#: apply.c:4962 builtin/add.c:618 builtin/mv.c:304 builtin/rm.c:406
+#: apply.c:4960 builtin/add.c:618 builtin/mv.c:304 builtin/rm.c:406
 msgid "Unable to write new index file"
 msgstr "Konnte neue Index-Datei nicht schreiben."
 
-#: apply.c:4990
+#: apply.c:4988
 msgid "don't apply changes matching the given path"
 msgstr "keine Änderungen im angegebenen Pfad anwenden"
 
-#: apply.c:4993
+#: apply.c:4991
 msgid "apply changes matching the given path"
 msgstr "Änderungen nur im angegebenen Pfad anwenden"
 
-#: apply.c:4995 builtin/am.c:2266
+#: apply.c:4993 builtin/am.c:2266
 msgid "num"
 msgstr "Anzahl"
 
-#: apply.c:4996
+#: apply.c:4994
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr ""
 "<Anzahl> vorangestellte Schrägstriche von herkömmlichen Differenzpfaden "
 "entfernen"
 
-#: apply.c:4999
+#: apply.c:4997
 msgid "ignore additions made by the patch"
 msgstr "hinzugefügte Zeilen des Patches ignorieren"
 
-#: apply.c:5001
+#: apply.c:4999
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr ""
 "anstatt der Anwendung des Patches, den \"diffstat\" für die Eingabe "
 "ausgegeben"
 
-#: apply.c:5005
+#: apply.c:5003
 msgid "show number of added and deleted lines in decimal notation"
 msgstr ""
 "die Anzahl von hinzugefügten/entfernten Zeilen in Dezimalnotation anzeigen"
 
-#: apply.c:5007
+#: apply.c:5005
 msgid "instead of applying the patch, output a summary for the input"
 msgstr ""
 "anstatt der Anwendung des Patches, eine Zusammenfassung für die Eingabe "
 "ausgeben"
 
-#: apply.c:5009
+#: apply.c:5007
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr ""
 "anstatt der Anwendung des Patches, zeige ob Patch angewendet werden kann"
 
-#: apply.c:5011
+#: apply.c:5009
 msgid "make sure the patch is applicable to the current index"
 msgstr ""
 "sicherstellen, dass der Patch mit dem aktuellen Index angewendet werden kann"
 
-#: apply.c:5013
+#: apply.c:5011
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "neue Dateien mit `git add --intent-to-add` markieren"
 
-#: apply.c:5015
+#: apply.c:5013
 msgid "apply a patch without touching the working tree"
 msgstr "Patch anwenden, ohne Änderungen im Arbeitsverzeichnis vorzunehmen"
 
-#: apply.c:5017
+#: apply.c:5015
 msgid "accept a patch that touches outside the working area"
 msgstr ""
 "Patch anwenden, der Änderungen außerhalb des Arbeitsverzeichnisses vornimmt"
 
-#: apply.c:5020
+#: apply.c:5018
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr "Patch anwenden (Benutzung mit --stat/--summary/--check)"
 
-#: apply.c:5022
+#: apply.c:5020
 msgid "attempt three-way merge if a patch does not apply"
 msgstr "versuche 3-Wege-Merge, wenn der Patch nicht angewendet werden konnte"
 
-#: apply.c:5024
+#: apply.c:5022
 msgid "build a temporary index based on embedded index information"
 msgstr ""
 "einen temporären Index, basierend auf den integrierten Index-Informationen, "
 "erstellen"
 
-#: apply.c:5027 builtin/checkout-index.c:182 builtin/ls-files.c:525
+#: apply.c:5025 builtin/checkout-index.c:182 builtin/ls-files.c:525
 msgid "paths are separated with NUL character"
 msgstr "Pfade sind getrennt durch NUL Zeichen"
 
-#: apply.c:5029
+#: apply.c:5027
 msgid "ensure at least <n> lines of context match"
 msgstr ""
 "sicher stellen, dass mindestens <n> Zeilen des Kontextes übereinstimmen"
 
-#: apply.c:5030 builtin/am.c:2245 builtin/interpret-trailers.c:98
+#: apply.c:5028 builtin/am.c:2245 builtin/interpret-trailers.c:98
 #: builtin/interpret-trailers.c:100 builtin/interpret-trailers.c:102
 #: builtin/pack-objects.c:3562 builtin/rebase.c:1346
 msgid "action"
 msgstr "Aktion"
 
-#: apply.c:5031
+#: apply.c:5029
 msgid "detect new or modified lines that have whitespace errors"
 msgstr "neue oder geänderte Zeilen, die Whitespace-Fehler haben, ermitteln"
 
-#: apply.c:5034 apply.c:5037
+#: apply.c:5032 apply.c:5035
 msgid "ignore changes in whitespace when finding context"
 msgstr "Änderungen im Whitespace bei der Suche des Kontextes ignorieren"
 
-#: apply.c:5040
+#: apply.c:5038
 msgid "apply the patch in reverse"
 msgstr "den Patch in umgekehrter Reihenfolge anwenden"
 
-#: apply.c:5042
+#: apply.c:5040
 msgid "don't expect at least one line of context"
 msgstr "keinen Kontext erwarten"
 
-#: apply.c:5044
+#: apply.c:5042
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr ""
 "zurückgewiesene Patch-Blöcke in entsprechenden *.rej Dateien hinterlassen"
 
-#: apply.c:5046
+#: apply.c:5044
 msgid "allow overlapping hunks"
 msgstr "sich überlappende Patch-Blöcke erlauben"
 
-#: apply.c:5047 builtin/add.c:329 builtin/check-ignore.c:22
+#: apply.c:5045 builtin/add.c:329 builtin/check-ignore.c:22
 #: builtin/commit.c:1364 builtin/count-objects.c:98 builtin/fsck.c:775
 #: builtin/log.c:2287 builtin/mv.c:123 builtin/read-tree.c:128
 msgid "be verbose"
 msgstr "erweiterte Ausgaben"
 
-#: apply.c:5049
+#: apply.c:5047
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr "fehlerhaft erkannten fehlenden Zeilenumbruch am Dateiende tolerieren"
 
-#: apply.c:5052
+#: apply.c:5050
 msgid "do not trust the line counts in the hunk headers"
 msgstr "den Zeilennummern im Kopf des Patch-Blocks nicht vertrauen"
 
-#: apply.c:5054 builtin/am.c:2254
+#: apply.c:5052 builtin/am.c:2254
 msgid "root"
 msgstr "Wurzelverzeichnis"
 
-#: apply.c:5055
+#: apply.c:5053
 msgid "prepend <root> to all filenames"
 msgstr "<Wurzelverzeichnis> vor alle Dateinamen stellen"
 
@@ -1652,8 +1652,8 @@ msgstr "einen Präfix vor jeden Pfadnamen in dem Archiv stellen"
 
 #: archive.c:558 archive.c:561 builtin/blame.c:886 builtin/blame.c:890
 #: builtin/blame.c:891 builtin/commit-tree.c:117 builtin/config.c:135
-#: builtin/fast-export.c:1208 builtin/fast-export.c:1210
-#: builtin/fast-export.c:1214 builtin/grep.c:919 builtin/hash-object.c:105
+#: builtin/fast-export.c:1207 builtin/fast-export.c:1209
+#: builtin/fast-export.c:1213 builtin/grep.c:919 builtin/hash-object.c:105
 #: builtin/ls-files.c:561 builtin/ls-files.c:564 builtin/notes.c:412
 #: builtin/notes.c:578 builtin/read-tree.c:123 parse-options.h:190
 msgid "file"
@@ -2219,182 +2219,173 @@ msgstr "Ungültige Commit-Position. Commit-Graph ist wahrscheinlich beschädigt.
 msgid "could not find commit %s"
 msgstr "Konnte Commit %s nicht finden."
 
-#: commit-graph.c:1042 builtin/am.c:1292
+#: commit-graph.c:1036 builtin/am.c:1292
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "Konnte Commit '%s' nicht parsen."
 
-#: commit-graph.c:1265 builtin/pack-objects.c:2864
+#: commit-graph.c:1252 builtin/pack-objects.c:2864
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "Konnte Art von Objekt '%s' nicht bestimmen."
 
-#: commit-graph.c:1301
+#: commit-graph.c:1283
 msgid "Loading known commits in commit graph"
 msgstr "Lade bekannte Commits in Commit-Graph"
 
-#: commit-graph.c:1318
+#: commit-graph.c:1300
 msgid "Expanding reachable commits in commit graph"
 msgstr "Erweitere erreichbare Commits in Commit-Graph"
 
-#: commit-graph.c:1338
+#: commit-graph.c:1320
 msgid "Clearing commit marks in commit graph"
 msgstr "Lösche Commit-Markierungen in Commit-Graph"
 
-#: commit-graph.c:1357
+#: commit-graph.c:1339
 msgid "Computing commit graph generation numbers"
 msgstr "Commit-Graph Generationsnummern berechnen"
 
-#: commit-graph.c:1424
+#: commit-graph.c:1406
 msgid "Computing commit changed paths Bloom filters"
 msgstr "Berechnung der Bloom-Filter für veränderte Pfade des Commits"
 
-#: commit-graph.c:1501
+#: commit-graph.c:1483
 msgid "Collecting referenced commits"
 msgstr "Sammle referenzierte Commits"
 
-#: commit-graph.c:1526
+#: commit-graph.c:1508
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] "Suche Commits für Commit-Graph in %d Paket"
 msgstr[1] "Suche Commits für Commit-Graph in %d Paketen"
 
-#: commit-graph.c:1539
+#: commit-graph.c:1521
 #, c-format
 msgid "error adding pack %s"
 msgstr "Fehler beim Hinzufügen von Paket %s."
 
-#: commit-graph.c:1543
+#: commit-graph.c:1525
 #, c-format
 msgid "error opening index for %s"
 msgstr "Fehler beim Öffnen des Index für %s."
 
-#: commit-graph.c:1582
+#: commit-graph.c:1562
 msgid "Finding commits for commit graph among packed objects"
 msgstr "Suche Commits für Commit-Graph in gepackten Objekten"
 
-#: commit-graph.c:1597
-msgid "Counting distinct commits in commit graph"
-msgstr "Zähle Commits in Commit-Graph"
-
-#: commit-graph.c:1629
+#: commit-graph.c:1580
 msgid "Finding extra edges in commit graph"
 msgstr "Suche zusätzliche Ränder in Commit-Graph"
 
-#: commit-graph.c:1678
+#: commit-graph.c:1628
 msgid "failed to write correct number of base graph ids"
 msgstr "Fehler beim Schreiben der korrekten Anzahl von Basis-Graph-IDs."
 
-#: commit-graph.c:1720 midx.c:819
+#: commit-graph.c:1670 midx.c:819
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "Konnte führende Verzeichnisse von '%s' nicht erstellen."
 
-#: commit-graph.c:1733
+#: commit-graph.c:1683
 msgid "unable to create temporary graph layer"
 msgstr "konnte temporäre Graphen-Schicht nicht erstellen"
 
-#: commit-graph.c:1738
+#: commit-graph.c:1688
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "konnte geteilte Zugriffsberechtigungen für '%s' nicht ändern"
 
-#: commit-graph.c:1808
+#: commit-graph.c:1758
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "Schreibe Commit-Graph in %d Durchgang"
 msgstr[1] "Schreibe Commit-Graph in %d Durchgängen"
 
-#: commit-graph.c:1853
+#: commit-graph.c:1803
 msgid "unable to open commit-graph chain file"
 msgstr "konnte Commit-Graph Chain-Datei nicht öffnen"
 
-#: commit-graph.c:1869
+#: commit-graph.c:1819
 msgid "failed to rename base commit-graph file"
 msgstr "konnte Basis-Commit-Graph-Datei nicht umbenennen"
 
-#: commit-graph.c:1889
+#: commit-graph.c:1839
 msgid "failed to rename temporary commit-graph file"
 msgstr "konnte temporäre Commit-Graph-Datei nicht umbenennen"
 
-#: commit-graph.c:2015
+#: commit-graph.c:1965
 msgid "Scanning merged commits"
 msgstr "Durchsuche zusammengeführte Commits"
 
-#: commit-graph.c:2059
+#: commit-graph.c:2009
 msgid "Merging commit-graph"
 msgstr "Zusammenführen von Commit-Graph"
 
-#: commit-graph.c:2165
+#: commit-graph.c:2115
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 "versuche einen Commit-Graph zu schreiben, aber 'core.commitGraph' ist "
 "deaktiviert"
 
-#: commit-graph.c:2274
-#, c-format
-msgid "the commit graph format cannot write %d commits"
-msgstr "das Commit-Graph Format kann nicht %d Commits schreiben"
-
-#: commit-graph.c:2285
+#: commit-graph.c:2214
 msgid "too many commits to write graph"
 msgstr "zu viele Commits zum Schreiben des Graphen"
 
-#: commit-graph.c:2378
+#: commit-graph.c:2307
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "die Commit-Graph-Datei hat eine falsche Prüfsumme und ist wahrscheinlich "
 "beschädigt"
 
-#: commit-graph.c:2388
+#: commit-graph.c:2317
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "Commit-Graph hat fehlerhafte OID-Reihenfolge: %s dann %s"
 
-#: commit-graph.c:2398 commit-graph.c:2413
+#: commit-graph.c:2327 commit-graph.c:2342
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr "Commit-Graph hat fehlerhaften Fanout-Wert: fanout[%d] = %u != %u"
 
-#: commit-graph.c:2405
+#: commit-graph.c:2334
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "konnte Commit %s von Commit-Graph nicht parsen"
 
-#: commit-graph.c:2423
+#: commit-graph.c:2352
 msgid "Verifying commits in commit graph"
 msgstr "Commit in Commit-Graph überprüfen"
 
-#: commit-graph.c:2438
+#: commit-graph.c:2367
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "Fehler beim Parsen des Commits %s von Objekt-Datenbank für Commit-Graph"
 
-#: commit-graph.c:2445
+#: commit-graph.c:2374
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 "OID des Wurzelverzeichnisses für Commit %s in Commit-Graph ist %s != %s"
 
-#: commit-graph.c:2455
+#: commit-graph.c:2384
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr "Commit-Graph Vorgänger-Liste für Commit %s ist zu lang"
 
-#: commit-graph.c:2464
+#: commit-graph.c:2393
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "Commit-Graph-Vorgänger für %s ist %s != %s"
 
-#: commit-graph.c:2478
+#: commit-graph.c:2407
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr "Commit-Graph Vorgänger-Liste für Commit %s endet zu früh"
 
-#: commit-graph.c:2483
+#: commit-graph.c:2412
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2402,7 +2393,7 @@ msgstr ""
 "Commit-Graph hat Generationsnummer null für Commit %s, aber sonst ungleich "
 "null"
 
-#: commit-graph.c:2487
+#: commit-graph.c:2416
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2410,12 +2401,12 @@ msgstr ""
 "Commit-Graph hat Generationsnummer ungleich null für Commit %s, aber sonst "
 "null"
 
-#: commit-graph.c:2503
+#: commit-graph.c:2432
 #, c-format
 msgid "commit-graph generation for commit %s is %u != %u"
 msgstr "Commit-Graph Erstellung für Commit %s ist %u != %u"
 
-#: commit-graph.c:2509
+#: commit-graph.c:2438
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
@@ -3346,22 +3337,22 @@ msgstr ""
 msgid "-G, -S and --find-object are mutually exclusive"
 msgstr "-G, -S und --find-object schließen sich gegenseitig aus"
 
-#: diff.c:4706
+#: diff.c:4707
 msgid "--follow requires exactly one pathspec"
 msgstr "--follow erfordert genau eine Pfadspezifikation"
 
-#: diff.c:4754
+#: diff.c:4755
 #, c-format
 msgid "invalid --stat value: %s"
 msgstr "Ungültiger --stat Wert: %s"
 
-#: diff.c:4759 diff.c:4764 diff.c:4769 diff.c:4774 diff.c:5302
+#: diff.c:4760 diff.c:4765 diff.c:4770 diff.c:4775 diff.c:5303
 #: parse-options.c:197 parse-options.c:201 builtin/commit-graph.c:180
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "%s erwartet einen numerischen Wert."
 
-#: diff.c:4791
+#: diff.c:4792
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -3370,42 +3361,42 @@ msgstr ""
 "Fehler beim Parsen des --dirstat/-X Optionsparameters:\n"
 "%s"
 
-#: diff.c:4876
+#: diff.c:4877
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
 msgstr "unbekannte Änderungsklasse '%c' in --diff-filter=%s"
 
-#: diff.c:4900
+#: diff.c:4901
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
 msgstr "unbekannter Wert nach ws-error-highlight=%.*s"
 
-#: diff.c:4914
+#: diff.c:4915
 #, c-format
 msgid "unable to resolve '%s'"
 msgstr "konnte '%s' nicht auflösen"
 
-#: diff.c:4964 diff.c:4970
+#: diff.c:4965 diff.c:4971
 #, c-format
 msgid "%s expects <n>/<m> form"
 msgstr "%s erwartet die Form <n>/<m>"
 
-#: diff.c:4982
+#: diff.c:4983
 #, c-format
 msgid "%s expects a character, got '%s'"
 msgstr "%s erwartet ein Zeichen, '%s' bekommen"
 
-#: diff.c:5003
+#: diff.c:5004
 #, c-format
 msgid "bad --color-moved argument: %s"
 msgstr "ungültiges --color-moved Argument: %s"
 
-#: diff.c:5022
+#: diff.c:5023
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
 msgstr "ungültiger Modus '%s' in --color-moved-ws"
 
-#: diff.c:5062
+#: diff.c:5063
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
@@ -3413,157 +3404,157 @@ msgstr ""
 "Option diff-algorithm akzeptiert: \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
 
-#: diff.c:5098 diff.c:5118
+#: diff.c:5099 diff.c:5119
 #, c-format
 msgid "invalid argument to %s"
 msgstr "ungültiges Argument für %s"
 
-#: diff.c:5222
+#: diff.c:5223
 #, c-format
 msgid "invalid regex given to -I: '%s'"
 msgstr "ungültiger regulärer Ausdruck für -I gegeben: '%s'"
 
-#: diff.c:5271
+#: diff.c:5272
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
 msgstr "Fehler beim Parsen des --submodule Optionsparameters: '%s'"
 
-#: diff.c:5327
+#: diff.c:5328
 #, c-format
 msgid "bad --word-diff argument: %s"
 msgstr "ungültiges --word-diff Argument: %s"
 
-#: diff.c:5350
+#: diff.c:5351
 msgid "Diff output format options"
 msgstr "Diff-Optionen zu Ausgabeformaten"
 
-#: diff.c:5352 diff.c:5358
+#: diff.c:5353 diff.c:5359
 msgid "generate patch"
 msgstr "Patch erzeugen"
 
-#: diff.c:5355 builtin/log.c:178
+#: diff.c:5356 builtin/log.c:178
 msgid "suppress diff output"
 msgstr "Ausgabe der Unterschiede unterdrücken"
 
-#: diff.c:5360 diff.c:5474 diff.c:5481
+#: diff.c:5361 diff.c:5475 diff.c:5482
 msgid "<n>"
 msgstr "<n>"
 
-#: diff.c:5361 diff.c:5364
+#: diff.c:5362 diff.c:5365
 msgid "generate diffs with <n> lines context"
 msgstr "Unterschiede mit <n> Zeilen des Kontextes erstellen"
 
-#: diff.c:5366
+#: diff.c:5367
 msgid "generate the diff in raw format"
 msgstr "Unterschiede im Rohformat erstellen"
 
-#: diff.c:5369
+#: diff.c:5370
 msgid "synonym for '-p --raw'"
 msgstr "Synonym für '-p --raw'"
 
-#: diff.c:5373
+#: diff.c:5374
 msgid "synonym for '-p --stat'"
 msgstr "Synonym für '-p --stat'"
 
-#: diff.c:5377
+#: diff.c:5378
 msgid "machine friendly --stat"
 msgstr "maschinenlesbare Ausgabe von --stat"
 
-#: diff.c:5380
+#: diff.c:5381
 msgid "output only the last line of --stat"
 msgstr "nur die letzte Zeile von --stat ausgeben"
 
-#: diff.c:5382 diff.c:5390
+#: diff.c:5383 diff.c:5391
 msgid "<param1,param2>..."
 msgstr "<Parameter1,Parameter2>..."
 
-#: diff.c:5383
+#: diff.c:5384
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr ""
 "die Verteilung des relativen Umfangs der Änderungen für jedes "
 "Unterverzeichnis ausgeben"
 
-#: diff.c:5387
+#: diff.c:5388
 msgid "synonym for --dirstat=cumulative"
 msgstr "Synonym für --dirstat=cumulative"
 
-#: diff.c:5391
+#: diff.c:5392
 msgid "synonym for --dirstat=files,param1,param2..."
 msgstr "Synonym für --dirstat=files,Parameter1,Parameter2..."
 
-#: diff.c:5395
+#: diff.c:5396
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
 "warnen, wenn Änderungen Konfliktmarker oder Whitespace-Fehler einbringen"
 
-#: diff.c:5398
+#: diff.c:5399
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr ""
 "gekürzte Zusammenfassung, wie z.B. Erstellungen, Umbenennungen und "
 "Änderungen der Datei-Rechte"
 
-#: diff.c:5401
+#: diff.c:5402
 msgid "show only names of changed files"
 msgstr "nur Dateinamen der geänderten Dateien anzeigen"
 
-#: diff.c:5404
+#: diff.c:5405
 msgid "show only names and status of changed files"
 msgstr "nur Dateinamen und Status der geänderten Dateien anzeigen"
 
-#: diff.c:5406
+#: diff.c:5407
 msgid "<width>[,<name-width>[,<count>]]"
 msgstr "<Breite>[,<Namens-Breite>[,<Anzahl>]]"
 
-#: diff.c:5407
+#: diff.c:5408
 msgid "generate diffstat"
 msgstr "Zusammenfassung der Unterschiede erzeugen"
 
-#: diff.c:5409 diff.c:5412 diff.c:5415
+#: diff.c:5410 diff.c:5413 diff.c:5416
 msgid "<width>"
 msgstr "<Breite>"
 
-#: diff.c:5410
+#: diff.c:5411
 msgid "generate diffstat with a given width"
 msgstr "Zusammenfassung der Unterschiede mit gegebener Breite erzeugen"
 
-#: diff.c:5413
+#: diff.c:5414
 msgid "generate diffstat with a given name width"
 msgstr "Zusammenfassung der Unterschiede mit gegebener Namens-Breite erzeugen"
 
-#: diff.c:5416
+#: diff.c:5417
 msgid "generate diffstat with a given graph width"
 msgstr "Zusammenfassung der Unterschiede mit gegebener Graph-Breite erzeugen"
 
-#: diff.c:5418
+#: diff.c:5419
 msgid "<count>"
 msgstr "<Anzahl>"
 
-#: diff.c:5419
+#: diff.c:5420
 msgid "generate diffstat with limited lines"
 msgstr "Zusammenfassung der Unterschiede mit begrenzten Zeilen erzeugen"
 
-#: diff.c:5422
+#: diff.c:5423
 msgid "generate compact summary in diffstat"
 msgstr "kompakte Zusammenstellung in Zusammenfassung der Unterschiede erzeugen"
 
-#: diff.c:5425
+#: diff.c:5426
 msgid "output a binary diff that can be applied"
 msgstr "eine binäre Differenz ausgeben, dass angewendet werden kann"
 
-#: diff.c:5428
+#: diff.c:5429
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr "vollständige Objekt-Namen in den \"index\"-Zeilen anzeigen"
 
-#: diff.c:5430
+#: diff.c:5431
 msgid "show colored diff"
 msgstr "farbige Unterschiede anzeigen"
 
-#: diff.c:5431
+#: diff.c:5432
 msgid "<kind>"
 msgstr "<Art>"
 
-#: diff.c:5432
+#: diff.c:5433
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
@@ -3571,7 +3562,7 @@ msgstr ""
 "Whitespace-Fehler in den Zeilen 'context', 'old' oder 'new' bei den "
 "Unterschieden hervorheben"
 
-#: diff.c:5435
+#: diff.c:5436
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
@@ -3579,256 +3570,256 @@ msgstr ""
 "die Pfadnamen nicht verschleiern und NUL-Zeichen als Schlusszeichen in "
 "Ausgabefeldern bei --raw oder --numstat nutzen"
 
-#: diff.c:5438 diff.c:5441 diff.c:5444 diff.c:5553
+#: diff.c:5439 diff.c:5442 diff.c:5445 diff.c:5554
 msgid "<prefix>"
 msgstr "<Präfix>"
 
-#: diff.c:5439
+#: diff.c:5440
 msgid "show the given source prefix instead of \"a/\""
 msgstr "den gegebenen Quell-Präfix statt \"a/\" anzeigen"
 
-#: diff.c:5442
+#: diff.c:5443
 msgid "show the given destination prefix instead of \"b/\""
 msgstr "den gegebenen Ziel-Präfix statt \"b/\" anzeigen"
 
-#: diff.c:5445
+#: diff.c:5446
 msgid "prepend an additional prefix to every line of output"
 msgstr "einen zusätzlichen Präfix bei jeder Ausgabezeile voranstellen"
 
-#: diff.c:5448
+#: diff.c:5449
 msgid "do not show any source or destination prefix"
 msgstr "keine Quell- oder Ziel-Präfixe anzeigen"
 
-#: diff.c:5451
+#: diff.c:5452
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
 "Kontext zwischen Unterschied-Blöcken bis zur angegebenen Anzahl von Zeilen "
 "anzeigen"
 
-#: diff.c:5455 diff.c:5460 diff.c:5465
+#: diff.c:5456 diff.c:5461 diff.c:5466
 msgid "<char>"
 msgstr "<Zeichen>"
 
-#: diff.c:5456
+#: diff.c:5457
 msgid "specify the character to indicate a new line instead of '+'"
 msgstr "das Zeichen festlegen, das eine neue Zeile kennzeichnet (statt '+')"
 
-#: diff.c:5461
+#: diff.c:5462
 msgid "specify the character to indicate an old line instead of '-'"
 msgstr "das Zeichen festlegen, das eine alte Zeile kennzeichnet (statt '-')"
 
-#: diff.c:5466
+#: diff.c:5467
 msgid "specify the character to indicate a context instead of ' '"
 msgstr "das Zeichen festlegen, das den Kontext kennzeichnet (statt ' ')"
 
-#: diff.c:5469
+#: diff.c:5470
 msgid "Diff rename options"
 msgstr "Diff-Optionen zur Umbenennung"
 
-#: diff.c:5470
+#: diff.c:5471
 msgid "<n>[/<m>]"
 msgstr "<n>[/<m>]"
 
-#: diff.c:5471
+#: diff.c:5472
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr ""
 "teile komplette Rewrite-Änderungen in Änderungen mit \"löschen\" und "
 "\"erstellen\""
 
-#: diff.c:5475
+#: diff.c:5476
 msgid "detect renames"
 msgstr "Umbenennungen erkennen"
 
-#: diff.c:5479
+#: diff.c:5480
 msgid "omit the preimage for deletes"
 msgstr "Preimage für Löschungen weglassen"
 
-#: diff.c:5482
+#: diff.c:5483
 msgid "detect copies"
 msgstr "Kopien erkennen"
 
-#: diff.c:5486
+#: diff.c:5487
 msgid "use unmodified files as source to find copies"
 msgstr "ungeänderte Dateien als Quelle zum Finden von Kopien nutzen"
 
-#: diff.c:5488
+#: diff.c:5489
 msgid "disable rename detection"
 msgstr "Erkennung von Umbenennungen deaktivieren"
 
-#: diff.c:5491
+#: diff.c:5492
 msgid "use empty blobs as rename source"
 msgstr "leere Blobs als Quelle von Umbenennungen nutzen"
 
-#: diff.c:5493
+#: diff.c:5494
 msgid "continue listing the history of a file beyond renames"
 msgstr "Auflistung der Historie einer Datei nach Umbenennung fortführen"
 
-#: diff.c:5496
+#: diff.c:5497
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
 msgstr ""
-"Erkennung von Umbenennungen und Kopien verhindern, wenn die Anzahl der "
-"Ziele für Umbenennungen und Kopien das gegebene Limit überschreitet"
+"Erkennung von Umbenennungen und Kopien verhindern, wenn die Anzahl der Ziele "
+"für Umbenennungen und Kopien das gegebene Limit überschreitet"
 
-#: diff.c:5498
+#: diff.c:5499
 msgid "Diff algorithm options"
 msgstr "Diff Algorithmus-Optionen"
 
-#: diff.c:5500
+#: diff.c:5501
 msgid "produce the smallest possible diff"
 msgstr "die kleinstmöglichen Änderungen erzeugen"
 
-#: diff.c:5503
+#: diff.c:5504
 msgid "ignore whitespace when comparing lines"
 msgstr "Whitespace-Änderungen beim Vergleich von Zeilen ignorieren"
 
-#: diff.c:5506
+#: diff.c:5507
 msgid "ignore changes in amount of whitespace"
 msgstr "Änderungen bei der Anzahl von Whitespace ignorieren"
 
-#: diff.c:5509
+#: diff.c:5510
 msgid "ignore changes in whitespace at EOL"
 msgstr "Whitespace-Änderungen am Zeilenende ignorieren"
 
-#: diff.c:5512
+#: diff.c:5513
 msgid "ignore carrier-return at the end of line"
 msgstr "den Zeilenumbruch am Ende der Zeile ignorieren"
 
-#: diff.c:5515
+#: diff.c:5516
 msgid "ignore changes whose lines are all blank"
 msgstr "Änderungen in leeren Zeilen ignorieren"
 
-#: diff.c:5517 diff.c:5539 diff.c:5542 diff.c:5587
+#: diff.c:5518 diff.c:5540 diff.c:5543 diff.c:5588
 msgid "<regex>"
 msgstr "<Regex>"
 
-#: diff.c:5518
+#: diff.c:5519
 msgid "ignore changes whose all lines match <regex>"
 msgstr ""
 "Änderungen ignorieren, bei denen alle Zeilen mit <Regex> übereinstimmen"
 
-#: diff.c:5521
+#: diff.c:5522
 msgid "heuristic to shift diff hunk boundaries for easy reading"
 msgstr ""
 "Heuristik, um Grenzen der Änderungsblöcke für bessere Lesbarkeit zu "
 "verschieben"
 
-#: diff.c:5524
+#: diff.c:5525
 msgid "generate diff using the \"patience diff\" algorithm"
 msgstr "Änderungen durch Nutzung des Algorithmus \"Patience Diff\" erzeugen"
 
-#: diff.c:5528
+#: diff.c:5529
 msgid "generate diff using the \"histogram diff\" algorithm"
 msgstr "Änderungen durch Nutzung des Algorithmus \"Histogram Diff\" erzeugen"
 
-#: diff.c:5530
+#: diff.c:5531
 msgid "<algorithm>"
 msgstr "<Algorithmus>"
 
-#: diff.c:5531
+#: diff.c:5532
 msgid "choose a diff algorithm"
 msgstr "einen Algorithmus für Änderungen wählen"
 
-#: diff.c:5533
+#: diff.c:5534
 msgid "<text>"
 msgstr "<Text>"
 
-#: diff.c:5534
+#: diff.c:5535
 msgid "generate diff using the \"anchored diff\" algorithm"
 msgstr "Änderungen durch Nutzung des Algorithmus \"Anchored Diff\" erzeugen"
 
-#: diff.c:5536 diff.c:5545 diff.c:5548
+#: diff.c:5537 diff.c:5546 diff.c:5549
 msgid "<mode>"
 msgstr "<Modus>"
 
-#: diff.c:5537
+#: diff.c:5538
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr "Wort-Änderungen zeigen, nutze <Modus>, um Wörter abzugrenzen"
 
-#: diff.c:5540
+#: diff.c:5541
 msgid "use <regex> to decide what a word is"
 msgstr "<Regex> nutzen, um zu entscheiden, was ein Wort ist"
 
-#: diff.c:5543
+#: diff.c:5544
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
 msgstr "entsprechend wie --word-diff=color --word-diff-regex=<Regex>"
 
-#: diff.c:5546
+#: diff.c:5547
 msgid "moved lines of code are colored differently"
 msgstr "verschobene Codezeilen sind andersfarbig"
 
-#: diff.c:5549
+#: diff.c:5550
 msgid "how white spaces are ignored in --color-moved"
 msgstr "wie Whitespaces in --color-moved ignoriert werden"
 
-#: diff.c:5552
+#: diff.c:5553
 msgid "Other diff options"
 msgstr "Andere Diff-Optionen"
 
-#: diff.c:5554
+#: diff.c:5555
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
 "wenn vom Unterverzeichnis aufgerufen, schließe Änderungen außerhalb aus und "
 "zeige relative Pfade an"
 
-#: diff.c:5558
+#: diff.c:5559
 msgid "treat all files as text"
 msgstr "alle Dateien als Text behandeln"
 
-#: diff.c:5560
+#: diff.c:5561
 msgid "swap two inputs, reverse the diff"
 msgstr "die beiden Eingaben vertauschen und die Änderungen umkehren"
 
-#: diff.c:5562
+#: diff.c:5563
 msgid "exit with 1 if there were differences, 0 otherwise"
 msgstr ""
 "mit Exit-Status 1 beenden, wenn Änderungen vorhanden sind, andernfalls mit 0"
 
-#: diff.c:5564
+#: diff.c:5565
 msgid "disable all output of the program"
 msgstr "alle Ausgaben vom Programm deaktivieren"
 
-#: diff.c:5566
+#: diff.c:5567
 msgid "allow an external diff helper to be executed"
 msgstr "erlaube die Ausführung eines externes Programms für Änderungen"
 
-#: diff.c:5568
+#: diff.c:5569
 msgid "run external text conversion filters when comparing binary files"
 msgstr ""
 "Führe externe Text-Konvertierungsfilter aus, wenn binäre Dateien vergleicht "
 "werden"
 
-#: diff.c:5570
+#: diff.c:5571
 msgid "<when>"
 msgstr "<wann>"
 
-#: diff.c:5571
+#: diff.c:5572
 msgid "ignore changes to submodules in the diff generation"
 msgstr ""
 "Änderungen in Submodulen während der Erstellung der Unterschiede ignorieren"
 
-#: diff.c:5574
+#: diff.c:5575
 msgid "<format>"
 msgstr "<Format>"
 
-#: diff.c:5575
+#: diff.c:5576
 msgid "specify how differences in submodules are shown"
 msgstr "angeben, wie Unterschiede in Submodulen gezeigt werden"
 
-#: diff.c:5579
+#: diff.c:5580
 msgid "hide 'git add -N' entries from the index"
 msgstr "'git add -N' Einträge vom Index verstecken"
 
-#: diff.c:5582
+#: diff.c:5583
 msgid "treat 'git add -N' entries as real in the index"
 msgstr "'git add -N' Einträge im Index als echt behandeln"
 
-#: diff.c:5584
+#: diff.c:5585
 msgid "<string>"
 msgstr "<Zeichenkette>"
 
-#: diff.c:5585
+#: diff.c:5586
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
@@ -3836,7 +3827,7 @@ msgstr ""
 "nach Unterschieden suchen, welche die Anzahl des Vorkommens der angegebenen "
 "Zeichenkette verändern"
 
-#: diff.c:5588
+#: diff.c:5589
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
@@ -3844,25 +3835,25 @@ msgstr ""
 "nach Unterschieden suchen, welche die Anzahl des Vorkommens des angegebenen "
 "regulären Ausdrucks verändern"
 
-#: diff.c:5591
+#: diff.c:5592
 msgid "show all changes in the changeset with -S or -G"
 msgstr "alle Änderungen im Changeset mit -S oder -G anzeigen"
 
-#: diff.c:5594
+#: diff.c:5595
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr ""
 "<Zeichenkette> bei -S als erweiterten POSIX regulären Ausdruck behandeln"
 
-#: diff.c:5597
+#: diff.c:5598
 msgid "control the order in which files appear in the output"
 msgstr ""
 "die Reihenfolge kontrollieren, in der die Dateien in der Ausgabe erscheinen"
 
-#: diff.c:5598
+#: diff.c:5599
 msgid "<object-id>"
 msgstr "<Objekt-ID>"
 
-#: diff.c:5599
+#: diff.c:5600
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
@@ -3870,33 +3861,33 @@ msgstr ""
 "nach Unterschieden suchen, welche die Anzahl des Vorkommens des angegebenen "
 "Objektes verändern"
 
-#: diff.c:5601
+#: diff.c:5602
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "[(A|C|D|M|R|T|U|X|B)...[*]]"
 
-#: diff.c:5602
+#: diff.c:5603
 msgid "select files by diff type"
 msgstr "Dateien anhand der Art der Änderung wählen"
 
-#: diff.c:5604
+#: diff.c:5605
 msgid "<file>"
 msgstr "<Datei>"
 
-#: diff.c:5605
+#: diff.c:5606
 msgid "Output to a specific file"
 msgstr "Ausgabe zu einer bestimmten Datei"
 
-#: diff.c:6262
+#: diff.c:6263
 msgid "inexact rename detection was skipped due to too many files."
 msgstr ""
 "ungenaue Erkennung für Umbenennungen wurde aufgrund zu vieler Dateien\n"
 "übersprungen."
 
-#: diff.c:6265
+#: diff.c:6266
 msgid "only found copies from modified paths due to too many files."
 msgstr "nur Kopien von geänderten Pfaden, aufgrund zu vieler Dateien, gefunden"
 
-#: diff.c:6268
+#: diff.c:6269
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
@@ -3916,8 +3907,7 @@ msgstr "Führe Erkennung für ungenaue Umbenennung aus"
 #: dir.c:578
 #, c-format
 msgid "pathspec '%s' did not match any file(s) known to git"
-msgstr ""
-"Pfadspezifikation '%s' stimmt mit keinen git-bekannten Dateien überein"
+msgstr "Pfadspezifikation '%s' stimmt mit keinen git-bekannten Dateien überein"
 
 #: dir.c:718 dir.c:747 dir.c:760
 #, c-format
@@ -6238,7 +6228,7 @@ msgstr "fehlerhaftes Objekt bei '%s'"
 msgid "ignoring ref with broken name %s"
 msgstr "Ignoriere Referenz mit fehlerhaftem Namen %s"
 
-#: ref-filter.c:2156 refs.c:660
+#: ref-filter.c:2156 refs.c:676
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "Ignoriere fehlerhafte Referenz %s"
@@ -6263,67 +6253,82 @@ msgstr "die Option `%s' muss auf einen Commit zeigen"
 msgid "%s does not point to a valid object!"
 msgstr "%s zeigt auf kein gültiges Objekt!"
 
-#: refs.c:575
+#: refs.c:566
+#, c-format
+msgid ""
+"Using '%s' as the name for the initial branch. This default branch name\n"
+"is subject to change. To configure the initial branch name to use in all\n"
+"of your new repositories, which will suppress this warning, call:\n"
+"\n"
+"\tgit config --global init.defaultBranch <name>\n"
+"\n"
+"Names commonly chosen instead of 'master' are 'main', 'trunk' and\n"
+"'development'. The just-created branch can be renamed via this command:\n"
+"\n"
+"\tgit branch -m <name>\n"
+msgstr ""
+
+#: refs.c:588
 #, c-format
 msgid "could not retrieve `%s`"
 msgstr "konnte `%s` nicht abrufen"
 
-#: refs.c:582
+#: refs.c:598
 #, c-format
 msgid "invalid branch name: %s = %s"
 msgstr "ungültiger Branchname: %s = %s"
 
-#: refs.c:658
+#: refs.c:674
 #, c-format
 msgid "ignoring dangling symref %s"
 msgstr "Ignoriere unreferenzierte symbolische Referenz %s"
 
-#: refs.c:895
+#: refs.c:911
 #, c-format
 msgid "log for ref %s has gap after %s"
 msgstr "Log für Referenz %s hat eine Lücke nach %s."
 
-#: refs.c:901
+#: refs.c:917
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
 msgstr "Log für Referenz %s unerwartet bei %s beendet."
 
-#: refs.c:960
+#: refs.c:976
 #, c-format
 msgid "log for %s is empty"
 msgstr "Log für %s ist leer."
 
-#: refs.c:1052
+#: refs.c:1068
 #, c-format
 msgid "refusing to update ref with bad name '%s'"
 msgstr "verweigere Aktualisierung einer Referenz mit fehlerhaftem Namen '%s'"
 
-#: refs.c:1123
+#: refs.c:1139
 #, c-format
 msgid "update_ref failed for ref '%s': %s"
 msgstr "update_ref für Referenz '%s' fehlgeschlagen: %s"
 
-#: refs.c:1947
+#: refs.c:1963
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "mehrere Aktualisierungen für Referenz '%s' nicht erlaubt"
 
-#: refs.c:2027
+#: refs.c:2043
 msgid "ref updates forbidden inside quarantine environment"
 msgstr ""
 "Aktualisierungen von Referenzen ist innerhalb der Quarantäne-Umgebung "
 "verboten"
 
-#: refs.c:2038
+#: refs.c:2054
 msgid "ref updates aborted by hook"
 msgstr "Aktualisierungen von Referenzen durch Hook abgebrochen"
 
-#: refs.c:2138 refs.c:2168
+#: refs.c:2154 refs.c:2184
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "'%s' existiert; kann '%s' nicht erstellen"
 
-#: refs.c:2144 refs.c:2179
+#: refs.c:2160 refs.c:2195
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "kann '%s' und '%s' nicht zur selben Zeit verarbeiten"
@@ -6620,7 +6625,7 @@ msgstr ""
 "  (benutzen Sie \"git pull\", um Ihren Branch mit dem Remote-Branch "
 "zusammenzuführen)\n"
 
-#: remote.c:2348
+#: remote.c:2349
 #, c-format
 msgid "cannot parse expected object name '%s'"
 msgstr "Kann erwarteten Objektnamen '%s' nicht parsen."
@@ -8428,7 +8433,7 @@ msgstr ""
 msgid "process for submodule '%s' failed"
 msgstr "Prozess für Submodul '%s' fehlgeschlagen"
 
-#: submodule.c:1156 builtin/branch.c:678 builtin/submodule--helper.c:2469
+#: submodule.c:1156 builtin/branch.c:680 builtin/submodule--helper.c:2469
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "Konnte HEAD nicht als gültige Referenz auflösen."
 
@@ -10357,7 +10362,7 @@ msgstr "historische Option -- kein Effekt"
 msgid "allow fall back on 3way merging if needed"
 msgstr "erlaube, falls notwendig, das Zurückfallen auf einen 3-Wege-Merge"
 
-#: builtin/am.c:2225 builtin/init-db.c:558 builtin/prune-packed.c:16
+#: builtin/am.c:2225 builtin/init-db.c:560 builtin/prune-packed.c:16
 #: builtin/repack.c:335 builtin/stash.c:815
 msgid "be quiet"
 msgstr "weniger Ausgaben"
@@ -10410,7 +10415,7 @@ msgstr "an git-apply übergeben"
 msgid "n"
 msgstr "Anzahl"
 
-#: builtin/am.c:2269 builtin/branch.c:659 builtin/bugreport.c:136
+#: builtin/am.c:2269 builtin/branch.c:661 builtin/bugreport.c:136
 #: builtin/for-each-ref.c:38 builtin/replace.c:556 builtin/tag.c:438
 #: builtin/verify-tag.c:38
 msgid "format"
@@ -11193,42 +11198,42 @@ msgstr ""
 msgid "Invalid branch name: '%s'"
 msgstr "Ungültiger Branchname: '%s'"
 
-#: builtin/branch.c:542
+#: builtin/branch.c:544
 msgid "Branch rename failed"
 msgstr "Umbenennung des Branches fehlgeschlagen"
 
-#: builtin/branch.c:544
+#: builtin/branch.c:546
 msgid "Branch copy failed"
 msgstr "Kopie des Branches fehlgeschlagen"
 
-#: builtin/branch.c:548
+#: builtin/branch.c:550
 #, c-format
 msgid "Created a copy of a misnamed branch '%s'"
 msgstr "Kopie eines falsch benannten Branches '%s' erstellt."
 
-#: builtin/branch.c:551
+#: builtin/branch.c:553
 #, c-format
 msgid "Renamed a misnamed branch '%s' away"
 msgstr "falsch benannten Branch '%s' umbenannt"
 
-#: builtin/branch.c:557
+#: builtin/branch.c:559
 #, c-format
 msgid "Branch renamed to %s, but HEAD is not updated!"
 msgstr "Branch umbenannt zu %s, aber HEAD ist nicht aktualisiert!"
 
-#: builtin/branch.c:566
+#: builtin/branch.c:568
 msgid "Branch is renamed, but update of config-file failed"
 msgstr ""
 "Branch ist umbenannt, aber die Aktualisierung der Konfigurationsdatei ist "
 "fehlgeschlagen."
 
-#: builtin/branch.c:568
+#: builtin/branch.c:570
 msgid "Branch is copied, but update of config-file failed"
 msgstr ""
 "Branch wurde kopiert, aber die Aktualisierung der Konfigurationsdatei ist\n"
 "fehlgeschlagen."
 
-#: builtin/branch.c:584
+#: builtin/branch.c:586
 #, c-format
 msgid ""
 "Please edit the description for the branch\n"
@@ -11239,181 +11244,181 @@ msgstr ""
 "  %s\n"
 "Zeilen, die mit '%c' beginnen, werden entfernt.\n"
 
-#: builtin/branch.c:618
+#: builtin/branch.c:620
 msgid "Generic options"
 msgstr "Allgemeine Optionen"
 
-#: builtin/branch.c:620
+#: builtin/branch.c:622
 msgid "show hash and subject, give twice for upstream branch"
 msgstr "Hash und Betreff anzeigen; -vv: zusätzlich Upstream-Branch"
 
-#: builtin/branch.c:621
+#: builtin/branch.c:623
 msgid "suppress informational messages"
 msgstr "Informationsmeldungen unterdrücken"
 
-#: builtin/branch.c:622
+#: builtin/branch.c:624
 msgid "set up tracking mode (see git-pull(1))"
 msgstr "Modus zum Folgen von Branches einstellen (siehe git-pull(1))"
 
-#: builtin/branch.c:624
+#: builtin/branch.c:626
 msgid "do not use"
 msgstr "nicht verwenden"
 
-#: builtin/branch.c:626 builtin/rebase.c:532
+#: builtin/branch.c:628 builtin/rebase.c:532
 msgid "upstream"
 msgstr "Upstream"
 
-#: builtin/branch.c:626
+#: builtin/branch.c:628
 msgid "change the upstream info"
 msgstr "Informationen zum Upstream-Branch ändern"
 
-#: builtin/branch.c:627
+#: builtin/branch.c:629
 msgid "unset the upstream info"
 msgstr "Informationen zum Upstream-Branch entfernen"
 
-#: builtin/branch.c:628
+#: builtin/branch.c:630
 msgid "use colored output"
 msgstr "farbige Ausgaben verwenden"
 
-#: builtin/branch.c:629
+#: builtin/branch.c:631
 msgid "act on remote-tracking branches"
 msgstr "auf Remote-Tracking-Branches wirken"
 
-#: builtin/branch.c:631 builtin/branch.c:633
+#: builtin/branch.c:633 builtin/branch.c:635
 msgid "print only branches that contain the commit"
 msgstr "nur Branches ausgeben, die diesen Commit enthalten"
 
-#: builtin/branch.c:632 builtin/branch.c:634
+#: builtin/branch.c:634 builtin/branch.c:636
 msgid "print only branches that don't contain the commit"
 msgstr "nur Branches ausgeben, die diesen Commit nicht enthalten"
 
-#: builtin/branch.c:637
+#: builtin/branch.c:639
 msgid "Specific git-branch actions:"
 msgstr "spezifische Aktionen für \"git-branch\":"
 
-#: builtin/branch.c:638
+#: builtin/branch.c:640
 msgid "list both remote-tracking and local branches"
 msgstr "Remote-Tracking und lokale Branches auflisten"
 
-#: builtin/branch.c:640
+#: builtin/branch.c:642
 msgid "delete fully merged branch"
 msgstr "vollständig zusammengeführten Branch entfernen"
 
-#: builtin/branch.c:641
+#: builtin/branch.c:643
 msgid "delete branch (even if not merged)"
 msgstr "Branch löschen (auch wenn nicht zusammengeführt)"
 
-#: builtin/branch.c:642
+#: builtin/branch.c:644
 msgid "move/rename a branch and its reflog"
 msgstr "einen Branch und dessen Reflog verschieben/umbenennen"
 
-#: builtin/branch.c:643
+#: builtin/branch.c:645
 msgid "move/rename a branch, even if target exists"
 msgstr ""
 "einen Branch verschieben/umbenennen, auch wenn das Ziel bereits existiert"
 
-#: builtin/branch.c:644
+#: builtin/branch.c:646
 msgid "copy a branch and its reflog"
 msgstr "einen Branch und dessen Reflog kopieren"
 
-#: builtin/branch.c:645
+#: builtin/branch.c:647
 msgid "copy a branch, even if target exists"
 msgstr "einen Branch kopieren, auch wenn das Ziel bereits existiert"
 
-#: builtin/branch.c:646
+#: builtin/branch.c:648
 msgid "list branch names"
 msgstr "Branchnamen auflisten"
 
-#: builtin/branch.c:647
+#: builtin/branch.c:649
 msgid "show current branch name"
 msgstr "Zeige aktuellen Branch-Namen."
 
-#: builtin/branch.c:648
+#: builtin/branch.c:650
 msgid "create the branch's reflog"
 msgstr "das Reflog des Branches erzeugen"
 
-#: builtin/branch.c:650
+#: builtin/branch.c:652
 msgid "edit the description for the branch"
 msgstr "die Beschreibung für den Branch bearbeiten"
 
-#: builtin/branch.c:651
+#: builtin/branch.c:653
 msgid "force creation, move/rename, deletion"
 msgstr "Erstellung, Verschiebung/Umbenennung oder Löschung erzwingen"
 
-#: builtin/branch.c:652
+#: builtin/branch.c:654
 msgid "print only branches that are merged"
 msgstr "nur zusammengeführte Branches ausgeben"
 
-#: builtin/branch.c:653
+#: builtin/branch.c:655
 msgid "print only branches that are not merged"
 msgstr "nur nicht zusammengeführte Branches ausgeben"
 
-#: builtin/branch.c:654
+#: builtin/branch.c:656
 msgid "list branches in columns"
 msgstr "Branches in Spalten auflisten"
 
-#: builtin/branch.c:656 builtin/for-each-ref.c:42 builtin/notes.c:415
+#: builtin/branch.c:658 builtin/for-each-ref.c:42 builtin/notes.c:415
 #: builtin/notes.c:418 builtin/notes.c:581 builtin/notes.c:584
 #: builtin/tag.c:434
 msgid "object"
 msgstr "Objekt"
 
-#: builtin/branch.c:657
+#: builtin/branch.c:659
 msgid "print only branches of the object"
 msgstr "nur Branches von diesem Objekt ausgeben"
 
-#: builtin/branch.c:658 builtin/for-each-ref.c:48 builtin/tag.c:441
+#: builtin/branch.c:660 builtin/for-each-ref.c:48 builtin/tag.c:441
 msgid "sorting and filtering are case insensitive"
 msgstr "Sortierung und Filterung sind unabhängig von Groß- und Kleinschreibung"
 
-#: builtin/branch.c:659 builtin/for-each-ref.c:38 builtin/tag.c:439
+#: builtin/branch.c:661 builtin/for-each-ref.c:38 builtin/tag.c:439
 #: builtin/verify-tag.c:38
 msgid "format to use for the output"
 msgstr "für die Ausgabe zu verwendendes Format"
 
-#: builtin/branch.c:682 builtin/clone.c:790
+#: builtin/branch.c:684 builtin/clone.c:790
 msgid "HEAD not found below refs/heads!"
 msgstr "HEAD wurde nicht unter \"refs/heads\" gefunden!"
 
-#: builtin/branch.c:706
+#: builtin/branch.c:708
 msgid "--column and --verbose are incompatible"
 msgstr "Die Optionen --column und --verbose sind inkompatibel."
 
-#: builtin/branch.c:721 builtin/branch.c:775 builtin/branch.c:784
+#: builtin/branch.c:723 builtin/branch.c:777 builtin/branch.c:786
 msgid "branch name required"
 msgstr "Branchname erforderlich"
 
-#: builtin/branch.c:751
+#: builtin/branch.c:753
 msgid "Cannot give description to detached HEAD"
 msgstr "zu losgelöstem HEAD kann keine Beschreibung hinterlegt werden"
 
-#: builtin/branch.c:756
+#: builtin/branch.c:758
 msgid "cannot edit description of more than one branch"
 msgstr "Beschreibung von mehr als einem Branch kann nicht bearbeitet werden"
 
-#: builtin/branch.c:763
+#: builtin/branch.c:765
 #, c-format
 msgid "No commit on branch '%s' yet."
 msgstr "Noch kein Commit in Branch '%s'."
 
-#: builtin/branch.c:766
+#: builtin/branch.c:768
 #, c-format
 msgid "No branch named '%s'."
 msgstr "Branch '%s' nicht vorhanden."
 
-#: builtin/branch.c:781
+#: builtin/branch.c:783
 msgid "too many branches for a copy operation"
 msgstr "zu viele Branches für eine Kopieroperation angegeben"
 
-#: builtin/branch.c:790
+#: builtin/branch.c:792
 msgid "too many arguments for a rename operation"
 msgstr "zu viele Argumente für eine Umbenennen-Operation angegeben"
 
-#: builtin/branch.c:795
+#: builtin/branch.c:797
 msgid "too many arguments to set new upstream"
 msgstr "zu viele Argumente angegeben, um Upstream-Branch zu setzen"
 
-#: builtin/branch.c:799
+#: builtin/branch.c:801
 #, c-format
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch."
@@ -11421,34 +11426,34 @@ msgstr ""
 "Konnte keinen neuen Upstream-Branch von HEAD zu %s setzen, da dieser auf\n"
 "keinen Branch zeigt."
 
-#: builtin/branch.c:802 builtin/branch.c:825
+#: builtin/branch.c:804 builtin/branch.c:827
 #, c-format
 msgid "no such branch '%s'"
 msgstr "Kein solcher Branch '%s'"
 
-#: builtin/branch.c:806
+#: builtin/branch.c:808
 #, c-format
 msgid "branch '%s' does not exist"
 msgstr "Branch '%s' existiert nicht"
 
-#: builtin/branch.c:819
+#: builtin/branch.c:821
 msgid "too many arguments to unset upstream"
 msgstr ""
 "zu viele Argumente angegeben, um Konfiguration zu Upstream-Branch zu "
 "entfernen"
 
-#: builtin/branch.c:823
+#: builtin/branch.c:825
 msgid "could not unset upstream of HEAD when it does not point to any branch."
 msgstr ""
 "Konnte Konfiguration zu Upstream-Branch von HEAD nicht entfernen, da dieser\n"
 "auf keinen Branch zeigt."
 
-#: builtin/branch.c:829
+#: builtin/branch.c:831
 #, c-format
 msgid "Branch '%s' has no upstream information"
 msgstr "Branch '%s' hat keinen Upstream-Branch gesetzt"
 
-#: builtin/branch.c:839
+#: builtin/branch.c:841
 msgid ""
 "The -a, and -r, options to 'git branch' do not take a branch name.\n"
 "Did you mean to use: -a|-r --list <pattern>?"
@@ -11457,7 +11462,7 @@ msgstr ""
 "verwendet werden.\n"
 "Wollten Sie -a|-r --list <Muster> benutzen?"
 
-#: builtin/branch.c:843
+#: builtin/branch.c:845
 msgid ""
 "the '--set-upstream' option is no longer supported. Please use '--track' or "
 "'--set-upstream-to' instead."
@@ -12592,7 +12597,7 @@ msgstr "git clone [<Optionen>] [--] <Repository> [<Verzeichnis>]"
 msgid "don't create a checkout"
 msgstr "kein Auschecken"
 
-#: builtin/clone.c:95 builtin/clone.c:97 builtin/init-db.c:553
+#: builtin/clone.c:95 builtin/clone.c:97 builtin/init-db.c:555
 msgid "create a bare repository"
 msgstr "ein Bare-Repository erstellen"
 
@@ -12624,11 +12629,11 @@ msgstr "Submodule im Klon initialisieren"
 msgid "number of submodules cloned in parallel"
 msgstr "Anzahl der parallel zu klonenden Submodule"
 
-#: builtin/clone.c:112 builtin/init-db.c:550
+#: builtin/clone.c:112 builtin/init-db.c:552
 msgid "template-directory"
 msgstr "Vorlagenverzeichnis"
 
-#: builtin/clone.c:113 builtin/init-db.c:551
+#: builtin/clone.c:113 builtin/init-db.c:553
 msgid "directory from which templates will be used"
 msgstr "Verzeichnis, von welchem die Vorlagen verwendet werden"
 
@@ -12642,7 +12647,7 @@ msgstr "Repository referenzieren"
 msgid "use --reference only while cloning"
 msgstr "--reference nur während des Klonens benutzen"
 
-#: builtin/clone.c:120 builtin/column.c:27 builtin/init-db.c:561
+#: builtin/clone.c:120 builtin/column.c:27 builtin/init-db.c:563
 #: builtin/merge-file.c:46 builtin/pack-objects.c:3546 builtin/repack.c:358
 msgid "name"
 msgstr "Name"
@@ -12705,11 +12710,11 @@ msgstr "keine Tags klonen, und auch bei späteren Abrufen nicht beachten"
 msgid "any cloned submodules will be shallow"
 msgstr "jedes geklonte Submodul mit unvollständiger Historie (shallow)"
 
-#: builtin/clone.c:138 builtin/init-db.c:559
+#: builtin/clone.c:138 builtin/init-db.c:561
 msgid "gitdir"
 msgstr ".git-Verzeichnis"
 
-#: builtin/clone.c:139 builtin/init-db.c:560
+#: builtin/clone.c:139 builtin/init-db.c:562
 msgid "separate git dir from working tree"
 msgstr "Git-Verzeichnis vom Arbeitsverzeichnis separieren"
 
@@ -12950,12 +12955,12 @@ msgstr ""
 msgid "--local is ignored"
 msgstr "--local wird ignoriert"
 
-#: builtin/clone.c:1308 builtin/clone.c:1316
+#: builtin/clone.c:1311 builtin/clone.c:1319
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "Remote-Branch %s nicht im Upstream-Repository %s gefunden"
 
-#: builtin/clone.c:1319
+#: builtin/clone.c:1322
 msgid "You appear to have cloned an empty repository."
 msgstr "Sie scheinen ein leeres Repository geklont zu haben."
 
@@ -13525,8 +13530,8 @@ msgid "terminate entries with NUL"
 msgstr "Einträge mit NUL-Zeichen abschließen"
 
 #: builtin/commit.c:1382 builtin/commit.c:1386 builtin/commit.c:1541
-#: builtin/fast-export.c:1199 builtin/fast-export.c:1202
-#: builtin/fast-export.c:1205 builtin/rebase.c:1406 parse-options.h:336
+#: builtin/fast-export.c:1198 builtin/fast-export.c:1201
+#: builtin/fast-export.c:1204 builtin/rebase.c:1406 parse-options.h:336
 msgid "mode"
 msgstr "Modus"
 
@@ -14480,94 +14485,94 @@ msgstr ""
 "Fehler: Verschachtelte Tags können nicht exportiert werden, außer --mark-"
 "tags wurde angegeben."
 
-#: builtin/fast-export.c:1178
+#: builtin/fast-export.c:1177
 msgid "--anonymize-map token cannot be empty"
 msgstr "Token für --anonymize-map kann nicht leer sein"
 
-#: builtin/fast-export.c:1198
+#: builtin/fast-export.c:1197
 msgid "show progress after <n> objects"
 msgstr "Fortschritt nach <n> Objekten anzeigen"
 
-#: builtin/fast-export.c:1200
+#: builtin/fast-export.c:1199
 msgid "select handling of signed tags"
 msgstr "Behandlung von signierten Tags wählen"
 
-#: builtin/fast-export.c:1203
+#: builtin/fast-export.c:1202
 msgid "select handling of tags that tag filtered objects"
 msgstr "Behandlung von Tags wählen, die gefilterte Objekte markieren"
 
-#: builtin/fast-export.c:1206
+#: builtin/fast-export.c:1205
 msgid "select handling of commit messages in an alternate encoding"
 msgstr ""
 "Auswählen der Behandlung von Commit-Beschreibungen bei wechselndem Encoding"
 
-#: builtin/fast-export.c:1209
+#: builtin/fast-export.c:1208
 msgid "Dump marks to this file"
 msgstr "Markierungen in diese Datei schreiben"
 
-#: builtin/fast-export.c:1211
+#: builtin/fast-export.c:1210
 msgid "Import marks from this file"
 msgstr "Markierungen von dieser Datei importieren"
 
-#: builtin/fast-export.c:1215
+#: builtin/fast-export.c:1214
 msgid "Import marks from this file if it exists"
 msgstr "Markierungen von dieser Datei importieren, wenn diese existiert"
 
-#: builtin/fast-export.c:1217
+#: builtin/fast-export.c:1216
 msgid "Fake a tagger when tags lack one"
 msgstr "künstlich einen Tag-Ersteller erzeugen, wenn das Tag keinen hat"
 
-#: builtin/fast-export.c:1219
+#: builtin/fast-export.c:1218
 msgid "Output full tree for each commit"
 msgstr "für jeden Commit das gesamte Verzeichnis ausgeben"
 
-#: builtin/fast-export.c:1221
+#: builtin/fast-export.c:1220
 msgid "Use the done feature to terminate the stream"
 msgstr "die \"done\"-Funktion benutzen, um den Datenstrom abzuschließen"
 
-#: builtin/fast-export.c:1222
+#: builtin/fast-export.c:1221
 msgid "Skip output of blob data"
 msgstr "Ausgabe von Blob-Daten überspringen"
 
-#: builtin/fast-export.c:1223 builtin/log.c:1816
+#: builtin/fast-export.c:1222 builtin/log.c:1816
 msgid "refspec"
 msgstr "Refspec"
 
-#: builtin/fast-export.c:1224
+#: builtin/fast-export.c:1223
 msgid "Apply refspec to exported refs"
 msgstr "Refspec auf exportierte Referenzen anwenden"
 
-#: builtin/fast-export.c:1225
+#: builtin/fast-export.c:1224
 msgid "anonymize output"
 msgstr "Ausgabe anonymisieren"
 
-#: builtin/fast-export.c:1226
+#: builtin/fast-export.c:1225
 msgid "from:to"
 msgstr "von:nach"
 
-#: builtin/fast-export.c:1227
+#: builtin/fast-export.c:1226
 msgid "convert <from> to <to> in anonymized output"
 msgstr "konvertiere <von> zu <nach> in anonymisierter Ausgabe"
 
-#: builtin/fast-export.c:1230
+#: builtin/fast-export.c:1229
 msgid "Reference parents which are not in fast-export stream by object id"
 msgstr ""
 "Eltern, die nicht im Fast-Export-Stream sind, anhand ihrer Objekt-ID "
 "referenzieren"
 
-#: builtin/fast-export.c:1232
+#: builtin/fast-export.c:1231
 msgid "Show original object ids of blobs/commits"
 msgstr "originale Objekt-IDs von Blobs/Commits anzeigen"
 
-#: builtin/fast-export.c:1234
+#: builtin/fast-export.c:1233
 msgid "Label tags with mark ids"
 msgstr "Tags mit Markierungs-IDs beschriften"
 
-#: builtin/fast-export.c:1257
+#: builtin/fast-export.c:1256
 msgid "--anonymize-map without --anonymize does not make sense"
 msgstr "--anonymize-map ohne --anonymize ist nicht sinnvoll"
 
-#: builtin/fast-export.c:1272
+#: builtin/fast-export.c:1271
 msgid "Cannot pass both --import-marks and --import-marks-if-exists"
 msgstr ""
 "--import-marks und --import-marks-if-exists können nicht zusammen "
@@ -15575,8 +15580,8 @@ msgstr ""
 #: builtin/gc.c:1544
 msgid "failed to run 'crontab'; your system might not support 'cron'"
 msgstr ""
-"Fehler beim Ausführen von 'crontab'; Ihr System unterstützt eventuell "
-"'cron' nicht"
+"Fehler beim Ausführen von 'crontab'; Ihr System unterstützt eventuell 'cron' "
+"nicht"
 
 #: builtin/gc.c:1550
 msgid "failed to open stdin of 'crontab'"
@@ -16300,7 +16305,7 @@ msgstr "Kann nicht zurück zum Arbeitsverzeichnis wechseln"
 msgid "bad %s"
 msgstr "%s ist ungültig"
 
-#: builtin/index-pack.c:1806 builtin/init-db.c:391 builtin/init-db.c:623
+#: builtin/index-pack.c:1806 builtin/init-db.c:392 builtin/init-db.c:625
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "unbekannter Hash-Algorithmus '%s'"
@@ -16365,56 +16370,56 @@ msgstr "Keine Vorlagen in %s gefunden."
 msgid "not copying templates from '%s': %s"
 msgstr "kopiere keine Vorlagen von '%s': %s"
 
-#: builtin/init-db.c:274
+#: builtin/init-db.c:275
 #, c-format
 msgid "invalid initial branch name: '%s'"
 msgstr "ungültiger initialer Branchname: '%s'"
 
-#: builtin/init-db.c:366
+#: builtin/init-db.c:367
 #, c-format
 msgid "unable to handle file type %d"
 msgstr "kann nicht mit Dateityp %d umgehen"
 
-#: builtin/init-db.c:369
+#: builtin/init-db.c:370
 #, c-format
 msgid "unable to move %s to %s"
 msgstr "Konnte %s nicht nach %s verschieben"
 
-#: builtin/init-db.c:385
+#: builtin/init-db.c:386
 msgid "attempt to reinitialize repository with different hash"
 msgstr "Versuch, das Repository mit einem anderen Hash zu reinitialisieren"
 
-#: builtin/init-db.c:409 builtin/init-db.c:412
+#: builtin/init-db.c:410 builtin/init-db.c:413
 #, c-format
 msgid "%s already exists"
 msgstr "%s existiert bereits"
 
-#: builtin/init-db.c:443
+#: builtin/init-db.c:445
 #, c-format
 msgid "re-init: ignored --initial-branch=%s"
 msgstr "Neu-Initialisierung: --initial-branch=%s ignoriert"
 
-#: builtin/init-db.c:474
+#: builtin/init-db.c:476
 #, c-format
 msgid "Reinitialized existing shared Git repository in %s%s\n"
 msgstr "Bestehendes verteiltes Git-Repository in %s%s neuinitialisiert\n"
 
-#: builtin/init-db.c:475
+#: builtin/init-db.c:477
 #, c-format
 msgid "Reinitialized existing Git repository in %s%s\n"
 msgstr "Bestehendes Git-Repository in %s%s neuinitialisiert\n"
 
-#: builtin/init-db.c:479
+#: builtin/init-db.c:481
 #, c-format
 msgid "Initialized empty shared Git repository in %s%s\n"
 msgstr "Leeres verteiltes Git-Repository in %s%s initialisiert\n"
 
-#: builtin/init-db.c:480
+#: builtin/init-db.c:482
 #, c-format
 msgid "Initialized empty Git repository in %s%s\n"
 msgstr "Leeres Git-Repository in %s%s initialisiert\n"
 
-#: builtin/init-db.c:529
+#: builtin/init-db.c:531
 msgid ""
 "git init [-q | --quiet] [--bare] [--template=<template-directory>] [--"
 "shared[=<permissions>]] [<directory>]"
@@ -16422,41 +16427,41 @@ msgstr ""
 "git init [-q | --quiet] [--bare] [--template=<Vorlagenverzeichnis>] [--"
 "shared[=<Berechtigungen>]] [<Verzeichnis>]"
 
-#: builtin/init-db.c:555
+#: builtin/init-db.c:557
 msgid "permissions"
 msgstr "Berechtigungen"
 
-#: builtin/init-db.c:556
+#: builtin/init-db.c:558
 msgid "specify that the git repository is to be shared amongst several users"
 msgstr "angeben, dass das Git-Repository mit mehreren Benutzern geteilt wird"
 
-#: builtin/init-db.c:562
+#: builtin/init-db.c:564
 msgid "override the name of the initial branch"
 msgstr "den Namen des initialen Branches überschreiben"
 
-#: builtin/init-db.c:563 builtin/verify-pack.c:74
+#: builtin/init-db.c:565 builtin/verify-pack.c:74
 msgid "hash"
 msgstr "Hash"
 
-#: builtin/init-db.c:564 builtin/show-index.c:22 builtin/verify-pack.c:75
+#: builtin/init-db.c:566 builtin/show-index.c:22 builtin/verify-pack.c:75
 msgid "specify the hash algorithm to use"
 msgstr "den zu verwendenen Hash-Algorithmus angeben"
 
-#: builtin/init-db.c:571
+#: builtin/init-db.c:573
 msgid "--separate-git-dir and --bare are mutually exclusive"
 msgstr "--separate-git-dir und --bare schließen sich gegenseitig aus"
 
-#: builtin/init-db.c:600 builtin/init-db.c:605
+#: builtin/init-db.c:602 builtin/init-db.c:607
 #, c-format
 msgid "cannot mkdir %s"
 msgstr "kann Verzeichnis %s nicht erstellen"
 
-#: builtin/init-db.c:609 builtin/init-db.c:664
+#: builtin/init-db.c:611 builtin/init-db.c:666
 #, c-format
 msgid "cannot chdir to %s"
 msgstr "kann nicht in Verzeichnis %s wechseln"
 
-#: builtin/init-db.c:636
+#: builtin/init-db.c:638
 #, c-format
 msgid ""
 "%s (or --work-tree=<directory>) not allowed without specifying %s (or --git-"
@@ -16465,12 +16470,12 @@ msgstr ""
 "%s (oder --work-tree=<Verzeichnis>) nicht erlaubt ohne Spezifizierung von %s "
 "(oder --git-dir=<Verzeichnis>)"
 
-#: builtin/init-db.c:688
+#: builtin/init-db.c:690
 #, c-format
 msgid "Cannot access work tree '%s'"
 msgstr "Kann nicht auf Arbeitsverzeichnis '%s' zugreifen."
 
-#: builtin/init-db.c:693
+#: builtin/init-db.c:695
 msgid "--separate-git-dir incompatible with bare repository"
 msgstr "--separate-git-dir nicht kompatibel mit Bare-Repository"
 
@@ -16578,8 +16583,8 @@ msgid ""
 "Trace the evolution of line range <start>,<end> or function :<funcname> in "
 "<file>"
 msgstr ""
-"Entwicklung der Zeilen vom Bereich <Start>,<Ende> oder Funktion "
-":<Funktionsname> in <Datei> verfolgen"
+"Entwicklung der Zeilen vom Bereich <Start>,<Ende> oder Funktion :"
+"<Funktionsname> in <Datei> verfolgen"
 
 #: builtin/log.c:212
 msgid "-L<range>:<file> cannot be used with pathspec"
@@ -26115,3 +26120,9 @@ msgstr "Lasse %s mit Backup-Suffix '%s' aus.\n"
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Wollen Sie %s wirklich versenden? [y|N]: "
+
+#~ msgid "Counting distinct commits in commit graph"
+#~ msgstr "Zähle Commits in Commit-Graph"
+
+#~ msgid "the commit graph format cannot write %d commits"
+#~ msgstr "das Commit-Graph Format kann nicht %d Commits schreiben"


### PR DESCRIPTION
@ralfth and @PhillipSz: please have a look at my suggestions for the German translation of Git 2.30.0. Only the commit 82e73d3857 needs to be reviewed, the other commit is the automatically generated one to update the po file.
The release of Git 2.23.0 is planned for Dec 28th, so I would send the pull request upstream before the next weekend (Dec 25th at the latest).

As always I also cleaned up some other translations that were not related to the current update. Those changes are proposed as best practises by the software poedit (which is also used by other translation teams).
I would consider also switching to poedit on the long-term since the software could help me a lot for some translations and we could implement some best practices.