### PR TITLE
Update German translation for Git v2.31.0

### DIFF
--- a/Documentation/RelNotes/2.31.0.txt
+++ b/Documentation/RelNotes/2.31.0.txt
@@ -197,6 +197,31 @@ Performance, Internal Implementation, Development Support etc.
  * The code to implement "git merge-base --independent" was poorly
    done and was kept from the very beginning of the feature.
 
+ * Preliminary changes to fsmonitor integration.
+
+ * Performance optimization work on the rename detection continues.
+
+ * The common code to deal with "chunked file format" that is shared
+   by the multi-pack-index and commit-graph files have been factored
+   out, to help codepaths for both filetypes to become more robust.
+
+ * The approach to "fsck" the incoming objects in "index-pack" is
+   attractive for performance reasons (we have them already in core,
+   inflated and ready to be inspected), but fundamentally cannot be
+   applied fully when we receive more than one pack stream, as a tree
+   object in one pack may refer to a blob object in another pack as
+   ".gitmodules", when we want to inspect blobs that are used as
+   ".gitmodules" file, for example.  Teach "index-pack" to emit
+   objects that must be inspected later and check them in the calling
+   "fetch-pack" process.
+
+ * The logic to handle "trailer" related placeholders in the
+   "--format=" mechanisms in the "log" family and "for-each-ref"
+   family is getting unified.
+
+ * Raise the buffer size used when writing the index file out from
+   (obviously too small) 8kB to (clearly sufficiently large) 128kB.
+
 
 Fixes since v2.30
 -----------------
@@ -317,6 +342,12 @@ Fixes since v2.30
    error, but instead turned into a matching push, which has been
    corrected.
    (merge 20e416409f jc/push-delete-nothing later to maint).
+
+ * Test script modernization.
+   (merge 488acf15df sv/t7001-modernize later to maint).
+
+ * An under-allocation for the untracked cache data has been corrected.
+   (merge 6347d649bc jh/untracked-cache-fix later to maint).
 
  * Other code cleanup, docfix, build fix, etc.
    (merge e3f5da7e60 sg/t7800-difftool-robustify later to maint).

--- a/Documentation/git-for-each-ref.txt
+++ b/Documentation/git-for-each-ref.txt
@@ -260,11 +260,9 @@ contents:lines=N::
 	The first `N` lines of the message.
 
 Additionally, the trailers as interpreted by linkgit:git-interpret-trailers[1]
-are obtained as `trailers` (or by using the historical alias
-`contents:trailers`).  Non-trailer lines from the trailer block can be omitted
-with `trailers:only`. Whitespace-continuations can be removed from trailers so
-that each trailer appears on a line by itself with its full content with
-`trailers:unfold`. Both can be used together as `trailers:unfold,only`.
+are obtained as `trailers[:options]` (or by using the historical alias
+`contents:trailers[:options]`). For valid [:option] values see `trailers`
+section of linkgit:git-log[1].
 
 For sorting purposes, fields with numeric values sort in numeric order
 (`objectsize`, `authordate`, `committerdate`, `creatordate`, `taggerdate`).

--- a/Documentation/git-http-fetch.txt
+++ b/Documentation/git-http-fetch.txt
@@ -41,11 +41,17 @@ commit-id::
 		<commit-id>['\t'<filename-as-in--w>]
 
 --packfile=<hash>::
-	Instead of a commit id on the command line (which is not expected in
+	For internal use only. Instead of a commit id on the command
+	line (which is not expected in
 	this case), 'git http-fetch' fetches the packfile directly at the given
 	URL and uses index-pack to generate corresponding .idx and .keep files.
 	The hash is used to determine the name of the temporary file and is
-	arbitrary. The output of index-pack is printed to stdout.
+	arbitrary. The output of index-pack is printed to stdout. Requires
+	--index-pack-args.
+
+--index-pack-args=<args>::
+	For internal use only. The command to run on the contents of the
+	downloaded pack. Arguments are URL-encoded separated by spaces.
 
 --recover::
 	Verify that everything reachable from target is fetched.  Used after

--- a/Documentation/git-index-pack.txt
+++ b/Documentation/git-index-pack.txt
@@ -78,7 +78,12 @@ OPTIONS
 	Die if the pack contains broken links. For internal use only.
 
 --fsck-objects::
-	Die if the pack contains broken objects. For internal use only.
+	For internal use only.
++
+Die if the pack contains broken objects. If the pack contains a tree
+pointing to a .gitmodules blob that does not exist, prints the hash of
+that blob (for the caller to check) after the hash that goes into the
+name of the pack/idx file (see "Notes").
 
 --threads=<n>::
 	Specifies the number of threads to spawn when resolving

--- a/Documentation/gitdiffcore.txt
+++ b/Documentation/gitdiffcore.txt
@@ -168,6 +168,26 @@ a similarity score different from the default of 50% by giving a
 number after the "-M" or "-C" option (e.g. "-M8" to tell it to use
 8/10 = 80%).
 
+Note that when rename detection is on but both copy and break
+detection are off, rename detection adds a preliminary step that first
+checks if files are moved across directories while keeping their
+filename the same.  If there is a file added to a directory whose
+contents is sufficiently similar to a file with the same name that got
+deleted from a different directory, it will mark them as renames and
+exclude them from the later quadratic step (the one that pairwise
+compares all unmatched files to find the "best" matches, determined by
+the highest content similarity).  So, for example, if a deleted
+docs/ext.txt and an added docs/config/ext.txt are similar enough, they
+will be marked as a rename and prevent an added docs/ext.md that may
+be even more similar to the deleted docs/ext.txt from being considered
+as the rename destination in the later step.  For this reason, the
+preliminary "match same filename" step uses a bit higher threshold to
+mark a file pair as a rename and stop considering other candidates for
+better matches.  At most, one comparison is done per file in this
+preliminary pass; so if there are several remaining ext.txt files
+throughout the directory hierarchy after exact rename detection, this
+preliminary step will be skipped for those files.
+
 Note.  When the "-C" option is used with `--find-copies-harder`
 option, 'git diff-{asterisk}' commands feed unmodified filepairs to
 diffcore mechanism as well as modified ones.  This lets the copy

--- a/Documentation/technical/chunk-format.txt
+++ b/Documentation/technical/chunk-format.txt
@@ -1,0 +1,116 @@
+Chunk-based file formats
+========================
+
+Some file formats in Git use a common concept of "chunks" to describe
+sections of the file. This allows structured access to a large file by
+scanning a small "table of contents" for the remaining data. This common
+format is used by the `commit-graph` and `multi-pack-index` files. See
+link:technical/pack-format.html[the `multi-pack-index` format] and
+link:technical/commit-graph-format.html[the `commit-graph` format] for
+how they use the chunks to describe structured data.
+
+A chunk-based file format begins with some header information custom to
+that format. That header should include enough information to identify
+the file type, format version, and number of chunks in the file. From this
+information, that file can determine the start of the chunk-based region.
+
+The chunk-based region starts with a table of contents describing where
+each chunk starts and ends. This consists of (C+1) rows of 12 bytes each,
+where C is the number of chunks. Consider the following table:
+
+  | Chunk ID (4 bytes) | Chunk Offset (8 bytes) |
+  |--------------------|------------------------|
+  | ID[0]              | OFFSET[0]              |
+  | ...                | ...                    |
+  | ID[C]              | OFFSET[C]              |
+  | 0x0000             | OFFSET[C+1]            |
+
+Each row consists of a 4-byte chunk identifier (ID) and an 8-byte offset.
+Each integer is stored in network-byte order.
+
+The chunk identifier `ID[i]` is a label for the data stored within this
+fill from `OFFSET[i]` (inclusive) to `OFFSET[i+1]` (exclusive). Thus, the
+size of the `i`th chunk is equal to the difference between `OFFSET[i+1]`
+and `OFFSET[i]`. This requires that the chunk data appears contiguously
+in the same order as the table of contents.
+
+The final entry in the table of contents must be four zero bytes. This
+confirms that the table of contents is ending and provides the offset for
+the end of the chunk-based data.
+
+Note: The chunk-based format expects that the file contains _at least_ a
+trailing hash after `OFFSET[C+1]`.
+
+Functions for working with chunk-based file formats are declared in
+`chunk-format.h`. Using these methods provide extra checks that assist
+developers when creating new file formats.
+
+Writing chunk-based file formats
+--------------------------------
+
+To write a chunk-based file format, create a `struct chunkfile` by
+calling `init_chunkfile()` and pass a `struct hashfile` pointer. The
+caller is responsible for opening the `hashfile` and writing header
+information so the file format is identifiable before the chunk-based
+format begins.
+
+Then, call `add_chunk()` for each chunk that is intended for write. This
+populates the `chunkfile` with information about the order and size of
+each chunk to write. Provide a `chunk_write_fn` function pointer to
+perform the write of the chunk data upon request.
+
+Call `write_chunkfile()` to write the table of contents to the `hashfile`
+followed by each of the chunks. This will verify that each chunk wrote
+the expected amount of data so the table of contents is correct.
+
+Finally, call `free_chunkfile()` to clear the `struct chunkfile` data. The
+caller is responsible for finalizing the `hashfile` by writing the trailing
+hash and closing the file.
+
+Reading chunk-based file formats
+--------------------------------
+
+To read a chunk-based file format, the file must be opened as a
+memory-mapped region. The chunk-format API expects that the entire file
+is mapped as a contiguous memory region.
+
+Initialize a `struct chunkfile` pointer with `init_chunkfile(NULL)`.
+
+After reading the header information from the beginning of the file,
+including the chunk count, call `read_table_of_contents()` to populate
+the `struct chunkfile` with the list of chunks, their offsets, and their
+sizes.
+
+Extract the data information for each chunk using `pair_chunk()` or
+`read_chunk()`:
+
+* `pair_chunk()` assigns a given pointer with the location inside the
+  memory-mapped file corresponding to that chunk's offset. If the chunk
+  does not exist, then the pointer is not modified.
+
+* `read_chunk()` takes a `chunk_read_fn` function pointer and calls it
+  with the appropriate initial pointer and size information. The function
+  is not called if the chunk does not exist. Use this method to read chunks
+  if you need to perform immediate parsing or if you need to execute logic
+  based on the size of the chunk.
+
+After calling these methods, call `free_chunkfile()` to clear the
+`struct chunkfile` data. This will not close the memory-mapped region.
+Callers are expected to own that data for the timeframe the pointers into
+the region are needed.
+
+Examples
+--------
+
+These file formats use the chunk-format API, and can be used as examples
+for future formats:
+
+* *commit-graph:* see `write_commit_graph_file()` and `parse_commit_graph()`
+  in `commit-graph.c` for how the chunk-format API is used to write and
+  parse the commit-graph file format documented in
+  link:technical/commit-graph-format.html[the commit-graph file format].
+
+* *multi-pack-index:* see `write_midx_internal()` and `load_multi_pack_index()`
+  in `midx.c` for how the chunk-format API is used to write and
+  parse the multi-pack-index file format documented in
+  link:technical/pack-format.html[the multi-pack-index file format].

--- a/Documentation/technical/commit-graph-format.txt
+++ b/Documentation/technical/commit-graph-format.txt
@@ -61,6 +61,9 @@ CHUNK LOOKUP:
       the length using the next chunk position if necessary.) Each chunk
       ID appears at most once.
 
+  The CHUNK LOOKUP matches the table of contents from
+  link:technical/chunk-format.html[the chunk-based file format].
+
   The remaining data in the body is described one chunk at a time, and
   these chunks may be given in any order. Chunks are required unless
   otherwise specified.

--- a/Documentation/technical/pack-format.txt
+++ b/Documentation/technical/pack-format.txt
@@ -301,6 +301,9 @@ CHUNK LOOKUP:
 	    (Chunks are provided in file-order, so you can infer the length
 	    using the next chunk position if necessary.)
 
+	The CHUNK LOOKUP matches the table of contents from
+	link:technical/chunk-format.html[the chunk-based file format].
+
 	The remaining data in the body is described one chunk at a time, and
 	these chunks may be given in any order. Chunks are required unless
 	otherwise specified.

--- a/Documentation/technical/reftable.txt
+++ b/Documentation/technical/reftable.txt
@@ -872,17 +872,11 @@ A repository must set its `$GIT_DIR/config` to configure reftable:
 Layout
 ^^^^^^
 
-A collection of reftable files are stored in the `$GIT_DIR/reftable/`
-directory:
-
-....
-00000001-00000001.log
-00000002-00000002.ref
-00000003-00000003.ref
-....
-
-where reftable files are named by a unique name such as produced by the
-function `${min_update_index}-${max_update_index}.ref`.
+A collection of reftable files are stored in the `$GIT_DIR/reftable/` directory.
+Their names should have a random element, such that each filename is globally
+unique; this helps avoid spurious failures on Windows, where open files cannot
+be removed or overwritten. It suggested to use
+`${min_update_index}-${max_update_index}-${random}.ref` as a naming convention.
 
 Log-only files use the `.log` extension, while ref-only and mixed ref
 and log files use `.ref`. extension.
@@ -893,9 +887,9 @@ current files, one per line, in order, from oldest (base) to newest
 
 ....
 $ cat .git/reftable/tables.list
-00000001-00000001.log
-00000002-00000002.ref
-00000003-00000003.ref
+00000001-00000001-RANDOM1.log
+00000002-00000002-RANDOM2.ref
+00000003-00000003-RANDOM3.ref
 ....
 
 Readers must read `$GIT_DIR/reftable/tables.list` to determine which
@@ -940,7 +934,7 @@ new reftable and atomically appending it to the stack:
 3.  Select `update_index` to be most recent file's
 `max_update_index + 1`.
 4.  Prepare temp reftable `tmp_XXXXXX`, including log entries.
-5.  Rename `tmp_XXXXXX` to `${update_index}-${update_index}.ref`.
+5.  Rename `tmp_XXXXXX` to `${update_index}-${update_index}-${random}.ref`.
 6.  Copy `tables.list` to `tables.list.lock`, appending file from (5).
 7.  Rename `tables.list.lock` to `tables.list`.
 
@@ -993,7 +987,7 @@ prevents other processes from trying to compact these files.
 should always be the case, assuming that other processes are adhering to
 the locking protocol.
 7.  Rename `${min_update_index}-${max_update_index}_XXXXXX` to
-`${min_update_index}-${max_update_index}.ref`.
+`${min_update_index}-${max_update_index}-${random}.ref`.
 8.  Write the new stack to `tables.list.lock`, replacing `B` and `C`
 with the file from (4).
 9.  Rename `tables.list.lock` to `tables.list`.
@@ -1004,6 +998,22 @@ This strategy permits compactions to proceed independently of updates.
 
 Each reftable (compacted or not) is uniquely identified by its name, so
 open reftables can be cached by their name.
+
+Windows
+^^^^^^^
+
+On windows, and other systems that do not allow deleting or renaming to open
+files, compaction may succeed, but other readers may prevent obsolete tables
+from being deleted.
+
+On these platforms, the following strategy can be followed: on closing a
+reftable stack, reload `tables.list`, and delete any tables no longer mentioned
+in `tables.list`.
+
+Irregular program exit may still leave about unused files. In this case, a
+cleanup operation can read `tables.list`, note its modification timestamp, and
+delete any unreferenced `*.ref` files that are older.
+
 
 Alternatives considered
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/GIT-VERSION-GEN
+++ b/GIT-VERSION-GEN
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 GVF=GIT-VERSION-FILE
-DEF_VER=v2.31.0-rc0
+DEF_VER=v2.31.0-rc1
 
 LF='
 '

--- a/Makefile
+++ b/Makefile
@@ -854,6 +854,7 @@ LIB_OBJS += bundle.o
 LIB_OBJS += cache-tree.o
 LIB_OBJS += chdir-notify.o
 LIB_OBJS += checkout.o
+LIB_OBJS += chunk-format.o
 LIB_OBJS += color.o
 LIB_OBJS += column.o
 LIB_OBJS += combine-diff.o

--- a/builtin/index-pack.c
+++ b/builtin/index-pack.c
@@ -1693,6 +1693,22 @@ static void show_pack_info(int stat_only)
 	}
 }
 
+static int print_dangling_gitmodules(struct fsck_options *o,
+				     const struct object_id *oid,
+				     enum object_type object_type,
+				     int msg_type, const char *message)
+{
+	/*
+	 * NEEDSWORK: Plumb the MSG_ID (from fsck.c) here and use it
+	 * instead of relying on this string check.
+	 */
+	if (starts_with(message, "gitmodulesMissing")) {
+		printf("%s\n", oid_to_hex(oid));
+		return 0;
+	}
+	return fsck_error_function(o, oid, object_type, msg_type, message);
+}
+
 int cmd_index_pack(int argc, const char **argv, const char *prefix)
 {
 	int i, fix_thin_pack = 0, verify = 0, stat_only = 0;
@@ -1888,8 +1904,13 @@ int cmd_index_pack(int argc, const char **argv, const char *prefix)
 	else
 		close(input_fd);
 
-	if (do_fsck_object && fsck_finish(&fsck_options))
-		die(_("fsck error in pack objects"));
+	if (do_fsck_object) {
+		struct fsck_options fo = fsck_options;
+
+		fo.error_func = print_dangling_gitmodules;
+		if (fsck_finish(&fo))
+			die(_("fsck error in pack objects"));
+	}
 
 	free(objects);
 	strbuf_release(&index_name_buf);

--- a/builtin/receive-pack.c
+++ b/builtin/receive-pack.c
@@ -2275,7 +2275,7 @@ static const char *unpack(int err_fd, struct shallow_info *si)
 		status = start_command(&child);
 		if (status)
 			return "index-pack fork failed";
-		pack_lockfile = index_pack_lockfile(child.out);
+		pack_lockfile = index_pack_lockfile(child.out, NULL);
 		close(child.out);
 		status = finish_command(&child);
 		if (status)

--- a/chunk-format.c
+++ b/chunk-format.c
@@ -1,0 +1,90 @@
+#include "cache.h"
+#include "chunk-format.h"
+#include "csum-file.h"
+
+/*
+ * When writing a chunk-based file format, collect the chunks in
+ * an array of chunk_info structs. The size stores the _expected_
+ * amount of data that will be written by write_fn.
+ */
+struct chunk_info {
+	uint32_t id;
+	uint64_t size;
+	chunk_write_fn write_fn;
+};
+
+struct chunkfile {
+	struct hashfile *f;
+
+	struct chunk_info *chunks;
+	size_t chunks_nr;
+	size_t chunks_alloc;
+};
+
+struct chunkfile *init_chunkfile(struct hashfile *f)
+{
+	struct chunkfile *cf = xcalloc(1, sizeof(*cf));
+	cf->f = f;
+	return cf;
+}
+
+void free_chunkfile(struct chunkfile *cf)
+{
+	if (!cf)
+		return;
+	free(cf->chunks);
+	free(cf);
+}
+
+int get_num_chunks(struct chunkfile *cf)
+{
+	return cf->chunks_nr;
+}
+
+void add_chunk(struct chunkfile *cf,
+	       uint32_t id,
+	       size_t size,
+	       chunk_write_fn fn)
+{
+	ALLOC_GROW(cf->chunks, cf->chunks_nr + 1, cf->chunks_alloc);
+
+	cf->chunks[cf->chunks_nr].id = id;
+	cf->chunks[cf->chunks_nr].write_fn = fn;
+	cf->chunks[cf->chunks_nr].size = size;
+	cf->chunks_nr++;
+}
+
+int write_chunkfile(struct chunkfile *cf, void *data)
+{
+	int i;
+	uint64_t cur_offset = hashfile_total(cf->f);
+
+	/* Add the table of contents to the current offset */
+	cur_offset += (cf->chunks_nr + 1) * CHUNK_TOC_ENTRY_SIZE;
+
+	for (i = 0; i < cf->chunks_nr; i++) {
+		hashwrite_be32(cf->f, cf->chunks[i].id);
+		hashwrite_be64(cf->f, cur_offset);
+
+		cur_offset += cf->chunks[i].size;
+	}
+
+	/* Trailing entry marks the end of the chunks */
+	hashwrite_be32(cf->f, 0);
+	hashwrite_be64(cf->f, cur_offset);
+
+	for (i = 0; i < cf->chunks_nr; i++) {
+		off_t start_offset = hashfile_total(cf->f);
+		int result = cf->chunks[i].write_fn(cf->f, data);
+
+		if (result)
+			return result;
+
+		if (hashfile_total(cf->f) - start_offset != cf->chunks[i].size)
+			BUG("expected to write %"PRId64" bytes to chunk %"PRIx32", but wrote %"PRId64" instead",
+			    cf->chunks[i].size, cf->chunks[i].id,
+			    hashfile_total(cf->f) - start_offset);
+	}
+
+	return 0;
+}

--- a/chunk-format.c
+++ b/chunk-format.c
@@ -97,6 +97,7 @@ int read_table_of_contents(struct chunkfile *cf,
 			   uint64_t toc_offset,
 			   int toc_length)
 {
+	int i;
 	uint32_t chunk_id;
 	const unsigned char *table_of_contents = mfile + toc_offset;
 
@@ -121,6 +122,14 @@ int read_table_of_contents(struct chunkfile *cf,
 			error(_("improper chunk offset(s) %"PRIx64" and %"PRIx64""),
 			      chunk_offset, next_chunk_offset);
 			return -1;
+		}
+
+		for (i = 0; i < cf->chunks_nr; i++) {
+			if (cf->chunks[i].id == chunk_id) {
+				error(_("duplicate chunk ID %"PRIx32" found"),
+					chunk_id);
+				return -1;
+			}
 		}
 
 		cf->chunks[cf->chunks_nr].id = chunk_id;

--- a/chunk-format.h
+++ b/chunk-format.h
@@ -8,6 +8,20 @@ struct chunkfile;
 
 #define CHUNK_TOC_ENTRY_SIZE (sizeof(uint32_t) + sizeof(uint64_t))
 
+/*
+ * Initialize a 'struct chunkfile' for writing _or_ reading a file
+ * with the chunk format.
+ *
+ * If writing a file, supply a non-NULL 'struct hashfile *' that will
+ * be used to write.
+ *
+ * If reading a file, use a NULL 'struct hashfile *' and then call
+ * read_table_of_contents(). Supply the memory-mapped data to the
+ * pair_chunk() or read_chunk() methods, as appropriate.
+ *
+ * DO NOT MIX THESE MODES. Use different 'struct chunkfile' instances
+ * for reading and writing.
+ */
 struct chunkfile *init_chunkfile(struct hashfile *f);
 void free_chunkfile(struct chunkfile *cf);
 int get_num_chunks(struct chunkfile *cf);
@@ -17,5 +31,38 @@ void add_chunk(struct chunkfile *cf,
 	       size_t size,
 	       chunk_write_fn fn);
 int write_chunkfile(struct chunkfile *cf, void *data);
+
+int read_table_of_contents(struct chunkfile *cf,
+			   const unsigned char *mfile,
+			   size_t mfile_size,
+			   uint64_t toc_offset,
+			   int toc_length);
+
+#define CHUNK_NOT_FOUND (-2)
+
+/*
+ * Find 'chunk_id' in the given chunkfile and assign the
+ * given pointer to the position in the mmap'd file where
+ * that chunk begins.
+ *
+ * Returns CHUNK_NOT_FOUND if the chunk does not exist.
+ */
+int pair_chunk(struct chunkfile *cf,
+	       uint32_t chunk_id,
+	       const unsigned char **p);
+
+typedef int (*chunk_read_fn)(const unsigned char *chunk_start,
+			     size_t chunk_size, void *data);
+/*
+ * Find 'chunk_id' in the given chunkfile and call the
+ * given chunk_read_fn method with the information for
+ * that chunk.
+ *
+ * Returns CHUNK_NOT_FOUND if the chunk does not exist.
+ */
+int read_chunk(struct chunkfile *cf,
+	       uint32_t chunk_id,
+	       chunk_read_fn fn,
+	       void *data);
 
 #endif

--- a/chunk-format.h
+++ b/chunk-format.h
@@ -1,0 +1,21 @@
+#ifndef CHUNK_FORMAT_H
+#define CHUNK_FORMAT_H
+
+#include "git-compat-util.h"
+
+struct hashfile;
+struct chunkfile;
+
+#define CHUNK_TOC_ENTRY_SIZE (sizeof(uint32_t) + sizeof(uint64_t))
+
+struct chunkfile *init_chunkfile(struct hashfile *f);
+void free_chunkfile(struct chunkfile *cf);
+int get_num_chunks(struct chunkfile *cf);
+typedef int (*chunk_write_fn)(struct hashfile *f, void *data);
+void add_chunk(struct chunkfile *cf,
+	       uint32_t id,
+	       size_t size,
+	       chunk_write_fn fn);
+int write_chunkfile(struct chunkfile *cf, void *data);
+
+#endif

--- a/commit-graph.c
+++ b/commit-graph.c
@@ -1715,7 +1715,6 @@ static int write_commit_graph_file(struct write_commit_graph_context *ctx)
 	struct lock_file lk = LOCK_INIT;
 	const unsigned hashsz = the_hash_algo->rawsz;
 	struct strbuf progress_title = STRBUF_INIT;
-	int num_chunks = 3;
 	struct object_id file_hash;
 	struct chunkfile *cf;
 
@@ -1811,11 +1810,11 @@ static int write_commit_graph_file(struct write_commit_graph_context *ctx)
 		strbuf_addf(&progress_title,
 			    Q_("Writing out commit graph in %d pass",
 			       "Writing out commit graph in %d passes",
-			       num_chunks),
-			    num_chunks);
+			       get_num_chunks(cf)),
+			    get_num_chunks(cf));
 		ctx->progress = start_delayed_progress(
 			progress_title.buf,
-			num_chunks * ctx->commits.nr);
+			get_num_chunks(cf) * ctx->commits.nr);
 	}
 
 	write_chunkfile(cf, ctx);

--- a/commit-graph.c
+++ b/commit-graph.c
@@ -59,8 +59,7 @@ void git_test_write_commit_graph_or_die(void)
 
 #define GRAPH_HEADER_SIZE 8
 #define GRAPH_FANOUT_SIZE (4 * 256)
-#define GRAPH_CHUNKLOOKUP_WIDTH 12
-#define GRAPH_MIN_SIZE (GRAPH_HEADER_SIZE + 4 * GRAPH_CHUNKLOOKUP_WIDTH \
+#define GRAPH_MIN_SIZE (GRAPH_HEADER_SIZE + 4 * CHUNK_TOC_ENTRY_SIZE \
 			+ GRAPH_FANOUT_SIZE + the_hash_algo->rawsz)
 
 #define CORRECTED_COMMIT_DATE_OFFSET_OVERFLOW (1ULL << 31)
@@ -298,15 +297,43 @@ static int verify_commit_graph_lite(struct commit_graph *g)
 	return 0;
 }
 
+static int graph_read_oid_lookup(const unsigned char *chunk_start,
+				 size_t chunk_size, void *data)
+{
+	struct commit_graph *g = data;
+	g->chunk_oid_lookup = chunk_start;
+	g->num_commits = chunk_size / g->hash_len;
+	return 0;
+}
+
+static int graph_read_bloom_data(const unsigned char *chunk_start,
+				  size_t chunk_size, void *data)
+{
+	struct commit_graph *g = data;
+	uint32_t hash_version;
+	g->chunk_bloom_data = chunk_start;
+	hash_version = get_be32(chunk_start);
+
+	if (hash_version != 1)
+		return 0;
+
+	g->bloom_filter_settings = xmalloc(sizeof(struct bloom_filter_settings));
+	g->bloom_filter_settings->hash_version = hash_version;
+	g->bloom_filter_settings->num_hashes = get_be32(chunk_start + 4);
+	g->bloom_filter_settings->bits_per_entry = get_be32(chunk_start + 8);
+	g->bloom_filter_settings->max_changed_paths = DEFAULT_BLOOM_MAX_CHANGES;
+
+	return 0;
+}
+
 struct commit_graph *parse_commit_graph(struct repository *r,
 					void *graph_map, size_t graph_size)
 {
-	const unsigned char *data, *chunk_lookup;
-	uint32_t i;
+	const unsigned char *data;
 	struct commit_graph *graph;
-	uint64_t next_chunk_offset;
 	uint32_t graph_signature;
 	unsigned char graph_version, hash_version;
+	struct chunkfile *cf = NULL;
 
 	if (!graph_map)
 		return NULL;
@@ -347,7 +374,7 @@ struct commit_graph *parse_commit_graph(struct repository *r,
 	graph->data_len = graph_size;
 
 	if (graph_size < GRAPH_HEADER_SIZE +
-			 (graph->num_chunks + 1) * GRAPH_CHUNKLOOKUP_WIDTH +
+			 (graph->num_chunks + 1) * CHUNK_TOC_ENTRY_SIZE +
 			 GRAPH_FANOUT_SIZE + the_hash_algo->rawsz) {
 		error(_("commit-graph file is too small to hold %u chunks"),
 		      graph->num_chunks);
@@ -355,108 +382,28 @@ struct commit_graph *parse_commit_graph(struct repository *r,
 		return NULL;
 	}
 
-	chunk_lookup = data + 8;
-	next_chunk_offset = get_be64(chunk_lookup + 4);
-	for (i = 0; i < graph->num_chunks; i++) {
-		uint32_t chunk_id;
-		uint64_t chunk_offset = next_chunk_offset;
-		int chunk_repeated = 0;
+	cf = init_chunkfile(NULL);
 
-		chunk_id = get_be32(chunk_lookup + 0);
+	if (read_table_of_contents(cf, graph->data, graph_size,
+				   GRAPH_HEADER_SIZE, graph->num_chunks))
+		goto free_and_return;
 
-		chunk_lookup += GRAPH_CHUNKLOOKUP_WIDTH;
-		next_chunk_offset = get_be64(chunk_lookup + 4);
+	pair_chunk(cf, GRAPH_CHUNKID_OIDFANOUT,
+		   (const unsigned char **)&graph->chunk_oid_fanout);
+	read_chunk(cf, GRAPH_CHUNKID_OIDLOOKUP, graph_read_oid_lookup, graph);
+	pair_chunk(cf, GRAPH_CHUNKID_DATA, &graph->chunk_commit_data);
+	pair_chunk(cf, GRAPH_CHUNKID_EXTRAEDGES, &graph->chunk_extra_edges);
+	pair_chunk(cf, GRAPH_CHUNKID_BASE, &graph->chunk_base_graphs);
+	pair_chunk(cf, GRAPH_CHUNKID_GENERATION_DATA,
+		   &graph->chunk_generation_data);
+	pair_chunk(cf, GRAPH_CHUNKID_GENERATION_DATA_OVERFLOW,
+		   &graph->chunk_generation_data_overflow);
 
-		if (chunk_offset > graph_size - the_hash_algo->rawsz) {
-			error(_("commit-graph improper chunk offset %08x%08x"), (uint32_t)(chunk_offset >> 32),
-			      (uint32_t)chunk_offset);
-			goto free_and_return;
-		}
-
-		switch (chunk_id) {
-		case GRAPH_CHUNKID_OIDFANOUT:
-			if (graph->chunk_oid_fanout)
-				chunk_repeated = 1;
-			else
-				graph->chunk_oid_fanout = (uint32_t*)(data + chunk_offset);
-			break;
-
-		case GRAPH_CHUNKID_OIDLOOKUP:
-			if (graph->chunk_oid_lookup)
-				chunk_repeated = 1;
-			else {
-				graph->chunk_oid_lookup = data + chunk_offset;
-				graph->num_commits = (next_chunk_offset - chunk_offset)
-						     / graph->hash_len;
-			}
-			break;
-
-		case GRAPH_CHUNKID_DATA:
-			if (graph->chunk_commit_data)
-				chunk_repeated = 1;
-			else
-				graph->chunk_commit_data = data + chunk_offset;
-			break;
-
-		case GRAPH_CHUNKID_GENERATION_DATA:
-			if (graph->chunk_generation_data)
-				chunk_repeated = 1;
-			else
-				graph->chunk_generation_data = data + chunk_offset;
-			break;
-
-		case GRAPH_CHUNKID_GENERATION_DATA_OVERFLOW:
-			if (graph->chunk_generation_data_overflow)
-				chunk_repeated = 1;
-			else
-				graph->chunk_generation_data_overflow = data + chunk_offset;
-			break;
-
-		case GRAPH_CHUNKID_EXTRAEDGES:
-			if (graph->chunk_extra_edges)
-				chunk_repeated = 1;
-			else
-				graph->chunk_extra_edges = data + chunk_offset;
-			break;
-
-		case GRAPH_CHUNKID_BASE:
-			if (graph->chunk_base_graphs)
-				chunk_repeated = 1;
-			else
-				graph->chunk_base_graphs = data + chunk_offset;
-			break;
-
-		case GRAPH_CHUNKID_BLOOMINDEXES:
-			if (graph->chunk_bloom_indexes)
-				chunk_repeated = 1;
-			else if (r->settings.commit_graph_read_changed_paths)
-				graph->chunk_bloom_indexes = data + chunk_offset;
-			break;
-
-		case GRAPH_CHUNKID_BLOOMDATA:
-			if (graph->chunk_bloom_data)
-				chunk_repeated = 1;
-			else if (r->settings.commit_graph_read_changed_paths) {
-				uint32_t hash_version;
-				graph->chunk_bloom_data = data + chunk_offset;
-				hash_version = get_be32(data + chunk_offset);
-
-				if (hash_version != 1)
-					break;
-
-				graph->bloom_filter_settings = xmalloc(sizeof(struct bloom_filter_settings));
-				graph->bloom_filter_settings->hash_version = hash_version;
-				graph->bloom_filter_settings->num_hashes = get_be32(data + chunk_offset + 4);
-				graph->bloom_filter_settings->bits_per_entry = get_be32(data + chunk_offset + 8);
-				graph->bloom_filter_settings->max_changed_paths = DEFAULT_BLOOM_MAX_CHANGES;
-			}
-			break;
-		}
-
-		if (chunk_repeated) {
-			error(_("commit-graph chunk id %08x appears multiple times"), chunk_id);
-			goto free_and_return;
-		}
+	if (r->settings.commit_graph_read_changed_paths) {
+		pair_chunk(cf, GRAPH_CHUNKID_BLOOMINDEXES,
+			   &graph->chunk_bloom_indexes);
+		read_chunk(cf, GRAPH_CHUNKID_BLOOMDATA,
+			   graph_read_bloom_data, graph);
 	}
 
 	if (graph->chunk_bloom_indexes && graph->chunk_bloom_data) {
@@ -473,9 +420,11 @@ struct commit_graph *parse_commit_graph(struct repository *r,
 	if (verify_commit_graph_lite(graph))
 		goto free_and_return;
 
+	free_chunkfile(cf);
 	return graph;
 
 free_and_return:
+	free_chunkfile(cf);
 	free(graph->bloom_filter_settings);
 	free(graph);
 	return NULL;

--- a/commit-graph.c
+++ b/commit-graph.c
@@ -205,24 +205,16 @@ static int commit_graph_compatible(struct repository *r)
 
 	if (read_replace_refs) {
 		prepare_replace_object(r);
-		if (hashmap_get_size(&r->objects->replace_map->map)) {
-			warning(_("repository contains replace objects; "
-			       "skipping commit-graph"));
+		if (hashmap_get_size(&r->objects->replace_map->map))
 			return 0;
-		}
 	}
 
 	prepare_commit_graft(r);
 	if (r->parsed_objects &&
-	    (r->parsed_objects->grafts_nr || r->parsed_objects->substituted_parent)) {
-		warning(_("repository contains (deprecated) grafts; "
-		       "skipping commit-graph"));
+	    (r->parsed_objects->grafts_nr || r->parsed_objects->substituted_parent))
 		return 0;
-	}
-	if (is_repository_shallow(r)) {
-		warning(_("repository is shallow; skipping commit-graph"));
+	if (is_repository_shallow(r))
 		return 0;
-	}
 
 	return 1;
 }

--- a/commit-graph.c
+++ b/commit-graph.c
@@ -1040,8 +1040,9 @@ struct write_commit_graph_context {
 };
 
 static int write_graph_chunk_fanout(struct hashfile *f,
-				    struct write_commit_graph_context *ctx)
+				    void *data)
 {
+	struct write_commit_graph_context *ctx = data;
 	int i, count = 0;
 	struct commit **list = ctx->commits.list;
 
@@ -1066,8 +1067,9 @@ static int write_graph_chunk_fanout(struct hashfile *f,
 }
 
 static int write_graph_chunk_oids(struct hashfile *f,
-				  struct write_commit_graph_context *ctx)
+				  void *data)
 {
+	struct write_commit_graph_context *ctx = data;
 	struct commit **list = ctx->commits.list;
 	int count;
 	for (count = 0; count < ctx->commits.nr; count++, list++) {
@@ -1085,8 +1087,9 @@ static const unsigned char *commit_to_sha1(size_t index, void *table)
 }
 
 static int write_graph_chunk_data(struct hashfile *f,
-				  struct write_commit_graph_context *ctx)
+				  void *data)
 {
+	struct write_commit_graph_context *ctx = data;
 	struct commit **list = ctx->commits.list;
 	struct commit **last = ctx->commits.list + ctx->commits.nr;
 	uint32_t num_extra_edges = 0;
@@ -1187,8 +1190,9 @@ static int write_graph_chunk_data(struct hashfile *f,
 }
 
 static int write_graph_chunk_generation_data(struct hashfile *f,
-					      struct write_commit_graph_context *ctx)
+					     void *data)
 {
+	struct write_commit_graph_context *ctx = data;
 	int i, num_generation_data_overflows = 0;
 
 	for (i = 0; i < ctx->commits.nr; i++) {
@@ -1208,8 +1212,9 @@ static int write_graph_chunk_generation_data(struct hashfile *f,
 }
 
 static int write_graph_chunk_generation_data_overflow(struct hashfile *f,
-						       struct write_commit_graph_context *ctx)
+						      void *data)
 {
+	struct write_commit_graph_context *ctx = data;
 	int i;
 	for (i = 0; i < ctx->commits.nr; i++) {
 		struct commit *c = ctx->commits.list[i];
@@ -1226,8 +1231,9 @@ static int write_graph_chunk_generation_data_overflow(struct hashfile *f,
 }
 
 static int write_graph_chunk_extra_edges(struct hashfile *f,
-					 struct write_commit_graph_context *ctx)
+					 void *data)
 {
+	struct write_commit_graph_context *ctx = data;
 	struct commit **list = ctx->commits.list;
 	struct commit **last = ctx->commits.list + ctx->commits.nr;
 	struct commit_list *parent;
@@ -1280,8 +1286,9 @@ static int write_graph_chunk_extra_edges(struct hashfile *f,
 }
 
 static int write_graph_chunk_bloom_indexes(struct hashfile *f,
-					   struct write_commit_graph_context *ctx)
+					   void *data)
 {
+	struct write_commit_graph_context *ctx = data;
 	struct commit **list = ctx->commits.list;
 	struct commit **last = ctx->commits.list + ctx->commits.nr;
 	uint32_t cur_pos = 0;
@@ -1315,8 +1322,9 @@ static void trace2_bloom_filter_settings(struct write_commit_graph_context *ctx)
 }
 
 static int write_graph_chunk_bloom_data(struct hashfile *f,
-					struct write_commit_graph_context *ctx)
+					void *data)
 {
+	struct write_commit_graph_context *ctx = data;
 	struct commit **list = ctx->commits.list;
 	struct commit **last = ctx->commits.list + ctx->commits.nr;
 
@@ -1737,8 +1745,9 @@ static int write_graph_chunk_base_1(struct hashfile *f,
 }
 
 static int write_graph_chunk_base(struct hashfile *f,
-				  struct write_commit_graph_context *ctx)
+				    void *data)
 {
+	struct write_commit_graph_context *ctx = data;
 	int num = write_graph_chunk_base_1(f, ctx->new_base_graph);
 
 	if (num != ctx->num_commit_graphs_after - 1) {
@@ -1750,7 +1759,7 @@ static int write_graph_chunk_base(struct hashfile *f,
 }
 
 typedef int (*chunk_write_fn)(struct hashfile *f,
-			      struct write_commit_graph_context *ctx);
+			      void *data);
 
 struct chunk_info {
 	uint32_t id;

--- a/dir.c
+++ b/dir.c
@@ -2730,11 +2730,8 @@ static struct untracked_cache_dir *validate_untracked_cache(struct dir_struct *d
 		return NULL;
 	}
 
-	if (!dir->untracked->root) {
-		const int len = sizeof(*dir->untracked->root);
-		dir->untracked->root = xmalloc(len);
-		memset(dir->untracked->root, 0, len);
-	}
+	if (!dir->untracked->root)
+		FLEX_ALLOC_STR(dir->untracked->root, name, "");
 
 	/* Validate $GIT_DIR/info/exclude and core.excludesfile */
 	root = dir->untracked->root;

--- a/fetch-pack.c
+++ b/fetch-pack.c
@@ -796,6 +796,26 @@ static void write_promisor_file(const char *keep_name,
 	strbuf_release(&promisor_name);
 }
 
+static void parse_gitmodules_oids(int fd, struct oidset *gitmodules_oids)
+{
+	int len = the_hash_algo->hexsz + 1; /* hash + NL */
+
+	do {
+		char hex_hash[GIT_MAX_HEXSZ + 1];
+		int read_len = read_in_full(fd, hex_hash, len);
+		struct object_id oid;
+		const char *end;
+
+		if (!read_len)
+			return;
+		if (read_len != len)
+			die("invalid length read %d", read_len);
+		if (parse_oid_hex(hex_hash, &oid, &end) || *end != '\n')
+			die("invalid hash");
+		oidset_insert(gitmodules_oids, &oid);
+	} while (1);
+}
+
 /*
  * If packfile URIs were provided, pass a non-NULL pointer to index_pack_args.
  * The strings to pass as the --index-pack-arg arguments to http-fetch will be
@@ -804,7 +824,8 @@ static void write_promisor_file(const char *keep_name,
 static int get_pack(struct fetch_pack_args *args,
 		    int xd[2], struct string_list *pack_lockfiles,
 		    struct strvec *index_pack_args,
-		    struct ref **sought, int nr_sought)
+		    struct ref **sought, int nr_sought,
+		    struct oidset *gitmodules_oids)
 {
 	struct async demux;
 	int do_keep = args->keep_pack;
@@ -812,6 +833,7 @@ static int get_pack(struct fetch_pack_args *args,
 	struct pack_header header;
 	int pass_header = 0;
 	struct child_process cmd = CHILD_PROCESS_INIT;
+	int fsck_objects = 0;
 	int ret;
 
 	memset(&demux, 0, sizeof(demux));
@@ -846,8 +868,15 @@ static int get_pack(struct fetch_pack_args *args,
 		strvec_push(&cmd.args, alternate_shallow_file);
 	}
 
-	if (do_keep || args->from_promisor || index_pack_args) {
-		if (pack_lockfiles)
+	if (fetch_fsck_objects >= 0
+	    ? fetch_fsck_objects
+	    : transfer_fsck_objects >= 0
+	    ? transfer_fsck_objects
+	    : 0)
+		fsck_objects = 1;
+
+	if (do_keep || args->from_promisor || index_pack_args || fsck_objects) {
+		if (pack_lockfiles || fsck_objects)
 			cmd.out = -1;
 		cmd_name = "index-pack";
 		strvec_push(&cmd.args, cmd_name);
@@ -897,11 +926,7 @@ static int get_pack(struct fetch_pack_args *args,
 		strvec_pushf(&cmd.args, "--pack_header=%"PRIu32",%"PRIu32,
 			     ntohl(header.hdr_version),
 				 ntohl(header.hdr_entries));
-	if (fetch_fsck_objects >= 0
-	    ? fetch_fsck_objects
-	    : transfer_fsck_objects >= 0
-	    ? transfer_fsck_objects
-	    : 0) {
+	if (fsck_objects) {
 		if (args->from_promisor || index_pack_args)
 			/*
 			 * We cannot use --strict in index-pack because it
@@ -925,10 +950,15 @@ static int get_pack(struct fetch_pack_args *args,
 	cmd.git_cmd = 1;
 	if (start_command(&cmd))
 		die(_("fetch-pack: unable to fork off %s"), cmd_name);
-	if (do_keep && pack_lockfiles) {
-		char *pack_lockfile = index_pack_lockfile(cmd.out);
+	if (do_keep && (pack_lockfiles || fsck_objects)) {
+		int is_well_formed;
+		char *pack_lockfile = index_pack_lockfile(cmd.out, &is_well_formed);
+
+		if (!is_well_formed)
+			die(_("fetch-pack: invalid index-pack output"));
 		if (pack_lockfile)
 			string_list_append_nodup(pack_lockfiles, pack_lockfile);
+		parse_gitmodules_oids(cmd.out, gitmodules_oids);
 		close(cmd.out);
 	}
 
@@ -963,6 +993,22 @@ static int cmp_ref_by_name(const void *a_, const void *b_)
 	return strcmp(a->name, b->name);
 }
 
+static void fsck_gitmodules_oids(struct oidset *gitmodules_oids)
+{
+	struct oidset_iter iter;
+	const struct object_id *oid;
+	struct fsck_options fo = FSCK_OPTIONS_STRICT;
+
+	if (!oidset_size(gitmodules_oids))
+		return;
+
+	oidset_iter_init(gitmodules_oids, &iter);
+	while ((oid = oidset_iter_next(&iter)))
+		register_found_gitmodules(oid);
+	if (fsck_finish(&fo))
+		die("fsck failed");
+}
+
 static struct ref *do_fetch_pack(struct fetch_pack_args *args,
 				 int fd[2],
 				 const struct ref *orig_ref,
@@ -977,6 +1023,7 @@ static struct ref *do_fetch_pack(struct fetch_pack_args *args,
 	int agent_len;
 	struct fetch_negotiator negotiator_alloc;
 	struct fetch_negotiator *negotiator;
+	struct oidset gitmodules_oids = OIDSET_INIT;
 
 	negotiator = &negotiator_alloc;
 	fetch_negotiator_init(r, negotiator);
@@ -1092,8 +1139,10 @@ static struct ref *do_fetch_pack(struct fetch_pack_args *args,
 		alternate_shallow_file = setup_temporary_shallow(si->shallow);
 	else
 		alternate_shallow_file = NULL;
-	if (get_pack(args, fd, pack_lockfiles, NULL, sought, nr_sought))
+	if (get_pack(args, fd, pack_lockfiles, NULL, sought, nr_sought,
+		     &gitmodules_oids))
 		die(_("git fetch-pack: fetch failed."));
+	fsck_gitmodules_oids(&gitmodules_oids);
 
  all_done:
 	if (negotiator)
@@ -1544,6 +1593,7 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 	struct string_list packfile_uris = STRING_LIST_INIT_DUP;
 	int i;
 	struct strvec index_pack_args = STRVEC_INIT;
+	struct oidset gitmodules_oids = OIDSET_INIT;
 
 	negotiator = &negotiator_alloc;
 	fetch_negotiator_init(r, negotiator);
@@ -1634,7 +1684,7 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 			process_section_header(&reader, "packfile", 0);
 			if (get_pack(args, fd, pack_lockfiles,
 				     packfile_uris.nr ? &index_pack_args : NULL,
-				     sought, nr_sought))
+				     sought, nr_sought, &gitmodules_oids))
 				die(_("git fetch-pack: fetch failed."));
 			do_check_stateless_delimiter(args, &reader);
 
@@ -1677,6 +1727,8 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 
 		packname[the_hash_algo->hexsz] = '\0';
 
+		parse_gitmodules_oids(cmd.out, &gitmodules_oids);
+
 		close(cmd.out);
 
 		if (finish_command(&cmd))
@@ -1695,6 +1747,8 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 	}
 	string_list_clear(&packfile_uris, 0);
 	strvec_clear(&index_pack_args);
+
+	fsck_gitmodules_oids(&gitmodules_oids);
 
 	if (negotiator)
 		negotiator->release(negotiator);

--- a/fetch-pack.c
+++ b/fetch-pack.c
@@ -1645,6 +1645,9 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 		strvec_pushf(&cmd.args, "--packfile=%.*s",
 			     (int) the_hash_algo->hexsz,
 			     packfile_uris.items[i].string);
+		strvec_push(&cmd.args, "--index-pack-arg=index-pack");
+		strvec_push(&cmd.args, "--index-pack-arg=--stdin");
+		strvec_push(&cmd.args, "--index-pack-arg=--keep");
 		strvec_push(&cmd.args, uri);
 		cmd.git_cmd = 1;
 		cmd.no_stdin = 1;

--- a/fetch-pack.c
+++ b/fetch-pack.c
@@ -797,12 +797,13 @@ static void write_promisor_file(const char *keep_name,
 }
 
 /*
- * Pass 1 as "only_packfile" if the pack received is the only pack in this
- * fetch request (that is, if there were no packfile URIs provided).
+ * If packfile URIs were provided, pass a non-NULL pointer to index_pack_args.
+ * The strings to pass as the --index-pack-arg arguments to http-fetch will be
+ * stored there. (It must be freed by the caller.)
  */
 static int get_pack(struct fetch_pack_args *args,
 		    int xd[2], struct string_list *pack_lockfiles,
-		    int only_packfile,
+		    struct strvec *index_pack_args,
 		    struct ref **sought, int nr_sought)
 {
 	struct async demux;
@@ -845,7 +846,7 @@ static int get_pack(struct fetch_pack_args *args,
 		strvec_push(&cmd.args, alternate_shallow_file);
 	}
 
-	if (do_keep || args->from_promisor) {
+	if (do_keep || args->from_promisor || index_pack_args) {
 		if (pack_lockfiles)
 			cmd.out = -1;
 		cmd_name = "index-pack";
@@ -863,7 +864,7 @@ static int get_pack(struct fetch_pack_args *args,
 				     "--keep=fetch-pack %"PRIuMAX " on %s",
 				     (uintmax_t)getpid(), hostname);
 		}
-		if (only_packfile && args->check_self_contained_and_connected)
+		if (!index_pack_args && args->check_self_contained_and_connected)
 			strvec_push(&cmd.args, "--check-self-contained-and-connected");
 		else
 			/*
@@ -901,7 +902,7 @@ static int get_pack(struct fetch_pack_args *args,
 	    : transfer_fsck_objects >= 0
 	    ? transfer_fsck_objects
 	    : 0) {
-		if (args->from_promisor || !only_packfile)
+		if (args->from_promisor || index_pack_args)
 			/*
 			 * We cannot use --strict in index-pack because it
 			 * checks both broken objects and links, but we only
@@ -911,6 +912,13 @@ static int get_pack(struct fetch_pack_args *args,
 		else
 			strvec_pushf(&cmd.args, "--strict%s",
 				     fsck_msg_types.buf);
+	}
+
+	if (index_pack_args) {
+		int i;
+
+		for (i = 0; i < cmd.args.nr; i++)
+			strvec_push(index_pack_args, cmd.args.v[i]);
 	}
 
 	cmd.in = demux.out;
@@ -1084,7 +1092,7 @@ static struct ref *do_fetch_pack(struct fetch_pack_args *args,
 		alternate_shallow_file = setup_temporary_shallow(si->shallow);
 	else
 		alternate_shallow_file = NULL;
-	if (get_pack(args, fd, pack_lockfiles, 1, sought, nr_sought))
+	if (get_pack(args, fd, pack_lockfiles, NULL, sought, nr_sought))
 		die(_("git fetch-pack: fetch failed."));
 
  all_done:
@@ -1535,6 +1543,7 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 	int seen_ack = 0;
 	struct string_list packfile_uris = STRING_LIST_INIT_DUP;
 	int i;
+	struct strvec index_pack_args = STRVEC_INIT;
 
 	negotiator = &negotiator_alloc;
 	fetch_negotiator_init(r, negotiator);
@@ -1624,7 +1633,8 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 				receive_packfile_uris(&reader, &packfile_uris);
 			process_section_header(&reader, "packfile", 0);
 			if (get_pack(args, fd, pack_lockfiles,
-				     !packfile_uris.nr, sought, nr_sought))
+				     packfile_uris.nr ? &index_pack_args : NULL,
+				     sought, nr_sought))
 				die(_("git fetch-pack: fetch failed."));
 			do_check_stateless_delimiter(args, &reader);
 
@@ -1636,6 +1646,7 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 	}
 
 	for (i = 0; i < packfile_uris.nr; i++) {
+		int j;
 		struct child_process cmd = CHILD_PROCESS_INIT;
 		char packname[GIT_MAX_HEXSZ + 1];
 		const char *uri = packfile_uris.items[i].string +
@@ -1645,9 +1656,9 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 		strvec_pushf(&cmd.args, "--packfile=%.*s",
 			     (int) the_hash_algo->hexsz,
 			     packfile_uris.items[i].string);
-		strvec_push(&cmd.args, "--index-pack-arg=index-pack");
-		strvec_push(&cmd.args, "--index-pack-arg=--stdin");
-		strvec_push(&cmd.args, "--index-pack-arg=--keep");
+		for (j = 0; j < index_pack_args.nr; j++)
+			strvec_pushf(&cmd.args, "--index-pack-arg=%s",
+				     index_pack_args.v[j]);
 		strvec_push(&cmd.args, uri);
 		cmd.git_cmd = 1;
 		cmd.no_stdin = 1;
@@ -1683,6 +1694,7 @@ static struct ref *do_fetch_pack_v2(struct fetch_pack_args *args,
 						 packname));
 	}
 	string_list_clear(&packfile_uris, 0);
+	strvec_clear(&index_pack_args);
 
 	if (negotiator)
 		negotiator->release(negotiator);

--- a/fsck.c
+++ b/fsck.c
@@ -1243,6 +1243,11 @@ int fsck_error_function(struct fsck_options *o,
 	return 1;
 }
 
+void register_found_gitmodules(const struct object_id *oid)
+{
+	oidset_insert(&gitmodules_found, oid);
+}
+
 int fsck_finish(struct fsck_options *options)
 {
 	int ret = 0;

--- a/fsck.h
+++ b/fsck.h
@@ -62,6 +62,8 @@ int fsck_walk(struct object *obj, void *data, struct fsck_options *options);
 int fsck_object(struct object *obj, void *data, unsigned long size,
 	struct fsck_options *options);
 
+void register_found_gitmodules(const struct object_id *oid);
+
 /*
  * Some fsck checks are context-dependent, and may end up queued; run this
  * after completing all fsck_object() calls in order to resolve any remaining

--- a/fsmonitor.c
+++ b/fsmonitor.c
@@ -87,7 +87,11 @@ int read_fsmonitor_extension(struct index_state *istate, const void *data,
 		BUG("fsmonitor_dirty has more entries than the index (%"PRIuMAX" > %u)",
 		    (uintmax_t)istate->fsmonitor_dirty->bit_size, istate->cache_nr);
 
-	trace_printf_key(&trace_fsmonitor, "read fsmonitor extension successful");
+	trace2_data_string("index", NULL, "extension/fsmn/read/token",
+			   istate->fsmonitor_last_update);
+	trace_printf_key(&trace_fsmonitor,
+			 "read fsmonitor extension successful '%s'",
+			 istate->fsmonitor_last_update);
 	return 0;
 }
 
@@ -133,7 +137,11 @@ void write_fsmonitor_extension(struct strbuf *sb, struct index_state *istate)
 	put_be32(&ewah_size, sb->len - ewah_start);
 	memcpy(sb->buf + fixup, &ewah_size, sizeof(uint32_t));
 
-	trace_printf_key(&trace_fsmonitor, "write fsmonitor extension successful");
+	trace2_data_string("index", NULL, "extension/fsmn/write/token",
+			   istate->fsmonitor_last_update);
+	trace_printf_key(&trace_fsmonitor,
+			 "write fsmonitor extension successful '%s'",
+			 istate->fsmonitor_last_update);
 }
 
 /*

--- a/fsmonitor.h
+++ b/fsmonitor.h
@@ -45,6 +45,11 @@ void tweak_fsmonitor(struct index_state *istate);
 void refresh_fsmonitor(struct index_state *istate);
 
 /*
+ * Does the received result contain the "trivial" response?
+ */
+int fsmonitor_is_trivial_response(const struct strbuf *query_result);
+
+/*
  * Set the given cache entries CE_FSMONITOR_VALID bit. This should be
  * called any time the cache entry has been updated to reflect the
  * current state of the file on disk.

--- a/git-gui.sh
+++ b/git-gui.sh
@@ -875,6 +875,7 @@ set default_config(merge.summary) false
 set default_config(merge.verbosity) 2
 set default_config(user.name) {}
 set default_config(user.email) {}
+set default_config(core.commentchar) "#"
 
 set default_config(gui.encoding) [encoding system]
 set default_config(gui.matchtrackingbranch) false
@@ -3436,6 +3437,10 @@ proc trace_commit_type {varname args} {
 	merge         {set txt [mc "Merge Commit Message:"]}
 	*             {set txt [mc "Commit Message:"]}
 	}
+
+	set comment_char [get_config core.commentchar]
+	set txt [string cat $txt \
+				 [mc " (Lines starting with '$comment_char' will be ignored)"]]
 	$ui_coml conf -text $txt
 }
 trace add variable commit_type write trace_commit_type

--- a/http-fetch.c
+++ b/http-fetch.c
@@ -3,6 +3,7 @@
 #include "exec-cmd.h"
 #include "http.h"
 #include "walker.h"
+#include "strvec.h"
 
 static const char http_fetch_usage[] = "git http-fetch "
 "[-c] [-t] [-a] [-v] [--recover] [-w ref] [--stdin | --packfile=hash | commit-id] url";
@@ -43,11 +44,9 @@ static int fetch_using_walker(const char *raw_url, int get_verbosely,
 	return rc;
 }
 
-static const char *index_pack_args[] =
-	{"index-pack", "--stdin", "--keep", NULL};
-
 static void fetch_single_packfile(struct object_id *packfile_hash,
-				  const char *url) {
+				  const char *url,
+				  const char **index_pack_args) {
 	struct http_pack_request *preq;
 	struct slot_results results;
 	int ret;
@@ -90,6 +89,7 @@ int cmd_main(int argc, const char **argv)
 	int packfile = 0;
 	int nongit;
 	struct object_id packfile_hash;
+	struct strvec index_pack_args = STRVEC_INIT;
 
 	setup_git_directory_gently(&nongit);
 
@@ -116,6 +116,8 @@ int cmd_main(int argc, const char **argv)
 			packfile = 1;
 			if (parse_oid_hex(p, &packfile_hash, &end) || *end)
 				die(_("argument to --packfile must be a valid hash (got '%s')"), p);
+		} else if (skip_prefix(argv[arg], "--index-pack-arg=", &p)) {
+			strvec_push(&index_pack_args, p);
 		}
 		arg++;
 	}
@@ -128,9 +130,17 @@ int cmd_main(int argc, const char **argv)
 	git_config(git_default_config, NULL);
 
 	if (packfile) {
-		fetch_single_packfile(&packfile_hash, argv[arg]);
+		if (!index_pack_args.nr)
+			die(_("--packfile requires --index-pack-args"));
+
+		fetch_single_packfile(&packfile_hash, argv[arg],
+				      index_pack_args.v);
+
 		return 0;
 	}
+
+	if (index_pack_args.nr)
+		die(_("--index-pack-args can only be used with --packfile"));
 
 	if (commits_on_stdin) {
 		commits = walker_targets_stdin(&commit_id, &write_ref);

--- a/http-fetch.c
+++ b/http-fetch.c
@@ -43,6 +43,9 @@ static int fetch_using_walker(const char *raw_url, int get_verbosely,
 	return rc;
 }
 
+static const char *index_pack_args[] =
+	{"index-pack", "--stdin", "--keep", NULL};
+
 static void fetch_single_packfile(struct object_id *packfile_hash,
 				  const char *url) {
 	struct http_pack_request *preq;
@@ -55,7 +58,8 @@ static void fetch_single_packfile(struct object_id *packfile_hash,
 	if (preq == NULL)
 		die("couldn't create http pack request");
 	preq->slot->results = &results;
-	preq->generate_keep = 1;
+	preq->index_pack_args = index_pack_args;
+	preq->preserve_index_pack_stdout = 1;
 
 	if (start_active_slot(preq->slot)) {
 		run_active_slot(preq->slot);

--- a/http.h
+++ b/http.h
@@ -218,12 +218,12 @@ struct http_pack_request {
 	char *url;
 
 	/*
-	 * If this is true, finish_http_pack_request() will pass "--keep" to
-	 * index-pack, resulting in the creation of a keep file, and will not
-	 * suppress its stdout (that is, the "keep\t<hash>\n" line will be
-	 * printed to stdout).
+	 * index-pack command to run. Must be terminated by NULL.
+	 *
+	 * If NULL, defaults to	{"index-pack", "--stdin", NULL}.
 	 */
-	unsigned generate_keep : 1;
+	const char **index_pack_args;
+	unsigned preserve_index_pack_stdout : 1;
 
 	FILE *packfile;
 	struct strbuf tmpfile;

--- a/lib/commit.tcl
+++ b/lib/commit.tcl
@@ -141,6 +141,20 @@ proc setup_commit_encoding {msg_wt {quiet 0}} {
 	}
 }
 
+proc strip_msg {msg} {
+	set cmd [concat [list | ] [_git_cmd stripspace] --strip-comments]
+	_trace_exec $cmd
+	set fd [open $cmd r+]
+	fconfigure $fd -translation binary -encoding utf-8
+
+	puts -nonewline $fd $msg
+	close $fd w
+	set result [read $fd]
+	close $fd
+
+	return $result
+}
+
 proc commit_tree {} {
 	global HEAD commit_type file_states ui_comm repo_config
 	global pch_error
@@ -207,8 +221,8 @@ You must stage at least 1 file before you can commit.
 
 	# -- A message is required.
 	#
-	set msg [string trim [$ui_comm get 1.0 end]]
-	regsub -all -line {[ \t\r]+$} $msg {} msg
+	set msg [strip_msg [$ui_comm get 1.0 end]]
+
 	if {$msg eq {}} {
 		error_popup [mc "Please supply a commit message.
 

--- a/midx.c
+++ b/midx.c
@@ -244,7 +244,7 @@ static off_t nth_midxed_offset(struct multi_pack_index *m, uint32_t pos)
 	const unsigned char *offset_data;
 	uint32_t offset32;
 
-	offset_data = m->chunk_object_offsets + pos * MIDX_CHUNK_OFFSET_WIDTH;
+	offset_data = m->chunk_object_offsets + (off_t)pos * MIDX_CHUNK_OFFSET_WIDTH;
 	offset32 = get_be32(offset_data + sizeof(uint32_t));
 
 	if (m->chunk_large_offsets && offset32 & MIDX_LARGE_OFFSET_NEEDED) {
@@ -260,7 +260,8 @@ static off_t nth_midxed_offset(struct multi_pack_index *m, uint32_t pos)
 
 static uint32_t nth_midxed_pack_int_id(struct multi_pack_index *m, uint32_t pos)
 {
-	return get_be32(m->chunk_object_offsets + pos * MIDX_CHUNK_OFFSET_WIDTH);
+	return get_be32(m->chunk_object_offsets +
+			(off_t)pos * MIDX_CHUNK_OFFSET_WIDTH);
 }
 
 static int nth_midxed_pack_entry(struct repository *r,
@@ -912,15 +913,15 @@ static int write_midx_internal(const char *object_dir, struct multi_pack_index *
 	add_chunk(cf, MIDX_CHUNKID_OIDFANOUT, MIDX_CHUNK_FANOUT_SIZE,
 		  write_midx_oid_fanout);
 	add_chunk(cf, MIDX_CHUNKID_OIDLOOKUP,
-		  ctx.entries_nr * the_hash_algo->rawsz,
+		  (size_t)ctx.entries_nr * the_hash_algo->rawsz,
 		  write_midx_oid_lookup);
 	add_chunk(cf, MIDX_CHUNKID_OBJECTOFFSETS,
-		  ctx.entries_nr * MIDX_CHUNK_OFFSET_WIDTH,
+		  (size_t)ctx.entries_nr * MIDX_CHUNK_OFFSET_WIDTH,
 		  write_midx_object_offsets);
 
 	if (ctx.large_offsets_needed)
 		add_chunk(cf, MIDX_CHUNKID_LARGEOFFSETS,
-			ctx.num_large_offsets * MIDX_CHUNK_LARGE_OFFSET_WIDTH,
+			(size_t)ctx.num_large_offsets * MIDX_CHUNK_LARGE_OFFSET_WIDTH,
 			write_midx_large_offsets);
 
 	write_midx_header(f, get_num_chunks(cf), ctx.nr - dropped_packs);

--- a/midx.c
+++ b/midx.c
@@ -11,6 +11,7 @@
 #include "trace2.h"
 #include "run-command.h"
 #include "repository.h"
+#include "chunk-format.h"
 
 #define MIDX_SIGNATURE 0x4d494458 /* "MIDX" */
 #define MIDX_VERSION 1
@@ -21,7 +22,6 @@
 #define MIDX_HEADER_SIZE 12
 #define MIDX_MIN_SIZE (MIDX_HEADER_SIZE + the_hash_algo->rawsz)
 
-#define MIDX_MAX_CHUNKS 5
 #define MIDX_CHUNK_ALIGNMENT 4
 #define MIDX_CHUNKID_PACKNAMES 0x504e414d /* "PNAM" */
 #define MIDX_CHUNKID_OIDFANOUT 0x4f494446 /* "OIDF" */
@@ -799,18 +799,15 @@ static int write_midx_large_offsets(struct hashfile *f,
 static int write_midx_internal(const char *object_dir, struct multi_pack_index *m,
 			       struct string_list *packs_to_drop, unsigned flags)
 {
-	unsigned char cur_chunk, num_chunks = 0;
 	char *midx_name;
 	uint32_t i;
 	struct hashfile *f = NULL;
 	struct lock_file lk;
 	struct write_midx_context ctx = { 0 };
-	uint64_t header_size = 0;
-	uint32_t chunk_ids[MIDX_MAX_CHUNKS + 1];
-	uint64_t chunk_offsets[MIDX_MAX_CHUNKS + 1];
 	int pack_name_concat_len = 0;
 	int dropped_packs = 0;
 	int result = 0;
+	struct chunkfile *cf;
 
 	midx_name = get_midx_filename(object_dir);
 	if (safe_create_leading_directories(midx_name))
@@ -923,98 +920,35 @@ static int write_midx_internal(const char *object_dir, struct multi_pack_index *
 	if (ctx.m)
 		close_midx(ctx.m);
 
-	cur_chunk = 0;
-	num_chunks = ctx.large_offsets_needed ? 5 : 4;
-
 	if (ctx.nr - dropped_packs == 0) {
 		error(_("no pack files to index."));
 		result = 1;
 		goto cleanup;
 	}
 
-	header_size = write_midx_header(f, num_chunks, ctx.nr - dropped_packs);
+	cf = init_chunkfile(f);
 
-	chunk_ids[cur_chunk] = MIDX_CHUNKID_PACKNAMES;
-	chunk_offsets[cur_chunk] = header_size + (num_chunks + 1) * MIDX_CHUNKLOOKUP_WIDTH;
+	add_chunk(cf, MIDX_CHUNKID_PACKNAMES, pack_name_concat_len,
+		  write_midx_pack_names);
+	add_chunk(cf, MIDX_CHUNKID_OIDFANOUT, MIDX_CHUNK_FANOUT_SIZE,
+		  write_midx_oid_fanout);
+	add_chunk(cf, MIDX_CHUNKID_OIDLOOKUP,
+		  ctx.entries_nr * the_hash_algo->rawsz,
+		  write_midx_oid_lookup);
+	add_chunk(cf, MIDX_CHUNKID_OBJECTOFFSETS,
+		  ctx.entries_nr * MIDX_CHUNK_OFFSET_WIDTH,
+		  write_midx_object_offsets);
 
-	cur_chunk++;
-	chunk_ids[cur_chunk] = MIDX_CHUNKID_OIDFANOUT;
-	chunk_offsets[cur_chunk] = chunk_offsets[cur_chunk - 1] + pack_name_concat_len;
+	if (ctx.large_offsets_needed)
+		add_chunk(cf, MIDX_CHUNKID_LARGEOFFSETS,
+			ctx.num_large_offsets * MIDX_CHUNK_LARGE_OFFSET_WIDTH,
+			write_midx_large_offsets);
 
-	cur_chunk++;
-	chunk_ids[cur_chunk] = MIDX_CHUNKID_OIDLOOKUP;
-	chunk_offsets[cur_chunk] = chunk_offsets[cur_chunk - 1] + MIDX_CHUNK_FANOUT_SIZE;
-
-	cur_chunk++;
-	chunk_ids[cur_chunk] = MIDX_CHUNKID_OBJECTOFFSETS;
-	chunk_offsets[cur_chunk] = chunk_offsets[cur_chunk - 1] + ctx.entries_nr * the_hash_algo->rawsz;
-
-	cur_chunk++;
-	chunk_offsets[cur_chunk] = chunk_offsets[cur_chunk - 1] + ctx.entries_nr * MIDX_CHUNK_OFFSET_WIDTH;
-	if (ctx.large_offsets_needed) {
-		chunk_ids[cur_chunk] = MIDX_CHUNKID_LARGEOFFSETS;
-
-		cur_chunk++;
-		chunk_offsets[cur_chunk] = chunk_offsets[cur_chunk - 1] +
-					   ctx.num_large_offsets * MIDX_CHUNK_LARGE_OFFSET_WIDTH;
-	}
-
-	chunk_ids[cur_chunk] = 0;
-
-	for (i = 0; i <= num_chunks; i++) {
-		if (i && chunk_offsets[i] < chunk_offsets[i - 1])
-			BUG("incorrect chunk offsets: %"PRIu64" before %"PRIu64,
-			    chunk_offsets[i - 1],
-			    chunk_offsets[i]);
-
-		if (chunk_offsets[i] % MIDX_CHUNK_ALIGNMENT)
-			BUG("chunk offset %"PRIu64" is not properly aligned",
-			    chunk_offsets[i]);
-
-		hashwrite_be32(f, chunk_ids[i]);
-		hashwrite_be64(f, chunk_offsets[i]);
-	}
-
-	for (i = 0; i < num_chunks; i++) {
-		if (f->total + f->offset != chunk_offsets[i])
-			BUG("incorrect chunk offset (%"PRIu64" != %"PRIu64") for chunk id %"PRIx32,
-			    chunk_offsets[i],
-			    f->total + f->offset,
-			    chunk_ids[i]);
-
-		switch (chunk_ids[i]) {
-			case MIDX_CHUNKID_PACKNAMES:
-				write_midx_pack_names(f, &ctx);
-				break;
-
-			case MIDX_CHUNKID_OIDFANOUT:
-				write_midx_oid_fanout(f, &ctx);
-				break;
-
-			case MIDX_CHUNKID_OIDLOOKUP:
-				write_midx_oid_lookup(f, &ctx);
-				break;
-
-			case MIDX_CHUNKID_OBJECTOFFSETS:
-				write_midx_object_offsets(f, &ctx);
-				break;
-
-			case MIDX_CHUNKID_LARGEOFFSETS:
-				write_midx_large_offsets(f, &ctx);
-				break;
-
-			default:
-				BUG("trying to write unknown chunk id %"PRIx32,
-				    chunk_ids[i]);
-		}
-	}
-
-	if (hashfile_total(f) != chunk_offsets[num_chunks])
-		BUG("incorrect final offset %"PRIu64" != %"PRIu64,
-		    hashfile_total(f),
-		    chunk_offsets[num_chunks]);
+	write_midx_header(f, get_num_chunks(cf), ctx.nr - dropped_packs);
+	write_chunkfile(cf, &ctx);
 
 	finalize_hashfile(f, NULL, CSUM_FSYNC | CSUM_HASH_IN_STREAM);
+	free_chunkfile(cf);
 	commit_lock_file(&lk);
 
 cleanup:

--- a/midx.c
+++ b/midx.c
@@ -451,7 +451,7 @@ static int pack_info_compare(const void *_a, const void *_b)
 	return strcmp(a->pack_name, b->pack_name);
 }
 
-struct pack_list {
+struct write_midx_context {
 	struct pack_info *info;
 	uint32_t nr;
 	uint32_t alloc;
@@ -463,37 +463,37 @@ struct pack_list {
 static void add_pack_to_midx(const char *full_path, size_t full_path_len,
 			     const char *file_name, void *data)
 {
-	struct pack_list *packs = (struct pack_list *)data;
+	struct write_midx_context *ctx = data;
 
 	if (ends_with(file_name, ".idx")) {
-		display_progress(packs->progress, ++packs->pack_paths_checked);
-		if (packs->m && midx_contains_pack(packs->m, file_name))
+		display_progress(ctx->progress, ++ctx->pack_paths_checked);
+		if (ctx->m && midx_contains_pack(ctx->m, file_name))
 			return;
 
-		ALLOC_GROW(packs->info, packs->nr + 1, packs->alloc);
+		ALLOC_GROW(ctx->info, ctx->nr + 1, ctx->alloc);
 
-		packs->info[packs->nr].p = add_packed_git(full_path,
-							  full_path_len,
-							  0);
+		ctx->info[ctx->nr].p = add_packed_git(full_path,
+						      full_path_len,
+						      0);
 
-		if (!packs->info[packs->nr].p) {
+		if (!ctx->info[ctx->nr].p) {
 			warning(_("failed to add packfile '%s'"),
 				full_path);
 			return;
 		}
 
-		if (open_pack_index(packs->info[packs->nr].p)) {
+		if (open_pack_index(ctx->info[ctx->nr].p)) {
 			warning(_("failed to open pack-index '%s'"),
 				full_path);
-			close_pack(packs->info[packs->nr].p);
-			FREE_AND_NULL(packs->info[packs->nr].p);
+			close_pack(ctx->info[ctx->nr].p);
+			FREE_AND_NULL(ctx->info[ctx->nr].p);
 			return;
 		}
 
-		packs->info[packs->nr].pack_name = xstrdup(file_name);
-		packs->info[packs->nr].orig_pack_int_id = packs->nr;
-		packs->info[packs->nr].expired = 0;
-		packs->nr++;
+		ctx->info[ctx->nr].pack_name = xstrdup(file_name);
+		ctx->info[ctx->nr].orig_pack_int_id = ctx->nr;
+		ctx->info[ctx->nr].expired = 0;
+		ctx->nr++;
 	}
 }
 
@@ -801,7 +801,7 @@ static int write_midx_internal(const char *object_dir, struct multi_pack_index *
 	uint32_t i;
 	struct hashfile *f = NULL;
 	struct lock_file lk;
-	struct pack_list packs;
+	struct write_midx_context ctx = { 0 };
 	uint32_t *pack_perm = NULL;
 	uint64_t written = 0;
 	uint32_t chunk_ids[MIDX_MAX_CHUNKS + 1];
@@ -820,40 +820,40 @@ static int write_midx_internal(const char *object_dir, struct multi_pack_index *
 			  midx_name);
 
 	if (m)
-		packs.m = m;
+		ctx.m = m;
 	else
-		packs.m = load_multi_pack_index(object_dir, 1);
+		ctx.m = load_multi_pack_index(object_dir, 1);
 
-	packs.nr = 0;
-	packs.alloc = packs.m ? packs.m->num_packs : 16;
-	packs.info = NULL;
-	ALLOC_ARRAY(packs.info, packs.alloc);
+	ctx.nr = 0;
+	ctx.alloc = ctx.m ? ctx.m->num_packs : 16;
+	ctx.info = NULL;
+	ALLOC_ARRAY(ctx.info, ctx.alloc);
 
-	if (packs.m) {
-		for (i = 0; i < packs.m->num_packs; i++) {
-			ALLOC_GROW(packs.info, packs.nr + 1, packs.alloc);
+	if (ctx.m) {
+		for (i = 0; i < ctx.m->num_packs; i++) {
+			ALLOC_GROW(ctx.info, ctx.nr + 1, ctx.alloc);
 
-			packs.info[packs.nr].orig_pack_int_id = i;
-			packs.info[packs.nr].pack_name = xstrdup(packs.m->pack_names[i]);
-			packs.info[packs.nr].p = NULL;
-			packs.info[packs.nr].expired = 0;
-			packs.nr++;
+			ctx.info[ctx.nr].orig_pack_int_id = i;
+			ctx.info[ctx.nr].pack_name = xstrdup(ctx.m->pack_names[i]);
+			ctx.info[ctx.nr].p = NULL;
+			ctx.info[ctx.nr].expired = 0;
+			ctx.nr++;
 		}
 	}
 
-	packs.pack_paths_checked = 0;
+	ctx.pack_paths_checked = 0;
 	if (flags & MIDX_PROGRESS)
-		packs.progress = start_delayed_progress(_("Adding packfiles to multi-pack-index"), 0);
+		ctx.progress = start_delayed_progress(_("Adding packfiles to multi-pack-index"), 0);
 	else
-		packs.progress = NULL;
+		ctx.progress = NULL;
 
-	for_each_file_in_pack_dir(object_dir, add_pack_to_midx, &packs);
-	stop_progress(&packs.progress);
+	for_each_file_in_pack_dir(object_dir, add_pack_to_midx, &ctx);
+	stop_progress(&ctx.progress);
 
-	if (packs.m && packs.nr == packs.m->num_packs && !packs_to_drop)
+	if (ctx.m && ctx.nr == ctx.m->num_packs && !packs_to_drop)
 		goto cleanup;
 
-	entries = get_sorted_entries(packs.m, packs.info, packs.nr, &nr_entries);
+	entries = get_sorted_entries(ctx.m, ctx.info, ctx.nr, &nr_entries);
 
 	for (i = 0; i < nr_entries; i++) {
 		if (entries[i].offset > 0x7fffffff)
@@ -862,19 +862,19 @@ static int write_midx_internal(const char *object_dir, struct multi_pack_index *
 			large_offsets_needed = 1;
 	}
 
-	QSORT(packs.info, packs.nr, pack_info_compare);
+	QSORT(ctx.info, ctx.nr, pack_info_compare);
 
 	if (packs_to_drop && packs_to_drop->nr) {
 		int drop_index = 0;
 		int missing_drops = 0;
 
-		for (i = 0; i < packs.nr && drop_index < packs_to_drop->nr; i++) {
-			int cmp = strcmp(packs.info[i].pack_name,
+		for (i = 0; i < ctx.nr && drop_index < packs_to_drop->nr; i++) {
+			int cmp = strcmp(ctx.info[i].pack_name,
 					 packs_to_drop->items[drop_index].string);
 
 			if (!cmp) {
 				drop_index++;
-				packs.info[i].expired = 1;
+				ctx.info[i].expired = 1;
 			} else if (cmp > 0) {
 				error(_("did not see pack-file %s to drop"),
 				      packs_to_drop->items[drop_index].string);
@@ -882,7 +882,7 @@ static int write_midx_internal(const char *object_dir, struct multi_pack_index *
 				missing_drops++;
 				i--;
 			} else {
-				packs.info[i].expired = 0;
+				ctx.info[i].expired = 0;
 			}
 		}
 
@@ -898,19 +898,19 @@ static int write_midx_internal(const char *object_dir, struct multi_pack_index *
 	 *
 	 * pack_perm[old_id] = new_id
 	 */
-	ALLOC_ARRAY(pack_perm, packs.nr);
-	for (i = 0; i < packs.nr; i++) {
-		if (packs.info[i].expired) {
+	ALLOC_ARRAY(pack_perm, ctx.nr);
+	for (i = 0; i < ctx.nr; i++) {
+		if (ctx.info[i].expired) {
 			dropped_packs++;
-			pack_perm[packs.info[i].orig_pack_int_id] = PACK_EXPIRED;
+			pack_perm[ctx.info[i].orig_pack_int_id] = PACK_EXPIRED;
 		} else {
-			pack_perm[packs.info[i].orig_pack_int_id] = i - dropped_packs;
+			pack_perm[ctx.info[i].orig_pack_int_id] = i - dropped_packs;
 		}
 	}
 
-	for (i = 0; i < packs.nr; i++) {
-		if (!packs.info[i].expired)
-			pack_name_concat_len += strlen(packs.info[i].pack_name) + 1;
+	for (i = 0; i < ctx.nr; i++) {
+		if (!ctx.info[i].expired)
+			pack_name_concat_len += strlen(ctx.info[i].pack_name) + 1;
 	}
 
 	if (pack_name_concat_len % MIDX_CHUNK_ALIGNMENT)
@@ -921,19 +921,19 @@ static int write_midx_internal(const char *object_dir, struct multi_pack_index *
 	f = hashfd(lk.tempfile->fd, lk.tempfile->filename.buf);
 	FREE_AND_NULL(midx_name);
 
-	if (packs.m)
-		close_midx(packs.m);
+	if (ctx.m)
+		close_midx(ctx.m);
 
 	cur_chunk = 0;
 	num_chunks = large_offsets_needed ? 5 : 4;
 
-	if (packs.nr - dropped_packs == 0) {
+	if (ctx.nr - dropped_packs == 0) {
 		error(_("no pack files to index."));
 		result = 1;
 		goto cleanup;
 	}
 
-	written = write_midx_header(f, num_chunks, packs.nr - dropped_packs);
+	written = write_midx_header(f, num_chunks, ctx.nr - dropped_packs);
 
 	chunk_ids[cur_chunk] = MIDX_CHUNKID_PACKNAMES;
 	chunk_offsets[cur_chunk] = written + (num_chunks + 1) * MIDX_CHUNKLOOKUP_WIDTH;
@@ -990,7 +990,7 @@ static int write_midx_internal(const char *object_dir, struct multi_pack_index *
 
 		switch (chunk_ids[i]) {
 			case MIDX_CHUNKID_PACKNAMES:
-				written += write_midx_pack_names(f, packs.info, packs.nr);
+				written += write_midx_pack_names(f, ctx.info, ctx.nr);
 				break;
 
 			case MIDX_CHUNKID_OIDFANOUT:
@@ -1027,15 +1027,15 @@ static int write_midx_internal(const char *object_dir, struct multi_pack_index *
 	commit_lock_file(&lk);
 
 cleanup:
-	for (i = 0; i < packs.nr; i++) {
-		if (packs.info[i].p) {
-			close_pack(packs.info[i].p);
-			free(packs.info[i].p);
+	for (i = 0; i < ctx.nr; i++) {
+		if (ctx.info[i].p) {
+			close_pack(ctx.info[i].p);
+			free(ctx.info[i].p);
 		}
-		free(packs.info[i].pack_name);
+		free(ctx.info[i].pack_name);
 	}
 
-	free(packs.info);
+	free(ctx.info);
 	free(entries);
 	free(pack_perm);
 	free(midx_name);

--- a/midx.c
+++ b/midx.c
@@ -808,7 +808,6 @@ static int write_midx_internal(const char *object_dir, struct multi_pack_index *
 	uint64_t header_size = 0;
 	uint32_t chunk_ids[MIDX_MAX_CHUNKS + 1];
 	uint64_t chunk_offsets[MIDX_MAX_CHUNKS + 1];
-	struct progress *progress = NULL;
 	int pack_name_concat_len = 0;
 	int dropped_packs = 0;
 	int result = 0;
@@ -976,9 +975,6 @@ static int write_midx_internal(const char *object_dir, struct multi_pack_index *
 		hashwrite_be64(f, chunk_offsets[i]);
 	}
 
-	if (flags & MIDX_PROGRESS)
-		progress = start_delayed_progress(_("Writing chunks to multi-pack-index"),
-					  num_chunks);
 	for (i = 0; i < num_chunks; i++) {
 		if (f->total + f->offset != chunk_offsets[i])
 			BUG("incorrect chunk offset (%"PRIu64" != %"PRIu64") for chunk id %"PRIx32,
@@ -1011,10 +1007,7 @@ static int write_midx_internal(const char *object_dir, struct multi_pack_index *
 				BUG("trying to write unknown chunk id %"PRIx32,
 				    chunk_ids[i]);
 		}
-
-		display_progress(progress, i + 1);
 	}
-	stop_progress(&progress);
 
 	if (hashfile_total(f) != chunk_offsets[num_chunks])
 		BUG("incorrect final offset %"PRIu64" != %"PRIu64,

--- a/pack-write.c
+++ b/pack-write.c
@@ -272,7 +272,7 @@ void fixup_pack_header_footer(int pack_fd,
 	fsync_or_die(pack_fd, pack_name);
 }
 
-char *index_pack_lockfile(int ip_out)
+char *index_pack_lockfile(int ip_out, int *is_well_formed)
 {
 	char packname[GIT_MAX_HEXSZ + 6];
 	const int len = the_hash_algo->hexsz + 6;
@@ -286,11 +286,17 @@ char *index_pack_lockfile(int ip_out)
 	 */
 	if (read_in_full(ip_out, packname, len) == len && packname[len-1] == '\n') {
 		const char *name;
+
+		if (is_well_formed)
+			*is_well_formed = 1;
 		packname[len-1] = 0;
 		if (skip_prefix(packname, "keep\t", &name))
 			return xstrfmt("%s/pack/pack-%s.keep",
 				       get_object_directory(), name);
+		return NULL;
 	}
+	if (is_well_formed)
+		*is_well_formed = 0;
 	return NULL;
 }
 

--- a/pack.h
+++ b/pack.h
@@ -85,7 +85,7 @@ int verify_pack_index(struct packed_git *);
 int verify_pack(struct repository *, struct packed_git *, verify_fn fn, struct progress *, uint32_t);
 off_t write_pack_header(struct hashfile *f, uint32_t);
 void fixup_pack_header_footer(int, unsigned char *, const char *, uint32_t, unsigned char *, off_t);
-char *index_pack_lockfile(int fd);
+char *index_pack_lockfile(int fd, int *is_well_formed);
 
 /*
  * The "hdr" output buffer should be at least this big, which will handle sizes

--- a/po/de.po
+++ b/po/de.po
@@ -2144,24 +2144,23 @@ msgid "index-pack died"
 msgstr "Erstellung der Paketindexdatei abgebrochen"
 
 #: chunk-format.c:113
-#, fuzzy
 msgid "terminating chunk id appears earlier than expected"
-msgstr "abschließende multi-pack-index Chunk-Id erscheint eher als erwartet"
+msgstr "abschließende Chunk-ID erscheint eher als erwartet"
 
 #: chunk-format.c:122
-#, fuzzy, c-format
+#, c-format
 msgid "improper chunk offset(s) %<PRIx64> and %<PRIx64>"
-msgstr "Falscher Objekt-Offset für oid[%d] = %s: %<PRIx64> != %<PRIx64>"
+msgstr "unzulässige(r) Chunk-Offset(s) %<PRIx64> und %<PRIx64>"
 
 #: chunk-format.c:129
 #, c-format
 msgid "duplicate chunk ID %<PRIx32> found"
-msgstr ""
+msgstr "doppelte Chunk-ID %<PRIx32> gefunden"
 
 #: chunk-format.c:143
 #, c-format
 msgid "final chunk has non-zero id %<PRIx32>"
-msgstr ""
+msgstr "letzter Chunk hat nicht-Null ID %<PRIx32>"
 
 #: color.c:329
 #, c-format
@@ -4178,7 +4177,7 @@ msgstr "fetch-pack: konnte %s nicht starten"
 
 #: fetch-pack.c:952
 msgid "fetch-pack: invalid index-pack output"
-msgstr ""
+msgstr "fetch-pack: ungültige index-pack Ausgabe"
 
 #: fetch-pack.c:969
 #, c-format
@@ -5250,9 +5249,8 @@ msgid "unable to write new index file"
 msgstr "Konnte neue Index-Datei nicht schreiben."
 
 #: midx.c:62
-#, fuzzy
 msgid "multi-pack-index OID fanout is of the wrong size"
-msgstr "multi-pack-index-Version %d nicht erkannt."
+msgstr "multi-pack-index OID fanout hat die falsche Größe"
 
 #: midx.c:93
 #, c-format
@@ -6680,7 +6678,7 @@ msgstr "nicht erkanntes %%(subject) Argument: %s"
 #: ref-filter.c:334
 #, c-format
 msgid "expected %%(trailers:key=<value>)"
-msgstr ""
+msgstr "%%(trailers:key=<Wert>) erwartet"
 
 #: ref-filter.c:336
 #, c-format
@@ -23979,14 +23977,12 @@ msgid "not a git repository"
 msgstr "kein Git-Repository"
 
 #: http-fetch.c:134
-#, fuzzy
 msgid "--packfile requires --index-pack-args"
-msgstr "--pathspec-file-nul benötigt --pathspec-from-file"
+msgstr "--packfile benötigt --index-pack-args"
 
 #: http-fetch.c:143
-#, fuzzy
 msgid "--index-pack-args can only be used with --packfile"
-msgstr "-N kann nur mit -mixed benutzt werden"
+msgstr "--index-pack-args kann nur mit --packfile benutzt werden"
 
 #: t/helper/test-fast-rebase.c:141
 msgid "unhandled options"

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-02-26 22:09+0800\n"
+"POT-Creation-Date: 2021-03-04 22:41+0800\n"
 "PO-Revision-Date: 2021-03-03 20:13+0100\n"
 "Last-Translator: Matthias Rüster <matthias.ruester@gmail.com>\n"
 "Language-Team: Matthias Rüster <matthias.ruester@gmail.com>\n"
@@ -1130,7 +1130,7 @@ msgstr "Anwendung des Patches fehlgeschlagen: %s:%ld"
 msgid "cannot checkout %s"
 msgstr "kann %s nicht auschecken"
 
-#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:73 pack-revindex.c:213
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:86 pack-revindex.c:213
 #: setup.c:308
 #, c-format
 msgid "failed to read %s"
@@ -1879,7 +1879,7 @@ msgstr ""
 "endgültigen\n"
 "Commits"
 
-#: blame.c:2821 bundle.c:213 ref-filter.c:2202 remote.c:2041 sequencer.c:2146
+#: blame.c:2821 bundle.c:213 ref-filter.c:2206 remote.c:2041 sequencer.c:2146
 #: sequencer.c:4641 submodule.c:856 builtin/commit.c:1045 builtin/log.c:411
 #: builtin/log.c:1016 builtin/log.c:1624 builtin/log.c:2045 builtin/log.c:2335
 #: builtin/merge.c:424 builtin/pack-objects.c:3395 builtin/pack-objects.c:3410
@@ -2143,265 +2143,260 @@ msgstr "kann '%s' nicht erstellen"
 msgid "index-pack died"
 msgstr "Erstellung der Paketindexdatei abgebrochen"
 
+#: chunk-format.c:113
+#, fuzzy
+msgid "terminating chunk id appears earlier than expected"
+msgstr "abschließende multi-pack-index Chunk-Id erscheint eher als erwartet"
+
+#: chunk-format.c:122
+#, fuzzy, c-format
+msgid "improper chunk offset(s) %<PRIx64> and %<PRIx64>"
+msgstr "Falscher Objekt-Offset für oid[%d] = %s: %<PRIx64> != %<PRIx64>"
+
+#: chunk-format.c:129
+#, c-format
+msgid "duplicate chunk ID %<PRIx32> found"
+msgstr ""
+
+#: chunk-format.c:143
+#, c-format
+msgid "final chunk has non-zero id %<PRIx32>"
+msgstr ""
+
 #: color.c:329
 #, c-format
 msgid "invalid color value: %.*s"
 msgstr "Ungültiger Farbwert: %.*s"
 
-#: commit-graph.c:198 midx.c:47
+#: commit-graph.c:197 midx.c:46
 msgid "invalid hash version"
 msgstr "ungültige Hash-Version"
 
-#: commit-graph.c:219
-msgid "repository contains replace objects; skipping commit-graph"
-msgstr "Repository enthält ersetzende Objekte; überspringe Commit-Graph"
-
-#: commit-graph.c:228
-msgid "repository contains (deprecated) grafts; skipping commit-graph"
-msgstr ""
-"Repository enthält (veraltete) künstliche Vorgänger (\"grafts\"); "
-"überspringe Commit-Graph"
-
-#: commit-graph.c:233
-msgid "repository is shallow; skipping commit-graph"
-msgstr ""
-"Repository hat unvollständige Historie (shallow); überspringe Commit-Graph"
-
-#: commit-graph.c:264
+#: commit-graph.c:255
 msgid "commit-graph file is too small"
 msgstr "Commit-Graph-Datei ist zu klein"
 
-#: commit-graph.c:329
+#: commit-graph.c:348
 #, c-format
 msgid "commit-graph signature %X does not match signature %X"
 msgstr "Commit-Graph-Signatur %X stimmt nicht mit Signatur %X überein."
 
-#: commit-graph.c:336
+#: commit-graph.c:355
 #, c-format
 msgid "commit-graph version %X does not match version %X"
 msgstr "Commit-Graph-Version %X stimmt nicht mit Version %X überein."
 
-#: commit-graph.c:343
+#: commit-graph.c:362
 #, c-format
 msgid "commit-graph hash version %X does not match version %X"
 msgstr "Hash-Version des Commit-Graph %X stimmt nicht mit Version %X überein."
 
-#: commit-graph.c:360
+#: commit-graph.c:379
 #, c-format
 msgid "commit-graph file is too small to hold %u chunks"
 msgstr "Commit-Graph-Datei ist zu klein, um %u Chunks zu enthalten"
 
-#: commit-graph.c:379
-#, c-format
-msgid "commit-graph improper chunk offset %08x%08x"
-msgstr "Unzulässiger Commit-Graph Chunk-Offset %08x%08x"
-
-#: commit-graph.c:465
-#, c-format
-msgid "commit-graph chunk id %08x appears multiple times"
-msgstr "Commit-Graph Chunk-Id %08x kommt mehrfach vor."
-
-#: commit-graph.c:531
+#: commit-graph.c:472
 msgid "commit-graph has no base graphs chunk"
 msgstr "Commit-Graph hat keinen Basis-Graph-Chunk"
 
-#: commit-graph.c:541
+#: commit-graph.c:482
 msgid "commit-graph chain does not match"
 msgstr "Commit-Graph Verkettung stimmt nicht überein."
 
-#: commit-graph.c:589
+#: commit-graph.c:530
 #, c-format
 msgid "invalid commit-graph chain: line '%s' not a hash"
 msgstr "Ungültige Commit-Graph Verkettung: Zeile '%s' ist kein Hash"
 
-#: commit-graph.c:613
+#: commit-graph.c:554
 msgid "unable to find all commit-graph files"
 msgstr "Konnte nicht alle Commit-Graph-Dateien finden."
 
-#: commit-graph.c:794 commit-graph.c:831
+#: commit-graph.c:735 commit-graph.c:772
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr "Ungültige Commit-Position. Commit-Graph ist wahrscheinlich beschädigt."
 
-#: commit-graph.c:815
+#: commit-graph.c:756
 #, c-format
 msgid "could not find commit %s"
 msgstr "Konnte Commit %s nicht finden."
 
-#: commit-graph.c:848
+#: commit-graph.c:789
 msgid "commit-graph requires overflow generation data but has none"
 msgstr "Commit-Graph erfordert Überlaufgenerierungsdaten, aber hat keine"
 
-#: commit-graph.c:1121 builtin/am.c:1292
+#: commit-graph.c:1065 builtin/am.c:1292
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "Konnte Commit '%s' nicht parsen."
 
-#: commit-graph.c:1378 builtin/pack-objects.c:2872
+#: commit-graph.c:1327 builtin/pack-objects.c:2872
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "Konnte Art von Objekt '%s' nicht bestimmen."
 
-#: commit-graph.c:1409
+#: commit-graph.c:1358
 msgid "Loading known commits in commit graph"
 msgstr "Lade bekannte Commits in Commit-Graph"
 
-#: commit-graph.c:1426
+#: commit-graph.c:1375
 msgid "Expanding reachable commits in commit graph"
 msgstr "Erweitere erreichbare Commits in Commit-Graph"
 
-#: commit-graph.c:1446
+#: commit-graph.c:1395
 msgid "Clearing commit marks in commit graph"
 msgstr "Lösche Commit-Markierungen in Commit-Graph"
 
-#: commit-graph.c:1465
+#: commit-graph.c:1414
 msgid "Computing commit graph topological levels"
 msgstr "Topologische Ebenen des Commit-Graph werden berechnet"
 
-#: commit-graph.c:1518
+#: commit-graph.c:1467
 msgid "Computing commit graph generation numbers"
 msgstr "Commit-Graph Generationsnummern berechnen"
 
-#: commit-graph.c:1599
+#: commit-graph.c:1548
 msgid "Computing commit changed paths Bloom filters"
 msgstr "Berechnung der Bloom-Filter für veränderte Pfade des Commits"
 
-#: commit-graph.c:1676
+#: commit-graph.c:1625
 msgid "Collecting referenced commits"
 msgstr "Sammle referenzierte Commits"
 
-#: commit-graph.c:1701
+#: commit-graph.c:1650
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] "Suche Commits für Commit-Graph in %d Paket"
 msgstr[1] "Suche Commits für Commit-Graph in %d Paketen"
 
-#: commit-graph.c:1714
+#: commit-graph.c:1663
 #, c-format
 msgid "error adding pack %s"
 msgstr "Fehler beim Hinzufügen von Paket %s."
 
-#: commit-graph.c:1718
+#: commit-graph.c:1667
 #, c-format
 msgid "error opening index for %s"
 msgstr "Fehler beim Öffnen des Index für %s."
 
-#: commit-graph.c:1755
+#: commit-graph.c:1704
 msgid "Finding commits for commit graph among packed objects"
 msgstr "Suche Commits für Commit-Graph in gepackten Objekten"
 
-#: commit-graph.c:1773
+#: commit-graph.c:1722
 msgid "Finding extra edges in commit graph"
 msgstr "Suche zusätzliche Ränder in Commit-Graph"
 
-#: commit-graph.c:1821
+#: commit-graph.c:1771
 msgid "failed to write correct number of base graph ids"
 msgstr "Fehler beim Schreiben der korrekten Anzahl von Basis-Graph-IDs."
 
-#: commit-graph.c:1863 midx.c:819
+#: commit-graph.c:1802 midx.c:794
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "Konnte führende Verzeichnisse von '%s' nicht erstellen."
 
-#: commit-graph.c:1876
+#: commit-graph.c:1815
 msgid "unable to create temporary graph layer"
 msgstr "konnte temporäre Graphen-Schicht nicht erstellen"
 
-#: commit-graph.c:1881
+#: commit-graph.c:1820
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "konnte geteilte Zugriffsberechtigungen für '%s' nicht ändern"
 
-#: commit-graph.c:1966
+#: commit-graph.c:1879
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "Schreibe Commit-Graph in %d Durchgang"
 msgstr[1] "Schreibe Commit-Graph in %d Durchgängen"
 
-#: commit-graph.c:2011
+#: commit-graph.c:1915
 msgid "unable to open commit-graph chain file"
 msgstr "konnte Commit-Graph Chain-Datei nicht öffnen"
 
-#: commit-graph.c:2027
+#: commit-graph.c:1931
 msgid "failed to rename base commit-graph file"
 msgstr "konnte Basis-Commit-Graph-Datei nicht umbenennen"
 
-#: commit-graph.c:2047
+#: commit-graph.c:1951
 msgid "failed to rename temporary commit-graph file"
 msgstr "konnte temporäre Commit-Graph-Datei nicht umbenennen"
 
-#: commit-graph.c:2180
+#: commit-graph.c:2084
 msgid "Scanning merged commits"
 msgstr "Durchsuche zusammengeführte Commits"
 
-#: commit-graph.c:2224
+#: commit-graph.c:2128
 msgid "Merging commit-graph"
 msgstr "Zusammenführen von Commit-Graph"
 
-#: commit-graph.c:2331
+#: commit-graph.c:2235
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 "versuche einen Commit-Graph zu schreiben, aber 'core.commitGraph' ist "
 "deaktiviert"
 
-#: commit-graph.c:2438
+#: commit-graph.c:2342
 msgid "too many commits to write graph"
 msgstr "zu viele Commits zum Schreiben des Graphen"
 
-#: commit-graph.c:2536
+#: commit-graph.c:2440
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "die Commit-Graph-Datei hat eine falsche Prüfsumme und ist wahrscheinlich "
 "beschädigt"
 
-#: commit-graph.c:2546
+#: commit-graph.c:2450
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "Commit-Graph hat fehlerhafte OID-Reihenfolge: %s dann %s"
 
-#: commit-graph.c:2556 commit-graph.c:2571
+#: commit-graph.c:2460 commit-graph.c:2475
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr "Commit-Graph hat fehlerhaften Fanout-Wert: fanout[%d] = %u != %u"
 
-#: commit-graph.c:2563
+#: commit-graph.c:2467
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "konnte Commit %s von Commit-Graph nicht parsen"
 
-#: commit-graph.c:2581
+#: commit-graph.c:2485
 msgid "Verifying commits in commit graph"
 msgstr "Commit in Commit-Graph überprüfen"
 
-#: commit-graph.c:2596
+#: commit-graph.c:2500
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "Fehler beim Parsen des Commits %s von Objekt-Datenbank für Commit-Graph"
 
-#: commit-graph.c:2603
+#: commit-graph.c:2507
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 "OID des Wurzelverzeichnisses für Commit %s in Commit-Graph ist %s != %s"
 
-#: commit-graph.c:2613
+#: commit-graph.c:2517
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr "Commit-Graph Vorgänger-Liste für Commit %s ist zu lang"
 
-#: commit-graph.c:2622
+#: commit-graph.c:2526
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "Commit-Graph-Vorgänger für %s ist %s != %s"
 
-#: commit-graph.c:2636
+#: commit-graph.c:2540
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr "Commit-Graph Vorgänger-Liste für Commit %s endet zu früh"
 
-#: commit-graph.c:2641
+#: commit-graph.c:2545
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2409,7 +2404,7 @@ msgstr ""
 "Commit-Graph hat Generationsnummer null für Commit %s, aber sonst ungleich "
 "null"
 
-#: commit-graph.c:2645
+#: commit-graph.c:2549
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2417,12 +2412,12 @@ msgstr ""
 "Commit-Graph hat Generationsnummer ungleich null für Commit %s, aber sonst "
 "null"
 
-#: commit-graph.c:2662
+#: commit-graph.c:2566
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr "Commit-Graph Erstellung für Commit %s ist %<PRIuMAX> < %<PRIuMAX>"
 
-#: commit-graph.c:2668
+#: commit-graph.c:2572
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
@@ -3981,7 +3976,7 @@ msgstr ""
 msgid "failed to read orderfile '%s'"
 msgstr "Fehler beim Lesen der Reihenfolgedatei '%s'"
 
-#: diffcore-rename.c:555
+#: diffcore-rename.c:786
 msgid "Performing inexact rename detection"
 msgstr "Führe Erkennung für ungenaue Umbenennung aus"
 
@@ -4036,17 +4031,17 @@ msgstr ""
 "Cache für unversionierte Dateien ist auf diesem System oder\n"
 "für dieses Verzeichnis deaktiviert"
 
-#: dir.c:3537
+#: dir.c:3534
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "Index-Datei in Repository %s beschädigt"
 
-#: dir.c:3582 dir.c:3587
+#: dir.c:3579 dir.c:3584
 #, c-format
 msgid "could not create directories for %s"
 msgstr "Konnte Verzeichnisse für '%s' nicht erstellen"
 
-#: dir.c:3616
+#: dir.c:3613
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "Konnte Git-Verzeichnis nicht von '%s' nach '%s' migrieren"
@@ -4105,32 +4100,32 @@ msgstr "konnte nicht zum Remote schreiben"
 msgid "--stateless-rpc requires multi_ack_detailed"
 msgstr "--stateless-rpc benötigt multi_ack_detailed"
 
-#: fetch-pack.c:378 fetch-pack.c:1400
+#: fetch-pack.c:378 fetch-pack.c:1457
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "ungültige shallow-Zeile: %s"
 
-#: fetch-pack.c:384 fetch-pack.c:1406
+#: fetch-pack.c:384 fetch-pack.c:1463
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "ungültige unshallow-Zeile: %s"
 
-#: fetch-pack.c:386 fetch-pack.c:1408
+#: fetch-pack.c:386 fetch-pack.c:1465
 #, c-format
 msgid "object not found: %s"
 msgstr "Objekt nicht gefunden: %s"
 
-#: fetch-pack.c:389 fetch-pack.c:1411
+#: fetch-pack.c:389 fetch-pack.c:1468
 #, c-format
 msgid "error in object: %s"
 msgstr "Fehler in Objekt: %s"
 
-#: fetch-pack.c:391 fetch-pack.c:1413
+#: fetch-pack.c:391 fetch-pack.c:1470
 #, c-format
 msgid "no shallow found: %s"
 msgstr "kein shallow-Objekt gefunden: %s"
 
-#: fetch-pack.c:394 fetch-pack.c:1417
+#: fetch-pack.c:394 fetch-pack.c:1474
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "shallow/unshallow erwartet, %s bekommen"
@@ -4168,157 +4163,161 @@ msgstr "Markiere %s als vollständig"
 msgid "already have %s (%s)"
 msgstr "habe %s (%s) bereits"
 
-#: fetch-pack.c:821
+#: fetch-pack.c:844
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-pack: Fehler beim Starten des sideband demultiplexer"
 
-#: fetch-pack.c:829
+#: fetch-pack.c:852
 msgid "protocol error: bad pack header"
 msgstr "Protokollfehler: ungültiger Pack-Header"
 
-#: fetch-pack.c:913
+#: fetch-pack.c:946
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-pack: konnte %s nicht starten"
 
-#: fetch-pack.c:931
+#: fetch-pack.c:952
+msgid "fetch-pack: invalid index-pack output"
+msgstr ""
+
+#: fetch-pack.c:969
 #, c-format
 msgid "%s failed"
 msgstr "%s fehlgeschlagen"
 
-#: fetch-pack.c:933
+#: fetch-pack.c:971
 msgid "error in sideband demultiplexer"
 msgstr "Fehler in sideband demultiplexer"
 
-#: fetch-pack.c:976
+#: fetch-pack.c:1031
 #, c-format
 msgid "Server version is %.*s"
 msgstr "Server-Version ist %.*s"
 
-#: fetch-pack.c:984 fetch-pack.c:990 fetch-pack.c:993 fetch-pack.c:999
-#: fetch-pack.c:1003 fetch-pack.c:1007 fetch-pack.c:1011 fetch-pack.c:1015
-#: fetch-pack.c:1019 fetch-pack.c:1023 fetch-pack.c:1027 fetch-pack.c:1031
-#: fetch-pack.c:1037 fetch-pack.c:1043 fetch-pack.c:1048 fetch-pack.c:1053
+#: fetch-pack.c:1039 fetch-pack.c:1045 fetch-pack.c:1048 fetch-pack.c:1054
+#: fetch-pack.c:1058 fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070
+#: fetch-pack.c:1074 fetch-pack.c:1078 fetch-pack.c:1082 fetch-pack.c:1086
+#: fetch-pack.c:1092 fetch-pack.c:1098 fetch-pack.c:1103 fetch-pack.c:1108
 #, c-format
 msgid "Server supports %s"
 msgstr "Server unterstützt %s"
 
-#: fetch-pack.c:986
+#: fetch-pack.c:1041
 msgid "Server does not support shallow clients"
 msgstr "Server unterstützt keine shallow-Clients"
 
-#: fetch-pack.c:1046
+#: fetch-pack.c:1101
 msgid "Server does not support --shallow-since"
 msgstr "Server unterstützt kein --shallow-since"
 
-#: fetch-pack.c:1051
+#: fetch-pack.c:1106
 msgid "Server does not support --shallow-exclude"
 msgstr "Server unterstützt kein --shallow-exclude"
 
-#: fetch-pack.c:1055
+#: fetch-pack.c:1110
 msgid "Server does not support --deepen"
 msgstr "Server unterstützt kein --deepen"
 
-#: fetch-pack.c:1057
+#: fetch-pack.c:1112
 msgid "Server does not support this repository's object format"
 msgstr "Server unterstützt das Objekt-Format dieses Repositories nicht"
 
-#: fetch-pack.c:1070
+#: fetch-pack.c:1125
 msgid "no common commits"
 msgstr "keine gemeinsamen Commits"
 
-#: fetch-pack.c:1082 fetch-pack.c:1622
+#: fetch-pack.c:1138 fetch-pack.c:1682
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack: Abholen fehlgeschlagen."
 
-#: fetch-pack.c:1208
+#: fetch-pack.c:1265
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "Algorithmen stimmen nicht überein: Client %s; Server %s"
 
-#: fetch-pack.c:1212
+#: fetch-pack.c:1269
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "der Server unterstützt Algorithmus '%s' nicht"
 
-#: fetch-pack.c:1232
+#: fetch-pack.c:1289
 msgid "Server does not support shallow requests"
 msgstr "Server unterstützt keine shallow-Anfragen"
 
-#: fetch-pack.c:1239
+#: fetch-pack.c:1296
 msgid "Server supports filter"
 msgstr "Server unterstützt Filter"
 
-#: fetch-pack.c:1278
+#: fetch-pack.c:1335
 msgid "unable to write request to remote"
 msgstr "konnte Anfrage nicht zum Remote schreiben"
 
-#: fetch-pack.c:1296
+#: fetch-pack.c:1353
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "Fehler beim Lesen von Sektionskopf '%s'."
 
-#: fetch-pack.c:1302
+#: fetch-pack.c:1359
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "'%s' erwartet, '%s' empfangen"
 
-#: fetch-pack.c:1363
+#: fetch-pack.c:1420
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "Unerwartete Acknowledgment-Zeile: '%s'"
 
-#: fetch-pack.c:1368
+#: fetch-pack.c:1425
 #, c-format
 msgid "error processing acks: %d"
 msgstr "Fehler beim Verarbeiten von ACKS: %d"
 
-#: fetch-pack.c:1378
+#: fetch-pack.c:1435
 msgid "expected packfile to be sent after 'ready'"
 msgstr "Erwartete Versand einer Packdatei nach 'ready'."
 
-#: fetch-pack.c:1380
+#: fetch-pack.c:1437
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr "Erwartete keinen Versand einer anderen Sektion ohne 'ready'."
 
-#: fetch-pack.c:1422
+#: fetch-pack.c:1479
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "Fehler beim Verarbeiten von Shallow-Informationen: %d"
 
-#: fetch-pack.c:1469
+#: fetch-pack.c:1526
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "wanted-ref erwartet, '%s' bekommen"
 
-#: fetch-pack.c:1474
+#: fetch-pack.c:1531
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "unerwartetes wanted-ref: '%s'"
 
-#: fetch-pack.c:1479
+#: fetch-pack.c:1536
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "Fehler beim Verarbeiten von wanted-refs: %d"
 
-#: fetch-pack.c:1509
+#: fetch-pack.c:1566
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: Antwort-Endpaket erwartet"
 
-#: fetch-pack.c:1891
+#: fetch-pack.c:1960
 msgid "no matching remote head"
 msgstr "kein übereinstimmender Remote-Branch"
 
-#: fetch-pack.c:1914 builtin/clone.c:693
+#: fetch-pack.c:1983 builtin/clone.c:693
 msgid "remote did not send all necessary objects"
 msgstr "Remote-Repository hat nicht alle erforderlichen Objekte gesendet"
 
-#: fetch-pack.c:1941
+#: fetch-pack.c:2010
 #, c-format
 msgid "no such remote ref %s"
 msgstr "Remote-Referenz %s nicht gefunden"
 
-#: fetch-pack.c:1944
+#: fetch-pack.c:2013
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Der Server lehnt Anfrage nach nicht angebotenem Objekt %s ab."
@@ -4683,32 +4682,32 @@ msgstr "ungültiger Wert '%s' für lsrefs.unborn"
 msgid "expected flush after ls-refs arguments"
 msgstr "erwartete Flush nach Argumenten für die Auflistung der Referenzen"
 
-#: merge-ort.c:855 merge-recursive.c:1191
+#: merge-ort.c:888 merge-recursive.c:1191
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
 msgstr "Fehler beim Merge von Submodul %s (nicht ausgecheckt)."
 
-#: merge-ort.c:864 merge-recursive.c:1198
+#: merge-ort.c:897 merge-recursive.c:1198
 #, c-format
 msgid "Failed to merge submodule %s (commits not present)"
 msgstr "Fehler beim Merge von Submodul %s (Commits nicht vorhanden)."
 
-#: merge-ort.c:873 merge-recursive.c:1205
+#: merge-ort.c:906 merge-recursive.c:1205
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
 msgstr "Fehler beim Merge von Submodul %s (Commits folgen keiner Merge-Basis)"
 
-#: merge-ort.c:883 merge-ort.c:890
+#: merge-ort.c:916 merge-ort.c:923
 #, c-format
 msgid "Note: Fast-forwarding submodule %s to %s"
 msgstr "Hinweis: Spule Submodul %s vor zu %s"
 
-#: merge-ort.c:911
+#: merge-ort.c:944
 #, c-format
 msgid "Failed to merge submodule %s"
 msgstr "Fehler beim Zusammenführen von Submodul %s"
 
-#: merge-ort.c:918
+#: merge-ort.c:951
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but a possible merge resolution exists:\n"
@@ -4718,7 +4717,7 @@ msgstr ""
 "Auflösung des Merges vorhanden:\n"
 "%s\n"
 
-#: merge-ort.c:922 merge-recursive.c:1259
+#: merge-ort.c:955 merge-recursive.c:1259
 #, c-format
 msgid ""
 "If this is correct simply add it to the index for example\n"
@@ -4735,7 +4734,7 @@ msgstr ""
 "\n"
 "hinzu, um diesen Vorschlag zu akzeptieren.\n"
 
-#: merge-ort.c:935
+#: merge-ort.c:968
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but multiple possible merges exist:\n"
@@ -4745,21 +4744,21 @@ msgstr ""
 "sind vorhanden:\n"
 "%s"
 
-#: merge-ort.c:1094 merge-recursive.c:1341
+#: merge-ort.c:1127 merge-recursive.c:1341
 msgid "Failed to execute internal merge"
 msgstr "Fehler bei Ausführung des internen Merges"
 
-#: merge-ort.c:1099 merge-recursive.c:1346
+#: merge-ort.c:1132 merge-recursive.c:1346
 #, c-format
 msgid "Unable to add %s to database"
 msgstr "Konnte %s nicht zur Datenbank hinzufügen"
 
-#: merge-ort.c:1106 merge-recursive.c:1378
+#: merge-ort.c:1139 merge-recursive.c:1378
 #, c-format
 msgid "Auto-merging %s"
 msgstr "automatischer Merge von %s"
 
-#: merge-ort.c:1245 merge-recursive.c:2100
+#: merge-ort.c:1278 merge-recursive.c:2100
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
@@ -4770,7 +4769,7 @@ msgstr ""
 "Weg von impliziter Verzeichnisumbenennung, die versucht, einen oder mehrere\n"
 "Pfade dahin zu setzen: %s."
 
-#: merge-ort.c:1255 merge-recursive.c:2110
+#: merge-ort.c:1288 merge-recursive.c:2110
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
@@ -4781,7 +4780,7 @@ msgstr ""
 "%s mappen; implizite Verzeichnisumbenennungen versuchten diese Pfade dahin\n"
 "zu setzen: %s"
 
-#: merge-ort.c:1438
+#: merge-ort.c:1471
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to rename %s to; it was "
@@ -4792,7 +4791,7 @@ msgstr ""
 "ist; es wurde zu mehreren anderen Verzeichnissen umbenannt, ohne dass ein "
 "Ziel die Mehrheit der Dateien erhält."
 
-#: merge-ort.c:1604 merge-recursive.c:2447
+#: merge-ort.c:1637 merge-recursive.c:2447
 #, c-format
 msgid ""
 "WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
@@ -4801,7 +4800,7 @@ msgstr ""
 "WARNUNG: Vermeide Umbenennung %s -> %s von %s, weil %s selbst umbenannt "
 "wurde."
 
-#: merge-ort.c:1748 merge-recursive.c:3215
+#: merge-ort.c:1781 merge-recursive.c:3215
 #, c-format
 msgid ""
 "Path updated: %s added in %s inside a directory that was renamed in %s; "
@@ -4810,7 +4809,7 @@ msgstr ""
 "Pfad aktualisiert: %s hinzugefügt in %s innerhalb eines Verzeichnisses, das "
 "umbenannt wurde in %s; Verschiebe es nach %s."
 
-#: merge-ort.c:1755 merge-recursive.c:3222
+#: merge-ort.c:1788 merge-recursive.c:3222
 #, c-format
 msgid ""
 "Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
@@ -4819,7 +4818,7 @@ msgstr ""
 "Pfad aktualisiert: %s umbenannt nach %s in %s, innerhalb eines "
 "Verzeichnisses, das umbenannt wurde in %s; Verschiebe es nach %s."
 
-#: merge-ort.c:1768 merge-recursive.c:3218
+#: merge-ort.c:1801 merge-recursive.c:3218
 #, c-format
 msgid ""
 "CONFLICT (file location): %s added in %s inside a directory that was renamed "
@@ -4828,7 +4827,7 @@ msgstr ""
 "KONFLIKT (Speicherort): %s hinzugefügt in %s innerhalb eines Verzeichnisses, "
 "das umbenannt wurde in %s, es sollte vielleicht nach %s verschoben werden."
 
-#: merge-ort.c:1776 merge-recursive.c:3225
+#: merge-ort.c:1809 merge-recursive.c:3225
 #, c-format
 msgid ""
 "CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
@@ -4838,13 +4837,13 @@ msgstr ""
 "Verzeichnisses, das umbenannt wurde in %s, es sollte vielleicht nach %s "
 "verschoben werden."
 
-#: merge-ort.c:1919
+#: merge-ort.c:1952
 #, c-format
 msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
 msgstr ""
 "KONFLIKT (umbenennen/umbenennen): %s zu %s in %s umbenannt und zu %s in %s."
 
-#: merge-ort.c:2014
+#: merge-ort.c:2047
 #, c-format
 msgid ""
 "CONFLICT (rename involved in collision): rename of %s -> %s has content "
@@ -4855,13 +4854,13 @@ msgstr ""
 "Inhaltskonflikte UND kollidiert mit einem anderen Pfad; dies kann zu "
 "verschachtelten Konfliktmarkierungen führen."
 
-#: merge-ort.c:2033 merge-ort.c:2057
+#: merge-ort.c:2066 merge-ort.c:2090
 #, c-format
 msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
 msgstr ""
 "KONFLIKT (umbenennen/löschen): %s zu %s in %s umbenannt, aber in %s gelöscht."
 
-#: merge-ort.c:2683
+#: merge-ort.c:2735
 #, c-format
 msgid ""
 "CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
@@ -4870,7 +4869,7 @@ msgstr ""
 "KONFLIKT (Datei/Verzeichnis): Verzeichnis im Weg von %s aus %s; stattdessen "
 "nach %s verschieben."
 
-#: merge-ort.c:2756
+#: merge-ort.c:2808
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed %s "
@@ -4879,32 +4878,32 @@ msgstr ""
 "KONFLIKT (verschiedene Typen): %s hatte unterschiedliche Typen auf jeder "
 "Seite; %s wurde(n) umbenannt, damit jeder irgendwo aufgezeichnet werden kann."
 
-#: merge-ort.c:2760
+#: merge-ort.c:2812
 msgid "both"
 msgstr "beide"
 
-#: merge-ort.c:2760
+#: merge-ort.c:2812
 msgid "one"
 msgstr "einer"
 
-#: merge-ort.c:2855 merge-recursive.c:3052
+#: merge-ort.c:2907 merge-recursive.c:3052
 msgid "content"
 msgstr "Inhalt"
 
-#: merge-ort.c:2857 merge-recursive.c:3056
+#: merge-ort.c:2909 merge-recursive.c:3056
 msgid "add/add"
 msgstr "hinzufügen/hinzufügen"
 
-#: merge-ort.c:2859 merge-recursive.c:3101
+#: merge-ort.c:2911 merge-recursive.c:3101
 msgid "submodule"
 msgstr "Submodul"
 
-#: merge-ort.c:2861 merge-recursive.c:3102
+#: merge-ort.c:2913 merge-recursive.c:3102
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "KONFLIKT (%s): Merge-Konflikt in %s"
 
-#: merge-ort.c:2886
+#: merge-ort.c:2938
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
@@ -4916,7 +4915,7 @@ msgstr ""
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
-#: merge-ort.c:3354
+#: merge-ort.c:3406
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
 msgstr ""
@@ -5250,112 +5249,105 @@ msgstr "Lesen des Zwischenspeichers fehlgeschlagen"
 msgid "unable to write new index file"
 msgstr "Konnte neue Index-Datei nicht schreiben."
 
-#: midx.c:80
+#: midx.c:62
+#, fuzzy
+msgid "multi-pack-index OID fanout is of the wrong size"
+msgstr "multi-pack-index-Version %d nicht erkannt."
+
+#: midx.c:93
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "multi-pack-index-Datei %s ist zu klein."
 
-#: midx.c:96
+#: midx.c:109
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr ""
 "multi-pack-index-Signatur 0x%08x stimmt nicht mit Signatur 0x%08x überein."
 
-#: midx.c:101
+#: midx.c:114
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "multi-pack-index-Version %d nicht erkannt."
 
-#: midx.c:106
+#: midx.c:119
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr "multi-pack-index Hash-Version %u stimmt nicht mit Version %u überein"
 
-#: midx.c:123
-msgid "invalid chunk offset (too large)"
-msgstr "Ungültiger Chunk-Offset (zu groß)"
-
-#: midx.c:147
-msgid "terminating multi-pack-index chunk id appears earlier than expected"
-msgstr "abschließende multi-pack-index Chunk-Id erscheint eher als erwartet"
-
-#: midx.c:160
+#: midx.c:136
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "multi-pack-index fehlt erforderlicher Pack-Namen Chunk"
 
-#: midx.c:162
+#: midx.c:138
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "multi-pack-index fehlt erforderlicher OID fanout Chunk"
 
-#: midx.c:164
+#: midx.c:140
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr "multi-pack-index fehlt erforderlicher OID lookup Chunk"
 
-#: midx.c:166
+#: midx.c:142
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr "multi-pack-index fehlt erforderlicher Objekt offset Chunk"
 
-#: midx.c:180
+#: midx.c:158
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr "Falsche Reihenfolge bei multi-pack-index Pack-Namen: '%s' vor '%s'"
 
-#: midx.c:223
+#: midx.c:202
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr "Ungültige pack-int-id: %u (%u Pakete insgesamt)"
 
-#: midx.c:273
+#: midx.c:252
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr ""
 "multi-pack-index speichert einen 64-Bit Offset, aber off_t ist zu klein"
 
-#: midx.c:480
+#: midx.c:467
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "Fehler beim Hinzufügen von Packdatei '%s'"
 
-#: midx.c:486
+#: midx.c:473
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "Fehler beim Öffnen von pack-index '%s'"
 
-#: midx.c:546
+#: midx.c:533
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "Fehler beim Lokalisieren von Objekt %d in Packdatei"
 
-#: midx.c:846
+#: midx.c:821
 msgid "Adding packfiles to multi-pack-index"
 msgstr "Packdateien zum multi-pack-index hinzufügen"
 
-#: midx.c:879
+#: midx.c:855
 #, c-format
 msgid "did not see pack-file %s to drop"
 msgstr "Pack-Datei %s zum Weglassen nicht gefunden"
 
-#: midx.c:931
+#: midx.c:904
 msgid "no pack files to index."
 msgstr "keine Packdateien zum Indizieren."
 
-#: midx.c:982
-msgid "Writing chunks to multi-pack-index"
-msgstr "Chunks zum multi-pack-index schreiben"
-
-#: midx.c:1060
+#: midx.c:965
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "Fehler beim Löschen des multi-pack-index bei %s"
 
-#: midx.c:1116
+#: midx.c:1021
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr "multi-pack-index-Datei existiert, aber das Parsen schlug fehl"
 
-#: midx.c:1124
+#: midx.c:1029
 msgid "Looking for referenced packfiles"
 msgstr "Suche nach referenzierten Pack-Dateien"
 
-#: midx.c:1139
+#: midx.c:1044
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
@@ -5363,55 +5355,55 @@ msgstr ""
 "Ungültige oid fanout Reihenfolge: fanout[%d] = %<PRIx32> > %<PRIx32> = "
 "fanout[%d]"
 
-#: midx.c:1144
+#: midx.c:1049
 msgid "the midx contains no oid"
 msgstr "das midx enthält keine oid"
 
-#: midx.c:1153
+#: midx.c:1058
 msgid "Verifying OID order in multi-pack-index"
 msgstr "Verifiziere OID-Reihenfolge im multi-pack-index"
 
-#: midx.c:1162
+#: midx.c:1067
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr "Ungültige oid lookup Reihenfolge: oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1182
+#: midx.c:1087
 msgid "Sorting objects by packfile"
 msgstr "Sortiere Objekte nach Pack-Datei"
 
-#: midx.c:1189
+#: midx.c:1094
 msgid "Verifying object offsets"
 msgstr "Überprüfe Objekt-Offsets"
 
-#: midx.c:1205
+#: midx.c:1110
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "Fehler beim Laden des Pack-Eintrags für oid[%d] = %s"
 
-#: midx.c:1211
+#: midx.c:1116
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "Fehler beim Laden des Pack-Index für Packdatei %s"
 
-#: midx.c:1220
+#: midx.c:1125
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr "Falscher Objekt-Offset für oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#: midx.c:1245
+#: midx.c:1150
 msgid "Counting referenced objects"
 msgstr "Referenzierte Objekte zählen"
 
-#: midx.c:1255
+#: midx.c:1160
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "Suchen und Löschen von unreferenzierten Pack-Dateien"
 
-#: midx.c:1446
+#: midx.c:1351
 msgid "could not start pack-objects"
 msgstr "Konnte 'pack-objects' nicht ausführen"
 
-#: midx.c:1466
+#: midx.c:1371
 msgid "could not finish pack-objects"
 msgstr "Konnte 'pack-objects' nicht beenden"
 
@@ -5914,7 +5906,7 @@ msgstr "konnte nicht lesen: %s"
 msgid "failed to make %s readable"
 msgstr "Fehler beim lesbar machen von %s"
 
-#: pack-write.c:502
+#: pack-write.c:508
 #, c-format
 msgid "could not write '%s' promisor file"
 msgstr "konnte Promisor-Datei '%s' nicht schreiben"
@@ -6183,11 +6175,11 @@ msgstr "Protokollfehler: ungültige Zeilenlänge %d"
 msgid "remote error: %s"
 msgstr "Fehler am anderen Ende: %s"
 
-#: preload-index.c:119
+#: preload-index.c:125
 msgid "Refreshing index"
 msgstr "Aktualisiere Index"
 
-#: preload-index.c:138
+#: preload-index.c:144
 #, c-format
 msgid "unable to create threaded lstat: %s"
 msgstr "Kann Thread für lstat nicht erzeugen: %s"
@@ -6301,11 +6293,11 @@ msgstr "konnte '%s' nicht lesen"
 msgid "'%s' appears as both a file and as a directory"
 msgstr "'%s' scheint eine Datei und ein Verzeichnis zu sein"
 
-#: read-cache.c:1524
+#: read-cache.c:1532
 msgid "Refresh index"
 msgstr "Aktualisiere Index"
 
-#: read-cache.c:1639
+#: read-cache.c:1657
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -6314,7 +6306,7 @@ msgstr ""
 "index.version gesetzt, aber Wert ungültig.\n"
 "Verwende Version %i"
 
-#: read-cache.c:1649
+#: read-cache.c:1667
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -6323,55 +6315,55 @@ msgstr ""
 "GIT_INDEX_VERSION gesetzt, aber Wert ungültig.\n"
 "Verwende Version %i"
 
-#: read-cache.c:1705
+#: read-cache.c:1723
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr "Ungültige Signatur 0x%08x"
 
-#: read-cache.c:1708
+#: read-cache.c:1726
 #, c-format
 msgid "bad index version %d"
 msgstr "Ungültige Index-Version %d"
 
-#: read-cache.c:1717
+#: read-cache.c:1735
 msgid "bad index file sha1 signature"
 msgstr "Ungültige SHA1-Signatur der Index-Datei."
 
-#: read-cache.c:1747
+#: read-cache.c:1765
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr "Index verwendet Erweiterung %.4s, welche wir nicht unterstützen."
 
-#: read-cache.c:1749
+#: read-cache.c:1767
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr "Ignoriere Erweiterung %.4s"
 
-#: read-cache.c:1786
+#: read-cache.c:1804
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr "Unbekanntes Format für Index-Eintrag 0x%08x"
 
-#: read-cache.c:1802
+#: read-cache.c:1820
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "Ungültiges Namensfeld im Index, in der Nähe von Pfad '%s'."
 
-#: read-cache.c:1859
+#: read-cache.c:1877
 msgid "unordered stage entries in index"
 msgstr "Ungeordnete Stage-Einträge im Index."
 
-#: read-cache.c:1862
+#: read-cache.c:1880
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr "Mehrere Stage-Einträge für zusammengeführte Datei '%s'."
 
-#: read-cache.c:1865
+#: read-cache.c:1883
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr "Ungeordnete Stage-Einträge für '%s'."
 
-#: read-cache.c:1971 read-cache.c:2262 rerere.c:549 rerere.c:583 rerere.c:1095
+#: read-cache.c:1989 read-cache.c:2280 rerere.c:549 rerere.c:583 rerere.c:1095
 #: submodule.c:1634 builtin/add.c:546 builtin/check-ignore.c:181
 #: builtin/checkout.c:504 builtin/checkout.c:690 builtin/clean.c:991
 #: builtin/commit.c:364 builtin/diff-tree.c:122 builtin/grep.c:505
@@ -6380,82 +6372,82 @@ msgstr "Ungeordnete Stage-Einträge für '%s'."
 msgid "index file corrupt"
 msgstr "Index-Datei beschädigt"
 
-#: read-cache.c:2115
+#: read-cache.c:2133
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr "Kann Thread für load_cache_entries nicht erzeugen: %s"
 
-#: read-cache.c:2128
+#: read-cache.c:2146
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr "Kann Thread für load_cache_entries nicht erzeugen: %s"
 
-#: read-cache.c:2161
+#: read-cache.c:2179
 #, c-format
 msgid "%s: index file open failed"
 msgstr "%s: Öffnen der Index-Datei fehlgeschlagen."
 
-#: read-cache.c:2165
+#: read-cache.c:2183
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr "%s: Kann geöffneten Index nicht lesen."
 
-#: read-cache.c:2169
+#: read-cache.c:2187
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr "%s: Index-Datei ist kleiner als erwartet."
 
-#: read-cache.c:2173
+#: read-cache.c:2191
 #, c-format
 msgid "%s: unable to map index file"
 msgstr "%s: Konnte Index-Datei nicht einlesen."
 
-#: read-cache.c:2215
+#: read-cache.c:2233
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr "Kann Thread für load_index_extensions nicht erzeugen: %s"
 
-#: read-cache.c:2242
+#: read-cache.c:2260
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr "Kann Thread für load_index_extensions nicht beitreten: %s"
 
-#: read-cache.c:2274
+#: read-cache.c:2292
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr "Konnte geteilten Index '%s' nicht aktualisieren."
 
-#: read-cache.c:2321
+#: read-cache.c:2339
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr "Fehlerhafter Index. Erwartete %s in %s, erhielt %s."
 
-#: read-cache.c:3017 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1141
+#: read-cache.c:3035 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1141
 #, c-format
 msgid "could not close '%s'"
 msgstr "Konnte '%s' nicht schließen."
 
-#: read-cache.c:3120 sequencer.c:2487 sequencer.c:4239
+#: read-cache.c:3138 sequencer.c:2487 sequencer.c:4239
 #, c-format
 msgid "could not stat '%s'"
 msgstr "Konnte '%s' nicht lesen."
 
-#: read-cache.c:3133
+#: read-cache.c:3151
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "konnte Git-Verzeichnis nicht öffnen: %s"
 
-#: read-cache.c:3145
+#: read-cache.c:3163
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "Konnte '%s' nicht entfernen."
 
-#: read-cache.c:3170
+#: read-cache.c:3188
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr "Konnte Zugriffsberechtigung auf '%s' nicht setzen."
 
-#: read-cache.c:3319
+#: read-cache.c:3337
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr "%s: Kann nicht auf Stufe #0 wechseln."
@@ -6635,243 +6627,248 @@ msgstr "%d hinterher"
 msgid "ahead %d, behind %d"
 msgstr "%d voraus, %d hinterher"
 
-#: ref-filter.c:169
+#: ref-filter.c:175
 #, c-format
 msgid "expected format: %%(color:<color>)"
 msgstr "Erwartetes Format: %%(color:<Farbe>)"
 
-#: ref-filter.c:171
+#: ref-filter.c:177
 #, c-format
 msgid "unrecognized color: %%(color:%s)"
 msgstr "nicht erkannte Farbe: %%(color:%s)"
 
-#: ref-filter.c:193
+#: ref-filter.c:199
 #, c-format
 msgid "Integer value expected refname:lstrip=%s"
 msgstr "Positiver Wert erwartet refname:lstrip=%s"
 
-#: ref-filter.c:197
+#: ref-filter.c:203
 #, c-format
 msgid "Integer value expected refname:rstrip=%s"
 msgstr "Positiver Wert erwartet refname:rstrip=%s"
 
-#: ref-filter.c:199
+#: ref-filter.c:205
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
 msgstr "nicht erkanntes %%(%s) Argument: %s"
 
-#: ref-filter.c:254
+#: ref-filter.c:260
 #, c-format
 msgid "%%(objecttype) does not take arguments"
 msgstr "%%(objecttype) akzeptiert keine Argumente"
 
-#: ref-filter.c:276
+#: ref-filter.c:282
 #, c-format
 msgid "unrecognized %%(objectsize) argument: %s"
 msgstr "nicht erkanntes %%(objectsize) Argument: %s"
 
-#: ref-filter.c:284
+#: ref-filter.c:290
 #, c-format
 msgid "%%(deltabase) does not take arguments"
 msgstr "%%(deltabase) akzeptiert keine Argumente"
 
-#: ref-filter.c:296
+#: ref-filter.c:302
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr "%%(body) akzeptiert keine Argumente"
 
-#: ref-filter.c:309
+#: ref-filter.c:315
 #, c-format
 msgid "unrecognized %%(subject) argument: %s"
 msgstr "nicht erkanntes %%(subject) Argument: %s"
 
-#: ref-filter.c:330
+#: ref-filter.c:334
+#, c-format
+msgid "expected %%(trailers:key=<value>)"
+msgstr ""
+
+#: ref-filter.c:336
 #, c-format
 msgid "unknown %%(trailers) argument: %s"
 msgstr "unbekanntes %%(trailers) Argument: %s"
 
-#: ref-filter.c:363
+#: ref-filter.c:367
 #, c-format
 msgid "positive value expected contents:lines=%s"
 msgstr "Positiver Wert erwartet contents:lines=%s"
 
-#: ref-filter.c:365
+#: ref-filter.c:369
 #, c-format
 msgid "unrecognized %%(contents) argument: %s"
 msgstr "nicht erkanntes %%(contents) Argument: %s"
 
-#: ref-filter.c:380
+#: ref-filter.c:384
 #, c-format
 msgid "positive value expected '%s' in %%(%s)"
 msgstr "positiver Wert erwartet '%s' in %%(%s)"
 
-#: ref-filter.c:384
+#: ref-filter.c:388
 #, c-format
 msgid "unrecognized argument '%s' in %%(%s)"
 msgstr "nicht erkanntes Argument '%s' in %%(%s)"
 
-#: ref-filter.c:398
+#: ref-filter.c:402
 #, c-format
 msgid "unrecognized email option: %s"
 msgstr "nicht erkannte E-Mail Option: %s"
 
-#: ref-filter.c:428
+#: ref-filter.c:432
 #, c-format
 msgid "expected format: %%(align:<width>,<position>)"
 msgstr "erwartetes Format: %%(align:<Breite>,<Position>)"
 
-#: ref-filter.c:440
+#: ref-filter.c:444
 #, c-format
 msgid "unrecognized position:%s"
 msgstr "nicht erkannte Position:%s"
 
-#: ref-filter.c:447
+#: ref-filter.c:451
 #, c-format
 msgid "unrecognized width:%s"
 msgstr "nicht erkannte Breite:%s"
 
-#: ref-filter.c:456
+#: ref-filter.c:460
 #, c-format
 msgid "unrecognized %%(align) argument: %s"
 msgstr "nicht erkanntes %%(align) Argument: %s"
 
-#: ref-filter.c:464
+#: ref-filter.c:468
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr "Positive Breitenangabe für %%(align) erwartet"
 
-#: ref-filter.c:482
+#: ref-filter.c:486
 #, c-format
 msgid "unrecognized %%(if) argument: %s"
 msgstr "nicht erkanntes %%(if) Argument: %s"
 
-#: ref-filter.c:584
+#: ref-filter.c:588
 #, c-format
 msgid "malformed field name: %.*s"
 msgstr "Fehlerhafter Feldname: %.*s"
 
-#: ref-filter.c:611
+#: ref-filter.c:615
 #, c-format
 msgid "unknown field name: %.*s"
 msgstr "Unbekannter Feldname: %.*s"
 
-#: ref-filter.c:615
+#: ref-filter.c:619
 #, c-format
 msgid ""
 "not a git repository, but the field '%.*s' requires access to object data"
 msgstr ""
 "Kein Git-Repository, aber das Feld '%.*s' erfordert Zugriff auf Objektdaten."
 
-#: ref-filter.c:739
+#: ref-filter.c:743
 #, c-format
 msgid "format: %%(if) atom used without a %%(then) atom"
 msgstr "format: %%(if) Atom ohne ein %%(then) Atom verwendet"
 
-#: ref-filter.c:802
+#: ref-filter.c:806
 #, c-format
 msgid "format: %%(then) atom used without an %%(if) atom"
 msgstr "format: %%(then) Atom ohne ein %%(if) Atom verwendet"
 
-#: ref-filter.c:804
+#: ref-filter.c:808
 #, c-format
 msgid "format: %%(then) atom used more than once"
 msgstr "format: %%(then) Atom mehr als einmal verwendet"
 
-#: ref-filter.c:806
+#: ref-filter.c:810
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr "format: %%(then) Atom nach %%(else) verwendet"
 
-#: ref-filter.c:834
+#: ref-filter.c:838
 #, c-format
 msgid "format: %%(else) atom used without an %%(if) atom"
 msgstr "format: %%(else) Atom ohne ein %%(if) Atom verwendet"
 
-#: ref-filter.c:836
+#: ref-filter.c:840
 #, c-format
 msgid "format: %%(else) atom used without a %%(then) atom"
 msgstr "Format: %%(else) Atom ohne ein %%(then) Atom verwendet"
 
-#: ref-filter.c:838
+#: ref-filter.c:842
 #, c-format
 msgid "format: %%(else) atom used more than once"
 msgstr "Format: %%(end) Atom mehr als einmal verwendet"
 
-#: ref-filter.c:853
+#: ref-filter.c:857
 #, c-format
 msgid "format: %%(end) atom used without corresponding atom"
 msgstr "Format: %%(end) Atom ohne zugehöriges Atom verwendet"
 
-#: ref-filter.c:910
+#: ref-filter.c:914
 #, c-format
 msgid "malformed format string %s"
 msgstr "Fehlerhafter Formatierungsstring %s"
 
-#: ref-filter.c:1551
+#: ref-filter.c:1555
 #, c-format
 msgid "(no branch, rebasing %s)"
 msgstr "(kein Branch, Rebase von %s)"
 
-#: ref-filter.c:1554
+#: ref-filter.c:1558
 #, c-format
 msgid "(no branch, rebasing detached HEAD %s)"
 msgstr "(kein Branch, Rebase von losgelöstem HEAD %s)"
 
-#: ref-filter.c:1557
+#: ref-filter.c:1561
 #, c-format
 msgid "(no branch, bisect started on %s)"
 msgstr "(kein Branch, binäre Suche begonnen bei %s)"
 
-#: ref-filter.c:1561
+#: ref-filter.c:1565
 #, c-format
 msgid "(HEAD detached at %s)"
 msgstr "(HEAD losgelöst bei %s)"
 
-#: ref-filter.c:1564
+#: ref-filter.c:1568
 #, c-format
 msgid "(HEAD detached from %s)"
 msgstr "(HEAD losgelöst von %s)"
 
-#: ref-filter.c:1567
+#: ref-filter.c:1571
 msgid "(no branch)"
 msgstr "(kein Branch)"
 
-#: ref-filter.c:1599 ref-filter.c:1808
+#: ref-filter.c:1603 ref-filter.c:1812
 #, c-format
 msgid "missing object %s for %s"
 msgstr "Objekt %s fehlt für %s"
 
-#: ref-filter.c:1609
+#: ref-filter.c:1613
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr "parse_object_buffer bei %s für %s fehlgeschlagen"
 
-#: ref-filter.c:1992
+#: ref-filter.c:1996
 #, c-format
 msgid "malformed object at '%s'"
 msgstr "fehlerhaftes Objekt bei '%s'"
 
-#: ref-filter.c:2081
+#: ref-filter.c:2085
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr "Ignoriere Referenz mit fehlerhaftem Namen %s"
 
-#: ref-filter.c:2086 refs.c:676
+#: ref-filter.c:2090 refs.c:676
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "Ignoriere fehlerhafte Referenz %s"
 
-#: ref-filter.c:2426
+#: ref-filter.c:2430
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "Format: %%(end) Atom fehlt"
 
-#: ref-filter.c:2525
+#: ref-filter.c:2529
 #, c-format
 msgid "malformed object name %s"
 msgstr "missgebildeter Objektname %s"
 
-#: ref-filter.c:2530
+#: ref-filter.c:2534
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "die Option `%s' muss auf einen Commit zeigen"
@@ -13218,8 +13215,8 @@ msgstr "'%s' ist kein gültiger Name für ein Remote-Repository"
 #: builtin/clone.c:1211
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr ""
-"--depth wird in lokalen Klonen ignoriert; benutzen Sie stattdessen "
-"\"file://\"."
+"--depth wird in lokalen Klonen ignoriert; benutzen Sie stattdessen \"file://"
+"\"."
 
 #: builtin/clone.c:1213
 msgid "--shallow-since is ignored in local clones; use file:// instead."
@@ -13236,8 +13233,8 @@ msgstr ""
 #: builtin/clone.c:1217
 msgid "--filter is ignored in local clones; use file:// instead."
 msgstr ""
-"--filter wird in lokalen Klonen ignoriert; benutzen Sie stattdessen "
-"\"file://\"."
+"--filter wird in lokalen Klonen ignoriert; benutzen Sie stattdessen \"file://"
+"\"."
 
 #: builtin/clone.c:1220
 msgid "source repository is shallow, ignoring --local"
@@ -15949,7 +15946,7 @@ msgstr "ungültige Anzahl von Threads (%d) für %s angegeben"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:285 builtin/index-pack.c:1589 builtin/index-pack.c:1792
+#: builtin/grep.c:285 builtin/index-pack.c:1589 builtin/index-pack.c:1808
 #: builtin/pack-objects.c:2944
 #, c-format
 msgid "no threads support, ignoring %s"
@@ -16626,38 +16623,38 @@ msgid_plural "chain length = %d: %lu objects"
 msgstr[0] "Länge der Objekt-Liste = %d: %lu Objekt"
 msgstr[1] "Länge der Objekt-Liste = %d: %lu Objekte"
 
-#: builtin/index-pack.c:1749
+#: builtin/index-pack.c:1765
 msgid "Cannot come back to cwd"
 msgstr "Kann nicht zurück zum Arbeitsverzeichnis wechseln"
 
-#: builtin/index-pack.c:1803 builtin/index-pack.c:1806
-#: builtin/index-pack.c:1822 builtin/index-pack.c:1826
+#: builtin/index-pack.c:1819 builtin/index-pack.c:1822
+#: builtin/index-pack.c:1838 builtin/index-pack.c:1842
 #, c-format
 msgid "bad %s"
 msgstr "%s ist ungültig"
 
-#: builtin/index-pack.c:1832 builtin/init-db.c:392 builtin/init-db.c:625
+#: builtin/index-pack.c:1848 builtin/init-db.c:392 builtin/init-db.c:625
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "unbekannter Hash-Algorithmus '%s'"
 
-#: builtin/index-pack.c:1851
+#: builtin/index-pack.c:1867
 msgid "--fix-thin cannot be used without --stdin"
 msgstr "--fix-thin kann nicht ohne --stdin verwendet werden"
 
-#: builtin/index-pack.c:1853
+#: builtin/index-pack.c:1869
 msgid "--stdin requires a git repository"
 msgstr "--stdin erfordert ein Git-Repository"
 
-#: builtin/index-pack.c:1855
+#: builtin/index-pack.c:1871
 msgid "--object-format cannot be used with --stdin"
 msgstr "--object-format kann nicht mit --stdin verwendet werden"
 
-#: builtin/index-pack.c:1870
+#: builtin/index-pack.c:1886
 msgid "--verify with no packfile name given"
 msgstr "--verify wurde ohne Namen der Paketdatei angegeben"
 
-#: builtin/index-pack.c:1936 builtin/unpack-objects.c:582
+#: builtin/index-pack.c:1956 builtin/unpack-objects.c:582
 msgid "fsck error in pack objects"
 msgstr "fsck Fehler beim Packen von Objekten"
 
@@ -23972,14 +23969,24 @@ msgstr "das Tree-Objekt für ein Unterverzeichnis <Präfix> schreiben"
 msgid "only useful for debugging"
 msgstr "nur nützlich für Fehlersuche"
 
-#: http-fetch.c:114
+#: http-fetch.c:118
 #, c-format
 msgid "argument to --packfile must be a valid hash (got '%s')"
 msgstr "Argument für --packfile muss ein gültiger Hash sein ('%s' erhalten)"
 
-#: http-fetch.c:122
+#: http-fetch.c:128
 msgid "not a git repository"
 msgstr "kein Git-Repository"
+
+#: http-fetch.c:134
+#, fuzzy
+msgid "--packfile requires --index-pack-args"
+msgstr "--pathspec-file-nul benötigt --pathspec-from-file"
+
+#: http-fetch.c:143
+#, fuzzy
+msgid "--index-pack-args can only be used with --packfile"
+msgstr "-N kann nur mit -mixed benutzt werden"
 
 #: t/helper/test-fast-rebase.c:141
 msgid "unhandled options"
@@ -26486,3 +26493,27 @@ msgstr "Lasse %s mit Backup-Suffix '%s' aus.\n"
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Wollen Sie %s wirklich versenden? [y|N]: "
+
+#~ msgid "repository contains replace objects; skipping commit-graph"
+#~ msgstr "Repository enthält ersetzende Objekte; überspringe Commit-Graph"
+
+#~ msgid "repository contains (deprecated) grafts; skipping commit-graph"
+#~ msgstr ""
+#~ "Repository enthält (veraltete) künstliche Vorgänger (\"grafts\"); "
+#~ "überspringe Commit-Graph"
+
+#~ msgid "repository is shallow; skipping commit-graph"
+#~ msgstr ""
+#~ "Repository hat unvollständige Historie (shallow); überspringe Commit-Graph"
+
+#~ msgid "commit-graph improper chunk offset %08x%08x"
+#~ msgstr "Unzulässiger Commit-Graph Chunk-Offset %08x%08x"
+
+#~ msgid "commit-graph chunk id %08x appears multiple times"
+#~ msgstr "Commit-Graph Chunk-Id %08x kommt mehrfach vor."
+
+#~ msgid "invalid chunk offset (too large)"
+#~ msgstr "Ungültiger Chunk-Offset (zu groß)"
+
+#~ msgid "Writing chunks to multi-pack-index"
+#~ msgstr "Chunks zum multi-pack-index schreiben"

--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
 "POT-Creation-Date: 2021-02-26 22:09+0800\n"
-"PO-Revision-Date: 2020-12-19 14:01+0100\n"
+"PO-Revision-Date: 2021-03-03 20:13+0100\n"
 "Last-Translator: Matthias Rüster <matthias.ruester@gmail.com>\n"
 "Language-Team: Matthias Rüster <matthias.ruester@gmail.com>\n"
 "Language: de\n"
@@ -17,6 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
+"X-Generator: Poedit 2.4.2\n"
 
 #: add-interactive.c:376
 #, c-format
@@ -55,7 +56,7 @@ msgstr "Konnte '%s' nicht zum Commit vormerken."
 
 #: add-interactive.c:703 add-interactive.c:892 reset.c:89 sequencer.c:3486
 msgid "could not write index"
-msgstr "Konnte Index nicht schreiben."
+msgstr "konnte Index nicht schreiben"
 
 #: add-interactive.c:706 git-add--interactive.perl:626
 #, c-format, perl-format
@@ -97,7 +98,7 @@ msgstr "Keine unversionierten Dateien.\n"
 
 #: add-interactive.c:868 git-add--interactive.perl:687
 msgid "Add untracked"
-msgstr "unversionierte Dateien hinzufügen"
+msgstr "Unversionierte Dateien hinzufügen"
 
 #: add-interactive.c:895 git-add--interactive.perl:623
 #, c-format, perl-format
@@ -901,18 +902,15 @@ msgstr "--cached und --3way können nicht gemeinsam verwendet werden."
 
 #: apply.c:140
 msgid "--3way outside a repository"
-msgstr ""
-"Die Option --3way kann nicht außerhalb eines Repositories verwendet werden."
+msgstr "--3way kann nicht außerhalb eines Repositories verwendet werden"
 
 #: apply.c:151
 msgid "--index outside a repository"
-msgstr ""
-"Die Option --index kann nicht außerhalb eines Repositories verwendet werden."
+msgstr "--index kann nicht außerhalb eines Repositories verwendet werden"
 
 #: apply.c:154
 msgid "--cached outside a repository"
-msgstr ""
-"Die Option --cached kann nicht außerhalb eines Repositories verwendet werden."
+msgstr "--cached kann nicht außerhalb eines Repositories verwendet werden"
 
 #: apply.c:801
 #, c-format
@@ -927,7 +925,7 @@ msgstr "Ausführung des regulären Ausdrucks gab %d zurück. Eingabe: %s"
 #: apply.c:884
 #, c-format
 msgid "unable to find filename in patch at line %d"
-msgstr "Konnte keinen Dateinamen in Zeile %d des Patches finden."
+msgstr "konnte keinen Dateinamen in Zeile %d des Patches finden"
 
 #: apply.c:922
 #, c-format
@@ -1413,8 +1411,7 @@ msgstr "hinzugefügte Zeilen des Patches ignorieren"
 #: apply.c:4999
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr ""
-"anstatt der Anwendung des Patches, den \"diffstat\" für die Eingabe "
-"ausgegeben"
+"statt den Patch anzuwenden, den \"diffstat\" für die Eingabe ausgegeben"
 
 #: apply.c:5003
 msgid "show number of added and deleted lines in decimal notation"
@@ -1424,13 +1421,12 @@ msgstr ""
 #: apply.c:5005
 msgid "instead of applying the patch, output a summary for the input"
 msgstr ""
-"anstatt der Anwendung des Patches, eine Zusammenfassung für die Eingabe "
-"ausgeben"
+"statt den Patch anzuwenden, eine Zusammenfassung für die Eingabe ausgeben"
 
 #: apply.c:5007
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr ""
-"anstatt der Anwendung des Patches, zeige ob Patch angewendet werden kann"
+"statt den Patch anzuwenden, anzeigen ob der Patch angewendet werden kann"
 
 #: apply.c:5009
 msgid "make sure the patch is applicable to the current index"
@@ -1609,7 +1605,7 @@ msgstr "Pfadspezifikation '%s' stimmt mit keinen Dateien überein"
 #: archive.c:454
 #, c-format
 msgid "no such ref: %.*s"
-msgstr "Keine solche Referenz: %.*s"
+msgstr "Referenz nicht gefunden: %.*s"
 
 #: archive.c:460
 #, c-format
@@ -1708,7 +1704,7 @@ msgstr "Unerwartete Option --remote"
 
 #: archive.c:584
 msgid "Option --exec can only be used together with --remote"
-msgstr "Die Option --exec kann nur zusammen mit --remote verwendet werden."
+msgstr "Die Option --exec kann nur zusammen mit --remote verwendet werden"
 
 #: archive.c:586
 msgid "Unexpected option --output"
@@ -1717,7 +1713,7 @@ msgstr "Unerwartete Option --output"
 #: archive.c:588
 msgid "Options --add-file and --remote cannot be used together"
 msgstr ""
-"Die Optionen --add-file und --remote können nicht gemeinsam verwendet werden."
+"Die Optionen --add-file und --remote können nicht gemeinsam verwendet werden"
 
 #: archive.c:610
 #, c-format
@@ -1842,13 +1838,13 @@ msgid "%s was both %s and %s\n"
 msgstr "%s war sowohl %s als auch %s\n"
 
 #: bisect.c:1066
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "No testable commit found.\n"
 "Maybe you started with bad path arguments?\n"
 msgstr ""
 "Kein testbarer Commit gefunden.\n"
-"Vielleicht starteten Sie mit falschen Pfad-Parametern?\n"
+"Vielleicht starteten Sie mit schlechten Pfad-Argumenten?\n"
 
 #: bisect.c:1095
 #, c-format
@@ -1901,7 +1897,7 @@ msgstr ""
 #: blame.c:2850
 #, c-format
 msgid "no such path %s in %s"
-msgstr "Pfad %s nicht in %s"
+msgstr "Pfad %s nicht in %s gefunden"
 
 #: blame.c:2861
 #, c-format
@@ -2158,22 +2154,22 @@ msgstr "ungültige Hash-Version"
 
 #: commit-graph.c:219
 msgid "repository contains replace objects; skipping commit-graph"
-msgstr ""
+msgstr "Repository enthält ersetzende Objekte; überspringe Commit-Graph"
 
 #: commit-graph.c:228
 msgid "repository contains (deprecated) grafts; skipping commit-graph"
 msgstr ""
+"Repository enthält (veraltete) künstliche Vorgänger (\"grafts\"); "
+"überspringe Commit-Graph"
 
 #: commit-graph.c:233
-#, fuzzy
 msgid "repository is shallow; skipping commit-graph"
 msgstr ""
-"Quelle ist ein Repository mit unvollständiger Historie (shallow),\n"
-"ignoriere --local"
+"Repository hat unvollständige Historie (shallow); überspringe Commit-Graph"
 
 #: commit-graph.c:264
 msgid "commit-graph file is too small"
-msgstr "Commit-Graph-Datei ist zu klein."
+msgstr "Commit-Graph-Datei ist zu klein"
 
 #: commit-graph.c:329
 #, c-format
@@ -2233,7 +2229,7 @@ msgstr "Konnte Commit %s nicht finden."
 
 #: commit-graph.c:848
 msgid "commit-graph requires overflow generation data but has none"
-msgstr ""
+msgstr "Commit-Graph erfordert Überlaufgenerierungsdaten, aber hat keine"
 
 #: commit-graph.c:1121 builtin/am.c:1292
 #, c-format
@@ -2258,9 +2254,8 @@ msgid "Clearing commit marks in commit graph"
 msgstr "Lösche Commit-Markierungen in Commit-Graph"
 
 #: commit-graph.c:1465
-#, fuzzy
 msgid "Computing commit graph topological levels"
-msgstr "Commit-Graph Generationsnummern berechnen"
+msgstr "Topologische Ebenen des Commit-Graph werden berechnet"
 
 #: commit-graph.c:1518
 msgid "Computing commit graph generation numbers"
@@ -2423,9 +2418,9 @@ msgstr ""
 "null"
 
 #: commit-graph.c:2662
-#, fuzzy, c-format
+#, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
-msgstr "Commit-Graph Erstellung für Commit %s ist %u != %u"
+msgstr "Commit-Graph Erstellung für Commit %s ist %<PRIuMAX> < %<PRIuMAX>"
 
 #: commit-graph.c:2668
 #, c-format
@@ -2535,19 +2530,19 @@ msgstr ""
 "aus Dateien kommen."
 
 #: config.c:396
-#, fuzzy, c-format
+#, c-format
 msgid "invalid config format: %s"
-msgstr "Ungültiges Format für Referenzen: %s"
+msgstr "ungültiges Konfigurationsformat: %s"
 
 #: config.c:400
 #, c-format
 msgid "missing environment variable name for configuration '%.*s'"
-msgstr ""
+msgstr "fehlender Name der Umgebungsvariable für Konfiguration '%.*s'"
 
 #: config.c:405
 #, c-format
 msgid "missing environment variable '%s' for configuration '%.*s'"
-msgstr ""
+msgstr "fehlende Umgebungsvariable '%s' für Konfiguration '%.*s'"
 
 #: config.c:442
 #, c-format
@@ -2570,9 +2565,8 @@ msgid "invalid key (newline): %s"
 msgstr "Ungültiger Schlüssel (neue Zeile): %s"
 
 #: config.c:511
-#, fuzzy
 msgid "empty config key"
-msgstr "Konfigurationsdatei des Repositories verwenden"
+msgstr "leerer Konfigurationsschlüssel"
 
 #: config.c:529 config.c:541
 #, c-format
@@ -2585,24 +2579,24 @@ msgid "bogus format in %s"
 msgstr "Fehlerhaftes Format in %s"
 
 #: config.c:622
-#, fuzzy, c-format
+#, c-format
 msgid "bogus count in %s"
-msgstr "Fehlerhaftes Format in %s"
+msgstr "falsche Zählung in %s"
 
 #: config.c:626
-#, fuzzy, c-format
+#, c-format
 msgid "too many entries in %s"
-msgstr "zu viele Argumente angegeben, um %s auszuführen"
+msgstr "zu viele Einträge in %s"
 
 #: config.c:636
-#, fuzzy, c-format
+#, c-format
 msgid "missing config key %s"
-msgstr "Ungültige Konfigurationsdatei %s"
+msgstr "fehlender Konfigurationsschlüssel %s"
 
 #: config.c:644
-#, fuzzy, c-format
+#, c-format
 msgid "missing config value %s"
-msgstr "Fehlender Wert für '%s'"
+msgstr "fehlender Konfigurationswert %s"
 
 #: config.c:995
 #, c-format
@@ -2685,9 +2679,9 @@ msgid "bad numeric config value '%s' for '%s' in %s: %s"
 msgstr "Ungültiger numerischer Wert '%s' für Konfiguration '%s' in %s: %s"
 
 #: config.c:1194
-#, fuzzy, c-format
+#, c-format
 msgid "bad boolean config value '%s' for '%s'"
-msgstr "Ungültiger numerischer Wert '%s' für Konfiguration '%s': %s"
+msgstr "ungültiger boolescher Konfigurationswert '%s' für '%s'"
 
 #: config.c:1289
 #, c-format
@@ -3015,33 +3009,32 @@ msgstr "Kann Proxy %s nicht starten."
 
 #: connect.c:1050
 msgid "no path specified; see 'git help pull' for valid url syntax"
-msgstr ""
-"Kein Pfad angegeben; siehe 'git help pull' für eine gültige URL-Syntax."
+msgstr "kein Pfad angegeben; siehe 'git help pull' für eine gültige URL-Syntax"
 
 #: connect.c:1190
 msgid "newline is forbidden in git:// hosts and repo paths"
-msgstr ""
+msgstr "Zeilenumbruch ist in git:// Hosts und Repository-Pfaden verboten"
 
 #: connect.c:1247
 msgid "ssh variant 'simple' does not support -4"
-msgstr "SSH-Variante 'simple' unterstützt kein -4."
+msgstr "SSH-Variante 'simple' unterstützt kein -4"
 
 #: connect.c:1259
 msgid "ssh variant 'simple' does not support -6"
-msgstr "SSH-Variante 'simple' unterstützt kein -6."
+msgstr "SSH-Variante 'simple' unterstützt kein -6"
 
 #: connect.c:1276
 msgid "ssh variant 'simple' does not support setting port"
-msgstr "SSH-Variante 'simple' unterstützt nicht das Setzen eines Ports."
+msgstr "SSH-Variante 'simple' unterstützt nicht das Setzen eines Ports"
 
 #: connect.c:1388
 #, c-format
 msgid "strange pathname '%s' blocked"
-msgstr "Merkwürdigen Pfadnamen '%s' blockiert."
+msgstr "Merkwürdigen Pfadnamen '%s' blockiert"
 
 #: connect.c:1436
 msgid "unable to fork"
-msgstr "Kann Prozess nicht starten."
+msgstr "kann Prozess nicht starten"
 
 #: connected.c:108 builtin/fsck.c:191 builtin/prune.c:45
 msgid "Checking connectivity"
@@ -3067,7 +3060,7 @@ msgstr "Unerlaubte crlf_action %d"
 #: convert.c:207
 #, c-format
 msgid "CRLF would be replaced by LF in %s"
-msgstr "CRLF würde in %s durch LF ersetzt werden."
+msgstr "CRLF würde in %s durch LF ersetzt werden"
 
 #: convert.c:209
 #, c-format
@@ -3082,7 +3075,7 @@ msgstr ""
 #: convert.c:217
 #, c-format
 msgid "LF would be replaced by CRLF in %s"
-msgstr "LF würde in %s durch CRLF ersetzt werden."
+msgstr "LF würde in %s durch CRLF ersetzt werden"
 
 #: convert.c:219
 #, c-format
@@ -3097,7 +3090,7 @@ msgstr ""
 #: convert.c:284
 #, c-format
 msgid "BOM is prohibited in '%s' if encoded as %s"
-msgstr "BOM ist in '%s' unzulässig, wenn als %s codiert."
+msgstr "BOM ist in '%s' unzulässig, wenn als %s codiert"
 
 #: convert.c:291
 #, c-format
@@ -3111,7 +3104,7 @@ msgstr ""
 #: convert.c:304
 #, c-format
 msgid "BOM is required in '%s' if encoded as %s"
-msgstr "BOM ist erforderlich in '%s', wenn als %s codiert."
+msgstr "BOM ist erforderlich in '%s', wenn als %s codiert"
 
 #: convert.c:306
 #, c-format
@@ -3126,45 +3119,45 @@ msgstr ""
 #: convert.c:419 convert.c:490
 #, c-format
 msgid "failed to encode '%s' from %s to %s"
-msgstr "Fehler beim Codieren von '%s' von %s nach %s."
+msgstr "Fehler beim Codieren von '%s' von %s nach %s"
 
 #: convert.c:462
 #, c-format
 msgid "encoding '%s' from %s to %s and back is not the same"
-msgstr "Die Codierung '%s' von %s nach %s und zurück ist nicht dasselbe."
+msgstr "Codierung '%s' von %s nach %s und zurück ist nicht dasselbe"
 
 #: convert.c:665
 #, c-format
 msgid "cannot fork to run external filter '%s'"
-msgstr "Kann externen Filter '%s' nicht starten."
+msgstr "kann externen Filter '%s' nicht starten"
 
 #: convert.c:685
 #, c-format
 msgid "cannot feed the input to external filter '%s'"
-msgstr "Kann Eingaben nicht an externen Filter '%s' übergeben."
+msgstr "kann Eingaben nicht an externen Filter '%s' übergeben"
 
 #: convert.c:692
 #, c-format
 msgid "external filter '%s' failed %d"
-msgstr "Externer Filter '%s' fehlgeschlagen %d"
+msgstr "externer Filter '%s' fehlgeschlagen %d"
 
 #: convert.c:727 convert.c:730
 #, c-format
 msgid "read from external filter '%s' failed"
-msgstr "Lesen von externem Filter '%s' fehlgeschlagen."
+msgstr "Lesen von externem Filter '%s' fehlgeschlagen"
 
 #: convert.c:733 convert.c:788
 #, c-format
 msgid "external filter '%s' failed"
-msgstr "Externer Filter '%s' fehlgeschlagen."
+msgstr "externer Filter '%s' fehlgeschlagen"
 
 #: convert.c:837
 msgid "unexpected filter type"
-msgstr "Unerwartete Filterart."
+msgstr "unerwartete Filterart"
 
 #: convert.c:848
 msgid "path name too long for external filter"
-msgstr "Pfadname zu lang für externen Filter."
+msgstr "Pfadname zu lang für externen Filter"
 
 #: convert.c:940
 #, c-format
@@ -3172,21 +3165,22 @@ msgid ""
 "external filter '%s' is not available anymore although not all paths have "
 "been filtered"
 msgstr ""
-"Externer Filter '%s' nicht mehr verfügbar. Nicht alle Pfade wurden gefiltert."
+"externer Filter '%s' nicht mehr verfügbar, obwohl nicht alle Pfade gefiltert "
+"wurden"
 
 #: convert.c:1240
 msgid "true/false are no valid working-tree-encodings"
-msgstr "true/false sind keine gültigen Codierungen im Arbeitsverzeichnis."
+msgstr "true/false sind keine gültigen Codierungen im Arbeitsverzeichnis"
 
 #: convert.c:1428 convert.c:1462
 #, c-format
 msgid "%s: clean filter '%s' failed"
-msgstr "%s: clean-Filter '%s' fehlgeschlagen."
+msgstr "%s: clean-Filter '%s' fehlgeschlagen"
 
 #: convert.c:1508
 #, c-format
 msgid "%s: smudge filter %s failed"
-msgstr "%s: smudge-Filter '%s' fehlgeschlagen."
+msgstr "%s: smudge-Filter '%s' fehlgeschlagen"
 
 #: credential.c:96
 #, c-format
@@ -3925,20 +3919,16 @@ msgstr ""
 "die Reihenfolge kontrollieren, in der die Dateien in der Ausgabe erscheinen"
 
 #: diff.c:5615 diff.c:5618
-#, fuzzy
 msgid "<path>"
-msgstr "Pfad"
+msgstr "<Pfad>"
 
 #: diff.c:5616
-#, fuzzy
 msgid "show the change in the specified path first"
-msgstr ""
-"die Index-Datei des Paketes in der angegebenen Indexformat-Version schreiben"
+msgstr "die Änderung des angegebenen Pfades zuerst anzeigen"
 
 #: diff.c:5619
-#, fuzzy
 msgid "skip the output to the specified path"
-msgstr "aktuellen HEAD zu einem spezifizierten Zustand setzen"
+msgstr "überspringe die Ausgabe zum angegebenen Pfad"
 
 #: diff.c:5621
 msgid "<object-id>"
@@ -3996,9 +3986,9 @@ msgid "Performing inexact rename detection"
 msgstr "Führe Erkennung für ungenaue Umbenennung aus"
 
 #: diffcore-rotate.c:29
-#, fuzzy, c-format
+#, c-format
 msgid "No such path '%s' in the diff"
-msgstr "Pfad %s nicht in %s"
+msgstr "Pfad '%s' nicht im Diff gefunden"
 
 #: dir.c:578
 #, c-format
@@ -4326,7 +4316,7 @@ msgstr "Remote-Repository hat nicht alle erforderlichen Objekte gesendet"
 #: fetch-pack.c:1941
 #, c-format
 msgid "no such remote ref %s"
-msgstr "keine solche Remote-Referenz %s"
+msgstr "Remote-Referenz %s nicht gefunden"
 
 #: fetch-pack.c:1944
 #, c-format
@@ -4685,9 +4675,9 @@ msgid "Unable to create '%s.lock': %s"
 msgstr "Konnte '%s.lock' nicht erstellen: %s"
 
 #: ls-refs.c:37
-#, fuzzy, c-format
+#, c-format
 msgid "invalid value '%s' for lsrefs.unborn"
-msgstr "ungültiger Wert für blame.coloring"
+msgstr "ungültiger Wert '%s' für lsrefs.unborn"
 
 #: ls-refs.c:167
 msgid "expected flush after ls-refs arguments"
@@ -4709,21 +4699,24 @@ msgid "Failed to merge submodule %s (commits don't follow merge-base)"
 msgstr "Fehler beim Merge von Submodul %s (Commits folgen keiner Merge-Basis)"
 
 #: merge-ort.c:883 merge-ort.c:890
-#, fuzzy, c-format
+#, c-format
 msgid "Note: Fast-forwarding submodule %s to %s"
-msgstr "Spule Submodul %s vor"
+msgstr "Hinweis: Spule Submodul %s vor zu %s"
 
 #: merge-ort.c:911
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to merge submodule %s"
-msgstr "Fehler bei Rekursion in Submodul '%s'."
+msgstr "Fehler beim Zusammenführen von Submodul %s"
 
 #: merge-ort.c:918
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Failed to merge submodule %s, but a possible merge resolution exists:\n"
 "%s\n"
-msgstr "Fehler beim Merge von Submodul %s (mehrere Merges gefunden)"
+msgstr ""
+"Fehler beim Zusammenführen von Submodul %s, aber es ist eine mögliche "
+"Auflösung des Merges vorhanden:\n"
+"%s\n"
 
 #: merge-ort.c:922 merge-recursive.c:1259
 #, c-format
@@ -4743,11 +4736,14 @@ msgstr ""
 "hinzu, um diesen Vorschlag zu akzeptieren.\n"
 
 #: merge-ort.c:935
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Failed to merge submodule %s, but multiple possible merges exist:\n"
 "%s"
-msgstr "Fehler beim Merge von Submodul %s (mehrere Merges gefunden)"
+msgstr ""
+"Fehler beim Zusammenführen von Submodul %s, aber mehrere mögliche Merges "
+"sind vorhanden:\n"
+"%s"
 
 #: merge-ort.c:1094 merge-recursive.c:1341
 msgid "Failed to execute internal merge"
@@ -4786,17 +4782,15 @@ msgstr ""
 "zu setzen: %s"
 
 #: merge-ort.c:1438
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to rename %s to; it was "
 "renamed to multiple other directories, with no destination getting a "
 "majority of the files."
 msgstr ""
 "KONFLIKT (Aufteilung Verzeichnisumbenennung): Unklar, wo %s zu platzieren "
-"ist,\n"
-"weil Verzeichnis %s zu mehreren anderen Verzeichnissen umbenannt wurde, "
-"wobei\n"
-"keines dieser Ziele die Mehrheit der Dateien erhielt."
+"ist; es wurde zu mehreren anderen Verzeichnissen umbenannt, ohne dass ein "
+"Ziel die Mehrheit der Dateien erhält."
 
 #: merge-ort.c:1604 merge-recursive.c:2447
 #, c-format
@@ -4845,11 +4839,10 @@ msgstr ""
 "verschoben werden."
 
 #: merge-ort.c:1919
-#, fuzzy, c-format
+#, c-format
 msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
 msgstr ""
-"KONFLIKT (umbenennen/umbenennen): Benenne um %s->%s in %s. Benenne um %s->%s "
-"in %s"
+"KONFLIKT (umbenennen/umbenennen): %s zu %s in %s umbenannt und zu %s in %s."
 
 #: merge-ort.c:2014
 #, c-format
@@ -4858,13 +4851,15 @@ msgid ""
 "conflicts AND collides with another path; this may result in nested conflict "
 "markers."
 msgstr ""
+"KONFLIKT (Umbenennung in Kollision beteiligt): Umbenennung von %s -> %s hat "
+"Inhaltskonflikte UND kollidiert mit einem anderen Pfad; dies kann zu "
+"verschachtelten Konfliktmarkierungen führen."
 
 #: merge-ort.c:2033 merge-ort.c:2057
-#, fuzzy, c-format
+#, c-format
 msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
 msgstr ""
-"KONFLIKT (umbenennen/hinzufügen): Benenne um %s->%s in %s. %s hinzugefügt in "
-"%s"
+"KONFLIKT (umbenennen/löschen): %s zu %s in %s umbenannt, aber in %s gelöscht."
 
 #: merge-ort.c:2683
 #, c-format
@@ -4872,6 +4867,8 @@ msgid ""
 "CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
 "%s instead."
 msgstr ""
+"KONFLIKT (Datei/Verzeichnis): Verzeichnis im Weg von %s aus %s; stattdessen "
+"nach %s verschieben."
 
 #: merge-ort.c:2756
 #, c-format
@@ -4879,15 +4876,16 @@ msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed %s "
 "of them so each can be recorded somewhere."
 msgstr ""
+"KONFLIKT (verschiedene Typen): %s hatte unterschiedliche Typen auf jeder "
+"Seite; %s wurde(n) umbenannt, damit jeder irgendwo aufgezeichnet werden kann."
 
 #: merge-ort.c:2760
 msgid "both"
-msgstr ""
+msgstr "beide"
 
 #: merge-ort.c:2760
-#, fuzzy
 msgid "one"
-msgstr "fertig"
+msgstr "einer"
 
 #: merge-ort.c:2855 merge-recursive.c:3052
 msgid "content"
@@ -4907,21 +4905,22 @@ msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "KONFLIKT (%s): Merge-Konflikt in %s"
 
 #: merge-ort.c:2886
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
 "of %s left in tree."
 msgstr ""
-"KONFLIKT (%s/löschen): %s gelöscht in %s und %s in %s. Stand %s von %s wurde "
-"im Arbeitsbereich gelassen."
+"KONFLIKT (ändern/löschen): %s gelöscht in %s und geändert in %s. Stand %s "
+"von %s wurde im Arbeitsbereich gelassen."
 
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
 #: merge-ort.c:3354
-#, fuzzy, c-format
+#, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
-msgstr "update_ref für Referenz '%s' fehlgeschlagen: %s"
+msgstr ""
+"Sammeln von Merge-Informationen für die Referenzen %s, %s, %s fehlgeschlagen"
 
 #: merge-ort-wrappers.c:13 merge-recursive.c:3661
 #, c-format
@@ -5278,23 +5277,23 @@ msgstr "Ungültiger Chunk-Offset (zu groß)"
 
 #: midx.c:147
 msgid "terminating multi-pack-index chunk id appears earlier than expected"
-msgstr "Abschließende multi-pack-index Chunk-Id erscheint eher als erwartet."
+msgstr "abschließende multi-pack-index Chunk-Id erscheint eher als erwartet"
 
 #: midx.c:160
 msgid "multi-pack-index missing required pack-name chunk"
-msgstr "multi-pack-index fehlt erforderlicher pack-name Chunk."
+msgstr "multi-pack-index fehlt erforderlicher Pack-Namen Chunk"
 
 #: midx.c:162
 msgid "multi-pack-index missing required OID fanout chunk"
-msgstr "multi-pack-index fehlt erforderlicher OID fanout Chunk."
+msgstr "multi-pack-index fehlt erforderlicher OID fanout Chunk"
 
 #: midx.c:164
 msgid "multi-pack-index missing required OID lookup chunk"
-msgstr "multi-pack-index fehlt erforderlicher OID lookup Chunk."
+msgstr "multi-pack-index fehlt erforderlicher OID lookup Chunk"
 
 #: midx.c:166
 msgid "multi-pack-index missing required object offsets chunk"
-msgstr "multi-pack-index fehlt erforderlicher object offset Chunk."
+msgstr "multi-pack-index fehlt erforderlicher Objekt offset Chunk"
 
 #: midx.c:180
 #, c-format
@@ -5309,12 +5308,12 @@ msgstr "Ungültige pack-int-id: %u (%u Pakete insgesamt)"
 #: midx.c:273
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr ""
-"multi-pack-index speichert einen 64-Bit Offset, aber off_t ist zu klein."
+"multi-pack-index speichert einen 64-Bit Offset, aber off_t ist zu klein"
 
 #: midx.c:480
 #, c-format
 msgid "failed to add packfile '%s'"
-msgstr "Fehler beim Hinzufügen von Packdatei '%s'."
+msgstr "Fehler beim Hinzufügen von Packdatei '%s'"
 
 #: midx.c:486
 #, c-format
@@ -5324,7 +5323,7 @@ msgstr "Fehler beim Öffnen von pack-index '%s'"
 #: midx.c:546
 #, c-format
 msgid "failed to locate object %d in packfile"
-msgstr "Fehler beim Lokalisieren von Objekt %d in Packdatei."
+msgstr "Fehler beim Lokalisieren von Objekt %d in Packdatei"
 
 #: midx.c:846
 msgid "Adding packfiles to multi-pack-index"
@@ -5739,9 +5738,9 @@ msgid "unable to unpack contents of %s"
 msgstr "Konnte Inhalt von %s nicht entpacken."
 
 #: object-name.c:486
-#, fuzzy, c-format
+#, c-format
 msgid "short object ID %s is ambiguous"
-msgstr "Kurzer SHA-1 %s ist mehrdeutig."
+msgstr "kurze Objekt-ID %s ist mehrdeutig"
 
 #: object-name.c:497
 msgid "The candidates are:"
@@ -5871,54 +5870,54 @@ msgid "unable to get size of %s"
 msgstr "Konnte Größe von %s nicht bestimmen."
 
 #: pack-bitmap.c:1489 builtin/rev-list.c:92
-#, fuzzy, c-format
+#, c-format
 msgid "unable to get disk usage of %s"
-msgstr "Konnte Größe von %s nicht bestimmen."
+msgstr "konnte Festplattennutzung von %s nicht bekommen"
 
 #: pack-revindex.c:220
-#, fuzzy, c-format
+#, c-format
 msgid "reverse-index file %s is too small"
-msgstr "multi-pack-index-Datei %s ist zu klein."
+msgstr "Reverse-Index-Datei %s ist zu klein"
 
 #: pack-revindex.c:225
-#, fuzzy, c-format
+#, c-format
 msgid "reverse-index file %s is corrupt"
-msgstr "Index-Datei beschädigt"
+msgstr "Reverse-Index-Datei %s ist beschädigt"
 
 #: pack-revindex.c:233
-#, fuzzy, c-format
+#, c-format
 msgid "reverse-index file %s has unknown signature"
-msgstr "Ungültige SHA1-Signatur der Index-Datei."
+msgstr "Reverse-Index-Datei %s hat eine unbekannte Signatur"
 
 #: pack-revindex.c:237
 #, c-format
 msgid "reverse-index file %s has unsupported version %<PRIu32>"
-msgstr ""
+msgstr "Reverse-Index-Datei %s hat nicht unterstützte Version %<PRIu32>"
 
 #: pack-revindex.c:242
 #, c-format
 msgid "reverse-index file %s has unsupported hash id %<PRIu32>"
-msgstr ""
+msgstr "Reverse-Index-Datei %s hat nicht unterstützte Hash-ID %<PRIu32>"
 
 #: pack-write.c:236
-#, fuzzy
 msgid "cannot both write and verify reverse index"
-msgstr "Kann Index nicht lesen"
+msgstr ""
+"Reverse-Index kann nicht gleichzeitig geschrieben und verifiziert werden"
 
 #: pack-write.c:257
-#, fuzzy, c-format
+#, c-format
 msgid "could not stat: %s"
-msgstr "Konnte '%s' nicht lesen"
+msgstr "konnte nicht lesen: %s"
 
 #: pack-write.c:269
-#, fuzzy, c-format
+#, c-format
 msgid "failed to make %s readable"
-msgstr "Fehler beim Parsen von %s."
+msgstr "Fehler beim lesbar machen von %s"
 
 #: pack-write.c:502
-#, fuzzy, c-format
+#, c-format
 msgid "could not write '%s' promisor file"
-msgstr "Konnte '%s' nicht schreiben."
+msgstr "konnte Promisor-Datei '%s' nicht schreiben"
 
 #: packfile.c:625
 msgid "offset before end of packfile (broken .idx?)"
@@ -6252,9 +6251,8 @@ msgid "failed to generate diff"
 msgstr "Fehler beim Generieren des Diffs."
 
 #: range-diff.c:558
-#, fuzzy
 msgid "--left-only and --right-only are mutually exclusive"
-msgstr "-p und --overlay schließen sich gegenseitig aus."
+msgstr "--left-only und --right-only schließen sich gegenseitig aus"
 
 #: range-diff.c:561 range-diff.c:563
 #, c-format
@@ -6296,12 +6294,12 @@ msgstr "Konnte '%s' nicht dem Index hinzufügen."
 #: read-cache.c:807
 #, c-format
 msgid "unable to stat '%s'"
-msgstr "Konnte '%s' nicht lesen."
+msgstr "konnte '%s' nicht lesen"
 
 #: read-cache.c:1318
 #, c-format
 msgid "'%s' appears as both a file and as a directory"
-msgstr "'%s' scheint eine Datei und ein Verzeichnis zu sein."
+msgstr "'%s' scheint eine Datei und ein Verzeichnis zu sein"
 
 #: read-cache.c:1524
 msgid "Refresh index"
@@ -6810,34 +6808,33 @@ msgid "malformed format string %s"
 msgstr "Fehlerhafter Formatierungsstring %s"
 
 #: ref-filter.c:1551
-#, fuzzy, c-format
+#, c-format
 msgid "(no branch, rebasing %s)"
-msgstr "kein Branch, Rebase von %s"
+msgstr "(kein Branch, Rebase von %s)"
 
 #: ref-filter.c:1554
-#, fuzzy, c-format
+#, c-format
 msgid "(no branch, rebasing detached HEAD %s)"
-msgstr "kein Branch, Rebase von losgelöstem HEAD %s"
+msgstr "(kein Branch, Rebase von losgelöstem HEAD %s)"
 
 #: ref-filter.c:1557
-#, fuzzy, c-format
+#, c-format
 msgid "(no branch, bisect started on %s)"
-msgstr "kein Branch, binäre Suche begonnen bei %s"
+msgstr "(kein Branch, binäre Suche begonnen bei %s)"
 
 #: ref-filter.c:1561
-#, fuzzy, c-format
+#, c-format
 msgid "(HEAD detached at %s)"
-msgstr "HEAD losgelöst bei "
+msgstr "(HEAD losgelöst bei %s)"
 
 #: ref-filter.c:1564
-#, fuzzy, c-format
+#, c-format
 msgid "(HEAD detached from %s)"
-msgstr "HEAD losgelöst von "
+msgstr "(HEAD losgelöst von %s)"
 
 #: ref-filter.c:1567
-#, fuzzy
 msgid "(no branch)"
-msgstr "kein Branch"
+msgstr "(kein Branch)"
 
 #: ref-filter.c:1599 ref-filter.c:1808
 #, c-format
@@ -7149,7 +7146,7 @@ msgstr "HEAD zeigt auf keinen Branch"
 #: remote.c:1733
 #, c-format
 msgid "no such branch: '%s'"
-msgstr "Kein solcher Branch: '%s'"
+msgstr "Branch nicht gefunden: '%s'"
 
 #: remote.c:1736
 #, c-format
@@ -8401,7 +8398,7 @@ msgid ""
 "%s: no such path in the working tree.\n"
 "Use 'git <command> -- <path>...' to specify paths that do not exist locally."
 msgstr ""
-"%s: kein solcher Pfad im Arbeitsverzeichnis.\n"
+"%s: Pfad nicht im Arbeitsverzeichnis gefunden.\n"
 "Benutzen Sie 'git <Befehl> -- <Pfad>...' zur Angabe von Pfaden, die lokal\n"
 "nicht existieren."
 
@@ -9551,9 +9548,9 @@ msgid "unable to locate repository; .git is not a file"
 msgstr "Konnte Repository nicht finden; .git ist keine Datei"
 
 #: worktree.c:737
-#, fuzzy
 msgid "unable to locate repository; .git file does not reference a repository"
-msgstr "Konnte Repository nicht finden; .git ist keine Datei"
+msgstr ""
+"konnte Repository nicht finden; .git-Datei referenziert kein Repository"
 
 #: worktree.c:741
 msgid "unable to locate repository; .git file broken"
@@ -10192,9 +10189,9 @@ msgid "git add [<options>] [--] <pathspec>..."
 msgstr "git add [<Optionen>] [--] <Pfadspezifikation>..."
 
 #: builtin/add.c:58
-#, fuzzy, c-format
+#, c-format
 msgid "cannot chmod %cx '%s'"
-msgstr "Kann nicht in Verzeichnis '%s' wechseln."
+msgstr "kann nicht chmod %cx '%s'"
 
 #: builtin/add.c:96
 #, c-format
@@ -10378,22 +10375,20 @@ msgstr "Hinzufügen von Dateien fehlgeschlagen"
 
 #: builtin/add.c:461 builtin/commit.c:345
 msgid "--pathspec-from-file is incompatible with --interactive/--patch"
-msgstr ""
-"Die Optionen --pathspec-from-file und --interactive/--patch sind "
-"inkompatibel."
+msgstr "--pathspec-from-file und --interactive/--patch sind inkompatibel"
 
 #: builtin/add.c:478
 msgid "--pathspec-from-file is incompatible with --edit"
-msgstr "Die Optionen --pathspec-from-file und --edit sind inkompatibel."
+msgstr "--pathspec-from-file und --edit sind inkompatibel"
 
 #: builtin/add.c:490
 msgid "-A and -u are mutually incompatible"
-msgstr "Die Optionen -A und -u sind zueinander inkompatibel."
+msgstr "-A und -u sind zueinander inkompatibel"
 
 #: builtin/add.c:493
 msgid "Option --ignore-missing can only be used together with --dry-run"
 msgstr ""
-"Die Option --ignore-missing kann nur zusammen mit --dry-run verwendet werden."
+"Die Option --ignore-missing kann nur zusammen mit --dry-run verwendet werden"
 
 #: builtin/add.c:497
 #, c-format
@@ -10403,14 +10398,12 @@ msgstr "--chmod Parameter '%s' muss entweder -x oder +x sein"
 #: builtin/add.c:515 builtin/checkout.c:1714 builtin/commit.c:351
 #: builtin/reset.c:328 builtin/rm.c:272 builtin/stash.c:1569
 msgid "--pathspec-from-file is incompatible with pathspec arguments"
-msgstr ""
-"Die Option --pathspec-from-file ist inkompatibel mit\n"
-"Pfadspezifikation-Argumenten."
+msgstr "--pathspec-from-file ist inkompatibel mit Pfadspezifikation-Argumenten"
 
 #: builtin/add.c:522 builtin/checkout.c:1726 builtin/commit.c:357
 #: builtin/reset.c:334 builtin/rm.c:278 builtin/stash.c:1575
 msgid "--pathspec-file-nul requires --pathspec-from-file"
-msgstr "Die Option --pathspec-file-nul benötigt --pathspec-from-file"
+msgstr "--pathspec-file-nul benötigt --pathspec-from-file"
 
 #: builtin/add.c:526
 #, c-format
@@ -10760,13 +10753,11 @@ msgid "skip the current patch"
 msgstr "den aktuellen Patch auslassen"
 
 #: builtin/am.c:2287
-#, fuzzy
 msgid "restore the original branch and abort the patching operation"
 msgstr ""
 "ursprünglichen Branch wiederherstellen und Anwendung der Patches abbrechen"
 
 #: builtin/am.c:2290
-#, fuzzy
 msgid "abort the patching operation but keep HEAD where it is"
 msgstr "Patch-Operation abbrechen, aber HEAD an aktueller Stelle belassen"
 
@@ -10905,14 +10896,12 @@ msgid "git bisect--helper --bisect-state (good|old) [<rev>...]"
 msgstr "git bisect--helper --bisect-state (good|old) [<Commit>...]"
 
 #: builtin/bisect--helper.c:31
-#, fuzzy
 msgid "git bisect--helper --bisect-replay <filename>"
-msgstr "git bisect--helper --bisect-next"
+msgstr "git bisect--helper --bisect-replay <Dateiname>"
 
 #: builtin/bisect--helper.c:32
-#, fuzzy
 msgid "git bisect--helper --bisect-skip [(<rev>|<range>)...]"
-msgstr "git bisect--helper --bisect-state (good|old) [<Commit>...]"
+msgstr "git bisect--helper --bisect-skip [(<Commit>|<Bereich>)...]"
 
 #: builtin/bisect--helper.c:107
 #, c-format
@@ -10969,17 +10958,17 @@ msgstr "Ungültiges \"bisect_write\" Argument: %s"
 #: builtin/bisect--helper.c:259
 #, c-format
 msgid "couldn't get the oid of the rev '%s'"
-msgstr "Konnte die OID der Revision '%s' nicht erhalten."
+msgstr "konnte die OID der Revision '%s' nicht erhalten"
 
 #: builtin/bisect--helper.c:271
 #, c-format
 msgid "couldn't open the file '%s'"
-msgstr "Konnte die Datei '%s' nicht öffnen."
+msgstr "konnte die Datei '%s' nicht öffnen"
 
 #: builtin/bisect--helper.c:297
 #, c-format
 msgid "Invalid command: you're currently in a %s/%s bisect"
-msgstr "Ungültiger Befehl: Sie sind gerade bei einer binären %s/%s Suche."
+msgstr "Ungültiger Befehl: Sie sind gerade innerhalb einer binären %s/%s Suche"
 
 #: builtin/bisect--helper.c:324
 #, c-format
@@ -11004,7 +10993,7 @@ msgstr ""
 #: builtin/bisect--helper.c:348
 #, c-format
 msgid "bisecting only with a %s commit"
-msgstr "Binäre Suche nur mit einem %s Commit."
+msgstr "binäre Suche nur mit einem %s Commit"
 
 #. TRANSLATORS: Make sure to include [Y] and [n] in your
 #. translation. The program will only accept English input
@@ -11016,7 +11005,7 @@ msgstr "Sind Sie sicher [Y/n]? "
 
 #: builtin/bisect--helper.c:417
 msgid "no terms defined"
-msgstr "Keine Begriffe definiert."
+msgstr "keine Begriffe definiert"
 
 #: builtin/bisect--helper.c:420
 #, c-format
@@ -11115,14 +11104,14 @@ msgid "We are not bisecting."
 msgstr "Keine binäre Suche im Gange."
 
 #: builtin/bisect--helper.c:962
-#, fuzzy, c-format
+#, c-format
 msgid "'%s'?? what are you talking about?"
-msgstr "?? Was reden Sie da?"
+msgstr "'%s'?? Was reden Sie da?"
 
 #: builtin/bisect--helper.c:974
-#, fuzzy, c-format
+#, c-format
 msgid "cannot read file '%s' for replaying"
-msgstr "kann $file nicht für das Abspielen lesen"
+msgstr "kann Datei '%s' nicht für die Wiederholung lesen"
 
 #: builtin/bisect--helper.c:1047
 msgid "reset the bisection state"
@@ -11149,18 +11138,16 @@ msgid "mark the state of ref (or refs)"
 msgstr "den Status der Referenz(en) markieren"
 
 #: builtin/bisect--helper.c:1059
-#, fuzzy
 msgid "list the bisection steps so far"
-msgstr "den Zustand der binären Suche zurücksetzen"
+msgstr "die bisherigen Schritte der binären Suche auflisten"
 
 #: builtin/bisect--helper.c:1061
 msgid "replay the bisection process from the given file"
-msgstr ""
+msgstr "binäre Suche aus der angegebenen Datei wiederholen"
 
 #: builtin/bisect--helper.c:1063
-#, fuzzy
 msgid "skip some commits for checkout"
-msgstr "der Branch oder Commit zum Auschecken"
+msgstr "einige Commits für das Auschecken überspringen"
 
 #: builtin/bisect--helper.c:1065
 msgid "no log for BISECT_WRITE"
@@ -11183,14 +11170,12 @@ msgid "--bisect-next requires 0 arguments"
 msgstr "--bisect-next benötigt 0 Argumente"
 
 #: builtin/bisect--helper.c:1111
-#, fuzzy
 msgid "--bisect-log requires 0 arguments"
-msgstr "--bisect-next benötigt 0 Argumente"
+msgstr "--bisect-log benötigt 0 Argumente"
 
 #: builtin/bisect--helper.c:1116
-#, fuzzy
 msgid "no logfile given"
-msgstr "Keine Log-Datei gegeben"
+msgstr "keine Log-Datei angegeben"
 
 #: builtin/blame.c:32
 msgid "git blame [<options>] [<rev-opts>] [<rev>] [--] <file>"
@@ -11224,22 +11209,19 @@ msgid "cannot find revision %s to ignore"
 msgstr "konnte Commit %s zum Ignorieren nicht finden"
 
 #: builtin/blame.c:867
-#, fuzzy
 msgid "show blame entries as we find them, incrementally"
-msgstr "\"blame\"-Einträge schrittweise anzeigen, während wir sie generieren"
+msgstr "\"blame\"-Einträge schrittweise anzeigen, während wir sie finden"
 
 #: builtin/blame.c:868
-#, fuzzy
 msgid "do not show object names of boundary commits (Default: off)"
-msgstr "Zeige keine Objektnamen für Grenz-Commits an (Standard: aus)"
+msgstr ""
+"keine Objektnkeine Objektnamen für Grenz-Commits anzeigen (Standard: aus)"
 
 #: builtin/blame.c:869
-#, fuzzy
 msgid "do not treat root commits as boundaries (Default: off)"
 msgstr "Root-Commits nicht als Grenzen behandeln (Standard: aus)"
 
 #: builtin/blame.c:870
-#, fuzzy
 msgid "show work cost statistics"
 msgstr "Statistiken zum Arbeitsaufwand anzeigen"
 
@@ -11251,76 +11233,63 @@ msgid "force progress reporting"
 msgstr "Fortschrittsanzeige erzwingen"
 
 #: builtin/blame.c:872
-#, fuzzy
 msgid "show output score for blame entries"
 msgstr "Ausgabebewertung für \"blame\"-Einträge anzeigen"
 
 #: builtin/blame.c:873
-#, fuzzy
 msgid "show original filename (Default: auto)"
 msgstr "ursprünglichen Dateinamen anzeigen (Standard: auto)"
 
 #: builtin/blame.c:874
-#, fuzzy
 msgid "show original linenumber (Default: off)"
 msgstr "ursprüngliche Zeilennummer anzeigen (Standard: aus)"
 
 #: builtin/blame.c:875
-#, fuzzy
 msgid "show in a format designed for machine consumption"
 msgstr "Anzeige in einem Format für maschinelle Auswertung"
 
 #: builtin/blame.c:876
-#, fuzzy
 msgid "show porcelain format with per-line commit information"
 msgstr ""
 "Anzeige in Format für Fremdprogramme mit Commit-Informationen pro Zeile"
 
 #: builtin/blame.c:877
-#, fuzzy
 msgid "use the same output mode as git-annotate (Default: off)"
 msgstr ""
-"Den gleichen Ausgabemodus benutzen wie \"git-annotate\" (Standard: aus)"
+"den gleichen Ausgabemodus benutzen wie \"git-annotate\" (Standard: aus)"
 
 #: builtin/blame.c:878
-#, fuzzy
 msgid "show raw timestamp (Default: off)"
-msgstr "Unbearbeiteten Zeitstempel anzeigen (Standard: aus)"
+msgstr "unbearbeiteten Zeitstempel anzeigen (Standard: aus)"
 
 #: builtin/blame.c:879
-#, fuzzy
 msgid "show long commit SHA1 (Default: off)"
-msgstr "Langen Commit-SHA1 anzeigen (Standard: aus)"
+msgstr "langen Commit-SHA1 anzeigen (Standard: aus)"
 
 #: builtin/blame.c:880
-#, fuzzy
 msgid "suppress author name and timestamp (Default: off)"
-msgstr "Den Namen des Autors und den Zeitstempel unterdrücken (Standard: aus)"
+msgstr "den Namen des Autors und den Zeitstempel unterdrücken (Standard: aus)"
 
 #: builtin/blame.c:881
-#, fuzzy
 msgid "show author email instead of name (Default: off)"
 msgstr ""
-"Anstatt des Namens die E-Mail-Adresse des Autors anzeigen (Standard: aus)"
+"statt des Namens die E-Mail-Adresse des Autors anzeigen (Standard: aus)"
 
 #: builtin/blame.c:882
-#, fuzzy
 msgid "ignore whitespace differences"
-msgstr "Unterschiede im Whitespace ignorieren"
+msgstr "Whitespace-Unterschiede ignorieren"
 
 #: builtin/blame.c:883 builtin/log.c:1812
 msgid "rev"
 msgstr "Commit"
 
 #: builtin/blame.c:883
-#, fuzzy
 msgid "ignore <rev> when blaming"
-msgstr "Ignoriere <Commit> beim Ausführen von 'blame'"
+msgstr "ignoriere <Commit> beim Ausführen von 'blame'"
 
 #: builtin/blame.c:884
-#, fuzzy
 msgid "ignore revisions from <file>"
-msgstr "Ignoriere Commits aus <Datei>"
+msgstr "ignoriere Commits aus <Datei>"
 
 #: builtin/blame.c:885
 msgid "color redundant metadata from previous line differently"
@@ -11331,17 +11300,15 @@ msgid "color lines by age"
 msgstr "Zeilen nach Alter einfärben"
 
 #: builtin/blame.c:887
-#, fuzzy
 msgid "spend extra cycles to find better match"
-msgstr "Länger arbeiten, um bessere Übereinstimmungen zu finden"
+msgstr ""
+"mehr Arbeitsschritte ausführen, um eine bessere Übereinstimmung zu finden"
 
 #: builtin/blame.c:888
-#, fuzzy
 msgid "use revisions from <file> instead of calling git-rev-list"
-msgstr "Commits von <Datei> benutzen, anstatt \"git-rev-list\" aufzurufen"
+msgstr "Commits von <Datei> benutzen, statt \"git-rev-list\" aufzurufen"
 
 #: builtin/blame.c:889
-#, fuzzy
 msgid "use <file>'s contents as the final image"
 msgstr "Inhalte der <Datei>en als endgültiges Abbild benutzen"
 
@@ -11350,12 +11317,10 @@ msgid "score"
 msgstr "Bewertung"
 
 #: builtin/blame.c:890
-#, fuzzy
 msgid "find line copies within and across files"
 msgstr "kopierte Zeilen innerhalb oder zwischen Dateien finden"
 
 #: builtin/blame.c:891
-#, fuzzy
 msgid "find line movements within and across files"
 msgstr "verschobene Zeilen innerhalb oder zwischen Dateien finden"
 
@@ -11364,10 +11329,9 @@ msgid "range"
 msgstr "Bereich"
 
 #: builtin/blame.c:893
-#, fuzzy
 msgid "process only line range <start>,<end> or function :<funcname>"
 msgstr ""
-"Nur Zeilen im Bereich <Start>,<Ende> oder Funktion :<Funktionsname> "
+"nur Zeilen im Bereich <Start>,<Ende> oder Funktion :<Funktionsname> "
 "verarbeiten"
 
 #: builtin/blame.c:945
@@ -11720,7 +11684,7 @@ msgstr "HEAD wurde nicht unter \"refs/heads\" gefunden!"
 
 #: builtin/branch.c:717
 msgid "--column and --verbose are incompatible"
-msgstr "Die Optionen --column und --verbose sind inkompatibel."
+msgstr "--column und --verbose sind inkompatibel"
 
 #: builtin/branch.c:732 builtin/branch.c:788 builtin/branch.c:797
 msgid "branch name required"
@@ -11767,7 +11731,7 @@ msgstr ""
 #: builtin/branch.c:815 builtin/branch.c:838
 #, c-format
 msgid "no such branch '%s'"
-msgstr "Kein solcher Branch '%s'"
+msgstr "Branch '%s' nicht gefunden"
 
 #: builtin/branch.c:819
 #, c-format
@@ -12100,7 +12064,7 @@ msgstr "Angabe von Pfadnamen kann nicht gemeinsam mit --stdin verwendet werden"
 
 #: builtin/check-ignore.c:166
 msgid "-z only makes sense with --stdin"
-msgstr "Die Option -z kann nur mit --stdin verwendet werden."
+msgstr "-z kann nur mit --stdin verwendet werden"
 
 #: builtin/check-ignore.c:168
 msgid "no path specified"
@@ -12108,12 +12072,11 @@ msgstr "kein Pfad angegeben"
 
 #: builtin/check-ignore.c:172
 msgid "--quiet is only valid with a single pathname"
-msgstr "Die Option --quiet ist nur mit einem einzelnen Pfadnamen gültig."
+msgstr "--quiet ist nur mit einem einzelnen Pfadnamen gültig"
 
 #: builtin/check-ignore.c:174
 msgid "cannot have both --quiet and --verbose"
-msgstr ""
-"Die Optionen --quiet und --verbose können nicht gemeinsam verwendet werden."
+msgstr "--quiet und --verbose können nicht gemeinsam verwendet werden"
 
 #: builtin/check-ignore.c:177
 msgid "--non-matching is only valid with --verbose"
@@ -12623,15 +12586,15 @@ msgstr "keine Einschränkung bei Pfadspezifikationen zum partiellen Auschecken"
 #: builtin/checkout.c:1603
 #, c-format
 msgid "-%c, -%c and --orphan are mutually exclusive"
-msgstr "die Optionen -%c, -%c und --orphan schließen sich gegenseitig aus"
+msgstr "-%c, -%c und --orphan schließen sich gegenseitig aus"
 
 #: builtin/checkout.c:1607
 msgid "-p and --overlay are mutually exclusive"
-msgstr "-p und --overlay schließen sich gegenseitig aus."
+msgstr "-p und --overlay schließen sich gegenseitig aus"
 
 #: builtin/checkout.c:1644
 msgid "--track needs a branch name"
-msgstr "Bei der Option --track muss ein Branchname angegeben werden."
+msgstr "--track benötigt ein Branchname"
 
 #: builtin/checkout.c:1649
 #, c-format
@@ -12641,7 +12604,7 @@ msgstr "kein Branchname; versuchen Sie -%c"
 #: builtin/checkout.c:1681
 #, c-format
 msgid "could not resolve %s"
-msgstr "Konnte %s nicht auflösen."
+msgstr "konnte %s nicht auflösen"
 
 #: builtin/checkout.c:1697
 msgid "invalid path specification"
@@ -12660,11 +12623,11 @@ msgstr "git checkout: --detach nimmt kein Pfad-Argument '%s'"
 
 #: builtin/checkout.c:1717
 msgid "--pathspec-from-file is incompatible with --detach"
-msgstr "Die Optionen --pathspec-from-file und --detach sind inkompatibel."
+msgstr "--pathspec-from-file und --detach sind inkompatibel"
 
 #: builtin/checkout.c:1720 builtin/reset.c:325 builtin/stash.c:1566
 msgid "--pathspec-from-file is incompatible with --patch"
-msgstr "Die Optionen --pathspec-from-file und --patch sind inkompatibel."
+msgstr "--pathspec-from-file und --patch sind inkompatibel"
 
 #: builtin/checkout.c:1733
 msgid ""
@@ -12918,7 +12881,7 @@ msgstr ""
 
 #: builtin/clean.c:944
 msgid "-x and -X cannot be used together"
-msgstr "Die Optionen -x und -X können nicht gemeinsam verwendet werden."
+msgstr "-x und -X können nicht gemeinsam verwendet werden"
 
 #: builtin/clone.c:45
 msgid "git clone [<options>] [--] <repo> [<dir>]"
@@ -13187,16 +13150,16 @@ msgstr "Sie müssen ein Repository zum Klonen angeben."
 #: builtin/clone.c:1010
 #, c-format
 msgid "--bare and --origin %s options are incompatible."
-msgstr "Die Optionen --bare und --origin %s sind inkompatibel."
+msgstr "--bare und --origin %s sind inkompatibel."
 
 #: builtin/clone.c:1013
 msgid "--bare and --separate-git-dir are incompatible."
-msgstr "Die Optionen --bare und --separate-git-dir sind inkompatibel."
+msgstr "--bare und --separate-git-dir sind inkompatibel."
 
 #: builtin/clone.c:1026
 #, c-format
 msgid "repository '%s' does not exist"
-msgstr "Repository '%s' existiert nicht."
+msgstr "Repository '%s' existiert nicht"
 
 #: builtin/clone.c:1030 builtin/fetch.c:1951
 #, c-format
@@ -13256,8 +13219,7 @@ msgstr "'%s' ist kein gültiger Name für ein Remote-Repository"
 #: builtin/clone.c:1211
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr ""
-"Die Option --depth wird in lokalen Klonen ignoriert; benutzen Sie "
-"stattdessen file://"
+"--depth wird in lokalen Klonen ignoriert; benutzen Sie stattdessen file://"
 
 #: builtin/clone.c:1213
 msgid "--shallow-since is ignored in local clones; use file:// instead."
@@ -13325,7 +13287,7 @@ msgstr "Abstand zwischen Spalten"
 
 #: builtin/column.c:51
 msgid "--command must be the first argument"
-msgstr "Die Option --command muss an erster Stelle stehen."
+msgstr "--command muss an erster Stelle stehen"
 
 #: builtin/commit-graph.c:13 builtin/commit-graph.c:22
 msgid ""
@@ -13356,9 +13318,8 @@ msgstr "Verzeichnis"
 
 #: builtin/commit-graph.c:81 builtin/commit-graph.c:211
 #: builtin/commit-graph.c:317
-#, fuzzy
 msgid "the object directory to store the graph"
-msgstr "Das Objektverzeichnis zum Speichern des Graphen."
+msgstr "das Objektverzeichnis zum Speichern des Graphen"
 
 #: builtin/commit-graph.c:83
 msgid "if the commit-graph is split, only verify the tip file"
@@ -13775,13 +13736,11 @@ msgstr "Ungültiger Modus '%s' für unversionierte Dateien"
 
 #: builtin/commit.c:1127
 msgid "--long and -z are incompatible"
-msgstr "Die Optionen --long und -z sind inkompatibel."
+msgstr "--long und -z sind inkompatibel"
 
 #: builtin/commit.c:1171
 msgid "Using both --reset-author and --author does not make sense"
-msgstr ""
-"Die Optionen --reset-author und --author können nicht gemeinsam verwendet "
-"werden."
+msgstr "--reset-author und --author können nicht gemeinsam verwendet werden"
 
 #: builtin/commit.c:1180
 msgid "You have nothing to amend."
@@ -13802,7 +13761,7 @@ msgstr "Ein Rebase ist im Gange -- kann \"--amend\" nicht ausführen."
 #: builtin/commit.c:1190
 msgid "Options --squash and --fixup cannot be used together"
 msgstr ""
-"Die Optionen --squash und --fixup können nicht gemeinsam verwendet werden."
+"Die Optionen --squash und --fixup können nicht gemeinsam verwendet werden"
 
 #: builtin/commit.c:1200
 msgid "Only one of -c/-C/-F/--fixup can be used."
@@ -13814,8 +13773,7 @@ msgstr "Die Option -m kann nicht mit -c/-C/-F kombiniert werden."
 
 #: builtin/commit.c:1211
 msgid "--reset-author can be used only with -C, -c or --amend."
-msgstr ""
-"Die Option --reset--author kann nur mit -C, -c oder --amend verwendet werden."
+msgstr "--reset--author kann nur mit -C, -c oder --amend verwendet werden"
 
 #: builtin/commit.c:1229
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
@@ -14399,7 +14357,7 @@ msgstr ""
 #: builtin/config.c:943 builtin/config.c:954
 #, c-format
 msgid "no such section: %s"
-msgstr "Keine solche Sektion: %s"
+msgstr "Sektion nicht gefunden: %s"
 
 #: builtin/count-objects.c:90
 msgid "git count-objects [-v] [-H | --human-readable]"
@@ -14598,7 +14556,7 @@ msgstr ""
 
 #: builtin/describe.c:593
 msgid "--long is incompatible with --abbrev=0"
-msgstr "Die Optionen --long und --abbrev=0 sind inkompatibel."
+msgstr "--long und --abbrev=0 sind inkompatibel"
 
 #: builtin/describe.c:622
 msgid "No names found, cannot describe anything."
@@ -14606,11 +14564,11 @@ msgstr "Keine Namen gefunden, kann nichts beschreiben."
 
 #: builtin/describe.c:673
 msgid "--dirty is incompatible with commit-ishes"
-msgstr "Die Option --dirty kann nicht mit Commits verwendet werden."
+msgstr "--dirty kann nicht mit Commits verwendet werden"
 
 #: builtin/describe.c:675
 msgid "--broken is incompatible with commit-ishes"
-msgstr "Die Option --broken kann nicht mit Commits verwendet werden."
+msgstr "--broken kann nicht mit Commits verwendet werden"
 
 #: builtin/diff-tree.c:155
 msgid "--stdin and --merge-base are mutually exclusive"
@@ -14711,7 +14669,7 @@ msgstr "Sie könnten diese aufräumen oder wiederherstellen."
 
 #: builtin/difftool.c:696
 msgid "use `diff.guitool` instead of `diff.tool`"
-msgstr "`diff.guitool` anstatt `diff.tool` benutzen"
+msgstr "`diff.guitool` statt `diff.tool` benutzen"
 
 #: builtin/difftool.c:698
 msgid "perform a full-directory diff"
@@ -14839,37 +14797,30 @@ msgstr ""
 "Auswählen der Behandlung von Commit-Beschreibungen bei wechselndem Encoding"
 
 #: builtin/fast-export.c:1208
-#, fuzzy
 msgid "dump marks to this file"
 msgstr "Markierungen in diese Datei schreiben"
 
 #: builtin/fast-export.c:1210
-#, fuzzy
 msgid "import marks from this file"
 msgstr "Markierungen von dieser Datei importieren"
 
 #: builtin/fast-export.c:1214
-#, fuzzy
 msgid "import marks from this file if it exists"
 msgstr "Markierungen von dieser Datei importieren, wenn diese existiert"
 
 #: builtin/fast-export.c:1216
-#, fuzzy
 msgid "fake a tagger when tags lack one"
-msgstr "künstlich einen Tag-Ersteller erzeugen, wenn das Tag keinen hat"
+msgstr "einen Tag-Ersteller vortäuschen, wenn das Tag keinen hat"
 
 #: builtin/fast-export.c:1218
-#, fuzzy
 msgid "output full tree for each commit"
 msgstr "für jeden Commit das gesamte Verzeichnis ausgeben"
 
 #: builtin/fast-export.c:1220
-#, fuzzy
 msgid "use the done feature to terminate the stream"
 msgstr "die \"done\"-Funktion benutzen, um den Datenstrom abzuschließen"
 
 #: builtin/fast-export.c:1221
-#, fuzzy
 msgid "skip output of blob data"
 msgstr "Ausgabe von Blob-Daten überspringen"
 
@@ -14878,7 +14829,6 @@ msgid "refspec"
 msgstr "Refspec"
 
 #: builtin/fast-export.c:1223
-#, fuzzy
 msgid "apply refspec to exported refs"
 msgstr "Refspec auf exportierte Referenzen anwenden"
 
@@ -14895,19 +14845,16 @@ msgid "convert <from> to <to> in anonymized output"
 msgstr "konvertiere <von> zu <nach> in anonymisierter Ausgabe"
 
 #: builtin/fast-export.c:1229
-#, fuzzy
 msgid "reference parents which are not in fast-export stream by object id"
 msgstr ""
 "Eltern, die nicht im Fast-Export-Stream sind, anhand ihrer Objekt-ID "
 "referenzieren"
 
 #: builtin/fast-export.c:1231
-#, fuzzy
 msgid "show original object ids of blobs/commits"
 msgstr "originale Objekt-IDs von Blobs/Commits anzeigen"
 
 #: builtin/fast-export.c:1233
-#, fuzzy
 msgid "label tags with mark ids"
 msgstr "Tags mit Markierungs-IDs beschriften"
 
@@ -14985,12 +14932,11 @@ msgstr "Upstream für \"git pull/fetch\" setzen"
 
 #: builtin/fetch.c:147 builtin/pull.c:188
 msgid "append to .git/FETCH_HEAD instead of overwriting"
-msgstr "an .git/FETCH_HEAD anhängen, anstatt zu überschreiben"
+msgstr "an .git/FETCH_HEAD anhängen statt zu überschreiben"
 
 #: builtin/fetch.c:149
-#, fuzzy
 msgid "use atomic transaction to update references"
-msgstr "Referenzen atomar versenden"
+msgstr "atomare Transaktionen nutzen, um Referenzen zu aktualisieren"
 
 #: builtin/fetch.c:151 builtin/pull.c:191
 msgid "path to upload pack on remote end"
@@ -15318,14 +15264,13 @@ msgstr "--deepen und --depth schließen sich gegenseitig aus"
 
 #: builtin/fetch.c:1942
 msgid "--depth and --unshallow cannot be used together"
-msgstr ""
-"Die Optionen --depth und --unshallow können nicht gemeinsam verwendet werden."
+msgstr "--depth und --unshallow können nicht gemeinsam verwendet werden"
 
 #: builtin/fetch.c:1944
 msgid "--unshallow on a complete repository does not make sense"
 msgstr ""
-"Die Option --unshallow kann nicht in einem Repository mit vollständiger "
-"Historie verwendet werden."
+"--unshallow kann nicht in einem Repository mit vollständiger Historie "
+"verwendet werden"
 
 #: builtin/fetch.c:1961
 msgid "fetch --all does not take a repository argument"
@@ -15333,12 +15278,12 @@ msgstr "fetch --all akzeptiert kein Repository als Argument"
 
 #: builtin/fetch.c:1963
 msgid "fetch --all does not make sense with refspecs"
-msgstr "fetch --all kann nicht mit Refspecs verwendet werden."
+msgstr "fetch --all kann nicht mit Refspecs verwendet werden"
 
 #: builtin/fetch.c:1972
 #, c-format
 msgid "No such remote or remote group: %s"
-msgstr "Kein Remote-Repository (einzeln oder Gruppe): %s"
+msgstr "Remote-Repository (einzeln oder Gruppe) nicht gefunden: %s"
 
 #: builtin/fetch.c:1979
 msgid "Fetching a group and specifying refspecs does not make sense"
@@ -15355,17 +15300,16 @@ msgstr ""
 "die in extensions.partialclone konfiguriert sind"
 
 #: builtin/fetch.c:2001
-#, fuzzy
 msgid "--atomic can only be used when fetching from one remote"
 msgstr ""
-"die Option --stdin kann nur verwendet werden, wenn nur von einem Remote-\n"
-"Repository abgefragt wird"
+"--atomic kann nur verwendet werden, wenn nur von einem Remote-Repository "
+"abgefragt wird"
 
 #: builtin/fetch.c:2005
 msgid "--stdin can only be used when fetching from one remote"
 msgstr ""
-"die Option --stdin kann nur verwendet werden, wenn nur von einem Remote-\n"
-"Repository abgefragt wird"
+"--stdin kann nur verwendet werden, wenn nur von einem Remote-Repository "
+"abgefragt wird"
 
 #: builtin/fmt-merge-msg.c:7
 msgid ""
@@ -15923,34 +15867,31 @@ msgid "failed to run 'git config'"
 msgstr "Fehler beim Ausführen von 'git config'"
 
 #: builtin/gc.c:1562
-#, fuzzy, c-format
+#, c-format
 msgid "failed to expand path '%s'"
-msgstr "Fehler beim Erstellen des Pfades '%s'%s"
+msgstr " Erweitern des Pfades '%s'"
 
 #: builtin/gc.c:1591
-#, fuzzy
 msgid "failed to start launchctl"
-msgstr "Konnte emacsclient nicht starten."
+msgstr "konnte launchctl nicht starten"
 
 #: builtin/gc.c:1628
-#, fuzzy, c-format
+#, c-format
 msgid "failed to create directories for '%s'"
-msgstr "Fehler beim Erstellen von Verzeichnis '%s'"
+msgstr "Fehler beim Erstellen von Verzeichnissen für '%s'"
 
 #: builtin/gc.c:1689
-#, fuzzy, c-format
+#, c-format
 msgid "failed to bootstrap service %s"
-msgstr "Fehler beim Löschen von %s"
+msgstr "Fehler beim Laden des Services %s"
 
 #: builtin/gc.c:1760
-#, fuzzy
 msgid "failed to create temp xml file"
-msgstr "Fehler beim Erstellen der Ausgabedateien."
+msgstr "Fehler beim Erstellen der temporären XML-Datei"
 
 #: builtin/gc.c:1850
-#, fuzzy
 msgid "failed to start schtasks"
-msgstr "Konnte '%s' nicht lesen"
+msgstr "Fehler beim Starten von schtasks"
 
 #: builtin/gc.c:1894
 msgid "failed to run 'crontab -l'; your system might not support 'cron'"
@@ -16030,7 +15971,7 @@ msgstr "Schalter '%c' erwartet einen numerischen Wert"
 
 #: builtin/grep.c:836
 msgid "search in index instead of in the work tree"
-msgstr "im Index anstatt im Arbeitsverzeichnis suchen"
+msgstr "im Index statt im Arbeitsverzeichnis suchen"
 
 #: builtin/grep.c:838
 msgid "find in contents not managed by git"
@@ -16249,23 +16190,22 @@ msgstr "ungültige Anzahl von Threads angegeben (%d)"
 #: builtin/grep.c:1130
 msgid "--open-files-in-pager only works on the worktree"
 msgstr ""
-"Die Option --open-files-in-pager kann nur innerhalb des "
-"Arbeitsverzeichnisses verwendet werden."
+"--open-files-in-pager kann nur innerhalb des Arbeitsverzeichnisses verwendet "
+"werden"
 
 #: builtin/grep.c:1156
 msgid "--cached or --untracked cannot be used with --no-index"
-msgstr "--cached und --untracked können nicht mit --no-index verwendet werden."
+msgstr "--cached und --untracked können nicht mit --no-index verwendet werden"
 
 #: builtin/grep.c:1159
-#, fuzzy
 msgid "--untracked cannot be used with --cached"
-msgstr "--cached und --untracked können nicht mit --no-index verwendet werden."
+msgstr "--untracked kann nicht mit --cached verwendet werden"
 
 #: builtin/grep.c:1165
 msgid "--[no-]exclude-standard cannot be used for tracked contents"
 msgstr ""
 "--[no-]exclude-standard kann nicht mit versionierten Inhalten verwendet "
-"werden."
+"werden"
 
 #: builtin/grep.c:1173
 msgid "both --cached and trees are given"
@@ -16626,9 +16566,9 @@ msgid "local object %s is corrupt"
 msgstr "lokales Objekt %s ist beschädigt"
 
 #: builtin/index-pack.c:1445
-#, fuzzy, c-format
+#, c-format
 msgid "packfile name '%s' does not end with '.%s'"
-msgstr "Name der Paketdatei '%s' endet nicht mit '.pack'"
+msgstr "Name der Paketdatei '%s' endet nicht mit '.%s'"
 
 #: builtin/index-pack.c:1469
 #, c-format
@@ -16653,9 +16593,8 @@ msgid "cannot store index file"
 msgstr "Kann Indexdatei nicht speichern"
 
 #: builtin/index-pack.c:1534
-#, fuzzy
 msgid "cannot store reverse index file"
-msgstr "Kann Indexdatei nicht speichern"
+msgstr "kann Reverse-Index-Datei nicht speichern"
 
 #: builtin/index-pack.c:1580 builtin/pack-objects.c:2952
 #, c-format
@@ -16703,7 +16642,7 @@ msgstr "unbekannter Hash-Algorithmus '%s'"
 
 #: builtin/index-pack.c:1851
 msgid "--fix-thin cannot be used without --stdin"
-msgstr "Die Option --fix-thin kann nicht ohne --stdin verwendet werden."
+msgstr "--fix-thin kann nicht ohne --stdin verwendet werden"
 
 #: builtin/index-pack.c:1853
 msgid "--stdin requires a git repository"
@@ -16711,11 +16650,11 @@ msgstr "--stdin erfordert ein Git-Repository"
 
 #: builtin/index-pack.c:1855
 msgid "--object-format cannot be used with --stdin"
-msgstr "Die Option --object-format kann nicht mit --stdin verwendet werden."
+msgstr "--object-format kann nicht mit --stdin verwendet werden"
 
 #: builtin/index-pack.c:1870
 msgid "--verify with no packfile name given"
-msgstr "Die Option --verify wurde ohne Namen der Paketdatei angegeben."
+msgstr "--verify wurde ohne Namen der Paketdatei angegeben"
 
 #: builtin/index-pack.c:1936 builtin/unpack-objects.c:582
 msgid "fsck error in pack objects"
@@ -16928,9 +16867,7 @@ msgstr "Anhang/Anhänge hinzufügen"
 
 #: builtin/interpret-trailers.c:123
 msgid "--trailer with --only-input does not make sense"
-msgstr ""
-"Die Optionen --trailer und --only-input können nicht gemeinsam verwendet "
-"werden."
+msgstr "--trailer und --only-input können nicht gemeinsam verwendet werden"
 
 #: builtin/interpret-trailers.c:133
 msgid "no input file given for in-place editing"
@@ -16954,7 +16891,6 @@ msgid "show source"
 msgstr "Quelle anzeigen"
 
 #: builtin/log.c:181
-#, fuzzy
 msgid "use mail map file"
 msgstr "\"mailmap\"-Datei verwenden"
 
@@ -16971,7 +16907,6 @@ msgid "decorate options"
 msgstr "decorate-Optionen"
 
 #: builtin/log.c:190
-#, fuzzy
 msgid ""
 "trace the evolution of line range <start>,<end> or function :<funcname> in "
 "<file>"
@@ -17124,11 +17059,11 @@ msgstr "Dateiendung"
 
 #: builtin/log.c:1751
 msgid "use <sfx> instead of '.patch'"
-msgstr "<Dateiendung> anstatt '.patch' verwenden"
+msgstr "<Dateiendung> statt '.patch' verwenden"
 
 #: builtin/log.c:1753
 msgid "start numbering patches at <n> instead of 1"
-msgstr "die Nummerierung der Patches bei <n> anstatt bei 1 beginnen"
+msgstr "die Nummerierung der Patches bei <n> statt bei 1 beginnen"
 
 #: builtin/log.c:1755
 msgid "mark the series as Nth re-roll"
@@ -17139,9 +17074,8 @@ msgid "max length of output filename"
 msgstr "maximale Länge des Dateinamens für die Ausgabe"
 
 #: builtin/log.c:1759
-#, fuzzy
 msgid "use [RFC PATCH] instead of [PATCH]"
-msgstr "[RFC PATCH] anstatt [PATCH] verwenden"
+msgstr "[RFC PATCH] statt [PATCH] verwenden"
 
 #: builtin/log.c:1762
 msgid "cover-from-description-mode"
@@ -17153,9 +17087,8 @@ msgstr ""
 "Erzeuge Teile des Deckblattes basierend auf der Beschreibung des Branches"
 
 #: builtin/log.c:1765
-#, fuzzy
 msgid "use [<prefix>] instead of [PATCH]"
-msgstr "Nutze [<Präfix>] statt [PATCH]"
+msgstr "nutze [<Präfix>] statt [PATCH]"
 
 #: builtin/log.c:1768
 msgid "store resulting files in <dir>"
@@ -17297,15 +17230,15 @@ msgstr "--subject-prefix/--rfc und -k schließen sich gegenseitig aus"
 
 #: builtin/log.c:1929
 msgid "--name-only does not make sense"
-msgstr "die Option --name-only kann nicht verwendet werden"
+msgstr "--name-only kann nicht verwendet werden"
 
 #: builtin/log.c:1931
 msgid "--name-status does not make sense"
-msgstr "die Option --name-status kann nicht verwendet werden"
+msgstr "--name-status kann nicht verwendet werden"
 
 #: builtin/log.c:1933
 msgid "--check does not make sense"
-msgstr "die Option --check kann nicht verwendet werden"
+msgstr "--check kann nicht verwendet werden"
 
 #: builtin/log.c:1955
 msgid "--stdout, --output, and --output-directory are mutually exclusive"
@@ -17477,9 +17410,8 @@ msgid "show debugging data"
 msgstr "Ausgaben zur Fehlersuche anzeigen"
 
 #: builtin/ls-files.c:597
-#, fuzzy
 msgid "suppress duplicate entries"
-msgstr "Namen unterdrücken"
+msgstr "doppelte Einträge unterdrücken"
 
 #: builtin/ls-remote.c:9
 msgid ""
@@ -17739,7 +17671,7 @@ msgstr ""
 
 #: builtin/merge.c:265 builtin/pull.c:148
 msgid "create a single commit instead of doing a merge"
-msgstr "einen einzelnen Commit anstatt eines Merges erzeugen"
+msgstr "einen einzelnen Commit erzeugen statt einen Merge durchzuführen"
 
 #: builtin/merge.c:267 builtin/pull.c:151
 msgid "perform a commit if the merge succeeds (default)"
@@ -18079,41 +18011,41 @@ msgstr ""
 
 #: builtin/mktag.c:10
 msgid "git mktag"
-msgstr ""
+msgstr "git mktag"
 
 #: builtin/mktag.c:30
-#, fuzzy, c-format
+#, c-format
 msgid "warning: tag input does not pass fsck: %s"
-msgstr "Warnung: `:include:` wird nicht unterstützt: %s\n"
+msgstr "Warnung: Tag-Eingabe ungültig für fsck: %s"
 
 #: builtin/mktag.c:41
 #, c-format
 msgid "error: tag input does not pass fsck: %s"
-msgstr ""
+msgstr "Fehler: Tag-Eingabe ungültig für fsck: %s"
 
 #: builtin/mktag.c:44
 #, c-format
 msgid "%d (FSCK_IGNORE?) should never trigger this callback"
-msgstr ""
+msgstr "%d (FSCK_IGNORE?) sollte diesen Aufruf niemals auslösen"
 
 #: builtin/mktag.c:59
-#, fuzzy, c-format
+#, c-format
 msgid "could not read tagged object '%s'"
-msgstr "Konnte Objekt %s nicht lesen."
+msgstr "konnte getaggtes Objekt '%s' nicht lesen"
 
 #: builtin/mktag.c:62
-#, fuzzy, c-format
+#, c-format
 msgid "object '%s' tagged as '%s', but is a '%s' type"
-msgstr "Objekt %s ist ein %s, kein %s"
+msgstr "Objekt '%s' als '%s' getaggt, aber ist ein '%s' Typ"
 
 #: builtin/mktag.c:99
 msgid "tag on stdin did not pass our strict fsck check"
 msgstr ""
+"Tag von der Standardeingabe für unsere strenge Überprüfung bei fsck ungültig"
 
 #: builtin/mktag.c:102
-#, fuzzy
 msgid "tag on stdin did not refer to a valid object"
-msgstr "%s zeigt auf kein gültiges Objekt!"
+msgstr "Tag von der Standard-Eingabe verweiste nicht auf gültiges Objekt"
 
 #: builtin/mktag.c:105 builtin/tag.c:232
 msgid "unable to write tag file"
@@ -18560,9 +18492,8 @@ msgstr ""
 "stdin)"
 
 #: builtin/notes.c:517
-#, fuzzy
 msgid "too few arguments"
-msgstr "Zu viele Argumente."
+msgstr "zu wenige Argumente"
 
 #: builtin/notes.c:538
 #, c-format
@@ -18753,6 +18684,8 @@ msgid ""
 "write_reuse_object: could not locate %s, expected at offset %<PRIuMAX> in "
 "pack %s"
 msgstr ""
+"write_reuse_object: konnte %s nicht finden, erwartet bei Offset %<PRIuMAX> "
+"in Paket %s"
 
 #: builtin/pack-objects.c:448
 #, c-format
@@ -18775,9 +18708,9 @@ msgid "ordered %u objects, expected %<PRIu32>"
 msgstr "%u Objekte geordnet, %<PRIu32> erwartet."
 
 #: builtin/pack-objects.c:896
-#, fuzzy, c-format
+#, c-format
 msgid "expected object at offset %<PRIuMAX> in pack %s"
-msgstr "Paket hat ein ungültiges Objekt bei Versatz %<PRIuMAX>: %s"
+msgstr "Objekt beim Offset %<PRIuMAX> in Paket %s erwartet"
 
 #: builtin/pack-objects.c:1015
 msgid "disabling bitmap writing, packs are split due to pack.packSizeLimit"
@@ -19153,6 +19086,12 @@ msgid ""
 "and let us know you still use it by sending an e-mail\n"
 "to <git@vger.kernel.org>.  Thanks.\n"
 msgstr ""
+"'git pack-redundant' ist für die Entfernung vorgesehen.\n"
+"Wenn Sie diesen Befehl weiterhin verwenden, fügen Sie\n"
+"bitte eine zusätzliche Option '--i-still-use-this' in\n"
+"der Befehlszeile hinzu und lassen Sie uns wissen, dass\n"
+"Sie es immer noch verwenden, indem Sie eine E-Mail an\n"
+"<git@vger.kernel.org> senden.  Danke.\n"
 
 #: builtin/pack-refs.c:8
 msgid "git pack-refs [<options>]"
@@ -19426,7 +19365,7 @@ msgstr "Kurzschrift für Tag ohne <Tag>"
 
 #: builtin/push.c:119
 msgid "--delete only accepts plain target ref names"
-msgstr "Die Option --delete akzeptiert nur reine Referenznamen als Ziel."
+msgstr "--delete akzeptiert nur reine Referenznamen als Ziel"
 
 #: builtin/push.c:164
 msgid ""
@@ -19676,11 +19615,11 @@ msgstr "Referenzen atomar versenden"
 
 #: builtin/push.c:601
 msgid "--delete is incompatible with --all, --mirror and --tags"
-msgstr "Die Option --delete ist inkompatibel mit --all, --mirror und --tags."
+msgstr "--delete ist inkompatibel mit --all, --mirror und --tags"
 
 #: builtin/push.c:603
 msgid "--delete doesn't make sense without any refs"
-msgstr "Die Option --delete kann nur mit Referenzen verwendet werden."
+msgstr "--delete kann nur mit Referenzen verwendet werden"
 
 #: builtin/push.c:623
 #, c-format
@@ -19711,23 +19650,23 @@ msgstr ""
 
 #: builtin/push.c:639
 msgid "--all and --tags are incompatible"
-msgstr "Die Optionen --all und --tags sind inkompatibel."
+msgstr "--all und --tags sind inkompatibel"
 
 #: builtin/push.c:641
 msgid "--all can't be combined with refspecs"
-msgstr "Die Option --all kann nicht mit Refspecs kombiniert werden."
+msgstr "--all kann nicht mit Refspecs kombiniert werden"
 
 #: builtin/push.c:645
 msgid "--mirror and --tags are incompatible"
-msgstr "Die Optionen --mirror und --tags sind inkompatibel."
+msgstr "--mirror und --tags sind inkompatibel"
 
 #: builtin/push.c:647
 msgid "--mirror can't be combined with refspecs"
-msgstr "Die Option --mirror kann nicht mit Refspecs kombiniert werden."
+msgstr "--mirror kann nicht mit Refspecs kombiniert werden"
 
 #: builtin/push.c:650
 msgid "--all and --mirror are incompatible"
-msgstr "Die Optionen --all und --mirror sind inkompatibel."
+msgstr "--all und --mirror sind inkompatibel"
 
 #: builtin/push.c:657
 msgid "push options must not have new line characters"
@@ -19764,19 +19703,17 @@ msgid "passed to 'git log'"
 msgstr "an 'git log' übergeben"
 
 #: builtin/range-diff.c:35
-#, fuzzy
 msgid "only emit output related to the first range"
-msgstr "nur Commits anzeigen, die sich nicht im ersten Branch befinden"
+msgstr "nur Ausgaben anzeigen, die sich auf den ersten Bereich beziehen"
 
 #: builtin/range-diff.c:37
-#, fuzzy
 msgid "only emit output related to the second range"
-msgstr "Ausgabe relativ zum Projektverzeichnis"
+msgstr "nur Ausgaben anzeigen, die sich auf den zweiten Bereich beziehen"
 
 #: builtin/range-diff.c:60 builtin/range-diff.c:64
-#, fuzzy, c-format
+#, c-format
 msgid "not a commit range: '%s'"
-msgstr "Kein .. im Bereich: '%s'"
+msgstr "kein Commit-Bereich: '%s'"
 
 #: builtin/range-diff.c:74
 msgid "single arg format must be symmetric range"
@@ -20248,8 +20185,7 @@ msgstr "den Benutzer die Liste der Commits für den Rebase bearbeiten lassen"
 
 #: builtin/rebase.c:1386
 msgid "(DEPRECATED) try to recreate merges instead of ignoring them"
-msgstr ""
-"(VERALTET) Versuche, Merges wiederherzustellen anstatt sie zu ignorieren"
+msgstr "(VERALTET) Versuche, Merges wiederherzustellen statt sie zu ignorieren"
 
 #: builtin/rebase.c:1391
 msgid "how to handle commits that become empty"
@@ -20269,8 +20205,7 @@ msgstr "Rebase von Commits mit leerer Beschreibung erlauben"
 
 #: builtin/rebase.c:1413
 msgid "try to rebase merges instead of skipping them"
-msgstr ""
-"versuchen, Rebase mit Merges auszuführen, anstatt diese zu überspringen"
+msgstr "versuchen, Rebase mit Merges auszuführen, statt diese zu überspringen"
 
 #: builtin/rebase.c:1416
 msgid "use 'merge-base --fork-point' to refine upstream"
@@ -20772,19 +20707,18 @@ msgstr ""
 #: builtin/remote.c:186
 msgid "specifying a master branch makes no sense with --mirror"
 msgstr ""
-"Die Option --mirror kann nicht mit der Angabe eines Hauptbranches verwendet "
-"werden."
+"--mirror kann nicht mit der Angabe eines Hauptbranches verwendet werden"
 
 #: builtin/remote.c:188
 msgid "specifying branches to track makes sense only with fetch mirrors"
 msgstr ""
-"Die Angabe von zu folgenden Branches kann nur mit dem Anfordern von "
-"Spiegelarchiven verwendet werden."
+"die Angabe von zu folgenden Branches kann nur mit dem Anfordern von "
+"Spiegelarchiven verwendet werden"
 
 #: builtin/remote.c:195 builtin/remote.c:700
 #, c-format
 msgid "remote %s already exists."
-msgstr "externes Repository %s existiert bereits"
+msgstr "externes Repository %s existiert bereits."
 
 #: builtin/remote.c:240
 #, c-format
@@ -20823,7 +20757,7 @@ msgstr ""
 #: builtin/remote.c:691 builtin/remote.c:836 builtin/remote.c:946
 #, c-format
 msgid "No such remote: '%s'"
-msgstr "Kein solches Remote-Repository: '%s'"
+msgstr "Remote-Repository nicht gefunden: '%s'"
 
 #: builtin/remote.c:710
 #, c-format
@@ -21110,7 +21044,7 @@ msgstr "entferne veraltete Branches im Remote-Repository nach \"fetch\""
 #: builtin/remote.c:1521 builtin/remote.c:1577 builtin/remote.c:1647
 #, c-format
 msgid "No such remote '%s'"
-msgstr "Kein solches Remote-Repository '%s'"
+msgstr "Remote-Repository '%s' nicht gefunden"
 
 #: builtin/remote.c:1539
 msgid "add branch"
@@ -21147,8 +21081,7 @@ msgstr "URLs löschen"
 
 #: builtin/remote.c:1632
 msgid "--add --delete doesn't make sense"
-msgstr ""
-"Die Optionen --add und --delete können nicht gemeinsam verwendet werden."
+msgstr "--add und --delete können nicht gemeinsam verwendet werden"
 
 #: builtin/remote.c:1673
 #, c-format
@@ -21158,7 +21091,7 @@ msgstr "ungültiges altes URL Format: %s"
 #: builtin/remote.c:1681
 #, c-format
 msgid "No such URL found: %s"
-msgstr "Keine solche URL gefunden: %s"
+msgstr "URL nicht gefunden: %s"
 
 #: builtin/remote.c:1683
 msgid "Will not delete all non-push URLs"
@@ -21253,8 +21186,8 @@ msgstr "Bytes"
 #: builtin/repack.c:348
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr ""
-"gleiches wie oben, aber die Speichergröße anstatt der\n"
-"Anzahl der Einträge limitieren"
+"gleiches wie oben, aber die Speichergröße statt der Anzahl der Einträge "
+"limitieren"
 
 #: builtin/repack.c:350
 msgid "limits the maximum delta depth"
@@ -21445,7 +21378,7 @@ msgid ""
 "instead of --graft"
 msgstr ""
 "Der ursprüngliche Commit '%s' enthält Merge-Tag '%s', der verworfen\n"
-"wird; benutzen Sie --edit anstatt --graft"
+"wird; benutzen Sie --edit statt --graft"
 
 #: builtin/replace.c:469
 #, c-format
@@ -21992,30 +21925,26 @@ msgid "unknown group type: %s"
 msgstr "unbekannter Gruppen-Typ: %s"
 
 #: builtin/shortlog.c:351
-#, fuzzy
 msgid "group by committer rather than author"
-msgstr "über Commit-Ersteller anstatt Autor gruppieren"
+msgstr "nach Commit-Ersteller statt Autor gruppieren"
 
 #: builtin/shortlog.c:354
 msgid "sort output according to the number of commits per author"
 msgstr "die Ausgabe entsprechend der Anzahl von Commits pro Autor sortieren"
 
 #: builtin/shortlog.c:356
-#, fuzzy
 msgid "suppress commit descriptions, only provides commit count"
 msgstr "Commit-Beschreibungen unterdrücken, nur Anzahl der Commits liefern"
 
 #: builtin/shortlog.c:358
-#, fuzzy
 msgid "show the email address of each author"
-msgstr "die E-Mail-Adresse von jedem Autor anzeigen"
+msgstr "die E-Mail-Adresse jedes Autors anzeigen"
 
 #: builtin/shortlog.c:359
 msgid "<w>[,<i1>[,<i2>]]"
 msgstr "<w>[,<i1>[,<i2>]]"
 
 #: builtin/shortlog.c:360
-#, fuzzy
 msgid "linewrap output"
 msgstr "Ausgabe mit Zeilenumbrüchen"
 
@@ -22024,9 +21953,8 @@ msgid "field"
 msgstr "Feld"
 
 #: builtin/shortlog.c:363
-#, fuzzy
 msgid "group by field"
-msgstr "Gruppieren über Feld"
+msgstr "Gruppieren nach Feld"
 
 #: builtin/shortlog.c:391
 msgid "too many arguments given outside repository"
@@ -22138,14 +22066,14 @@ msgstr "keine Branches angegeben, und HEAD ist ungültig"
 
 #: builtin/show-branch.c:738
 msgid "--reflog option needs one branch name"
-msgstr "Die Option --reflog benötigt einen Branchnamen."
+msgstr "die Option --reflog benötigt einen Branchnamen"
 
 #: builtin/show-branch.c:741
 #, c-format
 msgid "only %d entry can be shown at one time."
 msgid_plural "only %d entries can be shown at one time."
-msgstr[0] "nur %d Eintrag kann zur selben Zeit angezeigt werden"
-msgstr[1] "nur %d Einträge können zur selben Zeit angezeigt werden"
+msgstr[0] "nur %d Eintrag kann zur selben Zeit angezeigt werden."
+msgstr[1] "nur %d Einträge können zur selben Zeit angezeigt werden."
 
 #: builtin/show-branch.c:745
 #, c-format
@@ -22388,7 +22316,6 @@ msgid "%s is not a valid reference"
 msgstr "'%s' ist kein gültiger Referenzname."
 
 #: builtin/stash.c:225
-#, fuzzy
 msgid "git stash clear with arguments is unimplemented"
 msgstr "git stash clear mit Parametern ist nicht implementiert"
 
@@ -22399,6 +22326,10 @@ msgid ""
 "            %s -> %s\n"
 "         to make room.\n"
 msgstr ""
+"WARNUNG: Nicht versionierte Datei im Weg von versionierter Datei!  "
+"Umbenennung\n"
+"            %s -> %s\n"
+"         um Platz zu schaffen.\n"
 
 #: builtin/stash.c:490
 msgid "cannot apply a stash in the middle of a merge"
@@ -22627,11 +22558,8 @@ msgstr ""
 "."
 
 #: builtin/submodule--helper.c:565
-#, fuzzy
 msgid "suppress output of entering each submodule command"
-msgstr ""
-"Ausgaben beim Betreten und der Befehlsausführung in einem Submodul "
-"unterdrücken"
+msgstr "Ausgaben beim Betreten eines Submodul-Befehls unterdrücken"
 
 #: builtin/submodule--helper.c:567 builtin/submodule--helper.c:888
 #: builtin/submodule--helper.c:1487
@@ -22675,7 +22603,6 @@ msgstr ""
 "Konfiguration."
 
 #: builtin/submodule--helper.c:709
-#, fuzzy
 msgid "suppress output for initializing a submodule"
 msgstr "Ausgaben bei Initialisierung eines Submoduls unterdrücken"
 
@@ -22699,17 +22626,15 @@ msgid "failed to recurse into submodule '%s'"
 msgstr "Fehler bei Rekursion in Submodul '%s'."
 
 #: builtin/submodule--helper.c:886 builtin/submodule--helper.c:1623
-#, fuzzy
 msgid "suppress submodule status output"
-msgstr "Ausgabe über Submodul-Status unterdrücken"
+msgstr "Ausgabe des Submodul-Status unterdrücken"
 
 #: builtin/submodule--helper.c:887
-#, fuzzy
 msgid ""
 "use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
 msgstr ""
-"Benutze den Commit, der im Index gespeichert ist, statt den im Submodul HEAD"
+"den Commit benutzen, der im Index gespeichert ist, statt den im Submodul HEAD"
 
 #: builtin/submodule--helper.c:893
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
@@ -22795,7 +22720,6 @@ msgid "failed to update remote for submodule '%s'"
 msgstr "Fehler beim Aktualisieren des Remote-Repositories für Submodul '%s'"
 
 #: builtin/submodule--helper.c:1485
-#, fuzzy
 msgid "suppress output of synchronizing submodule url"
 msgstr "Ausgaben bei der Synchronisierung der Submodul-URLs unterdrücken"
 
@@ -22843,16 +22767,14 @@ msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "Submodul '%s' (%s) für Pfad '%s' ausgetragen.\n"
 
 #: builtin/submodule--helper.c:1624
-#, fuzzy
 msgid "remove submodule working trees even if they contain local changes"
 msgstr ""
 "Arbeitsverzeichnisse von Submodulen löschen, auch wenn lokale Änderungen "
 "vorliegen"
 
 #: builtin/submodule--helper.c:1625
-#, fuzzy
 msgid "unregister all submodules"
-msgstr "alle Submodule austragen"
+msgstr "alle Submodule autragen"
 
 #: builtin/submodule--helper.c:1630
 msgid ""
@@ -23004,12 +22926,10 @@ msgid "rebase, merge, checkout or none"
 msgstr "rebase, merge, checkout oder none"
 
 #: builtin/submodule--helper.c:2340
-#, fuzzy
 msgid "create a shallow clone truncated to the specified number of revisions"
 msgstr ""
-"Erstellung eines Klons mit unvollständiger Historie (shallow), abgeschnitten "
-"bei\n"
-"der angegebenen Anzahl von Commits."
+"einen Klon mit unvollständiger Historie (shallow) erstellen, abgeschnitten "
+"bei der angegebenen Anzahl von Commits"
 
 #: builtin/submodule--helper.c:2343
 msgid "parallel jobs"
@@ -23083,7 +23003,6 @@ msgstr ""
 "Arbeitsverzeichnis befindet."
 
 #: builtin/submodule--helper.c:2681
-#, fuzzy
 msgid "suppress output for setting url of a submodule"
 msgstr "Ausgaben beim Setzen der URL eines Submoduls unterdrücken"
 
@@ -23335,23 +23254,23 @@ msgstr "--column und -n sind inkompatibel"
 
 #: builtin/tag.c:537
 msgid "-n option is only allowed in list mode"
-msgstr "Die Option -n ist nur im Listenmodus erlaubt."
+msgstr "die Option -n ist nur im Listenmodus erlaubt"
 
 #: builtin/tag.c:539
 msgid "--contains option is only allowed in list mode"
-msgstr "Die Option --contains ist nur im Listenmodus erlaubt."
+msgstr "--contains ist nur im Listenmodus erlaubt"
 
 #: builtin/tag.c:541
 msgid "--no-contains option is only allowed in list mode"
-msgstr "Die Option --no-contains ist nur im Listenmodus erlaubt."
+msgstr "--no-contains ist nur im Listenmodus erlaubt"
 
 #: builtin/tag.c:543
 msgid "--points-at option is only allowed in list mode"
-msgstr "Die Option --points-at ist nur im Listenmodus erlaubt."
+msgstr "--points-at ist nur im Listenmodus erlaubt"
 
 #: builtin/tag.c:545
 msgid "--merged and --no-merged options are only allowed in list mode"
-msgstr "Die Optionen --merged und --no-merged sind nur im Listenmodus erlaubt."
+msgstr "--merged und --no-merged sind nur im Listenmodus erlaubt"
 
 #: builtin/tag.c:556
 msgid "only one -F or -m option is allowed."
@@ -23593,24 +23512,24 @@ msgid ""
 "core.splitIndex is set to false; remove or change it, if you really want to "
 "enable split index"
 msgstr ""
-"core.splitIndex ist auf 'false' gesetzt. Entfernen oder ändern Sie dies,\n"
-"wenn sie wirklich das Splitting des Index aktivieren möchten."
+"core.splitIndex ist auf 'false' gesetzt; entfernen oder ändern Sie dies,\n"
+"wenn sie wirklich das Splitting des Index aktivieren möchten"
 
 #: builtin/update-index.c:1182
 msgid ""
 "core.splitIndex is set to true; remove or change it, if you really want to "
 "disable split index"
 msgstr ""
-"core.splitIndex ist auf 'true' gesetzt. Entfernen oder ändern Sie dies,\n"
-"wenn Sie wirklich das Splitting des Index deaktivieren möchten."
+"core.splitIndex ist auf 'true' gesetzt; entfernen oder ändern Sie dies,\n"
+"wenn Sie wirklich das Splitting des Index deaktivieren möchten"
 
 #: builtin/update-index.c:1194
 msgid ""
 "core.untrackedCache is set to true; remove or change it, if you really want "
 "to disable the untracked cache"
 msgstr ""
-"core.untrackedCache ist auf 'true' gesetzt. Entfernen oder ändern Sie dies,\n"
-"wenn Sie wirklich den Cache für unversionierte Dateien deaktivieren möchten."
+"core.untrackedCache ist auf 'true' gesetzt; entfernen oder ändern Sie dies,\n"
+"wenn Sie wirklich den Cache für unversionierte Dateien deaktivieren möchten"
 
 #: builtin/update-index.c:1198
 msgid "Untracked cache disabled"
@@ -23621,9 +23540,9 @@ msgid ""
 "core.untrackedCache is set to false; remove or change it, if you really want "
 "to enable the untracked cache"
 msgstr ""
-"core.untrackedCache ist auf 'false' gesetzt. Entfernen oder ändern Sie "
+"core.untrackedCache ist auf 'false' gesetzt; entfernen oder ändern Sie "
 "dies,\n"
-"wenn sie wirklich den Cache für unversionierte Dateien aktivieren möchten."
+"wenn sie wirklich den Cache für unversionierte Dateien aktivieren möchten"
 
 #: builtin/update-index.c:1210
 #, c-format
@@ -23633,9 +23552,9 @@ msgstr "Cache für unversionierte Dateien für '%s' aktiviert"
 #: builtin/update-index.c:1218
 msgid "core.fsmonitor is unset; set it if you really want to enable fsmonitor"
 msgstr ""
-"core.fsmonitor nicht gesetzt. Setzen Sie es, wenn Sie den Dateisystem-"
+"core.fsmonitor nicht gesetzt; setzen Sie es, wenn Sie den Dateisystem-"
 "Monitor\n"
-"wirklich aktivieren möchten."
+"wirklich aktivieren möchten"
 
 #: builtin/update-index.c:1222
 msgid "fsmonitor enabled"
@@ -23645,7 +23564,7 @@ msgstr "Dateisystem-Monitor aktiviert"
 msgid ""
 "core.fsmonitor is set; remove it if you really want to disable fsmonitor"
 msgstr ""
-"core.fsmonitor ist gesetzt. Löschen Sie es, wenn Sie den Dateisystem-"
+"core.fsmonitor ist gesetzt; löschen Sie es, wenn Sie den Dateisystem-"
 "Monitor\n"
 "wirklich deaktivieren möchten."
 
@@ -23888,17 +23807,16 @@ msgstr ""
 
 #: builtin/worktree.c:680
 msgid "show extended annotations and reasons, if available"
-msgstr ""
+msgstr "erweiterte Anmerkungen und Gründe anzeigen, falls vorhanden"
 
 #: builtin/worktree.c:682
-#, fuzzy
 msgid "add 'prunable' annotation to worktrees older than <time>"
-msgstr "Arbeitsverzeichnisse älter als <Zeit> verfallen lassen"
+msgstr ""
+"'prunable'-Anmerkung zu Arbeitsverzeichnissen älter als <Zeit> hinzufügen"
 
 #: builtin/worktree.c:691
-#, fuzzy
 msgid "--verbose and --porcelain are mutually exclusive"
-msgstr "-p und --overlay schließen sich gegenseitig aus."
+msgstr "--verbose und --porcelain schließen sich gegenseitig aus"
 
 #: builtin/worktree.c:718
 msgid "reason for locking"
@@ -24088,7 +24006,6 @@ msgid "exit immediately after advertising capabilities"
 msgstr "direkt nach Anzeige der angebotenen Fähigkeiten beenden"
 
 #: git.c:28
-#, fuzzy
 msgid ""
 "git [--version] [--help] [-C <path>] [-c <name>=<value>]\n"
 "           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]\n"
@@ -24103,6 +24020,7 @@ msgstr ""
 "           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--"
 "bare]\n"
 "           [--git-dir=<Pfad>] [--work-tree=<Pfad>] [--namespace=<Name>]\n"
+"           [--super-prefix=<Pfad>] [--config-env=<Name>=<Variable>]\n"
 "           <Befehl> [<Argumente>]"
 
 #: git.c:36
@@ -24211,7 +24129,7 @@ msgstr ""
 #: git.c:906
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
-msgstr "Erweiterung von Alias '%s' fehlgeschlagen; '%s' ist kein Git-Befehl.\n"
+msgstr "Erweiterung von Alias '%s' fehlgeschlagen; '%s' ist kein Git-Befehl\n"
 
 #: git.c:918
 #, c-format
@@ -24280,17 +24198,17 @@ msgstr "%sinfo/refs nicht gültig: Ist das ein Git-Repository?"
 
 #: remote-curl.c:408
 msgid "invalid server response; expected service, got flush packet"
-msgstr "Ungültige Antwort des Servers. Service erwartet, Flush-Paket bekommen"
+msgstr "ungültige Antwort des Servers; Service erwartet, Flush-Paket bekommen"
 
 #: remote-curl.c:439
 #, c-format
 msgid "invalid server response; got '%s'"
-msgstr "Ungültige Serverantwort; '%s' bekommen"
+msgstr "ungültige Serverantwort; '%s' bekommen"
 
 #: remote-curl.c:499
 #, c-format
 msgid "repository '%s' not found"
-msgstr "Repository '%s' nicht gefunden."
+msgstr "Repository '%s' nicht gefunden"
 
 #: remote-curl.c:503
 #, c-format
@@ -24818,9 +24736,8 @@ msgid "Write and verify multi-pack-indexes"
 msgstr "multi-pack-indexes schreiben und überprüfen"
 
 #: command-list.h:132
-#, fuzzy
 msgid "Creates a tag object with extra validation"
-msgstr "ein Tag-Objekt erstellen"
+msgstr "Erstellt ein Tag-Objekt mit zusätzlicher Validierung"
 
 #: command-list.h:133
 msgid "Build a tree-object from ls-tree formatted text"
@@ -25138,7 +25055,7 @@ msgstr "Spezifikation von bewusst ignorierten, unversionierten Dateien"
 
 #: command-list.h:209
 msgid "Map author/committer names and/or E-Mail addresses"
-msgstr ""
+msgstr "Autor/Commit-Ersteller und/oder E-Mail-Adressen zuordnen"
 
 #: command-list.h:210
 msgid "Defining submodule properties"
@@ -26278,7 +26195,7 @@ msgstr ""
 "\n"
 "    * \"./%s\" angeben, wenn Sie eine Datei meinen, oder\n"
 "    * die Option --format-patch angeben, wenn Sie einen Commit-Bereich "
-"meinen\n"
+"meinen.\n"
 
 #: git-send-email.perl:678
 #, perl-format
@@ -26292,7 +26209,7 @@ msgid ""
 "warning: no patches were sent\n"
 msgstr ""
 "fatal: %s: %s\n"
-"Warnung: Es wurden keine Patches versendet.\n"
+"Warnung: Es wurden keine Patches versendet\n"
 
 #: git-send-email.perl:713
 msgid ""
@@ -26301,7 +26218,7 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"keine Patch-Dateien angegeben!\n"
+"Keine Patch-Dateien angegeben!\n"
 "\n"
 
 #: git-send-email.perl:726
@@ -26568,71 +26485,3 @@ msgstr "Lasse %s mit Backup-Suffix '%s' aus.\n"
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Wollen Sie %s wirklich versenden? [y|N]: "
-
-#~ msgid "rev-list died"
-#~ msgstr "\"rev-list\" abgebrochen"
-
-#~ msgid ""
-#~ "git bisect--helper --bisect-write [--no-log] <state> <revision> "
-#~ "<good_term> <bad_term>"
-#~ msgstr ""
-#~ "git bisect--helper --bisect-write [--no-log] <Zustand> <Revision> "
-#~ "<Begriff_gut> <Begriff_schlecht>"
-
-#~ msgid ""
-#~ "git bisect--helper --bisect-check-and-set-terms <command> <good_term> "
-#~ "<bad_term>"
-#~ msgstr ""
-#~ "git bisect--helper --bisect-check-and-set-terms <Befehl> <Begriff_gut> "
-#~ "<Begriff_schlecht>"
-
-#~ msgid "git bisect--helper --bisect-auto-next"
-#~ msgstr "git bisect--helper --bisect-auto-next"
-
-#~ msgid "write out the bisection state in BISECT_LOG"
-#~ msgstr "den Zustand der binären Suche nach BISECT_LOG schreiben"
-
-#~ msgid "check and set terms in a bisection state"
-#~ msgstr "Begriffe innerhalb einer binären Suche prüfen und setzen"
-
-#~ msgid ""
-#~ "verify the next bisection state then checkout the next bisection commit"
-#~ msgstr ""
-#~ "überprüfe den nächsten Zustand der binären Suche, checke dann den "
-#~ "nächsten Commit der binären Suche aus"
-
-#~ msgid "--bisect-write requires either 4 or 5 arguments"
-#~ msgstr "--bisect-write benötigt entweder 4 oder 5 Argumente"
-
-#~ msgid "--check-and-set-terms requires 3 arguments"
-#~ msgstr "--check-and-set-terms benötigt 3 Argumente"
-
-#~ msgid "--bisect-auto-next requires 0 arguments"
-#~ msgstr "--bisect-auto-next benötigt 0 Argumente"
-
-#~ msgid "Force progress reporting"
-#~ msgstr "Fortschrittsanzeige erzwingen"
-
-#~ msgid "Error deleting remote-tracking branch '%s'"
-#~ msgstr "Fehler beim Entfernen des Remote-Tracking-Branches '%s'"
-
-#~ msgid "Error deleting branch '%s'"
-#~ msgstr "Fehler beim Entfernen des Branches '%s'"
-
-#~ msgid "show parse tree for grep expression"
-#~ msgstr "geparstes Verzeichnis für \"grep\"-Ausdruck anzeigen"
-
-#~ msgid "too many parameters"
-#~ msgstr "zu viele Parameter"
-
-#~ msgid "too few parameters"
-#~ msgstr "zu wenig Parameter"
-
-#~ msgid "Recurse into nested submodules"
-#~ msgstr "Rekursion in verschachtelte Submodule durchführen"
-
-#~ msgid "too many params"
-#~ msgstr "zu viele Parameter"
-
-#~ msgid "Bad rev input: $arg"
-#~ msgstr "Ungültige Referenz-Eingabe: $arg"

--- a/po/de.po
+++ b/po/de.po
@@ -3124,7 +3124,7 @@ msgstr "Fehler beim Codieren von '%s' von %s nach %s"
 #: convert.c:462
 #, c-format
 msgid "encoding '%s' from %s to %s and back is not the same"
-msgstr "Codierung '%s' von %s nach %s und zurück ist nicht dasselbe"
+msgstr "Codierung von '%s' von %s nach %s und zurück ist nicht dasselbe"
 
 #: convert.c:665
 #, c-format
@@ -3928,7 +3928,7 @@ msgstr "die Änderung des angegebenen Pfades zuerst anzeigen"
 
 #: diff.c:5619
 msgid "skip the output to the specified path"
-msgstr "überspringe die Ausgabe zum angegebenen Pfad"
+msgstr "überspringe die Ausgabe bis zum angegebenen Pfad"
 
 #: diff.c:5621
 msgid "<object-id>"
@@ -10191,7 +10191,7 @@ msgstr "git add [<Optionen>] [--] <Pfadspezifikation>..."
 #: builtin/add.c:58
 #, c-format
 msgid "cannot chmod %cx '%s'"
-msgstr "kann nicht chmod %cx '%s'"
+msgstr "kann chmod %cx '%s' nicht ausführen"
 
 #: builtin/add.c:96
 #, c-format
@@ -11214,8 +11214,7 @@ msgstr "\"blame\"-Einträge schrittweise anzeigen, während wir sie finden"
 
 #: builtin/blame.c:868
 msgid "do not show object names of boundary commits (Default: off)"
-msgstr ""
-"keine Objektnkeine Objektnamen für Grenz-Commits anzeigen (Standard: aus)"
+msgstr "keine Objektnamen für Grenz-Commits anzeigen (Standard: aus)"
 
 #: builtin/blame.c:869
 msgid "do not treat root commits as boundaries (Default: off)"
@@ -13219,24 +13218,26 @@ msgstr "'%s' ist kein gültiger Name für ein Remote-Repository"
 #: builtin/clone.c:1211
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr ""
-"--depth wird in lokalen Klonen ignoriert; benutzen Sie stattdessen file://"
+"--depth wird in lokalen Klonen ignoriert; benutzen Sie stattdessen "
+"\"file://\"."
 
 #: builtin/clone.c:1213
 msgid "--shallow-since is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-since wird in lokalen Klonen ignoriert; benutzen Sie stattdessen "
-"file://"
+"\"file://\"."
 
 #: builtin/clone.c:1215
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-exclude wird in lokalen Klonen ignoriert; benutzen Sie stattdessen "
-"file://"
+"\"file://\"."
 
 #: builtin/clone.c:1217
 msgid "--filter is ignored in local clones; use file:// instead."
 msgstr ""
-"--filter wird in lokalen Klonen ignoriert; benutzen Sie stattdessen file://"
+"--filter wird in lokalen Klonen ignoriert; benutzen Sie stattdessen "
+"\"file://\"."
 
 #: builtin/clone.c:1220
 msgid "source repository is shallow, ignoring --local"
@@ -15869,7 +15870,7 @@ msgstr "Fehler beim Ausführen von 'git config'"
 #: builtin/gc.c:1562
 #, c-format
 msgid "failed to expand path '%s'"
-msgstr " Erweitern des Pfades '%s'"
+msgstr "Fehler beim Erweitern des Pfades '%s'"
 
 #: builtin/gc.c:1591
 msgid "failed to start launchctl"
@@ -19091,7 +19092,7 @@ msgstr ""
 "bitte eine zusätzliche Option '--i-still-use-this' in\n"
 "der Befehlszeile hinzu und lassen Sie uns wissen, dass\n"
 "Sie es immer noch verwenden, indem Sie eine E-Mail an\n"
-"<git@vger.kernel.org> senden.  Danke.\n"
+"<git@vger.kernel.org> senden. Danke.\n"
 
 #: builtin/pack-refs.c:8
 msgid "git pack-refs [<options>]"
@@ -22326,7 +22327,7 @@ msgid ""
 "            %s -> %s\n"
 "         to make room.\n"
 msgstr ""
-"WARNUNG: Nicht versionierte Datei im Weg von versionierter Datei!  "
+"WARNUNG: Nicht versionierte Datei im Weg von versionierter Datei! "
 "Umbenennung\n"
 "            %s -> %s\n"
 "         um Platz zu schaffen.\n"
@@ -22774,7 +22775,7 @@ msgstr ""
 
 #: builtin/submodule--helper.c:1625
 msgid "unregister all submodules"
-msgstr "alle Submodule autragen"
+msgstr "alle Submodule austragen"
 
 #: builtin/submodule--helper.c:1630
 msgid ""

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2020-12-21 07:10+0800\n"
+"POT-Creation-Date: 2021-02-26 22:09+0800\n"
 "PO-Revision-Date: 2020-12-19 14:01+0100\n"
 "Last-Translator: Matthias Rüster <matthias.ruester@gmail.com>\n"
 "Language-Team: Matthias Rüster <matthias.ruester@gmail.com>\n"
@@ -23,9 +23,9 @@ msgstr ""
 msgid "Huh (%s)?"
 msgstr "Wie bitte (%s)?"
 
-#: add-interactive.c:529 add-interactive.c:830 reset.c:65 sequencer.c:3284
-#: sequencer.c:3735 sequencer.c:3890 builtin/rebase.c:1532
-#: builtin/rebase.c:1955
+#: add-interactive.c:529 add-interactive.c:830 reset.c:65 sequencer.c:3292
+#: sequencer.c:3743 sequencer.c:3898 builtin/rebase.c:1538
+#: builtin/rebase.c:1963
 msgid "could not read index"
 msgstr "Index konnte nicht gelesen werden"
 
@@ -53,7 +53,7 @@ msgstr "Aktualisieren"
 msgid "could not stage '%s'"
 msgstr "Konnte '%s' nicht zum Commit vormerken."
 
-#: add-interactive.c:703 add-interactive.c:892 reset.c:89 sequencer.c:3478
+#: add-interactive.c:703 add-interactive.c:892 reset.c:89 sequencer.c:3486
 msgid "could not write index"
 msgstr "Konnte Index nicht schreiben."
 
@@ -211,7 +211,7 @@ msgstr "aus Staging-Area entfernt"
 
 #: add-interactive.c:1144 apply.c:4987 apply.c:4990 builtin/am.c:2257
 #: builtin/am.c:2260 builtin/bugreport.c:134 builtin/clone.c:124
-#: builtin/fetch.c:147 builtin/merge.c:284 builtin/pull.c:190
+#: builtin/fetch.c:150 builtin/merge.c:285 builtin/pull.c:190
 #: builtin/submodule--helper.c:409 builtin/submodule--helper.c:1818
 #: builtin/submodule--helper.c:1821 builtin/submodule--helper.c:2326
 #: builtin/submodule--helper.c:2329 builtin/submodule--helper.c:2572
@@ -818,7 +818,7 @@ msgstr ""
 msgid "Exiting because of an unresolved conflict."
 msgstr "Beende wegen unaufgelöstem Konflikt."
 
-#: advice.c:281 builtin/merge.c:1369
+#: advice.c:281 builtin/merge.c:1370
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "Sie haben Ihren Merge nicht abgeschlossen (MERGE_HEAD existiert)."
 
@@ -1132,7 +1132,8 @@ msgstr "Anwendung des Patches fehlgeschlagen: %s:%ld"
 msgid "cannot checkout %s"
 msgstr "kann %s nicht auschecken"
 
-#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:73 setup.c:308
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:73 pack-revindex.c:213
+#: setup.c:308
 #, c-format
 msgid "failed to read %s"
 msgstr "Fehler beim Lesen von %s"
@@ -1293,7 +1294,7 @@ msgstr "kann internen Speicher für eben erstellte Datei %s nicht erzeugen"
 msgid "unable to add cache entry for %s"
 msgstr "kann für %s keinen Eintrag in den Zwischenspeicher hinzufügen"
 
-#: apply.c:4374 builtin/bisect--helper.c:524
+#: apply.c:4374 builtin/bisect--helper.c:523
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "Fehler beim Schreiben nach '%s'"
@@ -1329,7 +1330,7 @@ msgstr[1] "Wende Patch %%s mit %d Zurückweisungen an..."
 msgid "truncating .rej filename to %.*s.rej"
 msgstr "Verkürze Name von .rej Datei zu %.*s.rej"
 
-#: apply.c:4576 builtin/fetch.c:927 builtin/fetch.c:1228
+#: apply.c:4576 builtin/fetch.c:933 builtin/fetch.c:1334
 #, c-format
 msgid "cannot open %s"
 msgstr "kann '%s' nicht öffnen"
@@ -1383,7 +1384,7 @@ msgid_plural "%d lines applied after fixing whitespace errors."
 msgstr[0] "%d Zeile nach Behebung von Whitespace-Fehlern angewendet."
 msgstr[1] "%d Zeilen nach Behebung von Whitespace-Fehlern angewendet."
 
-#: apply.c:4960 builtin/add.c:618 builtin/mv.c:304 builtin/rm.c:406
+#: apply.c:4960 builtin/add.c:626 builtin/mv.c:304 builtin/rm.c:406
 msgid "Unable to write new index file"
 msgstr "Konnte neue Index-Datei nicht schreiben."
 
@@ -1463,7 +1464,7 @@ msgstr ""
 "einen temporären Index, basierend auf den integrierten Index-Informationen, "
 "erstellen"
 
-#: apply.c:5025 builtin/checkout-index.c:182 builtin/ls-files.c:525
+#: apply.c:5025 builtin/checkout-index.c:195 builtin/ls-files.c:540
 msgid "paths are separated with NUL character"
 msgstr "Pfade sind getrennt durch NUL Zeichen"
 
@@ -1474,7 +1475,7 @@ msgstr ""
 
 #: apply.c:5028 builtin/am.c:2245 builtin/interpret-trailers.c:98
 #: builtin/interpret-trailers.c:100 builtin/interpret-trailers.c:102
-#: builtin/pack-objects.c:3562 builtin/rebase.c:1346
+#: builtin/pack-objects.c:3577 builtin/rebase.c:1352
 msgid "action"
 msgstr "Aktion"
 
@@ -1503,9 +1504,9 @@ msgstr ""
 msgid "allow overlapping hunks"
 msgstr "sich überlappende Patch-Blöcke erlauben"
 
-#: apply.c:5045 builtin/add.c:329 builtin/check-ignore.c:22
-#: builtin/commit.c:1364 builtin/count-objects.c:98 builtin/fsck.c:775
-#: builtin/log.c:2287 builtin/mv.c:123 builtin/read-tree.c:128
+#: apply.c:5045 builtin/add.c:337 builtin/check-ignore.c:22
+#: builtin/commit.c:1364 builtin/count-objects.c:98 builtin/fsck.c:757
+#: builtin/log.c:2286 builtin/mv.c:123 builtin/read-tree.c:128
 msgid "be verbose"
 msgstr "erweiterte Ausgaben"
 
@@ -1593,14 +1594,14 @@ msgstr "git archive --remote <Repository> [--exec <Programm>] --list"
 msgid "cannot read %s"
 msgstr "Kann %s nicht lesen."
 
-#: archive.c:345 sequencer.c:459 sequencer.c:1736 sequencer.c:2886
-#: sequencer.c:3327 sequencer.c:3436 builtin/am.c:249 builtin/commit.c:786
-#: builtin/merge.c:1138
+#: archive.c:345 sequencer.c:459 sequencer.c:1744 sequencer.c:2894
+#: sequencer.c:3335 sequencer.c:3444 builtin/am.c:249 builtin/commit.c:786
+#: builtin/merge.c:1139
 #, c-format
 msgid "could not read '%s'"
 msgstr "Konnte '%s' nicht lesen"
 
-#: archive.c:430 builtin/add.c:181 builtin/add.c:594 builtin/rm.c:315
+#: archive.c:430 builtin/add.c:189 builtin/add.c:602 builtin/rm.c:315
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "Pfadspezifikation '%s' stimmt mit keinen Dateien überein"
@@ -1642,7 +1643,7 @@ msgstr "Format"
 msgid "archive format"
 msgstr "Archivformat"
 
-#: archive.c:556 builtin/log.c:1765
+#: archive.c:556 builtin/log.c:1764
 msgid "prefix"
 msgstr "Präfix"
 
@@ -1650,11 +1651,11 @@ msgstr "Präfix"
 msgid "prepend prefix to each pathname in the archive"
 msgstr "einen Präfix vor jeden Pfadnamen in dem Archiv stellen"
 
-#: archive.c:558 archive.c:561 builtin/blame.c:886 builtin/blame.c:890
-#: builtin/blame.c:891 builtin/commit-tree.c:117 builtin/config.c:135
+#: archive.c:558 archive.c:561 builtin/blame.c:884 builtin/blame.c:888
+#: builtin/blame.c:889 builtin/commit-tree.c:117 builtin/config.c:135
 #: builtin/fast-export.c:1207 builtin/fast-export.c:1209
-#: builtin/fast-export.c:1213 builtin/grep.c:919 builtin/hash-object.c:105
-#: builtin/ls-files.c:561 builtin/ls-files.c:564 builtin/notes.c:412
+#: builtin/fast-export.c:1213 builtin/grep.c:920 builtin/hash-object.c:105
+#: builtin/ls-files.c:576 builtin/ls-files.c:579 builtin/notes.c:412
 #: builtin/notes.c:578 builtin/read-tree.c:123 parse-options.h:190
 msgid "file"
 msgstr "Datei"
@@ -1821,12 +1822,12 @@ msgstr "binäre Suche: eine Merge-Basis muss geprüft werden\n"
 msgid "a %s revision is needed"
 msgstr "ein %s Commit wird benötigt"
 
-#: bisect.c:941 builtin/notes.c:177 builtin/tag.c:255
+#: bisect.c:941 builtin/notes.c:177 builtin/tag.c:287
 #, c-format
 msgid "could not create file '%s'"
 msgstr "konnte Datei '%s' nicht erstellen"
 
-#: bisect.c:987 builtin/merge.c:152
+#: bisect.c:987 builtin/merge.c:153
 #, c-format
 msgid "could not read file '%s'"
 msgstr "Konnte Datei '%s' nicht lesen"
@@ -1841,10 +1842,10 @@ msgid "%s was both %s and %s\n"
 msgstr "%s war sowohl %s als auch %s\n"
 
 #: bisect.c:1066
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "No testable commit found.\n"
-"Maybe you started with bad path parameters?\n"
+"Maybe you started with bad path arguments?\n"
 msgstr ""
 "Kein testbarer Commit gefunden.\n"
 "Vielleicht starteten Sie mit falschen Pfad-Parametern?\n"
@@ -1882,11 +1883,11 @@ msgstr ""
 "endgültigen\n"
 "Commits"
 
-#: blame.c:2821 bundle.c:213 ref-filter.c:2272 remote.c:2031 sequencer.c:2138
-#: sequencer.c:4633 submodule.c:855 builtin/commit.c:1045 builtin/log.c:409
-#: builtin/log.c:1023 builtin/log.c:1625 builtin/log.c:2046 builtin/log.c:2336
-#: builtin/merge.c:423 builtin/pack-objects.c:3380 builtin/pack-objects.c:3395
-#: builtin/shortlog.c:267
+#: blame.c:2821 bundle.c:213 ref-filter.c:2202 remote.c:2041 sequencer.c:2146
+#: sequencer.c:4641 submodule.c:856 builtin/commit.c:1045 builtin/log.c:411
+#: builtin/log.c:1016 builtin/log.c:1624 builtin/log.c:2045 builtin/log.c:2335
+#: builtin/merge.c:424 builtin/pack-objects.c:3395 builtin/pack-objects.c:3410
+#: builtin/shortlog.c:255
 msgid "revision walk setup failed"
 msgstr "Einrichtung des Revisionsgangs fehlgeschlagen"
 
@@ -2069,7 +2070,7 @@ msgstr "'%s' sieht nicht wie eine v2 oder v3 Paketdatei aus"
 msgid "unrecognized header: %s%s (%d)"
 msgstr "nicht erkannter Kopfbereich: %s%s (%d)"
 
-#: bundle.c:136 rerere.c:480 rerere.c:690 sequencer.c:2390 sequencer.c:3176
+#: bundle.c:136 rerere.c:464 rerere.c:674 sequencer.c:2398 sequencer.c:3184
 #: builtin/commit.c:814
 #, c-format
 msgid "could not open '%s'"
@@ -2113,40 +2114,36 @@ msgstr "Konnte Paketobjekte nicht erstellen"
 msgid "pack-objects died"
 msgstr "Erstellung der Paketobjekte abgebrochen"
 
-#: bundle.c:379
-msgid "rev-list died"
-msgstr "\"rev-list\" abgebrochen"
-
-#: bundle.c:428
+#: bundle.c:386
 #, c-format
 msgid "ref '%s' is excluded by the rev-list options"
 msgstr "Referenz '%s' wird durch \"rev-list\" Optionen ausgeschlossen"
 
-#: bundle.c:498
+#: bundle.c:490
 #, c-format
 msgid "unsupported bundle version %d"
 msgstr "nicht unterstützte Paket-Version %d"
 
-#: bundle.c:500
+#: bundle.c:492
 #, c-format
 msgid "cannot write bundle version %d with algorithm %s"
 msgstr "kann Paket-Version %d nicht mit Algorithmus %s schreiben"
 
-#: bundle.c:522 builtin/log.c:209 builtin/log.c:1927 builtin/shortlog.c:408
+#: bundle.c:510 builtin/log.c:210 builtin/log.c:1926 builtin/shortlog.c:396
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr "nicht erkanntes Argument: %s"
 
-#: bundle.c:530
+#: bundle.c:539
 msgid "Refusing to create empty bundle."
 msgstr "Erstellung eines leeren Pakets zurückgewiesen."
 
-#: bundle.c:540
+#: bundle.c:549
 #, c-format
 msgid "cannot create '%s'"
 msgstr "kann '%s' nicht erstellen"
 
-#: bundle.c:565
+#: bundle.c:574
 msgid "index-pack died"
 msgstr "Erstellung der Paketindexdatei abgebrochen"
 
@@ -2155,237 +2152,261 @@ msgstr "Erstellung der Paketindexdatei abgebrochen"
 msgid "invalid color value: %.*s"
 msgstr "Ungültiger Farbwert: %.*s"
 
-#: commit-graph.c:188 midx.c:47
+#: commit-graph.c:198 midx.c:47
 msgid "invalid hash version"
 msgstr "ungültige Hash-Version"
 
-#: commit-graph.c:246
+#: commit-graph.c:219
+msgid "repository contains replace objects; skipping commit-graph"
+msgstr ""
+
+#: commit-graph.c:228
+msgid "repository contains (deprecated) grafts; skipping commit-graph"
+msgstr ""
+
+#: commit-graph.c:233
+#, fuzzy
+msgid "repository is shallow; skipping commit-graph"
+msgstr ""
+"Quelle ist ein Repository mit unvollständiger Historie (shallow),\n"
+"ignoriere --local"
+
+#: commit-graph.c:264
 msgid "commit-graph file is too small"
 msgstr "Commit-Graph-Datei ist zu klein."
 
-#: commit-graph.c:311
+#: commit-graph.c:329
 #, c-format
 msgid "commit-graph signature %X does not match signature %X"
 msgstr "Commit-Graph-Signatur %X stimmt nicht mit Signatur %X überein."
 
-#: commit-graph.c:318
+#: commit-graph.c:336
 #, c-format
 msgid "commit-graph version %X does not match version %X"
 msgstr "Commit-Graph-Version %X stimmt nicht mit Version %X überein."
 
-#: commit-graph.c:325
+#: commit-graph.c:343
 #, c-format
 msgid "commit-graph hash version %X does not match version %X"
 msgstr "Hash-Version des Commit-Graph %X stimmt nicht mit Version %X überein."
 
-#: commit-graph.c:342
+#: commit-graph.c:360
 #, c-format
 msgid "commit-graph file is too small to hold %u chunks"
 msgstr "Commit-Graph-Datei ist zu klein, um %u Chunks zu enthalten"
 
-#: commit-graph.c:361
+#: commit-graph.c:379
 #, c-format
 msgid "commit-graph improper chunk offset %08x%08x"
 msgstr "Unzulässiger Commit-Graph Chunk-Offset %08x%08x"
 
-#: commit-graph.c:433
+#: commit-graph.c:465
 #, c-format
 msgid "commit-graph chunk id %08x appears multiple times"
 msgstr "Commit-Graph Chunk-Id %08x kommt mehrfach vor."
 
-#: commit-graph.c:499
+#: commit-graph.c:531
 msgid "commit-graph has no base graphs chunk"
 msgstr "Commit-Graph hat keinen Basis-Graph-Chunk"
 
-#: commit-graph.c:509
+#: commit-graph.c:541
 msgid "commit-graph chain does not match"
 msgstr "Commit-Graph Verkettung stimmt nicht überein."
 
-#: commit-graph.c:557
+#: commit-graph.c:589
 #, c-format
 msgid "invalid commit-graph chain: line '%s' not a hash"
 msgstr "Ungültige Commit-Graph Verkettung: Zeile '%s' ist kein Hash"
 
-#: commit-graph.c:581
+#: commit-graph.c:613
 msgid "unable to find all commit-graph files"
 msgstr "Konnte nicht alle Commit-Graph-Dateien finden."
 
-#: commit-graph.c:721 commit-graph.c:785
+#: commit-graph.c:794 commit-graph.c:831
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr "Ungültige Commit-Position. Commit-Graph ist wahrscheinlich beschädigt."
 
-#: commit-graph.c:742
+#: commit-graph.c:815
 #, c-format
 msgid "could not find commit %s"
 msgstr "Konnte Commit %s nicht finden."
 
-#: commit-graph.c:1036 builtin/am.c:1292
+#: commit-graph.c:848
+msgid "commit-graph requires overflow generation data but has none"
+msgstr ""
+
+#: commit-graph.c:1121 builtin/am.c:1292
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "Konnte Commit '%s' nicht parsen."
 
-#: commit-graph.c:1252 builtin/pack-objects.c:2864
+#: commit-graph.c:1378 builtin/pack-objects.c:2872
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "Konnte Art von Objekt '%s' nicht bestimmen."
 
-#: commit-graph.c:1283
+#: commit-graph.c:1409
 msgid "Loading known commits in commit graph"
 msgstr "Lade bekannte Commits in Commit-Graph"
 
-#: commit-graph.c:1300
+#: commit-graph.c:1426
 msgid "Expanding reachable commits in commit graph"
 msgstr "Erweitere erreichbare Commits in Commit-Graph"
 
-#: commit-graph.c:1320
+#: commit-graph.c:1446
 msgid "Clearing commit marks in commit graph"
 msgstr "Lösche Commit-Markierungen in Commit-Graph"
 
-#: commit-graph.c:1339
+#: commit-graph.c:1465
+#, fuzzy
+msgid "Computing commit graph topological levels"
+msgstr "Commit-Graph Generationsnummern berechnen"
+
+#: commit-graph.c:1518
 msgid "Computing commit graph generation numbers"
 msgstr "Commit-Graph Generationsnummern berechnen"
 
-#: commit-graph.c:1406
+#: commit-graph.c:1599
 msgid "Computing commit changed paths Bloom filters"
 msgstr "Berechnung der Bloom-Filter für veränderte Pfade des Commits"
 
-#: commit-graph.c:1483
+#: commit-graph.c:1676
 msgid "Collecting referenced commits"
 msgstr "Sammle referenzierte Commits"
 
-#: commit-graph.c:1508
+#: commit-graph.c:1701
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] "Suche Commits für Commit-Graph in %d Paket"
 msgstr[1] "Suche Commits für Commit-Graph in %d Paketen"
 
-#: commit-graph.c:1521
+#: commit-graph.c:1714
 #, c-format
 msgid "error adding pack %s"
 msgstr "Fehler beim Hinzufügen von Paket %s."
 
-#: commit-graph.c:1525
+#: commit-graph.c:1718
 #, c-format
 msgid "error opening index for %s"
 msgstr "Fehler beim Öffnen des Index für %s."
 
-#: commit-graph.c:1562
+#: commit-graph.c:1755
 msgid "Finding commits for commit graph among packed objects"
 msgstr "Suche Commits für Commit-Graph in gepackten Objekten"
 
-#: commit-graph.c:1580
+#: commit-graph.c:1773
 msgid "Finding extra edges in commit graph"
 msgstr "Suche zusätzliche Ränder in Commit-Graph"
 
-#: commit-graph.c:1628
+#: commit-graph.c:1821
 msgid "failed to write correct number of base graph ids"
 msgstr "Fehler beim Schreiben der korrekten Anzahl von Basis-Graph-IDs."
 
-#: commit-graph.c:1670 midx.c:819
+#: commit-graph.c:1863 midx.c:819
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "Konnte führende Verzeichnisse von '%s' nicht erstellen."
 
-#: commit-graph.c:1683
+#: commit-graph.c:1876
 msgid "unable to create temporary graph layer"
 msgstr "konnte temporäre Graphen-Schicht nicht erstellen"
 
-#: commit-graph.c:1688
+#: commit-graph.c:1881
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "konnte geteilte Zugriffsberechtigungen für '%s' nicht ändern"
 
-#: commit-graph.c:1758
+#: commit-graph.c:1966
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "Schreibe Commit-Graph in %d Durchgang"
 msgstr[1] "Schreibe Commit-Graph in %d Durchgängen"
 
-#: commit-graph.c:1803
+#: commit-graph.c:2011
 msgid "unable to open commit-graph chain file"
 msgstr "konnte Commit-Graph Chain-Datei nicht öffnen"
 
-#: commit-graph.c:1819
+#: commit-graph.c:2027
 msgid "failed to rename base commit-graph file"
 msgstr "konnte Basis-Commit-Graph-Datei nicht umbenennen"
 
-#: commit-graph.c:1839
+#: commit-graph.c:2047
 msgid "failed to rename temporary commit-graph file"
 msgstr "konnte temporäre Commit-Graph-Datei nicht umbenennen"
 
-#: commit-graph.c:1965
+#: commit-graph.c:2180
 msgid "Scanning merged commits"
 msgstr "Durchsuche zusammengeführte Commits"
 
-#: commit-graph.c:2009
+#: commit-graph.c:2224
 msgid "Merging commit-graph"
 msgstr "Zusammenführen von Commit-Graph"
 
-#: commit-graph.c:2115
+#: commit-graph.c:2331
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 "versuche einen Commit-Graph zu schreiben, aber 'core.commitGraph' ist "
 "deaktiviert"
 
-#: commit-graph.c:2214
+#: commit-graph.c:2438
 msgid "too many commits to write graph"
 msgstr "zu viele Commits zum Schreiben des Graphen"
 
-#: commit-graph.c:2307
+#: commit-graph.c:2536
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "die Commit-Graph-Datei hat eine falsche Prüfsumme und ist wahrscheinlich "
 "beschädigt"
 
-#: commit-graph.c:2317
+#: commit-graph.c:2546
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "Commit-Graph hat fehlerhafte OID-Reihenfolge: %s dann %s"
 
-#: commit-graph.c:2327 commit-graph.c:2342
+#: commit-graph.c:2556 commit-graph.c:2571
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr "Commit-Graph hat fehlerhaften Fanout-Wert: fanout[%d] = %u != %u"
 
-#: commit-graph.c:2334
+#: commit-graph.c:2563
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "konnte Commit %s von Commit-Graph nicht parsen"
 
-#: commit-graph.c:2352
+#: commit-graph.c:2581
 msgid "Verifying commits in commit graph"
 msgstr "Commit in Commit-Graph überprüfen"
 
-#: commit-graph.c:2367
+#: commit-graph.c:2596
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "Fehler beim Parsen des Commits %s von Objekt-Datenbank für Commit-Graph"
 
-#: commit-graph.c:2374
+#: commit-graph.c:2603
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 "OID des Wurzelverzeichnisses für Commit %s in Commit-Graph ist %s != %s"
 
-#: commit-graph.c:2384
+#: commit-graph.c:2613
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr "Commit-Graph Vorgänger-Liste für Commit %s ist zu lang"
 
-#: commit-graph.c:2393
+#: commit-graph.c:2622
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "Commit-Graph-Vorgänger für %s ist %s != %s"
 
-#: commit-graph.c:2407
+#: commit-graph.c:2636
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr "Commit-Graph Vorgänger-Liste für Commit %s endet zu früh"
 
-#: commit-graph.c:2412
+#: commit-graph.c:2641
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2393,7 +2414,7 @@ msgstr ""
 "Commit-Graph hat Generationsnummer null für Commit %s, aber sonst ungleich "
 "null"
 
-#: commit-graph.c:2416
+#: commit-graph.c:2645
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2401,18 +2422,18 @@ msgstr ""
 "Commit-Graph hat Generationsnummer ungleich null für Commit %s, aber sonst "
 "null"
 
-#: commit-graph.c:2432
-#, c-format
-msgid "commit-graph generation for commit %s is %u != %u"
+#: commit-graph.c:2662
+#, fuzzy, c-format
+msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr "Commit-Graph Erstellung für Commit %s ist %u != %u"
 
-#: commit-graph.c:2438
+#: commit-graph.c:2668
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 "Commit-Datum für Commit %s in Commit-Graph ist %<PRIuMAX> != %<PRIuMAX>"
 
-#: commit.c:52 sequencer.c:2879 builtin/am.c:359 builtin/am.c:403
+#: commit.c:52 sequencer.c:2887 builtin/am.c:359 builtin/am.c:403
 #: builtin/am.c:1371 builtin/am.c:2018 builtin/replace.c:457
 #, c-format
 msgid "could not parse %s"
@@ -2444,28 +2465,28 @@ msgstr ""
 "Sie können diese Meldung unterdrücken, indem Sie\n"
 "\"git config advice.graftFileDeprecated false\" ausführen."
 
-#: commit.c:1172
+#: commit.c:1223
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
 msgstr ""
 "Commit %s hat eine nicht vertrauenswürdige GPG-Signatur, angeblich von %s."
 
-#: commit.c:1176
+#: commit.c:1227
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
 msgstr "Commit %s hat eine ungültige GPG-Signatur, angeblich von %s."
 
-#: commit.c:1179
+#: commit.c:1230
 #, c-format
 msgid "Commit %s does not have a GPG signature."
 msgstr "Commit %s hat keine GPG-Signatur."
 
-#: commit.c:1182
+#: commit.c:1233
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
 msgstr "Commit %s hat eine gültige GPG-Signatur von %s\n"
 
-#: commit.c:1436
+#: commit.c:1487
 msgid ""
 "Warning: commit message did not conform to UTF-8.\n"
 "You may want to amend it after fixing the message, or set the config\n"
@@ -2481,7 +2502,7 @@ msgstr ""
 msgid "memory exhausted"
 msgstr "Speicher verbraucht"
 
-#: config.c:125
+#: config.c:126
 #, c-format
 msgid ""
 "exceeded maximum include depth (%d) while including\n"
@@ -2497,306 +2518,351 @@ msgstr ""
 "überschritten.\n"
 "Das könnte durch zirkulare Includes entstanden sein."
 
-#: config.c:141
+#: config.c:142
 #, c-format
 msgid "could not expand include path '%s'"
 msgstr "Konnte Include-Pfad '%s' nicht erweitern."
 
-#: config.c:152
+#: config.c:153
 msgid "relative config includes must come from files"
 msgstr "Relative Includes von Konfigurationen müssen aus Dateien kommen."
 
-#: config.c:198
+#: config.c:199
 msgid "relative config include conditionals must come from files"
 msgstr ""
 "Bedingungen für das Einbinden von Konfigurationen aus relativen Pfaden "
 "müssen\n"
 "aus Dateien kommen."
 
-#: config.c:378
+#: config.c:396
+#, fuzzy, c-format
+msgid "invalid config format: %s"
+msgstr "Ungültiges Format für Referenzen: %s"
+
+#: config.c:400
+#, c-format
+msgid "missing environment variable name for configuration '%.*s'"
+msgstr ""
+
+#: config.c:405
+#, c-format
+msgid "missing environment variable '%s' for configuration '%.*s'"
+msgstr ""
+
+#: config.c:442
 #, c-format
 msgid "key does not contain a section: %s"
 msgstr "Schlüssel enthält keine Sektion: %s"
 
-#: config.c:384
+#: config.c:448
 #, c-format
 msgid "key does not contain variable name: %s"
 msgstr "Schlüssel enthält keinen Variablennamen: %s"
 
-#: config.c:408 sequencer.c:2580
+#: config.c:472 sequencer.c:2588
 #, c-format
 msgid "invalid key: %s"
 msgstr "Ungültiger Schlüssel: %s"
 
-#: config.c:414
+#: config.c:478
 #, c-format
 msgid "invalid key (newline): %s"
 msgstr "Ungültiger Schlüssel (neue Zeile): %s"
 
-#: config.c:450 config.c:462
+#: config.c:511
+#, fuzzy
+msgid "empty config key"
+msgstr "Konfigurationsdatei des Repositories verwenden"
+
+#: config.c:529 config.c:541
 #, c-format
 msgid "bogus config parameter: %s"
 msgstr "Fehlerhafter Konfigurationsparameter: %s"
 
-#: config.c:497
+#: config.c:555 config.c:572 config.c:579 config.c:588
 #, c-format
 msgid "bogus format in %s"
 msgstr "Fehlerhaftes Format in %s"
 
-#: config.c:836
+#: config.c:622
+#, fuzzy, c-format
+msgid "bogus count in %s"
+msgstr "Fehlerhaftes Format in %s"
+
+#: config.c:626
+#, fuzzy, c-format
+msgid "too many entries in %s"
+msgstr "zu viele Argumente angegeben, um %s auszuführen"
+
+#: config.c:636
+#, fuzzy, c-format
+msgid "missing config key %s"
+msgstr "Ungültige Konfigurationsdatei %s"
+
+#: config.c:644
+#, fuzzy, c-format
+msgid "missing config value %s"
+msgstr "Fehlender Wert für '%s'"
+
+#: config.c:995
 #, c-format
 msgid "bad config line %d in blob %s"
 msgstr "Ungültige Konfigurationszeile %d in Blob %s"
 
-#: config.c:840
+#: config.c:999
 #, c-format
 msgid "bad config line %d in file %s"
 msgstr "Ungültige Konfigurationszeile %d in Datei %s"
 
-#: config.c:844
+#: config.c:1003
 #, c-format
 msgid "bad config line %d in standard input"
 msgstr "Ungültige Konfigurationszeile %d in Standard-Eingabe"
 
-#: config.c:848
+#: config.c:1007
 #, c-format
 msgid "bad config line %d in submodule-blob %s"
 msgstr "Ungültige Konfigurationszeile %d in Submodul-Blob %s"
 
-#: config.c:852
+#: config.c:1011
 #, c-format
 msgid "bad config line %d in command line %s"
 msgstr "Ungültige Konfigurationszeile %d in Kommandozeile %s"
 
-#: config.c:856
+#: config.c:1015
 #, c-format
 msgid "bad config line %d in %s"
 msgstr "Ungültige Konfigurationszeile %d in %s"
 
-#: config.c:993
+#: config.c:1152
 msgid "out of range"
 msgstr "Außerhalb des Bereichs"
 
-#: config.c:993
+#: config.c:1152
 msgid "invalid unit"
 msgstr "Ungültige Einheit"
 
-#: config.c:994
+#: config.c:1153
 #, c-format
 msgid "bad numeric config value '%s' for '%s': %s"
 msgstr "Ungültiger numerischer Wert '%s' für Konfiguration '%s': %s"
 
-#: config.c:1013
+#: config.c:1163
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in blob %s: %s"
 msgstr "Ungültiger numerischer Wert '%s' für Konfiguration '%s' in Blob %s: %s"
 
-#: config.c:1016
+#: config.c:1166
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in file %s: %s"
 msgstr ""
 "Ungültiger numerischer Wert '%s' für Konfiguration '%s' in Datei %s: %s"
 
-#: config.c:1019
+#: config.c:1169
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in standard input: %s"
 msgstr ""
 "Ungültiger numerischer Wert '%s' für Konfiguration '%s' in Standard-Eingabe: "
 "%s"
 
-#: config.c:1022
+#: config.c:1172
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in submodule-blob %s: %s"
 msgstr ""
 "Ungültiger numerischer Wert '%s' für Konfiguration '%s' in Submodul-Blob %s: "
 "%s"
 
-#: config.c:1025
+#: config.c:1175
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in command line %s: %s"
 msgstr ""
 "Ungültiger numerischer Wert '%s' für Konfiguration '%s' in Befehlszeile %s: "
 "%s"
 
-#: config.c:1028
+#: config.c:1178
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in %s: %s"
 msgstr "Ungültiger numerischer Wert '%s' für Konfiguration '%s' in %s: %s"
 
-#: config.c:1123
+#: config.c:1194
+#, fuzzy, c-format
+msgid "bad boolean config value '%s' for '%s'"
+msgstr "Ungültiger numerischer Wert '%s' für Konfiguration '%s': %s"
+
+#: config.c:1289
 #, c-format
 msgid "failed to expand user dir in: '%s'"
 msgstr "Fehler beim Erweitern des Nutzerverzeichnisses in: '%s'"
 
-#: config.c:1132
+#: config.c:1298
 #, c-format
 msgid "'%s' for '%s' is not a valid timestamp"
 msgstr "'%s' ist kein gültiger Zeitstempel für '%s'"
 
-#: config.c:1223
+#: config.c:1391
 #, c-format
 msgid "abbrev length out of range: %d"
 msgstr "Länge für Abkürzung von Commit-IDs außerhalb des Bereichs: %d"
 
-#: config.c:1237 config.c:1248
+#: config.c:1405 config.c:1416
 #, c-format
 msgid "bad zlib compression level %d"
 msgstr "ungültiger zlib Komprimierungsgrad %d"
 
-#: config.c:1340
+#: config.c:1508
 msgid "core.commentChar should only be one character"
 msgstr "core.commentChar sollte nur ein Zeichen sein"
 
-#: config.c:1373
+#: config.c:1541
 #, c-format
 msgid "invalid mode for object creation: %s"
 msgstr "Ungültiger Modus für Objekterstellung: %s"
 
-#: config.c:1445
+#: config.c:1613
 #, c-format
 msgid "malformed value for %s"
 msgstr "Ungültiger Wert für %s."
 
-#: config.c:1471
+#: config.c:1639
 #, c-format
 msgid "malformed value for %s: %s"
 msgstr "Ungültiger Wert für %s: %s"
 
-#: config.c:1472
+#: config.c:1640
 msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr ""
 "Muss einer von diesen sein: nothing, matching, simple, upstream, current"
 
-#: config.c:1533 builtin/pack-objects.c:3649
+#: config.c:1701 builtin/pack-objects.c:3666
 #, c-format
 msgid "bad pack compression level %d"
 msgstr "ungültiger Komprimierungsgrad (%d) für Paketierung"
 
-#: config.c:1655
+#: config.c:1823
 #, c-format
 msgid "unable to load config blob object '%s'"
 msgstr "Konnte Blob-Objekt '%s' für Konfiguration nicht laden."
 
-#: config.c:1658
+#: config.c:1826
 #, c-format
 msgid "reference '%s' does not point to a blob"
 msgstr "Referenz '%s' zeigt auf keinen Blob."
 
-#: config.c:1675
+#: config.c:1843
 #, c-format
 msgid "unable to resolve config blob '%s'"
 msgstr "Konnte Blob '%s' für Konfiguration nicht auflösen."
 
-#: config.c:1705
+#: config.c:1873
 #, c-format
 msgid "failed to parse %s"
 msgstr "Fehler beim Parsen von %s."
 
-#: config.c:1759
+#: config.c:1927
 msgid "unable to parse command-line config"
 msgstr ""
 "Konnte die über die Befehlszeile angegebene Konfiguration nicht parsen."
 
-#: config.c:2122
+#: config.c:2290
 msgid "unknown error occurred while reading the configuration files"
 msgstr ""
 "Es trat ein unbekannter Fehler beim Lesen der Konfigurationsdateien auf."
 
-#: config.c:2296
+#: config.c:2464
 #, c-format
 msgid "Invalid %s: '%s'"
 msgstr "Ungültiger %s: '%s'"
 
-#: config.c:2341
+#: config.c:2509
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
 msgstr ""
 "Der Wert '%d' von splitIndex.maxPercentChange sollte zwischen 0 und 100 "
 "liegen."
 
-#: config.c:2387
+#: config.c:2555
 #, c-format
 msgid "unable to parse '%s' from command-line config"
 msgstr ""
 "Konnte Wert '%s' aus der über die Befehlszeile angegebenen Konfiguration\n"
 "nicht parsen."
 
-#: config.c:2389
+#: config.c:2557
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
 msgstr "ungültige Konfigurationsvariable '%s' in Datei '%s' bei Zeile %d"
 
-#: config.c:2473
+#: config.c:2641
 #, c-format
 msgid "invalid section name '%s'"
 msgstr "Ungültiger Sektionsname '%s'"
 
-#: config.c:2505
+#: config.c:2673
 #, c-format
 msgid "%s has multiple values"
 msgstr "%s hat mehrere Werte"
 
-#: config.c:2534
+#: config.c:2702
 #, c-format
 msgid "failed to write new configuration file %s"
 msgstr "Konnte neue Konfigurationsdatei '%s' nicht schreiben."
 
-#: config.c:2786 config.c:3112
+#: config.c:2954 config.c:3280
 #, c-format
 msgid "could not lock config file %s"
 msgstr "Konnte Konfigurationsdatei '%s' nicht sperren."
 
-#: config.c:2797
+#: config.c:2965
 #, c-format
 msgid "opening %s"
 msgstr "Öffne %s"
 
-#: config.c:2834 builtin/config.c:361
+#: config.c:3002 builtin/config.c:361
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "Ungültiges Muster: %s"
 
-#: config.c:2859
+#: config.c:3027
 #, c-format
 msgid "invalid config file %s"
 msgstr "Ungültige Konfigurationsdatei %s"
 
-#: config.c:2872 config.c:3125
+#: config.c:3040 config.c:3293
 #, c-format
 msgid "fstat on %s failed"
 msgstr "fstat auf %s fehlgeschlagen"
 
-#: config.c:2883
+#: config.c:3051
 #, c-format
 msgid "unable to mmap '%s'"
 msgstr "mmap für '%s' fehlgeschlagen"
 
-#: config.c:2892 config.c:3130
+#: config.c:3060 config.c:3298
 #, c-format
 msgid "chmod on %s failed"
 msgstr "chmod auf %s fehlgeschlagen"
 
-#: config.c:2977 config.c:3227
+#: config.c:3145 config.c:3395
 #, c-format
 msgid "could not write config file %s"
 msgstr "Konnte Konfigurationsdatei %s nicht schreiben."
 
-#: config.c:3011
+#: config.c:3179
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "Konnte '%s' nicht zu '%s' setzen."
 
-#: config.c:3013 builtin/remote.c:657 builtin/remote.c:855 builtin/remote.c:863
+#: config.c:3181 builtin/remote.c:657 builtin/remote.c:855 builtin/remote.c:863
 #, c-format
 msgid "could not unset '%s'"
 msgstr "Konnte '%s' nicht aufheben."
 
-#: config.c:3103
+#: config.c:3271
 #, c-format
 msgid "invalid section name: %s"
 msgstr "Ungültiger Sektionsname: %s"
 
-#: config.c:3270
+#: config.c:3438
 #, c-format
 msgid "missing value for '%s'"
 msgstr "Fehlender Wert für '%s'"
@@ -2861,45 +2927,45 @@ msgstr "ungültiges Paket"
 msgid "protocol error: unexpected '%s'"
 msgstr "Protokollfehler: unerwartetes '%s'"
 
-#: connect.c:473
+#: connect.c:497
 #, c-format
 msgid "unknown object format '%s' specified by server"
 msgstr "unbekanntes Objekt-Format '%s' vom Server angegeben"
 
-#: connect.c:500
+#: connect.c:526
 #, c-format
 msgid "invalid ls-refs response: %s"
 msgstr "ungültige ls-refs Antwort: %s"
 
-#: connect.c:504
+#: connect.c:530
 msgid "expected flush after ref listing"
 msgstr "Flush nach Auflistung der Referenzen erwartet"
 
-#: connect.c:507
+#: connect.c:533
 msgid "expected response end packet after ref listing"
 msgstr "Antwort-Endpaket nach Auflistung der Referenzen erwartet"
 
-#: connect.c:640
+#: connect.c:666
 #, c-format
 msgid "protocol '%s' is not supported"
 msgstr "Protokoll '%s' wird nicht unterstützt"
 
-#: connect.c:691
+#: connect.c:717
 msgid "unable to set SO_KEEPALIVE on socket"
 msgstr "kann SO_KEEPALIVE bei Socket nicht setzen"
 
-#: connect.c:731 connect.c:794
+#: connect.c:757 connect.c:820
 #, c-format
 msgid "Looking up %s ... "
 msgstr "Suche nach %s ..."
 
-#: connect.c:735
+#: connect.c:761
 #, c-format
 msgid "unable to look up %s (port %s) (%s)"
 msgstr "Fehler bei Suche nach %s (Port %s) (%s)."
 
 #. TRANSLATORS: this is the end of "Looking up %s ... "
-#: connect.c:739 connect.c:810
+#: connect.c:765 connect.c:836
 #, c-format
 msgid ""
 "done.\n"
@@ -2908,7 +2974,7 @@ msgstr ""
 "Fertig.\n"
 "Verbinde nach %s (Port %s) ... "
 
-#: connect.c:761 connect.c:838
+#: connect.c:787 connect.c:864
 #, c-format
 msgid ""
 "unable to connect to %s:\n"
@@ -2918,62 +2984,66 @@ msgstr ""
 "%s"
 
 #. TRANSLATORS: this is the end of "Connecting to %s (port %s) ... "
-#: connect.c:767 connect.c:844
+#: connect.c:793 connect.c:870
 msgid "done."
 msgstr "Fertig."
 
-#: connect.c:798
+#: connect.c:824
 #, c-format
 msgid "unable to look up %s (%s)"
 msgstr "Fehler bei der Suche nach %s (%s)"
 
-#: connect.c:804
+#: connect.c:830
 #, c-format
 msgid "unknown port %s"
 msgstr "Unbekannter Port %s"
 
-#: connect.c:941 connect.c:1271
+#: connect.c:967 connect.c:1299
 #, c-format
 msgid "strange hostname '%s' blocked"
 msgstr "Merkwürdigen Hostnamen '%s' blockiert."
 
-#: connect.c:943
+#: connect.c:969
 #, c-format
 msgid "strange port '%s' blocked"
 msgstr "Merkwürdigen Port '%s' blockiert."
 
-#: connect.c:953
+#: connect.c:979
 #, c-format
 msgid "cannot start proxy %s"
 msgstr "Kann Proxy %s nicht starten."
 
-#: connect.c:1024
+#: connect.c:1050
 msgid "no path specified; see 'git help pull' for valid url syntax"
 msgstr ""
 "Kein Pfad angegeben; siehe 'git help pull' für eine gültige URL-Syntax."
 
-#: connect.c:1219
+#: connect.c:1190
+msgid "newline is forbidden in git:// hosts and repo paths"
+msgstr ""
+
+#: connect.c:1247
 msgid "ssh variant 'simple' does not support -4"
 msgstr "SSH-Variante 'simple' unterstützt kein -4."
 
-#: connect.c:1231
+#: connect.c:1259
 msgid "ssh variant 'simple' does not support -6"
 msgstr "SSH-Variante 'simple' unterstützt kein -6."
 
-#: connect.c:1248
+#: connect.c:1276
 msgid "ssh variant 'simple' does not support setting port"
 msgstr "SSH-Variante 'simple' unterstützt nicht das Setzen eines Ports."
 
-#: connect.c:1360
+#: connect.c:1388
 #, c-format
 msgid "strange pathname '%s' blocked"
 msgstr "Merkwürdigen Pfadnamen '%s' blockiert."
 
-#: connect.c:1408
+#: connect.c:1436
 msgid "unable to fork"
 msgstr "Kann Prozess nicht starten."
 
-#: connected.c:108 builtin/fsck.c:209 builtin/prune.c:45
+#: connected.c:108 builtin/fsck.c:191 builtin/prune.c:45
 msgid "Checking connectivity"
 msgstr "Prüfe Konnektivität"
 
@@ -3241,6 +3311,11 @@ msgstr ""
 msgid "Marked %d islands, done.\n"
 msgstr "%d Delta-Islands markiert, fertig.\n"
 
+#: diff-merges.c:70
+#, c-format
+msgid "unknown value for --diff-merges: %s"
+msgstr "unbekannter Wert für --diff-merges: %s"
+
 #: diff-lib.c:534
 msgid "--merge-base does not work with ranges"
 msgstr "--merge-base funktioniert nicht mit Bereichen"
@@ -3328,31 +3403,31 @@ msgstr ""
 msgid "external diff died, stopping at %s"
 msgstr "externes Diff-Programm unerwartet beendet, angehalten bei %s"
 
-#: diff.c:4625
+#: diff.c:4628
 msgid "--name-only, --name-status, --check and -s are mutually exclusive"
 msgstr ""
 "--name-only, --name-status, --check und -s schließen sich gegenseitig aus"
 
-#: diff.c:4628
+#: diff.c:4631
 msgid "-G, -S and --find-object are mutually exclusive"
 msgstr "-G, -S und --find-object schließen sich gegenseitig aus"
 
-#: diff.c:4707
+#: diff.c:4710
 msgid "--follow requires exactly one pathspec"
 msgstr "--follow erfordert genau eine Pfadspezifikation"
 
-#: diff.c:4755
+#: diff.c:4758
 #, c-format
 msgid "invalid --stat value: %s"
 msgstr "Ungültiger --stat Wert: %s"
 
-#: diff.c:4760 diff.c:4765 diff.c:4770 diff.c:4775 diff.c:5303
+#: diff.c:4763 diff.c:4768 diff.c:4773 diff.c:4778 diff.c:5306
 #: parse-options.c:197 parse-options.c:201 builtin/commit-graph.c:180
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "%s erwartet einen numerischen Wert."
 
-#: diff.c:4792
+#: diff.c:4795
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -3361,42 +3436,42 @@ msgstr ""
 "Fehler beim Parsen des --dirstat/-X Optionsparameters:\n"
 "%s"
 
-#: diff.c:4877
+#: diff.c:4880
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
 msgstr "unbekannte Änderungsklasse '%c' in --diff-filter=%s"
 
-#: diff.c:4901
+#: diff.c:4904
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
 msgstr "unbekannter Wert nach ws-error-highlight=%.*s"
 
-#: diff.c:4915
+#: diff.c:4918
 #, c-format
 msgid "unable to resolve '%s'"
 msgstr "konnte '%s' nicht auflösen"
 
-#: diff.c:4965 diff.c:4971
+#: diff.c:4968 diff.c:4974
 #, c-format
 msgid "%s expects <n>/<m> form"
 msgstr "%s erwartet die Form <n>/<m>"
 
-#: diff.c:4983
+#: diff.c:4986
 #, c-format
 msgid "%s expects a character, got '%s'"
 msgstr "%s erwartet ein Zeichen, '%s' bekommen"
 
-#: diff.c:5004
+#: diff.c:5007
 #, c-format
 msgid "bad --color-moved argument: %s"
 msgstr "ungültiges --color-moved Argument: %s"
 
-#: diff.c:5023
+#: diff.c:5026
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
 msgstr "ungültiger Modus '%s' in --color-moved-ws"
 
-#: diff.c:5063
+#: diff.c:5066
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
@@ -3404,157 +3479,157 @@ msgstr ""
 "Option diff-algorithm akzeptiert: \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
 
-#: diff.c:5099 diff.c:5119
+#: diff.c:5102 diff.c:5122
 #, c-format
 msgid "invalid argument to %s"
 msgstr "ungültiges Argument für %s"
 
-#: diff.c:5223
+#: diff.c:5226
 #, c-format
 msgid "invalid regex given to -I: '%s'"
 msgstr "ungültiger regulärer Ausdruck für -I gegeben: '%s'"
 
-#: diff.c:5272
+#: diff.c:5275
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
 msgstr "Fehler beim Parsen des --submodule Optionsparameters: '%s'"
 
-#: diff.c:5328
+#: diff.c:5331
 #, c-format
 msgid "bad --word-diff argument: %s"
 msgstr "ungültiges --word-diff Argument: %s"
 
-#: diff.c:5351
+#: diff.c:5367
 msgid "Diff output format options"
 msgstr "Diff-Optionen zu Ausgabeformaten"
 
-#: diff.c:5353 diff.c:5359
+#: diff.c:5369 diff.c:5375
 msgid "generate patch"
 msgstr "Patch erzeugen"
 
-#: diff.c:5356 builtin/log.c:178
+#: diff.c:5372 builtin/log.c:179
 msgid "suppress diff output"
 msgstr "Ausgabe der Unterschiede unterdrücken"
 
-#: diff.c:5361 diff.c:5475 diff.c:5482
+#: diff.c:5377 diff.c:5491 diff.c:5498
 msgid "<n>"
 msgstr "<n>"
 
-#: diff.c:5362 diff.c:5365
+#: diff.c:5378 diff.c:5381
 msgid "generate diffs with <n> lines context"
 msgstr "Unterschiede mit <n> Zeilen des Kontextes erstellen"
 
-#: diff.c:5367
+#: diff.c:5383
 msgid "generate the diff in raw format"
 msgstr "Unterschiede im Rohformat erstellen"
 
-#: diff.c:5370
+#: diff.c:5386
 msgid "synonym for '-p --raw'"
 msgstr "Synonym für '-p --raw'"
 
-#: diff.c:5374
+#: diff.c:5390
 msgid "synonym for '-p --stat'"
 msgstr "Synonym für '-p --stat'"
 
-#: diff.c:5378
+#: diff.c:5394
 msgid "machine friendly --stat"
 msgstr "maschinenlesbare Ausgabe von --stat"
 
-#: diff.c:5381
+#: diff.c:5397
 msgid "output only the last line of --stat"
 msgstr "nur die letzte Zeile von --stat ausgeben"
 
-#: diff.c:5383 diff.c:5391
+#: diff.c:5399 diff.c:5407
 msgid "<param1,param2>..."
 msgstr "<Parameter1,Parameter2>..."
 
-#: diff.c:5384
+#: diff.c:5400
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr ""
 "die Verteilung des relativen Umfangs der Änderungen für jedes "
 "Unterverzeichnis ausgeben"
 
-#: diff.c:5388
+#: diff.c:5404
 msgid "synonym for --dirstat=cumulative"
 msgstr "Synonym für --dirstat=cumulative"
 
-#: diff.c:5392
+#: diff.c:5408
 msgid "synonym for --dirstat=files,param1,param2..."
 msgstr "Synonym für --dirstat=files,Parameter1,Parameter2..."
 
-#: diff.c:5396
+#: diff.c:5412
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
 "warnen, wenn Änderungen Konfliktmarker oder Whitespace-Fehler einbringen"
 
-#: diff.c:5399
+#: diff.c:5415
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr ""
 "gekürzte Zusammenfassung, wie z.B. Erstellungen, Umbenennungen und "
 "Änderungen der Datei-Rechte"
 
-#: diff.c:5402
+#: diff.c:5418
 msgid "show only names of changed files"
 msgstr "nur Dateinamen der geänderten Dateien anzeigen"
 
-#: diff.c:5405
+#: diff.c:5421
 msgid "show only names and status of changed files"
 msgstr "nur Dateinamen und Status der geänderten Dateien anzeigen"
 
-#: diff.c:5407
+#: diff.c:5423
 msgid "<width>[,<name-width>[,<count>]]"
 msgstr "<Breite>[,<Namens-Breite>[,<Anzahl>]]"
 
-#: diff.c:5408
+#: diff.c:5424
 msgid "generate diffstat"
 msgstr "Zusammenfassung der Unterschiede erzeugen"
 
-#: diff.c:5410 diff.c:5413 diff.c:5416
+#: diff.c:5426 diff.c:5429 diff.c:5432
 msgid "<width>"
 msgstr "<Breite>"
 
-#: diff.c:5411
+#: diff.c:5427
 msgid "generate diffstat with a given width"
 msgstr "Zusammenfassung der Unterschiede mit gegebener Breite erzeugen"
 
-#: diff.c:5414
+#: diff.c:5430
 msgid "generate diffstat with a given name width"
 msgstr "Zusammenfassung der Unterschiede mit gegebener Namens-Breite erzeugen"
 
-#: diff.c:5417
+#: diff.c:5433
 msgid "generate diffstat with a given graph width"
 msgstr "Zusammenfassung der Unterschiede mit gegebener Graph-Breite erzeugen"
 
-#: diff.c:5419
+#: diff.c:5435
 msgid "<count>"
 msgstr "<Anzahl>"
 
-#: diff.c:5420
+#: diff.c:5436
 msgid "generate diffstat with limited lines"
 msgstr "Zusammenfassung der Unterschiede mit begrenzten Zeilen erzeugen"
 
-#: diff.c:5423
+#: diff.c:5439
 msgid "generate compact summary in diffstat"
 msgstr "kompakte Zusammenstellung in Zusammenfassung der Unterschiede erzeugen"
 
-#: diff.c:5426
+#: diff.c:5442
 msgid "output a binary diff that can be applied"
 msgstr "eine binäre Differenz ausgeben, dass angewendet werden kann"
 
-#: diff.c:5429
+#: diff.c:5445
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr "vollständige Objekt-Namen in den \"index\"-Zeilen anzeigen"
 
-#: diff.c:5431
+#: diff.c:5447
 msgid "show colored diff"
 msgstr "farbige Unterschiede anzeigen"
 
-#: diff.c:5432
+#: diff.c:5448
 msgid "<kind>"
 msgstr "<Art>"
 
-#: diff.c:5433
+#: diff.c:5449
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
@@ -3562,7 +3637,7 @@ msgstr ""
 "Whitespace-Fehler in den Zeilen 'context', 'old' oder 'new' bei den "
 "Unterschieden hervorheben"
 
-#: diff.c:5436
+#: diff.c:5452
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
@@ -3570,91 +3645,91 @@ msgstr ""
 "die Pfadnamen nicht verschleiern und NUL-Zeichen als Schlusszeichen in "
 "Ausgabefeldern bei --raw oder --numstat nutzen"
 
-#: diff.c:5439 diff.c:5442 diff.c:5445 diff.c:5554
+#: diff.c:5455 diff.c:5458 diff.c:5461 diff.c:5570
 msgid "<prefix>"
 msgstr "<Präfix>"
 
-#: diff.c:5440
+#: diff.c:5456
 msgid "show the given source prefix instead of \"a/\""
 msgstr "den gegebenen Quell-Präfix statt \"a/\" anzeigen"
 
-#: diff.c:5443
+#: diff.c:5459
 msgid "show the given destination prefix instead of \"b/\""
 msgstr "den gegebenen Ziel-Präfix statt \"b/\" anzeigen"
 
-#: diff.c:5446
+#: diff.c:5462
 msgid "prepend an additional prefix to every line of output"
 msgstr "einen zusätzlichen Präfix bei jeder Ausgabezeile voranstellen"
 
-#: diff.c:5449
+#: diff.c:5465
 msgid "do not show any source or destination prefix"
 msgstr "keine Quell- oder Ziel-Präfixe anzeigen"
 
-#: diff.c:5452
+#: diff.c:5468
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
 "Kontext zwischen Unterschied-Blöcken bis zur angegebenen Anzahl von Zeilen "
 "anzeigen"
 
-#: diff.c:5456 diff.c:5461 diff.c:5466
+#: diff.c:5472 diff.c:5477 diff.c:5482
 msgid "<char>"
 msgstr "<Zeichen>"
 
-#: diff.c:5457
+#: diff.c:5473
 msgid "specify the character to indicate a new line instead of '+'"
 msgstr "das Zeichen festlegen, das eine neue Zeile kennzeichnet (statt '+')"
 
-#: diff.c:5462
+#: diff.c:5478
 msgid "specify the character to indicate an old line instead of '-'"
 msgstr "das Zeichen festlegen, das eine alte Zeile kennzeichnet (statt '-')"
 
-#: diff.c:5467
+#: diff.c:5483
 msgid "specify the character to indicate a context instead of ' '"
 msgstr "das Zeichen festlegen, das den Kontext kennzeichnet (statt ' ')"
 
-#: diff.c:5470
+#: diff.c:5486
 msgid "Diff rename options"
 msgstr "Diff-Optionen zur Umbenennung"
 
-#: diff.c:5471
+#: diff.c:5487
 msgid "<n>[/<m>]"
 msgstr "<n>[/<m>]"
 
-#: diff.c:5472
+#: diff.c:5488
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr ""
 "teile komplette Rewrite-Änderungen in Änderungen mit \"löschen\" und "
 "\"erstellen\""
 
-#: diff.c:5476
+#: diff.c:5492
 msgid "detect renames"
 msgstr "Umbenennungen erkennen"
 
-#: diff.c:5480
+#: diff.c:5496
 msgid "omit the preimage for deletes"
 msgstr "Preimage für Löschungen weglassen"
 
-#: diff.c:5483
+#: diff.c:5499
 msgid "detect copies"
 msgstr "Kopien erkennen"
 
-#: diff.c:5487
+#: diff.c:5503
 msgid "use unmodified files as source to find copies"
 msgstr "ungeänderte Dateien als Quelle zum Finden von Kopien nutzen"
 
-#: diff.c:5489
+#: diff.c:5505
 msgid "disable rename detection"
 msgstr "Erkennung von Umbenennungen deaktivieren"
 
-#: diff.c:5492
+#: diff.c:5508
 msgid "use empty blobs as rename source"
 msgstr "leere Blobs als Quelle von Umbenennungen nutzen"
 
-#: diff.c:5494
+#: diff.c:5510
 msgid "continue listing the history of a file beyond renames"
 msgstr "Auflistung der Historie einer Datei nach Umbenennung fortführen"
 
-#: diff.c:5497
+#: diff.c:5513
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
@@ -3662,164 +3737,164 @@ msgstr ""
 "Erkennung von Umbenennungen und Kopien verhindern, wenn die Anzahl der Ziele "
 "für Umbenennungen und Kopien das gegebene Limit überschreitet"
 
-#: diff.c:5499
+#: diff.c:5515
 msgid "Diff algorithm options"
 msgstr "Diff Algorithmus-Optionen"
 
-#: diff.c:5501
+#: diff.c:5517
 msgid "produce the smallest possible diff"
 msgstr "die kleinstmöglichen Änderungen erzeugen"
 
-#: diff.c:5504
+#: diff.c:5520
 msgid "ignore whitespace when comparing lines"
 msgstr "Whitespace-Änderungen beim Vergleich von Zeilen ignorieren"
 
-#: diff.c:5507
+#: diff.c:5523
 msgid "ignore changes in amount of whitespace"
 msgstr "Änderungen bei der Anzahl von Whitespace ignorieren"
 
-#: diff.c:5510
+#: diff.c:5526
 msgid "ignore changes in whitespace at EOL"
 msgstr "Whitespace-Änderungen am Zeilenende ignorieren"
 
-#: diff.c:5513
+#: diff.c:5529
 msgid "ignore carrier-return at the end of line"
 msgstr "den Zeilenumbruch am Ende der Zeile ignorieren"
 
-#: diff.c:5516
+#: diff.c:5532
 msgid "ignore changes whose lines are all blank"
 msgstr "Änderungen in leeren Zeilen ignorieren"
 
-#: diff.c:5518 diff.c:5540 diff.c:5543 diff.c:5588
+#: diff.c:5534 diff.c:5556 diff.c:5559 diff.c:5604
 msgid "<regex>"
 msgstr "<Regex>"
 
-#: diff.c:5519
+#: diff.c:5535
 msgid "ignore changes whose all lines match <regex>"
 msgstr ""
 "Änderungen ignorieren, bei denen alle Zeilen mit <Regex> übereinstimmen"
 
-#: diff.c:5522
+#: diff.c:5538
 msgid "heuristic to shift diff hunk boundaries for easy reading"
 msgstr ""
 "Heuristik, um Grenzen der Änderungsblöcke für bessere Lesbarkeit zu "
 "verschieben"
 
-#: diff.c:5525
+#: diff.c:5541
 msgid "generate diff using the \"patience diff\" algorithm"
 msgstr "Änderungen durch Nutzung des Algorithmus \"Patience Diff\" erzeugen"
 
-#: diff.c:5529
+#: diff.c:5545
 msgid "generate diff using the \"histogram diff\" algorithm"
 msgstr "Änderungen durch Nutzung des Algorithmus \"Histogram Diff\" erzeugen"
 
-#: diff.c:5531
+#: diff.c:5547
 msgid "<algorithm>"
 msgstr "<Algorithmus>"
 
-#: diff.c:5532
+#: diff.c:5548
 msgid "choose a diff algorithm"
 msgstr "einen Algorithmus für Änderungen wählen"
 
-#: diff.c:5534
+#: diff.c:5550
 msgid "<text>"
 msgstr "<Text>"
 
-#: diff.c:5535
+#: diff.c:5551
 msgid "generate diff using the \"anchored diff\" algorithm"
 msgstr "Änderungen durch Nutzung des Algorithmus \"Anchored Diff\" erzeugen"
 
-#: diff.c:5537 diff.c:5546 diff.c:5549
+#: diff.c:5553 diff.c:5562 diff.c:5565
 msgid "<mode>"
 msgstr "<Modus>"
 
-#: diff.c:5538
+#: diff.c:5554
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr "Wort-Änderungen zeigen, nutze <Modus>, um Wörter abzugrenzen"
 
-#: diff.c:5541
+#: diff.c:5557
 msgid "use <regex> to decide what a word is"
 msgstr "<Regex> nutzen, um zu entscheiden, was ein Wort ist"
 
-#: diff.c:5544
+#: diff.c:5560
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
 msgstr "entsprechend wie --word-diff=color --word-diff-regex=<Regex>"
 
-#: diff.c:5547
+#: diff.c:5563
 msgid "moved lines of code are colored differently"
 msgstr "verschobene Codezeilen sind andersfarbig"
 
-#: diff.c:5550
+#: diff.c:5566
 msgid "how white spaces are ignored in --color-moved"
 msgstr "wie Whitespaces in --color-moved ignoriert werden"
 
-#: diff.c:5553
+#: diff.c:5569
 msgid "Other diff options"
 msgstr "Andere Diff-Optionen"
 
-#: diff.c:5555
+#: diff.c:5571
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
 "wenn vom Unterverzeichnis aufgerufen, schließe Änderungen außerhalb aus und "
 "zeige relative Pfade an"
 
-#: diff.c:5559
+#: diff.c:5575
 msgid "treat all files as text"
 msgstr "alle Dateien als Text behandeln"
 
-#: diff.c:5561
+#: diff.c:5577
 msgid "swap two inputs, reverse the diff"
 msgstr "die beiden Eingaben vertauschen und die Änderungen umkehren"
 
-#: diff.c:5563
+#: diff.c:5579
 msgid "exit with 1 if there were differences, 0 otherwise"
 msgstr ""
 "mit Exit-Status 1 beenden, wenn Änderungen vorhanden sind, andernfalls mit 0"
 
-#: diff.c:5565
+#: diff.c:5581
 msgid "disable all output of the program"
 msgstr "alle Ausgaben vom Programm deaktivieren"
 
-#: diff.c:5567
+#: diff.c:5583
 msgid "allow an external diff helper to be executed"
 msgstr "erlaube die Ausführung eines externes Programms für Änderungen"
 
-#: diff.c:5569
+#: diff.c:5585
 msgid "run external text conversion filters when comparing binary files"
 msgstr ""
 "Führe externe Text-Konvertierungsfilter aus, wenn binäre Dateien vergleicht "
 "werden"
 
-#: diff.c:5571
+#: diff.c:5587
 msgid "<when>"
 msgstr "<wann>"
 
-#: diff.c:5572
+#: diff.c:5588
 msgid "ignore changes to submodules in the diff generation"
 msgstr ""
 "Änderungen in Submodulen während der Erstellung der Unterschiede ignorieren"
 
-#: diff.c:5575
+#: diff.c:5591
 msgid "<format>"
 msgstr "<Format>"
 
-#: diff.c:5576
+#: diff.c:5592
 msgid "specify how differences in submodules are shown"
 msgstr "angeben, wie Unterschiede in Submodulen gezeigt werden"
 
-#: diff.c:5580
+#: diff.c:5596
 msgid "hide 'git add -N' entries from the index"
 msgstr "'git add -N' Einträge vom Index verstecken"
 
-#: diff.c:5583
+#: diff.c:5599
 msgid "treat 'git add -N' entries as real in the index"
 msgstr "'git add -N' Einträge im Index als echt behandeln"
 
-#: diff.c:5585
+#: diff.c:5601
 msgid "<string>"
 msgstr "<Zeichenkette>"
 
-#: diff.c:5586
+#: diff.c:5602
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
@@ -3827,7 +3902,7 @@ msgstr ""
 "nach Unterschieden suchen, welche die Anzahl des Vorkommens der angegebenen "
 "Zeichenkette verändern"
 
-#: diff.c:5589
+#: diff.c:5605
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
@@ -3835,25 +3910,41 @@ msgstr ""
 "nach Unterschieden suchen, welche die Anzahl des Vorkommens des angegebenen "
 "regulären Ausdrucks verändern"
 
-#: diff.c:5592
+#: diff.c:5608
 msgid "show all changes in the changeset with -S or -G"
 msgstr "alle Änderungen im Changeset mit -S oder -G anzeigen"
 
-#: diff.c:5595
+#: diff.c:5611
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr ""
 "<Zeichenkette> bei -S als erweiterten POSIX regulären Ausdruck behandeln"
 
-#: diff.c:5598
+#: diff.c:5614
 msgid "control the order in which files appear in the output"
 msgstr ""
 "die Reihenfolge kontrollieren, in der die Dateien in der Ausgabe erscheinen"
 
-#: diff.c:5599
+#: diff.c:5615 diff.c:5618
+#, fuzzy
+msgid "<path>"
+msgstr "Pfad"
+
+#: diff.c:5616
+#, fuzzy
+msgid "show the change in the specified path first"
+msgstr ""
+"die Index-Datei des Paketes in der angegebenen Indexformat-Version schreiben"
+
+#: diff.c:5619
+#, fuzzy
+msgid "skip the output to the specified path"
+msgstr "aktuellen HEAD zu einem spezifizierten Zustand setzen"
+
+#: diff.c:5621
 msgid "<object-id>"
 msgstr "<Objekt-ID>"
 
-#: diff.c:5600
+#: diff.c:5622
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
@@ -3861,33 +3952,33 @@ msgstr ""
 "nach Unterschieden suchen, welche die Anzahl des Vorkommens des angegebenen "
 "Objektes verändern"
 
-#: diff.c:5602
+#: diff.c:5624
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "[(A|C|D|M|R|T|U|X|B)...[*]]"
 
-#: diff.c:5603
+#: diff.c:5625
 msgid "select files by diff type"
 msgstr "Dateien anhand der Art der Änderung wählen"
 
-#: diff.c:5605
+#: diff.c:5627
 msgid "<file>"
 msgstr "<Datei>"
 
-#: diff.c:5606
+#: diff.c:5628
 msgid "Output to a specific file"
 msgstr "Ausgabe zu einer bestimmten Datei"
 
-#: diff.c:6263
+#: diff.c:6285
 msgid "inexact rename detection was skipped due to too many files."
 msgstr ""
 "ungenaue Erkennung für Umbenennungen wurde aufgrund zu vieler Dateien\n"
 "übersprungen."
 
-#: diff.c:6266
+#: diff.c:6288
 msgid "only found copies from modified paths due to too many files."
 msgstr "nur Kopien von geänderten Pfaden, aufgrund zu vieler Dateien, gefunden"
 
-#: diff.c:6269
+#: diff.c:6291
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
@@ -3900,9 +3991,14 @@ msgstr ""
 msgid "failed to read orderfile '%s'"
 msgstr "Fehler beim Lesen der Reihenfolgedatei '%s'"
 
-#: diffcore-rename.c:592
+#: diffcore-rename.c:555
 msgid "Performing inexact rename detection"
 msgstr "Führe Erkennung für ungenaue Umbenennung aus"
+
+#: diffcore-rotate.c:29
+#, fuzzy, c-format
+msgid "No such path '%s' in the diff"
+msgstr "Pfad %s nicht in %s"
 
 #: dir.c:578
 #, c-format
@@ -3950,17 +4046,17 @@ msgstr ""
 "Cache für unversionierte Dateien ist auf diesem System oder\n"
 "für dieses Verzeichnis deaktiviert"
 
-#: dir.c:3520
+#: dir.c:3537
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "Index-Datei in Repository %s beschädigt"
 
-#: dir.c:3565 dir.c:3570
+#: dir.c:3582 dir.c:3587
 #, c-format
 msgid "could not create directories for %s"
 msgstr "Konnte Verzeichnisse für '%s' nicht erstellen"
 
-#: dir.c:3599
+#: dir.c:3616
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "Konnte Git-Verzeichnis nicht von '%s' nach '%s' migrieren"
@@ -3979,12 +4075,12 @@ msgstr "Filtere Inhalt"
 msgid "could not stat file '%s'"
 msgstr "konnte Datei '%s' nicht lesen"
 
-#: environment.c:150
+#: environment.c:152
 #, c-format
 msgid "bad git namespace path \"%s\""
 msgstr "ungültiger Git-Namespace-Pfad \"%s\""
 
-#: environment.c:337
+#: environment.c:335
 #, c-format
 msgid "could not set GIT_DIR to '%s'"
 msgstr "konnte GIT_DIR nicht zu '%s' setzen"
@@ -4019,32 +4115,32 @@ msgstr "konnte nicht zum Remote schreiben"
 msgid "--stateless-rpc requires multi_ack_detailed"
 msgstr "--stateless-rpc benötigt multi_ack_detailed"
 
-#: fetch-pack.c:378 fetch-pack.c:1406
+#: fetch-pack.c:378 fetch-pack.c:1400
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "ungültige shallow-Zeile: %s"
 
-#: fetch-pack.c:384 fetch-pack.c:1412
+#: fetch-pack.c:384 fetch-pack.c:1406
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "ungültige unshallow-Zeile: %s"
 
-#: fetch-pack.c:386 fetch-pack.c:1414
+#: fetch-pack.c:386 fetch-pack.c:1408
 #, c-format
 msgid "object not found: %s"
 msgstr "Objekt nicht gefunden: %s"
 
-#: fetch-pack.c:389 fetch-pack.c:1417
+#: fetch-pack.c:389 fetch-pack.c:1411
 #, c-format
 msgid "error in object: %s"
 msgstr "Fehler in Objekt: %s"
 
-#: fetch-pack.c:391 fetch-pack.c:1419
+#: fetch-pack.c:391 fetch-pack.c:1413
 #, c-format
 msgid "no shallow found: %s"
 msgstr "kein shallow-Objekt gefunden: %s"
 
-#: fetch-pack.c:394 fetch-pack.c:1423
+#: fetch-pack.c:394 fetch-pack.c:1417
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "shallow/unshallow erwartet, %s bekommen"
@@ -4082,171 +4178,171 @@ msgstr "Markiere %s als vollständig"
 msgid "already have %s (%s)"
 msgstr "habe %s (%s) bereits"
 
-#: fetch-pack.c:827
+#: fetch-pack.c:821
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-pack: Fehler beim Starten des sideband demultiplexer"
 
-#: fetch-pack.c:835
+#: fetch-pack.c:829
 msgid "protocol error: bad pack header"
 msgstr "Protokollfehler: ungültiger Pack-Header"
 
-#: fetch-pack.c:919
+#: fetch-pack.c:913
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-pack: konnte %s nicht starten"
 
-#: fetch-pack.c:937
+#: fetch-pack.c:931
 #, c-format
 msgid "%s failed"
 msgstr "%s fehlgeschlagen"
 
-#: fetch-pack.c:939
+#: fetch-pack.c:933
 msgid "error in sideband demultiplexer"
 msgstr "Fehler in sideband demultiplexer"
 
-#: fetch-pack.c:982
+#: fetch-pack.c:976
 #, c-format
 msgid "Server version is %.*s"
 msgstr "Server-Version ist %.*s"
 
-#: fetch-pack.c:990 fetch-pack.c:996 fetch-pack.c:999 fetch-pack.c:1005
-#: fetch-pack.c:1009 fetch-pack.c:1013 fetch-pack.c:1017 fetch-pack.c:1021
-#: fetch-pack.c:1025 fetch-pack.c:1029 fetch-pack.c:1033 fetch-pack.c:1037
-#: fetch-pack.c:1043 fetch-pack.c:1049 fetch-pack.c:1054 fetch-pack.c:1059
+#: fetch-pack.c:984 fetch-pack.c:990 fetch-pack.c:993 fetch-pack.c:999
+#: fetch-pack.c:1003 fetch-pack.c:1007 fetch-pack.c:1011 fetch-pack.c:1015
+#: fetch-pack.c:1019 fetch-pack.c:1023 fetch-pack.c:1027 fetch-pack.c:1031
+#: fetch-pack.c:1037 fetch-pack.c:1043 fetch-pack.c:1048 fetch-pack.c:1053
 #, c-format
 msgid "Server supports %s"
 msgstr "Server unterstützt %s"
 
-#: fetch-pack.c:992
+#: fetch-pack.c:986
 msgid "Server does not support shallow clients"
 msgstr "Server unterstützt keine shallow-Clients"
 
-#: fetch-pack.c:1052
+#: fetch-pack.c:1046
 msgid "Server does not support --shallow-since"
 msgstr "Server unterstützt kein --shallow-since"
 
-#: fetch-pack.c:1057
+#: fetch-pack.c:1051
 msgid "Server does not support --shallow-exclude"
 msgstr "Server unterstützt kein --shallow-exclude"
 
-#: fetch-pack.c:1061
+#: fetch-pack.c:1055
 msgid "Server does not support --deepen"
 msgstr "Server unterstützt kein --deepen"
 
-#: fetch-pack.c:1063
+#: fetch-pack.c:1057
 msgid "Server does not support this repository's object format"
 msgstr "Server unterstützt das Objekt-Format dieses Repositories nicht"
 
-#: fetch-pack.c:1076
+#: fetch-pack.c:1070
 msgid "no common commits"
 msgstr "keine gemeinsamen Commits"
 
-#: fetch-pack.c:1088 fetch-pack.c:1628
+#: fetch-pack.c:1082 fetch-pack.c:1622
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack: Abholen fehlgeschlagen."
 
-#: fetch-pack.c:1214
+#: fetch-pack.c:1208
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "Algorithmen stimmen nicht überein: Client %s; Server %s"
 
-#: fetch-pack.c:1218
+#: fetch-pack.c:1212
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "der Server unterstützt Algorithmus '%s' nicht"
 
-#: fetch-pack.c:1238
+#: fetch-pack.c:1232
 msgid "Server does not support shallow requests"
 msgstr "Server unterstützt keine shallow-Anfragen"
 
-#: fetch-pack.c:1245
+#: fetch-pack.c:1239
 msgid "Server supports filter"
 msgstr "Server unterstützt Filter"
 
-#: fetch-pack.c:1284
+#: fetch-pack.c:1278
 msgid "unable to write request to remote"
 msgstr "konnte Anfrage nicht zum Remote schreiben"
 
-#: fetch-pack.c:1302
+#: fetch-pack.c:1296
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "Fehler beim Lesen von Sektionskopf '%s'."
 
-#: fetch-pack.c:1308
+#: fetch-pack.c:1302
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "'%s' erwartet, '%s' empfangen"
 
-#: fetch-pack.c:1369
+#: fetch-pack.c:1363
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "Unerwartete Acknowledgment-Zeile: '%s'"
 
-#: fetch-pack.c:1374
+#: fetch-pack.c:1368
 #, c-format
 msgid "error processing acks: %d"
 msgstr "Fehler beim Verarbeiten von ACKS: %d"
 
-#: fetch-pack.c:1384
+#: fetch-pack.c:1378
 msgid "expected packfile to be sent after 'ready'"
 msgstr "Erwartete Versand einer Packdatei nach 'ready'."
 
-#: fetch-pack.c:1386
+#: fetch-pack.c:1380
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr "Erwartete keinen Versand einer anderen Sektion ohne 'ready'."
 
-#: fetch-pack.c:1428
+#: fetch-pack.c:1422
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "Fehler beim Verarbeiten von Shallow-Informationen: %d"
 
-#: fetch-pack.c:1475
+#: fetch-pack.c:1469
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "wanted-ref erwartet, '%s' bekommen"
 
-#: fetch-pack.c:1480
+#: fetch-pack.c:1474
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "unerwartetes wanted-ref: '%s'"
 
-#: fetch-pack.c:1485
+#: fetch-pack.c:1479
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "Fehler beim Verarbeiten von wanted-refs: %d"
 
-#: fetch-pack.c:1515
+#: fetch-pack.c:1509
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: Antwort-Endpaket erwartet"
 
-#: fetch-pack.c:1897
+#: fetch-pack.c:1891
 msgid "no matching remote head"
 msgstr "kein übereinstimmender Remote-Branch"
 
-#: fetch-pack.c:1920 builtin/clone.c:693
+#: fetch-pack.c:1914 builtin/clone.c:693
 msgid "remote did not send all necessary objects"
 msgstr "Remote-Repository hat nicht alle erforderlichen Objekte gesendet"
 
-#: fetch-pack.c:1947
+#: fetch-pack.c:1941
 #, c-format
 msgid "no such remote ref %s"
 msgstr "keine solche Remote-Referenz %s"
 
-#: fetch-pack.c:1950
+#: fetch-pack.c:1944
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Der Server lehnt Anfrage nach nicht angebotenem Objekt %s ab."
 
-#: gpg-interface.c:272
+#: gpg-interface.c:273
 msgid "could not create temporary file"
 msgstr "konnte temporäre Datei nicht erstellen"
 
-#: gpg-interface.c:275
+#: gpg-interface.c:276
 #, c-format
 msgid "failed writing detached signature to '%s'"
 msgstr "Fehler beim Schreiben der losgelösten Signatur nach '%s'"
 
-#: gpg-interface.c:457
+#: gpg-interface.c:470
 msgid "gpg failed to sign the data"
 msgstr "gpg beim Signieren der Daten fehlgeschlagen"
 
@@ -4255,7 +4351,7 @@ msgstr "gpg beim Signieren der Daten fehlgeschlagen"
 msgid "ignore invalid color '%.*s' in log.graphColors"
 msgstr "Ignoriere ungültige Farbe '%.*s' in log.graphColors"
 
-#: grep.c:640
+#: grep.c:543
 msgid ""
 "given pattern contains NULL byte (via -f <file>). This is only supported "
 "with -P under PCRE v2"
@@ -4263,18 +4359,18 @@ msgstr ""
 "Angegebenes Muster enthält NULL Byte (über -f <Datei>). Das wird nur mit -"
 "Punter PCRE v2 unterstützt."
 
-#: grep.c:2100
+#: grep.c:1906
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr "'%s': konnte %s nicht lesen"
 
-#: grep.c:2117 setup.c:176 builtin/clone.c:412 builtin/diff.c:89
+#: grep.c:1923 setup.c:176 builtin/clone.c:412 builtin/diff.c:90
 #: builtin/rm.c:135
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "Konnte '%s' nicht lesen"
 
-#: grep.c:2128
+#: grep.c:1934
 #, c-format
 msgid "'%s': short read"
 msgstr "'%s': read() zu kurz"
@@ -4344,7 +4440,7 @@ msgstr "Vorhandene Git-Befehle anderswo in Ihrem $PATH"
 msgid "These are common Git commands used in various situations:"
 msgstr "Allgemeine Git-Befehle, verwendet in verschiedenen Situationen:"
 
-#: help.c:365 git.c:99
+#: help.c:365 git.c:100
 #, c-format
 msgid "unsupported command listing type '%s'"
 msgstr "Nicht unterstützte Art zur Befehlsauflistung '%s'."
@@ -4588,11 +4684,246 @@ msgstr ""
 msgid "Unable to create '%s.lock': %s"
 msgstr "Konnte '%s.lock' nicht erstellen: %s"
 
-#: ls-refs.c:109
+#: ls-refs.c:37
+#, fuzzy, c-format
+msgid "invalid value '%s' for lsrefs.unborn"
+msgstr "ungültiger Wert für blame.coloring"
+
+#: ls-refs.c:167
 msgid "expected flush after ls-refs arguments"
 msgstr "erwartete Flush nach Argumenten für die Auflistung der Referenzen"
 
-#: merge-ort-wrappers.c:13 merge-recursive.c:3672
+#: merge-ort.c:855 merge-recursive.c:1191
+#, c-format
+msgid "Failed to merge submodule %s (not checked out)"
+msgstr "Fehler beim Merge von Submodul %s (nicht ausgecheckt)."
+
+#: merge-ort.c:864 merge-recursive.c:1198
+#, c-format
+msgid "Failed to merge submodule %s (commits not present)"
+msgstr "Fehler beim Merge von Submodul %s (Commits nicht vorhanden)."
+
+#: merge-ort.c:873 merge-recursive.c:1205
+#, c-format
+msgid "Failed to merge submodule %s (commits don't follow merge-base)"
+msgstr "Fehler beim Merge von Submodul %s (Commits folgen keiner Merge-Basis)"
+
+#: merge-ort.c:883 merge-ort.c:890
+#, fuzzy, c-format
+msgid "Note: Fast-forwarding submodule %s to %s"
+msgstr "Spule Submodul %s vor"
+
+#: merge-ort.c:911
+#, fuzzy, c-format
+msgid "Failed to merge submodule %s"
+msgstr "Fehler bei Rekursion in Submodul '%s'."
+
+#: merge-ort.c:918
+#, fuzzy, c-format
+msgid ""
+"Failed to merge submodule %s, but a possible merge resolution exists:\n"
+"%s\n"
+msgstr "Fehler beim Merge von Submodul %s (mehrere Merges gefunden)"
+
+#: merge-ort.c:922 merge-recursive.c:1259
+#, c-format
+msgid ""
+"If this is correct simply add it to the index for example\n"
+"by using:\n"
+"\n"
+"  git update-index --cacheinfo 160000 %s \"%s\"\n"
+"\n"
+"which will accept this suggestion.\n"
+msgstr ""
+"Falls das korrekt ist, fügen Sie es einfach der Staging-Area, zum Beispiel "
+"mit:\n"
+"\n"
+"  git update-index --cacheinfo 160000 %s \"%s\"\n"
+"\n"
+"hinzu, um diesen Vorschlag zu akzeptieren.\n"
+
+#: merge-ort.c:935
+#, fuzzy, c-format
+msgid ""
+"Failed to merge submodule %s, but multiple possible merges exist:\n"
+"%s"
+msgstr "Fehler beim Merge von Submodul %s (mehrere Merges gefunden)"
+
+#: merge-ort.c:1094 merge-recursive.c:1341
+msgid "Failed to execute internal merge"
+msgstr "Fehler bei Ausführung des internen Merges"
+
+#: merge-ort.c:1099 merge-recursive.c:1346
+#, c-format
+msgid "Unable to add %s to database"
+msgstr "Konnte %s nicht zur Datenbank hinzufügen"
+
+#: merge-ort.c:1106 merge-recursive.c:1378
+#, c-format
+msgid "Auto-merging %s"
+msgstr "automatischer Merge von %s"
+
+#: merge-ort.c:1245 merge-recursive.c:2100
+#, c-format
+msgid ""
+"CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
+"implicit directory rename(s) putting the following path(s) there: %s."
+msgstr ""
+"KONFLIKT (implizite Verzeichnisumbenennung): Existierende Datei/Pfad bei %s "
+"im\n"
+"Weg von impliziter Verzeichnisumbenennung, die versucht, einen oder mehrere\n"
+"Pfade dahin zu setzen: %s."
+
+#: merge-ort.c:1255 merge-recursive.c:2110
+#, c-format
+msgid ""
+"CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
+"implicit directory renames tried to put these paths there: %s"
+msgstr ""
+"KONFLIKT (implizite Verzeichnisumbenennung): Kann nicht mehr als ein Pfad "
+"zu\n"
+"%s mappen; implizite Verzeichnisumbenennungen versuchten diese Pfade dahin\n"
+"zu setzen: %s"
+
+#: merge-ort.c:1438
+#, fuzzy, c-format
+msgid ""
+"CONFLICT (directory rename split): Unclear where to rename %s to; it was "
+"renamed to multiple other directories, with no destination getting a "
+"majority of the files."
+msgstr ""
+"KONFLIKT (Aufteilung Verzeichnisumbenennung): Unklar, wo %s zu platzieren "
+"ist,\n"
+"weil Verzeichnis %s zu mehreren anderen Verzeichnissen umbenannt wurde, "
+"wobei\n"
+"keines dieser Ziele die Mehrheit der Dateien erhielt."
+
+#: merge-ort.c:1604 merge-recursive.c:2447
+#, c-format
+msgid ""
+"WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
+"renamed."
+msgstr ""
+"WARNUNG: Vermeide Umbenennung %s -> %s von %s, weil %s selbst umbenannt "
+"wurde."
+
+#: merge-ort.c:1748 merge-recursive.c:3215
+#, c-format
+msgid ""
+"Path updated: %s added in %s inside a directory that was renamed in %s; "
+"moving it to %s."
+msgstr ""
+"Pfad aktualisiert: %s hinzugefügt in %s innerhalb eines Verzeichnisses, das "
+"umbenannt wurde in %s; Verschiebe es nach %s."
+
+#: merge-ort.c:1755 merge-recursive.c:3222
+#, c-format
+msgid ""
+"Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
+"%s; moving it to %s."
+msgstr ""
+"Pfad aktualisiert: %s umbenannt nach %s in %s, innerhalb eines "
+"Verzeichnisses, das umbenannt wurde in %s; Verschiebe es nach %s."
+
+#: merge-ort.c:1768 merge-recursive.c:3218
+#, c-format
+msgid ""
+"CONFLICT (file location): %s added in %s inside a directory that was renamed "
+"in %s, suggesting it should perhaps be moved to %s."
+msgstr ""
+"KONFLIKT (Speicherort): %s hinzugefügt in %s innerhalb eines Verzeichnisses, "
+"das umbenannt wurde in %s, es sollte vielleicht nach %s verschoben werden."
+
+#: merge-ort.c:1776 merge-recursive.c:3225
+#, c-format
+msgid ""
+"CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
+"was renamed in %s, suggesting it should perhaps be moved to %s."
+msgstr ""
+"KONFLIKT (Speicherort): %s umbenannt nach %s in %s, innerhalb eines "
+"Verzeichnisses, das umbenannt wurde in %s, es sollte vielleicht nach %s "
+"verschoben werden."
+
+#: merge-ort.c:1919
+#, fuzzy, c-format
+msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
+msgstr ""
+"KONFLIKT (umbenennen/umbenennen): Benenne um %s->%s in %s. Benenne um %s->%s "
+"in %s"
+
+#: merge-ort.c:2014
+#, c-format
+msgid ""
+"CONFLICT (rename involved in collision): rename of %s -> %s has content "
+"conflicts AND collides with another path; this may result in nested conflict "
+"markers."
+msgstr ""
+
+#: merge-ort.c:2033 merge-ort.c:2057
+#, fuzzy, c-format
+msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
+msgstr ""
+"KONFLIKT (umbenennen/hinzufügen): Benenne um %s->%s in %s. %s hinzugefügt in "
+"%s"
+
+#: merge-ort.c:2683
+#, c-format
+msgid ""
+"CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
+"%s instead."
+msgstr ""
+
+#: merge-ort.c:2756
+#, c-format
+msgid ""
+"CONFLICT (distinct types): %s had different types on each side; renamed %s "
+"of them so each can be recorded somewhere."
+msgstr ""
+
+#: merge-ort.c:2760
+msgid "both"
+msgstr ""
+
+#: merge-ort.c:2760
+#, fuzzy
+msgid "one"
+msgstr "fertig"
+
+#: merge-ort.c:2855 merge-recursive.c:3052
+msgid "content"
+msgstr "Inhalt"
+
+#: merge-ort.c:2857 merge-recursive.c:3056
+msgid "add/add"
+msgstr "hinzufügen/hinzufügen"
+
+#: merge-ort.c:2859 merge-recursive.c:3101
+msgid "submodule"
+msgstr "Submodul"
+
+#: merge-ort.c:2861 merge-recursive.c:3102
+#, c-format
+msgid "CONFLICT (%s): Merge conflict in %s"
+msgstr "KONFLIKT (%s): Merge-Konflikt in %s"
+
+#: merge-ort.c:2886
+#, fuzzy, c-format
+msgid ""
+"CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
+"of %s left in tree."
+msgstr ""
+"KONFLIKT (%s/löschen): %s gelöscht in %s und %s in %s. Stand %s von %s wurde "
+"im Arbeitsbereich gelassen."
+
+#. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
+#. base, and 2-3) the trees for the two trees we're merging.
+#.
+#: merge-ort.c:3354
+#, fuzzy, c-format
+msgid "collecting merge info failed for trees %s, %s, %s"
+msgstr "update_ref für Referenz '%s' fehlgeschlagen: %s"
+
+#: merge-ort-wrappers.c:13 merge-recursive.c:3661
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -4667,21 +4998,6 @@ msgstr "Fehler beim Erstellen einer symbolischen Verknüpfung für '%s': %s"
 msgid "do not know what to do with %06o %s '%s'"
 msgstr "weiß nicht was mit %06o %s '%s' zu machen ist"
 
-#: merge-recursive.c:1191
-#, c-format
-msgid "Failed to merge submodule %s (not checked out)"
-msgstr "Fehler beim Merge von Submodul %s (nicht ausgecheckt)."
-
-#: merge-recursive.c:1198
-#, c-format
-msgid "Failed to merge submodule %s (commits not present)"
-msgstr "Fehler beim Merge von Submodul %s (Commits nicht vorhanden)."
-
-#: merge-recursive.c:1205
-#, c-format
-msgid "Failed to merge submodule %s (commits don't follow merge-base)"
-msgstr "Fehler beim Merge von Submodul %s (Commits folgen keiner Merge-Basis)"
-
 #: merge-recursive.c:1213 merge-recursive.c:1225
 #, c-format
 msgid "Fast-forwarding submodule %s to the following commit:"
@@ -4708,41 +5024,10 @@ msgstr "Fehler beim Merge von Submodul %s (kein Vorspulen)"
 msgid "Found a possible merge resolution for the submodule:\n"
 msgstr "Mögliche Auflösung des Merges für Submodul gefunden:\n"
 
-#: merge-recursive.c:1259
-#, c-format
-msgid ""
-"If this is correct simply add it to the index for example\n"
-"by using:\n"
-"\n"
-"  git update-index --cacheinfo 160000 %s \"%s\"\n"
-"\n"
-"which will accept this suggestion.\n"
-msgstr ""
-"Falls das korrekt ist, fügen Sie es einfach der Staging-Area, zum Beispiel "
-"mit:\n"
-"\n"
-"  git update-index --cacheinfo 160000 %s \"%s\"\n"
-"\n"
-"hinzu, um diesen Vorschlag zu akzeptieren.\n"
-
 #: merge-recursive.c:1268
 #, c-format
 msgid "Failed to merge submodule %s (multiple merges found)"
 msgstr "Fehler beim Merge von Submodul %s (mehrere Merges gefunden)"
-
-#: merge-recursive.c:1341
-msgid "Failed to execute internal merge"
-msgstr "Fehler bei Ausführung des internen Merges"
-
-#: merge-recursive.c:1346
-#, c-format
-msgid "Unable to add %s to database"
-msgstr "Konnte %s nicht zur Datenbank hinzufügen"
-
-#: merge-recursive.c:1378
-#, c-format
-msgid "Auto-merging %s"
-msgstr "automatischer Merge von %s"
 
 #: merge-recursive.c:1402
 #, c-format
@@ -4859,28 +5144,6 @@ msgstr ""
 "wobei\n"
 "keines dieser Ziele die Mehrheit der Dateien erhielt."
 
-#: merge-recursive.c:2100
-#, c-format
-msgid ""
-"CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
-"implicit directory rename(s) putting the following path(s) there: %s."
-msgstr ""
-"KONFLIKT (implizite Verzeichnisumbenennung): Existierende Datei/Pfad bei %s "
-"im\n"
-"Weg von impliziter Verzeichnisumbenennung, die versucht, einen oder mehrere\n"
-"Pfade dahin zu setzen: %s."
-
-#: merge-recursive.c:2110
-#, c-format
-msgid ""
-"CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
-"implicit directory renames tried to put these paths there: %s"
-msgstr ""
-"KONFLIKT (implizite Verzeichnisumbenennung): Kann nicht mehr als ein Pfad "
-"zu\n"
-"%s mappen; implizite Verzeichnisumbenennungen versuchten diese Pfade dahin\n"
-"zu setzen: %s"
-
 #: merge-recursive.c:2202
 #, c-format
 msgid ""
@@ -4889,15 +5152,6 @@ msgid ""
 msgstr ""
 "KONFLIKT (umbenennen/umbenennen): Benenne Verzeichnis um %s->%s in %s.\n"
 "Benenne Verzeichnis um %s->%s in %s"
-
-#: merge-recursive.c:2447
-#, c-format
-msgid ""
-"WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
-"renamed."
-msgstr ""
-"WARNUNG: Vermeide Umbenennung %s -> %s von %s, weil %s selbst umbenannt "
-"wurde."
 
 #: merge-recursive.c:2973
 #, c-format
@@ -4917,69 +5171,15 @@ msgstr "ändern"
 msgid "modified"
 msgstr "geändert"
 
-#: merge-recursive.c:3052
-msgid "content"
-msgstr "Inhalt"
-
-#: merge-recursive.c:3056
-msgid "add/add"
-msgstr "hinzufügen/hinzufügen"
-
 #: merge-recursive.c:3079
 #, c-format
 msgid "Skipped %s (merged same as existing)"
 msgstr "%s ausgelassen (Ergebnis des Merges existiert bereits)"
 
-#: merge-recursive.c:3101
-msgid "submodule"
-msgstr "Submodul"
-
-#: merge-recursive.c:3102
-#, c-format
-msgid "CONFLICT (%s): Merge conflict in %s"
-msgstr "KONFLIKT (%s): Merge-Konflikt in %s"
-
 #: merge-recursive.c:3132
 #, c-format
 msgid "Adding as %s instead"
 msgstr "Füge stattdessen als %s hinzu"
-
-#: merge-recursive.c:3215
-#, c-format
-msgid ""
-"Path updated: %s added in %s inside a directory that was renamed in %s; "
-"moving it to %s."
-msgstr ""
-"Pfad aktualisiert: %s hinzugefügt in %s innerhalb eines Verzeichnisses, das "
-"umbenannt wurde in %s; Verschiebe es nach %s."
-
-#: merge-recursive.c:3218
-#, c-format
-msgid ""
-"CONFLICT (file location): %s added in %s inside a directory that was renamed "
-"in %s, suggesting it should perhaps be moved to %s."
-msgstr ""
-"KONFLIKT (Speicherort): %s hinzugefügt in %s innerhalb eines Verzeichnisses, "
-"das umbenannt wurde in %s, es sollte vielleicht nach %s verschoben werden."
-
-#: merge-recursive.c:3222
-#, c-format
-msgid ""
-"Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
-"%s; moving it to %s."
-msgstr ""
-"Pfad aktualisiert: %s umbenannt nach %s in %s, innerhalb eines "
-"Verzeichnisses, das umbenannt wurde in %s; Verschiebe es nach %s."
-
-#: merge-recursive.c:3225
-#, c-format
-msgid ""
-"CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
-"was renamed in %s, suggesting it should perhaps be moved to %s."
-msgstr ""
-"KONFLIKT (Speicherort): %s umbenannt nach %s in %s, innerhalb eines "
-"Verzeichnisses, das umbenannt wurde in %s, es sollte vielleicht nach %s "
-"verschoben werden."
 
 #: merge-recursive.c:3339
 #, c-format
@@ -5016,27 +5216,28 @@ msgstr "KONFLIKT (hinzufügen/hinzufügen): Merge-Konflikt in %s"
 msgid "merging of trees %s and %s failed"
 msgstr "Zusammenführen der \"Tree\"-Objekte %s und %s fehlgeschlagen"
 
-#: merge-recursive.c:3550
+#: merge-recursive.c:3539
 msgid "Merging:"
 msgstr "Merge:"
 
-#: merge-recursive.c:3563
+#: merge-recursive.c:3552
 #, c-format
 msgid "found %u common ancestor:"
 msgid_plural "found %u common ancestors:"
 msgstr[0] "%u gemeinsamen Vorgänger-Commit gefunden"
 msgstr[1] "%u gemeinsame Vorgänger-Commits gefunden"
 
-#: merge-recursive.c:3613
+#: merge-recursive.c:3602
 msgid "merge returned no commit"
 msgstr "Merge hat keinen Commit zurückgegeben"
 
-#: merge-recursive.c:3769
+#: merge-recursive.c:3758
 #, c-format
 msgid "Could not parse object '%s'"
 msgstr "Konnte Objekt '%s' nicht parsen."
 
-#: merge-recursive.c:3787 builtin/merge.c:711 builtin/merge.c:895
+#: merge-recursive.c:3776 builtin/merge.c:712 builtin/merge.c:896
+#: builtin/stash.c:471
 msgid "Unable to write index."
 msgstr "Konnte Index nicht schreiben."
 
@@ -5044,8 +5245,8 @@ msgstr "Konnte Index nicht schreiben."
 msgid "failed to read the cache"
 msgstr "Lesen des Zwischenspeichers fehlgeschlagen"
 
-#: merge.c:109 rerere.c:720 builtin/am.c:1883 builtin/am.c:1917
-#: builtin/checkout.c:573 builtin/checkout.c:829 builtin/clone.c:817
+#: merge.c:109 rerere.c:704 builtin/am.c:1883 builtin/am.c:1917
+#: builtin/checkout.c:575 builtin/checkout.c:828 builtin/clone.c:817
 #: builtin/stash.c:265
 msgid "unable to write new index file"
 msgstr "Konnte neue Index-Datei nicht schreiben."
@@ -5215,17 +5416,17 @@ msgstr "Konnte 'pack-objects' nicht ausführen"
 msgid "could not finish pack-objects"
 msgstr "Konnte 'pack-objects' nicht beenden"
 
-#: name-hash.c:537
+#: name-hash.c:538
 #, c-format
 msgid "unable to create lazy_dir thread: %s"
 msgstr "Kann lazy_dir Thread nicht erzeugen: %s"
 
-#: name-hash.c:559
+#: name-hash.c:560
 #, c-format
 msgid "unable to create lazy_name thread: %s"
 msgstr "Kann lazy_name Thread nicht erzeugen: %s"
 
-#: name-hash.c:565
+#: name-hash.c:566
 #, c-format
 msgid "unable to join lazy_name thread: %s"
 msgstr "Kann lazy_name Thread nicht beitreten: %s"
@@ -5275,6 +5476,370 @@ msgstr ""
 msgid "Bad %s value: '%s'"
 msgstr "Ungültiger %s Wert: '%s'"
 
+#: object-file.c:480
+#, c-format
+msgid "object directory %s does not exist; check .git/objects/info/alternates"
+msgstr ""
+"Objektverzeichnis %s existiert nicht; prüfe .git/objects/info/alternates"
+
+#: object-file.c:531
+#, c-format
+msgid "unable to normalize alternate object path: %s"
+msgstr "Konnte alternativen Objektpfad '%s' nicht normalisieren."
+
+#: object-file.c:603
+#, c-format
+msgid "%s: ignoring alternate object stores, nesting too deep"
+msgstr "%s: ignoriere alternative Objektspeicher - Verschachtelung zu tief"
+
+#: object-file.c:610
+#, c-format
+msgid "unable to normalize object directory: %s"
+msgstr "Konnte Objektverzeichnis '%s' nicht normalisieren."
+
+#: object-file.c:653
+msgid "unable to fdopen alternates lockfile"
+msgstr "Konnte fdopen nicht auf Lock-Datei für \"alternates\" aufrufen."
+
+#: object-file.c:671
+msgid "unable to read alternates file"
+msgstr "Konnte \"alternates\"-Datei nicht lesen."
+
+#: object-file.c:678
+msgid "unable to move new alternates file into place"
+msgstr "Konnte neue \"alternates\"-Datei nicht übernehmen."
+
+#: object-file.c:713
+#, c-format
+msgid "path '%s' does not exist"
+msgstr "Pfad '%s' existiert nicht"
+
+#: object-file.c:734
+#, c-format
+msgid "reference repository '%s' as a linked checkout is not supported yet."
+msgstr ""
+"Referenziertes Repository '%s' wird noch nicht als verknüpftes\n"
+"Arbeitsverzeichnis unterstützt."
+
+#: object-file.c:740
+#, c-format
+msgid "reference repository '%s' is not a local repository."
+msgstr "Referenziertes Repository '%s' ist kein lokales Repository."
+
+#: object-file.c:746
+#, c-format
+msgid "reference repository '%s' is shallow"
+msgstr ""
+"Referenziertes Repository '%s' hat eine unvollständige Historie (shallow)."
+
+#: object-file.c:754
+#, c-format
+msgid "reference repository '%s' is grafted"
+msgstr ""
+"Referenziertes Repository '%s' ist mit künstlichen Vorgängern (\"grafts\") "
+"eingehängt."
+
+#: object-file.c:814
+#, c-format
+msgid "invalid line while parsing alternate refs: %s"
+msgstr "Ungültige Zeile beim Parsen alternativer Referenzen: %s"
+
+#: object-file.c:964
+#, c-format
+msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
+msgstr "Versuche mmap %<PRIuMAX> über Limit %<PRIuMAX>."
+
+#: object-file.c:985
+msgid "mmap failed"
+msgstr "mmap fehlgeschlagen"
+
+#: object-file.c:1149
+#, c-format
+msgid "object file %s is empty"
+msgstr "Objektdatei %s ist leer."
+
+#: object-file.c:1284 object-file.c:2477
+#, c-format
+msgid "corrupt loose object '%s'"
+msgstr "Fehlerhaftes loses Objekt '%s'."
+
+#: object-file.c:1286 object-file.c:2481
+#, c-format
+msgid "garbage at end of loose object '%s'"
+msgstr "Nutzlose Daten am Ende von losem Objekt '%s'."
+
+#: object-file.c:1328
+msgid "invalid object type"
+msgstr "ungültiger Objekt-Typ"
+
+#: object-file.c:1412
+#, c-format
+msgid "unable to unpack %s header with --allow-unknown-type"
+msgstr "Konnte %s Kopfbereich nicht mit --allow-unknown-type entpacken."
+
+#: object-file.c:1415
+#, c-format
+msgid "unable to unpack %s header"
+msgstr "Konnte %s Kopfbereich nicht entpacken."
+
+#: object-file.c:1421
+#, c-format
+msgid "unable to parse %s header with --allow-unknown-type"
+msgstr "Konnte %s Kopfbereich mit --allow-unknown-type nicht parsen."
+
+#: object-file.c:1424
+#, c-format
+msgid "unable to parse %s header"
+msgstr "Konnte %s Kopfbereich nicht parsen."
+
+#: object-file.c:1651
+#, c-format
+msgid "failed to read object %s"
+msgstr "Konnte Objekt %s nicht lesen."
+
+#: object-file.c:1655
+#, c-format
+msgid "replacement %s not found for %s"
+msgstr "Ersetzung %s für %s nicht gefunden."
+
+#: object-file.c:1659
+#, c-format
+msgid "loose object %s (stored in %s) is corrupt"
+msgstr "Loses Objekt %s (gespeichert in %s) ist beschädigt."
+
+#: object-file.c:1663
+#, c-format
+msgid "packed object %s (stored in %s) is corrupt"
+msgstr "Gepacktes Objekt %s (gespeichert in %s) ist beschädigt."
+
+#: object-file.c:1768
+#, c-format
+msgid "unable to write file %s"
+msgstr "Konnte Datei %s nicht schreiben."
+
+#: object-file.c:1775
+#, c-format
+msgid "unable to set permission to '%s'"
+msgstr "Konnte Zugriffsberechtigung auf '%s' nicht setzen."
+
+#: object-file.c:1782
+msgid "file write error"
+msgstr "Fehler beim Schreiben einer Datei."
+
+#: object-file.c:1802
+msgid "error when closing loose object file"
+msgstr "Fehler beim Schließen der Datei für lose Objekte."
+
+#: object-file.c:1867
+#, c-format
+msgid "insufficient permission for adding an object to repository database %s"
+msgstr ""
+"Unzureichende Berechtigung zum Hinzufügen eines Objektes zur Repository-"
+"Datenbank %s"
+
+#: object-file.c:1869
+msgid "unable to create temporary file"
+msgstr "Konnte temporäre Datei nicht erstellen."
+
+#: object-file.c:1893
+msgid "unable to write loose object file"
+msgstr "Fehler beim Schreiben der Datei für lose Objekte."
+
+#: object-file.c:1899
+#, c-format
+msgid "unable to deflate new object %s (%d)"
+msgstr "Konnte neues Objekt %s (%d) nicht komprimieren."
+
+#: object-file.c:1903
+#, c-format
+msgid "deflateEnd on object %s failed (%d)"
+msgstr "deflateEnd auf Objekt %s fehlgeschlagen (%d)"
+
+#: object-file.c:1907
+#, c-format
+msgid "confused by unstable object source data for %s"
+msgstr "Fehler wegen instabilen Objektquelldaten für %s"
+
+#: object-file.c:1917 builtin/pack-objects.c:1097
+#, c-format
+msgid "failed utime() on %s"
+msgstr "Fehler beim Aufruf von utime() auf '%s'."
+
+#: object-file.c:1994
+#, c-format
+msgid "cannot read object for %s"
+msgstr "Kann Objekt für %s nicht lesen."
+
+#: object-file.c:2045
+msgid "corrupt commit"
+msgstr "fehlerhafter Commit"
+
+#: object-file.c:2053
+msgid "corrupt tag"
+msgstr "fehlerhaftes Tag"
+
+#: object-file.c:2153
+#, c-format
+msgid "read error while indexing %s"
+msgstr "Lesefehler beim Indizieren von '%s'."
+
+#: object-file.c:2156
+#, c-format
+msgid "short read while indexing %s"
+msgstr "read() zu kurz beim Indizieren von '%s'."
+
+#: object-file.c:2229 object-file.c:2239
+#, c-format
+msgid "%s: failed to insert into database"
+msgstr "%s: Fehler beim Einfügen in die Datenbank"
+
+#: object-file.c:2245
+#, c-format
+msgid "%s: unsupported file type"
+msgstr "%s: nicht unterstützte Dateiart"
+
+#: object-file.c:2269
+#, c-format
+msgid "%s is not a valid object"
+msgstr "%s ist kein gültiges Objekt"
+
+#: object-file.c:2271
+#, c-format
+msgid "%s is not a valid '%s' object"
+msgstr "%s ist kein gültiges '%s' Objekt"
+
+#: object-file.c:2298 builtin/index-pack.c:192
+#, c-format
+msgid "unable to open %s"
+msgstr "kann %s nicht öffnen"
+
+#: object-file.c:2488 object-file.c:2541
+#, c-format
+msgid "hash mismatch for %s (expected %s)"
+msgstr "Hash für %s stimmt nicht überein (%s erwartet)."
+
+#: object-file.c:2512
+#, c-format
+msgid "unable to mmap %s"
+msgstr "Konnte mmap nicht auf %s ausführen."
+
+#: object-file.c:2517
+#, c-format
+msgid "unable to unpack header of %s"
+msgstr "Konnte Kopfbereich von %s nicht entpacken."
+
+#: object-file.c:2523
+#, c-format
+msgid "unable to parse header of %s"
+msgstr "Konnte Kopfbereich von %s nicht parsen."
+
+#: object-file.c:2534
+#, c-format
+msgid "unable to unpack contents of %s"
+msgstr "Konnte Inhalt von %s nicht entpacken."
+
+#: object-name.c:486
+#, fuzzy, c-format
+msgid "short object ID %s is ambiguous"
+msgstr "Kurzer SHA-1 %s ist mehrdeutig."
+
+#: object-name.c:497
+msgid "The candidates are:"
+msgstr "Die Kandidaten sind:"
+
+#: object-name.c:796
+msgid ""
+"Git normally never creates a ref that ends with 40 hex characters\n"
+"because it will be ignored when you just specify 40-hex. These refs\n"
+"may be created by mistake. For example,\n"
+"\n"
+"  git switch -c $br $(git rev-parse ...)\n"
+"\n"
+"where \"$br\" is somehow empty and a 40-hex ref is created. Please\n"
+"examine these refs and maybe delete them. Turn this message off by\n"
+"running \"git config advice.objectNameWarning false\""
+msgstr ""
+"Git erzeugt normalerweise keine Referenzen die mit\n"
+"40 Hex-Zeichen enden, da diese ignoriert werden wenn\n"
+"Sie diese angeben. Diese Referenzen könnten aus Versehen\n"
+"erzeugt worden sein. Zum Beispiel,\n"
+"\n"
+"  git switch -c $br $(git rev-parse ...)\n"
+"\n"
+"wobei \"$br\" leer ist und eine 40-Hex-Referenz erzeugt\n"
+"wurde. Bitte prüfen Sie diese Referenzen und löschen\n"
+"Sie sie gegebenenfalls. Unterdrücken Sie diese Meldung\n"
+"indem Sie \"git config advice.objectNameWarning false\"\n"
+"ausführen."
+
+#: object-name.c:916
+#, c-format
+msgid "log for '%.*s' only goes back to %s"
+msgstr "Log für '%.*s' geht nur bis %s zurück"
+
+#: object-name.c:924
+#, c-format
+msgid "log for '%.*s' only has %d entries"
+msgstr "Log für '%.*s' hat nur %d Einträge"
+
+#: object-name.c:1702
+#, c-format
+msgid "path '%s' exists on disk, but not in '%.*s'"
+msgstr "Pfad '%s' befindet sich im Dateisystem, aber nicht in '%.*s'"
+
+#: object-name.c:1708
+#, c-format
+msgid ""
+"path '%s' exists, but not '%s'\n"
+"hint: Did you mean '%.*s:%s' aka '%.*s:./%s'?"
+msgstr ""
+"Pfad '%s' existiert, aber nicht '%s'\n"
+"Hinweis: Meinten Sie '%.*s:%s' auch bekannt als '%.*s:./%s'?"
+
+#: object-name.c:1717
+#, c-format
+msgid "path '%s' does not exist in '%.*s'"
+msgstr "Pfad '%s' existiert nicht in '%.*s'"
+
+#: object-name.c:1745
+#, c-format
+msgid ""
+"path '%s' is in the index, but not at stage %d\n"
+"hint: Did you mean ':%d:%s'?"
+msgstr ""
+"Pfad '%s' ist im Index, aber nicht in Stufe %d\n"
+"Hinweis: Meinten Sie ':%d:%s'?"
+
+#: object-name.c:1761
+#, c-format
+msgid ""
+"path '%s' is in the index, but not '%s'\n"
+"hint: Did you mean ':%d:%s' aka ':%d:./%s'?"
+msgstr ""
+"Pfad '%s' ist im Index, aber nicht '%s'\n"
+"Hinweis: Meinten Sie ':%d:%s' auch bekannt als ':%d:./%s'?"
+
+#: object-name.c:1769
+#, c-format
+msgid "path '%s' exists on disk, but not in the index"
+msgstr "Pfad '%s' existiert im Dateisystem, aber nicht im Index"
+
+#: object-name.c:1771
+#, c-format
+msgid "path '%s' does not exist (neither on disk nor in the index)"
+msgstr "Pfad '%s' existiert nicht (weder im Dateisystem noch im Index)"
+
+#: object-name.c:1784
+msgid "relative path syntax can't be used outside working tree"
+msgstr ""
+"Die Syntax für relative Pfade kann nicht außerhalb des Arbeitsverzeichnisses "
+"benutzt werden."
+
+#: object-name.c:1922
+#, c-format
+msgid "invalid object name '%.*s'."
+msgstr "ungültiger Objektname '%.*s'."
+
 #: object.c:53
 #, c-format
 msgid "invalid object type \"%s\""
@@ -5300,21 +5865,71 @@ msgstr "Konnte Objekt '%s' nicht parsen."
 msgid "hash mismatch %s"
 msgstr "Hash stimmt nicht mit %s überein."
 
-#: pack-bitmap.c:815 pack-bitmap.c:821 builtin/pack-objects.c:2216
+#: pack-bitmap.c:843 pack-bitmap.c:849 builtin/pack-objects.c:2226
 #, c-format
 msgid "unable to get size of %s"
 msgstr "Konnte Größe von %s nicht bestimmen."
 
-#: packfile.c:615
+#: pack-bitmap.c:1489 builtin/rev-list.c:92
+#, fuzzy, c-format
+msgid "unable to get disk usage of %s"
+msgstr "Konnte Größe von %s nicht bestimmen."
+
+#: pack-revindex.c:220
+#, fuzzy, c-format
+msgid "reverse-index file %s is too small"
+msgstr "multi-pack-index-Datei %s ist zu klein."
+
+#: pack-revindex.c:225
+#, fuzzy, c-format
+msgid "reverse-index file %s is corrupt"
+msgstr "Index-Datei beschädigt"
+
+#: pack-revindex.c:233
+#, fuzzy, c-format
+msgid "reverse-index file %s has unknown signature"
+msgstr "Ungültige SHA1-Signatur der Index-Datei."
+
+#: pack-revindex.c:237
+#, c-format
+msgid "reverse-index file %s has unsupported version %<PRIu32>"
+msgstr ""
+
+#: pack-revindex.c:242
+#, c-format
+msgid "reverse-index file %s has unsupported hash id %<PRIu32>"
+msgstr ""
+
+#: pack-write.c:236
+#, fuzzy
+msgid "cannot both write and verify reverse index"
+msgstr "Kann Index nicht lesen"
+
+#: pack-write.c:257
+#, fuzzy, c-format
+msgid "could not stat: %s"
+msgstr "Konnte '%s' nicht lesen"
+
+#: pack-write.c:269
+#, fuzzy, c-format
+msgid "failed to make %s readable"
+msgstr "Fehler beim Parsen von %s."
+
+#: pack-write.c:502
+#, fuzzy, c-format
+msgid "could not write '%s' promisor file"
+msgstr "Konnte '%s' nicht schreiben."
+
+#: packfile.c:625
 msgid "offset before end of packfile (broken .idx?)"
 msgstr "Offset vor Ende der Packdatei (fehlerhafte Indexdatei?)"
 
-#: packfile.c:1907
+#: packfile.c:1934
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr "Offset vor Beginn des Pack-Index für %s (beschädigter Index?)"
 
-#: packfile.c:1911
+#: packfile.c:1938
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr "Offset hinter Ende des Pack-Index für %s (abgeschnittener Index?)"
@@ -5578,7 +6193,7 @@ msgstr "Aktualisiere Index"
 msgid "unable to create threaded lstat: %s"
 msgstr "Kann Thread für lstat nicht erzeugen: %s"
 
-#: pretty.c:983
+#: pretty.c:984
 msgid "unable to parse --pretty format"
 msgstr "Konnte --pretty Format nicht parsen."
 
@@ -5605,20 +6220,20 @@ msgstr "Promisor-Remote-Name kann nicht mit '/' beginnen: %s"
 msgid "Removing duplicate objects"
 msgstr "Lösche doppelte Objekte"
 
-#: range-diff.c:77
+#: range-diff.c:78
 msgid "could not start `log`"
 msgstr "Konnte `log` nicht starten."
 
-#: range-diff.c:79
+#: range-diff.c:80
 msgid "could not read `log` output"
 msgstr "Konnte Ausgabe von `log` nicht lesen."
 
-#: range-diff.c:98 sequencer.c:5310
+#: range-diff.c:101 sequencer.c:5318
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr "Konnte Commit '%s' nicht parsen."
 
-#: range-diff.c:112
+#: range-diff.c:115
 #, c-format
 msgid ""
 "could not parse first line of `log` output: did not start with 'commit ': "
@@ -5627,16 +6242,21 @@ msgstr ""
 "konnte erste Zeile der Ausgabe von `log` nicht parsen: fängt nicht mit "
 "'commit ' an: '%s'"
 
-#: range-diff.c:137
+#: range-diff.c:140
 #, c-format
 msgid "could not parse git header '%.*s'"
 msgstr "Konnte Git-Header '%.*s' nicht parsen."
 
-#: range-diff.c:299
+#: range-diff.c:306
 msgid "failed to generate diff"
 msgstr "Fehler beim Generieren des Diffs."
 
-#: range-diff.c:532 range-diff.c:534
+#: range-diff.c:558
+#, fuzzy
+msgid "--left-only and --right-only are mutually exclusive"
+msgstr "-p und --overlay schließen sich gegenseitig aus."
+
+#: range-diff.c:561 range-diff.c:563
 #, c-format
 msgid "could not parse log for '%s'"
 msgstr "Konnte Log für '%s' nicht parsen."
@@ -5753,10 +6373,10 @@ msgstr "Mehrere Stage-Einträge für zusammengeführte Datei '%s'."
 msgid "unordered stage entries for '%s'"
 msgstr "Ungeordnete Stage-Einträge für '%s'."
 
-#: read-cache.c:1971 read-cache.c:2262 rerere.c:565 rerere.c:599 rerere.c:1111
-#: submodule.c:1628 builtin/add.c:538 builtin/check-ignore.c:181
-#: builtin/checkout.c:502 builtin/checkout.c:688 builtin/clean.c:991
-#: builtin/commit.c:364 builtin/diff-tree.c:122 builtin/grep.c:507
+#: read-cache.c:1971 read-cache.c:2262 rerere.c:549 rerere.c:583 rerere.c:1095
+#: submodule.c:1634 builtin/add.c:546 builtin/check-ignore.c:181
+#: builtin/checkout.c:504 builtin/checkout.c:690 builtin/clean.c:991
+#: builtin/commit.c:364 builtin/diff-tree.c:122 builtin/grep.c:505
 #: builtin/mv.c:146 builtin/reset.c:247 builtin/rm.c:290
 #: builtin/submodule--helper.c:332
 msgid "index file corrupt"
@@ -5812,12 +6432,12 @@ msgstr "Konnte geteilten Index '%s' nicht aktualisieren."
 msgid "broken index, expect %s in %s, got %s"
 msgstr "Fehlerhafter Index. Erwartete %s in %s, erhielt %s."
 
-#: read-cache.c:3017 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1140
+#: read-cache.c:3017 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1141
 #, c-format
 msgid "could not close '%s'"
 msgstr "Konnte '%s' nicht schließen."
 
-#: read-cache.c:3120 sequencer.c:2479 sequencer.c:4231
+#: read-cache.c:3120 sequencer.c:2487 sequencer.c:4239
 #, c-format
 msgid "could not stat '%s'"
 msgstr "Konnte '%s' nicht lesen."
@@ -5953,14 +6573,14 @@ msgstr ""
 "Wenn Sie jedoch alles löschen, wird der Rebase abgebrochen.\n"
 "\n"
 
-#: rebase-interactive.c:110 rerere.c:485 rerere.c:692 sequencer.c:3607
-#: sequencer.c:3633 sequencer.c:5416 builtin/fsck.c:347 builtin/rebase.c:270
+#: rebase-interactive.c:110 rerere.c:469 rerere.c:676 sequencer.c:3615
+#: sequencer.c:3641 sequencer.c:5424 builtin/fsck.c:329 builtin/rebase.c:272
 #, c-format
 msgid "could not write '%s'"
 msgstr "Konnte '%s' nicht schreiben."
 
-#: rebase-interactive.c:116 builtin/rebase.c:202 builtin/rebase.c:228
-#: builtin/rebase.c:252
+#: rebase-interactive.c:116 builtin/rebase.c:204 builtin/rebase.c:230
+#: builtin/rebase.c:254
 #, c-format
 msgid "could not write '%s'."
 msgstr "Konnte '%s' nicht schreiben."
@@ -5991,14 +6611,14 @@ msgstr ""
 "Warnungen zu ändern.\n"
 "Die möglichen Verhaltensweisen sind: ignore, warn, error.\n"
 
-#: rebase-interactive.c:233 rebase-interactive.c:238 sequencer.c:2394
-#: builtin/rebase.c:188 builtin/rebase.c:213 builtin/rebase.c:239
-#: builtin/rebase.c:264
+#: rebase-interactive.c:233 rebase-interactive.c:238 sequencer.c:2402
+#: builtin/rebase.c:190 builtin/rebase.c:215 builtin/rebase.c:241
+#: builtin/rebase.c:266
 #, c-format
 msgid "could not read '%s'."
 msgstr "Konnte '%s' nicht lesen."
 
-#: ref-filter.c:42 wt-status.c:1973
+#: ref-filter.c:42 wt-status.c:1975
 msgid "gone"
 msgstr "entfernt"
 
@@ -6189,23 +6809,34 @@ msgstr "Format: %%(end) Atom ohne zugehöriges Atom verwendet"
 msgid "malformed format string %s"
 msgstr "Fehlerhafter Formatierungsstring %s"
 
-#: ref-filter.c:1549
-#, c-format
-msgid "no branch, rebasing %s"
+#: ref-filter.c:1551
+#, fuzzy, c-format
+msgid "(no branch, rebasing %s)"
 msgstr "kein Branch, Rebase von %s"
 
-#: ref-filter.c:1552
-#, c-format
-msgid "no branch, rebasing detached HEAD %s"
+#: ref-filter.c:1554
+#, fuzzy, c-format
+msgid "(no branch, rebasing detached HEAD %s)"
 msgstr "kein Branch, Rebase von losgelöstem HEAD %s"
 
-#: ref-filter.c:1555
-#, c-format
-msgid "no branch, bisect started on %s"
+#: ref-filter.c:1557
+#, fuzzy, c-format
+msgid "(no branch, bisect started on %s)"
 msgstr "kein Branch, binäre Suche begonnen bei %s"
 
-#: ref-filter.c:1565
-msgid "no branch"
+#: ref-filter.c:1561
+#, fuzzy, c-format
+msgid "(HEAD detached at %s)"
+msgstr "HEAD losgelöst bei "
+
+#: ref-filter.c:1564
+#, fuzzy, c-format
+msgid "(HEAD detached from %s)"
+msgstr "HEAD losgelöst von "
+
+#: ref-filter.c:1567
+#, fuzzy
+msgid "(no branch)"
 msgstr "kein Branch"
 
 #: ref-filter.c:1599 ref-filter.c:1808
@@ -6218,32 +6849,32 @@ msgstr "Objekt %s fehlt für %s"
 msgid "parse_object_buffer failed on %s for %s"
 msgstr "parse_object_buffer bei %s für %s fehlgeschlagen"
 
-#: ref-filter.c:2062
+#: ref-filter.c:1992
 #, c-format
 msgid "malformed object at '%s'"
 msgstr "fehlerhaftes Objekt bei '%s'"
 
-#: ref-filter.c:2151
+#: ref-filter.c:2081
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr "Ignoriere Referenz mit fehlerhaftem Namen %s"
 
-#: ref-filter.c:2156 refs.c:676
+#: ref-filter.c:2086 refs.c:676
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "Ignoriere fehlerhafte Referenz %s"
 
-#: ref-filter.c:2472
+#: ref-filter.c:2426
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "Format: %%(end) Atom fehlt"
 
-#: ref-filter.c:2571
+#: ref-filter.c:2525
 #, c-format
 msgid "malformed object name %s"
 msgstr "missgebildeter Objektname %s"
 
-#: ref-filter.c:2576
+#: ref-filter.c:2530
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "die Option `%s' muss auf einen Commit zeigen"
@@ -6295,52 +6926,52 @@ msgstr "ungültiger Branchname: %s = %s"
 msgid "ignoring dangling symref %s"
 msgstr "Ignoriere unreferenzierte symbolische Referenz %s"
 
-#: refs.c:911
+#: refs.c:922
 #, c-format
 msgid "log for ref %s has gap after %s"
 msgstr "Log für Referenz %s hat eine Lücke nach %s."
 
-#: refs.c:917
+#: refs.c:929
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
 msgstr "Log für Referenz %s unerwartet bei %s beendet."
 
-#: refs.c:976
+#: refs.c:994
 #, c-format
 msgid "log for %s is empty"
 msgstr "Log für %s ist leer."
 
-#: refs.c:1068
+#: refs.c:1086
 #, c-format
 msgid "refusing to update ref with bad name '%s'"
 msgstr "verweigere Aktualisierung einer Referenz mit fehlerhaftem Namen '%s'"
 
-#: refs.c:1139
+#: refs.c:1157
 #, c-format
 msgid "update_ref failed for ref '%s': %s"
 msgstr "update_ref für Referenz '%s' fehlgeschlagen: %s"
 
-#: refs.c:1963
+#: refs.c:2051
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "mehrere Aktualisierungen für Referenz '%s' nicht erlaubt"
 
-#: refs.c:2043
+#: refs.c:2131
 msgid "ref updates forbidden inside quarantine environment"
 msgstr ""
 "Aktualisierungen von Referenzen ist innerhalb der Quarantäne-Umgebung "
 "verboten"
 
-#: refs.c:2054
+#: refs.c:2142
 msgid "ref updates aborted by hook"
 msgstr "Aktualisierungen von Referenzen durch Hook abgebrochen"
 
-#: refs.c:2154 refs.c:2184
+#: refs.c:2242 refs.c:2272
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "'%s' existiert; kann '%s' nicht erstellen"
 
-#: refs.c:2160 refs.c:2195
+#: refs.c:2248 refs.c:2283
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "kann '%s' und '%s' nicht zur selben Zeit verarbeiten"
@@ -6406,12 +7037,12 @@ msgstr "Schlüssel '%s' des Musters hatte kein '*'."
 msgid "value '%s' of pattern has no '*'"
 msgstr "Wert '%s' des Musters hat kein '*'."
 
-#: remote.c:1073
+#: remote.c:1083
 #, c-format
 msgid "src refspec %s does not match any"
 msgstr "Src-Refspec %s entspricht keiner Referenz."
 
-#: remote.c:1078
+#: remote.c:1088
 #, c-format
 msgid "src refspec %s matches more than one"
 msgstr "Src-Refspec %s entspricht mehr als einer Referenz."
@@ -6420,7 +7051,7 @@ msgstr "Src-Refspec %s entspricht mehr als einer Referenz."
 #. <remote> <src>:<dst>" push, and "being pushed ('%s')" is
 #. the <src>.
 #.
-#: remote.c:1093
+#: remote.c:1103
 #, c-format
 msgid ""
 "The destination you provided is not a full refname (i.e.,\n"
@@ -6447,7 +7078,7 @@ msgstr ""
 "Keines hat funktioniert, sodass wir aufgegeben haben. Sie müssen die\n"
 "Referenz mit vollqualifizierten Namen angeben."
 
-#: remote.c:1113
+#: remote.c:1123
 #, c-format
 msgid ""
 "The <src> part of the refspec is a commit object.\n"
@@ -6458,7 +7089,7 @@ msgstr ""
 "Meinten Sie, einen neuen Branch mittels Push nach\n"
 "'%s:refs/heads/%s' zu erstellen?"
 
-#: remote.c:1118
+#: remote.c:1128
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tag object.\n"
@@ -6469,7 +7100,7 @@ msgstr ""
 "Meinten Sie, einen neuen Tag mittels Push nach\n"
 "'%s:refs/tags/%s' zu erstellen?"
 
-#: remote.c:1123
+#: remote.c:1133
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tree object.\n"
@@ -6480,7 +7111,7 @@ msgstr ""
 "Meinten Sie, einen Tag für ein neues Tree-Objekt\n"
 "mittels Push nach '%s:refs/tags/'%s' zu erstellen?"
 
-#: remote.c:1128
+#: remote.c:1138
 #, c-format
 msgid ""
 "The <src> part of the refspec is a blob object.\n"
@@ -6491,117 +7122,117 @@ msgstr ""
 "Meinten Sie, einen Tag für ein neues Blob-Objekt\n"
 "mittels Push nach '%s:refs/tags/%s' zu erstellen?"
 
-#: remote.c:1164
+#: remote.c:1174
 #, c-format
 msgid "%s cannot be resolved to branch"
 msgstr "%s kann nicht zu Branch aufgelöst werden."
 
-#: remote.c:1175
+#: remote.c:1185
 #, c-format
 msgid "unable to delete '%s': remote ref does not exist"
 msgstr "Konnte '%s' nicht löschen: Remote-Referenz existiert nicht."
 
-#: remote.c:1187
+#: remote.c:1197
 #, c-format
 msgid "dst refspec %s matches more than one"
 msgstr "Dst-Refspec %s entspricht mehr als einer Referenz."
 
-#: remote.c:1194
+#: remote.c:1204
 #, c-format
 msgid "dst ref %s receives from more than one src"
 msgstr "Dst-Referenz %s empfängt von mehr als einer Quelle"
 
-#: remote.c:1714 remote.c:1815
+#: remote.c:1724 remote.c:1825
 msgid "HEAD does not point to a branch"
 msgstr "HEAD zeigt auf keinen Branch"
 
-#: remote.c:1723
+#: remote.c:1733
 #, c-format
 msgid "no such branch: '%s'"
 msgstr "Kein solcher Branch: '%s'"
 
-#: remote.c:1726
+#: remote.c:1736
 #, c-format
 msgid "no upstream configured for branch '%s'"
 msgstr "Kein Upstream-Branch für Branch '%s' konfiguriert."
 
-#: remote.c:1732
+#: remote.c:1742
 #, c-format
 msgid "upstream branch '%s' not stored as a remote-tracking branch"
 msgstr "Upstream-Branch '%s' nicht als Remote-Tracking-Branch gespeichert"
 
-#: remote.c:1747
+#: remote.c:1757
 #, c-format
 msgid "push destination '%s' on remote '%s' has no local tracking branch"
 msgstr ""
 "Ziel für \"push\" '%s' auf Remote-Repository '%s' hat keinen lokal gefolgten "
 "Branch"
 
-#: remote.c:1759
+#: remote.c:1769
 #, c-format
 msgid "branch '%s' has no remote for pushing"
 msgstr "Branch '%s' hat keinen Upstream-Branch gesetzt"
 
-#: remote.c:1769
+#: remote.c:1779
 #, c-format
 msgid "push refspecs for '%s' do not include '%s'"
 msgstr "Push-Refspecs für '%s' beinhalten nicht '%s'"
 
-#: remote.c:1782
+#: remote.c:1792
 msgid "push has no destination (push.default is 'nothing')"
 msgstr "kein Ziel für \"push\" (push.default ist 'nothing')"
 
-#: remote.c:1804
+#: remote.c:1814
 msgid "cannot resolve 'simple' push to a single destination"
 msgstr "kann einzelnes Ziel für \"push\" im Modus 'simple' nicht auflösen"
 
-#: remote.c:1933
+#: remote.c:1943
 #, c-format
 msgid "couldn't find remote ref %s"
 msgstr "Konnte Remote-Referenz %s nicht finden."
 
-#: remote.c:1946
+#: remote.c:1956
 #, c-format
 msgid "* Ignoring funny ref '%s' locally"
 msgstr "* Ignoriere sonderbare Referenz '%s' lokal"
 
-#: remote.c:2109
+#: remote.c:2119
 #, c-format
 msgid "Your branch is based on '%s', but the upstream is gone.\n"
 msgstr ""
 "Ihr Branch basiert auf '%s', aber der Upstream-Branch wurde entfernt.\n"
 
-#: remote.c:2113
+#: remote.c:2123
 msgid "  (use \"git branch --unset-upstream\" to fixup)\n"
 msgstr "  (benutzen Sie \"git branch --unset-upstream\" zum Beheben)\n"
 
-#: remote.c:2116
+#: remote.c:2126
 #, c-format
 msgid "Your branch is up to date with '%s'.\n"
 msgstr "Ihr Branch ist auf demselben Stand wie '%s'.\n"
 
-#: remote.c:2120
+#: remote.c:2130
 #, c-format
 msgid "Your branch and '%s' refer to different commits.\n"
 msgstr "Ihr Branch und '%s' zeigen auf unterschiedliche Commits.\n"
 
-#: remote.c:2123
+#: remote.c:2133
 #, c-format
 msgid "  (use \"%s\" for details)\n"
 msgstr "  (benutzen Sie \"%s\" für Details)\n"
 
-#: remote.c:2127
+#: remote.c:2137
 #, c-format
 msgid "Your branch is ahead of '%s' by %d commit.\n"
 msgid_plural "Your branch is ahead of '%s' by %d commits.\n"
 msgstr[0] "Ihr Branch ist %2$d Commit vor '%1$s'.\n"
 msgstr[1] "Ihr Branch ist %2$d Commits vor '%1$s'.\n"
 
-#: remote.c:2133
+#: remote.c:2143
 msgid "  (use \"git push\" to publish your local commits)\n"
 msgstr "  (benutzen Sie \"git push\", um lokale Commits zu publizieren)\n"
 
-#: remote.c:2136
+#: remote.c:2146
 #, c-format
 msgid "Your branch is behind '%s' by %d commit, and can be fast-forwarded.\n"
 msgid_plural ""
@@ -6611,12 +7242,12 @@ msgstr[0] ""
 msgstr[1] ""
 "Ihr Branch ist %2$d Commits hinter '%1$s', und kann vorgespult werden.\n"
 
-#: remote.c:2144
+#: remote.c:2154
 msgid "  (use \"git pull\" to update your local branch)\n"
 msgstr ""
 "  (benutzen Sie \"git pull\", um Ihren lokalen Branch zu aktualisieren)\n"
 
-#: remote.c:2147
+#: remote.c:2157
 #, c-format
 msgid ""
 "Your branch and '%s' have diverged,\n"
@@ -6631,13 +7262,13 @@ msgstr[1] ""
 "Ihr Branch und '%s' sind divergiert,\n"
 "und haben jeweils %d und %d unterschiedliche Commits.\n"
 
-#: remote.c:2157
+#: remote.c:2167
 msgid "  (use \"git pull\" to merge the remote branch into yours)\n"
 msgstr ""
 "  (benutzen Sie \"git pull\", um Ihren Branch mit dem Remote-Branch "
 "zusammenzuführen)\n"
 
-#: remote.c:2349
+#: remote.c:2359
 #, c-format
 msgid "cannot parse expected object name '%s'"
 msgstr "Kann erwarteten Objektnamen '%s' nicht parsen."
@@ -6657,96 +7288,96 @@ msgstr "doppelte ersetzende Referenz: %s"
 msgid "replace depth too high for object %s"
 msgstr "Ersetzungstiefe zu hoch für Objekt %s"
 
-#: rerere.c:217 rerere.c:226 rerere.c:229
+#: rerere.c:201 rerere.c:210 rerere.c:213
 msgid "corrupt MERGE_RR"
 msgstr "Fehlerhaftes MERGE_RR"
 
-#: rerere.c:264 rerere.c:269
+#: rerere.c:248 rerere.c:253
 msgid "unable to write rerere record"
 msgstr "Konnte Rerere-Eintrag nicht schreiben."
 
-#: rerere.c:495
+#: rerere.c:479
 #, c-format
 msgid "there were errors while writing '%s' (%s)"
 msgstr "Fehler beim Schreiben von '%s' (%s)."
 
-#: rerere.c:498
+#: rerere.c:482
 #, c-format
 msgid "failed to flush '%s'"
 msgstr "Flush bei '%s' fehlgeschlagen."
 
-#: rerere.c:503 rerere.c:1039
+#: rerere.c:487 rerere.c:1023
 #, c-format
 msgid "could not parse conflict hunks in '%s'"
 msgstr "Konnte Konflikt-Blöcke in '%s' nicht parsen."
 
-#: rerere.c:684
+#: rerere.c:668
 #, c-format
 msgid "failed utime() on '%s'"
 msgstr "Fehler beim Aufruf von utime() auf '%s'."
 
-#: rerere.c:694
+#: rerere.c:678
 #, c-format
 msgid "writing '%s' failed"
 msgstr "Schreiben von '%s' fehlgeschlagen."
 
-#: rerere.c:714
+#: rerere.c:698
 #, c-format
 msgid "Staged '%s' using previous resolution."
 msgstr "'%s' mit vorheriger Konfliktauflösung zum Commit vorgemerkt."
 
-#: rerere.c:753
+#: rerere.c:737
 #, c-format
 msgid "Recorded resolution for '%s'."
 msgstr "Konfliktauflösung für '%s' aufgezeichnet."
 
-#: rerere.c:788
+#: rerere.c:772
 #, c-format
 msgid "Resolved '%s' using previous resolution."
 msgstr "Konflikte in '%s' mit vorheriger Konfliktauflösung beseitigt."
 
-#: rerere.c:803
+#: rerere.c:787
 #, c-format
 msgid "cannot unlink stray '%s'"
 msgstr "Kann '%s' nicht löschen."
 
-#: rerere.c:807
+#: rerere.c:791
 #, c-format
 msgid "Recorded preimage for '%s'"
 msgstr "Preimage für '%s' aufgezeichnet."
 
-#: rerere.c:881 submodule.c:2082 builtin/log.c:1992
+#: rerere.c:865 submodule.c:2088 builtin/log.c:1991
 #: builtin/submodule--helper.c:1878 builtin/submodule--helper.c:1890
 #, c-format
 msgid "could not create directory '%s'"
 msgstr "Konnte Verzeichnis '%s' nicht erstellen."
 
-#: rerere.c:1057
+#: rerere.c:1041
 #, c-format
 msgid "failed to update conflicted state in '%s'"
 msgstr "Fehler beim Aktualisieren des Konflikt-Status in '%s'."
 
-#: rerere.c:1068 rerere.c:1075
+#: rerere.c:1052 rerere.c:1059
 #, c-format
 msgid "no remembered resolution for '%s'"
 msgstr "Keine aufgezeichnete Konfliktauflösung für '%s'."
 
-#: rerere.c:1077
+#: rerere.c:1061
 #, c-format
 msgid "cannot unlink '%s'"
 msgstr "Kann '%s' nicht löschen."
 
-#: rerere.c:1087
+#: rerere.c:1071
 #, c-format
 msgid "Updated preimage for '%s'"
 msgstr "Preimage für '%s' aktualisiert."
 
-#: rerere.c:1096
+#: rerere.c:1080
 #, c-format
 msgid "Forgot resolution for '%s'\n"
 msgstr "Aufgezeichnete Konfliktauflösung für '%s' gelöscht.\n"
 
-#: rerere.c:1199
+#: rerere.c:1191
 msgid "unable to open rr-cache directory"
 msgstr "Konnte rr-cache Verzeichnis nicht öffnen."
 
@@ -6754,43 +7385,38 @@ msgstr "Konnte rr-cache Verzeichnis nicht öffnen."
 msgid "could not determine HEAD revision"
 msgstr "Konnte HEAD-Commit nicht bestimmen."
 
-#: reset.c:70 reset.c:76 sequencer.c:3460
+#: reset.c:70 reset.c:76 sequencer.c:3468
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "Fehler beim Finden des \"Tree\"-Objektes von %s."
 
-#: revision.c:2336
+#: revision.c:2338
 msgid "--unpacked=<packfile> no longer supported"
 msgstr "--unpacked=<Pack-Datei> wird nicht länger unterstützt"
 
-#: revision.c:2356
-#, c-format
-msgid "unknown value for --diff-merges: %s"
-msgstr "unbekannter Wert für --diff-merges: %s"
-
-#: revision.c:2694
+#: revision.c:2668
 msgid "your current branch appears to be broken"
 msgstr "Ihr aktueller Branch scheint fehlerhaft zu sein."
 
-#: revision.c:2697
+#: revision.c:2671
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
 msgstr "Ihr aktueller Branch '%s' hat noch keine Commits."
 
-#: revision.c:2907
+#: revision.c:2877
 msgid "-L does not yet support diff formats besides -p and -s"
 msgstr "-L unterstützt noch keine anderen Diff-Formate außer -p und -s"
 
-#: run-command.c:764
+#: run-command.c:767
 msgid "open /dev/null failed"
 msgstr "Öffnen von /dev/null fehlgeschlagen"
 
-#: run-command.c:1271
+#: run-command.c:1274
 #, c-format
 msgid "cannot create async thread: %s"
 msgstr "Konnte Thread für async nicht erzeugen: %s"
 
-#: run-command.c:1335
+#: run-command.c:1338
 #, c-format
 msgid ""
 "The '%s' hook was ignored because it's not set as executable.\n"
@@ -6854,7 +7480,7 @@ msgstr "Ungültiger \"cleanup\"-Modus '%s' für Commit-Beschreibungen."
 msgid "could not delete '%s'"
 msgstr "Konnte '%s' nicht löschen."
 
-#: sequencer.c:343 builtin/rebase.c:755 builtin/rebase.c:1596 builtin/rm.c:385
+#: sequencer.c:343 builtin/rebase.c:757 builtin/rebase.c:1602 builtin/rm.c:385
 #, c-format
 msgid "could not remove '%s'"
 msgstr "Konnte '%s' nicht löschen"
@@ -6894,13 +7520,13 @@ msgstr ""
 "mit 'git add <Pfade>' oder 'git rm <Pfade>' und tragen Sie das Ergebnis mit\n"
 "'git commit' ein"
 
-#: sequencer.c:434 sequencer.c:3062
+#: sequencer.c:434 sequencer.c:3070
 #, c-format
 msgid "could not lock '%s'"
 msgstr "Konnte '%s' nicht sperren"
 
-#: sequencer.c:436 sequencer.c:2861 sequencer.c:3066 sequencer.c:3080
-#: sequencer.c:3337 sequencer.c:5326 strbuf.c:1168 wrapper.c:631
+#: sequencer.c:436 sequencer.c:2869 sequencer.c:3074 sequencer.c:3088
+#: sequencer.c:3345 sequencer.c:5334 strbuf.c:1168 wrapper.c:631
 #, c-format
 msgid "could not write to '%s'"
 msgstr "Konnte nicht nach '%s' schreiben."
@@ -6910,8 +7536,8 @@ msgstr "Konnte nicht nach '%s' schreiben."
 msgid "could not write eol to '%s'"
 msgstr "Konnte EOL nicht nach '%s' schreiben."
 
-#: sequencer.c:446 sequencer.c:2866 sequencer.c:3068 sequencer.c:3082
-#: sequencer.c:3345
+#: sequencer.c:446 sequencer.c:2874 sequencer.c:3076 sequencer.c:3090
+#: sequencer.c:3353
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "Fehler beim Fertigstellen von '%s'."
@@ -6931,7 +7557,7 @@ msgstr ""
 msgid "%s: fast-forward"
 msgstr "%s: Vorspulen"
 
-#: sequencer.c:560 builtin/tag.c:566
+#: sequencer.c:560 builtin/tag.c:598
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Ungültiger \"cleanup\" Modus %s"
@@ -6944,60 +7570,60 @@ msgstr "Ungültiger \"cleanup\" Modus %s"
 msgid "%s: Unable to write new index file"
 msgstr "%s: Konnte neue Index-Datei nicht schreiben"
 
-#: sequencer.c:687
+#: sequencer.c:684
 msgid "unable to update cache tree"
 msgstr "Konnte Cache-Verzeichnis nicht aktualisieren."
 
-#: sequencer.c:701
+#: sequencer.c:698
 msgid "could not resolve HEAD commit"
 msgstr "Konnte HEAD-Commit nicht auflösen."
 
-#: sequencer.c:781
+#: sequencer.c:778
 #, c-format
 msgid "no key present in '%.*s'"
 msgstr "Kein Schlüssel in '%.*s' vorhanden."
 
-#: sequencer.c:792
+#: sequencer.c:789
 #, c-format
 msgid "unable to dequote value of '%s'"
 msgstr "Konnte Anführungszeichen von '%s' nicht entfernen."
 
-#: sequencer.c:829 wrapper.c:201 wrapper.c:371 builtin/am.c:710
-#: builtin/am.c:802 builtin/merge.c:1135 builtin/rebase.c:908
+#: sequencer.c:826 wrapper.c:201 wrapper.c:371 builtin/am.c:710
+#: builtin/am.c:802 builtin/merge.c:1136 builtin/rebase.c:910
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "Konnte '%s' nicht zum Lesen öffnen."
 
-#: sequencer.c:839
+#: sequencer.c:836
 msgid "'GIT_AUTHOR_NAME' already given"
 msgstr "'GIT_AUTHOR_NAME' bereits angegeben."
 
-#: sequencer.c:844
+#: sequencer.c:841
 msgid "'GIT_AUTHOR_EMAIL' already given"
 msgstr "'GIT_AUTHOR_EMAIL' bereits angegeben."
 
-#: sequencer.c:849
+#: sequencer.c:846
 msgid "'GIT_AUTHOR_DATE' already given"
 msgstr "'GIT_AUTHOR_DATE' bereits angegeben."
 
-#: sequencer.c:853
+#: sequencer.c:850
 #, c-format
 msgid "unknown variable '%s'"
 msgstr "Unbekannte Variable '%s'"
 
-#: sequencer.c:858
+#: sequencer.c:855
 msgid "missing 'GIT_AUTHOR_NAME'"
 msgstr "'GIT_AUTHOR_NAME' fehlt."
 
-#: sequencer.c:860
+#: sequencer.c:857
 msgid "missing 'GIT_AUTHOR_EMAIL'"
 msgstr "'GIT_AUTHOR_EMAIL' fehlt."
 
-#: sequencer.c:862
+#: sequencer.c:859
 msgid "missing 'GIT_AUTHOR_DATE'"
 msgstr "'GIT_AUTHOR_DATE' fehlt."
 
-#: sequencer.c:927
+#: sequencer.c:924
 #, c-format
 msgid ""
 "you have staged changes in your working tree\n"
@@ -7028,11 +7654,11 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:1208
+#: sequencer.c:1211
 msgid "'prepare-commit-msg' hook failed"
 msgstr "'prepare-commit-msg' Hook fehlgeschlagen."
 
-#: sequencer.c:1214
+#: sequencer.c:1217
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7060,7 +7686,7 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1227
+#: sequencer.c:1230
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7086,340 +7712,340 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1269
+#: sequencer.c:1272
 msgid "couldn't look up newly created commit"
 msgstr "Konnte neu erstellten Commit nicht nachschlagen."
 
-#: sequencer.c:1271
+#: sequencer.c:1274
 msgid "could not parse newly created commit"
 msgstr "Konnte neu erstellten Commit nicht analysieren."
 
-#: sequencer.c:1317
+#: sequencer.c:1320
 msgid "unable to resolve HEAD after creating commit"
 msgstr "Konnte HEAD nicht auflösen, nachdem der Commit erstellt wurde."
 
-#: sequencer.c:1319
+#: sequencer.c:1322
 msgid "detached HEAD"
 msgstr "losgelöster HEAD"
 
-#: sequencer.c:1323
+#: sequencer.c:1326
 msgid " (root-commit)"
 msgstr " (Root-Commit)"
 
-#: sequencer.c:1344
+#: sequencer.c:1347
 msgid "could not parse HEAD"
 msgstr "Konnte HEAD nicht parsen."
 
-#: sequencer.c:1346
+#: sequencer.c:1349
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "HEAD %s ist kein Commit!"
 
-#: sequencer.c:1350 sequencer.c:1425 builtin/commit.c:1577
+#: sequencer.c:1353 sequencer.c:1431 builtin/commit.c:1577
 msgid "could not parse HEAD commit"
 msgstr "Konnte Commit von HEAD nicht analysieren."
 
-#: sequencer.c:1403 sequencer.c:2100
+#: sequencer.c:1409 sequencer.c:2108
 msgid "unable to parse commit author"
 msgstr "Konnte Commit-Autor nicht parsen."
 
-#: sequencer.c:1414 builtin/am.c:1566 builtin/merge.c:701
+#: sequencer.c:1420 builtin/am.c:1566 builtin/merge.c:702
 msgid "git write-tree failed to write a tree"
 msgstr "\"git write-tree\" schlug beim Schreiben eines \"Tree\"-Objektes fehl"
 
-#: sequencer.c:1447 sequencer.c:1565
+#: sequencer.c:1453 sequencer.c:1573
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "Konnte Commit-Beschreibung von '%s' nicht lesen."
 
-#: sequencer.c:1476 sequencer.c:1508
+#: sequencer.c:1484 sequencer.c:1516
 #, c-format
 msgid "invalid author identity '%s'"
 msgstr "ungültige Autor-Identität '%s'"
 
-#: sequencer.c:1482
+#: sequencer.c:1490
 msgid "corrupt author: missing date information"
 msgstr "unbrauchbarer Autor: Datumsinformationen fehlen"
 
-#: sequencer.c:1521 builtin/am.c:1593 builtin/commit.c:1678 builtin/merge.c:904
-#: builtin/merge.c:929 t/helper/test-fast-rebase.c:78
+#: sequencer.c:1529 builtin/am.c:1593 builtin/commit.c:1678 builtin/merge.c:905
+#: builtin/merge.c:930 t/helper/test-fast-rebase.c:78
 msgid "failed to write commit object"
 msgstr "Fehler beim Schreiben des Commit-Objektes."
 
-#: sequencer.c:1548 sequencer.c:4283 t/helper/test-fast-rebase.c:198
+#: sequencer.c:1556 sequencer.c:4291 t/helper/test-fast-rebase.c:198
 #, c-format
 msgid "could not update %s"
 msgstr "Konnte %s nicht aktualisieren."
 
-#: sequencer.c:1597
+#: sequencer.c:1605
 #, c-format
 msgid "could not parse commit %s"
 msgstr "Konnte Commit %s nicht parsen."
 
-#: sequencer.c:1602
+#: sequencer.c:1610
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "Konnte Eltern-Commit %s nicht parsen."
 
-#: sequencer.c:1685 sequencer.c:1796
+#: sequencer.c:1693 sequencer.c:1804
 #, c-format
 msgid "unknown command: %d"
 msgstr "Unbekannter Befehl: %d"
 
-#: sequencer.c:1743 sequencer.c:1768
+#: sequencer.c:1751 sequencer.c:1776
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr "Das ist eine Kombination aus %d Commits."
 
-#: sequencer.c:1753
+#: sequencer.c:1761
 msgid "need a HEAD to fixup"
 msgstr "benötige HEAD für fixup"
 
-#: sequencer.c:1755 sequencer.c:3372
+#: sequencer.c:1763 sequencer.c:3380
 msgid "could not read HEAD"
 msgstr "Konnte HEAD nicht lesen"
 
-#: sequencer.c:1757
+#: sequencer.c:1765
 msgid "could not read HEAD's commit message"
 msgstr "Konnte Commit-Beschreibung von HEAD nicht lesen"
 
-#: sequencer.c:1763
+#: sequencer.c:1771
 #, c-format
 msgid "cannot write '%s'"
 msgstr "kann '%s' nicht schreiben"
 
-#: sequencer.c:1770 git-rebase--preserve-merges.sh:486
+#: sequencer.c:1778 git-rebase--preserve-merges.sh:486
 msgid "This is the 1st commit message:"
 msgstr "Das ist die erste Commit-Beschreibung:"
 
-#: sequencer.c:1778
+#: sequencer.c:1786
 #, c-format
 msgid "could not read commit message of %s"
 msgstr "Konnte Commit-Beschreibung von %s nicht lesen."
 
-#: sequencer.c:1785
+#: sequencer.c:1793
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "Das ist Commit-Beschreibung #%d:"
 
-#: sequencer.c:1791
+#: sequencer.c:1799
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "Die Commit-Beschreibung #%d wird ausgelassen:"
 
-#: sequencer.c:1879
+#: sequencer.c:1887
 msgid "your index file is unmerged."
 msgstr "Ihre Index-Datei ist nicht zusammengeführt."
 
-#: sequencer.c:1886
+#: sequencer.c:1894
 msgid "cannot fixup root commit"
 msgstr "kann fixup nicht auf Root-Commit anwenden"
 
-#: sequencer.c:1905
+#: sequencer.c:1913
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "Commit %s ist ein Merge, aber die Option -m wurde nicht angegeben."
 
-#: sequencer.c:1913 sequencer.c:1921
+#: sequencer.c:1921 sequencer.c:1929
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "Commit %s hat keinen Eltern-Commit %d"
 
-#: sequencer.c:1927
+#: sequencer.c:1935
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "Kann keine Commit-Beschreibung für %s bekommen."
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:1946
+#: sequencer.c:1954
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: kann Eltern-Commit %s nicht parsen"
 
-#: sequencer.c:2011
+#: sequencer.c:2019
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "Konnte '%s' nicht zu '%s' umbenennen."
 
-#: sequencer.c:2071
+#: sequencer.c:2079
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "Konnte \"revert\" nicht auf %s... (%s) ausführen"
 
-#: sequencer.c:2072
+#: sequencer.c:2080
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "Konnte %s... (%s) nicht anwenden"
 
-#: sequencer.c:2092
+#: sequencer.c:2100
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr "Weglassen von %s %s -- Patch-Inhalte sind bereits im Upstream-Branch\n"
 
-#: sequencer.c:2150
+#: sequencer.c:2158
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: Fehler beim Lesen des Index"
 
-#: sequencer.c:2157
+#: sequencer.c:2165
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: Fehler beim Aktualisieren des Index"
 
-#: sequencer.c:2234
+#: sequencer.c:2242
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "%s akzeptiert keine Argumente: '%s'"
 
-#: sequencer.c:2243
+#: sequencer.c:2251
 #, c-format
 msgid "missing arguments for %s"
 msgstr "Fehlende Argumente für %s."
 
-#: sequencer.c:2274
+#: sequencer.c:2282
 #, c-format
 msgid "could not parse '%s'"
 msgstr "Konnte '%s' nicht parsen."
 
-#: sequencer.c:2335
+#: sequencer.c:2343
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "Ungültige Zeile %d: %.*s"
 
-#: sequencer.c:2346
+#: sequencer.c:2354
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "Kann '%s' nicht ohne vorherigen Commit ausführen"
 
-#: sequencer.c:2432
+#: sequencer.c:2440
 msgid "cancelling a cherry picking in progress"
 msgstr "Abbrechen eines laufenden \"cherry-pick\""
 
-#: sequencer.c:2441
+#: sequencer.c:2449
 msgid "cancelling a revert in progress"
 msgstr "Abbrechen eines laufenden \"revert\""
 
-#: sequencer.c:2485
+#: sequencer.c:2493
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr ""
 "Bitte beheben Sie dieses, indem Sie 'git rebase --edit-todo' ausführen."
 
-#: sequencer.c:2487
+#: sequencer.c:2495
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "Unbenutzbares Instruktionsblatt: '%s'"
 
-#: sequencer.c:2492
+#: sequencer.c:2500
 msgid "no commits parsed."
 msgstr "Keine Commits geparst."
 
-#: sequencer.c:2503
+#: sequencer.c:2511
 msgid "cannot cherry-pick during a revert."
 msgstr "Kann Cherry-Pick nicht während eines Reverts ausführen."
 
-#: sequencer.c:2505
+#: sequencer.c:2513
 msgid "cannot revert during a cherry-pick."
 msgstr "Kann Revert nicht während eines Cherry-Picks ausführen."
 
-#: sequencer.c:2583
+#: sequencer.c:2591
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr "Ungültiger Wert für %s: %s"
 
-#: sequencer.c:2690
+#: sequencer.c:2698
 msgid "unusable squash-onto"
 msgstr "Unbenutzbares squash-onto."
 
-#: sequencer.c:2710
+#: sequencer.c:2718
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "Fehlerhaftes Optionsblatt: '%s'"
 
-#: sequencer.c:2803 sequencer.c:4636
+#: sequencer.c:2811 sequencer.c:4644
 msgid "empty commit set passed"
 msgstr "leere Menge von Commits übergeben"
 
-#: sequencer.c:2820
+#: sequencer.c:2828
 msgid "revert is already in progress"
 msgstr "\"revert\" ist bereits im Gange"
 
-#: sequencer.c:2822
+#: sequencer.c:2830
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr "Versuchen Sie \"git revert (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:2825
+#: sequencer.c:2833
 msgid "cherry-pick is already in progress"
 msgstr "\"cherry-pick\" wird bereits durchgeführt"
 
-#: sequencer.c:2827
+#: sequencer.c:2835
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr "Versuchen Sie \"git cherry-pick (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:2841
+#: sequencer.c:2849
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr "Konnte \"sequencer\"-Verzeichnis '%s' nicht erstellen."
 
-#: sequencer.c:2856
+#: sequencer.c:2864
 msgid "could not lock HEAD"
 msgstr "Konnte HEAD nicht sperren"
 
-#: sequencer.c:2916 sequencer.c:4371
+#: sequencer.c:2924 sequencer.c:4379
 msgid "no cherry-pick or revert in progress"
 msgstr "kein \"cherry-pick\" oder \"revert\" im Gange"
 
-#: sequencer.c:2918 sequencer.c:2929
+#: sequencer.c:2926 sequencer.c:2937
 msgid "cannot resolve HEAD"
 msgstr "kann HEAD nicht auflösen"
 
-#: sequencer.c:2920 sequencer.c:2964
+#: sequencer.c:2928 sequencer.c:2972
 msgid "cannot abort from a branch yet to be born"
 msgstr "kann nicht abbrechen: bin auf einem Branch, der noch nicht geboren ist"
 
-#: sequencer.c:2950 builtin/grep.c:756
+#: sequencer.c:2958 builtin/grep.c:757
 #, c-format
 msgid "cannot open '%s'"
 msgstr "kann '%s' nicht öffnen"
 
-#: sequencer.c:2952
+#: sequencer.c:2960
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "Kann '%s' nicht lesen: %s"
 
-#: sequencer.c:2953
+#: sequencer.c:2961
 msgid "unexpected end of file"
 msgstr "Unerwartetes Dateiende"
 
-#: sequencer.c:2959
+#: sequencer.c:2967
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr "gespeicherte \"pre-cherry-pick\" HEAD Datei '%s' ist beschädigt"
 
-#: sequencer.c:2970
+#: sequencer.c:2978
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr ""
 "Sie scheinen HEAD verändert zu haben. Keine Rückspulung, prüfen Sie HEAD."
 
-#: sequencer.c:3011
+#: sequencer.c:3019
 msgid "no revert in progress"
 msgstr "Kein Revert im Gange"
 
-#: sequencer.c:3020
+#: sequencer.c:3028
 msgid "no cherry-pick in progress"
 msgstr "kein \"cherry-pick\" im Gange"
 
-#: sequencer.c:3030
+#: sequencer.c:3038
 msgid "failed to skip the commit"
 msgstr "Überspringen des Commits fehlgeschlagen"
 
-#: sequencer.c:3037
+#: sequencer.c:3045
 msgid "there is nothing to skip"
 msgstr "Nichts zum Überspringen vorhanden"
 
-#: sequencer.c:3040
+#: sequencer.c:3048
 #, c-format
 msgid ""
 "have you committed already?\n"
@@ -7428,16 +8054,16 @@ msgstr ""
 "Haben Sie bereits committet?\n"
 "Versuchen Sie \"git %s --continue\""
 
-#: sequencer.c:3202 sequencer.c:4263
+#: sequencer.c:3210 sequencer.c:4271
 msgid "cannot read HEAD"
 msgstr "Kann HEAD nicht lesen"
 
-#: sequencer.c:3219
+#: sequencer.c:3227
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "Konnte '%s' nicht nach '%s' kopieren."
 
-#: sequencer.c:3227
+#: sequencer.c:3235
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -7456,27 +8082,27 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:3237
+#: sequencer.c:3245
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "Konnte %s... (%.*s) nicht anwenden"
 
-#: sequencer.c:3244
+#: sequencer.c:3252
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "Konnte \"%.*s\" nicht zusammenführen."
 
-#: sequencer.c:3258 sequencer.c:3262 builtin/difftool.c:640
+#: sequencer.c:3266 sequencer.c:3270 builtin/difftool.c:640
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "Konnte '%s' nicht nach '%s' kopieren."
 
-#: sequencer.c:3274
+#: sequencer.c:3282
 #, c-format
 msgid "Executing: %s\n"
 msgstr "Führe aus: %s\n"
 
-#: sequencer.c:3289
+#: sequencer.c:3297
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -7492,11 +8118,11 @@ msgstr ""
 "\n"
 "ausführen.\n"
 
-#: sequencer.c:3295
+#: sequencer.c:3303
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "Der Index und/oder das Arbeitsverzeichnis wurde geändert.\n"
 
-#: sequencer.c:3301
+#: sequencer.c:3309
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -7514,91 +8140,91 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3362
+#: sequencer.c:3370
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "Unerlaubter Beschriftungsname: '%.*s'"
 
-#: sequencer.c:3416
+#: sequencer.c:3424
 msgid "writing fake root commit"
 msgstr "unechten Root-Commit schreiben"
 
-#: sequencer.c:3421
+#: sequencer.c:3429
 msgid "writing squash-onto"
 msgstr "squash-onto schreiben"
 
-#: sequencer.c:3505
+#: sequencer.c:3513
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "Konnte '%s' nicht auflösen."
 
-#: sequencer.c:3538
+#: sequencer.c:3546
 msgid "cannot merge without a current revision"
 msgstr "Kann nicht ohne einen aktuellen Commit mergen."
 
-#: sequencer.c:3560
+#: sequencer.c:3568
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "Konnte '%.*s' nicht parsen."
 
-#: sequencer.c:3569
+#: sequencer.c:3577
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "Nichts zum Zusammenführen: '%.*s'"
 
-#: sequencer.c:3581
+#: sequencer.c:3589
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr ""
 "Oktopus-Merge kann nicht auf Basis von [neuem Root-Commit] ausgeführt werden."
 
-#: sequencer.c:3597
+#: sequencer.c:3605
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "Konnte keine Commit-Beschreibung von '%s' bekommen."
 
-#: sequencer.c:3780
+#: sequencer.c:3788
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "Konnte nicht einmal versuchen '%.*s' zu mergen."
 
-#: sequencer.c:3796
+#: sequencer.c:3804
 msgid "merge: Unable to write new index file"
 msgstr "merge: Konnte neue Index-Datei nicht schreiben."
 
-#: sequencer.c:3870
+#: sequencer.c:3878
 msgid "Cannot autostash"
 msgstr "Kann automatischen Stash nicht erzeugen."
 
-#: sequencer.c:3873
+#: sequencer.c:3881
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Unerwartete 'stash'-Antwort: '%s'"
 
-#: sequencer.c:3879
+#: sequencer.c:3887
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "Konnte Verzeichnis für '%s' nicht erstellen."
 
-#: sequencer.c:3882
+#: sequencer.c:3890
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "Automatischen Stash erzeugt: %s\n"
 
-#: sequencer.c:3886
+#: sequencer.c:3894
 msgid "could not reset --hard"
 msgstr "Konnte 'reset --hard' nicht ausführen."
 
-#: sequencer.c:3911
+#: sequencer.c:3919
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "Automatischen Stash angewendet.\n"
 
-#: sequencer.c:3923
+#: sequencer.c:3931
 #, c-format
 msgid "cannot store %s"
 msgstr "kann %s nicht speichern"
 
-#: sequencer.c:3926
+#: sequencer.c:3934
 #, c-format
 msgid ""
 "%s\n"
@@ -7609,29 +8235,29 @@ msgstr ""
 "Ihre Änderungen sind im Stash sicher.\n"
 "Sie können jederzeit \"git stash pop\" oder \"git stash drop\" ausführen.\n"
 
-#: sequencer.c:3931
+#: sequencer.c:3939
 msgid "Applying autostash resulted in conflicts."
 msgstr "Beim Anwenden des automatischen Stash traten Konflikte auf."
 
-#: sequencer.c:3932
+#: sequencer.c:3940
 msgid "Autostash exists; creating a new stash entry."
 msgstr "Automatischer Stash existiert; ein neuer Stash-Eintrag wird erstellt."
 
-#: sequencer.c:4025 git-rebase--preserve-merges.sh:769
+#: sequencer.c:4033 git-rebase--preserve-merges.sh:769
 msgid "could not detach HEAD"
 msgstr "Konnte HEAD nicht loslösen"
 
-#: sequencer.c:4040
+#: sequencer.c:4048
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Angehalten bei HEAD\n"
 
-#: sequencer.c:4042
+#: sequencer.c:4050
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Angehalten bei %s\n"
 
-#: sequencer.c:4050
+#: sequencer.c:4058
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -7653,60 +8279,60 @@ msgstr ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:4096
+#: sequencer.c:4104
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr "Rebase (%d/%d)%s"
 
-#: sequencer.c:4141
+#: sequencer.c:4149
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Angehalten bei %s... %.*s\n"
 
-#: sequencer.c:4212
+#: sequencer.c:4220
 #, c-format
 msgid "unknown command %d"
 msgstr "Unbekannter Befehl %d"
 
-#: sequencer.c:4271
+#: sequencer.c:4279
 msgid "could not read orig-head"
 msgstr "Konnte orig-head nicht lesen."
 
-#: sequencer.c:4276
+#: sequencer.c:4284
 msgid "could not read 'onto'"
 msgstr "Konnte 'onto' nicht lesen."
 
-#: sequencer.c:4290
+#: sequencer.c:4298
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "Konnte HEAD nicht auf %s aktualisieren."
 
-#: sequencer.c:4350
+#: sequencer.c:4358
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr "Erfolgreich Rebase ausgeführt und %s aktualisiert.\n"
 
-#: sequencer.c:4383
+#: sequencer.c:4391
 msgid "cannot rebase: You have unstaged changes."
 msgstr ""
 "Rebase nicht möglich: Sie haben Änderungen, die nicht zum Commit\n"
 "vorgemerkt sind."
 
-#: sequencer.c:4392
+#: sequencer.c:4400
 msgid "cannot amend non-existing commit"
 msgstr "Kann nicht existierenden Commit nicht nachbessern."
 
-#: sequencer.c:4394
+#: sequencer.c:4402
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "Ungültige Datei: '%s'"
 
-#: sequencer.c:4396
+#: sequencer.c:4404
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "Ungültige Inhalte: '%s'"
 
-#: sequencer.c:4399
+#: sequencer.c:4407
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -7717,50 +8343,50 @@ msgstr ""
 "committen Sie diese zuerst und führen Sie dann 'git rebase --continue'\n"
 "erneut aus."
 
-#: sequencer.c:4435 sequencer.c:4474
+#: sequencer.c:4443 sequencer.c:4482
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "Konnte Datei nicht schreiben: '%s'"
 
-#: sequencer.c:4490
+#: sequencer.c:4498
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "Konnte CHERRY_PICK_HEAD nicht löschen."
 
-#: sequencer.c:4497
+#: sequencer.c:4505
 msgid "could not commit staged changes."
 msgstr "Konnte Änderungen aus der Staging-Area nicht committen."
 
-#: sequencer.c:4613
+#: sequencer.c:4621
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: %s kann nicht in \"cherry-pick\" benutzt werden"
 
-#: sequencer.c:4617
+#: sequencer.c:4625
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: ungültiger Commit"
 
-#: sequencer.c:4652
+#: sequencer.c:4660
 msgid "can't revert as initial commit"
 msgstr "Kann nicht als allerersten Commit einen Revert ausführen."
 
-#: sequencer.c:5129
+#: sequencer.c:5137
 msgid "make_script: unhandled options"
 msgstr "make_script: unbehandelte Optionen"
 
-#: sequencer.c:5132
+#: sequencer.c:5140
 msgid "make_script: error preparing revisions"
 msgstr "make_script: Fehler beim Vorbereiten der Commits"
 
-#: sequencer.c:5374 sequencer.c:5391
+#: sequencer.c:5382 sequencer.c:5399
 msgid "nothing to do"
 msgstr "Nichts zu tun."
 
-#: sequencer.c:5410
+#: sequencer.c:5418
 msgid "could not skip unnecessary pick commands"
 msgstr "Konnte unnötige \"pick\"-Befehle nicht auslassen."
 
-#: sequencer.c:5504
+#: sequencer.c:5512
 msgid "the script was already rearranged."
 msgstr "Das Script wurde bereits umgeordnet."
 
@@ -7929,370 +8555,6 @@ msgstr "fork fehlgeschlagen"
 msgid "setsid failed"
 msgstr "setsid fehlgeschlagen"
 
-#: sha1-file.c:480
-#, c-format
-msgid "object directory %s does not exist; check .git/objects/info/alternates"
-msgstr ""
-"Objektverzeichnis %s existiert nicht; prüfe .git/objects/info/alternates"
-
-#: sha1-file.c:531
-#, c-format
-msgid "unable to normalize alternate object path: %s"
-msgstr "Konnte alternativen Objektpfad '%s' nicht normalisieren."
-
-#: sha1-file.c:603
-#, c-format
-msgid "%s: ignoring alternate object stores, nesting too deep"
-msgstr "%s: ignoriere alternative Objektspeicher - Verschachtelung zu tief"
-
-#: sha1-file.c:610
-#, c-format
-msgid "unable to normalize object directory: %s"
-msgstr "Konnte Objektverzeichnis '%s' nicht normalisieren."
-
-#: sha1-file.c:653
-msgid "unable to fdopen alternates lockfile"
-msgstr "Konnte fdopen nicht auf Lock-Datei für \"alternates\" aufrufen."
-
-#: sha1-file.c:671
-msgid "unable to read alternates file"
-msgstr "Konnte \"alternates\"-Datei nicht lesen."
-
-#: sha1-file.c:678
-msgid "unable to move new alternates file into place"
-msgstr "Konnte neue \"alternates\"-Datei nicht übernehmen."
-
-#: sha1-file.c:713
-#, c-format
-msgid "path '%s' does not exist"
-msgstr "Pfad '%s' existiert nicht"
-
-#: sha1-file.c:734
-#, c-format
-msgid "reference repository '%s' as a linked checkout is not supported yet."
-msgstr ""
-"Referenziertes Repository '%s' wird noch nicht als verknüpftes\n"
-"Arbeitsverzeichnis unterstützt."
-
-#: sha1-file.c:740
-#, c-format
-msgid "reference repository '%s' is not a local repository."
-msgstr "Referenziertes Repository '%s' ist kein lokales Repository."
-
-#: sha1-file.c:746
-#, c-format
-msgid "reference repository '%s' is shallow"
-msgstr ""
-"Referenziertes Repository '%s' hat eine unvollständige Historie (shallow)."
-
-#: sha1-file.c:754
-#, c-format
-msgid "reference repository '%s' is grafted"
-msgstr ""
-"Referenziertes Repository '%s' ist mit künstlichen Vorgängern (\"grafts\") "
-"eingehängt."
-
-#: sha1-file.c:814
-#, c-format
-msgid "invalid line while parsing alternate refs: %s"
-msgstr "Ungültige Zeile beim Parsen alternativer Referenzen: %s"
-
-#: sha1-file.c:964
-#, c-format
-msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
-msgstr "Versuche mmap %<PRIuMAX> über Limit %<PRIuMAX>."
-
-#: sha1-file.c:985
-msgid "mmap failed"
-msgstr "mmap fehlgeschlagen"
-
-#: sha1-file.c:1149
-#, c-format
-msgid "object file %s is empty"
-msgstr "Objektdatei %s ist leer."
-
-#: sha1-file.c:1284 sha1-file.c:2477
-#, c-format
-msgid "corrupt loose object '%s'"
-msgstr "Fehlerhaftes loses Objekt '%s'."
-
-#: sha1-file.c:1286 sha1-file.c:2481
-#, c-format
-msgid "garbage at end of loose object '%s'"
-msgstr "Nutzlose Daten am Ende von losem Objekt '%s'."
-
-#: sha1-file.c:1328
-msgid "invalid object type"
-msgstr "ungültiger Objekt-Typ"
-
-#: sha1-file.c:1412
-#, c-format
-msgid "unable to unpack %s header with --allow-unknown-type"
-msgstr "Konnte %s Kopfbereich nicht mit --allow-unknown-type entpacken."
-
-#: sha1-file.c:1415
-#, c-format
-msgid "unable to unpack %s header"
-msgstr "Konnte %s Kopfbereich nicht entpacken."
-
-#: sha1-file.c:1421
-#, c-format
-msgid "unable to parse %s header with --allow-unknown-type"
-msgstr "Konnte %s Kopfbereich mit --allow-unknown-type nicht parsen."
-
-#: sha1-file.c:1424
-#, c-format
-msgid "unable to parse %s header"
-msgstr "Konnte %s Kopfbereich nicht parsen."
-
-#: sha1-file.c:1651
-#, c-format
-msgid "failed to read object %s"
-msgstr "Konnte Objekt %s nicht lesen."
-
-#: sha1-file.c:1655
-#, c-format
-msgid "replacement %s not found for %s"
-msgstr "Ersetzung %s für %s nicht gefunden."
-
-#: sha1-file.c:1659
-#, c-format
-msgid "loose object %s (stored in %s) is corrupt"
-msgstr "Loses Objekt %s (gespeichert in %s) ist beschädigt."
-
-#: sha1-file.c:1663
-#, c-format
-msgid "packed object %s (stored in %s) is corrupt"
-msgstr "Gepacktes Objekt %s (gespeichert in %s) ist beschädigt."
-
-#: sha1-file.c:1768
-#, c-format
-msgid "unable to write file %s"
-msgstr "Konnte Datei %s nicht schreiben."
-
-#: sha1-file.c:1775
-#, c-format
-msgid "unable to set permission to '%s'"
-msgstr "Konnte Zugriffsberechtigung auf '%s' nicht setzen."
-
-#: sha1-file.c:1782
-msgid "file write error"
-msgstr "Fehler beim Schreiben einer Datei."
-
-#: sha1-file.c:1802
-msgid "error when closing loose object file"
-msgstr "Fehler beim Schließen der Datei für lose Objekte."
-
-#: sha1-file.c:1867
-#, c-format
-msgid "insufficient permission for adding an object to repository database %s"
-msgstr ""
-"Unzureichende Berechtigung zum Hinzufügen eines Objektes zur Repository-"
-"Datenbank %s"
-
-#: sha1-file.c:1869
-msgid "unable to create temporary file"
-msgstr "Konnte temporäre Datei nicht erstellen."
-
-#: sha1-file.c:1893
-msgid "unable to write loose object file"
-msgstr "Fehler beim Schreiben der Datei für lose Objekte."
-
-#: sha1-file.c:1899
-#, c-format
-msgid "unable to deflate new object %s (%d)"
-msgstr "Konnte neues Objekt %s (%d) nicht komprimieren."
-
-#: sha1-file.c:1903
-#, c-format
-msgid "deflateEnd on object %s failed (%d)"
-msgstr "deflateEnd auf Objekt %s fehlgeschlagen (%d)"
-
-#: sha1-file.c:1907
-#, c-format
-msgid "confused by unstable object source data for %s"
-msgstr "Fehler wegen instabilen Objektquelldaten für %s"
-
-#: sha1-file.c:1917 builtin/pack-objects.c:1086
-#, c-format
-msgid "failed utime() on %s"
-msgstr "Fehler beim Aufruf von utime() auf '%s'."
-
-#: sha1-file.c:1994
-#, c-format
-msgid "cannot read object for %s"
-msgstr "Kann Objekt für %s nicht lesen."
-
-#: sha1-file.c:2045
-msgid "corrupt commit"
-msgstr "fehlerhafter Commit"
-
-#: sha1-file.c:2053
-msgid "corrupt tag"
-msgstr "fehlerhaftes Tag"
-
-#: sha1-file.c:2153
-#, c-format
-msgid "read error while indexing %s"
-msgstr "Lesefehler beim Indizieren von '%s'."
-
-#: sha1-file.c:2156
-#, c-format
-msgid "short read while indexing %s"
-msgstr "read() zu kurz beim Indizieren von '%s'."
-
-#: sha1-file.c:2229 sha1-file.c:2239
-#, c-format
-msgid "%s: failed to insert into database"
-msgstr "%s: Fehler beim Einfügen in die Datenbank"
-
-#: sha1-file.c:2245
-#, c-format
-msgid "%s: unsupported file type"
-msgstr "%s: nicht unterstützte Dateiart"
-
-#: sha1-file.c:2269
-#, c-format
-msgid "%s is not a valid object"
-msgstr "%s ist kein gültiges Objekt"
-
-#: sha1-file.c:2271
-#, c-format
-msgid "%s is not a valid '%s' object"
-msgstr "%s ist kein gültiges '%s' Objekt"
-
-#: sha1-file.c:2298 builtin/index-pack.c:192
-#, c-format
-msgid "unable to open %s"
-msgstr "kann %s nicht öffnen"
-
-#: sha1-file.c:2488 sha1-file.c:2541
-#, c-format
-msgid "hash mismatch for %s (expected %s)"
-msgstr "Hash für %s stimmt nicht überein (%s erwartet)."
-
-#: sha1-file.c:2512
-#, c-format
-msgid "unable to mmap %s"
-msgstr "Konnte mmap nicht auf %s ausführen."
-
-#: sha1-file.c:2517
-#, c-format
-msgid "unable to unpack header of %s"
-msgstr "Konnte Kopfbereich von %s nicht entpacken."
-
-#: sha1-file.c:2523
-#, c-format
-msgid "unable to parse header of %s"
-msgstr "Konnte Kopfbereich von %s nicht parsen."
-
-#: sha1-file.c:2534
-#, c-format
-msgid "unable to unpack contents of %s"
-msgstr "Konnte Inhalt von %s nicht entpacken."
-
-#: sha1-name.c:486
-#, c-format
-msgid "short SHA1 %s is ambiguous"
-msgstr "Kurzer SHA-1 %s ist mehrdeutig."
-
-#: sha1-name.c:497
-msgid "The candidates are:"
-msgstr "Die Kandidaten sind:"
-
-#: sha1-name.c:796
-msgid ""
-"Git normally never creates a ref that ends with 40 hex characters\n"
-"because it will be ignored when you just specify 40-hex. These refs\n"
-"may be created by mistake. For example,\n"
-"\n"
-"  git switch -c $br $(git rev-parse ...)\n"
-"\n"
-"where \"$br\" is somehow empty and a 40-hex ref is created. Please\n"
-"examine these refs and maybe delete them. Turn this message off by\n"
-"running \"git config advice.objectNameWarning false\""
-msgstr ""
-"Git erzeugt normalerweise keine Referenzen die mit\n"
-"40 Hex-Zeichen enden, da diese ignoriert werden wenn\n"
-"Sie diese angeben. Diese Referenzen könnten aus Versehen\n"
-"erzeugt worden sein. Zum Beispiel,\n"
-"\n"
-"  git switch -c $br $(git rev-parse ...)\n"
-"\n"
-"wobei \"$br\" leer ist und eine 40-Hex-Referenz erzeugt\n"
-"wurde. Bitte prüfen Sie diese Referenzen und löschen\n"
-"Sie sie gegebenenfalls. Unterdrücken Sie diese Meldung\n"
-"indem Sie \"git config advice.objectNameWarning false\"\n"
-"ausführen."
-
-#: sha1-name.c:916
-#, c-format
-msgid "log for '%.*s' only goes back to %s"
-msgstr "Log für '%.*s' geht nur bis %s zurück"
-
-#: sha1-name.c:924
-#, c-format
-msgid "log for '%.*s' only has %d entries"
-msgstr "Log für '%.*s' hat nur %d Einträge"
-
-#: sha1-name.c:1702
-#, c-format
-msgid "path '%s' exists on disk, but not in '%.*s'"
-msgstr "Pfad '%s' befindet sich im Dateisystem, aber nicht in '%.*s'"
-
-#: sha1-name.c:1708
-#, c-format
-msgid ""
-"path '%s' exists, but not '%s'\n"
-"hint: Did you mean '%.*s:%s' aka '%.*s:./%s'?"
-msgstr ""
-"Pfad '%s' existiert, aber nicht '%s'\n"
-"Hinweis: Meinten Sie '%.*s:%s' auch bekannt als '%.*s:./%s'?"
-
-#: sha1-name.c:1717
-#, c-format
-msgid "path '%s' does not exist in '%.*s'"
-msgstr "Pfad '%s' existiert nicht in '%.*s'"
-
-#: sha1-name.c:1745
-#, c-format
-msgid ""
-"path '%s' is in the index, but not at stage %d\n"
-"hint: Did you mean ':%d:%s'?"
-msgstr ""
-"Pfad '%s' ist im Index, aber nicht in Stufe %d\n"
-"Hinweis: Meinten Sie ':%d:%s'?"
-
-#: sha1-name.c:1761
-#, c-format
-msgid ""
-"path '%s' is in the index, but not '%s'\n"
-"hint: Did you mean ':%d:%s' aka ':%d:./%s'?"
-msgstr ""
-"Pfad '%s' ist im Index, aber nicht '%s'\n"
-"Hinweis: Meinten Sie ':%d:%s' auch bekannt als ':%d:./%s'?"
-
-#: sha1-name.c:1769
-#, c-format
-msgid "path '%s' exists on disk, but not in the index"
-msgstr "Pfad '%s' existiert im Dateisystem, aber nicht im Index"
-
-#: sha1-name.c:1771
-#, c-format
-msgid "path '%s' does not exist (neither on disk nor in the index)"
-msgstr "Pfad '%s' existiert nicht (weder im Dateisystem noch im Index)"
-
-#: sha1-name.c:1784
-msgid "relative path syntax can't be used outside working tree"
-msgstr ""
-"Die Syntax für relative Pfade kann nicht außerhalb des Arbeitsverzeichnisses "
-"benutzt werden."
-
-#: sha1-name.c:1922
-#, c-format
-msgid "invalid object name '%.*s'."
-msgstr "ungültiger Objektname '%.*s'."
-
 #. TRANSLATORS: IEC 80000-13:2008 gibibyte
 #: strbuf.c:848
 #, c-format
@@ -8346,7 +8608,7 @@ msgstr[0] "%u Byte/s"
 msgstr[1] "%u Bytes/s"
 
 #: strbuf.c:1166 wrapper.c:199 wrapper.c:369 builtin/am.c:719
-#: builtin/rebase.c:864
+#: builtin/rebase.c:866
 #, c-format
 msgid "could not open '%s' for writing"
 msgstr "Konnte '%s' nicht zum Schreiben öffnen."
@@ -8412,12 +8674,12 @@ msgstr "In nicht ausgechecktem Submodul '%s'."
 msgid "Pathspec '%s' is in submodule '%.*s'"
 msgstr "Pfadspezifikation '%s' befindet sich in Submodul '%.*s'"
 
-#: submodule.c:434
+#: submodule.c:435
 #, c-format
 msgid "bad --ignore-submodules argument: %s"
 msgstr "ungültiges --ignore-submodules Argument: %s"
 
-#: submodule.c:816
+#: submodule.c:817
 #, c-format
 msgid ""
 "Submodule in commit %s at path: '%s' collides with a submodule named the "
@@ -8426,12 +8688,12 @@ msgstr ""
 "Submodul in Commit %s beim Pfad: '%s' hat den gleichen Namen wie ein "
 "Submodul. Wird übersprungen."
 
-#: submodule.c:919
+#: submodule.c:920
 #, c-format
 msgid "submodule entry '%s' (%s) is a %s, not a commit"
 msgstr "Submodul-Eintrag '%s' (%s) ist ein %s, kein Commit."
 
-#: submodule.c:1004
+#: submodule.c:1005
 #, c-format
 msgid ""
 "Could not run 'git rev-list <commits> --not --remotes -n 1' command in "
@@ -8440,36 +8702,36 @@ msgstr ""
 "Konnte 'git rev-list <Commits> --not --remotes -n 1' nicht in Submodul '%s' "
 "ausführen."
 
-#: submodule.c:1127
+#: submodule.c:1128
 #, c-format
 msgid "process for submodule '%s' failed"
 msgstr "Prozess für Submodul '%s' fehlgeschlagen"
 
-#: submodule.c:1156 builtin/branch.c:680 builtin/submodule--helper.c:2469
+#: submodule.c:1157 builtin/branch.c:689 builtin/submodule--helper.c:2469
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "Konnte HEAD nicht als gültige Referenz auflösen."
 
-#: submodule.c:1167
+#: submodule.c:1168
 #, c-format
 msgid "Pushing submodule '%s'\n"
 msgstr "Pushe Submodul '%s'\n"
 
-#: submodule.c:1170
+#: submodule.c:1171
 #, c-format
 msgid "Unable to push submodule '%s'\n"
 msgstr "Kann Push für Submodul '%s' nicht ausführen\n"
 
-#: submodule.c:1462
+#: submodule.c:1463
 #, c-format
 msgid "Fetching submodule %s%s\n"
 msgstr "Anfordern des Submoduls %s%s\n"
 
-#: submodule.c:1492
+#: submodule.c:1497
 #, c-format
 msgid "Could not access submodule '%s'\n"
 msgstr "Konnte nicht auf Submodul '%s' zugreifen\n"
 
-#: submodule.c:1646
+#: submodule.c:1652
 #, c-format
 msgid ""
 "Errors during submodule fetch:\n"
@@ -8478,62 +8740,62 @@ msgstr ""
 "Fehler während des Anforderns der Submodule:\n"
 "%s"
 
-#: submodule.c:1671
+#: submodule.c:1677
 #, c-format
 msgid "'%s' not recognized as a git repository"
 msgstr "'%s' nicht als Git-Repository erkannt"
 
-#: submodule.c:1688
+#: submodule.c:1694
 #, c-format
 msgid "Could not run 'git status --porcelain=2' in submodule %s"
 msgstr "Konnte 'git status --porcelain=2' nicht in Submodul %s ausführen"
 
-#: submodule.c:1729
+#: submodule.c:1735
 #, c-format
 msgid "'git status --porcelain=2' failed in submodule %s"
 msgstr "'git status --porcelain=2' ist in Submodul %s fehlgeschlagen"
 
-#: submodule.c:1804
+#: submodule.c:1810
 #, c-format
 msgid "could not start 'git status' in submodule '%s'"
 msgstr "Konnte 'git status' in Submodul '%s' nicht starten."
 
-#: submodule.c:1817
+#: submodule.c:1823
 #, c-format
 msgid "could not run 'git status' in submodule '%s'"
 msgstr "Konnte 'git status' in Submodul '%s' nicht ausführen."
 
-#: submodule.c:1832
+#: submodule.c:1838
 #, c-format
 msgid "Could not unset core.worktree setting in submodule '%s'"
 msgstr "Konnte core.worktree Einstellung in Submodul '%s' nicht aufheben."
 
-#: submodule.c:1859 submodule.c:2169
+#: submodule.c:1865 submodule.c:2175
 #, c-format
 msgid "could not recurse into submodule '%s'"
 msgstr "Fehler bei Rekursion in Submodul-Pfad '%s'"
 
-#: submodule.c:1880
+#: submodule.c:1886
 msgid "could not reset submodule index"
 msgstr "konnte Index des Submoduls nicht zurücksetzen"
 
-#: submodule.c:1922
+#: submodule.c:1928
 #, c-format
 msgid "submodule '%s' has dirty index"
 msgstr "Submodul '%s' hat einen geänderten Index."
 
-#: submodule.c:1974
+#: submodule.c:1980
 #, c-format
 msgid "Submodule '%s' could not be updated."
 msgstr "Submodule '%s' konnte nicht aktualisiert werden."
 
-#: submodule.c:2042
+#: submodule.c:2048
 #, c-format
 msgid "submodule git dir '%s' is inside git dir '%.*s'"
 msgstr ""
 "Git-Verzeichnis des Submoduls '%s' ist im Git-Verzeichnis '%.*s' enthalten."
 
-#: submodule.c:2063
+#: submodule.c:2069
 #, c-format
 msgid ""
 "relocate_gitdir for submodule '%s' with more than one worktree not supported"
@@ -8541,17 +8803,17 @@ msgstr ""
 "relocate_gitdir für Submodul '%s' mit mehr als einem Arbeitsverzeichnis\n"
 "wird nicht unterstützt"
 
-#: submodule.c:2075 submodule.c:2134
+#: submodule.c:2081 submodule.c:2140
 #, c-format
 msgid "could not lookup name for submodule '%s'"
 msgstr "Konnte Name für Submodul '%s' nicht nachschlagen."
 
-#: submodule.c:2079
+#: submodule.c:2085
 #, c-format
 msgid "refusing to move '%s' into an existing git dir"
 msgstr "Verschieben von '%s' in ein existierendes Git-Verzeichnis verweigert."
 
-#: submodule.c:2086
+#: submodule.c:2092
 #, c-format
 msgid ""
 "Migrating git directory of '%s%s' from\n"
@@ -8562,11 +8824,11 @@ msgstr ""
 "'%s' nach\n"
 "'%s'\n"
 
-#: submodule.c:2214
+#: submodule.c:2220
 msgid "could not start ls-files in .."
 msgstr "Konnte 'ls-files' nicht in .. starten"
 
-#: submodule.c:2254
+#: submodule.c:2260
 #, c-format
 msgid "ls-tree returned unexpected return code %d"
 msgstr "ls-tree mit unerwartetem Rückgabewert %d beendet"
@@ -8597,7 +8859,7 @@ msgstr "leerer Anhang-Token in Anhang '%.*s'"
 msgid "could not read input file '%s'"
 msgstr "Konnte Eingabe-Datei '%s' nicht lesen"
 
-#: trailer.c:751
+#: trailer.c:751 builtin/mktag.c:91
 msgid "could not read from stdin"
 msgstr "konnte nicht von der Standard-Eingabe lesen"
 
@@ -8671,7 +8933,7 @@ msgstr "konnte \"fast-import\" nicht ausführen"
 msgid "error while running fast-import"
 msgstr "Fehler beim Ausführen von 'fast-import'."
 
-#: transport-helper.c:549 transport-helper.c:1236
+#: transport-helper.c:549 transport-helper.c:1237
 #, c-format
 msgid "could not read ref %s"
 msgstr "konnte Referenz %s nicht lesen"
@@ -8690,7 +8952,7 @@ msgstr ""
 msgid "invalid remote service path"
 msgstr "ungültiger Remote-Service Pfad."
 
-#: transport-helper.c:661 transport.c:1446
+#: transport-helper.c:661 transport.c:1447
 msgid "operation not supported by protocol"
 msgstr "die Operation wird von dem Protokoll nicht unterstützt"
 
@@ -8769,52 +9031,52 @@ msgstr ""
 "Keine gemeinsamen Referenzen und nichts spezifiziert; keine Ausführung.\n"
 "Vielleicht sollten Sie einen Branch angeben.\n"
 
-#: transport-helper.c:1213
+#: transport-helper.c:1214
 #, c-format
 msgid "unsupported object format '%s'"
 msgstr "nicht unterstütztes Objekt-Format '%s'"
 
-#: transport-helper.c:1222
+#: transport-helper.c:1223
 #, c-format
 msgid "malformed response in ref list: %s"
 msgstr "Ungültige Antwort in Referenzliste: %s"
 
-#: transport-helper.c:1374
+#: transport-helper.c:1375
 #, c-format
 msgid "read(%s) failed"
 msgstr "Lesen von %s fehlgeschlagen."
 
-#: transport-helper.c:1401
+#: transport-helper.c:1402
 #, c-format
 msgid "write(%s) failed"
 msgstr "Schreiben von %s fehlgeschlagen."
 
-#: transport-helper.c:1450
+#: transport-helper.c:1451
 #, c-format
 msgid "%s thread failed"
 msgstr "Thread %s fehlgeschlagen."
 
-#: transport-helper.c:1454
+#: transport-helper.c:1455
 #, c-format
 msgid "%s thread failed to join: %s"
 msgstr "Fehler beim Beitreten zu Thread %s: %s"
 
-#: transport-helper.c:1473 transport-helper.c:1477
+#: transport-helper.c:1474 transport-helper.c:1478
 #, c-format
 msgid "can't start thread for copying data: %s"
 msgstr "Kann Thread zum Kopieren von Daten nicht starten: %s"
 
-#: transport-helper.c:1514
+#: transport-helper.c:1515
 #, c-format
 msgid "%s process failed to wait"
 msgstr "Fehler beim Warten von Prozess %s."
 
-#: transport-helper.c:1518
+#: transport-helper.c:1519
 #, c-format
 msgid "%s process failed"
 msgstr "Prozess %s fehlgeschlagen"
 
-#: transport-helper.c:1536 transport-helper.c:1545
+#: transport-helper.c:1537 transport-helper.c:1546
 msgid "can't start thread for copying data"
 msgstr "Kann Thread zum Kopieren von Daten nicht starten."
 
@@ -8903,23 +9165,23 @@ msgstr ""
 msgid "Aborting."
 msgstr "Abbruch."
 
-#: transport.c:1315
+#: transport.c:1316
 msgid "failed to push all needed submodules"
 msgstr "Fehler beim Versand aller erforderlichen Submodule."
 
-#: tree-walk.c:32
+#: tree-walk.c:33
 msgid "too-short tree object"
 msgstr "zu kurzes Tree-Objekt"
 
-#: tree-walk.c:38
+#: tree-walk.c:39
 msgid "malformed mode in tree entry"
 msgstr "fehlerhafter Modus in Tree-Eintrag"
 
-#: tree-walk.c:42
+#: tree-walk.c:43
 msgid "empty filename in tree entry"
 msgstr "leerer Dateiname in Tree-Eintrag"
 
-#: tree-walk.c:117
+#: tree-walk.c:118
 msgid "too-short tree file"
 msgstr "zu kurze Tree-Datei"
 
@@ -9197,7 +9459,7 @@ msgstr ""
 msgid "Updating index flags"
 msgstr "Aktualisiere Index-Markierungen"
 
-#: upload-pack.c:1550
+#: upload-pack.c:1543
 msgid "expected flush after fetch arguments"
 msgstr "erwartete Flush nach Abrufen der Argumente"
 
@@ -9234,71 +9496,102 @@ msgstr "ungültiges '..' Pfadsegment"
 msgid "Fetching objects"
 msgstr "Anfordern der Objekte"
 
-#: worktree.c:236 builtin/am.c:2103
+#: worktree.c:238 builtin/am.c:2103
 #, c-format
 msgid "failed to read '%s'"
 msgstr "Fehler beim Lesen von '%s'"
 
-#: worktree.c:283
+#: worktree.c:304
 #, c-format
 msgid "'%s' at main working tree is not the repository directory"
 msgstr "'%s' im Hauptarbeitsverzeichnis ist nicht das Repository-Verzeichnis."
 
-#: worktree.c:294
+#: worktree.c:315
 #, c-format
 msgid "'%s' file does not contain absolute path to the working tree location"
 msgstr "'%s' Datei enthält nicht den absoluten Pfad zum Arbeitsverzeichnis."
 
-#: worktree.c:306
+#: worktree.c:327
 #, c-format
 msgid "'%s' does not exist"
 msgstr "'%s' existiert nicht."
 
-#: worktree.c:312
+#: worktree.c:333
 #, c-format
 msgid "'%s' is not a .git file, error code %d"
 msgstr "'%s' ist keine .git-Datei, Fehlercode %d"
 
-#: worktree.c:321
+#: worktree.c:342
 #, c-format
 msgid "'%s' does not point back to '%s'"
 msgstr "'%s' zeigt nicht zurück auf '%s'"
 
-#: worktree.c:587
+#: worktree.c:608
 msgid "not a directory"
 msgstr "kein Verzeichnis"
 
-#: worktree.c:596
+#: worktree.c:617
 msgid ".git is not a file"
 msgstr ".git ist keine Datei"
 
-#: worktree.c:598
+#: worktree.c:619
 msgid ".git file broken"
 msgstr ".git-Datei kaputt"
 
-#: worktree.c:600
+#: worktree.c:621
 msgid ".git file incorrect"
 msgstr ".git-Datei fehlerhaft"
 
-#: worktree.c:670
+#: worktree.c:727
 msgid "not a valid path"
 msgstr "kein gültiger Pfad"
 
-#: worktree.c:676
+#: worktree.c:733
 msgid "unable to locate repository; .git is not a file"
 msgstr "Konnte Repository nicht finden; .git ist keine Datei"
 
-#: worktree.c:679
+#: worktree.c:737
+#, fuzzy
+msgid "unable to locate repository; .git file does not reference a repository"
+msgstr "Konnte Repository nicht finden; .git ist keine Datei"
+
+#: worktree.c:741
 msgid "unable to locate repository; .git file broken"
 msgstr "Konnte Repository nicht finden; .git-Datei ist kaputt"
 
-#: worktree.c:685
+#: worktree.c:747
 msgid "gitdir unreadable"
 msgstr "gitdir nicht lesbar"
 
-#: worktree.c:689
+#: worktree.c:751
 msgid "gitdir incorrect"
 msgstr "gitdir fehlerhaft"
+
+#: worktree.c:776
+msgid "not a valid directory"
+msgstr "kein gültiges Verzeichnis"
+
+#: worktree.c:782
+msgid "gitdir file does not exist"
+msgstr "gitdir-Datei existiert nicht"
+
+#: worktree.c:787 worktree.c:796
+#, c-format
+msgid "unable to read gitdir file (%s)"
+msgstr "konnte gitdir-Datei nicht lesen (%s)"
+
+#: worktree.c:806
+#, c-format
+msgid "short read (expected %<PRIuMAX> bytes, read %<PRIuMAX>)"
+msgstr "read() zu kurz (%<PRIuMAX> Bytes erwartet, %<PRIuMAX> gelesen)"
+
+#: worktree.c:814
+msgid "invalid gitdir file"
+msgstr "ungültige gitdir-Datei"
+
+#: worktree.c:822
+msgid "gitdir file points to non-existent location"
+msgstr "gitdir-Datei verweist auf nicht existierenden Ort"
 
 #: wrapper.c:197 wrapper.c:367
 #, c-format
@@ -9353,11 +9646,11 @@ msgid "  (use \"git rm <file>...\" to mark resolution)"
 msgstr ""
 "  (benutzen Sie \"git add/rm <Datei>...\", um die Auflösung zu markieren)"
 
-#: wt-status.c:211 wt-status.c:1070
+#: wt-status.c:211 wt-status.c:1072
 msgid "Changes to be committed:"
 msgstr "Zum Commit vorgemerkte Änderungen:"
 
-#: wt-status.c:234 wt-status.c:1079
+#: wt-status.c:234 wt-status.c:1081
 msgid "Changes not staged for commit:"
 msgstr "Änderungen, die nicht zum Commit vorgemerkt sind:"
 
@@ -9465,22 +9758,22 @@ msgstr "geänderter Inhalt, "
 msgid "untracked content, "
 msgstr "unversionierter Inhalt, "
 
-#: wt-status.c:903
+#: wt-status.c:905
 #, c-format
 msgid "Your stash currently has %d entry"
 msgid_plural "Your stash currently has %d entries"
 msgstr[0] "Ihr Stash hat gerade %d Eintrag"
 msgstr[1] "Ihr Stash hat gerade %d Einträge"
 
-#: wt-status.c:934
+#: wt-status.c:936
 msgid "Submodules changed but not updated:"
 msgstr "Submodule geändert, aber nicht aktualisiert:"
 
-#: wt-status.c:936
+#: wt-status.c:938
 msgid "Submodule changes to be committed:"
 msgstr "Änderungen in Submodul zum Committen:"
 
-#: wt-status.c:1018
+#: wt-status.c:1020
 msgid ""
 "Do not modify or remove the line above.\n"
 "Everything below it will be ignored."
@@ -9488,7 +9781,7 @@ msgstr ""
 "Ändern oder entfernen Sie nicht die obige Zeile.\n"
 "Alles unterhalb von ihr wird ignoriert."
 
-#: wt-status.c:1110
+#: wt-status.c:1112
 #, c-format
 msgid ""
 "\n"
@@ -9500,114 +9793,114 @@ msgstr ""
 "berechnen.\n"
 "Sie können '--no-ahead-behind' benutzen, um das zu verhindern.\n"
 
-#: wt-status.c:1140
+#: wt-status.c:1142
 msgid "You have unmerged paths."
 msgstr "Sie haben nicht zusammengeführte Pfade."
 
-#: wt-status.c:1143
+#: wt-status.c:1145
 msgid "  (fix conflicts and run \"git commit\")"
 msgstr "  (beheben Sie die Konflikte und führen Sie \"git commit\" aus)"
 
-#: wt-status.c:1145
+#: wt-status.c:1147
 msgid "  (use \"git merge --abort\" to abort the merge)"
 msgstr "  (benutzen Sie \"git merge --abort\", um den Merge abzubrechen)"
 
-#: wt-status.c:1149
+#: wt-status.c:1151
 msgid "All conflicts fixed but you are still merging."
 msgstr "Alle Konflikte sind behoben, aber Sie sind immer noch beim Merge."
 
-#: wt-status.c:1152
+#: wt-status.c:1154
 msgid "  (use \"git commit\" to conclude merge)"
 msgstr "  (benutzen Sie \"git commit\", um den Merge abzuschließen)"
 
-#: wt-status.c:1161
+#: wt-status.c:1163
 msgid "You are in the middle of an am session."
 msgstr "Eine \"am\"-Sitzung ist im Gange."
 
-#: wt-status.c:1164
+#: wt-status.c:1166
 msgid "The current patch is empty."
 msgstr "Der aktuelle Patch ist leer."
 
-#: wt-status.c:1168
+#: wt-status.c:1170
 msgid "  (fix conflicts and then run \"git am --continue\")"
 msgstr ""
 "  (beheben Sie die Konflikte und führen Sie dann \"git am --continue\" aus)"
 
-#: wt-status.c:1170
+#: wt-status.c:1172
 msgid "  (use \"git am --skip\" to skip this patch)"
 msgstr "  (benutzen Sie \"git am --skip\", um diesen Patch auszulassen)"
 
-#: wt-status.c:1172
+#: wt-status.c:1174
 msgid "  (use \"git am --abort\" to restore the original branch)"
 msgstr ""
 "  (benutzen Sie \"git am --abort\", um den ursprünglichen Branch "
 "wiederherzustellen)"
 
-#: wt-status.c:1305
+#: wt-status.c:1307
 msgid "git-rebase-todo is missing."
 msgstr "git-rebase-todo fehlt."
 
-#: wt-status.c:1307
+#: wt-status.c:1309
 msgid "No commands done."
 msgstr "Keine Befehle ausgeführt."
 
-#: wt-status.c:1310
+#: wt-status.c:1312
 #, c-format
 msgid "Last command done (%d command done):"
 msgid_plural "Last commands done (%d commands done):"
 msgstr[0] "Zuletzt ausgeführter Befehl (%d Befehl ausgeführt):"
 msgstr[1] "Zuletzt ausgeführte Befehle (%d Befehle ausgeführt):"
 
-#: wt-status.c:1321
+#: wt-status.c:1323
 #, c-format
 msgid "  (see more in file %s)"
 msgstr "  (mehr Informationen in Datei %s)"
 
-#: wt-status.c:1326
+#: wt-status.c:1328
 msgid "No commands remaining."
 msgstr "Keine Befehle verbleibend."
 
-#: wt-status.c:1329
+#: wt-status.c:1331
 #, c-format
 msgid "Next command to do (%d remaining command):"
 msgid_plural "Next commands to do (%d remaining commands):"
 msgstr[0] "Nächster auszuführender Befehl (%d Befehle verbleibend):"
 msgstr[1] "Nächste auszuführende Befehle (%d Befehle verbleibend):"
 
-#: wt-status.c:1337
+#: wt-status.c:1339
 msgid "  (use \"git rebase --edit-todo\" to view and edit)"
 msgstr "  (benutzen Sie \"git rebase --edit-todo\" zum Ansehen und Bearbeiten)"
 
-#: wt-status.c:1349
+#: wt-status.c:1351
 #, c-format
 msgid "You are currently rebasing branch '%s' on '%s'."
 msgstr "Sie sind gerade beim Rebase von Branch '%s' auf '%s'."
 
-#: wt-status.c:1354
+#: wt-status.c:1356
 msgid "You are currently rebasing."
 msgstr "Sie sind gerade beim Rebase."
 
-#: wt-status.c:1367
+#: wt-status.c:1369
 msgid "  (fix conflicts and then run \"git rebase --continue\")"
 msgstr ""
 "  (beheben Sie die Konflikte und führen Sie dann \"git rebase --continue\" "
 "aus)"
 
-#: wt-status.c:1369
+#: wt-status.c:1371
 msgid "  (use \"git rebase --skip\" to skip this patch)"
 msgstr "  (benutzen Sie \"git rebase --skip\", um diesen Patch auszulassen)"
 
-#: wt-status.c:1371
+#: wt-status.c:1373
 msgid "  (use \"git rebase --abort\" to check out the original branch)"
 msgstr ""
 "  (benutzen Sie \"git rebase --abort\", um den ursprünglichen Branch "
 "auszuchecken)"
 
-#: wt-status.c:1378
+#: wt-status.c:1380
 msgid "  (all conflicts fixed: run \"git rebase --continue\")"
 msgstr "  (alle Konflikte behoben: führen Sie \"git rebase --continue\" aus)"
 
-#: wt-status.c:1382
+#: wt-status.c:1384
 #, c-format
 msgid ""
 "You are currently splitting a commit while rebasing branch '%s' on '%s'."
@@ -9615,162 +9908,170 @@ msgstr ""
 "Sie teilen gerade einen Commit auf, während ein Rebase von Branch '%s' auf "
 "'%s' im Gange ist."
 
-#: wt-status.c:1387
+#: wt-status.c:1389
 msgid "You are currently splitting a commit during a rebase."
 msgstr "Sie teilen gerade einen Commit während eines Rebase auf."
 
-#: wt-status.c:1390
+#: wt-status.c:1392
 msgid "  (Once your working directory is clean, run \"git rebase --continue\")"
 msgstr ""
 "  (Sobald Ihr Arbeitsverzeichnis unverändert ist, führen Sie \"git rebase --"
 "continue\" aus)"
 
-#: wt-status.c:1394
+#: wt-status.c:1396
 #, c-format
 msgid "You are currently editing a commit while rebasing branch '%s' on '%s'."
 msgstr ""
 "Sie editieren gerade einen Commit während eines Rebase von Branch '%s' auf "
 "'%s'."
 
-#: wt-status.c:1399
+#: wt-status.c:1401
 msgid "You are currently editing a commit during a rebase."
 msgstr "Sie editieren gerade einen Commit während eines Rebase."
 
-#: wt-status.c:1402
+#: wt-status.c:1404
 msgid "  (use \"git commit --amend\" to amend the current commit)"
 msgstr ""
 "  (benutzen Sie \"git commit --amend\", um den aktuellen Commit "
 "nachzubessern)"
 
-#: wt-status.c:1404
+#: wt-status.c:1406
 msgid ""
 "  (use \"git rebase --continue\" once you are satisfied with your changes)"
 msgstr ""
 "  (benutzen Sie \"git rebase --continue\" sobald Ihre Änderungen "
 "abgeschlossen sind)"
 
-#: wt-status.c:1415
+#: wt-status.c:1417
 msgid "Cherry-pick currently in progress."
 msgstr "Cherry-pick zurzeit im Gange."
 
-#: wt-status.c:1418
+#: wt-status.c:1420
 #, c-format
 msgid "You are currently cherry-picking commit %s."
 msgstr "Sie führen gerade \"cherry-pick\" von Commit %s aus."
 
-#: wt-status.c:1425
+#: wt-status.c:1427
 msgid "  (fix conflicts and run \"git cherry-pick --continue\")"
 msgstr ""
 "  (beheben Sie die Konflikte und führen Sie dann \"git cherry-pick --continue"
 "\" aus)"
 
-#: wt-status.c:1428
+#: wt-status.c:1430
 msgid "  (run \"git cherry-pick --continue\" to continue)"
 msgstr "  (Führen Sie \"git cherry-pick --continue\" aus, um weiterzumachen)"
 
-#: wt-status.c:1431
+#: wt-status.c:1433
 msgid "  (all conflicts fixed: run \"git cherry-pick --continue\")"
 msgstr ""
 "  (alle Konflikte behoben: führen Sie \"git cherry-pick --continue\" aus)"
 
-#: wt-status.c:1433
+#: wt-status.c:1435
 msgid "  (use \"git cherry-pick --skip\" to skip this patch)"
 msgstr ""
 "  (benutzen Sie \"git cherry-pick --skip\", um diesen Patch auszulassen)"
 
-#: wt-status.c:1435
+#: wt-status.c:1437
 msgid "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)"
 msgstr ""
 "  (benutzen Sie \"git cherry-pick --abort\", um die Cherry-Pick-Operation "
 "abzubrechen)"
 
-#: wt-status.c:1445
+#: wt-status.c:1447
 msgid "Revert currently in progress."
 msgstr "Revert zurzeit im Gange."
 
-#: wt-status.c:1448
+#: wt-status.c:1450
 #, c-format
 msgid "You are currently reverting commit %s."
 msgstr "Sie sind gerade beim Revert von Commit '%s'."
 
-#: wt-status.c:1454
+#: wt-status.c:1456
 msgid "  (fix conflicts and run \"git revert --continue\")"
 msgstr ""
 "  (beheben Sie die Konflikte und führen Sie dann \"git revert --continue\" "
 "aus)"
 
-#: wt-status.c:1457
+#: wt-status.c:1459
 msgid "  (run \"git revert --continue\" to continue)"
 msgstr "  (Führen Sie \"git revert --continue\", um weiterzumachen)"
 
-#: wt-status.c:1460
+#: wt-status.c:1462
 msgid "  (all conflicts fixed: run \"git revert --continue\")"
 msgstr "  (alle Konflikte behoben: führen Sie \"git revert --continue\" aus)"
 
-#: wt-status.c:1462
+#: wt-status.c:1464
 msgid "  (use \"git revert --skip\" to skip this patch)"
 msgstr "  (benutzen Sie \"git revert --skip\", um diesen Patch auszulassen)"
 
-#: wt-status.c:1464
+#: wt-status.c:1466
 msgid "  (use \"git revert --abort\" to cancel the revert operation)"
 msgstr ""
 "  (benutzen Sie \"git revert --abort\", um die Revert-Operation abzubrechen)"
 
-#: wt-status.c:1474
+#: wt-status.c:1476
 #, c-format
 msgid "You are currently bisecting, started from branch '%s'."
 msgstr "Sie sind gerade bei einer binären Suche, gestartet von Branch '%s'."
 
-#: wt-status.c:1478
+#: wt-status.c:1480
 msgid "You are currently bisecting."
 msgstr "Sie sind gerade bei einer binären Suche."
 
-#: wt-status.c:1481
+#: wt-status.c:1483
 msgid "  (use \"git bisect reset\" to get back to the original branch)"
 msgstr ""
 "  (benutzen Sie \"git bisect reset\", um zum ursprünglichen Branch "
 "zurückzukehren)"
 
-#: wt-status.c:1492
+#: wt-status.c:1494
 #, c-format
 msgid "You are in a sparse checkout with %d%% of tracked files present."
 msgstr ""
 "Sie sind in einem partiellen Checkout mit %d%% vorhandenen versionierten "
 "Dateien."
 
-#: wt-status.c:1731
+#: wt-status.c:1733
 msgid "On branch "
 msgstr "Auf Branch "
 
-#: wt-status.c:1738
+#: wt-status.c:1740
 msgid "interactive rebase in progress; onto "
 msgstr "interaktives Rebase im Gange; auf "
 
-#: wt-status.c:1740
+#: wt-status.c:1742
 msgid "rebase in progress; onto "
 msgstr "Rebase im Gange; auf "
 
-#: wt-status.c:1750
+#: wt-status.c:1747
+msgid "HEAD detached at "
+msgstr "HEAD losgelöst bei "
+
+#: wt-status.c:1749
+msgid "HEAD detached from "
+msgstr "HEAD losgelöst von "
+
+#: wt-status.c:1752
 msgid "Not currently on any branch."
 msgstr "Im Moment auf keinem Branch."
 
-#: wt-status.c:1767
+#: wt-status.c:1769
 msgid "Initial commit"
 msgstr "Initialer Commit"
 
-#: wt-status.c:1768
+#: wt-status.c:1770
 msgid "No commits yet"
 msgstr "Noch keine Commits"
 
-#: wt-status.c:1782
+#: wt-status.c:1784
 msgid "Untracked files"
 msgstr "Unversionierte Dateien"
 
-#: wt-status.c:1784
+#: wt-status.c:1786
 msgid "Ignored files"
 msgstr "Ignorierte Dateien"
 
-#: wt-status.c:1788
+#: wt-status.c:1790
 #, c-format
 msgid ""
 "It took %.2f seconds to enumerate untracked files. 'status -uno'\n"
@@ -9781,32 +10082,32 @@ msgstr ""
 "'status -uno' könnte das beschleunigen, aber Sie müssen darauf achten,\n"
 "neue Dateien selbstständig hinzuzufügen (siehe 'git help status')."
 
-#: wt-status.c:1794
+#: wt-status.c:1796
 #, c-format
 msgid "Untracked files not listed%s"
 msgstr "Unversionierte Dateien nicht aufgelistet%s"
 
-#: wt-status.c:1796
+#: wt-status.c:1798
 msgid " (use -u option to show untracked files)"
 msgstr " (benutzen Sie die Option -u, um unversionierte Dateien anzuzeigen)"
 
-#: wt-status.c:1802
+#: wt-status.c:1804
 msgid "No changes"
 msgstr "Keine Änderungen"
 
-#: wt-status.c:1807
+#: wt-status.c:1809
 #, c-format
 msgid "no changes added to commit (use \"git add\" and/or \"git commit -a\")\n"
 msgstr ""
 "keine Änderungen zum Commit vorgemerkt (benutzen Sie \"git add\" und/oder "
 "\"git commit -a\")\n"
 
-#: wt-status.c:1811
+#: wt-status.c:1813
 #, c-format
 msgid "no changes added to commit\n"
 msgstr "keine Änderungen zum Commit vorgemerkt\n"
 
-#: wt-status.c:1815
+#: wt-status.c:1817
 #, c-format
 msgid ""
 "nothing added to commit but untracked files present (use \"git add\" to "
@@ -9815,67 +10116,67 @@ msgstr ""
 "nichts zum Commit vorgemerkt, aber es gibt unversionierte Dateien\n"
 "(benutzen Sie \"git add\" zum Versionieren)\n"
 
-#: wt-status.c:1819
+#: wt-status.c:1821
 #, c-format
 msgid "nothing added to commit but untracked files present\n"
 msgstr "nichts zum Commit vorgemerkt, aber es gibt unversionierte Dateien\n"
 
-#: wt-status.c:1823
+#: wt-status.c:1825
 #, c-format
 msgid "nothing to commit (create/copy files and use \"git add\" to track)\n"
 msgstr ""
 "nichts zu committen (erstellen/kopieren Sie Dateien und benutzen\n"
 "Sie \"git add\" zum Versionieren)\n"
 
-#: wt-status.c:1827 wt-status.c:1833
+#: wt-status.c:1829 wt-status.c:1835
 #, c-format
 msgid "nothing to commit\n"
 msgstr "nichts zu committen\n"
 
-#: wt-status.c:1830
+#: wt-status.c:1832
 #, c-format
 msgid "nothing to commit (use -u to show untracked files)\n"
 msgstr ""
 "nichts zu committen (benutzen Sie die Option -u, um unversionierte Dateien "
 "anzuzeigen)\n"
 
-#: wt-status.c:1835
+#: wt-status.c:1837
 #, c-format
 msgid "nothing to commit, working tree clean\n"
 msgstr "nichts zu committen, Arbeitsverzeichnis unverändert\n"
 
-#: wt-status.c:1940
+#: wt-status.c:1942
 msgid "No commits yet on "
 msgstr "Noch keine Commits in "
 
-#: wt-status.c:1944
+#: wt-status.c:1946
 msgid "HEAD (no branch)"
 msgstr "HEAD (kein Branch)"
 
-#: wt-status.c:1975
+#: wt-status.c:1977
 msgid "different"
 msgstr "unterschiedlich"
 
-#: wt-status.c:1977 wt-status.c:1985
+#: wt-status.c:1979 wt-status.c:1987
 msgid "behind "
 msgstr "hinterher "
 
-#: wt-status.c:1980 wt-status.c:1983
+#: wt-status.c:1982 wt-status.c:1985
 msgid "ahead "
 msgstr "voraus "
 
 #. TRANSLATORS: the action is e.g. "pull with rebase"
-#: wt-status.c:2505
+#: wt-status.c:2507
 #, c-format
 msgid "cannot %s: You have unstaged changes."
 msgstr ""
 "%s nicht möglich: Sie haben Änderungen, die nicht zum Commit vorgemerkt sind."
 
-#: wt-status.c:2511
+#: wt-status.c:2513
 msgid "additionally, your index contains uncommitted changes."
 msgstr "Zusätzlich enthält die Staging-Area nicht committete Änderungen."
 
-#: wt-status.c:2513
+#: wt-status.c:2515
 #, c-format
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr ""
@@ -9890,134 +10191,139 @@ msgstr "Konnte '%s' nicht entfernen."
 msgid "git add [<options>] [--] <pathspec>..."
 msgstr "git add [<Optionen>] [--] <Pfadspezifikation>..."
 
-#: builtin/add.c:88
+#: builtin/add.c:58
+#, fuzzy, c-format
+msgid "cannot chmod %cx '%s'"
+msgstr "Kann nicht in Verzeichnis '%s' wechseln."
+
+#: builtin/add.c:96
 #, c-format
 msgid "unexpected diff status %c"
 msgstr "unerwarteter Differenz-Status %c"
 
-#: builtin/add.c:93 builtin/commit.c:285
+#: builtin/add.c:101 builtin/commit.c:285
 msgid "updating files failed"
 msgstr "Aktualisierung der Dateien fehlgeschlagen"
 
-#: builtin/add.c:103
+#: builtin/add.c:111
 #, c-format
 msgid "remove '%s'\n"
 msgstr "lösche '%s'\n"
 
-#: builtin/add.c:178
+#: builtin/add.c:186
 msgid "Unstaged changes after refreshing the index:"
 msgstr ""
 "Nicht zum Commit vorgemerkte Änderungen nach Aktualisierung der Staging-Area:"
 
-#: builtin/add.c:272 builtin/rev-parse.c:908
+#: builtin/add.c:280 builtin/rev-parse.c:991
 msgid "Could not read the index"
 msgstr "Konnte den Index nicht lesen"
 
-#: builtin/add.c:283
+#: builtin/add.c:291
 #, c-format
 msgid "Could not open '%s' for writing."
 msgstr "Konnte '%s' nicht zum Schreiben öffnen."
 
-#: builtin/add.c:287
+#: builtin/add.c:295
 msgid "Could not write patch"
 msgstr "Konnte Patch nicht schreiben"
 
-#: builtin/add.c:290
+#: builtin/add.c:298
 msgid "editing patch failed"
 msgstr "Bearbeitung des Patches fehlgeschlagen"
 
-#: builtin/add.c:293
+#: builtin/add.c:301
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "Konnte Verzeichnis '%s' nicht lesen"
 
-#: builtin/add.c:295
+#: builtin/add.c:303
 msgid "Empty patch. Aborted."
 msgstr "Leerer Patch. Abgebrochen."
 
-#: builtin/add.c:300
+#: builtin/add.c:308
 #, c-format
 msgid "Could not apply '%s'"
 msgstr "Konnte '%s' nicht anwenden."
 
-#: builtin/add.c:308
+#: builtin/add.c:316
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr ""
 "Die folgenden Pfade werden durch eine Ihrer \".gitignore\" Dateien "
 "ignoriert:\n"
 
-#: builtin/add.c:328 builtin/clean.c:904 builtin/fetch.c:166 builtin/mv.c:124
+#: builtin/add.c:336 builtin/clean.c:904 builtin/fetch.c:169 builtin/mv.c:124
 #: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:559
 #: builtin/remote.c:1427 builtin/rm.c:242 builtin/send-pack.c:190
 msgid "dry run"
 msgstr "Probelauf"
 
-#: builtin/add.c:331
+#: builtin/add.c:339
 msgid "interactive picking"
 msgstr "interaktives Auswählen"
 
-#: builtin/add.c:332 builtin/checkout.c:1547 builtin/reset.c:308
+#: builtin/add.c:340 builtin/checkout.c:1546 builtin/reset.c:308
 msgid "select hunks interactively"
 msgstr "Blöcke interaktiv auswählen"
 
-#: builtin/add.c:333
+#: builtin/add.c:341
 msgid "edit current diff and apply"
 msgstr "aktuelle Unterschiede editieren und anwenden"
 
-#: builtin/add.c:334
+#: builtin/add.c:342
 msgid "allow adding otherwise ignored files"
 msgstr "das Hinzufügen andernfalls ignorierter Dateien erlauben"
 
-#: builtin/add.c:335
+#: builtin/add.c:343
 msgid "update tracked files"
 msgstr "versionierte Dateien aktualisieren"
 
-#: builtin/add.c:336
+#: builtin/add.c:344
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr ""
 "erneutes Normalisieren der Zeilenenden von versionierten Dateien (impliziert "
 "-u)"
 
-#: builtin/add.c:337
+#: builtin/add.c:345
 msgid "record only the fact that the path will be added later"
 msgstr "nur speichern, dass der Pfad später hinzugefügt werden soll"
 
-#: builtin/add.c:338
+#: builtin/add.c:346
 msgid "add changes from all tracked and untracked files"
 msgstr ""
 "Änderungen von allen versionierten und unversionierten Dateien hinzufügen"
 
-#: builtin/add.c:341
+#: builtin/add.c:349
 msgid "ignore paths removed in the working tree (same as --no-all)"
 msgstr "gelöschte Pfade im Arbeitsverzeichnis ignorieren (genau wie --no-all)"
 
-#: builtin/add.c:343
+#: builtin/add.c:351
 msgid "don't add, only refresh the index"
 msgstr "nichts hinzufügen, nur den Index aktualisieren"
 
-#: builtin/add.c:344
+#: builtin/add.c:352
 msgid "just skip files which cannot be added because of errors"
 msgstr ""
 "Dateien überspringen, die aufgrund von Fehlern nicht hinzugefügt werden "
 "konnten"
 
-#: builtin/add.c:345
+#: builtin/add.c:353
 msgid "check if - even missing - files are ignored in dry run"
 msgstr "prüfen ob - auch fehlende - Dateien im Probelauf ignoriert werden"
 
-#: builtin/add.c:347 builtin/update-index.c:1004
+#: builtin/add.c:355 builtin/update-index.c:1004
 msgid "override the executable bit of the listed files"
 msgstr "das \"ausführbar\"-Bit der aufgelisteten Dateien überschreiben"
 
-#: builtin/add.c:349
+#: builtin/add.c:357
 msgid "warn when adding an embedded repository"
 msgstr "warnen wenn eingebettetes Repository hinzugefügt wird"
 
-#: builtin/add.c:351
+#: builtin/add.c:359
 msgid "backend for `git stash -p`"
 msgstr "Backend für `git stash -p`"
 
-#: builtin/add.c:369
+#: builtin/add.c:377
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -10051,12 +10357,12 @@ msgstr ""
 "\n"
 "Siehe \"git help submodule\" für weitere Informationen."
 
-#: builtin/add.c:397
+#: builtin/add.c:405
 #, c-format
 msgid "adding embedded git repository: %s"
 msgstr "Füge eingebettetes Repository hinzu: %s"
 
-#: builtin/add.c:416
+#: builtin/add.c:424
 msgid ""
 "Use -f if you really want to add them.\n"
 "Turn this message off by running\n"
@@ -10066,52 +10372,52 @@ msgstr ""
 "Um diese Meldung abzuschalten, führen Sie folgenden Befehl aus:\n"
 "\"git config advice.addIgnoredFile false\""
 
-#: builtin/add.c:425
+#: builtin/add.c:433
 msgid "adding files failed"
 msgstr "Hinzufügen von Dateien fehlgeschlagen"
 
-#: builtin/add.c:453 builtin/commit.c:345
+#: builtin/add.c:461 builtin/commit.c:345
 msgid "--pathspec-from-file is incompatible with --interactive/--patch"
 msgstr ""
 "Die Optionen --pathspec-from-file und --interactive/--patch sind "
 "inkompatibel."
 
-#: builtin/add.c:470
+#: builtin/add.c:478
 msgid "--pathspec-from-file is incompatible with --edit"
 msgstr "Die Optionen --pathspec-from-file und --edit sind inkompatibel."
 
-#: builtin/add.c:482
+#: builtin/add.c:490
 msgid "-A and -u are mutually incompatible"
 msgstr "Die Optionen -A und -u sind zueinander inkompatibel."
 
-#: builtin/add.c:485
+#: builtin/add.c:493
 msgid "Option --ignore-missing can only be used together with --dry-run"
 msgstr ""
 "Die Option --ignore-missing kann nur zusammen mit --dry-run verwendet werden."
 
-#: builtin/add.c:489
+#: builtin/add.c:497
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "--chmod Parameter '%s' muss entweder -x oder +x sein"
 
-#: builtin/add.c:507 builtin/checkout.c:1715 builtin/commit.c:351
-#: builtin/reset.c:328 builtin/rm.c:272 builtin/stash.c:1502
+#: builtin/add.c:515 builtin/checkout.c:1714 builtin/commit.c:351
+#: builtin/reset.c:328 builtin/rm.c:272 builtin/stash.c:1569
 msgid "--pathspec-from-file is incompatible with pathspec arguments"
 msgstr ""
 "Die Option --pathspec-from-file ist inkompatibel mit\n"
 "Pfadspezifikation-Argumenten."
 
-#: builtin/add.c:514 builtin/checkout.c:1727 builtin/commit.c:357
-#: builtin/reset.c:334 builtin/rm.c:278 builtin/stash.c:1508
+#: builtin/add.c:522 builtin/checkout.c:1726 builtin/commit.c:357
+#: builtin/reset.c:334 builtin/rm.c:278 builtin/stash.c:1575
 msgid "--pathspec-file-nul requires --pathspec-from-file"
 msgstr "Die Option --pathspec-file-nul benötigt --pathspec-from-file"
 
-#: builtin/add.c:518
+#: builtin/add.c:526
 #, c-format
 msgid "Nothing specified, nothing added.\n"
 msgstr "Nichts spezifiziert, nichts hinzugefügt.\n"
 
-#: builtin/add.c:520
+#: builtin/add.c:528
 msgid ""
 "Maybe you wanted to say 'git add .'?\n"
 "Turn this message off by running\n"
@@ -10375,7 +10681,7 @@ msgid "allow fall back on 3way merging if needed"
 msgstr "erlaube, falls notwendig, das Zurückfallen auf einen 3-Wege-Merge"
 
 #: builtin/am.c:2225 builtin/init-db.c:560 builtin/prune-packed.c:16
-#: builtin/repack.c:335 builtin/stash.c:815
+#: builtin/repack.c:334 builtin/stash.c:882
 msgid "be quiet"
 msgstr "weniger Ausgaben"
 
@@ -10418,17 +10724,17 @@ msgid "pass it through git-apply"
 msgstr "an git-apply übergeben"
 
 #: builtin/am.c:2263 builtin/commit.c:1395 builtin/fmt-merge-msg.c:17
-#: builtin/fmt-merge-msg.c:20 builtin/grep.c:903 builtin/merge.c:260
+#: builtin/fmt-merge-msg.c:20 builtin/grep.c:904 builtin/merge.c:261
 #: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
-#: builtin/rebase.c:1341 builtin/repack.c:346 builtin/repack.c:350
-#: builtin/repack.c:352 builtin/show-branch.c:650 builtin/show-ref.c:172
-#: builtin/tag.c:404 parse-options.h:154 parse-options.h:175
+#: builtin/rebase.c:1347 builtin/repack.c:345 builtin/repack.c:349
+#: builtin/repack.c:351 builtin/show-branch.c:650 builtin/show-ref.c:172
+#: builtin/tag.c:436 parse-options.h:154 parse-options.h:175
 #: parse-options.h:316
 msgid "n"
 msgstr "Anzahl"
 
-#: builtin/am.c:2269 builtin/branch.c:661 builtin/bugreport.c:136
-#: builtin/for-each-ref.c:38 builtin/replace.c:556 builtin/tag.c:438
+#: builtin/am.c:2269 builtin/branch.c:670 builtin/bugreport.c:136
+#: builtin/for-each-ref.c:38 builtin/replace.c:556 builtin/tag.c:470
 #: builtin/verify-tag.c:38
 msgid "format"
 msgstr "Format"
@@ -10454,12 +10760,14 @@ msgid "skip the current patch"
 msgstr "den aktuellen Patch auslassen"
 
 #: builtin/am.c:2287
-msgid "restore the original branch and abort the patching operation."
+#, fuzzy
+msgid "restore the original branch and abort the patching operation"
 msgstr ""
 "ursprünglichen Branch wiederherstellen und Anwendung der Patches abbrechen"
 
 #: builtin/am.c:2290
-msgid "abort the patching operation but keep HEAD where it is."
+#, fuzzy
+msgid "abort the patching operation but keep HEAD where it is"
 msgstr "Patch-Operation abbrechen, aber HEAD an aktueller Stelle belassen"
 
 #: builtin/am.c:2294
@@ -10475,12 +10783,12 @@ msgid "use current timestamp for author date"
 msgstr "aktuellen Zeitstempel als Autor-Datum verwenden"
 
 #: builtin/am.c:2303 builtin/commit-tree.c:120 builtin/commit.c:1515
-#: builtin/merge.c:297 builtin/pull.c:175 builtin/rebase.c:536
-#: builtin/rebase.c:1394 builtin/revert.c:117 builtin/tag.c:419
+#: builtin/merge.c:298 builtin/pull.c:175 builtin/rebase.c:538
+#: builtin/rebase.c:1400 builtin/revert.c:117 builtin/tag.c:451
 msgid "key-id"
 msgstr "GPG-Schlüsselkennung"
 
-#: builtin/am.c:2304 builtin/rebase.c:537 builtin/rebase.c:1395
+#: builtin/am.c:2304 builtin/rebase.c:539 builtin/rebase.c:1401
 msgid "GPG-sign commits"
 msgstr "Commits mit GPG signieren"
 
@@ -10561,28 +10869,12 @@ msgid "git bisect--helper --bisect-reset [<commit>]"
 msgstr "git bisect--helper --bisect-reset [<Commit>]"
 
 #: builtin/bisect--helper.c:24
-msgid ""
-"git bisect--helper --bisect-write [--no-log] <state> <revision> <good_term> "
-"<bad_term>"
-msgstr ""
-"git bisect--helper --bisect-write [--no-log] <Zustand> <Revision> "
-"<Begriff_gut> <Begriff_schlecht>"
-
-#: builtin/bisect--helper.c:25
-msgid ""
-"git bisect--helper --bisect-check-and-set-terms <command> <good_term> "
-"<bad_term>"
-msgstr ""
-"git bisect--helper --bisect-check-and-set-terms <Befehl> <Begriff_gut> "
-"<Begriff_schlecht>"
-
-#: builtin/bisect--helper.c:26
 msgid "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
 msgstr ""
 "git bisect--helper --bisect-next-check <Begriff_gut> <Begriff_schlecht> "
 "[<Begriff>]"
 
-#: builtin/bisect--helper.c:27
+#: builtin/bisect--helper.c:25
 msgid ""
 "git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
 "term-new]"
@@ -10590,7 +10882,7 @@ msgstr ""
 "git bisect--helper --bisect-terms [--term-good | --term-old | --term-bad | --"
 "term-new]"
 
-#: builtin/bisect--helper.c:28
+#: builtin/bisect--helper.c:26
 msgid ""
 "git bisect--helper --bisect-start [--term-{new,bad}=<term> --term-{old,good}"
 "=<term>] [--no-checkout] [--first-parent] [<bad> [<good>...]] [--] "
@@ -10600,62 +10892,68 @@ msgstr ""
 "good}=<Begriff>] [--no-checkout] [--first-parent] [<schlecht> [<gut>...]] "
 "[--] [<Pfade>...]"
 
-#: builtin/bisect--helper.c:30
+#: builtin/bisect--helper.c:28
 msgid "git bisect--helper --bisect-next"
 msgstr "git bisect--helper --bisect-next"
 
-#: builtin/bisect--helper.c:31
-msgid "git bisect--helper --bisect-auto-next"
-msgstr "git bisect--helper --bisect-auto-next"
-
-#: builtin/bisect--helper.c:32
+#: builtin/bisect--helper.c:29
 msgid "git bisect--helper --bisect-state (bad|new) [<rev>]"
 msgstr "git bisect--helper --bisect-state (bad|new) [<Commit>]"
 
-#: builtin/bisect--helper.c:33
+#: builtin/bisect--helper.c:30
 msgid "git bisect--helper --bisect-state (good|old) [<rev>...]"
 msgstr "git bisect--helper --bisect-state (good|old) [<Commit>...]"
 
-#: builtin/bisect--helper.c:108
+#: builtin/bisect--helper.c:31
+#, fuzzy
+msgid "git bisect--helper --bisect-replay <filename>"
+msgstr "git bisect--helper --bisect-next"
+
+#: builtin/bisect--helper.c:32
+#, fuzzy
+msgid "git bisect--helper --bisect-skip [(<rev>|<range>)...]"
+msgstr "git bisect--helper --bisect-state (good|old) [<Commit>...]"
+
+#: builtin/bisect--helper.c:107
 #, c-format
 msgid "cannot open file '%s' in mode '%s'"
 msgstr "kann Datei '%s' nicht im Modus '%s' öffnen"
 
-#: builtin/bisect--helper.c:115
+#: builtin/bisect--helper.c:114
 #, c-format
 msgid "could not write to file '%s'"
 msgstr "konnte nicht in Datei '%s' schreiben"
 
-#: builtin/bisect--helper.c:154
+#: builtin/bisect--helper.c:153
 #, c-format
 msgid "'%s' is not a valid term"
 msgstr "'%s' ist kein gültiger Begriff"
 
-#: builtin/bisect--helper.c:158
+#: builtin/bisect--helper.c:157
 #, c-format
 msgid "can't use the builtin command '%s' as a term"
 msgstr "kann den eingebauten Befehl '%s' nicht als Begriff verwenden"
 
-#: builtin/bisect--helper.c:168
+#: builtin/bisect--helper.c:167
 #, c-format
 msgid "can't change the meaning of the term '%s'"
 msgstr "kann die Bedeutung von dem Begriff '%s' nicht ändern"
 
-#: builtin/bisect--helper.c:178
+#: builtin/bisect--helper.c:177
 msgid "please use two different terms"
 msgstr "bitte verwenden Sie zwei verschiedene Begriffe"
 
-#: builtin/bisect--helper.c:194
+#: builtin/bisect--helper.c:193
 #, c-format
 msgid "We are not bisecting.\n"
 msgstr "Keine binäre Suche im Gange.\n"
 
-#: builtin/bisect--helper.c:202
+#: builtin/bisect--helper.c:201
 #, c-format
 msgid "'%s' is not a valid commit"
 msgstr "'%s' ist kein gültiger Commit"
 
-#: builtin/bisect--helper.c:211
+#: builtin/bisect--helper.c:210
 #, c-format
 msgid ""
 "could not check out original HEAD '%s'. Try 'git bisect reset <commit>'."
@@ -10663,27 +10961,27 @@ msgstr ""
 "Konnte den ursprünglichen HEAD '%s' nicht auschecken.\n"
 "Versuchen Sie 'git bisect reset <Commit>'."
 
-#: builtin/bisect--helper.c:255
+#: builtin/bisect--helper.c:254
 #, c-format
 msgid "Bad bisect_write argument: %s"
 msgstr "Ungültiges \"bisect_write\" Argument: %s"
 
-#: builtin/bisect--helper.c:260
+#: builtin/bisect--helper.c:259
 #, c-format
 msgid "couldn't get the oid of the rev '%s'"
 msgstr "Konnte die OID der Revision '%s' nicht erhalten."
 
-#: builtin/bisect--helper.c:272
+#: builtin/bisect--helper.c:271
 #, c-format
 msgid "couldn't open the file '%s'"
 msgstr "Konnte die Datei '%s' nicht öffnen."
 
-#: builtin/bisect--helper.c:298
+#: builtin/bisect--helper.c:297
 #, c-format
 msgid "Invalid command: you're currently in a %s/%s bisect"
 msgstr "Ungültiger Befehl: Sie sind gerade bei einer binären %s/%s Suche."
 
-#: builtin/bisect--helper.c:325
+#: builtin/bisect--helper.c:324
 #, c-format
 msgid ""
 "You need to give me at least one %s and %s revision.\n"
@@ -10692,7 +10990,7 @@ msgstr ""
 "Sie müssen mindestens einen \"%s\" und einen \"%s\" Commit angeben.\n"
 "Sie können dafür \"git bisect %s\" und \"git bisect %s\" benutzen."
 
-#: builtin/bisect--helper.c:329
+#: builtin/bisect--helper.c:328
 #, c-format
 msgid ""
 "You need to start by \"git bisect start\".\n"
@@ -10703,7 +11001,7 @@ msgstr ""
 "Danach müssen Sie mindestens einen \"%s\" und einen \"%s\" Commit angeben.\n"
 "Sie können dafür \"git bisect %s\" und \"git bisect %s\" benutzen."
 
-#: builtin/bisect--helper.c:349
+#: builtin/bisect--helper.c:348
 #, c-format
 msgid "bisecting only with a %s commit"
 msgstr "Binäre Suche nur mit einem %s Commit."
@@ -10712,15 +11010,15 @@ msgstr "Binäre Suche nur mit einem %s Commit."
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:357
+#: builtin/bisect--helper.c:356
 msgid "Are you sure [Y/n]? "
 msgstr "Sind Sie sicher [Y/n]? "
 
-#: builtin/bisect--helper.c:418
+#: builtin/bisect--helper.c:417
 msgid "no terms defined"
 msgstr "Keine Begriffe definiert."
 
-#: builtin/bisect--helper.c:421
+#: builtin/bisect--helper.c:420
 #, c-format
 msgid ""
 "Your current terms are %s for the old state\n"
@@ -10729,7 +11027,7 @@ msgstr ""
 "Ihre aktuellen Begriffe sind %s für den alten Zustand\n"
 "und %s für den neuen Zustand.\n"
 
-#: builtin/bisect--helper.c:431
+#: builtin/bisect--helper.c:430
 #, c-format
 msgid ""
 "invalid argument %s for 'git bisect terms'.\n"
@@ -10738,55 +11036,55 @@ msgstr ""
 "Ungültiges Argument %s für 'git bisect terms'.\n"
 "Unterstützte Optionen sind: --term-good|--term-old und --term-bad|--term-new."
 
-#: builtin/bisect--helper.c:498
+#: builtin/bisect--helper.c:497 builtin/bisect--helper.c:1014
 msgid "revision walk setup failed\n"
 msgstr "Einrichtung des Revisionsgangs fehlgeschlagen\n"
 
-#: builtin/bisect--helper.c:520
+#: builtin/bisect--helper.c:519
 #, c-format
 msgid "could not open '%s' for appending"
 msgstr "konnte '%s' nicht zum Anhängen öffnen"
 
-#: builtin/bisect--helper.c:639 builtin/bisect--helper.c:652
+#: builtin/bisect--helper.c:638 builtin/bisect--helper.c:651
 msgid "'' is not a valid term"
 msgstr "'' ist kein gültiger Begriff"
 
-#: builtin/bisect--helper.c:662
+#: builtin/bisect--helper.c:661
 #, c-format
 msgid "unrecognized option: '%s'"
 msgstr "nicht erkannte Option: '%s'"
 
-#: builtin/bisect--helper.c:666
+#: builtin/bisect--helper.c:665
 #, c-format
 msgid "'%s' does not appear to be a valid revision"
 msgstr "'%s' scheint kein gültiger Commit zu sein"
 
-#: builtin/bisect--helper.c:697
+#: builtin/bisect--helper.c:696
 msgid "bad HEAD - I need a HEAD"
 msgstr "ungültiger HEAD - HEAD wird benötigt"
 
-#: builtin/bisect--helper.c:712
+#: builtin/bisect--helper.c:711
 #, c-format
 msgid "checking out '%s' failed. Try 'git bisect start <valid-branch>'."
 msgstr ""
 "Auschecken von '%s' fehlgeschlagen. Versuchen Sie 'git bisect start "
 "<gültiger-Branch>'."
 
-#: builtin/bisect--helper.c:733
+#: builtin/bisect--helper.c:732
 msgid "won't bisect on cg-seek'ed tree"
 msgstr ""
 "binäre Suche auf einem durch 'cg-seek' geändertem Verzeichnis nicht möglich"
 
-#: builtin/bisect--helper.c:736
+#: builtin/bisect--helper.c:735
 msgid "bad HEAD - strange symbolic ref"
 msgstr "ungültiger HEAD - merkwürdige symbolische Referenz"
 
-#: builtin/bisect--helper.c:756
+#: builtin/bisect--helper.c:755
 #, c-format
 msgid "invalid ref: '%s'"
 msgstr "ungültige Referenz: '%s'"
 
-#: builtin/bisect--helper.c:814
+#: builtin/bisect--helper.c:813
 msgid "You need to start by \"git bisect start\"\n"
 msgstr "Sie müssen mit \"git bisect start\" beginnen\n"
 
@@ -10794,93 +11092,105 @@ msgstr "Sie müssen mit \"git bisect start\" beginnen\n"
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:825
+#: builtin/bisect--helper.c:824
 msgid "Do you want me to do it for you [Y/n]? "
 msgstr "Wollen Sie, dass ich es für Sie mache [Y/n]? "
 
-#: builtin/bisect--helper.c:843
+#: builtin/bisect--helper.c:842
 msgid "Please call `--bisect-state` with at least one argument"
 msgstr "Bitte führen Sie `--bisect-state` mit mindestens einem Argument aus"
 
-#: builtin/bisect--helper.c:856
+#: builtin/bisect--helper.c:855
 #, c-format
 msgid "'git bisect %s' can take only one argument."
 msgstr "'git bisect %s' kann nur ein Argument entgegennehmen."
 
-#: builtin/bisect--helper.c:868 builtin/bisect--helper.c:879
+#: builtin/bisect--helper.c:867 builtin/bisect--helper.c:878
 #, c-format
 msgid "Bad rev input: %s"
 msgstr "Ungültige Referenz-Eingabe: %s"
 
-#: builtin/bisect--helper.c:924
+#: builtin/bisect--helper.c:912
+msgid "We are not bisecting."
+msgstr "Keine binäre Suche im Gange."
+
+#: builtin/bisect--helper.c:962
+#, fuzzy, c-format
+msgid "'%s'?? what are you talking about?"
+msgstr "?? Was reden Sie da?"
+
+#: builtin/bisect--helper.c:974
+#, fuzzy, c-format
+msgid "cannot read file '%s' for replaying"
+msgstr "kann $file nicht für das Abspielen lesen"
+
+#: builtin/bisect--helper.c:1047
 msgid "reset the bisection state"
 msgstr "den Zustand der binären Suche zurücksetzen"
 
-#: builtin/bisect--helper.c:926
-msgid "write out the bisection state in BISECT_LOG"
-msgstr "den Zustand der binären Suche nach BISECT_LOG schreiben"
-
-#: builtin/bisect--helper.c:928
-msgid "check and set terms in a bisection state"
-msgstr "Begriffe innerhalb einer binären Suche prüfen und setzen"
-
-#: builtin/bisect--helper.c:930
+#: builtin/bisect--helper.c:1049
 msgid "check whether bad or good terms exist"
 msgstr "prüfen, ob Begriffe für gute und schlechte Commits existieren"
 
-#: builtin/bisect--helper.c:932
+#: builtin/bisect--helper.c:1051
 msgid "print out the bisect terms"
 msgstr "die Begriffe für die binäre Suche ausgeben"
 
-#: builtin/bisect--helper.c:934
+#: builtin/bisect--helper.c:1053
 msgid "start the bisect session"
 msgstr "Sitzung für binäre Suche starten"
 
-#: builtin/bisect--helper.c:936
+#: builtin/bisect--helper.c:1055
 msgid "find the next bisection commit"
 msgstr "nächsten Commit für die binäre Suche finden"
 
-#: builtin/bisect--helper.c:938
-msgid "verify the next bisection state then checkout the next bisection commit"
-msgstr ""
-"überprüfe den nächsten Zustand der binären Suche, checke dann den nächsten "
-"Commit der binären Suche aus"
-
-#: builtin/bisect--helper.c:940
+#: builtin/bisect--helper.c:1057
 msgid "mark the state of ref (or refs)"
 msgstr "den Status der Referenz(en) markieren"
 
-#: builtin/bisect--helper.c:942
+#: builtin/bisect--helper.c:1059
+#, fuzzy
+msgid "list the bisection steps so far"
+msgstr "den Zustand der binären Suche zurücksetzen"
+
+#: builtin/bisect--helper.c:1061
+msgid "replay the bisection process from the given file"
+msgstr ""
+
+#: builtin/bisect--helper.c:1063
+#, fuzzy
+msgid "skip some commits for checkout"
+msgstr "der Branch oder Commit zum Auschecken"
+
+#: builtin/bisect--helper.c:1065
 msgid "no log for BISECT_WRITE"
 msgstr "kein Log für BISECT_WRITE"
 
-#: builtin/bisect--helper.c:957
+#: builtin/bisect--helper.c:1080
 msgid "--bisect-reset requires either no argument or a commit"
 msgstr "--bisect-reset benötigt entweder kein Argument oder ein Commit"
 
-#: builtin/bisect--helper.c:961
-msgid "--bisect-write requires either 4 or 5 arguments"
-msgstr "--bisect-write benötigt entweder 4 oder 5 Argumente"
-
-#: builtin/bisect--helper.c:967
-msgid "--check-and-set-terms requires 3 arguments"
-msgstr "--check-and-set-terms benötigt 3 Argumente"
-
-#: builtin/bisect--helper.c:973
+#: builtin/bisect--helper.c:1085
 msgid "--bisect-next-check requires 2 or 3 arguments"
 msgstr "--bisect-next-check benötigt 2 oder 3 Argumente"
 
-#: builtin/bisect--helper.c:979
+#: builtin/bisect--helper.c:1091
 msgid "--bisect-terms requires 0 or 1 argument"
 msgstr "--bisect-terms benötigt 0 oder 1 Argument"
 
-#: builtin/bisect--helper.c:988
+#: builtin/bisect--helper.c:1100
 msgid "--bisect-next requires 0 arguments"
 msgstr "--bisect-next benötigt 0 Argumente"
 
-#: builtin/bisect--helper.c:994
-msgid "--bisect-auto-next requires 0 arguments"
-msgstr "--bisect-auto-next benötigt 0 Argumente"
+#: builtin/bisect--helper.c:1111
+#, fuzzy
+msgid "--bisect-log requires 0 arguments"
+msgstr "--bisect-next benötigt 0 Argumente"
+
+#: builtin/bisect--helper.c:1116
+#, fuzzy
+msgid "no logfile given"
+msgstr "Keine Log-Datei gegeben"
 
 #: builtin/blame.c:32
 msgid "git blame [<options>] [<rev-opts>] [<rev>] [--] <file>"
@@ -10899,142 +11209,168 @@ msgstr "erwarte eine Farbe: %s"
 msgid "must end with a color"
 msgstr "muss mit einer Farbe enden"
 
-#: builtin/blame.c:730
+#: builtin/blame.c:728
 #, c-format
 msgid "invalid color '%s' in color.blame.repeatedLines"
 msgstr "ungültige Farbe '%s' in color.blame.repeatedLines"
 
-#: builtin/blame.c:748
+#: builtin/blame.c:746
 msgid "invalid value for blame.coloring"
 msgstr "ungültiger Wert für blame.coloring"
 
-#: builtin/blame.c:847
+#: builtin/blame.c:845
 #, c-format
 msgid "cannot find revision %s to ignore"
 msgstr "konnte Commit %s zum Ignorieren nicht finden"
 
-#: builtin/blame.c:869
-msgid "Show blame entries as we find them, incrementally"
+#: builtin/blame.c:867
+#, fuzzy
+msgid "show blame entries as we find them, incrementally"
 msgstr "\"blame\"-Einträge schrittweise anzeigen, während wir sie generieren"
 
-#: builtin/blame.c:870
-msgid "Do not show object names of boundary commits (Default: off)"
+#: builtin/blame.c:868
+#, fuzzy
+msgid "do not show object names of boundary commits (Default: off)"
 msgstr "Zeige keine Objektnamen für Grenz-Commits an (Standard: aus)"
 
-#: builtin/blame.c:871
-msgid "Do not treat root commits as boundaries (Default: off)"
+#: builtin/blame.c:869
+#, fuzzy
+msgid "do not treat root commits as boundaries (Default: off)"
 msgstr "Root-Commits nicht als Grenzen behandeln (Standard: aus)"
 
-#: builtin/blame.c:872
-msgid "Show work cost statistics"
+#: builtin/blame.c:870
+#, fuzzy
+msgid "show work cost statistics"
 msgstr "Statistiken zum Arbeitsaufwand anzeigen"
 
-#: builtin/blame.c:873
-msgid "Force progress reporting"
+#: builtin/blame.c:871 builtin/checkout.c:1503 builtin/clone.c:92
+#: builtin/commit-graph.c:84 builtin/commit-graph.c:222 builtin/fetch.c:175
+#: builtin/merge.c:297 builtin/multi-pack-index.c:27 builtin/pull.c:119
+#: builtin/push.c:575 builtin/send-pack.c:198
+msgid "force progress reporting"
 msgstr "Fortschrittsanzeige erzwingen"
 
-#: builtin/blame.c:874
-msgid "Show output score for blame entries"
+#: builtin/blame.c:872
+#, fuzzy
+msgid "show output score for blame entries"
 msgstr "Ausgabebewertung für \"blame\"-Einträge anzeigen"
 
-#: builtin/blame.c:875
-msgid "Show original filename (Default: auto)"
+#: builtin/blame.c:873
+#, fuzzy
+msgid "show original filename (Default: auto)"
 msgstr "ursprünglichen Dateinamen anzeigen (Standard: auto)"
 
-#: builtin/blame.c:876
-msgid "Show original linenumber (Default: off)"
+#: builtin/blame.c:874
+#, fuzzy
+msgid "show original linenumber (Default: off)"
 msgstr "ursprüngliche Zeilennummer anzeigen (Standard: aus)"
 
-#: builtin/blame.c:877
-msgid "Show in a format designed for machine consumption"
+#: builtin/blame.c:875
+#, fuzzy
+msgid "show in a format designed for machine consumption"
 msgstr "Anzeige in einem Format für maschinelle Auswertung"
 
-#: builtin/blame.c:878
-msgid "Show porcelain format with per-line commit information"
+#: builtin/blame.c:876
+#, fuzzy
+msgid "show porcelain format with per-line commit information"
 msgstr ""
 "Anzeige in Format für Fremdprogramme mit Commit-Informationen pro Zeile"
 
-#: builtin/blame.c:879
-msgid "Use the same output mode as git-annotate (Default: off)"
+#: builtin/blame.c:877
+#, fuzzy
+msgid "use the same output mode as git-annotate (Default: off)"
 msgstr ""
 "Den gleichen Ausgabemodus benutzen wie \"git-annotate\" (Standard: aus)"
 
-#: builtin/blame.c:880
-msgid "Show raw timestamp (Default: off)"
+#: builtin/blame.c:878
+#, fuzzy
+msgid "show raw timestamp (Default: off)"
 msgstr "Unbearbeiteten Zeitstempel anzeigen (Standard: aus)"
 
-#: builtin/blame.c:881
-msgid "Show long commit SHA1 (Default: off)"
+#: builtin/blame.c:879
+#, fuzzy
+msgid "show long commit SHA1 (Default: off)"
 msgstr "Langen Commit-SHA1 anzeigen (Standard: aus)"
 
-#: builtin/blame.c:882
-msgid "Suppress author name and timestamp (Default: off)"
+#: builtin/blame.c:880
+#, fuzzy
+msgid "suppress author name and timestamp (Default: off)"
 msgstr "Den Namen des Autors und den Zeitstempel unterdrücken (Standard: aus)"
 
-#: builtin/blame.c:883
-msgid "Show author email instead of name (Default: off)"
+#: builtin/blame.c:881
+#, fuzzy
+msgid "show author email instead of name (Default: off)"
 msgstr ""
 "Anstatt des Namens die E-Mail-Adresse des Autors anzeigen (Standard: aus)"
 
-#: builtin/blame.c:884
-msgid "Ignore whitespace differences"
+#: builtin/blame.c:882
+#, fuzzy
+msgid "ignore whitespace differences"
 msgstr "Unterschiede im Whitespace ignorieren"
 
-#: builtin/blame.c:885 builtin/log.c:1813
+#: builtin/blame.c:883 builtin/log.c:1812
 msgid "rev"
 msgstr "Commit"
 
-#: builtin/blame.c:885
-msgid "Ignore <rev> when blaming"
+#: builtin/blame.c:883
+#, fuzzy
+msgid "ignore <rev> when blaming"
 msgstr "Ignoriere <Commit> beim Ausführen von 'blame'"
 
-#: builtin/blame.c:886
-msgid "Ignore revisions from <file>"
+#: builtin/blame.c:884
+#, fuzzy
+msgid "ignore revisions from <file>"
 msgstr "Ignoriere Commits aus <Datei>"
 
-#: builtin/blame.c:887
+#: builtin/blame.c:885
 msgid "color redundant metadata from previous line differently"
 msgstr "redundante Metadaten der vorherigen Zeile unterschiedlich einfärben"
 
-#: builtin/blame.c:888
+#: builtin/blame.c:886
 msgid "color lines by age"
 msgstr "Zeilen nach Alter einfärben"
 
-#: builtin/blame.c:889
-msgid "Spend extra cycles to find better match"
+#: builtin/blame.c:887
+#, fuzzy
+msgid "spend extra cycles to find better match"
 msgstr "Länger arbeiten, um bessere Übereinstimmungen zu finden"
 
-#: builtin/blame.c:890
-msgid "Use revisions from <file> instead of calling git-rev-list"
+#: builtin/blame.c:888
+#, fuzzy
+msgid "use revisions from <file> instead of calling git-rev-list"
 msgstr "Commits von <Datei> benutzen, anstatt \"git-rev-list\" aufzurufen"
 
-#: builtin/blame.c:891
-msgid "Use <file>'s contents as the final image"
+#: builtin/blame.c:889
+#, fuzzy
+msgid "use <file>'s contents as the final image"
 msgstr "Inhalte der <Datei>en als endgültiges Abbild benutzen"
 
-#: builtin/blame.c:892 builtin/blame.c:893
+#: builtin/blame.c:890 builtin/blame.c:891
 msgid "score"
 msgstr "Bewertung"
 
-#: builtin/blame.c:892
-msgid "Find line copies within and across files"
+#: builtin/blame.c:890
+#, fuzzy
+msgid "find line copies within and across files"
 msgstr "kopierte Zeilen innerhalb oder zwischen Dateien finden"
 
-#: builtin/blame.c:893
-msgid "Find line movements within and across files"
+#: builtin/blame.c:891
+#, fuzzy
+msgid "find line movements within and across files"
 msgstr "verschobene Zeilen innerhalb oder zwischen Dateien finden"
 
-#: builtin/blame.c:894
+#: builtin/blame.c:892
 msgid "range"
 msgstr "Bereich"
 
-#: builtin/blame.c:895
-msgid "Process only line range <start>,<end> or function :<funcname>"
+#: builtin/blame.c:893
+#, fuzzy
+msgid "process only line range <start>,<end> or function :<funcname>"
 msgstr ""
 "Nur Zeilen im Bereich <Start>,<Ende> oder Funktion :<Funktionsname> "
 "verarbeiten"
 
-#: builtin/blame.c:947
+#: builtin/blame.c:945
 msgid "--progress can't be used with --incremental or porcelain formats"
 msgstr ""
 "--progress kann nicht mit --incremental oder Formaten für Fremdprogramme\n"
@@ -11048,18 +11384,18 @@ msgstr ""
 #. your language may need more or fewer display
 #. columns.
 #.
-#: builtin/blame.c:998
+#: builtin/blame.c:996
 msgid "4 years, 11 months ago"
 msgstr "vor 4 Jahren und 11 Monaten"
 
-#: builtin/blame.c:1114
+#: builtin/blame.c:1112
 #, c-format
 msgid "file %s has only %lu line"
 msgid_plural "file %s has only %lu lines"
 msgstr[0] "Datei %s hat nur %lu Zeile"
 msgstr[1] "Datei %s hat nur %lu Zeilen"
 
-#: builtin/blame.c:1159
+#: builtin/blame.c:1157
 msgid "Blaming lines"
 msgstr "Verarbeite Zeilen"
 
@@ -11128,124 +11464,114 @@ msgstr ""
 msgid "Update of config-file failed"
 msgstr "Aktualisierung der Konfigurationsdatei fehlgeschlagen."
 
-#: builtin/branch.c:220
+#: builtin/branch.c:223
 msgid "cannot use -a with -d"
 msgstr "kann -a nicht mit -d benutzen"
 
-#: builtin/branch.c:226
+#: builtin/branch.c:230
 msgid "Couldn't look up commit object for HEAD"
 msgstr "Konnte Commit-Objekt für HEAD nicht nachschlagen."
 
-#: builtin/branch.c:240
+#: builtin/branch.c:244
 #, c-format
 msgid "Cannot delete branch '%s' checked out at '%s'"
 msgstr "Kann Branch '%s' nicht entfernen, ausgecheckt in '%s'."
 
-#: builtin/branch.c:255
+#: builtin/branch.c:259
 #, c-format
 msgid "remote-tracking branch '%s' not found."
 msgstr "Remote-Tracking-Branch '%s' nicht gefunden"
 
-#: builtin/branch.c:256
+#: builtin/branch.c:260
 #, c-format
 msgid "branch '%s' not found."
 msgstr "Branch '%s' nicht gefunden."
 
-#: builtin/branch.c:271
-#, c-format
-msgid "Error deleting remote-tracking branch '%s'"
-msgstr "Fehler beim Entfernen des Remote-Tracking-Branches '%s'"
-
-#: builtin/branch.c:272
-#, c-format
-msgid "Error deleting branch '%s'"
-msgstr "Fehler beim Entfernen des Branches '%s'"
-
-#: builtin/branch.c:279
+#: builtin/branch.c:291
 #, c-format
 msgid "Deleted remote-tracking branch %s (was %s).\n"
 msgstr "Remote-Tracking-Branch %s entfernt (war %s).\n"
 
-#: builtin/branch.c:280
+#: builtin/branch.c:292
 #, c-format
 msgid "Deleted branch %s (was %s).\n"
 msgstr "Branch %s entfernt (war %s).\n"
 
-#: builtin/branch.c:429 builtin/tag.c:61
+#: builtin/branch.c:438 builtin/tag.c:61
 msgid "unable to parse format string"
 msgstr "Konnte Formatierungsstring nicht parsen."
 
-#: builtin/branch.c:460
+#: builtin/branch.c:469
 msgid "could not resolve HEAD"
 msgstr "Konnte HEAD-Commit nicht auflösen."
 
-#: builtin/branch.c:466
+#: builtin/branch.c:475
 #, c-format
 msgid "HEAD (%s) points outside of refs/heads/"
 msgstr "HEAD (%s) wurde nicht unter \"refs/heads/\" gefunden!"
 
-#: builtin/branch.c:481
+#: builtin/branch.c:490
 #, c-format
 msgid "Branch %s is being rebased at %s"
 msgstr "Branch %s wird auf %s umgesetzt"
 
-#: builtin/branch.c:485
+#: builtin/branch.c:494
 #, c-format
 msgid "Branch %s is being bisected at %s"
 msgstr "Binäre Suche von Branch %s zu %s im Gange"
 
-#: builtin/branch.c:502
+#: builtin/branch.c:511
 msgid "cannot copy the current branch while not on any."
 msgstr ""
 "Kann den aktuellen Branch nicht kopieren, solange Sie sich auf keinem "
 "befinden."
 
-#: builtin/branch.c:504
+#: builtin/branch.c:513
 msgid "cannot rename the current branch while not on any."
 msgstr ""
 "Kann aktuellen Branch nicht umbenennen, solange Sie sich auf keinem befinden."
 
-#: builtin/branch.c:515
+#: builtin/branch.c:524
 #, c-format
 msgid "Invalid branch name: '%s'"
 msgstr "Ungültiger Branchname: '%s'"
 
-#: builtin/branch.c:544
+#: builtin/branch.c:553
 msgid "Branch rename failed"
 msgstr "Umbenennung des Branches fehlgeschlagen"
 
-#: builtin/branch.c:546
+#: builtin/branch.c:555
 msgid "Branch copy failed"
 msgstr "Kopie des Branches fehlgeschlagen"
 
-#: builtin/branch.c:550
+#: builtin/branch.c:559
 #, c-format
 msgid "Created a copy of a misnamed branch '%s'"
 msgstr "Kopie eines falsch benannten Branches '%s' erstellt."
 
-#: builtin/branch.c:553
+#: builtin/branch.c:562
 #, c-format
 msgid "Renamed a misnamed branch '%s' away"
 msgstr "falsch benannten Branch '%s' umbenannt"
 
-#: builtin/branch.c:559
+#: builtin/branch.c:568
 #, c-format
 msgid "Branch renamed to %s, but HEAD is not updated!"
 msgstr "Branch umbenannt zu %s, aber HEAD ist nicht aktualisiert!"
 
-#: builtin/branch.c:568
+#: builtin/branch.c:577
 msgid "Branch is renamed, but update of config-file failed"
 msgstr ""
 "Branch ist umbenannt, aber die Aktualisierung der Konfigurationsdatei ist "
 "fehlgeschlagen."
 
-#: builtin/branch.c:570
+#: builtin/branch.c:579
 msgid "Branch is copied, but update of config-file failed"
 msgstr ""
 "Branch wurde kopiert, aber die Aktualisierung der Konfigurationsdatei ist\n"
 "fehlgeschlagen."
 
-#: builtin/branch.c:586
+#: builtin/branch.c:595
 #, c-format
 msgid ""
 "Please edit the description for the branch\n"
@@ -11256,181 +11582,181 @@ msgstr ""
 "  %s\n"
 "Zeilen, die mit '%c' beginnen, werden entfernt.\n"
 
-#: builtin/branch.c:620
+#: builtin/branch.c:629
 msgid "Generic options"
 msgstr "Allgemeine Optionen"
 
-#: builtin/branch.c:622
+#: builtin/branch.c:631
 msgid "show hash and subject, give twice for upstream branch"
 msgstr "Hash und Betreff anzeigen; -vv: zusätzlich Upstream-Branch"
 
-#: builtin/branch.c:623
+#: builtin/branch.c:632
 msgid "suppress informational messages"
 msgstr "Informationsmeldungen unterdrücken"
 
-#: builtin/branch.c:624
+#: builtin/branch.c:633
 msgid "set up tracking mode (see git-pull(1))"
 msgstr "Modus zum Folgen von Branches einstellen (siehe git-pull(1))"
 
-#: builtin/branch.c:626
+#: builtin/branch.c:635
 msgid "do not use"
 msgstr "nicht verwenden"
 
-#: builtin/branch.c:628 builtin/rebase.c:532
+#: builtin/branch.c:637 builtin/rebase.c:534
 msgid "upstream"
 msgstr "Upstream"
 
-#: builtin/branch.c:628
+#: builtin/branch.c:637
 msgid "change the upstream info"
 msgstr "Informationen zum Upstream-Branch ändern"
 
-#: builtin/branch.c:629
+#: builtin/branch.c:638
 msgid "unset the upstream info"
 msgstr "Informationen zum Upstream-Branch entfernen"
 
-#: builtin/branch.c:630
+#: builtin/branch.c:639
 msgid "use colored output"
 msgstr "farbige Ausgaben verwenden"
 
-#: builtin/branch.c:631
+#: builtin/branch.c:640
 msgid "act on remote-tracking branches"
 msgstr "auf Remote-Tracking-Branches wirken"
 
-#: builtin/branch.c:633 builtin/branch.c:635
+#: builtin/branch.c:642 builtin/branch.c:644
 msgid "print only branches that contain the commit"
 msgstr "nur Branches ausgeben, die diesen Commit enthalten"
 
-#: builtin/branch.c:634 builtin/branch.c:636
+#: builtin/branch.c:643 builtin/branch.c:645
 msgid "print only branches that don't contain the commit"
 msgstr "nur Branches ausgeben, die diesen Commit nicht enthalten"
 
-#: builtin/branch.c:639
+#: builtin/branch.c:648
 msgid "Specific git-branch actions:"
 msgstr "spezifische Aktionen für \"git-branch\":"
 
-#: builtin/branch.c:640
+#: builtin/branch.c:649
 msgid "list both remote-tracking and local branches"
 msgstr "Remote-Tracking und lokale Branches auflisten"
 
-#: builtin/branch.c:642
+#: builtin/branch.c:651
 msgid "delete fully merged branch"
 msgstr "vollständig zusammengeführten Branch entfernen"
 
-#: builtin/branch.c:643
+#: builtin/branch.c:652
 msgid "delete branch (even if not merged)"
 msgstr "Branch löschen (auch wenn nicht zusammengeführt)"
 
-#: builtin/branch.c:644
+#: builtin/branch.c:653
 msgid "move/rename a branch and its reflog"
 msgstr "einen Branch und dessen Reflog verschieben/umbenennen"
 
-#: builtin/branch.c:645
+#: builtin/branch.c:654
 msgid "move/rename a branch, even if target exists"
 msgstr ""
 "einen Branch verschieben/umbenennen, auch wenn das Ziel bereits existiert"
 
-#: builtin/branch.c:646
+#: builtin/branch.c:655
 msgid "copy a branch and its reflog"
 msgstr "einen Branch und dessen Reflog kopieren"
 
-#: builtin/branch.c:647
+#: builtin/branch.c:656
 msgid "copy a branch, even if target exists"
 msgstr "einen Branch kopieren, auch wenn das Ziel bereits existiert"
 
-#: builtin/branch.c:648
+#: builtin/branch.c:657
 msgid "list branch names"
 msgstr "Branchnamen auflisten"
 
-#: builtin/branch.c:649
+#: builtin/branch.c:658
 msgid "show current branch name"
 msgstr "Zeige aktuellen Branch-Namen."
 
-#: builtin/branch.c:650
+#: builtin/branch.c:659
 msgid "create the branch's reflog"
 msgstr "das Reflog des Branches erzeugen"
 
-#: builtin/branch.c:652
+#: builtin/branch.c:661
 msgid "edit the description for the branch"
 msgstr "die Beschreibung für den Branch bearbeiten"
 
-#: builtin/branch.c:653
+#: builtin/branch.c:662
 msgid "force creation, move/rename, deletion"
 msgstr "Erstellung, Verschiebung/Umbenennung oder Löschung erzwingen"
 
-#: builtin/branch.c:654
+#: builtin/branch.c:663
 msgid "print only branches that are merged"
 msgstr "nur zusammengeführte Branches ausgeben"
 
-#: builtin/branch.c:655
+#: builtin/branch.c:664
 msgid "print only branches that are not merged"
 msgstr "nur nicht zusammengeführte Branches ausgeben"
 
-#: builtin/branch.c:656
+#: builtin/branch.c:665
 msgid "list branches in columns"
 msgstr "Branches in Spalten auflisten"
 
-#: builtin/branch.c:658 builtin/for-each-ref.c:42 builtin/notes.c:415
+#: builtin/branch.c:667 builtin/for-each-ref.c:42 builtin/notes.c:415
 #: builtin/notes.c:418 builtin/notes.c:581 builtin/notes.c:584
-#: builtin/tag.c:434
+#: builtin/tag.c:466
 msgid "object"
 msgstr "Objekt"
 
-#: builtin/branch.c:659
+#: builtin/branch.c:668
 msgid "print only branches of the object"
 msgstr "nur Branches von diesem Objekt ausgeben"
 
-#: builtin/branch.c:660 builtin/for-each-ref.c:48 builtin/tag.c:441
+#: builtin/branch.c:669 builtin/for-each-ref.c:48 builtin/tag.c:473
 msgid "sorting and filtering are case insensitive"
 msgstr "Sortierung und Filterung sind unabhängig von Groß- und Kleinschreibung"
 
-#: builtin/branch.c:661 builtin/for-each-ref.c:38 builtin/tag.c:439
+#: builtin/branch.c:670 builtin/for-each-ref.c:38 builtin/tag.c:471
 #: builtin/verify-tag.c:38
 msgid "format to use for the output"
 msgstr "für die Ausgabe zu verwendendes Format"
 
-#: builtin/branch.c:684 builtin/clone.c:790
+#: builtin/branch.c:693 builtin/clone.c:790
 msgid "HEAD not found below refs/heads!"
 msgstr "HEAD wurde nicht unter \"refs/heads\" gefunden!"
 
-#: builtin/branch.c:708
+#: builtin/branch.c:717
 msgid "--column and --verbose are incompatible"
 msgstr "Die Optionen --column und --verbose sind inkompatibel."
 
-#: builtin/branch.c:723 builtin/branch.c:777 builtin/branch.c:786
+#: builtin/branch.c:732 builtin/branch.c:788 builtin/branch.c:797
 msgid "branch name required"
 msgstr "Branchname erforderlich"
 
-#: builtin/branch.c:753
+#: builtin/branch.c:764
 msgid "Cannot give description to detached HEAD"
 msgstr "zu losgelöstem HEAD kann keine Beschreibung hinterlegt werden"
 
-#: builtin/branch.c:758
+#: builtin/branch.c:769
 msgid "cannot edit description of more than one branch"
 msgstr "Beschreibung von mehr als einem Branch kann nicht bearbeitet werden"
 
-#: builtin/branch.c:765
+#: builtin/branch.c:776
 #, c-format
 msgid "No commit on branch '%s' yet."
 msgstr "Noch kein Commit in Branch '%s'."
 
-#: builtin/branch.c:768
+#: builtin/branch.c:779
 #, c-format
 msgid "No branch named '%s'."
 msgstr "Branch '%s' nicht vorhanden."
 
-#: builtin/branch.c:783
+#: builtin/branch.c:794
 msgid "too many branches for a copy operation"
 msgstr "zu viele Branches für eine Kopieroperation angegeben"
 
-#: builtin/branch.c:792
+#: builtin/branch.c:803
 msgid "too many arguments for a rename operation"
 msgstr "zu viele Argumente für eine Umbenennen-Operation angegeben"
 
-#: builtin/branch.c:797
+#: builtin/branch.c:808
 msgid "too many arguments to set new upstream"
 msgstr "zu viele Argumente angegeben, um Upstream-Branch zu setzen"
 
-#: builtin/branch.c:801
+#: builtin/branch.c:812
 #, c-format
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch."
@@ -11438,34 +11764,34 @@ msgstr ""
 "Konnte keinen neuen Upstream-Branch von HEAD zu %s setzen, da dieser auf\n"
 "keinen Branch zeigt."
 
-#: builtin/branch.c:804 builtin/branch.c:827
+#: builtin/branch.c:815 builtin/branch.c:838
 #, c-format
 msgid "no such branch '%s'"
 msgstr "Kein solcher Branch '%s'"
 
-#: builtin/branch.c:808
+#: builtin/branch.c:819
 #, c-format
 msgid "branch '%s' does not exist"
 msgstr "Branch '%s' existiert nicht"
 
-#: builtin/branch.c:821
+#: builtin/branch.c:832
 msgid "too many arguments to unset upstream"
 msgstr ""
 "zu viele Argumente angegeben, um Konfiguration zu Upstream-Branch zu "
 "entfernen"
 
-#: builtin/branch.c:825
+#: builtin/branch.c:836
 msgid "could not unset upstream of HEAD when it does not point to any branch."
 msgstr ""
 "Konnte Konfiguration zu Upstream-Branch von HEAD nicht entfernen, da dieser\n"
 "auf keinen Branch zeigt."
 
-#: builtin/branch.c:831
+#: builtin/branch.c:842
 #, c-format
 msgid "Branch '%s' has no upstream information"
 msgstr "Branch '%s' hat keinen Upstream-Branch gesetzt"
 
-#: builtin/branch.c:841
+#: builtin/branch.c:852
 msgid ""
 "The -a, and -r, options to 'git branch' do not take a branch name.\n"
 "Did you mean to use: -a|-r --list <pattern>?"
@@ -11474,7 +11800,7 @@ msgstr ""
 "verwendet werden.\n"
 "Wollten Sie -a|-r --list <Muster> benutzen?"
 
-#: builtin/branch.c:845
+#: builtin/branch.c:856
 msgid ""
 "the '--set-upstream' option is no longer supported. Please use '--track' or "
 "'--set-upstream-to' instead."
@@ -11596,19 +11922,19 @@ msgstr "git bundle list-heads <Datei> [<Referenzname>...]"
 msgid "git bundle unbundle <file> [<refname>...]"
 msgstr "git bundle unbundle <Datei> [<Referenzname>...]"
 
-#: builtin/bundle.c:67 builtin/pack-objects.c:3480
+#: builtin/bundle.c:67 builtin/pack-objects.c:3495
 msgid "do not show progress meter"
 msgstr "keine Fortschrittsanzeige anzeigen"
 
-#: builtin/bundle.c:69 builtin/pack-objects.c:3482
+#: builtin/bundle.c:69 builtin/pack-objects.c:3497
 msgid "show progress meter"
 msgstr "Fortschrittsanzeige anzeigen"
 
-#: builtin/bundle.c:71 builtin/pack-objects.c:3484
+#: builtin/bundle.c:71 builtin/pack-objects.c:3499
 msgid "show progress meter during object writing phase"
 msgstr "Forschrittsanzeige während des Schreibens von Objekten anzeigen"
 
-#: builtin/bundle.c:74 builtin/pack-objects.c:3487
+#: builtin/bundle.c:74 builtin/pack-objects.c:3502
 msgid "similar to --all-progress when progress meter is shown"
 msgstr "ähnlich zu --all-progress wenn Fortschrittsanzeige darstellt wird"
 
@@ -11755,8 +12081,8 @@ msgstr "Dateinamen von der Standard-Eingabe lesen"
 msgid "terminate input and output records by a NUL character"
 msgstr "Einträge von Ein- und Ausgabe mit NUL-Zeichen abschließen"
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1500 builtin/gc.c:541
-#: builtin/worktree.c:561
+#: builtin/check-ignore.c:21 builtin/checkout.c:1499 builtin/gc.c:549
+#: builtin/worktree.c:489
 msgid "suppress progress reporting"
 msgstr "Fortschrittsanzeige unterdrücken"
 
@@ -11810,57 +12136,57 @@ msgstr "Konnte Kontakt '%s' nicht parsen."
 msgid "no contacts specified"
 msgstr "keine Kontakte angegeben"
 
-#: builtin/checkout-index.c:139
+#: builtin/checkout-index.c:152
 msgid "git checkout-index [<options>] [--] [<file>...]"
 msgstr "git checkout-index [<Optionen>] [--] [<Datei>...]"
 
-#: builtin/checkout-index.c:156
+#: builtin/checkout-index.c:169
 msgid "stage should be between 1 and 3 or all"
 msgstr "--stage sollte zwischen 1 und 3 oder 'all' sein"
 
-#: builtin/checkout-index.c:173
+#: builtin/checkout-index.c:186
 msgid "check out all files in the index"
 msgstr "alle Dateien im Index auschecken"
 
-#: builtin/checkout-index.c:174
+#: builtin/checkout-index.c:187
 msgid "force overwrite of existing files"
 msgstr "das Überschreiben bereits existierender Dateien erzwingen"
 
-#: builtin/checkout-index.c:176
+#: builtin/checkout-index.c:189
 msgid "no warning for existing files and files not in index"
 msgstr ""
 "keine Warnung für existierende Dateien, und Dateien, die sich nicht im Index "
 "befinden"
 
-#: builtin/checkout-index.c:178
+#: builtin/checkout-index.c:191
 msgid "don't checkout new files"
 msgstr "keine neuen Dateien auschecken"
 
-#: builtin/checkout-index.c:180
+#: builtin/checkout-index.c:193
 msgid "update stat information in the index file"
 msgstr "Dateiinformationen in der Index-Datei aktualisieren"
 
-#: builtin/checkout-index.c:184
+#: builtin/checkout-index.c:197
 msgid "read list of paths from the standard input"
 msgstr "eine Liste von Pfaden von der Standard-Eingabe lesen"
 
-#: builtin/checkout-index.c:186
+#: builtin/checkout-index.c:199
 msgid "write the content to temporary files"
 msgstr "den Inhalt in temporäre Dateien schreiben"
 
-#: builtin/checkout-index.c:187 builtin/column.c:31
+#: builtin/checkout-index.c:200 builtin/column.c:31
 #: builtin/submodule--helper.c:1824 builtin/submodule--helper.c:1827
 #: builtin/submodule--helper.c:1835 builtin/submodule--helper.c:2333
-#: builtin/worktree.c:757
+#: builtin/worktree.c:717
 msgid "string"
 msgstr "Zeichenkette"
 
-#: builtin/checkout-index.c:188
+#: builtin/checkout-index.c:201
 msgid "when creating files, prepend <string>"
 msgstr ""
 "wenn Dateien erzeugt werden, stelle <Zeichenkette> dem Dateinamen voran"
 
-#: builtin/checkout-index.c:190
+#: builtin/checkout-index.c:203
 msgid "copy out the files from named stage"
 msgstr "Dateien von dem benannten Stand kopieren"
 
@@ -11963,16 +12289,16 @@ msgstr "'%s' kann nur genutzt werden, wenn '%s' nicht verwendet wird"
 msgid "'%s' or '%s' cannot be used with %s"
 msgstr "'%s' oder '%s' kann nicht mit %s verwendet werden"
 
-#: builtin/checkout.c:541 builtin/checkout.c:548
+#: builtin/checkout.c:543 builtin/checkout.c:550
 #, c-format
 msgid "path '%s' is unmerged"
 msgstr "Pfad '%s' ist nicht zusammengeführt."
 
-#: builtin/checkout.c:716
+#: builtin/checkout.c:718
 msgid "you need to resolve your current index first"
 msgstr "Sie müssen zuerst die Konflikte in Ihrem aktuellen Index auflösen."
 
-#: builtin/checkout.c:770
+#: builtin/checkout.c:772
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -11981,50 +12307,50 @@ msgstr ""
 "Kann nicht mit vorgemerkten Änderungen in folgenden Dateien fortsetzen:\n"
 "%s"
 
-#: builtin/checkout.c:866
+#: builtin/checkout.c:865
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Kann \"reflog\" für '%s' nicht durchführen: %s\n"
 
-#: builtin/checkout.c:908
+#: builtin/checkout.c:907
 msgid "HEAD is now at"
 msgstr "HEAD ist jetzt bei"
 
-#: builtin/checkout.c:912 builtin/clone.c:721 t/helper/test-fast-rebase.c:202
+#: builtin/checkout.c:911 builtin/clone.c:721 t/helper/test-fast-rebase.c:202
 msgid "unable to update HEAD"
 msgstr "Konnte HEAD nicht aktualisieren."
 
-#: builtin/checkout.c:916
+#: builtin/checkout.c:915
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Setze Branch '%s' neu\n"
 
-#: builtin/checkout.c:919
+#: builtin/checkout.c:918
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Bereits auf '%s'\n"
 
-#: builtin/checkout.c:923
+#: builtin/checkout.c:922
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Zu umgesetztem Branch '%s' gewechselt\n"
 
-#: builtin/checkout.c:925 builtin/checkout.c:1356
+#: builtin/checkout.c:924 builtin/checkout.c:1355
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Zu neuem Branch '%s' gewechselt\n"
 
-#: builtin/checkout.c:927
+#: builtin/checkout.c:926
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Zu Branch '%s' gewechselt\n"
 
-#: builtin/checkout.c:978
+#: builtin/checkout.c:977
 #, c-format
 msgid " ... and %d more.\n"
 msgstr " ... und %d weitere.\n"
 
-#: builtin/checkout.c:984
+#: builtin/checkout.c:983
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -12047,7 +12373,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:1003
+#: builtin/checkout.c:1002
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -12074,19 +12400,19 @@ msgstr[1] ""
 " git branch <neuer-Branchname> %s\n"
 "\n"
 
-#: builtin/checkout.c:1038
+#: builtin/checkout.c:1037
 msgid "internal error in revision walk"
 msgstr "interner Fehler im Revisionsgang"
 
-#: builtin/checkout.c:1042
+#: builtin/checkout.c:1041
 msgid "Previous HEAD position was"
 msgstr "Vorherige Position von HEAD war"
 
-#: builtin/checkout.c:1082 builtin/checkout.c:1351
+#: builtin/checkout.c:1081 builtin/checkout.c:1350
 msgid "You are on a branch yet to be born"
 msgstr "Sie sind auf einem Branch, der noch nicht geboren ist"
 
-#: builtin/checkout.c:1164
+#: builtin/checkout.c:1163
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
@@ -12096,7 +12422,7 @@ msgstr ""
 "Bitte benutzen Sie -- (und optional --no-guess), um diese\n"
 "eindeutig voneinander zu unterscheiden."
 
-#: builtin/checkout.c:1171
+#: builtin/checkout.c:1170
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -12119,51 +12445,51 @@ msgstr ""
 "bevorzugen möchten, z.B. 'origin', können Sie die Einstellung\n"
 "checkout.defaultRemote=origin in Ihrer Konfiguration setzen."
 
-#: builtin/checkout.c:1181
+#: builtin/checkout.c:1180
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "'%s' entspricht mehreren (%d) Remote-Tracking-Branches"
 
-#: builtin/checkout.c:1247
+#: builtin/checkout.c:1246
 msgid "only one reference expected"
 msgstr "nur eine Referenz erwartet"
 
-#: builtin/checkout.c:1264
+#: builtin/checkout.c:1263
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "nur eine Referenz erwartet, %d gegeben."
 
-#: builtin/checkout.c:1310 builtin/worktree.c:342 builtin/worktree.c:510
+#: builtin/checkout.c:1309 builtin/worktree.c:270 builtin/worktree.c:438
 #, c-format
 msgid "invalid reference: %s"
 msgstr "Ungültige Referenz: %s"
 
-#: builtin/checkout.c:1323 builtin/checkout.c:1689
+#: builtin/checkout.c:1322 builtin/checkout.c:1688
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "Referenz ist kein \"Tree\"-Objekt: %s"
 
-#: builtin/checkout.c:1370
+#: builtin/checkout.c:1369
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "Ein Branch wird erwartet, Tag '%s' bekommen"
 
-#: builtin/checkout.c:1372
+#: builtin/checkout.c:1371
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "Ein Branch wird erwartet, Remote-Branch '%s' bekommen"
 
-#: builtin/checkout.c:1373 builtin/checkout.c:1381
+#: builtin/checkout.c:1372 builtin/checkout.c:1380
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "Ein Branch wird erwartet, '%s' bekommen"
 
-#: builtin/checkout.c:1376
+#: builtin/checkout.c:1375
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "Ein Branch wird erwartet, Commit '%s' bekommen"
 
-#: builtin/checkout.c:1392
+#: builtin/checkout.c:1391
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -12171,7 +12497,7 @@ msgstr ""
 "Der Branch kann nicht während eines Merges gewechselt werden.\n"
 "Ziehen Sie \"git merge --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1396
+#: builtin/checkout.c:1395
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
@@ -12180,7 +12506,7 @@ msgstr ""
 "werden.\n"
 "Ziehen Sie \"git am --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1400
+#: builtin/checkout.c:1399
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
@@ -12189,7 +12515,7 @@ msgstr ""
 "werden.\n"
 "Ziehen Sie \"git rebase --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1404
+#: builtin/checkout.c:1403
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
@@ -12198,7 +12524,7 @@ msgstr ""
 "gewechselt werden.\n"
 "Ziehen Sie \"git cherry-pick --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1408
+#: builtin/checkout.c:1407
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -12207,147 +12533,140 @@ msgstr ""
 "werden.\n"
 "Ziehen Sie \"git revert --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1412
+#: builtin/checkout.c:1411
 msgid "you are switching branch while bisecting"
 msgstr "Sie wechseln den Branch während einer binären Suche"
 
-#: builtin/checkout.c:1419
+#: builtin/checkout.c:1418
 msgid "paths cannot be used with switching branches"
 msgstr "Pfade können nicht beim Wechseln von Branches verwendet werden"
 
-#: builtin/checkout.c:1422 builtin/checkout.c:1426 builtin/checkout.c:1430
+#: builtin/checkout.c:1421 builtin/checkout.c:1425 builtin/checkout.c:1429
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "'%s' kann nicht beim Wechseln von Branches verwendet werden"
 
-#: builtin/checkout.c:1434 builtin/checkout.c:1437 builtin/checkout.c:1440
-#: builtin/checkout.c:1445 builtin/checkout.c:1450
+#: builtin/checkout.c:1433 builtin/checkout.c:1436 builtin/checkout.c:1439
+#: builtin/checkout.c:1444 builtin/checkout.c:1449
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "'%s' kann nicht mit '%s' verwendet werden"
 
-#: builtin/checkout.c:1447
+#: builtin/checkout.c:1446
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "'%s' kann nicht <Startpunkt> bekommen"
 
-#: builtin/checkout.c:1455
+#: builtin/checkout.c:1454
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "Kann Branch nicht zu Nicht-Commit '%s' wechseln"
 
-#: builtin/checkout.c:1462
+#: builtin/checkout.c:1461
 msgid "missing branch or commit argument"
 msgstr "Branch- oder Commit-Argument fehlt"
 
-#: builtin/checkout.c:1504 builtin/clone.c:92 builtin/commit-graph.c:84
-#: builtin/commit-graph.c:222 builtin/fetch.c:172 builtin/merge.c:296
-#: builtin/multi-pack-index.c:27 builtin/pull.c:119 builtin/push.c:575
-#: builtin/send-pack.c:198
-msgid "force progress reporting"
-msgstr "Fortschrittsanzeige erzwingen"
-
-#: builtin/checkout.c:1505
+#: builtin/checkout.c:1504
 msgid "perform a 3-way merge with the new branch"
 msgstr "einen 3-Wege-Merge mit dem neuen Branch ausführen"
 
-#: builtin/checkout.c:1506 builtin/log.c:1800 parse-options.h:322
+#: builtin/checkout.c:1505 builtin/log.c:1799 parse-options.h:322
 msgid "style"
 msgstr "Stil"
 
-#: builtin/checkout.c:1507
+#: builtin/checkout.c:1506
 msgid "conflict style (merge or diff3)"
 msgstr "Konfliktstil (merge oder diff3)"
 
-#: builtin/checkout.c:1519 builtin/worktree.c:558
+#: builtin/checkout.c:1518 builtin/worktree.c:486
 msgid "detach HEAD at named commit"
 msgstr "HEAD bei benanntem Commit loslösen"
 
-#: builtin/checkout.c:1520
+#: builtin/checkout.c:1519
 msgid "set upstream info for new branch"
 msgstr "Informationen zum Upstream-Branch für den neuen Branch setzen"
 
-#: builtin/checkout.c:1522
+#: builtin/checkout.c:1521
 msgid "force checkout (throw away local modifications)"
 msgstr "Auschecken erzwingen (verwirft lokale Änderungen)"
 
-#: builtin/checkout.c:1524
+#: builtin/checkout.c:1523
 msgid "new-branch"
 msgstr "neuer Branch"
 
-#: builtin/checkout.c:1524
+#: builtin/checkout.c:1523
 msgid "new unparented branch"
 msgstr "neuer Branch ohne Eltern-Commit"
 
-#: builtin/checkout.c:1526 builtin/merge.c:300
+#: builtin/checkout.c:1525 builtin/merge.c:301
 msgid "update ignored files (default)"
 msgstr "ignorierte Dateien aktualisieren (Standard)"
 
-#: builtin/checkout.c:1529
+#: builtin/checkout.c:1528
 msgid "do not check if another worktree is holding the given ref"
 msgstr ""
 "Prüfung, ob die Referenz bereits in einem anderen Arbeitsverzeichnis "
 "ausgecheckt wurde, deaktivieren"
 
-#: builtin/checkout.c:1542
+#: builtin/checkout.c:1541
 msgid "checkout our version for unmerged files"
 msgstr "unsere Variante für nicht zusammengeführte Dateien auschecken"
 
-#: builtin/checkout.c:1545
+#: builtin/checkout.c:1544
 msgid "checkout their version for unmerged files"
 msgstr "ihre Variante für nicht zusammengeführte Dateien auschecken"
 
-#: builtin/checkout.c:1549
+#: builtin/checkout.c:1548
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "keine Einschränkung bei Pfadspezifikationen zum partiellen Auschecken"
 
-#: builtin/checkout.c:1604
+#: builtin/checkout.c:1603
 #, c-format
 msgid "-%c, -%c and --orphan are mutually exclusive"
 msgstr "die Optionen -%c, -%c und --orphan schließen sich gegenseitig aus"
 
-#: builtin/checkout.c:1608
+#: builtin/checkout.c:1607
 msgid "-p and --overlay are mutually exclusive"
 msgstr "-p und --overlay schließen sich gegenseitig aus."
 
-#: builtin/checkout.c:1645
+#: builtin/checkout.c:1644
 msgid "--track needs a branch name"
 msgstr "Bei der Option --track muss ein Branchname angegeben werden."
 
-#: builtin/checkout.c:1650
+#: builtin/checkout.c:1649
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "kein Branchname; versuchen Sie -%c"
 
-#: builtin/checkout.c:1682
+#: builtin/checkout.c:1681
 #, c-format
 msgid "could not resolve %s"
 msgstr "Konnte %s nicht auflösen."
 
-#: builtin/checkout.c:1698
+#: builtin/checkout.c:1697
 msgid "invalid path specification"
 msgstr "ungültige Pfadspezifikation"
 
-#: builtin/checkout.c:1705
+#: builtin/checkout.c:1704
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr ""
 "'%s' ist kein Commit und es kann kein Branch '%s' aus diesem erstellt werden."
 
-#: builtin/checkout.c:1709
+#: builtin/checkout.c:1708
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach nimmt kein Pfad-Argument '%s'"
 
-#: builtin/checkout.c:1718
+#: builtin/checkout.c:1717
 msgid "--pathspec-from-file is incompatible with --detach"
 msgstr "Die Optionen --pathspec-from-file und --detach sind inkompatibel."
 
-#: builtin/checkout.c:1721 builtin/reset.c:325 builtin/stash.c:1499
+#: builtin/checkout.c:1720 builtin/reset.c:325 builtin/stash.c:1566
 msgid "--pathspec-from-file is incompatible with --patch"
 msgstr "Die Optionen --pathspec-from-file und --patch sind inkompatibel."
 
-#: builtin/checkout.c:1734
+#: builtin/checkout.c:1733
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -12355,70 +12674,70 @@ msgstr ""
 "git checkout: --ours/--theirs, --force und --merge sind inkompatibel wenn\n"
 "Sie aus dem Index auschecken."
 
-#: builtin/checkout.c:1739
+#: builtin/checkout.c:1738
 msgid "you must specify path(s) to restore"
 msgstr "Sie müssen Pfad(e) zur Wiederherstellung angeben."
 
-#: builtin/checkout.c:1765 builtin/checkout.c:1767 builtin/checkout.c:1816
-#: builtin/checkout.c:1818 builtin/clone.c:122 builtin/remote.c:170
-#: builtin/remote.c:172 builtin/submodule--helper.c:2719 builtin/worktree.c:554
-#: builtin/worktree.c:556
+#: builtin/checkout.c:1764 builtin/checkout.c:1766 builtin/checkout.c:1815
+#: builtin/checkout.c:1817 builtin/clone.c:122 builtin/remote.c:170
+#: builtin/remote.c:172 builtin/submodule--helper.c:2719 builtin/worktree.c:482
+#: builtin/worktree.c:484
 msgid "branch"
 msgstr "Branch"
 
-#: builtin/checkout.c:1766
+#: builtin/checkout.c:1765
 msgid "create and checkout a new branch"
 msgstr "einen neuen Branch erzeugen und auschecken"
 
-#: builtin/checkout.c:1768
+#: builtin/checkout.c:1767
 msgid "create/reset and checkout a branch"
 msgstr "einen Branch erstellen/umsetzen und auschecken"
 
-#: builtin/checkout.c:1769
+#: builtin/checkout.c:1768
 msgid "create reflog for new branch"
 msgstr "das Reflog für den neuen Branch erzeugen"
 
-#: builtin/checkout.c:1771
+#: builtin/checkout.c:1770
 msgid "second guess 'git checkout <no-such-branch>' (default)"
 msgstr "Zweite Vermutung 'git checkout <kein-solcher-Branch>' (Standard)"
 
-#: builtin/checkout.c:1772
+#: builtin/checkout.c:1771
 msgid "use overlay mode (default)"
 msgstr "benutze Overlay-Modus (Standard)"
 
-#: builtin/checkout.c:1817
+#: builtin/checkout.c:1816
 msgid "create and switch to a new branch"
 msgstr "einen neuen Branch erzeugen und dahin wechseln"
 
-#: builtin/checkout.c:1819
+#: builtin/checkout.c:1818
 msgid "create/reset and switch to a branch"
 msgstr "einen Branch erstellen/umsetzen und dahin wechseln"
 
-#: builtin/checkout.c:1821
+#: builtin/checkout.c:1820
 msgid "second guess 'git switch <no-such-branch>'"
 msgstr "Zweite Vermutung 'git switch <kein-solcher-Branch>'"
 
-#: builtin/checkout.c:1823
+#: builtin/checkout.c:1822
 msgid "throw away local modifications"
 msgstr "lokale Änderungen verwerfen"
 
-#: builtin/checkout.c:1857
+#: builtin/checkout.c:1856
 msgid "which tree-ish to checkout from"
 msgstr "Von welcher Commit-Referenz ausgecheckt werden soll"
 
-#: builtin/checkout.c:1859
+#: builtin/checkout.c:1858
 msgid "restore the index"
 msgstr "Index wiederherstellen"
 
-#: builtin/checkout.c:1861
+#: builtin/checkout.c:1860
 msgid "restore the working tree (default)"
 msgstr "das Arbeitsverzeichnis wiederherstellen (Standard)"
 
-#: builtin/checkout.c:1863
+#: builtin/checkout.c:1862
 msgid "ignore unmerged entries"
 msgstr "ignoriere nicht zusammengeführte Einträge"
 
-#: builtin/checkout.c:1864
+#: builtin/checkout.c:1863
 msgid "use overlay mode"
 msgstr "benutze Overlay-Modus"
 
@@ -12563,8 +12882,8 @@ msgid "remove whole directories"
 msgstr "ganze Verzeichnisse löschen"
 
 #: builtin/clean.c:909 builtin/describe.c:565 builtin/describe.c:567
-#: builtin/grep.c:921 builtin/log.c:183 builtin/log.c:185
-#: builtin/ls-files.c:558 builtin/name-rev.c:526 builtin/name-rev.c:528
+#: builtin/grep.c:922 builtin/log.c:184 builtin/log.c:186
+#: builtin/ls-files.c:573 builtin/name-rev.c:526 builtin/name-rev.c:528
 #: builtin/show-ref.c:179
 msgid "pattern"
 msgstr "Muster"
@@ -12660,7 +12979,7 @@ msgid "use --reference only while cloning"
 msgstr "--reference nur während des Klonens benutzen"
 
 #: builtin/clone.c:120 builtin/column.c:27 builtin/init-db.c:563
-#: builtin/merge-file.c:46 builtin/pack-objects.c:3546 builtin/repack.c:358
+#: builtin/merge-file.c:46 builtin/pack-objects.c:3561 builtin/repack.c:357
 msgid "name"
 msgstr "Name"
 
@@ -12676,7 +12995,7 @@ msgstr "<Branch> auschecken, anstatt HEAD des Remote-Repositories"
 msgid "path to git-upload-pack on the remote"
 msgstr "Pfad zu \"git-upload-pack\" auf der Gegenseite"
 
-#: builtin/clone.c:126 builtin/fetch.c:173 builtin/grep.c:860
+#: builtin/clone.c:126 builtin/fetch.c:176 builtin/grep.c:861
 #: builtin/pull.c:208
 msgid "depth"
 msgstr "Tiefe"
@@ -12686,7 +13005,7 @@ msgid "create a shallow clone of that depth"
 msgstr ""
 "einen Klon mit unvollständiger Historie (shallow) in dieser Tiefe erstellen"
 
-#: builtin/clone.c:128 builtin/fetch.c:175 builtin/pack-objects.c:3535
+#: builtin/clone.c:128 builtin/fetch.c:178 builtin/pack-objects.c:3550
 #: builtin/pull.c:211
 msgid "time"
 msgstr "Zeit"
@@ -12698,12 +13017,12 @@ msgstr ""
 "Zeit\n"
 "erstellen"
 
-#: builtin/clone.c:130 builtin/fetch.c:177 builtin/fetch.c:200
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1317
+#: builtin/clone.c:130 builtin/fetch.c:180 builtin/fetch.c:203
+#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1323
 msgid "revision"
 msgstr "Commit"
 
-#: builtin/clone.c:131 builtin/fetch.c:178 builtin/pull.c:215
+#: builtin/clone.c:131 builtin/fetch.c:181 builtin/pull.c:215
 msgid "deepen history of shallow clone, excluding rev"
 msgstr ""
 "die Historie eines Klons mit unvollständiger Historie (shallow) mittels\n"
@@ -12738,22 +13057,22 @@ msgstr "Schlüssel=Wert"
 msgid "set config inside the new repository"
 msgstr "Konfiguration innerhalb des neuen Repositories setzen"
 
-#: builtin/clone.c:143 builtin/fetch.c:195 builtin/ls-remote.c:76
+#: builtin/clone.c:143 builtin/fetch.c:198 builtin/ls-remote.c:77
 #: builtin/pull.c:230 builtin/push.c:584 builtin/send-pack.c:196
 msgid "server-specific"
 msgstr "serverspezifisch"
 
-#: builtin/clone.c:143 builtin/fetch.c:195 builtin/ls-remote.c:76
+#: builtin/clone.c:143 builtin/fetch.c:198 builtin/ls-remote.c:77
 #: builtin/pull.c:231 builtin/push.c:584 builtin/send-pack.c:197
 msgid "option to transmit"
 msgstr "Option übertragen"
 
-#: builtin/clone.c:144 builtin/fetch.c:196 builtin/pull.c:234
+#: builtin/clone.c:144 builtin/fetch.c:199 builtin/pull.c:234
 #: builtin/push.c:585
 msgid "use IPv4 addresses only"
 msgstr "nur IPv4-Adressen benutzen"
 
-#: builtin/clone.c:146 builtin/fetch.c:198 builtin/pull.c:237
+#: builtin/clone.c:146 builtin/fetch.c:201 builtin/pull.c:237
 #: builtin/push.c:587
 msgid "use IPv6 addresses only"
 msgstr "nur IPv6-Adressen benutzen"
@@ -12857,71 +13176,71 @@ msgstr "Kann \"repack\" zum Aufräumen nicht aufrufen"
 msgid "cannot unlink temporary alternates file"
 msgstr "Kann temporäre \"alternates\"-Datei nicht entfernen"
 
-#: builtin/clone.c:992 builtin/receive-pack.c:2493
+#: builtin/clone.c:993 builtin/receive-pack.c:2493
 msgid "Too many arguments."
 msgstr "Zu viele Argumente."
 
-#: builtin/clone.c:996
+#: builtin/clone.c:997
 msgid "You must specify a repository to clone."
 msgstr "Sie müssen ein Repository zum Klonen angeben."
 
-#: builtin/clone.c:1009
+#: builtin/clone.c:1010
 #, c-format
 msgid "--bare and --origin %s options are incompatible."
 msgstr "Die Optionen --bare und --origin %s sind inkompatibel."
 
-#: builtin/clone.c:1012
+#: builtin/clone.c:1013
 msgid "--bare and --separate-git-dir are incompatible."
 msgstr "Die Optionen --bare und --separate-git-dir sind inkompatibel."
 
-#: builtin/clone.c:1025
+#: builtin/clone.c:1026
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "Repository '%s' existiert nicht."
 
-#: builtin/clone.c:1029 builtin/fetch.c:1841
+#: builtin/clone.c:1030 builtin/fetch.c:1951
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "Tiefe %s ist keine positive Zahl"
 
-#: builtin/clone.c:1039
+#: builtin/clone.c:1040
 #, c-format
 msgid "destination path '%s' already exists and is not an empty directory."
 msgstr "Zielpfad '%s' existiert bereits und ist kein leeres Verzeichnis."
 
-#: builtin/clone.c:1045
+#: builtin/clone.c:1046
 #, c-format
 msgid "repository path '%s' already exists and is not an empty directory."
 msgstr ""
 "Pfad des Repositories '%s' existiert bereits und ist kein leeres Verzeichnis."
 
-#: builtin/clone.c:1059
+#: builtin/clone.c:1060
 #, c-format
 msgid "working tree '%s' already exists."
 msgstr "Arbeitsverzeichnis '%s' existiert bereits."
 
-#: builtin/clone.c:1074 builtin/clone.c:1095 builtin/difftool.c:271
-#: builtin/log.c:1987 builtin/worktree.c:354 builtin/worktree.c:386
+#: builtin/clone.c:1075 builtin/clone.c:1096 builtin/difftool.c:271
+#: builtin/log.c:1986 builtin/worktree.c:282 builtin/worktree.c:314
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "Konnte führende Verzeichnisse von '%s' nicht erstellen."
 
-#: builtin/clone.c:1079
+#: builtin/clone.c:1080
 #, c-format
 msgid "could not create work tree dir '%s'"
 msgstr "Konnte Arbeitsverzeichnis '%s' nicht erstellen"
 
-#: builtin/clone.c:1099
+#: builtin/clone.c:1100
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
 msgstr "Klone in Bare-Repository '%s' ...\n"
 
-#: builtin/clone.c:1101
+#: builtin/clone.c:1102
 #, c-format
 msgid "Cloning into '%s'...\n"
 msgstr "Klone nach '%s' ...\n"
 
-#: builtin/clone.c:1125
+#: builtin/clone.c:1126
 msgid ""
 "clone --recursive is not compatible with both --reference and --reference-if-"
 "able"
@@ -12929,50 +13248,50 @@ msgstr ""
 "'clone --recursive' ist nicht kompatibel mit --reference und --reference-if-"
 "able"
 
-#: builtin/clone.c:1169 builtin/remote.c:200 builtin/remote.c:705
+#: builtin/clone.c:1170 builtin/remote.c:200 builtin/remote.c:705
 #, c-format
 msgid "'%s' is not a valid remote name"
 msgstr "'%s' ist kein gültiger Name für ein Remote-Repository"
 
-#: builtin/clone.c:1210
+#: builtin/clone.c:1211
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr ""
 "Die Option --depth wird in lokalen Klonen ignoriert; benutzen Sie "
 "stattdessen file://"
 
-#: builtin/clone.c:1212
+#: builtin/clone.c:1213
 msgid "--shallow-since is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-since wird in lokalen Klonen ignoriert; benutzen Sie stattdessen "
 "file://"
 
-#: builtin/clone.c:1214
+#: builtin/clone.c:1215
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-exclude wird in lokalen Klonen ignoriert; benutzen Sie stattdessen "
 "file://"
 
-#: builtin/clone.c:1216
+#: builtin/clone.c:1217
 msgid "--filter is ignored in local clones; use file:// instead."
 msgstr ""
 "--filter wird in lokalen Klonen ignoriert; benutzen Sie stattdessen file://"
 
-#: builtin/clone.c:1219
+#: builtin/clone.c:1220
 msgid "source repository is shallow, ignoring --local"
 msgstr ""
 "Quelle ist ein Repository mit unvollständiger Historie (shallow),\n"
 "ignoriere --local"
 
-#: builtin/clone.c:1224
+#: builtin/clone.c:1225
 msgid "--local is ignored"
 msgstr "--local wird ignoriert"
 
-#: builtin/clone.c:1311 builtin/clone.c:1319
+#: builtin/clone.c:1315 builtin/clone.c:1323
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "Remote-Branch %s nicht im Upstream-Repository %s gefunden"
 
-#: builtin/clone.c:1322
+#: builtin/clone.c:1326
 msgid "You appear to have cloned an empty repository."
 msgstr "Sie scheinen ein leeres Repository geklont zu haben."
 
@@ -13031,13 +13350,14 @@ msgid "could not find object directory matching %s"
 msgstr "konnte Objekt-Verzeichnis nicht finden, dass '%s' entsprechen soll"
 
 #: builtin/commit-graph.c:80 builtin/commit-graph.c:210
-#: builtin/commit-graph.c:316 builtin/fetch.c:184 builtin/log.c:1769
+#: builtin/commit-graph.c:316 builtin/fetch.c:187 builtin/log.c:1768
 msgid "dir"
 msgstr "Verzeichnis"
 
 #: builtin/commit-graph.c:81 builtin/commit-graph.c:211
 #: builtin/commit-graph.c:317
-msgid "The object directory to store the graph"
+#, fuzzy
+msgid "the object directory to store the graph"
 msgstr "Das Objektverzeichnis zum Speichern des Graphen."
 
 #: builtin/commit-graph.c:83
@@ -13132,7 +13452,7 @@ msgstr ""
 msgid "duplicate parent %s ignored"
 msgstr "doppelter Vorgänger %s ignoriert"
 
-#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:555
+#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:557
 #, c-format
 msgid "not a valid object name %s"
 msgstr "Kein gültiger Objektname: %s"
@@ -13160,9 +13480,9 @@ msgstr "Eltern-Commit"
 msgid "id of a parent commit object"
 msgstr "ID eines Eltern-Commit-Objektes."
 
-#: builtin/commit-tree.c:114 builtin/commit.c:1504 builtin/merge.c:281
-#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1470
-#: builtin/tag.c:413
+#: builtin/commit-tree.c:114 builtin/commit.c:1504 builtin/merge.c:282
+#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1537
+#: builtin/tag.c:445
 msgid "message"
 msgstr "Beschreibung"
 
@@ -13174,7 +13494,7 @@ msgstr "Commit-Beschreibung"
 msgid "read commit log message from file"
 msgstr "Commit-Beschreibung von Datei lesen"
 
-#: builtin/commit-tree.c:121 builtin/commit.c:1516 builtin/merge.c:298
+#: builtin/commit-tree.c:121 builtin/commit.c:1516 builtin/merge.c:299
 #: builtin/pull.c:176 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "Commit mit GPG signieren"
@@ -13330,7 +13650,7 @@ msgstr ""
 msgid "could not lookup commit %s"
 msgstr "Konnte Commit %s nicht nachschlagen"
 
-#: builtin/commit.c:729 builtin/shortlog.c:425
+#: builtin/commit.c:729 builtin/shortlog.c:413
 #, c-format
 msgid "(reading log message from standard input)\n"
 msgstr "(lese Log-Nachricht von Standard-Eingabe)\n"
@@ -13430,7 +13750,7 @@ msgstr "Kann Index nicht lesen"
 msgid "Error building trees"
 msgstr "Fehler beim Erzeugen der \"Tree\"-Objekte"
 
-#: builtin/commit.c:1011 builtin/tag.c:276
+#: builtin/commit.c:1011 builtin/tag.c:308
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr ""
@@ -13529,7 +13849,7 @@ msgid "version"
 msgstr "Version"
 
 #: builtin/commit.c:1374 builtin/commit.c:1533 builtin/push.c:560
-#: builtin/worktree.c:725
+#: builtin/worktree.c:679
 msgid "machine-readable output"
 msgstr "maschinenlesbare Ausgabe"
 
@@ -13543,7 +13863,7 @@ msgstr "Einträge mit NUL-Zeichen abschließen"
 
 #: builtin/commit.c:1382 builtin/commit.c:1386 builtin/commit.c:1541
 #: builtin/fast-export.c:1198 builtin/fast-export.c:1201
-#: builtin/fast-export.c:1204 builtin/rebase.c:1406 parse-options.h:336
+#: builtin/fast-export.c:1204 builtin/rebase.c:1412 parse-options.h:336
 msgid "mode"
 msgstr "Modus"
 
@@ -13602,7 +13922,7 @@ msgstr "Unterschiede in Commit-Beschreibungsvorlage anzeigen"
 msgid "Commit message options"
 msgstr "Optionen für Commit-Beschreibung"
 
-#: builtin/commit.c:1501 builtin/merge.c:285 builtin/tag.c:415
+#: builtin/commit.c:1501 builtin/merge.c:286 builtin/tag.c:447
 msgid "read message from file"
 msgstr "Beschreibung von Datei lesen"
 
@@ -13614,7 +13934,7 @@ msgstr "Autor"
 msgid "override author for commit"
 msgstr "Autor eines Commits überschreiben"
 
-#: builtin/commit.c:1503 builtin/gc.c:542
+#: builtin/commit.c:1503 builtin/gc.c:550
 msgid "date"
 msgstr "Datum"
 
@@ -13623,7 +13943,7 @@ msgid "override date for commit"
 msgstr "Datum eines Commits überschreiben"
 
 #: builtin/commit.c:1505 builtin/commit.c:1506 builtin/commit.c:1507
-#: builtin/commit.c:1508 parse-options.h:328 ref-filter.h:87
+#: builtin/commit.c:1508 parse-options.h:328 ref-filter.h:90
 msgid "commit"
 msgstr "Commit"
 
@@ -13651,7 +13971,7 @@ msgstr ""
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr "Sie als Autor des Commits setzen (verwendet mit -C/-c/--amend)"
 
-#: builtin/commit.c:1510 builtin/log.c:1744 builtin/merge.c:301
+#: builtin/commit.c:1510 builtin/log.c:1743 builtin/merge.c:302
 #: builtin/pull.c:145 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "eine Signed-off-by Zeile hinzufügen"
@@ -14300,41 +14620,41 @@ msgstr "--stdin und --merge-base schließen sich gegenseitig aus"
 msgid "--merge-base only works with two commits"
 msgstr "--merge-base funktioniert nur mit zwei Commits"
 
-#: builtin/diff.c:91
+#: builtin/diff.c:92
 #, c-format
 msgid "'%s': not a regular file or symlink"
 msgstr "'%s': keine reguläre Datei oder symbolische Verknüpfung"
 
-#: builtin/diff.c:258
+#: builtin/diff.c:259
 #, c-format
 msgid "invalid option: %s"
 msgstr "Ungültige Option: %s"
 
-#: builtin/diff.c:375
+#: builtin/diff.c:376
 #, c-format
 msgid "%s...%s: no merge base"
 msgstr "%s...%s: keine Merge-Basis"
 
-#: builtin/diff.c:485
+#: builtin/diff.c:486
 msgid "Not a git repository"
 msgstr "Kein Git-Repository"
 
-#: builtin/diff.c:530 builtin/grep.c:681
+#: builtin/diff.c:532 builtin/grep.c:682
 #, c-format
 msgid "invalid object '%s' given."
 msgstr "Objekt '%s' ist ungültig."
 
-#: builtin/diff.c:541
+#: builtin/diff.c:543
 #, c-format
 msgid "more than two blobs given: '%s'"
 msgstr "Mehr als zwei Blobs angegeben: '%s'"
 
-#: builtin/diff.c:546
+#: builtin/diff.c:548
 #, c-format
 msgid "unhandled object '%s' given."
 msgstr "unbehandeltes Objekt '%s' angegeben"
 
-#: builtin/diff.c:580
+#: builtin/diff.c:582
 #, c-format
 msgid "%s...%s: multiple merge bases, using %s"
 msgstr "%s...%s: mehrere Merge-Basen, nutze %s"
@@ -14519,39 +14839,47 @@ msgstr ""
 "Auswählen der Behandlung von Commit-Beschreibungen bei wechselndem Encoding"
 
 #: builtin/fast-export.c:1208
-msgid "Dump marks to this file"
+#, fuzzy
+msgid "dump marks to this file"
 msgstr "Markierungen in diese Datei schreiben"
 
 #: builtin/fast-export.c:1210
-msgid "Import marks from this file"
+#, fuzzy
+msgid "import marks from this file"
 msgstr "Markierungen von dieser Datei importieren"
 
 #: builtin/fast-export.c:1214
-msgid "Import marks from this file if it exists"
+#, fuzzy
+msgid "import marks from this file if it exists"
 msgstr "Markierungen von dieser Datei importieren, wenn diese existiert"
 
 #: builtin/fast-export.c:1216
-msgid "Fake a tagger when tags lack one"
+#, fuzzy
+msgid "fake a tagger when tags lack one"
 msgstr "künstlich einen Tag-Ersteller erzeugen, wenn das Tag keinen hat"
 
 #: builtin/fast-export.c:1218
-msgid "Output full tree for each commit"
+#, fuzzy
+msgid "output full tree for each commit"
 msgstr "für jeden Commit das gesamte Verzeichnis ausgeben"
 
 #: builtin/fast-export.c:1220
-msgid "Use the done feature to terminate the stream"
+#, fuzzy
+msgid "use the done feature to terminate the stream"
 msgstr "die \"done\"-Funktion benutzen, um den Datenstrom abzuschließen"
 
 #: builtin/fast-export.c:1221
-msgid "Skip output of blob data"
+#, fuzzy
+msgid "skip output of blob data"
 msgstr "Ausgabe von Blob-Daten überspringen"
 
-#: builtin/fast-export.c:1222 builtin/log.c:1816
+#: builtin/fast-export.c:1222 builtin/log.c:1815
 msgid "refspec"
 msgstr "Refspec"
 
 #: builtin/fast-export.c:1223
-msgid "Apply refspec to exported refs"
+#, fuzzy
+msgid "apply refspec to exported refs"
 msgstr "Refspec auf exportierte Referenzen anwenden"
 
 #: builtin/fast-export.c:1224
@@ -14567,17 +14895,20 @@ msgid "convert <from> to <to> in anonymized output"
 msgstr "konvertiere <von> zu <nach> in anonymisierter Ausgabe"
 
 #: builtin/fast-export.c:1229
-msgid "Reference parents which are not in fast-export stream by object id"
+#, fuzzy
+msgid "reference parents which are not in fast-export stream by object id"
 msgstr ""
 "Eltern, die nicht im Fast-Export-Stream sind, anhand ihrer Objekt-ID "
 "referenzieren"
 
 #: builtin/fast-export.c:1231
-msgid "Show original object ids of blobs/commits"
+#, fuzzy
+msgid "show original object ids of blobs/commits"
 msgstr "originale Objekt-IDs von Blobs/Commits anzeigen"
 
 #: builtin/fast-export.c:1233
-msgid "Label tags with mark ids"
+#, fuzzy
+msgid "label tags with mark ids"
 msgstr "Tags mit Markierungs-IDs beschriften"
 
 #: builtin/fast-export.c:1256
@@ -14619,7 +14950,7 @@ msgstr "Format 'Name:Dateiname' für Submodul-Rewrite-Option erwartet"
 msgid "feature '%s' forbidden in input without --allow-unsafe-features"
 msgstr "Feature '%s' verboten in Eingabe ohne Option --allow-unsafe-features"
 
-#: builtin/fetch-pack.c:241
+#: builtin/fetch-pack.c:242
 #, c-format
 msgid "Lockfile created but not reported: %s"
 msgstr "Lock-Datei erstellt, aber nicht gemeldet: %s"
@@ -14640,100 +14971,105 @@ msgstr "git fetch --multiple [<Optionen>] [(<Repository> | <Gruppe>)...]"
 msgid "git fetch --all [<options>]"
 msgstr "git fetch --all [<Optionen>]"
 
-#: builtin/fetch.c:119
+#: builtin/fetch.c:120
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel kann nicht negativ sein"
 
-#: builtin/fetch.c:142 builtin/pull.c:185
+#: builtin/fetch.c:143 builtin/pull.c:185
 msgid "fetch from all remotes"
 msgstr "fordert von allen Remote-Repositories an"
 
-#: builtin/fetch.c:144 builtin/pull.c:245
+#: builtin/fetch.c:145 builtin/pull.c:245
 msgid "set upstream for git pull/fetch"
 msgstr "Upstream für \"git pull/fetch\" setzen"
 
-#: builtin/fetch.c:146 builtin/pull.c:188
+#: builtin/fetch.c:147 builtin/pull.c:188
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "an .git/FETCH_HEAD anhängen, anstatt zu überschreiben"
 
-#: builtin/fetch.c:148 builtin/pull.c:191
+#: builtin/fetch.c:149
+#, fuzzy
+msgid "use atomic transaction to update references"
+msgstr "Referenzen atomar versenden"
+
+#: builtin/fetch.c:151 builtin/pull.c:191
 msgid "path to upload pack on remote end"
 msgstr "Pfad des Programms zum Hochladen von Paketen auf der Gegenseite"
 
-#: builtin/fetch.c:149
+#: builtin/fetch.c:152
 msgid "force overwrite of local reference"
 msgstr "das Überschreiben einer lokalen Referenz erzwingen"
 
-#: builtin/fetch.c:151
+#: builtin/fetch.c:154
 msgid "fetch from multiple remotes"
 msgstr "von mehreren Remote-Repositories anfordern"
 
-#: builtin/fetch.c:153 builtin/pull.c:195
+#: builtin/fetch.c:156 builtin/pull.c:195
 msgid "fetch all tags and associated objects"
 msgstr "alle Tags und verbundene Objekte anfordern"
 
-#: builtin/fetch.c:155
+#: builtin/fetch.c:158
 msgid "do not fetch all tags (--no-tags)"
 msgstr "nicht alle Tags anfordern (--no-tags)"
 
-#: builtin/fetch.c:157
+#: builtin/fetch.c:160
 msgid "number of submodules fetched in parallel"
 msgstr "Anzahl der parallel anzufordernden Submodule"
 
-#: builtin/fetch.c:159 builtin/pull.c:198
+#: builtin/fetch.c:162 builtin/pull.c:198
 msgid "prune remote-tracking branches no longer on remote"
 msgstr ""
 "Remote-Tracking-Branches entfernen, die sich nicht mehr im Remote-Repository "
 "befinden"
 
-#: builtin/fetch.c:161
+#: builtin/fetch.c:164
 msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr ""
 "lokale Tags entfernen, die sich nicht mehr im Remote-Repository befinden, "
 "und geänderte Tags aktualisieren"
 
-#: builtin/fetch.c:162 builtin/fetch.c:187 builtin/pull.c:122
+#: builtin/fetch.c:165 builtin/fetch.c:190 builtin/pull.c:122
 msgid "on-demand"
 msgstr "bei-Bedarf"
 
-#: builtin/fetch.c:163
+#: builtin/fetch.c:166
 msgid "control recursive fetching of submodules"
 msgstr "rekursive Anforderungen von Submodulen kontrollieren"
 
-#: builtin/fetch.c:168
+#: builtin/fetch.c:171
 msgid "write fetched references to the FETCH_HEAD file"
 msgstr "schreibe angeforderte Referenzen in die FETCH_HEAD-Datei"
 
-#: builtin/fetch.c:169 builtin/pull.c:206
+#: builtin/fetch.c:172 builtin/pull.c:206
 msgid "keep downloaded pack"
 msgstr "heruntergeladenes Paket behalten"
 
-#: builtin/fetch.c:171
+#: builtin/fetch.c:174
 msgid "allow updating of HEAD ref"
 msgstr "Aktualisierung der \"HEAD\"-Referenz erlauben"
 
-#: builtin/fetch.c:174 builtin/fetch.c:180 builtin/pull.c:209
+#: builtin/fetch.c:177 builtin/fetch.c:183 builtin/pull.c:209
 #: builtin/pull.c:218
 msgid "deepen history of shallow clone"
 msgstr ""
 "die Historie eines Klons mit unvollständiger Historie (shallow) vertiefen"
 
-#: builtin/fetch.c:176 builtin/pull.c:212
+#: builtin/fetch.c:179 builtin/pull.c:212
 msgid "deepen history of shallow repository based on time"
 msgstr ""
 "die Historie eines Klons mit unvollständiger Historie (shallow) auf "
 "Zeitbasis\n"
 "vertiefen"
 
-#: builtin/fetch.c:182 builtin/pull.c:221
+#: builtin/fetch.c:185 builtin/pull.c:221
 msgid "convert to a complete repository"
 msgstr "zu einem vollständigen Repository konvertieren"
 
-#: builtin/fetch.c:185
+#: builtin/fetch.c:188
 msgid "prepend this to submodule path output"
 msgstr "dies an die Ausgabe der Submodul-Pfade voranstellen"
 
-#: builtin/fetch.c:188
+#: builtin/fetch.c:191
 msgid ""
 "default for recursive fetching of submodules (lower priority than config "
 "files)"
@@ -14741,100 +15077,100 @@ msgstr ""
 "Standard für die rekursive Anforderung von Submodulen (geringere Priorität\n"
 "als Konfigurationsdateien)"
 
-#: builtin/fetch.c:192 builtin/pull.c:224
+#: builtin/fetch.c:195 builtin/pull.c:224
 msgid "accept refs that update .git/shallow"
 msgstr "Referenzen, die .git/shallow aktualisieren, akzeptieren"
 
-#: builtin/fetch.c:193 builtin/pull.c:226
+#: builtin/fetch.c:196 builtin/pull.c:226
 msgid "refmap"
 msgstr "Refmap"
 
-#: builtin/fetch.c:194 builtin/pull.c:227
+#: builtin/fetch.c:197 builtin/pull.c:227
 msgid "specify fetch refmap"
 msgstr "Refmap für 'fetch' angeben"
 
-#: builtin/fetch.c:201 builtin/pull.c:240
+#: builtin/fetch.c:204 builtin/pull.c:240
 msgid "report that we have only objects reachable from this object"
 msgstr ""
 "ausgeben, dass wir nur Objekte haben, die von diesem Objekt aus erreichbar "
 "sind"
 
-#: builtin/fetch.c:204 builtin/fetch.c:206
+#: builtin/fetch.c:207 builtin/fetch.c:209
 msgid "run 'maintenance --auto' after fetching"
 msgstr "führe 'maintenance --auto' nach \"fetch\" aus"
 
-#: builtin/fetch.c:208 builtin/pull.c:243
+#: builtin/fetch.c:211 builtin/pull.c:243
 msgid "check for forced-updates on all updated branches"
 msgstr "Prüfe auf erzwungene Aktualisierungen in allen aktualisierten Branches"
 
-#: builtin/fetch.c:210
+#: builtin/fetch.c:213
 msgid "write the commit-graph after fetching"
 msgstr "Schreibe den Commit-Graph nach \"fetch\""
 
-#: builtin/fetch.c:212
+#: builtin/fetch.c:215
 msgid "accept refspecs from stdin"
 msgstr "akzeptiere Refspecs von der Standard-Eingabe"
 
-#: builtin/fetch.c:523
+#: builtin/fetch.c:526
 msgid "Couldn't find remote ref HEAD"
 msgstr "Konnte Remote-Referenz von HEAD nicht finden."
 
-#: builtin/fetch.c:677
+#: builtin/fetch.c:697
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "Konfiguration fetch.output enthält ungültigen Wert %s"
 
-#: builtin/fetch.c:775
+#: builtin/fetch.c:796
 #, c-format
 msgid "object %s not found"
 msgstr "Objekt %s nicht gefunden"
 
-#: builtin/fetch.c:779
+#: builtin/fetch.c:800
 msgid "[up to date]"
 msgstr "[aktuell]"
 
-#: builtin/fetch.c:792 builtin/fetch.c:808 builtin/fetch.c:880
+#: builtin/fetch.c:813 builtin/fetch.c:829 builtin/fetch.c:901
 msgid "[rejected]"
 msgstr "[zurückgewiesen]"
 
-#: builtin/fetch.c:793
+#: builtin/fetch.c:814
 msgid "can't fetch in current branch"
 msgstr "kann \"fetch\" im aktuellen Branch nicht ausführen"
 
-#: builtin/fetch.c:803
+#: builtin/fetch.c:824
 msgid "[tag update]"
 msgstr "[Tag Aktualisierung]"
 
-#: builtin/fetch.c:804 builtin/fetch.c:841 builtin/fetch.c:863
-#: builtin/fetch.c:875
+#: builtin/fetch.c:825 builtin/fetch.c:862 builtin/fetch.c:884
+#: builtin/fetch.c:896
 msgid "unable to update local ref"
 msgstr "kann lokale Referenz nicht aktualisieren"
 
-#: builtin/fetch.c:808
+#: builtin/fetch.c:829
 msgid "would clobber existing tag"
 msgstr "würde bestehende Tags verändern"
 
-#: builtin/fetch.c:830
+#: builtin/fetch.c:851
 msgid "[new tag]"
 msgstr "[neues Tag]"
 
-#: builtin/fetch.c:833
+#: builtin/fetch.c:854
 msgid "[new branch]"
 msgstr "[neuer Branch]"
 
-#: builtin/fetch.c:836
+#: builtin/fetch.c:857
 msgid "[new ref]"
 msgstr "[neue Referenz]"
 
-#: builtin/fetch.c:875
+#: builtin/fetch.c:896
 msgid "forced update"
 msgstr "Aktualisierung erzwungen"
 
-#: builtin/fetch.c:880
+#: builtin/fetch.c:901
 msgid "non-fast-forward"
 msgstr "kein Vorspulen"
 
-#: builtin/fetch.c:901
+#: builtin/fetch.c:1005
 msgid ""
 "Fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled. To re-enable, use '--show-forced-updates'\n"
@@ -14845,7 +15181,7 @@ msgstr ""
 "aktivieren, nutzen Sie die Option '--show-forced-updated' oder führen\n"
 "Sie 'git config fetch.showForcedUpdates true' aus."
 
-#: builtin/fetch.c:905
+#: builtin/fetch.c:1009
 #, c-format
 msgid ""
 "It took %.2f seconds to check forced updates. You can use\n"
@@ -14858,12 +15194,12 @@ msgstr ""
 "'git config fetch.showForcedUpdates false' ausführen, um diese Überprüfung\n"
 "zu umgehen.\n"
 
-#: builtin/fetch.c:939
+#: builtin/fetch.c:1041
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s hat nicht alle erforderlichen Objekte gesendet\n"
 
-#: builtin/fetch.c:960
+#: builtin/fetch.c:1069
 #, c-format
 msgid "reject %s because shallow roots are not allowed to be updated"
 msgstr ""
@@ -14871,12 +15207,12 @@ msgstr ""
 "unvollständiger\n"
 "Historie (shallow) nicht aktualisiert werden dürfen."
 
-#: builtin/fetch.c:1053 builtin/fetch.c:1191
+#: builtin/fetch.c:1146 builtin/fetch.c:1297
 #, c-format
 msgid "From %.*s\n"
 msgstr "Von %.*s\n"
 
-#: builtin/fetch.c:1064
+#: builtin/fetch.c:1168
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -14885,58 +15221,58 @@ msgstr ""
 "Einige lokale Referenzen konnten nicht aktualisiert werden; versuchen Sie\n"
 "'git remote prune %s', um jeden älteren, widersprüchlichen Branch zu löschen."
 
-#: builtin/fetch.c:1161
+#: builtin/fetch.c:1267
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s wird unreferenziert)"
 
-#: builtin/fetch.c:1162
+#: builtin/fetch.c:1268
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s wurde unreferenziert)"
 
-#: builtin/fetch.c:1194
+#: builtin/fetch.c:1300
 msgid "[deleted]"
 msgstr "[gelöscht]"
 
-#: builtin/fetch.c:1195 builtin/remote.c:1118
+#: builtin/fetch.c:1301 builtin/remote.c:1118
 msgid "(none)"
 msgstr "(nichts)"
 
-#: builtin/fetch.c:1218
+#: builtin/fetch.c:1324
 #, c-format
 msgid "Refusing to fetch into current branch %s of non-bare repository"
 msgstr ""
 "Der \"fetch\" in den aktuellen Branch %s von einem Nicht-Bare-Repository "
 "wurde verweigert."
 
-#: builtin/fetch.c:1237
+#: builtin/fetch.c:1343
 #, c-format
 msgid "Option \"%s\" value \"%s\" is not valid for %s"
 msgstr "Option \"%s\" Wert \"%s\" ist nicht gültig für %s"
 
-#: builtin/fetch.c:1240
+#: builtin/fetch.c:1346
 #, c-format
 msgid "Option \"%s\" is ignored for %s\n"
 msgstr "Option \"%s\" wird ignoriert für %s\n"
 
-#: builtin/fetch.c:1448
+#: builtin/fetch.c:1558
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "Mehrere Branches erkannt, inkompatibel mit --set-upstream"
 
-#: builtin/fetch.c:1463
+#: builtin/fetch.c:1573
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "Setze keinen Upstream für einen entfernten Remote-Tracking-Branch."
 
-#: builtin/fetch.c:1465
+#: builtin/fetch.c:1575
 msgid "not setting upstream for a remote tag"
 msgstr "Setze keinen Upstream für einen Tag eines Remote-Repositories."
 
-#: builtin/fetch.c:1467
+#: builtin/fetch.c:1577
 msgid "unknown branch type"
 msgstr "Unbekannter Branch-Typ"
 
-#: builtin/fetch.c:1469
+#: builtin/fetch.c:1579
 msgid ""
 "no source branch found.\n"
 "you need to specify exactly one branch with the --set-upstream option."
@@ -14944,22 +15280,22 @@ msgstr ""
 "Keinen Quell-Branch gefunden.\n"
 "Sie müssen bei der Option --set-upstream genau einen Branch angeben."
 
-#: builtin/fetch.c:1598 builtin/fetch.c:1661
+#: builtin/fetch.c:1708 builtin/fetch.c:1771
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Fordere an von %s\n"
 
-#: builtin/fetch.c:1608 builtin/fetch.c:1663 builtin/remote.c:101
+#: builtin/fetch.c:1718 builtin/fetch.c:1773 builtin/remote.c:101
 #, c-format
 msgid "Could not fetch %s"
 msgstr "Konnte nicht von %s anfordern"
 
-#: builtin/fetch.c:1620
+#: builtin/fetch.c:1730
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "Konnte '%s' nicht anfordern (Exit-Code: %d)\n"
 
-#: builtin/fetch.c:1724
+#: builtin/fetch.c:1834
 msgid ""
 "No remote repository specified.  Please, specify either a URL or a\n"
 "remote name from which new revisions should be fetched."
@@ -14968,49 +15304,49 @@ msgstr ""
 "oder den Namen des Remote-Repositories an, von welchem neue\n"
 "Commits angefordert werden sollen."
 
-#: builtin/fetch.c:1760
+#: builtin/fetch.c:1870
 msgid "You need to specify a tag name."
 msgstr "Sie müssen den Namen des Tags angeben."
 
-#: builtin/fetch.c:1825
+#: builtin/fetch.c:1935
 msgid "Negative depth in --deepen is not supported"
 msgstr "Negative Tiefe wird von --deepen nicht unterstützt."
 
-#: builtin/fetch.c:1827
+#: builtin/fetch.c:1937
 msgid "--deepen and --depth are mutually exclusive"
 msgstr "--deepen und --depth schließen sich gegenseitig aus"
 
-#: builtin/fetch.c:1832
+#: builtin/fetch.c:1942
 msgid "--depth and --unshallow cannot be used together"
 msgstr ""
 "Die Optionen --depth und --unshallow können nicht gemeinsam verwendet werden."
 
-#: builtin/fetch.c:1834
+#: builtin/fetch.c:1944
 msgid "--unshallow on a complete repository does not make sense"
 msgstr ""
 "Die Option --unshallow kann nicht in einem Repository mit vollständiger "
 "Historie verwendet werden."
 
-#: builtin/fetch.c:1851
+#: builtin/fetch.c:1961
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all akzeptiert kein Repository als Argument"
 
-#: builtin/fetch.c:1853
+#: builtin/fetch.c:1963
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all kann nicht mit Refspecs verwendet werden."
 
-#: builtin/fetch.c:1862
+#: builtin/fetch.c:1972
 #, c-format
 msgid "No such remote or remote group: %s"
 msgstr "Kein Remote-Repository (einzeln oder Gruppe): %s"
 
-#: builtin/fetch.c:1869
+#: builtin/fetch.c:1979
 msgid "Fetching a group and specifying refspecs does not make sense"
 msgstr ""
 "Das Abholen einer Gruppe von Remote-Repositories kann nicht mit der Angabe\n"
 "von Refspecs verwendet werden."
 
-#: builtin/fetch.c:1887
+#: builtin/fetch.c:1997
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -15018,7 +15354,14 @@ msgstr ""
 "--filter kann nur mit den Remote-Repositories verwendet werden,\n"
 "die in extensions.partialclone konfiguriert sind"
 
-#: builtin/fetch.c:1891
+#: builtin/fetch.c:2001
+#, fuzzy
+msgid "--atomic can only be used when fetching from one remote"
+msgstr ""
+"die Option --stdin kann nur verwendet werden, wenn nur von einem Remote-\n"
+"Repository abgefragt wird"
+
+#: builtin/fetch.c:2005
 msgid "--stdin can only be used when fetching from one remote"
 msgstr ""
 "die Option --stdin kann nur verwendet werden, wenn nur von einem Remote-\n"
@@ -15087,7 +15430,7 @@ msgstr "Platzhalter als Tcl-String formatieren"
 msgid "show only <n> matched refs"
 msgstr "nur <n> passende Referenzen anzeigen"
 
-#: builtin/for-each-ref.c:39 builtin/tag.c:440
+#: builtin/for-each-ref.c:39 builtin/tag.c:472
 msgid "respect format colors"
 msgstr "Formatfarben beachten"
 
@@ -15127,32 +15470,32 @@ msgstr "Konfigurationsschlüssel für eine Liste von Repository-Pfaden"
 msgid "missing --config=<config>"
 msgstr "Option --config=<Konfiguration> fehlt"
 
-#: builtin/fsck.c:69 builtin/fsck.c:148 builtin/fsck.c:149
+#: builtin/fsck.c:69 builtin/fsck.c:130 builtin/fsck.c:131
 msgid "unknown"
 msgstr "unbekannt"
 
 #. TRANSLATORS: e.g. error in tree 01bfda: <more explanation>
-#: builtin/fsck.c:101 builtin/fsck.c:121
+#: builtin/fsck.c:83 builtin/fsck.c:103
 #, c-format
 msgid "error in %s %s: %s"
 msgstr "Fehler in %s %s: %s"
 
 #. TRANSLATORS: e.g. warning in tree 01bfda: <more explanation>
-#: builtin/fsck.c:115
+#: builtin/fsck.c:97
 #, c-format
 msgid "warning in %s %s: %s"
 msgstr "Warnung in %s %s: %s"
 
-#: builtin/fsck.c:144 builtin/fsck.c:147
+#: builtin/fsck.c:126 builtin/fsck.c:129
 #, c-format
 msgid "broken link from %7s %s"
 msgstr "fehlerhafte Verknüpfung von %7s %s"
 
-#: builtin/fsck.c:156
+#: builtin/fsck.c:138
 msgid "wrong object type in link"
 msgstr "falscher Objekttyp in Verknüpfung"
 
-#: builtin/fsck.c:172
+#: builtin/fsck.c:154
 #, c-format
 msgid ""
 "broken link from %7s %s\n"
@@ -15161,211 +15504,211 @@ msgstr ""
 "fehlerhafte Verknüpfung von %7s %s\n"
 "                       nach %7s %s"
 
-#: builtin/fsck.c:283
+#: builtin/fsck.c:265
 #, c-format
 msgid "missing %s %s"
 msgstr "%s %s fehlt"
 
-#: builtin/fsck.c:310
+#: builtin/fsck.c:292
 #, c-format
 msgid "unreachable %s %s"
 msgstr "%s %s nicht erreichbar"
 
-#: builtin/fsck.c:330
+#: builtin/fsck.c:312
 #, c-format
 msgid "dangling %s %s"
 msgstr "%s %s unreferenziert"
 
-#: builtin/fsck.c:340
+#: builtin/fsck.c:322
 msgid "could not create lost-found"
 msgstr "Konnte lost-found nicht erstellen."
 
-#: builtin/fsck.c:351
+#: builtin/fsck.c:333
 #, c-format
 msgid "could not finish '%s'"
 msgstr "Konnte '%s' nicht abschließen."
 
-#: builtin/fsck.c:368
+#: builtin/fsck.c:350
 #, c-format
 msgid "Checking %s"
 msgstr "Prüfe %s"
 
-#: builtin/fsck.c:406
+#: builtin/fsck.c:388
 #, c-format
 msgid "Checking connectivity (%d objects)"
 msgstr "Prüfe Konnektivität (%d Objekte)"
 
-#: builtin/fsck.c:425
+#: builtin/fsck.c:407
 #, c-format
 msgid "Checking %s %s"
 msgstr "Prüfe %s %s"
 
-#: builtin/fsck.c:430
+#: builtin/fsck.c:412
 msgid "broken links"
 msgstr "Fehlerhafte Verknüpfungen"
 
-#: builtin/fsck.c:439
+#: builtin/fsck.c:421
 #, c-format
 msgid "root %s"
 msgstr "Wurzel %s"
 
-#: builtin/fsck.c:447
+#: builtin/fsck.c:429
 #, c-format
 msgid "tagged %s %s (%s) in %s"
 msgstr "%s %s (%s) in %s getaggt"
 
-#: builtin/fsck.c:476
+#: builtin/fsck.c:458
 #, c-format
 msgid "%s: object corrupt or missing"
 msgstr "%s: Objekt fehlerhaft oder nicht vorhanden"
 
-#: builtin/fsck.c:501
+#: builtin/fsck.c:483
 #, c-format
 msgid "%s: invalid reflog entry %s"
 msgstr "%s: Ungültiger Reflog-Eintrag %s"
 
-#: builtin/fsck.c:515
+#: builtin/fsck.c:497
 #, c-format
 msgid "Checking reflog %s->%s"
 msgstr "Prüfe Reflog %s->%s"
 
-#: builtin/fsck.c:549
+#: builtin/fsck.c:531
 #, c-format
 msgid "%s: invalid sha1 pointer %s"
 msgstr "%s: Ungültiger SHA1-Zeiger %s"
 
-#: builtin/fsck.c:556
+#: builtin/fsck.c:538
 #, c-format
 msgid "%s: not a commit"
 msgstr "%s: kein Commit"
 
-#: builtin/fsck.c:610
+#: builtin/fsck.c:592
 msgid "notice: No default references"
 msgstr "Notiz: Keine Standardreferenzen"
 
-#: builtin/fsck.c:625
+#: builtin/fsck.c:607
 #, c-format
 msgid "%s: object corrupt or missing: %s"
 msgstr "%s: Objekt fehlerhaft oder nicht vorhanden: %s"
 
-#: builtin/fsck.c:638
+#: builtin/fsck.c:620
 #, c-format
 msgid "%s: object could not be parsed: %s"
 msgstr "%s: Objekt konnte nicht geparst werden: %s"
 
-#: builtin/fsck.c:658
+#: builtin/fsck.c:640
 #, c-format
 msgid "bad sha1 file: %s"
 msgstr "Ungültige SHA1-Datei: %s"
 
-#: builtin/fsck.c:673
+#: builtin/fsck.c:655
 msgid "Checking object directory"
 msgstr "Prüfe Objekt-Verzeichnis"
 
-#: builtin/fsck.c:676
+#: builtin/fsck.c:658
 msgid "Checking object directories"
 msgstr "Prüfe Objekt-Verzeichnisse"
 
-#: builtin/fsck.c:691
+#: builtin/fsck.c:673
 #, c-format
 msgid "Checking %s link"
 msgstr "Prüfe %s Verknüpfung"
 
-#: builtin/fsck.c:696 builtin/index-pack.c:865
+#: builtin/fsck.c:678 builtin/index-pack.c:865
 #, c-format
 msgid "invalid %s"
 msgstr "Ungültiger Objekt-Typ %s"
 
-#: builtin/fsck.c:703
+#: builtin/fsck.c:685
 #, c-format
 msgid "%s points to something strange (%s)"
 msgstr "%s zeigt auf etwas seltsames (%s)"
 
-#: builtin/fsck.c:709
+#: builtin/fsck.c:691
 #, c-format
 msgid "%s: detached HEAD points at nothing"
 msgstr "%s: losgelöster HEAD zeigt auf nichts"
 
-#: builtin/fsck.c:713
+#: builtin/fsck.c:695
 #, c-format
 msgid "notice: %s points to an unborn branch (%s)"
 msgstr "Notiz: %s zeigt auf einen ungeborenen Branch (%s)"
 
-#: builtin/fsck.c:725
+#: builtin/fsck.c:707
 msgid "Checking cache tree"
 msgstr "Prüfe Cache-Verzeichnis"
 
-#: builtin/fsck.c:730
+#: builtin/fsck.c:712
 #, c-format
 msgid "%s: invalid sha1 pointer in cache-tree"
 msgstr "%s: Ungültiger SHA1-Zeiger in Cache-Verzeichnis"
 
-#: builtin/fsck.c:739
+#: builtin/fsck.c:721
 msgid "non-tree in cache-tree"
 msgstr "non-tree in Cache-Verzeichnis"
 
-#: builtin/fsck.c:770
+#: builtin/fsck.c:752
 msgid "git fsck [<options>] [<object>...]"
 msgstr "git fsck [<Optionen>] [<Objekt>...]"
 
-#: builtin/fsck.c:776
+#: builtin/fsck.c:758
 msgid "show unreachable objects"
 msgstr "unerreichbare Objekte anzeigen"
 
-#: builtin/fsck.c:777
+#: builtin/fsck.c:759
 msgid "show dangling objects"
 msgstr "unreferenzierte Objekte anzeigen"
 
-#: builtin/fsck.c:778
+#: builtin/fsck.c:760
 msgid "report tags"
 msgstr "Tags melden"
 
-#: builtin/fsck.c:779
+#: builtin/fsck.c:761
 msgid "report root nodes"
 msgstr "Hauptwurzeln melden"
 
-#: builtin/fsck.c:780
+#: builtin/fsck.c:762
 msgid "make index objects head nodes"
 msgstr "Index-Objekte in Erreichbarkeitsprüfung einbeziehen"
 
-#: builtin/fsck.c:781
+#: builtin/fsck.c:763
 msgid "make reflogs head nodes (default)"
 msgstr "Reflogs in Erreichbarkeitsprüfung einbeziehen (Standard)"
 
-#: builtin/fsck.c:782
+#: builtin/fsck.c:764
 msgid "also consider packs and alternate objects"
 msgstr "ebenso Pakete und alternative Objekte betrachten"
 
-#: builtin/fsck.c:783
+#: builtin/fsck.c:765
 msgid "check only connectivity"
 msgstr "nur Konnektivität prüfen"
 
-#: builtin/fsck.c:784
+#: builtin/fsck.c:766 builtin/mktag.c:78
 msgid "enable more strict checking"
 msgstr "genauere Prüfung aktivieren"
 
-#: builtin/fsck.c:786
+#: builtin/fsck.c:768
 msgid "write dangling objects in .git/lost-found"
 msgstr "unreferenzierte Objekte nach .git/lost-found schreiben"
 
-#: builtin/fsck.c:787 builtin/prune.c:134
+#: builtin/fsck.c:769 builtin/prune.c:134
 msgid "show progress"
 msgstr "Fortschrittsanzeige anzeigen"
 
-#: builtin/fsck.c:788
+#: builtin/fsck.c:770
 msgid "show verbose names for reachable objects"
 msgstr "ausführliche Namen für erreichbare Objekte anzeigen"
 
-#: builtin/fsck.c:847 builtin/index-pack.c:261
+#: builtin/fsck.c:829 builtin/index-pack.c:261
 msgid "Checking objects"
 msgstr "Prüfe Objekte"
 
-#: builtin/fsck.c:875
+#: builtin/fsck.c:857
 #, c-format
 msgid "%s: object missing"
 msgstr "%s: Objekt nicht vorhanden"
 
-#: builtin/fsck.c:886
+#: builtin/fsck.c:868
 #, c-format
 msgid "invalid parameter: expected sha1, got '%s'"
 msgstr "Ungültiger Parameter: SHA-1 erwartet, '%s' bekommen"
@@ -15374,27 +15717,27 @@ msgstr "Ungültiger Parameter: SHA-1 erwartet, '%s' bekommen"
 msgid "git gc [<options>]"
 msgstr "git gc [<Optionen>]"
 
-#: builtin/gc.c:94
+#: builtin/gc.c:93
 #, c-format
 msgid "Failed to fstat %s: %s"
 msgstr "Konnte '%s' nicht lesen: %s"
 
-#: builtin/gc.c:130
+#: builtin/gc.c:129
 #, c-format
 msgid "failed to parse '%s' value '%s'"
 msgstr "Fehler beim Parsen von '%s' mit dem Wert '%s'"
 
-#: builtin/gc.c:479 builtin/init-db.c:58
+#: builtin/gc.c:487 builtin/init-db.c:58
 #, c-format
 msgid "cannot stat '%s'"
 msgstr "Kann '%s' nicht lesen"
 
-#: builtin/gc.c:488 builtin/notes.c:240 builtin/tag.c:530
+#: builtin/gc.c:496 builtin/notes.c:240 builtin/tag.c:562
 #, c-format
 msgid "cannot read '%s'"
 msgstr "kann '%s' nicht lesen"
 
-#: builtin/gc.c:495
+#: builtin/gc.c:503
 #, c-format
 msgid ""
 "The last gc run reported the following. Please correct the root cause\n"
@@ -15410,58 +15753,58 @@ msgstr ""
 "\n"
 "%s"
 
-#: builtin/gc.c:543
+#: builtin/gc.c:551
 msgid "prune unreferenced objects"
 msgstr "unreferenzierte Objekte entfernen"
 
-#: builtin/gc.c:545
+#: builtin/gc.c:553
 msgid "be more thorough (increased runtime)"
 msgstr "mehr Gründlichkeit (erhöht Laufzeit)"
 
-#: builtin/gc.c:546
+#: builtin/gc.c:554
 msgid "enable auto-gc mode"
 msgstr "\"auto-gc\" Modus aktivieren"
 
-#: builtin/gc.c:549
+#: builtin/gc.c:557
 msgid "force running gc even if there may be another gc running"
 msgstr ""
 "Ausführung von \"git gc\" erzwingen, selbst wenn ein anderes\n"
 "\"git gc\" bereits ausgeführt wird"
 
-#: builtin/gc.c:552
+#: builtin/gc.c:560
 msgid "repack all other packs except the largest pack"
 msgstr "alle anderen Pakete, außer das größte Paket, neu packen"
 
-#: builtin/gc.c:569
+#: builtin/gc.c:576
 #, c-format
 msgid "failed to parse gc.logexpiry value %s"
 msgstr "Fehler beim Parsen des Wertes '%s' von gc.logexpiry."
 
-#: builtin/gc.c:580
+#: builtin/gc.c:587
 #, c-format
 msgid "failed to parse prune expiry value %s"
 msgstr "Fehler beim Parsen des \"prune expiry\" Wertes %s"
 
-#: builtin/gc.c:600
+#: builtin/gc.c:607
 #, c-format
 msgid "Auto packing the repository in background for optimum performance.\n"
 msgstr ""
 "Die Datenbank des Repositories wird für eine optimale Performance im\n"
 "Hintergrund komprimiert.\n"
 
-#: builtin/gc.c:602
+#: builtin/gc.c:609
 #, c-format
 msgid "Auto packing the repository for optimum performance.\n"
 msgstr ""
 "Die Datenbank des Projektarchivs wird für eine optimale Performance "
 "komprimiert.\n"
 
-#: builtin/gc.c:603
+#: builtin/gc.c:610
 #, c-format
 msgid "See \"git help gc\" for manual housekeeping.\n"
 msgstr "Siehe \"git help gc\" für manuelles Aufräumen.\n"
 
-#: builtin/gc.c:643
+#: builtin/gc.c:650
 #, c-format
 msgid ""
 "gc is already running on machine '%s' pid %<PRIuMAX> (use --force if not)"
@@ -15469,149 +15812,179 @@ msgstr ""
 "\"git gc\" wird bereits auf Maschine '%s' pid %<PRIuMAX> ausgeführt\n"
 "(benutzen Sie --force falls nicht)"
 
-#: builtin/gc.c:698
+#: builtin/gc.c:705
 msgid ""
 "There are too many unreachable loose objects; run 'git prune' to remove them."
 msgstr ""
 "Es gibt zu viele unerreichbare lose Objekte; führen Sie 'git prune' aus, um "
 "diese zu löschen."
 
-#: builtin/gc.c:708
+#: builtin/gc.c:715
 msgid ""
 "git maintenance run [--auto] [--[no-]quiet] [--task=<task>] [--schedule]"
 msgstr ""
 "git maintenance run [--auto] [--[no-]quiet] [--task=<Aufgabe>] [--schedule]"
 
-#: builtin/gc.c:738
+#: builtin/gc.c:745
 msgid "--no-schedule is not allowed"
 msgstr "--no-schedule ist nicht erlaubt"
 
-#: builtin/gc.c:743
+#: builtin/gc.c:750
 #, c-format
 msgid "unrecognized --schedule argument '%s'"
 msgstr "nicht erkanntes --schedule Argument '%s'"
 
-#: builtin/gc.c:862
+#: builtin/gc.c:869
 msgid "failed to write commit-graph"
 msgstr "Fehler beim Schreiben des Commit-Graph"
 
-#: builtin/gc.c:901
+#: builtin/gc.c:914
 msgid "failed to fill remotes"
 msgstr "Fehler beim Eintragen der Remote-Repositories"
 
-#: builtin/gc.c:1024
+#: builtin/gc.c:1037
 msgid "failed to start 'git pack-objects' process"
 msgstr "konnte 'git pack-objects' Prozess nicht starten"
 
-#: builtin/gc.c:1041
+#: builtin/gc.c:1054
 msgid "failed to finish 'git pack-objects' process"
 msgstr "konnte 'git pack-objects' Prozess nicht beenden"
 
-#: builtin/gc.c:1093
+#: builtin/gc.c:1106
 msgid "failed to write multi-pack-index"
 msgstr "Fehler beim Schreiben des multi-pack-index"
 
-#: builtin/gc.c:1111
+#: builtin/gc.c:1124
 msgid "'git multi-pack-index expire' failed"
 msgstr "Fehler beim Ausführen von 'git multi-pack-index expire'"
 
-#: builtin/gc.c:1172
+#: builtin/gc.c:1185
 msgid "'git multi-pack-index repack' failed"
 msgstr "Fehler beim Ausführen von 'git multi-pack-index repack'"
 
-#: builtin/gc.c:1181
+#: builtin/gc.c:1194
 msgid ""
 "skipping incremental-repack task because core.multiPackIndex is disabled"
 msgstr ""
 "Überspringen der Aufgabe 'incremental-repack', weil core.multiPackIndex "
 "deaktiviert ist"
 
-#: builtin/gc.c:1279
+#: builtin/gc.c:1298
 #, c-format
 msgid "lock file '%s' exists, skipping maintenance"
 msgstr "Sperrdatei '%s' existiert, Wartung wird übersprungen"
 
-#: builtin/gc.c:1309
+#: builtin/gc.c:1328
 #, c-format
 msgid "task '%s' failed"
 msgstr "Aufgabe '%s' fehlgeschlagen"
 
-#: builtin/gc.c:1389
+#: builtin/gc.c:1410
 #, c-format
 msgid "'%s' is not a valid task"
 msgstr "'%s' ist keine gültige Aufgabe"
 
-#: builtin/gc.c:1394
+#: builtin/gc.c:1415
 #, c-format
 msgid "task '%s' cannot be selected multiple times"
 msgstr "Aufgabe '%s' kann nicht mehrfach ausgewählt werden"
 
-#: builtin/gc.c:1409
+#: builtin/gc.c:1430
 msgid "run tasks based on the state of the repository"
 msgstr "Aufgaben abhängig vom Zustand des Repositories ausführen"
 
-#: builtin/gc.c:1410
+#: builtin/gc.c:1431
 msgid "frequency"
 msgstr "Häufigkeit"
 
-#: builtin/gc.c:1411
+#: builtin/gc.c:1432
 msgid "run tasks based on frequency"
 msgstr "Aufgaben abhängig von der Häufigkeit ausführen"
 
-#: builtin/gc.c:1414
+#: builtin/gc.c:1435
 msgid "do not report progress or other information over stderr"
 msgstr "zeige keinen Fortschritt oder andere Informationen über stderr"
 
-#: builtin/gc.c:1415
+#: builtin/gc.c:1436
 msgid "task"
 msgstr "Aufgabe"
 
-#: builtin/gc.c:1416
+#: builtin/gc.c:1437
 msgid "run a specific task"
 msgstr "eine bestimmte Aufgabe ausführen"
 
-#: builtin/gc.c:1433
+#: builtin/gc.c:1454
 msgid "use at most one of --auto and --schedule=<frequency>"
 msgstr ""
 "nutzen Sie höchstens eine der Optionen --auto oder --schedule=<Häufigkeit>"
 
-#: builtin/gc.c:1467
+#: builtin/gc.c:1497
 msgid "failed to run 'git config'"
 msgstr "Fehler beim Ausführen von 'git config'"
 
-#: builtin/gc.c:1512
-msgid "another process is scheduling background maintenance"
-msgstr "ein anderer Prozess plant die Hintergrundwartung"
+#: builtin/gc.c:1562
+#, fuzzy, c-format
+msgid "failed to expand path '%s'"
+msgstr "Fehler beim Erstellen des Pfades '%s'%s"
 
-#: builtin/gc.c:1525
+#: builtin/gc.c:1591
+#, fuzzy
+msgid "failed to start launchctl"
+msgstr "Konnte emacsclient nicht starten."
+
+#: builtin/gc.c:1628
+#, fuzzy, c-format
+msgid "failed to create directories for '%s'"
+msgstr "Fehler beim Erstellen von Verzeichnis '%s'"
+
+#: builtin/gc.c:1689
+#, fuzzy, c-format
+msgid "failed to bootstrap service %s"
+msgstr "Fehler beim Löschen von %s"
+
+#: builtin/gc.c:1760
+#, fuzzy
+msgid "failed to create temp xml file"
+msgstr "Fehler beim Erstellen der Ausgabedateien."
+
+#: builtin/gc.c:1850
+#, fuzzy
+msgid "failed to start schtasks"
+msgstr "Konnte '%s' nicht lesen"
+
+#: builtin/gc.c:1894
 msgid "failed to run 'crontab -l'; your system might not support 'cron'"
 msgstr ""
 "Fehler beim Ausführen von 'crontab -l'; Ihr System unterstützt eventuell "
 "'cron' nicht"
 
-#: builtin/gc.c:1544
+#: builtin/gc.c:1911
 msgid "failed to run 'crontab'; your system might not support 'cron'"
 msgstr ""
 "Fehler beim Ausführen von 'crontab'; Ihr System unterstützt eventuell 'cron' "
 "nicht"
 
-#: builtin/gc.c:1550
+#: builtin/gc.c:1915
 msgid "failed to open stdin of 'crontab'"
 msgstr "Fehler beim Öffnen der Standard-Eingabe von 'crontab'"
 
-#: builtin/gc.c:1592
+#: builtin/gc.c:1956
 msgid "'crontab' died"
 msgstr "'crontab' abgebrochen"
 
-#: builtin/gc.c:1605
+#: builtin/gc.c:1990
+msgid "another process is scheduling background maintenance"
+msgstr "ein anderer Prozess plant die Hintergrundwartung"
+
+#: builtin/gc.c:2009
 msgid "failed to add repo to global config"
 msgstr "Repository konnte nicht zur globalen Konfiguration hinzugefügt werden"
 
-#: builtin/gc.c:1615
+#: builtin/gc.c:2019
 msgid "git maintenance <subcommand> [<options>]"
 msgstr "git maintenance <Unterbefehl> [<Optionen>]"
 
-#: builtin/gc.c:1634
+#: builtin/gc.c:2038
 #, c-format
 msgid "invalid subcommand: %s"
 msgstr "ungültiger Unterbefehl: %s"
@@ -15620,12 +15993,12 @@ msgstr "ungültiger Unterbefehl: %s"
 msgid "git grep [<options>] [-e] <pattern> [<rev>...] [[--] <path>...]"
 msgstr "git grep [<Optionen>] [-e] <Muster> [<Commit>...] [[--] <Pfad>...]"
 
-#: builtin/grep.c:225
+#: builtin/grep.c:223
 #, c-format
 msgid "grep: failed to create thread: %s"
 msgstr "grep: Fehler beim Erzeugen eines Thread: %s"
 
-#: builtin/grep.c:279
+#: builtin/grep.c:277
 #, c-format
 msgid "invalid number of threads specified (%d) for %s"
 msgstr "ungültige Anzahl von Threads (%d) für %s angegeben"
@@ -15634,266 +16007,267 @@ msgstr "ungültige Anzahl von Threads (%d) für %s angegeben"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:287 builtin/index-pack.c:1576 builtin/index-pack.c:1766
-#: builtin/pack-objects.c:2936
+#: builtin/grep.c:285 builtin/index-pack.c:1589 builtin/index-pack.c:1792
+#: builtin/pack-objects.c:2944
 #, c-format
 msgid "no threads support, ignoring %s"
 msgstr "keine Unterstützung von Threads, '%s' wird ignoriert"
 
-#: builtin/grep.c:475 builtin/grep.c:600 builtin/grep.c:640
+#: builtin/grep.c:473 builtin/grep.c:601 builtin/grep.c:641
 #, c-format
 msgid "unable to read tree (%s)"
 msgstr "konnte \"Tree\"-Objekt (%s) nicht lesen"
 
-#: builtin/grep.c:655
+#: builtin/grep.c:656
 #, c-format
 msgid "unable to grep from object of type %s"
 msgstr "kann \"grep\" nicht mit Objekten des Typs %s durchführen"
 
-#: builtin/grep.c:736
+#: builtin/grep.c:737
 #, c-format
 msgid "switch `%c' expects a numerical value"
 msgstr "Schalter '%c' erwartet einen numerischen Wert"
 
-#: builtin/grep.c:835
+#: builtin/grep.c:836
 msgid "search in index instead of in the work tree"
 msgstr "im Index anstatt im Arbeitsverzeichnis suchen"
 
-#: builtin/grep.c:837
+#: builtin/grep.c:838
 msgid "find in contents not managed by git"
 msgstr "auch in Inhalten finden, die nicht von Git verwaltet werden"
 
-#: builtin/grep.c:839
+#: builtin/grep.c:840
 msgid "search in both tracked and untracked files"
 msgstr "in versionierten und unversionierten Dateien suchen"
 
-#: builtin/grep.c:841
+#: builtin/grep.c:842
 msgid "ignore files specified via '.gitignore'"
 msgstr "Dateien, die über '.gitignore' angegeben sind, ignorieren"
 
-#: builtin/grep.c:843
+#: builtin/grep.c:844
 msgid "recursively search in each submodule"
 msgstr "rekursive Suche in jedem Submodul"
 
-#: builtin/grep.c:846
+#: builtin/grep.c:847
 msgid "show non-matching lines"
 msgstr "Zeilen ohne Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:848
+#: builtin/grep.c:849
 msgid "case insensitive matching"
 msgstr "Übereinstimmungen unabhängig von Groß- und Kleinschreibung finden"
 
-#: builtin/grep.c:850
+#: builtin/grep.c:851
 msgid "match patterns only at word boundaries"
 msgstr "nur ganze Wörter suchen"
 
-#: builtin/grep.c:852
+#: builtin/grep.c:853
 msgid "process binary files as text"
 msgstr "binäre Dateien als Text verarbeiten"
 
-#: builtin/grep.c:854
+#: builtin/grep.c:855
 msgid "don't match patterns in binary files"
 msgstr "keine Muster in Binärdateien finden"
 
-#: builtin/grep.c:857
+#: builtin/grep.c:858
 msgid "process binary files with textconv filters"
 msgstr "binäre Dateien mit \"textconv\"-Filtern verarbeiten"
 
-#: builtin/grep.c:859
+#: builtin/grep.c:860
 msgid "search in subdirectories (default)"
 msgstr "in Unterverzeichnissen suchen (Standard)"
 
-#: builtin/grep.c:861
+#: builtin/grep.c:862
 msgid "descend at most <depth> levels"
 msgstr "höchstens <Tiefe> Ebenen durchlaufen"
 
-#: builtin/grep.c:865
+#: builtin/grep.c:866
 msgid "use extended POSIX regular expressions"
 msgstr "erweiterte reguläre Ausdrücke aus POSIX verwenden"
 
-#: builtin/grep.c:868
+#: builtin/grep.c:869
 msgid "use basic POSIX regular expressions (default)"
 msgstr "grundlegende reguläre Ausdrücke aus POSIX verwenden (Standard)"
 
-#: builtin/grep.c:871
+#: builtin/grep.c:872
 msgid "interpret patterns as fixed strings"
 msgstr "Muster als feste Zeichenketten interpretieren"
 
-#: builtin/grep.c:874
+#: builtin/grep.c:875
 msgid "use Perl-compatible regular expressions"
 msgstr "Perl-kompatible reguläre Ausdrücke verwenden"
 
-#: builtin/grep.c:877
+#: builtin/grep.c:878
 msgid "show line numbers"
 msgstr "Zeilennummern anzeigen"
 
-#: builtin/grep.c:878
+#: builtin/grep.c:879
 msgid "show column number of first match"
 msgstr "Nummer der Spalte des ersten Treffers anzeigen"
 
-#: builtin/grep.c:879
+#: builtin/grep.c:880
 msgid "don't show filenames"
 msgstr "keine Dateinamen anzeigen"
 
-#: builtin/grep.c:880
+#: builtin/grep.c:881
 msgid "show filenames"
 msgstr "Dateinamen anzeigen"
 
-#: builtin/grep.c:882
+#: builtin/grep.c:883
 msgid "show filenames relative to top directory"
 msgstr "Dateinamen relativ zum Projektverzeichnis anzeigen"
 
-#: builtin/grep.c:884
+#: builtin/grep.c:885
 msgid "show only filenames instead of matching lines"
 msgstr "nur Dateinamen anzeigen anstatt übereinstimmende Zeilen"
 
-#: builtin/grep.c:886
+#: builtin/grep.c:887
 msgid "synonym for --files-with-matches"
 msgstr "Synonym für --files-with-matches"
 
-#: builtin/grep.c:889
+#: builtin/grep.c:890
 msgid "show only the names of files without match"
 msgstr "nur die Dateinamen ohne Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:891
+#: builtin/grep.c:892
 msgid "print NUL after filenames"
 msgstr "NUL-Zeichen nach Dateinamen ausgeben"
 
-#: builtin/grep.c:894
+#: builtin/grep.c:895
 msgid "show only matching parts of a line"
 msgstr "nur übereinstimmende Teile der Zeile anzeigen"
 
-#: builtin/grep.c:896
+#: builtin/grep.c:897
 msgid "show the number of matches instead of matching lines"
 msgstr "anstatt der Zeilen, die Anzahl der übereinstimmenden Zeilen anzeigen"
 
-#: builtin/grep.c:897
+#: builtin/grep.c:898
 msgid "highlight matches"
 msgstr "Übereinstimmungen hervorheben"
 
-#: builtin/grep.c:899
+#: builtin/grep.c:900
 msgid "print empty line between matches from different files"
 msgstr ""
 "eine Leerzeile zwischen Übereinstimmungen in verschiedenen Dateien ausgeben"
 
-#: builtin/grep.c:901
+#: builtin/grep.c:902
 msgid "show filename only once above matches from same file"
 msgstr ""
 "den Dateinamen nur einmal oberhalb der Übereinstimmungen aus dieser Datei "
 "anzeigen"
 
-#: builtin/grep.c:904
+#: builtin/grep.c:905
 msgid "show <n> context lines before and after matches"
 msgstr "<n> Zeilen vor und nach den Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:907
+#: builtin/grep.c:908
 msgid "show <n> context lines before matches"
 msgstr "<n> Zeilen vor den Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:909
+#: builtin/grep.c:910
 msgid "show <n> context lines after matches"
 msgstr "<n> Zeilen nach den Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:911
+#: builtin/grep.c:912
 msgid "use <n> worker threads"
 msgstr "<n> Threads benutzen"
 
-#: builtin/grep.c:912
+#: builtin/grep.c:913
 msgid "shortcut for -C NUM"
 msgstr "Kurzform für -C NUM"
 
-#: builtin/grep.c:915
+#: builtin/grep.c:916
 msgid "show a line with the function name before matches"
 msgstr "eine Zeile mit dem Funktionsnamen vor Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:917
+#: builtin/grep.c:918
 msgid "show the surrounding function"
 msgstr "die umgebende Funktion anzeigen"
 
-#: builtin/grep.c:920
+#: builtin/grep.c:921
 msgid "read patterns from file"
 msgstr "Muster von einer Datei lesen"
 
-#: builtin/grep.c:922
+#: builtin/grep.c:923
 msgid "match <pattern>"
 msgstr "<Muster> finden"
 
-#: builtin/grep.c:924
+#: builtin/grep.c:925
 msgid "combine patterns specified with -e"
 msgstr "Muster kombinieren, die mit -e angegeben wurden"
 
-#: builtin/grep.c:936
+#: builtin/grep.c:937
 msgid "indicate hit with exit status without output"
 msgstr "Übereinstimmungen nur durch Beendigungsstatus anzeigen"
 
-#: builtin/grep.c:938
+#: builtin/grep.c:939
 msgid "show only matches from files that match all patterns"
 msgstr ""
 "nur Übereinstimmungen von Dateien anzeigen, die allen Mustern entsprechen"
 
-#: builtin/grep.c:940
-msgid "show parse tree for grep expression"
-msgstr "geparstes Verzeichnis für \"grep\"-Ausdruck anzeigen"
-
-#: builtin/grep.c:944
+#: builtin/grep.c:942
 msgid "pager"
 msgstr "Anzeigeprogramm"
 
-#: builtin/grep.c:944
+#: builtin/grep.c:942
 msgid "show matching files in the pager"
 msgstr "Dateien mit Übereinstimmungen im Anzeigeprogramm anzeigen"
 
-#: builtin/grep.c:948
+#: builtin/grep.c:946
 msgid "allow calling of grep(1) (ignored by this build)"
 msgstr "den Aufruf von grep(1) erlauben (von dieser Programmversion ignoriert)"
 
-#: builtin/grep.c:1014
+#: builtin/grep.c:1012
 msgid "no pattern given"
 msgstr "Kein Muster angegeben."
 
-#: builtin/grep.c:1050
+#: builtin/grep.c:1048
 msgid "--no-index or --untracked cannot be used with revs"
 msgstr "--no-index oder --untracked können nicht mit Commits verwendet werden"
 
-#: builtin/grep.c:1058
+#: builtin/grep.c:1056
 #, c-format
 msgid "unable to resolve revision: %s"
 msgstr "Konnte Commit nicht auflösen: %s"
 
-#: builtin/grep.c:1088
+#: builtin/grep.c:1086
 msgid "--untracked not supported with --recurse-submodules"
 msgstr "--untracked zusammen mit --recurse-submodules wird nicht unterstützt"
 
-#: builtin/grep.c:1092
+#: builtin/grep.c:1090
 msgid "invalid option combination, ignoring --threads"
 msgstr "Ungültige Kombination von Optionen, --threads wird ignoriert."
 
-#: builtin/grep.c:1095 builtin/pack-objects.c:3655
+#: builtin/grep.c:1093 builtin/pack-objects.c:3672
 msgid "no threads support, ignoring --threads"
 msgstr "Keine Unterstützung für Threads, --threads wird ignoriert."
 
-#: builtin/grep.c:1098 builtin/index-pack.c:1573 builtin/pack-objects.c:2933
+#: builtin/grep.c:1096 builtin/index-pack.c:1586 builtin/pack-objects.c:2941
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "ungültige Anzahl von Threads angegeben (%d)"
 
-#: builtin/grep.c:1132
+#: builtin/grep.c:1130
 msgid "--open-files-in-pager only works on the worktree"
 msgstr ""
 "Die Option --open-files-in-pager kann nur innerhalb des "
 "Arbeitsverzeichnisses verwendet werden."
 
-#: builtin/grep.c:1158
+#: builtin/grep.c:1156
 msgid "--cached or --untracked cannot be used with --no-index"
 msgstr "--cached und --untracked können nicht mit --no-index verwendet werden."
 
-#: builtin/grep.c:1164
+#: builtin/grep.c:1159
+#, fuzzy
+msgid "--untracked cannot be used with --cached"
+msgstr "--cached und --untracked können nicht mit --no-index verwendet werden."
+
+#: builtin/grep.c:1165
 msgid "--[no-]exclude-standard cannot be used for tracked contents"
 msgstr ""
 "--[no-]exclude-standard kann nicht mit versionierten Inhalten verwendet "
 "werden."
 
-#: builtin/grep.c:1172
+#: builtin/grep.c:1173
 msgid "both --cached and trees are given"
 msgstr "--cached und \"Tree\"-Objekte angegeben"
 
@@ -16026,12 +16400,12 @@ msgstr "kein Handbuch-Betrachter konnte mit dieser Anfrage umgehen"
 msgid "no info viewer handled the request"
 msgstr "kein Informations-Betrachter konnte mit dieser Anfrage umgehen"
 
-#: builtin/help.c:520 builtin/help.c:531 git.c:337
+#: builtin/help.c:520 builtin/help.c:531 git.c:340
 #, c-format
 msgid "'%s' is aliased to '%s'"
 msgstr "Für '%s' wurde der Alias '%s' angelegt."
 
-#: builtin/help.c:534 git.c:369
+#: builtin/help.c:534 git.c:372
 #, c-format
 msgid "bad alias.%s string: %s"
 msgstr "Ungültiger alias.%s String: %s"
@@ -16079,7 +16453,7 @@ msgstr "Fehler beim Lesen der Eingabe"
 msgid "used more bytes than were available"
 msgstr "verwendete mehr Bytes als verfügbar waren"
 
-#: builtin/index-pack.c:324 builtin/pack-objects.c:619
+#: builtin/index-pack.c:324 builtin/pack-objects.c:624
 msgid "pack too large for current definition of off_t"
 msgstr "Paket ist zu groß für die aktuelle Definition von off_t"
 
@@ -16087,7 +16461,7 @@ msgstr "Paket ist zu groß für die aktuelle Definition von off_t"
 msgid "pack exceeds maximum allowed size"
 msgstr "Paket überschreitet die maximal erlaubte Größe"
 
-#: builtin/index-pack.c:342 builtin/repack.c:286
+#: builtin/index-pack.c:342
 #, c-format
 msgid "unable to create '%s'"
 msgstr "konnte '%s' nicht erstellen"
@@ -16213,7 +16587,7 @@ msgstr "Fehler beim Ausführen von \"parse_pack_objects()\""
 msgid "Resolving deltas"
 msgstr "Löse Unterschiede auf"
 
-#: builtin/index-pack.c:1249 builtin/pack-objects.c:2697
+#: builtin/index-pack.c:1249 builtin/pack-objects.c:2707
 #, c-format
 msgid "unable to create thread: %s"
 msgstr "kann Thread nicht erzeugen: %s"
@@ -16251,9 +16625,9 @@ msgstr "Konnte angehängtes Objekt (%d) nicht komprimieren"
 msgid "local object %s is corrupt"
 msgstr "lokales Objekt %s ist beschädigt"
 
-#: builtin/index-pack.c:1444
-#, c-format
-msgid "packfile name '%s' does not end with '.pack'"
+#: builtin/index-pack.c:1445
+#, fuzzy, c-format
+msgid "packfile name '%s' does not end with '.%s'"
 msgstr "Name der Paketdatei '%s' endet nicht mit '.pack'"
 
 #: builtin/index-pack.c:1469
@@ -16266,79 +16640,84 @@ msgstr "Kann %s Datei '%s' nicht schreiben."
 msgid "cannot close written %s file '%s'"
 msgstr "Kann eben geschriebene %s Datei '%s' nicht schließen."
 
-#: builtin/index-pack.c:1501
+#: builtin/index-pack.c:1503
 msgid "error while closing pack file"
 msgstr "Fehler beim Schließen der Paketdatei"
 
-#: builtin/index-pack.c:1515
+#: builtin/index-pack.c:1517
 msgid "cannot store pack file"
 msgstr "Kann Paketdatei nicht speichern"
 
-#: builtin/index-pack.c:1523
+#: builtin/index-pack.c:1525
 msgid "cannot store index file"
 msgstr "Kann Indexdatei nicht speichern"
 
-#: builtin/index-pack.c:1567 builtin/pack-objects.c:2944
+#: builtin/index-pack.c:1534
+#, fuzzy
+msgid "cannot store reverse index file"
+msgstr "Kann Indexdatei nicht speichern"
+
+#: builtin/index-pack.c:1580 builtin/pack-objects.c:2952
 #, c-format
 msgid "bad pack.indexversion=%<PRIu32>"
 msgstr "\"pack.indexversion=%<PRIu32>\" ist ungültig"
 
-#: builtin/index-pack.c:1631
+#: builtin/index-pack.c:1650
 #, c-format
 msgid "Cannot open existing pack file '%s'"
 msgstr "Kann existierende Paketdatei '%s' nicht öffnen"
 
-#: builtin/index-pack.c:1633
+#: builtin/index-pack.c:1652
 #, c-format
 msgid "Cannot open existing pack idx file for '%s'"
 msgstr "Kann existierende Indexdatei für Paket '%s' nicht öffnen"
 
-#: builtin/index-pack.c:1681
+#: builtin/index-pack.c:1700
 #, c-format
 msgid "non delta: %d object"
 msgid_plural "non delta: %d objects"
 msgstr[0] "kein Unterschied: %d Objekt"
 msgstr[1] "kein Unterschied: %d Objekte"
 
-#: builtin/index-pack.c:1688
+#: builtin/index-pack.c:1707
 #, c-format
 msgid "chain length = %d: %lu object"
 msgid_plural "chain length = %d: %lu objects"
 msgstr[0] "Länge der Objekt-Liste = %d: %lu Objekt"
 msgstr[1] "Länge der Objekt-Liste = %d: %lu Objekte"
 
-#: builtin/index-pack.c:1728
+#: builtin/index-pack.c:1749
 msgid "Cannot come back to cwd"
 msgstr "Kann nicht zurück zum Arbeitsverzeichnis wechseln"
 
-#: builtin/index-pack.c:1777 builtin/index-pack.c:1780
-#: builtin/index-pack.c:1796 builtin/index-pack.c:1800
+#: builtin/index-pack.c:1803 builtin/index-pack.c:1806
+#: builtin/index-pack.c:1822 builtin/index-pack.c:1826
 #, c-format
 msgid "bad %s"
 msgstr "%s ist ungültig"
 
-#: builtin/index-pack.c:1806 builtin/init-db.c:392 builtin/init-db.c:625
+#: builtin/index-pack.c:1832 builtin/init-db.c:392 builtin/init-db.c:625
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "unbekannter Hash-Algorithmus '%s'"
 
-#: builtin/index-pack.c:1821
+#: builtin/index-pack.c:1851
 msgid "--fix-thin cannot be used without --stdin"
 msgstr "Die Option --fix-thin kann nicht ohne --stdin verwendet werden."
 
-#: builtin/index-pack.c:1823
+#: builtin/index-pack.c:1853
 msgid "--stdin requires a git repository"
 msgstr "--stdin erfordert ein Git-Repository"
 
-#: builtin/index-pack.c:1825
+#: builtin/index-pack.c:1855
 msgid "--object-format cannot be used with --stdin"
 msgstr "Die Option --object-format kann nicht mit --stdin verwendet werden."
 
-#: builtin/index-pack.c:1831
+#: builtin/index-pack.c:1870
 msgid "--verify with no packfile name given"
 msgstr "Die Option --verify wurde ohne Namen der Paketdatei angegeben."
 
-#: builtin/index-pack.c:1892 builtin/unpack-objects.c:582
+#: builtin/index-pack.c:1936 builtin/unpack-objects.c:582
 msgid "fsck error in pack objects"
 msgstr "fsck Fehler beim Packen von Objekten"
 
@@ -16557,131 +16936,133 @@ msgstr ""
 msgid "no input file given for in-place editing"
 msgstr "keine Datei zur direkten Bearbeitung angegeben"
 
-#: builtin/log.c:58
+#: builtin/log.c:59
 msgid "git log [<options>] [<revision-range>] [[--] <path>...]"
 msgstr "git log [<Optionen>] [<Commitbereich>] [[--] <Pfad>...]"
 
-#: builtin/log.c:59
+#: builtin/log.c:60
 msgid "git show [<options>] <object>..."
 msgstr "git show [<Optionen>] <Objekt>..."
 
-#: builtin/log.c:112
+#: builtin/log.c:113
 #, c-format
 msgid "invalid --decorate option: %s"
 msgstr "Ungültige Option für --decorate: %s"
 
-#: builtin/log.c:179
+#: builtin/log.c:180
 msgid "show source"
 msgstr "Quelle anzeigen"
 
-#: builtin/log.c:180
-msgid "Use mail map file"
+#: builtin/log.c:181
+#, fuzzy
+msgid "use mail map file"
 msgstr "\"mailmap\"-Datei verwenden"
 
-#: builtin/log.c:183
+#: builtin/log.c:184
 msgid "only decorate refs that match <pattern>"
 msgstr "\"decorate\" nur bei Referenzen anwenden, die <Muster> entsprechen"
 
-#: builtin/log.c:185
+#: builtin/log.c:186
 msgid "do not decorate refs that match <pattern>"
 msgstr "\"decorate\" nicht bei Referenzen anwenden, die <Muster> entsprechen"
 
-#: builtin/log.c:186
+#: builtin/log.c:187
 msgid "decorate options"
 msgstr "decorate-Optionen"
 
-#: builtin/log.c:189
+#: builtin/log.c:190
+#, fuzzy
 msgid ""
-"Trace the evolution of line range <start>,<end> or function :<funcname> in "
+"trace the evolution of line range <start>,<end> or function :<funcname> in "
 "<file>"
 msgstr ""
 "Entwicklung der Zeilen vom Bereich <Start>,<Ende> oder Funktion :"
 "<Funktionsname> in <Datei> verfolgen"
 
-#: builtin/log.c:212
+#: builtin/log.c:213
 msgid "-L<range>:<file> cannot be used with pathspec"
 msgstr "-L<Bereich>:<Datei> kann nicht mit Pfadspezifikation verwendet werden"
 
-#: builtin/log.c:302
+#: builtin/log.c:303
 #, c-format
 msgid "Final output: %d %s\n"
 msgstr "letzte Ausgabe: %d %s\n"
 
-#: builtin/log.c:564
+#: builtin/log.c:566
 #, c-format
 msgid "git show %s: bad file"
 msgstr "git show %s: ungültige Datei"
 
-#: builtin/log.c:579 builtin/log.c:674
+#: builtin/log.c:581 builtin/log.c:671
 #, c-format
 msgid "could not read object %s"
 msgstr "Konnte Objekt %s nicht lesen."
 
-#: builtin/log.c:699
+#: builtin/log.c:696
 #, c-format
 msgid "unknown type: %d"
 msgstr "Unbekannter Typ: %d"
 
-#: builtin/log.c:848
+#: builtin/log.c:841
 #, c-format
 msgid "%s: invalid cover from description mode"
 msgstr ""
 "%s: Ungültiger Modus für Erstellung des Deckblattes aus der Beschreibung"
 
-#: builtin/log.c:855
+#: builtin/log.c:848
 msgid "format.headers without value"
 msgstr "format.headers ohne Wert"
 
-#: builtin/log.c:984
+#: builtin/log.c:977
 #, c-format
 msgid "cannot open patch file %s"
 msgstr "Kann Patch-Datei %s nicht öffnen"
 
-#: builtin/log.c:1001
+#: builtin/log.c:994
 msgid "need exactly one range"
 msgstr "Brauche genau einen Commit-Bereich."
 
-#: builtin/log.c:1011
+#: builtin/log.c:1004
 msgid "not a range"
 msgstr "Kein Commit-Bereich."
 
-#: builtin/log.c:1175
+#: builtin/log.c:1168
 msgid "cover letter needs email format"
 msgstr "Anschreiben benötigt E-Mail-Format"
 
-#: builtin/log.c:1181
+#: builtin/log.c:1174
 msgid "failed to create cover-letter file"
 msgstr "Fehler beim Erstellen der Datei für das Anschreiben."
 
-#: builtin/log.c:1262
+#: builtin/log.c:1261
 #, c-format
 msgid "insane in-reply-to: %s"
 msgstr "ungültiges in-reply-to: %s"
 
-#: builtin/log.c:1289
+#: builtin/log.c:1288
 msgid "git format-patch [<options>] [<since> | <revision-range>]"
 msgstr "git format-patch [<Optionen>] [<seit> | <Commitbereich>]"
 
-#: builtin/log.c:1347
+#: builtin/log.c:1346
 msgid "two output directories?"
 msgstr "Zwei Ausgabeverzeichnisse?"
 
-#: builtin/log.c:1498 builtin/log.c:2318 builtin/log.c:2320 builtin/log.c:2332
+#: builtin/log.c:1497 builtin/log.c:2317 builtin/log.c:2319 builtin/log.c:2331
 #, c-format
 msgid "unknown commit %s"
 msgstr "Unbekannter Commit %s"
 
-#: builtin/log.c:1509 builtin/replace.c:58 builtin/replace.c:207
+#: builtin/log.c:1508 builtin/replace.c:58 builtin/replace.c:207
 #: builtin/replace.c:210
 #, c-format
 msgid "failed to resolve '%s' as a valid ref"
 msgstr "Konnte '%s' nicht als gültige Referenz auflösen."
 
-#: builtin/log.c:1518
+#: builtin/log.c:1517
 msgid "could not find exact merge base"
 msgstr "Konnte keine exakte Merge-Basis finden."
 
-#: builtin/log.c:1528
+#: builtin/log.c:1527
 msgid ""
 "failed to get upstream, if you want to record base commit automatically,\n"
 "please use git branch --set-upstream-to to track a remote branch.\n"
@@ -16692,291 +17073,293 @@ msgstr ""
 "'git branch --set-upstream-to', um einem Remote-Branch zu folgen.\n"
 "Oder geben Sie den Basis-Commit mit '--base=<Basis-Commit-Id>' manuell an."
 
-#: builtin/log.c:1551
+#: builtin/log.c:1550
 msgid "failed to find exact merge base"
 msgstr "Fehler beim Finden einer exakten Merge-Basis."
 
-#: builtin/log.c:1568
+#: builtin/log.c:1567
 msgid "base commit should be the ancestor of revision list"
 msgstr "Basis-Commit sollte der Vorgänger der Revisionsliste sein."
 
-#: builtin/log.c:1578
+#: builtin/log.c:1577
 msgid "base commit shouldn't be in revision list"
 msgstr "Basis-Commit sollte nicht in der Revisionsliste enthalten sein."
 
-#: builtin/log.c:1636
+#: builtin/log.c:1635
 msgid "cannot get patch id"
 msgstr "kann Patch-Id nicht lesen"
 
-#: builtin/log.c:1693
+#: builtin/log.c:1692
 msgid "failed to infer range-diff origin of current series"
 msgstr "Fehler beim Ableiten des range-diff Ursprungs der aktuellen Serie"
 
-#: builtin/log.c:1695
+#: builtin/log.c:1694
 #, c-format
 msgid "using '%s' as range-diff origin of current series"
 msgstr "nutze '%s' als range-diff Ursprung der aktuellen Serie"
 
-#: builtin/log.c:1739
+#: builtin/log.c:1738
 msgid "use [PATCH n/m] even with a single patch"
 msgstr "[PATCH n/m] auch mit einzelnem Patch verwenden"
 
-#: builtin/log.c:1742
+#: builtin/log.c:1741
 msgid "use [PATCH] even with multiple patches"
 msgstr "[PATCH] auch mit mehreren Patches verwenden"
 
-#: builtin/log.c:1746
+#: builtin/log.c:1745
 msgid "print patches to standard out"
 msgstr "Ausgabe der Patches in Standard-Ausgabe"
 
-#: builtin/log.c:1748
+#: builtin/log.c:1747
 msgid "generate a cover letter"
 msgstr "ein Deckblatt erzeugen"
 
-#: builtin/log.c:1750
+#: builtin/log.c:1749
 msgid "use simple number sequence for output file names"
 msgstr "einfache Nummernfolge für die Namen der Ausgabedateien verwenden"
 
-#: builtin/log.c:1751
+#: builtin/log.c:1750
 msgid "sfx"
 msgstr "Dateiendung"
 
-#: builtin/log.c:1752
+#: builtin/log.c:1751
 msgid "use <sfx> instead of '.patch'"
 msgstr "<Dateiendung> anstatt '.patch' verwenden"
 
-#: builtin/log.c:1754
+#: builtin/log.c:1753
 msgid "start numbering patches at <n> instead of 1"
 msgstr "die Nummerierung der Patches bei <n> anstatt bei 1 beginnen"
 
-#: builtin/log.c:1756
+#: builtin/log.c:1755
 msgid "mark the series as Nth re-roll"
 msgstr "die Serie als n-te Fassung kennzeichnen"
 
-#: builtin/log.c:1758
+#: builtin/log.c:1757
 msgid "max length of output filename"
 msgstr "maximale Länge des Dateinamens für die Ausgabe"
 
-#: builtin/log.c:1760
-msgid "Use [RFC PATCH] instead of [PATCH]"
+#: builtin/log.c:1759
+#, fuzzy
+msgid "use [RFC PATCH] instead of [PATCH]"
 msgstr "[RFC PATCH] anstatt [PATCH] verwenden"
 
-#: builtin/log.c:1763
+#: builtin/log.c:1762
 msgid "cover-from-description-mode"
 msgstr "Modus für Erstellung des Deckblattes aus der Beschreibung"
 
-#: builtin/log.c:1764
+#: builtin/log.c:1763
 msgid "generate parts of a cover letter based on a branch's description"
 msgstr ""
 "Erzeuge Teile des Deckblattes basierend auf der Beschreibung des Branches"
 
-#: builtin/log.c:1766
-msgid "Use [<prefix>] instead of [PATCH]"
+#: builtin/log.c:1765
+#, fuzzy
+msgid "use [<prefix>] instead of [PATCH]"
 msgstr "Nutze [<Präfix>] statt [PATCH]"
 
-#: builtin/log.c:1769
+#: builtin/log.c:1768
 msgid "store resulting files in <dir>"
 msgstr "erzeugte Dateien in <Verzeichnis> speichern"
 
-#: builtin/log.c:1772
+#: builtin/log.c:1771
 msgid "don't strip/add [PATCH]"
 msgstr "[PATCH] nicht entfernen/hinzufügen"
 
-#: builtin/log.c:1775
+#: builtin/log.c:1774
 msgid "don't output binary diffs"
 msgstr "keine binären Unterschiede ausgeben"
 
-#: builtin/log.c:1777
+#: builtin/log.c:1776
 msgid "output all-zero hash in From header"
 msgstr "Hash mit Nullen in \"From\"-Header ausgeben"
 
-#: builtin/log.c:1779
+#: builtin/log.c:1778
 msgid "don't include a patch matching a commit upstream"
 msgstr ""
 "keine Patches einschließen, die einem Commit im Upstream-Branch entsprechen"
 
-#: builtin/log.c:1781
+#: builtin/log.c:1780
 msgid "show patch format instead of default (patch + stat)"
 msgstr "Patchformat anstatt des Standards anzeigen (Patch + Zusammenfassung)"
 
-#: builtin/log.c:1783
+#: builtin/log.c:1782
 msgid "Messaging"
 msgstr "E-Mail-Einstellungen"
 
-#: builtin/log.c:1784
+#: builtin/log.c:1783
 msgid "header"
 msgstr "Header"
 
-#: builtin/log.c:1785
+#: builtin/log.c:1784
 msgid "add email header"
 msgstr "E-Mail-Header hinzufügen"
 
-#: builtin/log.c:1786 builtin/log.c:1787
+#: builtin/log.c:1785 builtin/log.c:1786
 msgid "email"
 msgstr "E-Mail"
 
-#: builtin/log.c:1786
+#: builtin/log.c:1785
 msgid "add To: header"
 msgstr "\"To:\"-Header hinzufügen"
 
-#: builtin/log.c:1787
+#: builtin/log.c:1786
 msgid "add Cc: header"
 msgstr "\"Cc:\"-Header hinzufügen"
 
-#: builtin/log.c:1788
+#: builtin/log.c:1787
 msgid "ident"
 msgstr "Ident"
 
-#: builtin/log.c:1789
+#: builtin/log.c:1788
 msgid "set From address to <ident> (or committer ident if absent)"
 msgstr ""
 "\"From\"-Adresse auf <Ident> setzen (oder Ident des Commit-Erstellers, wenn "
 "fehlend)"
 
-#: builtin/log.c:1791
+#: builtin/log.c:1790
 msgid "message-id"
 msgstr "message-id"
 
-#: builtin/log.c:1792
+#: builtin/log.c:1791
 msgid "make first mail a reply to <message-id>"
 msgstr "aus erster E-Mail eine Antwort zu <message-id> machen"
 
-#: builtin/log.c:1793 builtin/log.c:1796
+#: builtin/log.c:1792 builtin/log.c:1795
 msgid "boundary"
 msgstr "Grenze"
 
-#: builtin/log.c:1794
+#: builtin/log.c:1793
 msgid "attach the patch"
 msgstr "den Patch anhängen"
 
-#: builtin/log.c:1797
+#: builtin/log.c:1796
 msgid "inline the patch"
 msgstr "den Patch direkt in die Nachricht einfügen"
 
-#: builtin/log.c:1801
+#: builtin/log.c:1800
 msgid "enable message threading, styles: shallow, deep"
 msgstr "Nachrichtenverkettung aktivieren, Stile: shallow, deep"
 
-#: builtin/log.c:1803
+#: builtin/log.c:1802
 msgid "signature"
 msgstr "Signatur"
 
-#: builtin/log.c:1804
+#: builtin/log.c:1803
 msgid "add a signature"
 msgstr "eine Signatur hinzufügen"
 
-#: builtin/log.c:1805
+#: builtin/log.c:1804
 msgid "base-commit"
 msgstr "Basis-Commit"
 
-#: builtin/log.c:1806
+#: builtin/log.c:1805
 msgid "add prerequisite tree info to the patch series"
 msgstr "erforderliche Revisions-Informationen der Patch-Serie hinzufügen"
 
-#: builtin/log.c:1809
+#: builtin/log.c:1808
 msgid "add a signature from a file"
 msgstr "eine Signatur aus einer Datei hinzufügen"
 
-#: builtin/log.c:1810
+#: builtin/log.c:1809
 msgid "don't print the patch filenames"
 msgstr "keine Dateinamen der Patches anzeigen"
 
-#: builtin/log.c:1812
+#: builtin/log.c:1811
 msgid "show progress while generating patches"
 msgstr "Forschrittsanzeige während der Erzeugung der Patches"
 
-#: builtin/log.c:1814
+#: builtin/log.c:1813
 msgid "show changes against <rev> in cover letter or single patch"
 msgstr ""
 "Änderungen gegenüber <Commit> im Deckblatt oder einzelnem Patch anzeigen"
 
-#: builtin/log.c:1817
+#: builtin/log.c:1816
 msgid "show changes against <refspec> in cover letter or single patch"
 msgstr ""
 "Änderungen gegenüber <Refspec> im Deckblatt oder einzelnem Patch anzeigen"
 
-#: builtin/log.c:1819
+#: builtin/log.c:1818
 msgid "percentage by which creation is weighted"
 msgstr "Prozentsatz mit welchem Erzeugung gewichtet wird"
 
-#: builtin/log.c:1905
+#: builtin/log.c:1904
 #, c-format
 msgid "invalid ident line: %s"
 msgstr "Ungültige Identifikationszeile: %s"
 
-#: builtin/log.c:1920
+#: builtin/log.c:1919
 msgid "-n and -k are mutually exclusive"
 msgstr "-n und -k schließen sich gegenseitig aus"
 
-#: builtin/log.c:1922
+#: builtin/log.c:1921
 msgid "--subject-prefix/--rfc and -k are mutually exclusive"
 msgstr "--subject-prefix/--rfc und -k schließen sich gegenseitig aus"
 
-#: builtin/log.c:1930
+#: builtin/log.c:1929
 msgid "--name-only does not make sense"
 msgstr "die Option --name-only kann nicht verwendet werden"
 
-#: builtin/log.c:1932
+#: builtin/log.c:1931
 msgid "--name-status does not make sense"
 msgstr "die Option --name-status kann nicht verwendet werden"
 
-#: builtin/log.c:1934
+#: builtin/log.c:1933
 msgid "--check does not make sense"
 msgstr "die Option --check kann nicht verwendet werden"
 
-#: builtin/log.c:1956
+#: builtin/log.c:1955
 msgid "--stdout, --output, and --output-directory are mutually exclusive"
 msgstr ""
 "--stdout, --output und --output-directory schließen sich gegenseitig aus"
 
-#: builtin/log.c:2079
+#: builtin/log.c:2078
 msgid "--interdiff requires --cover-letter or single patch"
 msgstr "--interdiff erfordert --cover-letter oder einzelnen Patch"
 
-#: builtin/log.c:2083
+#: builtin/log.c:2082
 msgid "Interdiff:"
 msgstr "Interdiff:"
 
-#: builtin/log.c:2084
+#: builtin/log.c:2083
 #, c-format
 msgid "Interdiff against v%d:"
 msgstr "Interdiff gegen v%d:"
 
-#: builtin/log.c:2090
+#: builtin/log.c:2089
 msgid "--creation-factor requires --range-diff"
 msgstr "--creation-factor erfordert --range-diff"
 
-#: builtin/log.c:2094
+#: builtin/log.c:2093
 msgid "--range-diff requires --cover-letter or single patch"
 msgstr "--range-diff erfordert --cover-letter oder einzelnen Patch."
 
-#: builtin/log.c:2102
+#: builtin/log.c:2101
 msgid "Range-diff:"
 msgstr "Range-Diff:"
 
-#: builtin/log.c:2103
+#: builtin/log.c:2102
 #, c-format
 msgid "Range-diff against v%d:"
 msgstr "Range-Diff gegen v%d:"
 
-#: builtin/log.c:2114
+#: builtin/log.c:2113
 #, c-format
 msgid "unable to read signature file '%s'"
 msgstr "Konnte Signatur-Datei '%s' nicht lesen"
 
-#: builtin/log.c:2150
+#: builtin/log.c:2149
 msgid "Generating patches"
 msgstr "Erzeuge Patches"
 
-#: builtin/log.c:2194
+#: builtin/log.c:2193
 msgid "failed to create output files"
 msgstr "Fehler beim Erstellen der Ausgabedateien."
 
-#: builtin/log.c:2253
+#: builtin/log.c:2252
 msgid "git cherry [-v] [<upstream> [<head> [<limit>]]]"
 msgstr "git cherry [-v] [<Upstream> [<Branch> [<Limit>]]]"
 
-#: builtin/log.c:2307
+#: builtin/log.c:2306
 #, c-format
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> manually.\n"
@@ -16984,114 +17367,119 @@ msgstr ""
 "Konnte gefolgten Remote-Branch nicht finden, bitte geben Sie <Upstream> "
 "manuell an.\n"
 
-#: builtin/ls-files.c:471
+#: builtin/ls-files.c:486
 msgid "git ls-files [<options>] [<file>...]"
 msgstr "git ls-files [<Optionen>] [<Datei>...]"
 
-#: builtin/ls-files.c:527
+#: builtin/ls-files.c:542
 msgid "identify the file status with tags"
 msgstr "den Dateistatus mit Tags anzeigen"
 
-#: builtin/ls-files.c:529
+#: builtin/ls-files.c:544
 msgid "use lowercase letters for 'assume unchanged' files"
 msgstr ""
 "Kleinbuchstaben für Dateien mit 'assume unchanged' Markierung verwenden"
 
-#: builtin/ls-files.c:531
+#: builtin/ls-files.c:546
 msgid "use lowercase letters for 'fsmonitor clean' files"
 msgstr "Kleinbuchstaben für 'fsmonitor clean' Dateien verwenden"
 
-#: builtin/ls-files.c:533
+#: builtin/ls-files.c:548
 msgid "show cached files in the output (default)"
 msgstr "zwischengespeicherte Dateien in der Ausgabe anzeigen (Standard)"
 
-#: builtin/ls-files.c:535
+#: builtin/ls-files.c:550
 msgid "show deleted files in the output"
 msgstr "entfernte Dateien in der Ausgabe anzeigen"
 
-#: builtin/ls-files.c:537
+#: builtin/ls-files.c:552
 msgid "show modified files in the output"
 msgstr "geänderte Dateien in der Ausgabe anzeigen"
 
-#: builtin/ls-files.c:539
+#: builtin/ls-files.c:554
 msgid "show other files in the output"
 msgstr "sonstige Dateien in der Ausgabe anzeigen"
 
-#: builtin/ls-files.c:541
+#: builtin/ls-files.c:556
 msgid "show ignored files in the output"
 msgstr "ignorierte Dateien in der Ausgabe anzeigen"
 
-#: builtin/ls-files.c:544
+#: builtin/ls-files.c:559
 msgid "show staged contents' object name in the output"
 msgstr ""
 "Objektnamen von Inhalten, die zum Commit vorgemerkt sind, in der Ausgabe "
 "anzeigen"
 
-#: builtin/ls-files.c:546
+#: builtin/ls-files.c:561
 msgid "show files on the filesystem that need to be removed"
 msgstr "Dateien im Dateisystem, die gelöscht werden müssen, anzeigen"
 
-#: builtin/ls-files.c:548
+#: builtin/ls-files.c:563
 msgid "show 'other' directories' names only"
 msgstr "nur Namen von 'sonstigen' Verzeichnissen anzeigen"
 
-#: builtin/ls-files.c:550
+#: builtin/ls-files.c:565
 msgid "show line endings of files"
 msgstr "Zeilenenden von Dateien anzeigen"
 
-#: builtin/ls-files.c:552
+#: builtin/ls-files.c:567
 msgid "don't show empty directories"
 msgstr "keine leeren Verzeichnisse anzeigen"
 
-#: builtin/ls-files.c:555
+#: builtin/ls-files.c:570
 msgid "show unmerged files in the output"
 msgstr "nicht zusammengeführte Dateien in der Ausgabe anzeigen"
 
-#: builtin/ls-files.c:557
+#: builtin/ls-files.c:572
 msgid "show resolve-undo information"
 msgstr "'resolve-undo' Informationen anzeigen"
 
-#: builtin/ls-files.c:559
+#: builtin/ls-files.c:574
 msgid "skip files matching pattern"
 msgstr "Dateien auslassen, die einem Muster entsprechen"
 
-#: builtin/ls-files.c:562
+#: builtin/ls-files.c:577
 msgid "exclude patterns are read from <file>"
 msgstr "Muster, gelesen von <Datei>, ausschließen"
 
-#: builtin/ls-files.c:565
+#: builtin/ls-files.c:580
 msgid "read additional per-directory exclude patterns in <file>"
 msgstr "zusätzliche pro-Verzeichnis Auschlussmuster aus <Datei> auslesen"
 
-#: builtin/ls-files.c:567
+#: builtin/ls-files.c:582
 msgid "add the standard git exclusions"
 msgstr "die standardmäßigen Git-Ausschlüsse hinzufügen"
 
-#: builtin/ls-files.c:571
+#: builtin/ls-files.c:586
 msgid "make the output relative to the project top directory"
 msgstr "Ausgabe relativ zum Projektverzeichnis"
 
-#: builtin/ls-files.c:574
+#: builtin/ls-files.c:589
 msgid "recurse through submodules"
 msgstr "Rekursion in Submodulen durchführen"
 
-#: builtin/ls-files.c:576
+#: builtin/ls-files.c:591
 msgid "if any <file> is not in the index, treat this as an error"
 msgstr "als Fehler behandeln, wenn sich eine <Datei> nicht im Index befindet"
 
-#: builtin/ls-files.c:577
+#: builtin/ls-files.c:592
 msgid "tree-ish"
 msgstr "Commit-Referenz"
 
-#: builtin/ls-files.c:578
+#: builtin/ls-files.c:593
 msgid "pretend that paths removed since <tree-ish> are still present"
 msgstr ""
 "vorgeben, dass Pfade, die seit <Commit-Referenz> gelöscht wurden, immer noch "
 "vorhanden sind"
 
-#: builtin/ls-files.c:580
+#: builtin/ls-files.c:595
 msgid "show debugging data"
 msgstr "Ausgaben zur Fehlersuche anzeigen"
+
+#: builtin/ls-files.c:597
+#, fuzzy
+msgid "suppress duplicate entries"
+msgstr "Namen unterdrücken"
 
 #: builtin/ls-remote.c:9
 msgid ""
@@ -17103,41 +17491,41 @@ msgstr ""
 "                     [-q | --quiet] [--exit-code] [--get-url]\n"
 "                     [--symref] [<Repository> [<Referenzen>...]]"
 
-#: builtin/ls-remote.c:59
+#: builtin/ls-remote.c:60
 msgid "do not print remote URL"
 msgstr "URL des Remote-Repositories nicht ausgeben"
 
-#: builtin/ls-remote.c:60 builtin/ls-remote.c:62 builtin/rebase.c:1398
+#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1404
 msgid "exec"
 msgstr "Programm"
 
-#: builtin/ls-remote.c:61 builtin/ls-remote.c:63
+#: builtin/ls-remote.c:62 builtin/ls-remote.c:64
 msgid "path of git-upload-pack on the remote host"
 msgstr "Pfad zu \"git-upload-pack\" auf der Gegenseite"
 
-#: builtin/ls-remote.c:65
+#: builtin/ls-remote.c:66
 msgid "limit to tags"
 msgstr "auf Tags einschränken"
 
-#: builtin/ls-remote.c:66
+#: builtin/ls-remote.c:67
 msgid "limit to heads"
 msgstr "auf Branches einschränken"
 
-#: builtin/ls-remote.c:67
+#: builtin/ls-remote.c:68
 msgid "do not show peeled tags"
 msgstr "keine Tags anzeigen, die andere Tags enthalten"
 
-#: builtin/ls-remote.c:69
+#: builtin/ls-remote.c:70
 msgid "take url.<base>.insteadOf into account"
 msgstr "url.<Basis>.insteadOf berücksichtigen"
 
-#: builtin/ls-remote.c:72
+#: builtin/ls-remote.c:73
 msgid "exit with exit code 2 if no matching refs are found"
 msgstr ""
 "mit Exit-Code 2 beenden, wenn keine übereinstimmenden Referenzen\n"
 "gefunden wurden"
 
-#: builtin/ls-remote.c:75
+#: builtin/ls-remote.c:76
 msgid "show underlying ref in addition to the object pointed by it"
 msgstr "zusätzlich zum Objekt die darauf verweisenden Referenzen anzeigen"
 
@@ -17295,194 +17683,194 @@ msgstr "Konnte Referenz '%s' nicht auflösen"
 msgid "Merging %s with %s\n"
 msgstr "Führe %s mit %s zusammen\n"
 
-#: builtin/merge.c:57
+#: builtin/merge.c:58
 msgid "git merge [<options>] [<commit>...]"
 msgstr "git merge [<Optionen>] [<Commit>...]"
 
-#: builtin/merge.c:58
+#: builtin/merge.c:59
 msgid "git merge --abort"
 msgstr "git merge --abort"
 
-#: builtin/merge.c:59
+#: builtin/merge.c:60
 msgid "git merge --continue"
 msgstr "git merge --continue"
 
-#: builtin/merge.c:122
+#: builtin/merge.c:123
 msgid "switch `m' requires a value"
 msgstr "Schalter 'm' erfordert einen Wert."
 
-#: builtin/merge.c:145
+#: builtin/merge.c:146
 #, c-format
 msgid "option `%s' requires a value"
 msgstr "Option `%s' erfordert einen Wert."
 
-#: builtin/merge.c:198
+#: builtin/merge.c:199
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
 msgstr "Konnte Merge-Strategie '%s' nicht finden.\n"
 
-#: builtin/merge.c:199
+#: builtin/merge.c:200
 #, c-format
 msgid "Available strategies are:"
 msgstr "Verfügbare Strategien sind:"
 
-#: builtin/merge.c:204
+#: builtin/merge.c:205
 #, c-format
 msgid "Available custom strategies are:"
 msgstr "Verfügbare benutzerdefinierte Strategien sind:"
 
-#: builtin/merge.c:255 builtin/pull.c:133
+#: builtin/merge.c:256 builtin/pull.c:133
 msgid "do not show a diffstat at the end of the merge"
 msgstr "keine Zusammenfassung der Unterschiede am Schluss des Merges anzeigen"
 
-#: builtin/merge.c:258 builtin/pull.c:136
+#: builtin/merge.c:259 builtin/pull.c:136
 msgid "show a diffstat at the end of the merge"
 msgstr "eine Zusammenfassung der Unterschiede am Schluss des Merges anzeigen"
 
-#: builtin/merge.c:259 builtin/pull.c:139
+#: builtin/merge.c:260 builtin/pull.c:139
 msgid "(synonym to --stat)"
 msgstr "(Synonym für --stat)"
 
-#: builtin/merge.c:261 builtin/pull.c:142
+#: builtin/merge.c:262 builtin/pull.c:142
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "(höchstens <n>) Einträge von \"shortlog\" zur Beschreibung des Merge-Commits "
 "hinzufügen"
 
-#: builtin/merge.c:264 builtin/pull.c:148
+#: builtin/merge.c:265 builtin/pull.c:148
 msgid "create a single commit instead of doing a merge"
 msgstr "einen einzelnen Commit anstatt eines Merges erzeugen"
 
-#: builtin/merge.c:266 builtin/pull.c:151
+#: builtin/merge.c:267 builtin/pull.c:151
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "einen Commit durchführen, wenn der Merge erfolgreich war (Standard)"
 
-#: builtin/merge.c:268 builtin/pull.c:154
+#: builtin/merge.c:269 builtin/pull.c:154
 msgid "edit message before committing"
 msgstr "Bearbeitung der Beschreibung vor dem Commit"
 
-#: builtin/merge.c:270
+#: builtin/merge.c:271
 msgid "allow fast-forward (default)"
 msgstr "Vorspulen erlauben (Standard)"
 
-#: builtin/merge.c:272 builtin/pull.c:161
+#: builtin/merge.c:273 builtin/pull.c:161
 msgid "abort if fast-forward is not possible"
 msgstr "abbrechen, wenn kein Vorspulen möglich ist"
 
-#: builtin/merge.c:276 builtin/pull.c:164
+#: builtin/merge.c:277 builtin/pull.c:164
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "den genannten Commit auf eine gültige GPG-Signatur überprüfen"
 
-#: builtin/merge.c:277 builtin/notes.c:787 builtin/pull.c:168
-#: builtin/rebase.c:539 builtin/rebase.c:1412 builtin/revert.c:114
+#: builtin/merge.c:278 builtin/notes.c:787 builtin/pull.c:168
+#: builtin/rebase.c:541 builtin/rebase.c:1418 builtin/revert.c:114
 msgid "strategy"
 msgstr "Strategie"
 
-#: builtin/merge.c:278 builtin/pull.c:169
+#: builtin/merge.c:279 builtin/pull.c:169
 msgid "merge strategy to use"
 msgstr "zu verwendende Merge-Strategie"
 
-#: builtin/merge.c:279 builtin/pull.c:172
+#: builtin/merge.c:280 builtin/pull.c:172
 msgid "option=value"
 msgstr "Option=Wert"
 
-#: builtin/merge.c:280 builtin/pull.c:173
+#: builtin/merge.c:281 builtin/pull.c:173
 msgid "option for selected merge strategy"
 msgstr "Option für ausgewählte Merge-Strategie"
 
-#: builtin/merge.c:282
+#: builtin/merge.c:283
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr ""
 "Commit-Beschreibung zusammenführen (für einen Merge, der kein Vorspulen war)"
 
-#: builtin/merge.c:289
+#: builtin/merge.c:290
 msgid "abort the current in-progress merge"
 msgstr "den sich im Gange befindlichen Merge abbrechen"
 
-#: builtin/merge.c:291
+#: builtin/merge.c:292
 msgid "--abort but leave index and working tree alone"
 msgstr "--abort, aber Index und Arbeitsverzeichnis unverändert lassen"
 
-#: builtin/merge.c:293
+#: builtin/merge.c:294
 msgid "continue the current in-progress merge"
 msgstr "den sich im Gange befindlichen Merge fortsetzen"
 
-#: builtin/merge.c:295 builtin/pull.c:180
+#: builtin/merge.c:296 builtin/pull.c:180
 msgid "allow merging unrelated histories"
 msgstr "erlaube das Zusammenführen von nicht zusammenhängenden Historien"
 
-#: builtin/merge.c:302
+#: builtin/merge.c:303
 msgid "bypass pre-merge-commit and commit-msg hooks"
 msgstr "Hooks pre-merge-commit und commit-msg umgehen"
 
-#: builtin/merge.c:319
+#: builtin/merge.c:320
 msgid "could not run stash."
 msgstr "Konnte \"stash\" nicht ausführen."
 
-#: builtin/merge.c:324
+#: builtin/merge.c:325
 msgid "stash failed"
 msgstr "\"stash\" fehlgeschlagen"
 
-#: builtin/merge.c:329
+#: builtin/merge.c:330
 #, c-format
 msgid "not a valid object: %s"
 msgstr "kein gültiges Objekt: %s"
 
-#: builtin/merge.c:351 builtin/merge.c:368
+#: builtin/merge.c:352 builtin/merge.c:369
 msgid "read-tree failed"
 msgstr "read-tree fehlgeschlagen"
 
-#: builtin/merge.c:398
+#: builtin/merge.c:399
 msgid " (nothing to squash)"
 msgstr " (nichts zu quetschen)"
 
-#: builtin/merge.c:409
+#: builtin/merge.c:410
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
 msgstr "Quetsche Commit -- HEAD wird nicht aktualisiert\n"
 
-#: builtin/merge.c:459
+#: builtin/merge.c:460
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
 msgstr "Keine Merge-Commit-Beschreibung -- HEAD wird nicht aktualisiert\n"
 
-#: builtin/merge.c:510
+#: builtin/merge.c:511
 #, c-format
 msgid "'%s' does not point to a commit"
 msgstr "'%s' zeigt auf keinen Commit"
 
-#: builtin/merge.c:597
+#: builtin/merge.c:598
 #, c-format
 msgid "Bad branch.%s.mergeoptions string: %s"
 msgstr "Ungültiger branch.%s.mergeoptions String: %s"
 
-#: builtin/merge.c:723
+#: builtin/merge.c:724
 msgid "Not handling anything other than two heads merge."
 msgstr "Es wird nur der Merge von zwei Branches behandelt."
 
-#: builtin/merge.c:736
+#: builtin/merge.c:737
 #, c-format
 msgid "Unknown option for merge-recursive: -X%s"
 msgstr "Unbekannte Option für merge-recursive: -X%s"
 
-#: builtin/merge.c:755 t/helper/test-fast-rebase.c:209
+#: builtin/merge.c:756 t/helper/test-fast-rebase.c:209
 #, c-format
 msgid "unable to write %s"
 msgstr "konnte %s nicht schreiben"
 
-#: builtin/merge.c:807
+#: builtin/merge.c:808
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "konnte nicht von '%s' lesen"
 
-#: builtin/merge.c:816
+#: builtin/merge.c:817
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
 "Merge wurde nicht committet; benutzen Sie 'git commit', um den Merge "
 "abzuschließen.\n"
 
-#: builtin/merge.c:822
+#: builtin/merge.c:823
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
@@ -17493,11 +17881,11 @@ msgstr ""
 "Upstream-Branch mit einem Thema-Branch zusammenführt.\n"
 "\n"
 
-#: builtin/merge.c:827
+#: builtin/merge.c:828
 msgid "An empty message aborts the commit.\n"
 msgstr "Eine leere Commit-Beschreibung bricht den Commit ab.\n"
 
-#: builtin/merge.c:830
+#: builtin/merge.c:831
 #, c-format
 msgid ""
 "Lines starting with '%c' will be ignored, and an empty message aborts\n"
@@ -17506,75 +17894,75 @@ msgstr ""
 "Zeilen, die mit '%c' beginnen, werden ignoriert,\n"
 "und eine leere Beschreibung bricht den Commit ab.\n"
 
-#: builtin/merge.c:883
+#: builtin/merge.c:884
 msgid "Empty commit message."
 msgstr "Leere Commit-Beschreibung"
 
-#: builtin/merge.c:898
+#: builtin/merge.c:899
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Wunderbar.\n"
 
-#: builtin/merge.c:959
+#: builtin/merge.c:960
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
 "Automatischer Merge fehlgeschlagen; beheben Sie die Konflikte und committen "
 "Sie dann das Ergebnis.\n"
 
-#: builtin/merge.c:998
+#: builtin/merge.c:999
 msgid "No current branch."
 msgstr "Sie befinden sich auf keinem Branch."
 
-#: builtin/merge.c:1000
+#: builtin/merge.c:1001
 msgid "No remote for the current branch."
 msgstr "Kein Remote-Repository für den aktuellen Branch."
 
-#: builtin/merge.c:1002
+#: builtin/merge.c:1003
 msgid "No default upstream defined for the current branch."
 msgstr ""
 "Es ist kein Standard-Upstream-Branch für den aktuellen Branch definiert."
 
-#: builtin/merge.c:1007
+#: builtin/merge.c:1008
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "Kein Remote-Tracking-Branch für %s von %s"
 
-#: builtin/merge.c:1064
+#: builtin/merge.c:1065
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Fehlerhafter Wert '%s' in Umgebungsvariable '%s'"
 
-#: builtin/merge.c:1167
+#: builtin/merge.c:1168
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "nichts was wir in %s zusammenführen können: %s"
 
-#: builtin/merge.c:1201
+#: builtin/merge.c:1202
 msgid "not something we can merge"
 msgstr "nichts was wir zusammenführen können"
 
-#: builtin/merge.c:1311
+#: builtin/merge.c:1312
 msgid "--abort expects no arguments"
 msgstr "--abort akzeptiert keine Argumente"
 
-#: builtin/merge.c:1315
+#: builtin/merge.c:1316
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr "Es gibt keinen Merge abzubrechen (MERGE_HEAD fehlt)"
 
-#: builtin/merge.c:1333
+#: builtin/merge.c:1334
 msgid "--quit expects no arguments"
 msgstr "--quit erwartet keine Argumente"
 
-#: builtin/merge.c:1346
+#: builtin/merge.c:1347
 msgid "--continue expects no arguments"
 msgstr "--continue erwartet keine Argumente"
 
-#: builtin/merge.c:1350
+#: builtin/merge.c:1351
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "Es ist kein Merge im Gange (MERGE_HEAD fehlt)."
 
-#: builtin/merge.c:1366
+#: builtin/merge.c:1367
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17582,7 +17970,7 @@ msgstr ""
 "Sie haben Ihren Merge nicht abgeschlossen (MERGE_HEAD existiert).\n"
 "Bitte committen Sie Ihre Änderungen, bevor Sie den Merge ausführen."
 
-#: builtin/merge.c:1373
+#: builtin/merge.c:1374
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17590,104 +17978,146 @@ msgstr ""
 "Sie haben \"cherry-pick\" nicht abgeschlossen (CHERRY_PICK_HEAD existiert).\n"
 "Bitte committen Sie Ihre Änderungen, bevor Sie den Merge ausführen."
 
-#: builtin/merge.c:1376
+#: builtin/merge.c:1377
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr ""
 "Sie haben \"cherry-pick\" nicht abgeschlossen (CHERRY_PICK_HEAD existiert)."
 
-#: builtin/merge.c:1390
+#: builtin/merge.c:1391
 msgid "You cannot combine --squash with --no-ff."
 msgstr "Sie können --squash nicht mit --no-ff kombinieren."
 
-#: builtin/merge.c:1392
+#: builtin/merge.c:1393
 msgid "You cannot combine --squash with --commit."
 msgstr "Sie können --squash nicht mit --commit kombinieren."
 
-#: builtin/merge.c:1408
+#: builtin/merge.c:1409
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr "Kein Commit angegeben und merge.defaultToUpstream ist nicht gesetzt."
 
-#: builtin/merge.c:1425
+#: builtin/merge.c:1426
 msgid "Squash commit into empty head not supported yet"
 msgstr ""
 "Bin auf einem Commit, der noch geboren wird; kann \"squash\" nicht ausführen."
 
-#: builtin/merge.c:1427
+#: builtin/merge.c:1428
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr ""
 "Nicht vorzuspulender Commit kann nicht in einem leeren Branch verwendet "
 "werden."
 
-#: builtin/merge.c:1432
+#: builtin/merge.c:1433
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "%s - nichts was wir zusammenführen können"
 
-#: builtin/merge.c:1434
+#: builtin/merge.c:1435
 msgid "Can merge only exactly one commit into empty head"
 msgstr "Kann nur exakt einen Commit in einem leeren Branch zusammenführen."
 
-#: builtin/merge.c:1515
+#: builtin/merge.c:1516
 msgid "refusing to merge unrelated histories"
 msgstr "Verweigere den Merge von nicht zusammenhängenden Historien."
 
-#: builtin/merge.c:1524
+#: builtin/merge.c:1525
 msgid "Already up to date."
 msgstr "Bereits aktuell."
 
-#: builtin/merge.c:1534
+#: builtin/merge.c:1535
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "Aktualisiere %s..%s\n"
 
-#: builtin/merge.c:1580
+#: builtin/merge.c:1581
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "Probiere wirklich trivialen \"in-index\"-Merge ...\n"
 
-#: builtin/merge.c:1587
+#: builtin/merge.c:1588
 #, c-format
 msgid "Nope.\n"
 msgstr "Nein.\n"
 
-#: builtin/merge.c:1612
+#: builtin/merge.c:1613
 msgid "Already up to date. Yeeah!"
 msgstr "Bereits aktuell."
 
-#: builtin/merge.c:1618
+#: builtin/merge.c:1619
 msgid "Not possible to fast-forward, aborting."
 msgstr "Vorspulen nicht möglich, breche ab."
 
-#: builtin/merge.c:1646 builtin/merge.c:1711
+#: builtin/merge.c:1647 builtin/merge.c:1712
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "Rücklauf des Verzeichnisses bis zum Ursprung ...\n"
 
-#: builtin/merge.c:1650
+#: builtin/merge.c:1651
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Probiere Merge-Strategie %s ...\n"
 
-#: builtin/merge.c:1702
+#: builtin/merge.c:1703
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Keine Merge-Strategie behandelt diesen Merge.\n"
 
-#: builtin/merge.c:1704
+#: builtin/merge.c:1705
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "Merge mit Strategie %s fehlgeschlagen.\n"
 
-#: builtin/merge.c:1713
+#: builtin/merge.c:1714
 #, c-format
 msgid "Using the %s to prepare resolving by hand.\n"
 msgstr "Benutzen Sie \"%s\", um die Auflösung per Hand vorzubereiten.\n"
 
-#: builtin/merge.c:1727
+#: builtin/merge.c:1728
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
 "Automatischer Merge abgeschlossen; halte, wie gewünscht, vor dem Commit an\n"
+
+#: builtin/mktag.c:10
+msgid "git mktag"
+msgstr ""
+
+#: builtin/mktag.c:30
+#, fuzzy, c-format
+msgid "warning: tag input does not pass fsck: %s"
+msgstr "Warnung: `:include:` wird nicht unterstützt: %s\n"
+
+#: builtin/mktag.c:41
+#, c-format
+msgid "error: tag input does not pass fsck: %s"
+msgstr ""
+
+#: builtin/mktag.c:44
+#, c-format
+msgid "%d (FSCK_IGNORE?) should never trigger this callback"
+msgstr ""
+
+#: builtin/mktag.c:59
+#, fuzzy, c-format
+msgid "could not read tagged object '%s'"
+msgstr "Konnte Objekt %s nicht lesen."
+
+#: builtin/mktag.c:62
+#, fuzzy, c-format
+msgid "object '%s' tagged as '%s', but is a '%s' type"
+msgstr "Objekt %s ist ein %s, kein %s"
+
+#: builtin/mktag.c:99
+msgid "tag on stdin did not pass our strict fsck check"
+msgstr ""
+
+#: builtin/mktag.c:102
+#, fuzzy
+msgid "tag on stdin did not refer to a valid object"
+msgstr "%s zeigt auf kein gültiges Objekt!"
+
+#: builtin/mktag.c:105 builtin/tag.c:232
+msgid "unable to write tag file"
+msgstr "konnte Tag-Datei nicht schreiben"
 
 #: builtin/mktree.c:66
 msgid "git mktree [-z] [--missing] [--batch]"
@@ -17726,7 +18156,10 @@ msgstr ""
 "Während des Umpackens, sammle Paket-Dateien von geringerer Größe in "
 "einenStapel, welcher größer ist als diese Größe"
 
-#: builtin/multi-pack-index.c:50 builtin/prune-packed.c:25
+#: builtin/multi-pack-index.c:50 builtin/notes.c:376 builtin/notes.c:431
+#: builtin/notes.c:509 builtin/notes.c:521 builtin/notes.c:598
+#: builtin/notes.c:665 builtin/notes.c:815 builtin/notes.c:963
+#: builtin/notes.c:985 builtin/prune-packed.c:25 builtin/tag.c:575
 msgid "too many arguments"
 msgstr "Zu viele Argumente."
 
@@ -17833,7 +18266,7 @@ msgstr "%s, Quelle=%s, Ziel=%s"
 msgid "Renaming %s to %s\n"
 msgstr "Benenne %s nach %s um\n"
 
-#: builtin/mv.c:280 builtin/remote.c:785 builtin/repack.c:484
+#: builtin/mv.c:280 builtin/remote.c:785 builtin/repack.c:483
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "Umbenennung von '%s' fehlgeschlagen"
@@ -18026,7 +18459,7 @@ msgstr "Konnte Notiz-Objekt nicht schreiben"
 msgid "the note contents have been left in %s"
 msgstr "Die Notiz-Inhalte wurden in %s belassen."
 
-#: builtin/notes.c:242 builtin/tag.c:533
+#: builtin/notes.c:242 builtin/tag.c:565
 #, c-format
 msgid "could not open or read '%s'"
 msgstr "konnte '%s' nicht öffnen oder lesen"
@@ -18067,12 +18500,6 @@ msgid "refusing to %s notes in %s (outside of refs/notes/)"
 msgstr ""
 "Ausführung von %s auf Notizen in %s (außerhalb von refs/notes/) "
 "zurückgewiesen"
-
-#: builtin/notes.c:376 builtin/notes.c:431 builtin/notes.c:509
-#: builtin/notes.c:521 builtin/notes.c:598 builtin/notes.c:665
-#: builtin/notes.c:815 builtin/notes.c:963 builtin/notes.c:985
-msgid "too many parameters"
-msgstr "zu viele Parameter"
 
 #: builtin/notes.c:389 builtin/notes.c:678
 #, c-format
@@ -18133,8 +18560,9 @@ msgstr ""
 "stdin)"
 
 #: builtin/notes.c:517
-msgid "too few parameters"
-msgstr "zu wenig Parameter"
+#, fuzzy
+msgid "too few arguments"
+msgstr "Zu viele Argumente."
 
 #: builtin/notes.c:538
 #, c-format
@@ -18266,7 +18694,7 @@ msgstr ""
 "commit',\n"
 "oder brechen Sie den Merge mit 'git notes merge --abort' ab.\n"
 
-#: builtin/notes.c:897 builtin/tag.c:546
+#: builtin/notes.c:897 builtin/tag.c:578
 #, c-format
 msgid "Failed to resolve '%s' as a valid ref."
 msgstr "Konnte '%s' nicht als gültige Referenz auflösen."
@@ -18284,7 +18712,7 @@ msgstr "der Versuch, eine nicht existierende Notiz zu löschen, ist kein Fehler"
 msgid "read object names from the standard input"
 msgstr "Objektnamen von der Standard-Eingabe lesen"
 
-#: builtin/notes.c:954 builtin/prune.c:132 builtin/worktree.c:220
+#: builtin/notes.c:954 builtin/prune.c:132 builtin/worktree.c:148
 msgid "do not remove, show only"
 msgstr "nicht löschen, nur anzeigen"
 
@@ -18300,7 +18728,7 @@ msgstr "Notiz-Referenz"
 msgid "use notes from <notes-ref>"
 msgstr "Notizen von <Notiz-Referenz> verwenden"
 
-#: builtin/notes.c:1034 builtin/stash.c:1604
+#: builtin/notes.c:1034 builtin/stash.c:1671
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr "Unbekannter Unterbefehl: %s"
@@ -18319,106 +18747,118 @@ msgstr ""
 "git pack-objects [<Optionen>...] <Basis-Name> [< <Referenzliste> | < "
 "<Objektliste>]"
 
-#: builtin/pack-objects.c:443
+#: builtin/pack-objects.c:440
+#, c-format
+msgid ""
+"write_reuse_object: could not locate %s, expected at offset %<PRIuMAX> in "
+"pack %s"
+msgstr ""
+
+#: builtin/pack-objects.c:448
 #, c-format
 msgid "bad packed object CRC for %s"
 msgstr "Ungültiges CRC für gepacktes Objekt %s."
 
-#: builtin/pack-objects.c:454
+#: builtin/pack-objects.c:459
 #, c-format
 msgid "corrupt packed object for %s"
 msgstr "Fehlerhaftes gepacktes Objekt für %s."
 
-#: builtin/pack-objects.c:585
+#: builtin/pack-objects.c:590
 #, c-format
 msgid "recursive delta detected for object %s"
 msgstr "Rekursiver Unterschied für Objekt %s festgestellt."
 
-#: builtin/pack-objects.c:796
+#: builtin/pack-objects.c:801
 #, c-format
 msgid "ordered %u objects, expected %<PRIu32>"
 msgstr "%u Objekte geordnet, %<PRIu32> erwartet."
 
-#: builtin/pack-objects.c:1004
+#: builtin/pack-objects.c:896
+#, fuzzy, c-format
+msgid "expected object at offset %<PRIuMAX> in pack %s"
+msgstr "Paket hat ein ungültiges Objekt bei Versatz %<PRIuMAX>: %s"
+
+#: builtin/pack-objects.c:1015
 msgid "disabling bitmap writing, packs are split due to pack.packSizeLimit"
 msgstr ""
 "Deaktiviere Schreiben der Bitmap, Pakete wurden durch pack.packSizeLimit\n"
 "aufgetrennt."
 
-#: builtin/pack-objects.c:1017
+#: builtin/pack-objects.c:1028
 msgid "Writing objects"
 msgstr "Schreibe Objekte"
 
-#: builtin/pack-objects.c:1078 builtin/update-index.c:90
+#: builtin/pack-objects.c:1089 builtin/update-index.c:90
 #, c-format
 msgid "failed to stat %s"
 msgstr "Konnte '%s' nicht lesen"
 
-#: builtin/pack-objects.c:1131
+#: builtin/pack-objects.c:1141
 #, c-format
 msgid "wrote %<PRIu32> objects while expecting %<PRIu32>"
 msgstr "Schrieb %<PRIu32> Objekte während %<PRIu32> erwartet waren."
 
-#: builtin/pack-objects.c:1348
+#: builtin/pack-objects.c:1358
 msgid "disabling bitmap writing, as some objects are not being packed"
 msgstr ""
 "Deaktiviere Schreiben der Bitmap, da einige Objekte nicht in eine Pack-"
 "Datei\n"
 "geschrieben wurden."
 
-#: builtin/pack-objects.c:1796
+#: builtin/pack-objects.c:1806
 #, c-format
 msgid "delta base offset overflow in pack for %s"
 msgstr "\"delta base offset\" Überlauf in Paket für %s"
 
-#: builtin/pack-objects.c:1805
+#: builtin/pack-objects.c:1815
 #, c-format
 msgid "delta base offset out of bound for %s"
 msgstr "\"delta base offset\" liegt außerhalb des gültigen Bereichs für %s"
 
-#: builtin/pack-objects.c:2086
+#: builtin/pack-objects.c:2096
 msgid "Counting objects"
 msgstr "Zähle Objekte"
 
-#: builtin/pack-objects.c:2231
+#: builtin/pack-objects.c:2241
 #, c-format
 msgid "unable to parse object header of %s"
 msgstr "Konnte Kopfbereich von Objekt '%s' nicht parsen."
 
-#: builtin/pack-objects.c:2301 builtin/pack-objects.c:2317
-#: builtin/pack-objects.c:2327
+#: builtin/pack-objects.c:2311 builtin/pack-objects.c:2327
+#: builtin/pack-objects.c:2337
 #, c-format
 msgid "object %s cannot be read"
 msgstr "Objekt %s kann nicht gelesen werden."
 
-#: builtin/pack-objects.c:2304 builtin/pack-objects.c:2331
+#: builtin/pack-objects.c:2314 builtin/pack-objects.c:2341
 #, c-format
 msgid "object %s inconsistent object length (%<PRIuMAX> vs %<PRIuMAX>)"
 msgstr "Inkonsistente Objektlänge bei Objekt %s (%<PRIuMAX> vs %<PRIuMAX>)"
 
-#: builtin/pack-objects.c:2341
+#: builtin/pack-objects.c:2351
 msgid "suboptimal pack - out of memory"
 msgstr "ungünstiges Packet - Speicher voll"
 
-#: builtin/pack-objects.c:2656
+#: builtin/pack-objects.c:2666
 #, c-format
 msgid "Delta compression using up to %d threads"
 msgstr "Delta-Kompression verwendet bis zu %d Threads."
 
-#: builtin/pack-objects.c:2795
+#: builtin/pack-objects.c:2805
 #, c-format
 msgid "unable to pack objects reachable from tag %s"
 msgstr "Konnte keine Objekte packen, die von Tag %s erreichbar sind."
 
-#: builtin/pack-objects.c:2883
+#: builtin/pack-objects.c:2891
 msgid "Compressing objects"
 msgstr "Komprimiere Objekte"
 
-#: builtin/pack-objects.c:2889
+#: builtin/pack-objects.c:2897
 msgid "inconsistency with delta count"
 msgstr "Inkonsistenz mit der Anzahl von Deltas"
 
-#: builtin/pack-objects.c:2961
+#: builtin/pack-objects.c:2976
 #, c-format
 msgid ""
 "value of uploadpack.blobpackfileuri must be of the form '<object-hash> <pack-"
@@ -18427,7 +18867,7 @@ msgstr ""
 "Wert für uploadpack.blobpackfileuri muss in der Form '<Objekt-Hash> <Pack-"
 "Hash> <URI>' vorliegen ('%s' erhalten)"
 
-#: builtin/pack-objects.c:2964
+#: builtin/pack-objects.c:2979
 #, c-format
 msgid ""
 "object already configured in another uploadpack.blobpackfileuri (got '%s')"
@@ -18435,7 +18875,7 @@ msgstr ""
 "Objekt bereits in einem anderen uploadpack.blobpackfileuri konfiguriert "
 "('%s' erhalten)"
 
-#: builtin/pack-objects.c:2993
+#: builtin/pack-objects.c:3008
 #, c-format
 msgid ""
 "expected edge object ID, got garbage:\n"
@@ -18444,7 +18884,7 @@ msgstr ""
 "erwartete Randobjekt-ID, erhielt nutzlose Daten:\n"
 " %s"
 
-#: builtin/pack-objects.c:2999
+#: builtin/pack-objects.c:3014
 #, c-format
 msgid ""
 "expected object ID, got garbage:\n"
@@ -18453,250 +18893,250 @@ msgstr ""
 "erwartete Objekt-ID, erhielt nutzlose Daten:\n"
 " %s"
 
-#: builtin/pack-objects.c:3097
+#: builtin/pack-objects.c:3112
 msgid "invalid value for --missing"
 msgstr "ungültiger Wert für --missing"
 
-#: builtin/pack-objects.c:3156 builtin/pack-objects.c:3264
+#: builtin/pack-objects.c:3171 builtin/pack-objects.c:3279
 msgid "cannot open pack index"
 msgstr "kann Paketindex nicht öffnen"
 
-#: builtin/pack-objects.c:3187
+#: builtin/pack-objects.c:3202
 #, c-format
 msgid "loose object at %s could not be examined"
 msgstr "loses Objekt bei %s konnte nicht untersucht werden"
 
-#: builtin/pack-objects.c:3272
+#: builtin/pack-objects.c:3287
 msgid "unable to force loose object"
 msgstr "konnte loses Objekt nicht erzwingen"
 
-#: builtin/pack-objects.c:3365
+#: builtin/pack-objects.c:3380
 #, c-format
 msgid "not a rev '%s'"
 msgstr "'%s' ist kein Commit"
 
-#: builtin/pack-objects.c:3368
+#: builtin/pack-objects.c:3383
 #, c-format
 msgid "bad revision '%s'"
 msgstr "ungültiger Commit '%s'"
 
-#: builtin/pack-objects.c:3393
+#: builtin/pack-objects.c:3408
 msgid "unable to add recent objects"
 msgstr "konnte neuere Objekte nicht hinzufügen"
 
-#: builtin/pack-objects.c:3446
+#: builtin/pack-objects.c:3461
 #, c-format
 msgid "unsupported index version %s"
 msgstr "nicht unterstützte Index-Version %s"
 
-#: builtin/pack-objects.c:3450
+#: builtin/pack-objects.c:3465
 #, c-format
 msgid "bad index version '%s'"
 msgstr "ungültige Index-Version '%s'"
 
-#: builtin/pack-objects.c:3488
+#: builtin/pack-objects.c:3503
 msgid "<version>[,<offset>]"
 msgstr "<Version>[,<Offset>]"
 
-#: builtin/pack-objects.c:3489
+#: builtin/pack-objects.c:3504
 msgid "write the pack index file in the specified idx format version"
 msgstr ""
 "die Index-Datei des Paketes in der angegebenen Indexformat-Version schreiben"
 
-#: builtin/pack-objects.c:3492
+#: builtin/pack-objects.c:3507
 msgid "maximum size of each output pack file"
 msgstr "maximale Größe für jede ausgegebene Paketdatei"
 
-#: builtin/pack-objects.c:3494
+#: builtin/pack-objects.c:3509
 msgid "ignore borrowed objects from alternate object store"
 msgstr "geliehene Objekte von alternativem Objektspeicher ignorieren"
 
-#: builtin/pack-objects.c:3496
+#: builtin/pack-objects.c:3511
 msgid "ignore packed objects"
 msgstr "gepackte Objekte ignorieren"
 
-#: builtin/pack-objects.c:3498
+#: builtin/pack-objects.c:3513
 msgid "limit pack window by objects"
 msgstr "Paketfenster durch Objekte begrenzen"
 
-#: builtin/pack-objects.c:3500
+#: builtin/pack-objects.c:3515
 msgid "limit pack window by memory in addition to object limit"
 msgstr ""
 "Paketfenster, zusätzlich zur Objektbegrenzung, durch Speicher begrenzen"
 
-#: builtin/pack-objects.c:3502
+#: builtin/pack-objects.c:3517
 msgid "maximum length of delta chain allowed in the resulting pack"
 msgstr ""
 "maximale Länge der erlaubten Differenzverkettung im resultierenden Paket"
 
-#: builtin/pack-objects.c:3504
+#: builtin/pack-objects.c:3519
 msgid "reuse existing deltas"
 msgstr "existierende Unterschiede wiederverwenden"
 
-#: builtin/pack-objects.c:3506
+#: builtin/pack-objects.c:3521
 msgid "reuse existing objects"
 msgstr "existierende Objekte wiederverwenden"
 
-#: builtin/pack-objects.c:3508
+#: builtin/pack-objects.c:3523
 msgid "use OFS_DELTA objects"
 msgstr "OFS_DELTA Objekte verwenden"
 
-#: builtin/pack-objects.c:3510
+#: builtin/pack-objects.c:3525
 msgid "use threads when searching for best delta matches"
 msgstr ""
 "Threads bei der Suche nach den besten Übereinstimmungen bei Unterschieden "
 "verwenden"
 
-#: builtin/pack-objects.c:3512
+#: builtin/pack-objects.c:3527
 msgid "do not create an empty pack output"
 msgstr "keine leeren Pakete erzeugen"
 
-#: builtin/pack-objects.c:3514
+#: builtin/pack-objects.c:3529
 msgid "read revision arguments from standard input"
 msgstr "Argumente bezüglich Commits von der Standard-Eingabe lesen"
 
-#: builtin/pack-objects.c:3516
+#: builtin/pack-objects.c:3531
 msgid "limit the objects to those that are not yet packed"
 msgstr "die Objekte zu solchen, die noch nicht gepackt wurden, begrenzen"
 
-#: builtin/pack-objects.c:3519
+#: builtin/pack-objects.c:3534
 msgid "include objects reachable from any reference"
 msgstr "Objekte einschließen, die von jeder Referenz erreichbar sind"
 
-#: builtin/pack-objects.c:3522
+#: builtin/pack-objects.c:3537
 msgid "include objects referred by reflog entries"
 msgstr ""
 "Objekte einschließen, die von Einträgen des Reflogs referenziert werden"
 
-#: builtin/pack-objects.c:3525
+#: builtin/pack-objects.c:3540
 msgid "include objects referred to by the index"
 msgstr "Objekte einschließen, die vom Index referenziert werden"
 
-#: builtin/pack-objects.c:3528
+#: builtin/pack-objects.c:3543
 msgid "output pack to stdout"
 msgstr "Paket in die Standard-Ausgabe schreiben"
 
-#: builtin/pack-objects.c:3530
+#: builtin/pack-objects.c:3545
 msgid "include tag objects that refer to objects to be packed"
 msgstr "Tag-Objekte einschließen, die auf gepackte Objekte referenzieren"
 
-#: builtin/pack-objects.c:3532
+#: builtin/pack-objects.c:3547
 msgid "keep unreachable objects"
 msgstr "nicht erreichbare Objekte behalten"
 
-#: builtin/pack-objects.c:3534
+#: builtin/pack-objects.c:3549
 msgid "pack loose unreachable objects"
 msgstr "nicht erreichbare lose Objekte packen"
 
-#: builtin/pack-objects.c:3536
+#: builtin/pack-objects.c:3551
 msgid "unpack unreachable objects newer than <time>"
 msgstr "nicht erreichbare Objekte entpacken, die neuer als <Zeit> sind"
 
-#: builtin/pack-objects.c:3539
+#: builtin/pack-objects.c:3554
 msgid "use the sparse reachability algorithm"
 msgstr "den \"sparse\" Algorithmus zur Bestimmung der Erreichbarkeit benutzen"
 
-#: builtin/pack-objects.c:3541
+#: builtin/pack-objects.c:3556
 msgid "create thin packs"
 msgstr "dünnere Pakete erzeugen"
 
-#: builtin/pack-objects.c:3543
+#: builtin/pack-objects.c:3558
 msgid "create packs suitable for shallow fetches"
 msgstr ""
 "Pakete geeignet für Abholung mit unvollständiger Historie (shallow) erzeugen"
 
-#: builtin/pack-objects.c:3545
+#: builtin/pack-objects.c:3560
 msgid "ignore packs that have companion .keep file"
 msgstr "Pakete ignorieren, die .keep Dateien haben"
 
-#: builtin/pack-objects.c:3547
+#: builtin/pack-objects.c:3562
 msgid "ignore this pack"
 msgstr "dieses Paket ignorieren"
 
-#: builtin/pack-objects.c:3549
+#: builtin/pack-objects.c:3564
 msgid "pack compression level"
 msgstr "Komprimierungsgrad für Paketierung"
 
-#: builtin/pack-objects.c:3551
+#: builtin/pack-objects.c:3566
 msgid "do not hide commits by grafts"
 msgstr "keine künstlichen Vorgänger-Commits (\"grafts\") verbergen"
 
-#: builtin/pack-objects.c:3553
+#: builtin/pack-objects.c:3568
 msgid "use a bitmap index if available to speed up counting objects"
 msgstr ""
 "Bitmap-Index (falls verfügbar) zur Optimierung der Objektzählung benutzen"
 
-#: builtin/pack-objects.c:3555
+#: builtin/pack-objects.c:3570
 msgid "write a bitmap index together with the pack index"
 msgstr "Bitmap-Index zusammen mit Pack-Index schreiben"
 
-#: builtin/pack-objects.c:3559
+#: builtin/pack-objects.c:3574
 msgid "write a bitmap index if possible"
 msgstr "Bitmap-Index schreiben, wenn möglich"
 
-#: builtin/pack-objects.c:3563
+#: builtin/pack-objects.c:3578
 msgid "handling for missing objects"
 msgstr "Behandlung für fehlende Objekte"
 
-#: builtin/pack-objects.c:3566
+#: builtin/pack-objects.c:3581
 msgid "do not pack objects in promisor packfiles"
 msgstr ""
 "keine Objekte aus Packdateien von partiell geklonten Remote-Repositories "
 "packen"
 
-#: builtin/pack-objects.c:3568
+#: builtin/pack-objects.c:3583
 msgid "respect islands during delta compression"
 msgstr "Delta-Islands bei Delta-Kompression beachten"
 
-#: builtin/pack-objects.c:3570
+#: builtin/pack-objects.c:3585
 msgid "protocol"
 msgstr "Protokoll"
 
-#: builtin/pack-objects.c:3571
+#: builtin/pack-objects.c:3586
 msgid "exclude any configured uploadpack.blobpackfileuri with this protocol"
 msgstr ""
 "jegliche konfigurierte uploadpack.blobpackfileuri für dieses Protkoll "
 "ausschließen"
 
-#: builtin/pack-objects.c:3600
+#: builtin/pack-objects.c:3617
 #, c-format
 msgid "delta chain depth %d is too deep, forcing %d"
 msgstr "Tiefe für Verkettung von Unterschieden %d ist zu tief, erzwinge %d"
 
-#: builtin/pack-objects.c:3605
+#: builtin/pack-objects.c:3622
 #, c-format
 msgid "pack.deltaCacheLimit is too high, forcing %d"
 msgstr "pack.deltaCacheLimit ist zu hoch, erzwinge %d"
 
-#: builtin/pack-objects.c:3659
+#: builtin/pack-objects.c:3676
 msgid "--max-pack-size cannot be used to build a pack for transfer"
 msgstr ""
 "--max-pack-size kann nicht für die Erstellung eines Pakets für eine "
 "Übertragung\n"
 "benutzt werden."
 
-#: builtin/pack-objects.c:3661
+#: builtin/pack-objects.c:3678
 msgid "minimum pack size limit is 1 MiB"
 msgstr "Minimales Limit für die Paketgröße ist 1 MiB."
 
-#: builtin/pack-objects.c:3666
+#: builtin/pack-objects.c:3683
 msgid "--thin cannot be used to build an indexable pack"
 msgstr ""
 "--thin kann nicht benutzt werden, um ein indizierbares Paket zu erstellen."
 
-#: builtin/pack-objects.c:3669
+#: builtin/pack-objects.c:3686
 msgid "--keep-unreachable and --unpack-unreachable are incompatible"
 msgstr "--keep-unreachable und --unpack-unreachable sind inkompatibel"
 
-#: builtin/pack-objects.c:3675
+#: builtin/pack-objects.c:3692
 msgid "cannot use --filter without --stdout"
 msgstr "Kann --filter nicht ohne --stdout benutzen."
 
-#: builtin/pack-objects.c:3735
+#: builtin/pack-objects.c:3752
 msgid "Enumerating objects"
 msgstr "Objekte aufzählen"
 
-#: builtin/pack-objects.c:3766
+#: builtin/pack-objects.c:3783
 #, c-format
 msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
@@ -18704,6 +19144,15 @@ msgid ""
 msgstr ""
 "Gesamt %<PRIu32> (Delta %<PRIu32>), Wiederverwendet %<PRIu32> (Delta "
 "%<PRIu32>), Pack wiederverwendet %<PRIu32>"
+
+#: builtin/pack-redundant.c:601
+msgid ""
+"'git pack-redundant' is nominated for removal.\n"
+"If you still use this command, please add an extra\n"
+"option, '--i-still-use-this', on the command line\n"
+"and let us know you still use it by sending an e-mail\n"
+"to <git@vger.kernel.org>.  Thanks.\n"
+msgstr ""
 
 #: builtin/pack-refs.c:8
 msgid "git pack-refs [<options>]"
@@ -18764,7 +19213,7 @@ msgstr "Optionen bezogen auf Merge"
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "Integration von Änderungen durch Rebase statt Merge"
 
-#: builtin/pull.c:158 builtin/rebase.c:490 builtin/revert.c:126
+#: builtin/pull.c:158 builtin/rebase.c:492 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "Vorspulen erlauben"
 
@@ -18789,7 +19238,100 @@ msgstr "Anzahl der parallel mit 'pull' zu verarbeitenden Submodule"
 msgid "Invalid value for pull.ff: %s"
 msgstr "Ungültiger Wert für pull.ff: %s"
 
-#: builtin/pull.c:348
+#: builtin/pull.c:445
+msgid ""
+"There is no candidate for rebasing against among the refs that you just "
+"fetched."
+msgstr ""
+"Es gibt keinen Kandidaten für Rebase innerhalb der Referenzen, die eben "
+"angefordert wurden."
+
+#: builtin/pull.c:447
+msgid ""
+"There are no candidates for merging among the refs that you just fetched."
+msgstr ""
+"Es gibt keine Kandidaten für Merge innerhalb der Referenzen, die eben "
+"angefordert wurden."
+
+#: builtin/pull.c:448
+msgid ""
+"Generally this means that you provided a wildcard refspec which had no\n"
+"matches on the remote end."
+msgstr ""
+"Im Allgemeinen bedeutet das, dass Sie einen Refspec mit Wildcards angegeben\n"
+"haben, der auf der Gegenseite mit keinen Referenzen übereinstimmt."
+
+#: builtin/pull.c:451
+#, c-format
+msgid ""
+"You asked to pull from the remote '%s', but did not specify\n"
+"a branch. Because this is not the default configured remote\n"
+"for your current branch, you must specify a branch on the command line."
+msgstr ""
+"Sie führten \"pull\" von Remote-Repository '%s' aus, ohne einen\n"
+"Branch anzugeben. Da das nicht das konfigurierte Standard-Remote-\n"
+"Repository für den aktuellen Branch ist, müssen Sie einen Branch auf\n"
+"der Befehlszeile angeben."
+
+#: builtin/pull.c:456 builtin/rebase.c:1253
+msgid "You are not currently on a branch."
+msgstr "Im Moment auf keinem Branch."
+
+#: builtin/pull.c:458 builtin/pull.c:473
+msgid "Please specify which branch you want to rebase against."
+msgstr ""
+"Bitte geben Sie den Branch an, gegen welchen Sie \"rebase\" ausführen "
+"möchten."
+
+#: builtin/pull.c:460 builtin/pull.c:475
+msgid "Please specify which branch you want to merge with."
+msgstr "Bitte geben Sie den Branch an, welchen Sie zusammenführen möchten."
+
+#: builtin/pull.c:461 builtin/pull.c:476
+msgid "See git-pull(1) for details."
+msgstr "Siehe git-pull(1) für weitere Details."
+
+#: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
+#: builtin/rebase.c:1259
+msgid "<remote>"
+msgstr "<Remote-Repository>"
+
+#: builtin/pull.c:463 builtin/pull.c:478 builtin/pull.c:483
+msgid "<branch>"
+msgstr "<Branch>"
+
+#: builtin/pull.c:471 builtin/rebase.c:1251
+msgid "There is no tracking information for the current branch."
+msgstr "Es gibt keine Tracking-Informationen für den aktuellen Branch."
+
+#: builtin/pull.c:480
+msgid ""
+"If you wish to set tracking information for this branch you can do so with:"
+msgstr ""
+"Wenn Sie Tracking-Informationen für diesen Branch setzen möchten, können "
+"Sie\n"
+"dies tun mit:"
+
+#: builtin/pull.c:485
+#, c-format
+msgid ""
+"Your configuration specifies to merge with the ref '%s'\n"
+"from the remote, but no such ref was fetched."
+msgstr ""
+"Ihre Konfiguration gibt an, den Merge mit Referenz '%s'\n"
+"des Remote-Repositories durchzuführen, aber diese Referenz\n"
+"wurde nicht angefordert."
+
+#: builtin/pull.c:596
+#, c-format
+msgid "unable to access commit %s"
+msgstr "Konnte nicht auf Commit '%s' zugreifen."
+
+#: builtin/pull.c:902
+msgid "ignoring --verify-signatures for rebase"
+msgstr "Ignoriere --verify-signatures für Rebase"
+
+#: builtin/pull.c:930
 msgid ""
 "Pulling without specifying how to reconcile divergent branches is\n"
 "discouraged. You can squelch this message by running one of the following\n"
@@ -18819,114 +19361,21 @@ msgstr ""
 "Option --rebase, --no-rebase oder --ff-only auf der Kommandozeile nutzen,\n"
 "um das konfigurierte Standardverhalten pro Aufruf zu überschreiben.\n"
 
-#: builtin/pull.c:458
-msgid ""
-"There is no candidate for rebasing against among the refs that you just "
-"fetched."
-msgstr ""
-"Es gibt keinen Kandidaten für Rebase innerhalb der Referenzen, die eben "
-"angefordert wurden."
-
-#: builtin/pull.c:460
-msgid ""
-"There are no candidates for merging among the refs that you just fetched."
-msgstr ""
-"Es gibt keine Kandidaten für Merge innerhalb der Referenzen, die eben "
-"angefordert wurden."
-
-#: builtin/pull.c:461
-msgid ""
-"Generally this means that you provided a wildcard refspec which had no\n"
-"matches on the remote end."
-msgstr ""
-"Im Allgemeinen bedeutet das, dass Sie einen Refspec mit Wildcards angegeben\n"
-"haben, der auf der Gegenseite mit keinen Referenzen übereinstimmt."
-
-#: builtin/pull.c:464
-#, c-format
-msgid ""
-"You asked to pull from the remote '%s', but did not specify\n"
-"a branch. Because this is not the default configured remote\n"
-"for your current branch, you must specify a branch on the command line."
-msgstr ""
-"Sie führten \"pull\" von Remote-Repository '%s' aus, ohne einen\n"
-"Branch anzugeben. Da das nicht das konfigurierte Standard-Remote-\n"
-"Repository für den aktuellen Branch ist, müssen Sie einen Branch auf\n"
-"der Befehlszeile angeben."
-
-#: builtin/pull.c:469 builtin/rebase.c:1246
-msgid "You are not currently on a branch."
-msgstr "Im Moment auf keinem Branch."
-
-#: builtin/pull.c:471 builtin/pull.c:486
-msgid "Please specify which branch you want to rebase against."
-msgstr ""
-"Bitte geben Sie den Branch an, gegen welchen Sie \"rebase\" ausführen "
-"möchten."
-
-#: builtin/pull.c:473 builtin/pull.c:488
-msgid "Please specify which branch you want to merge with."
-msgstr "Bitte geben Sie den Branch an, welchen Sie zusammenführen möchten."
-
-#: builtin/pull.c:474 builtin/pull.c:489
-msgid "See git-pull(1) for details."
-msgstr "Siehe git-pull(1) für weitere Details."
-
-#: builtin/pull.c:476 builtin/pull.c:482 builtin/pull.c:491
-#: builtin/rebase.c:1252
-msgid "<remote>"
-msgstr "<Remote-Repository>"
-
-#: builtin/pull.c:476 builtin/pull.c:491 builtin/pull.c:496
-msgid "<branch>"
-msgstr "<Branch>"
-
-#: builtin/pull.c:484 builtin/rebase.c:1244
-msgid "There is no tracking information for the current branch."
-msgstr "Es gibt keine Tracking-Informationen für den aktuellen Branch."
-
-#: builtin/pull.c:493
-msgid ""
-"If you wish to set tracking information for this branch you can do so with:"
-msgstr ""
-"Wenn Sie Tracking-Informationen für diesen Branch setzen möchten, können "
-"Sie\n"
-"dies tun mit:"
-
-#: builtin/pull.c:498
-#, c-format
-msgid ""
-"Your configuration specifies to merge with the ref '%s'\n"
-"from the remote, but no such ref was fetched."
-msgstr ""
-"Ihre Konfiguration gibt an, den Merge mit Referenz '%s'\n"
-"des Remote-Repositories durchzuführen, aber diese Referenz\n"
-"wurde nicht angefordert."
-
-#: builtin/pull.c:609
-#, c-format
-msgid "unable to access commit %s"
-msgstr "Konnte nicht auf Commit '%s' zugreifen."
-
-#: builtin/pull.c:915
-msgid "ignoring --verify-signatures for rebase"
-msgstr "Ignoriere --verify-signatures für Rebase"
-
-#: builtin/pull.c:972
+#: builtin/pull.c:991
 msgid "Updating an unborn branch with changes added to the index."
 msgstr ""
 "Aktualisiere einen ungeborenen Branch mit Änderungen, die zum Commit "
 "vorgemerkt sind."
 
-#: builtin/pull.c:976
+#: builtin/pull.c:995
 msgid "pull with rebase"
 msgstr "Pull mit Rebase"
 
-#: builtin/pull.c:977
+#: builtin/pull.c:996
 msgid "please commit or stash them."
 msgstr "Bitte committen Sie die Änderungen oder benutzen Sie \"stash\"."
 
-#: builtin/pull.c:1002
+#: builtin/pull.c:1021
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -18936,7 +19385,7 @@ msgstr ""
 "\"fetch\" aktualisierte die Spitze des aktuellen Branches.\n"
 "Spule Ihr Arbeitsverzeichnis von Commit %s vor."
 
-#: builtin/pull.c:1008
+#: builtin/pull.c:1027
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -18953,15 +19402,15 @@ msgstr ""
 "$ git reset --hard\n"
 "zur Wiederherstellung aus."
 
-#: builtin/pull.c:1023
+#: builtin/pull.c:1042
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Kann nicht mehrere Branches in einen leeren Branch zusammenführen."
 
-#: builtin/pull.c:1027
+#: builtin/pull.c:1046
 msgid "Cannot rebase onto multiple branches."
 msgstr "Kann Rebase nicht auf mehrere Branches ausführen."
 
-#: builtin/pull.c:1041
+#: builtin/pull.c:1067
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "Kann Rebase nicht mit lokal aufgezeichneten Änderungen in Submodulen "
@@ -19284,46 +19733,56 @@ msgstr "Die Optionen --all und --mirror sind inkompatibel."
 msgid "push options must not have new line characters"
 msgstr "Push-Optionen dürfen keine Zeilenvorschubzeichen haben"
 
-#: builtin/range-diff.c:8
+#: builtin/range-diff.c:9
 msgid "git range-diff [<options>] <old-base>..<old-tip> <new-base>..<new-tip>"
 msgstr ""
 "git range-diff [<Optionen>] <alte-Basis>..<alte-Spitze> <neue-Basis>..<neue-"
 "Spitze>"
 
-#: builtin/range-diff.c:9
+#: builtin/range-diff.c:10
 msgid "git range-diff [<options>] <old-tip>...<new-tip>"
 msgstr "git range-diff [<Optionen>] <alte-Spitze>...<neue-Spitze>"
 
-#: builtin/range-diff.c:10
+#: builtin/range-diff.c:11
 msgid "git range-diff [<options>] <base> <old-tip> <new-tip>"
 msgstr "git range-diff [<Optionen>] <Basis> <alte-Spitze> <neue-Spitze>"
 
-#: builtin/range-diff.c:22
+#: builtin/range-diff.c:28
 msgid "Percentage by which creation is weighted"
 msgstr "Prozentsatz mit welchem Erzeugung gewichtet wird"
 
-#: builtin/range-diff.c:24
+#: builtin/range-diff.c:30
 msgid "use simple diff colors"
 msgstr "einfache Diff-Farben benutzen"
 
-#: builtin/range-diff.c:26
+#: builtin/range-diff.c:32
 msgid "notes"
 msgstr "Notizen"
 
-#: builtin/range-diff.c:26
+#: builtin/range-diff.c:32
 msgid "passed to 'git log'"
 msgstr "an 'git log' übergeben"
 
-#: builtin/range-diff.c:50 builtin/range-diff.c:54
-#, c-format
-msgid "no .. in range: '%s'"
+#: builtin/range-diff.c:35
+#, fuzzy
+msgid "only emit output related to the first range"
+msgstr "nur Commits anzeigen, die sich nicht im ersten Branch befinden"
+
+#: builtin/range-diff.c:37
+#, fuzzy
+msgid "only emit output related to the second range"
+msgstr "Ausgabe relativ zum Projektverzeichnis"
+
+#: builtin/range-diff.c:60 builtin/range-diff.c:64
+#, fuzzy, c-format
+msgid "not a commit range: '%s'"
 msgstr "Kein .. im Bereich: '%s'"
 
-#: builtin/range-diff.c:64
+#: builtin/range-diff.c:74
 msgid "single arg format must be symmetric range"
 msgstr "Format mit einfachem Argument muss symmetrischer Bereich sein."
 
-#: builtin/range-diff.c:79
+#: builtin/range-diff.c:89
 msgid "need two commit ranges"
 msgstr "Benötige zwei Commit-Bereiche."
 
@@ -19429,194 +19888,194 @@ msgstr ""
 msgid "git rebase --continue | --abort | --skip | --edit-todo"
 msgstr "git rebase --continue | --abort | --skip | --edit-todo"
 
-#: builtin/rebase.c:193 builtin/rebase.c:217 builtin/rebase.c:244
+#: builtin/rebase.c:195 builtin/rebase.c:219 builtin/rebase.c:246
 #, c-format
 msgid "unusable todo list: '%s'"
 msgstr "Unbenutzbare TODO-Liste: '%s'"
 
-#: builtin/rebase.c:310
+#: builtin/rebase.c:312
 #, c-format
 msgid "could not create temporary %s"
 msgstr "Konnte temporäres Verzeichnis '%s' nicht erstellen."
 
-#: builtin/rebase.c:316
+#: builtin/rebase.c:318
 msgid "could not mark as interactive"
 msgstr "Markierung auf interaktiven Rebase fehlgeschlagen."
 
-#: builtin/rebase.c:369
+#: builtin/rebase.c:371
 msgid "could not generate todo list"
 msgstr "Konnte TODO-Liste nicht erzeugen."
 
-#: builtin/rebase.c:411
+#: builtin/rebase.c:413
 msgid "a base commit must be provided with --upstream or --onto"
 msgstr "Ein Basis-Commit muss mit --upstream oder --onto angegeben werden."
 
-#: builtin/rebase.c:480
+#: builtin/rebase.c:482
 msgid "git rebase--interactive [<options>]"
 msgstr "git rebase--interactive [<Optionen>]"
 
-#: builtin/rebase.c:493 builtin/rebase.c:1388
+#: builtin/rebase.c:495 builtin/rebase.c:1394
 msgid "keep commits which start empty"
 msgstr "behalte Commits, die leer beginnen"
 
-#: builtin/rebase.c:497 builtin/revert.c:128
+#: builtin/rebase.c:499 builtin/revert.c:128
 msgid "allow commits with empty messages"
 msgstr "Commits mit leerer Beschreibung erlauben"
 
-#: builtin/rebase.c:499
+#: builtin/rebase.c:501
 msgid "rebase merge commits"
 msgstr "Rebase auf Merge-Commits ausführen"
 
-#: builtin/rebase.c:501
+#: builtin/rebase.c:503
 msgid "keep original branch points of cousins"
 msgstr "originale Branch-Punkte der Cousins behalten"
 
-#: builtin/rebase.c:503
+#: builtin/rebase.c:505
 msgid "move commits that begin with squash!/fixup!"
 msgstr "Commits verschieben, die mit squash!/fixup! beginnen"
 
-#: builtin/rebase.c:504
+#: builtin/rebase.c:506
 msgid "sign commits"
 msgstr "Commits signieren"
 
-#: builtin/rebase.c:506 builtin/rebase.c:1327
+#: builtin/rebase.c:508 builtin/rebase.c:1333
 msgid "display a diffstat of what changed upstream"
 msgstr ""
 "Zusammenfassung der Unterschiede gegenüber dem Upstream-Branch anzeigen"
 
-#: builtin/rebase.c:508
+#: builtin/rebase.c:510
 msgid "continue rebase"
 msgstr "Rebase fortsetzen"
 
-#: builtin/rebase.c:510
+#: builtin/rebase.c:512
 msgid "skip commit"
 msgstr "Commit auslassen"
 
-#: builtin/rebase.c:511
+#: builtin/rebase.c:513
 msgid "edit the todo list"
 msgstr "die TODO-Liste bearbeiten"
 
-#: builtin/rebase.c:513
+#: builtin/rebase.c:515
 msgid "show the current patch"
 msgstr "den aktuellen Patch anzeigen"
 
-#: builtin/rebase.c:516
+#: builtin/rebase.c:518
 msgid "shorten commit ids in the todo list"
 msgstr "Commit-IDs in der TODO-Liste verkürzen"
 
-#: builtin/rebase.c:518
+#: builtin/rebase.c:520
 msgid "expand commit ids in the todo list"
 msgstr "Commit-IDs in der TODO-Liste erweitern"
 
-#: builtin/rebase.c:520
+#: builtin/rebase.c:522
 msgid "check the todo list"
 msgstr "die TODO-Liste prüfen"
 
-#: builtin/rebase.c:522
+#: builtin/rebase.c:524
 msgid "rearrange fixup/squash lines"
 msgstr "fixup/squash-Zeilen umordnen"
 
-#: builtin/rebase.c:524
+#: builtin/rebase.c:526
 msgid "insert exec commands in todo list"
 msgstr "\"exec\"-Befehle in TODO-Liste einfügen"
 
-#: builtin/rebase.c:525
+#: builtin/rebase.c:527
 msgid "onto"
 msgstr "auf"
 
-#: builtin/rebase.c:528
+#: builtin/rebase.c:530
 msgid "restrict-revision"
 msgstr "Begrenzungscommit"
 
-#: builtin/rebase.c:528
+#: builtin/rebase.c:530
 msgid "restrict revision"
 msgstr "Begrenzungscommit"
 
-#: builtin/rebase.c:530
+#: builtin/rebase.c:532
 msgid "squash-onto"
 msgstr "squash-onto"
 
-#: builtin/rebase.c:531
+#: builtin/rebase.c:533
 msgid "squash onto"
 msgstr "squash onto"
 
-#: builtin/rebase.c:533
+#: builtin/rebase.c:535
 msgid "the upstream commit"
 msgstr "der Upstream-Commit"
 
-#: builtin/rebase.c:535
+#: builtin/rebase.c:537
 msgid "head-name"
 msgstr "head-Name"
 
-#: builtin/rebase.c:535
+#: builtin/rebase.c:537
 msgid "head name"
 msgstr "head-Name"
 
-#: builtin/rebase.c:540
+#: builtin/rebase.c:542
 msgid "rebase strategy"
 msgstr "Rebase-Strategie"
 
-#: builtin/rebase.c:541
+#: builtin/rebase.c:543
 msgid "strategy-opts"
 msgstr "Strategie-Optionen"
 
-#: builtin/rebase.c:542
+#: builtin/rebase.c:544
 msgid "strategy options"
 msgstr "Strategie-Optionen"
 
-#: builtin/rebase.c:543
+#: builtin/rebase.c:545
 msgid "switch-to"
 msgstr "wechseln zu"
 
-#: builtin/rebase.c:544
+#: builtin/rebase.c:546
 msgid "the branch or commit to checkout"
 msgstr "der Branch oder Commit zum Auschecken"
 
-#: builtin/rebase.c:545
+#: builtin/rebase.c:547
 msgid "onto-name"
 msgstr "onto-Name"
 
-#: builtin/rebase.c:545
+#: builtin/rebase.c:547
 msgid "onto name"
 msgstr "onto-Name"
 
-#: builtin/rebase.c:546
+#: builtin/rebase.c:548
 msgid "cmd"
 msgstr "Befehl"
 
-#: builtin/rebase.c:546
+#: builtin/rebase.c:548
 msgid "the command to run"
 msgstr "auszuführender Befehl"
 
-#: builtin/rebase.c:549 builtin/rebase.c:1421
+#: builtin/rebase.c:551 builtin/rebase.c:1427
 msgid "automatically re-schedule any `exec` that fails"
 msgstr "jeden fehlgeschlagenen `exec`-Befehl neu ansetzen"
 
-#: builtin/rebase.c:565
+#: builtin/rebase.c:567
 msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
 msgstr "--[no-]rebase-cousins hat ohne --rebase-merges keine Auswirkung"
 
-#: builtin/rebase.c:581
+#: builtin/rebase.c:583
 #, c-format
 msgid "%s requires the merge backend"
 msgstr "%s erfordert das Merge-Backend"
 
-#: builtin/rebase.c:624
+#: builtin/rebase.c:626
 #, c-format
 msgid "could not get 'onto': '%s'"
 msgstr "Konnte 'onto' nicht bestimmen: '%s'"
 
-#: builtin/rebase.c:641
+#: builtin/rebase.c:643
 #, c-format
 msgid "invalid orig-head: '%s'"
 msgstr "Ungültiges orig-head: '%s'"
 
-#: builtin/rebase.c:666
+#: builtin/rebase.c:668
 #, c-format
 msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
 msgstr "Ignoriere ungültiges allow_rerere_autoupdate: '%s'"
 
-#: builtin/rebase.c:811 git-rebase--preserve-merges.sh:81
+#: builtin/rebase.c:813 git-rebase--preserve-merges.sh:81
 msgid ""
 "Resolve all conflicts manually, mark them as resolved with\n"
 "\"git add/rm <conflicted_files>\", then run \"git rebase --continue\".\n"
@@ -19632,7 +20091,7 @@ msgstr ""
 "Um abzubrechen und zurück zum Zustand vor \"git rebase\" zu gelangen,\n"
 "führen Sie \"git rebase --abort\" aus."
 
-#: builtin/rebase.c:894
+#: builtin/rebase.c:896
 #, c-format
 msgid ""
 "\n"
@@ -19652,7 +20111,7 @@ msgstr ""
 "Infolge dessen kann Git auf diesen Revisionen Rebase nicht\n"
 "ausführen."
 
-#: builtin/rebase.c:1220
+#: builtin/rebase.c:1227
 #, c-format
 msgid ""
 "unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and \"ask"
@@ -19661,7 +20120,7 @@ msgstr ""
 "nicht erkannter leerer Typ '%s'; Gültige Werte sind \"drop\", \"keep\", und "
 "\"ask\"."
 
-#: builtin/rebase.c:1238
+#: builtin/rebase.c:1245
 #, c-format
 msgid ""
 "%s\n"
@@ -19679,7 +20138,7 @@ msgstr ""
 "    git rebase '<Branch>'\n"
 "\n"
 
-#: builtin/rebase.c:1254
+#: builtin/rebase.c:1261
 #, c-format
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:\n"
@@ -19693,154 +20152,154 @@ msgstr ""
 "    git branch --set-upstream-to=%s/<Branch> %s\n"
 "\n"
 
-#: builtin/rebase.c:1284
+#: builtin/rebase.c:1291
 msgid "exec commands cannot contain newlines"
 msgstr "\"exec\"-Befehle können keine neuen Zeilen enthalten"
 
-#: builtin/rebase.c:1288
+#: builtin/rebase.c:1295
 msgid "empty exec command"
 msgstr "Leerer \"exec\"-Befehl."
 
-#: builtin/rebase.c:1318
+#: builtin/rebase.c:1324
 msgid "rebase onto given branch instead of upstream"
 msgstr "Rebase auf angegebenen Branch anstelle des Upstream-Branches ausführen"
 
-#: builtin/rebase.c:1320
+#: builtin/rebase.c:1326
 msgid "use the merge-base of upstream and branch as the current base"
 msgstr "Nutze die Merge-Basis von Upstream und Branch als die aktuelle Basis"
 
-#: builtin/rebase.c:1322
+#: builtin/rebase.c:1328
 msgid "allow pre-rebase hook to run"
 msgstr "Ausführung des pre-rebase-Hooks erlauben"
 
-#: builtin/rebase.c:1324
+#: builtin/rebase.c:1330
 msgid "be quiet. implies --no-stat"
 msgstr "weniger Ausgaben (impliziert --no-stat)"
 
-#: builtin/rebase.c:1330
+#: builtin/rebase.c:1336
 msgid "do not show diffstat of what changed upstream"
 msgstr ""
 "Zusammenfassung der Unterschiede gegenüber dem Upstream-Branch verbergen"
 
-#: builtin/rebase.c:1333
+#: builtin/rebase.c:1339
 msgid "add a Signed-off-by trailer to each commit"
 msgstr "eine Signed-off-by Zeile zu jedem Commit hinzufügen"
 
-#: builtin/rebase.c:1336
+#: builtin/rebase.c:1342
 msgid "make committer date match author date"
 msgstr "Datum des Commit-Erstellers soll mit Datum des Autors übereinstimmen"
 
-#: builtin/rebase.c:1338
+#: builtin/rebase.c:1344
 msgid "ignore author date and use current date"
 msgstr "ignoriere Autor-Datum und nutze aktuelles Datum"
 
-#: builtin/rebase.c:1340
+#: builtin/rebase.c:1346
 msgid "synonym of --reset-author-date"
 msgstr "Synonym für --reset-author-date"
 
-#: builtin/rebase.c:1342 builtin/rebase.c:1346
+#: builtin/rebase.c:1348 builtin/rebase.c:1352
 msgid "passed to 'git apply'"
 msgstr "an 'git apply' übergeben"
 
-#: builtin/rebase.c:1344
+#: builtin/rebase.c:1350
 msgid "ignore changes in whitespace"
 msgstr "Whitespace-Änderungen ignorieren"
 
-#: builtin/rebase.c:1348 builtin/rebase.c:1351
+#: builtin/rebase.c:1354 builtin/rebase.c:1357
 msgid "cherry-pick all commits, even if unchanged"
 msgstr ""
 "Cherry-Pick auf alle Commits ausführen, auch wenn diese unverändert sind"
 
-#: builtin/rebase.c:1353
+#: builtin/rebase.c:1359
 msgid "continue"
 msgstr "fortsetzen"
 
-#: builtin/rebase.c:1356
+#: builtin/rebase.c:1362
 msgid "skip current patch and continue"
 msgstr "den aktuellen Patch auslassen und fortfahren"
 
-#: builtin/rebase.c:1358
+#: builtin/rebase.c:1364
 msgid "abort and check out the original branch"
 msgstr "abbrechen und den ursprünglichen Branch auschecken"
 
-#: builtin/rebase.c:1361
+#: builtin/rebase.c:1367
 msgid "abort but keep HEAD where it is"
 msgstr "abbrechen, aber HEAD an aktueller Stelle belassen"
 
-#: builtin/rebase.c:1362
+#: builtin/rebase.c:1368
 msgid "edit the todo list during an interactive rebase"
 msgstr "TODO-Liste während eines interaktiven Rebase bearbeiten"
 
-#: builtin/rebase.c:1365
+#: builtin/rebase.c:1371
 msgid "show the patch file being applied or merged"
 msgstr "den Patch, der gerade angewendet oder zusammengeführt wird, anzeigen"
 
-#: builtin/rebase.c:1368
+#: builtin/rebase.c:1374
 msgid "use apply strategies to rebase"
 msgstr "Strategien von 'git am' bei Rebase verwenden"
 
-#: builtin/rebase.c:1372
+#: builtin/rebase.c:1378
 msgid "use merging strategies to rebase"
 msgstr "Merge-Strategien beim Rebase verwenden"
 
-#: builtin/rebase.c:1376
+#: builtin/rebase.c:1382
 msgid "let the user edit the list of commits to rebase"
 msgstr "den Benutzer die Liste der Commits für den Rebase bearbeiten lassen"
 
-#: builtin/rebase.c:1380
+#: builtin/rebase.c:1386
 msgid "(DEPRECATED) try to recreate merges instead of ignoring them"
 msgstr ""
 "(VERALTET) Versuche, Merges wiederherzustellen anstatt sie zu ignorieren"
 
-#: builtin/rebase.c:1385
+#: builtin/rebase.c:1391
 msgid "how to handle commits that become empty"
 msgstr "wie sollen Commits behandelt werden, die leer werden"
 
-#: builtin/rebase.c:1392
+#: builtin/rebase.c:1398
 msgid "move commits that begin with squash!/fixup! under -i"
 msgstr "bei -i Commits verschieben, die mit squash!/fixup! beginnen"
 
-#: builtin/rebase.c:1399
+#: builtin/rebase.c:1405
 msgid "add exec lines after each commit of the editable list"
 msgstr "exec-Zeilen nach jedem Commit der editierbaren Liste hinzufügen"
 
-#: builtin/rebase.c:1403
+#: builtin/rebase.c:1409
 msgid "allow rebasing commits with empty messages"
 msgstr "Rebase von Commits mit leerer Beschreibung erlauben"
 
-#: builtin/rebase.c:1407
+#: builtin/rebase.c:1413
 msgid "try to rebase merges instead of skipping them"
 msgstr ""
 "versuchen, Rebase mit Merges auszuführen, anstatt diese zu überspringen"
 
-#: builtin/rebase.c:1410
+#: builtin/rebase.c:1416
 msgid "use 'merge-base --fork-point' to refine upstream"
 msgstr ""
 "'git merge-base --fork-point' benutzen, um Upstream-Branch zu bestimmen"
 
-#: builtin/rebase.c:1412
+#: builtin/rebase.c:1418
 msgid "use the given merge strategy"
 msgstr "angegebene Merge-Strategie verwenden"
 
-#: builtin/rebase.c:1414 builtin/revert.c:115
+#: builtin/rebase.c:1420 builtin/revert.c:115
 msgid "option"
 msgstr "Option"
 
-#: builtin/rebase.c:1415
+#: builtin/rebase.c:1421
 msgid "pass the argument through to the merge strategy"
 msgstr "Argument zur Merge-Strategie durchreichen"
 
-#: builtin/rebase.c:1418
+#: builtin/rebase.c:1424
 msgid "rebase all reachable commits up to the root(s)"
 msgstr "Rebase auf alle erreichbaren Commits bis zum Root-Commit ausführen"
 
-#: builtin/rebase.c:1423
+#: builtin/rebase.c:1429
 msgid "apply all changes, even those already present upstream"
 msgstr ""
 "alle Änderungen anwenden, auch jene, die bereits im Upstream-Branch "
 "vorhanden sind"
 
-#: builtin/rebase.c:1440
+#: builtin/rebase.c:1446
 msgid ""
 "the rebase.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -19848,44 +20307,44 @@ msgstr ""
 "Die Unterstützung für rebase.useBuiltin wurde entfernt!\n"
 "Siehe dessen Eintrag in 'git help config' für Details."
 
-#: builtin/rebase.c:1446
+#: builtin/rebase.c:1452
 msgid "It looks like 'git am' is in progress. Cannot rebase."
 msgstr "'git-am' scheint im Gange zu sein. Kann Rebase nicht durchführen."
 
-#: builtin/rebase.c:1487
+#: builtin/rebase.c:1493
 msgid ""
 "git rebase --preserve-merges is deprecated. Use --rebase-merges instead."
 msgstr ""
 "'git rebase --preserve-merges' ist veraltet. Benutzen Sie stattdessen '--"
 "rebase-merges'."
 
-#: builtin/rebase.c:1492
+#: builtin/rebase.c:1498
 msgid "cannot combine '--keep-base' with '--onto'"
 msgstr "'--keep-base' kann nicht mit '--onto' kombiniert werden"
 
-#: builtin/rebase.c:1494
+#: builtin/rebase.c:1500
 msgid "cannot combine '--keep-base' with '--root'"
 msgstr "'--keep-base' kann nicht mit '--root' kombiniert werden"
 
-#: builtin/rebase.c:1498
+#: builtin/rebase.c:1504
 msgid "cannot combine '--root' with '--fork-point'"
 msgstr "'--root' kann nicht mit '--fork-point' kombiniert werden"
 
-#: builtin/rebase.c:1501
+#: builtin/rebase.c:1507
 msgid "No rebase in progress?"
 msgstr "Kein Rebase im Gange?"
 
-#: builtin/rebase.c:1505
+#: builtin/rebase.c:1511
 msgid "The --edit-todo action can only be used during interactive rebase."
 msgstr ""
 "Die --edit-todo Aktion kann nur während eines interaktiven Rebase verwendet "
 "werden."
 
-#: builtin/rebase.c:1528 t/helper/test-fast-rebase.c:123
+#: builtin/rebase.c:1534 t/helper/test-fast-rebase.c:123
 msgid "Cannot read HEAD"
 msgstr "Kann HEAD nicht lesen"
 
-#: builtin/rebase.c:1540
+#: builtin/rebase.c:1546
 msgid ""
 "You must edit all merge conflicts and then\n"
 "mark them as resolved using git add"
@@ -19893,16 +20352,16 @@ msgstr ""
 "Sie müssen alle Merge-Konflikte editieren und diese dann\n"
 "mittels \"git add\" als aufgelöst markieren"
 
-#: builtin/rebase.c:1559
+#: builtin/rebase.c:1565
 msgid "could not discard worktree changes"
 msgstr "Konnte Änderungen im Arbeitsverzeichnis nicht verwerfen."
 
-#: builtin/rebase.c:1578
+#: builtin/rebase.c:1584
 #, c-format
 msgid "could not move back to %s"
 msgstr "Konnte nicht zu %s zurückgehen."
 
-#: builtin/rebase.c:1624
+#: builtin/rebase.c:1630
 #, c-format
 msgid ""
 "It seems that there is already a %s directory, and\n"
@@ -19923,138 +20382,138 @@ msgstr ""
 "und führen Sie diesen Befehl nochmal aus. Es wird angehalten, falls noch\n"
 "etwas Schützenswertes vorhanden ist.\n"
 
-#: builtin/rebase.c:1652
+#: builtin/rebase.c:1658
 msgid "switch `C' expects a numerical value"
 msgstr "Schalter `C' erwartet einen numerischen Wert."
 
-#: builtin/rebase.c:1694
+#: builtin/rebase.c:1700
 #, c-format
 msgid "Unknown mode: %s"
 msgstr "Unbekannter Modus: %s"
 
-#: builtin/rebase.c:1733
+#: builtin/rebase.c:1739
 msgid "--strategy requires --merge or --interactive"
 msgstr "--strategy erfordert --merge oder --interactive"
 
-#: builtin/rebase.c:1763
+#: builtin/rebase.c:1769
 msgid "cannot combine apply options with merge options"
 msgstr ""
 "Optionen für \"am\" können nicht mit Optionen für \"merge\" kombiniert "
 "werden."
 
-#: builtin/rebase.c:1776
+#: builtin/rebase.c:1782
 #, c-format
 msgid "Unknown rebase backend: %s"
 msgstr "Unbekanntes Rebase-Backend: %s"
 
-#: builtin/rebase.c:1806
+#: builtin/rebase.c:1812
 msgid "--reschedule-failed-exec requires --exec or --interactive"
 msgstr "--reschedule-failed-exec erfordert --exec oder --interactive"
 
-#: builtin/rebase.c:1826
+#: builtin/rebase.c:1832
 msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
 msgstr ""
 "'--preserve-merges' kann nicht mit '--rebase-merges' kombiniert werden."
 
-#: builtin/rebase.c:1830
+#: builtin/rebase.c:1836
 msgid ""
 "error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
 msgstr ""
 "Fehler: '--preserve-merges' kann nicht mit '--reschedule-failed-exec' "
 "kombiniert werden."
 
-#: builtin/rebase.c:1854
+#: builtin/rebase.c:1860
 #, c-format
 msgid "invalid upstream '%s'"
 msgstr "Ungültiger Upstream '%s'"
 
-#: builtin/rebase.c:1860
+#: builtin/rebase.c:1866
 msgid "Could not create new root commit"
 msgstr "Konnte neuen Root-Commit nicht erstellen."
 
-#: builtin/rebase.c:1886
+#: builtin/rebase.c:1892
 #, c-format
 msgid "'%s': need exactly one merge base with branch"
 msgstr "'%s': benötige genau eine Merge-Basis mit dem Branch"
 
-#: builtin/rebase.c:1889
+#: builtin/rebase.c:1895
 #, c-format
 msgid "'%s': need exactly one merge base"
 msgstr "'%s': benötige genau eine Merge-Basis"
 
-#: builtin/rebase.c:1897
+#: builtin/rebase.c:1903
 #, c-format
 msgid "Does not point to a valid commit '%s'"
 msgstr "'%s' zeigt auf keinen gültigen Commit."
 
-#: builtin/rebase.c:1923
+#: builtin/rebase.c:1931
 #, c-format
 msgid "fatal: no such branch/commit '%s'"
 msgstr "fatal: Branch/Commit '%s' nicht gefunden"
 
-#: builtin/rebase.c:1931 builtin/submodule--helper.c:40
+#: builtin/rebase.c:1939 builtin/submodule--helper.c:40
 #: builtin/submodule--helper.c:2414
 #, c-format
 msgid "No such ref: %s"
 msgstr "Referenz nicht gefunden: %s"
 
-#: builtin/rebase.c:1942
+#: builtin/rebase.c:1950
 msgid "Could not resolve HEAD to a revision"
 msgstr "Konnte HEAD zu keinem Commit auflösen."
 
-#: builtin/rebase.c:1963
+#: builtin/rebase.c:1971
 msgid "Please commit or stash them."
 msgstr "Bitte committen Sie die Änderungen oder benutzen Sie \"stash\"."
 
-#: builtin/rebase.c:1999
+#: builtin/rebase.c:2007
 #, c-format
 msgid "could not switch to %s"
 msgstr "Konnte nicht zu %s wechseln."
 
-#: builtin/rebase.c:2010
+#: builtin/rebase.c:2018
 msgid "HEAD is up to date."
 msgstr "HEAD ist aktuell."
 
-#: builtin/rebase.c:2012
+#: builtin/rebase.c:2020
 #, c-format
 msgid "Current branch %s is up to date.\n"
 msgstr "Aktueller Branch %s ist auf dem neuesten Stand.\n"
 
-#: builtin/rebase.c:2020
+#: builtin/rebase.c:2028
 msgid "HEAD is up to date, rebase forced."
 msgstr "HEAD ist aktuell, Rebase erzwungen."
 
-#: builtin/rebase.c:2022
+#: builtin/rebase.c:2030
 #, c-format
 msgid "Current branch %s is up to date, rebase forced.\n"
 msgstr "Aktueller Branch %s ist auf dem neuesten Stand, Rebase erzwungen.\n"
 
-#: builtin/rebase.c:2030
+#: builtin/rebase.c:2038
 msgid "The pre-rebase hook refused to rebase."
 msgstr "Der \"pre-rebase hook\" hat den Rebase zurückgewiesen."
 
-#: builtin/rebase.c:2037
+#: builtin/rebase.c:2045
 #, c-format
 msgid "Changes to %s:\n"
 msgstr "Änderungen zu %s:\n"
 
-#: builtin/rebase.c:2040
+#: builtin/rebase.c:2048
 #, c-format
 msgid "Changes from %s to %s:\n"
 msgstr "Änderungen von %s zu %s:\n"
 
-#: builtin/rebase.c:2065
+#: builtin/rebase.c:2073
 #, c-format
 msgid "First, rewinding head to replay your work on top of it...\n"
 msgstr ""
 "Zunächst wird der Branch zurückgespult, um Ihre Änderungen darauf neu "
 "anzuwenden...\n"
 
-#: builtin/rebase.c:2074
+#: builtin/rebase.c:2082
 msgid "Could not detach HEAD"
 msgstr "Konnte HEAD nicht loslösen."
 
-#: builtin/rebase.c:2083
+#: builtin/rebase.c:2091
 #, c-format
 msgid "Fast-forwarded %s to %s.\n"
 msgstr "Spule %s vor zu %s.\n"
@@ -20151,36 +20610,36 @@ msgstr "git reflog exists <Referenz>"
 msgid "'%s' is not a valid timestamp"
 msgstr "'%s' ist kein gültiger Zeitstempel"
 
-#: builtin/reflog.c:606
+#: builtin/reflog.c:609
 #, c-format
 msgid "Marking reachable objects..."
 msgstr "Markiere nicht erreichbare Objekte..."
 
-#: builtin/reflog.c:644
+#: builtin/reflog.c:647
 #, c-format
 msgid "%s points nowhere!"
 msgstr "%s zeigt auf nichts!"
 
-#: builtin/reflog.c:696
+#: builtin/reflog.c:699
 msgid "no reflog specified to delete"
 msgstr "Kein Reflog zum Löschen angegeben."
 
-#: builtin/reflog.c:705
+#: builtin/reflog.c:708
 #, c-format
 msgid "not a reflog: %s"
 msgstr "Kein Reflog: %s"
 
-#: builtin/reflog.c:710
+#: builtin/reflog.c:713
 #, c-format
 msgid "no reflog for '%s'"
 msgstr "Kein Reflog für '%s'."
 
-#: builtin/reflog.c:756
+#: builtin/reflog.c:759
 #, c-format
 msgid "invalid ref format: %s"
 msgstr "Ungültiges Format für Referenzen: %s"
 
-#: builtin/reflog.c:765
+#: builtin/reflog.c:768
 msgid "git reflog [ show | expire | delete | exists ]"
 msgstr "git reflog [ show | expire | delete | exists ]"
 
@@ -20705,11 +21164,11 @@ msgstr "Keine solche URL gefunden: %s"
 msgid "Will not delete all non-push URLs"
 msgstr "Werde keine URLs entfernen, die nicht für \"push\" bestimmt sind"
 
-#: builtin/repack.c:25
+#: builtin/repack.c:26
 msgid "git repack [<options>]"
 msgstr "git repack [<Optionen>]"
 
-#: builtin/repack.c:30
+#: builtin/repack.c:31
 msgid ""
 "Incremental repacks are incompatible with bitmap indexes.  Use\n"
 "--no-write-bitmap-index or disable the pack.writebitmaps configuration."
@@ -20718,124 +21177,124 @@ msgstr ""
 "--no-write-bitmap-index oder deaktivieren Sie die pack.writebitmaps\n"
 "Konfiguration."
 
-#: builtin/repack.c:197
+#: builtin/repack.c:198
 msgid "could not start pack-objects to repack promisor objects"
 msgstr ""
 "Konnte 'pack-objects' für das Neupacken von Objekten aus partiell geklonten\n"
 "Remote-Repositories nicht starten."
 
-#: builtin/repack.c:268 builtin/repack.c:447
+#: builtin/repack.c:270 builtin/repack.c:446
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
 msgstr ""
 "repack: Erwarte Zeilen mit vollständiger Hex-Objekt-ID nur von pack-objects."
 
-#: builtin/repack.c:295
+#: builtin/repack.c:294
 msgid "could not finish pack-objects to repack promisor objects"
 msgstr ""
 "Konnte 'pack-objects' für das Neupacken von Objekten aus partiell geklonten\n"
 "Remote-Repositories nicht abschließen."
 
-#: builtin/repack.c:323
+#: builtin/repack.c:322
 msgid "pack everything in a single pack"
 msgstr "alles in eine einzige Pack-Datei packen"
 
-#: builtin/repack.c:325
+#: builtin/repack.c:324
 msgid "same as -a, and turn unreachable objects loose"
 msgstr "genau wie -a, unerreichbare Objekte werden aber nicht gelöscht"
 
-#: builtin/repack.c:328
+#: builtin/repack.c:327
 msgid "remove redundant packs, and run git-prune-packed"
 msgstr "redundante Pakete entfernen und \"git-prune-packed\" ausführen"
 
-#: builtin/repack.c:330
+#: builtin/repack.c:329
 msgid "pass --no-reuse-delta to git-pack-objects"
 msgstr "--no-reuse-delta an git-pack-objects übergeben"
 
-#: builtin/repack.c:332
+#: builtin/repack.c:331
 msgid "pass --no-reuse-object to git-pack-objects"
 msgstr "--no-reuse-object an git-pack-objects übergeben"
 
-#: builtin/repack.c:334
+#: builtin/repack.c:333
 msgid "do not run git-update-server-info"
 msgstr "git-update-server-info nicht ausführen"
 
-#: builtin/repack.c:337
+#: builtin/repack.c:336
 msgid "pass --local to git-pack-objects"
 msgstr "--local an git-pack-objects übergeben"
 
-#: builtin/repack.c:339
+#: builtin/repack.c:338
 msgid "write bitmap index"
 msgstr "Bitmap-Index schreiben"
 
-#: builtin/repack.c:341
+#: builtin/repack.c:340
 msgid "pass --delta-islands to git-pack-objects"
 msgstr "--delta-islands an git-pack-objects übergeben"
 
-#: builtin/repack.c:342
+#: builtin/repack.c:341
 msgid "approxidate"
 msgstr "Datumsangabe"
 
-#: builtin/repack.c:343
+#: builtin/repack.c:342
 msgid "with -A, do not loosen objects older than this"
 msgstr "mit -A, keine Objekte älter als dieses Datum löschen"
 
-#: builtin/repack.c:345
+#: builtin/repack.c:344
 msgid "with -a, repack unreachable objects"
 msgstr "mit -a, nicht erreichbare Objekte neu packen"
 
-#: builtin/repack.c:347
+#: builtin/repack.c:346
 msgid "size of the window used for delta compression"
 msgstr "Größe des Fensters für die Delta-Kompression"
 
-#: builtin/repack.c:348 builtin/repack.c:354
+#: builtin/repack.c:347 builtin/repack.c:353
 msgid "bytes"
 msgstr "Bytes"
 
-#: builtin/repack.c:349
+#: builtin/repack.c:348
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr ""
 "gleiches wie oben, aber die Speichergröße anstatt der\n"
 "Anzahl der Einträge limitieren"
 
-#: builtin/repack.c:351
+#: builtin/repack.c:350
 msgid "limits the maximum delta depth"
 msgstr "die maximale Delta-Tiefe limitieren"
 
-#: builtin/repack.c:353
+#: builtin/repack.c:352
 msgid "limits the maximum number of threads"
 msgstr "maximale Anzahl von Threads limitieren"
 
-#: builtin/repack.c:355
+#: builtin/repack.c:354
 msgid "maximum size of each packfile"
 msgstr "maximale Größe für jede Paketdatei"
 
-#: builtin/repack.c:357
+#: builtin/repack.c:356
 msgid "repack objects in packs marked with .keep"
 msgstr ""
 "Objekte umpacken, die sich in mit .keep markierten Pack-Dateien befinden"
 
-#: builtin/repack.c:359
+#: builtin/repack.c:358
 msgid "do not repack this pack"
 msgstr "dieses Paket nicht neu packen"
 
-#: builtin/repack.c:369
+#: builtin/repack.c:368
 msgid "cannot delete packs in a precious-objects repo"
 msgstr "kann Pack-Dateien in precious-objects Repository nicht löschen"
 
-#: builtin/repack.c:373
+#: builtin/repack.c:372
 msgid "--keep-unreachable and -A are incompatible"
 msgstr "--keep-unreachable und -A sind inkompatibel"
 
-#: builtin/repack.c:456
+#: builtin/repack.c:455
 msgid "Nothing new to pack."
 msgstr "Nichts Neues zum Packen."
 
-#: builtin/repack.c:486
+#: builtin/repack.c:485
 #, c-format
 msgid "missing required file: %s"
 msgstr "benötigte Datei fehlt: %s"
 
-#: builtin/repack.c:488
+#: builtin/repack.c:487
 #, c-format
 msgid "could not unlink: %s"
 msgstr "konnte nicht löschen: %s"
@@ -21170,8 +21629,8 @@ msgstr "HEAD ist jetzt bei %s"
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "Kann keinen '%s'-Reset durchführen, während ein Merge im Gange ist."
 
-#: builtin/reset.c:295 builtin/stash.c:520 builtin/stash.c:594
-#: builtin/stash.c:618
+#: builtin/reset.c:295 builtin/stash.c:587 builtin/stash.c:661
+#: builtin/stash.c:685
 msgid "be quiet, only report errors"
 msgstr "weniger Ausgaben, nur Fehler melden"
 
@@ -21256,20 +21715,20 @@ msgstr "Konnte Index-Datei nicht zu Commit '%s' setzen."
 msgid "Could not write new index file."
 msgstr "Konnte neue Index-Datei nicht schreiben."
 
-#: builtin/rev-list.c:499
+#: builtin/rev-list.c:534
 msgid "cannot combine --exclude-promisor-objects and --missing"
 msgstr ""
 "--exclude-promisor-objects und --missing können nicht kombiniert werden."
 
-#: builtin/rev-list.c:560
+#: builtin/rev-list.c:595
 msgid "object filtering requires --objects"
 msgstr "Das Filtern von Objekten erfordert --objects."
 
-#: builtin/rev-list.c:610
+#: builtin/rev-list.c:651
 msgid "rev-list does not support display of notes"
 msgstr "rev-list unterstützt keine Anzeige von Notizen"
 
-#: builtin/rev-list.c:615
+#: builtin/rev-list.c:656
 msgid "marked counting is incompatible with --objects"
 msgstr "markiertes Zählen ist inkompatibel mit der Option --objects"
 
@@ -21518,53 +21977,58 @@ msgstr "git shortlog [<Optionen>] [<Commitbereich>] [[--] <Pfad>...]"
 msgid "git log --pretty=short | git shortlog [<options>]"
 msgstr "git log --pretty=short | git shortlog [<Optionen>]"
 
-#: builtin/shortlog.c:135
+#: builtin/shortlog.c:123
 msgid "using multiple --group options with stdin is not supported"
 msgstr "mehrere Optionen --group mit Standard-Eingabe wird nicht unterstützt"
 
-#: builtin/shortlog.c:145
+#: builtin/shortlog.c:133
 msgid "using --group=trailer with stdin is not supported"
 msgstr ""
 "Nutzung von --group=trailer mit Standard-Eingabe wird nicht unterstützt"
 
-#: builtin/shortlog.c:335
+#: builtin/shortlog.c:323
 #, c-format
 msgid "unknown group type: %s"
 msgstr "unbekannter Gruppen-Typ: %s"
 
-#: builtin/shortlog.c:363
-msgid "Group by committer rather than author"
+#: builtin/shortlog.c:351
+#, fuzzy
+msgid "group by committer rather than author"
 msgstr "über Commit-Ersteller anstatt Autor gruppieren"
 
-#: builtin/shortlog.c:366
+#: builtin/shortlog.c:354
 msgid "sort output according to the number of commits per author"
 msgstr "die Ausgabe entsprechend der Anzahl von Commits pro Autor sortieren"
 
-#: builtin/shortlog.c:368
-msgid "Suppress commit descriptions, only provides commit count"
+#: builtin/shortlog.c:356
+#, fuzzy
+msgid "suppress commit descriptions, only provides commit count"
 msgstr "Commit-Beschreibungen unterdrücken, nur Anzahl der Commits liefern"
 
-#: builtin/shortlog.c:370
-msgid "Show the email address of each author"
+#: builtin/shortlog.c:358
+#, fuzzy
+msgid "show the email address of each author"
 msgstr "die E-Mail-Adresse von jedem Autor anzeigen"
 
-#: builtin/shortlog.c:371
+#: builtin/shortlog.c:359
 msgid "<w>[,<i1>[,<i2>]]"
 msgstr "<w>[,<i1>[,<i2>]]"
 
-#: builtin/shortlog.c:372
-msgid "Linewrap output"
+#: builtin/shortlog.c:360
+#, fuzzy
+msgid "linewrap output"
 msgstr "Ausgabe mit Zeilenumbrüchen"
 
-#: builtin/shortlog.c:374
+#: builtin/shortlog.c:362
 msgid "field"
 msgstr "Feld"
 
-#: builtin/shortlog.c:375
-msgid "Group by field"
+#: builtin/shortlog.c:363
+#, fuzzy
+msgid "group by field"
 msgstr "Gruppieren über Feld"
 
-#: builtin/shortlog.c:403
+#: builtin/shortlog.c:391
 msgid "too many arguments given outside repository"
 msgstr "zu viele Argumente außerhalb des Repositories angegeben"
 
@@ -21765,76 +22229,76 @@ msgstr ""
 msgid "git sparse-checkout (init|list|set|add|reapply|disable) <options>"
 msgstr "git sparse-checkout (init|list|set|add|reapply|disable) <Optionen>"
 
-#: builtin/sparse-checkout.c:50
+#: builtin/sparse-checkout.c:45
 msgid "git sparse-checkout list"
 msgstr "git sparse-checkout list"
 
-#: builtin/sparse-checkout.c:76
+#: builtin/sparse-checkout.c:71
 msgid "this worktree is not sparse (sparse-checkout file may not exist)"
 msgstr ""
 "dieses Arbeitsverzeichnis ist nicht partiell (Datei für partieller Checkout "
 "existiert eventuell nicht)"
 
-#: builtin/sparse-checkout.c:228
+#: builtin/sparse-checkout.c:223
 msgid "failed to create directory for sparse-checkout file"
 msgstr ""
 "Fehler beim Erstellen eines Verzeichnisses für Datei eines partiellen "
 "Checkouts"
 
-#: builtin/sparse-checkout.c:269
+#: builtin/sparse-checkout.c:264
 msgid "unable to upgrade repository format to enable worktreeConfig"
 msgstr ""
 "Repository-Format konnte nicht erweitert werden, um worktreeConfig zu "
 "aktivieren"
 
-#: builtin/sparse-checkout.c:271
+#: builtin/sparse-checkout.c:266
 msgid "failed to set extensions.worktreeConfig setting"
 msgstr "Einstellung für extensions.worktreeConfig konnte nicht gesetzt werden"
 
-#: builtin/sparse-checkout.c:288
+#: builtin/sparse-checkout.c:283
 msgid "git sparse-checkout init [--cone]"
 msgstr "git sparse-checkout init [--cone]"
 
-#: builtin/sparse-checkout.c:307
+#: builtin/sparse-checkout.c:302
 msgid "initialize the sparse-checkout in cone mode"
 msgstr "initialisiere den partiellen Checkout im Cone-Modus"
 
-#: builtin/sparse-checkout.c:344
+#: builtin/sparse-checkout.c:339
 #, c-format
 msgid "failed to open '%s'"
 msgstr "Fehler beim Öffnen von '%s'"
 
-#: builtin/sparse-checkout.c:401
+#: builtin/sparse-checkout.c:396
 #, c-format
 msgid "could not normalize path %s"
 msgstr "konnte Pfad '%s' nicht normalisieren"
 
-#: builtin/sparse-checkout.c:413
+#: builtin/sparse-checkout.c:408
 msgid "git sparse-checkout (set|add) (--stdin | <patterns>)"
 msgstr "git sparse-checkout (set|add) (--stdin | <Muster>)"
 
-#: builtin/sparse-checkout.c:438
+#: builtin/sparse-checkout.c:433
 #, c-format
 msgid "unable to unquote C-style string '%s'"
 msgstr "konnte Anführungszeichen von C-Style Zeichenkette '%s' nicht entfernen"
 
-#: builtin/sparse-checkout.c:492 builtin/sparse-checkout.c:516
+#: builtin/sparse-checkout.c:487 builtin/sparse-checkout.c:511
 msgid "unable to load existing sparse-checkout patterns"
 msgstr "konnte die existierenden Muster des partiellen Checkouts nicht laden"
 
-#: builtin/sparse-checkout.c:561
+#: builtin/sparse-checkout.c:556
 msgid "read patterns from standard in"
 msgstr "Muster von der Standard-Eingabe lesen"
 
-#: builtin/sparse-checkout.c:576
+#: builtin/sparse-checkout.c:571
 msgid "git sparse-checkout reapply"
 msgstr "git sparse-checkout reapply"
 
-#: builtin/sparse-checkout.c:595
+#: builtin/sparse-checkout.c:590
 msgid "git sparse-checkout disable"
 msgstr "git sparse-checkout disable"
 
-#: builtin/sparse-checkout.c:623
+#: builtin/sparse-checkout.c:618
 msgid "error while refreshing working directory"
 msgstr "Fehler während der Aktualisierung des Arbeitsverzeichnisses."
 
@@ -21924,156 +22388,165 @@ msgid "%s is not a valid reference"
 msgstr "'%s' ist kein gültiger Referenzname."
 
 #: builtin/stash.c:225
-msgid "git stash clear with parameters is unimplemented"
+#, fuzzy
+msgid "git stash clear with arguments is unimplemented"
 msgstr "git stash clear mit Parametern ist nicht implementiert"
 
-#: builtin/stash.c:404
+#: builtin/stash.c:429
+#, c-format
+msgid ""
+"WARNING: Untracked file in way of tracked file!  Renaming\n"
+"            %s -> %s\n"
+"         to make room.\n"
+msgstr ""
+
+#: builtin/stash.c:490
 msgid "cannot apply a stash in the middle of a merge"
 msgstr "Kann Stash nicht anwenden, solange ein Merge im Gange ist"
 
-#: builtin/stash.c:415
+#: builtin/stash.c:501
 #, c-format
 msgid "could not generate diff %s^!."
 msgstr "Konnte keinen Diff erzeugen %s^!."
 
-#: builtin/stash.c:422
+#: builtin/stash.c:508
 msgid "conflicts in index. Try without --index."
 msgstr "Konflikte im Index. Versuchen Sie es ohne --index."
 
-#: builtin/stash.c:428
+#: builtin/stash.c:514
 msgid "could not save index tree"
 msgstr "Konnte Index-Verzeichnis nicht speichern"
 
-#: builtin/stash.c:437
+#: builtin/stash.c:523
 msgid "could not restore untracked files from stash"
 msgstr "Konnte unversionierte Dateien vom Stash nicht wiederherstellen."
 
-#: builtin/stash.c:451
+#: builtin/stash.c:537
 #, c-format
 msgid "Merging %s with %s"
 msgstr "Führe %s mit %s zusammen"
 
-#: builtin/stash.c:461
+#: builtin/stash.c:547
 msgid "Index was not unstashed."
 msgstr "Index wurde nicht aus dem Stash zurückgeladen."
 
-#: builtin/stash.c:522 builtin/stash.c:620
+#: builtin/stash.c:589 builtin/stash.c:687
 msgid "attempt to recreate the index"
 msgstr "Versuche Index wiederherzustellen."
 
-#: builtin/stash.c:566
+#: builtin/stash.c:633
 #, c-format
 msgid "Dropped %s (%s)"
 msgstr "%s (%s) gelöscht"
 
-#: builtin/stash.c:569
+#: builtin/stash.c:636
 #, c-format
 msgid "%s: Could not drop stash entry"
 msgstr "%s: Konnte Stash-Eintrag nicht löschen"
 
-#: builtin/stash.c:582
+#: builtin/stash.c:649
 #, c-format
 msgid "'%s' is not a stash reference"
 msgstr "'%s' ist keine Stash-Referenz"
 
-#: builtin/stash.c:632
+#: builtin/stash.c:699
 msgid "The stash entry is kept in case you need it again."
 msgstr ""
 "Der Stash-Eintrag wird für den Fall behalten, dass Sie diesen nochmal "
 "benötigen."
 
-#: builtin/stash.c:655
+#: builtin/stash.c:722
 msgid "No branch name specified"
 msgstr "Kein Branchname spezifiziert"
 
-#: builtin/stash.c:799 builtin/stash.c:836
+#: builtin/stash.c:866 builtin/stash.c:903
 #, c-format
 msgid "Cannot update %s with %s"
 msgstr "Kann nicht %s mit %s aktualisieren."
 
-#: builtin/stash.c:817 builtin/stash.c:1471 builtin/stash.c:1536
+#: builtin/stash.c:884 builtin/stash.c:1538 builtin/stash.c:1603
 msgid "stash message"
 msgstr "Stash-Beschreibung"
 
-#: builtin/stash.c:827
+#: builtin/stash.c:894
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "\"git stash store\" erwartet ein Argument <Commit>"
 
-#: builtin/stash.c:1042
+#: builtin/stash.c:1109
 msgid "No changes selected"
 msgstr "Keine Änderungen ausgewählt"
 
-#: builtin/stash.c:1142
+#: builtin/stash.c:1209
 msgid "You do not have the initial commit yet"
 msgstr "Sie haben bisher noch keinen initialen Commit"
 
-#: builtin/stash.c:1169
+#: builtin/stash.c:1236
 msgid "Cannot save the current index state"
 msgstr "Kann den aktuellen Zustand des Index nicht speichern"
 
-#: builtin/stash.c:1178
+#: builtin/stash.c:1245
 msgid "Cannot save the untracked files"
 msgstr "Kann die unversionierten Dateien nicht speichern"
 
-#: builtin/stash.c:1189 builtin/stash.c:1198
+#: builtin/stash.c:1256 builtin/stash.c:1265
 msgid "Cannot save the current worktree state"
 msgstr "Kann den aktuellen Zustand des Arbeitsverzeichnisses nicht speichern"
 
-#: builtin/stash.c:1226
+#: builtin/stash.c:1293
 msgid "Cannot record working tree state"
 msgstr "Kann Zustand des Arbeitsverzeichnisses nicht aufzeichnen"
 
-#: builtin/stash.c:1275
+#: builtin/stash.c:1342
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr ""
 "Kann nicht gleichzeitig --patch und --include-untracked oder --all verwenden"
 
-#: builtin/stash.c:1291
+#: builtin/stash.c:1358
 msgid "Did you forget to 'git add'?"
 msgstr "Haben Sie vielleicht 'git add' vergessen?"
 
-#: builtin/stash.c:1306
+#: builtin/stash.c:1373
 msgid "No local changes to save"
 msgstr "Keine lokalen Änderungen zum Speichern"
 
-#: builtin/stash.c:1313
+#: builtin/stash.c:1380
 msgid "Cannot initialize stash"
 msgstr "Kann \"stash\" nicht initialisieren"
 
-#: builtin/stash.c:1328
+#: builtin/stash.c:1395
 msgid "Cannot save the current status"
 msgstr "Kann den aktuellen Status nicht speichern"
 
-#: builtin/stash.c:1333
+#: builtin/stash.c:1400
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "Arbeitsverzeichnis und Index-Status %s gespeichert."
 
-#: builtin/stash.c:1423
+#: builtin/stash.c:1490
 msgid "Cannot remove worktree changes"
 msgstr "Kann Änderungen im Arbeitsverzeichnis nicht löschen"
 
-#: builtin/stash.c:1462 builtin/stash.c:1527
+#: builtin/stash.c:1529 builtin/stash.c:1594
 msgid "keep index"
 msgstr "behalte Index"
 
-#: builtin/stash.c:1464 builtin/stash.c:1529
+#: builtin/stash.c:1531 builtin/stash.c:1596
 msgid "stash in patch mode"
 msgstr "Stash in Patch-Modus"
 
-#: builtin/stash.c:1465 builtin/stash.c:1530
+#: builtin/stash.c:1532 builtin/stash.c:1597
 msgid "quiet mode"
 msgstr "weniger Ausgaben"
 
-#: builtin/stash.c:1467 builtin/stash.c:1532
+#: builtin/stash.c:1534 builtin/stash.c:1599
 msgid "include untracked files in stash"
 msgstr "unversionierte Dateien in Stash einbeziehen"
 
-#: builtin/stash.c:1469 builtin/stash.c:1534
+#: builtin/stash.c:1536 builtin/stash.c:1601
 msgid "include ignore files"
 msgstr "ignorierte Dateien einbeziehen"
 
-#: builtin/stash.c:1569
+#: builtin/stash.c:1636
 msgid ""
 "the stash.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -22154,13 +22627,15 @@ msgstr ""
 "."
 
 #: builtin/submodule--helper.c:565
-msgid "Suppress output of entering each submodule command"
+#, fuzzy
+msgid "suppress output of entering each submodule command"
 msgstr ""
 "Ausgaben beim Betreten und der Befehlsausführung in einem Submodul "
 "unterdrücken"
 
-#: builtin/submodule--helper.c:567 builtin/submodule--helper.c:1487
-msgid "Recurse into nested submodules"
+#: builtin/submodule--helper.c:567 builtin/submodule--helper.c:888
+#: builtin/submodule--helper.c:1487
+msgid "recurse into nested submodules"
 msgstr "Rekursion in verschachtelte Submodule durchführen"
 
 #: builtin/submodule--helper.c:572
@@ -22200,7 +22675,8 @@ msgstr ""
 "Konfiguration."
 
 #: builtin/submodule--helper.c:709
-msgid "Suppress output for initializing a submodule"
+#, fuzzy
+msgid "suppress output for initializing a submodule"
 msgstr "Ausgaben bei Initialisierung eines Submoduls unterdrücken"
 
 #: builtin/submodule--helper.c:714
@@ -22223,19 +22699,17 @@ msgid "failed to recurse into submodule '%s'"
 msgstr "Fehler bei Rekursion in Submodul '%s'."
 
 #: builtin/submodule--helper.c:886 builtin/submodule--helper.c:1623
-msgid "Suppress submodule status output"
+#, fuzzy
+msgid "suppress submodule status output"
 msgstr "Ausgabe über Submodul-Status unterdrücken"
 
 #: builtin/submodule--helper.c:887
+#, fuzzy
 msgid ""
-"Use commit stored in the index instead of the one stored in the submodule "
+"use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
 msgstr ""
 "Benutze den Commit, der im Index gespeichert ist, statt den im Submodul HEAD"
-
-#: builtin/submodule--helper.c:888
-msgid "recurse into nested submodules"
-msgstr "Rekursion in verschachtelte Submodule durchführen"
 
 #: builtin/submodule--helper.c:893
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
@@ -22321,7 +22795,8 @@ msgid "failed to update remote for submodule '%s'"
 msgstr "Fehler beim Aktualisieren des Remote-Repositories für Submodul '%s'"
 
 #: builtin/submodule--helper.c:1485
-msgid "Suppress output of synchronizing submodule url"
+#, fuzzy
+msgid "suppress output of synchronizing submodule url"
 msgstr "Ausgaben bei der Synchronisierung der Submodul-URLs unterdrücken"
 
 #: builtin/submodule--helper.c:1492
@@ -22368,13 +22843,15 @@ msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "Submodul '%s' (%s) für Pfad '%s' ausgetragen.\n"
 
 #: builtin/submodule--helper.c:1624
-msgid "Remove submodule working trees even if they contain local changes"
+#, fuzzy
+msgid "remove submodule working trees even if they contain local changes"
 msgstr ""
 "Arbeitsverzeichnisse von Submodulen löschen, auch wenn lokale Änderungen "
 "vorliegen"
 
 #: builtin/submodule--helper.c:1625
-msgid "Unregister all submodules"
+#, fuzzy
+msgid "unregister all submodules"
 msgstr "alle Submodule austragen"
 
 #: builtin/submodule--helper.c:1630
@@ -22527,7 +23004,8 @@ msgid "rebase, merge, checkout or none"
 msgstr "rebase, merge, checkout oder none"
 
 #: builtin/submodule--helper.c:2340
-msgid "Create a shallow clone truncated to the specified number of revisions"
+#, fuzzy
+msgid "create a shallow clone truncated to the specified number of revisions"
 msgstr ""
 "Erstellung eines Klons mit unvollständiger Historie (shallow), abgeschnitten "
 "bei\n"
@@ -22605,7 +23083,8 @@ msgstr ""
 "Arbeitsverzeichnis befindet."
 
 #: builtin/submodule--helper.c:2681
-msgid "Suppress output for setting url of a submodule"
+#, fuzzy
+msgid "suppress output for setting url of a submodule"
 msgstr "Ausgaben beim Setzen der URL eines Submoduls unterdrücken"
 
 #: builtin/submodule--helper.c:2685
@@ -22638,7 +23117,7 @@ msgstr "Option --branch oder --default erforderlich"
 msgid "--branch and --default are mutually exclusive"
 msgstr "--branch und --default schließen sich gegenseitig aus"
 
-#: builtin/submodule--helper.c:2792 git.c:438 git.c:711
+#: builtin/submodule--helper.c:2792 git.c:441 git.c:714
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s unterstützt kein --super-prefix"
@@ -22710,12 +23189,12 @@ msgstr "git tag -v [--format=<Format>] <Tagname>..."
 msgid "tag '%s' not found."
 msgstr "Tag '%s' nicht gefunden."
 
-#: builtin/tag.c:105
+#: builtin/tag.c:124
 #, c-format
 msgid "Deleted tag '%s' (was %s)\n"
 msgstr "Tag '%s' gelöscht (war %s)\n"
 
-#: builtin/tag.c:135
+#: builtin/tag.c:159
 #, c-format
 msgid ""
 "\n"
@@ -22728,7 +23207,7 @@ msgstr ""
 "  %s\n"
 "ein. Zeilen, die mit '%c' beginnen, werden ignoriert.\n"
 
-#: builtin/tag.c:139
+#: builtin/tag.c:163
 #, c-format
 msgid ""
 "\n"
@@ -22743,15 +23222,11 @@ msgstr ""
 "ein. Zeilen, die mit '%c' beginnen, werden behalten; Sie dürfen diese\n"
 "selbst entfernen wenn Sie möchten.\n"
 
-#: builtin/tag.c:198
+#: builtin/tag.c:230
 msgid "unable to sign the tag"
 msgstr "konnte Tag nicht signieren"
 
-#: builtin/tag.c:200
-msgid "unable to write tag file"
-msgstr "konnte Tag-Datei nicht schreiben"
-
-#: builtin/tag.c:216
+#: builtin/tag.c:248
 #, c-format
 msgid ""
 "You have created a nested tag. The object referred to by your new tag is\n"
@@ -22765,138 +23240,134 @@ msgstr ""
 "\n"
 "\tgit tag -f %s %s^{}"
 
-#: builtin/tag.c:232
+#: builtin/tag.c:264
 msgid "bad object type."
 msgstr "ungültiger Objekt-Typ"
 
-#: builtin/tag.c:285
+#: builtin/tag.c:317
 msgid "no tag message?"
 msgstr "keine Tag-Beschreibung?"
 
-#: builtin/tag.c:292
+#: builtin/tag.c:324
 #, c-format
 msgid "The tag message has been left in %s\n"
 msgstr "Die Tag-Beschreibung wurde in %s gelassen\n"
 
-#: builtin/tag.c:403
+#: builtin/tag.c:435
 msgid "list tag names"
 msgstr "Tagnamen auflisten"
 
-#: builtin/tag.c:405
+#: builtin/tag.c:437
 msgid "print <n> lines of each tag message"
 msgstr "<n> Zeilen jeder Tag-Beschreibung anzeigen"
 
-#: builtin/tag.c:407
+#: builtin/tag.c:439
 msgid "delete tags"
 msgstr "Tags löschen"
 
-#: builtin/tag.c:408
+#: builtin/tag.c:440
 msgid "verify tags"
 msgstr "Tags überprüfen"
 
-#: builtin/tag.c:410
+#: builtin/tag.c:442
 msgid "Tag creation options"
 msgstr "Optionen für Erstellung von Tags"
 
-#: builtin/tag.c:412
+#: builtin/tag.c:444
 msgid "annotated tag, needs a message"
 msgstr "annotiertes Tag, benötigt eine Beschreibung"
 
-#: builtin/tag.c:414
+#: builtin/tag.c:446
 msgid "tag message"
 msgstr "Tag-Beschreibung"
 
-#: builtin/tag.c:416
+#: builtin/tag.c:448
 msgid "force edit of tag message"
 msgstr "Bearbeitung der Tag-Beschreibung erzwingen"
 
-#: builtin/tag.c:417
+#: builtin/tag.c:449
 msgid "annotated and GPG-signed tag"
 msgstr "annotiertes und GPG-signiertes Tag"
 
-#: builtin/tag.c:420
+#: builtin/tag.c:452
 msgid "use another key to sign the tag"
 msgstr "einen anderen Schlüssel verwenden, um das Tag zu signieren"
 
-#: builtin/tag.c:421
+#: builtin/tag.c:453
 msgid "replace the tag if exists"
 msgstr "das Tag ersetzen, wenn es existiert"
 
-#: builtin/tag.c:422 builtin/update-ref.c:505
+#: builtin/tag.c:454 builtin/update-ref.c:505
 msgid "create a reflog"
 msgstr "Reflog erstellen"
 
-#: builtin/tag.c:424
+#: builtin/tag.c:456
 msgid "Tag listing options"
 msgstr "Optionen für Auflistung der Tags"
 
-#: builtin/tag.c:425
+#: builtin/tag.c:457
 msgid "show tag list in columns"
 msgstr "Liste der Tags in Spalten anzeigen"
 
-#: builtin/tag.c:426 builtin/tag.c:428
+#: builtin/tag.c:458 builtin/tag.c:460
 msgid "print only tags that contain the commit"
 msgstr "nur Tags ausgeben, die diesen Commit beinhalten"
 
-#: builtin/tag.c:427 builtin/tag.c:429
+#: builtin/tag.c:459 builtin/tag.c:461
 msgid "print only tags that don't contain the commit"
 msgstr "nur Tags ausgeben, die diesen Commit nicht enthalten"
 
-#: builtin/tag.c:430
+#: builtin/tag.c:462
 msgid "print only tags that are merged"
 msgstr "nur Tags ausgeben, die gemerged wurden"
 
-#: builtin/tag.c:431
+#: builtin/tag.c:463
 msgid "print only tags that are not merged"
 msgstr "nur Tags ausgeben, die nicht gemerged wurden"
 
-#: builtin/tag.c:435
+#: builtin/tag.c:467
 msgid "print only tags of the object"
 msgstr "nur Tags von dem Objekt ausgeben"
 
-#: builtin/tag.c:483
+#: builtin/tag.c:515
 msgid "--column and -n are incompatible"
 msgstr "--column und -n sind inkompatibel"
 
-#: builtin/tag.c:505
+#: builtin/tag.c:537
 msgid "-n option is only allowed in list mode"
 msgstr "Die Option -n ist nur im Listenmodus erlaubt."
 
-#: builtin/tag.c:507
+#: builtin/tag.c:539
 msgid "--contains option is only allowed in list mode"
 msgstr "Die Option --contains ist nur im Listenmodus erlaubt."
 
-#: builtin/tag.c:509
+#: builtin/tag.c:541
 msgid "--no-contains option is only allowed in list mode"
 msgstr "Die Option --no-contains ist nur im Listenmodus erlaubt."
 
-#: builtin/tag.c:511
+#: builtin/tag.c:543
 msgid "--points-at option is only allowed in list mode"
 msgstr "Die Option --points-at ist nur im Listenmodus erlaubt."
 
-#: builtin/tag.c:513
+#: builtin/tag.c:545
 msgid "--merged and --no-merged options are only allowed in list mode"
 msgstr "Die Optionen --merged und --no-merged sind nur im Listenmodus erlaubt."
 
-#: builtin/tag.c:524
+#: builtin/tag.c:556
 msgid "only one -F or -m option is allowed."
 msgstr "nur eine -F oder -m Option ist erlaubt."
 
-#: builtin/tag.c:543
-msgid "too many params"
-msgstr "zu viele Parameter"
-
-#: builtin/tag.c:549
+#: builtin/tag.c:581
 #, c-format
 msgid "'%s' is not a valid tag name."
 msgstr "'%s' ist kein gültiger Tagname."
 
-#: builtin/tag.c:554
+#: builtin/tag.c:586
 #, c-format
 msgid "tag '%s' already exists"
 msgstr "Tag '%s' existiert bereits"
 
-#: builtin/tag.c:585
+#: builtin/tag.c:617
 #, c-format
 msgid "Updated tag '%s' (was %s)\n"
 msgstr "Tag '%s' aktualisiert (war %s)\n"
@@ -23273,89 +23744,63 @@ msgstr "git verify-tag [-v | --verbose] [--format=<Format>] <Tag>..."
 msgid "print tag contents"
 msgstr "Tag-Inhalte ausgeben"
 
-#: builtin/worktree.c:17
+#: builtin/worktree.c:18
 msgid "git worktree add [<options>] <path> [<commit-ish>]"
 msgstr "git worktree add [<Optionen>] <Pfad> [<Commit-Angabe>]"
 
-#: builtin/worktree.c:18
+#: builtin/worktree.c:19
 msgid "git worktree list [<options>]"
 msgstr "git worktree list [<Optionen>]"
 
-#: builtin/worktree.c:19
+#: builtin/worktree.c:20
 msgid "git worktree lock [<options>] <path>"
 msgstr "git worktree lock [<Optionen>] <Pfad>"
 
-#: builtin/worktree.c:20
+#: builtin/worktree.c:21
 msgid "git worktree move <worktree> <new-path>"
 msgstr "git worktree move <Arbeitsverzeichnis> <neuer-Pfad>"
 
-#: builtin/worktree.c:21
+#: builtin/worktree.c:22
 msgid "git worktree prune [<options>]"
 msgstr "git worktree prune [<Optionen>]"
 
-#: builtin/worktree.c:22
+#: builtin/worktree.c:23
 msgid "git worktree remove [<options>] <worktree>"
 msgstr "git worktree remove [<Optionen>] <Arbeitsverzeichnis>"
 
-#: builtin/worktree.c:23
+#: builtin/worktree.c:24
 msgid "git worktree unlock <path>"
 msgstr "git worktree unlock <Pfad>"
 
-#: builtin/worktree.c:60 builtin/worktree.c:973
+#: builtin/worktree.c:61 builtin/worktree.c:933
 #, c-format
 msgid "failed to delete '%s'"
 msgstr "Fehler beim Löschen von '%s'"
 
-#: builtin/worktree.c:85
-msgid "not a valid directory"
-msgstr "kein gültiges Verzeichnis"
-
-#: builtin/worktree.c:91
-msgid "gitdir file does not exist"
-msgstr "gitdir-Datei existiert nicht"
-
-#: builtin/worktree.c:96 builtin/worktree.c:105
-#, c-format
-msgid "unable to read gitdir file (%s)"
-msgstr "konnte gitdir-Datei nicht lesen (%s)"
-
-#: builtin/worktree.c:115
-#, c-format
-msgid "short read (expected %<PRIuMAX> bytes, read %<PRIuMAX>)"
-msgstr "read() zu kurz (%<PRIuMAX> Bytes erwartet, %<PRIuMAX> gelesen)"
-
-#: builtin/worktree.c:123
-msgid "invalid gitdir file"
-msgstr "ungültige gitdir-Datei"
-
-#: builtin/worktree.c:131
-msgid "gitdir file points to non-existent location"
-msgstr "gitdir-Datei verweist auf nicht existierenden Ort"
-
-#: builtin/worktree.c:146
+#: builtin/worktree.c:74
 #, c-format
 msgid "Removing %s/%s: %s"
 msgstr "Entferne %s/%s: %s"
 
-#: builtin/worktree.c:221
+#: builtin/worktree.c:149
 msgid "report pruned working trees"
 msgstr "entfernte Arbeitsverzeichnisse ausgeben"
 
-#: builtin/worktree.c:223
+#: builtin/worktree.c:151
 msgid "expire working trees older than <time>"
 msgstr "Arbeitsverzeichnisse älter als <Zeit> verfallen lassen"
 
-#: builtin/worktree.c:293
+#: builtin/worktree.c:221
 #, c-format
 msgid "'%s' already exists"
 msgstr "'%s' existiert bereits"
 
-#: builtin/worktree.c:302
+#: builtin/worktree.c:230
 #, c-format
 msgid "unusable worktree destination '%s'"
 msgstr "nicht nutzbares Ziel des Arbeitsverzeichnisses '%s'"
 
-#: builtin/worktree.c:307
+#: builtin/worktree.c:235
 #, c-format
 msgid ""
 "'%s' is a missing but locked worktree;\n"
@@ -23365,7 +23810,7 @@ msgstr ""
 "Benutzen Sie '%s -f -f' zum Überschreiben, oder 'unlock' und 'prune'\n"
 "oder 'remove' zum Löschen."
 
-#: builtin/worktree.c:309
+#: builtin/worktree.c:237
 #, c-format
 msgid ""
 "'%s' is a missing but already registered worktree;\n"
@@ -23375,124 +23820,138 @@ msgstr ""
 "Benutzen Sie '%s -f' zum Überschreiben, oder 'prune' oder 'remove' zum\n"
 "Löschen."
 
-#: builtin/worktree.c:360
+#: builtin/worktree.c:288
 #, c-format
 msgid "could not create directory of '%s'"
 msgstr "Konnte Verzeichnis '%s' nicht erstellen."
 
-#: builtin/worktree.c:494 builtin/worktree.c:500
+#: builtin/worktree.c:422 builtin/worktree.c:428
 #, c-format
 msgid "Preparing worktree (new branch '%s')"
 msgstr "Bereite Arbeitsverzeichnis vor (neuer Branch '%s')"
 
-#: builtin/worktree.c:496
+#: builtin/worktree.c:424
 #, c-format
 msgid "Preparing worktree (resetting branch '%s'; was at %s)"
 msgstr "Bereite Arbeitsverzeichnis vor (setze Branch '%s' um; war bei %s)"
 
-#: builtin/worktree.c:505
+#: builtin/worktree.c:433
 #, c-format
 msgid "Preparing worktree (checking out '%s')"
 msgstr "Bereite Arbeitsverzeichnis vor (checke '%s' aus)"
 
-#: builtin/worktree.c:511
+#: builtin/worktree.c:439
 #, c-format
 msgid "Preparing worktree (detached HEAD %s)"
 msgstr "Bereite Arbeitsverzeichnis vor (losgelöster HEAD %s)"
 
-#: builtin/worktree.c:552
+#: builtin/worktree.c:480
 msgid "checkout <branch> even if already checked out in other worktree"
 msgstr ""
 "<Branch> auschecken, auch wenn dieser bereits in einem anderen "
 "Arbeitsverzeichnis ausgecheckt ist"
 
-#: builtin/worktree.c:555
+#: builtin/worktree.c:483
 msgid "create a new branch"
 msgstr "neuen Branch erstellen"
 
-#: builtin/worktree.c:557
+#: builtin/worktree.c:485
 msgid "create or reset a branch"
 msgstr "Branch erstellen oder umsetzen"
 
-#: builtin/worktree.c:559
+#: builtin/worktree.c:487
 msgid "populate the new working tree"
 msgstr "das neue Arbeitsverzeichnis auschecken"
 
-#: builtin/worktree.c:560
+#: builtin/worktree.c:488
 msgid "keep the new working tree locked"
 msgstr "das neue Arbeitsverzeichnis gesperrt lassen"
 
-#: builtin/worktree.c:563
+#: builtin/worktree.c:491
 msgid "set up tracking mode (see git-branch(1))"
 msgstr "Modus zum Folgen von Branches einstellen (siehe git-branch(1))"
 
-#: builtin/worktree.c:566
+#: builtin/worktree.c:494
 msgid "try to match the new branch name with a remote-tracking branch"
 msgstr ""
 "versuchen, eine Übereinstimmung des Branch-Namens mit einem\n"
 "Remote-Tracking-Branch herzustellen"
 
-#: builtin/worktree.c:574
+#: builtin/worktree.c:502
 msgid "-b, -B, and --detach are mutually exclusive"
 msgstr "-b, -B und --detach schließen sich gegenseitig aus"
 
-#: builtin/worktree.c:635
+#: builtin/worktree.c:563
 msgid "--[no-]track can only be used if a new branch is created"
 msgstr ""
 "--[no]-track kann nur verwendet werden, wenn ein neuer Branch erstellt wird."
 
-#: builtin/worktree.c:758
+#: builtin/worktree.c:680
+msgid "show extended annotations and reasons, if available"
+msgstr ""
+
+#: builtin/worktree.c:682
+#, fuzzy
+msgid "add 'prunable' annotation to worktrees older than <time>"
+msgstr "Arbeitsverzeichnisse älter als <Zeit> verfallen lassen"
+
+#: builtin/worktree.c:691
+#, fuzzy
+msgid "--verbose and --porcelain are mutually exclusive"
+msgstr "-p und --overlay schließen sich gegenseitig aus."
+
+#: builtin/worktree.c:718
 msgid "reason for locking"
 msgstr "Sperrgrund"
 
-#: builtin/worktree.c:770 builtin/worktree.c:803 builtin/worktree.c:877
-#: builtin/worktree.c:1001
+#: builtin/worktree.c:730 builtin/worktree.c:763 builtin/worktree.c:837
+#: builtin/worktree.c:961
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr "'%s' ist kein Arbeitsverzeichnis"
 
-#: builtin/worktree.c:772 builtin/worktree.c:805
+#: builtin/worktree.c:732 builtin/worktree.c:765
 msgid "The main working tree cannot be locked or unlocked"
 msgstr "Das Hauptarbeitsverzeichnis kann nicht gesperrt oder entsperrt werden."
 
-#: builtin/worktree.c:777
+#: builtin/worktree.c:737
 #, c-format
 msgid "'%s' is already locked, reason: %s"
 msgstr "'%s' ist bereits gesperrt, Grund: %s"
 
-#: builtin/worktree.c:779
+#: builtin/worktree.c:739
 #, c-format
 msgid "'%s' is already locked"
 msgstr "'%s' ist bereits gesperrt"
 
-#: builtin/worktree.c:807
+#: builtin/worktree.c:767
 #, c-format
 msgid "'%s' is not locked"
 msgstr "'%s' ist nicht gesperrt"
 
-#: builtin/worktree.c:848
+#: builtin/worktree.c:808
 msgid "working trees containing submodules cannot be moved or removed"
 msgstr ""
 "Arbeitsverzeichnisse, die Submodule enthalten, können nicht verschoben oder\n"
 "entfernt werden."
 
-#: builtin/worktree.c:856
+#: builtin/worktree.c:816
 msgid "force move even if worktree is dirty or locked"
 msgstr ""
 "Verschieben erzwingen, auch wenn das Arbeitsverzeichnis geändert oder "
 "gesperrt ist"
 
-#: builtin/worktree.c:879 builtin/worktree.c:1003
+#: builtin/worktree.c:839 builtin/worktree.c:963
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr "'%s' ist ein Hauptarbeitsverzeichnis"
 
-#: builtin/worktree.c:884
+#: builtin/worktree.c:844
 #, c-format
 msgid "could not figure out destination name from '%s'"
 msgstr "Konnte Zielname aus '%s' nicht bestimmen."
 
-#: builtin/worktree.c:897
+#: builtin/worktree.c:857
 #, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
@@ -23502,7 +23961,7 @@ msgstr ""
 "Benutzen Sie 'move -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:899
+#: builtin/worktree.c:859
 msgid ""
 "cannot move a locked working tree;\n"
 "use 'move -f -f' to override or unlock first"
@@ -23511,40 +23970,40 @@ msgstr ""
 "Benutzen Sie 'move -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:902
+#: builtin/worktree.c:862
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
 msgstr "Validierung fehlgeschlagen, kann Arbeitszeichnis nicht verschieben: %s"
 
-#: builtin/worktree.c:907
+#: builtin/worktree.c:867
 #, c-format
 msgid "failed to move '%s' to '%s'"
 msgstr "Fehler beim Verschieben von '%s' nach '%s'"
 
-#: builtin/worktree.c:953
+#: builtin/worktree.c:913
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr "Fehler beim Ausführen von 'git status' auf '%s'"
 
-#: builtin/worktree.c:957
+#: builtin/worktree.c:917
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
 "'%s' enthält geänderte oder nicht versionierte Dateien, benutzen Sie --force "
 "zum Löschen"
 
-#: builtin/worktree.c:962
+#: builtin/worktree.c:922
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr "Fehler beim Ausführen von 'git status' auf '%s'. Code: %d"
 
-#: builtin/worktree.c:985
+#: builtin/worktree.c:945
 msgid "force removal even if worktree is dirty or locked"
 msgstr ""
 "Löschen erzwingen, auch wenn das Arbeitsverzeichnis geändert oder gesperrt "
 "ist"
 
-#: builtin/worktree.c:1008
+#: builtin/worktree.c:968
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
@@ -23554,7 +24013,7 @@ msgstr ""
 "Benutzen Sie 'remove -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:1010
+#: builtin/worktree.c:970
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
@@ -23563,17 +24022,17 @@ msgstr ""
 "Benutzen Sie 'remove -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:1013
+#: builtin/worktree.c:973
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr "Validierung fehlgeschlagen, kann Arbeitsverzeichnis nicht löschen: %s"
 
-#: builtin/worktree.c:1037
+#: builtin/worktree.c:997
 #, c-format
 msgid "repair: %s: %s"
 msgstr "repariere: %s: %s"
 
-#: builtin/worktree.c:1040
+#: builtin/worktree.c:1000
 #, c-format
 msgid "error: %s: %s"
 msgstr "Fehler: %s: %s"
@@ -23629,12 +24088,14 @@ msgid "exit immediately after advertising capabilities"
 msgstr "direkt nach Anzeige der angebotenen Fähigkeiten beenden"
 
 #: git.c:28
+#, fuzzy
 msgid ""
 "git [--version] [--help] [-C <path>] [-c <name>=<value>]\n"
 "           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]\n"
 "           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--"
 "bare]\n"
 "           [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]\n"
+"           [--super-prefix=<path>] [--config-env=<name>=<envvar>]\n"
 "           <command> [<args>]"
 msgstr ""
 "git [--version] [--help] [-C <Pfad>] [-c <Name>=<Wert>]\n"
@@ -23644,7 +24105,7 @@ msgstr ""
 "           [--git-dir=<Pfad>] [--work-tree=<Pfad>] [--namespace=<Name>]\n"
 "           <Befehl> [<Argumente>]"
 
-#: git.c:35
+#: git.c:36
 msgid ""
 "'git help -a' and 'git help -g' list available subcommands and some\n"
 "concept guides. See 'git help <command>' or 'git help <concept>'\n"
@@ -23657,47 +24118,47 @@ msgstr ""
 "Konzept zu erfahren.\n"
 "Benutzen Sie 'git help git' für einen Überblick des Systems."
 
-#: git.c:187
+#: git.c:188
 #, c-format
 msgid "no directory given for --git-dir\n"
 msgstr "Kein Verzeichnis für --git-dir angegeben.\n"
 
-#: git.c:201
+#: git.c:202
 #, c-format
 msgid "no namespace given for --namespace\n"
 msgstr "Kein Namespace für --namespace angegeben.\n"
 
-#: git.c:215
+#: git.c:216
 #, c-format
 msgid "no directory given for --work-tree\n"
 msgstr "Kein Verzeichnis für --work-tree angegeben.\n"
 
-#: git.c:229
+#: git.c:230
 #, c-format
 msgid "no prefix given for --super-prefix\n"
 msgstr "Kein Präfix für --super-prefix angegeben.\n"
 
-#: git.c:251
+#: git.c:252
 #, c-format
 msgid "-c expects a configuration string\n"
 msgstr "-c erwartet einen Konfigurationsstring.\n"
 
-#: git.c:289
+#: git.c:292
 #, c-format
 msgid "no directory given for -C\n"
 msgstr "Kein Verzeichnis für -C angegeben.\n"
 
-#: git.c:315
+#: git.c:318
 #, c-format
 msgid "unknown option: %s\n"
 msgstr "Unbekannte Option: %s\n"
 
-#: git.c:364
+#: git.c:367
 #, c-format
 msgid "while expanding alias '%s': '%s'"
 msgstr "beim Erweitern von Alias '%s': '%s'"
 
-#: git.c:373
+#: git.c:376
 #, c-format
 msgid ""
 "alias '%s' changes environment variables.\n"
@@ -23706,39 +24167,39 @@ msgstr ""
 "Alias '%s' ändert Umgebungsvariablen.\n"
 "Sie können '!git' im Alias benutzen, um dies zu tun."
 
-#: git.c:380
+#: git.c:383
 #, c-format
 msgid "empty alias for %s"
 msgstr "leerer Alias für %s"
 
-#: git.c:383
+#: git.c:386
 #, c-format
 msgid "recursive alias: %s"
 msgstr "rekursiver Alias: %s"
 
-#: git.c:465
+#: git.c:468
 msgid "write failure on standard output"
 msgstr "Fehler beim Schreiben in die Standard-Ausgabe."
 
-#: git.c:467
+#: git.c:470
 msgid "unknown write failure on standard output"
 msgstr "Unbekannter Fehler beim Schreiben in die Standard-Ausgabe."
 
-#: git.c:469
+#: git.c:472
 msgid "close failed on standard output"
 msgstr "Fehler beim Schließen der Standard-Ausgabe."
 
-#: git.c:820
+#: git.c:823
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr "Alias-Schleife erkannt: Erweiterung von '%s' schließt nicht ab:%s"
 
-#: git.c:870
+#: git.c:873
 #, c-format
 msgid "cannot handle %s as a builtin"
 msgstr "Kann %s nicht als eingebauten Befehl behandeln."
 
-#: git.c:883
+#: git.c:886
 #, c-format
 msgid ""
 "usage: %s\n"
@@ -23747,12 +24208,12 @@ msgstr ""
 "Verwendung: %s\n"
 "\n"
 
-#: git.c:903
+#: git.c:906
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr "Erweiterung von Alias '%s' fehlgeschlagen; '%s' ist kein Git-Befehl.\n"
 
-#: git.c:915
+#: git.c:918
 #, c-format
 msgid "failed to run command '%s': %s\n"
 msgstr "Fehler beim Ausführen von Befehl '%s': %s\n"
@@ -23992,11 +24453,11 @@ msgid ""
 msgstr ""
 "Mit der Option --pathspec-from-file sind Pfade durch NUL-Zeichen getrennt"
 
-#: ref-filter.h:96
+#: ref-filter.h:99
 msgid "key"
 msgstr "Schüssel"
 
-#: ref-filter.h:96
+#: ref-filter.h:99
 msgid "field name to sort on"
 msgstr "sortiere nach diesem Feld"
 
@@ -24004,14 +24465,6 @@ msgstr "sortiere nach diesem Feld"
 msgid "update the index with reused conflict resolution if possible"
 msgstr ""
 "Index, wenn möglich, mit wiederverwendeter Konfliktauflösung aktualisieren"
-
-#: wt-status.h:80
-msgid "HEAD detached at "
-msgstr "HEAD losgelöst bei "
-
-#: wt-status.h:81
-msgid "HEAD detached from "
-msgstr "HEAD losgelöst von "
 
 #: command-list.h:50
 msgid "Add file contents to the index"
@@ -24365,7 +24818,8 @@ msgid "Write and verify multi-pack-indexes"
 msgstr "multi-pack-indexes schreiben und überprüfen"
 
 #: command-list.h:132
-msgid "Creates a tag object"
+#, fuzzy
+msgid "Creates a tag object with extra validation"
 msgstr "ein Tag-Objekt erstellen"
 
 #: command-list.h:133
@@ -24683,69 +25137,55 @@ msgid "Specifies intentionally untracked files to ignore"
 msgstr "Spezifikation von bewusst ignorierten, unversionierten Dateien"
 
 #: command-list.h:209
+msgid "Map author/committer names and/or E-Mail addresses"
+msgstr ""
+
+#: command-list.h:210
 msgid "Defining submodule properties"
 msgstr "Definition von Submodul-Eigenschaften"
 
-#: command-list.h:210
+#: command-list.h:211
 msgid "Git namespaces"
 msgstr "Git Namensbereiche"
 
-#: command-list.h:211
+#: command-list.h:212
 msgid "Helper programs to interact with remote repositories"
 msgstr "Hilfsprogramme zur Interaktion mit Remote-Repositories"
 
-#: command-list.h:212
+#: command-list.h:213
 msgid "Git Repository Layout"
 msgstr "Git Repository Aufbau"
 
-#: command-list.h:213
+#: command-list.h:214
 msgid "Specifying revisions and ranges for Git"
 msgstr "Spezifikation von Commits und Bereichen für Git"
 
-#: command-list.h:214
+#: command-list.h:215
 msgid "Mounting one repository inside another"
 msgstr "Einbinden eines Repositories in ein anderes"
 
-#: command-list.h:215
+#: command-list.h:216
 msgid "A tutorial introduction to Git: part two"
 msgstr "eine einführende Anleitung zu Git: Teil zwei"
 
-#: command-list.h:216
+#: command-list.h:217
 msgid "A tutorial introduction to Git"
 msgstr "eine einführende Anleitung zu Git"
 
-#: command-list.h:217
+#: command-list.h:218
 msgid "An overview of recommended workflows with Git"
 msgstr "Eine Übersicht über empfohlene Arbeitsabläufe mit Git"
 
-#: git-bisect.sh:48
-#, sh-format
-msgid "Bad rev input: $arg"
-msgstr "Ungültige Referenz-Eingabe: $arg"
-
-#: git-bisect.sh:82
-msgid "No logfile given"
-msgstr "Keine Log-Datei gegeben"
-
-#: git-bisect.sh:83
-#, sh-format
-msgid "cannot read $file for replaying"
-msgstr "kann $file nicht für das Abspielen lesen"
-
-#: git-bisect.sh:105
-msgid "?? what are you talking about?"
-msgstr "?? Was reden Sie da?"
-
-#: git-bisect.sh:115
+#: git-bisect.sh:68
 msgid "bisect run failed: no command provided."
 msgstr "'bisect run' fehlgeschlagen: kein Befehl angegeben."
 
-#: git-bisect.sh:120
+#: git-bisect.sh:73
 #, sh-format
 msgid "running $command"
 msgstr "führe $command aus"
 
-#: git-bisect.sh:127
+#: git-bisect.sh:80
 #, sh-format
 msgid ""
 "bisect run failed:\n"
@@ -24754,11 +25194,11 @@ msgstr ""
 "'bisect run' fehlgeschlagen:\n"
 "Exit-Code $res von '$command' ist < 0 oder >= 128"
 
-#: git-bisect.sh:152
+#: git-bisect.sh:105
 msgid "bisect run cannot continue any more"
 msgstr "'bisect run' kann nicht mehr fortgesetzt werden"
 
-#: git-bisect.sh:158
+#: git-bisect.sh:111
 #, sh-format
 msgid ""
 "bisect run failed:\n"
@@ -24767,13 +25207,9 @@ msgstr ""
 "'bisect run' fehlgeschlagen:\n"
 "'bisect-state $state' wurde mit Fehlerwert $res beendet"
 
-#: git-bisect.sh:165
+#: git-bisect.sh:118
 msgid "bisect run success"
 msgstr "'bisect run' erfolgreich ausgeführt"
-
-#: git-bisect.sh:173
-msgid "We are not bisecting."
-msgstr "Keine binäre Suche im Gange."
 
 #: git-merge-octopus.sh:46
 msgid ""
@@ -26132,3 +26568,71 @@ msgstr "Lasse %s mit Backup-Suffix '%s' aus.\n"
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Wollen Sie %s wirklich versenden? [y|N]: "
+
+#~ msgid "rev-list died"
+#~ msgstr "\"rev-list\" abgebrochen"
+
+#~ msgid ""
+#~ "git bisect--helper --bisect-write [--no-log] <state> <revision> "
+#~ "<good_term> <bad_term>"
+#~ msgstr ""
+#~ "git bisect--helper --bisect-write [--no-log] <Zustand> <Revision> "
+#~ "<Begriff_gut> <Begriff_schlecht>"
+
+#~ msgid ""
+#~ "git bisect--helper --bisect-check-and-set-terms <command> <good_term> "
+#~ "<bad_term>"
+#~ msgstr ""
+#~ "git bisect--helper --bisect-check-and-set-terms <Befehl> <Begriff_gut> "
+#~ "<Begriff_schlecht>"
+
+#~ msgid "git bisect--helper --bisect-auto-next"
+#~ msgstr "git bisect--helper --bisect-auto-next"
+
+#~ msgid "write out the bisection state in BISECT_LOG"
+#~ msgstr "den Zustand der binären Suche nach BISECT_LOG schreiben"
+
+#~ msgid "check and set terms in a bisection state"
+#~ msgstr "Begriffe innerhalb einer binären Suche prüfen und setzen"
+
+#~ msgid ""
+#~ "verify the next bisection state then checkout the next bisection commit"
+#~ msgstr ""
+#~ "überprüfe den nächsten Zustand der binären Suche, checke dann den "
+#~ "nächsten Commit der binären Suche aus"
+
+#~ msgid "--bisect-write requires either 4 or 5 arguments"
+#~ msgstr "--bisect-write benötigt entweder 4 oder 5 Argumente"
+
+#~ msgid "--check-and-set-terms requires 3 arguments"
+#~ msgstr "--check-and-set-terms benötigt 3 Argumente"
+
+#~ msgid "--bisect-auto-next requires 0 arguments"
+#~ msgstr "--bisect-auto-next benötigt 0 Argumente"
+
+#~ msgid "Force progress reporting"
+#~ msgstr "Fortschrittsanzeige erzwingen"
+
+#~ msgid "Error deleting remote-tracking branch '%s'"
+#~ msgstr "Fehler beim Entfernen des Remote-Tracking-Branches '%s'"
+
+#~ msgid "Error deleting branch '%s'"
+#~ msgstr "Fehler beim Entfernen des Branches '%s'"
+
+#~ msgid "show parse tree for grep expression"
+#~ msgstr "geparstes Verzeichnis für \"grep\"-Ausdruck anzeigen"
+
+#~ msgid "too many parameters"
+#~ msgstr "zu viele Parameter"
+
+#~ msgid "too few parameters"
+#~ msgstr "zu wenig Parameter"
+
+#~ msgid "Recurse into nested submodules"
+#~ msgstr "Rekursion in verschachtelte Submodule durchführen"
+
+#~ msgid "too many params"
+#~ msgstr "zu viele Parameter"
+
+#~ msgid "Bad rev input: $arg"
+#~ msgstr "Ungültige Referenz-Eingabe: $arg"

--- a/po/fr.po
+++ b/po/fr.po
@@ -76,8 +76,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-02-26 22:09+0800\n"
-"PO-Revision-Date: 2021-02-27 15:40+0100\n"
+"POT-Creation-Date: 2021-03-04 22:41+0800\n"
+"PO-Revision-Date: 2021-03-04 21:45+0100\n"
 "Last-Translator: Cédric Malard <c.malard-git@valdun.net>\n"
 "Language-Team: Jean-Noël Avila <jn.avila@free.fr>\n"
 "Language: fr\n"
@@ -1182,7 +1182,7 @@ msgstr "le patch a échoué : %s:%ld"
 msgid "cannot checkout %s"
 msgstr "extraction de %s impossible"
 
-#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:73 pack-revindex.c:213
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:86 pack-revindex.c:213
 #: setup.c:308
 #, c-format
 msgid "failed to read %s"
@@ -1927,7 +1927,7 @@ msgstr ""
 "--reverse et --first-parent ensemble nécessitent la spécification d'un "
 "dernier commit"
 
-#: blame.c:2821 bundle.c:213 ref-filter.c:2202 remote.c:2041 sequencer.c:2146
+#: blame.c:2821 bundle.c:213 ref-filter.c:2206 remote.c:2041 sequencer.c:2146
 #: sequencer.c:4641 submodule.c:856 builtin/commit.c:1045 builtin/log.c:411
 #: builtin/log.c:1016 builtin/log.c:1624 builtin/log.c:2045 builtin/log.c:2335
 #: builtin/merge.c:424 builtin/pack-objects.c:3395 builtin/pack-objects.c:3410
@@ -2197,274 +2197,273 @@ msgstr "impossible de créer '%s'"
 msgid "index-pack died"
 msgstr "l'index de groupe a disparu"
 
+#: chunk-format.c:113
+msgid "terminating chunk id appears earlier than expected"
+msgstr "l'identifiant de terminaison de tronçon apparaît plus tôt qu'attendu"
+
+#: chunk-format.c:122
+#, c-format
+msgid "improper chunk offset(s) %<PRIx64> and %<PRIx64>"
+msgstr "décalage(s) de section incorrect(s) %<PRIx64> et %<PRIx64>"
+
+#: chunk-format.c:129
+#, c-format
+msgid "duplicate chunk ID %<PRIx32> found"
+msgstr "ID de section dupliqué %<PRIx32>"
+
+#: chunk-format.c:143
+#, c-format
+msgid "final chunk has non-zero id %<PRIx32>"
+msgstr "la section finale a un id non nul %<PRIx32>"
+
 #: color.c:329
 #, c-format
 msgid "invalid color value: %.*s"
 msgstr "Valeur invalide de couleur : %.*s"
 
-#: commit-graph.c:198 midx.c:47
+#: commit-graph.c:197 midx.c:46
 msgid "invalid hash version"
 msgstr "version d'empreinte invalide"
 
-#: commit-graph.c:219
-msgid "repository contains replace objects; skipping commit-graph"
-msgstr "le dépôt contient des object de remplacement ; saut du graphe de commits"
-
-#: commit-graph.c:228
-msgid "repository contains (deprecated) grafts; skipping commit-graph"
-msgstr "le dépôt contient des greffes (déconseillées) ; saut du graphe de commits"
-
-#: commit-graph.c:233
-msgid "repository is shallow; skipping commit-graph"
-msgstr "le dépôt est superficiel ; saut du graphe de commit"
-
-#: commit-graph.c:264
+#: commit-graph.c:255
 msgid "commit-graph file is too small"
 msgstr "le graphe de commit est trop petit"
 
-#: commit-graph.c:329
+#: commit-graph.c:348
 #, c-format
 msgid "commit-graph signature %X does not match signature %X"
 msgstr ""
 "la signature du graphe de commit %X ne correspond pas à la signature %X"
 
-#: commit-graph.c:336
+#: commit-graph.c:355
 #, c-format
 msgid "commit-graph version %X does not match version %X"
 msgstr "la version %X du graphe de commit ne correspond pas à la version %X"
 
-#: commit-graph.c:343
+#: commit-graph.c:362
 #, c-format
 msgid "commit-graph hash version %X does not match version %X"
 msgstr ""
 "l'empreinte de la version %X du graphe de commit ne correspond pas à la "
 "version %X"
 
-#: commit-graph.c:360
+#: commit-graph.c:379
 #, c-format
 msgid "commit-graph file is too small to hold %u chunks"
 msgstr "le graphe de commit est trop petit pour contenir %u sections"
 
-#: commit-graph.c:379
-#, c-format
-msgid "commit-graph improper chunk offset %08x%08x"
-msgstr "décalage de bloc %08x%08x du graphe de commit inadéquat"
-
-#: commit-graph.c:465
-#, c-format
-msgid "commit-graph chunk id %08x appears multiple times"
-msgstr "l'id de bloc de graphe de commit %08x apparaît des multiples fois"
-
-#: commit-graph.c:531
+#: commit-graph.c:472
 msgid "commit-graph has no base graphs chunk"
 msgstr "le graphe de commit n'a pas de section de graphes de base"
 
-#: commit-graph.c:541
+#: commit-graph.c:482
 msgid "commit-graph chain does not match"
 msgstr "la chaîne de graphe de commit ne correspond pas"
 
-#: commit-graph.c:589
+#: commit-graph.c:530
 #, c-format
 msgid "invalid commit-graph chain: line '%s' not a hash"
 msgstr ""
 "chaîne de graphe de commit invalide : la ligne '%s' n'est pas une empreinte"
 
-#: commit-graph.c:613
+#: commit-graph.c:554
 msgid "unable to find all commit-graph files"
 msgstr "impossible de trouver tous les fichiers du graphe de commit"
 
-#: commit-graph.c:794 commit-graph.c:831
+#: commit-graph.c:735 commit-graph.c:772
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr ""
 "position de commit invalide. Le graphe de commit est vraisemblablement "
 "corrompu"
 
-#: commit-graph.c:815
+#: commit-graph.c:756
 #, c-format
 msgid "could not find commit %s"
 msgstr "impossible de trouver le commit %s"
 
-#: commit-graph.c:848
+#: commit-graph.c:789
 msgid "commit-graph requires overflow generation data but has none"
-msgstr "le graphe de commits requiert des données de génération de débordement mais n'en contient pas"
+msgstr ""
+"le graphe de commits requiert des données de génération de débordement mais "
+"n'en contient pas"
 
-#: commit-graph.c:1121 builtin/am.c:1292
+#: commit-graph.c:1065 builtin/am.c:1292
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "impossible d'analyser le commit %s"
 
-#: commit-graph.c:1378 builtin/pack-objects.c:2872
+#: commit-graph.c:1327 builtin/pack-objects.c:2872
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "impossible d'obtenir le type de l'objet %s"
 
-#: commit-graph.c:1409
+#: commit-graph.c:1358
 msgid "Loading known commits in commit graph"
 msgstr "Lecture des commits connus dans un graphe de commit"
 
-#: commit-graph.c:1426
+#: commit-graph.c:1375
 msgid "Expanding reachable commits in commit graph"
 msgstr "Expansion des commits joignables dans un graphe de commit"
 
-#: commit-graph.c:1446
+#: commit-graph.c:1395
 msgid "Clearing commit marks in commit graph"
 msgstr "Suppression les marques de commit dans le graphe de commits"
 
-#: commit-graph.c:1465
+#: commit-graph.c:1414
 msgid "Computing commit graph topological levels"
 msgstr "Calcul des niveaux topologiques du graphe de commits"
 
-#: commit-graph.c:1518
+#: commit-graph.c:1467
 msgid "Computing commit graph generation numbers"
 msgstr "Calcul des chiffres de génération du graphe de commits"
 
-#: commit-graph.c:1599
+#: commit-graph.c:1548
 msgid "Computing commit changed paths Bloom filters"
 msgstr "Calcul des filtres Bloom des chemins modifiés du commit"
 
-#: commit-graph.c:1676
+#: commit-graph.c:1625
 msgid "Collecting referenced commits"
 msgstr "Collecte des commits référencés"
 
-#: commit-graph.c:1701
+#: commit-graph.c:1650
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] "Recherche de commits pour un graphe de commits dans %d paquet"
 msgstr[1] "Recherche de commits pour un graphe de commits dans %d paquets"
 
-#: commit-graph.c:1714
+#: commit-graph.c:1663
 #, c-format
 msgid "error adding pack %s"
 msgstr "erreur à l'ajout du packet %s"
 
-#: commit-graph.c:1718
+#: commit-graph.c:1667
 #, c-format
 msgid "error opening index for %s"
 msgstr "erreur à l'ouverture de l'index pour %s"
 
-#: commit-graph.c:1755
+#: commit-graph.c:1704
 msgid "Finding commits for commit graph among packed objects"
 msgstr ""
 "Recherche de commits pour un graphe de commits parmi les objets empaquetés"
 
-#: commit-graph.c:1773
+#: commit-graph.c:1722
 msgid "Finding extra edges in commit graph"
 msgstr "Recherche d'arêtes supplémentaires dans un graphe de commits"
 
-#: commit-graph.c:1821
+#: commit-graph.c:1771
 msgid "failed to write correct number of base graph ids"
 msgstr "échec à l'écriture le nombre correct d'id de base de fusion"
 
-#: commit-graph.c:1863 midx.c:819
+#: commit-graph.c:1802 midx.c:794
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "impossible de créer les répertoires de premier niveau de %s"
 
-#: commit-graph.c:1876
+#: commit-graph.c:1815
 msgid "unable to create temporary graph layer"
 msgstr "impossible de créer une couche de graphe temporaire"
 
-#: commit-graph.c:1881
+#: commit-graph.c:1820
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "impossible de régler les droits partagés pour '%s'"
 
-#: commit-graph.c:1966
+#: commit-graph.c:1879
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "Écriture le graphe de commits en %d passe"
 msgstr[1] "Écriture le graphe de commits en %d passes"
 
-#: commit-graph.c:2011
+#: commit-graph.c:1915
 msgid "unable to open commit-graph chain file"
 msgstr "impossible d'ouvrir le fichier de graphe de commit"
 
-#: commit-graph.c:2027
+#: commit-graph.c:1931
 msgid "failed to rename base commit-graph file"
 msgstr "échec du renommage du fichier de graphe de commits"
 
-#: commit-graph.c:2047
+#: commit-graph.c:1951
 msgid "failed to rename temporary commit-graph file"
 msgstr "impossible de renommer le fichier temporaire de graphe de commits"
 
-#: commit-graph.c:2180
+#: commit-graph.c:2084
 msgid "Scanning merged commits"
 msgstr "Analyse des commits de fusion"
 
-#: commit-graph.c:2224
+#: commit-graph.c:2128
 msgid "Merging commit-graph"
 msgstr "fusion du graphe de commits"
 
-#: commit-graph.c:2331
+#: commit-graph.c:2235
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 "essai d'écriture de graphe de commits, mais 'core.commitGraph' est désactivé"
 
-#: commit-graph.c:2438
+#: commit-graph.c:2342
 msgid "too many commits to write graph"
 msgstr "trop de commits pour écrire un graphe"
 
-#: commit-graph.c:2536
+#: commit-graph.c:2440
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "le graphe de commit a une somme de contrôle incorrecte et est "
 "vraisemblablement corrompu"
 
-#: commit-graph.c:2546
+#: commit-graph.c:2450
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "le graphe de commit a un ordre d'OID incorrect : %s puis %s"
 
-#: commit-graph.c:2556 commit-graph.c:2571
+#: commit-graph.c:2460 commit-graph.c:2475
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr ""
 "le graphe de commit a une valeur de dispersion incorrecte : dispersion[%d] = "
 "%u != %u"
 
-#: commit-graph.c:2563
+#: commit-graph.c:2467
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "échec de l'analyse le commit %s depuis le graphe de commits"
 
-#: commit-graph.c:2581
+#: commit-graph.c:2485
 msgid "Verifying commits in commit graph"
 msgstr "Verification des commits dans le graphe de commits"
 
-#: commit-graph.c:2596
+#: commit-graph.c:2500
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "échec de l'analyse du commit %s depuis la base de données d'objets pour le "
 "graphe de commit"
 
-#: commit-graph.c:2603
+#: commit-graph.c:2507
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 "l'OID de l'arbre racine pour le commit %s dans le graphe de commit est %s != "
 "%s"
 
-#: commit-graph.c:2613
+#: commit-graph.c:2517
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr ""
 "la liste des parents du graphe de commit pour le commit %s est trop longue"
 
-#: commit-graph.c:2622
+#: commit-graph.c:2526
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "le parent du graphe de commit pour %s est %s != %s"
 
-#: commit-graph.c:2636
+#: commit-graph.c:2540
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr ""
 "la liste de parents du graphe de commit pour le commit %s se termine trop tôt"
 
-#: commit-graph.c:2641
+#: commit-graph.c:2545
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2472,7 +2471,7 @@ msgstr ""
 "le graphe de commit a un numéro de génération nul pour le commit %s, mais "
 "non-nul ailleurs"
 
-#: commit-graph.c:2645
+#: commit-graph.c:2549
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2480,12 +2479,14 @@ msgstr ""
 "le graphe de commit a un numéro de génération non-nul pour le commit %s, "
 "mais nul ailleurs"
 
-#: commit-graph.c:2662
+#: commit-graph.c:2566
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
-msgstr "la génération du graphe de commit pour le commit %s est %<PRIuMAX> < %<PRIuMAX>"
+msgstr ""
+"la génération du graphe de commit pour le commit %s est %<PRIuMAX> < "
+"%<PRIuMAX>"
 
-#: commit-graph.c:2668
+#: commit-graph.c:2572
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
@@ -3073,7 +3074,8 @@ msgstr ""
 
 #: connect.c:1190
 msgid "newline is forbidden in git:// hosts and repo paths"
-msgstr "le retour chariot est interdit dans les hôtes git:// et les chemins de dépôt"
+msgstr ""
+"le retour chariot est interdit dans les hôtes git:// et les chemins de dépôt"
 
 #: connect.c:1247
 msgid "ssh variant 'simple' does not support -4"
@@ -4053,7 +4055,7 @@ msgstr ""
 msgid "failed to read orderfile '%s'"
 msgstr "impossible de lire le fichier de commande '%s'"
 
-#: diffcore-rename.c:555
+#: diffcore-rename.c:786
 msgid "Performing inexact rename detection"
 msgstr "Détection de renommage inexact en cours"
 
@@ -4107,17 +4109,17 @@ msgstr "echec de l'obtention d'information de kernel"
 msgid "untracked cache is disabled on this system or location"
 msgstr "Le cache non suivi est désactivé sur ce système ou sur cet endroit"
 
-#: dir.c:3537
+#: dir.c:3534
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "fichier d'index corrompu dans le dépôt %s"
 
-#: dir.c:3582 dir.c:3587
+#: dir.c:3579 dir.c:3584
 #, c-format
 msgid "could not create directories for %s"
 msgstr "impossible de créer les répertoires pour %s"
 
-#: dir.c:3616
+#: dir.c:3613
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "impossible de migrer le répertoire git de '%s' vers '%s'"
@@ -4179,32 +4181,32 @@ msgstr "impossible d'écrire sur un distant"
 msgid "--stateless-rpc requires multi_ack_detailed"
 msgstr "--stateless-rpc nécessite multi_ack_detailed"
 
-#: fetch-pack.c:378 fetch-pack.c:1400
+#: fetch-pack.c:378 fetch-pack.c:1457
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "ligne de superficiel invalide : %s"
 
-#: fetch-pack.c:384 fetch-pack.c:1406
+#: fetch-pack.c:384 fetch-pack.c:1463
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "ligne de fin de superficiel invalide : %s"
 
-#: fetch-pack.c:386 fetch-pack.c:1408
+#: fetch-pack.c:386 fetch-pack.c:1465
 #, c-format
 msgid "object not found: %s"
 msgstr "objet non trouvé : %s"
 
-#: fetch-pack.c:389 fetch-pack.c:1411
+#: fetch-pack.c:389 fetch-pack.c:1468
 #, c-format
 msgid "error in object: %s"
 msgstr "Erreur dans l'objet : %s"
 
-#: fetch-pack.c:391 fetch-pack.c:1413
+#: fetch-pack.c:391 fetch-pack.c:1470
 #, c-format
 msgid "no shallow found: %s"
 msgstr "Pas de superficiel trouvé : %s"
 
-#: fetch-pack.c:394 fetch-pack.c:1417
+#: fetch-pack.c:394 fetch-pack.c:1474
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "superficiel/non superficiel attendu, %s trouvé"
@@ -4242,157 +4244,161 @@ msgstr "Marquage de %s comme terminé"
 msgid "already have %s (%s)"
 msgstr "%s déjà possédé (%s)"
 
-#: fetch-pack.c:821
+#: fetch-pack.c:844
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-pack : impossible de dupliquer le démultiplexeur latéral"
 
-#: fetch-pack.c:829
+#: fetch-pack.c:852
 msgid "protocol error: bad pack header"
 msgstr "erreur de protocole : mauvais entête de paquet"
 
-#: fetch-pack.c:913
+#: fetch-pack.c:946
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-pack : impossible de dupliquer %s"
 
-#: fetch-pack.c:931
+#: fetch-pack.c:952
+msgid "fetch-pack: invalid index-pack output"
+msgstr "fetch-pack : sortie d'index de pack invalide"
+
+#: fetch-pack.c:969
 #, c-format
 msgid "%s failed"
 msgstr "échec de %s"
 
-#: fetch-pack.c:933
+#: fetch-pack.c:971
 msgid "error in sideband demultiplexer"
 msgstr "erreur dans le démultiplexer latéral"
 
-#: fetch-pack.c:976
+#: fetch-pack.c:1031
 #, c-format
 msgid "Server version is %.*s"
 msgstr "La version du serveur est %.*s"
 
-#: fetch-pack.c:984 fetch-pack.c:990 fetch-pack.c:993 fetch-pack.c:999
-#: fetch-pack.c:1003 fetch-pack.c:1007 fetch-pack.c:1011 fetch-pack.c:1015
-#: fetch-pack.c:1019 fetch-pack.c:1023 fetch-pack.c:1027 fetch-pack.c:1031
-#: fetch-pack.c:1037 fetch-pack.c:1043 fetch-pack.c:1048 fetch-pack.c:1053
+#: fetch-pack.c:1039 fetch-pack.c:1045 fetch-pack.c:1048 fetch-pack.c:1054
+#: fetch-pack.c:1058 fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070
+#: fetch-pack.c:1074 fetch-pack.c:1078 fetch-pack.c:1082 fetch-pack.c:1086
+#: fetch-pack.c:1092 fetch-pack.c:1098 fetch-pack.c:1103 fetch-pack.c:1108
 #, c-format
 msgid "Server supports %s"
 msgstr "Le serveur supporte %s"
 
-#: fetch-pack.c:986
+#: fetch-pack.c:1041
 msgid "Server does not support shallow clients"
 msgstr "Le serveur ne supporte les clients superficiels"
 
-#: fetch-pack.c:1046
+#: fetch-pack.c:1101
 msgid "Server does not support --shallow-since"
 msgstr "Le receveur ne gère pas --shallow-since"
 
-#: fetch-pack.c:1051
+#: fetch-pack.c:1106
 msgid "Server does not support --shallow-exclude"
 msgstr "Le receveur ne gère pas --shallow-exclude"
 
-#: fetch-pack.c:1055
+#: fetch-pack.c:1110
 msgid "Server does not support --deepen"
 msgstr "Le receveur ne gère pas --deepen"
 
-#: fetch-pack.c:1057
+#: fetch-pack.c:1112
 msgid "Server does not support this repository's object format"
 msgstr "Le serveur ne supporte pas ce format d'objets de ce dépôt"
 
-#: fetch-pack.c:1070
+#: fetch-pack.c:1125
 msgid "no common commits"
 msgstr "pas de commit commun"
 
-#: fetch-pack.c:1082 fetch-pack.c:1622
+#: fetch-pack.c:1138 fetch-pack.c:1682
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack : échec de le récupération."
 
-#: fetch-pack.c:1208
+#: fetch-pack.c:1265
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "non-correspondance des algorithmes : client %s ; serveur %s"
 
-#: fetch-pack.c:1212
+#: fetch-pack.c:1269
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "Le serveur ne supporte pas l'algorithme '%s'"
 
-#: fetch-pack.c:1232
+#: fetch-pack.c:1289
 msgid "Server does not support shallow requests"
 msgstr "Le serveur ne supporte pas les requêtes superficielles"
 
-#: fetch-pack.c:1239
+#: fetch-pack.c:1296
 msgid "Server supports filter"
 msgstr "Le serveur supporte filter"
 
-#: fetch-pack.c:1278
+#: fetch-pack.c:1335
 msgid "unable to write request to remote"
 msgstr "impossible d'écrire la requête sur le distant"
 
-#: fetch-pack.c:1296
+#: fetch-pack.c:1353
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "erreur à la lecture de l'entête de section '%s'"
 
-#: fetch-pack.c:1302
+#: fetch-pack.c:1359
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "'%s' attendu, '%s' reçu"
 
-#: fetch-pack.c:1363
+#: fetch-pack.c:1420
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "ligne d'acquittement inattendue : '%s'"
 
-#: fetch-pack.c:1368
+#: fetch-pack.c:1425
 #, c-format
 msgid "error processing acks: %d"
 msgstr "erreur lors du traitement des acquittements : %d"
 
-#: fetch-pack.c:1378
+#: fetch-pack.c:1435
 msgid "expected packfile to be sent after 'ready'"
 msgstr "fichier paquet attendu à envoyer après 'ready'"
 
-#: fetch-pack.c:1380
+#: fetch-pack.c:1437
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr "aucune autre section attendue à envoyer après absence de 'ready'"
 
-#: fetch-pack.c:1422
+#: fetch-pack.c:1479
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "erreur lors du traitement de l'information de superficialité : %d"
 
-#: fetch-pack.c:1469
+#: fetch-pack.c:1526
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "wanted-ref attendu, '%s' trouvé"
 
-#: fetch-pack.c:1474
+#: fetch-pack.c:1531
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "wanted-ref inattendu : '%s'"
 
-#: fetch-pack.c:1479
+#: fetch-pack.c:1536
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "erreur lors du traitement des références voulues : %d"
 
-#: fetch-pack.c:1509
+#: fetch-pack.c:1566
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack : paquet de fin de réponse attendu"
 
-#: fetch-pack.c:1891
+#: fetch-pack.c:1960
 msgid "no matching remote head"
 msgstr "pas de HEAD distante correspondante"
 
-#: fetch-pack.c:1914 builtin/clone.c:693
+#: fetch-pack.c:1983 builtin/clone.c:693
 msgid "remote did not send all necessary objects"
 msgstr "le serveur distant n'a pas envoyé tous les objets nécessaires"
 
-#: fetch-pack.c:1941
+#: fetch-pack.c:2010
 #, c-format
 msgid "no such remote ref %s"
 msgstr "référence distante inconnue %s"
 
-#: fetch-pack.c:1944
+#: fetch-pack.c:2013
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Le serveur n'autorise pas de requête pour l'objet %s non annoncé"
@@ -4760,43 +4766,44 @@ msgstr "valeur invalide '%s' pour lsrefs.unborn"
 msgid "expected flush after ls-refs arguments"
 msgstr "vidage attendu après les arguments ls-refs"
 
-#: merge-ort.c:855 merge-recursive.c:1191
+#: merge-ort.c:888 merge-recursive.c:1191
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
 msgstr "Échec de la fusion du sous-module %s (non extrait)"
 
-#: merge-ort.c:864 merge-recursive.c:1198
+#: merge-ort.c:897 merge-recursive.c:1198
 #, c-format
 msgid "Failed to merge submodule %s (commits not present)"
 msgstr "Échec de fusion du sous-module %s (commits non présents)"
 
-#: merge-ort.c:873 merge-recursive.c:1205
+#: merge-ort.c:906 merge-recursive.c:1205
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
 msgstr ""
 "Échec de la fusion du sous-module %s (les commits ne descendent pas de la "
 "base de fusion)"
 
-#: merge-ort.c:883 merge-ort.c:890
+#: merge-ort.c:916 merge-ort.c:923
 #, c-format
 msgid "Note: Fast-forwarding submodule %s to %s"
 msgstr "Note : Avance rapide du sous-module %s à %s"
 
-#: merge-ort.c:911
+#: merge-ort.c:944
 #, c-format
 msgid "Failed to merge submodule %s"
 msgstr "Échec de la fusion du sous-module %s"
 
-#: merge-ort.c:918
+#: merge-ort.c:951
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but a possible merge resolution exists:\n"
 "%s\n"
 msgstr ""
-"Échec de fusion du sous-module %s mais une résolution possible de fusion existe :\n"
+"Échec de fusion du sous-module %s mais une résolution possible de fusion "
+"existe :\n"
 "%s\n"
 
-#: merge-ort.c:922 merge-recursive.c:1259
+#: merge-ort.c:955 merge-recursive.c:1259
 #, c-format
 msgid ""
 "If this is correct simply add it to the index for example\n"
@@ -4813,30 +4820,31 @@ msgstr ""
 "\n"
 "qui acceptera cette suggestion.\n"
 
-#: merge-ort.c:935
+#: merge-ort.c:968
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but multiple possible merges exist:\n"
 "%s"
 msgstr ""
-"Échec de fusion du sous-module %s mais de multiples solutions de fusion existent :\n"
+"Échec de fusion du sous-module %s mais de multiples solutions de fusion "
+"existent :\n"
 "%s"
 
-#: merge-ort.c:1094 merge-recursive.c:1341
+#: merge-ort.c:1127 merge-recursive.c:1341
 msgid "Failed to execute internal merge"
 msgstr "Échec à l'exécution de la fusion interne"
 
-#: merge-ort.c:1099 merge-recursive.c:1346
+#: merge-ort.c:1132 merge-recursive.c:1346
 #, c-format
 msgid "Unable to add %s to database"
 msgstr "Impossible d'ajouter %s à la base de données"
 
-#: merge-ort.c:1106 merge-recursive.c:1378
+#: merge-ort.c:1139 merge-recursive.c:1378
 #, c-format
 msgid "Auto-merging %s"
 msgstr "Fusion automatique de %s"
 
-#: merge-ort.c:1245 merge-recursive.c:2100
+#: merge-ort.c:1278 merge-recursive.c:2100
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
@@ -4845,7 +4853,7 @@ msgstr ""
 "CONFLIT (renommage implicite de répertoire) : le répertoire/fichier %s gêne "
 "des renommages implicites de répertoire déplaçant les chemins suivants : %s."
 
-#: merge-ort.c:1255 merge-recursive.c:2110
+#: merge-ort.c:1288 merge-recursive.c:2110
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
@@ -4854,15 +4862,18 @@ msgstr ""
 "CONFLIT (renommage implicite de répertoire) : impossible de transformer "
 "plusieurs chemins sur %s ; les chemins concernés sont : %s"
 
-#: merge-ort.c:1438
+#: merge-ort.c:1471
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to rename %s to; it was "
 "renamed to multiple other directories, with no destination getting a "
 "majority of the files."
-msgstr "CONFLIT (renommage de répertoire coupé) : le renommage de %s n'est pas clair parce que le répertoire a été renommé en plusieurs autres répertoires, sans aucune destination récupérant la majorité des fichiers."
+msgstr ""
+"CONFLIT (renommage de répertoire coupé) : le renommage de %s n'est pas clair "
+"parce que le répertoire a été renommé en plusieurs autres répertoires, sans "
+"aucune destination récupérant la majorité des fichiers."
 
-#: merge-ort.c:1604 merge-recursive.c:2447
+#: merge-ort.c:1637 merge-recursive.c:2447
 #, c-format
 msgid ""
 "WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
@@ -4871,7 +4882,7 @@ msgstr ""
 "AVERTISSEMENT : ne renomme pas %s->%s dans %s, parce que %s lui-même a été "
 "renommé."
 
-#: merge-ort.c:1748 merge-recursive.c:3215
+#: merge-ort.c:1781 merge-recursive.c:3215
 #, c-format
 msgid ""
 "Path updated: %s added in %s inside a directory that was renamed in %s; "
@@ -4880,7 +4891,7 @@ msgstr ""
 "Chemin mis à jour : %s ajouté dans %s dans un répertoire qui a été renommé "
 "en %s ; déplacé dans %s."
 
-#: merge-ort.c:1755 merge-recursive.c:3222
+#: merge-ort.c:1788 merge-recursive.c:3222
 #, c-format
 msgid ""
 "Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
@@ -4889,7 +4900,7 @@ msgstr ""
 "Chemin mis à jour : %s renommé en %s dans %s, dans un répertoire qui a été "
 "renommé en %s ; déplacé dans %s."
 
-#: merge-ort.c:1768 merge-recursive.c:3218
+#: merge-ort.c:1801 merge-recursive.c:3218
 #, c-format
 msgid ""
 "CONFLICT (file location): %s added in %s inside a directory that was renamed "
@@ -4899,7 +4910,7 @@ msgstr ""
 "a été renommé dans %s, ce qui suggère qu'il devrait peut-être être déplacé "
 "vers %s."
 
-#: merge-ort.c:1776 merge-recursive.c:3225
+#: merge-ort.c:1809 merge-recursive.c:3225
 #, c-format
 msgid ""
 "CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
@@ -4909,74 +4920,86 @@ msgstr ""
 "répertoire qui a été renommé dans %s, ce qui suggère qu'il devrait peut-être "
 "être déplacé vers %s."
 
-#: merge-ort.c:1919
+#: merge-ort.c:1952
 #, c-format
 msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
-msgstr "CONFLIT (renommage/renommage) : %s renommé en %s dans %s et en %s dans %s."
+msgstr ""
+"CONFLIT (renommage/renommage) : %s renommé en %s dans %s et en %s dans %s."
 
-#: merge-ort.c:2014
+#: merge-ort.c:2047
 #, c-format
 msgid ""
 "CONFLICT (rename involved in collision): rename of %s -> %s has content "
 "conflicts AND collides with another path; this may result in nested conflict "
 "markers."
-msgstr "CONFLIT (renommage au sein d'une collision) : lre renommage de %s -> %s a des conflits de contenu ET entre en collision avec un autre chemin ; ceci peut resulter en des marqueurs de conflit imbriqués."
+msgstr ""
+"CONFLIT (renommage au sein d'une collision) : lre renommage de %s -> %s a "
+"des conflits de contenu ET entre en collision avec un autre chemin ; ceci "
+"peut resulter en des marqueurs de conflit imbriqués."
 
-#: merge-ort.c:2033 merge-ort.c:2057
+#: merge-ort.c:2066 merge-ort.c:2090
 #, c-format
 msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
-msgstr "CONFLIT (renommage/suppression) : Renommage de %s en %s dans %s mais supprimé dans %s."
+msgstr ""
+"CONFLIT (renommage/suppression) : Renommage de %s en %s dans %s mais "
+"supprimé dans %s."
 
-#: merge-ort.c:2683
+#: merge-ort.c:2735
 #, c-format
 msgid ""
 "CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
 "%s instead."
-msgstr "CONFLIT (fichier/répertoire) : répertoire au milieu de %s depuis %s ; déplacement dans %s à la place."
+msgstr ""
+"CONFLIT (fichier/répertoire) : répertoire au milieu de %s depuis %s ; "
+"déplacement dans %s à la place."
 
-#: merge-ort.c:2756
+#: merge-ort.c:2808
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed %s "
 "of them so each can be recorded somewhere."
-msgstr "CONFLIT (types différents) : %s a des types différents des deux côtés ; renommé la version %s de manière à pouvoir enregistrer les deux quelque part."
+msgstr ""
+"CONFLIT (types différents) : %s a des types différents des deux côtés ; "
+"renommé la version %s de manière à pouvoir enregistrer les deux quelque part."
 
-#: merge-ort.c:2760
+#: merge-ort.c:2812
 msgid "both"
 msgstr "les deux"
 
-#: merge-ort.c:2760
+#: merge-ort.c:2812
 msgid "one"
 msgstr "un"
 
-#: merge-ort.c:2855 merge-recursive.c:3052
+#: merge-ort.c:2907 merge-recursive.c:3052
 msgid "content"
 msgstr "contenu"
 
-#: merge-ort.c:2857 merge-recursive.c:3056
+#: merge-ort.c:2909 merge-recursive.c:3056
 msgid "add/add"
 msgstr "ajout/ajout"
 
-#: merge-ort.c:2859 merge-recursive.c:3101
+#: merge-ort.c:2911 merge-recursive.c:3101
 msgid "submodule"
 msgstr "sous-module"
 
-#: merge-ort.c:2861 merge-recursive.c:3102
+#: merge-ort.c:2913 merge-recursive.c:3102
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "CONFLIT (%s) : Conflit de fusion dans %s"
 
-#: merge-ort.c:2886
+#: merge-ort.c:2938
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
 "of %s left in tree."
-msgstr "CONFLIT (modification/suppression) : %s supprimé dans %s et modifié dans %s. Version %s de %s laissée dans l'arbre."
+msgstr ""
+"CONFLIT (modification/suppression) : %s supprimé dans %s et modifié dans %s. "
+"Version %s de %s laissée dans l'arbre."
 
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
-#: merge-ort.c:3354
+#: merge-ort.c:3406
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
 msgstr "échec de collecte l'information de fusion pour les arbres %s, %s, %s"
@@ -5298,118 +5321,108 @@ msgstr "impossible de lire le cache"
 msgid "unable to write new index file"
 msgstr "impossible d'écrire le nouveau fichier d'index"
 
-#: midx.c:80
+#: midx.c:62
+msgid "multi-pack-index OID fanout is of the wrong size"
+msgstr "l'étalement de l'OID d'index multi-paquet n'a pas la bonne taille"
+
+#: midx.c:93
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "le fichier d'index multi-paquet %s est trop petit"
 
-#: midx.c:96
+#: midx.c:109
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr ""
 "la signature de l'index multi-paquet 0x%08x ne correspond pas à la signature "
 "0x%08x"
 
-#: midx.c:101
+#: midx.c:114
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "la version d'index multi-paquet %d n'est pas reconnue"
 
-#: midx.c:106
+#: midx.c:119
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr ""
 "la version d'empreinte d'index multi-paquet %u ne correspond pas à la "
 "version %u"
 
-#: midx.c:123
-msgid "invalid chunk offset (too large)"
-msgstr "décalage de section invalide (trop grand)"
-
-#: midx.c:147
-msgid "terminating multi-pack-index chunk id appears earlier than expected"
-msgstr ""
-"identifiant de terminaison de tronçon d'index multi-paquet terminant "
-"apparaît plus tôt qu'attendu"
-
-#: midx.c:160
+#: midx.c:136
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "index multi-paquet manque de tronçon de nom de paquet"
 
-#: midx.c:162
+#: midx.c:138
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "index multi-paquet manque de tronçon de d'étalement OID requis"
 
-#: midx.c:164
+#: midx.c:140
 msgid "multi-pack-index missing required OID lookup chunk"
-msgstr "index multi-paquet manque de tronçon de recherche OID"
+msgstr "index multi-paquet manque de tronçon de recherche OID requis"
 
-#: midx.c:166
+#: midx.c:142
 msgid "multi-pack-index missing required object offsets chunk"
-msgstr "index multi-paquet manque de tronçon de décalage d'objet"
+msgstr "index multi-paquet manque de tronçon de décalage d'objet requis"
 
-#: midx.c:180
+#: midx.c:158
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr ""
 "index multi-paquet les noms de paquets sont en désordre : '%s' avant '%s'"
 
-#: midx.c:223
+#: midx.c:202
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr "mauvais pack-int-id : %u (%u paquets au total)"
 
-#: midx.c:273
+#: midx.c:252
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr ""
 "l'index multi-paquet stock un décalage en 64-bit, mais off_t est trop petit"
 
-#: midx.c:480
+#: midx.c:467
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "échec de l'ajout du fichier paquet '%s'"
 
-#: midx.c:486
+#: midx.c:473
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "échec à l'ouverture du fichier paquet '%s'"
 
-#: midx.c:546
+#: midx.c:533
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "échec de localisation de l'objet %d dans le fichier paquet"
 
-#: midx.c:846
+#: midx.c:821
 msgid "Adding packfiles to multi-pack-index"
 msgstr "Ajout de fichiers paquet à un index multi-paquet"
 
-#: midx.c:879
+#: midx.c:855
 #, c-format
 msgid "did not see pack-file %s to drop"
 msgstr "fichier paquet à éliminer %s non trouvé"
 
-#: midx.c:931
+#: midx.c:904
 msgid "no pack files to index."
 msgstr "Aucun fichier paquet à l'index."
 
-#: midx.c:982
-msgid "Writing chunks to multi-pack-index"
-msgstr "Écriture des sections dans l'index multi-paquet"
-
-#: midx.c:1060
+#: midx.c:965
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "échec du nettoyage de l'index de multi-paquet à %s"
 
-#: midx.c:1116
+#: midx.c:1021
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr "le fichier d'index multi-paquet existe mais n'a pu être analysé"
 
-#: midx.c:1124
+#: midx.c:1029
 msgid "Looking for referenced packfiles"
 msgstr "Recherche de fichiers paquets référencés"
 
-#: midx.c:1139
+#: midx.c:1044
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
@@ -5417,55 +5430,55 @@ msgstr ""
 "étalement oid en désordre : étalement[%d] = %<PRIx32> > %<PRIx32> = "
 "étalement[%d]"
 
-#: midx.c:1144
+#: midx.c:1049
 msgid "the midx contains no oid"
 msgstr "le midx ne contient aucun oid"
 
-#: midx.c:1153
+#: midx.c:1058
 msgid "Verifying OID order in multi-pack-index"
 msgstr "Vérification de l'ordre des OID dans l'index multi-paquet"
 
-#: midx.c:1162
+#: midx.c:1067
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr "recherche d'oid en désordre : oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1182
+#: midx.c:1087
 msgid "Sorting objects by packfile"
 msgstr "Classement des objets par fichier paquet"
 
-#: midx.c:1189
+#: midx.c:1094
 msgid "Verifying object offsets"
 msgstr "Vérification des décalages des objets"
 
-#: midx.c:1205
+#: midx.c:1110
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "échec de la lecture de l'élément de cache pour oid[%d] = %s"
 
-#: midx.c:1211
+#: midx.c:1116
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "impossible de lire le fichier paquet %s"
 
-#: midx.c:1220
+#: midx.c:1125
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr "décalage d'objet incorrect pour oid[%d] = %s : %<PRIx64> != %<PRIx64>"
 
-#: midx.c:1245
+#: midx.c:1150
 msgid "Counting referenced objects"
 msgstr "Comptage des objets référencés"
 
-#: midx.c:1255
+#: midx.c:1160
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "Recherche et effacement des fichiers paquets non-référencés"
 
-#: midx.c:1446
+#: midx.c:1351
 msgid "could not start pack-objects"
 msgstr "Impossible de démarrer le groupement d'objets"
 
-#: midx.c:1466
+#: midx.c:1371
 msgid "could not finish pack-objects"
 msgstr "Impossible de finir le groupement d'objets"
 
@@ -5956,7 +5969,7 @@ msgstr "stat impossible de %s"
 msgid "failed to make %s readable"
 msgstr "échec de rendre %s lisible"
 
-#: pack-write.c:502
+#: pack-write.c:508
 #, c-format
 msgid "could not write '%s' promisor file"
 msgstr "impossible d'écrire le fichier de prometteur '%s'"
@@ -6228,11 +6241,11 @@ msgstr "erreur de protocole : mauvaise longueur de ligne %d"
 msgid "remote error: %s"
 msgstr "erreur distante : %s"
 
-#: preload-index.c:119
+#: preload-index.c:125
 msgid "Refreshing index"
 msgstr "Rafraîchissement de l'index"
 
-#: preload-index.c:138
+#: preload-index.c:144
 #, c-format
 msgid "unable to create threaded lstat: %s"
 msgstr "impossible de créer le lstat en fil : %s"
@@ -6347,11 +6360,11 @@ msgstr "fstat de '%s' impossible"
 msgid "'%s' appears as both a file and as a directory"
 msgstr "'%s' existe à la fois comme un fichier et un répertoire"
 
-#: read-cache.c:1524
+#: read-cache.c:1532
 msgid "Refresh index"
 msgstr "Rafraîchir l'index"
 
-#: read-cache.c:1639
+#: read-cache.c:1657
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -6360,7 +6373,7 @@ msgstr ""
 "version d'index renseignée, mais la valeur est invalide.\n"
 "Utilisation de la version %i"
 
-#: read-cache.c:1649
+#: read-cache.c:1667
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -6369,55 +6382,55 @@ msgstr ""
 "GIT_INDEX_VERSION est renseigné, mais la valeur est invalide.\n"
 "Utilisation de la version %i"
 
-#: read-cache.c:1705
+#: read-cache.c:1723
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr "signature incorrecte 0x%08x"
 
-#: read-cache.c:1708
+#: read-cache.c:1726
 #, c-format
 msgid "bad index version %d"
 msgstr "mauvaise version d'index %d"
 
-#: read-cache.c:1717
+#: read-cache.c:1735
 msgid "bad index file sha1 signature"
 msgstr "mauvaise signature sha1 d'index"
 
-#: read-cache.c:1747
+#: read-cache.c:1765
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr "l'index utilise l'extension %.4s qui n'est pas comprise"
 
-#: read-cache.c:1749
+#: read-cache.c:1767
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr "extension %.4s ignorée"
 
-#: read-cache.c:1786
+#: read-cache.c:1804
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr "format d'entrée d'index inconnu 0x%08x"
 
-#: read-cache.c:1802
+#: read-cache.c:1820
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "champ de nom malformé dans l'index, près du chemin '%s'"
 
-#: read-cache.c:1859
+#: read-cache.c:1877
 msgid "unordered stage entries in index"
 msgstr "entrées de préparation non ordonnées dans l'index"
 
-#: read-cache.c:1862
+#: read-cache.c:1880
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr "entrées multiples de préparation pour le fichier fusionné '%s'"
 
-#: read-cache.c:1865
+#: read-cache.c:1883
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr "entrées de préparation non ordonnées pour '%s'"
 
-#: read-cache.c:1971 read-cache.c:2262 rerere.c:549 rerere.c:583 rerere.c:1095
+#: read-cache.c:1989 read-cache.c:2280 rerere.c:549 rerere.c:583 rerere.c:1095
 #: submodule.c:1634 builtin/add.c:546 builtin/check-ignore.c:181
 #: builtin/checkout.c:504 builtin/checkout.c:690 builtin/clean.c:991
 #: builtin/commit.c:364 builtin/diff-tree.c:122 builtin/grep.c:505
@@ -6426,82 +6439,82 @@ msgstr "entrées de préparation non ordonnées pour '%s'"
 msgid "index file corrupt"
 msgstr "fichier d'index corrompu"
 
-#: read-cache.c:2115
+#: read-cache.c:2133
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr "impossible de créer le fil load_cache_entries : %s"
 
-#: read-cache.c:2128
+#: read-cache.c:2146
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr "impossible de joindre le fil load_cach_entries : %s"
 
-#: read-cache.c:2161
+#: read-cache.c:2179
 #, c-format
 msgid "%s: index file open failed"
 msgstr "%s : l'ouverture du fichier d'index a échoué"
 
-#: read-cache.c:2165
+#: read-cache.c:2183
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr "%s : impossible de faire un stat sur l'index ouvert"
 
-#: read-cache.c:2169
+#: read-cache.c:2187
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr "%s : fichier d'index plus petit qu'attendu"
 
-#: read-cache.c:2173
+#: read-cache.c:2191
 #, c-format
 msgid "%s: unable to map index file"
 msgstr "%s : impossible de mapper le fichier d'index"
 
-#: read-cache.c:2215
+#: read-cache.c:2233
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr "impossible de créer le fil load_index_extensions : %s"
 
-#: read-cache.c:2242
+#: read-cache.c:2260
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr "impossible de joindre le fil load_index_extensions : %s"
 
-#: read-cache.c:2274
+#: read-cache.c:2292
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr "impossible de rafraîchir l'index partagé '%s'"
 
-#: read-cache.c:2321
+#: read-cache.c:2339
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr "index cassé, %s attendu dans %s, %s obtenu"
 
-#: read-cache.c:3017 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1141
+#: read-cache.c:3035 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1141
 #, c-format
 msgid "could not close '%s'"
 msgstr "impossible de fermer '%s'"
 
-#: read-cache.c:3120 sequencer.c:2487 sequencer.c:4239
+#: read-cache.c:3138 sequencer.c:2487 sequencer.c:4239
 #, c-format
 msgid "could not stat '%s'"
 msgstr "stat impossible de '%s'"
 
-#: read-cache.c:3133
+#: read-cache.c:3151
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "impossible d'ouvrir le répertoire git : %s"
 
-#: read-cache.c:3145
+#: read-cache.c:3163
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "échec lors de l'unlink : %s"
 
-#: read-cache.c:3170
+#: read-cache.c:3188
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr "impossible de régler les bits de droit de '%s'"
 
-#: read-cache.c:3319
+#: read-cache.c:3337
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr "%s : impossible de revenir à l'étape 0"
@@ -6680,243 +6693,248 @@ msgstr "en retard de %d"
 msgid "ahead %d, behind %d"
 msgstr "en avance de %d, en retard de %d"
 
-#: ref-filter.c:169
+#: ref-filter.c:175
 #, c-format
 msgid "expected format: %%(color:<color>)"
 msgstr "format attendu : %%(color:<couleur>)"
 
-#: ref-filter.c:171
+#: ref-filter.c:177
 #, c-format
 msgid "unrecognized color: %%(color:%s)"
 msgstr "couleur non reconnue : %%(color:%s)"
 
-#: ref-filter.c:193
+#: ref-filter.c:199
 #, c-format
 msgid "Integer value expected refname:lstrip=%s"
 msgstr "Valeur entière attendue refname:lstrip=%s"
 
-#: ref-filter.c:197
+#: ref-filter.c:203
 #, c-format
 msgid "Integer value expected refname:rstrip=%s"
 msgstr "Valeur entière attendue refname:rstrip=%s"
 
-#: ref-filter.c:199
+#: ref-filter.c:205
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
 msgstr "argument %%(%s) non reconnu : %s"
 
-#: ref-filter.c:254
+#: ref-filter.c:260
 #, c-format
 msgid "%%(objecttype) does not take arguments"
 msgstr "%%(objecttype) n'accepte pas d'argument"
 
-#: ref-filter.c:276
+#: ref-filter.c:282
 #, c-format
 msgid "unrecognized %%(objectsize) argument: %s"
 msgstr "argument %%(objectsize) non reconnu : %s"
 
-#: ref-filter.c:284
+#: ref-filter.c:290
 #, c-format
 msgid "%%(deltabase) does not take arguments"
 msgstr "%%(deltabase) n'accepte pas d'argument"
 
-#: ref-filter.c:296
+#: ref-filter.c:302
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr "%%(body) n'accepte pas d'argument"
 
-#: ref-filter.c:309
+#: ref-filter.c:315
 #, c-format
 msgid "unrecognized %%(subject) argument: %s"
 msgstr "argument %%(subject) non reconnu : %s"
 
-#: ref-filter.c:330
+#: ref-filter.c:334
+#, c-format
+msgid "expected %%(trailers:key=<value>)"
+msgstr "%%(trailers:key=<value>) attendu"
+
+#: ref-filter.c:336
 #, c-format
 msgid "unknown %%(trailers) argument: %s"
 msgstr "argument %%(trailers) inconnu : %s"
 
-#: ref-filter.c:363
+#: ref-filter.c:367
 #, c-format
 msgid "positive value expected contents:lines=%s"
 msgstr "valeur positive attendue contents:lines=%s"
 
-#: ref-filter.c:365
+#: ref-filter.c:369
 #, c-format
 msgid "unrecognized %%(contents) argument: %s"
 msgstr "argument %%(contents) non reconnu : %s"
 
-#: ref-filter.c:380
+#: ref-filter.c:384
 #, c-format
 msgid "positive value expected '%s' in %%(%s)"
 msgstr "valeur positive attendue '%s' dans %%(%s)"
 
-#: ref-filter.c:384
+#: ref-filter.c:388
 #, c-format
 msgid "unrecognized argument '%s' in %%(%s)"
 msgstr "argument '%s' non reconnu dans %%(%s)"
 
-#: ref-filter.c:398
+#: ref-filter.c:402
 #, c-format
 msgid "unrecognized email option: %s"
 msgstr "option de courriel non reconnue : %s"
 
-#: ref-filter.c:428
+#: ref-filter.c:432
 #, c-format
 msgid "expected format: %%(align:<width>,<position>)"
 msgstr "format attendu : %%(align:<largeur>,<position>)"
 
-#: ref-filter.c:440
+#: ref-filter.c:444
 #, c-format
 msgid "unrecognized position:%s"
 msgstr "position non reconnue : %s"
 
-#: ref-filter.c:447
+#: ref-filter.c:451
 #, c-format
 msgid "unrecognized width:%s"
 msgstr "largeur non reconnue : %s"
 
-#: ref-filter.c:456
+#: ref-filter.c:460
 #, c-format
 msgid "unrecognized %%(align) argument: %s"
 msgstr "argument %%(align) non reconnu : %s"
 
-#: ref-filter.c:464
+#: ref-filter.c:468
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr "valeur positive attendue avec l'atome %%(align)"
 
-#: ref-filter.c:482
+#: ref-filter.c:486
 #, c-format
 msgid "unrecognized %%(if) argument: %s"
 msgstr "argument %%(if) non reconnu : %s"
 
-#: ref-filter.c:584
+#: ref-filter.c:588
 #, c-format
 msgid "malformed field name: %.*s"
 msgstr "nom de champ malformé %.*s"
 
-#: ref-filter.c:611
+#: ref-filter.c:615
 #, c-format
 msgid "unknown field name: %.*s"
 msgstr "nom de champ inconnu : %.*s"
 
-#: ref-filter.c:615
+#: ref-filter.c:619
 #, c-format
 msgid ""
 "not a git repository, but the field '%.*s' requires access to object data"
 msgstr ""
 "pas un dépôt git, mais le champ '%.*s' nécessite l'accès aux données d'objet"
 
-#: ref-filter.c:739
+#: ref-filter.c:743
 #, c-format
 msgid "format: %%(if) atom used without a %%(then) atom"
 msgstr "format : atome %%(if) utilisé sans un atome %%(then)"
 
-#: ref-filter.c:802
+#: ref-filter.c:806
 #, c-format
 msgid "format: %%(then) atom used without an %%(if) atom"
 msgstr "format : atome %%(then) utilisé sans un atome %%(if)"
 
-#: ref-filter.c:804
+#: ref-filter.c:808
 #, c-format
 msgid "format: %%(then) atom used more than once"
 msgstr "format : atome %%(then) utilisé plus d'une fois"
 
-#: ref-filter.c:806
+#: ref-filter.c:810
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr "format: atome %%(then) utilisé après %%(else)"
 
-#: ref-filter.c:834
+#: ref-filter.c:838
 #, c-format
 msgid "format: %%(else) atom used without an %%(if) atom"
 msgstr "format : atome %%(else) utilisé sans un atome %%(if)"
 
-#: ref-filter.c:836
+#: ref-filter.c:840
 #, c-format
 msgid "format: %%(else) atom used without a %%(then) atom"
 msgstr "format : atome %%(else) utilisé sans un atome %%(then)"
 
-#: ref-filter.c:838
+#: ref-filter.c:842
 #, c-format
 msgid "format: %%(else) atom used more than once"
 msgstr "format : atome %%(else) utilisé plus d'une fois"
 
-#: ref-filter.c:853
+#: ref-filter.c:857
 #, c-format
 msgid "format: %%(end) atom used without corresponding atom"
 msgstr "format : atome %%(end) utilisé sans atome correspondant"
 
-#: ref-filter.c:910
+#: ref-filter.c:914
 #, c-format
 msgid "malformed format string %s"
 msgstr "Chaîne de formatage mal formée %s"
 
-#: ref-filter.c:1551
+#: ref-filter.c:1555
 #, c-format
 msgid "(no branch, rebasing %s)"
 msgstr "(aucune branche, rebasage de %s)"
 
-#: ref-filter.c:1554
+#: ref-filter.c:1558
 #, c-format
 msgid "(no branch, rebasing detached HEAD %s)"
 msgstr "(aucune branche, rebasage de la HEAD détachée %s)"
 
-#: ref-filter.c:1557
+#: ref-filter.c:1561
 #, c-format
 msgid "(no branch, bisect started on %s)"
 msgstr "(aucune branche, bisect a démarré sur %s)"
 
-#: ref-filter.c:1561
+#: ref-filter.c:1565
 #, c-format
 msgid "(HEAD detached at %s)"
 msgstr "(HEAD détachée sur %s)"
 
-#: ref-filter.c:1564
+#: ref-filter.c:1568
 #, c-format
 msgid "(HEAD detached from %s)"
 msgstr "(HEAD détachée depuis %s)"
 
-#: ref-filter.c:1567
+#: ref-filter.c:1571
 msgid "(no branch)"
 msgstr "(aucune branche)"
 
-#: ref-filter.c:1599 ref-filter.c:1808
+#: ref-filter.c:1603 ref-filter.c:1812
 #, c-format
 msgid "missing object %s for %s"
 msgstr "objet manquant %s pour %s"
 
-#: ref-filter.c:1609
+#: ref-filter.c:1613
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr "échec de parse_object_buffer sur %s pour %s"
 
-#: ref-filter.c:1992
+#: ref-filter.c:1996
 #, c-format
 msgid "malformed object at '%s'"
 msgstr "objet malformé à '%s'"
 
-#: ref-filter.c:2081
+#: ref-filter.c:2085
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr "réf avec un nom cassé %s ignoré"
 
-#: ref-filter.c:2086 refs.c:676
+#: ref-filter.c:2090 refs.c:676
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "réf cassé %s ignoré"
 
-#: ref-filter.c:2426
+#: ref-filter.c:2430
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "format: atome %%(end) manquant"
 
-#: ref-filter.c:2525
+#: ref-filter.c:2529
 #, c-format
 msgid "malformed object name %s"
 msgstr "nom d'objet malformé %s"
 
-#: ref-filter.c:2530
+#: ref-filter.c:2534
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "l'option '%s' doit pointer sur un commit"
@@ -9582,7 +9600,8 @@ msgstr "impossible de localiser le dépôt ; .git n'est pas un fichier"
 
 #: worktree.c:737
 msgid "unable to locate repository; .git file does not reference a repository"
-msgstr "impossible de localiser le dépôt ; .git ne fait pas référence à un dépôt"
+msgstr ""
+"impossible de localiser le dépôt ; .git ne fait pas référence à un dépôt"
 
 #: worktree.c:741
 msgid "unable to locate repository; .git file broken"
@@ -11206,15 +11225,20 @@ msgstr "référence à ignorer %s introuvable"
 
 #: builtin/blame.c:867
 msgid "show blame entries as we find them, incrementally"
-msgstr "montrer les éléments de blâme au fur et à mesure de leur découverte, de manière incrémentale"
+msgstr ""
+"montrer les éléments de blâme au fur et à mesure de leur découverte, de "
+"manière incrémentale"
 
 #: builtin/blame.c:868
 msgid "do not show object names of boundary commits (Default: off)"
-msgstr "ne pas montrer les noms des objets pour les commits de limite (Défaut : désactivé)"
+msgstr ""
+"ne pas montrer les noms des objets pour les commits de limite (Défaut : "
+"désactivé)"
 
 #: builtin/blame.c:869
 msgid "do not treat root commits as boundaries (Default: off)"
-msgstr "ne pas traiter les commits racine comme des limites (Défaut : désactivé)"
+msgstr ""
+"ne pas traiter les commits racine comme des limites (Défaut : désactivé)"
 
 #: builtin/blame.c:870
 msgid "show work cost statistics"
@@ -11294,11 +11318,13 @@ msgstr "colorier les lignes par âge"
 
 #: builtin/blame.c:887
 msgid "spend extra cycles to find better match"
-msgstr "dépenser des cycles supplémentaires pour trouver une meilleure correspondance"
+msgstr ""
+"dépenser des cycles supplémentaires pour trouver une meilleure correspondance"
 
 #: builtin/blame.c:888
 msgid "use revisions from <file> instead of calling git-rev-list"
-msgstr "utiliser les révisions du fichier <fichier> au lieu d'appeler git-rev-list"
+msgstr ""
+"utiliser les révisions du fichier <fichier> au lieu d'appeler git-rev-list"
 
 #: builtin/blame.c:889
 msgid "use <file>'s contents as the final image"
@@ -11322,7 +11348,9 @@ msgstr "plage"
 
 #: builtin/blame.c:893
 msgid "process only line range <start>,<end> or function :<funcname>"
-msgstr "traiter seulement l'intervalle de ligne <début>,<fin> ou la fonction : <nom-de-fonction>"
+msgstr ""
+"traiter seulement l'intervalle de ligne <début>,<fin> ou la fonction : <nom-"
+"de-fonction>"
 
 #: builtin/blame.c:945
 msgid "--progress can't be used with --incremental or porcelain formats"
@@ -14809,7 +14837,9 @@ msgstr "convertit <depuis> en <vers> dans la sortie anonymisée"
 
 #: builtin/fast-export.c:1229
 msgid "reference parents which are not in fast-export stream by object id"
-msgstr "référencer les parents qui ne sont pas dans le flux d'export rapide par id d'objet"
+msgstr ""
+"référencer les parents qui ne sont pas dans le flux d'export rapide par id "
+"d'objet"
 
 #: builtin/fast-export.c:1231
 msgid "show original object ids of blobs/commits"
@@ -15891,7 +15921,7 @@ msgstr "nombre de fils spécifié invalide (%d) pour %s"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:285 builtin/index-pack.c:1589 builtin/index-pack.c:1792
+#: builtin/grep.c:285 builtin/index-pack.c:1589 builtin/index-pack.c:1808
 #: builtin/pack-objects.c:2944
 #, c-format
 msgid "no threads support, ignoring %s"
@@ -16568,38 +16598,38 @@ msgid_plural "chain length = %d: %lu objects"
 msgstr[0] "longueur chaînée = %d : %lu objet"
 msgstr[1] "longueur chaînée = %d : %lu objets"
 
-#: builtin/index-pack.c:1749
+#: builtin/index-pack.c:1765
 msgid "Cannot come back to cwd"
 msgstr "Impossible de revenir au répertoire de travail courant"
 
-#: builtin/index-pack.c:1803 builtin/index-pack.c:1806
-#: builtin/index-pack.c:1822 builtin/index-pack.c:1826
+#: builtin/index-pack.c:1819 builtin/index-pack.c:1822
+#: builtin/index-pack.c:1838 builtin/index-pack.c:1842
 #, c-format
 msgid "bad %s"
 msgstr "mauvais %s"
 
-#: builtin/index-pack.c:1832 builtin/init-db.c:392 builtin/init-db.c:625
+#: builtin/index-pack.c:1848 builtin/init-db.c:392 builtin/init-db.c:625
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "algorithme d'empreinte inconnu '%s'"
 
-#: builtin/index-pack.c:1851
+#: builtin/index-pack.c:1867
 msgid "--fix-thin cannot be used without --stdin"
 msgstr "--fix-thin ne peut pas être utilisé sans --stdin"
 
-#: builtin/index-pack.c:1853
+#: builtin/index-pack.c:1869
 msgid "--stdin requires a git repository"
 msgstr "--stdin requiert un dépôt git"
 
-#: builtin/index-pack.c:1855
+#: builtin/index-pack.c:1871
 msgid "--object-format cannot be used with --stdin"
 msgstr "--object-format ne peut pas être utilisé avec --stdin"
 
-#: builtin/index-pack.c:1870
+#: builtin/index-pack.c:1886
 msgid "--verify with no packfile name given"
 msgstr "--verify sans nom de fichier paquet donné"
 
-#: builtin/index-pack.c:1936 builtin/unpack-objects.c:582
+#: builtin/index-pack.c:1956 builtin/unpack-objects.c:582
 msgid "fsck error in pack objects"
 msgstr "erreur de fsck dans les objets paquets"
 
@@ -18625,7 +18655,9 @@ msgstr ""
 msgid ""
 "write_reuse_object: could not locate %s, expected at offset %<PRIuMAX> in "
 "pack %s"
-msgstr "write_reuse_object : impossible de localiser %s, attendu à l'offset %<PRIuMAX> dans le paquet %s"
+msgstr ""
+"write_reuse_object : impossible de localiser %s, attendu à l'offset "
+"%<PRIuMAX> dans le paquet %s"
 
 #: builtin/pack-objects.c:448
 #, c-format
@@ -21852,7 +21884,9 @@ msgstr "trier la sortie sur le nombre de validations par auteur"
 
 #: builtin/shortlog.c:356
 msgid "suppress commit descriptions, only provides commit count"
-msgstr "supprimer les descriptions de validation, fournit seulement le nombre de validations"
+msgstr ""
+"supprimer les descriptions de validation, fournit seulement le nombre de "
+"validations"
 
 #: builtin/shortlog.c:358
 msgid "show the email address of each author"
@@ -22244,7 +22278,8 @@ msgid ""
 "            %s -> %s\n"
 "         to make room.\n"
 msgstr ""
-"AVERTISSEMENT : un fichier non-suivi en travers d'un fichier suivi ! Renommage\n"
+"AVERTISSEMENT : un fichier non-suivi en travers d'un fichier suivi ! "
+"Renommage\n"
 "            %s -> %s\n"
 "         pour faire de la place.\n"
 
@@ -22474,7 +22509,8 @@ msgstr ""
 
 #: builtin/submodule--helper.c:565
 msgid "suppress output of entering each submodule command"
-msgstr "supprimer la sortie lors de l'entrée dans chaque commande de sous-module"
+msgstr ""
+"supprimer la sortie lors de l'entrée dans chaque commande de sous-module"
 
 #: builtin/submodule--helper.c:567 builtin/submodule--helper.c:888
 #: builtin/submodule--helper.c:1487
@@ -22551,7 +22587,9 @@ msgstr "supprimer la sortie d'état du sous-module"
 msgid ""
 "use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
-msgstr "utiliser le commit stocké dans l'index au lieu de celui stocké dans la HEAD du sous-module"
+msgstr ""
+"utiliser le commit stocké dans l'index au lieu de celui stocké dans la HEAD "
+"du sous-module"
 
 #: builtin/submodule--helper.c:893
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
@@ -22639,7 +22677,8 @@ msgstr "échec de mise à jour du dépôt distant pour le sous-module '%s'"
 
 #: builtin/submodule--helper.c:1485
 msgid "suppress output of synchronizing submodule url"
-msgstr "supprimer la sortie lors de la synchronisation de l'URL d'un sous-module"
+msgstr ""
+"supprimer la sortie lors de la synchronisation de l'URL d'un sous-module"
 
 #: builtin/submodule--helper.c:1492
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
@@ -22686,7 +22725,9 @@ msgstr "Sous-module '%s' (%s) non enregistré pour le chemin '%s'\n"
 
 #: builtin/submodule--helper.c:1624
 msgid "remove submodule working trees even if they contain local changes"
-msgstr "éliminer les arbres de travail des sous-modules même s'ils contiennent des modifications locales"
+msgstr ""
+"éliminer les arbres de travail des sous-modules même s'ils contiennent des "
+"modifications locales"
 
 #: builtin/submodule--helper.c:1625
 msgid "unregister all submodules"
@@ -23714,7 +23755,8 @@ msgstr "afficher les annotations étendues et les raisons, si disponible"
 
 #: builtin/worktree.c:682
 msgid "add 'prunable' annotation to worktrees older than <time>"
-msgstr "ajouter l'annotation 'prunable' aux arbres de travail plus vieux que <temps>"
+msgstr ""
+"ajouter l'annotation 'prunable' aux arbres de travail plus vieux que <temps>"
 
 #: builtin/worktree.c:691
 msgid "--verbose and --porcelain are mutually exclusive"
@@ -23871,14 +23913,22 @@ msgstr "écrire l'objet arbre pour un sous-répertoire <préfixe>"
 msgid "only useful for debugging"
 msgstr "seulement utile pour le débogage"
 
-#: http-fetch.c:114
+#: http-fetch.c:118
 #, c-format
 msgid "argument to --packfile must be a valid hash (got '%s')"
 msgstr "l'argument de --packfile doit être une empreinte valide ('%s' reçu)"
 
-#: http-fetch.c:122
+#: http-fetch.c:128
 msgid "not a git repository"
 msgstr "pas un dépôt git"
+
+#: http-fetch.c:134
+msgid "--packfile requires --index-pack-args"
+msgstr "--packfile nécessite --index-pack-args"
+
+#: http-fetch.c:143
+msgid "--index-pack-args can only be used with --packfile"
+msgstr "--index-pack-args ne peut être utilisé qu'avec --packfile"
 
 #: t/helper/test-fast-rebase.c:141
 msgid "unhandled options"
@@ -23916,10 +23966,13 @@ msgid ""
 "           <command> [<args>]"
 msgstr ""
 "git [--version] [--help] [-C <chemin>] [-c <nom>=<valeur>]\n"
-"           [--exec-path[=<chemin>]] [--html-path] [--man-path] [--info-path]\n"
-"           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--bare]\n"
+"           [--exec-path[=<chemin>]] [--html-path] [--man-path] [--info-"
+"path]\n"
+"           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--"
+"bare]\n"
 "           [--git-dir=<chemin>] [--work-tree=<chemin>] [--namespace=<nom>]\n"
-"           [--super-prefix=<chemin>] [--config-env=<nom>=<variable-d-environnement>]\n"
+"           [--super-prefix=<chemin>] [--config-env=<nom>=<variable-d-"
+"environnement>]\n"
 "           <commande> [<args>]"
 
 #: git.c:36
@@ -24947,7 +25000,8 @@ msgstr "Spécifie les fichiers non-suivis à ignorer intentionnellement"
 
 #: command-list.h:209
 msgid "Map author/committer names and/or E-Mail addresses"
-msgstr "Fait correspondre les noms d'auteur/validateur avec les adresses de courriel"
+msgstr ""
+"Fait correspondre les noms d'auteur/validateur avec les adresses de courriel"
 
 #: command-list.h:210
 msgid "Defining submodule properties"
@@ -26334,3 +26388,28 @@ msgstr "%s sauté avec un suffix de sauvegarde '%s'.\n"
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Souhaitez-vous réellement envoyer %s ?[y|N] : "
+
+#~ msgid "repository contains replace objects; skipping commit-graph"
+#~ msgstr ""
+#~ "le dépôt contient des object de remplacement ; saut du graphe de commits"
+
+#~ msgid "repository contains (deprecated) grafts; skipping commit-graph"
+#~ msgstr ""
+#~ "le dépôt contient des greffes (déconseillées) ; saut du graphe de commits"
+
+#~ msgid "repository is shallow; skipping commit-graph"
+#~ msgstr "le dépôt est superficiel ; saut du graphe de commit"
+
+#, c-format
+#~ msgid "commit-graph improper chunk offset %08x%08x"
+#~ msgstr "décalage de bloc %08x%08x du graphe de commit inadéquat"
+
+#, c-format
+#~ msgid "commit-graph chunk id %08x appears multiple times"
+#~ msgstr "l'id de bloc de graphe de commit %08x apparaît des multiples fois"
+
+#~ msgid "invalid chunk offset (too large)"
+#~ msgstr "décalage de section invalide (trop grand)"
+
+#~ msgid "Writing chunks to multi-pack-index"
+#~ msgstr "Écriture des sections dans l'index multi-paquet"

--- a/po/git.pot
+++ b/po/git.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-02-26 22:09+0800\n"
+"POT-Creation-Date: 2021-03-04 22:41+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -979,7 +979,7 @@ msgstr ""
 msgid "cannot checkout %s"
 msgstr ""
 
-#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:73 pack-revindex.c:213
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:86 pack-revindex.c:213
 #: setup.c:308
 #, c-format
 msgid "failed to read %s"
@@ -1690,7 +1690,7 @@ msgstr ""
 msgid "--reverse and --first-parent together require specified latest commit"
 msgstr ""
 
-#: blame.c:2821 bundle.c:213 ref-filter.c:2202 remote.c:2041 sequencer.c:2146
+#: blame.c:2821 bundle.c:213 ref-filter.c:2206 remote.c:2041 sequencer.c:2146
 #: sequencer.c:4641 submodule.c:856 builtin/commit.c:1045 builtin/log.c:411
 #: builtin/log.c:1016 builtin/log.c:1624 builtin/log.c:2045 builtin/log.c:2335
 #: builtin/merge.c:424 builtin/pack-objects.c:3395 builtin/pack-objects.c:3410
@@ -1934,273 +1934,270 @@ msgstr ""
 msgid "index-pack died"
 msgstr ""
 
+#: chunk-format.c:113
+msgid "terminating chunk id appears earlier than expected"
+msgstr ""
+
+#: chunk-format.c:122
+#, c-format
+msgid "improper chunk offset(s) %<PRIx64> and %<PRIx64>"
+msgstr ""
+
+#: chunk-format.c:129
+#, c-format
+msgid "duplicate chunk ID %<PRIx32> found"
+msgstr ""
+
+#: chunk-format.c:143
+#, c-format
+msgid "final chunk has non-zero id %<PRIx32>"
+msgstr ""
+
 #: color.c:329
 #, c-format
 msgid "invalid color value: %.*s"
 msgstr ""
 
-#: commit-graph.c:198 midx.c:47
+#: commit-graph.c:197 midx.c:46
 msgid "invalid hash version"
 msgstr ""
 
-#: commit-graph.c:219
-msgid "repository contains replace objects; skipping commit-graph"
-msgstr ""
-
-#: commit-graph.c:228
-msgid "repository contains (deprecated) grafts; skipping commit-graph"
-msgstr ""
-
-#: commit-graph.c:233
-msgid "repository is shallow; skipping commit-graph"
-msgstr ""
-
-#: commit-graph.c:264
+#: commit-graph.c:255
 msgid "commit-graph file is too small"
 msgstr ""
 
-#: commit-graph.c:329
+#: commit-graph.c:348
 #, c-format
 msgid "commit-graph signature %X does not match signature %X"
 msgstr ""
 
-#: commit-graph.c:336
+#: commit-graph.c:355
 #, c-format
 msgid "commit-graph version %X does not match version %X"
 msgstr ""
 
-#: commit-graph.c:343
+#: commit-graph.c:362
 #, c-format
 msgid "commit-graph hash version %X does not match version %X"
 msgstr ""
 
-#: commit-graph.c:360
+#: commit-graph.c:379
 #, c-format
 msgid "commit-graph file is too small to hold %u chunks"
 msgstr ""
 
-#: commit-graph.c:379
-#, c-format
-msgid "commit-graph improper chunk offset %08x%08x"
-msgstr ""
-
-#: commit-graph.c:465
-#, c-format
-msgid "commit-graph chunk id %08x appears multiple times"
-msgstr ""
-
-#: commit-graph.c:531
+#: commit-graph.c:472
 msgid "commit-graph has no base graphs chunk"
 msgstr ""
 
-#: commit-graph.c:541
+#: commit-graph.c:482
 msgid "commit-graph chain does not match"
 msgstr ""
 
-#: commit-graph.c:589
+#: commit-graph.c:530
 #, c-format
 msgid "invalid commit-graph chain: line '%s' not a hash"
 msgstr ""
 
-#: commit-graph.c:613
+#: commit-graph.c:554
 msgid "unable to find all commit-graph files"
 msgstr ""
 
-#: commit-graph.c:794 commit-graph.c:831
+#: commit-graph.c:735 commit-graph.c:772
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr ""
 
-#: commit-graph.c:815
+#: commit-graph.c:756
 #, c-format
 msgid "could not find commit %s"
 msgstr ""
 
-#: commit-graph.c:848
+#: commit-graph.c:789
 msgid "commit-graph requires overflow generation data but has none"
 msgstr ""
 
-#: commit-graph.c:1121 builtin/am.c:1292
+#: commit-graph.c:1065 builtin/am.c:1292
 #, c-format
 msgid "unable to parse commit %s"
 msgstr ""
 
-#: commit-graph.c:1378 builtin/pack-objects.c:2872
+#: commit-graph.c:1327 builtin/pack-objects.c:2872
 #, c-format
 msgid "unable to get type of object %s"
 msgstr ""
 
-#: commit-graph.c:1409
+#: commit-graph.c:1358
 msgid "Loading known commits in commit graph"
 msgstr ""
 
-#: commit-graph.c:1426
+#: commit-graph.c:1375
 msgid "Expanding reachable commits in commit graph"
 msgstr ""
 
-#: commit-graph.c:1446
+#: commit-graph.c:1395
 msgid "Clearing commit marks in commit graph"
 msgstr ""
 
-#: commit-graph.c:1465
+#: commit-graph.c:1414
 msgid "Computing commit graph topological levels"
 msgstr ""
 
-#: commit-graph.c:1518
+#: commit-graph.c:1467
 msgid "Computing commit graph generation numbers"
 msgstr ""
 
-#: commit-graph.c:1599
+#: commit-graph.c:1548
 msgid "Computing commit changed paths Bloom filters"
 msgstr ""
 
-#: commit-graph.c:1676
+#: commit-graph.c:1625
 msgid "Collecting referenced commits"
 msgstr ""
 
-#: commit-graph.c:1701
+#: commit-graph.c:1650
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] ""
 msgstr[1] ""
 
-#: commit-graph.c:1714
+#: commit-graph.c:1663
 #, c-format
 msgid "error adding pack %s"
 msgstr ""
 
-#: commit-graph.c:1718
+#: commit-graph.c:1667
 #, c-format
 msgid "error opening index for %s"
 msgstr ""
 
-#: commit-graph.c:1755
+#: commit-graph.c:1704
 msgid "Finding commits for commit graph among packed objects"
 msgstr ""
 
-#: commit-graph.c:1773
+#: commit-graph.c:1722
 msgid "Finding extra edges in commit graph"
 msgstr ""
 
-#: commit-graph.c:1821
+#: commit-graph.c:1771
 msgid "failed to write correct number of base graph ids"
 msgstr ""
 
-#: commit-graph.c:1863 midx.c:819
+#: commit-graph.c:1802 midx.c:794
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr ""
 
-#: commit-graph.c:1876
+#: commit-graph.c:1815
 msgid "unable to create temporary graph layer"
 msgstr ""
 
-#: commit-graph.c:1881
+#: commit-graph.c:1820
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr ""
 
-#: commit-graph.c:1966
+#: commit-graph.c:1879
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: commit-graph.c:2011
+#: commit-graph.c:1915
 msgid "unable to open commit-graph chain file"
 msgstr ""
 
-#: commit-graph.c:2027
+#: commit-graph.c:1931
 msgid "failed to rename base commit-graph file"
 msgstr ""
 
-#: commit-graph.c:2047
+#: commit-graph.c:1951
 msgid "failed to rename temporary commit-graph file"
 msgstr ""
 
-#: commit-graph.c:2180
+#: commit-graph.c:2084
 msgid "Scanning merged commits"
 msgstr ""
 
-#: commit-graph.c:2224
+#: commit-graph.c:2128
 msgid "Merging commit-graph"
 msgstr ""
 
-#: commit-graph.c:2331
+#: commit-graph.c:2235
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 
-#: commit-graph.c:2438
+#: commit-graph.c:2342
 msgid "too many commits to write graph"
 msgstr ""
 
-#: commit-graph.c:2536
+#: commit-graph.c:2440
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 
-#: commit-graph.c:2546
+#: commit-graph.c:2450
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr ""
 
-#: commit-graph.c:2556 commit-graph.c:2571
+#: commit-graph.c:2460 commit-graph.c:2475
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr ""
 
-#: commit-graph.c:2563
+#: commit-graph.c:2467
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr ""
 
-#: commit-graph.c:2581
+#: commit-graph.c:2485
 msgid "Verifying commits in commit graph"
 msgstr ""
 
-#: commit-graph.c:2596
+#: commit-graph.c:2500
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 
-#: commit-graph.c:2603
+#: commit-graph.c:2507
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 
-#: commit-graph.c:2613
+#: commit-graph.c:2517
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr ""
 
-#: commit-graph.c:2622
+#: commit-graph.c:2526
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr ""
 
-#: commit-graph.c:2636
+#: commit-graph.c:2540
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr ""
 
-#: commit-graph.c:2641
+#: commit-graph.c:2545
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
 msgstr ""
 
-#: commit-graph.c:2645
+#: commit-graph.c:2549
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
 msgstr ""
 
-#: commit-graph.c:2662
+#: commit-graph.c:2566
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr ""
 
-#: commit-graph.c:2668
+#: commit-graph.c:2572
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
@@ -3641,7 +3638,7 @@ msgstr ""
 msgid "failed to read orderfile '%s'"
 msgstr ""
 
-#: diffcore-rename.c:555
+#: diffcore-rename.c:786
 msgid "Performing inexact rename detection"
 msgstr ""
 
@@ -3692,17 +3689,17 @@ msgstr ""
 msgid "untracked cache is disabled on this system or location"
 msgstr ""
 
-#: dir.c:3537
+#: dir.c:3534
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr ""
 
-#: dir.c:3582 dir.c:3587
+#: dir.c:3579 dir.c:3584
 #, c-format
 msgid "could not create directories for %s"
 msgstr ""
 
-#: dir.c:3616
+#: dir.c:3613
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr ""
@@ -3761,32 +3758,32 @@ msgstr ""
 msgid "--stateless-rpc requires multi_ack_detailed"
 msgstr ""
 
-#: fetch-pack.c:378 fetch-pack.c:1400
+#: fetch-pack.c:378 fetch-pack.c:1457
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr ""
 
-#: fetch-pack.c:384 fetch-pack.c:1406
+#: fetch-pack.c:384 fetch-pack.c:1463
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr ""
 
-#: fetch-pack.c:386 fetch-pack.c:1408
+#: fetch-pack.c:386 fetch-pack.c:1465
 #, c-format
 msgid "object not found: %s"
 msgstr ""
 
-#: fetch-pack.c:389 fetch-pack.c:1411
+#: fetch-pack.c:389 fetch-pack.c:1468
 #, c-format
 msgid "error in object: %s"
 msgstr ""
 
-#: fetch-pack.c:391 fetch-pack.c:1413
+#: fetch-pack.c:391 fetch-pack.c:1470
 #, c-format
 msgid "no shallow found: %s"
 msgstr ""
 
-#: fetch-pack.c:394 fetch-pack.c:1417
+#: fetch-pack.c:394 fetch-pack.c:1474
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr ""
@@ -3824,157 +3821,161 @@ msgstr ""
 msgid "already have %s (%s)"
 msgstr ""
 
-#: fetch-pack.c:821
+#: fetch-pack.c:844
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr ""
 
-#: fetch-pack.c:829
+#: fetch-pack.c:852
 msgid "protocol error: bad pack header"
 msgstr ""
 
-#: fetch-pack.c:913
+#: fetch-pack.c:946
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr ""
 
-#: fetch-pack.c:931
+#: fetch-pack.c:952
+msgid "fetch-pack: invalid index-pack output"
+msgstr ""
+
+#: fetch-pack.c:969
 #, c-format
 msgid "%s failed"
 msgstr ""
 
-#: fetch-pack.c:933
+#: fetch-pack.c:971
 msgid "error in sideband demultiplexer"
 msgstr ""
 
-#: fetch-pack.c:976
+#: fetch-pack.c:1031
 #, c-format
 msgid "Server version is %.*s"
 msgstr ""
 
-#: fetch-pack.c:984 fetch-pack.c:990 fetch-pack.c:993 fetch-pack.c:999
-#: fetch-pack.c:1003 fetch-pack.c:1007 fetch-pack.c:1011 fetch-pack.c:1015
-#: fetch-pack.c:1019 fetch-pack.c:1023 fetch-pack.c:1027 fetch-pack.c:1031
-#: fetch-pack.c:1037 fetch-pack.c:1043 fetch-pack.c:1048 fetch-pack.c:1053
+#: fetch-pack.c:1039 fetch-pack.c:1045 fetch-pack.c:1048 fetch-pack.c:1054
+#: fetch-pack.c:1058 fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070
+#: fetch-pack.c:1074 fetch-pack.c:1078 fetch-pack.c:1082 fetch-pack.c:1086
+#: fetch-pack.c:1092 fetch-pack.c:1098 fetch-pack.c:1103 fetch-pack.c:1108
 #, c-format
 msgid "Server supports %s"
 msgstr ""
 
-#: fetch-pack.c:986
+#: fetch-pack.c:1041
 msgid "Server does not support shallow clients"
 msgstr ""
 
-#: fetch-pack.c:1046
+#: fetch-pack.c:1101
 msgid "Server does not support --shallow-since"
 msgstr ""
 
-#: fetch-pack.c:1051
+#: fetch-pack.c:1106
 msgid "Server does not support --shallow-exclude"
 msgstr ""
 
-#: fetch-pack.c:1055
+#: fetch-pack.c:1110
 msgid "Server does not support --deepen"
 msgstr ""
 
-#: fetch-pack.c:1057
+#: fetch-pack.c:1112
 msgid "Server does not support this repository's object format"
 msgstr ""
 
-#: fetch-pack.c:1070
+#: fetch-pack.c:1125
 msgid "no common commits"
 msgstr ""
 
-#: fetch-pack.c:1082 fetch-pack.c:1622
+#: fetch-pack.c:1138 fetch-pack.c:1682
 msgid "git fetch-pack: fetch failed."
 msgstr ""
 
-#: fetch-pack.c:1208
+#: fetch-pack.c:1265
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr ""
 
-#: fetch-pack.c:1212
+#: fetch-pack.c:1269
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr ""
 
-#: fetch-pack.c:1232
+#: fetch-pack.c:1289
 msgid "Server does not support shallow requests"
 msgstr ""
 
-#: fetch-pack.c:1239
+#: fetch-pack.c:1296
 msgid "Server supports filter"
 msgstr ""
 
-#: fetch-pack.c:1278
+#: fetch-pack.c:1335
 msgid "unable to write request to remote"
 msgstr ""
 
-#: fetch-pack.c:1296
+#: fetch-pack.c:1353
 #, c-format
 msgid "error reading section header '%s'"
 msgstr ""
 
-#: fetch-pack.c:1302
+#: fetch-pack.c:1359
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr ""
 
-#: fetch-pack.c:1363
+#: fetch-pack.c:1420
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr ""
 
-#: fetch-pack.c:1368
+#: fetch-pack.c:1425
 #, c-format
 msgid "error processing acks: %d"
 msgstr ""
 
-#: fetch-pack.c:1378
+#: fetch-pack.c:1435
 msgid "expected packfile to be sent after 'ready'"
 msgstr ""
 
-#: fetch-pack.c:1380
+#: fetch-pack.c:1437
 msgid "expected no other sections to be sent after no 'ready'"
-msgstr ""
-
-#: fetch-pack.c:1422
-#, c-format
-msgid "error processing shallow info: %d"
-msgstr ""
-
-#: fetch-pack.c:1469
-#, c-format
-msgid "expected wanted-ref, got '%s'"
-msgstr ""
-
-#: fetch-pack.c:1474
-#, c-format
-msgid "unexpected wanted-ref: '%s'"
 msgstr ""
 
 #: fetch-pack.c:1479
 #, c-format
+msgid "error processing shallow info: %d"
+msgstr ""
+
+#: fetch-pack.c:1526
+#, c-format
+msgid "expected wanted-ref, got '%s'"
+msgstr ""
+
+#: fetch-pack.c:1531
+#, c-format
+msgid "unexpected wanted-ref: '%s'"
+msgstr ""
+
+#: fetch-pack.c:1536
+#, c-format
 msgid "error processing wanted refs: %d"
 msgstr ""
 
-#: fetch-pack.c:1509
+#: fetch-pack.c:1566
 msgid "git fetch-pack: expected response end packet"
 msgstr ""
 
-#: fetch-pack.c:1891
+#: fetch-pack.c:1960
 msgid "no matching remote head"
 msgstr ""
 
-#: fetch-pack.c:1914 builtin/clone.c:693
+#: fetch-pack.c:1983 builtin/clone.c:693
 msgid "remote did not send all necessary objects"
 msgstr ""
 
-#: fetch-pack.c:1941
+#: fetch-pack.c:2010
 #, c-format
 msgid "no such remote ref %s"
 msgstr ""
 
-#: fetch-pack.c:1944
+#: fetch-pack.c:2013
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr ""
@@ -4302,39 +4303,39 @@ msgstr ""
 msgid "expected flush after ls-refs arguments"
 msgstr ""
 
-#: merge-ort.c:855 merge-recursive.c:1191
+#: merge-ort.c:888 merge-recursive.c:1191
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
 msgstr ""
 
-#: merge-ort.c:864 merge-recursive.c:1198
+#: merge-ort.c:897 merge-recursive.c:1198
 #, c-format
 msgid "Failed to merge submodule %s (commits not present)"
 msgstr ""
 
-#: merge-ort.c:873 merge-recursive.c:1205
+#: merge-ort.c:906 merge-recursive.c:1205
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
 msgstr ""
 
-#: merge-ort.c:883 merge-ort.c:890
+#: merge-ort.c:916 merge-ort.c:923
 #, c-format
 msgid "Note: Fast-forwarding submodule %s to %s"
 msgstr ""
 
-#: merge-ort.c:911
+#: merge-ort.c:944
 #, c-format
 msgid "Failed to merge submodule %s"
 msgstr ""
 
-#: merge-ort.c:918
+#: merge-ort.c:951
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but a possible merge resolution exists:\n"
 "%s\n"
 msgstr ""
 
-#: merge-ort.c:922 merge-recursive.c:1259
+#: merge-ort.c:955 merge-recursive.c:1259
 #, c-format
 msgid ""
 "If this is correct simply add it to the index for example\n"
@@ -4345,42 +4346,42 @@ msgid ""
 "which will accept this suggestion.\n"
 msgstr ""
 
-#: merge-ort.c:935
+#: merge-ort.c:968
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but multiple possible merges exist:\n"
 "%s"
 msgstr ""
 
-#: merge-ort.c:1094 merge-recursive.c:1341
+#: merge-ort.c:1127 merge-recursive.c:1341
 msgid "Failed to execute internal merge"
 msgstr ""
 
-#: merge-ort.c:1099 merge-recursive.c:1346
+#: merge-ort.c:1132 merge-recursive.c:1346
 #, c-format
 msgid "Unable to add %s to database"
 msgstr ""
 
-#: merge-ort.c:1106 merge-recursive.c:1378
+#: merge-ort.c:1139 merge-recursive.c:1378
 #, c-format
 msgid "Auto-merging %s"
 msgstr ""
 
-#: merge-ort.c:1245 merge-recursive.c:2100
+#: merge-ort.c:1278 merge-recursive.c:2100
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
 "implicit directory rename(s) putting the following path(s) there: %s."
 msgstr ""
 
-#: merge-ort.c:1255 merge-recursive.c:2110
+#: merge-ort.c:1288 merge-recursive.c:2110
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
 "implicit directory renames tried to put these paths there: %s"
 msgstr ""
 
-#: merge-ort.c:1438
+#: merge-ort.c:1471
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to rename %s to; it was "
@@ -4388,47 +4389,47 @@ msgid ""
 "majority of the files."
 msgstr ""
 
-#: merge-ort.c:1604 merge-recursive.c:2447
+#: merge-ort.c:1637 merge-recursive.c:2447
 #, c-format
 msgid ""
 "WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
 "renamed."
 msgstr ""
 
-#: merge-ort.c:1748 merge-recursive.c:3215
+#: merge-ort.c:1781 merge-recursive.c:3215
 #, c-format
 msgid ""
 "Path updated: %s added in %s inside a directory that was renamed in %s; "
 "moving it to %s."
 msgstr ""
 
-#: merge-ort.c:1755 merge-recursive.c:3222
+#: merge-ort.c:1788 merge-recursive.c:3222
 #, c-format
 msgid ""
 "Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
 "%s; moving it to %s."
 msgstr ""
 
-#: merge-ort.c:1768 merge-recursive.c:3218
+#: merge-ort.c:1801 merge-recursive.c:3218
 #, c-format
 msgid ""
 "CONFLICT (file location): %s added in %s inside a directory that was renamed "
 "in %s, suggesting it should perhaps be moved to %s."
 msgstr ""
 
-#: merge-ort.c:1776 merge-recursive.c:3225
+#: merge-ort.c:1809 merge-recursive.c:3225
 #, c-format
 msgid ""
 "CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
 "was renamed in %s, suggesting it should perhaps be moved to %s."
 msgstr ""
 
-#: merge-ort.c:1919
+#: merge-ort.c:1952
 #, c-format
 msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
 msgstr ""
 
-#: merge-ort.c:2014
+#: merge-ort.c:2047
 #, c-format
 msgid ""
 "CONFLICT (rename involved in collision): rename of %s -> %s has content "
@@ -4436,51 +4437,51 @@ msgid ""
 "markers."
 msgstr ""
 
-#: merge-ort.c:2033 merge-ort.c:2057
+#: merge-ort.c:2066 merge-ort.c:2090
 #, c-format
 msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
 msgstr ""
 
-#: merge-ort.c:2683
+#: merge-ort.c:2735
 #, c-format
 msgid ""
 "CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
 "%s instead."
 msgstr ""
 
-#: merge-ort.c:2756
+#: merge-ort.c:2808
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed %s "
 "of them so each can be recorded somewhere."
 msgstr ""
 
-#: merge-ort.c:2760
+#: merge-ort.c:2812
 msgid "both"
 msgstr ""
 
-#: merge-ort.c:2760
+#: merge-ort.c:2812
 msgid "one"
 msgstr ""
 
-#: merge-ort.c:2855 merge-recursive.c:3052
+#: merge-ort.c:2907 merge-recursive.c:3052
 msgid "content"
 msgstr ""
 
-#: merge-ort.c:2857 merge-recursive.c:3056
+#: merge-ort.c:2909 merge-recursive.c:3056
 msgid "add/add"
 msgstr ""
 
-#: merge-ort.c:2859 merge-recursive.c:3101
+#: merge-ort.c:2911 merge-recursive.c:3101
 msgid "submodule"
 msgstr ""
 
-#: merge-ort.c:2861 merge-recursive.c:3102
+#: merge-ort.c:2913 merge-recursive.c:3102
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr ""
 
-#: merge-ort.c:2886
+#: merge-ort.c:2938
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
@@ -4490,7 +4491,7 @@ msgstr ""
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
-#: merge-ort.c:3354
+#: merge-ort.c:3406
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
 msgstr ""
@@ -4787,164 +4788,156 @@ msgstr ""
 msgid "unable to write new index file"
 msgstr ""
 
-#: midx.c:80
+#: midx.c:62
+msgid "multi-pack-index OID fanout is of the wrong size"
+msgstr ""
+
+#: midx.c:93
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr ""
 
-#: midx.c:96
+#: midx.c:109
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr ""
 
-#: midx.c:101
+#: midx.c:114
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr ""
 
-#: midx.c:106
+#: midx.c:119
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr ""
 
-#: midx.c:123
-msgid "invalid chunk offset (too large)"
-msgstr ""
-
-#: midx.c:147
-msgid "terminating multi-pack-index chunk id appears earlier than expected"
-msgstr ""
-
-#: midx.c:160
+#: midx.c:136
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr ""
 
-#: midx.c:162
+#: midx.c:138
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr ""
 
-#: midx.c:164
+#: midx.c:140
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr ""
 
-#: midx.c:166
+#: midx.c:142
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr ""
 
-#: midx.c:180
+#: midx.c:158
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr ""
 
-#: midx.c:223
+#: midx.c:202
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr ""
 
-#: midx.c:273
+#: midx.c:252
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr ""
 
-#: midx.c:480
+#: midx.c:467
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr ""
 
-#: midx.c:486
+#: midx.c:473
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr ""
 
-#: midx.c:546
+#: midx.c:533
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr ""
 
-#: midx.c:846
+#: midx.c:821
 msgid "Adding packfiles to multi-pack-index"
 msgstr ""
 
-#: midx.c:879
+#: midx.c:855
 #, c-format
 msgid "did not see pack-file %s to drop"
 msgstr ""
 
-#: midx.c:931
+#: midx.c:904
 msgid "no pack files to index."
 msgstr ""
 
-#: midx.c:982
-msgid "Writing chunks to multi-pack-index"
-msgstr ""
-
-#: midx.c:1060
+#: midx.c:965
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr ""
 
-#: midx.c:1116
+#: midx.c:1021
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr ""
 
-#: midx.c:1124
+#: midx.c:1029
 msgid "Looking for referenced packfiles"
 msgstr ""
 
-#: midx.c:1139
+#: midx.c:1044
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 msgstr ""
 
-#: midx.c:1144
+#: midx.c:1049
 msgid "the midx contains no oid"
 msgstr ""
 
-#: midx.c:1153
+#: midx.c:1058
 msgid "Verifying OID order in multi-pack-index"
 msgstr ""
 
-#: midx.c:1162
+#: midx.c:1067
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr ""
 
-#: midx.c:1182
+#: midx.c:1087
 msgid "Sorting objects by packfile"
 msgstr ""
 
-#: midx.c:1189
+#: midx.c:1094
 msgid "Verifying object offsets"
 msgstr ""
 
-#: midx.c:1205
+#: midx.c:1110
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr ""
 
-#: midx.c:1211
+#: midx.c:1116
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr ""
 
-#: midx.c:1220
+#: midx.c:1125
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr ""
 
-#: midx.c:1245
+#: midx.c:1150
 msgid "Counting referenced objects"
 msgstr ""
 
-#: midx.c:1255
+#: midx.c:1160
 msgid "Finding and deleting unreferenced packfiles"
 msgstr ""
 
-#: midx.c:1446
+#: midx.c:1351
 msgid "could not start pack-objects"
 msgstr ""
 
-#: midx.c:1466
+#: midx.c:1371
 msgid "could not finish pack-objects"
 msgstr ""
 
@@ -5409,7 +5402,7 @@ msgstr ""
 msgid "failed to make %s readable"
 msgstr ""
 
-#: pack-write.c:502
+#: pack-write.c:508
 #, c-format
 msgid "could not write '%s' promisor file"
 msgstr ""
@@ -5670,11 +5663,11 @@ msgstr ""
 msgid "remote error: %s"
 msgstr ""
 
-#: preload-index.c:119
+#: preload-index.c:125
 msgid "Refreshing index"
 msgstr ""
 
-#: preload-index.c:138
+#: preload-index.c:144
 #, c-format
 msgid "unable to create threaded lstat: %s"
 msgstr ""
@@ -5781,73 +5774,73 @@ msgstr ""
 msgid "'%s' appears as both a file and as a directory"
 msgstr ""
 
-#: read-cache.c:1524
+#: read-cache.c:1532
 msgid "Refresh index"
 msgstr ""
 
-#: read-cache.c:1639
+#: read-cache.c:1657
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
 "Using version %i"
 msgstr ""
 
-#: read-cache.c:1649
+#: read-cache.c:1667
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
 "Using version %i"
 msgstr ""
 
-#: read-cache.c:1705
+#: read-cache.c:1723
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr ""
 
-#: read-cache.c:1708
+#: read-cache.c:1726
 #, c-format
 msgid "bad index version %d"
 msgstr ""
 
-#: read-cache.c:1717
+#: read-cache.c:1735
 msgid "bad index file sha1 signature"
 msgstr ""
 
-#: read-cache.c:1747
+#: read-cache.c:1765
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr ""
 
-#: read-cache.c:1749
+#: read-cache.c:1767
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr ""
 
-#: read-cache.c:1786
+#: read-cache.c:1804
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr ""
 
-#: read-cache.c:1802
+#: read-cache.c:1820
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr ""
 
-#: read-cache.c:1859
+#: read-cache.c:1877
 msgid "unordered stage entries in index"
 msgstr ""
 
-#: read-cache.c:1862
+#: read-cache.c:1880
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr ""
 
-#: read-cache.c:1865
+#: read-cache.c:1883
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr ""
 
-#: read-cache.c:1971 read-cache.c:2262 rerere.c:549 rerere.c:583 rerere.c:1095
+#: read-cache.c:1989 read-cache.c:2280 rerere.c:549 rerere.c:583 rerere.c:1095
 #: submodule.c:1634 builtin/add.c:546 builtin/check-ignore.c:181
 #: builtin/checkout.c:504 builtin/checkout.c:690 builtin/clean.c:991
 #: builtin/commit.c:364 builtin/diff-tree.c:122 builtin/grep.c:505
@@ -5856,82 +5849,82 @@ msgstr ""
 msgid "index file corrupt"
 msgstr ""
 
-#: read-cache.c:2115
+#: read-cache.c:2133
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr ""
 
-#: read-cache.c:2128
+#: read-cache.c:2146
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr ""
 
-#: read-cache.c:2161
+#: read-cache.c:2179
 #, c-format
 msgid "%s: index file open failed"
 msgstr ""
 
-#: read-cache.c:2165
+#: read-cache.c:2183
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr ""
 
-#: read-cache.c:2169
+#: read-cache.c:2187
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr ""
 
-#: read-cache.c:2173
+#: read-cache.c:2191
 #, c-format
 msgid "%s: unable to map index file"
 msgstr ""
 
-#: read-cache.c:2215
+#: read-cache.c:2233
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr ""
 
-#: read-cache.c:2242
+#: read-cache.c:2260
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr ""
 
-#: read-cache.c:2274
+#: read-cache.c:2292
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr ""
 
-#: read-cache.c:2321
+#: read-cache.c:2339
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr ""
 
-#: read-cache.c:3017 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1141
+#: read-cache.c:3035 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1141
 #, c-format
 msgid "could not close '%s'"
 msgstr ""
 
-#: read-cache.c:3120 sequencer.c:2487 sequencer.c:4239
+#: read-cache.c:3138 sequencer.c:2487 sequencer.c:4239
 #, c-format
 msgid "could not stat '%s'"
 msgstr ""
 
-#: read-cache.c:3133
+#: read-cache.c:3151
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr ""
 
-#: read-cache.c:3145
+#: read-cache.c:3163
 #, c-format
 msgid "unable to unlink: %s"
 msgstr ""
 
-#: read-cache.c:3170
+#: read-cache.c:3188
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr ""
 
-#: read-cache.c:3319
+#: read-cache.c:3337
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr ""
@@ -6062,242 +6055,247 @@ msgstr ""
 msgid "ahead %d, behind %d"
 msgstr ""
 
-#: ref-filter.c:169
+#: ref-filter.c:175
 #, c-format
 msgid "expected format: %%(color:<color>)"
 msgstr ""
 
-#: ref-filter.c:171
+#: ref-filter.c:177
 #, c-format
 msgid "unrecognized color: %%(color:%s)"
 msgstr ""
 
-#: ref-filter.c:193
+#: ref-filter.c:199
 #, c-format
 msgid "Integer value expected refname:lstrip=%s"
 msgstr ""
 
-#: ref-filter.c:197
+#: ref-filter.c:203
 #, c-format
 msgid "Integer value expected refname:rstrip=%s"
 msgstr ""
 
-#: ref-filter.c:199
+#: ref-filter.c:205
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
 msgstr ""
 
-#: ref-filter.c:254
+#: ref-filter.c:260
 #, c-format
 msgid "%%(objecttype) does not take arguments"
 msgstr ""
 
-#: ref-filter.c:276
+#: ref-filter.c:282
 #, c-format
 msgid "unrecognized %%(objectsize) argument: %s"
 msgstr ""
 
-#: ref-filter.c:284
+#: ref-filter.c:290
 #, c-format
 msgid "%%(deltabase) does not take arguments"
 msgstr ""
 
-#: ref-filter.c:296
+#: ref-filter.c:302
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr ""
 
-#: ref-filter.c:309
+#: ref-filter.c:315
 #, c-format
 msgid "unrecognized %%(subject) argument: %s"
 msgstr ""
 
-#: ref-filter.c:330
+#: ref-filter.c:334
+#, c-format
+msgid "expected %%(trailers:key=<value>)"
+msgstr ""
+
+#: ref-filter.c:336
 #, c-format
 msgid "unknown %%(trailers) argument: %s"
 msgstr ""
 
-#: ref-filter.c:363
+#: ref-filter.c:367
 #, c-format
 msgid "positive value expected contents:lines=%s"
 msgstr ""
 
-#: ref-filter.c:365
+#: ref-filter.c:369
 #, c-format
 msgid "unrecognized %%(contents) argument: %s"
 msgstr ""
 
-#: ref-filter.c:380
+#: ref-filter.c:384
 #, c-format
 msgid "positive value expected '%s' in %%(%s)"
 msgstr ""
 
-#: ref-filter.c:384
+#: ref-filter.c:388
 #, c-format
 msgid "unrecognized argument '%s' in %%(%s)"
 msgstr ""
 
-#: ref-filter.c:398
+#: ref-filter.c:402
 #, c-format
 msgid "unrecognized email option: %s"
 msgstr ""
 
-#: ref-filter.c:428
+#: ref-filter.c:432
 #, c-format
 msgid "expected format: %%(align:<width>,<position>)"
 msgstr ""
 
-#: ref-filter.c:440
+#: ref-filter.c:444
 #, c-format
 msgid "unrecognized position:%s"
 msgstr ""
 
-#: ref-filter.c:447
+#: ref-filter.c:451
 #, c-format
 msgid "unrecognized width:%s"
 msgstr ""
 
-#: ref-filter.c:456
+#: ref-filter.c:460
 #, c-format
 msgid "unrecognized %%(align) argument: %s"
 msgstr ""
 
-#: ref-filter.c:464
+#: ref-filter.c:468
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr ""
 
-#: ref-filter.c:482
+#: ref-filter.c:486
 #, c-format
 msgid "unrecognized %%(if) argument: %s"
 msgstr ""
 
-#: ref-filter.c:584
+#: ref-filter.c:588
 #, c-format
 msgid "malformed field name: %.*s"
 msgstr ""
 
-#: ref-filter.c:611
+#: ref-filter.c:615
 #, c-format
 msgid "unknown field name: %.*s"
 msgstr ""
 
-#: ref-filter.c:615
+#: ref-filter.c:619
 #, c-format
 msgid ""
 "not a git repository, but the field '%.*s' requires access to object data"
 msgstr ""
 
-#: ref-filter.c:739
+#: ref-filter.c:743
 #, c-format
 msgid "format: %%(if) atom used without a %%(then) atom"
 msgstr ""
 
-#: ref-filter.c:802
+#: ref-filter.c:806
 #, c-format
 msgid "format: %%(then) atom used without an %%(if) atom"
 msgstr ""
 
-#: ref-filter.c:804
+#: ref-filter.c:808
 #, c-format
 msgid "format: %%(then) atom used more than once"
 msgstr ""
 
-#: ref-filter.c:806
+#: ref-filter.c:810
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr ""
 
-#: ref-filter.c:834
+#: ref-filter.c:838
 #, c-format
 msgid "format: %%(else) atom used without an %%(if) atom"
 msgstr ""
 
-#: ref-filter.c:836
+#: ref-filter.c:840
 #, c-format
 msgid "format: %%(else) atom used without a %%(then) atom"
 msgstr ""
 
-#: ref-filter.c:838
+#: ref-filter.c:842
 #, c-format
 msgid "format: %%(else) atom used more than once"
 msgstr ""
 
-#: ref-filter.c:853
+#: ref-filter.c:857
 #, c-format
 msgid "format: %%(end) atom used without corresponding atom"
 msgstr ""
 
-#: ref-filter.c:910
+#: ref-filter.c:914
 #, c-format
 msgid "malformed format string %s"
 msgstr ""
 
-#: ref-filter.c:1551
+#: ref-filter.c:1555
 #, c-format
 msgid "(no branch, rebasing %s)"
 msgstr ""
 
-#: ref-filter.c:1554
+#: ref-filter.c:1558
 #, c-format
 msgid "(no branch, rebasing detached HEAD %s)"
 msgstr ""
 
-#: ref-filter.c:1557
+#: ref-filter.c:1561
 #, c-format
 msgid "(no branch, bisect started on %s)"
 msgstr ""
 
-#: ref-filter.c:1561
+#: ref-filter.c:1565
 #, c-format
 msgid "(HEAD detached at %s)"
 msgstr ""
 
-#: ref-filter.c:1564
+#: ref-filter.c:1568
 #, c-format
 msgid "(HEAD detached from %s)"
 msgstr ""
 
-#: ref-filter.c:1567
+#: ref-filter.c:1571
 msgid "(no branch)"
 msgstr ""
 
-#: ref-filter.c:1599 ref-filter.c:1808
+#: ref-filter.c:1603 ref-filter.c:1812
 #, c-format
 msgid "missing object %s for %s"
 msgstr ""
 
-#: ref-filter.c:1609
+#: ref-filter.c:1613
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr ""
 
-#: ref-filter.c:1992
+#: ref-filter.c:1996
 #, c-format
 msgid "malformed object at '%s'"
 msgstr ""
 
-#: ref-filter.c:2081
+#: ref-filter.c:2085
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr ""
 
-#: ref-filter.c:2086 refs.c:676
+#: ref-filter.c:2090 refs.c:676
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr ""
 
-#: ref-filter.c:2426
+#: ref-filter.c:2430
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr ""
 
-#: ref-filter.c:2525
+#: ref-filter.c:2529
 #, c-format
 msgid "malformed object name %s"
 msgstr ""
 
-#: ref-filter.c:2530
+#: ref-filter.c:2534
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr ""
@@ -14572,7 +14570,7 @@ msgstr ""
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:285 builtin/index-pack.c:1589 builtin/index-pack.c:1792
+#: builtin/grep.c:285 builtin/index-pack.c:1589 builtin/index-pack.c:1808
 #: builtin/pack-objects.c:2944
 #, c-format
 msgid "no threads support, ignoring %s"
@@ -15232,38 +15230,38 @@ msgid_plural "chain length = %d: %lu objects"
 msgstr[0] ""
 msgstr[1] ""
 
-#: builtin/index-pack.c:1749
+#: builtin/index-pack.c:1765
 msgid "Cannot come back to cwd"
 msgstr ""
 
-#: builtin/index-pack.c:1803 builtin/index-pack.c:1806
-#: builtin/index-pack.c:1822 builtin/index-pack.c:1826
+#: builtin/index-pack.c:1819 builtin/index-pack.c:1822
+#: builtin/index-pack.c:1838 builtin/index-pack.c:1842
 #, c-format
 msgid "bad %s"
 msgstr ""
 
-#: builtin/index-pack.c:1832 builtin/init-db.c:392 builtin/init-db.c:625
+#: builtin/index-pack.c:1848 builtin/init-db.c:392 builtin/init-db.c:625
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr ""
 
-#: builtin/index-pack.c:1851
+#: builtin/index-pack.c:1867
 msgid "--fix-thin cannot be used without --stdin"
 msgstr ""
 
-#: builtin/index-pack.c:1853
+#: builtin/index-pack.c:1869
 msgid "--stdin requires a git repository"
 msgstr ""
 
-#: builtin/index-pack.c:1855
+#: builtin/index-pack.c:1871
 msgid "--object-format cannot be used with --stdin"
 msgstr ""
 
-#: builtin/index-pack.c:1870
+#: builtin/index-pack.c:1886
 msgid "--verify with no packfile name given"
 msgstr ""
 
-#: builtin/index-pack.c:1936 builtin/unpack-objects.c:582
+#: builtin/index-pack.c:1956 builtin/unpack-objects.c:582
 msgid "fsck error in pack objects"
 msgstr ""
 
@@ -21969,13 +21967,21 @@ msgstr ""
 msgid "only useful for debugging"
 msgstr ""
 
-#: http-fetch.c:114
+#: http-fetch.c:118
 #, c-format
 msgid "argument to --packfile must be a valid hash (got '%s')"
 msgstr ""
 
-#: http-fetch.c:122
+#: http-fetch.c:128
 msgid "not a git repository"
+msgstr ""
+
+#: http-fetch.c:134
+msgid "--packfile requires --index-pack-args"
+msgstr ""
+
+#: http-fetch.c:143
+msgid "--index-pack-args can only be used with --packfile"
 msgstr ""
 
 #: t/helper/test-fast-rebase.c:141

--- a/po/ru.po
+++ b/po/ru.po
@@ -331,7 +331,7 @@ msgstr "Добавить изменённые файлы в индекс"
 
 #: git-gui.sh:2936
 msgid "Unstage From Commit"
-msgstr "Убрать из издекса"
+msgstr "Убрать из индекса"
 
 #: git-gui.sh:2942 lib/index.tcl:521
 msgid "Revert Changes"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git 2.31.0\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-02-26 22:09+0800\n"
-"PO-Revision-Date: 2021-02-28 22:18+0100\n"
+"POT-Creation-Date: 2021-03-04 22:41+0800\n"
+"PO-Revision-Date: 2021-03-04 19:06+0100\n"
 "Last-Translator: Peter Krefting <peter@softwolves.pp.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
 "Language: sv\n"
@@ -1101,7 +1101,7 @@ msgstr "patch misslyckades: %s:%ld"
 msgid "cannot checkout %s"
 msgstr "kan inte checka ut %s"
 
-#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:73 pack-revindex.c:213
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:86 pack-revindex.c:213
 #: setup.c:308
 #, c-format
 msgid "failed to read %s"
@@ -1835,7 +1835,7 @@ msgstr ""
 "--reverse och --first-parent tillsammans kräver att du anger senaste "
 "incheckningen"
 
-#: blame.c:2821 bundle.c:213 ref-filter.c:2202 remote.c:2041 sequencer.c:2146
+#: blame.c:2821 bundle.c:213 ref-filter.c:2206 remote.c:2041 sequencer.c:2146
 #: sequencer.c:4641 submodule.c:856 builtin/commit.c:1045 builtin/log.c:411
 #: builtin/log.c:1016 builtin/log.c:1624 builtin/log.c:2045 builtin/log.c:2335
 #: builtin/merge.c:424 builtin/pack-objects.c:3395 builtin/pack-objects.c:3410
@@ -2100,262 +2100,258 @@ msgstr "kan inte skapa \"%s\""
 msgid "index-pack died"
 msgstr "index-pack dog"
 
+#: chunk-format.c:113
+msgid "terminating chunk id appears earlier than expected"
+msgstr "avslutande stycke-id förekommer tidigare än förväntat"
+
+#: chunk-format.c:122
+#, c-format
+msgid "improper chunk offset(s) %<PRIx64> and %<PRIx64>"
+msgstr "felaktigt stycke-offset %<PRIx64> och %<PRIx64>"
+
+#: chunk-format.c:129
+#, c-format
+msgid "duplicate chunk ID %<PRIx32> found"
+msgstr "dubblerat stycke-ID %<PRIx32> upptäckt"
+
+#: chunk-format.c:143
+#, c-format
+msgid "final chunk has non-zero id %<PRIx32>"
+msgstr "avslutande stycke har id %<PRIx32> som inte är noll"
+
 #: color.c:329
 #, c-format
 msgid "invalid color value: %.*s"
 msgstr "felaktigt färgvärde: %.*s"
 
-#: commit-graph.c:198 midx.c:47
+#: commit-graph.c:197 midx.c:46
 msgid "invalid hash version"
 msgstr "felaktig hashnings-version"
 
-#: commit-graph.c:219
-msgid "repository contains replace objects; skipping commit-graph"
-msgstr "arkivet innehåller replace-objekt; hoppar över incheckningsgraf"
-
-#: commit-graph.c:228
-msgid "repository contains (deprecated) grafts; skipping commit-graph"
-msgstr ""
-"arkivet innehåller ympningar (avråds från); hoppar över incheckningsgraf"
-
-#: commit-graph.c:233
-msgid "repository is shallow; skipping commit-graph"
-msgstr "källarkivet är grunt; hoppar över incheckningsgraf"
-
-#: commit-graph.c:264
+#: commit-graph.c:255
 msgid "commit-graph file is too small"
 msgstr "incheckningsgraffilen %s är för liten"
 
-#: commit-graph.c:329
+#: commit-graph.c:348
 #, c-format
 msgid "commit-graph signature %X does not match signature %X"
 msgstr "incheckningsgrafens signatur %X stämmer inte med signaturen %X"
 
-#: commit-graph.c:336
+#: commit-graph.c:355
 #, c-format
 msgid "commit-graph version %X does not match version %X"
 msgstr "incheckningsgrafens version %X stämmer inte med versionen %X"
 
-#: commit-graph.c:343
+#: commit-graph.c:362
 #, c-format
 msgid "commit-graph hash version %X does not match version %X"
 msgstr "incheckningsgrafens hashversion %X stämmer inte med versionen %X"
 
-#: commit-graph.c:360
+#: commit-graph.c:379
 #, c-format
 msgid "commit-graph file is too small to hold %u chunks"
 msgstr "incheckningsgraffilen är för liten för att innehålla %u stycken"
 
-#: commit-graph.c:379
-#, c-format
-msgid "commit-graph improper chunk offset %08x%08x"
-msgstr "felaktigt offset för stycke %08x%08x i incheckningsgraffilen"
-
-#: commit-graph.c:465
-#, c-format
-msgid "commit-graph chunk id %08x appears multiple times"
-msgstr "incheckningsgrafens stycke-id %08x förekommer flera gånger"
-
-#: commit-graph.c:531
+#: commit-graph.c:472
 msgid "commit-graph has no base graphs chunk"
 msgstr "incheckningsgrafen har inga bas-graf-stycken"
 
-#: commit-graph.c:541
+#: commit-graph.c:482
 msgid "commit-graph chain does not match"
 msgstr "incheckningsgrafens kedja stämmer inte"
 
-#: commit-graph.c:589
+#: commit-graph.c:530
 #, c-format
 msgid "invalid commit-graph chain: line '%s' not a hash"
 msgstr "ogiltig incheckingsgrafkedja: rad \"%s\" är inte ett hash-värde"
 
-#: commit-graph.c:613
+#: commit-graph.c:554
 msgid "unable to find all commit-graph files"
 msgstr "kan inte hitta alla incheckingsgraffiler"
 
-#: commit-graph.c:794 commit-graph.c:831
+#: commit-graph.c:735 commit-graph.c:772
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr "ogiltig incheckningsposition. incheckningsgrafen är troligtvis trasig"
 
-#: commit-graph.c:815
+#: commit-graph.c:756
 #, c-format
 msgid "could not find commit %s"
 msgstr "kunde inte hitta incheckningen %s"
 
-#: commit-graph.c:848
+#: commit-graph.c:789
 msgid "commit-graph requires overflow generation data but has none"
 msgstr "incheckningsgraf kräver spillgenerationsdata, men har ingen"
 
-#: commit-graph.c:1121 builtin/am.c:1292
+#: commit-graph.c:1065 builtin/am.c:1292
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "kunde inte tolka incheckningen %s"
 
-#: commit-graph.c:1378 builtin/pack-objects.c:2872
+#: commit-graph.c:1327 builtin/pack-objects.c:2872
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "kunde inte hämta typ för objektet %s"
 
-#: commit-graph.c:1409
+#: commit-graph.c:1358
 msgid "Loading known commits in commit graph"
 msgstr "Läser in kända incheckningar i incheckningsgraf"
 
-#: commit-graph.c:1426
+#: commit-graph.c:1375
 msgid "Expanding reachable commits in commit graph"
 msgstr "Expanderar nåbara incheckningar i incheckningsgraf"
 
-#: commit-graph.c:1446
+#: commit-graph.c:1395
 msgid "Clearing commit marks in commit graph"
 msgstr "Rensar incheckningsmärken i incheckningsgraf"
 
-#: commit-graph.c:1465
+#: commit-graph.c:1414
 msgid "Computing commit graph topological levels"
 msgstr "Beräknar topografiska nivåer för incheckningsgraf"
 
-#: commit-graph.c:1518
+#: commit-graph.c:1467
 msgid "Computing commit graph generation numbers"
 msgstr "Beräknar generationsvärden för incheckningsgraf"
 
-#: commit-graph.c:1599
+#: commit-graph.c:1548
 msgid "Computing commit changed paths Bloom filters"
 msgstr "Beräknar Bloom-filter för sökvägar ändrade av incheckningen"
 
-#: commit-graph.c:1676
+#: commit-graph.c:1625
 msgid "Collecting referenced commits"
 msgstr "Samlar refererade incheckningar"
 
-#: commit-graph.c:1701
+#: commit-graph.c:1650
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] "Söker incheckningar för incheckingsgraf i %d paket"
 msgstr[1] "Söker incheckningar för incheckingsgraf i %d paket"
 
-#: commit-graph.c:1714
+#: commit-graph.c:1663
 #, c-format
 msgid "error adding pack %s"
 msgstr "fel vid tillägg av paketet %s"
 
-#: commit-graph.c:1718
+#: commit-graph.c:1667
 #, c-format
 msgid "error opening index for %s"
 msgstr "fel vid öppning av indexet för %s"
 
-#: commit-graph.c:1755
+#: commit-graph.c:1704
 msgid "Finding commits for commit graph among packed objects"
 msgstr "Söker incheckningar för incheckingsgraf i packade objekt"
 
-#: commit-graph.c:1773
+#: commit-graph.c:1722
 msgid "Finding extra edges in commit graph"
 msgstr "Söker ytterligare kanter i incheckingsgraf"
 
-#: commit-graph.c:1821
+#: commit-graph.c:1771
 msgid "failed to write correct number of base graph ids"
 msgstr "kunde inte skriva korrekt antal bas-graf-id:n"
 
-#: commit-graph.c:1863 midx.c:819
+#: commit-graph.c:1802 midx.c:794
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "kunde inte skapa inledande kataloger för %s"
 
-#: commit-graph.c:1876
+#: commit-graph.c:1815
 msgid "unable to create temporary graph layer"
 msgstr "kan inte skapa temporärt graflager"
 
-#: commit-graph.c:1881
+#: commit-graph.c:1820
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "kan inte justera delade behörigheter för \"%s\""
 
-#: commit-graph.c:1966
+#: commit-graph.c:1879
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "Skriver ut incheckningsgraf i %d pass"
 msgstr[1] "Skriver ut incheckningsgraf i %d pass"
 
-#: commit-graph.c:2011
+#: commit-graph.c:1915
 msgid "unable to open commit-graph chain file"
 msgstr "Kunde inte öppna incheckningsgrafkedjefilen"
 
-#: commit-graph.c:2027
+#: commit-graph.c:1931
 msgid "failed to rename base commit-graph file"
 msgstr "kunde inte byta namn på bas-incheckingsgraffilen"
 
-#: commit-graph.c:2047
+#: commit-graph.c:1951
 msgid "failed to rename temporary commit-graph file"
 msgstr "kunde inte byta namn på temporär incheckningsgraffil"
 
-#: commit-graph.c:2180
+#: commit-graph.c:2084
 msgid "Scanning merged commits"
 msgstr "Söker sammanslagna incheckningar"
 
-#: commit-graph.c:2224
+#: commit-graph.c:2128
 msgid "Merging commit-graph"
 msgstr "Slår ihop incheckningsgraf"
 
-#: commit-graph.c:2331
+#: commit-graph.c:2235
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 "försöker skriva en incheckningsgraf, men \"core.commitGraph\" är inaktiverad"
 
-#: commit-graph.c:2438
+#: commit-graph.c:2342
 msgid "too many commits to write graph"
 msgstr "för många incheckningar för att skriva graf"
 
-#: commit-graph.c:2536
+#: commit-graph.c:2440
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "filen med incheckningsgraf har felaktig checksumma och är troligtvis trasig"
 
-#: commit-graph.c:2546
+#: commit-graph.c:2450
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "incheckningsgrafen har felaktig OID-ordning: %s så %s"
 
-#: commit-graph.c:2556 commit-graph.c:2571
+#: commit-graph.c:2460 commit-graph.c:2475
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr ""
 "incheckningsgrafen har felaktig utbredningsvärde: fanout[%d] = %u != %u"
 
-#: commit-graph.c:2563
+#: commit-graph.c:2467
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "kunde inte tolka incheckning %s från incheckningsgraf"
 
-#: commit-graph.c:2581
+#: commit-graph.c:2485
 msgid "Verifying commits in commit graph"
 msgstr "Bekräftar incheckningar i incheckningsgrafen"
 
-#: commit-graph.c:2596
+#: commit-graph.c:2500
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "misslyckades tolka incheckning %s från objektdatabasen för incheckningsgraf"
 
-#: commit-graph.c:2603
+#: commit-graph.c:2507
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr "rot-trädets OID för incheckningen %s i incheckningsgrafen är %s != %s"
 
-#: commit-graph.c:2613
+#: commit-graph.c:2517
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr "incheckningsgrafens föräldralista för incheckningen %s är för lång"
 
-#: commit-graph.c:2622
+#: commit-graph.c:2526
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "incheckningsgrafens förälder för %s är %s != %s"
 
-#: commit-graph.c:2636
+#: commit-graph.c:2540
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr ""
 "incheckningsgrafens föräldralista för incheckningen %s avslutas för tidigt"
 
-#: commit-graph.c:2641
+#: commit-graph.c:2545
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2363,7 +2359,7 @@ msgstr ""
 "incheckningsgrafen har generationsnummer noll för incheckningen %s, men icke-"
 "noll på annan plats"
 
-#: commit-graph.c:2645
+#: commit-graph.c:2549
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2371,14 +2367,14 @@ msgstr ""
 "incheckningsgrafen har generationsnummer skilt från noll för incheckningen "
 "%s, men noll på annan plats"
 
-#: commit-graph.c:2662
+#: commit-graph.c:2566
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr ""
 "incheckningsgrafens generation för incheckningen %s är %<PRIuMAX> < "
 "%<PRIuMAX>"
 
-#: commit-graph.c:2668
+#: commit-graph.c:2572
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
@@ -3896,7 +3892,7 @@ msgstr ""
 msgid "failed to read orderfile '%s'"
 msgstr "kunde inte läsa orderfilen \"%s\""
 
-#: diffcore-rename.c:555
+#: diffcore-rename.c:786
 msgid "Performing inexact rename detection"
 msgstr "Utför onöjaktig namnbytesdetektering"
 
@@ -3949,17 +3945,17 @@ msgstr "misslyckades hämta kärnans namn och information"
 msgid "untracked cache is disabled on this system or location"
 msgstr "ospårad cache är inaktiverad på systemet eller platsen"
 
-#: dir.c:3537
+#: dir.c:3534
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "indexfilen trasig i arkivet %s"
 
-#: dir.c:3582 dir.c:3587
+#: dir.c:3579 dir.c:3584
 #, c-format
 msgid "could not create directories for %s"
 msgstr "kunde inte skapa kataloger för %s"
 
-#: dir.c:3616
+#: dir.c:3613
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "kunde inte migrera git-katalog från \"%s\" till \"%s\""
@@ -4018,32 +4014,32 @@ msgstr "kunde inte skriva till fjärren"
 msgid "--stateless-rpc requires multi_ack_detailed"
 msgstr "--stateless-rpc kräver \"multi_ack_detailed\""
 
-#: fetch-pack.c:378 fetch-pack.c:1400
+#: fetch-pack.c:378 fetch-pack.c:1457
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "ogiltig \"shallow\"-rad: %s"
 
-#: fetch-pack.c:384 fetch-pack.c:1406
+#: fetch-pack.c:384 fetch-pack.c:1463
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "ogiltig \"unshallow\"-rad: %s"
 
-#: fetch-pack.c:386 fetch-pack.c:1408
+#: fetch-pack.c:386 fetch-pack.c:1465
 #, c-format
 msgid "object not found: %s"
 msgstr "objektet hittades inte: %s"
 
-#: fetch-pack.c:389 fetch-pack.c:1411
+#: fetch-pack.c:389 fetch-pack.c:1468
 #, c-format
 msgid "error in object: %s"
 msgstr "fel i objekt: %s"
 
-#: fetch-pack.c:391 fetch-pack.c:1413
+#: fetch-pack.c:391 fetch-pack.c:1470
 #, c-format
 msgid "no shallow found: %s"
 msgstr "ingen \"shallow\" hittades: %s"
 
-#: fetch-pack.c:394 fetch-pack.c:1417
+#: fetch-pack.c:394 fetch-pack.c:1474
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "förväntade shallow/unshallow, fick %s"
@@ -4081,158 +4077,162 @@ msgstr "Markerar %s som komplett"
 msgid "already have %s (%s)"
 msgstr "har redan %s (%s)"
 
-#: fetch-pack.c:821
+#: fetch-pack.c:844
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-patch: kunde inte grena av sidbandsmultiplexare"
 
-#: fetch-pack.c:829
+#: fetch-pack.c:852
 msgid "protocol error: bad pack header"
 msgstr "protokollfel: felaktigt packhuvud"
 
-#: fetch-pack.c:913
+#: fetch-pack.c:946
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-patch: kunde inte grena av %s"
 
-#: fetch-pack.c:931
+#: fetch-pack.c:952
+msgid "fetch-pack: invalid index-pack output"
+msgstr "fetch-patch: ogiltig utdata från index-pack"
+
+#: fetch-pack.c:969
 #, c-format
 msgid "%s failed"
 msgstr "%s misslyckades"
 
-#: fetch-pack.c:933
+#: fetch-pack.c:971
 msgid "error in sideband demultiplexer"
 msgstr "fel i sidbands-avmultiplexare"
 
-#: fetch-pack.c:976
+#: fetch-pack.c:1031
 #, c-format
 msgid "Server version is %.*s"
 msgstr "Serverversionen är %.*s"
 
-#: fetch-pack.c:984 fetch-pack.c:990 fetch-pack.c:993 fetch-pack.c:999
-#: fetch-pack.c:1003 fetch-pack.c:1007 fetch-pack.c:1011 fetch-pack.c:1015
-#: fetch-pack.c:1019 fetch-pack.c:1023 fetch-pack.c:1027 fetch-pack.c:1031
-#: fetch-pack.c:1037 fetch-pack.c:1043 fetch-pack.c:1048 fetch-pack.c:1053
+#: fetch-pack.c:1039 fetch-pack.c:1045 fetch-pack.c:1048 fetch-pack.c:1054
+#: fetch-pack.c:1058 fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070
+#: fetch-pack.c:1074 fetch-pack.c:1078 fetch-pack.c:1082 fetch-pack.c:1086
+#: fetch-pack.c:1092 fetch-pack.c:1098 fetch-pack.c:1103 fetch-pack.c:1108
 #, c-format
 msgid "Server supports %s"
 msgstr "Servern stöder %s"
 
-#: fetch-pack.c:986
+#: fetch-pack.c:1041
 msgid "Server does not support shallow clients"
 msgstr "Servern stöder inte klienter med grunda arkiv"
 
-#: fetch-pack.c:1046
+#: fetch-pack.c:1101
 msgid "Server does not support --shallow-since"
 msgstr "Servern stöder inte --shallow-since"
 
-#: fetch-pack.c:1051
+#: fetch-pack.c:1106
 msgid "Server does not support --shallow-exclude"
 msgstr "Servern stöder inte --shallow-exclude"
 
-#: fetch-pack.c:1055
+#: fetch-pack.c:1110
 msgid "Server does not support --deepen"
 msgstr "Servern stöder inte --deepen"
 
-#: fetch-pack.c:1057
+#: fetch-pack.c:1112
 msgid "Server does not support this repository's object format"
 msgstr "Servern stöder inte det här arkivets objektformat"
 
-#: fetch-pack.c:1070
+#: fetch-pack.c:1125
 msgid "no common commits"
 msgstr "inga gemensamma incheckningar"
 
-#: fetch-pack.c:1082 fetch-pack.c:1622
+#: fetch-pack.c:1138 fetch-pack.c:1682
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-patch: hämtning misslyckades."
 
-#: fetch-pack.c:1208
+#: fetch-pack.c:1265
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "omaka algoritmer: klient %s; server %s"
 
-#: fetch-pack.c:1212
+#: fetch-pack.c:1269
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "servern stöder inte algoritmen \"%s\""
 
-#: fetch-pack.c:1232
+#: fetch-pack.c:1289
 msgid "Server does not support shallow requests"
 msgstr "Servern stöder inte grunda förfrågningar"
 
-#: fetch-pack.c:1239
+#: fetch-pack.c:1296
 msgid "Server supports filter"
 msgstr "Servern stöder filter"
 
-#: fetch-pack.c:1278
+#: fetch-pack.c:1335
 msgid "unable to write request to remote"
 msgstr "kunde inte skriva anrop till fjärren"
 
-#: fetch-pack.c:1296
+#: fetch-pack.c:1353
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "fel vid läsning av styckehuvudet \"%s\""
 
-#: fetch-pack.c:1302
+#: fetch-pack.c:1359
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "förväntade \"%s\", tog emot \"%s\""
 
-#: fetch-pack.c:1363
+#: fetch-pack.c:1420
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "oväntad bekräftelserad: \"%s\""
 
-#: fetch-pack.c:1368
+#: fetch-pack.c:1425
 #, c-format
 msgid "error processing acks: %d"
 msgstr "fel vid hantering av bekräftelser: %d"
 
-#: fetch-pack.c:1378
+#: fetch-pack.c:1435
 msgid "expected packfile to be sent after 'ready'"
 msgstr "väntade att paketfil skulle sändas efter \"ready\""
 
-#: fetch-pack.c:1380
+#: fetch-pack.c:1437
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr ""
 "väntade inte att några ytterligare sektioner skulle sändas efter \"ready\""
 
-#: fetch-pack.c:1422
+#: fetch-pack.c:1479
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "fel vid hantering av grund (\"shallow\") info: %d"
 
-#: fetch-pack.c:1469
+#: fetch-pack.c:1526
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "förväntade wanted-ref, fick %s"
 
-#: fetch-pack.c:1474
+#: fetch-pack.c:1531
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "oväntad wanted-ref: \"%s\""
 
-#: fetch-pack.c:1479
+#: fetch-pack.c:1536
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "fel vid hantering av önskade referenser: %d"
 
-#: fetch-pack.c:1509
+#: fetch-pack.c:1566
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: förväntade svarsavslutningspaket"
 
-#: fetch-pack.c:1891
+#: fetch-pack.c:1960
 msgid "no matching remote head"
 msgstr "inget motsvarande fjärrhuvud"
 
-#: fetch-pack.c:1914 builtin/clone.c:693
+#: fetch-pack.c:1983 builtin/clone.c:693
 msgid "remote did not send all necessary objects"
 msgstr "fjärren sände inte alla nödvändiga objekt"
 
-#: fetch-pack.c:1941
+#: fetch-pack.c:2010
 #, c-format
 msgid "no such remote ref %s"
 msgstr "ingen sådan fjärreferens: %s"
 
-#: fetch-pack.c:1944
+#: fetch-pack.c:2013
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Servern tillåter inte förfrågan om ej tillkännagivet objekt %s"
@@ -4592,34 +4592,34 @@ msgstr "ogiltigt värde \"%s\" för lsrefs.unborn"
 msgid "expected flush after ls-refs arguments"
 msgstr "förväntade \"flush\" efter ls-refs-argument"
 
-#: merge-ort.c:855 merge-recursive.c:1191
+#: merge-ort.c:888 merge-recursive.c:1191
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
 msgstr "Misslyckades slå ihop undermodulen %s (ej utcheckad)"
 
-#: merge-ort.c:864 merge-recursive.c:1198
+#: merge-ort.c:897 merge-recursive.c:1198
 #, c-format
 msgid "Failed to merge submodule %s (commits not present)"
 msgstr "Misslyckades slå ihop undermodulen %s (incheckningar saknas)"
 
-#: merge-ort.c:873 merge-recursive.c:1205
+#: merge-ort.c:906 merge-recursive.c:1205
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
 msgstr ""
 "Misslyckades slå ihop undermodulen %s (incheckningar följer inte "
 "sammanslagningsbasen)"
 
-#: merge-ort.c:883 merge-ort.c:890
+#: merge-ort.c:916 merge-ort.c:923
 #, c-format
 msgid "Note: Fast-forwarding submodule %s to %s"
 msgstr "Obs: Snabbspolar undermodulen %s till %s"
 
-#: merge-ort.c:911
+#: merge-ort.c:944
 #, c-format
 msgid "Failed to merge submodule %s"
 msgstr "Misslyckades slå ihop undermodulen %s"
 
-#: merge-ort.c:918
+#: merge-ort.c:951
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but a possible merge resolution exists:\n"
@@ -4628,7 +4628,7 @@ msgstr ""
 "Misslyckades slå ihop undermodulen %s, men en möjlig lösning finns:\n"
 "%s\n"
 
-#: merge-ort.c:922 merge-recursive.c:1259
+#: merge-ort.c:955 merge-recursive.c:1259
 #, c-format
 msgid ""
 "If this is correct simply add it to the index for example\n"
@@ -4645,7 +4645,7 @@ msgstr ""
 "\n"
 "vilket godtar lösningen.\n"
 
-#: merge-ort.c:935
+#: merge-ort.c:968
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but multiple possible merges exist:\n"
@@ -4655,21 +4655,21 @@ msgstr ""
 "finns:\n"
 "%s"
 
-#: merge-ort.c:1094 merge-recursive.c:1341
+#: merge-ort.c:1127 merge-recursive.c:1341
 msgid "Failed to execute internal merge"
 msgstr "Misslyckades exekvera intern sammanslagning"
 
-#: merge-ort.c:1099 merge-recursive.c:1346
+#: merge-ort.c:1132 merge-recursive.c:1346
 #, c-format
 msgid "Unable to add %s to database"
 msgstr "Kunde inte lägga till %s till databasen"
 
-#: merge-ort.c:1106 merge-recursive.c:1378
+#: merge-ort.c:1139 merge-recursive.c:1378
 #, c-format
 msgid "Auto-merging %s"
 msgstr "Slår ihop %s automatiskt"
 
-#: merge-ort.c:1245 merge-recursive.c:2100
+#: merge-ort.c:1278 merge-recursive.c:2100
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
@@ -4678,7 +4678,7 @@ msgstr ""
 "KONFLIKT (implicit nämnändrad kat): Befintlig fil/kat vid %s är i vägen för "
 "implicit namnändrad(e) katalog(er) som lägger dit följande sökväg(ar): %s."
 
-#: merge-ort.c:1255 merge-recursive.c:2110
+#: merge-ort.c:1288 merge-recursive.c:2110
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
@@ -4687,7 +4687,7 @@ msgstr ""
 "KONFLIKT (implicit namnändrad kat): Kan inte koppla mer än en sökväg till "
 "%s; implicita katalognamnändringar försökte lägga följande sökvägar där: %s"
 
-#: merge-ort.c:1438
+#: merge-ort.c:1471
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to rename %s to; it was "
@@ -4698,7 +4698,7 @@ msgstr ""
 "den har namnbytts till flera andra kataloger, utan att någon destination "
 "fick en majoritet av filerna."
 
-#: merge-ort.c:1604 merge-recursive.c:2447
+#: merge-ort.c:1637 merge-recursive.c:2447
 #, c-format
 msgid ""
 "WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
@@ -4707,7 +4707,7 @@ msgstr ""
 "VARNING: Undviker att applicera namnändring %s -> %s på %s, då %s själv har "
 "bytt namn."
 
-#: merge-ort.c:1748 merge-recursive.c:3215
+#: merge-ort.c:1781 merge-recursive.c:3215
 #, c-format
 msgid ""
 "Path updated: %s added in %s inside a directory that was renamed in %s; "
@@ -4716,7 +4716,7 @@ msgstr ""
 "Uppdaterad sökväg: %s lade till %s inuti en katalog som bytte namn i %s; "
 "flyttar den till %s."
 
-#: merge-ort.c:1755 merge-recursive.c:3222
+#: merge-ort.c:1788 merge-recursive.c:3222
 #, c-format
 msgid ""
 "Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
@@ -4725,7 +4725,7 @@ msgstr ""
 "Uppdaterad sökväg: %s bytte namn till %s i %s, inuti en katalog som bytte "
 "namn i %s; flyttar den till %s."
 
-#: merge-ort.c:1768 merge-recursive.c:3218
+#: merge-ort.c:1801 merge-recursive.c:3218
 #, c-format
 msgid ""
 "CONFLICT (file location): %s added in %s inside a directory that was renamed "
@@ -4734,7 +4734,7 @@ msgstr ""
 "KONFLIKT (filplacering): %s lade till %s inuti en katalog som bytte namn i "
 "%s, föreslår att den bör flyttas till%s."
 
-#: merge-ort.c:1776 merge-recursive.c:3225
+#: merge-ort.c:1809 merge-recursive.c:3225
 #, c-format
 msgid ""
 "CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
@@ -4743,13 +4743,13 @@ msgstr ""
 "KONFLIKT (filplacering): %s bytte namn till %s i %s, inuti en katalog som "
 "bytte namn i %s; flyttar den till %s."
 
-#: merge-ort.c:1919
+#: merge-ort.c:1952
 #, c-format
 msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
 msgstr ""
 "KONFLIKT (namnbyte/namnbyte): %s namnbytt till %s i %s och till %s i %s."
 
-#: merge-ort.c:2014
+#: merge-ort.c:2047
 #, c-format
 msgid ""
 "CONFLICT (rename involved in collision): rename of %s -> %s has content "
@@ -4760,13 +4760,13 @@ msgstr ""
 "innehållskonflikter OCH krockar med en annan sökväg; detta kan leda till "
 "nästlade konfliktmarkörer."
 
-#: merge-ort.c:2033 merge-ort.c:2057
+#: merge-ort.c:2066 merge-ort.c:2090
 #, c-format
 msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
 msgstr ""
 "KONFLIKT (namnbyte/radera): %s namnbytt till %s i %s, men borttagen i %s."
 
-#: merge-ort.c:2683
+#: merge-ort.c:2735
 #, c-format
 msgid ""
 "CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
@@ -4775,7 +4775,7 @@ msgstr ""
 "KONFLIKT (fil/katalog): katalogen är i vägen för %s från %s; flyttar den "
 "till %s istället."
 
-#: merge-ort.c:2756
+#: merge-ort.c:2808
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed %s "
@@ -4784,32 +4784,32 @@ msgstr ""
 "KONFLIKT (olika typer): %s hade olika typer på varje sida; namnbytte %s så "
 "att de kan protokollföras någonstans."
 
-#: merge-ort.c:2760
+#: merge-ort.c:2812
 msgid "both"
 msgstr "båda"
 
-#: merge-ort.c:2760
+#: merge-ort.c:2812
 msgid "one"
 msgstr "en"
 
-#: merge-ort.c:2855 merge-recursive.c:3052
+#: merge-ort.c:2907 merge-recursive.c:3052
 msgid "content"
 msgstr "innehåll"
 
-#: merge-ort.c:2857 merge-recursive.c:3056
+#: merge-ort.c:2909 merge-recursive.c:3056
 msgid "add/add"
 msgstr "tillägg/tillägg"
 
-#: merge-ort.c:2859 merge-recursive.c:3101
+#: merge-ort.c:2911 merge-recursive.c:3101
 msgid "submodule"
 msgstr "undermodul"
 
-#: merge-ort.c:2861 merge-recursive.c:3102
+#: merge-ort.c:2913 merge-recursive.c:3102
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "KONFLIKT (%s): Sammanslagningskonflikt i %s"
 
-#: merge-ort.c:2886
+#: merge-ort.c:2938
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
@@ -4821,7 +4821,7 @@ msgstr ""
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
-#: merge-ort.c:3354
+#: merge-ort.c:3406
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
 msgstr "samling av sammanslagningsinfo misslyckades för träden %s, %s, %s"
@@ -5144,165 +5144,157 @@ msgstr "misslyckades läsa cachen"
 msgid "unable to write new index file"
 msgstr "kunde inte skriva ny indexfil"
 
-#: midx.c:80
+#: midx.c:62
+msgid "multi-pack-index OID fanout is of the wrong size"
+msgstr "multi-pack-indexets OID-utbredning har fel storlek"
+
+#: midx.c:93
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "multi-pack-indexfilen %s är för liten"
 
-#: midx.c:96
+#: midx.c:109
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr "multi-pack-indexsignaturen 0x%08x stämmer inte med signaturen 0x%08x"
 
-#: midx.c:101
+#: midx.c:114
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "multi-pack-indexversionen %d stöds inte"
 
-#: midx.c:106
+#: midx.c:119
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr "multi-pack-index-hashversionen %u stämmer inte med versionen %u"
 
-#: midx.c:123
-msgid "invalid chunk offset (too large)"
-msgstr "felaktigt offset för stycke (för stort)"
-
-#: midx.c:147
-msgid "terminating multi-pack-index chunk id appears earlier than expected"
-msgstr "avslutande multi-pack-index-stycke-id förekommer tidigare än förväntat"
-
-#: midx.c:160
+#: midx.c:136
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "multi-pack-index saknar krävd paketnamn-stycke"
 
-#: midx.c:162
+#: midx.c:138
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "multi-pack-index saknar krävt OID-utbredningsstycke"
 
-#: midx.c:164
+#: midx.c:140
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr "multi-pack-index saknar krävt OID-uppslagnignsstycke"
 
-#: midx.c:166
+#: midx.c:142
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr "multi-pack-index saknar krävt objekt-offsetstycke"
 
-#: midx.c:180
+#: midx.c:158
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr "multi-pack-index-paketnamn i fel ordning: \"%s\" före \"%s\""
 
-#: midx.c:223
+#: midx.c:202
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr "bad pack-int-id: %u (%u paket totalt)"
 
-#: midx.c:273
+#: midx.c:252
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr "multi-pack-index skriver 64-bitars offset, men off_t är för liten"
 
-#: midx.c:480
+#: midx.c:467
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "misslyckades läsa paketfilen \"%s\""
 
-#: midx.c:486
+#: midx.c:473
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "misslyckades öppna paketindexet \"%s\""
 
-#: midx.c:546
+#: midx.c:533
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "misslyckades hitta objekt %d i paketfilen"
 
-#: midx.c:846
+#: midx.c:821
 msgid "Adding packfiles to multi-pack-index"
 msgstr "Lägger till paketfiler till multi-pack-index"
 
-#: midx.c:879
+#: midx.c:855
 #, c-format
 msgid "did not see pack-file %s to drop"
 msgstr "såg inte paketfilen %s som skulle kastas"
 
-#: midx.c:931
+#: midx.c:904
 msgid "no pack files to index."
 msgstr "inga paketfiler att indexera."
 
-#: midx.c:982
-msgid "Writing chunks to multi-pack-index"
-msgstr "Skriver stycken till multi-pack-index"
-
-#: midx.c:1060
+#: midx.c:965
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "misslyckades städa multi-pack-index på %s"
 
-#: midx.c:1116
+#: midx.c:1021
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr "multi-pack-indexfilen finns, men kunde inte tolkas"
 
-#: midx.c:1124
+#: midx.c:1029
 msgid "Looking for referenced packfiles"
 msgstr "Ser efter refererade packfiler"
 
-#: midx.c:1139
+#: midx.c:1044
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 msgstr ""
 "oid-utbredning i fel ordning: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 
-#: midx.c:1144
+#: midx.c:1049
 msgid "the midx contains no oid"
 msgstr "midx saknar oid"
 
-#: midx.c:1153
+#: midx.c:1058
 msgid "Verifying OID order in multi-pack-index"
 msgstr "Bekräftar OID-ordning i multi-pack-index"
 
-#: midx.c:1162
+#: midx.c:1067
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr "oid-uppslagning i fel ordning: oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1182
+#: midx.c:1087
 msgid "Sorting objects by packfile"
 msgstr "Sorterar objekt efter packfil"
 
-#: midx.c:1189
+#: midx.c:1094
 msgid "Verifying object offsets"
 msgstr "Bekräftar offset för objekt"
 
-#: midx.c:1205
+#: midx.c:1110
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "misslyckades läsa paketpost för oid[%d] = %s"
 
-#: midx.c:1211
+#: midx.c:1116
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "misslyckades läsa paketindex för paketfil %s"
 
-#: midx.c:1220
+#: midx.c:1125
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr "felaktigt objekt-offset för oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#: midx.c:1245
+#: midx.c:1150
 msgid "Counting referenced objects"
 msgstr "Räknar refererade objekt"
 
-#: midx.c:1255
+#: midx.c:1160
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "Ser efter och tar bort orefererade packfiler"
 
-#: midx.c:1446
+#: midx.c:1351
 msgid "could not start pack-objects"
 msgstr "kunde inte starta pack-objects"
 
-#: midx.c:1466
+#: midx.c:1371
 msgid "could not finish pack-objects"
 msgstr "kunde inte avsluta pack-objects"
 
@@ -5787,7 +5779,7 @@ msgstr "kunde inte ta status: %s"
 msgid "failed to make %s readable"
 msgstr "kunde inte göra %s läsbar"
 
-#: pack-write.c:502
+#: pack-write.c:508
 #, c-format
 msgid "could not write '%s' promisor file"
 msgstr "kunde inte skriva kontraktsfilen \"%s\""
@@ -6052,11 +6044,11 @@ msgstr "protokollfel: felaktig radlängd: %d"
 msgid "remote error: %s"
 msgstr "fjärrfel: %s"
 
-#: preload-index.c:119
+#: preload-index.c:125
 msgid "Refreshing index"
 msgstr "Uppdaterar indexet"
 
-#: preload-index.c:138
+#: preload-index.c:144
 #, c-format
 msgid "unable to create threaded lstat: %s"
 msgstr "kunde inte skapa trådad lstat: %s"
@@ -6167,11 +6159,11 @@ msgstr "kan inte ta status på \"%s\""
 msgid "'%s' appears as both a file and as a directory"
 msgstr "\"%s\" finns både som en fil och en katalog"
 
-#: read-cache.c:1524
+#: read-cache.c:1532
 msgid "Refresh index"
 msgstr "Uppdatera indexet"
 
-#: read-cache.c:1639
+#: read-cache.c:1657
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -6180,7 +6172,7 @@ msgstr ""
 "index.version satt, men värdet är ogiltigt.\n"
 "Använder version %i"
 
-#: read-cache.c:1649
+#: read-cache.c:1667
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -6189,55 +6181,55 @@ msgstr ""
 "GIT_INDEX_VERSION satt, men värdet är ogiltigt.\n"
 "Använder version %i"
 
-#: read-cache.c:1705
+#: read-cache.c:1723
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr "felaktig signatur 0x%08x"
 
-#: read-cache.c:1708
+#: read-cache.c:1726
 #, c-format
 msgid "bad index version %d"
 msgstr "felaktig indexversion %d"
 
-#: read-cache.c:1717
+#: read-cache.c:1735
 msgid "bad index file sha1 signature"
 msgstr "felaktig sha1-signatur för indexfil"
 
-#: read-cache.c:1747
+#: read-cache.c:1765
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr "index använder filtillägget %.4s, vilket vi inte förstår"
 
-#: read-cache.c:1749
+#: read-cache.c:1767
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr "ignorerar filtillägget %.4s"
 
-#: read-cache.c:1786
+#: read-cache.c:1804
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr "okänt format 0x%08x på indexpost"
 
-#: read-cache.c:1802
+#: read-cache.c:1820
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "felformat namnfält i indexet, nära sökvägen \"%s\""
 
-#: read-cache.c:1859
+#: read-cache.c:1877
 msgid "unordered stage entries in index"
 msgstr "osorterade köposter i index"
 
-#: read-cache.c:1862
+#: read-cache.c:1880
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr "flera köposter för den sammanslagna filen \"%s\""
 
-#: read-cache.c:1865
+#: read-cache.c:1883
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr "osorterade köposter för \"%s\""
 
-#: read-cache.c:1971 read-cache.c:2262 rerere.c:549 rerere.c:583 rerere.c:1095
+#: read-cache.c:1989 read-cache.c:2280 rerere.c:549 rerere.c:583 rerere.c:1095
 #: submodule.c:1634 builtin/add.c:546 builtin/check-ignore.c:181
 #: builtin/checkout.c:504 builtin/checkout.c:690 builtin/clean.c:991
 #: builtin/commit.c:364 builtin/diff-tree.c:122 builtin/grep.c:505
@@ -6246,82 +6238,82 @@ msgstr "osorterade köposter för \"%s\""
 msgid "index file corrupt"
 msgstr "indexfilen trasig"
 
-#: read-cache.c:2115
+#: read-cache.c:2133
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr "kunde inte läsa in cache_entries-tråden: %s"
 
-#: read-cache.c:2128
+#: read-cache.c:2146
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr "kunde inte utföra join på cache_entries-tråden: %s"
 
-#: read-cache.c:2161
+#: read-cache.c:2179
 #, c-format
 msgid "%s: index file open failed"
 msgstr "%s: öppning av indexfilen misslyckades"
 
-#: read-cache.c:2165
+#: read-cache.c:2183
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr "%s: kan inte ta startus på det öppna indexet"
 
-#: read-cache.c:2169
+#: read-cache.c:2187
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr "%s: indexfilen mindre än förväntat"
 
-#: read-cache.c:2173
+#: read-cache.c:2191
 #, c-format
 msgid "%s: unable to map index file"
 msgstr "%s: kan inte koppla indexfilen"
 
-#: read-cache.c:2215
+#: read-cache.c:2233
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr "kunde inte skapa load_index_extensions-tråden: %s"
 
-#: read-cache.c:2242
+#: read-cache.c:2260
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr "kunde inte utföra join på load_index_extensions-tråden: %s"
 
-#: read-cache.c:2274
+#: read-cache.c:2292
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr "kunde inte uppdatera delat index \"%s\""
 
-#: read-cache.c:2321
+#: read-cache.c:2339
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr "trasigt index, förväntade %s i %s, fick %s"
 
-#: read-cache.c:3017 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1141
+#: read-cache.c:3035 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1141
 #, c-format
 msgid "could not close '%s'"
 msgstr "kunde inte stänga \"%s\""
 
-#: read-cache.c:3120 sequencer.c:2487 sequencer.c:4239
+#: read-cache.c:3138 sequencer.c:2487 sequencer.c:4239
 #, c-format
 msgid "could not stat '%s'"
 msgstr "kunde inte ta status på \"%s\""
 
-#: read-cache.c:3133
+#: read-cache.c:3151
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "kunde inte öppna git-katalog: %s"
 
-#: read-cache.c:3145
+#: read-cache.c:3163
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "misslyckades ta bort länken: %s"
 
-#: read-cache.c:3170
+#: read-cache.c:3188
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr "kan inte rätta behörighetsbitar på \"%s\""
 
-#: read-cache.c:3319
+#: read-cache.c:3337
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr "%s: kan inte återgå till kö 0"
@@ -6502,243 +6494,248 @@ msgstr "bakom %d"
 msgid "ahead %d, behind %d"
 msgstr "före %d, bakom %d"
 
-#: ref-filter.c:169
+#: ref-filter.c:175
 #, c-format
 msgid "expected format: %%(color:<color>)"
 msgstr "förväntat format: %%(color:<color>)"
 
-#: ref-filter.c:171
+#: ref-filter.c:177
 #, c-format
 msgid "unrecognized color: %%(color:%s)"
 msgstr "okänd färg: %%(color:%s)"
 
-#: ref-filter.c:193
+#: ref-filter.c:199
 #, c-format
 msgid "Integer value expected refname:lstrip=%s"
 msgstr "Heltalsvärde förväntades refname:lstrip=%s"
 
-#: ref-filter.c:197
+#: ref-filter.c:203
 #, c-format
 msgid "Integer value expected refname:rstrip=%s"
 msgstr "Heltalsvärde förväntades refname:rstrip=%s"
 
-#: ref-filter.c:199
+#: ref-filter.c:205
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
 msgstr "okänt %%(%s)-argument: %s"
 
-#: ref-filter.c:254
+#: ref-filter.c:260
 #, c-format
 msgid "%%(objecttype) does not take arguments"
 msgstr "%%(objecttype) tar inte argument"
 
-#: ref-filter.c:276
+#: ref-filter.c:282
 #, c-format
 msgid "unrecognized %%(objectsize) argument: %s"
 msgstr "okänt %%(objectsize)-argument: %s"
 
-#: ref-filter.c:284
+#: ref-filter.c:290
 #, c-format
 msgid "%%(deltabase) does not take arguments"
 msgstr "%%(deltabase) tar inte argument"
 
-#: ref-filter.c:296
+#: ref-filter.c:302
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr "%%(body) tar inte argument"
 
-#: ref-filter.c:309
+#: ref-filter.c:315
 #, c-format
 msgid "unrecognized %%(subject) argument: %s"
 msgstr "okänt %%(subject)-argument: %s"
 
-#: ref-filter.c:330
+#: ref-filter.c:334
+#, c-format
+msgid "expected %%(trailers:key=<value>)"
+msgstr "förvändate %%(trailers:nyckel=<värde>)"
+
+#: ref-filter.c:336
 #, c-format
 msgid "unknown %%(trailers) argument: %s"
 msgstr "okänt %%(trailers)-argument: %s"
 
-#: ref-filter.c:363
+#: ref-filter.c:367
 #, c-format
 msgid "positive value expected contents:lines=%s"
 msgstr "positivt värde förväntat contents:lines=%s"
 
-#: ref-filter.c:365
+#: ref-filter.c:369
 #, c-format
 msgid "unrecognized %%(contents) argument: %s"
 msgstr "okänt %%(contents)-argument: %s"
 
-#: ref-filter.c:380
+#: ref-filter.c:384
 #, c-format
 msgid "positive value expected '%s' in %%(%s)"
 msgstr "positivt värde förväntat \"%s\" i %%(%s)"
 
-#: ref-filter.c:384
+#: ref-filter.c:388
 #, c-format
 msgid "unrecognized argument '%s' in %%(%s)"
 msgstr "okänt argument \"%s\" i %%(%s)"
 
-#: ref-filter.c:398
+#: ref-filter.c:402
 #, c-format
 msgid "unrecognized email option: %s"
 msgstr "okänd e-postalternativ: %s"
 
-#: ref-filter.c:428
+#: ref-filter.c:432
 #, c-format
 msgid "expected format: %%(align:<width>,<position>)"
 msgstr "förväntat format: %%(align:<bredd>,<position>)"
 
-#: ref-filter.c:440
+#: ref-filter.c:444
 #, c-format
 msgid "unrecognized position:%s"
 msgstr "okänd position:%s"
 
-#: ref-filter.c:447
+#: ref-filter.c:451
 #, c-format
 msgid "unrecognized width:%s"
 msgstr "okänd bredd:%s"
 
-#: ref-filter.c:456
+#: ref-filter.c:460
 #, c-format
 msgid "unrecognized %%(align) argument: %s"
 msgstr "okänt %%(align)-argument: %s"
 
-#: ref-filter.c:464
+#: ref-filter.c:468
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr "positiv bredd förväntad med atomen %%(align)"
 
-#: ref-filter.c:482
+#: ref-filter.c:486
 #, c-format
 msgid "unrecognized %%(if) argument: %s"
 msgstr "okänt %%(if)-argument: %s"
 
-#: ref-filter.c:584
+#: ref-filter.c:588
 #, c-format
 msgid "malformed field name: %.*s"
 msgstr "felformat fältnamn: %.*s"
 
-#: ref-filter.c:611
+#: ref-filter.c:615
 #, c-format
 msgid "unknown field name: %.*s"
 msgstr "okänt fältnamn: %.*s"
 
-#: ref-filter.c:615
+#: ref-filter.c:619
 #, c-format
 msgid ""
 "not a git repository, but the field '%.*s' requires access to object data"
 msgstr ""
 "inte ett git-arkiv, men fältet \"%.*s\" kräver tillgång till objektdata"
 
-#: ref-filter.c:739
+#: ref-filter.c:743
 #, c-format
 msgid "format: %%(if) atom used without a %%(then) atom"
 msgstr "format: atomen %%(if) använd utan en %%(then)-atom"
 
-#: ref-filter.c:802
+#: ref-filter.c:806
 #, c-format
 msgid "format: %%(then) atom used without an %%(if) atom"
 msgstr "format: atomen %%(then) använd utan en %%(if)-atom"
 
-#: ref-filter.c:804
+#: ref-filter.c:808
 #, c-format
 msgid "format: %%(then) atom used more than once"
 msgstr "format: atomen %%(then) använd mer än en gång"
 
-#: ref-filter.c:806
+#: ref-filter.c:810
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr "format: atomen %%(then) använd efter %%(else)"
 
-#: ref-filter.c:834
+#: ref-filter.c:838
 #, c-format
 msgid "format: %%(else) atom used without an %%(if) atom"
 msgstr "format: atomen %%(else) använd utan en %%(if)-atom"
 
-#: ref-filter.c:836
+#: ref-filter.c:840
 #, c-format
 msgid "format: %%(else) atom used without a %%(then) atom"
 msgstr "format: atomen %%(else) använd utan en %%(then)-atom"
 
-#: ref-filter.c:838
+#: ref-filter.c:842
 #, c-format
 msgid "format: %%(else) atom used more than once"
 msgstr "format: atomen %%(else) använd mer än en gång"
 
-#: ref-filter.c:853
+#: ref-filter.c:857
 #, c-format
 msgid "format: %%(end) atom used without corresponding atom"
 msgstr "format: atomen %%(end) använd utan motsvarande atom"
 
-#: ref-filter.c:910
+#: ref-filter.c:914
 #, c-format
 msgid "malformed format string %s"
 msgstr "felformad formatsträng %s"
 
-#: ref-filter.c:1551
+#: ref-filter.c:1555
 #, c-format
 msgid "(no branch, rebasing %s)"
 msgstr "(ingen gren, ombaserar %s)"
 
-#: ref-filter.c:1554
+#: ref-filter.c:1558
 #, c-format
 msgid "(no branch, rebasing detached HEAD %s)"
 msgstr "(ingen gren, ombaserar frånkopplat HEAD %s)"
 
-#: ref-filter.c:1557
+#: ref-filter.c:1561
 #, c-format
 msgid "(no branch, bisect started on %s)"
 msgstr "(ingen gren, \"bisect\" startad på %s)"
 
-#: ref-filter.c:1561
+#: ref-filter.c:1565
 #, c-format
 msgid "(HEAD detached at %s)"
 msgstr "(HEAD frånkopplat vid %s)"
 
-#: ref-filter.c:1564
+#: ref-filter.c:1568
 #, c-format
 msgid "(HEAD detached from %s)"
 msgstr "(HEAD frånkopplat från %s)"
 
-#: ref-filter.c:1567
+#: ref-filter.c:1571
 msgid "(no branch)"
 msgstr "(ingen gren)"
 
-#: ref-filter.c:1599 ref-filter.c:1808
+#: ref-filter.c:1603 ref-filter.c:1812
 #, c-format
 msgid "missing object %s for %s"
 msgstr "objektet %s saknas för %s"
 
-#: ref-filter.c:1609
+#: ref-filter.c:1613
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr "parse_object_buffer misslyckades på %s för %s"
 
-#: ref-filter.c:1992
+#: ref-filter.c:1996
 #, c-format
 msgid "malformed object at '%s'"
 msgstr "felformat objekt vid \"%s\""
 
-#: ref-filter.c:2081
+#: ref-filter.c:2085
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr "ignorerar referens med trasigt namn %s"
 
-#: ref-filter.c:2086 refs.c:676
+#: ref-filter.c:2090 refs.c:676
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "ignorerar trasig referens %s"
 
-#: ref-filter.c:2426
+#: ref-filter.c:2430
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "format: atomen %%(end) saknas"
 
-#: ref-filter.c:2525
+#: ref-filter.c:2529
 #, c-format
 msgid "malformed object name %s"
 msgstr "felformat objektnamn %s"
 
-#: ref-filter.c:2530
+#: ref-filter.c:2534
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "flaggan \"%s\" måste peka på en incheckning"
@@ -15575,7 +15572,7 @@ msgstr "felaktigt antal trådar angivet (%d) för %s"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:285 builtin/index-pack.c:1589 builtin/index-pack.c:1792
+#: builtin/grep.c:285 builtin/index-pack.c:1589 builtin/index-pack.c:1808
 #: builtin/pack-objects.c:2944
 #, c-format
 msgid "no threads support, ignoring %s"
@@ -16242,38 +16239,38 @@ msgid_plural "chain length = %d: %lu objects"
 msgstr[0] "kedjelängd = %d: %lu objekt"
 msgstr[1] "kedjelängd = %d: %lu objekt"
 
-#: builtin/index-pack.c:1749
+#: builtin/index-pack.c:1765
 msgid "Cannot come back to cwd"
 msgstr "Kan inte gå tillbaka till arbetskatalogen (cwd)"
 
-#: builtin/index-pack.c:1803 builtin/index-pack.c:1806
-#: builtin/index-pack.c:1822 builtin/index-pack.c:1826
+#: builtin/index-pack.c:1819 builtin/index-pack.c:1822
+#: builtin/index-pack.c:1838 builtin/index-pack.c:1842
 #, c-format
 msgid "bad %s"
 msgstr "felaktig %s"
 
-#: builtin/index-pack.c:1832 builtin/init-db.c:392 builtin/init-db.c:625
+#: builtin/index-pack.c:1848 builtin/init-db.c:392 builtin/init-db.c:625
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "okänd hashningsalgoritm \"%s\""
 
-#: builtin/index-pack.c:1851
+#: builtin/index-pack.c:1867
 msgid "--fix-thin cannot be used without --stdin"
 msgstr "--fix-thin kan inte användas med --stdin"
 
-#: builtin/index-pack.c:1853
+#: builtin/index-pack.c:1869
 msgid "--stdin requires a git repository"
 msgstr "--stdin kräver ett git-arkiv"
 
-#: builtin/index-pack.c:1855
+#: builtin/index-pack.c:1871
 msgid "--object-format cannot be used with --stdin"
 msgstr "--object-format kan inte användas med --stdin"
 
-#: builtin/index-pack.c:1870
+#: builtin/index-pack.c:1886
 msgid "--verify with no packfile name given"
 msgstr "--verify angavs utan paketfilnamn"
 
-#: builtin/index-pack.c:1936 builtin/unpack-objects.c:582
+#: builtin/index-pack.c:1956 builtin/unpack-objects.c:582
 msgid "fsck error in pack objects"
 msgstr "fsck-fel i packat objekt"
 
@@ -23374,15 +23371,23 @@ msgstr "visa trädobjekt för underkatalogen <prefix>"
 msgid "only useful for debugging"
 msgstr "endast användbart vid felsökning"
 
-#: http-fetch.c:114
+#: http-fetch.c:118
 #, c-format
 msgid "argument to --packfile must be a valid hash (got '%s')"
 msgstr ""
 "argumentet till --packfile måste vara ett giltigt hashvärde (fick '%s')"
 
-#: http-fetch.c:122
+#: http-fetch.c:128
 msgid "not a git repository"
 msgstr "inte ett git-arkiv"
+
+#: http-fetch.c:134
+msgid "--packfile requires --index-pack-args"
+msgstr "--packfile kräver --index-pack-args"
+
+#: http-fetch.c:143
+msgid "--index-pack-args can only be used with --packfile"
+msgstr "--index-pack-args kan endast användas med --packfile"
 
 #: t/helper/test-fast-rebase.c:141
 msgid "unhandled options"
@@ -25785,6 +25790,28 @@ msgstr ""
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Vill du verkligen sända %s? [y=ja, n=nej]: "
+
+#~ msgid "repository contains replace objects; skipping commit-graph"
+#~ msgstr "arkivet innehåller replace-objekt; hoppar över incheckningsgraf"
+
+#~ msgid "repository contains (deprecated) grafts; skipping commit-graph"
+#~ msgstr ""
+#~ "arkivet innehåller ympningar (avråds från); hoppar över incheckningsgraf"
+
+#~ msgid "repository is shallow; skipping commit-graph"
+#~ msgstr "källarkivet är grunt; hoppar över incheckningsgraf"
+
+#~ msgid "commit-graph improper chunk offset %08x%08x"
+#~ msgstr "felaktigt offset för stycke %08x%08x i incheckningsgraffilen"
+
+#~ msgid "commit-graph chunk id %08x appears multiple times"
+#~ msgstr "incheckningsgrafens stycke-id %08x förekommer flera gånger"
+
+#~ msgid "invalid chunk offset (too large)"
+#~ msgstr "felaktigt offset för stycke (för stort)"
+
+#~ msgid "Writing chunks to multi-pack-index"
+#~ msgstr "Skriver stycken till multi-pack-index"
 
 #~ msgid "rev-list died"
 #~ msgstr "rev-list dog"

--- a/po/tr.po
+++ b/po/tr.po
@@ -90,7 +90,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git Turkish Localization Project\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-02-26 22:09+0800\n"
+"POT-Creation-Date: 2021-03-04 22:41+0800\n"
 "PO-Revision-Date: 2020-02/27 16:00+0300\n"
 "Last-Translator: Emir SARI <bitigchi@me.com>\n"
 "Language-Team: Turkish (https://github.com/bitigchi/git-po/)\n"
@@ -1170,7 +1170,7 @@ msgstr "yama başarısız oldu: %s:%ld"
 msgid "cannot checkout %s"
 msgstr "%s çıkışı yapılamıyor"
 
-#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:73 pack-revindex.c:213
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:86 pack-revindex.c:213
 #: setup.c:308
 #, c-format
 msgid "failed to read %s"
@@ -1902,7 +1902,7 @@ msgstr ""
 "--reverse ve --first-parent birlikte en son işlemenin belirtilmesini "
 "gerektiriyor"
 
-#: blame.c:2821 bundle.c:213 ref-filter.c:2202 remote.c:2041 sequencer.c:2146
+#: blame.c:2821 bundle.c:213 ref-filter.c:2206 remote.c:2041 sequencer.c:2146
 #: sequencer.c:4641 submodule.c:856 builtin/commit.c:1045 builtin/log.c:411
 #: builtin/log.c:1016 builtin/log.c:1624 builtin/log.c:2045 builtin/log.c:2335
 #: builtin/merge.c:424 builtin/pack-objects.c:3395 builtin/pack-objects.c:3410
@@ -2167,262 +2167,259 @@ msgstr "'%s' oluşturulamıyor"
 msgid "index-pack died"
 msgstr "index-pack sonlandı"
 
+#: chunk-format.c:113
+msgid "terminating chunk id appears earlier than expected"
+msgstr "iri parça numarası sonlandırması beklenenden önce ortaya çıkıyor"
+
+#: chunk-format.c:122
+#, c-format
+msgid "improper chunk offset(s) %<PRIx64> and %<PRIx64>"
+msgstr "düzgün olmayan iri parça ofseti %<PRIx64> ve %<PRIx64>"
+
+#: chunk-format.c:129
+#, c-format
+msgid "duplicate chunk ID %<PRIx32> found"
+msgstr "yinelenmiş iri parça numarası %<PRIx32> bulundu"
+
+#: chunk-format.c:143
+#, c-format
+msgid "final chunk has non-zero id %<PRIx32>"
+msgstr "en son iri parçanın numarası sıfır olmayan %<PRIx32>"
+
 #: color.c:329
 #, c-format
 msgid "invalid color value: %.*s"
 msgstr "geçersiz renk değeri: %.*s"
 
-#: commit-graph.c:198 midx.c:47
+#: commit-graph.c:197 midx.c:46
 msgid "invalid hash version"
 msgstr "geçersiz sağlama sürümü"
 
-#: commit-graph.c:219
-msgid "repository contains replace objects; skipping commit-graph"
-msgstr "depo değiştirme nesneleri içeriyor; commit-graph atlanıyor"
-
-#: commit-graph.c:228
-msgid "repository contains (deprecated) grafts; skipping commit-graph"
-msgstr "depo (eskimiş) aşılar içeriyor; commit-graph atlanıyor"
-
-#: commit-graph.c:233
-msgid "repository is shallow; skipping commit-graph"
-msgstr "depo sığ; commit-graph atlanıyor"
-
-#: commit-graph.c:264
+#: commit-graph.c:255
 msgid "commit-graph file is too small"
 msgstr "commit-graph dosyası pek küçük"
 
-#: commit-graph.c:329
+#: commit-graph.c:348
 #, c-format
 msgid "commit-graph signature %X does not match signature %X"
 msgstr "commit-graph imzası %X, %X ile eşleşmiyor"
 
-#: commit-graph.c:336
+#: commit-graph.c:355
 #, c-format
 msgid "commit-graph version %X does not match version %X"
 msgstr "commit-graph sürümü %x, %X ile eşleşmiyor"
 
-#: commit-graph.c:343
+#: commit-graph.c:362
 #, c-format
 msgid "commit-graph hash version %X does not match version %X"
 msgstr "commit-graph sağlama sürümü %X, %X ile eşleşmiyor"
 
-#: commit-graph.c:360
+#: commit-graph.c:379
 #, c-format
 msgid "commit-graph file is too small to hold %u chunks"
 msgstr "commit-graph dosyası %u iri parça tutmak için pek küçük"
 
-#: commit-graph.c:379
-#, c-format
-msgid "commit-graph improper chunk offset %08x%08x"
-msgstr "commit-graph biçimsiz iri parça ofseti %08x%08x"
-
-#: commit-graph.c:465
-#, c-format
-msgid "commit-graph chunk id %08x appears multiple times"
-msgstr "commit-graph iri parça numarası %08x birden çok görünüyor"
-
-#: commit-graph.c:531
+#: commit-graph.c:472
 msgid "commit-graph has no base graphs chunk"
 msgstr "commit-graph temel grafiği iri parçasına iye değil"
 
-#: commit-graph.c:541
+#: commit-graph.c:482
 msgid "commit-graph chain does not match"
 msgstr "commit-graph zinciri eşleşmiyor"
 
-#: commit-graph.c:589
+#: commit-graph.c:530
 #, c-format
 msgid "invalid commit-graph chain: line '%s' not a hash"
 msgstr "geçersiz commit-graph zinciri: '%s'. satır bir sağlama değil"
 
-#: commit-graph.c:613
+#: commit-graph.c:554
 msgid "unable to find all commit-graph files"
 msgstr "tüm commit-graph dosyaları bulunamıyor"
 
-#: commit-graph.c:794 commit-graph.c:831
+#: commit-graph.c:735 commit-graph.c:772
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr "geçersiz işleme konumu. commit-graph büyük olasılıkla hasar görmüş."
 
-#: commit-graph.c:815
+#: commit-graph.c:756
 #, c-format
 msgid "could not find commit %s"
 msgstr "%s işlemesi bulunamadı"
 
-#: commit-graph.c:848
+#: commit-graph.c:789
 msgid "commit-graph requires overflow generation data but has none"
 msgstr "commit-graph, taşım oluşturma verisi gerektiriyor; ancak hiç yok"
 
-#: commit-graph.c:1121 builtin/am.c:1292
+#: commit-graph.c:1065 builtin/am.c:1292
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "%s işlemesi ayrıştırılamıyor"
 
-#: commit-graph.c:1378 builtin/pack-objects.c:2872
+#: commit-graph.c:1327 builtin/pack-objects.c:2872
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "%s nesnesinin türü alınamıyor"
 
-#: commit-graph.c:1409
+#: commit-graph.c:1358
 msgid "Loading known commits in commit graph"
 msgstr "İşleme grafiğindeki bilinen işlemeler yükleniyor"
 
-#: commit-graph.c:1426
+#: commit-graph.c:1375
 msgid "Expanding reachable commits in commit graph"
 msgstr "İşleme grafiğindeki ulaşılabilir işlemeler genişletiliyor"
 
-#: commit-graph.c:1446
+#: commit-graph.c:1395
 msgid "Clearing commit marks in commit graph"
 msgstr "İşleme grafiğindeki işleme imleri temizleniyor"
 
-#: commit-graph.c:1465
+#: commit-graph.c:1414
 msgid "Computing commit graph topological levels"
 msgstr "İşleme grafiği ilingesel düzeyleri hesaplanıyor"
 
-#: commit-graph.c:1518
+#: commit-graph.c:1467
 msgid "Computing commit graph generation numbers"
 msgstr "İşleme grafiği kuşak sayıları hesaplanıyor"
 
-#: commit-graph.c:1599
+#: commit-graph.c:1548
 msgid "Computing commit changed paths Bloom filters"
 msgstr ""
 "Geçerli işlemelerdeki değiştirilmiş yollar için Bloom süzgeci hesaplanıyor"
 
-#: commit-graph.c:1676
+#: commit-graph.c:1625
 msgid "Collecting referenced commits"
 msgstr "Başvurulmuş işlemeler toplanıyor"
 
-#: commit-graph.c:1701
+#: commit-graph.c:1650
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] "%d pakette işleme grafiği için işlemeler bulunuyor"
 msgstr[1] "%d pakette işleme grafiği için işlemeler bulunuyor"
 
-#: commit-graph.c:1714
+#: commit-graph.c:1663
 #, c-format
 msgid "error adding pack %s"
 msgstr "%s paketi eklenirken hata"
 
-#: commit-graph.c:1718
+#: commit-graph.c:1667
 #, c-format
 msgid "error opening index for %s"
 msgstr "%s için indeks açılırken hata"
 
-#: commit-graph.c:1755
+#: commit-graph.c:1704
 msgid "Finding commits for commit graph among packed objects"
 msgstr "Paketlenmiş nesneler arasından işleme grafiği için işlemeler bulunuyor"
 
-#: commit-graph.c:1773
+#: commit-graph.c:1722
 msgid "Finding extra edges in commit graph"
 msgstr "İşleme grafiğindeki ek sınırlar bulunuyor"
 
-#: commit-graph.c:1821
+#: commit-graph.c:1771
 msgid "failed to write correct number of base graph ids"
 msgstr "temel grafiği numaralarının doğru sayısı yazılamadı"
 
-#: commit-graph.c:1863 midx.c:819
+#: commit-graph.c:1802 midx.c:794
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "%s öncü dizinleri oluşturulamıyor"
 
-#: commit-graph.c:1876
+#: commit-graph.c:1815
 msgid "unable to create temporary graph layer"
 msgstr "geçici grafik katmanı oluşturulamıyor"
 
-#: commit-graph.c:1881
+#: commit-graph.c:1820
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "'%s' için paylaşılan izinler ayarlanamıyor"
 
-#: commit-graph.c:1966
+#: commit-graph.c:1879
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "İşleme grafiği %d geçişte yazılıyor"
 msgstr[1] "İşleme grafiği %d geçişte yazılıyor"
 
-#: commit-graph.c:2011
+#: commit-graph.c:1915
 msgid "unable to open commit-graph chain file"
 msgstr "commit-graph zincir dosyası açılamıyor"
 
-#: commit-graph.c:2027
+#: commit-graph.c:1931
 msgid "failed to rename base commit-graph file"
 msgstr "temel commit-graph dosyası yeniden adlandırılamadı"
 
-#: commit-graph.c:2047
+#: commit-graph.c:1951
 msgid "failed to rename temporary commit-graph file"
 msgstr "geçici commit-graph dosyası yeniden adlandırılamadı"
 
-#: commit-graph.c:2180
+#: commit-graph.c:2084
 msgid "Scanning merged commits"
 msgstr "Birleştirilen işlemeler taranıyor"
 
-#: commit-graph.c:2224
+#: commit-graph.c:2128
 msgid "Merging commit-graph"
 msgstr "commit-graph birleştiriliyor"
 
-#: commit-graph.c:2331
+#: commit-graph.c:2235
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 "bir commit-graph yazılmaya çalışılıyor; ancak 'core.commitGraph' devre dışı"
 
-#: commit-graph.c:2438
+#: commit-graph.c:2342
 msgid "too many commits to write graph"
 msgstr "grafik yazımı için çok fazla işleme"
 
-#: commit-graph.c:2536
+#: commit-graph.c:2440
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "commit-graph dosyasının sağlama toplamı yanlış ve büyük olasılıkla hasar "
 "görmüş"
 
-#: commit-graph.c:2546
+#: commit-graph.c:2450
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "commit-graph hatalı nesne tanımlayıcı sırasına iye: %s, sonra %s"
 
-#: commit-graph.c:2556 commit-graph.c:2571
+#: commit-graph.c:2460 commit-graph.c:2475
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr "commit-graph hatalı fanout değerine iye: fanout[%d] = %u != %u"
 
-#: commit-graph.c:2563
+#: commit-graph.c:2467
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "%s işlemesi commit-graph'tan ayrıştırılamadı"
 
-#: commit-graph.c:2581
+#: commit-graph.c:2485
 msgid "Verifying commits in commit graph"
 msgstr "İşleme grafiğindeki işlemeler doğrulanıyor"
 
-#: commit-graph.c:2596
+#: commit-graph.c:2500
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "%s işlemesi commit-graph için olan nesne veritabanından ayrıştırılamadı"
 
-#: commit-graph.c:2603
+#: commit-graph.c:2507
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 "commit-graph'teki %s işlemesi için olan kök ağaç nesne tanımlayıcısı %s != %s"
 
-#: commit-graph.c:2613
+#: commit-graph.c:2517
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr "%s işlemesi için olan commit-graph üst öge listesi çok uzun"
 
-#: commit-graph.c:2622
+#: commit-graph.c:2526
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "%s için olan commit-graph üst ögesi %s != %s"
 
-#: commit-graph.c:2636
+#: commit-graph.c:2540
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr "%s işlemesi için olan commit-graph üst öge listesi erkenden sonlanıyor"
 
-#: commit-graph.c:2641
+#: commit-graph.c:2545
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2430,7 +2427,7 @@ msgstr ""
 "%s işlemesi için commit-graph kuşak sayısı sıfır; ancak başka yerlerde "
 "sıfırdan farklı"
 
-#: commit-graph.c:2645
+#: commit-graph.c:2549
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2438,12 +2435,12 @@ msgstr ""
 "%s işlemesi için commit-graph kuşak sayısı sıfırdan farklı; ancak başka "
 "yerlerde sıfır"
 
-#: commit-graph.c:2662
+#: commit-graph.c:2566
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr "%s işlemesi için commit-graph kuşağı %<PRIuMAX> < %<PRIuMAX>"
 
-#: commit-graph.c:2668
+#: commit-graph.c:2572
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
@@ -2545,6 +2542,7 @@ msgid "relative config include conditionals must come from files"
 msgstr "göreceli yapılandırma içerme koşulluları dosyalardan gelmeli"
 
 #: config.c:396
+#, c-format
 msgid "invalid config format: %s"
 msgstr "geçersiz yapılandırma biçimi: %s"
 
@@ -2608,6 +2606,7 @@ msgid "missing config key %s"
 msgstr "%s yapılandırma anahtarı eksik"
 
 #: config.c:644
+#, c-format
 msgid "missing config value %s"
 msgstr "%s yapılandırma değeri eksik"
 
@@ -3963,7 +3962,7 @@ msgstr ""
 msgid "failed to read orderfile '%s'"
 msgstr "orderfile '%s' okunamadı"
 
-#: diffcore-rename.c:555
+#: diffcore-rename.c:786
 msgid "Performing inexact rename detection"
 msgstr "Kesin olmayan yeniden adlandırma algılaması gerçekleştiriliyor"
 
@@ -4014,17 +4013,17 @@ msgstr "çekirdek adı ve bilgisi alınamadı"
 msgid "untracked cache is disabled on this system or location"
 msgstr "izlenmeyen önbellek bu sistemde veya konumda devre dışı bırakılmış"
 
-#: dir.c:3537
+#: dir.c:3534
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "%s deposundaki indeks dosyası hasarlı"
 
-#: dir.c:3582 dir.c:3587
+#: dir.c:3579 dir.c:3584
 #, c-format
 msgid "could not create directories for %s"
 msgstr "%s için dizinler oluşturulamadı"
 
-#: dir.c:3616
+#: dir.c:3613
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "git dizini '%s' konumundan '%s' konumuna göç ettirilemedi"
@@ -4083,32 +4082,32 @@ msgstr "uzak konuma yazılamıyor"
 msgid "--stateless-rpc requires multi_ack_detailed"
 msgstr "--stateless-rpc multi_ack_detailed gerektiriyor"
 
-#: fetch-pack.c:378 fetch-pack.c:1400
+#: fetch-pack.c:378 fetch-pack.c:1457
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "geçersiz sığ satır: %s"
 
-#: fetch-pack.c:384 fetch-pack.c:1406
+#: fetch-pack.c:384 fetch-pack.c:1463
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "geçersiz sığ olmayan satır: %s"
 
-#: fetch-pack.c:386 fetch-pack.c:1408
+#: fetch-pack.c:386 fetch-pack.c:1465
 #, c-format
 msgid "object not found: %s"
 msgstr "nesne bulunamadı: %s"
 
-#: fetch-pack.c:389 fetch-pack.c:1411
+#: fetch-pack.c:389 fetch-pack.c:1468
 #, c-format
 msgid "error in object: %s"
 msgstr "nesne içinde hata: %s"
 
-#: fetch-pack.c:391 fetch-pack.c:1413
+#: fetch-pack.c:391 fetch-pack.c:1470
 #, c-format
 msgid "no shallow found: %s"
 msgstr "sığ bulunamadı: %s"
 
-#: fetch-pack.c:394 fetch-pack.c:1417
+#: fetch-pack.c:394 fetch-pack.c:1474
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "sığ/sığ olmayan bekleniyordu, %s alındı"
@@ -4146,157 +4145,161 @@ msgstr "%s tamam olarak imleniyor"
 msgid "already have %s (%s)"
 msgstr "%s halihazırda var (%s)"
 
-#: fetch-pack.c:821
+#: fetch-pack.c:844
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-pack: yanbant çoğullama çözücüsü ayrı çatallanamıyor"
 
-#: fetch-pack.c:829
+#: fetch-pack.c:852
 msgid "protocol error: bad pack header"
 msgstr "protokol hatası: hatalı paket üstbilgisi"
 
-#: fetch-pack.c:913
+#: fetch-pack.c:946
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-pack: %s ayrı çatallanamıyor"
 
-#: fetch-pack.c:931
+#: fetch-pack.c:952
+msgid "fetch-pack: invalid index-pack output"
+msgstr "fetch-pack: geçersiz index-pack çıktısı"
+
+#: fetch-pack.c:969
 #, c-format
 msgid "%s failed"
 msgstr "%s başarısız oldu"
 
-#: fetch-pack.c:933
+#: fetch-pack.c:971
 msgid "error in sideband demultiplexer"
 msgstr "yanbant çoğullama çözücüsünde hata"
 
-#: fetch-pack.c:976
+#: fetch-pack.c:1031
 #, c-format
 msgid "Server version is %.*s"
 msgstr "Sunucu sürümü %.*s"
 
-#: fetch-pack.c:984 fetch-pack.c:990 fetch-pack.c:993 fetch-pack.c:999
-#: fetch-pack.c:1003 fetch-pack.c:1007 fetch-pack.c:1011 fetch-pack.c:1015
-#: fetch-pack.c:1019 fetch-pack.c:1023 fetch-pack.c:1027 fetch-pack.c:1031
-#: fetch-pack.c:1037 fetch-pack.c:1043 fetch-pack.c:1048 fetch-pack.c:1053
+#: fetch-pack.c:1039 fetch-pack.c:1045 fetch-pack.c:1048 fetch-pack.c:1054
+#: fetch-pack.c:1058 fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070
+#: fetch-pack.c:1074 fetch-pack.c:1078 fetch-pack.c:1082 fetch-pack.c:1086
+#: fetch-pack.c:1092 fetch-pack.c:1098 fetch-pack.c:1103 fetch-pack.c:1108
 #, c-format
 msgid "Server supports %s"
 msgstr "Sunucu %s destekliyor"
 
-#: fetch-pack.c:986
+#: fetch-pack.c:1041
 msgid "Server does not support shallow clients"
 msgstr "Sunucu sığ istemcileri desteklemiyor"
 
-#: fetch-pack.c:1046
+#: fetch-pack.c:1101
 msgid "Server does not support --shallow-since"
 msgstr "Sunucu --shallow-since desteklemiyor"
 
-#: fetch-pack.c:1051
+#: fetch-pack.c:1106
 msgid "Server does not support --shallow-exclude"
 msgstr "Sunucu --shallow-exclude desteklemiyor"
 
-#: fetch-pack.c:1055
+#: fetch-pack.c:1110
 msgid "Server does not support --deepen"
 msgstr "Sunucu --deepen desteklemiyor"
 
-#: fetch-pack.c:1057
+#: fetch-pack.c:1112
 msgid "Server does not support this repository's object format"
 msgstr "Sunucu bu deponun nesne türünü desteklemiyor"
 
-#: fetch-pack.c:1070
+#: fetch-pack.c:1125
 msgid "no common commits"
 msgstr "ortak işleme yok"
 
-#: fetch-pack.c:1082 fetch-pack.c:1622
+#: fetch-pack.c:1138 fetch-pack.c:1682
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack: getirme başarısız"
 
-#: fetch-pack.c:1208
+#: fetch-pack.c:1265
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "eşleşmeyen algoritmalar: istemci %s; sunucu %s"
 
-#: fetch-pack.c:1212
+#: fetch-pack.c:1269
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "sunucu '%s' algoritmasını desteklemiyor"
 
-#: fetch-pack.c:1232
+#: fetch-pack.c:1289
 msgid "Server does not support shallow requests"
 msgstr "Sunucu sığ istekleri desteklemiyor"
 
-#: fetch-pack.c:1239
+#: fetch-pack.c:1296
 msgid "Server supports filter"
 msgstr "Sunucu süzgeç destekliyor"
 
-#: fetch-pack.c:1278
+#: fetch-pack.c:1335
 msgid "unable to write request to remote"
 msgstr "uzak konuma istek yazılamıyor"
 
-#: fetch-pack.c:1296
+#: fetch-pack.c:1353
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "bölüm üstbilgisi '%s' okunurken hata"
 
-#: fetch-pack.c:1302
+#: fetch-pack.c:1359
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "'%s' bekleniyordu, '%s' alındı"
 
-#: fetch-pack.c:1363
+#: fetch-pack.c:1420
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "beklenmedik alındı satırı: '%s'"
 
-#: fetch-pack.c:1368
+#: fetch-pack.c:1425
 #, c-format
 msgid "error processing acks: %d"
 msgstr "alındılar işlenirken hata: %d"
 
-#: fetch-pack.c:1378
+#: fetch-pack.c:1435
 msgid "expected packfile to be sent after 'ready'"
 msgstr "paket dosyasının 'ready'den sonra gönderilmesi gerekiyordu"
 
-#: fetch-pack.c:1380
+#: fetch-pack.c:1437
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr "'ready' \"yok\" iken başka hiçbir bölümün gönderilmemesi gerekiyordu"
 
-#: fetch-pack.c:1422
+#: fetch-pack.c:1479
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "sığ bilgi işlenirken hata: %d"
 
-#: fetch-pack.c:1469
+#: fetch-pack.c:1526
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "wanted-ref bekleniyordu, '%s' alındı"
 
-#: fetch-pack.c:1474
+#: fetch-pack.c:1531
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "beklenmedik wanted-ref: '%s'"
 
-#: fetch-pack.c:1479
+#: fetch-pack.c:1536
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "aranan başvurular işlenirken hata: %d"
 
-#: fetch-pack.c:1509
+#: fetch-pack.c:1566
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: yanıt sonu paketi bekleniyordu"
 
-#: fetch-pack.c:1891
+#: fetch-pack.c:1960
 msgid "no matching remote head"
 msgstr "eşleşen uzak dal ucu yok"
 
-#: fetch-pack.c:1914 builtin/clone.c:693
+#: fetch-pack.c:1983 builtin/clone.c:693
 msgid "remote did not send all necessary objects"
 msgstr "uzak konum gereken tüm nesneleri göndermedi"
 
-#: fetch-pack.c:1941
+#: fetch-pack.c:2010
 #, c-format
 msgid "no such remote ref %s"
 msgstr "böyle bir uzak başvuru yok: %s"
 
-#: fetch-pack.c:1944
+#: fetch-pack.c:2013
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Sunucu %s tanıtılmamış nesnesi için isteğe izin vermiyor"
@@ -4659,32 +4662,32 @@ msgstr "lsrefs.unborn için '%s' geçersiz değeri"
 msgid "expected flush after ls-refs arguments"
 msgstr "ls-refs argümanlarından sonra floş bekleniyordu"
 
-#: merge-ort.c:855 merge-recursive.c:1191
+#: merge-ort.c:888 merge-recursive.c:1191
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
 msgstr "%s altmodülü birleştirilemedi (çıkış yapılmadı)"
 
-#: merge-ort.c:864 merge-recursive.c:1198
+#: merge-ort.c:897 merge-recursive.c:1198
 #, c-format
 msgid "Failed to merge submodule %s (commits not present)"
 msgstr "%s altmodülü birleştirilemedi (işlemeler mevcut değil)"
 
-#: merge-ort.c:873 merge-recursive.c:1205
+#: merge-ort.c:906 merge-recursive.c:1205
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
 msgstr "%s altmodülü birleştirilemedi (işlemeler merge-base'i takip etmiyor)"
 
-#: merge-ort.c:883 merge-ort.c:890
+#: merge-ort.c:916 merge-ort.c:923
 #, c-format
 msgid "Note: Fast-forwarding submodule %s to %s"
 msgstr "Not: %s altmodülü %s yönüne ileri sarılıyor"
 
-#: merge-ort.c:911
+#: merge-ort.c:944
 #, c-format
 msgid "Failed to merge submodule %s"
 msgstr "'%s' altmodülünü birleştirilemedi"
 
-#: merge-ort.c:918
+#: merge-ort.c:951
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but a possible merge resolution exists:\n"
@@ -4693,7 +4696,7 @@ msgstr ""
 "%s altmodülü birleştirilemedi; ancak olası bir birleştirme çözümü mevcut:\n"
 "%s\n"
 
-#: merge-ort.c:922 merge-recursive.c:1259
+#: merge-ort.c:955 merge-recursive.c:1259
 #, c-format
 msgid ""
 "If this is correct simply add it to the index for example\n"
@@ -4709,30 +4712,31 @@ msgstr ""
 "\n"
 "komutu bu öneriyi kabul edecektir.\n"
 
-#: merge-ort.c:935
+#: merge-ort.c:968
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but multiple possible merges exist:\n"
 "%s"
 msgstr ""
-"%s altmodülü birleştirilemedi; ancak birden çok olası birleştirmeler mevcut:\n"
+"%s altmodülü birleştirilemedi; ancak birden çok olası birleştirmeler "
+"mevcut:\n"
 "%s"
 
-#: merge-ort.c:1094 merge-recursive.c:1341
+#: merge-ort.c:1127 merge-recursive.c:1341
 msgid "Failed to execute internal merge"
 msgstr "İç birleştirme çalıştırılamadı"
 
-#: merge-ort.c:1099 merge-recursive.c:1346
+#: merge-ort.c:1132 merge-recursive.c:1346
 #, c-format
 msgid "Unable to add %s to database"
 msgstr "%s veritabanına eklenemedi"
 
-#: merge-ort.c:1106 merge-recursive.c:1378
+#: merge-ort.c:1139 merge-recursive.c:1378
 #, c-format
 msgid "Auto-merging %s"
 msgstr "%s kendiliğinden birleştiriliyor"
 
-#: merge-ort.c:1245 merge-recursive.c:2100
+#: merge-ort.c:1278 merge-recursive.c:2100
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
@@ -4742,7 +4746,7 @@ msgstr ""
 "örtülü yeniden adlandırmanın aşağıdaki yolları oraya koymasına engel oluyor: "
 "%s."
 
-#: merge-ort.c:1255 merge-recursive.c:2110
+#: merge-ort.c:1288 merge-recursive.c:2110
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
@@ -4752,18 +4756,18 @@ msgstr ""
 "eşlemlenemiyor; örtülü dizin yeniden adlandırmaları aşağıdaki yolları oraya "
 "koymayı denedi: %s."
 
-#: merge-ort.c:1438
+#: merge-ort.c:1471
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to rename %s to; it was "
 "renamed to multiple other directories, with no destination getting a "
 "majority of the files."
 msgstr ""
-"ÇAKIŞMA: (dizin yeniden adlandırma ayrılması): %s ögesinin nereye "
-"yeniden adlandırılacağı belirsiz; herhangi bir hedef dosyaların çoğunu "
-"almadan birden çok başka dizine yeniden adlandırılmıştı."
+"ÇAKIŞMA: (dizin yeniden adlandırma ayrılması): %s ögesinin nereye yeniden "
+"adlandırılacağı belirsiz; herhangi bir hedef dosyaların çoğunu almadan "
+"birden çok başka dizine yeniden adlandırılmıştı."
 
-#: merge-ort.c:1604 merge-recursive.c:2447
+#: merge-ort.c:1637 merge-recursive.c:2447
 #, c-format
 msgid ""
 "WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
@@ -4772,7 +4776,7 @@ msgstr ""
 "UYARI: %s -> %s yeniden adlandırmasını %s ögesine uygulamadan kaçınılıyor, "
 "çünkü %s ögesinin kendisi yeniden adlandırıldı."
 
-#: merge-ort.c:1748 merge-recursive.c:3215
+#: merge-ort.c:1781 merge-recursive.c:3215
 #, c-format
 msgid ""
 "Path updated: %s added in %s inside a directory that was renamed in %s; "
@@ -4781,7 +4785,7 @@ msgstr ""
 "Yol güncellendi: %s, (%s içinde eklenen) %s içinde yeniden adlandırılan bir "
 "dizinde; onu %s konumuna taşıdı."
 
-#: merge-ort.c:1755 merge-recursive.c:3222
+#: merge-ort.c:1788 merge-recursive.c:3222
 #, c-format
 msgid ""
 "Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
@@ -4790,7 +4794,7 @@ msgstr ""
 "Yol güncellendi: %s, %s olarak yeniden adlandırıldı (%s içinde), %s içinde "
 "yeniden adlandırılan bir dizinde; onu %s konumuna taşıdı."
 
-#: merge-ort.c:1768 merge-recursive.c:3218
+#: merge-ort.c:1801 merge-recursive.c:3218
 #, c-format
 msgid ""
 "CONFLICT (file location): %s added in %s inside a directory that was renamed "
@@ -4799,7 +4803,7 @@ msgstr ""
 "ÇAKIŞMA (dosya konumu): %s, (%s içinde eklenen) %s içinde yeniden "
 "adlandırılan bir dizinde, belki de %s konumuna taşınmalı."
 
-#: merge-ort.c:1776 merge-recursive.c:3225
+#: merge-ort.c:1809 merge-recursive.c:3225
 #, c-format
 msgid ""
 "CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
@@ -4808,14 +4812,14 @@ msgstr ""
 "ÇAKIŞMA (dosya konumu): %s, %s olarak yeniden adlandırıldı (%s içinde), %s "
 "içinde yeniden adlandırılan bir dizinde, belki de %s konumuna taşınmalı."
 
-#: merge-ort.c:1919
+#: merge-ort.c:1952
 #, c-format
 msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
 msgstr ""
 "ÇAKIŞMA (y. adlandır/y. adlandır): %s->%s olarak adlandırıldı (%s içinde) ve "
 "ek olarak %s olarak da adlandırıldı (%s içinde)."
 
-#: merge-ort.c:2014
+#: merge-ort.c:2047
 #, c-format
 msgid ""
 "CONFLICT (rename involved in collision): rename of %s -> %s has content "
@@ -4823,17 +4827,17 @@ msgid ""
 "markers."
 msgstr ""
 "ÇAKIŞMA (yeniden adlandırma çarpışması): %s -> %s yeniden adlandırmasının "
-"içerik çakışmaları var ve başka bir yolla çarpışıyor; bu iç içe geçmiş çakışma"
-"imleyicilerine neden olabilir."
+"içerik çakışmaları var ve başka bir yolla çarpışıyor; bu iç içe geçmiş "
+"çakışmaimleyicilerine neden olabilir."
 
-#: merge-ort.c:2033 merge-ort.c:2057
+#: merge-ort.c:2066 merge-ort.c:2090
 #, c-format
 msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
 msgstr ""
-"ÇAKIŞMA (yeniden adlandır/sil): %s->%s olarak adlandırıldı (%s içinde); ancak "
-"%s içinde silindi."
+"ÇAKIŞMA (yeniden adlandır/sil): %s->%s olarak adlandırıldı (%s içinde); "
+"ancak %s içinde silindi."
 
-#: merge-ort.c:2683
+#: merge-ort.c:2735
 #, c-format
 msgid ""
 "CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
@@ -4842,7 +4846,7 @@ msgstr ""
 "ÇAKIŞMA (dosya/dizin): Dizin, şuradan %s yolunda: %s; bunun yerine %s "
 "konumuna taşınıyor."
 
-#: merge-ort.c:2756
+#: merge-ort.c:2808
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed %s "
@@ -4852,44 +4856,44 @@ msgstr ""
 "bunlardan %s tanesi yeniden adlandırıldı; böylelikle başka bir yerde "
 "kayıtları yazılabilir."
 
-#: merge-ort.c:2760
+#: merge-ort.c:2812
 msgid "both"
 msgstr "her ikisi de"
 
-#: merge-ort.c:2760
+#: merge-ort.c:2812
 msgid "one"
 msgstr "bir"
 
-#: merge-ort.c:2855 merge-recursive.c:3052
+#: merge-ort.c:2907 merge-recursive.c:3052
 msgid "content"
 msgstr "içerik"
 
-#: merge-ort.c:2857 merge-recursive.c:3056
+#: merge-ort.c:2909 merge-recursive.c:3056
 msgid "add/add"
 msgstr "ekle/ekle"
 
-#: merge-ort.c:2859 merge-recursive.c:3101
+#: merge-ort.c:2911 merge-recursive.c:3101
 msgid "submodule"
 msgstr "altmodül"
 
-#: merge-ort.c:2861 merge-recursive.c:3102
+#: merge-ort.c:2913 merge-recursive.c:3102
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "ÇAKIŞMA (%s): %s içinde birleştirme çakışması"
 
-#: merge-ort.c:2886
+#: merge-ort.c:2938
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
 "of %s left in tree."
 msgstr ""
-"ÇAKIŞMA (değiştir/sil): %s silindi (%s içinde) ve %s içinde değiştirildi. "
-"%s sürümü (şunun: %s) ağaçta bırakıldı."
+"ÇAKIŞMA (değiştir/sil): %s silindi (%s içinde) ve %s içinde değiştirildi. %s "
+"sürümü (şunun: %s) ağaçta bırakıldı."
 
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
-#: merge-ort.c:3354
+#: merge-ort.c:3406
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
 msgstr "şu ağaçlar için birleştirme bilgisi toplama başarısız: %s, %s, %s"
@@ -5216,166 +5220,156 @@ msgstr "önbellek okunamadı"
 msgid "unable to write new index file"
 msgstr "yeni indeks dosyası yazılamıyor"
 
-#: midx.c:80
+#: midx.c:62
+msgid "multi-pack-index OID fanout is of the wrong size"
+msgstr "multi-pack-index OID ikiye bölümünün boyutu hatalı"
+
+#: midx.c:93
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "multi-pack-index dosyası %s pek küçük"
 
-#: midx.c:96
+#: midx.c:109
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr "multi-pack-index imzası 0x%08x, 0x%08x imzası ile eşleşmiyor"
 
-#: midx.c:101
+#: midx.c:114
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "multi-pack-index sürümü %d tanımlanamıyor"
 
-#: midx.c:106
+#: midx.c:119
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr "multi-pack-index sağlama sürümü %u, %u sürümü ile eşleşmiyor"
 
-#: midx.c:123
-msgid "invalid chunk offset (too large)"
-msgstr "geçersiz iri parça ofseti (çok geniş)"
-
-#: midx.c:147
-msgid "terminating multi-pack-index chunk id appears earlier than expected"
-msgstr ""
-"multi-pack-index iri parçası sonlandırılıyor, numarası beklenenden önce "
-"görünüyor"
-
-#: midx.c:160
+#: midx.c:136
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "multi-pack-index'ten gerekli pack-name iri parçası eksik"
 
-#: midx.c:162
+#: midx.c:138
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "multi-pack-index'ten gerekli OID fanout iri parçası eksik"
 
-#: midx.c:164
+#: midx.c:140
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr "multi-pack-index'ten gerekli OID arama iri parçası eksik"
 
-#: midx.c:166
+#: midx.c:142
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr "multi-pack-index'ten gerekli nesne ofsetleri iri parçası eksik"
 
-#: midx.c:180
+#: midx.c:158
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr "multi-pack-index paket adlarının sırasız: '%s' şundan önce: '%s'"
 
-#: midx.c:223
+#: midx.c:202
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr "hatalı pack-int-id: %u (%u toplam paket)"
 
-#: midx.c:273
+#: midx.c:252
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr "multi-pack-index bir 64 bit ofset depoluyor; ancak off_t pek küçük"
 
-#: midx.c:480
+#: midx.c:467
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "paket dosyası '%s' eklenemedi"
 
-#: midx.c:486
+#: midx.c:473
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "pack-index '%s' açılamadı"
 
-#: midx.c:546
+#: midx.c:533
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "%d nesnesi paket dosyasında bulunamadı"
 
-#: midx.c:846
+#: midx.c:821
 msgid "Adding packfiles to multi-pack-index"
 msgstr "Paket dosyaları multi-pack-index'e ekleniyor"
 
-#: midx.c:879
+#: midx.c:855
 #, c-format
 msgid "did not see pack-file %s to drop"
 msgstr "bırakılacak pack-file %s görülmedi"
 
-#: midx.c:931
+#: midx.c:904
 msgid "no pack files to index."
 msgstr "indekslenecek paket dosyası yok."
 
-#: midx.c:982
-msgid "Writing chunks to multi-pack-index"
-msgstr "İri parçalar multi-pack-index'e yazılıyor"
-
-#: midx.c:1060
+#: midx.c:965
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "multi-pack-index %s konumunda temizlenemedi"
 
-#: midx.c:1116
+#: midx.c:1021
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr "multi-pack-index dosyası mevcut, ancak ayrıştırılamadı"
 
-#: midx.c:1124
+#: midx.c:1029
 msgid "Looking for referenced packfiles"
 msgstr "Başvurulmuş paket dosyaları aranıyor"
 
-#: midx.c:1139
+#: midx.c:1044
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 msgstr "oid fanout sırasız: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 
-#: midx.c:1144
+#: midx.c:1049
 msgid "the midx contains no oid"
 msgstr "midx bir oid içermiyor"
 
-#: midx.c:1153
+#: midx.c:1058
 msgid "Verifying OID order in multi-pack-index"
 msgstr "multi-pack-index içindeki OID sırası doğrulanıyor"
 
-#: midx.c:1162
+#: midx.c:1067
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr "oid araması sırasız: oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1182
+#: midx.c:1087
 msgid "Sorting objects by packfile"
 msgstr "Nesneler paket dosyasına göre sıralanıyor"
 
-#: midx.c:1189
+#: midx.c:1094
 msgid "Verifying object offsets"
 msgstr "Nesne ofsetleri doğrulanıyor"
 
-#: midx.c:1205
+#: midx.c:1110
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "şunun için paket girdisi yüklenemedi: oid[%d] = %s"
 
-#: midx.c:1211
+#: midx.c:1116
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "paket dosyası %s için pack-index yüklenemedi"
 
-#: midx.c:1220
+#: midx.c:1125
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr "şunun için yanlış nesne ofseti: oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#: midx.c:1245
+#: midx.c:1150
 msgid "Counting referenced objects"
 msgstr "Başvurulmuş nesneler sayılıyor"
 
-#: midx.c:1255
+#: midx.c:1160
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "Başvurulmamış paket dosyaları bulunuyor ve siliniyor"
 
-#: midx.c:1446
+#: midx.c:1351
 msgid "could not start pack-objects"
 msgstr "pack-objects başlatılamadı"
 
-#: midx.c:1466
+#: midx.c:1371
 msgid "could not finish pack-objects"
 msgstr "pack-objects bitirilemedi"
 
@@ -5861,7 +5855,7 @@ msgstr "dosya bilgileri alınamadı: %s"
 msgid "failed to make %s readable"
 msgstr "%s, yazılabilir yapılamadı"
 
-#: pack-write.c:502
+#: pack-write.c:508
 #, c-format
 msgid "could not write '%s' promisor file"
 msgstr "vaat dosyası '%s' yazılamadı"
@@ -6124,11 +6118,11 @@ msgstr "protokol hatası: hatalı satır uzunluğu %d"
 msgid "remote error: %s"
 msgstr "uzak konum hatası: %s"
 
-#: preload-index.c:119
+#: preload-index.c:125
 msgid "Refreshing index"
 msgstr "İndeks yenileniyor"
 
-#: preload-index.c:138
+#: preload-index.c:144
 #, c-format
 msgid "unable to create threaded lstat: %s"
 msgstr "iş parçacıklarına ayrılmış 'lstat' oluşturulamıyor: %s"
@@ -6237,11 +6231,11 @@ msgstr "'%s' dosyasının bilgileri alınamıyor"
 msgid "'%s' appears as both a file and as a directory"
 msgstr "'%s' hem bir dosya hem de bir dizin olarak görünüyor"
 
-#: read-cache.c:1524
+#: read-cache.c:1532
 msgid "Refresh index"
 msgstr "İndeks yenileniyor"
 
-#: read-cache.c:1639
+#: read-cache.c:1657
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -6250,7 +6244,7 @@ msgstr ""
 "index.version ayarlanmış; ancak değer geçersiz.\n"
 "%i sürümü kullanılıyor"
 
-#: read-cache.c:1649
+#: read-cache.c:1667
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -6259,55 +6253,55 @@ msgstr ""
 "GIT_INDEX_VERSION ayarlanmış; ancak değer geçersiz.\n"
 "%i sürümü kullanılıyor"
 
-#: read-cache.c:1705
+#: read-cache.c:1723
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr "hatalı imza 0x%08x"
 
-#: read-cache.c:1708
+#: read-cache.c:1726
 #, c-format
 msgid "bad index version %d"
 msgstr "hatalı indeks sürümü %d"
 
-#: read-cache.c:1717
+#: read-cache.c:1735
 msgid "bad index file sha1 signature"
 msgstr "hatalı indeks dosyası sha1 imzası"
 
-#: read-cache.c:1747
+#: read-cache.c:1765
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr "indeks bizim anlamadığımız %.4s imzası kullanıyor"
 
-#: read-cache.c:1749
+#: read-cache.c:1767
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr "%.4s uzantısı yok sayılıyor"
 
-#: read-cache.c:1786
+#: read-cache.c:1804
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr "bilinmeyen indeks girdisi biçimi 0x%08x"
 
-#: read-cache.c:1802
+#: read-cache.c:1820
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "indekste hatalı oluşturulmuş ad alanı, '%s' yolu yakınında"
 
-#: read-cache.c:1859
+#: read-cache.c:1877
 msgid "unordered stage entries in index"
 msgstr "indekste sırasız hazırlama alanı girdileri"
 
-#: read-cache.c:1862
+#: read-cache.c:1880
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr "birleştirilmiş dosya '%s' için çoklu hazırlama alanı girdileri"
 
-#: read-cache.c:1865
+#: read-cache.c:1883
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr "'%s' için sırasız hazırlama alanı girdileri"
 
-#: read-cache.c:1971 read-cache.c:2262 rerere.c:549 rerere.c:583 rerere.c:1095
+#: read-cache.c:1989 read-cache.c:2280 rerere.c:549 rerere.c:583 rerere.c:1095
 #: submodule.c:1634 builtin/add.c:546 builtin/check-ignore.c:181
 #: builtin/checkout.c:504 builtin/checkout.c:690 builtin/clean.c:991
 #: builtin/commit.c:364 builtin/diff-tree.c:122 builtin/grep.c:505
@@ -6316,82 +6310,82 @@ msgstr "'%s' için sırasız hazırlama alanı girdileri"
 msgid "index file corrupt"
 msgstr "indeks dosyası hasar görmüş"
 
-#: read-cache.c:2115
+#: read-cache.c:2133
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr "load_cache_entries iş parçacığı oluşturulamıyor: %s"
 
-#: read-cache.c:2128
+#: read-cache.c:2146
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr "load_cache_entries iş parçacığı ucu birleştirilemiyor: %s"
 
-#: read-cache.c:2161
+#: read-cache.c:2179
 #, c-format
 msgid "%s: index file open failed"
 msgstr "%s: indeks dosyası açılamadı"
 
-#: read-cache.c:2165
+#: read-cache.c:2183
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr "%s: açık indeksin bilgileri alınamıyor"
 
-#: read-cache.c:2169
+#: read-cache.c:2187
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr "%s: indeks dosyası beklenenden daha küçük"
 
-#: read-cache.c:2173
+#: read-cache.c:2191
 #, c-format
 msgid "%s: unable to map index file"
 msgstr "%s: indeks dosyası eşlemlenemiyor"
 
-#: read-cache.c:2215
+#: read-cache.c:2233
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr "load_index_extensions iş parçacığı oluşturulamıyor: %s"
 
-#: read-cache.c:2242
+#: read-cache.c:2260
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr "load_index_extensions iş parçacığı ucu birleştirilemiyor: %s"
 
-#: read-cache.c:2274
+#: read-cache.c:2292
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr "paylaşılan indeks '%s' tazelenemedi"
 
-#: read-cache.c:2321
+#: read-cache.c:2339
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr "bozuk indeks, %s bekleniyordu (%s içinde), %s alındı"
 
-#: read-cache.c:3017 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1141
+#: read-cache.c:3035 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1141
 #, c-format
 msgid "could not close '%s'"
 msgstr "'%s' kapatılamadı"
 
-#: read-cache.c:3120 sequencer.c:2487 sequencer.c:4239
+#: read-cache.c:3138 sequencer.c:2487 sequencer.c:4239
 #, c-format
 msgid "could not stat '%s'"
 msgstr "'%s' bilgileri alınamadı"
 
-#: read-cache.c:3133
+#: read-cache.c:3151
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "git dizini açılamıyor: %s"
 
-#: read-cache.c:3145
+#: read-cache.c:3163
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "bağlantı kesilemiyor: %s"
 
-#: read-cache.c:3170
+#: read-cache.c:3188
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr "'%s' üzerindeki izin bitleri onarılamıyor"
 
-#: read-cache.c:3319
+#: read-cache.c:3337
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr "%s: #0 numaralı hazırlama alanına bırakılamıyor"
@@ -6568,243 +6562,248 @@ msgstr "%d arkasında"
 msgid "ahead %d, behind %d"
 msgstr "%d önünde, %d arkasında"
 
-#: ref-filter.c:169
+#: ref-filter.c:175
 #, c-format
 msgid "expected format: %%(color:<color>)"
 msgstr "beklenen biçim: %%(color:<renk>)"
 
-#: ref-filter.c:171
+#: ref-filter.c:177
 #, c-format
 msgid "unrecognized color: %%(color:%s)"
 msgstr "tanımlanamayan renk: %%(color:%s)"
 
-#: ref-filter.c:193
+#: ref-filter.c:199
 #, c-format
 msgid "Integer value expected refname:lstrip=%s"
 msgstr "Tamsayı değeri şunu bekliyordu: refname:lstrip=%s"
 
-#: ref-filter.c:197
+#: ref-filter.c:203
 #, c-format
 msgid "Integer value expected refname:rstrip=%s"
 msgstr "Tamsayı değeri şunu bekliyordu: refname:rstrip=%s"
 
-#: ref-filter.c:199
+#: ref-filter.c:205
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
 msgstr "tanımlanamayan %%(%s) argümanı: %s"
 
-#: ref-filter.c:254
+#: ref-filter.c:260
 #, c-format
 msgid "%%(objecttype) does not take arguments"
 msgstr "%%(objecttype) argüman almıyor"
 
-#: ref-filter.c:276
+#: ref-filter.c:282
 #, c-format
 msgid "unrecognized %%(objectsize) argument: %s"
 msgstr "tanımlanamayan %%(objectsize) argümanı: %s"
 
-#: ref-filter.c:284
+#: ref-filter.c:290
 #, c-format
 msgid "%%(deltabase) does not take arguments"
 msgstr "%%(deltabase) argüman almıyor"
 
-#: ref-filter.c:296
+#: ref-filter.c:302
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr "%%(body) argüman almıyor"
 
-#: ref-filter.c:309
+#: ref-filter.c:315
 #, c-format
 msgid "unrecognized %%(subject) argument: %s"
 msgstr "tanımlanamayan %%(subject) argümanı: %s"
 
-#: ref-filter.c:330
+#: ref-filter.c:334
+#, c-format
+msgid "expected %%(trailers:key=<value>)"
+msgstr "%%(trailers:key=<değer>) bekleniyordu"
+
+#: ref-filter.c:336
 #, c-format
 msgid "unknown %%(trailers) argument: %s"
 msgstr "bilinmeyen %%(trailers) argümanı: %s"
 
-#: ref-filter.c:363
+#: ref-filter.c:367
 #, c-format
 msgid "positive value expected contents:lines=%s"
 msgstr "pozitif değer şunu bekliyordu: contents:lines=%s"
 
-#: ref-filter.c:365
+#: ref-filter.c:369
 #, c-format
 msgid "unrecognized %%(contents) argument: %s"
 msgstr "tanımlanamayan %%(contents) argümanı: %s"
 
-#: ref-filter.c:380
+#: ref-filter.c:384
 #, c-format
 msgid "positive value expected '%s' in %%(%s)"
 msgstr "pozitif değer şurada '%s' bekliyordu: %%(%s)"
 
-#: ref-filter.c:384
+#: ref-filter.c:388
 #, c-format
 msgid "unrecognized argument '%s' in %%(%s)"
 msgstr "şurada tanımlanamayan argüman '%s': %%(%s)"
 
-#: ref-filter.c:398
+#: ref-filter.c:402
 #, c-format
 msgid "unrecognized email option: %s"
 msgstr "tanımlanamayan e-posta seçeneği: %s"
 
-#: ref-filter.c:428
+#: ref-filter.c:432
 #, c-format
 msgid "expected format: %%(align:<width>,<position>)"
 msgstr "beklenen biçim: %%(align:<genişlik>,<konum>)"
 
-#: ref-filter.c:440
+#: ref-filter.c:444
 #, c-format
 msgid "unrecognized position:%s"
 msgstr "tanımlanamayan konum:%s"
 
-#: ref-filter.c:447
+#: ref-filter.c:451
 #, c-format
 msgid "unrecognized width:%s"
 msgstr "tanımlanamayan genişlik:%s"
 
-#: ref-filter.c:456
+#: ref-filter.c:460
 #, c-format
 msgid "unrecognized %%(align) argument: %s"
 msgstr "tanımlanamayan %%(align) argümanı: %s"
 
-#: ref-filter.c:464
+#: ref-filter.c:468
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr "pozitif genişlik %%(align) ögeciği ile birlikte bekleniyordu"
 
-#: ref-filter.c:482
+#: ref-filter.c:486
 #, c-format
 msgid "unrecognized %%(if) argument: %s"
 msgstr "tanımlanamayan %%(if) argümanı: %s"
 
-#: ref-filter.c:584
+#: ref-filter.c:588
 #, c-format
 msgid "malformed field name: %.*s"
 msgstr "hatalı oluşturulmuş alan adı: %.*s"
 
-#: ref-filter.c:611
+#: ref-filter.c:615
 #, c-format
 msgid "unknown field name: %.*s"
 msgstr "bilinmeyen alan adı: %.*s"
 
-#: ref-filter.c:615
+#: ref-filter.c:619
 #, c-format
 msgid ""
 "not a git repository, but the field '%.*s' requires access to object data"
 msgstr ""
 "bir git deposu değil; ancak '%.*s' alanı nesne verisine erişim gerektiriyor"
 
-#: ref-filter.c:739
+#: ref-filter.c:743
 #, c-format
 msgid "format: %%(if) atom used without a %%(then) atom"
 msgstr "biçim: %%(if) ögeciği bir %%(then) ögeciği olmadan kullanıldı"
 
-#: ref-filter.c:802
+#: ref-filter.c:806
 #, c-format
 msgid "format: %%(then) atom used without an %%(if) atom"
 msgstr "biçim: %%(then) ögeciği bir %%(if) ögeciği olmadan kullanıldı"
 
-#: ref-filter.c:804
+#: ref-filter.c:808
 #, c-format
 msgid "format: %%(then) atom used more than once"
 msgstr "biçim: %%(then) ögeciği birden çok kez kullanıldı"
 
-#: ref-filter.c:806
+#: ref-filter.c:810
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr "biçim: %%(then) ögeciği %%(else) ögeciğinden sonra kullanıldı"
 
-#: ref-filter.c:834
+#: ref-filter.c:838
 #, c-format
 msgid "format: %%(else) atom used without an %%(if) atom"
 msgstr "biçim: %%(else) ögeciği bir %%(if) ögeciği olmadan kullanıldı"
 
-#: ref-filter.c:836
+#: ref-filter.c:840
 #, c-format
 msgid "format: %%(else) atom used without a %%(then) atom"
 msgstr "biçim: %%(else) ögeciği bir %%(then) ögeciği olmadan kullanıldı"
 
-#: ref-filter.c:838
+#: ref-filter.c:842
 #, c-format
 msgid "format: %%(else) atom used more than once"
 msgstr "biçim: %%(else) ögeciği birden çok kez kullanıldı"
 
-#: ref-filter.c:853
+#: ref-filter.c:857
 #, c-format
 msgid "format: %%(end) atom used without corresponding atom"
 msgstr "biçim: %%(end) ögeciği eş ögeciği olmadan kullanıldı"
 
-#: ref-filter.c:910
+#: ref-filter.c:914
 #, c-format
 msgid "malformed format string %s"
 msgstr "hatalı oluşturulmuş biçim dizisi %s"
 
-#: ref-filter.c:1551
+#: ref-filter.c:1555
 #, c-format
 msgid "(no branch, rebasing %s)"
 msgstr "(dal yok, %s yeniden temellendiriliyor)"
 
-#: ref-filter.c:1554
+#: ref-filter.c:1558
 #, c-format
 msgid "(no branch, rebasing detached HEAD %s)"
 msgstr "(dal yok, ayrık HEAD %s yeniden temellendiriliyor)"
 
-#: ref-filter.c:1557
+#: ref-filter.c:1561
 #, c-format
 msgid "(no branch, bisect started on %s)"
 msgstr "(dal yok, ikili arama %s üzerinde başladı)"
 
-#: ref-filter.c:1561
+#: ref-filter.c:1565
 #, c-format
 msgid "(HEAD detached at %s)"
 msgstr "(HEAD, %s konumunda ayrıldı)"
 
-#: ref-filter.c:1564
+#: ref-filter.c:1568
 #, c-format
 msgid "(HEAD detached from %s)"
 msgstr "(HEAD, %s ögesinden ayrıldı)"
 
-#: ref-filter.c:1567
+#: ref-filter.c:1571
 msgid "(no branch)"
 msgstr "(dal yok)"
 
-#: ref-filter.c:1599 ref-filter.c:1808
+#: ref-filter.c:1603 ref-filter.c:1812
 #, c-format
 msgid "missing object %s for %s"
 msgstr "eksik nesne %s (%s için)"
 
-#: ref-filter.c:1609
+#: ref-filter.c:1613
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr "parse_object_buffer %s üzerinde başarısız oldu (%s için)"
 
-#: ref-filter.c:1992
+#: ref-filter.c:1996
 #, c-format
 msgid "malformed object at '%s'"
 msgstr "'%s' konumunda hatalı oluşturulmuş nesne"
 
-#: ref-filter.c:2081
+#: ref-filter.c:2085
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr "bozuk ada iye %s başvurusu yok sayılıyor"
 
-#: ref-filter.c:2086 refs.c:676
+#: ref-filter.c:2090 refs.c:676
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "bozuk başvuru %s yok sayılıyor"
 
-#: ref-filter.c:2426
+#: ref-filter.c:2430
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "biçim: %%(end) ögeciği eksik"
 
-#: ref-filter.c:2525
+#: ref-filter.c:2529
 #, c-format
 msgid "malformed object name %s"
 msgstr "hatalı oluşturulmuş nesne adı %s"
 
-#: ref-filter.c:2530
+#: ref-filter.c:2534
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "'%s' bir işlemeye işaret etmeli"
@@ -10019,6 +10018,7 @@ msgid "git add [<options>] [--] <pathspec>..."
 msgstr "git add [<seçenekler>] [--] <yol-blrtç>..."
 
 #: builtin/add.c:58
+#, c-format
 msgid "cannot chmod %cx '%s'"
 msgstr "%cx '%s' chmod yapılamıyor"
 
@@ -15642,7 +15642,7 @@ msgstr "geçersiz belirtilen iş parçacığı sayısı (%d), %s için"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:285 builtin/index-pack.c:1589 builtin/index-pack.c:1792
+#: builtin/grep.c:285 builtin/index-pack.c:1589 builtin/index-pack.c:1808
 #: builtin/pack-objects.c:2944
 #, c-format
 msgid "no threads support, ignoring %s"
@@ -16311,38 +16311,38 @@ msgid_plural "chain length = %d: %lu objects"
 msgstr[0] "zincir uzunluğu = %d: %lu nesne"
 msgstr[1] "zincir uzunluğu = %d: %lu nesne"
 
-#: builtin/index-pack.c:1749
+#: builtin/index-pack.c:1765
 msgid "Cannot come back to cwd"
 msgstr "Şu anki çalışma dizinine geri gelinemiyor"
 
-#: builtin/index-pack.c:1803 builtin/index-pack.c:1806
-#: builtin/index-pack.c:1822 builtin/index-pack.c:1826
+#: builtin/index-pack.c:1819 builtin/index-pack.c:1822
+#: builtin/index-pack.c:1838 builtin/index-pack.c:1842
 #, c-format
 msgid "bad %s"
 msgstr "hatalı %s"
 
-#: builtin/index-pack.c:1832 builtin/init-db.c:392 builtin/init-db.c:625
+#: builtin/index-pack.c:1848 builtin/init-db.c:392 builtin/init-db.c:625
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "bilinmeyen sağlama algoritması '%s'"
 
-#: builtin/index-pack.c:1851
+#: builtin/index-pack.c:1867
 msgid "--fix-thin cannot be used without --stdin"
 msgstr "--fix-thin, --stdin olmadan kullanılamaz"
 
-#: builtin/index-pack.c:1853
+#: builtin/index-pack.c:1869
 msgid "--stdin requires a git repository"
 msgstr "--stdin bir git dizini gerektirir"
 
-#: builtin/index-pack.c:1855
+#: builtin/index-pack.c:1871
 msgid "--object-format cannot be used with --stdin"
 msgstr "--object-format, --stdin olmadan kullanılamaz"
 
-#: builtin/index-pack.c:1870
+#: builtin/index-pack.c:1886
 msgid "--verify with no packfile name given"
 msgstr "--verify ile bir paket dosyası adı verilmedi"
 
-#: builtin/index-pack.c:1936 builtin/unpack-objects.c:582
+#: builtin/index-pack.c:1956 builtin/unpack-objects.c:582
 msgid "fsck error in pack objects"
 msgstr "paket nesnelerinde fsck hatası"
 
@@ -18328,8 +18328,8 @@ msgid ""
 "write_reuse_object: could not locate %s, expected at offset %<PRIuMAX> in "
 "pack %s"
 msgstr ""
-"write_reuse_object: %s bulunamıyor, %<PRIuMAX> ofsetinde bekleniyordu "
-"(%s paketinde)"
+"write_reuse_object: %s bulunamıyor, %<PRIuMAX> ofsetinde bekleniyordu (%s "
+"paketinde)"
 
 #: builtin/pack-objects.c:448
 #, c-format
@@ -23454,14 +23454,22 @@ msgstr "bir <önek> altdizini için ağaç nesnesi yaz"
 msgid "only useful for debugging"
 msgstr "yalnızca hata ayıklama için yararlı"
 
-#: http-fetch.c:114
+#: http-fetch.c:118
 #, c-format
 msgid "argument to --packfile must be a valid hash (got '%s')"
 msgstr "--packfile için argüman geçerli bir sağlama olmalıdır ('%s' alındı)"
 
-#: http-fetch.c:122
+#: http-fetch.c:128
 msgid "not a git repository"
 msgstr "bir git deposu değil"
+
+#: http-fetch.c:134
+msgid "--packfile requires --index-pack-args"
+msgstr "--packfile, --index-pack-args gerektiriyor"
+
+#: http-fetch.c:143
+msgid "--index-pack-args can only be used with --packfile"
+msgstr "--index-pack-args yalnızca --packfile ile kullanılabilir"
 
 #: t/helper/test-fast-rebase.c:141
 msgid "unhandled options"

--- a/preload-index.c
+++ b/preload-index.c
@@ -31,6 +31,7 @@ struct thread_data {
 	struct pathspec pathspec;
 	struct progress_data *progress;
 	int offset, nr;
+	int t2_nr_lstat;
 };
 
 static void *preload_thread(void *_data)
@@ -73,6 +74,7 @@ static void *preload_thread(void *_data)
 			continue;
 		if (threaded_has_symlink_leading_path(&cache, ce->name, ce_namelen(ce)))
 			continue;
+		p->t2_nr_lstat++;
 		if (lstat(ce->name, &st))
 			continue;
 		if (ie_match_stat(index, ce, &st, CE_MATCH_RACY_IS_DIRTY|CE_MATCH_IGNORE_FSMONITOR))
@@ -98,6 +100,7 @@ void preload_index(struct index_state *index,
 	int threads, i, work, offset;
 	struct thread_data data[MAX_PARALLEL];
 	struct progress_data pd;
+	int t2_sum_lstat = 0;
 
 	if (!HAVE_THREADS || !core_preload_index)
 		return;
@@ -107,6 +110,9 @@ void preload_index(struct index_state *index,
 		threads = 2;
 	if (threads < 2)
 		return;
+
+	trace2_region_enter("index", "preload", NULL);
+
 	trace_performance_enter();
 	if (threads > MAX_PARALLEL)
 		threads = MAX_PARALLEL;
@@ -141,10 +147,14 @@ void preload_index(struct index_state *index,
 		struct thread_data *p = data+i;
 		if (pthread_join(p->pthread, NULL))
 			die("unable to join threaded lstat");
+		t2_sum_lstat += p->t2_nr_lstat;
 	}
 	stop_progress(&pd.progress);
 
 	trace_performance_leave("preload index");
+
+	trace2_data_intmax("index", NULL, "preload/sum_lstat", t2_sum_lstat);
+	trace2_region_leave("index", "preload", NULL);
 }
 
 int repo_read_index_preload(struct repository *repo,

--- a/pretty.c
+++ b/pretty.c
@@ -1148,6 +1148,54 @@ static int format_trailer_match_cb(const struct strbuf *key, void *ud)
 	return 0;
 }
 
+int format_set_trailers_options(struct process_trailer_options *opts,
+				struct string_list *filter_list,
+				struct strbuf *sepbuf,
+				struct strbuf *kvsepbuf,
+				const char **arg)
+{
+	for (;;) {
+		const char *argval;
+		size_t arglen;
+
+		if (match_placeholder_arg_value(*arg, "key", arg, &argval, &arglen)) {
+			uintptr_t len = arglen;
+
+			if (!argval)
+				return -1;
+
+			if (len && argval[len - 1] == ':')
+				len--;
+			string_list_append(filter_list, argval)->util = (char *)len;
+
+			opts->filter = format_trailer_match_cb;
+			opts->filter_data = filter_list;
+			opts->only_trailers = 1;
+		} else if (match_placeholder_arg_value(*arg, "separator", arg, &argval, &arglen)) {
+			char *fmt;
+
+			strbuf_reset(sepbuf);
+			fmt = xstrndup(argval, arglen);
+			strbuf_expand(sepbuf, fmt, strbuf_expand_literal_cb, NULL);
+			free(fmt);
+			opts->separator = sepbuf;
+		} else if (match_placeholder_arg_value(*arg, "key_value_separator", arg, &argval, &arglen)) {
+			char *fmt;
+
+			strbuf_reset(kvsepbuf);
+			fmt = xstrndup(argval, arglen);
+			strbuf_expand(kvsepbuf, fmt, strbuf_expand_literal_cb, NULL);
+			free(fmt);
+			opts->key_value_separator = kvsepbuf;
+		} else if (!match_placeholder_bool_arg(*arg, "only", arg, &opts->only_trailers) &&
+			   !match_placeholder_bool_arg(*arg, "unfold", arg, &opts->unfold) &&
+			   !match_placeholder_bool_arg(*arg, "keyonly", arg, &opts->key_only) &&
+			   !match_placeholder_bool_arg(*arg, "valueonly", arg, &opts->value_only))
+			break;
+	}
+	return 0;
+}
+
 static size_t format_commit_one(struct strbuf *sb, /* in UTF-8 */
 				const char *placeholder,
 				void *context)
@@ -1425,45 +1473,8 @@ static size_t format_commit_one(struct strbuf *sb, /* in UTF-8 */
 
 		if (*arg == ':') {
 			arg++;
-			for (;;) {
-				const char *argval;
-				size_t arglen;
-
-				if (match_placeholder_arg_value(arg, "key", &arg, &argval, &arglen)) {
-					uintptr_t len = arglen;
-
-					if (!argval)
-						goto trailer_out;
-
-					if (len && argval[len - 1] == ':')
-						len--;
-					string_list_append(&filter_list, argval)->util = (char *)len;
-
-					opts.filter = format_trailer_match_cb;
-					opts.filter_data = &filter_list;
-					opts.only_trailers = 1;
-				} else if (match_placeholder_arg_value(arg, "separator", &arg, &argval, &arglen)) {
-					char *fmt;
-
-					strbuf_reset(&sepbuf);
-					fmt = xstrndup(argval, arglen);
-					strbuf_expand(&sepbuf, fmt, strbuf_expand_literal_cb, NULL);
-					free(fmt);
-					opts.separator = &sepbuf;
-				} else if (match_placeholder_arg_value(arg, "key_value_separator", &arg, &argval, &arglen)) {
-					char *fmt;
-
-					strbuf_reset(&kvsepbuf);
-					fmt = xstrndup(argval, arglen);
-					strbuf_expand(&kvsepbuf, fmt, strbuf_expand_literal_cb, NULL);
-					free(fmt);
-					opts.key_value_separator = &kvsepbuf;
-				} else if (!match_placeholder_bool_arg(arg, "only", &arg, &opts.only_trailers) &&
-					   !match_placeholder_bool_arg(arg, "unfold", &arg, &opts.unfold) &&
-					   !match_placeholder_bool_arg(arg, "keyonly", &arg, &opts.key_only) &&
-					   !match_placeholder_bool_arg(arg, "valueonly", &arg, &opts.value_only))
-					break;
-			}
+			if (format_set_trailers_options(&opts, &filter_list, &sepbuf, &kvsepbuf, &arg))
+				goto trailer_out;
 		}
 		if (*arg == ')') {
 			format_trailers_from_commit(sb, msg + c->subject_off, &opts);

--- a/pretty.h
+++ b/pretty.h
@@ -151,6 +151,7 @@ int format_set_trailers_options(struct process_trailer_options *opts,
 			struct string_list *filter_list,
 			struct strbuf *sepbuf,
 			struct strbuf *kvsepbuf,
-			const char **arg);
+			const char **arg,
+			char **invalid_arg);
 
 #endif /* PRETTY_H */

--- a/pretty.h
+++ b/pretty.h
@@ -6,6 +6,7 @@
 
 struct commit;
 struct strbuf;
+struct process_trailer_options;
 
 /* Commit formats */
 enum cmit_fmt {
@@ -141,5 +142,15 @@ int commit_format_is_empty(enum cmit_fmt);
 
 /* Make subject of commit message suitable for filename */
 void format_sanitized_subject(struct strbuf *sb, const char *msg, size_t len);
+
+/*
+ * Set values of fields in "struct process_trailer_options"
+ * according to trailers arguments.
+ */
+int format_set_trailers_options(struct process_trailer_options *opts,
+			struct string_list *filter_list,
+			struct strbuf *sepbuf,
+			struct strbuf *kvsepbuf,
+			const char **arg);
 
 #endif /* PRETTY_H */

--- a/read-cache.c
+++ b/read-cache.c
@@ -1364,7 +1364,8 @@ int add_index_entry(struct index_state *istate, struct cache_entry *ce, int opti
 static struct cache_entry *refresh_cache_ent(struct index_state *istate,
 					     struct cache_entry *ce,
 					     unsigned int options, int *err,
-					     int *changed_ret)
+					     int *changed_ret,
+					     int *t2_did_lstat)
 {
 	struct stat st;
 	struct cache_entry *updated;
@@ -1406,6 +1407,8 @@ static struct cache_entry *refresh_cache_ent(struct index_state *istate,
 		return NULL;
 	}
 
+	if (t2_did_lstat)
+		*t2_did_lstat = 1;
 	if (lstat(ce->name, &st) < 0) {
 		if (ignore_missing && errno == ENOENT)
 			return ce;
@@ -1519,6 +1522,7 @@ int refresh_index(struct index_state *istate, unsigned int flags,
 	const char *added_fmt;
 	const char *unmerged_fmt;
 	struct progress *progress = NULL;
+	int t2_sum_lstat = 0;
 
 	if (flags & REFRESH_PROGRESS && isatty(2))
 		progress = start_delayed_progress(_("Refresh index"),
@@ -1536,11 +1540,13 @@ int refresh_index(struct index_state *istate, unsigned int flags,
 	 * we only have to do the special cases that are left.
 	 */
 	preload_index(istate, pathspec, 0);
+	trace2_region_enter("index", "refresh", NULL);
 	for (i = 0; i < istate->cache_nr; i++) {
 		struct cache_entry *ce, *new_entry;
 		int cache_errno = 0;
 		int changed = 0;
 		int filtered = 0;
+		int t2_did_lstat = 0;
 
 		ce = istate->cache[i];
 		if (ignore_submodules && S_ISGITLINK(ce->ce_mode))
@@ -1566,7 +1572,10 @@ int refresh_index(struct index_state *istate, unsigned int flags,
 		if (filtered)
 			continue;
 
-		new_entry = refresh_cache_ent(istate, ce, options, &cache_errno, &changed);
+		new_entry = refresh_cache_ent(istate, ce, options,
+					      &cache_errno, &changed,
+					      &t2_did_lstat);
+		t2_sum_lstat += t2_did_lstat;
 		if (new_entry == ce)
 			continue;
 		if (progress)
@@ -1602,6 +1611,8 @@ int refresh_index(struct index_state *istate, unsigned int flags,
 
 		replace_index_entry(istate, i, new_entry);
 	}
+	trace2_data_intmax("index", NULL, "refresh/sum_lstat", t2_sum_lstat);
+	trace2_region_leave("index", "refresh", NULL);
 	if (progress) {
 		display_progress(progress, istate->cache_nr);
 		stop_progress(&progress);
@@ -1614,7 +1625,7 @@ struct cache_entry *refresh_cache_entry(struct index_state *istate,
 					struct cache_entry *ce,
 					unsigned int options)
 {
-	return refresh_cache_ent(istate, ce, options, NULL, NULL);
+	return refresh_cache_ent(istate, ce, options, NULL, NULL, NULL);
 }
 
 

--- a/read-cache.c
+++ b/read-cache.c
@@ -2447,7 +2447,7 @@ int repo_index_has_changes(struct repository *repo,
 	}
 }
 
-#define WRITE_BUFFER_SIZE 8192
+#define WRITE_BUFFER_SIZE (128 * 1024)
 static unsigned char write_buffer[WRITE_BUFFER_SIZE];
 static unsigned long write_buffer_len;
 

--- a/ref-filter.c
+++ b/ref-filter.c
@@ -67,6 +67,12 @@ struct refname_atom {
 	int lstrip, rstrip;
 };
 
+static struct ref_trailer_buf {
+	struct string_list filter_list;
+	struct strbuf sepbuf;
+	struct strbuf kvsepbuf;
+} ref_trailer_buf = {STRING_LIST_INIT_NODUP, STRBUF_INIT, STRBUF_INIT};
+
 static struct expand_data {
 	struct object_id oid;
 	enum object_type type;
@@ -313,28 +319,26 @@ static int subject_atom_parser(const struct ref_format *format, struct used_atom
 static int trailers_atom_parser(const struct ref_format *format, struct used_atom *atom,
 				const char *arg, struct strbuf *err)
 {
-	struct string_list params = STRING_LIST_INIT_DUP;
-	int i;
-
 	atom->u.contents.trailer_opts.no_divider = 1;
 
 	if (arg) {
-		string_list_split(&params, arg, ',', -1);
-		for (i = 0; i < params.nr; i++) {
-			const char *s = params.items[i].string;
-			if (!strcmp(s, "unfold"))
-				atom->u.contents.trailer_opts.unfold = 1;
-			else if (!strcmp(s, "only"))
-				atom->u.contents.trailer_opts.only_trailers = 1;
-			else {
-				strbuf_addf(err, _("unknown %%(trailers) argument: %s"), s);
-				string_list_clear(&params, 0);
-				return -1;
-			}
+		const char *argbuf = xstrfmt("%s)", arg);
+		char *invalid_arg = NULL;
+
+		if (format_set_trailers_options(&atom->u.contents.trailer_opts,
+		    &ref_trailer_buf.filter_list,
+		    &ref_trailer_buf.sepbuf,
+		    &ref_trailer_buf.kvsepbuf,
+		    &argbuf, &invalid_arg)) {
+			if (!invalid_arg)
+				strbuf_addf(err, _("expected %%(trailers:key=<value>)"));
+			else
+				strbuf_addf(err, _("unknown %%(trailers) argument: %s"), invalid_arg);
+			free((char *)invalid_arg);
+			return -1;
 		}
 	}
 	atom->u.contents.option = C_TRAILERS;
-	string_list_clear(&params, 0);
 	return 0;
 }
 

--- a/t/perf/.gitignore
+++ b/t/perf/.gitignore
@@ -1,3 +1,4 @@
 /build/
 /test-results/
+/test-trace/
 /trash directory*/

--- a/t/perf/Makefile
+++ b/t/perf/Makefile
@@ -7,10 +7,10 @@ perf: pre-clean
 	./run
 
 pre-clean:
-	rm -rf test-results
+	rm -rf test-results test-trace
 
 clean:
-	rm -rf build "trash directory".* test-results
+	rm -rf build "trash directory".* test-results test-trace
 
 test-lint:
 	$(MAKE) -C .. test-lint

--- a/t/perf/p7519-fsmonitor.sh
+++ b/t/perf/p7519-fsmonitor.sh
@@ -164,8 +164,18 @@ test_fsmonitor_suite() {
 		git status -uall
 	'
 
+	# Update the mtimes on upto 100k files to make status think
+	# that they are dirty.  For simplicity, omit any files with
+	# LFs (i.e. anything that ls-files thinks it needs to dquote).
+	# Then fully backslash-quote the paths to capture any
+	# whitespace so that they pass thru xargs properly.
+	#
 	test_perf_w_drop_caches "status (dirty) ($DESC)" '
-		git ls-files | head -100000 | xargs -d "\n" touch -h &&
+		git ls-files | \
+			head -100000 | \
+			grep -v \" | \
+			sed '\''s/\(.\)/\\\1/g'\'' | \
+			xargs test-tool chmtime -300 &&
 		git status
 	'
 

--- a/t/perf/p7519-fsmonitor.sh
+++ b/t/perf/p7519-fsmonitor.sh
@@ -32,6 +32,8 @@ test_description="Test core.fsmonitor"
 #
 # GIT_PERF_7519_DROP_CACHE: if set, the OS caches are dropped between tests
 #
+# GIT_PERF_7519_TRACE: if set, enable trace logging during the test.
+#   Trace logs will be grouped by fsmonitor provider.
 
 test_perf_large_repo
 test_checkout_worktree
@@ -69,6 +71,32 @@ then
 		GIT_PERF_REPEAT_COUNT=1
 	fi
 fi
+
+trace_start() {
+	if test -n "$GIT_PERF_7519_TRACE"
+	then
+		name="$1"
+		TEST_TRACE_DIR="$TEST_OUTPUT_DIRECTORY/test-trace/p7519/"
+		echo "Writing trace logging to $TEST_TRACE_DIR"
+
+		mkdir -p "$TEST_TRACE_DIR"
+
+		# Start Trace2 logging and any other GIT_TRACE_* logs that you
+		# want for this named test case.
+
+		GIT_TRACE2_PERF="$TEST_TRACE_DIR/$name.trace2perf"
+		export GIT_TRACE2_PERF
+
+		>"$GIT_TRACE2_PERF"
+	fi
+}
+
+trace_stop() {
+	if test -n "$GIT_PERF_7519_TRACE"
+	then
+		unset GIT_TRACE2_PERF
+	fi
+}
 
 test_expect_success "one time repo setup" '
 	# set untrackedCache depending on the environment
@@ -213,6 +241,7 @@ test_fsmonitor_suite() {
 # such as Watchman.
 #
 
+trace_start fsmonitor-watchman
 if test -n "$GIT_PERF_7519_FSMONITOR"; then
 	for INTEGRATION_PATH in $GIT_PERF_7519_FSMONITOR; do
 		test_expect_success "setup for fsmonitor $INTEGRATION_PATH" 'setup_for_fsmonitor'
@@ -231,11 +260,13 @@ then
 	# preventing the removal of the trash directory
 	watchman shutdown-server >/dev/null 2>&1
 fi
+trace_stop
 
 #
 # Run a full set of perf tests with the fsmonitor feature disabled.
 #
 
+trace_start fsmonitor-disabled
 test_expect_success "setup without fsmonitor" '
 	unset INTEGRATION_SCRIPT &&
 	git config --unset core.fsmonitor &&
@@ -243,5 +274,6 @@ test_expect_success "setup without fsmonitor" '
 '
 
 test_fsmonitor_suite
+trace_stop
 
 test_done

--- a/t/perf/p7519-fsmonitor.sh
+++ b/t/perf/p7519-fsmonitor.sh
@@ -208,6 +208,11 @@ test_fsmonitor_suite() {
 	'
 }
 
+#
+# Run a full set of perf tests using each Hook-based fsmonitor provider,
+# such as Watchman.
+#
+
 if test -n "$GIT_PERF_7519_FSMONITOR"; then
 	for INTEGRATION_PATH in $GIT_PERF_7519_FSMONITOR; do
 		test_expect_success "setup for fsmonitor $INTEGRATION_PATH" 'setup_for_fsmonitor'
@@ -218,14 +223,6 @@ else
 	test_fsmonitor_suite
 fi
 
-test_expect_success "setup without fsmonitor" '
-	unset INTEGRATION_SCRIPT &&
-	git config --unset core.fsmonitor &&
-	git update-index --no-fsmonitor
-'
-
-test_fsmonitor_suite
-
 if test_have_prereq WATCHMAN
 then
 	watchman watch-del "$GIT_WORK_TREE" >/dev/null 2>&1 &&
@@ -234,5 +231,17 @@ then
 	# preventing the removal of the trash directory
 	watchman shutdown-server >/dev/null 2>&1
 fi
+
+#
+# Run a full set of perf tests with the fsmonitor feature disabled.
+#
+
+test_expect_success "setup without fsmonitor" '
+	unset INTEGRATION_SCRIPT &&
+	git config --unset core.fsmonitor &&
+	git update-index --no-fsmonitor
+'
+
+test_fsmonitor_suite
 
 test_done

--- a/t/perf/p7519-fsmonitor.sh
+++ b/t/perf/p7519-fsmonitor.sh
@@ -101,7 +101,7 @@ test_expect_success "one time repo setup" '
 	# If Watchman exists, watch the work tree and attempt a query.
 	if test_have_prereq WATCHMAN; then
 		watchman watch "$GIT_WORK_TREE" &&
-		watchman watch-list | grep -q -F "$GIT_WORK_TREE"
+		watchman watch-list | grep -q -F "p7519-fsmonitor"
 	fi
 '
 

--- a/t/t4001-diff-rename.sh
+++ b/t/t4001-diff-rename.sh
@@ -277,10 +277,11 @@ test_expect_success 'basename similarity vs best similarity' '
 	git add file.txt file.md &&
 	git commit -a -m "rename" &&
 	git diff-tree -r -M --name-status HEAD^ HEAD >actual &&
-	# subdir/file.txt is 88% similar to file.md and 78% similar to file.txt
+	# subdir/file.txt is 88% similar to file.md, 78% similar to file.txt,
+	# but since same basenames are checked first...
 	cat >expected <<-\EOF &&
-	R088	subdir/file.txt	file.md
-	A	file.txt
+	A	file.md
+	R078	subdir/file.txt	file.txt
 	EOF
 	test_cmp expected actual
 '

--- a/t/t4001-diff-rename.sh
+++ b/t/t4001-diff-rename.sh
@@ -262,4 +262,27 @@ test_expect_success 'diff-tree -l0 defaults to a big rename limit, not zero' '
 	grep "myotherfile.*myfile" actual
 '
 
+test_expect_success 'basename similarity vs best similarity' '
+	mkdir subdir &&
+	test_write_lines line1 line2 line3 line4 line5 \
+			 line6 line7 line8 line9 line10 >subdir/file.txt &&
+	git add subdir/file.txt &&
+	git commit -m "base txt" &&
+
+	git rm subdir/file.txt &&
+	test_write_lines line1 line2 line3 line4 line5 \
+			  line6 line7 line8 >file.txt &&
+	test_write_lines line1 line2 line3 line4 line5 \
+			  line6 line7 line8 line9 >file.md &&
+	git add file.txt file.md &&
+	git commit -a -m "rename" &&
+	git diff-tree -r -M --name-status HEAD^ HEAD >actual &&
+	# subdir/file.txt is 88% similar to file.md and 78% similar to file.txt
+	cat >expected <<-\EOF &&
+	R088	subdir/file.txt	file.md
+	A	file.txt
+	EOF
+	test_cmp expected actual
+'
+
 test_done

--- a/t/t5318-commit-graph.sh
+++ b/t/t5318-commit-graph.sh
@@ -564,7 +564,7 @@ test_expect_success 'detect bad hash version' '
 
 test_expect_success 'detect low chunk count' '
 	corrupt_graph_and_verify $GRAPH_BYTE_CHUNK_COUNT "\01" \
-		"missing the .* chunk"
+		"final chunk has non-zero id"
 '
 
 test_expect_success 'detect missing OID fanout chunk' '

--- a/t/t5319-multi-pack-index.sh
+++ b/t/t5319-multi-pack-index.sh
@@ -314,12 +314,12 @@ test_expect_success 'verify bad OID version' '
 
 test_expect_success 'verify truncated chunk count' '
 	corrupt_midx_and_verify $MIDX_BYTE_CHUNK_COUNT "\01" $objdir \
-		"missing required"
+		"final chunk has non-zero id"
 '
 
 test_expect_success 'verify extended chunk count' '
 	corrupt_midx_and_verify $MIDX_BYTE_CHUNK_COUNT "\07" $objdir \
-		"terminating multi-pack-index chunk id appears earlier than expected"
+		"terminating chunk id appears earlier than expected"
 '
 
 test_expect_success 'verify missing required chunk' '
@@ -329,7 +329,7 @@ test_expect_success 'verify missing required chunk' '
 
 test_expect_success 'verify invalid chunk offset' '
 	corrupt_midx_and_verify $MIDX_BYTE_CHUNK_OFFSET "\01" $objdir \
-		"invalid chunk offset (too large)"
+		"improper chunk offset(s)"
 '
 
 test_expect_success 'verify packnames out of order' '

--- a/t/t5550-http-fetch-dumb.sh
+++ b/t/t5550-http-fetch-dumb.sh
@@ -224,7 +224,10 @@ test_expect_success 'http-fetch --packfile' '
 
 	git init packfileclient &&
 	p=$(cd "$HTTPD_DOCUMENT_ROOT_PATH"/repo_pack.git && ls objects/pack/pack-*.pack) &&
-	git -C packfileclient http-fetch --packfile=$ARBITRARY "$HTTPD_URL"/dumb/repo_pack.git/$p >out &&
+	git -C packfileclient http-fetch --packfile=$ARBITRARY \
+		--index-pack-arg=index-pack --index-pack-arg=--stdin \
+		--index-pack-arg=--keep \
+		"$HTTPD_URL"/dumb/repo_pack.git/$p >out &&
 
 	grep "^keep.[0-9a-f]\{16,\}$" out &&
 	cut -c6- out >packhash &&

--- a/t/t5702-protocol-v2.sh
+++ b/t/t5702-protocol-v2.sh
@@ -847,8 +847,9 @@ test_expect_success 'part of packfile response provided as URI' '
 	test -f hfound &&
 	test -f h2found &&
 
-	# Ensure that there are exactly 6 files (3 .pack and 3 .idx).
-	ls http_child/.git/objects/pack/* >filelist &&
+	# Ensure that there are exactly 3 packfiles with associated .idx
+	ls http_child/.git/objects/pack/*.pack \
+	    http_child/.git/objects/pack/*.idx >filelist &&
 	test_line_count = 6 filelist
 '
 
@@ -901,8 +902,9 @@ test_expect_success 'packfile-uri with transfer.fsckobjects' '
 		-c fetch.uriprotocols=http,https \
 		clone "$HTTPD_URL/smart/http_parent" http_child &&
 
-	# Ensure that there are exactly 4 files (2 .pack and 2 .idx).
-	ls http_child/.git/objects/pack/* >filelist &&
+	# Ensure that there are exactly 2 packfiles with associated .idx
+	ls http_child/.git/objects/pack/*.pack \
+	    http_child/.git/objects/pack/*.idx >filelist &&
 	test_line_count = 4 filelist
 '
 
@@ -934,6 +936,54 @@ test_expect_success 'packfile-uri with transfer.fsckobjects fails on bad object'
 		-c fetch.uriprotocols=http,https \
 		clone "$HTTPD_URL/smart/http_parent" http_child 2>error &&
 	test_i18ngrep "invalid author/committer line - missing email" error
+'
+
+test_expect_success 'packfile-uri with transfer.fsckobjects succeeds when .gitmodules is separate from tree' '
+	P="$HTTPD_DOCUMENT_ROOT_PATH/http_parent" &&
+	rm -rf "$P" http_child &&
+
+	git init "$P" &&
+	git -C "$P" config "uploadpack.allowsidebandall" "true" &&
+
+	echo "[submodule libfoo]" >"$P/.gitmodules" &&
+	echo "path = include/foo" >>"$P/.gitmodules" &&
+	echo "url = git://example.com/git/lib.git" >>"$P/.gitmodules" &&
+	git -C "$P" add .gitmodules &&
+	git -C "$P" commit -m x &&
+
+	configure_exclusion "$P" .gitmodules >h &&
+
+	sane_unset GIT_TEST_SIDEBAND_ALL &&
+	git -c protocol.version=2 -c transfer.fsckobjects=1 \
+		-c fetch.uriprotocols=http,https \
+		clone "$HTTPD_URL/smart/http_parent" http_child &&
+
+	# Ensure that there are exactly 2 packfiles with associated .idx
+	ls http_child/.git/objects/pack/*.pack \
+	    http_child/.git/objects/pack/*.idx >filelist &&
+	test_line_count = 4 filelist
+'
+
+test_expect_success 'packfile-uri with transfer.fsckobjects fails when .gitmodules separate from tree is invalid' '
+	P="$HTTPD_DOCUMENT_ROOT_PATH/http_parent" &&
+	rm -rf "$P" http_child err &&
+
+	git init "$P" &&
+	git -C "$P" config "uploadpack.allowsidebandall" "true" &&
+
+	echo "[submodule \"..\"]" >"$P/.gitmodules" &&
+	echo "path = include/foo" >>"$P/.gitmodules" &&
+	echo "url = git://example.com/git/lib.git" >>"$P/.gitmodules" &&
+	git -C "$P" add .gitmodules &&
+	git -C "$P" commit -m x &&
+
+	configure_exclusion "$P" .gitmodules >h &&
+
+	sane_unset GIT_TEST_SIDEBAND_ALL &&
+	test_must_fail git -c protocol.version=2 -c transfer.fsckobjects=1 \
+		-c fetch.uriprotocols=http,https \
+		clone "$HTTPD_URL/smart/http_parent" http_child 2>err &&
+	test_i18ngrep "disallowed submodule name" err
 '
 
 # DO NOT add non-httpd-specific tests here, because the last part of this

--- a/t/t7001-mv.sh
+++ b/t/t7001-mv.sh
@@ -181,38 +181,42 @@ test_expect_success "Sergey Vlasov's test case" '
 	git mv ab a
 '
 
-test_expect_success 'absolute pathname' '(
-	rm -fr mine &&
-	mkdir mine &&
-	cd mine &&
-	test_create_repo one &&
-	cd one &&
-	mkdir sub &&
-	>sub/file &&
-	git add sub/file &&
+test_expect_success 'absolute pathname' '
+	(
+		rm -fr mine &&
+		mkdir mine &&
+		cd mine &&
+		test_create_repo one &&
+		cd one &&
+		mkdir sub &&
+		>sub/file &&
+		git add sub/file &&
 
-	git mv sub "$(pwd)/in" &&
-	! test -d sub &&
-	test -d in &&
-	git ls-files --error-unmatch in/file
-)'
+		git mv sub "$(pwd)/in" &&
+		! test -d sub &&
+		test -d in &&
+		git ls-files --error-unmatch in/file
+	)
+'
 
-test_expect_success 'absolute pathname outside should fail' '(
-	rm -fr mine &&
-	mkdir mine &&
-	cd mine &&
-	out=$(pwd) &&
-	test_create_repo one &&
-	cd one &&
-	mkdir sub &&
-	>sub/file &&
-	git add sub/file &&
+test_expect_success 'absolute pathname outside should fail' '
+	(
+		rm -fr mine &&
+		mkdir mine &&
+		cd mine &&
+		out=$(pwd) &&
+		test_create_repo one &&
+		cd one &&
+		mkdir sub &&
+		>sub/file &&
+		git add sub/file &&
 
-	test_must_fail git mv sub "$out/out" &&
-	test -d sub &&
-	! test -d ../in &&
-	git ls-files --error-unmatch sub/file
-)'
+		test_must_fail git mv sub "$out/out" &&
+		test -d sub &&
+		! test -d ../in &&
+		git ls-files --error-unmatch sub/file
+	)
+'
 
 test_expect_success 'git mv to move multiple sources into a directory' '
 	rm -fr .git && git init &&
@@ -503,14 +507,16 @@ test_expect_success 'moving a submodule in nested directories' '
 test_expect_success 'moving nested submodules' '
 	git commit -am "cleanup commit" &&
 	mkdir sub_nested_nested &&
-	(cd sub_nested_nested &&
+	(
+		cd sub_nested_nested &&
 		touch nested_level2 &&
 		git init &&
 		git add . &&
 		git commit -m "nested level 2"
 	) &&
 	mkdir sub_nested &&
-	(cd sub_nested &&
+	(
+		cd sub_nested &&
 		touch nested_level1 &&
 		git init &&
 		git add . &&

--- a/t/t7001-mv.sh
+++ b/t/t7001-mv.sh
@@ -156,9 +156,9 @@ test_expect_success "Michael Cassar's test case" '
 	rm -fr .git papers partA &&
 	git init &&
 	mkdir -p papers/unsorted papers/all-papers partA &&
-	echo a > papers/unsorted/Thesis.pdf &&
-	echo b > partA/outline.txt &&
-	echo c > papers/unsorted/_another &&
+	echo a >papers/unsorted/Thesis.pdf &&
+	echo b >partA/outline.txt &&
+	echo c >papers/unsorted/_another &&
 	git add papers partA &&
 	T1=$(git write-tree) &&
 

--- a/t/t7001-mv.sh
+++ b/t/t7001-mv.sh
@@ -4,72 +4,72 @@ test_description='git mv in subdirs'
 . ./test-lib.sh
 
 test_expect_success 'prepare reference tree' '
-     mkdir path0 path1 &&
-     cp "$TEST_DIRECTORY"/../COPYING path0/COPYING &&
-     git add path0/COPYING &&
-     git commit -m add -a
+	mkdir path0 path1 &&
+	cp "$TEST_DIRECTORY"/../COPYING path0/COPYING &&
+	git add path0/COPYING &&
+	git commit -m add -a
 '
 
 test_expect_success 'moving the file out of subdirectory' '
-     cd path0 && git mv COPYING ../path1/COPYING
+	cd path0 && git mv COPYING ../path1/COPYING
 '
 
 # in path0 currently
 test_expect_success 'commiting the change' '
-     cd .. && git commit -m move-out -a
+	cd .. && git commit -m move-out -a
 '
 
 test_expect_success 'checking the commit' '
-     git diff-tree -r -M --name-status  HEAD^ HEAD >actual &&
-     grep "^R100..*path0/COPYING..*path1/COPYING" actual
+	git diff-tree -r -M --name-status  HEAD^ HEAD >actual &&
+	grep "^R100..*path0/COPYING..*path1/COPYING" actual
 '
 
 test_expect_success 'moving the file back into subdirectory' '
-     cd path0 && git mv ../path1/COPYING COPYING
+	cd path0 && git mv ../path1/COPYING COPYING
 '
 
 # in path0 currently
 test_expect_success 'commiting the change' '
-     cd .. && git commit -m move-in -a
+	cd .. && git commit -m move-in -a
 '
 
 test_expect_success 'checking the commit' '
-     git diff-tree -r -M --name-status  HEAD^ HEAD >actual &&
-     grep "^R100..*path1/COPYING..*path0/COPYING" actual
+	git diff-tree -r -M --name-status  HEAD^ HEAD >actual &&
+	grep "^R100..*path1/COPYING..*path0/COPYING" actual
 '
 
 test_expect_success 'mv --dry-run does not move file' '
-     git mv -n path0/COPYING MOVED &&
-     test -f path0/COPYING &&
-     test ! -f MOVED
+	git mv -n path0/COPYING MOVED &&
+	test -f path0/COPYING &&
+	test ! -f MOVED
 '
 
 test_expect_success 'checking -k on non-existing file' '
-     git mv -k idontexist path0
+	git mv -k idontexist path0
 '
 
 test_expect_success 'checking -k on untracked file' '
-     touch untracked1 &&
-     git mv -k untracked1 path0 &&
-     test -f untracked1 &&
-     test ! -f path0/untracked1
+	touch untracked1 &&
+	git mv -k untracked1 path0 &&
+	test -f untracked1 &&
+	test ! -f path0/untracked1
 '
 
 test_expect_success 'checking -k on multiple untracked files' '
-     touch untracked2 &&
-     git mv -k untracked1 untracked2 path0 &&
-     test -f untracked1 &&
-     test -f untracked2 &&
-     test ! -f path0/untracked1 &&
-     test ! -f path0/untracked2
+	touch untracked2 &&
+	git mv -k untracked1 untracked2 path0 &&
+	test -f untracked1 &&
+	test -f untracked2 &&
+	test ! -f path0/untracked1 &&
+	test ! -f path0/untracked2
 '
 
 test_expect_success 'checking -f on untracked file with existing target' '
-     touch path0/untracked1 &&
-     test_must_fail git mv -f untracked1 path0 &&
-     test ! -f .git/index.lock &&
-     test -f untracked1 &&
-     test -f path0/untracked1
+	touch path0/untracked1 &&
+	test_must_fail git mv -f untracked1 path0 &&
+	test ! -f .git/index.lock &&
+	test -f untracked1 &&
+	test -f path0/untracked1
 '
 
 # clean up the mess in case bad things happen
@@ -79,77 +79,77 @@ rm -f idontexist untracked1 untracked2 \
 rmdir path1
 
 test_expect_success 'moving to absent target with trailing slash' '
-     test_must_fail git mv path0/COPYING no-such-dir/ &&
-     test_must_fail git mv path0/COPYING no-such-dir// &&
-     git mv path0/ no-such-dir/ &&
-     test_path_is_dir no-such-dir
+	test_must_fail git mv path0/COPYING no-such-dir/ &&
+	test_must_fail git mv path0/COPYING no-such-dir// &&
+	git mv path0/ no-such-dir/ &&
+	test_path_is_dir no-such-dir
 '
 
 test_expect_success 'clean up' '
-     git reset --hard
+	git reset --hard
 '
 
 test_expect_success 'moving to existing untracked target with trailing slash' '
-     mkdir path1 &&
-     git mv path0/ path1/ &&
-     test_path_is_dir path1/path0/
+	mkdir path1 &&
+	git mv path0/ path1/ &&
+	test_path_is_dir path1/path0/
 '
 
 test_expect_success 'moving to existing tracked target with trailing slash' '
-     mkdir path2 &&
-     >path2/file && git add path2/file &&
-     git mv path1/path0/ path2/ &&
-     test_path_is_dir path2/path0/
+	mkdir path2 &&
+	>path2/file && git add path2/file &&
+	git mv path1/path0/ path2/ &&
+	test_path_is_dir path2/path0/
 '
 
 test_expect_success 'clean up' '
-     git reset --hard
+	git reset --hard
 '
 
 test_expect_success 'adding another file' '
-     cp "$TEST_DIRECTORY"/../README.md path0/README &&
-     git add path0/README &&
-     git commit -m add2 -a
+	cp "$TEST_DIRECTORY"/../README.md path0/README &&
+	git add path0/README &&
+	git commit -m add2 -a
 '
 
 test_expect_success 'moving whole subdirectory' '
-     git mv path0 path2
+	git mv path0 path2
 '
 
 test_expect_success 'commiting the change' '
-     git commit -m dir-move -a
+	git commit -m dir-move -a
 '
 
 test_expect_success 'checking the commit' '
-     git diff-tree -r -M --name-status  HEAD^ HEAD >actual &&
-     grep "^R100..*path0/COPYING..*path2/COPYING" actual &&
-     grep "^R100..*path0/README..*path2/README" actual
+	git diff-tree -r -M --name-status  HEAD^ HEAD >actual &&
+	grep "^R100..*path0/COPYING..*path2/COPYING" actual &&
+	grep "^R100..*path0/README..*path2/README" actual
 '
 
 test_expect_success 'succeed when source is a prefix of destination' '
-     git mv path2/COPYING path2/COPYING-renamed
+	git mv path2/COPYING path2/COPYING-renamed
 '
 
 test_expect_success 'moving whole subdirectory into subdirectory' '
-     git mv path2 path1
+	git mv path2 path1
 '
 
 test_expect_success 'commiting the change' '
-     git commit -m dir-move -a
+	git commit -m dir-move -a
 '
 
 test_expect_success 'checking the commit' '
-     git diff-tree -r -M --name-status  HEAD^ HEAD >actual &&
-     grep "^R100..*path2/COPYING..*path1/path2/COPYING" actual &&
-     grep "^R100..*path2/README..*path1/path2/README" actual
+	git diff-tree -r -M --name-status  HEAD^ HEAD >actual &&
+	grep "^R100..*path2/COPYING..*path1/path2/COPYING" actual &&
+	grep "^R100..*path2/README..*path1/path2/README" actual
 '
 
 test_expect_success 'do not move directory over existing directory' '
-     mkdir path0 && mkdir path0/path2 && test_must_fail git mv path2 path0
+	mkdir path0 && mkdir path0/path2 && test_must_fail git mv path2 path0
 '
 
 test_expect_success 'move into "."' '
-     git mv path1/path2/ .
+	git mv path1/path2/ .
 '
 
 test_expect_success "Michael Cassar's test case" '

--- a/t/t7001-mv.sh
+++ b/t/t7001-mv.sh
@@ -3,74 +3,74 @@
 test_description='git mv in subdirs'
 . ./test-lib.sh
 
-test_expect_success \
-    'prepare reference tree' \
-    'mkdir path0 path1 &&
+test_expect_success 'prepare reference tree' '
+     mkdir path0 path1 &&
      cp "$TEST_DIRECTORY"/../COPYING path0/COPYING &&
      git add path0/COPYING &&
-     git commit -m add -a'
+     git commit -m add -a
+'
 
-test_expect_success \
-    'moving the file out of subdirectory' \
-    'cd path0 && git mv COPYING ../path1/COPYING'
-
-# in path0 currently
-test_expect_success \
-    'commiting the change' \
-    'cd .. && git commit -m move-out -a'
-
-test_expect_success \
-    'checking the commit' \
-    'git diff-tree -r -M --name-status  HEAD^ HEAD >actual &&
-    grep "^R100..*path0/COPYING..*path1/COPYING" actual'
-
-test_expect_success \
-    'moving the file back into subdirectory' \
-    'cd path0 && git mv ../path1/COPYING COPYING'
+test_expect_success 'moving the file out of subdirectory' '
+     cd path0 && git mv COPYING ../path1/COPYING
+'
 
 # in path0 currently
-test_expect_success \
-    'commiting the change' \
-    'cd .. && git commit -m move-in -a'
+test_expect_success 'commiting the change' '
+     cd .. && git commit -m move-out -a
+'
 
-test_expect_success \
-    'checking the commit' \
-    'git diff-tree -r -M --name-status  HEAD^ HEAD >actual &&
-    grep "^R100..*path1/COPYING..*path0/COPYING" actual'
+test_expect_success 'checking the commit' '
+     git diff-tree -r -M --name-status  HEAD^ HEAD >actual &&
+     grep "^R100..*path0/COPYING..*path1/COPYING" actual
+'
 
-test_expect_success \
-    'mv --dry-run does not move file' \
-    'git mv -n path0/COPYING MOVED &&
+test_expect_success 'moving the file back into subdirectory' '
+     cd path0 && git mv ../path1/COPYING COPYING
+'
+
+# in path0 currently
+test_expect_success 'commiting the change' '
+     cd .. && git commit -m move-in -a
+'
+
+test_expect_success 'checking the commit' '
+     git diff-tree -r -M --name-status  HEAD^ HEAD >actual &&
+     grep "^R100..*path1/COPYING..*path0/COPYING" actual
+'
+
+test_expect_success 'mv --dry-run does not move file' '
+     git mv -n path0/COPYING MOVED &&
      test -f path0/COPYING &&
-     test ! -f MOVED'
+     test ! -f MOVED
+'
 
-test_expect_success \
-    'checking -k on non-existing file' \
-    'git mv -k idontexist path0'
+test_expect_success 'checking -k on non-existing file' '
+     git mv -k idontexist path0
+'
 
-test_expect_success \
-    'checking -k on untracked file' \
-    'touch untracked1 &&
+test_expect_success 'checking -k on untracked file' '
+     touch untracked1 &&
      git mv -k untracked1 path0 &&
      test -f untracked1 &&
-     test ! -f path0/untracked1'
+     test ! -f path0/untracked1
+'
 
-test_expect_success \
-    'checking -k on multiple untracked files' \
-    'touch untracked2 &&
+test_expect_success 'checking -k on multiple untracked files' '
+     touch untracked2 &&
      git mv -k untracked1 untracked2 path0 &&
      test -f untracked1 &&
      test -f untracked2 &&
      test ! -f path0/untracked1 &&
-     test ! -f path0/untracked2'
+     test ! -f path0/untracked2
+'
 
-test_expect_success \
-    'checking -f on untracked file with existing target' \
-    'touch path0/untracked1 &&
+test_expect_success 'checking -f on untracked file with existing target' '
+     touch path0/untracked1 &&
      test_must_fail git mv -f untracked1 path0 &&
      test ! -f .git/index.lock &&
      test -f untracked1 &&
-     test -f path0/untracked1'
+     test -f path0/untracked1
+'
 
 # clean up the mess in case bad things happen
 rm -f idontexist untracked1 untracked2 \
@@ -78,79 +78,79 @@ rm -f idontexist untracked1 untracked2 \
      .git/index.lock
 rmdir path1
 
-test_expect_success \
-    'moving to absent target with trailing slash' \
-    'test_must_fail git mv path0/COPYING no-such-dir/ &&
+test_expect_success 'moving to absent target with trailing slash' '
+     test_must_fail git mv path0/COPYING no-such-dir/ &&
      test_must_fail git mv path0/COPYING no-such-dir// &&
      git mv path0/ no-such-dir/ &&
-     test_path_is_dir no-such-dir'
+     test_path_is_dir no-such-dir
+'
 
-test_expect_success \
-    'clean up' \
-    'git reset --hard'
+test_expect_success 'clean up' '
+     git reset --hard
+'
 
-test_expect_success \
-    'moving to existing untracked target with trailing slash' \
-    'mkdir path1 &&
+test_expect_success 'moving to existing untracked target with trailing slash' '
+     mkdir path1 &&
      git mv path0/ path1/ &&
-     test_path_is_dir path1/path0/'
+     test_path_is_dir path1/path0/
+'
 
-test_expect_success \
-    'moving to existing tracked target with trailing slash' \
-    'mkdir path2 &&
+test_expect_success 'moving to existing tracked target with trailing slash' '
+     mkdir path2 &&
      >path2/file && git add path2/file &&
      git mv path1/path0/ path2/ &&
-     test_path_is_dir path2/path0/'
+     test_path_is_dir path2/path0/
+'
 
-test_expect_success \
-    'clean up' \
-    'git reset --hard'
+test_expect_success 'clean up' '
+     git reset --hard
+'
 
-test_expect_success \
-    'adding another file' \
-    'cp "$TEST_DIRECTORY"/../README.md path0/README &&
+test_expect_success 'adding another file' '
+     cp "$TEST_DIRECTORY"/../README.md path0/README &&
      git add path0/README &&
-     git commit -m add2 -a'
+     git commit -m add2 -a
+'
 
-test_expect_success \
-    'moving whole subdirectory' \
-    'git mv path0 path2'
+test_expect_success 'moving whole subdirectory' '
+     git mv path0 path2
+'
 
-test_expect_success \
-    'commiting the change' \
-    'git commit -m dir-move -a'
+test_expect_success 'commiting the change' '
+     git commit -m dir-move -a
+'
 
-test_expect_success \
-    'checking the commit' \
-    'git diff-tree -r -M --name-status  HEAD^ HEAD >actual &&
+test_expect_success 'checking the commit' '
+     git diff-tree -r -M --name-status  HEAD^ HEAD >actual &&
      grep "^R100..*path0/COPYING..*path2/COPYING" actual &&
-     grep "^R100..*path0/README..*path2/README" actual'
+     grep "^R100..*path0/README..*path2/README" actual
+'
 
-test_expect_success \
-    'succeed when source is a prefix of destination' \
-    'git mv path2/COPYING path2/COPYING-renamed'
+test_expect_success 'succeed when source is a prefix of destination' '
+     git mv path2/COPYING path2/COPYING-renamed
+'
 
-test_expect_success \
-    'moving whole subdirectory into subdirectory' \
-    'git mv path2 path1'
+test_expect_success 'moving whole subdirectory into subdirectory' '
+     git mv path2 path1
+'
 
-test_expect_success \
-    'commiting the change' \
-    'git commit -m dir-move -a'
+test_expect_success 'commiting the change' '
+     git commit -m dir-move -a
+'
 
-test_expect_success \
-    'checking the commit' \
-    'git diff-tree -r -M --name-status  HEAD^ HEAD >actual &&
+test_expect_success 'checking the commit' '
+     git diff-tree -r -M --name-status  HEAD^ HEAD >actual &&
      grep "^R100..*path2/COPYING..*path1/path2/COPYING" actual &&
-     grep "^R100..*path2/README..*path1/path2/README" actual'
+     grep "^R100..*path2/README..*path1/path2/README" actual
+'
 
-test_expect_success \
-    'do not move directory over existing directory' \
-    'mkdir path0 && mkdir path0/path2 && test_must_fail git mv path2 path0'
+test_expect_success 'do not move directory over existing directory' '
+     mkdir path0 && mkdir path0/path2 && test_must_fail git mv path2 path0
+'
 
-test_expect_success \
-    'move into "."' \
-    'git mv path1/path2/ .'
+test_expect_success 'move into "."' '
+     git mv path1/path2/ .
+'
 
 test_expect_success "Michael Cassar's test case" '
 	rm -fr .git papers partA &&

--- a/t/t7001-mv.sh
+++ b/t/t7001-mv.sh
@@ -182,7 +182,6 @@ test_expect_success "Sergey Vlasov's test case" '
 '
 
 test_expect_success 'absolute pathname' '(
-
 	rm -fr mine &&
 	mkdir mine &&
 	cd mine &&
@@ -196,12 +195,9 @@ test_expect_success 'absolute pathname' '(
 	! test -d sub &&
 	test -d in &&
 	git ls-files --error-unmatch in/file
-
-
 )'
 
 test_expect_success 'absolute pathname outside should fail' '(
-
 	rm -fr mine &&
 	mkdir mine &&
 	cd mine &&
@@ -216,7 +212,6 @@ test_expect_success 'absolute pathname outside should fail' '(
 	test -d sub &&
 	! test -d ../in &&
 	git ls-files --error-unmatch sub/file
-
 )'
 
 test_expect_success 'git mv to move multiple sources into a directory' '
@@ -232,7 +227,6 @@ test_expect_success 'git mv to move multiple sources into a directory' '
 '
 
 test_expect_success 'git mv should not change sha1 of moved cache entry' '
-
 	rm -fr .git &&
 	git init &&
 	echo 1 >dirty &&
@@ -243,7 +237,6 @@ test_expect_success 'git mv should not change sha1 of moved cache entry' '
 	echo 2 >dirty2 &&
 	git mv dirty2 dirty &&
 	[ "$entry" = "$(git ls-files --stage dirty | cut -f 1)" ]
-
 '
 
 rm -f dirty dirty2
@@ -266,7 +259,6 @@ test_expect_success 'git mv error on conflicted file' '
 '
 
 test_expect_success 'git mv should overwrite symlink to a file' '
-
 	rm -fr .git &&
 	git init &&
 	echo 1 >moved &&
@@ -279,13 +271,11 @@ test_expect_success 'git mv should overwrite symlink to a file' '
 	test "$(cat symlink)" = 1 &&
 	git update-index --refresh &&
 	git diff-files --quiet
-
 '
 
 rm -f moved symlink
 
 test_expect_success 'git mv should overwrite file with a symlink' '
-
 	rm -fr .git &&
 	git init &&
 	echo 1 >moved &&
@@ -296,11 +286,9 @@ test_expect_success 'git mv should overwrite file with a symlink' '
 	! test -e symlink &&
 	git update-index --refresh &&
 	git diff-files --quiet
-
 '
 
 test_expect_success SYMLINKS 'check moved symlink' '
-
 	test -h moved
 '
 

--- a/t/t7001-mv.sh
+++ b/t/t7001-mv.sh
@@ -49,14 +49,14 @@ test_expect_success 'checking -k on non-existing file' '
 '
 
 test_expect_success 'checking -k on untracked file' '
-	touch untracked1 &&
+	>untracked1 &&
 	git mv -k untracked1 path0 &&
 	test -f untracked1 &&
 	test ! -f path0/untracked1
 '
 
 test_expect_success 'checking -k on multiple untracked files' '
-	touch untracked2 &&
+	>untracked2 &&
 	git mv -k untracked1 untracked2 path0 &&
 	test -f untracked1 &&
 	test -f untracked2 &&
@@ -65,7 +65,7 @@ test_expect_success 'checking -k on multiple untracked files' '
 '
 
 test_expect_success 'checking -f on untracked file with existing target' '
-	touch path0/untracked1 &&
+	>path0/untracked1 &&
 	test_must_fail git mv -f untracked1 path0 &&
 	test ! -f .git/index.lock &&
 	test -f untracked1 &&
@@ -488,7 +488,7 @@ test_expect_success 'moving nested submodules' '
 	mkdir sub_nested_nested &&
 	(
 		cd sub_nested_nested &&
-		touch nested_level2 &&
+		>nested_level2 &&
 		git init &&
 		git add . &&
 		git commit -m "nested level 2"
@@ -496,7 +496,7 @@ test_expect_success 'moving nested submodules' '
 	mkdir sub_nested &&
 	(
 		cd sub_nested &&
-		touch nested_level1 &&
+		>nested_level1 &&
 		git init &&
 		git add . &&
 		git commit -m "nested level 1" &&

--- a/t/t7001-mv.sh
+++ b/t/t7001-mv.sh
@@ -11,12 +11,12 @@ test_expect_success 'prepare reference tree' '
 '
 
 test_expect_success 'moving the file out of subdirectory' '
-	cd path0 && git mv COPYING ../path1/COPYING
+	git -C path0 mv COPYING ../path1/COPYING
 '
 
 # in path0 currently
 test_expect_success 'commiting the change' '
-	cd .. && git commit -m move-out -a
+	git commit -m move-out -a
 '
 
 test_expect_success 'checking the commit' '
@@ -25,12 +25,12 @@ test_expect_success 'checking the commit' '
 '
 
 test_expect_success 'moving the file back into subdirectory' '
-	cd path0 && git mv ../path1/COPYING COPYING
+	git -C path0 mv ../path1/COPYING COPYING
 '
 
 # in path0 currently
 test_expect_success 'commiting the change' '
-	cd .. && git commit -m move-in -a
+	git commit -m move-in -a
 '
 
 test_expect_success 'checking the commit' '
@@ -328,10 +328,7 @@ test_expect_success 'git mv moves a submodule with a .git directory and no .gitm
 	git mv sub mod/sub &&
 	! test -e sub &&
 	[ "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" ] &&
-	(
-		cd mod/sub &&
-		git status
-	) &&
+	git -C mod/sub status &&
 	git update-index --refresh &&
 	git diff-files --quiet
 '
@@ -351,10 +348,7 @@ test_expect_success 'git mv moves a submodule with a .git directory and .gitmodu
 	git mv sub mod/sub &&
 	! test -e sub &&
 	[ "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" ] &&
-	(
-		cd mod/sub &&
-		git status
-	) &&
+	git -C mod/sub status &&
 	echo mod/sub >expected &&
 	git config -f .gitmodules submodule.sub.path >actual &&
 	test_cmp expected actual &&
@@ -368,16 +362,10 @@ test_expect_success 'git mv moves a submodule with gitfile' '
 	git submodule update &&
 	entry="$(git ls-files --stage sub | cut -f 1)" &&
 	mkdir mod &&
-	(
-		cd mod &&
-		git mv ../sub/ .
-	) &&
+	git -C mod mv ../sub/ . &&
 	! test -e sub &&
 	[ "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" ] &&
-	(
-		cd mod/sub &&
-		git status
-	) &&
+	git -C mod/sub status &&
 	echo mod/sub >expected &&
 	git config -f .gitmodules submodule.sub.path >actual &&
 	test_cmp expected actual &&
@@ -396,10 +384,7 @@ test_expect_success 'mv does not complain when no .gitmodules file is found' '
 	test_must_be_empty actual.err &&
 	! test -e sub &&
 	[ "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" ] &&
-	(
-		cd mod/sub &&
-		git status
-	) &&
+	git -C mod/sub status &&
 	git update-index --refresh &&
 	git diff-files --quiet
 '
@@ -420,10 +405,7 @@ test_expect_success 'mv will error out on a modified .gitmodules file unless sta
 	test_must_be_empty actual.err &&
 	! test -e sub &&
 	[ "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" ] &&
-	(
-		cd mod/sub &&
-		git status
-	) &&
+	git -C mod/sub status &&
 	git update-index --refresh &&
 	git diff-files --quiet
 '
@@ -441,10 +423,7 @@ test_expect_success 'mv issues a warning when section is not found in .gitmodule
 	test_i18ncmp expect.err actual.err &&
 	! test -e sub &&
 	[ "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" ] &&
-	(
-		cd mod/sub &&
-		git status
-	) &&
+	git -C mod/sub status &&
 	git update-index --refresh &&
 	git diff-files --quiet
 '

--- a/t/t7001-mv.sh
+++ b/t/t7001-mv.sh
@@ -228,7 +228,10 @@ test_expect_success 'git mv to move multiple sources into a directory' '
 	git add dir/?.txt &&
 	git mv dir/a.txt dir/b.txt other &&
 	git ls-files >actual &&
-	{ echo other/a.txt; echo other/b.txt; } >expect &&
+	cat >expect <<-\EOF &&
+	other/a.txt
+	other/b.txt
+	EOF
 	test_cmp expect actual
 '
 

--- a/t/t7001-mv.sh
+++ b/t/t7001-mv.sh
@@ -242,10 +242,10 @@ test_expect_success 'git mv should not change sha1 of moved cache entry' '
 	git add dirty &&
 	entry="$(git ls-files --stage dirty | cut -f 1)" &&
 	git mv dirty dirty2 &&
-	[ "$entry" = "$(git ls-files --stage dirty2 | cut -f 1)" ] &&
+	test "$entry" = "$(git ls-files --stage dirty2 | cut -f 1)" &&
 	echo 2 >dirty2 &&
 	git mv dirty2 dirty &&
-	[ "$entry" = "$(git ls-files --stage dirty | cut -f 1)" ]
+	test "$entry" = "$(git ls-files --stage dirty | cut -f 1)"
 '
 
 rm -f dirty dirty2
@@ -332,7 +332,7 @@ test_expect_success 'git mv moves a submodule with a .git directory and no .gitm
 	mkdir mod &&
 	git mv sub mod/sub &&
 	! test -e sub &&
-	[ "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" ] &&
+	test "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" &&
 	git -C mod/sub status &&
 	git update-index --refresh &&
 	git diff-files --quiet
@@ -352,7 +352,7 @@ test_expect_success 'git mv moves a submodule with a .git directory and .gitmodu
 	mkdir mod &&
 	git mv sub mod/sub &&
 	! test -e sub &&
-	[ "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" ] &&
+	test "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" &&
 	git -C mod/sub status &&
 	echo mod/sub >expected &&
 	git config -f .gitmodules submodule.sub.path >actual &&
@@ -369,7 +369,7 @@ test_expect_success 'git mv moves a submodule with gitfile' '
 	mkdir mod &&
 	git -C mod mv ../sub/ . &&
 	! test -e sub &&
-	[ "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" ] &&
+	test "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" &&
 	git -C mod/sub status &&
 	echo mod/sub >expected &&
 	git config -f .gitmodules submodule.sub.path >actual &&
@@ -388,7 +388,7 @@ test_expect_success 'mv does not complain when no .gitmodules file is found' '
 	git mv sub mod/sub 2>actual.err &&
 	test_must_be_empty actual.err &&
 	! test -e sub &&
-	[ "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" ] &&
+	test "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" &&
 	git -C mod/sub status &&
 	git update-index --refresh &&
 	git diff-files --quiet
@@ -409,7 +409,7 @@ test_expect_success 'mv will error out on a modified .gitmodules file unless sta
 	git mv sub mod/sub 2>actual.err &&
 	test_must_be_empty actual.err &&
 	! test -e sub &&
-	[ "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" ] &&
+	test "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" &&
 	git -C mod/sub status &&
 	git update-index --refresh &&
 	git diff-files --quiet
@@ -427,7 +427,7 @@ test_expect_success 'mv issues a warning when section is not found in .gitmodule
 	git mv sub mod/sub 2>actual.err &&
 	test_i18ncmp expect.err actual.err &&
 	! test -e sub &&
-	[ "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" ] &&
+	test "$entry" = "$(git ls-files --stage mod/sub | cut -f 1)" &&
 	git -C mod/sub status &&
 	git update-index --refresh &&
 	git diff-files --quiet

--- a/t/t7001-mv.sh
+++ b/t/t7001-mv.sh
@@ -145,7 +145,9 @@ test_expect_success 'checking the commit' '
 '
 
 test_expect_success 'do not move directory over existing directory' '
-	mkdir path0 && mkdir path0/path2 && test_must_fail git mv path2 path0
+	mkdir path0 &&
+	mkdir path0/path2 &&
+	test_must_fail git mv path2 path0
 '
 
 test_expect_success 'move into "."' '


### PR DESCRIPTION
@ralfth and @PhillipSz: please have a look at my suggestions for the German translation of Git v2.31.0. Only the commit b5e9ed2611 needs to be reviewed, the first commit is the automatically generated one to update the po file.

As always I also cleaned up some other translations that were not related to the current update. Some of these changes are proposed as best practises by the software poedit (which is also used by other translation teams).