### PR TITLE
Review: Update German translation for Git v2.32.0

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -1178,7 +1178,7 @@ msgstr ""
 #: apply.c:3574
 #, c-format
 msgid "Performing three-way merge...\n"
-msgstr "3-Wege-Merge durchführen...\n"
+msgstr "Führe 3-Wege-Merge durch...\n"
 
 #: apply.c:3590 apply.c:3594
 #, c-format
@@ -7531,7 +7531,7 @@ msgstr "send-pack: konnte Fetch-Subprozess nicht abspalten"
 
 #: send-pack.c:455
 msgid "push negotiation failed; proceeding anyway with push"
-msgstr "Push-Übertragung fehlgeschlagen; fahre trotzdem mit dem Push fort"
+msgstr "Push-Verhandlung fehlgeschlagen; fahre trotzdem mit dem Push fort"
 
 #: send-pack.c:520
 msgid "the receiving end does not support this repository's hash algorithm"
@@ -18375,7 +18375,7 @@ msgstr "bevorzugtes Paket"
 #: builtin/multi-pack-index.c:70
 msgid "pack for reuse when computing a multi-pack bitmap"
 msgstr ""
-"Paket für die Wiederbenutzung, wenn ein Multi-Pack Bitmap berechnet wird"
+"Paket für die Wiederbenutzung, wenn eine Multi-Pack Bitmap berechnet wird"
 
 #: builtin/multi-pack-index.c:128
 msgid ""
@@ -19379,7 +19379,7 @@ msgstr "kann --filter nicht mit --stdin-packs benutzen"
 #: builtin/pack-objects.c:3956
 msgid "cannot use internal rev list with --stdin-packs"
 msgstr ""
-"interne rev-list kann nicht gemeinsam mit --stdin-packs verwendet werden"
+"interne Commit-Liste kann nicht gemeinsam mit --stdin-packs verwendet werden"
 
 #: builtin/pack-objects.c:4015
 msgid "Enumerating objects"
@@ -21445,7 +21445,7 @@ msgstr ""
 #: builtin/repack.c:401 builtin/repack.c:408 builtin/repack.c:413
 #, c-format
 msgid "pack %s too large to roll up"
-msgstr "Paket %s zu groß, um aufzurollen"
+msgstr "Paket %s zu groß zum Aufrollen"
 
 #: builtin/repack.c:460
 msgid "pack everything in a single pack"
@@ -21687,7 +21687,7 @@ msgstr "neues Objekt ist dasselbe wie das alte: '%s'"
 #: builtin/replace.c:384
 #, c-format
 msgid "could not parse %s as a commit"
-msgstr "konnte nicht %s als Commit parsen"
+msgstr "konnte %s nicht als Commit parsen"
 
 #: builtin/replace.c:416
 #, c-format
@@ -22740,7 +22740,7 @@ msgstr "unversionierte Dateien in Stash einbeziehen"
 
 #: builtin/stash.c:842
 msgid "only show untracked files in the stash"
-msgstr "nur unversionierte Dateien in Stash anzeigen"
+msgstr "nur unversionierte Dateien im Stash anzeigen"
 
 #: builtin/stash.c:932 builtin/stash.c:969
 #, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
 "POT-Creation-Date: 2021-05-17 16:02+0800\n"
-"PO-Revision-Date: 2021-03-03 20:13+0100\n"
+"PO-Revision-Date: 2021-05-23 18:32+0200\n"
 "Last-Translator: Matthias Rüster <matthias.ruester@gmail.com>\n"
 "Language-Team: Matthias Rüster <matthias.ruester@gmail.com>\n"
 "Language: de\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
-"X-Generator: Poedit 2.4.2\n"
+"X-Generator: Poedit 2.4.3\n"
 
 #: add-interactive.c:376
 #, c-format
@@ -838,11 +838,15 @@ msgid ""
 "index\n"
 "entries outside the current sparse checkout:\n"
 msgstr ""
+"Die folgenden Pfadspezifikationen entsprachen keinem geeigneten Pfad, aber\n"
+"entsprechen Index-Einträgen außerhalb des aktuellen partiellen Checkouts:\n"
 
 #: advice.c:303
 msgid ""
 "Disable or modify the sparsity rules if you intend to update such entries."
 msgstr ""
+"Deaktivieren oder verändern Sie die Regeln für partielle Checkouts, wenn Sie "
+"solche Einträge aktualisieren möchten."
 
 #: advice.c:310
 #, c-format
@@ -1166,16 +1170,15 @@ msgid "%s: does not match index"
 msgstr "%s entspricht nicht der Version im Index"
 
 #: apply.c:3571
-#, fuzzy
 msgid "repository lacks the necessary blob to perform 3-way merge."
 msgstr ""
-"Dem Repository fehlt der notwendige Blob, um auf einen 3-Wege-Merge\n"
-"zurückzufallen."
+"Dem Repository fehlt der notwendige Blob, um einen 3-Wege-Merge "
+"durchzuführen."
 
 #: apply.c:3574
-#, fuzzy, c-format
+#, c-format
 msgid "Performing three-way merge...\n"
-msgstr "Falle zurück auf 3-Wege-Merge ...\n"
+msgstr "3-Wege-Merge durchführen...\n"
 
 #: apply.c:3590 apply.c:3594
 #, c-format
@@ -1183,9 +1186,9 @@ msgid "cannot read the current contents of '%s'"
 msgstr "kann aktuelle Inhalte von '%s' nicht lesen"
 
 #: apply.c:3606
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to perform three-way merge...\n"
-msgstr "Fehler beim Zurückfallen auf 3-Wege-Merge...\n"
+msgstr "Fehler beim Durchführen des 3-Wege-Merges...\n"
 
 #: apply.c:3620
 #, c-format
@@ -1198,9 +1201,9 @@ msgid "Applied patch to '%s' cleanly.\n"
 msgstr "Patch auf '%s' sauber angewendet.\n"
 
 #: apply.c:3642
-#, fuzzy, c-format
+#, c-format
 msgid "Falling back to direct application...\n"
-msgstr "Falle zurück auf 3-Wege-Merge ...\n"
+msgstr "Ausweichen auf direkte Anwendung...\n"
 
 #: apply.c:3654
 msgid "removal patch leaves file contents"
@@ -1466,9 +1469,9 @@ msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr "Patch anwenden (Benutzung mit --stat/--summary/--check)"
 
 #: apply.c:5027
-#, fuzzy
 msgid "attempt three-way merge, fall back on normal patch if that fails"
-msgstr "versuche 3-Wege-Merge, wenn der Patch nicht angewendet werden konnte"
+msgstr ""
+"versuche 3-Wege-Merge, weiche auf normalen Patch aus, wenn dies fehlschlägt"
 
 #: apply.c:5029
 msgid "build a temporary index based on embedded index information"
@@ -4243,11 +4246,10 @@ msgid "no common commits"
 msgstr "keine gemeinsamen Commits"
 
 #: fetch-pack.c:1122 fetch-pack.c:1469 builtin/clone.c:1238
-#, fuzzy
 msgid "source repository is shallow, reject to clone."
 msgstr ""
-"Quelle ist ein Repository mit unvollständiger Historie (shallow),\n"
-"ignoriere --local"
+"Quelle ist ein Repository mit unvollständiger Historie (shallow), Klonen "
+"zurückgewiesen."
 
 #: fetch-pack.c:1128 fetch-pack.c:1651
 msgid "git fetch-pack: fetch failed."
@@ -4336,9 +4338,8 @@ msgid "remote did not send all necessary objects"
 msgstr "Remote-Repository hat nicht alle erforderlichen Objekte gesendet"
 
 #: fetch-pack.c:2056
-#, fuzzy
 msgid "unexpected 'ready' from remote"
-msgstr "Unerwartetes Dateiende"
+msgstr "unerwartetes 'ready' von Remote-Repository"
 
 #: fetch-pack.c:2079
 #, c-format
@@ -4627,9 +4628,9 @@ msgid "sparse:path filters support has been dropped"
 msgstr "Keine Unterstützung für sparse:path Filter mehr"
 
 #: list-objects-filter-options.c:105
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' for 'object:type=<type>' isnot a valid object type"
-msgstr "'%s' ist kein gültiger Zeitstempel für '%s'"
+msgstr "'%s' für 'object:type=<Typ>' ist kein gültiger Objekttyp"
 
 #: list-objects-filter-options.c:124
 #, c-format
@@ -4717,12 +4718,12 @@ msgstr "erwartete Flush nach Argumenten für die Auflistung der Referenzen"
 
 #: mailinfo.c:1050
 msgid "quoted CRLF detected"
-msgstr ""
+msgstr "angeführtes CRLF entdeckt"
 
 #: mailinfo.c:1254 builtin/am.c:176 builtin/mailinfo.c:46
-#, fuzzy, c-format
+#, c-format
 msgid "bad action '%s' for '%s'"
-msgstr "ungültiger boolescher Konfigurationswert '%s' für '%s'"
+msgstr "ungültige Aktion '%s' für '%s'"
 
 #: merge-ort.c:1116 merge-recursive.c:1205
 #, c-format
@@ -4922,22 +4923,24 @@ msgstr ""
 "nach %s verschieben."
 
 #: merge-ort.c:3055
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed both "
 "of them so each can be recorded somewhere."
 msgstr ""
 "KONFLIKT (verschiedene Typen): %s hatte unterschiedliche Typen auf jeder "
-"Seite; %s wurde(n) umbenannt, damit jeder irgendwo aufgezeichnet werden kann."
+"Seite; beide wurden umbenannt, damit jeder irgendwo aufgezeichnet werden "
+"kann."
 
 #: merge-ort.c:3062
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed one "
 "of them so each can be recorded somewhere."
 msgstr ""
 "KONFLIKT (verschiedene Typen): %s hatte unterschiedliche Typen auf jeder "
-"Seite; %s wurde(n) umbenannt, damit jeder irgendwo aufgezeichnet werden kann."
+"Seite; eines der beiden wurde umbenannt, damit jeder irgendwo aufgezeichnet "
+"werden kann."
 
 #: merge-ort.c:3162 merge-recursive.c:3081
 msgid "content"
@@ -4971,6 +4974,8 @@ msgid ""
 "Note: %s not up to date and in way of checking out conflicted version; old "
 "copy renamed to %s"
 msgstr ""
+"Hinweis: %s nicht aktuell und konfliktbehaftete Version während des "
+"Auscheckens; alte Kopie zu %s umbenannt"
 
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
@@ -5383,16 +5388,14 @@ msgid "did not see pack-file %s to drop"
 msgstr "Pack-Datei %s zum Weglassen nicht gefunden"
 
 #: midx.c:1024
-#, fuzzy, c-format
+#, c-format
 msgid "unknown preferred pack: '%s'"
-msgstr "Unbekanntes Rebase-Backend: %s"
+msgstr "unbekanntes bevorzugtes Paket: '%s'"
 
 #: midx.c:1029
-#, fuzzy, c-format
+#, c-format
 msgid "preferred pack '%s' is expired"
-msgstr ""
-"Referenziertes Repository '%s' ist mit künstlichen Vorgängern (\"grafts\") "
-"eingehängt."
+msgstr "bevorzugtes Paket '%s' ist abgelaufen"
 
 #: midx.c:1045
 msgid "no pack files to index."
@@ -6218,9 +6221,9 @@ msgstr ""
 "Schreiben des Pakets fehlgeschlagen - Daten überschreiten maximale Paketgröße"
 
 #: pkt-line.c:222
-#, fuzzy, c-format
+#, c-format
 msgid "packet write failed: %s"
-msgstr "Schreiben des Pakets fehlgeschlagen."
+msgstr "Schreiben des Pakets fehlgeschlagen: %s"
 
 #: pkt-line.c:328 pkt-line.c:329
 msgid "read error"
@@ -6278,9 +6281,8 @@ msgid "promisor remote name cannot begin with '/': %s"
 msgstr "Promisor-Remote-Name kann nicht mit '/' beginnen: %s"
 
 #: protocol-caps.c:103
-#, fuzzy
 msgid "object-info: expected flush after arguments"
-msgstr "erwartete Flush nach Abrufen der Argumente"
+msgstr "object-info: erwartete Flush nach Argumenten"
 
 #: prune-packed.c:35
 msgid "Removing duplicate objects"
@@ -6503,9 +6505,8 @@ msgid "could not close '%s'"
 msgstr "Konnte '%s' nicht schließen."
 
 #: read-cache.c:3138
-#, fuzzy
 msgid "failed to convert to a sparse-index"
-msgstr "Fehler beim Bereinigen des Index"
+msgstr "Konvertierung zu einem Sparse-Index fehlgeschlagen"
 
 #: read-cache.c:3209 sequencer.c:2684 sequencer.c:4441
 #, c-format
@@ -6551,7 +6552,6 @@ msgstr ""
 "Ignoriere."
 
 #: rebase-interactive.c:42
-#, fuzzy
 msgid ""
 "\n"
 "Commands:\n"
@@ -6581,8 +6581,11 @@ msgstr ""
 "r, reword <Commit> = Commit verwenden, aber Commit-Beschreibung bearbeiten\n"
 "e, edit <Commit> = Commit verwenden, aber zum Nachbessern anhalten\n"
 "s, squash <Commit> = Commit verwenden, aber mit vorherigem Commit vereinen\n"
-"f, fixup <Commit> = wie \"squash\", aber diese Commit-Beschreibung "
-"verwerfen\n"
+"f, fixup [-C | -c] <Commit> = wie \"squash\", aber nur die vorherige\n"
+"                   Commit-Beschreibung behalten, außer -C wird verwendet,\n"
+"                   in diesem Fall wird nur diese Commit-Beschreibung "
+"behalten;\n"
+"                   -c ist das Gleiche wie -C, aber ein Editor wird geöffnet\n"
 "x, exec <Commit> = Befehl (Rest der Zeile) mittels Shell ausführen\n"
 "b, break = hier anhalten (Rebase später mit 'git rebase --continue' "
 "fortsetzen)\n"
@@ -7523,13 +7526,12 @@ msgid "failed to sign the push certificate"
 msgstr "Fehler beim Signieren des \"push\"-Zertifikates"
 
 #: send-pack.c:433
-#, fuzzy
 msgid "send-pack: unable to fork off fetch subprocess"
-msgstr "Promisor-Remote: konnte Fetch-Subprozess nicht abspalten"
+msgstr "send-pack: konnte Fetch-Subprozess nicht abspalten"
 
 #: send-pack.c:455
 msgid "push negotiation failed; proceeding anyway with push"
-msgstr ""
+msgstr "Push-Übertragung fehlgeschlagen; fahre trotzdem mit dem Push fort"
 
 #: send-pack.c:520
 msgid "the receiving end does not support this repository's hash algorithm"
@@ -7889,9 +7891,8 @@ msgid "This is the commit message #%d:"
 msgstr "Das ist Commit-Beschreibung #%d:"
 
 #: sequencer.c:1738
-#, fuzzy
 msgid "The 1st commit message will be skipped:"
-msgstr "Die Commit-Beschreibung #%d wird ausgelassen:"
+msgstr "Die erste Commit-Beschreibung wird übersprungen:"
 
 #: sequencer.c:1739
 #, c-format
@@ -8043,16 +8044,16 @@ msgstr "Kann Revert nicht während eines Cherry-Picks ausführen."
 #: sequencer.c:2788
 #, c-format
 msgid "invalid value for %s: %s"
-msgstr "Ungültiger Wert für %s: %s"
+msgstr "ungültiger Wert für %s: %s"
 
 #: sequencer.c:2897
 msgid "unusable squash-onto"
-msgstr "Unbenutzbares squash-onto."
+msgstr "unbenutzbares squash-onto"
 
 #: sequencer.c:2917
 #, c-format
 msgid "malformed options sheet: '%s'"
-msgstr "Fehlerhaftes Optionsblatt: '%s'"
+msgstr "fehlerhaftes Optionsblatt: '%s'"
 
 #: sequencer.c:3012 sequencer.c:4869
 msgid "empty commit set passed"
@@ -8065,7 +8066,7 @@ msgstr "\"revert\" ist bereits im Gange"
 #: sequencer.c:3031
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
-msgstr "Versuchen Sie \"git revert (--continue | %s--abort | --quit)\""
+msgstr "versuchen Sie \"git revert (--continue | %s--abort | --quit)\""
 
 #: sequencer.c:3034
 msgid "cherry-pick is already in progress"
@@ -8074,16 +8075,16 @@ msgstr "\"cherry-pick\" wird bereits durchgeführt"
 #: sequencer.c:3036
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
-msgstr "Versuchen Sie \"git cherry-pick (--continue | %s--abort | --quit)\""
+msgstr "versuchen Sie \"git cherry-pick (--continue | %s--abort | --quit)\""
 
 #: sequencer.c:3050
 #, c-format
 msgid "could not create sequencer directory '%s'"
-msgstr "Konnte \"sequencer\"-Verzeichnis '%s' nicht erstellen."
+msgstr "konnte \"sequencer\"-Verzeichnis '%s' nicht erstellen"
 
 #: sequencer.c:3065
 msgid "could not lock HEAD"
-msgstr "Konnte HEAD nicht sperren"
+msgstr "konnte HEAD nicht sperren"
 
 #: sequencer.c:3125 sequencer.c:4582
 msgid "no cherry-pick or revert in progress"
@@ -8105,11 +8106,11 @@ msgstr "kann '%s' nicht öffnen"
 #: sequencer.c:3161
 #, c-format
 msgid "cannot read '%s': %s"
-msgstr "Kann '%s' nicht lesen: %s"
+msgstr "kann '%s' nicht lesen: %s"
 
 #: sequencer.c:3162
 msgid "unexpected end of file"
-msgstr "Unerwartetes Dateiende"
+msgstr "unerwartetes Dateiende"
 
 #: sequencer.c:3168
 #, c-format
@@ -8123,7 +8124,7 @@ msgstr ""
 
 #: sequencer.c:3220
 msgid "no revert in progress"
-msgstr "Kein Revert im Gange"
+msgstr "kein Revert im Gange"
 
 #: sequencer.c:3229
 msgid "no cherry-pick in progress"
@@ -8135,7 +8136,7 @@ msgstr "Überspringen des Commits fehlgeschlagen"
 
 #: sequencer.c:3246
 msgid "there is nothing to skip"
-msgstr "Nichts zum Überspringen vorhanden"
+msgstr "nichts zum Überspringen vorhanden"
 
 #: sequencer.c:3249
 #, c-format
@@ -8148,12 +8149,12 @@ msgstr ""
 
 #: sequencer.c:3411 sequencer.c:4473
 msgid "cannot read HEAD"
-msgstr "Kann HEAD nicht lesen"
+msgstr "kann HEAD nicht lesen"
 
 #: sequencer.c:3428
 #, c-format
 msgid "unable to copy '%s' to '%s'"
-msgstr "Konnte '%s' nicht nach '%s' kopieren."
+msgstr "konnte '%s' nicht nach '%s' kopieren"
 
 #: sequencer.c:3436
 #, c-format
@@ -8182,12 +8183,12 @@ msgstr "Konnte %s... (%.*s) nicht anwenden"
 #: sequencer.c:3453
 #, c-format
 msgid "Could not merge %.*s"
-msgstr "Konnte \"%.*s\" nicht zusammenführen."
+msgstr "Konnte \"%.*s\" nicht zusammenführen"
 
 #: sequencer.c:3467 sequencer.c:3471 builtin/difftool.c:644
 #, c-format
 msgid "could not copy '%s' to '%s'"
-msgstr "Konnte '%s' nicht nach '%s' kopieren."
+msgstr "konnte '%s' nicht nach '%s' kopieren"
 
 #: sequencer.c:3483
 #, c-format
@@ -8235,7 +8236,7 @@ msgstr ""
 #: sequencer.c:3571
 #, c-format
 msgid "illegal label name: '%.*s'"
-msgstr "Unerlaubter Beschriftungsname: '%.*s'"
+msgstr "unerlaubter Beschriftungsname: '%.*s'"
 
 #: sequencer.c:3625
 msgid "writing fake root commit"
@@ -8248,36 +8249,36 @@ msgstr "squash-onto schreiben"
 #: sequencer.c:3714
 #, c-format
 msgid "could not resolve '%s'"
-msgstr "Konnte '%s' nicht auflösen."
+msgstr "konnte '%s' nicht auflösen"
 
 #: sequencer.c:3747
 msgid "cannot merge without a current revision"
-msgstr "Kann nicht ohne einen aktuellen Commit mergen."
+msgstr "kann nicht ohne einen aktuellen Commit mergen"
 
 #: sequencer.c:3769
 #, c-format
 msgid "unable to parse '%.*s'"
-msgstr "Konnte '%.*s' nicht parsen."
+msgstr "konnte '%.*s' nicht parsen"
 
 #: sequencer.c:3778
 #, c-format
 msgid "nothing to merge: '%.*s'"
-msgstr "Nichts zum Zusammenführen: '%.*s'"
+msgstr "nichts zum Zusammenführen: '%.*s'"
 
 #: sequencer.c:3790
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr ""
-"Oktopus-Merge kann nicht auf Basis von [neuem Root-Commit] ausgeführt werden."
+"Oktopus-Merge kann nicht auf Basis von [neuem Root-Commit] ausgeführt werden"
 
 #: sequencer.c:3806
 #, c-format
 msgid "could not get commit message of '%s'"
-msgstr "Konnte keine Commit-Beschreibung von '%s' bekommen."
+msgstr "konnte keine Commit-Beschreibung von '%s' bekommen"
 
 #: sequencer.c:3989
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
-msgstr "Konnte nicht einmal versuchen '%.*s' zu mergen."
+msgstr "konnte nicht einmal versuchen '%.*s' zu mergen"
 
 #: sequencer.c:4005
 msgid "merge: Unable to write new index file"
@@ -8285,7 +8286,7 @@ msgstr "merge: Konnte neue Index-Datei nicht schreiben."
 
 #: sequencer.c:4079
 msgid "Cannot autostash"
-msgstr "Kann automatischen Stash nicht erzeugen."
+msgstr "Kann automatischen Stash nicht erzeugen"
 
 #: sequencer.c:4082
 #, c-format
@@ -8295,7 +8296,7 @@ msgstr "Unerwartete 'stash'-Antwort: '%s'"
 #: sequencer.c:4088
 #, c-format
 msgid "Could not create directory for '%s'"
-msgstr "Konnte Verzeichnis für '%s' nicht erstellen."
+msgstr "Konnte Verzeichnis für '%s' nicht erstellen"
 
 #: sequencer.c:4091
 #, c-format
@@ -8304,7 +8305,7 @@ msgstr "Automatischen Stash erzeugt: %s\n"
 
 #: sequencer.c:4095
 msgid "could not reset --hard"
-msgstr "Konnte 'reset --hard' nicht ausführen."
+msgstr "konnte 'reset --hard' nicht ausführen"
 
 #: sequencer.c:4120
 #, c-format
@@ -8337,7 +8338,7 @@ msgstr "Automatischer Stash existiert; ein neuer Stash-Eintrag wird erstellt."
 
 #: sequencer.c:4234 git-rebase--preserve-merges.sh:769
 msgid "could not detach HEAD"
-msgstr "Konnte HEAD nicht loslösen"
+msgstr "konnte HEAD nicht loslösen"
 
 #: sequencer.c:4249
 #, c-format
@@ -8649,17 +8650,16 @@ msgstr "setsid fehlgeschlagen"
 
 #: sparse-index.c:151
 msgid "attempting to use sparse-index without cone mode"
-msgstr ""
+msgstr "versuche partiellen Index ohne Cone-Modus zu benutzen"
 
 #: sparse-index.c:156
-#, fuzzy
 msgid "unable to update cache-tree, staying full"
-msgstr "Konnte Cache-Verzeichnis nicht aktualisieren."
+msgstr "konnte Cache-Verzeichnis nicht aktualisieren, bleibt voll"
 
 #: sparse-index.c:239
 #, c-format
 msgid "index entry is a directory, but not sparse (%08x)"
-msgstr ""
+msgstr "Index-Eintrag ist ein Verzeichnis, aber nicht partiell (%08x)"
 
 #. TRANSLATORS: IEC 80000-13:2008 gibibyte
 #: strbuf.c:850
@@ -8940,9 +8940,9 @@ msgid "ls-tree returned unexpected return code %d"
 msgstr "ls-tree mit unerwartetem Rückgabewert %d beendet"
 
 #: symlinks.c:244
-#, fuzzy, c-format
+#, c-format
 msgid "failed to lstat '%s'"
-msgstr "Konnte '%s' nicht lesen"
+msgstr "'lstat' für '%s' fehlgeschlagen"
 
 #: trailer.c:244
 #, c-format
@@ -9075,7 +9075,7 @@ msgstr "kann keine Verbindung zu Subservice %s herstellen"
 
 #: transport-helper.c:693 transport.c:397
 msgid "--negotiate-only requires protocol v2"
-msgstr ""
+msgstr "--negotiate-only benötigt Protokoll v2"
 
 #: transport-helper.c:755
 msgid "'option' without a matching 'ok/error' directive"
@@ -9220,9 +9220,8 @@ msgid "server options require protocol version 2 or later"
 msgstr "Server-Optionen benötigen Protokoll-Version 2 oder höher"
 
 #: transport.c:400
-#, fuzzy
 msgid "server does not support wait-for-done"
-msgstr "Server unterstützt kein --deepen"
+msgstr "Server unterstützt nicht 'wait-for-done'"
 
 #: transport.c:751
 msgid "could not parse transport.color.* config"
@@ -9584,6 +9583,7 @@ msgstr "Aktualisiere Index-Markierungen"
 #, c-format
 msgid "worktree and untracked commit have duplicate entries: %s"
 msgstr ""
+"Arbeitsverzeichnis und unversionierter Commit haben doppelte Einträge: %s"
 
 #: upload-pack.c:1548
 msgid "expected flush after fetch arguments"
@@ -10309,24 +10309,22 @@ msgstr ""
 "%s nicht möglich: Die Staging-Area enthält nicht committete Änderungen."
 
 #: compat/simple-ipc/ipc-unix-socket.c:178
-#, fuzzy
 msgid "could not send IPC command"
-msgstr "Konnte Commit %s nicht finden."
+msgstr "konnte IPC-Befehl nicht senden"
 
 #: compat/simple-ipc/ipc-unix-socket.c:185
-#, fuzzy
 msgid "could not read IPC response"
-msgstr "konnte Referenz %s nicht lesen"
+msgstr "konnte IPC-Antwort nicht lesen"
 
 #: compat/simple-ipc/ipc-unix-socket.c:862
-#, fuzzy, c-format
+#, c-format
 msgid "could not start accept_thread '%s'"
-msgstr "konnte Datei '%s' nicht lesen"
+msgstr "konnte accept_thread nicht für '%s' starten"
 
 #: compat/simple-ipc/ipc-unix-socket.c:874
-#, fuzzy, c-format
+#, c-format
 msgid "could not start worker[0] for '%s'"
-msgstr "Konnte Log für '%s' nicht parsen."
+msgstr "konnte worker[0] nicht für '%s' starten"
 
 #: compat/precompose_utf8.c:58 builtin/clone.c:461
 #, c-format
@@ -10523,9 +10521,8 @@ msgid "adding files failed"
 msgstr "Hinzufügen von Dateien fehlgeschlagen"
 
 #: builtin/add.c:488
-#, fuzzy
 msgid "--dry-run is incompatible with --interactive/--patch"
-msgstr "--pathspec-from-file und --interactive/--patch sind inkompatibel"
+msgstr "--dry-run und --interactive/--patch sind inkompatibel"
 
 #: builtin/add.c:490 builtin/commit.c:357
 msgid "--pathspec-from-file is incompatible with --interactive/--patch"
@@ -10865,9 +10862,8 @@ msgid "strip everything before a scissors line"
 msgstr "alles vor einer Scheren-Zeile entfernen"
 
 #: builtin/am.c:2294
-#, fuzzy
 msgid "pass it through git-mailinfo"
-msgstr "an git-apply übergeben"
+msgstr "an git-mailinfo weitergeben"
 
 #: builtin/am.c:2297 builtin/am.c:2300 builtin/am.c:2303 builtin/am.c:2306
 #: builtin/am.c:2309 builtin/am.c:2312 builtin/am.c:2315 builtin/am.c:2318
@@ -11259,9 +11255,9 @@ msgid "Bad rev input: %s"
 msgstr "Ungültige Referenz-Eingabe: %s"
 
 #: builtin/bisect--helper.c:887
-#, fuzzy, c-format
+#, c-format
 msgid "Bad rev input (not a commit): %s"
-msgstr "Ungültige Referenz-Eingabe: %s"
+msgstr "Ungültige Referenz-Eingabe (kein Commit): %s"
 
 #: builtin/bisect--helper.c:919
 msgid "We are not bisecting."
@@ -12263,9 +12259,8 @@ msgid "no contacts specified"
 msgstr "keine Kontakte angegeben"
 
 #: builtin/checkout--worker.c:110
-#, fuzzy
 msgid "git checkout--worker [<options>]"
-msgstr "git checkout [<Optionen>] <Branch>"
+msgstr "git checkout--worker [<Optionen>]"
 
 #: builtin/checkout--worker.c:118 builtin/checkout-index.c:201
 #: builtin/column.c:31 builtin/submodule--helper.c:1825
@@ -13051,9 +13046,8 @@ msgid "git clone [<options>] [--] <repo> [<dir>]"
 msgstr "git clone [<Optionen>] [--] <Repository> [<Verzeichnis>]"
 
 #: builtin/clone.c:96
-#, fuzzy
 msgid "don't clone shallow repository"
-msgstr "von einem lokalen Repository klonen"
+msgstr "Repository mit unvollständiger Historie nicht klonen"
 
 #: builtin/clone.c:98
 msgid "don't create a checkout"
@@ -13441,24 +13435,20 @@ msgid "layout to use"
 msgstr "zu verwendende Anordnung"
 
 #: builtin/column.c:30
-#, fuzzy
 msgid "maximum width"
 msgstr "maximale Breite"
 
 #: builtin/column.c:31
-#, fuzzy
 msgid "padding space on left border"
-msgstr "Abstand zum linken Rand"
+msgstr "Abstand zum linken Rand auffüllen"
 
 #: builtin/column.c:32
-#, fuzzy
 msgid "padding space on right border"
-msgstr "Abstand zum rechten Rand"
+msgstr "Abstand zum rechten Rand auffüllen"
 
 #: builtin/column.c:33
-#, fuzzy
 msgid "padding space between columns"
-msgstr "Abstand zwischen Spalten"
+msgstr "Abstand zwischen Spalten auffüllen"
 
 #: builtin/column.c:51
 msgid "--command must be the first argument"
@@ -13801,9 +13791,9 @@ msgid "could not read log file '%s'"
 msgstr "Konnte Log-Datei '%s' nicht lesen"
 
 #: builtin/commit.c:801
-#, fuzzy, c-format
+#, c-format
 msgid "cannot combine -m with --fixup:%s"
-msgstr "'--root' kann nicht mit '--fork-point' kombiniert werden"
+msgstr "-m kann nicht mit --fixup:%s kombiniert werden"
 
 #: builtin/commit.c:813 builtin/commit.c:829
 msgid "could not read SQUASH_MSG"
@@ -13888,9 +13878,8 @@ msgid "Cannot read index"
 msgstr "Kann Index nicht lesen"
 
 #: builtin/commit.c:1018
-#, fuzzy
 msgid "unable to pass trailers to --trailers"
-msgstr "Konnte Kopfbereich von %s nicht parsen."
+msgstr "konnte Anhänge nicht an --trailers weitergeben"
 
 #: builtin/commit.c:1058
 msgid "Error building trees"
@@ -13924,27 +13913,27 @@ msgid "--long and -z are incompatible"
 msgstr "--long und -z sind inkompatibel"
 
 #: builtin/commit.c:1219
-#, fuzzy
 msgid "You are in the middle of a merge -- cannot reword."
-msgstr "Ein Merge ist im Gange -- kann \"--amend\" nicht ausführen."
+msgstr "Ein Merge ist im Gange -- kann Umformulierung nicht durchführen."
 
 #: builtin/commit.c:1221
-#, fuzzy
 msgid "You are in the middle of a cherry-pick -- cannot reword."
-msgstr "\"cherry-pick\" ist im Gange -- kann \"--amend\" nicht ausführen."
+msgstr "\"cherry-pick\" ist im Gange -- kann Umformulierung nicht durchführen."
 
 #: builtin/commit.c:1224
-#, fuzzy, c-format
+#, c-format
 msgid "cannot combine reword option of --fixup with path '%s'"
 msgstr ""
-"Optionen für \"am\" können nicht mit Optionen für \"merge\" kombiniert "
-"werden."
+"Option für Umformulierung bei --fixup kann nicht mit Pfad '%s' kombiniert "
+"werden"
 
 #: builtin/commit.c:1226
 msgid ""
 "reword option of --fixup is mutually exclusive with --patch/--interactive/--"
 "all/--include/--only"
 msgstr ""
+"Umformulierungsoption von --fixup und --patch/--interactive/--all/--"
+"include/--only schließen sich gegenseitig aus"
 
 #: builtin/commit.c:1245
 msgid "Using both --reset-author and --author does not make sense"
@@ -13990,9 +13979,9 @@ msgstr ""
 "verwendet werden."
 
 #: builtin/commit.c:1331
-#, fuzzy, c-format
+#, c-format
 msgid "unknown option: --fixup=%s:%s"
-msgstr "Unbekannte Option: %s\n"
+msgstr "unbekannte Option: --fixup=%s:%s"
 
 #: builtin/commit.c:1345
 #, c-format
@@ -14130,23 +14119,21 @@ msgstr "Beschreibung des angegebenen Commits wiederverwenden"
 #. and only translate <commit>.
 #.
 #: builtin/commit.c:1621
-#, fuzzy
 msgid "[(amend|reword):]commit"
-msgstr "vorherigen Commit ändern"
+msgstr "[(amend|reword):]Commit"
 
 #: builtin/commit.c:1621
-#, fuzzy
 msgid ""
 "use autosquash formatted message to fixup or amend/reword specified commit"
 msgstr ""
-"eine automatisch zusammengesetzte Beschreibung zum Nachbessern des "
+"eine autosquash-formatierte Beschreibung zum Nachbessern/Umformulieren des "
 "angegebenen Commits verwenden"
 
 #: builtin/commit.c:1622
 msgid "use autosquash formatted message to squash specified commit"
 msgstr ""
-"eine automatisch zusammengesetzte Beschreibung beim \"squash\" des "
-"angegebenen Commits verwenden"
+"eine autosquash-formatierte Beschreibung beim \"squash\" des angegebenen "
+"Commits verwenden"
 
 #: builtin/commit.c:1623
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
@@ -14158,7 +14145,7 @@ msgstr "Anhang"
 
 #: builtin/commit.c:1624
 msgid "add custom trailer(s)"
-msgstr ""
+msgstr "benutzerdefinierte Anhänge hinzufügen"
 
 #: builtin/commit.c:1625 builtin/log.c:1751 builtin/merge.c:302
 #: builtin/pull.c:145 builtin/revert.c:110
@@ -14250,9 +14237,9 @@ msgid "Aborting commit; you did not edit the message.\n"
 msgstr "Commit abgebrochen; Sie haben die Beschreibung nicht editiert.\n"
 
 #: builtin/commit.c:1788
-#, fuzzy, c-format
+#, c-format
 msgid "Aborting commit due to empty commit message body.\n"
-msgstr "Commit aufgrund leerer Beschreibung abgebrochen.\n"
+msgstr "Commit aufgrund leerer Commit-Beschreibung abgebrochen.\n"
 
 #: builtin/commit.c:1824
 msgid ""
@@ -15201,6 +15188,8 @@ msgstr "Anzahl der parallel anzufordernden Submodule"
 #: builtin/fetch.c:164
 msgid "modify the refspec to place all refs within refs/prefetch/"
 msgstr ""
+"Refspec verändern, damit alle Referenzen unter refs/prefetch/ platziert "
+"werden"
 
 #: builtin/fetch.c:166 builtin/pull.c:198
 msgid "prune remote-tracking branches no longer on remote"
@@ -15284,6 +15273,8 @@ msgstr ""
 #: builtin/fetch.c:210
 msgid "do not fetch a packfile; instead, print ancestors of negotiation tips"
 msgstr ""
+"keine Packdatei anfordern; stattdessen die Vorgänger der Verhandlungstipps "
+"anzeigen"
 
 #: builtin/fetch.c:213 builtin/fetch.c:215
 msgid "run 'maintenance --auto' after fetching"
@@ -15537,11 +15528,11 @@ msgstr ""
 
 #: builtin/fetch.c:2055
 msgid "must supply remote when using --negotiate-only"
-msgstr ""
+msgstr "Remote wird benötigt, wenn --negotiate-only benutzt wird"
 
 #: builtin/fetch.c:2060
 msgid "Protocol does not support --negotiate-only, exiting."
-msgstr ""
+msgstr "Protokoll unterstützt --negotiate-only nicht, beende."
 
 #: builtin/fetch.c:2079
 msgid ""
@@ -16035,9 +16026,8 @@ msgid "failed to write commit-graph"
 msgstr "Fehler beim Schreiben des Commit-Graph"
 
 #: builtin/gc.c:905
-#, fuzzy
 msgid "failed to prefetch remotes"
-msgstr "Fehler beim Eintragen der Remote-Repositories"
+msgstr "Vorabruf der Remote-Repositories fehlgeschlagen"
 
 #: builtin/gc.c:1022
 msgid "failed to start 'git pack-objects' process"
@@ -17312,7 +17302,7 @@ msgstr "die Nummerierung der Patches bei <n> statt bei 1 beginnen"
 
 #: builtin/log.c:1762
 msgid "reroll-count"
-msgstr ""
+msgstr "Reroll-Anzahl"
 
 #: builtin/log.c:1763
 msgid "mark the series as Nth re-roll"
@@ -17750,56 +17740,52 @@ msgstr ""
 
 #. TRANSLATORS: keep <> in "<" mail ">" info.
 #: builtin/mailinfo.c:14
-#, fuzzy
 msgid "git mailinfo [<options>] <msg> <patch> < mail >info"
-msgstr "git diff --no-index [<Optionen>] <Pfad> <Pfad>"
+msgstr "git mailinfo [<Optionen>] <Nachricht> <Patch> < mail >info"
 
 #: builtin/mailinfo.c:58
-#, fuzzy
 msgid "keep subject"
-msgstr "nicht erreichbare Objekte behalten"
+msgstr "Betreff beibehalten"
 
 #: builtin/mailinfo.c:60
 msgid "keep non patch brackets in subject"
-msgstr ""
+msgstr "behalte Klammern im Betreff, die nicht zum Patch gehören"
 
 #: builtin/mailinfo.c:62
-#, fuzzy
 msgid "copy Message-ID to the end of commit message"
-msgstr "Commit-Beschreibung bearbeiten"
+msgstr "Message-ID an das Ende der Commit-Beschreibung kopieren"
 
 #: builtin/mailinfo.c:64
 msgid "re-code metadata to i18n.commitEncoding"
-msgstr ""
+msgstr "Neukodierung der Metadaten nach 'i18n.commitEncoding'"
 
 #: builtin/mailinfo.c:67
 msgid "disable charset re-coding of metadata"
-msgstr ""
+msgstr "Zeichen-Neukodierung der Metadaten deaktivieren"
 
 #: builtin/mailinfo.c:69
 msgid "encoding"
-msgstr ""
+msgstr "Encoding"
 
 #: builtin/mailinfo.c:70
 msgid "re-code metadata to this encoding"
-msgstr ""
+msgstr "Neukodierung der Metadaten zu diesem Encoding"
 
 #: builtin/mailinfo.c:72
 msgid "use scissors"
-msgstr ""
+msgstr "nutze Scherenmarkierungen"
 
 #: builtin/mailinfo.c:73
-#, fuzzy
 msgid "<action>"
-msgstr "Aktion"
+msgstr "<Aktion>"
 
 #: builtin/mailinfo.c:74
 msgid "action when quoted CR is found"
-msgstr ""
+msgstr "Aktion, wenn ein angeführtes CR gefunden wird"
 
 #: builtin/mailinfo.c:77
 msgid "use headers in message's body"
-msgstr ""
+msgstr "nutze Header im Inhalt der Nachricht"
 
 #: builtin/mailsplit.c:241
 #, c-format
@@ -18055,14 +18041,13 @@ msgid "read-tree failed"
 msgstr "read-tree fehlgeschlagen"
 
 #: builtin/merge.c:400
-#, fuzzy
 msgid "Already up to date. (nothing to squash)"
-msgstr " (nichts zu quetschen)"
+msgstr "Bereits auf dem neuesten Stand. (nichts für Squash-Merge vorhanden)"
 
 #: builtin/merge.c:414
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
-msgstr "Quetsche Commit -- HEAD wird nicht aktualisiert\n"
+msgstr "Squash Commit -- HEAD wird nicht aktualisiert\n"
 
 #: builtin/merge.c:464
 #, c-format
@@ -18233,7 +18218,7 @@ msgstr "Kein Commit angegeben und merge.defaultToUpstream ist nicht gesetzt."
 #: builtin/merge.c:1430
 msgid "Squash commit into empty head not supported yet"
 msgstr ""
-"Bin auf einem Commit, der noch geboren wird; kann \"squash\" nicht ausführen."
+"Squash-Merge auf einen leeren Branch wird noch nicht unterstützt"
 
 #: builtin/merge.c:1432
 msgid "Non-fast-forward commit does not make sense into an empty head"
@@ -18248,11 +18233,11 @@ msgstr "%s - nichts was wir zusammenführen können"
 
 #: builtin/merge.c:1439
 msgid "Can merge only exactly one commit into empty head"
-msgstr "Kann nur exakt einen Commit in einem leeren Branch zusammenführen."
+msgstr "Kann nur exakt einen Commit in einem leeren Branch zusammenführen"
 
 #: builtin/merge.c:1520
 msgid "refusing to merge unrelated histories"
-msgstr "Verweigere den Merge von nicht zusammenhängenden Historien."
+msgstr "verweigere den Merge von nicht zusammenhängenden Historien"
 
 #: builtin/merge.c:1539
 #, c-format
@@ -18363,28 +18348,20 @@ msgid "allow creation of more than one tree"
 msgstr "die Erstellung von mehr als einem \"Tree\"-Objekt erlauben"
 
 #: builtin/multi-pack-index.c:10
-#, fuzzy
 msgid "git multi-pack-index [<options>] write [--preferred-pack=<pack>]"
-msgstr ""
-"git multi-pack-index [<Optionen>] (write|verify|expire|repack --batch-"
-"size=<Größe>)"
+msgstr "git multi-pack-index [<Optionen>] write [--preferred-pack=<Paket>]"
 
 #: builtin/multi-pack-index.c:13
-#, fuzzy
 msgid "git multi-pack-index [<options>] verify"
-msgstr "git upload-pack [<Optionen>] <Verzeichnis>"
+msgstr "git multi-pack-index [<Optionen>] verify"
 
 #: builtin/multi-pack-index.c:16
-#, fuzzy
 msgid "git multi-pack-index [<options>] expire"
-msgstr "git upload-pack [<Optionen>] <Verzeichnis>"
+msgstr "git multi-pack-index [<Optionen>] expire"
 
 #: builtin/multi-pack-index.c:19
-#, fuzzy
 msgid "git multi-pack-index [<options>] repack [--batch-size=<size>]"
-msgstr ""
-"git multi-pack-index [<Optionen>] (write|verify|expire|repack --batch-"
-"size=<Größe>)"
+msgstr "git multi-pack-index [<Optionen>] repack [--batch-size=<Größe>]"
 
 #: builtin/multi-pack-index.c:54
 msgid "object directory containing set of packfile and pack-index pairs"
@@ -18393,11 +18370,12 @@ msgstr ""
 
 #: builtin/multi-pack-index.c:69
 msgid "preferred-pack"
-msgstr ""
+msgstr "bevorzugtes Paket"
 
 #: builtin/multi-pack-index.c:70
 msgid "pack for reuse when computing a multi-pack bitmap"
 msgstr ""
+"Paket für die Wiederbenutzung, wenn ein Multi-Pack Bitmap berechnet wird"
 
 #: builtin/multi-pack-index.c:128
 msgid ""
@@ -19124,14 +19102,14 @@ msgstr ""
 "('%s' erhalten)"
 
 #: builtin/pack-objects.c:3039
-#, fuzzy, c-format
+#, c-format
 msgid "could not get type of object %s in pack %s"
-msgstr "Konnte Art von Objekt '%s' nicht bestimmen."
+msgstr "konnte Typ von Objekt %s in Paket %s nicht bestimmen"
 
 #: builtin/pack-objects.c:3161 builtin/pack-objects.c:3175
-#, fuzzy, c-format
+#, c-format
 msgid "could not find pack '%s'"
-msgstr "Konnte '%s' nicht abschließen."
+msgstr "Konnte Paket '%s' nicht finden"
 
 #: builtin/pack-objects.c:3218
 #, c-format
@@ -19271,9 +19249,8 @@ msgid "include objects referred to by the index"
 msgstr "Objekte einschließen, die vom Index referenziert werden"
 
 #: builtin/pack-objects.c:3795
-#, fuzzy
 msgid "read packs from stdin"
-msgstr "Aktualisierungen von der Standard-Eingabe lesen"
+msgstr "Pakete von der Standard-Eingabe lesen"
 
 #: builtin/pack-objects.c:3797
 msgid "output pack to stdout"
@@ -19396,14 +19373,13 @@ msgid "cannot use --filter without --stdout"
 msgstr "Kann --filter nicht ohne --stdout benutzen."
 
 #: builtin/pack-objects.c:3952
-#, fuzzy
 msgid "cannot use --filter with --stdin-packs"
-msgstr "Kann --filter nicht ohne --stdout benutzen."
+msgstr "kann --filter nicht mit --stdin-packs benutzen"
 
 #: builtin/pack-objects.c:3956
-#, fuzzy
 msgid "cannot use internal rev list with --stdin-packs"
-msgstr "Angabe von Pfadnamen kann nicht gemeinsam mit --stdin verwendet werden"
+msgstr ""
+"interne rev-list kann nicht gemeinsam mit --stdin-packs verwendet werden"
 
 #: builtin/pack-objects.c:4015
 msgid "Enumerating objects"
@@ -21456,19 +21432,20 @@ msgstr ""
 "Remote-Repositories nicht abschließen."
 
 #: builtin/repack.c:309
-#, fuzzy, c-format
+#, c-format
 msgid "cannot open index for %s"
-msgstr "Fehler beim Öffnen des Index für %s."
+msgstr "konnte Index für %s nicht öffnen"
 
 #: builtin/repack.c:368
 #, c-format
 msgid "pack %s too large to consider in geometric progression"
 msgstr ""
+"Paket %s zu groß, um es bei der geometrischen Progression zu berücksichtigen"
 
 #: builtin/repack.c:401 builtin/repack.c:408 builtin/repack.c:413
 #, c-format
 msgid "pack %s too large to roll up"
-msgstr ""
+msgstr "Paket %s zu groß, um aufzurollen"
 
 #: builtin/repack.c:460
 msgid "pack everything in a single pack"
@@ -21555,7 +21532,7 @@ msgstr "dieses Paket nicht neu packen"
 
 #: builtin/repack.c:498
 msgid "find a geometric progression with factor <N>"
-msgstr ""
+msgstr "eine geometrische Progression mit Faktor <N> finden"
 
 #: builtin/repack.c:508
 msgid "cannot delete packs in a precious-objects repo"
@@ -21566,9 +21543,8 @@ msgid "--keep-unreachable and -A are incompatible"
 msgstr "--keep-unreachable und -A sind inkompatibel"
 
 #: builtin/repack.c:527
-#, fuzzy
 msgid "--geometric is incompatible with -A, -a"
-msgstr "--long und --abbrev=0 sind inkompatibel"
+msgstr "--geometric ist inkompatibel mit -A, -a"
 
 #: builtin/repack.c:639
 msgid "Nothing new to pack."
@@ -21652,66 +21628,66 @@ msgstr ""
 #: builtin/replace.c:229
 #, c-format
 msgid "unable to open %s for writing"
-msgstr "Konnte '%s' nicht zum Schreiben öffnen."
+msgstr "konnte '%s' nicht zum Schreiben öffnen"
 
 #: builtin/replace.c:242
 msgid "cat-file reported failure"
-msgstr "cat-file meldete Fehler."
+msgstr "cat-file meldete Fehler"
 
 #: builtin/replace.c:258
 #, c-format
 msgid "unable to open %s for reading"
-msgstr "Konnte '%s' nicht zum Lesen öffnen."
+msgstr "konnte '%s' nicht zum Lesen öffnen"
 
 #: builtin/replace.c:272
 msgid "unable to spawn mktree"
-msgstr "Konnte mktree nicht ausführen."
+msgstr "konnte mktree nicht ausführen"
 
 #: builtin/replace.c:276
 msgid "unable to read from mktree"
-msgstr "Konnte nicht von mktree lesen."
+msgstr "konnte nicht von mktree lesen"
 
 #: builtin/replace.c:285
 msgid "mktree reported failure"
-msgstr "mktree meldete Fehler."
+msgstr "mktree meldete Fehler"
 
 #: builtin/replace.c:289
 msgid "mktree did not return an object name"
-msgstr "mktree lieferte keinen Objektnamen zurück."
+msgstr "mktree lieferte keinen Objektnamen zurück"
 
 #: builtin/replace.c:298
 #, c-format
 msgid "unable to fstat %s"
-msgstr "Kann fstat auf %s nicht ausführen."
+msgstr "kann fstat auf %s nicht ausführen"
 
 #: builtin/replace.c:303
 msgid "unable to write object to database"
-msgstr "Konnte Objekt nicht in Datenbank schreiben."
+msgstr "konnte Objekt nicht in Datenbank schreiben"
 
 #: builtin/replace.c:322 builtin/replace.c:378 builtin/replace.c:424
 #: builtin/replace.c:454
 #, c-format
 msgid "not a valid object name: '%s'"
-msgstr "Kein gültiger Objektname: '%s'"
+msgstr "kein gültiger Objektname: '%s'"
 
 #: builtin/replace.c:326
 #, c-format
 msgid "unable to get object type for %s"
-msgstr "Konnte Objektart von %s nicht bestimmten."
+msgstr "konnte Objektart von %s nicht bestimmten"
 
 #: builtin/replace.c:342
 msgid "editing object file failed"
-msgstr "Bearbeiten von Objektdatei fehlgeschlagen."
+msgstr "bearbeiten von Objektdatei fehlgeschlagen"
 
 #: builtin/replace.c:351
 #, c-format
 msgid "new object is the same as the old one: '%s'"
-msgstr "Neues Objekt ist dasselbe wie das alte: '%s'"
+msgstr "neues Objekt ist dasselbe wie das alte: '%s'"
 
 #: builtin/replace.c:384
 #, c-format
 msgid "could not parse %s as a commit"
-msgstr "Konnte nicht %s als Commit parsen."
+msgstr "konnte nicht %s als Commit parsen"
 
 #: builtin/replace.c:416
 #, c-format
@@ -21735,26 +21711,26 @@ msgstr ""
 #: builtin/replace.c:469
 #, c-format
 msgid "the original commit '%s' has a gpg signature"
-msgstr "Der originale Commit '%s' hat eine GPG-Signatur."
+msgstr "der originale Commit '%s' hat eine GPG-Signatur"
 
 #: builtin/replace.c:470
 msgid "the signature will be removed in the replacement commit!"
-msgstr "Die Signatur wird in dem Ersetzungs-Commit entfernt!"
+msgstr "die Signatur wird in dem Ersetzungs-Commit entfernt!"
 
 #: builtin/replace.c:480
 #, c-format
 msgid "could not write replacement commit for: '%s'"
-msgstr "Konnte Ersetzungs-Commit für '%s' nicht schreiben"
+msgstr "konnte Ersetzungs-Commit für '%s' nicht schreiben"
 
 #: builtin/replace.c:488
 #, c-format
 msgid "graft for '%s' unnecessary"
-msgstr "Künstlicher Vorgänger (\"graft\") für '%s' nicht notwendig."
+msgstr "künstlicher Vorgänger (\"graft\") für '%s' nicht notwendig"
 
 #: builtin/replace.c:492
 #, c-format
 msgid "new commit is the same as the old one: '%s'"
-msgstr "Neuer Commit ist derselbe wie der alte: '%s'"
+msgstr "neuer Commit ist derselbe wie der alte: '%s'"
 
 #: builtin/replace.c:527
 #, c-format
@@ -21762,7 +21738,7 @@ msgid ""
 "could not convert the following graft(s):\n"
 "%s"
 msgstr ""
-"Konnte die folgenden künstlichen Vorgänger (\"grafts\") nicht konvertieren:\n"
+"konnte die folgenden künstlichen Vorgänger (\"grafts\") nicht konvertieren:\n"
 "%s"
 
 #: builtin/replace.c:548
@@ -21799,31 +21775,31 @@ msgstr "das angegebene Format benutzen"
 
 #: builtin/replace.c:569
 msgid "--format cannot be used when not listing"
-msgstr "--format kann nicht beim Auflisten verwendet werden."
+msgstr "--format kann nicht beim Auflisten verwendet werden"
 
 #: builtin/replace.c:577
 msgid "-f only makes sense when writing a replacement"
-msgstr "-f macht nur beim Schreiben einer Ersetzung Sinn."
+msgstr "-f macht nur beim Schreiben einer Ersetzung Sinn"
 
 #: builtin/replace.c:581
 msgid "--raw only makes sense with --edit"
-msgstr "--raw macht nur mit --edit Sinn."
+msgstr "--raw macht nur mit --edit Sinn"
 
 #: builtin/replace.c:587
 msgid "-d needs at least one argument"
-msgstr "-d benötigt mindestens ein Argument."
+msgstr "-d benötigt mindestens ein Argument"
 
 #: builtin/replace.c:593
 msgid "bad number of arguments"
-msgstr "Ungültige Anzahl von Argumenten."
+msgstr "Ungültige Anzahl von Argumenten"
 
 #: builtin/replace.c:599
 msgid "-e needs exactly one argument"
-msgstr "-e benötigt genau ein Argument."
+msgstr "-e benötigt genau ein Argument"
 
 #: builtin/replace.c:605
 msgid "-g needs at least one argument"
-msgstr "-g benötigt mindestens ein Argument."
+msgstr "-g benötigt mindestens ein Argument"
 
 #: builtin/replace.c:611
 msgid "--convert-graft-file takes no argument"
@@ -21831,7 +21807,7 @@ msgstr "--convert-graft-file erwartet keine Argumente"
 
 #: builtin/replace.c:617
 msgid "only one pattern can be given with -l"
-msgstr "Mit -l kann nur ein Muster angegeben werden."
+msgstr "Mit -l kann nur ein Muster angegeben werden"
 
 #: builtin/rerere.c:13
 msgid "git rerere [clear | forget <path>... | status | remaining | diff | gc]"
@@ -21843,12 +21819,12 @@ msgstr "saubere Auflösungen im Index registrieren"
 
 #: builtin/rerere.c:79
 msgid "'git rerere forget' without paths is deprecated"
-msgstr "'git rerere forget' ohne Pfade ist veraltet."
+msgstr "'git rerere forget' ohne Pfade ist veraltet"
 
 #: builtin/rerere.c:113
 #, c-format
 msgid "unable to generate diff for '%s'"
-msgstr "Konnte kein Diff für '%s' generieren."
+msgstr "konnte kein Diff für '%s' generieren"
 
 #: builtin/reset.c:32
 msgid ""
@@ -22536,9 +22512,8 @@ msgid "failed to set extensions.worktreeConfig setting"
 msgstr "Einstellung für extensions.worktreeConfig konnte nicht gesetzt werden"
 
 #: builtin/sparse-checkout.c:290
-#, fuzzy
 msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
-msgstr "git sparse-checkout init [--cone]"
+msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
 
 #: builtin/sparse-checkout.c:310
 msgid "initialize the sparse-checkout in cone mode"
@@ -22546,12 +22521,11 @@ msgstr "initialisiere den partiellen Checkout im Cone-Modus"
 
 #: builtin/sparse-checkout.c:312
 msgid "toggle the use of a sparse index"
-msgstr ""
+msgstr "die Nutzung des Sparse-Index umschalten"
 
 #: builtin/sparse-checkout.c:340
-#, fuzzy
 msgid "failed to modify sparse-index config"
-msgstr "Fehler beim Laden des Pack-Index für Packdatei %s"
+msgstr "Verändern der Konfiguration für Sparse-Index fehlgeschlagen"
 
 #: builtin/sparse-checkout.c:361
 #, c-format
@@ -22753,24 +22727,20 @@ msgid "No branch name specified"
 msgstr "Kein Branchname spezifiziert"
 
 #: builtin/stash.c:808
-#, fuzzy
 msgid "failed to parse tree"
-msgstr "Fehler beim Parsen von %s."
+msgstr "Parsen der Tree-Objekte fehlgeschlagen"
 
 #: builtin/stash.c:819
-#, fuzzy
 msgid "failed to unpack trees"
-msgstr "Fehler beim Entpacken des Tree-Objektes von HEAD."
+msgstr "Entpacken der Tree-Objekte fehlgeschlagen"
 
 #: builtin/stash.c:839
-#, fuzzy
 msgid "include untracked files in the stash"
 msgstr "unversionierte Dateien in Stash einbeziehen"
 
 #: builtin/stash.c:842
-#, fuzzy
 msgid "only show untracked files in the stash"
-msgstr "unversionierte Dateien in Stash einbeziehen"
+msgstr "nur unversionierte Dateien in Stash anzeigen"
 
 #: builtin/stash.c:932 builtin/stash.c:969
 #, c-format
@@ -24410,9 +24380,9 @@ msgid "-c expects a configuration string\n"
 msgstr "-c erwartet einen Konfigurationsstring.\n"
 
 #: git.c:260
-#, fuzzy, c-format
+#, c-format
 msgid "no config key given for --config-env\n"
-msgstr "Kein Verzeichnis für --work-tree angegeben.\n"
+msgstr "kein Konfigurationsschlüssel für --config-env angegeben\n"
 
 #: git.c:300
 #, c-format
@@ -24534,111 +24504,108 @@ msgstr "direkt nach Anzeige der angebotenen Fähigkeiten beenden"
 #: t/helper/test-simple-ipc.c:262
 #, c-format
 msgid "socket/pipe already in use: '%s'"
-msgstr ""
+msgstr "Socket/Pipe bereits in Benutzung: '%s'"
 
 #: t/helper/test-simple-ipc.c:264
-#, fuzzy, c-format
+#, c-format
 msgid "could not start server on: '%s'"
-msgstr "konnte Datei '%s' nicht lesen"
+msgstr "konnte Server nicht starten auf: '%s'"
 
 #: t/helper/test-simple-ipc.c:295 t/helper/test-simple-ipc.c:331
 msgid "could not spawn daemon in the background"
-msgstr ""
+msgstr "Daemon konnte nicht im Hintergrund erzeugt werden"
 
 #: t/helper/test-simple-ipc.c:356
-#, fuzzy
 msgid "waitpid failed"
-msgstr "setsid fehlgeschlagen"
+msgstr "waitpid fehlgeschlagen"
 
 #: t/helper/test-simple-ipc.c:376
 msgid "daemon not online yet"
-msgstr ""
+msgstr "Daemon ist noch nicht online"
 
 #: t/helper/test-simple-ipc.c:406
-#, fuzzy
 msgid "daemon failed to start"
-msgstr "Konnte '%s' nicht lesen"
+msgstr "Fehler beim Starten des Daemons"
 
 #: t/helper/test-simple-ipc.c:410
 msgid "waitpid is confused"
-msgstr ""
+msgstr "waitpid ist verwirrt"
 
 #: t/helper/test-simple-ipc.c:541
 msgid "daemon has not shutdown yet"
-msgstr ""
+msgstr "Daemon ist noch nicht heruntergefahren"
 
 #: t/helper/test-simple-ipc.c:682
 msgid "test-helper simple-ipc is-active    [<name>] [<options>]"
-msgstr ""
+msgstr "test-helper simple-ipc is-active    [<Name>] [<Optionen>]"
 
 #: t/helper/test-simple-ipc.c:683
 msgid "test-helper simple-ipc run-daemon   [<name>] [<threads>]"
-msgstr ""
+msgstr "test-helper simple-ipc run-daemon   [<Name>] [<Threads>]"
 
 #: t/helper/test-simple-ipc.c:684
 msgid "test-helper simple-ipc start-daemon [<name>] [<threads>] [<max-wait>]"
-msgstr ""
+msgstr "test-helper simple-ipc start-daemon [<Name>] [<Threads>] [<max-wait>]"
 
 #: t/helper/test-simple-ipc.c:685
 msgid "test-helper simple-ipc stop-daemon  [<name>] [<max-wait>]"
-msgstr ""
+msgstr "test-helper simple-ipc stop-daemon  [<Name>] [<max-wait>]"
 
 #: t/helper/test-simple-ipc.c:686
 msgid "test-helper simple-ipc send         [<name>] [<token>]"
-msgstr ""
+msgstr "test-helper simple-ipc send         [<Name>] [<Token>]"
 
 #: t/helper/test-simple-ipc.c:687
 msgid "test-helper simple-ipc sendbytes    [<name>] [<bytecount>] [<byte>]"
-msgstr ""
+msgstr "test-helper simple-ipc sendbytes    [<Name>] [<bytecount>] [<Byte>]"
 
 #: t/helper/test-simple-ipc.c:688
 msgid ""
 "test-helper simple-ipc multiple     [<name>] [<threads>] [<bytecount>] "
 "[<batchsize>]"
 msgstr ""
+"test-helper simple-ipc multiple     [<Name>] [<Threads>] [<bytecount>] "
+"[<batchsize>]"
 
 #: t/helper/test-simple-ipc.c:696
 msgid "name or pathname of unix domain socket"
-msgstr ""
+msgstr "Name oder Pfadname des UNIX-Domain-Sockets"
 
 #: t/helper/test-simple-ipc.c:698
 msgid "named-pipe name"
-msgstr ""
+msgstr "Name der benannten Pipe"
 
 #: t/helper/test-simple-ipc.c:700
 msgid "number of threads in server thread pool"
-msgstr ""
+msgstr "Anzahl der Threads im Thread-Pool des Servers"
 
 #: t/helper/test-simple-ipc.c:701
 msgid "seconds to wait for daemon to start or stop"
-msgstr ""
+msgstr "Sekunden, um auf Starten oder Stoppen des Daemons zu warten"
 
 #: t/helper/test-simple-ipc.c:703
-#, fuzzy
 msgid "number of bytes"
-msgstr "Ungültige Anzahl von Argumenten."
+msgstr "Anzahl von Bytes"
 
 #: t/helper/test-simple-ipc.c:704
-#, fuzzy
 msgid "number of requests per thread"
-msgstr "kann Thread nicht erzeugen: %s"
+msgstr "Anzahl der Anfragen pro Thread"
 
 #: t/helper/test-simple-ipc.c:706
-#, fuzzy
 msgid "byte"
-msgstr "Bytes"
+msgstr "Byte"
 
 #: t/helper/test-simple-ipc.c:706
 msgid "ballast character"
-msgstr ""
+msgstr "Ballast-Zeichen"
 
 #: t/helper/test-simple-ipc.c:707
 msgid "token"
-msgstr ""
+msgstr "Token"
 
 #: t/helper/test-simple-ipc.c:707
 msgid "command token to send to the server"
-msgstr ""
+msgstr "Befehlstoken, der an den Server gesendet werden soll"
 
 #: http.c:399
 #, c-format
@@ -26610,7 +26577,7 @@ msgstr "lokaler Zeit-Offset größer oder gleich 24 Stunden\n"
 #: git-send-email.perl:222
 #, perl-format
 msgid "fatal: command '%s' died with exit code %d"
-msgstr ""
+msgstr "fatal: Befehl '%s' mit Exit-Code %d beendet"
 
 #: git-send-email.perl:235
 msgid "the editor exited uncleanly, aborting everything"
@@ -26966,14 +26933,15 @@ msgid "invalid transfer encoding"
 msgstr "Ungültiges Transfer-Encoding"
 
 #: git-send-email.perl:1966
-#, fuzzy, perl-format
+#, perl-format
 msgid ""
 "fatal: %s: rejected by sendemail-validate hook\n"
 "%s\n"
 "warning: no patches were sent\n"
 msgstr ""
-"fatal: %s: %s\n"
-"Warnung: Es wurden keine Patches versendet\n"
+"fatal: %s: zurückgewiesen durch 'sendemail-validate' Hook\n"
+"%s\n"
+"Warnung: Es wurden keine Patches gesendet\n"
 
 #: git-send-email.perl:1976 git-send-email.perl:2029 git-send-email.perl:2039
 #, perl-format
@@ -26981,13 +26949,13 @@ msgid "unable to open %s: %s\n"
 msgstr "konnte %s nicht öffnen: %s\n"
 
 #: git-send-email.perl:1979
-#, fuzzy, perl-format
+#, perl-format
 msgid ""
 "fatal: %s:%d is longer than 998 characters\n"
 "warning: no patches were sent\n"
 msgstr ""
-"fatal: %s: %s\n"
-"Warnung: Es wurden keine Patches versendet\n"
+"fatal: %s:%d ist länger als 998 Zeichen\n"
+"Warnung: Es wurden keine Patches gesendet\n"
 
 #: git-send-email.perl:1997
 #, perl-format

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-03-04 22:41+0800\n"
+"POT-Creation-Date: 2021-05-17 16:02+0800\n"
 "PO-Revision-Date: 2021-03-03 20:13+0100\n"
 "Last-Translator: Matthias Rüster <matthias.ruester@gmail.com>\n"
 "Language-Team: Matthias Rüster <matthias.ruester@gmail.com>\n"
@@ -24,9 +24,9 @@ msgstr ""
 msgid "Huh (%s)?"
 msgstr "Wie bitte (%s)?"
 
-#: add-interactive.c:529 add-interactive.c:830 reset.c:65 sequencer.c:3292
-#: sequencer.c:3743 sequencer.c:3898 builtin/rebase.c:1538
-#: builtin/rebase.c:1963
+#: add-interactive.c:529 add-interactive.c:830 reset.c:65 sequencer.c:3493
+#: sequencer.c:3944 sequencer.c:4099 builtin/rebase.c:1528
+#: builtin/rebase.c:1953
 msgid "could not read index"
 msgstr "Index konnte nicht gelesen werden"
 
@@ -54,7 +54,7 @@ msgstr "Aktualisieren"
 msgid "could not stage '%s'"
 msgstr "Konnte '%s' nicht zum Commit vormerken."
 
-#: add-interactive.c:703 add-interactive.c:892 reset.c:89 sequencer.c:3486
+#: add-interactive.c:703 add-interactive.c:892 reset.c:89 sequencer.c:3687
 msgid "could not write index"
 msgstr "konnte Index nicht schreiben"
 
@@ -70,7 +70,7 @@ msgstr[1] "%d Pfade aktualisiert\n"
 msgid "note: %s is untracked now.\n"
 msgstr "Hinweis: %s ist nun unversioniert.\n"
 
-#: add-interactive.c:729 apply.c:4125 builtin/checkout.c:295
+#: add-interactive.c:729 apply.c:4127 builtin/checkout.c:298
 #: builtin/reset.c:145
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
@@ -210,12 +210,12 @@ msgstr "zur Staging-Area hinzugefügt"
 msgid "unstaged"
 msgstr "aus Staging-Area entfernt"
 
-#: add-interactive.c:1144 apply.c:4987 apply.c:4990 builtin/am.c:2257
-#: builtin/am.c:2260 builtin/bugreport.c:134 builtin/clone.c:124
-#: builtin/fetch.c:150 builtin/merge.c:285 builtin/pull.c:190
-#: builtin/submodule--helper.c:409 builtin/submodule--helper.c:1818
-#: builtin/submodule--helper.c:1821 builtin/submodule--helper.c:2326
-#: builtin/submodule--helper.c:2329 builtin/submodule--helper.c:2572
+#: add-interactive.c:1144 apply.c:4994 apply.c:4997 builtin/am.c:2308
+#: builtin/am.c:2311 builtin/bugreport.c:135 builtin/clone.c:128
+#: builtin/fetch.c:152 builtin/merge.c:285 builtin/pull.c:190
+#: builtin/submodule--helper.c:409 builtin/submodule--helper.c:1819
+#: builtin/submodule--helper.c:1822 builtin/submodule--helper.c:2327
+#: builtin/submodule--helper.c:2330 builtin/submodule--helper.c:2573
 #: git-add--interactive.perl:213
 msgid "path"
 msgstr "Pfad"
@@ -761,7 +761,7 @@ msgstr "Entschuldigung, kann diesen Patch-Block nicht bearbeiten"
 msgid "'git apply' failed"
 msgstr "'git apply' schlug fehl"
 
-#: advice.c:143
+#: advice.c:145
 #, c-format
 msgid ""
 "\n"
@@ -770,43 +770,43 @@ msgstr ""
 "\n"
 "Deaktivieren Sie diese Nachricht mit \"git config advice.%s false\""
 
-#: advice.c:159
+#: advice.c:161
 #, c-format
 msgid "%shint: %.*s%s\n"
 msgstr "%sHinweis: %.*s%s\n"
 
-#: advice.c:250
+#: advice.c:252
 msgid "Cherry-picking is not possible because you have unmerged files."
 msgstr ""
 "Cherry-Picken ist nicht möglich, weil Sie nicht zusammengeführte Dateien "
 "haben."
 
-#: advice.c:252
+#: advice.c:254
 msgid "Committing is not possible because you have unmerged files."
 msgstr ""
 "Committen ist nicht möglich, weil Sie nicht zusammengeführte Dateien haben."
 
-#: advice.c:254
+#: advice.c:256
 msgid "Merging is not possible because you have unmerged files."
 msgstr ""
 "Mergen ist nicht möglich, weil Sie nicht zusammengeführte Dateien haben."
 
-#: advice.c:256
+#: advice.c:258
 msgid "Pulling is not possible because you have unmerged files."
 msgstr ""
 "Pullen ist nicht möglich, weil Sie nicht zusammengeführte Dateien haben."
 
-#: advice.c:258
+#: advice.c:260
 msgid "Reverting is not possible because you have unmerged files."
 msgstr ""
 "Reverten ist nicht möglich, weil Sie nicht zusammengeführte Dateien haben."
 
-#: advice.c:260
+#: advice.c:262
 #, c-format
 msgid "It is not possible to %s because you have unmerged files."
 msgstr "%s ist nicht möglich, weil Sie nicht zusammengeführte Dateien haben."
 
-#: advice.c:268
+#: advice.c:270
 msgid ""
 "Fix them up in the work tree, and then use 'git add/rm <file>'\n"
 "as appropriate to mark resolution and make a commit."
@@ -815,23 +815,36 @@ msgstr ""
 "dann 'git add/rm <Datei>', um die Auflösung entsprechend zu markieren\n"
 "und zu committen."
 
-#: advice.c:276
+#: advice.c:278
 msgid "Exiting because of an unresolved conflict."
 msgstr "Beende wegen unaufgelöstem Konflikt."
 
-#: advice.c:281 builtin/merge.c:1370
+#: advice.c:283 builtin/merge.c:1374
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "Sie haben Ihren Merge nicht abgeschlossen (MERGE_HEAD existiert)."
 
-#: advice.c:283
+#: advice.c:285
 msgid "Please, commit your changes before merging."
 msgstr "Bitte committen Sie Ihre Änderungen, bevor Sie mergen."
 
-#: advice.c:284
+#: advice.c:286
 msgid "Exiting because of unfinished merge."
 msgstr "Beende wegen nicht abgeschlossenem Merge."
 
-#: advice.c:290
+#: advice.c:296
+#, c-format
+msgid ""
+"The following pathspecs didn't match any eligible path, but they do match "
+"index\n"
+"entries outside the current sparse checkout:\n"
+msgstr ""
+
+#: advice.c:303
+msgid ""
+"Disable or modify the sparsity rules if you intend to update such entries."
+msgstr ""
+
+#: advice.c:310
 #, c-format
 msgid ""
 "Note: switching to '%s'.\n"
@@ -882,86 +895,82 @@ msgstr "Befehlszeile endet mit \\"
 msgid "unclosed quote"
 msgstr "Nicht geschlossene Anführungszeichen."
 
-#: apply.c:69
+#: apply.c:70
 #, c-format
 msgid "unrecognized whitespace option '%s'"
 msgstr "Nicht erkannte Whitespace-Option: '%s'"
 
-#: apply.c:85
+#: apply.c:86
 #, c-format
 msgid "unrecognized whitespace ignore option '%s'"
 msgstr "nicht erkannte Option zum Ignorieren von Whitespace: '%s'"
 
-#: apply.c:135
+#: apply.c:136
 msgid "--reject and --3way cannot be used together."
 msgstr "--reject und --3way können nicht gemeinsam verwendet werden."
 
-#: apply.c:137
-msgid "--cached and --3way cannot be used together."
-msgstr "--cached und --3way können nicht gemeinsam verwendet werden."
-
-#: apply.c:140
+#: apply.c:139
 msgid "--3way outside a repository"
 msgstr "--3way kann nicht außerhalb eines Repositories verwendet werden"
 
-#: apply.c:151
+#: apply.c:150
 msgid "--index outside a repository"
 msgstr "--index kann nicht außerhalb eines Repositories verwendet werden"
 
-#: apply.c:154
+#: apply.c:153
 msgid "--cached outside a repository"
 msgstr "--cached kann nicht außerhalb eines Repositories verwendet werden"
 
-#: apply.c:801
+#: apply.c:800
 #, c-format
 msgid "Cannot prepare timestamp regexp %s"
 msgstr "Kann regulären Ausdruck für Zeitstempel %s nicht verarbeiten"
 
-#: apply.c:810
+#: apply.c:809
 #, c-format
 msgid "regexec returned %d for input: %s"
 msgstr "Ausführung des regulären Ausdrucks gab %d zurück. Eingabe: %s"
 
-#: apply.c:884
+#: apply.c:883
 #, c-format
 msgid "unable to find filename in patch at line %d"
 msgstr "konnte keinen Dateinamen in Zeile %d des Patches finden"
 
-#: apply.c:922
+#: apply.c:921
 #, c-format
 msgid "git apply: bad git-diff - expected /dev/null, got %s on line %d"
 msgstr ""
 "git apply: ungültiges 'git-diff' - erwartete /dev/null, erhielt %s in Zeile "
 "%d"
 
-#: apply.c:928
+#: apply.c:927
 #, c-format
 msgid "git apply: bad git-diff - inconsistent new filename on line %d"
 msgstr ""
 "git apply: ungültiges 'git-diff' - Inkonsistenter neuer Dateiname in Zeile %d"
 
-#: apply.c:929
+#: apply.c:928
 #, c-format
 msgid "git apply: bad git-diff - inconsistent old filename on line %d"
 msgstr ""
 "git apply: ungültiges 'git-diff' - Inkonsistenter alter Dateiname in Zeile %d"
 
-#: apply.c:934
+#: apply.c:933
 #, c-format
 msgid "git apply: bad git-diff - expected /dev/null on line %d"
 msgstr "git apply: ungültiges 'git-diff' - erwartete /dev/null in Zeile %d"
 
-#: apply.c:963
+#: apply.c:962
 #, c-format
 msgid "invalid mode on line %d: %s"
 msgstr "Ungültiger Modus in Zeile %d: %s"
 
-#: apply.c:1282
+#: apply.c:1281
 #, c-format
 msgid "inconsistent header lines %d and %d"
 msgstr "Inkonsistente Kopfzeilen %d und %d."
 
-#: apply.c:1372
+#: apply.c:1371
 #, c-format
 msgid ""
 "git diff header lacks filename information when removing %d leading pathname "
@@ -976,82 +985,82 @@ msgstr[1] ""
 "Dem Kopfbereich von \"git diff\" fehlen Informationen zum Dateinamen, wenn "
 "%d vorangestellte Teile des Pfades entfernt werden (Zeile %d)"
 
-#: apply.c:1385
+#: apply.c:1384
 #, c-format
 msgid "git diff header lacks filename information (line %d)"
 msgstr ""
 "Dem Kopfbereich von \"git diff\" fehlen Informationen zum Dateinamen (Zeile "
 "%d)"
 
-#: apply.c:1481
+#: apply.c:1480
 #, c-format
 msgid "recount: unexpected line: %.*s"
 msgstr "recount: unerwartete Zeile: %.*s"
 
-#: apply.c:1550
+#: apply.c:1549
 #, c-format
 msgid "patch fragment without header at line %d: %.*s"
 msgstr "Patch-Fragment ohne Kopfbereich bei Zeile %d: %.*s"
 
-#: apply.c:1753
+#: apply.c:1752
 msgid "new file depends on old contents"
 msgstr "neue Datei hängt von alten Inhalten ab"
 
-#: apply.c:1755
+#: apply.c:1754
 msgid "deleted file still has contents"
 msgstr "entfernte Datei hat noch Inhalte"
 
-#: apply.c:1789
+#: apply.c:1788
 #, c-format
 msgid "corrupt patch at line %d"
 msgstr "fehlerhafter Patch bei Zeile %d"
 
-#: apply.c:1826
+#: apply.c:1825
 #, c-format
 msgid "new file %s depends on old contents"
 msgstr "neue Datei %s hängt von alten Inhalten ab"
 
-#: apply.c:1828
+#: apply.c:1827
 #, c-format
 msgid "deleted file %s still has contents"
 msgstr "entfernte Datei %s hat noch Inhalte"
 
-#: apply.c:1831
+#: apply.c:1830
 #, c-format
 msgid "** warning: file %s becomes empty but is not deleted"
 msgstr "** Warnung: Datei %s wird leer, aber nicht entfernt."
 
-#: apply.c:1978
+#: apply.c:1977
 #, c-format
 msgid "corrupt binary patch at line %d: %.*s"
 msgstr "fehlerhafter Binär-Patch bei Zeile %d: %.*s"
 
-#: apply.c:2015
+#: apply.c:2014
 #, c-format
 msgid "unrecognized binary patch at line %d"
 msgstr "nicht erkannter Binär-Patch bei Zeile %d"
 
-#: apply.c:2177
+#: apply.c:2176
 #, c-format
 msgid "patch with only garbage at line %d"
 msgstr "Patch mit nutzlosen Informationen bei Zeile %d"
 
-#: apply.c:2263
+#: apply.c:2262
 #, c-format
 msgid "unable to read symlink %s"
 msgstr "konnte symbolische Verknüpfung %s nicht lesen"
 
-#: apply.c:2267
+#: apply.c:2266
 #, c-format
 msgid "unable to open or read %s"
 msgstr "konnte %s nicht öffnen oder lesen"
 
-#: apply.c:2936
+#: apply.c:2935
 #, c-format
 msgid "invalid start of line: '%c'"
 msgstr "Ungültiger Zeilenanfang: '%c'"
 
-#: apply.c:3057
+#: apply.c:3056
 #, c-format
 msgid "Hunk #%d succeeded at %d (offset %d line)."
 msgid_plural "Hunk #%d succeeded at %d (offset %d lines)."
@@ -1059,12 +1068,12 @@ msgstr[0] "Patch-Bereich #%d erfolgreich angewendet bei %d (%d Zeile versetzt)"
 msgstr[1] ""
 "Patch-Bereich #%d erfolgreich angewendet bei %d (%d Zeilen versetzt)"
 
-#: apply.c:3069
+#: apply.c:3068
 #, c-format
 msgid "Context reduced to (%ld/%ld) to apply fragment at %d"
 msgstr "Kontext reduziert zu (%ld/%ld), um Patch-Bereich bei %d anzuwenden"
 
-#: apply.c:3075
+#: apply.c:3074
 #, c-format
 msgid ""
 "while searching for:\n"
@@ -1073,25 +1082,25 @@ msgstr ""
 "bei der Suche nach:\n"
 "%.*s"
 
-#: apply.c:3097
+#: apply.c:3096
 #, c-format
 msgid "missing binary patch data for '%s'"
 msgstr "keine Daten in Binär-Patch für '%s'"
 
-#: apply.c:3105
+#: apply.c:3104
 #, c-format
 msgid "cannot reverse-apply a binary patch without the reverse hunk to '%s'"
 msgstr ""
 "kann binären Patch nicht in umgekehrter Reihenfolge anwenden ohne einen\n"
 "umgekehrten Patch-Block auf '%s'"
 
-#: apply.c:3152
+#: apply.c:3151
 #, c-format
 msgid "cannot apply binary patch to '%s' without full index line"
 msgstr ""
 "kann binären Patch auf '%s' nicht ohne eine vollständige Index-Zeile anwenden"
 
-#: apply.c:3163
+#: apply.c:3162
 #, c-format
 msgid ""
 "the patch applies to '%s' (%s), which does not match the current contents."
@@ -1099,426 +1108,434 @@ msgstr ""
 "der Patch wird angewendet auf '%s' (%s), was nicht den aktuellen Inhalten\n"
 "entspricht"
 
-#: apply.c:3171
+#: apply.c:3170
 #, c-format
 msgid "the patch applies to an empty '%s' but it is not empty"
 msgstr "der Patch wird auf ein leeres '%s' angewendet, was aber nicht leer ist"
 
-#: apply.c:3189
+#: apply.c:3188
 #, c-format
 msgid "the necessary postimage %s for '%s' cannot be read"
 msgstr "das erforderliche Postimage %s für '%s' kann nicht gelesen werden"
 
-#: apply.c:3202
+#: apply.c:3201
 #, c-format
 msgid "binary patch does not apply to '%s'"
 msgstr "Konnte Binär-Patch nicht auf '%s' anwenden"
 
-#: apply.c:3209
+#: apply.c:3208
 #, c-format
 msgid "binary patch to '%s' creates incorrect result (expecting %s, got %s)"
 msgstr ""
 "Binär-Patch für '%s' erzeugt falsches Ergebnis (erwartete %s, bekam %s)"
 
-#: apply.c:3230
+#: apply.c:3229
 #, c-format
 msgid "patch failed: %s:%ld"
 msgstr "Anwendung des Patches fehlgeschlagen: %s:%ld"
 
-#: apply.c:3353
+#: apply.c:3352
 #, c-format
 msgid "cannot checkout %s"
 msgstr "kann %s nicht auschecken"
 
-#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:86 pack-revindex.c:213
+#: apply.c:3404 apply.c:3415 apply.c:3461 midx.c:98 pack-revindex.c:214
 #: setup.c:308
 #, c-format
 msgid "failed to read %s"
 msgstr "Fehler beim Lesen von %s"
 
-#: apply.c:3413
+#: apply.c:3412
 #, c-format
 msgid "reading from '%s' beyond a symbolic link"
 msgstr "'%s' ist hinter einer symbolischen Verknüpfung"
 
-#: apply.c:3442 apply.c:3685
+#: apply.c:3441 apply.c:3687
 #, c-format
 msgid "path %s has been renamed/deleted"
 msgstr "Pfad %s wurde umbenannt/gelöscht"
 
-#: apply.c:3528 apply.c:3700
+#: apply.c:3527 apply.c:3702
 #, c-format
 msgid "%s: does not exist in index"
 msgstr "%s ist nicht im Index"
 
-#: apply.c:3537 apply.c:3708 apply.c:3952
+#: apply.c:3536 apply.c:3710 apply.c:3954
 #, c-format
 msgid "%s: does not match index"
 msgstr "%s entspricht nicht der Version im Index"
 
-#: apply.c:3572
-msgid "repository lacks the necessary blob to fall back on 3-way merge."
+#: apply.c:3571
+#, fuzzy
+msgid "repository lacks the necessary blob to perform 3-way merge."
 msgstr ""
 "Dem Repository fehlt der notwendige Blob, um auf einen 3-Wege-Merge\n"
 "zurückzufallen."
 
-#: apply.c:3575
-#, c-format
-msgid "Falling back to three-way merge...\n"
+#: apply.c:3574
+#, fuzzy, c-format
+msgid "Performing three-way merge...\n"
 msgstr "Falle zurück auf 3-Wege-Merge ...\n"
 
-#: apply.c:3591 apply.c:3595
+#: apply.c:3590 apply.c:3594
 #, c-format
 msgid "cannot read the current contents of '%s'"
 msgstr "kann aktuelle Inhalte von '%s' nicht lesen"
 
-#: apply.c:3607
-#, c-format
-msgid "Failed to fall back on three-way merge...\n"
+#: apply.c:3606
+#, fuzzy, c-format
+msgid "Failed to perform three-way merge...\n"
 msgstr "Fehler beim Zurückfallen auf 3-Wege-Merge...\n"
 
-#: apply.c:3621
+#: apply.c:3620
 #, c-format
 msgid "Applied patch to '%s' with conflicts.\n"
 msgstr "Patch auf '%s' mit Konflikten angewendet.\n"
 
-#: apply.c:3626
+#: apply.c:3625
 #, c-format
 msgid "Applied patch to '%s' cleanly.\n"
 msgstr "Patch auf '%s' sauber angewendet.\n"
 
-#: apply.c:3652
+#: apply.c:3642
+#, fuzzy, c-format
+msgid "Falling back to direct application...\n"
+msgstr "Falle zurück auf 3-Wege-Merge ...\n"
+
+#: apply.c:3654
 msgid "removal patch leaves file contents"
 msgstr "Lösch-Patch hinterlässt Dateiinhalte"
 
-#: apply.c:3725
+#: apply.c:3727
 #, c-format
 msgid "%s: wrong type"
 msgstr "%s: falscher Typ"
 
-#: apply.c:3727
+#: apply.c:3729
 #, c-format
 msgid "%s has type %o, expected %o"
 msgstr "%s ist vom Typ %o, erwartete %o"
 
-#: apply.c:3892 apply.c:3894 read-cache.c:832 read-cache.c:858
-#: read-cache.c:1313
+#: apply.c:3894 apply.c:3896 read-cache.c:861 read-cache.c:890
+#: read-cache.c:1351
 #, c-format
 msgid "invalid path '%s'"
 msgstr "Ungültiger Pfad '%s'"
 
-#: apply.c:3950
+#: apply.c:3952
 #, c-format
 msgid "%s: already exists in index"
 msgstr "%s ist bereits bereitgestellt"
 
-#: apply.c:3954
+#: apply.c:3956
 #, c-format
 msgid "%s: already exists in working directory"
 msgstr "%s existiert bereits im Arbeitsverzeichnis"
 
-#: apply.c:3974
+#: apply.c:3976
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
 msgstr "neuer Modus (%o) von %s entspricht nicht dem alten Modus (%o)"
 
-#: apply.c:3979
+#: apply.c:3981
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
 msgstr "neuer Modus (%o) von %s entspricht nicht dem alten Modus (%o) von %s"
 
-#: apply.c:3999
+#: apply.c:4001
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
 msgstr "betroffene Datei '%s' ist hinter einer symbolischen Verknüpfung"
 
-#: apply.c:4003
+#: apply.c:4005
 #, c-format
 msgid "%s: patch does not apply"
 msgstr "%s: Patch konnte nicht angewendet werden"
 
-#: apply.c:4018
+#: apply.c:4020
 #, c-format
 msgid "Checking patch %s..."
 msgstr "Prüfe Patch %s ..."
 
-#: apply.c:4110
+#: apply.c:4112
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
 msgstr "SHA-1 Information fehlt oder ist unbrauchbar für Submodul %s"
 
-#: apply.c:4117
+#: apply.c:4119
 #, c-format
 msgid "mode change for %s, which is not in current HEAD"
 msgstr "Modusänderung für %s, was sich nicht im aktuellen HEAD befindet"
 
-#: apply.c:4120
+#: apply.c:4122
 #, c-format
 msgid "sha1 information is lacking or useless (%s)."
 msgstr "SHA-1 Information fehlt oder ist unbrauchbar (%s)."
 
-#: apply.c:4129
+#: apply.c:4131
 #, c-format
 msgid "could not add %s to temporary index"
 msgstr "konnte %s nicht zum temporären Index hinzufügen"
 
-#: apply.c:4139
+#: apply.c:4141
 #, c-format
 msgid "could not write temporary index to %s"
 msgstr "konnte temporären Index nicht nach %s schreiben"
 
-#: apply.c:4277
+#: apply.c:4279
 #, c-format
 msgid "unable to remove %s from index"
 msgstr "konnte %s nicht aus dem Index entfernen"
 
-#: apply.c:4311
+#: apply.c:4313
 #, c-format
 msgid "corrupt patch for submodule %s"
 msgstr "fehlerhafter Patch für Submodul %s"
 
-#: apply.c:4317
+#: apply.c:4319
 #, c-format
 msgid "unable to stat newly created file '%s'"
 msgstr "konnte neu erstellte Datei '%s' nicht lesen"
 
-#: apply.c:4325
+#: apply.c:4327
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr "kann internen Speicher für eben erstellte Datei %s nicht erzeugen"
 
-#: apply.c:4331 apply.c:4476
+#: apply.c:4333 apply.c:4478
 #, c-format
 msgid "unable to add cache entry for %s"
 msgstr "kann für %s keinen Eintrag in den Zwischenspeicher hinzufügen"
 
-#: apply.c:4374 builtin/bisect--helper.c:523
+#: apply.c:4376 builtin/bisect--helper.c:523
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "Fehler beim Schreiben nach '%s'"
 
-#: apply.c:4378
+#: apply.c:4380
 #, c-format
 msgid "closing file '%s'"
 msgstr "schließe Datei '%s'"
 
-#: apply.c:4448
+#: apply.c:4450
 #, c-format
 msgid "unable to write file '%s' mode %o"
 msgstr "konnte Datei '%s' mit Modus %o nicht schreiben"
 
-#: apply.c:4546
+#: apply.c:4548
 #, c-format
 msgid "Applied patch %s cleanly."
 msgstr "Patch %s sauber angewendet"
 
-#: apply.c:4554
+#: apply.c:4556
 msgid "internal error"
 msgstr "interner Fehler"
 
-#: apply.c:4557
+#: apply.c:4559
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
 msgstr[0] "Wende Patch %%s mit %d Zurückweisung an..."
 msgstr[1] "Wende Patch %%s mit %d Zurückweisungen an..."
 
-#: apply.c:4568
+#: apply.c:4570
 #, c-format
 msgid "truncating .rej filename to %.*s.rej"
 msgstr "Verkürze Name von .rej Datei zu %.*s.rej"
 
-#: apply.c:4576 builtin/fetch.c:933 builtin/fetch.c:1334
+#: apply.c:4578 builtin/fetch.c:993 builtin/fetch.c:1394
 #, c-format
 msgid "cannot open %s"
 msgstr "kann '%s' nicht öffnen"
 
-#: apply.c:4590
+#: apply.c:4592
 #, c-format
 msgid "Hunk #%d applied cleanly."
 msgstr "Patch-Bereich #%d sauber angewendet."
 
-#: apply.c:4594
+#: apply.c:4596
 #, c-format
 msgid "Rejected hunk #%d."
 msgstr "Patch-Block #%d zurückgewiesen."
 
-#: apply.c:4718
+#: apply.c:4725
 #, c-format
 msgid "Skipped patch '%s'."
 msgstr "Patch '%s' ausgelassen."
 
-#: apply.c:4726
+#: apply.c:4733
 msgid "unrecognized input"
 msgstr "nicht erkannte Eingabe"
 
-#: apply.c:4746
+#: apply.c:4753
 msgid "unable to read index file"
 msgstr "Konnte Index-Datei nicht lesen"
 
-#: apply.c:4903
+#: apply.c:4910
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr "kann Patch '%s' nicht öffnen: %s"
 
-#: apply.c:4930
+#: apply.c:4937
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "unterdrückte %d Whitespace-Fehler"
 msgstr[1] "unterdrückte %d Whitespace-Fehler"
 
-#: apply.c:4936 apply.c:4951
+#: apply.c:4943 apply.c:4958
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] "%d Zeile fügt Whitespace-Fehler hinzu."
 msgstr[1] "%d Zeilen fügen Whitespace-Fehler hinzu."
 
-#: apply.c:4944
+#: apply.c:4951
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
 msgstr[0] "%d Zeile nach Behebung von Whitespace-Fehlern angewendet."
 msgstr[1] "%d Zeilen nach Behebung von Whitespace-Fehlern angewendet."
 
-#: apply.c:4960 builtin/add.c:626 builtin/mv.c:304 builtin/rm.c:406
+#: apply.c:4967 builtin/add.c:679 builtin/mv.c:304 builtin/rm.c:423
 msgid "Unable to write new index file"
 msgstr "Konnte neue Index-Datei nicht schreiben."
 
-#: apply.c:4988
+#: apply.c:4995
 msgid "don't apply changes matching the given path"
 msgstr "keine Änderungen im angegebenen Pfad anwenden"
 
-#: apply.c:4991
+#: apply.c:4998
 msgid "apply changes matching the given path"
 msgstr "Änderungen nur im angegebenen Pfad anwenden"
 
-#: apply.c:4993 builtin/am.c:2266
+#: apply.c:5000 builtin/am.c:2317
 msgid "num"
 msgstr "Anzahl"
 
-#: apply.c:4994
+#: apply.c:5001
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr ""
 "<Anzahl> vorangestellte Schrägstriche von herkömmlichen Differenzpfaden "
 "entfernen"
 
-#: apply.c:4997
+#: apply.c:5004
 msgid "ignore additions made by the patch"
 msgstr "hinzugefügte Zeilen des Patches ignorieren"
 
-#: apply.c:4999
+#: apply.c:5006
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr ""
 "statt den Patch anzuwenden, den \"diffstat\" für die Eingabe ausgegeben"
 
-#: apply.c:5003
+#: apply.c:5010
 msgid "show number of added and deleted lines in decimal notation"
 msgstr ""
 "die Anzahl von hinzugefügten/entfernten Zeilen in Dezimalnotation anzeigen"
 
-#: apply.c:5005
+#: apply.c:5012
 msgid "instead of applying the patch, output a summary for the input"
 msgstr ""
 "statt den Patch anzuwenden, eine Zusammenfassung für die Eingabe ausgeben"
 
-#: apply.c:5007
+#: apply.c:5014
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr ""
 "statt den Patch anzuwenden, anzeigen ob der Patch angewendet werden kann"
 
-#: apply.c:5009
+#: apply.c:5016
 msgid "make sure the patch is applicable to the current index"
 msgstr ""
 "sicherstellen, dass der Patch mit dem aktuellen Index angewendet werden kann"
 
-#: apply.c:5011
+#: apply.c:5018
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "neue Dateien mit `git add --intent-to-add` markieren"
 
-#: apply.c:5013
+#: apply.c:5020
 msgid "apply a patch without touching the working tree"
 msgstr "Patch anwenden, ohne Änderungen im Arbeitsverzeichnis vorzunehmen"
 
-#: apply.c:5015
+#: apply.c:5022
 msgid "accept a patch that touches outside the working area"
 msgstr ""
 "Patch anwenden, der Änderungen außerhalb des Arbeitsverzeichnisses vornimmt"
 
-#: apply.c:5018
+#: apply.c:5025
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr "Patch anwenden (Benutzung mit --stat/--summary/--check)"
 
-#: apply.c:5020
-msgid "attempt three-way merge if a patch does not apply"
+#: apply.c:5027
+#, fuzzy
+msgid "attempt three-way merge, fall back on normal patch if that fails"
 msgstr "versuche 3-Wege-Merge, wenn der Patch nicht angewendet werden konnte"
 
-#: apply.c:5022
+#: apply.c:5029
 msgid "build a temporary index based on embedded index information"
 msgstr ""
 "einen temporären Index, basierend auf den integrierten Index-Informationen, "
 "erstellen"
 
-#: apply.c:5025 builtin/checkout-index.c:195 builtin/ls-files.c:540
+#: apply.c:5032 builtin/checkout-index.c:196 builtin/ls-files.c:617
 msgid "paths are separated with NUL character"
 msgstr "Pfade sind getrennt durch NUL Zeichen"
 
-#: apply.c:5027
+#: apply.c:5034
 msgid "ensure at least <n> lines of context match"
 msgstr ""
 "sicher stellen, dass mindestens <n> Zeilen des Kontextes übereinstimmen"
 
-#: apply.c:5028 builtin/am.c:2245 builtin/interpret-trailers.c:98
-#: builtin/interpret-trailers.c:100 builtin/interpret-trailers.c:102
-#: builtin/pack-objects.c:3577 builtin/rebase.c:1352
+#: apply.c:5035 builtin/am.c:2293 builtin/am.c:2296
+#: builtin/interpret-trailers.c:98 builtin/interpret-trailers.c:100
+#: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3831
+#: builtin/rebase.c:1347
 msgid "action"
 msgstr "Aktion"
 
-#: apply.c:5029
+#: apply.c:5036
 msgid "detect new or modified lines that have whitespace errors"
 msgstr "neue oder geänderte Zeilen, die Whitespace-Fehler haben, ermitteln"
 
-#: apply.c:5032 apply.c:5035
+#: apply.c:5039 apply.c:5042
 msgid "ignore changes in whitespace when finding context"
 msgstr "Änderungen im Whitespace bei der Suche des Kontextes ignorieren"
 
-#: apply.c:5038
+#: apply.c:5045
 msgid "apply the patch in reverse"
 msgstr "den Patch in umgekehrter Reihenfolge anwenden"
 
-#: apply.c:5040
+#: apply.c:5047
 msgid "don't expect at least one line of context"
 msgstr "keinen Kontext erwarten"
 
-#: apply.c:5042
+#: apply.c:5049
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr ""
 "zurückgewiesene Patch-Blöcke in entsprechenden *.rej Dateien hinterlassen"
 
-#: apply.c:5044
+#: apply.c:5051
 msgid "allow overlapping hunks"
 msgstr "sich überlappende Patch-Blöcke erlauben"
 
-#: apply.c:5045 builtin/add.c:337 builtin/check-ignore.c:22
-#: builtin/commit.c:1364 builtin/count-objects.c:98 builtin/fsck.c:757
-#: builtin/log.c:2286 builtin/mv.c:123 builtin/read-tree.c:128
+#: apply.c:5052 builtin/add.c:364 builtin/check-ignore.c:22
+#: builtin/commit.c:1474 builtin/count-objects.c:98 builtin/fsck.c:755
+#: builtin/log.c:2295 builtin/mv.c:123 builtin/read-tree.c:128
 msgid "be verbose"
 msgstr "erweiterte Ausgaben"
 
-#: apply.c:5047
+#: apply.c:5054
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr "fehlerhaft erkannten fehlenden Zeilenumbruch am Dateiende tolerieren"
 
-#: apply.c:5050
+#: apply.c:5057
 msgid "do not trust the line counts in the hunk headers"
 msgstr "den Zeilennummern im Kopf des Patch-Blocks nicht vertrauen"
 
-#: apply.c:5052 builtin/am.c:2254
+#: apply.c:5059 builtin/am.c:2305
 msgid "root"
 msgstr "Wurzelverzeichnis"
 
-#: apply.c:5053
+#: apply.c:5060
 msgid "prepend <root> to all filenames"
 msgstr "<Wurzelverzeichnis> vor alle Dateinamen stellen"
 
@@ -1585,142 +1602,142 @@ msgstr ""
 msgid "git archive --remote <repo> [--exec <cmd>] --list"
 msgstr "git archive --remote <Repository> [--exec <Programm>] --list"
 
-#: archive.c:192
+#: archive.c:188
 #, c-format
 msgid "cannot read %s"
 msgstr "Kann %s nicht lesen."
 
-#: archive.c:345 sequencer.c:459 sequencer.c:1744 sequencer.c:2894
-#: sequencer.c:3335 sequencer.c:3444 builtin/am.c:249 builtin/commit.c:786
-#: builtin/merge.c:1139
+#: archive.c:342 sequencer.c:460 sequencer.c:1915 sequencer.c:3095
+#: sequencer.c:3536 sequencer.c:3645 builtin/am.c:261 builtin/commit.c:833
+#: builtin/merge.c:1143
 #, c-format
 msgid "could not read '%s'"
 msgstr "Konnte '%s' nicht lesen"
 
-#: archive.c:430 builtin/add.c:189 builtin/add.c:602 builtin/rm.c:315
+#: archive.c:427 builtin/add.c:205 builtin/add.c:646 builtin/rm.c:328
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "Pfadspezifikation '%s' stimmt mit keinen Dateien überein"
 
-#: archive.c:454
+#: archive.c:451
 #, c-format
 msgid "no such ref: %.*s"
 msgstr "Referenz nicht gefunden: %.*s"
 
-#: archive.c:460
+#: archive.c:457
 #, c-format
 msgid "not a valid object name: %s"
 msgstr "Kein gültiger Objektname: %s"
 
-#: archive.c:473
+#: archive.c:470
 #, c-format
 msgid "not a tree object: %s"
 msgstr "Kein Tree-Objekt: %s"
 
-#: archive.c:485
+#: archive.c:482
 msgid "current working directory is untracked"
 msgstr "Aktuelles Arbeitsverzeichnis ist unversioniert."
 
-#: archive.c:526
+#: archive.c:523
 #, c-format
 msgid "File not found: %s"
 msgstr "Datei nicht gefunden: %s"
 
-#: archive.c:528
+#: archive.c:525
 #, c-format
 msgid "Not a regular file: %s"
 msgstr "Keine reguläre Datei: %s"
 
-#: archive.c:555
+#: archive.c:552
 msgid "fmt"
 msgstr "Format"
 
-#: archive.c:555
+#: archive.c:552
 msgid "archive format"
 msgstr "Archivformat"
 
-#: archive.c:556 builtin/log.c:1764
+#: archive.c:553 builtin/log.c:1772
 msgid "prefix"
 msgstr "Präfix"
 
-#: archive.c:557
+#: archive.c:554
 msgid "prepend prefix to each pathname in the archive"
 msgstr "einen Präfix vor jeden Pfadnamen in dem Archiv stellen"
 
-#: archive.c:558 archive.c:561 builtin/blame.c:884 builtin/blame.c:888
+#: archive.c:555 archive.c:558 builtin/blame.c:884 builtin/blame.c:888
 #: builtin/blame.c:889 builtin/commit-tree.c:117 builtin/config.c:135
 #: builtin/fast-export.c:1207 builtin/fast-export.c:1209
-#: builtin/fast-export.c:1213 builtin/grep.c:920 builtin/hash-object.c:105
-#: builtin/ls-files.c:576 builtin/ls-files.c:579 builtin/notes.c:412
-#: builtin/notes.c:578 builtin/read-tree.c:123 parse-options.h:190
+#: builtin/fast-export.c:1213 builtin/grep.c:922 builtin/hash-object.c:105
+#: builtin/ls-files.c:653 builtin/ls-files.c:656 builtin/notes.c:412
+#: builtin/notes.c:578 builtin/read-tree.c:123 parse-options.h:191
 msgid "file"
 msgstr "Datei"
 
-#: archive.c:559
+#: archive.c:556
 msgid "add untracked file to archive"
 msgstr "unversionierte Datei zum Archiv hinzufügen"
 
-#: archive.c:562 builtin/archive.c:90
+#: archive.c:559 builtin/archive.c:90
 msgid "write the archive to this file"
 msgstr "das Archiv in diese Datei schreiben"
 
-#: archive.c:564
+#: archive.c:561
 msgid "read .gitattributes in working directory"
 msgstr ".gitattributes aus dem Arbeitsverzeichnis lesen"
 
-#: archive.c:565
+#: archive.c:562
 msgid "report archived files on stderr"
 msgstr "archivierte Dateien in der Standard-Fehlerausgabe ausgeben"
 
-#: archive.c:567
+#: archive.c:564
 msgid "set compression level"
 msgstr "Komprimierungsgrad setzen"
 
-#: archive.c:570
+#: archive.c:567
 msgid "list supported archive formats"
 msgstr "unterstützte Archivformate auflisten"
 
-#: archive.c:572 builtin/archive.c:91 builtin/clone.c:114 builtin/clone.c:117
-#: builtin/submodule--helper.c:1830 builtin/submodule--helper.c:2335
+#: archive.c:569 builtin/archive.c:91 builtin/clone.c:118 builtin/clone.c:121
+#: builtin/submodule--helper.c:1831 builtin/submodule--helper.c:2336
 msgid "repo"
 msgstr "Repository"
 
-#: archive.c:573 builtin/archive.c:92
+#: archive.c:570 builtin/archive.c:92
 msgid "retrieve the archive from remote repository <repo>"
 msgstr "Archiv vom Remote-Repository <Repository> abrufen"
 
-#: archive.c:574 builtin/archive.c:93 builtin/difftool.c:714
+#: archive.c:571 builtin/archive.c:93 builtin/difftool.c:718
 #: builtin/notes.c:498
 msgid "command"
 msgstr "Programm"
 
-#: archive.c:575 builtin/archive.c:94
+#: archive.c:572 builtin/archive.c:94
 msgid "path to the remote git-upload-archive command"
 msgstr "Pfad zum externen \"git-upload-archive\"-Programm"
 
-#: archive.c:582
+#: archive.c:579
 msgid "Unexpected option --remote"
 msgstr "Unerwartete Option --remote"
 
-#: archive.c:584
+#: archive.c:581
 msgid "Option --exec can only be used together with --remote"
 msgstr "Die Option --exec kann nur zusammen mit --remote verwendet werden"
 
-#: archive.c:586
+#: archive.c:583
 msgid "Unexpected option --output"
 msgstr "Unerwartete Option --output"
 
-#: archive.c:588
+#: archive.c:585
 msgid "Options --add-file and --remote cannot be used together"
 msgstr ""
 "Die Optionen --add-file und --remote können nicht gemeinsam verwendet werden"
 
-#: archive.c:610
+#: archive.c:607
 #, c-format
 msgid "Unknown archive format '%s'"
 msgstr "Unbekanntes Archivformat '%s'"
 
-#: archive.c:619
+#: archive.c:616
 #, c-format
 msgid "Argument not supported for format '%s': -%d"
 msgstr "Argument für Format '%s' nicht unterstützt: -%d"
@@ -1730,12 +1747,12 @@ msgstr "Argument für Format '%s' nicht unterstützt: -%d"
 msgid "%.*s is not a valid attribute name"
 msgstr "%.*s ist kein gültiger Attributname"
 
-#: attr.c:359
+#: attr.c:363
 #, c-format
 msgid "%s not allowed: %s:%d"
 msgstr "%s nicht erlaubt: %s:%d"
 
-#: attr.c:399
+#: attr.c:403
 msgid ""
 "Negative patterns are ignored in git attributes\n"
 "Use '\\!' for literal leading exclamation."
@@ -1818,7 +1835,7 @@ msgstr "binäre Suche: eine Merge-Basis muss geprüft werden\n"
 msgid "a %s revision is needed"
 msgstr "ein %s Commit wird benötigt"
 
-#: bisect.c:941 builtin/notes.c:177 builtin/tag.c:287
+#: bisect.c:941 builtin/notes.c:177 builtin/tag.c:298
 #, c-format
 msgid "could not create file '%s'"
 msgstr "konnte Datei '%s' nicht erstellen"
@@ -1863,43 +1880,43 @@ msgid_plural "Bisecting: %d revisions left to test after this %s\n"
 msgstr[0] "binäre Suche: danach noch %d Commit zum Testen übrig %s\n"
 msgstr[1] "binäre Suche: danach noch %d Commits zum Testen übrig %s\n"
 
-#: blame.c:2777
+#: blame.c:2776
 msgid "--contents and --reverse do not blend well."
 msgstr "--contents und --reverse funktionieren gemeinsam nicht."
 
-#: blame.c:2791
+#: blame.c:2790
 msgid "cannot use --contents with final commit object name"
 msgstr ""
 "kann --contents nicht mit endgültigem Namen des Commit-Objektes benutzen"
 
-#: blame.c:2812
+#: blame.c:2811
 msgid "--reverse and --first-parent together require specified latest commit"
 msgstr ""
 "--reverse und --first-parent zusammen erfordern die Angabe eines "
 "endgültigen\n"
 "Commits"
 
-#: blame.c:2821 bundle.c:213 ref-filter.c:2206 remote.c:2041 sequencer.c:2146
-#: sequencer.c:4641 submodule.c:856 builtin/commit.c:1045 builtin/log.c:411
-#: builtin/log.c:1016 builtin/log.c:1624 builtin/log.c:2045 builtin/log.c:2335
-#: builtin/merge.c:424 builtin/pack-objects.c:3395 builtin/pack-objects.c:3410
-#: builtin/shortlog.c:255
+#: blame.c:2820 bundle.c:213 ref-filter.c:2207 remote.c:2041 sequencer.c:2333
+#: sequencer.c:4866 submodule.c:857 builtin/commit.c:1106 builtin/log.c:411
+#: builtin/log.c:1018 builtin/log.c:1626 builtin/log.c:2054 builtin/log.c:2344
+#: builtin/merge.c:428 builtin/pack-objects.c:3183 builtin/pack-objects.c:3646
+#: builtin/pack-objects.c:3661 builtin/shortlog.c:255
 msgid "revision walk setup failed"
 msgstr "Einrichtung des Revisionsgangs fehlgeschlagen"
 
-#: blame.c:2839
+#: blame.c:2838
 msgid ""
 "--reverse --first-parent together require range along first-parent chain"
 msgstr ""
 "--reverse und --first-parent zusammen erfordern einen Bereich entlang der\n"
 "\"first-parent\"-Kette"
 
-#: blame.c:2850
+#: blame.c:2849
 #, c-format
 msgid "no such path %s in %s"
 msgstr "Pfad %s nicht in %s gefunden"
 
-#: blame.c:2861
+#: blame.c:2860
 #, c-format
 msgid "cannot read blob %s for path %s"
 msgstr "kann Blob %s für Pfad '%s' nicht lesen"
@@ -2036,12 +2053,12 @@ msgstr "mehrdeutiger Objekt-Name: '%s'"
 msgid "Not a valid branch point: '%s'."
 msgstr "Ungültiger Branchpunkt: '%s'"
 
-#: branch.c:365
+#: branch.c:366
 #, c-format
 msgid "'%s' is already checked out at '%s'"
 msgstr "'%s' ist bereits in '%s' ausgecheckt"
 
-#: branch.c:388
+#: branch.c:389
 #, c-format
 msgid "HEAD of working tree %s is not updated"
 msgstr "HEAD des Arbeitsverzeichnisses %s ist nicht aktualisiert."
@@ -2066,8 +2083,8 @@ msgstr "'%s' sieht nicht wie eine v2 oder v3 Paketdatei aus"
 msgid "unrecognized header: %s%s (%d)"
 msgstr "nicht erkannter Kopfbereich: %s%s (%d)"
 
-#: bundle.c:136 rerere.c:464 rerere.c:674 sequencer.c:2398 sequencer.c:3184
-#: builtin/commit.c:814
+#: bundle.c:136 rerere.c:464 rerere.c:674 sequencer.c:2593 sequencer.c:3385
+#: builtin/commit.c:861
 #, c-format
 msgid "could not open '%s'"
 msgstr "Konnte '%s' nicht öffnen"
@@ -2125,7 +2142,7 @@ msgstr "nicht unterstützte Paket-Version %d"
 msgid "cannot write bundle version %d with algorithm %s"
 msgstr "kann Paket-Version %d nicht mit Algorithmus %s schreiben"
 
-#: bundle.c:510 builtin/log.c:210 builtin/log.c:1926 builtin/shortlog.c:396
+#: bundle.c:510 builtin/log.c:210 builtin/log.c:1935 builtin/shortlog.c:396
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr "nicht erkanntes Argument: %s"
@@ -2167,235 +2184,235 @@ msgstr "letzter Chunk hat nicht-Null ID %<PRIx32>"
 msgid "invalid color value: %.*s"
 msgstr "Ungültiger Farbwert: %.*s"
 
-#: commit-graph.c:197 midx.c:46
+#: commit-graph.c:204 midx.c:47
 msgid "invalid hash version"
 msgstr "ungültige Hash-Version"
 
-#: commit-graph.c:255
+#: commit-graph.c:262
 msgid "commit-graph file is too small"
 msgstr "Commit-Graph-Datei ist zu klein"
 
-#: commit-graph.c:348
+#: commit-graph.c:355
 #, c-format
 msgid "commit-graph signature %X does not match signature %X"
 msgstr "Commit-Graph-Signatur %X stimmt nicht mit Signatur %X überein."
 
-#: commit-graph.c:355
+#: commit-graph.c:362
 #, c-format
 msgid "commit-graph version %X does not match version %X"
 msgstr "Commit-Graph-Version %X stimmt nicht mit Version %X überein."
 
-#: commit-graph.c:362
+#: commit-graph.c:369
 #, c-format
 msgid "commit-graph hash version %X does not match version %X"
 msgstr "Hash-Version des Commit-Graph %X stimmt nicht mit Version %X überein."
 
-#: commit-graph.c:379
+#: commit-graph.c:386
 #, c-format
 msgid "commit-graph file is too small to hold %u chunks"
 msgstr "Commit-Graph-Datei ist zu klein, um %u Chunks zu enthalten"
 
-#: commit-graph.c:472
+#: commit-graph.c:482
 msgid "commit-graph has no base graphs chunk"
 msgstr "Commit-Graph hat keinen Basis-Graph-Chunk"
 
-#: commit-graph.c:482
+#: commit-graph.c:492
 msgid "commit-graph chain does not match"
 msgstr "Commit-Graph Verkettung stimmt nicht überein."
 
-#: commit-graph.c:530
+#: commit-graph.c:540
 #, c-format
 msgid "invalid commit-graph chain: line '%s' not a hash"
 msgstr "Ungültige Commit-Graph Verkettung: Zeile '%s' ist kein Hash"
 
-#: commit-graph.c:554
+#: commit-graph.c:564
 msgid "unable to find all commit-graph files"
 msgstr "Konnte nicht alle Commit-Graph-Dateien finden."
 
-#: commit-graph.c:735 commit-graph.c:772
+#: commit-graph.c:745 commit-graph.c:782
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr "Ungültige Commit-Position. Commit-Graph ist wahrscheinlich beschädigt."
 
-#: commit-graph.c:756
+#: commit-graph.c:766
 #, c-format
 msgid "could not find commit %s"
 msgstr "Konnte Commit %s nicht finden."
 
-#: commit-graph.c:789
+#: commit-graph.c:799
 msgid "commit-graph requires overflow generation data but has none"
 msgstr "Commit-Graph erfordert Überlaufgenerierungsdaten, aber hat keine"
 
-#: commit-graph.c:1065 builtin/am.c:1292
+#: commit-graph.c:1075 builtin/am.c:1340
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "Konnte Commit '%s' nicht parsen."
 
-#: commit-graph.c:1327 builtin/pack-objects.c:2872
+#: commit-graph.c:1337 builtin/pack-objects.c:2897
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "Konnte Art von Objekt '%s' nicht bestimmen."
 
-#: commit-graph.c:1358
+#: commit-graph.c:1368
 msgid "Loading known commits in commit graph"
 msgstr "Lade bekannte Commits in Commit-Graph"
 
-#: commit-graph.c:1375
+#: commit-graph.c:1385
 msgid "Expanding reachable commits in commit graph"
 msgstr "Erweitere erreichbare Commits in Commit-Graph"
 
-#: commit-graph.c:1395
+#: commit-graph.c:1405
 msgid "Clearing commit marks in commit graph"
 msgstr "Lösche Commit-Markierungen in Commit-Graph"
 
-#: commit-graph.c:1414
+#: commit-graph.c:1424
 msgid "Computing commit graph topological levels"
 msgstr "Topologische Ebenen des Commit-Graph werden berechnet"
 
-#: commit-graph.c:1467
+#: commit-graph.c:1477
 msgid "Computing commit graph generation numbers"
 msgstr "Commit-Graph Generationsnummern berechnen"
 
-#: commit-graph.c:1548
+#: commit-graph.c:1558
 msgid "Computing commit changed paths Bloom filters"
 msgstr "Berechnung der Bloom-Filter für veränderte Pfade des Commits"
 
-#: commit-graph.c:1625
+#: commit-graph.c:1635
 msgid "Collecting referenced commits"
 msgstr "Sammle referenzierte Commits"
 
-#: commit-graph.c:1650
+#: commit-graph.c:1660
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] "Suche Commits für Commit-Graph in %d Paket"
 msgstr[1] "Suche Commits für Commit-Graph in %d Paketen"
 
-#: commit-graph.c:1663
+#: commit-graph.c:1673
 #, c-format
 msgid "error adding pack %s"
 msgstr "Fehler beim Hinzufügen von Paket %s."
 
-#: commit-graph.c:1667
+#: commit-graph.c:1677
 #, c-format
 msgid "error opening index for %s"
 msgstr "Fehler beim Öffnen des Index für %s."
 
-#: commit-graph.c:1704
+#: commit-graph.c:1714
 msgid "Finding commits for commit graph among packed objects"
 msgstr "Suche Commits für Commit-Graph in gepackten Objekten"
 
-#: commit-graph.c:1722
+#: commit-graph.c:1732
 msgid "Finding extra edges in commit graph"
 msgstr "Suche zusätzliche Ränder in Commit-Graph"
 
-#: commit-graph.c:1771
+#: commit-graph.c:1781
 msgid "failed to write correct number of base graph ids"
 msgstr "Fehler beim Schreiben der korrekten Anzahl von Basis-Graph-IDs."
 
-#: commit-graph.c:1802 midx.c:794
+#: commit-graph.c:1812 midx.c:906
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "Konnte führende Verzeichnisse von '%s' nicht erstellen."
 
-#: commit-graph.c:1815
+#: commit-graph.c:1825
 msgid "unable to create temporary graph layer"
 msgstr "konnte temporäre Graphen-Schicht nicht erstellen"
 
-#: commit-graph.c:1820
+#: commit-graph.c:1830
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "konnte geteilte Zugriffsberechtigungen für '%s' nicht ändern"
 
-#: commit-graph.c:1879
+#: commit-graph.c:1887
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "Schreibe Commit-Graph in %d Durchgang"
 msgstr[1] "Schreibe Commit-Graph in %d Durchgängen"
 
-#: commit-graph.c:1915
+#: commit-graph.c:1923
 msgid "unable to open commit-graph chain file"
 msgstr "konnte Commit-Graph Chain-Datei nicht öffnen"
 
-#: commit-graph.c:1931
+#: commit-graph.c:1939
 msgid "failed to rename base commit-graph file"
 msgstr "konnte Basis-Commit-Graph-Datei nicht umbenennen"
 
-#: commit-graph.c:1951
+#: commit-graph.c:1959
 msgid "failed to rename temporary commit-graph file"
 msgstr "konnte temporäre Commit-Graph-Datei nicht umbenennen"
 
-#: commit-graph.c:2084
+#: commit-graph.c:2092
 msgid "Scanning merged commits"
 msgstr "Durchsuche zusammengeführte Commits"
 
-#: commit-graph.c:2128
+#: commit-graph.c:2136
 msgid "Merging commit-graph"
 msgstr "Zusammenführen von Commit-Graph"
 
-#: commit-graph.c:2235
+#: commit-graph.c:2244
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 "versuche einen Commit-Graph zu schreiben, aber 'core.commitGraph' ist "
 "deaktiviert"
 
-#: commit-graph.c:2342
+#: commit-graph.c:2351
 msgid "too many commits to write graph"
 msgstr "zu viele Commits zum Schreiben des Graphen"
 
-#: commit-graph.c:2440
+#: commit-graph.c:2450
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "die Commit-Graph-Datei hat eine falsche Prüfsumme und ist wahrscheinlich "
 "beschädigt"
 
-#: commit-graph.c:2450
+#: commit-graph.c:2460
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "Commit-Graph hat fehlerhafte OID-Reihenfolge: %s dann %s"
 
-#: commit-graph.c:2460 commit-graph.c:2475
+#: commit-graph.c:2470 commit-graph.c:2485
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr "Commit-Graph hat fehlerhaften Fanout-Wert: fanout[%d] = %u != %u"
 
-#: commit-graph.c:2467
+#: commit-graph.c:2477
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "konnte Commit %s von Commit-Graph nicht parsen"
 
-#: commit-graph.c:2485
+#: commit-graph.c:2495
 msgid "Verifying commits in commit graph"
 msgstr "Commit in Commit-Graph überprüfen"
 
-#: commit-graph.c:2500
+#: commit-graph.c:2510
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "Fehler beim Parsen des Commits %s von Objekt-Datenbank für Commit-Graph"
 
-#: commit-graph.c:2507
+#: commit-graph.c:2517
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 "OID des Wurzelverzeichnisses für Commit %s in Commit-Graph ist %s != %s"
 
-#: commit-graph.c:2517
+#: commit-graph.c:2527
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr "Commit-Graph Vorgänger-Liste für Commit %s ist zu lang"
 
-#: commit-graph.c:2526
+#: commit-graph.c:2536
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "Commit-Graph-Vorgänger für %s ist %s != %s"
 
-#: commit-graph.c:2540
+#: commit-graph.c:2550
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr "Commit-Graph Vorgänger-Liste für Commit %s endet zu früh"
 
-#: commit-graph.c:2545
+#: commit-graph.c:2555
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2403,7 +2420,7 @@ msgstr ""
 "Commit-Graph hat Generationsnummer null für Commit %s, aber sonst ungleich "
 "null"
 
-#: commit-graph.c:2549
+#: commit-graph.c:2559
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2411,19 +2428,19 @@ msgstr ""
 "Commit-Graph hat Generationsnummer ungleich null für Commit %s, aber sonst "
 "null"
 
-#: commit-graph.c:2566
+#: commit-graph.c:2576
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr "Commit-Graph Erstellung für Commit %s ist %<PRIuMAX> < %<PRIuMAX>"
 
-#: commit-graph.c:2572
+#: commit-graph.c:2582
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 "Commit-Datum für Commit %s in Commit-Graph ist %<PRIuMAX> != %<PRIuMAX>"
 
-#: commit.c:52 sequencer.c:2887 builtin/am.c:359 builtin/am.c:403
-#: builtin/am.c:1371 builtin/am.c:2018 builtin/replace.c:457
+#: commit.c:52 sequencer.c:3088 builtin/am.c:371 builtin/am.c:416
+#: builtin/am.c:421 builtin/am.c:1419 builtin/am.c:2066 builtin/replace.c:457
 #, c-format
 msgid "could not parse %s"
 msgstr "konnte %s nicht parsen"
@@ -2454,28 +2471,28 @@ msgstr ""
 "Sie können diese Meldung unterdrücken, indem Sie\n"
 "\"git config advice.graftFileDeprecated false\" ausführen."
 
-#: commit.c:1223
+#: commit.c:1237
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
 msgstr ""
 "Commit %s hat eine nicht vertrauenswürdige GPG-Signatur, angeblich von %s."
 
-#: commit.c:1227
+#: commit.c:1241
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
 msgstr "Commit %s hat eine ungültige GPG-Signatur, angeblich von %s."
 
-#: commit.c:1230
+#: commit.c:1244
 #, c-format
 msgid "Commit %s does not have a GPG signature."
 msgstr "Commit %s hat keine GPG-Signatur."
 
-#: commit.c:1233
+#: commit.c:1247
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
 msgstr "Commit %s hat eine gültige GPG-Signatur von %s\n"
 
-#: commit.c:1487
+#: commit.c:1501
 msgid ""
 "Warning: commit message did not conform to UTF-8.\n"
 "You may want to amend it after fixing the message, or set the config\n"
@@ -2548,7 +2565,7 @@ msgstr "Schlüssel enthält keine Sektion: %s"
 msgid "key does not contain variable name: %s"
 msgstr "Schlüssel enthält keinen Variablennamen: %s"
 
-#: config.c:472 sequencer.c:2588
+#: config.c:472 sequencer.c:2785
 #, c-format
 msgid "invalid key: %s"
 msgstr "Ungültiger Schlüssel: %s"
@@ -2672,71 +2689,71 @@ msgstr ""
 msgid "bad numeric config value '%s' for '%s' in %s: %s"
 msgstr "Ungültiger numerischer Wert '%s' für Konfiguration '%s' in %s: %s"
 
-#: config.c:1194
+#: config.c:1257
 #, c-format
 msgid "bad boolean config value '%s' for '%s'"
 msgstr "ungültiger boolescher Konfigurationswert '%s' für '%s'"
 
-#: config.c:1289
+#: config.c:1275
 #, c-format
 msgid "failed to expand user dir in: '%s'"
 msgstr "Fehler beim Erweitern des Nutzerverzeichnisses in: '%s'"
 
-#: config.c:1298
+#: config.c:1284
 #, c-format
 msgid "'%s' for '%s' is not a valid timestamp"
 msgstr "'%s' ist kein gültiger Zeitstempel für '%s'"
 
-#: config.c:1391
+#: config.c:1377
 #, c-format
 msgid "abbrev length out of range: %d"
 msgstr "Länge für Abkürzung von Commit-IDs außerhalb des Bereichs: %d"
 
-#: config.c:1405 config.c:1416
+#: config.c:1391 config.c:1402
 #, c-format
 msgid "bad zlib compression level %d"
 msgstr "ungültiger zlib Komprimierungsgrad %d"
 
-#: config.c:1508
+#: config.c:1494
 msgid "core.commentChar should only be one character"
 msgstr "core.commentChar sollte nur ein Zeichen sein"
 
-#: config.c:1541
+#: config.c:1527
 #, c-format
 msgid "invalid mode for object creation: %s"
 msgstr "Ungültiger Modus für Objekterstellung: %s"
 
-#: config.c:1613
+#: config.c:1599
 #, c-format
 msgid "malformed value for %s"
 msgstr "Ungültiger Wert für %s."
 
-#: config.c:1639
+#: config.c:1625
 #, c-format
 msgid "malformed value for %s: %s"
 msgstr "Ungültiger Wert für %s: %s"
 
-#: config.c:1640
+#: config.c:1626
 msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr ""
 "Muss einer von diesen sein: nothing, matching, simple, upstream, current"
 
-#: config.c:1701 builtin/pack-objects.c:3666
+#: config.c:1687 builtin/pack-objects.c:3924
 #, c-format
 msgid "bad pack compression level %d"
 msgstr "ungültiger Komprimierungsgrad (%d) für Paketierung"
 
-#: config.c:1823
+#: config.c:1809
 #, c-format
 msgid "unable to load config blob object '%s'"
 msgstr "Konnte Blob-Objekt '%s' für Konfiguration nicht laden."
 
-#: config.c:1826
+#: config.c:1812
 #, c-format
 msgid "reference '%s' does not point to a blob"
 msgstr "Referenz '%s' zeigt auf keinen Blob."
 
-#: config.c:1843
+#: config.c:1829
 #, c-format
 msgid "unable to resolve config blob '%s'"
 msgstr "Konnte Blob '%s' für Konfiguration nicht auflösen."
@@ -2746,111 +2763,111 @@ msgstr "Konnte Blob '%s' für Konfiguration nicht auflösen."
 msgid "failed to parse %s"
 msgstr "Fehler beim Parsen von %s."
 
-#: config.c:1927
+#: config.c:1929
 msgid "unable to parse command-line config"
 msgstr ""
 "Konnte die über die Befehlszeile angegebene Konfiguration nicht parsen."
 
-#: config.c:2290
+#: config.c:2293
 msgid "unknown error occurred while reading the configuration files"
 msgstr ""
 "Es trat ein unbekannter Fehler beim Lesen der Konfigurationsdateien auf."
 
-#: config.c:2464
+#: config.c:2467
 #, c-format
 msgid "Invalid %s: '%s'"
 msgstr "Ungültiger %s: '%s'"
 
-#: config.c:2509
+#: config.c:2512
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
 msgstr ""
 "Der Wert '%d' von splitIndex.maxPercentChange sollte zwischen 0 und 100 "
 "liegen."
 
-#: config.c:2555
+#: config.c:2558
 #, c-format
 msgid "unable to parse '%s' from command-line config"
 msgstr ""
 "Konnte Wert '%s' aus der über die Befehlszeile angegebenen Konfiguration\n"
 "nicht parsen."
 
-#: config.c:2557
+#: config.c:2560
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
 msgstr "ungültige Konfigurationsvariable '%s' in Datei '%s' bei Zeile %d"
 
-#: config.c:2641
+#: config.c:2644
 #, c-format
 msgid "invalid section name '%s'"
 msgstr "Ungültiger Sektionsname '%s'"
 
-#: config.c:2673
+#: config.c:2676
 #, c-format
 msgid "%s has multiple values"
 msgstr "%s hat mehrere Werte"
 
-#: config.c:2702
+#: config.c:2705
 #, c-format
 msgid "failed to write new configuration file %s"
 msgstr "Konnte neue Konfigurationsdatei '%s' nicht schreiben."
 
-#: config.c:2954 config.c:3280
+#: config.c:2957 config.c:3283
 #, c-format
 msgid "could not lock config file %s"
 msgstr "Konnte Konfigurationsdatei '%s' nicht sperren."
 
-#: config.c:2965
+#: config.c:2968
 #, c-format
 msgid "opening %s"
 msgstr "Öffne %s"
 
-#: config.c:3002 builtin/config.c:361
+#: config.c:3005 builtin/config.c:361
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "Ungültiges Muster: %s"
 
-#: config.c:3027
+#: config.c:3030
 #, c-format
 msgid "invalid config file %s"
 msgstr "Ungültige Konfigurationsdatei %s"
 
-#: config.c:3040 config.c:3293
+#: config.c:3043 config.c:3296
 #, c-format
 msgid "fstat on %s failed"
 msgstr "fstat auf %s fehlgeschlagen"
 
-#: config.c:3051
+#: config.c:3054
 #, c-format
 msgid "unable to mmap '%s'"
 msgstr "mmap für '%s' fehlgeschlagen"
 
-#: config.c:3060 config.c:3298
+#: config.c:3063 config.c:3301
 #, c-format
 msgid "chmod on %s failed"
 msgstr "chmod auf %s fehlgeschlagen"
 
-#: config.c:3145 config.c:3395
+#: config.c:3148 config.c:3398
 #, c-format
 msgid "could not write config file %s"
 msgstr "Konnte Konfigurationsdatei %s nicht schreiben."
 
-#: config.c:3179
+#: config.c:3182
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "Konnte '%s' nicht zu '%s' setzen."
 
-#: config.c:3181 builtin/remote.c:657 builtin/remote.c:855 builtin/remote.c:863
+#: config.c:3184 builtin/remote.c:657 builtin/remote.c:855 builtin/remote.c:863
 #, c-format
 msgid "could not unset '%s'"
 msgstr "Konnte '%s' nicht aufheben."
 
-#: config.c:3271
+#: config.c:3274
 #, c-format
 msgid "invalid section name: %s"
 msgstr "Ungültiger Sektionsname: %s"
 
-#: config.c:3438
+#: config.c:3441
 #, c-format
 msgid "missing value for '%s'"
 msgstr "Fehlender Wert für '%s'"
@@ -3030,7 +3047,7 @@ msgstr "Merkwürdigen Pfadnamen '%s' blockiert"
 msgid "unable to fork"
 msgstr "kann Prozess nicht starten"
 
-#: connected.c:108 builtin/fsck.c:191 builtin/prune.c:45
+#: connected.c:108 builtin/fsck.c:188 builtin/prune.c:45
 msgid "Checking connectivity"
 msgstr "Prüfe Konnektivität"
 
@@ -3046,17 +3063,17 @@ msgstr "Fehler beim Schreiben nach rev-list"
 msgid "failed to close rev-list's stdin"
 msgstr "Fehler beim Schließen von rev-lists Standard-Eingabe"
 
-#: convert.c:194
+#: convert.c:183
 #, c-format
 msgid "illegal crlf_action %d"
 msgstr "Unerlaubte crlf_action %d"
 
-#: convert.c:207
+#: convert.c:196
 #, c-format
 msgid "CRLF would be replaced by LF in %s"
 msgstr "CRLF würde in %s durch LF ersetzt werden"
 
-#: convert.c:209
+#: convert.c:198
 #, c-format
 msgid ""
 "CRLF will be replaced by LF in %s.\n"
@@ -3066,12 +3083,12 @@ msgstr ""
 "Die Datei wird ihre ursprünglichen Zeilenenden im Arbeitsverzeichnis "
 "behalten."
 
-#: convert.c:217
+#: convert.c:206
 #, c-format
 msgid "LF would be replaced by CRLF in %s"
 msgstr "LF würde in %s durch CRLF ersetzt werden"
 
-#: convert.c:219
+#: convert.c:208
 #, c-format
 msgid ""
 "LF will be replaced by CRLF in %s.\n"
@@ -3081,12 +3098,12 @@ msgstr ""
 "Die Datei wird ihre ursprünglichen Zeilenenden im Arbeitsverzeichnis "
 "behalten."
 
-#: convert.c:284
+#: convert.c:273
 #, c-format
 msgid "BOM is prohibited in '%s' if encoded as %s"
 msgstr "BOM ist in '%s' unzulässig, wenn als %s codiert"
 
-#: convert.c:291
+#: convert.c:280
 #, c-format
 msgid ""
 "The file '%s' contains a byte order mark (BOM). Please use UTF-%.*s as "
@@ -3095,12 +3112,12 @@ msgstr ""
 "Die Datei '%s' enthält ein Byte-Order-Mark (BOM). Bitte benutzen Sie\n"
 "UTF-%.*s als Codierung im Arbeitsverzeichnis."
 
-#: convert.c:304
+#: convert.c:293
 #, c-format
 msgid "BOM is required in '%s' if encoded as %s"
 msgstr "BOM ist erforderlich in '%s', wenn als %s codiert"
 
-#: convert.c:306
+#: convert.c:295
 #, c-format
 msgid ""
 "The file '%s' is missing a byte order mark (BOM). Please use UTF-%sBE or UTF-"
@@ -3110,50 +3127,50 @@ msgstr ""
 "oder UTF-%sLE (abhängig von der Byte-Reihenfolge) als Codierung im\n"
 "Arbeitsverzeichnis."
 
-#: convert.c:419 convert.c:490
+#: convert.c:408 convert.c:479
 #, c-format
 msgid "failed to encode '%s' from %s to %s"
 msgstr "Fehler beim Codieren von '%s' von %s nach %s"
 
-#: convert.c:462
+#: convert.c:451
 #, c-format
 msgid "encoding '%s' from %s to %s and back is not the same"
 msgstr "Codierung von '%s' von %s nach %s und zurück ist nicht dasselbe"
 
-#: convert.c:665
+#: convert.c:654
 #, c-format
 msgid "cannot fork to run external filter '%s'"
 msgstr "kann externen Filter '%s' nicht starten"
 
-#: convert.c:685
+#: convert.c:674
 #, c-format
 msgid "cannot feed the input to external filter '%s'"
 msgstr "kann Eingaben nicht an externen Filter '%s' übergeben"
 
-#: convert.c:692
+#: convert.c:681
 #, c-format
 msgid "external filter '%s' failed %d"
 msgstr "externer Filter '%s' fehlgeschlagen %d"
 
-#: convert.c:727 convert.c:730
+#: convert.c:716 convert.c:719
 #, c-format
 msgid "read from external filter '%s' failed"
 msgstr "Lesen von externem Filter '%s' fehlgeschlagen"
 
-#: convert.c:733 convert.c:788
+#: convert.c:722 convert.c:777
 #, c-format
 msgid "external filter '%s' failed"
 msgstr "externer Filter '%s' fehlgeschlagen"
 
-#: convert.c:837
+#: convert.c:826
 msgid "unexpected filter type"
 msgstr "unerwartete Filterart"
 
-#: convert.c:848
+#: convert.c:837
 msgid "path name too long for external filter"
 msgstr "Pfadname zu lang für externen Filter"
 
-#: convert.c:940
+#: convert.c:934
 #, c-format
 msgid ""
 "external filter '%s' is not available anymore although not all paths have "
@@ -3162,16 +3179,16 @@ msgstr ""
 "externer Filter '%s' nicht mehr verfügbar, obwohl nicht alle Pfade gefiltert "
 "wurden"
 
-#: convert.c:1240
+#: convert.c:1234
 msgid "true/false are no valid working-tree-encodings"
 msgstr "true/false sind keine gültigen Codierungen im Arbeitsverzeichnis"
 
-#: convert.c:1428 convert.c:1462
+#: convert.c:1414 convert.c:1447
 #, c-format
 msgid "%s: clean filter '%s' failed"
 msgstr "%s: clean-Filter '%s' fehlgeschlagen"
 
-#: convert.c:1508
+#: convert.c:1490
 #, c-format
 msgid "%s: smudge filter %s failed"
 msgstr "%s: smudge-Filter '%s' fehlgeschlagen"
@@ -3299,28 +3316,28 @@ msgstr ""
 msgid "Marked %d islands, done.\n"
 msgstr "%d Delta-Islands markiert, fertig.\n"
 
-#: diff-merges.c:70
+#: diff-merges.c:80
 #, c-format
 msgid "unknown value for --diff-merges: %s"
 msgstr "unbekannter Wert für --diff-merges: %s"
 
-#: diff-lib.c:534
+#: diff-lib.c:538
 msgid "--merge-base does not work with ranges"
 msgstr "--merge-base funktioniert nicht mit Bereichen"
 
-#: diff-lib.c:536
+#: diff-lib.c:540
 msgid "--merge-base only works with commits"
 msgstr "--merge-base funktioniert nur mit Commits"
 
-#: diff-lib.c:553
+#: diff-lib.c:557
 msgid "unable to get HEAD"
 msgstr "konnte HEAD nicht bekommen"
 
-#: diff-lib.c:560
+#: diff-lib.c:564
 msgid "no merge base found"
 msgstr "keine Merge-Basis gefunden"
 
-#: diff-lib.c:562
+#: diff-lib.c:566
 msgid "multiple merge bases found"
 msgstr "mehrere Merge-Basen gefunden"
 
@@ -3386,36 +3403,36 @@ msgstr ""
 "Fehler in 'diff.dirstat' Konfigurationsvariable gefunden:\n"
 "%s"
 
-#: diff.c:4276
+#: diff.c:4278
 #, c-format
 msgid "external diff died, stopping at %s"
 msgstr "externes Diff-Programm unerwartet beendet, angehalten bei %s"
 
-#: diff.c:4628
+#: diff.c:4630
 msgid "--name-only, --name-status, --check and -s are mutually exclusive"
 msgstr ""
 "--name-only, --name-status, --check und -s schließen sich gegenseitig aus"
 
-#: diff.c:4631
+#: diff.c:4633
 msgid "-G, -S and --find-object are mutually exclusive"
 msgstr "-G, -S und --find-object schließen sich gegenseitig aus"
 
-#: diff.c:4710
+#: diff.c:4712
 msgid "--follow requires exactly one pathspec"
 msgstr "--follow erfordert genau eine Pfadspezifikation"
 
-#: diff.c:4758
+#: diff.c:4760
 #, c-format
 msgid "invalid --stat value: %s"
 msgstr "Ungültiger --stat Wert: %s"
 
-#: diff.c:4763 diff.c:4768 diff.c:4773 diff.c:4778 diff.c:5306
+#: diff.c:4765 diff.c:4770 diff.c:4775 diff.c:4780 diff.c:5308
 #: parse-options.c:197 parse-options.c:201 builtin/commit-graph.c:180
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "%s erwartet einen numerischen Wert."
 
-#: diff.c:4795
+#: diff.c:4797
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -3424,42 +3441,42 @@ msgstr ""
 "Fehler beim Parsen des --dirstat/-X Optionsparameters:\n"
 "%s"
 
-#: diff.c:4880
+#: diff.c:4882
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
 msgstr "unbekannte Änderungsklasse '%c' in --diff-filter=%s"
 
-#: diff.c:4904
+#: diff.c:4906
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
 msgstr "unbekannter Wert nach ws-error-highlight=%.*s"
 
-#: diff.c:4918
+#: diff.c:4920
 #, c-format
 msgid "unable to resolve '%s'"
 msgstr "konnte '%s' nicht auflösen"
 
-#: diff.c:4968 diff.c:4974
+#: diff.c:4970 diff.c:4976
 #, c-format
 msgid "%s expects <n>/<m> form"
 msgstr "%s erwartet die Form <n>/<m>"
 
-#: diff.c:4986
+#: diff.c:4988
 #, c-format
 msgid "%s expects a character, got '%s'"
 msgstr "%s erwartet ein Zeichen, '%s' bekommen"
 
-#: diff.c:5007
+#: diff.c:5009
 #, c-format
 msgid "bad --color-moved argument: %s"
 msgstr "ungültiges --color-moved Argument: %s"
 
-#: diff.c:5026
+#: diff.c:5028
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
 msgstr "ungültiger Modus '%s' in --color-moved-ws"
 
-#: diff.c:5066
+#: diff.c:5068
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
@@ -3467,157 +3484,157 @@ msgstr ""
 "Option diff-algorithm akzeptiert: \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
 
-#: diff.c:5102 diff.c:5122
+#: diff.c:5104 diff.c:5124
 #, c-format
 msgid "invalid argument to %s"
 msgstr "ungültiges Argument für %s"
 
-#: diff.c:5226
+#: diff.c:5228
 #, c-format
 msgid "invalid regex given to -I: '%s'"
 msgstr "ungültiger regulärer Ausdruck für -I gegeben: '%s'"
 
-#: diff.c:5275
+#: diff.c:5277
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
 msgstr "Fehler beim Parsen des --submodule Optionsparameters: '%s'"
 
-#: diff.c:5331
+#: diff.c:5333
 #, c-format
 msgid "bad --word-diff argument: %s"
 msgstr "ungültiges --word-diff Argument: %s"
 
-#: diff.c:5367
+#: diff.c:5369
 msgid "Diff output format options"
 msgstr "Diff-Optionen zu Ausgabeformaten"
 
-#: diff.c:5369 diff.c:5375
+#: diff.c:5371 diff.c:5377
 msgid "generate patch"
 msgstr "Patch erzeugen"
 
-#: diff.c:5372 builtin/log.c:179
+#: diff.c:5374 builtin/log.c:179
 msgid "suppress diff output"
 msgstr "Ausgabe der Unterschiede unterdrücken"
 
-#: diff.c:5377 diff.c:5491 diff.c:5498
+#: diff.c:5379 diff.c:5493 diff.c:5500
 msgid "<n>"
 msgstr "<n>"
 
-#: diff.c:5378 diff.c:5381
+#: diff.c:5380 diff.c:5383
 msgid "generate diffs with <n> lines context"
 msgstr "Unterschiede mit <n> Zeilen des Kontextes erstellen"
 
-#: diff.c:5383
+#: diff.c:5385
 msgid "generate the diff in raw format"
 msgstr "Unterschiede im Rohformat erstellen"
 
-#: diff.c:5386
+#: diff.c:5388
 msgid "synonym for '-p --raw'"
 msgstr "Synonym für '-p --raw'"
 
-#: diff.c:5390
+#: diff.c:5392
 msgid "synonym for '-p --stat'"
 msgstr "Synonym für '-p --stat'"
 
-#: diff.c:5394
+#: diff.c:5396
 msgid "machine friendly --stat"
 msgstr "maschinenlesbare Ausgabe von --stat"
 
-#: diff.c:5397
+#: diff.c:5399
 msgid "output only the last line of --stat"
 msgstr "nur die letzte Zeile von --stat ausgeben"
 
-#: diff.c:5399 diff.c:5407
+#: diff.c:5401 diff.c:5409
 msgid "<param1,param2>..."
 msgstr "<Parameter1,Parameter2>..."
 
-#: diff.c:5400
+#: diff.c:5402
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr ""
 "die Verteilung des relativen Umfangs der Änderungen für jedes "
 "Unterverzeichnis ausgeben"
 
-#: diff.c:5404
+#: diff.c:5406
 msgid "synonym for --dirstat=cumulative"
 msgstr "Synonym für --dirstat=cumulative"
 
-#: diff.c:5408
+#: diff.c:5410
 msgid "synonym for --dirstat=files,param1,param2..."
 msgstr "Synonym für --dirstat=files,Parameter1,Parameter2..."
 
-#: diff.c:5412
+#: diff.c:5414
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
 "warnen, wenn Änderungen Konfliktmarker oder Whitespace-Fehler einbringen"
 
-#: diff.c:5415
+#: diff.c:5417
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr ""
 "gekürzte Zusammenfassung, wie z.B. Erstellungen, Umbenennungen und "
 "Änderungen der Datei-Rechte"
 
-#: diff.c:5418
+#: diff.c:5420
 msgid "show only names of changed files"
 msgstr "nur Dateinamen der geänderten Dateien anzeigen"
 
-#: diff.c:5421
+#: diff.c:5423
 msgid "show only names and status of changed files"
 msgstr "nur Dateinamen und Status der geänderten Dateien anzeigen"
 
-#: diff.c:5423
+#: diff.c:5425
 msgid "<width>[,<name-width>[,<count>]]"
 msgstr "<Breite>[,<Namens-Breite>[,<Anzahl>]]"
 
-#: diff.c:5424
+#: diff.c:5426
 msgid "generate diffstat"
 msgstr "Zusammenfassung der Unterschiede erzeugen"
 
-#: diff.c:5426 diff.c:5429 diff.c:5432
+#: diff.c:5428 diff.c:5431 diff.c:5434
 msgid "<width>"
 msgstr "<Breite>"
 
-#: diff.c:5427
+#: diff.c:5429
 msgid "generate diffstat with a given width"
 msgstr "Zusammenfassung der Unterschiede mit gegebener Breite erzeugen"
 
-#: diff.c:5430
+#: diff.c:5432
 msgid "generate diffstat with a given name width"
 msgstr "Zusammenfassung der Unterschiede mit gegebener Namens-Breite erzeugen"
 
-#: diff.c:5433
+#: diff.c:5435
 msgid "generate diffstat with a given graph width"
 msgstr "Zusammenfassung der Unterschiede mit gegebener Graph-Breite erzeugen"
 
-#: diff.c:5435
+#: diff.c:5437
 msgid "<count>"
 msgstr "<Anzahl>"
 
-#: diff.c:5436
+#: diff.c:5438
 msgid "generate diffstat with limited lines"
 msgstr "Zusammenfassung der Unterschiede mit begrenzten Zeilen erzeugen"
 
-#: diff.c:5439
+#: diff.c:5441
 msgid "generate compact summary in diffstat"
 msgstr "kompakte Zusammenstellung in Zusammenfassung der Unterschiede erzeugen"
 
-#: diff.c:5442
+#: diff.c:5444
 msgid "output a binary diff that can be applied"
 msgstr "eine binäre Differenz ausgeben, dass angewendet werden kann"
 
-#: diff.c:5445
+#: diff.c:5447
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr "vollständige Objekt-Namen in den \"index\"-Zeilen anzeigen"
 
-#: diff.c:5447
+#: diff.c:5449
 msgid "show colored diff"
 msgstr "farbige Unterschiede anzeigen"
 
-#: diff.c:5448
+#: diff.c:5450
 msgid "<kind>"
 msgstr "<Art>"
 
-#: diff.c:5449
+#: diff.c:5451
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
@@ -3625,7 +3642,7 @@ msgstr ""
 "Whitespace-Fehler in den Zeilen 'context', 'old' oder 'new' bei den "
 "Unterschieden hervorheben"
 
-#: diff.c:5452
+#: diff.c:5454
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
@@ -3633,91 +3650,91 @@ msgstr ""
 "die Pfadnamen nicht verschleiern und NUL-Zeichen als Schlusszeichen in "
 "Ausgabefeldern bei --raw oder --numstat nutzen"
 
-#: diff.c:5455 diff.c:5458 diff.c:5461 diff.c:5570
+#: diff.c:5457 diff.c:5460 diff.c:5463 diff.c:5572
 msgid "<prefix>"
 msgstr "<Präfix>"
 
-#: diff.c:5456
+#: diff.c:5458
 msgid "show the given source prefix instead of \"a/\""
 msgstr "den gegebenen Quell-Präfix statt \"a/\" anzeigen"
 
-#: diff.c:5459
+#: diff.c:5461
 msgid "show the given destination prefix instead of \"b/\""
 msgstr "den gegebenen Ziel-Präfix statt \"b/\" anzeigen"
 
-#: diff.c:5462
+#: diff.c:5464
 msgid "prepend an additional prefix to every line of output"
 msgstr "einen zusätzlichen Präfix bei jeder Ausgabezeile voranstellen"
 
-#: diff.c:5465
+#: diff.c:5467
 msgid "do not show any source or destination prefix"
 msgstr "keine Quell- oder Ziel-Präfixe anzeigen"
 
-#: diff.c:5468
+#: diff.c:5470
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
 "Kontext zwischen Unterschied-Blöcken bis zur angegebenen Anzahl von Zeilen "
 "anzeigen"
 
-#: diff.c:5472 diff.c:5477 diff.c:5482
+#: diff.c:5474 diff.c:5479 diff.c:5484
 msgid "<char>"
 msgstr "<Zeichen>"
 
-#: diff.c:5473
+#: diff.c:5475
 msgid "specify the character to indicate a new line instead of '+'"
 msgstr "das Zeichen festlegen, das eine neue Zeile kennzeichnet (statt '+')"
 
-#: diff.c:5478
+#: diff.c:5480
 msgid "specify the character to indicate an old line instead of '-'"
 msgstr "das Zeichen festlegen, das eine alte Zeile kennzeichnet (statt '-')"
 
-#: diff.c:5483
+#: diff.c:5485
 msgid "specify the character to indicate a context instead of ' '"
 msgstr "das Zeichen festlegen, das den Kontext kennzeichnet (statt ' ')"
 
-#: diff.c:5486
+#: diff.c:5488
 msgid "Diff rename options"
 msgstr "Diff-Optionen zur Umbenennung"
 
-#: diff.c:5487
+#: diff.c:5489
 msgid "<n>[/<m>]"
 msgstr "<n>[/<m>]"
 
-#: diff.c:5488
+#: diff.c:5490
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr ""
 "teile komplette Rewrite-Änderungen in Änderungen mit \"löschen\" und "
 "\"erstellen\""
 
-#: diff.c:5492
+#: diff.c:5494
 msgid "detect renames"
 msgstr "Umbenennungen erkennen"
 
-#: diff.c:5496
+#: diff.c:5498
 msgid "omit the preimage for deletes"
 msgstr "Preimage für Löschungen weglassen"
 
-#: diff.c:5499
+#: diff.c:5501
 msgid "detect copies"
 msgstr "Kopien erkennen"
 
-#: diff.c:5503
+#: diff.c:5505
 msgid "use unmodified files as source to find copies"
 msgstr "ungeänderte Dateien als Quelle zum Finden von Kopien nutzen"
 
-#: diff.c:5505
+#: diff.c:5507
 msgid "disable rename detection"
 msgstr "Erkennung von Umbenennungen deaktivieren"
 
-#: diff.c:5508
+#: diff.c:5510
 msgid "use empty blobs as rename source"
 msgstr "leere Blobs als Quelle von Umbenennungen nutzen"
 
-#: diff.c:5510
+#: diff.c:5512
 msgid "continue listing the history of a file beyond renames"
 msgstr "Auflistung der Historie einer Datei nach Umbenennung fortführen"
 
-#: diff.c:5513
+#: diff.c:5515
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
@@ -3725,164 +3742,164 @@ msgstr ""
 "Erkennung von Umbenennungen und Kopien verhindern, wenn die Anzahl der Ziele "
 "für Umbenennungen und Kopien das gegebene Limit überschreitet"
 
-#: diff.c:5515
+#: diff.c:5517
 msgid "Diff algorithm options"
 msgstr "Diff Algorithmus-Optionen"
 
-#: diff.c:5517
+#: diff.c:5519
 msgid "produce the smallest possible diff"
 msgstr "die kleinstmöglichen Änderungen erzeugen"
 
-#: diff.c:5520
+#: diff.c:5522
 msgid "ignore whitespace when comparing lines"
 msgstr "Whitespace-Änderungen beim Vergleich von Zeilen ignorieren"
 
-#: diff.c:5523
+#: diff.c:5525
 msgid "ignore changes in amount of whitespace"
 msgstr "Änderungen bei der Anzahl von Whitespace ignorieren"
 
-#: diff.c:5526
+#: diff.c:5528
 msgid "ignore changes in whitespace at EOL"
 msgstr "Whitespace-Änderungen am Zeilenende ignorieren"
 
-#: diff.c:5529
+#: diff.c:5531
 msgid "ignore carrier-return at the end of line"
 msgstr "den Zeilenumbruch am Ende der Zeile ignorieren"
 
-#: diff.c:5532
+#: diff.c:5534
 msgid "ignore changes whose lines are all blank"
 msgstr "Änderungen in leeren Zeilen ignorieren"
 
-#: diff.c:5534 diff.c:5556 diff.c:5559 diff.c:5604
+#: diff.c:5536 diff.c:5558 diff.c:5561 diff.c:5606
 msgid "<regex>"
 msgstr "<Regex>"
 
-#: diff.c:5535
+#: diff.c:5537
 msgid "ignore changes whose all lines match <regex>"
 msgstr ""
 "Änderungen ignorieren, bei denen alle Zeilen mit <Regex> übereinstimmen"
 
-#: diff.c:5538
+#: diff.c:5540
 msgid "heuristic to shift diff hunk boundaries for easy reading"
 msgstr ""
 "Heuristik, um Grenzen der Änderungsblöcke für bessere Lesbarkeit zu "
 "verschieben"
 
-#: diff.c:5541
+#: diff.c:5543
 msgid "generate diff using the \"patience diff\" algorithm"
 msgstr "Änderungen durch Nutzung des Algorithmus \"Patience Diff\" erzeugen"
 
-#: diff.c:5545
+#: diff.c:5547
 msgid "generate diff using the \"histogram diff\" algorithm"
 msgstr "Änderungen durch Nutzung des Algorithmus \"Histogram Diff\" erzeugen"
 
-#: diff.c:5547
+#: diff.c:5549
 msgid "<algorithm>"
 msgstr "<Algorithmus>"
 
-#: diff.c:5548
+#: diff.c:5550
 msgid "choose a diff algorithm"
 msgstr "einen Algorithmus für Änderungen wählen"
 
-#: diff.c:5550
+#: diff.c:5552
 msgid "<text>"
 msgstr "<Text>"
 
-#: diff.c:5551
+#: diff.c:5553
 msgid "generate diff using the \"anchored diff\" algorithm"
 msgstr "Änderungen durch Nutzung des Algorithmus \"Anchored Diff\" erzeugen"
 
-#: diff.c:5553 diff.c:5562 diff.c:5565
+#: diff.c:5555 diff.c:5564 diff.c:5567
 msgid "<mode>"
 msgstr "<Modus>"
 
-#: diff.c:5554
+#: diff.c:5556
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr "Wort-Änderungen zeigen, nutze <Modus>, um Wörter abzugrenzen"
 
-#: diff.c:5557
+#: diff.c:5559
 msgid "use <regex> to decide what a word is"
 msgstr "<Regex> nutzen, um zu entscheiden, was ein Wort ist"
 
-#: diff.c:5560
+#: diff.c:5562
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
 msgstr "entsprechend wie --word-diff=color --word-diff-regex=<Regex>"
 
-#: diff.c:5563
+#: diff.c:5565
 msgid "moved lines of code are colored differently"
 msgstr "verschobene Codezeilen sind andersfarbig"
 
-#: diff.c:5566
+#: diff.c:5568
 msgid "how white spaces are ignored in --color-moved"
 msgstr "wie Whitespaces in --color-moved ignoriert werden"
 
-#: diff.c:5569
+#: diff.c:5571
 msgid "Other diff options"
 msgstr "Andere Diff-Optionen"
 
-#: diff.c:5571
+#: diff.c:5573
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
 "wenn vom Unterverzeichnis aufgerufen, schließe Änderungen außerhalb aus und "
 "zeige relative Pfade an"
 
-#: diff.c:5575
+#: diff.c:5577
 msgid "treat all files as text"
 msgstr "alle Dateien als Text behandeln"
 
-#: diff.c:5577
+#: diff.c:5579
 msgid "swap two inputs, reverse the diff"
 msgstr "die beiden Eingaben vertauschen und die Änderungen umkehren"
 
-#: diff.c:5579
+#: diff.c:5581
 msgid "exit with 1 if there were differences, 0 otherwise"
 msgstr ""
 "mit Exit-Status 1 beenden, wenn Änderungen vorhanden sind, andernfalls mit 0"
 
-#: diff.c:5581
+#: diff.c:5583
 msgid "disable all output of the program"
 msgstr "alle Ausgaben vom Programm deaktivieren"
 
-#: diff.c:5583
+#: diff.c:5585
 msgid "allow an external diff helper to be executed"
 msgstr "erlaube die Ausführung eines externes Programms für Änderungen"
 
-#: diff.c:5585
+#: diff.c:5587
 msgid "run external text conversion filters when comparing binary files"
 msgstr ""
 "Führe externe Text-Konvertierungsfilter aus, wenn binäre Dateien vergleicht "
 "werden"
 
-#: diff.c:5587
+#: diff.c:5589
 msgid "<when>"
 msgstr "<wann>"
 
-#: diff.c:5588
+#: diff.c:5590
 msgid "ignore changes to submodules in the diff generation"
 msgstr ""
 "Änderungen in Submodulen während der Erstellung der Unterschiede ignorieren"
 
-#: diff.c:5591
+#: diff.c:5593
 msgid "<format>"
 msgstr "<Format>"
 
-#: diff.c:5592
+#: diff.c:5594
 msgid "specify how differences in submodules are shown"
 msgstr "angeben, wie Unterschiede in Submodulen gezeigt werden"
 
-#: diff.c:5596
+#: diff.c:5598
 msgid "hide 'git add -N' entries from the index"
 msgstr "'git add -N' Einträge vom Index verstecken"
 
-#: diff.c:5599
+#: diff.c:5601
 msgid "treat 'git add -N' entries as real in the index"
 msgstr "'git add -N' Einträge im Index als echt behandeln"
 
-#: diff.c:5601
+#: diff.c:5603
 msgid "<string>"
 msgstr "<Zeichenkette>"
 
-#: diff.c:5602
+#: diff.c:5604
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
@@ -3890,7 +3907,7 @@ msgstr ""
 "nach Unterschieden suchen, welche die Anzahl des Vorkommens der angegebenen "
 "Zeichenkette verändern"
 
-#: diff.c:5605
+#: diff.c:5607
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
@@ -3898,37 +3915,37 @@ msgstr ""
 "nach Unterschieden suchen, welche die Anzahl des Vorkommens des angegebenen "
 "regulären Ausdrucks verändern"
 
-#: diff.c:5608
+#: diff.c:5610
 msgid "show all changes in the changeset with -S or -G"
 msgstr "alle Änderungen im Changeset mit -S oder -G anzeigen"
 
-#: diff.c:5611
+#: diff.c:5613
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr ""
 "<Zeichenkette> bei -S als erweiterten POSIX regulären Ausdruck behandeln"
 
-#: diff.c:5614
+#: diff.c:5616
 msgid "control the order in which files appear in the output"
 msgstr ""
 "die Reihenfolge kontrollieren, in der die Dateien in der Ausgabe erscheinen"
 
-#: diff.c:5615 diff.c:5618
+#: diff.c:5617 diff.c:5620
 msgid "<path>"
 msgstr "<Pfad>"
 
-#: diff.c:5616
+#: diff.c:5618
 msgid "show the change in the specified path first"
 msgstr "die Änderung des angegebenen Pfades zuerst anzeigen"
 
-#: diff.c:5619
+#: diff.c:5621
 msgid "skip the output to the specified path"
 msgstr "überspringe die Ausgabe bis zum angegebenen Pfad"
 
-#: diff.c:5621
+#: diff.c:5623
 msgid "<object-id>"
 msgstr "<Objekt-ID>"
 
-#: diff.c:5622
+#: diff.c:5624
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
@@ -3936,33 +3953,33 @@ msgstr ""
 "nach Unterschieden suchen, welche die Anzahl des Vorkommens des angegebenen "
 "Objektes verändern"
 
-#: diff.c:5624
+#: diff.c:5626
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "[(A|C|D|M|R|T|U|X|B)...[*]]"
 
-#: diff.c:5625
+#: diff.c:5627
 msgid "select files by diff type"
 msgstr "Dateien anhand der Art der Änderung wählen"
 
-#: diff.c:5627
+#: diff.c:5629
 msgid "<file>"
 msgstr "<Datei>"
 
-#: diff.c:5628
+#: diff.c:5630
 msgid "Output to a specific file"
 msgstr "Ausgabe zu einer bestimmten Datei"
 
-#: diff.c:6285
+#: diff.c:6287
 msgid "inexact rename detection was skipped due to too many files."
 msgstr ""
 "ungenaue Erkennung für Umbenennungen wurde aufgrund zu vieler Dateien\n"
 "übersprungen."
 
-#: diff.c:6288
+#: diff.c:6290
 msgid "only found copies from modified paths due to too many files."
 msgstr "nur Kopien von geänderten Pfaden, aufgrund zu vieler Dateien, gefunden"
 
-#: diff.c:6291
+#: diff.c:6293
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
@@ -3975,7 +3992,7 @@ msgstr ""
 msgid "failed to read orderfile '%s'"
 msgstr "Fehler beim Lesen der Reihenfolgedatei '%s'"
 
-#: diffcore-rename.c:786
+#: diffcore-rename.c:1418
 msgid "Performing inexact rename detection"
 msgstr "Führe Erkennung für ungenaue Umbenennung aus"
 
@@ -4010,37 +4027,37 @@ msgstr ""
 msgid "disabling cone pattern matching"
 msgstr "deaktiviere Cone-Muster-Übereinstimmung"
 
-#: dir.c:1198
+#: dir.c:1206
 #, c-format
 msgid "cannot use %s as an exclude file"
 msgstr "kann %s nicht als exclude-Filter benutzen"
 
-#: dir.c:2305
+#: dir.c:2314
 #, c-format
 msgid "could not open directory '%s'"
 msgstr "konnte Verzeichnis '%s' nicht öffnen"
 
-#: dir.c:2605
+#: dir.c:2614
 msgid "failed to get kernel name and information"
 msgstr "Fehler beim Sammeln von Namen und Informationen zum Kernel"
 
-#: dir.c:2729
+#: dir.c:2738
 msgid "untracked cache is disabled on this system or location"
 msgstr ""
 "Cache für unversionierte Dateien ist auf diesem System oder\n"
 "für dieses Verzeichnis deaktiviert"
 
-#: dir.c:3534
+#: dir.c:3543
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "Index-Datei in Repository %s beschädigt"
 
-#: dir.c:3579 dir.c:3584
+#: dir.c:3590 dir.c:3595
 #, c-format
 msgid "could not create directories for %s"
 msgstr "Konnte Verzeichnisse für '%s' nicht erstellen"
 
-#: dir.c:3613
+#: dir.c:3624
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "Konnte Git-Verzeichnis nicht von '%s' nach '%s' migrieren"
@@ -4050,11 +4067,11 @@ msgstr "Konnte Git-Verzeichnis nicht von '%s' nach '%s' migrieren"
 msgid "hint: Waiting for your editor to close the file...%c"
 msgstr "Hinweis: Warte auf das Schließen der Datei durch Ihren Editor...%c"
 
-#: entry.c:177
+#: entry.c:179
 msgid "Filtering content"
 msgstr "Filtere Inhalt"
 
-#: entry.c:478
+#: entry.c:500
 #, c-format
 msgid "could not stat file '%s'"
 msgstr "konnte Datei '%s' nicht lesen"
@@ -4074,249 +4091,261 @@ msgstr "konnte GIT_DIR nicht zu '%s' setzen"
 msgid "too many args to run %s"
 msgstr "zu viele Argumente angegeben, um %s auszuführen"
 
-#: fetch-pack.c:177
+#: fetch-pack.c:182
 msgid "git fetch-pack: expected shallow list"
 msgstr "git fetch-pack: erwartete shallow-Liste"
 
-#: fetch-pack.c:180
+#: fetch-pack.c:185
 msgid "git fetch-pack: expected a flush packet after shallow list"
 msgstr "git fetch-pack: erwartete ein Flush-Paket nach der shallow-Liste"
 
-#: fetch-pack.c:191
+#: fetch-pack.c:196
 msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
 msgstr "git fetch-pack: ACK/NAK erwartet, Flush-Paket bekommen"
 
-#: fetch-pack.c:211
+#: fetch-pack.c:216
 #, c-format
 msgid "git fetch-pack: expected ACK/NAK, got '%s'"
 msgstr "git fetch-pack: ACK/NAK erwartet, '%s' bekommen"
 
-#: fetch-pack.c:222
+#: fetch-pack.c:227
 msgid "unable to write to remote"
 msgstr "konnte nicht zum Remote schreiben"
 
-#: fetch-pack.c:283
+#: fetch-pack.c:288
 msgid "--stateless-rpc requires multi_ack_detailed"
 msgstr "--stateless-rpc benötigt multi_ack_detailed"
 
-#: fetch-pack.c:378 fetch-pack.c:1457
+#: fetch-pack.c:383 fetch-pack.c:1423
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "ungültige shallow-Zeile: %s"
 
-#: fetch-pack.c:384 fetch-pack.c:1463
+#: fetch-pack.c:389 fetch-pack.c:1429
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "ungültige unshallow-Zeile: %s"
 
-#: fetch-pack.c:386 fetch-pack.c:1465
+#: fetch-pack.c:391 fetch-pack.c:1431
 #, c-format
 msgid "object not found: %s"
 msgstr "Objekt nicht gefunden: %s"
 
-#: fetch-pack.c:389 fetch-pack.c:1468
+#: fetch-pack.c:394 fetch-pack.c:1434
 #, c-format
 msgid "error in object: %s"
 msgstr "Fehler in Objekt: %s"
 
-#: fetch-pack.c:391 fetch-pack.c:1470
+#: fetch-pack.c:396 fetch-pack.c:1436
 #, c-format
 msgid "no shallow found: %s"
 msgstr "kein shallow-Objekt gefunden: %s"
 
-#: fetch-pack.c:394 fetch-pack.c:1474
+#: fetch-pack.c:399 fetch-pack.c:1440
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "shallow/unshallow erwartet, %s bekommen"
 
-#: fetch-pack.c:434
+#: fetch-pack.c:439
 #, c-format
 msgid "got %s %d %s"
 msgstr "%s %d %s bekommen"
 
-#: fetch-pack.c:451
+#: fetch-pack.c:456
 #, c-format
 msgid "invalid commit %s"
 msgstr "ungültiger Commit %s"
 
-#: fetch-pack.c:482
+#: fetch-pack.c:487
 msgid "giving up"
 msgstr "gebe auf"
 
-#: fetch-pack.c:495 progress.c:339
+#: fetch-pack.c:500 progress.c:339
 msgid "done"
 msgstr "fertig"
 
-#: fetch-pack.c:507
+#: fetch-pack.c:512
 #, c-format
 msgid "got %s (%d) %s"
 msgstr "%s (%d) %s bekommen"
 
-#: fetch-pack.c:543
+#: fetch-pack.c:548
 #, c-format
 msgid "Marking %s as complete"
 msgstr "Markiere %s als vollständig"
 
-#: fetch-pack.c:758
+#: fetch-pack.c:763
 #, c-format
 msgid "already have %s (%s)"
 msgstr "habe %s (%s) bereits"
 
-#: fetch-pack.c:844
+#: fetch-pack.c:849
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-pack: Fehler beim Starten des sideband demultiplexer"
 
-#: fetch-pack.c:852
+#: fetch-pack.c:857
 msgid "protocol error: bad pack header"
 msgstr "Protokollfehler: ungültiger Pack-Header"
 
-#: fetch-pack.c:946
+#: fetch-pack.c:951
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-pack: konnte %s nicht starten"
 
-#: fetch-pack.c:952
+#: fetch-pack.c:957
 msgid "fetch-pack: invalid index-pack output"
 msgstr "fetch-pack: ungültige index-pack Ausgabe"
 
-#: fetch-pack.c:969
+#: fetch-pack.c:974
 #, c-format
 msgid "%s failed"
 msgstr "%s fehlgeschlagen"
 
-#: fetch-pack.c:971
+#: fetch-pack.c:976
 msgid "error in sideband demultiplexer"
 msgstr "Fehler in sideband demultiplexer"
 
-#: fetch-pack.c:1031
+#: fetch-pack.c:1019
 #, c-format
 msgid "Server version is %.*s"
 msgstr "Server-Version ist %.*s"
 
-#: fetch-pack.c:1039 fetch-pack.c:1045 fetch-pack.c:1048 fetch-pack.c:1054
-#: fetch-pack.c:1058 fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070
-#: fetch-pack.c:1074 fetch-pack.c:1078 fetch-pack.c:1082 fetch-pack.c:1086
-#: fetch-pack.c:1092 fetch-pack.c:1098 fetch-pack.c:1103 fetch-pack.c:1108
+#: fetch-pack.c:1027 fetch-pack.c:1033 fetch-pack.c:1036 fetch-pack.c:1042
+#: fetch-pack.c:1046 fetch-pack.c:1050 fetch-pack.c:1054 fetch-pack.c:1058
+#: fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070 fetch-pack.c:1074
+#: fetch-pack.c:1080 fetch-pack.c:1086 fetch-pack.c:1091 fetch-pack.c:1096
 #, c-format
 msgid "Server supports %s"
 msgstr "Server unterstützt %s"
 
-#: fetch-pack.c:1041
+#: fetch-pack.c:1029
 msgid "Server does not support shallow clients"
 msgstr "Server unterstützt keine shallow-Clients"
 
-#: fetch-pack.c:1101
+#: fetch-pack.c:1089
 msgid "Server does not support --shallow-since"
 msgstr "Server unterstützt kein --shallow-since"
 
-#: fetch-pack.c:1106
+#: fetch-pack.c:1094
 msgid "Server does not support --shallow-exclude"
 msgstr "Server unterstützt kein --shallow-exclude"
 
-#: fetch-pack.c:1110
+#: fetch-pack.c:1098
 msgid "Server does not support --deepen"
 msgstr "Server unterstützt kein --deepen"
 
-#: fetch-pack.c:1112
+#: fetch-pack.c:1100
 msgid "Server does not support this repository's object format"
 msgstr "Server unterstützt das Objekt-Format dieses Repositories nicht"
 
-#: fetch-pack.c:1125
+#: fetch-pack.c:1113
 msgid "no common commits"
 msgstr "keine gemeinsamen Commits"
 
-#: fetch-pack.c:1138 fetch-pack.c:1682
+#: fetch-pack.c:1122 fetch-pack.c:1469 builtin/clone.c:1238
+#, fuzzy
+msgid "source repository is shallow, reject to clone."
+msgstr ""
+"Quelle ist ein Repository mit unvollständiger Historie (shallow),\n"
+"ignoriere --local"
+
+#: fetch-pack.c:1128 fetch-pack.c:1651
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack: Abholen fehlgeschlagen."
 
-#: fetch-pack.c:1265
+#: fetch-pack.c:1242
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "Algorithmen stimmen nicht überein: Client %s; Server %s"
 
-#: fetch-pack.c:1269
+#: fetch-pack.c:1246
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "der Server unterstützt Algorithmus '%s' nicht"
 
-#: fetch-pack.c:1289
+#: fetch-pack.c:1279
 msgid "Server does not support shallow requests"
 msgstr "Server unterstützt keine shallow-Anfragen"
 
-#: fetch-pack.c:1296
+#: fetch-pack.c:1286
 msgid "Server supports filter"
 msgstr "Server unterstützt Filter"
 
-#: fetch-pack.c:1335
+#: fetch-pack.c:1329 fetch-pack.c:2034
 msgid "unable to write request to remote"
 msgstr "konnte Anfrage nicht zum Remote schreiben"
 
-#: fetch-pack.c:1353
+#: fetch-pack.c:1347
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "Fehler beim Lesen von Sektionskopf '%s'."
 
-#: fetch-pack.c:1359
+#: fetch-pack.c:1353
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "'%s' erwartet, '%s' empfangen"
 
-#: fetch-pack.c:1420
+#: fetch-pack.c:1387
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "Unerwartete Acknowledgment-Zeile: '%s'"
 
-#: fetch-pack.c:1425
+#: fetch-pack.c:1392
 #, c-format
 msgid "error processing acks: %d"
 msgstr "Fehler beim Verarbeiten von ACKS: %d"
 
-#: fetch-pack.c:1435
+#: fetch-pack.c:1402
 msgid "expected packfile to be sent after 'ready'"
 msgstr "Erwartete Versand einer Packdatei nach 'ready'."
 
-#: fetch-pack.c:1437
+#: fetch-pack.c:1404
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr "Erwartete keinen Versand einer anderen Sektion ohne 'ready'."
 
-#: fetch-pack.c:1479
+#: fetch-pack.c:1445
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "Fehler beim Verarbeiten von Shallow-Informationen: %d"
 
-#: fetch-pack.c:1526
+#: fetch-pack.c:1494
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "wanted-ref erwartet, '%s' bekommen"
 
-#: fetch-pack.c:1531
+#: fetch-pack.c:1499
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "unerwartetes wanted-ref: '%s'"
 
-#: fetch-pack.c:1536
+#: fetch-pack.c:1504
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "Fehler beim Verarbeiten von wanted-refs: %d"
 
-#: fetch-pack.c:1566
+#: fetch-pack.c:1534
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: Antwort-Endpaket erwartet"
 
-#: fetch-pack.c:1960
+#: fetch-pack.c:1930
 msgid "no matching remote head"
 msgstr "kein übereinstimmender Remote-Branch"
 
-#: fetch-pack.c:1983 builtin/clone.c:693
+#: fetch-pack.c:1953 builtin/clone.c:697
 msgid "remote did not send all necessary objects"
 msgstr "Remote-Repository hat nicht alle erforderlichen Objekte gesendet"
 
-#: fetch-pack.c:2010
+#: fetch-pack.c:2056
+#, fuzzy
+msgid "unexpected 'ready' from remote"
+msgstr "Unerwartetes Dateiende"
+
+#: fetch-pack.c:2079
 #, c-format
 msgid "no such remote ref %s"
 msgstr "Remote-Referenz %s nicht gefunden"
 
-#: fetch-pack.c:2013
+#: fetch-pack.c:2082
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Der Server lehnt Anfrage nach nicht angebotenem Objekt %s ab."
@@ -4339,7 +4368,7 @@ msgstr "gpg beim Signieren der Daten fehlgeschlagen"
 msgid "ignore invalid color '%.*s' in log.graphColors"
 msgstr "Ignoriere ungültige Farbe '%.*s' in log.graphColors"
 
-#: grep.c:543
+#: grep.c:531
 msgid ""
 "given pattern contains NULL byte (via -f <file>). This is only supported "
 "with -P under PCRE v2"
@@ -4347,18 +4376,18 @@ msgstr ""
 "Angegebenes Muster enthält NULL Byte (über -f <Datei>). Das wird nur mit -"
 "Punter PCRE v2 unterstützt."
 
-#: grep.c:1906
+#: grep.c:1893
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr "'%s': konnte %s nicht lesen"
 
-#: grep.c:1923 setup.c:176 builtin/clone.c:412 builtin/diff.c:90
-#: builtin/rm.c:135
+#: grep.c:1910 setup.c:176 builtin/clone.c:416 builtin/diff.c:90
+#: builtin/rm.c:136
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "Konnte '%s' nicht lesen"
 
-#: grep.c:1934
+#: grep.c:1921
 #, c-format
 msgid "'%s': short read"
 msgstr "'%s': read() zu kurz"
@@ -4584,49 +4613,54 @@ msgstr "Leerer Name in Identifikation (für <%s>) nicht erlaubt."
 msgid "name consists only of disallowed characters: %s"
 msgstr "Name besteht nur aus nicht erlaubten Zeichen: %s"
 
-#: ident.c:454 builtin/commit.c:634
+#: ident.c:454 builtin/commit.c:647
 #, c-format
 msgid "invalid date format: %s"
 msgstr "Ungültiges Datumsformat: %s"
 
-#: list-objects-filter-options.c:81
+#: list-objects-filter-options.c:83
 msgid "expected 'tree:<depth>'"
 msgstr "'tree:<Tiefe>' erwartet"
 
-#: list-objects-filter-options.c:96
+#: list-objects-filter-options.c:98
 msgid "sparse:path filters support has been dropped"
 msgstr "Keine Unterstützung für sparse:path Filter mehr"
 
-#: list-objects-filter-options.c:109
+#: list-objects-filter-options.c:105
+#, fuzzy, c-format
+msgid "'%s' for 'object:type=<type>' isnot a valid object type"
+msgstr "'%s' ist kein gültiger Zeitstempel für '%s'"
+
+#: list-objects-filter-options.c:124
 #, c-format
 msgid "invalid filter-spec '%s'"
 msgstr "Ungültige filter-spec '%s'"
 
-#: list-objects-filter-options.c:125
+#: list-objects-filter-options.c:140
 #, c-format
 msgid "must escape char in sub-filter-spec: '%c'"
 msgstr "Zeichen in sub-filter-spec muss maskiert werden: '%c'"
 
-#: list-objects-filter-options.c:167
+#: list-objects-filter-options.c:182
 msgid "expected something after combine:"
 msgstr "erwartete etwas nach 'combine:'"
 
-#: list-objects-filter-options.c:249
+#: list-objects-filter-options.c:264
 msgid "multiple filter-specs cannot be combined"
 msgstr "mehrere filter-specs können nicht kombiniert werden"
 
-#: list-objects-filter-options.c:361
+#: list-objects-filter-options.c:376
 msgid "unable to upgrade repository format to support partial clone"
 msgstr ""
 "Repository-Format konnte nicht erweitert werden, um partielles Klonen zu "
 "unterstützen"
 
-#: list-objects-filter.c:492
+#: list-objects-filter.c:532
 #, c-format
 msgid "unable to access sparse blob in '%s'"
 msgstr "konnte nicht auf partiellen Blob '%s' zugreifen"
 
-#: list-objects-filter.c:495
+#: list-objects-filter.c:535
 #, c-format
 msgid "unable to parse sparse filter data in %s"
 msgstr "konnte partielle Filter-Daten in %s nicht parsen"
@@ -4642,7 +4676,7 @@ msgstr ""
 msgid "entry '%s' in tree %s has blob mode, but is not a blob"
 msgstr "Eintrag '%s' im Tree-Objekt %s hat Blob-Modus, aber ist kein Blob"
 
-#: list-objects.c:375
+#: list-objects.c:395
 #, c-format
 msgid "unable to load root tree for commit %s"
 msgstr "Konnte Root-Tree-Objekt für Commit %s nicht laden."
@@ -4681,32 +4715,41 @@ msgstr "ungültiger Wert '%s' für lsrefs.unborn"
 msgid "expected flush after ls-refs arguments"
 msgstr "erwartete Flush nach Argumenten für die Auflistung der Referenzen"
 
-#: merge-ort.c:888 merge-recursive.c:1191
+#: mailinfo.c:1050
+msgid "quoted CRLF detected"
+msgstr ""
+
+#: mailinfo.c:1254 builtin/am.c:176 builtin/mailinfo.c:46
+#, fuzzy, c-format
+msgid "bad action '%s' for '%s'"
+msgstr "ungültiger boolescher Konfigurationswert '%s' für '%s'"
+
+#: merge-ort.c:1116 merge-recursive.c:1205
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
 msgstr "Fehler beim Merge von Submodul %s (nicht ausgecheckt)."
 
-#: merge-ort.c:897 merge-recursive.c:1198
+#: merge-ort.c:1125 merge-recursive.c:1212
 #, c-format
 msgid "Failed to merge submodule %s (commits not present)"
 msgstr "Fehler beim Merge von Submodul %s (Commits nicht vorhanden)."
 
-#: merge-ort.c:906 merge-recursive.c:1205
+#: merge-ort.c:1134 merge-recursive.c:1219
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
 msgstr "Fehler beim Merge von Submodul %s (Commits folgen keiner Merge-Basis)"
 
-#: merge-ort.c:916 merge-ort.c:923
+#: merge-ort.c:1144 merge-ort.c:1151
 #, c-format
 msgid "Note: Fast-forwarding submodule %s to %s"
 msgstr "Hinweis: Spule Submodul %s vor zu %s"
 
-#: merge-ort.c:944
+#: merge-ort.c:1172
 #, c-format
 msgid "Failed to merge submodule %s"
 msgstr "Fehler beim Zusammenführen von Submodul %s"
 
-#: merge-ort.c:951
+#: merge-ort.c:1179
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but a possible merge resolution exists:\n"
@@ -4716,7 +4759,7 @@ msgstr ""
 "Auflösung des Merges vorhanden:\n"
 "%s\n"
 
-#: merge-ort.c:955 merge-recursive.c:1259
+#: merge-ort.c:1183 merge-recursive.c:1273
 #, c-format
 msgid ""
 "If this is correct simply add it to the index for example\n"
@@ -4733,7 +4776,7 @@ msgstr ""
 "\n"
 "hinzu, um diesen Vorschlag zu akzeptieren.\n"
 
-#: merge-ort.c:968
+#: merge-ort.c:1196
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but multiple possible merges exist:\n"
@@ -4743,21 +4786,21 @@ msgstr ""
 "sind vorhanden:\n"
 "%s"
 
-#: merge-ort.c:1127 merge-recursive.c:1341
+#: merge-ort.c:1415 merge-recursive.c:1362
 msgid "Failed to execute internal merge"
 msgstr "Fehler bei Ausführung des internen Merges"
 
-#: merge-ort.c:1132 merge-recursive.c:1346
+#: merge-ort.c:1420 merge-recursive.c:1367
 #, c-format
 msgid "Unable to add %s to database"
 msgstr "Konnte %s nicht zur Datenbank hinzufügen"
 
-#: merge-ort.c:1139 merge-recursive.c:1378
+#: merge-ort.c:1427 merge-recursive.c:1400
 #, c-format
 msgid "Auto-merging %s"
 msgstr "automatischer Merge von %s"
 
-#: merge-ort.c:1278 merge-recursive.c:2100
+#: merge-ort.c:1566 merge-recursive.c:2122
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
@@ -4768,7 +4811,7 @@ msgstr ""
 "Weg von impliziter Verzeichnisumbenennung, die versucht, einen oder mehrere\n"
 "Pfade dahin zu setzen: %s."
 
-#: merge-ort.c:1288 merge-recursive.c:2110
+#: merge-ort.c:1576 merge-recursive.c:2132
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
@@ -4779,7 +4822,7 @@ msgstr ""
 "%s mappen; implizite Verzeichnisumbenennungen versuchten diese Pfade dahin\n"
 "zu setzen: %s"
 
-#: merge-ort.c:1471
+#: merge-ort.c:1634
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to rename %s to; it was "
@@ -4790,7 +4833,7 @@ msgstr ""
 "ist; es wurde zu mehreren anderen Verzeichnissen umbenannt, ohne dass ein "
 "Ziel die Mehrheit der Dateien erhält."
 
-#: merge-ort.c:1637 merge-recursive.c:2447
+#: merge-ort.c:1788 merge-recursive.c:2468
 #, c-format
 msgid ""
 "WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
@@ -4799,7 +4842,7 @@ msgstr ""
 "WARNUNG: Vermeide Umbenennung %s -> %s von %s, weil %s selbst umbenannt "
 "wurde."
 
-#: merge-ort.c:1781 merge-recursive.c:3215
+#: merge-ort.c:1932 merge-recursive.c:3244
 #, c-format
 msgid ""
 "Path updated: %s added in %s inside a directory that was renamed in %s; "
@@ -4808,7 +4851,7 @@ msgstr ""
 "Pfad aktualisiert: %s hinzugefügt in %s innerhalb eines Verzeichnisses, das "
 "umbenannt wurde in %s; Verschiebe es nach %s."
 
-#: merge-ort.c:1788 merge-recursive.c:3222
+#: merge-ort.c:1939 merge-recursive.c:3251
 #, c-format
 msgid ""
 "Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
@@ -4817,7 +4860,7 @@ msgstr ""
 "Pfad aktualisiert: %s umbenannt nach %s in %s, innerhalb eines "
 "Verzeichnisses, das umbenannt wurde in %s; Verschiebe es nach %s."
 
-#: merge-ort.c:1801 merge-recursive.c:3218
+#: merge-ort.c:1952 merge-recursive.c:3247
 #, c-format
 msgid ""
 "CONFLICT (file location): %s added in %s inside a directory that was renamed "
@@ -4826,7 +4869,7 @@ msgstr ""
 "KONFLIKT (Speicherort): %s hinzugefügt in %s innerhalb eines Verzeichnisses, "
 "das umbenannt wurde in %s, es sollte vielleicht nach %s verschoben werden."
 
-#: merge-ort.c:1809 merge-recursive.c:3225
+#: merge-ort.c:1960 merge-recursive.c:3254
 #, c-format
 msgid ""
 "CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
@@ -4836,13 +4879,13 @@ msgstr ""
 "Verzeichnisses, das umbenannt wurde in %s, es sollte vielleicht nach %s "
 "verschoben werden."
 
-#: merge-ort.c:1952
+#: merge-ort.c:2103
 #, c-format
 msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
 msgstr ""
 "KONFLIKT (umbenennen/umbenennen): %s zu %s in %s umbenannt und zu %s in %s."
 
-#: merge-ort.c:2047
+#: merge-ort.c:2198
 #, c-format
 msgid ""
 "CONFLICT (rename involved in collision): rename of %s -> %s has content "
@@ -4853,13 +4896,23 @@ msgstr ""
 "Inhaltskonflikte UND kollidiert mit einem anderen Pfad; dies kann zu "
 "verschachtelten Konfliktmarkierungen führen."
 
-#: merge-ort.c:2066 merge-ort.c:2090
+#: merge-ort.c:2217 merge-ort.c:2241
 #, c-format
 msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
 msgstr ""
 "KONFLIKT (umbenennen/löschen): %s zu %s in %s umbenannt, aber in %s gelöscht."
 
-#: merge-ort.c:2735
+#: merge-ort.c:2550 merge-recursive.c:3002
+#, c-format
+msgid "cannot read object %s"
+msgstr "kann Objekt %s nicht lesen"
+
+#: merge-ort.c:2553 merge-recursive.c:3005
+#, c-format
+msgid "object %s is not a blob"
+msgstr "Objekt %s ist kein Blob"
+
+#: merge-ort.c:2981
 #, c-format
 msgid ""
 "CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
@@ -4868,41 +4921,42 @@ msgstr ""
 "KONFLIKT (Datei/Verzeichnis): Verzeichnis im Weg von %s aus %s; stattdessen "
 "nach %s verschieben."
 
-#: merge-ort.c:2808
-#, c-format
+#: merge-ort.c:3055
+#, fuzzy, c-format
 msgid ""
-"CONFLICT (distinct types): %s had different types on each side; renamed %s "
+"CONFLICT (distinct types): %s had different types on each side; renamed both "
 "of them so each can be recorded somewhere."
 msgstr ""
 "KONFLIKT (verschiedene Typen): %s hatte unterschiedliche Typen auf jeder "
 "Seite; %s wurde(n) umbenannt, damit jeder irgendwo aufgezeichnet werden kann."
 
-#: merge-ort.c:2812
-msgid "both"
-msgstr "beide"
+#: merge-ort.c:3062
+#, fuzzy, c-format
+msgid ""
+"CONFLICT (distinct types): %s had different types on each side; renamed one "
+"of them so each can be recorded somewhere."
+msgstr ""
+"KONFLIKT (verschiedene Typen): %s hatte unterschiedliche Typen auf jeder "
+"Seite; %s wurde(n) umbenannt, damit jeder irgendwo aufgezeichnet werden kann."
 
-#: merge-ort.c:2812
-msgid "one"
-msgstr "einer"
-
-#: merge-ort.c:2907 merge-recursive.c:3052
+#: merge-ort.c:3162 merge-recursive.c:3081
 msgid "content"
 msgstr "Inhalt"
 
-#: merge-ort.c:2909 merge-recursive.c:3056
+#: merge-ort.c:3164 merge-recursive.c:3085
 msgid "add/add"
 msgstr "hinzufügen/hinzufügen"
 
-#: merge-ort.c:2911 merge-recursive.c:3101
+#: merge-ort.c:3166 merge-recursive.c:3130
 msgid "submodule"
 msgstr "Submodul"
 
-#: merge-ort.c:2913 merge-recursive.c:3102
+#: merge-ort.c:3168 merge-recursive.c:3131
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "KONFLIKT (%s): Merge-Konflikt in %s"
 
-#: merge-ort.c:2938
+#: merge-ort.c:3198
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
@@ -4911,16 +4965,23 @@ msgstr ""
 "KONFLIKT (ändern/löschen): %s gelöscht in %s und geändert in %s. Stand %s "
 "von %s wurde im Arbeitsbereich gelassen."
 
+#: merge-ort.c:3433
+#, c-format
+msgid ""
+"Note: %s not up to date and in way of checking out conflicted version; old "
+"copy renamed to %s"
+msgstr ""
+
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
-#: merge-ort.c:3406
+#: merge-ort.c:3730
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
 msgstr ""
 "Sammeln von Merge-Informationen für die Referenzen %s, %s, %s fehlgeschlagen"
 
-#: merge-ort-wrappers.c:13 merge-recursive.c:3661
+#: merge-ort-wrappers.c:13 merge-recursive.c:3699
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -4930,10 +4991,9 @@ msgstr ""
 "überschrieben werden:\n"
 "  %s"
 
-#: merge-ort-wrappers.c:33 merge-recursive.c:3436
-#, c-format
-msgid "Already up to date!"
-msgstr "Bereits aktuell!"
+#: merge-ort-wrappers.c:33 merge-recursive.c:3465 builtin/merge.c:402
+msgid "Already up to date."
+msgstr "Bereits aktuell."
 
 #: merge-recursive.c:356
 msgid "(bad commit)\n"
@@ -4951,89 +5011,89 @@ msgstr ""
 "add_cacheinfo zur Aktualisierung für Pfad '%s' fehlgeschlagen;\n"
 "Merge wird abgebrochen."
 
-#: merge-recursive.c:874
+#: merge-recursive.c:876
 #, c-format
 msgid "failed to create path '%s'%s"
 msgstr "Fehler beim Erstellen des Pfades '%s'%s"
 
-#: merge-recursive.c:885
+#: merge-recursive.c:887
 #, c-format
 msgid "Removing %s to make room for subdirectory\n"
 msgstr "Entferne %s, um Platz für Unterverzeichnis zu schaffen\n"
 
-#: merge-recursive.c:899 merge-recursive.c:918
+#: merge-recursive.c:901 merge-recursive.c:920
 msgid ": perhaps a D/F conflict?"
 msgstr ": vielleicht ein Verzeichnis/Datei-Konflikt?"
 
-#: merge-recursive.c:908
+#: merge-recursive.c:910
 #, c-format
 msgid "refusing to lose untracked file at '%s'"
 msgstr "verweigere, da unversionierte Dateien in '%s' verloren gehen würden"
 
-#: merge-recursive.c:949 builtin/cat-file.c:41
+#: merge-recursive.c:951 builtin/cat-file.c:41
 #, c-format
 msgid "cannot read object %s '%s'"
 msgstr "kann Objekt %s '%s' nicht lesen"
 
-#: merge-recursive.c:954
+#: merge-recursive.c:956
 #, c-format
 msgid "blob expected for %s '%s'"
 msgstr "Blob erwartet für %s '%s'"
 
-#: merge-recursive.c:979
+#: merge-recursive.c:981
 #, c-format
 msgid "failed to open '%s': %s"
 msgstr "Fehler beim Öffnen von '%s': %s"
 
-#: merge-recursive.c:990
+#: merge-recursive.c:992
 #, c-format
 msgid "failed to symlink '%s': %s"
 msgstr "Fehler beim Erstellen einer symbolischen Verknüpfung für '%s': %s"
 
-#: merge-recursive.c:995
+#: merge-recursive.c:997
 #, c-format
 msgid "do not know what to do with %06o %s '%s'"
 msgstr "weiß nicht was mit %06o %s '%s' zu machen ist"
 
-#: merge-recursive.c:1213 merge-recursive.c:1225
+#: merge-recursive.c:1227 merge-recursive.c:1239
 #, c-format
 msgid "Fast-forwarding submodule %s to the following commit:"
 msgstr "Spule Submodul %s zu dem folgenden Commit vor:"
 
-#: merge-recursive.c:1216 merge-recursive.c:1228
+#: merge-recursive.c:1230 merge-recursive.c:1242
 #, c-format
 msgid "Fast-forwarding submodule %s"
 msgstr "Spule Submodul %s vor"
 
-#: merge-recursive.c:1251
+#: merge-recursive.c:1265
 #, c-format
 msgid "Failed to merge submodule %s (merge following commits not found)"
 msgstr ""
 "Fehler beim Merge von Submodule %s (dem Merge nachfolgende Commits nicht "
 "gefunden)"
 
-#: merge-recursive.c:1255
+#: merge-recursive.c:1269
 #, c-format
 msgid "Failed to merge submodule %s (not fast-forward)"
 msgstr "Fehler beim Merge von Submodul %s (kein Vorspulen)"
 
-#: merge-recursive.c:1256
+#: merge-recursive.c:1270
 msgid "Found a possible merge resolution for the submodule:\n"
 msgstr "Mögliche Auflösung des Merges für Submodul gefunden:\n"
 
-#: merge-recursive.c:1268
+#: merge-recursive.c:1282
 #, c-format
 msgid "Failed to merge submodule %s (multiple merges found)"
 msgstr "Fehler beim Merge von Submodul %s (mehrere Merges gefunden)"
 
-#: merge-recursive.c:1402
+#: merge-recursive.c:1424
 #, c-format
 msgid "Error: Refusing to lose untracked file at %s; writing to %s instead."
 msgstr ""
 "Fehler: Verweigere unversionierte Datei bei %s zu verlieren;\n"
 "schreibe stattdessen nach %s."
 
-#: merge-recursive.c:1474
+#: merge-recursive.c:1496
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
@@ -5042,7 +5102,7 @@ msgstr ""
 "KONFLIKT (%s/löschen): %s gelöscht in %s und %s in %s. Stand %s von %s wurde "
 "im Arbeitsbereich gelassen."
 
-#: merge-recursive.c:1479
+#: merge-recursive.c:1501
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
@@ -5051,7 +5111,7 @@ msgstr ""
 "KONFLIKT (%s/löschen): %s gelöscht in %s und %s nach %s in %s. Stand %s von "
 "%s wurde im Arbeitsbereich gelassen."
 
-#: merge-recursive.c:1486
+#: merge-recursive.c:1508
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
@@ -5060,7 +5120,7 @@ msgstr ""
 "KONFLIKT (%s/löschen): %s gelöscht in %s und %s in %s. Stand %s von %s wurde "
 "im Arbeitsbereich bei %s gelassen."
 
-#: merge-recursive.c:1491
+#: merge-recursive.c:1513
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
@@ -5069,46 +5129,46 @@ msgstr ""
 "KONFLIKT (%s/löschen): %s gelöscht in %s und %s nach %s in %s. Stand %s von "
 "%s wurde im Arbeitsbereich bei %s gelassen."
 
-#: merge-recursive.c:1526
+#: merge-recursive.c:1548
 msgid "rename"
 msgstr "umbenennen"
 
-#: merge-recursive.c:1526
+#: merge-recursive.c:1548
 msgid "renamed"
 msgstr "umbenannt"
 
-#: merge-recursive.c:1577 merge-recursive.c:2484 merge-recursive.c:3129
+#: merge-recursive.c:1599 merge-recursive.c:2505 merge-recursive.c:3158
 #, c-format
 msgid "Refusing to lose dirty file at %s"
 msgstr "Verweigere geänderte Datei bei %s zu verlieren."
 
-#: merge-recursive.c:1587
+#: merge-recursive.c:1609
 #, c-format
 msgid "Refusing to lose untracked file at %s, even though it's in the way."
 msgstr ""
 "Verweigere unversionierte Datei bei %s zu verlieren, auch wenn diese im Weg "
 "ist."
 
-#: merge-recursive.c:1645
+#: merge-recursive.c:1667
 #, c-format
 msgid "CONFLICT (rename/add): Rename %s->%s in %s.  Added %s in %s"
 msgstr ""
 "KONFLIKT (umbenennen/hinzufügen): Benenne um %s->%s in %s. %s hinzugefügt in "
 "%s"
 
-#: merge-recursive.c:1676
+#: merge-recursive.c:1698
 #, c-format
 msgid "%s is a directory in %s adding as %s instead"
 msgstr "%s ist ein Verzeichnis in %s, füge es stattdessen als %s hinzu"
 
-#: merge-recursive.c:1681
+#: merge-recursive.c:1703
 #, c-format
 msgid "Refusing to lose untracked file at %s; adding as %s instead"
 msgstr ""
 "Verweigere unversionierte Datei bei %s zu verlieren; füge stattdessen %s "
 "hinzu"
 
-#: merge-recursive.c:1708
+#: merge-recursive.c:1730
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename \"%s\"->\"%s\" in branch \"%s\" rename \"%s"
@@ -5117,18 +5177,18 @@ msgstr ""
 "KONFLIKT (umbenennen/umbenennen): Benenne um \"%s\"->\"%s\" in Branch \"%s\" "
 "und \"%s\"->\"%s\" in Branch \"%s\"%s"
 
-#: merge-recursive.c:1713
+#: merge-recursive.c:1735
 msgid " (left unresolved)"
 msgstr " (bleibt unaufgelöst)"
 
-#: merge-recursive.c:1805
+#: merge-recursive.c:1827
 #, c-format
 msgid "CONFLICT (rename/rename): Rename %s->%s in %s. Rename %s->%s in %s"
 msgstr ""
 "KONFLIKT (umbenennen/umbenennen): Benenne um %s->%s in %s. Benenne um %s->%s "
 "in %s"
 
-#: merge-recursive.c:2068
+#: merge-recursive.c:2090
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to place %s because "
@@ -5141,7 +5201,7 @@ msgstr ""
 "wobei\n"
 "keines dieser Ziele die Mehrheit der Dateien erhielt."
 
-#: merge-recursive.c:2202
+#: merge-recursive.c:2224
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename directory %s->%s in %s. Rename directory %s-"
@@ -5150,91 +5210,81 @@ msgstr ""
 "KONFLIKT (umbenennen/umbenennen): Benenne Verzeichnis um %s->%s in %s.\n"
 "Benenne Verzeichnis um %s->%s in %s"
 
-#: merge-recursive.c:2973
-#, c-format
-msgid "cannot read object %s"
-msgstr "kann Objekt %s nicht lesen"
-
-#: merge-recursive.c:2976
-#, c-format
-msgid "object %s is not a blob"
-msgstr "Objekt %s ist kein Blob"
-
-#: merge-recursive.c:3040
+#: merge-recursive.c:3069
 msgid "modify"
 msgstr "ändern"
 
-#: merge-recursive.c:3040
+#: merge-recursive.c:3069
 msgid "modified"
 msgstr "geändert"
 
-#: merge-recursive.c:3079
+#: merge-recursive.c:3108
 #, c-format
 msgid "Skipped %s (merged same as existing)"
 msgstr "%s ausgelassen (Ergebnis des Merges existiert bereits)"
 
-#: merge-recursive.c:3132
+#: merge-recursive.c:3161
 #, c-format
 msgid "Adding as %s instead"
 msgstr "Füge stattdessen als %s hinzu"
 
-#: merge-recursive.c:3339
+#: merge-recursive.c:3368
 #, c-format
 msgid "Removing %s"
 msgstr "Entferne %s"
 
-#: merge-recursive.c:3362
+#: merge-recursive.c:3391
 msgid "file/directory"
 msgstr "Datei/Verzeichnis"
 
-#: merge-recursive.c:3367
+#: merge-recursive.c:3396
 msgid "directory/file"
 msgstr "Verzeichnis/Datei"
 
-#: merge-recursive.c:3374
+#: merge-recursive.c:3403
 #, c-format
 msgid "CONFLICT (%s): There is a directory with name %s in %s. Adding %s as %s"
 msgstr ""
 "KONFLIKT (%s): Es existiert bereits ein Verzeichnis %s in %s. Füge %s als %s "
 "hinzu."
 
-#: merge-recursive.c:3383
+#: merge-recursive.c:3412
 #, c-format
 msgid "Adding %s"
 msgstr "Füge %s hinzu"
 
-#: merge-recursive.c:3392
+#: merge-recursive.c:3421
 #, c-format
 msgid "CONFLICT (add/add): Merge conflict in %s"
 msgstr "KONFLIKT (hinzufügen/hinzufügen): Merge-Konflikt in %s"
 
-#: merge-recursive.c:3445
+#: merge-recursive.c:3474
 #, c-format
 msgid "merging of trees %s and %s failed"
 msgstr "Zusammenführen der \"Tree\"-Objekte %s und %s fehlgeschlagen"
 
-#: merge-recursive.c:3539
+#: merge-recursive.c:3568
 msgid "Merging:"
 msgstr "Merge:"
 
-#: merge-recursive.c:3552
+#: merge-recursive.c:3581
 #, c-format
 msgid "found %u common ancestor:"
 msgid_plural "found %u common ancestors:"
 msgstr[0] "%u gemeinsamen Vorgänger-Commit gefunden"
 msgstr[1] "%u gemeinsame Vorgänger-Commits gefunden"
 
-#: merge-recursive.c:3602
+#: merge-recursive.c:3631
 msgid "merge returned no commit"
 msgstr "Merge hat keinen Commit zurückgegeben"
 
-#: merge-recursive.c:3758
+#: merge-recursive.c:3796
 #, c-format
 msgid "Could not parse object '%s'"
 msgstr "Konnte Objekt '%s' nicht parsen."
 
-#: merge-recursive.c:3776 builtin/merge.c:712 builtin/merge.c:896
-#: builtin/stash.c:471
+#: merge-recursive.c:3814 builtin/merge.c:716 builtin/merge.c:900
+#: builtin/stash.c:473
 msgid "Unable to write index."
 msgstr "Konnte Index nicht schreiben."
 
@@ -5242,110 +5292,131 @@ msgstr "Konnte Index nicht schreiben."
 msgid "failed to read the cache"
 msgstr "Lesen des Zwischenspeichers fehlgeschlagen"
 
-#: merge.c:109 rerere.c:704 builtin/am.c:1883 builtin/am.c:1917
-#: builtin/checkout.c:575 builtin/checkout.c:828 builtin/clone.c:817
-#: builtin/stash.c:265
+#: merge.c:109 rerere.c:704 builtin/am.c:1931 builtin/am.c:1965
+#: builtin/checkout.c:595 builtin/checkout.c:849 builtin/clone.c:821
+#: builtin/stash.c:267
 msgid "unable to write new index file"
 msgstr "Konnte neue Index-Datei nicht schreiben."
 
-#: midx.c:62
+#: midx.c:74
 msgid "multi-pack-index OID fanout is of the wrong size"
 msgstr "multi-pack-index OID fanout hat die falsche Größe"
 
-#: midx.c:93
+#: midx.c:105
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "multi-pack-index-Datei %s ist zu klein."
 
-#: midx.c:109
+#: midx.c:121
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr ""
 "multi-pack-index-Signatur 0x%08x stimmt nicht mit Signatur 0x%08x überein."
 
-#: midx.c:114
+#: midx.c:126
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "multi-pack-index-Version %d nicht erkannt."
 
-#: midx.c:119
+#: midx.c:131
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr "multi-pack-index Hash-Version %u stimmt nicht mit Version %u überein"
 
-#: midx.c:136
+#: midx.c:148
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "multi-pack-index fehlt erforderlicher Pack-Namen Chunk"
 
-#: midx.c:138
+#: midx.c:150
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "multi-pack-index fehlt erforderlicher OID fanout Chunk"
 
-#: midx.c:140
+#: midx.c:152
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr "multi-pack-index fehlt erforderlicher OID lookup Chunk"
 
-#: midx.c:142
+#: midx.c:154
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr "multi-pack-index fehlt erforderlicher Objekt offset Chunk"
 
-#: midx.c:158
+#: midx.c:170
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr "Falsche Reihenfolge bei multi-pack-index Pack-Namen: '%s' vor '%s'"
 
-#: midx.c:202
+#: midx.c:214
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr "Ungültige pack-int-id: %u (%u Pakete insgesamt)"
 
-#: midx.c:252
+#: midx.c:264
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr ""
 "multi-pack-index speichert einen 64-Bit Offset, aber off_t ist zu klein"
 
-#: midx.c:467
+#: midx.c:490
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "Fehler beim Hinzufügen von Packdatei '%s'"
 
-#: midx.c:473
+#: midx.c:496
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "Fehler beim Öffnen von pack-index '%s'"
 
-#: midx.c:533
+#: midx.c:564
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "Fehler beim Lokalisieren von Objekt %d in Packdatei"
 
-#: midx.c:821
+#: midx.c:880 builtin/index-pack.c:1535
+msgid "cannot store reverse index file"
+msgstr "kann Reverse-Index-Datei nicht speichern"
+
+#: midx.c:933
 msgid "Adding packfiles to multi-pack-index"
 msgstr "Packdateien zum multi-pack-index hinzufügen"
 
-#: midx.c:855
+#: midx.c:979
 #, c-format
 msgid "did not see pack-file %s to drop"
 msgstr "Pack-Datei %s zum Weglassen nicht gefunden"
 
-#: midx.c:904
+#: midx.c:1024
+#, fuzzy, c-format
+msgid "unknown preferred pack: '%s'"
+msgstr "Unbekanntes Rebase-Backend: %s"
+
+#: midx.c:1029
+#, fuzzy, c-format
+msgid "preferred pack '%s' is expired"
+msgstr ""
+"Referenziertes Repository '%s' ist mit künstlichen Vorgängern (\"grafts\") "
+"eingehängt."
+
+#: midx.c:1045
 msgid "no pack files to index."
 msgstr "keine Packdateien zum Indizieren."
 
-#: midx.c:965
+#: midx.c:1125 builtin/clean.c:37
+#, c-format
+msgid "failed to remove %s"
+msgstr "Fehler beim Löschen von %s"
+
+#: midx.c:1156
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "Fehler beim Löschen des multi-pack-index bei %s"
 
-#: midx.c:1021
+#: midx.c:1214
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr "multi-pack-index-Datei existiert, aber das Parsen schlug fehl"
 
-#: midx.c:1029
+#: midx.c:1222
 msgid "Looking for referenced packfiles"
 msgstr "Suche nach referenzierten Pack-Dateien"
 
-#: midx.c:1044
+#: midx.c:1237
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
@@ -5353,69 +5424,69 @@ msgstr ""
 "Ungültige oid fanout Reihenfolge: fanout[%d] = %<PRIx32> > %<PRIx32> = "
 "fanout[%d]"
 
-#: midx.c:1049
+#: midx.c:1242
 msgid "the midx contains no oid"
 msgstr "das midx enthält keine oid"
 
-#: midx.c:1058
+#: midx.c:1251
 msgid "Verifying OID order in multi-pack-index"
 msgstr "Verifiziere OID-Reihenfolge im multi-pack-index"
 
-#: midx.c:1067
+#: midx.c:1260
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr "Ungültige oid lookup Reihenfolge: oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1087
+#: midx.c:1280
 msgid "Sorting objects by packfile"
 msgstr "Sortiere Objekte nach Pack-Datei"
 
-#: midx.c:1094
+#: midx.c:1287
 msgid "Verifying object offsets"
 msgstr "Überprüfe Objekt-Offsets"
 
-#: midx.c:1110
+#: midx.c:1303
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "Fehler beim Laden des Pack-Eintrags für oid[%d] = %s"
 
-#: midx.c:1116
+#: midx.c:1309
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "Fehler beim Laden des Pack-Index für Packdatei %s"
 
-#: midx.c:1125
+#: midx.c:1318
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr "Falscher Objekt-Offset für oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#: midx.c:1150
+#: midx.c:1343
 msgid "Counting referenced objects"
 msgstr "Referenzierte Objekte zählen"
 
-#: midx.c:1160
+#: midx.c:1353
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "Suchen und Löschen von unreferenzierten Pack-Dateien"
 
-#: midx.c:1351
+#: midx.c:1544
 msgid "could not start pack-objects"
 msgstr "Konnte 'pack-objects' nicht ausführen"
 
-#: midx.c:1371
+#: midx.c:1564
 msgid "could not finish pack-objects"
 msgstr "Konnte 'pack-objects' nicht beenden"
 
-#: name-hash.c:538
+#: name-hash.c:542
 #, c-format
 msgid "unable to create lazy_dir thread: %s"
 msgstr "Kann lazy_dir Thread nicht erzeugen: %s"
 
-#: name-hash.c:560
+#: name-hash.c:564
 #, c-format
 msgid "unable to create lazy_name thread: %s"
 msgstr "Kann lazy_name Thread nicht erzeugen: %s"
 
-#: name-hash.c:566
+#: name-hash.c:570
 #, c-format
 msgid "unable to join lazy_name thread: %s"
 msgstr "Kann lazy_name Thread nicht beitreten: %s"
@@ -5465,264 +5536,264 @@ msgstr ""
 msgid "Bad %s value: '%s'"
 msgstr "Ungültiger %s Wert: '%s'"
 
-#: object-file.c:480
+#: object-file.c:526
 #, c-format
 msgid "object directory %s does not exist; check .git/objects/info/alternates"
 msgstr ""
 "Objektverzeichnis %s existiert nicht; prüfe .git/objects/info/alternates"
 
-#: object-file.c:531
+#: object-file.c:577
 #, c-format
 msgid "unable to normalize alternate object path: %s"
 msgstr "Konnte alternativen Objektpfad '%s' nicht normalisieren."
 
-#: object-file.c:603
+#: object-file.c:649
 #, c-format
 msgid "%s: ignoring alternate object stores, nesting too deep"
 msgstr "%s: ignoriere alternative Objektspeicher - Verschachtelung zu tief"
 
-#: object-file.c:610
+#: object-file.c:656
 #, c-format
 msgid "unable to normalize object directory: %s"
 msgstr "Konnte Objektverzeichnis '%s' nicht normalisieren."
 
-#: object-file.c:653
+#: object-file.c:699
 msgid "unable to fdopen alternates lockfile"
 msgstr "Konnte fdopen nicht auf Lock-Datei für \"alternates\" aufrufen."
 
-#: object-file.c:671
+#: object-file.c:717
 msgid "unable to read alternates file"
 msgstr "Konnte \"alternates\"-Datei nicht lesen."
 
-#: object-file.c:678
+#: object-file.c:724
 msgid "unable to move new alternates file into place"
 msgstr "Konnte neue \"alternates\"-Datei nicht übernehmen."
 
-#: object-file.c:713
+#: object-file.c:759
 #, c-format
 msgid "path '%s' does not exist"
 msgstr "Pfad '%s' existiert nicht"
 
-#: object-file.c:734
+#: object-file.c:780
 #, c-format
 msgid "reference repository '%s' as a linked checkout is not supported yet."
 msgstr ""
 "Referenziertes Repository '%s' wird noch nicht als verknüpftes\n"
 "Arbeitsverzeichnis unterstützt."
 
-#: object-file.c:740
+#: object-file.c:786
 #, c-format
 msgid "reference repository '%s' is not a local repository."
 msgstr "Referenziertes Repository '%s' ist kein lokales Repository."
 
-#: object-file.c:746
+#: object-file.c:792
 #, c-format
 msgid "reference repository '%s' is shallow"
 msgstr ""
 "Referenziertes Repository '%s' hat eine unvollständige Historie (shallow)."
 
-#: object-file.c:754
+#: object-file.c:800
 #, c-format
 msgid "reference repository '%s' is grafted"
 msgstr ""
 "Referenziertes Repository '%s' ist mit künstlichen Vorgängern (\"grafts\") "
 "eingehängt."
 
-#: object-file.c:814
+#: object-file.c:860
 #, c-format
 msgid "invalid line while parsing alternate refs: %s"
 msgstr "Ungültige Zeile beim Parsen alternativer Referenzen: %s"
 
-#: object-file.c:964
+#: object-file.c:1010
 #, c-format
 msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
 msgstr "Versuche mmap %<PRIuMAX> über Limit %<PRIuMAX>."
 
-#: object-file.c:985
+#: object-file.c:1031
 msgid "mmap failed"
 msgstr "mmap fehlgeschlagen"
 
-#: object-file.c:1149
+#: object-file.c:1195
 #, c-format
 msgid "object file %s is empty"
 msgstr "Objektdatei %s ist leer."
 
-#: object-file.c:1284 object-file.c:2477
+#: object-file.c:1330 object-file.c:2524
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr "Fehlerhaftes loses Objekt '%s'."
 
-#: object-file.c:1286 object-file.c:2481
+#: object-file.c:1332 object-file.c:2528
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr "Nutzlose Daten am Ende von losem Objekt '%s'."
 
-#: object-file.c:1328
+#: object-file.c:1374
 msgid "invalid object type"
 msgstr "ungültiger Objekt-Typ"
 
-#: object-file.c:1412
+#: object-file.c:1458
 #, c-format
 msgid "unable to unpack %s header with --allow-unknown-type"
 msgstr "Konnte %s Kopfbereich nicht mit --allow-unknown-type entpacken."
 
-#: object-file.c:1415
+#: object-file.c:1461
 #, c-format
 msgid "unable to unpack %s header"
 msgstr "Konnte %s Kopfbereich nicht entpacken."
 
-#: object-file.c:1421
+#: object-file.c:1467
 #, c-format
 msgid "unable to parse %s header with --allow-unknown-type"
 msgstr "Konnte %s Kopfbereich mit --allow-unknown-type nicht parsen."
 
-#: object-file.c:1424
+#: object-file.c:1470
 #, c-format
 msgid "unable to parse %s header"
 msgstr "Konnte %s Kopfbereich nicht parsen."
 
-#: object-file.c:1651
+#: object-file.c:1697
 #, c-format
 msgid "failed to read object %s"
 msgstr "Konnte Objekt %s nicht lesen."
 
-#: object-file.c:1655
+#: object-file.c:1701
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr "Ersetzung %s für %s nicht gefunden."
 
-#: object-file.c:1659
+#: object-file.c:1705
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr "Loses Objekt %s (gespeichert in %s) ist beschädigt."
 
-#: object-file.c:1663
+#: object-file.c:1709
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr "Gepacktes Objekt %s (gespeichert in %s) ist beschädigt."
 
-#: object-file.c:1768
+#: object-file.c:1814
 #, c-format
 msgid "unable to write file %s"
 msgstr "Konnte Datei %s nicht schreiben."
 
-#: object-file.c:1775
+#: object-file.c:1821
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr "Konnte Zugriffsberechtigung auf '%s' nicht setzen."
 
-#: object-file.c:1782
+#: object-file.c:1828
 msgid "file write error"
 msgstr "Fehler beim Schreiben einer Datei."
 
-#: object-file.c:1802
+#: object-file.c:1848
 msgid "error when closing loose object file"
 msgstr "Fehler beim Schließen der Datei für lose Objekte."
 
-#: object-file.c:1867
+#: object-file.c:1913
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 "Unzureichende Berechtigung zum Hinzufügen eines Objektes zur Repository-"
 "Datenbank %s"
 
-#: object-file.c:1869
+#: object-file.c:1915
 msgid "unable to create temporary file"
 msgstr "Konnte temporäre Datei nicht erstellen."
 
-#: object-file.c:1893
+#: object-file.c:1939
 msgid "unable to write loose object file"
 msgstr "Fehler beim Schreiben der Datei für lose Objekte."
 
-#: object-file.c:1899
+#: object-file.c:1945
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr "Konnte neues Objekt %s (%d) nicht komprimieren."
 
-#: object-file.c:1903
+#: object-file.c:1949
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr "deflateEnd auf Objekt %s fehlgeschlagen (%d)"
 
-#: object-file.c:1907
+#: object-file.c:1953
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr "Fehler wegen instabilen Objektquelldaten für %s"
 
-#: object-file.c:1917 builtin/pack-objects.c:1097
+#: object-file.c:1963 builtin/pack-objects.c:1097
 #, c-format
 msgid "failed utime() on %s"
 msgstr "Fehler beim Aufruf von utime() auf '%s'."
 
-#: object-file.c:1994
+#: object-file.c:2040
 #, c-format
 msgid "cannot read object for %s"
 msgstr "Kann Objekt für %s nicht lesen."
 
-#: object-file.c:2045
+#: object-file.c:2091
 msgid "corrupt commit"
 msgstr "fehlerhafter Commit"
 
-#: object-file.c:2053
+#: object-file.c:2099
 msgid "corrupt tag"
 msgstr "fehlerhaftes Tag"
 
-#: object-file.c:2153
+#: object-file.c:2199
 #, c-format
 msgid "read error while indexing %s"
 msgstr "Lesefehler beim Indizieren von '%s'."
 
-#: object-file.c:2156
+#: object-file.c:2202
 #, c-format
 msgid "short read while indexing %s"
 msgstr "read() zu kurz beim Indizieren von '%s'."
 
-#: object-file.c:2229 object-file.c:2239
+#: object-file.c:2275 object-file.c:2285
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr "%s: Fehler beim Einfügen in die Datenbank"
 
-#: object-file.c:2245
+#: object-file.c:2291
 #, c-format
 msgid "%s: unsupported file type"
 msgstr "%s: nicht unterstützte Dateiart"
 
-#: object-file.c:2269
+#: object-file.c:2315
 #, c-format
 msgid "%s is not a valid object"
 msgstr "%s ist kein gültiges Objekt"
 
-#: object-file.c:2271
+#: object-file.c:2317
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr "%s ist kein gültiges '%s' Objekt"
 
-#: object-file.c:2298 builtin/index-pack.c:192
+#: object-file.c:2344 builtin/index-pack.c:192
 #, c-format
 msgid "unable to open %s"
 msgstr "kann %s nicht öffnen"
 
-#: object-file.c:2488 object-file.c:2541
+#: object-file.c:2535 object-file.c:2588
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
 msgstr "Hash für %s stimmt nicht überein (%s erwartet)."
 
-#: object-file.c:2512
+#: object-file.c:2559
 #, c-format
 msgid "unable to mmap %s"
 msgstr "Konnte mmap nicht auf %s ausführen."
 
-#: object-file.c:2517
+#: object-file.c:2564
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr "Konnte Kopfbereich von %s nicht entpacken."
 
-#: object-file.c:2523
+#: object-file.c:2570
 #, c-format
 msgid "unable to parse header of %s"
 msgstr "Konnte Kopfbereich von %s nicht parsen."
 
-#: object-file.c:2534
+#: object-file.c:2581
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr "Konnte Inhalt von %s nicht entpacken."
@@ -5839,72 +5910,72 @@ msgstr "Ungültiger Objekttyp \"%s\""
 msgid "object %s is a %s, not a %s"
 msgstr "Objekt %s ist ein %s, kein %s"
 
-#: object.c:233
+#: object.c:232
 #, c-format
 msgid "object %s has unknown type id %d"
 msgstr "Objekt %s hat eine unbekannte Typ-Identifikation %d"
 
-#: object.c:246
+#: object.c:245
 #, c-format
 msgid "unable to parse object: %s"
 msgstr "Konnte Objekt '%s' nicht parsen."
 
-#: object.c:266 object.c:278
+#: object.c:265 object.c:277
 #, c-format
 msgid "hash mismatch %s"
 msgstr "Hash stimmt nicht mit %s überein."
 
-#: pack-bitmap.c:843 pack-bitmap.c:849 builtin/pack-objects.c:2226
+#: pack-bitmap.c:844 pack-bitmap.c:850 builtin/pack-objects.c:2251
 #, c-format
 msgid "unable to get size of %s"
 msgstr "Konnte Größe von %s nicht bestimmen."
 
-#: pack-bitmap.c:1489 builtin/rev-list.c:92
+#: pack-bitmap.c:1547 builtin/rev-list.c:92
 #, c-format
 msgid "unable to get disk usage of %s"
 msgstr "konnte Festplattennutzung von %s nicht bekommen"
 
-#: pack-revindex.c:220
+#: pack-revindex.c:221
 #, c-format
 msgid "reverse-index file %s is too small"
 msgstr "Reverse-Index-Datei %s ist zu klein"
 
-#: pack-revindex.c:225
+#: pack-revindex.c:226
 #, c-format
 msgid "reverse-index file %s is corrupt"
 msgstr "Reverse-Index-Datei %s ist beschädigt"
 
-#: pack-revindex.c:233
+#: pack-revindex.c:234
 #, c-format
 msgid "reverse-index file %s has unknown signature"
 msgstr "Reverse-Index-Datei %s hat eine unbekannte Signatur"
 
-#: pack-revindex.c:237
+#: pack-revindex.c:238
 #, c-format
 msgid "reverse-index file %s has unsupported version %<PRIu32>"
 msgstr "Reverse-Index-Datei %s hat nicht unterstützte Version %<PRIu32>"
 
-#: pack-revindex.c:242
+#: pack-revindex.c:243
 #, c-format
 msgid "reverse-index file %s has unsupported hash id %<PRIu32>"
 msgstr "Reverse-Index-Datei %s hat nicht unterstützte Hash-ID %<PRIu32>"
 
-#: pack-write.c:236
+#: pack-write.c:250
 msgid "cannot both write and verify reverse index"
 msgstr ""
 "Reverse-Index kann nicht gleichzeitig geschrieben und verifiziert werden"
 
-#: pack-write.c:257
+#: pack-write.c:271
 #, c-format
 msgid "could not stat: %s"
 msgstr "konnte nicht lesen: %s"
 
-#: pack-write.c:269
+#: pack-write.c:283
 #, c-format
 msgid "failed to make %s readable"
 msgstr "Fehler beim lesbar machen von %s"
 
-#: pack-write.c:508
+#: pack-write.c:522
 #, c-format
 msgid "could not write '%s' promisor file"
 msgstr "konnte Promisor-Datei '%s' nicht schreiben"
@@ -5913,12 +5984,12 @@ msgstr "konnte Promisor-Datei '%s' nicht schreiben"
 msgid "offset before end of packfile (broken .idx?)"
 msgstr "Offset vor Ende der Packdatei (fehlerhafte Indexdatei?)"
 
-#: packfile.c:1934
+#: packfile.c:1937
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr "Offset vor Beginn des Pack-Index für %s (beschädigter Index?)"
 
-#: packfile.c:1938
+#: packfile.c:1941
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr "Offset hinter Ende des Pack-Index für %s (abgeschnittener Index?)"
@@ -5985,31 +6056,31 @@ msgstr "Mehrdeutige Option: %s (kann --%s%s oder --%s%s sein)"
 msgid "did you mean `--%s` (with two dashes)?"
 msgstr "Meinten Sie `--%s` (mit zwei Strichen)?"
 
-#: parse-options.c:666 parse-options.c:971
+#: parse-options.c:668 parse-options.c:988
 #, c-format
 msgid "alias of --%s"
 msgstr "Alias für --%s"
 
-#: parse-options.c:862
+#: parse-options.c:879
 #, c-format
 msgid "unknown option `%s'"
 msgstr "Unbekannte Option: `%s'"
 
-#: parse-options.c:864
+#: parse-options.c:881
 #, c-format
 msgid "unknown switch `%c'"
 msgstr "Unbekannter Schalter `%c'"
 
-#: parse-options.c:866
+#: parse-options.c:883
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
 msgstr "Unbekannte nicht-Ascii Option in String: `%s'"
 
-#: parse-options.c:890
+#: parse-options.c:907
 msgid "..."
 msgstr "..."
 
-#: parse-options.c:909
+#: parse-options.c:926
 #, c-format
 msgid "usage: %s"
 msgstr "Verwendung: %s"
@@ -6017,17 +6088,17 @@ msgstr "Verwendung: %s"
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
 #.
-#: parse-options.c:915
+#: parse-options.c:932
 #, c-format
 msgid "   or: %s"
 msgstr "      oder: %s"
 
-#: parse-options.c:918
+#: parse-options.c:935
 #, c-format
 msgid "    %s"
 msgstr "    %s"
 
-#: parse-options.c:957
+#: parse-options.c:974
 msgid "-NUM"
 msgstr "-NUM"
 
@@ -6036,30 +6107,30 @@ msgstr "-NUM"
 msgid "Could not make %s writable by group"
 msgstr "Konnte Gruppenschreibrecht für %s nicht setzen."
 
-#: pathspec.c:130
+#: pathspec.c:151
 msgid "Escape character '\\' not allowed as last character in attr value"
 msgstr "Escape-Zeichen '\\' als letztes Zeichen in Attributwert nicht erlaubt"
 
-#: pathspec.c:148
+#: pathspec.c:169
 msgid "Only one 'attr:' specification is allowed."
 msgstr "Es ist nur eine Angabe von 'attr:' erlaubt."
 
-#: pathspec.c:151
+#: pathspec.c:172
 msgid "attr spec must not be empty"
 msgstr "Angabe von 'attr:' darf nicht leer sein"
 
-#: pathspec.c:194
+#: pathspec.c:215
 #, c-format
 msgid "invalid attribute name %s"
 msgstr "Ungültiger Attributname %s"
 
-#: pathspec.c:259
+#: pathspec.c:280
 msgid "global 'glob' and 'noglob' pathspec settings are incompatible"
 msgstr ""
 "Globale Einstellungen zur Pfadspezifikation 'glob' und 'noglob' sind "
 "inkompatibel."
 
-#: pathspec.c:266
+#: pathspec.c:287
 msgid ""
 "global 'literal' pathspec setting is incompatible with all other global "
 "pathspec settings"
@@ -6067,52 +6138,52 @@ msgstr ""
 "Globale Einstellung zur Pfadspezifikation 'literal' ist inkompatibel\n"
 "mit allen anderen Optionen."
 
-#: pathspec.c:306
+#: pathspec.c:327
 msgid "invalid parameter for pathspec magic 'prefix'"
 msgstr "ungültiger Parameter für Pfadspezifikationsangabe 'prefix'"
 
-#: pathspec.c:327
+#: pathspec.c:348
 #, c-format
 msgid "Invalid pathspec magic '%.*s' in '%s'"
 msgstr "ungültige Pfadspezifikationsangabe '%.*s' in '%s'"
 
-#: pathspec.c:332
+#: pathspec.c:353
 #, c-format
 msgid "Missing ')' at the end of pathspec magic in '%s'"
 msgstr "Fehlendes ')' am Ende der Pfadspezifikationsangabe in '%s'"
 
-#: pathspec.c:370
+#: pathspec.c:391
 #, c-format
 msgid "Unimplemented pathspec magic '%c' in '%s'"
 msgstr "nicht unterstützte Pfadspezifikationsangabe '%c' in '%s'"
 
-#: pathspec.c:429
+#: pathspec.c:450
 #, c-format
 msgid "%s: 'literal' and 'glob' are incompatible"
 msgstr "%s: 'literal' und 'glob' sind inkompatibel"
 
-#: pathspec.c:445
+#: pathspec.c:466
 #, c-format
 msgid "%s: '%s' is outside repository at '%s'"
 msgstr "%s: '%s' liegt außerhalb des Repositories von '%s'"
 
-#: pathspec.c:521
+#: pathspec.c:542
 #, c-format
 msgid "'%s' (mnemonic: '%c')"
 msgstr "'%s' (Kürzel: '%c')"
 
-#: pathspec.c:531
+#: pathspec.c:552
 #, c-format
 msgid "%s: pathspec magic not supported by this command: %s"
 msgstr ""
 "%s: Pfadspezifikationsangabe wird von diesem Befehl nicht unterstützt: %s"
 
-#: pathspec.c:598
+#: pathspec.c:619
 #, c-format
 msgid "pathspec '%s' is beyond a symbolic link"
 msgstr "Pfadspezifikation '%s' ist hinter einer symbolischen Verknüpfung"
 
-#: pathspec.c:643
+#: pathspec.c:664
 #, c-format
 msgid "line is badly quoted: %s"
 msgstr "Zeile enthält falsche Anführungszeichen: %s"
@@ -6133,7 +6204,7 @@ msgstr "konnte zustandsloses Separator-Paket nicht schreiben"
 msgid "flush packet write failed"
 msgstr "Flush beim Schreiben des Pakets fehlgeschlagen."
 
-#: pkt-line.c:153 pkt-line.c:239
+#: pkt-line.c:153 pkt-line.c:265
 msgid "protocol error: impossibly long line"
 msgstr "Protokollfehler: unmöglich lange Zeile"
 
@@ -6141,34 +6212,35 @@ msgstr "Protokollfehler: unmöglich lange Zeile"
 msgid "packet write with format failed"
 msgstr "Schreiben des Pakets mit Format fehlgeschlagen."
 
-#: pkt-line.c:203
+#: pkt-line.c:204
 msgid "packet write failed - data exceeds max packet size"
 msgstr ""
 "Schreiben des Pakets fehlgeschlagen - Daten überschreiten maximale Paketgröße"
 
-#: pkt-line.c:210 pkt-line.c:217
-msgid "packet write failed"
+#: pkt-line.c:222
+#, fuzzy, c-format
+msgid "packet write failed: %s"
 msgstr "Schreiben des Pakets fehlgeschlagen."
 
-#: pkt-line.c:302
+#: pkt-line.c:328 pkt-line.c:329
 msgid "read error"
 msgstr "Lesefehler"
 
-#: pkt-line.c:310
+#: pkt-line.c:339 pkt-line.c:340
 msgid "the remote end hung up unexpectedly"
 msgstr "Die Gegenseite hat unerwartet abgebrochen."
 
-#: pkt-line.c:338
+#: pkt-line.c:369 pkt-line.c:371
 #, c-format
 msgid "protocol error: bad line length character: %.4s"
 msgstr "Protokollfehler: ungültiges Zeichen für Zeilenlänge: %.4s"
 
-#: pkt-line.c:352 pkt-line.c:357
+#: pkt-line.c:386 pkt-line.c:388 pkt-line.c:394 pkt-line.c:396
 #, c-format
 msgid "protocol error: bad line length %d"
 msgstr "Protokollfehler: ungültige Zeilenlänge %d"
 
-#: pkt-line.c:373 sideband.c:165
+#: pkt-line.c:413 sideband.c:165
 #, c-format
 msgid "remote error: %s"
 msgstr "Fehler am anderen Ende: %s"
@@ -6182,7 +6254,7 @@ msgstr "Aktualisiere Index"
 msgid "unable to create threaded lstat: %s"
 msgstr "Kann Thread für lstat nicht erzeugen: %s"
 
-#: pretty.c:984
+#: pretty.c:988
 msgid "unable to parse --pretty format"
 msgstr "Konnte --pretty Format nicht parsen."
 
@@ -6205,6 +6277,11 @@ msgstr ""
 msgid "promisor remote name cannot begin with '/': %s"
 msgstr "Promisor-Remote-Name kann nicht mit '/' beginnen: %s"
 
+#: protocol-caps.c:103
+#, fuzzy
+msgid "object-info: expected flush after arguments"
+msgstr "erwartete Flush nach Abrufen der Argumente"
+
 #: prune-packed.c:35
 msgid "Removing duplicate objects"
 msgstr "Lösche doppelte Objekte"
@@ -6217,7 +6294,7 @@ msgstr "Konnte `log` nicht starten."
 msgid "could not read `log` output"
 msgstr "Konnte Ausgabe von `log` nicht lesen."
 
-#: range-diff.c:101 sequencer.c:5318
+#: range-diff.c:101 sequencer.c:5551
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr "Konnte Commit '%s' nicht parsen."
@@ -6249,53 +6326,53 @@ msgstr "--left-only und --right-only schließen sich gegenseitig aus"
 msgid "could not parse log for '%s'"
 msgstr "Konnte Log für '%s' nicht parsen."
 
-#: read-cache.c:682
+#: read-cache.c:708
 #, c-format
 msgid "will not add file alias '%s' ('%s' already exists in index)"
 msgstr ""
 "Dateialias '%s' wird nicht hinzugefügt ('%s' existiert bereits im Index)."
 
-#: read-cache.c:698
+#: read-cache.c:724
 msgid "cannot create an empty blob in the object database"
 msgstr "Kann keinen leeren Blob in die Objektdatenbank schreiben."
 
-#: read-cache.c:720
+#: read-cache.c:746
 #, c-format
 msgid "%s: can only add regular files, symbolic links or git-directories"
 msgstr ""
 "%s: Kann nur reguläre Dateien, symbolische Links oder Git-Verzeichnisse "
 "hinzufügen."
 
-#: read-cache.c:725
+#: read-cache.c:751
 #, c-format
 msgid "'%s' does not have a commit checked out"
 msgstr "'%s' hat keinen Commit ausgecheckt"
 
-#: read-cache.c:777
+#: read-cache.c:803
 #, c-format
 msgid "unable to index file '%s'"
 msgstr "Konnte Datei '%s' nicht indizieren."
 
-#: read-cache.c:796
+#: read-cache.c:822
 #, c-format
 msgid "unable to add '%s' to index"
 msgstr "Konnte '%s' nicht dem Index hinzufügen."
 
-#: read-cache.c:807
+#: read-cache.c:833
 #, c-format
 msgid "unable to stat '%s'"
 msgstr "konnte '%s' nicht lesen"
 
-#: read-cache.c:1318
+#: read-cache.c:1356
 #, c-format
 msgid "'%s' appears as both a file and as a directory"
 msgstr "'%s' scheint eine Datei und ein Verzeichnis zu sein"
 
-#: read-cache.c:1532
+#: read-cache.c:1571
 msgid "Refresh index"
 msgstr "Aktualisiere Index"
 
-#: read-cache.c:1657
+#: read-cache.c:1700
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -6304,7 +6381,7 @@ msgstr ""
 "index.version gesetzt, aber Wert ungültig.\n"
 "Verwende Version %i"
 
-#: read-cache.c:1667
+#: read-cache.c:1710
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -6313,139 +6390,144 @@ msgstr ""
 "GIT_INDEX_VERSION gesetzt, aber Wert ungültig.\n"
 "Verwende Version %i"
 
-#: read-cache.c:1723
+#: read-cache.c:1766
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr "Ungültige Signatur 0x%08x"
 
-#: read-cache.c:1726
+#: read-cache.c:1769
 #, c-format
 msgid "bad index version %d"
 msgstr "Ungültige Index-Version %d"
 
-#: read-cache.c:1735
+#: read-cache.c:1778
 msgid "bad index file sha1 signature"
 msgstr "Ungültige SHA1-Signatur der Index-Datei."
 
-#: read-cache.c:1765
+#: read-cache.c:1812
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr "Index verwendet Erweiterung %.4s, welche wir nicht unterstützen."
 
-#: read-cache.c:1767
+#: read-cache.c:1814
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr "Ignoriere Erweiterung %.4s"
 
-#: read-cache.c:1804
+#: read-cache.c:1851
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr "Unbekanntes Format für Index-Eintrag 0x%08x"
 
-#: read-cache.c:1820
+#: read-cache.c:1867
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "Ungültiges Namensfeld im Index, in der Nähe von Pfad '%s'."
 
-#: read-cache.c:1877
+#: read-cache.c:1924
 msgid "unordered stage entries in index"
 msgstr "Ungeordnete Stage-Einträge im Index."
 
-#: read-cache.c:1880
+#: read-cache.c:1927
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr "Mehrere Stage-Einträge für zusammengeführte Datei '%s'."
 
-#: read-cache.c:1883
+#: read-cache.c:1930
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr "Ungeordnete Stage-Einträge für '%s'."
 
-#: read-cache.c:1989 read-cache.c:2280 rerere.c:549 rerere.c:583 rerere.c:1095
-#: submodule.c:1634 builtin/add.c:546 builtin/check-ignore.c:181
-#: builtin/checkout.c:504 builtin/checkout.c:690 builtin/clean.c:991
-#: builtin/commit.c:364 builtin/diff-tree.c:122 builtin/grep.c:505
-#: builtin/mv.c:146 builtin/reset.c:247 builtin/rm.c:290
+#: read-cache.c:2036 read-cache.c:2333 rerere.c:549 rerere.c:583 rerere.c:1095
+#: submodule.c:1635 builtin/add.c:575 builtin/check-ignore.c:183
+#: builtin/checkout.c:522 builtin/checkout.c:711 builtin/clean.c:991
+#: builtin/commit.c:377 builtin/diff-tree.c:122 builtin/grep.c:505
+#: builtin/mv.c:146 builtin/reset.c:247 builtin/rm.c:291
 #: builtin/submodule--helper.c:332
 msgid "index file corrupt"
 msgstr "Index-Datei beschädigt"
 
-#: read-cache.c:2133
+#: read-cache.c:2180
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr "Kann Thread für load_cache_entries nicht erzeugen: %s"
 
-#: read-cache.c:2146
+#: read-cache.c:2193
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr "Kann Thread für load_cache_entries nicht erzeugen: %s"
 
-#: read-cache.c:2179
+#: read-cache.c:2226
 #, c-format
 msgid "%s: index file open failed"
 msgstr "%s: Öffnen der Index-Datei fehlgeschlagen."
 
-#: read-cache.c:2183
+#: read-cache.c:2230
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr "%s: Kann geöffneten Index nicht lesen."
 
-#: read-cache.c:2187
+#: read-cache.c:2234
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr "%s: Index-Datei ist kleiner als erwartet."
 
-#: read-cache.c:2191
+#: read-cache.c:2238
 #, c-format
 msgid "%s: unable to map index file"
 msgstr "%s: Konnte Index-Datei nicht einlesen."
 
-#: read-cache.c:2233
+#: read-cache.c:2280
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr "Kann Thread für load_index_extensions nicht erzeugen: %s"
 
-#: read-cache.c:2260
+#: read-cache.c:2307
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr "Kann Thread für load_index_extensions nicht beitreten: %s"
 
-#: read-cache.c:2292
+#: read-cache.c:2345
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr "Konnte geteilten Index '%s' nicht aktualisieren."
 
-#: read-cache.c:2339
+#: read-cache.c:2392
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr "Fehlerhafter Index. Erwartete %s in %s, erhielt %s."
 
-#: read-cache.c:3035 strbuf.c:1171 wrapper.c:633 builtin/merge.c:1141
+#: read-cache.c:3095 strbuf.c:1173 wrapper.c:633 builtin/merge.c:1145
 #, c-format
 msgid "could not close '%s'"
 msgstr "Konnte '%s' nicht schließen."
 
-#: read-cache.c:3138 sequencer.c:2487 sequencer.c:4239
+#: read-cache.c:3138
+#, fuzzy
+msgid "failed to convert to a sparse-index"
+msgstr "Fehler beim Bereinigen des Index"
+
+#: read-cache.c:3209 sequencer.c:2684 sequencer.c:4441
 #, c-format
 msgid "could not stat '%s'"
 msgstr "Konnte '%s' nicht lesen."
 
-#: read-cache.c:3151
+#: read-cache.c:3222
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "konnte Git-Verzeichnis nicht öffnen: %s"
 
-#: read-cache.c:3163
+#: read-cache.c:3234
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "Konnte '%s' nicht entfernen."
 
-#: read-cache.c:3188
+#: read-cache.c:3263
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr "Konnte Zugriffsberechtigung auf '%s' nicht setzen."
 
-#: read-cache.c:3337
+#: read-cache.c:3412
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr "%s: Kann nicht auf Stufe #0 wechseln."
@@ -6469,6 +6551,7 @@ msgstr ""
 "Ignoriere."
 
 #: rebase-interactive.c:42
+#, fuzzy
 msgid ""
 "\n"
 "Commands:\n"
@@ -6476,7 +6559,10 @@ msgid ""
 "r, reword <commit> = use commit, but edit the commit message\n"
 "e, edit <commit> = use commit, but stop for amending\n"
 "s, squash <commit> = use commit, but meld into previous commit\n"
-"f, fixup <commit> = like \"squash\", but discard this commit's log message\n"
+"f, fixup [-C | -c] <commit> = like \"squash\" but keep only the previous\n"
+"                   commit's log message, unless -C is used, in which case\n"
+"                   keep only this commit's message; -c is same as -C but\n"
+"                   opens the editor\n"
 "x, exec <command> = run command (the rest of the line) using shell\n"
 "b, break = stop here (continue rebase later with 'git rebase --continue')\n"
 "d, drop <commit> = remove commit\n"
@@ -6485,7 +6571,7 @@ msgid ""
 "m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
 ".       create a merge commit using the original merge commit's\n"
 ".       message (or the oneline, if no original merge commit was\n"
-".       specified). Use -c <commit> to reword the commit message.\n"
+".       specified); use -c <commit> to reword the commit message\n"
 "\n"
 "These lines can be re-ordered; they are executed from top to bottom.\n"
 msgstr ""
@@ -6513,14 +6599,14 @@ msgstr ""
 "Diese Zeilen können umsortiert werden; Sie werden von oben nach unten\n"
 "ausgeführt.\n"
 
-#: rebase-interactive.c:63
+#: rebase-interactive.c:66
 #, c-format
 msgid "Rebase %s onto %s (%d command)"
 msgid_plural "Rebase %s onto %s (%d commands)"
 msgstr[0] "Rebase von %s auf %s (%d Kommando)"
 msgstr[1] "Rebase von %s auf %s (%d Kommandos)"
 
-#: rebase-interactive.c:72 git-rebase--preserve-merges.sh:218
+#: rebase-interactive.c:75 git-rebase--preserve-merges.sh:218
 msgid ""
 "\n"
 "Do not remove any line. Use 'drop' explicitly to remove a commit.\n"
@@ -6529,7 +6615,7 @@ msgstr ""
 "Keine Zeile entfernen. Benutzen Sie 'drop', um explizit einen Commit zu\n"
 "entfernen.\n"
 
-#: rebase-interactive.c:75 git-rebase--preserve-merges.sh:222
+#: rebase-interactive.c:78 git-rebase--preserve-merges.sh:222
 msgid ""
 "\n"
 "If you remove a line here THAT COMMIT WILL BE LOST.\n"
@@ -6537,7 +6623,7 @@ msgstr ""
 "\n"
 "Wenn Sie hier eine Zeile entfernen, wird DIESER COMMIT VERLOREN GEHEN.\n"
 
-#: rebase-interactive.c:81 git-rebase--preserve-merges.sh:861
+#: rebase-interactive.c:84 git-rebase--preserve-merges.sh:861
 msgid ""
 "\n"
 "You are editing the todo file of an ongoing interactive rebase.\n"
@@ -6551,7 +6637,7 @@ msgstr ""
 "    git rebase --continue\n"
 "\n"
 
-#: rebase-interactive.c:86 git-rebase--preserve-merges.sh:938
+#: rebase-interactive.c:89 git-rebase--preserve-merges.sh:938
 msgid ""
 "\n"
 "However, if you remove everything, the rebase will be aborted.\n"
@@ -6561,19 +6647,19 @@ msgstr ""
 "Wenn Sie jedoch alles löschen, wird der Rebase abgebrochen.\n"
 "\n"
 
-#: rebase-interactive.c:110 rerere.c:469 rerere.c:676 sequencer.c:3615
-#: sequencer.c:3641 sequencer.c:5424 builtin/fsck.c:329 builtin/rebase.c:272
+#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3816
+#: sequencer.c:3842 sequencer.c:5657 builtin/fsck.c:327 builtin/rebase.c:271
 #, c-format
 msgid "could not write '%s'"
 msgstr "Konnte '%s' nicht schreiben."
 
-#: rebase-interactive.c:116 builtin/rebase.c:204 builtin/rebase.c:230
-#: builtin/rebase.c:254
+#: rebase-interactive.c:119 builtin/rebase.c:203 builtin/rebase.c:229
+#: builtin/rebase.c:253
 #, c-format
 msgid "could not write '%s'."
 msgstr "Konnte '%s' nicht schreiben."
 
-#: rebase-interactive.c:193
+#: rebase-interactive.c:196
 #, c-format
 msgid ""
 "Warning: some commits may have been dropped accidentally.\n"
@@ -6582,7 +6668,7 @@ msgstr ""
 "Warnung: Einige Commits könnten aus Versehen entfernt worden sein.\n"
 "Entfernte Commits (neu zu alt):\n"
 
-#: rebase-interactive.c:200
+#: rebase-interactive.c:203
 #, c-format
 msgid ""
 "To avoid this message, use \"drop\" to explicitly remove a commit.\n"
@@ -6599,14 +6685,14 @@ msgstr ""
 "Warnungen zu ändern.\n"
 "Die möglichen Verhaltensweisen sind: ignore, warn, error.\n"
 
-#: rebase-interactive.c:233 rebase-interactive.c:238 sequencer.c:2402
-#: builtin/rebase.c:190 builtin/rebase.c:215 builtin/rebase.c:241
-#: builtin/rebase.c:266
+#: rebase-interactive.c:236 rebase-interactive.c:241 sequencer.c:2597
+#: builtin/rebase.c:189 builtin/rebase.c:214 builtin/rebase.c:240
+#: builtin/rebase.c:265
 #, c-format
 msgid "could not read '%s'."
 msgstr "Konnte '%s' nicht lesen."
 
-#: ref-filter.c:42 wt-status.c:1975
+#: ref-filter.c:42 wt-status.c:1978
 msgid "gone"
 msgstr "entfernt"
 
@@ -6762,111 +6848,111 @@ msgstr ""
 msgid "format: %%(if) atom used without a %%(then) atom"
 msgstr "format: %%(if) Atom ohne ein %%(then) Atom verwendet"
 
-#: ref-filter.c:806
+#: ref-filter.c:807
 #, c-format
 msgid "format: %%(then) atom used without an %%(if) atom"
 msgstr "format: %%(then) Atom ohne ein %%(if) Atom verwendet"
 
-#: ref-filter.c:808
+#: ref-filter.c:809
 #, c-format
 msgid "format: %%(then) atom used more than once"
 msgstr "format: %%(then) Atom mehr als einmal verwendet"
 
-#: ref-filter.c:810
+#: ref-filter.c:811
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr "format: %%(then) Atom nach %%(else) verwendet"
 
-#: ref-filter.c:838
+#: ref-filter.c:839
 #, c-format
 msgid "format: %%(else) atom used without an %%(if) atom"
 msgstr "format: %%(else) Atom ohne ein %%(if) Atom verwendet"
 
-#: ref-filter.c:840
+#: ref-filter.c:841
 #, c-format
 msgid "format: %%(else) atom used without a %%(then) atom"
 msgstr "Format: %%(else) Atom ohne ein %%(then) Atom verwendet"
 
-#: ref-filter.c:842
+#: ref-filter.c:843
 #, c-format
 msgid "format: %%(else) atom used more than once"
 msgstr "Format: %%(end) Atom mehr als einmal verwendet"
 
-#: ref-filter.c:857
+#: ref-filter.c:858
 #, c-format
 msgid "format: %%(end) atom used without corresponding atom"
 msgstr "Format: %%(end) Atom ohne zugehöriges Atom verwendet"
 
-#: ref-filter.c:914
+#: ref-filter.c:915
 #, c-format
 msgid "malformed format string %s"
 msgstr "Fehlerhafter Formatierungsstring %s"
 
-#: ref-filter.c:1555
+#: ref-filter.c:1556
 #, c-format
 msgid "(no branch, rebasing %s)"
 msgstr "(kein Branch, Rebase von %s)"
 
-#: ref-filter.c:1558
+#: ref-filter.c:1559
 #, c-format
 msgid "(no branch, rebasing detached HEAD %s)"
 msgstr "(kein Branch, Rebase von losgelöstem HEAD %s)"
 
-#: ref-filter.c:1561
+#: ref-filter.c:1562
 #, c-format
 msgid "(no branch, bisect started on %s)"
 msgstr "(kein Branch, binäre Suche begonnen bei %s)"
 
-#: ref-filter.c:1565
+#: ref-filter.c:1566
 #, c-format
 msgid "(HEAD detached at %s)"
 msgstr "(HEAD losgelöst bei %s)"
 
-#: ref-filter.c:1568
+#: ref-filter.c:1569
 #, c-format
 msgid "(HEAD detached from %s)"
 msgstr "(HEAD losgelöst von %s)"
 
-#: ref-filter.c:1571
+#: ref-filter.c:1572
 msgid "(no branch)"
 msgstr "(kein Branch)"
 
-#: ref-filter.c:1603 ref-filter.c:1812
+#: ref-filter.c:1604 ref-filter.c:1813
 #, c-format
 msgid "missing object %s for %s"
 msgstr "Objekt %s fehlt für %s"
 
-#: ref-filter.c:1613
+#: ref-filter.c:1614
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr "parse_object_buffer bei %s für %s fehlgeschlagen"
 
-#: ref-filter.c:1996
+#: ref-filter.c:1997
 #, c-format
 msgid "malformed object at '%s'"
 msgstr "fehlerhaftes Objekt bei '%s'"
 
-#: ref-filter.c:2085
+#: ref-filter.c:2086
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr "Ignoriere Referenz mit fehlerhaftem Namen %s"
 
-#: ref-filter.c:2090 refs.c:676
+#: ref-filter.c:2091 refs.c:676
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "Ignoriere fehlerhafte Referenz %s"
 
-#: ref-filter.c:2430
+#: ref-filter.c:2431
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "Format: %%(end) Atom fehlt"
 
-#: ref-filter.c:2529
+#: ref-filter.c:2525
 #, c-format
 msgid "malformed object name %s"
 msgstr "missgebildeter Objektname %s"
 
-#: ref-filter.c:2534
+#: ref-filter.c:2530
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "die Option `%s' muss auf einen Commit zeigen"
@@ -7338,8 +7424,8 @@ msgstr "Kann '%s' nicht löschen."
 msgid "Recorded preimage for '%s'"
 msgstr "Preimage für '%s' aufgezeichnet."
 
-#: rerere.c:865 submodule.c:2088 builtin/log.c:1991
-#: builtin/submodule--helper.c:1878 builtin/submodule--helper.c:1890
+#: rerere.c:865 submodule.c:2089 builtin/log.c:2000
+#: builtin/submodule--helper.c:1879 builtin/submodule--helper.c:1891
 #, c-format
 msgid "could not create directory '%s'"
 msgstr "Konnte Verzeichnis '%s' nicht erstellen."
@@ -7377,25 +7463,25 @@ msgstr "Konnte rr-cache Verzeichnis nicht öffnen."
 msgid "could not determine HEAD revision"
 msgstr "Konnte HEAD-Commit nicht bestimmen."
 
-#: reset.c:70 reset.c:76 sequencer.c:3468
+#: reset.c:70 reset.c:76 sequencer.c:3669
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "Fehler beim Finden des \"Tree\"-Objektes von %s."
 
-#: revision.c:2338
+#: revision.c:2343
 msgid "--unpacked=<packfile> no longer supported"
 msgstr "--unpacked=<Pack-Datei> wird nicht länger unterstützt"
 
-#: revision.c:2668
+#: revision.c:2683
 msgid "your current branch appears to be broken"
 msgstr "Ihr aktueller Branch scheint fehlerhaft zu sein."
 
-#: revision.c:2671
+#: revision.c:2686
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
 msgstr "Ihr aktueller Branch '%s' hat noch keine Commits."
 
-#: revision.c:2877
+#: revision.c:2892
 msgid "-L does not yet support diff formats besides -p and -s"
 msgstr "-L unterstützt noch keine anderen Diff-Formate außer -p und -s"
 
@@ -7403,12 +7489,12 @@ msgstr "-L unterstützt noch keine anderen Diff-Formate außer -p und -s"
 msgid "open /dev/null failed"
 msgstr "Öffnen von /dev/null fehlgeschlagen"
 
-#: run-command.c:1274
+#: run-command.c:1275
 #, c-format
 msgid "cannot create async thread: %s"
 msgstr "Konnte Thread für async nicht erzeugen: %s"
 
-#: run-command.c:1338
+#: run-command.c:1345
 #, c-format
 msgid ""
 "The '%s' hook was ignored because it's not set as executable.\n"
@@ -7418,35 +7504,44 @@ msgstr ""
 "Sie können diese Warnung mit `git config advice.ignoredHook false` "
 "deaktivieren."
 
-#: send-pack.c:146
+#: send-pack.c:150
 msgid "unexpected flush packet while reading remote unpack status"
 msgstr "Unerwartetes Flush-Paket beim Lesen des Remote-Unpack-Status."
 
-#: send-pack.c:148
+#: send-pack.c:152
 #, c-format
 msgid "unable to parse remote unpack status: %s"
 msgstr "Konnte Status des Entpackens der Gegenseite nicht parsen: %s"
 
-#: send-pack.c:150
+#: send-pack.c:154
 #, c-format
 msgid "remote unpack failed: %s"
 msgstr "Entpacken auf der Gegenseite fehlgeschlagen: %s"
 
-#: send-pack.c:374
+#: send-pack.c:378
 msgid "failed to sign the push certificate"
 msgstr "Fehler beim Signieren des \"push\"-Zertifikates"
 
-#: send-pack.c:467
+#: send-pack.c:433
+#, fuzzy
+msgid "send-pack: unable to fork off fetch subprocess"
+msgstr "Promisor-Remote: konnte Fetch-Subprozess nicht abspalten"
+
+#: send-pack.c:455
+msgid "push negotiation failed; proceeding anyway with push"
+msgstr ""
+
+#: send-pack.c:520
 msgid "the receiving end does not support this repository's hash algorithm"
 msgstr ""
 "die Gegenseite unterstützt nicht den Hash-Algorithmus dieses Repositories"
 
-#: send-pack.c:476
+#: send-pack.c:529
 msgid "the receiving end does not support --signed push"
 msgstr ""
 "die Gegenseite unterstützt keinen signierten Versand (\"--signed push\")"
 
-#: send-pack.c:478
+#: send-pack.c:531
 msgid ""
 "not sending a push certificate since the receiving end does not support --"
 "signed push"
@@ -7454,47 +7549,47 @@ msgstr ""
 "kein Versand des \"push\"-Zertifikates, da die Gegenseite keinen signierten\n"
 "Versand (\"--signed push\") unterstützt"
 
-#: send-pack.c:490
+#: send-pack.c:543
 msgid "the receiving end does not support --atomic push"
 msgstr "die Gegenseite unterstützt keinen atomaren Versand (\"--atomic push\")"
 
-#: send-pack.c:495
+#: send-pack.c:548
 msgid "the receiving end does not support push options"
 msgstr "die Gegenseite unterstützt keine Push-Optionen"
 
-#: sequencer.c:195
+#: sequencer.c:196
 #, c-format
 msgid "invalid commit message cleanup mode '%s'"
 msgstr "Ungültiger \"cleanup\"-Modus '%s' für Commit-Beschreibungen."
 
-#: sequencer.c:323
+#: sequencer.c:324
 #, c-format
 msgid "could not delete '%s'"
 msgstr "Konnte '%s' nicht löschen."
 
-#: sequencer.c:343 builtin/rebase.c:757 builtin/rebase.c:1602 builtin/rm.c:385
+#: sequencer.c:344 builtin/rebase.c:757 builtin/rebase.c:1592 builtin/rm.c:402
 #, c-format
 msgid "could not remove '%s'"
 msgstr "Konnte '%s' nicht löschen"
 
-#: sequencer.c:353
+#: sequencer.c:354
 msgid "revert"
 msgstr "Revert"
 
-#: sequencer.c:355
+#: sequencer.c:356
 msgid "cherry-pick"
 msgstr "Cherry-Pick"
 
-#: sequencer.c:357
+#: sequencer.c:358
 msgid "rebase"
 msgstr "Rebase"
 
-#: sequencer.c:359
+#: sequencer.c:360
 #, c-format
 msgid "unknown action: %d"
 msgstr "Unbekannte Aktion: %d"
 
-#: sequencer.c:418
+#: sequencer.c:419
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'"
@@ -7502,7 +7597,7 @@ msgstr ""
 "nach Auflösung der Konflikte markieren Sie die korrigierten Pfade\n"
 "mit 'git add <Pfade>' oder 'git rm <Pfade>'"
 
-#: sequencer.c:421
+#: sequencer.c:422
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'\n"
@@ -7512,44 +7607,44 @@ msgstr ""
 "mit 'git add <Pfade>' oder 'git rm <Pfade>' und tragen Sie das Ergebnis mit\n"
 "'git commit' ein"
 
-#: sequencer.c:434 sequencer.c:3070
+#: sequencer.c:435 sequencer.c:3271
 #, c-format
 msgid "could not lock '%s'"
 msgstr "Konnte '%s' nicht sperren"
 
-#: sequencer.c:436 sequencer.c:2869 sequencer.c:3074 sequencer.c:3088
-#: sequencer.c:3345 sequencer.c:5334 strbuf.c:1168 wrapper.c:631
+#: sequencer.c:437 sequencer.c:3070 sequencer.c:3275 sequencer.c:3289
+#: sequencer.c:3546 sequencer.c:5567 strbuf.c:1170 wrapper.c:631
 #, c-format
 msgid "could not write to '%s'"
 msgstr "Konnte nicht nach '%s' schreiben."
 
-#: sequencer.c:441
+#: sequencer.c:442
 #, c-format
 msgid "could not write eol to '%s'"
 msgstr "Konnte EOL nicht nach '%s' schreiben."
 
-#: sequencer.c:446 sequencer.c:2874 sequencer.c:3076 sequencer.c:3090
-#: sequencer.c:3353
+#: sequencer.c:447 sequencer.c:3075 sequencer.c:3277 sequencer.c:3291
+#: sequencer.c:3554
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "Fehler beim Fertigstellen von '%s'."
 
-#: sequencer.c:485
+#: sequencer.c:486
 #, c-format
 msgid "your local changes would be overwritten by %s."
 msgstr "Ihre lokalen Änderungen würden durch den %s überschrieben werden."
 
-#: sequencer.c:489
+#: sequencer.c:490
 msgid "commit your changes or stash them to proceed."
 msgstr ""
 "Committen Sie Ihre Änderungen oder benutzen Sie \"stash\", um fortzufahren."
 
-#: sequencer.c:521
+#: sequencer.c:522
 #, c-format
 msgid "%s: fast-forward"
 msgstr "%s: Vorspulen"
 
-#: sequencer.c:560 builtin/tag.c:598
+#: sequencer.c:561 builtin/tag.c:609
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Ungültiger \"cleanup\" Modus %s"
@@ -7557,65 +7652,65 @@ msgstr "Ungültiger \"cleanup\" Modus %s"
 #. TRANSLATORS: %s will be "revert", "cherry-pick" or
 #. "rebase".
 #.
-#: sequencer.c:670
+#: sequencer.c:671
 #, c-format
 msgid "%s: Unable to write new index file"
 msgstr "%s: Konnte neue Index-Datei nicht schreiben"
 
-#: sequencer.c:684
+#: sequencer.c:685
 msgid "unable to update cache tree"
 msgstr "Konnte Cache-Verzeichnis nicht aktualisieren."
 
-#: sequencer.c:698
+#: sequencer.c:699
 msgid "could not resolve HEAD commit"
 msgstr "Konnte HEAD-Commit nicht auflösen."
 
-#: sequencer.c:778
+#: sequencer.c:779
 #, c-format
 msgid "no key present in '%.*s'"
 msgstr "Kein Schlüssel in '%.*s' vorhanden."
 
-#: sequencer.c:789
+#: sequencer.c:790
 #, c-format
 msgid "unable to dequote value of '%s'"
 msgstr "Konnte Anführungszeichen von '%s' nicht entfernen."
 
-#: sequencer.c:826 wrapper.c:201 wrapper.c:371 builtin/am.c:710
-#: builtin/am.c:802 builtin/merge.c:1136 builtin/rebase.c:910
+#: sequencer.c:827 wrapper.c:201 wrapper.c:371 builtin/am.c:728
+#: builtin/am.c:820 builtin/merge.c:1140 builtin/rebase.c:910
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "Konnte '%s' nicht zum Lesen öffnen."
 
-#: sequencer.c:836
+#: sequencer.c:837
 msgid "'GIT_AUTHOR_NAME' already given"
 msgstr "'GIT_AUTHOR_NAME' bereits angegeben."
 
-#: sequencer.c:841
+#: sequencer.c:842
 msgid "'GIT_AUTHOR_EMAIL' already given"
 msgstr "'GIT_AUTHOR_EMAIL' bereits angegeben."
 
-#: sequencer.c:846
+#: sequencer.c:847
 msgid "'GIT_AUTHOR_DATE' already given"
 msgstr "'GIT_AUTHOR_DATE' bereits angegeben."
 
-#: sequencer.c:850
+#: sequencer.c:851
 #, c-format
 msgid "unknown variable '%s'"
 msgstr "Unbekannte Variable '%s'"
 
-#: sequencer.c:855
+#: sequencer.c:856
 msgid "missing 'GIT_AUTHOR_NAME'"
 msgstr "'GIT_AUTHOR_NAME' fehlt."
 
-#: sequencer.c:857
+#: sequencer.c:858
 msgid "missing 'GIT_AUTHOR_EMAIL'"
 msgstr "'GIT_AUTHOR_EMAIL' fehlt."
 
-#: sequencer.c:859
+#: sequencer.c:860
 msgid "missing 'GIT_AUTHOR_DATE'"
 msgstr "'GIT_AUTHOR_DATE' fehlt."
 
-#: sequencer.c:924
+#: sequencer.c:925
 #, c-format
 msgid ""
 "you have staged changes in your working tree\n"
@@ -7646,11 +7741,11 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:1211
+#: sequencer.c:1212
 msgid "'prepare-commit-msg' hook failed"
 msgstr "'prepare-commit-msg' Hook fehlgeschlagen."
 
-#: sequencer.c:1217
+#: sequencer.c:1218
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7678,7 +7773,7 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1230
+#: sequencer.c:1231
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7704,340 +7799,345 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1272
+#: sequencer.c:1273
 msgid "couldn't look up newly created commit"
 msgstr "Konnte neu erstellten Commit nicht nachschlagen."
 
-#: sequencer.c:1274
+#: sequencer.c:1275
 msgid "could not parse newly created commit"
 msgstr "Konnte neu erstellten Commit nicht analysieren."
 
-#: sequencer.c:1320
+#: sequencer.c:1321
 msgid "unable to resolve HEAD after creating commit"
 msgstr "Konnte HEAD nicht auflösen, nachdem der Commit erstellt wurde."
 
-#: sequencer.c:1322
+#: sequencer.c:1323
 msgid "detached HEAD"
 msgstr "losgelöster HEAD"
 
-#: sequencer.c:1326
+#: sequencer.c:1327
 msgid " (root-commit)"
 msgstr " (Root-Commit)"
 
-#: sequencer.c:1347
+#: sequencer.c:1348
 msgid "could not parse HEAD"
 msgstr "Konnte HEAD nicht parsen."
 
-#: sequencer.c:1349
+#: sequencer.c:1350
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "HEAD %s ist kein Commit!"
 
-#: sequencer.c:1353 sequencer.c:1431 builtin/commit.c:1577
+#: sequencer.c:1354 sequencer.c:1432 builtin/commit.c:1692
 msgid "could not parse HEAD commit"
 msgstr "Konnte Commit von HEAD nicht analysieren."
 
-#: sequencer.c:1409 sequencer.c:2108
+#: sequencer.c:1410 sequencer.c:2295
 msgid "unable to parse commit author"
 msgstr "Konnte Commit-Autor nicht parsen."
 
-#: sequencer.c:1420 builtin/am.c:1566 builtin/merge.c:702
+#: sequencer.c:1421 builtin/am.c:1614 builtin/merge.c:706
 msgid "git write-tree failed to write a tree"
 msgstr "\"git write-tree\" schlug beim Schreiben eines \"Tree\"-Objektes fehl"
 
-#: sequencer.c:1453 sequencer.c:1573
+#: sequencer.c:1454 sequencer.c:1574
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "Konnte Commit-Beschreibung von '%s' nicht lesen."
 
-#: sequencer.c:1484 sequencer.c:1516
+#: sequencer.c:1485 sequencer.c:1517
 #, c-format
 msgid "invalid author identity '%s'"
 msgstr "ungültige Autor-Identität '%s'"
 
-#: sequencer.c:1490
+#: sequencer.c:1491
 msgid "corrupt author: missing date information"
 msgstr "unbrauchbarer Autor: Datumsinformationen fehlen"
 
-#: sequencer.c:1529 builtin/am.c:1593 builtin/commit.c:1678 builtin/merge.c:905
-#: builtin/merge.c:930 t/helper/test-fast-rebase.c:78
+#: sequencer.c:1530 builtin/am.c:1641 builtin/commit.c:1806 builtin/merge.c:909
+#: builtin/merge.c:934 t/helper/test-fast-rebase.c:78
 msgid "failed to write commit object"
 msgstr "Fehler beim Schreiben des Commit-Objektes."
 
-#: sequencer.c:1556 sequencer.c:4291 t/helper/test-fast-rebase.c:198
+#: sequencer.c:1557 sequencer.c:4493 t/helper/test-fast-rebase.c:198
 #, c-format
 msgid "could not update %s"
 msgstr "Konnte %s nicht aktualisieren."
 
-#: sequencer.c:1605
+#: sequencer.c:1606
 #, c-format
 msgid "could not parse commit %s"
 msgstr "Konnte Commit %s nicht parsen."
 
-#: sequencer.c:1610
+#: sequencer.c:1611
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "Konnte Eltern-Commit %s nicht parsen."
 
-#: sequencer.c:1693 sequencer.c:1804
+#: sequencer.c:1694 sequencer.c:1975
 #, c-format
 msgid "unknown command: %d"
 msgstr "Unbekannter Befehl: %d"
 
-#: sequencer.c:1751 sequencer.c:1776
-#, c-format
-msgid "This is a combination of %d commits."
-msgstr "Das ist eine Kombination aus %d Commits."
-
-#: sequencer.c:1761
-msgid "need a HEAD to fixup"
-msgstr "benötige HEAD für fixup"
-
-#: sequencer.c:1763 sequencer.c:3380
-msgid "could not read HEAD"
-msgstr "Konnte HEAD nicht lesen"
-
-#: sequencer.c:1765
-msgid "could not read HEAD's commit message"
-msgstr "Konnte Commit-Beschreibung von HEAD nicht lesen"
-
-#: sequencer.c:1771
-#, c-format
-msgid "cannot write '%s'"
-msgstr "kann '%s' nicht schreiben"
-
-#: sequencer.c:1778 git-rebase--preserve-merges.sh:486
+#: sequencer.c:1736 git-rebase--preserve-merges.sh:486
 msgid "This is the 1st commit message:"
 msgstr "Das ist die erste Commit-Beschreibung:"
 
-#: sequencer.c:1786
-#, c-format
-msgid "could not read commit message of %s"
-msgstr "Konnte Commit-Beschreibung von %s nicht lesen."
-
-#: sequencer.c:1793
+#: sequencer.c:1737
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "Das ist Commit-Beschreibung #%d:"
 
-#: sequencer.c:1799
+#: sequencer.c:1738
+#, fuzzy
+msgid "The 1st commit message will be skipped:"
+msgstr "Die Commit-Beschreibung #%d wird ausgelassen:"
+
+#: sequencer.c:1739
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "Die Commit-Beschreibung #%d wird ausgelassen:"
 
-#: sequencer.c:1887
+#: sequencer.c:1740
+#, c-format
+msgid "This is a combination of %d commits."
+msgstr "Das ist eine Kombination aus %d Commits."
+
+#: sequencer.c:1887 sequencer.c:1944
+#, c-format
+msgid "cannot write '%s'"
+msgstr "kann '%s' nicht schreiben"
+
+#: sequencer.c:1934
+msgid "need a HEAD to fixup"
+msgstr "benötige HEAD für fixup"
+
+#: sequencer.c:1936 sequencer.c:3581
+msgid "could not read HEAD"
+msgstr "Konnte HEAD nicht lesen"
+
+#: sequencer.c:1938
+msgid "could not read HEAD's commit message"
+msgstr "Konnte Commit-Beschreibung von HEAD nicht lesen"
+
+#: sequencer.c:1962
+#, c-format
+msgid "could not read commit message of %s"
+msgstr "Konnte Commit-Beschreibung von %s nicht lesen."
+
+#: sequencer.c:2072
 msgid "your index file is unmerged."
 msgstr "Ihre Index-Datei ist nicht zusammengeführt."
 
-#: sequencer.c:1894
+#: sequencer.c:2079
 msgid "cannot fixup root commit"
 msgstr "kann fixup nicht auf Root-Commit anwenden"
 
-#: sequencer.c:1913
+#: sequencer.c:2098
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "Commit %s ist ein Merge, aber die Option -m wurde nicht angegeben."
 
-#: sequencer.c:1921 sequencer.c:1929
+#: sequencer.c:2106 sequencer.c:2114
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "Commit %s hat keinen Eltern-Commit %d"
 
-#: sequencer.c:1935
+#: sequencer.c:2120
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "Kann keine Commit-Beschreibung für %s bekommen."
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:1954
+#: sequencer.c:2139
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: kann Eltern-Commit %s nicht parsen"
 
-#: sequencer.c:2019
+#: sequencer.c:2205
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "Konnte '%s' nicht zu '%s' umbenennen."
 
-#: sequencer.c:2079
+#: sequencer.c:2265
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "Konnte \"revert\" nicht auf %s... (%s) ausführen"
 
-#: sequencer.c:2080
+#: sequencer.c:2266
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "Konnte %s... (%s) nicht anwenden"
 
-#: sequencer.c:2100
+#: sequencer.c:2287
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr "Weglassen von %s %s -- Patch-Inhalte sind bereits im Upstream-Branch\n"
 
-#: sequencer.c:2158
+#: sequencer.c:2345
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: Fehler beim Lesen des Index"
 
-#: sequencer.c:2165
+#: sequencer.c:2352
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: Fehler beim Aktualisieren des Index"
 
-#: sequencer.c:2242
+#: sequencer.c:2425
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "%s akzeptiert keine Argumente: '%s'"
 
-#: sequencer.c:2251
+#: sequencer.c:2434
 #, c-format
 msgid "missing arguments for %s"
 msgstr "Fehlende Argumente für %s."
 
-#: sequencer.c:2282
+#: sequencer.c:2477
 #, c-format
 msgid "could not parse '%s'"
 msgstr "Konnte '%s' nicht parsen."
 
-#: sequencer.c:2343
+#: sequencer.c:2538
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "Ungültige Zeile %d: %.*s"
 
-#: sequencer.c:2354
+#: sequencer.c:2549
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "Kann '%s' nicht ohne vorherigen Commit ausführen"
 
-#: sequencer.c:2440
+#: sequencer.c:2635
 msgid "cancelling a cherry picking in progress"
 msgstr "Abbrechen eines laufenden \"cherry-pick\""
 
-#: sequencer.c:2449
+#: sequencer.c:2644
 msgid "cancelling a revert in progress"
 msgstr "Abbrechen eines laufenden \"revert\""
 
-#: sequencer.c:2493
+#: sequencer.c:2690
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr ""
 "Bitte beheben Sie dieses, indem Sie 'git rebase --edit-todo' ausführen."
 
-#: sequencer.c:2495
+#: sequencer.c:2692
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "Unbenutzbares Instruktionsblatt: '%s'"
 
-#: sequencer.c:2500
+#: sequencer.c:2697
 msgid "no commits parsed."
 msgstr "Keine Commits geparst."
 
-#: sequencer.c:2511
+#: sequencer.c:2708
 msgid "cannot cherry-pick during a revert."
 msgstr "Kann Cherry-Pick nicht während eines Reverts ausführen."
 
-#: sequencer.c:2513
+#: sequencer.c:2710
 msgid "cannot revert during a cherry-pick."
 msgstr "Kann Revert nicht während eines Cherry-Picks ausführen."
 
-#: sequencer.c:2591
+#: sequencer.c:2788
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr "Ungültiger Wert für %s: %s"
 
-#: sequencer.c:2698
+#: sequencer.c:2897
 msgid "unusable squash-onto"
 msgstr "Unbenutzbares squash-onto."
 
-#: sequencer.c:2718
+#: sequencer.c:2917
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "Fehlerhaftes Optionsblatt: '%s'"
 
-#: sequencer.c:2811 sequencer.c:4644
+#: sequencer.c:3012 sequencer.c:4869
 msgid "empty commit set passed"
 msgstr "leere Menge von Commits übergeben"
 
-#: sequencer.c:2828
+#: sequencer.c:3029
 msgid "revert is already in progress"
 msgstr "\"revert\" ist bereits im Gange"
 
-#: sequencer.c:2830
+#: sequencer.c:3031
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr "Versuchen Sie \"git revert (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:2833
+#: sequencer.c:3034
 msgid "cherry-pick is already in progress"
 msgstr "\"cherry-pick\" wird bereits durchgeführt"
 
-#: sequencer.c:2835
+#: sequencer.c:3036
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr "Versuchen Sie \"git cherry-pick (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:2849
+#: sequencer.c:3050
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr "Konnte \"sequencer\"-Verzeichnis '%s' nicht erstellen."
 
-#: sequencer.c:2864
+#: sequencer.c:3065
 msgid "could not lock HEAD"
 msgstr "Konnte HEAD nicht sperren"
 
-#: sequencer.c:2924 sequencer.c:4379
+#: sequencer.c:3125 sequencer.c:4582
 msgid "no cherry-pick or revert in progress"
 msgstr "kein \"cherry-pick\" oder \"revert\" im Gange"
 
-#: sequencer.c:2926 sequencer.c:2937
+#: sequencer.c:3127 sequencer.c:3138
 msgid "cannot resolve HEAD"
 msgstr "kann HEAD nicht auflösen"
 
-#: sequencer.c:2928 sequencer.c:2972
+#: sequencer.c:3129 sequencer.c:3173
 msgid "cannot abort from a branch yet to be born"
 msgstr "kann nicht abbrechen: bin auf einem Branch, der noch nicht geboren ist"
 
-#: sequencer.c:2958 builtin/grep.c:757
+#: sequencer.c:3159 builtin/grep.c:759
 #, c-format
 msgid "cannot open '%s'"
 msgstr "kann '%s' nicht öffnen"
 
-#: sequencer.c:2960
+#: sequencer.c:3161
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "Kann '%s' nicht lesen: %s"
 
-#: sequencer.c:2961
+#: sequencer.c:3162
 msgid "unexpected end of file"
 msgstr "Unerwartetes Dateiende"
 
-#: sequencer.c:2967
+#: sequencer.c:3168
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr "gespeicherte \"pre-cherry-pick\" HEAD Datei '%s' ist beschädigt"
 
-#: sequencer.c:2978
+#: sequencer.c:3179
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr ""
 "Sie scheinen HEAD verändert zu haben. Keine Rückspulung, prüfen Sie HEAD."
 
-#: sequencer.c:3019
+#: sequencer.c:3220
 msgid "no revert in progress"
 msgstr "Kein Revert im Gange"
 
-#: sequencer.c:3028
+#: sequencer.c:3229
 msgid "no cherry-pick in progress"
 msgstr "kein \"cherry-pick\" im Gange"
 
-#: sequencer.c:3038
+#: sequencer.c:3239
 msgid "failed to skip the commit"
 msgstr "Überspringen des Commits fehlgeschlagen"
 
-#: sequencer.c:3045
+#: sequencer.c:3246
 msgid "there is nothing to skip"
 msgstr "Nichts zum Überspringen vorhanden"
 
-#: sequencer.c:3048
+#: sequencer.c:3249
 #, c-format
 msgid ""
 "have you committed already?\n"
@@ -8046,16 +8146,16 @@ msgstr ""
 "Haben Sie bereits committet?\n"
 "Versuchen Sie \"git %s --continue\""
 
-#: sequencer.c:3210 sequencer.c:4271
+#: sequencer.c:3411 sequencer.c:4473
 msgid "cannot read HEAD"
 msgstr "Kann HEAD nicht lesen"
 
-#: sequencer.c:3227
+#: sequencer.c:3428
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "Konnte '%s' nicht nach '%s' kopieren."
 
-#: sequencer.c:3235
+#: sequencer.c:3436
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -8074,27 +8174,27 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:3245
+#: sequencer.c:3446
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "Konnte %s... (%.*s) nicht anwenden"
 
-#: sequencer.c:3252
+#: sequencer.c:3453
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "Konnte \"%.*s\" nicht zusammenführen."
 
-#: sequencer.c:3266 sequencer.c:3270 builtin/difftool.c:640
+#: sequencer.c:3467 sequencer.c:3471 builtin/difftool.c:644
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "Konnte '%s' nicht nach '%s' kopieren."
 
-#: sequencer.c:3282
+#: sequencer.c:3483
 #, c-format
 msgid "Executing: %s\n"
 msgstr "Führe aus: %s\n"
 
-#: sequencer.c:3297
+#: sequencer.c:3498
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -8110,11 +8210,11 @@ msgstr ""
 "\n"
 "ausführen.\n"
 
-#: sequencer.c:3303
+#: sequencer.c:3504
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "Der Index und/oder das Arbeitsverzeichnis wurde geändert.\n"
 
-#: sequencer.c:3309
+#: sequencer.c:3510
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -8132,91 +8232,91 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3370
+#: sequencer.c:3571
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "Unerlaubter Beschriftungsname: '%.*s'"
 
-#: sequencer.c:3424
+#: sequencer.c:3625
 msgid "writing fake root commit"
 msgstr "unechten Root-Commit schreiben"
 
-#: sequencer.c:3429
+#: sequencer.c:3630
 msgid "writing squash-onto"
 msgstr "squash-onto schreiben"
 
-#: sequencer.c:3513
+#: sequencer.c:3714
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "Konnte '%s' nicht auflösen."
 
-#: sequencer.c:3546
+#: sequencer.c:3747
 msgid "cannot merge without a current revision"
 msgstr "Kann nicht ohne einen aktuellen Commit mergen."
 
-#: sequencer.c:3568
+#: sequencer.c:3769
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "Konnte '%.*s' nicht parsen."
 
-#: sequencer.c:3577
+#: sequencer.c:3778
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "Nichts zum Zusammenführen: '%.*s'"
 
-#: sequencer.c:3589
+#: sequencer.c:3790
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr ""
 "Oktopus-Merge kann nicht auf Basis von [neuem Root-Commit] ausgeführt werden."
 
-#: sequencer.c:3605
+#: sequencer.c:3806
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "Konnte keine Commit-Beschreibung von '%s' bekommen."
 
-#: sequencer.c:3788
+#: sequencer.c:3989
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "Konnte nicht einmal versuchen '%.*s' zu mergen."
 
-#: sequencer.c:3804
+#: sequencer.c:4005
 msgid "merge: Unable to write new index file"
 msgstr "merge: Konnte neue Index-Datei nicht schreiben."
 
-#: sequencer.c:3878
+#: sequencer.c:4079
 msgid "Cannot autostash"
 msgstr "Kann automatischen Stash nicht erzeugen."
 
-#: sequencer.c:3881
+#: sequencer.c:4082
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Unerwartete 'stash'-Antwort: '%s'"
 
-#: sequencer.c:3887
+#: sequencer.c:4088
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "Konnte Verzeichnis für '%s' nicht erstellen."
 
-#: sequencer.c:3890
+#: sequencer.c:4091
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "Automatischen Stash erzeugt: %s\n"
 
-#: sequencer.c:3894
+#: sequencer.c:4095
 msgid "could not reset --hard"
 msgstr "Konnte 'reset --hard' nicht ausführen."
 
-#: sequencer.c:3919
+#: sequencer.c:4120
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "Automatischen Stash angewendet.\n"
 
-#: sequencer.c:3931
+#: sequencer.c:4132
 #, c-format
 msgid "cannot store %s"
 msgstr "kann %s nicht speichern"
 
-#: sequencer.c:3934
+#: sequencer.c:4135
 #, c-format
 msgid ""
 "%s\n"
@@ -8227,29 +8327,29 @@ msgstr ""
 "Ihre Änderungen sind im Stash sicher.\n"
 "Sie können jederzeit \"git stash pop\" oder \"git stash drop\" ausführen.\n"
 
-#: sequencer.c:3939
+#: sequencer.c:4140
 msgid "Applying autostash resulted in conflicts."
 msgstr "Beim Anwenden des automatischen Stash traten Konflikte auf."
 
-#: sequencer.c:3940
+#: sequencer.c:4141
 msgid "Autostash exists; creating a new stash entry."
 msgstr "Automatischer Stash existiert; ein neuer Stash-Eintrag wird erstellt."
 
-#: sequencer.c:4033 git-rebase--preserve-merges.sh:769
+#: sequencer.c:4234 git-rebase--preserve-merges.sh:769
 msgid "could not detach HEAD"
 msgstr "Konnte HEAD nicht loslösen"
 
-#: sequencer.c:4048
+#: sequencer.c:4249
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Angehalten bei HEAD\n"
 
-#: sequencer.c:4050
+#: sequencer.c:4251
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Angehalten bei %s\n"
 
-#: sequencer.c:4058
+#: sequencer.c:4259
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -8271,60 +8371,60 @@ msgstr ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:4104
+#: sequencer.c:4305
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr "Rebase (%d/%d)%s"
 
-#: sequencer.c:4149
+#: sequencer.c:4351
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Angehalten bei %s... %.*s\n"
 
-#: sequencer.c:4220
+#: sequencer.c:4422
 #, c-format
 msgid "unknown command %d"
 msgstr "Unbekannter Befehl %d"
 
-#: sequencer.c:4279
+#: sequencer.c:4481
 msgid "could not read orig-head"
 msgstr "Konnte orig-head nicht lesen."
 
-#: sequencer.c:4284
+#: sequencer.c:4486
 msgid "could not read 'onto'"
 msgstr "Konnte 'onto' nicht lesen."
 
-#: sequencer.c:4298
+#: sequencer.c:4500
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "Konnte HEAD nicht auf %s aktualisieren."
 
-#: sequencer.c:4358
+#: sequencer.c:4560
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr "Erfolgreich Rebase ausgeführt und %s aktualisiert.\n"
 
-#: sequencer.c:4391
+#: sequencer.c:4612
 msgid "cannot rebase: You have unstaged changes."
 msgstr ""
 "Rebase nicht möglich: Sie haben Änderungen, die nicht zum Commit\n"
 "vorgemerkt sind."
 
-#: sequencer.c:4400
+#: sequencer.c:4621
 msgid "cannot amend non-existing commit"
 msgstr "Kann nicht existierenden Commit nicht nachbessern."
 
-#: sequencer.c:4402
+#: sequencer.c:4623
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "Ungültige Datei: '%s'"
 
-#: sequencer.c:4404
+#: sequencer.c:4625
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "Ungültige Inhalte: '%s'"
 
-#: sequencer.c:4407
+#: sequencer.c:4628
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -8335,50 +8435,50 @@ msgstr ""
 "committen Sie diese zuerst und führen Sie dann 'git rebase --continue'\n"
 "erneut aus."
 
-#: sequencer.c:4443 sequencer.c:4482
+#: sequencer.c:4664 sequencer.c:4703
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "Konnte Datei nicht schreiben: '%s'"
 
-#: sequencer.c:4498
+#: sequencer.c:4719
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "Konnte CHERRY_PICK_HEAD nicht löschen."
 
-#: sequencer.c:4505
+#: sequencer.c:4726
 msgid "could not commit staged changes."
 msgstr "Konnte Änderungen aus der Staging-Area nicht committen."
 
-#: sequencer.c:4621
+#: sequencer.c:4846
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: %s kann nicht in \"cherry-pick\" benutzt werden"
 
-#: sequencer.c:4625
+#: sequencer.c:4850
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: ungültiger Commit"
 
-#: sequencer.c:4660
+#: sequencer.c:4885
 msgid "can't revert as initial commit"
 msgstr "Kann nicht als allerersten Commit einen Revert ausführen."
 
-#: sequencer.c:5137
+#: sequencer.c:5362
 msgid "make_script: unhandled options"
 msgstr "make_script: unbehandelte Optionen"
 
-#: sequencer.c:5140
+#: sequencer.c:5365
 msgid "make_script: error preparing revisions"
 msgstr "make_script: Fehler beim Vorbereiten der Commits"
 
-#: sequencer.c:5382 sequencer.c:5399
+#: sequencer.c:5615 sequencer.c:5632
 msgid "nothing to do"
 msgstr "Nichts zu tun."
 
-#: sequencer.c:5418
+#: sequencer.c:5651
 msgid "could not skip unnecessary pick commands"
 msgstr "Konnte unnötige \"pick\"-Befehle nicht auslassen."
 
-#: sequencer.c:5512
+#: sequencer.c:5751
 msgid "the script was already rearranged."
 msgstr "Das Script wurde bereits umgeordnet."
 
@@ -8526,7 +8626,7 @@ msgstr ""
 "%s)\n"
 "Stoppe bei Dateisystemgrenze (GIT_DISCOVERY_ACROSS_FILESYSTEM nicht gesetzt)."
 
-#: setup.c:1362
+#: setup.c:1370
 #, c-format
 msgid ""
 "problem with core.sharedRepository filemode value (0%.3o).\n"
@@ -8535,56 +8635,70 @@ msgstr ""
 "Problem mit Wert für Dateimodus (0%.3o) von core.sharedRepository.\n"
 "Der Besitzer der Dateien muss immer Lese- und Schreibrechte haben."
 
-#: setup.c:1409
+#: setup.c:1417
 msgid "open /dev/null or dup failed"
 msgstr "Öffnen von /dev/null oder dup fehlgeschlagen."
 
-#: setup.c:1424
+#: setup.c:1432
 msgid "fork failed"
 msgstr "fork fehlgeschlagen"
 
-#: setup.c:1429
+#: setup.c:1437 t/helper/test-simple-ipc.c:285
 msgid "setsid failed"
 msgstr "setsid fehlgeschlagen"
 
+#: sparse-index.c:151
+msgid "attempting to use sparse-index without cone mode"
+msgstr ""
+
+#: sparse-index.c:156
+#, fuzzy
+msgid "unable to update cache-tree, staying full"
+msgstr "Konnte Cache-Verzeichnis nicht aktualisieren."
+
+#: sparse-index.c:239
+#, c-format
+msgid "index entry is a directory, but not sparse (%08x)"
+msgstr ""
+
 #. TRANSLATORS: IEC 80000-13:2008 gibibyte
-#: strbuf.c:848
+#: strbuf.c:850
 #, c-format
 msgid "%u.%2.2u GiB"
 msgstr "%u.%2.2u GiB"
 
 #. TRANSLATORS: IEC 80000-13:2008 gibibyte/second
-#: strbuf.c:850
+#: strbuf.c:852
 #, c-format
 msgid "%u.%2.2u GiB/s"
 msgstr "%u.%2.2u GiB/s"
 
 #. TRANSLATORS: IEC 80000-13:2008 mebibyte
-#: strbuf.c:858
+#: strbuf.c:860
 #, c-format
 msgid "%u.%2.2u MiB"
 msgstr "%u.%2.2u MiB"
 
 #. TRANSLATORS: IEC 80000-13:2008 mebibyte/second
-#: strbuf.c:860
+#: strbuf.c:862
 #, c-format
 msgid "%u.%2.2u MiB/s"
 msgstr "%u.%2.2u MiB/s"
 
 #. TRANSLATORS: IEC 80000-13:2008 kibibyte
-#: strbuf.c:867
+#: strbuf.c:869
 #, c-format
 msgid "%u.%2.2u KiB"
 msgstr "%u.%2.2u KiB"
 
 #. TRANSLATORS: IEC 80000-13:2008 kibibyte/second
-#: strbuf.c:869
+#: strbuf.c:871
 #, c-format
 msgid "%u.%2.2u KiB/s"
 msgstr "%u.%2.2u KiB/s"
 
 #. TRANSLATORS: IEC 80000-13:2008 byte
-#: strbuf.c:875
+#: strbuf.c:877
 #, c-format
 msgid "%u byte"
 msgid_plural "%u bytes"
@@ -8592,20 +8706,20 @@ msgstr[0] "%u Byte"
 msgstr[1] "%u Bytes"
 
 #. TRANSLATORS: IEC 80000-13:2008 byte/second
-#: strbuf.c:877
+#: strbuf.c:879
 #, c-format
 msgid "%u byte/s"
 msgid_plural "%u bytes/s"
 msgstr[0] "%u Byte/s"
 msgstr[1] "%u Bytes/s"
 
-#: strbuf.c:1166 wrapper.c:199 wrapper.c:369 builtin/am.c:719
+#: strbuf.c:1168 wrapper.c:199 wrapper.c:369 builtin/am.c:737
 #: builtin/rebase.c:866
 #, c-format
 msgid "could not open '%s' for writing"
 msgstr "Konnte '%s' nicht zum Schreiben öffnen."
 
-#: strbuf.c:1175
+#: strbuf.c:1177
 #, c-format
 msgid "could not edit '%s'"
 msgstr "Konnte '%s' nicht editieren."
@@ -8656,22 +8770,22 @@ msgstr "Konnte Eintrag '%s' nicht aus .gitmodules entfernen"
 msgid "staging updated .gitmodules failed"
 msgstr "Konnte aktualisierte .gitmodules-Datei nicht zum Commit vormerken"
 
-#: submodule.c:327
+#: submodule.c:328
 #, c-format
 msgid "in unpopulated submodule '%s'"
 msgstr "In nicht ausgechecktem Submodul '%s'."
 
-#: submodule.c:358
+#: submodule.c:359
 #, c-format
 msgid "Pathspec '%s' is in submodule '%.*s'"
 msgstr "Pfadspezifikation '%s' befindet sich in Submodul '%.*s'"
 
-#: submodule.c:435
+#: submodule.c:436
 #, c-format
 msgid "bad --ignore-submodules argument: %s"
 msgstr "ungültiges --ignore-submodules Argument: %s"
 
-#: submodule.c:817
+#: submodule.c:818
 #, c-format
 msgid ""
 "Submodule in commit %s at path: '%s' collides with a submodule named the "
@@ -8680,12 +8794,12 @@ msgstr ""
 "Submodul in Commit %s beim Pfad: '%s' hat den gleichen Namen wie ein "
 "Submodul. Wird übersprungen."
 
-#: submodule.c:920
+#: submodule.c:921
 #, c-format
 msgid "submodule entry '%s' (%s) is a %s, not a commit"
 msgstr "Submodul-Eintrag '%s' (%s) ist ein %s, kein Commit."
 
-#: submodule.c:1005
+#: submodule.c:1006
 #, c-format
 msgid ""
 "Could not run 'git rev-list <commits> --not --remotes -n 1' command in "
@@ -8694,36 +8808,36 @@ msgstr ""
 "Konnte 'git rev-list <Commits> --not --remotes -n 1' nicht in Submodul '%s' "
 "ausführen."
 
-#: submodule.c:1128
+#: submodule.c:1129
 #, c-format
 msgid "process for submodule '%s' failed"
 msgstr "Prozess für Submodul '%s' fehlgeschlagen"
 
-#: submodule.c:1157 builtin/branch.c:689 builtin/submodule--helper.c:2469
+#: submodule.c:1158 builtin/branch.c:691 builtin/submodule--helper.c:2470
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "Konnte HEAD nicht als gültige Referenz auflösen."
 
-#: submodule.c:1168
+#: submodule.c:1169
 #, c-format
 msgid "Pushing submodule '%s'\n"
 msgstr "Pushe Submodul '%s'\n"
 
-#: submodule.c:1171
+#: submodule.c:1172
 #, c-format
 msgid "Unable to push submodule '%s'\n"
 msgstr "Kann Push für Submodul '%s' nicht ausführen\n"
 
-#: submodule.c:1463
+#: submodule.c:1464
 #, c-format
 msgid "Fetching submodule %s%s\n"
 msgstr "Anfordern des Submoduls %s%s\n"
 
-#: submodule.c:1497
+#: submodule.c:1498
 #, c-format
 msgid "Could not access submodule '%s'\n"
 msgstr "Konnte nicht auf Submodul '%s' zugreifen\n"
 
-#: submodule.c:1652
+#: submodule.c:1653
 #, c-format
 msgid ""
 "Errors during submodule fetch:\n"
@@ -8732,62 +8846,62 @@ msgstr ""
 "Fehler während des Anforderns der Submodule:\n"
 "%s"
 
-#: submodule.c:1677
+#: submodule.c:1678
 #, c-format
 msgid "'%s' not recognized as a git repository"
 msgstr "'%s' nicht als Git-Repository erkannt"
 
-#: submodule.c:1694
+#: submodule.c:1695
 #, c-format
 msgid "Could not run 'git status --porcelain=2' in submodule %s"
 msgstr "Konnte 'git status --porcelain=2' nicht in Submodul %s ausführen"
 
-#: submodule.c:1735
+#: submodule.c:1736
 #, c-format
 msgid "'git status --porcelain=2' failed in submodule %s"
 msgstr "'git status --porcelain=2' ist in Submodul %s fehlgeschlagen"
 
-#: submodule.c:1810
+#: submodule.c:1811
 #, c-format
 msgid "could not start 'git status' in submodule '%s'"
 msgstr "Konnte 'git status' in Submodul '%s' nicht starten."
 
-#: submodule.c:1823
+#: submodule.c:1824
 #, c-format
 msgid "could not run 'git status' in submodule '%s'"
 msgstr "Konnte 'git status' in Submodul '%s' nicht ausführen."
 
-#: submodule.c:1838
+#: submodule.c:1839
 #, c-format
 msgid "Could not unset core.worktree setting in submodule '%s'"
 msgstr "Konnte core.worktree Einstellung in Submodul '%s' nicht aufheben."
 
-#: submodule.c:1865 submodule.c:2175
+#: submodule.c:1866 submodule.c:2176
 #, c-format
 msgid "could not recurse into submodule '%s'"
 msgstr "Fehler bei Rekursion in Submodul-Pfad '%s'"
 
-#: submodule.c:1886
+#: submodule.c:1887
 msgid "could not reset submodule index"
 msgstr "konnte Index des Submoduls nicht zurücksetzen"
 
-#: submodule.c:1928
+#: submodule.c:1929
 #, c-format
 msgid "submodule '%s' has dirty index"
 msgstr "Submodul '%s' hat einen geänderten Index."
 
-#: submodule.c:1980
+#: submodule.c:1981
 #, c-format
 msgid "Submodule '%s' could not be updated."
 msgstr "Submodule '%s' konnte nicht aktualisiert werden."
 
-#: submodule.c:2048
+#: submodule.c:2049
 #, c-format
 msgid "submodule git dir '%s' is inside git dir '%.*s'"
 msgstr ""
 "Git-Verzeichnis des Submoduls '%s' ist im Git-Verzeichnis '%.*s' enthalten."
 
-#: submodule.c:2069
+#: submodule.c:2070
 #, c-format
 msgid ""
 "relocate_gitdir for submodule '%s' with more than one worktree not supported"
@@ -8795,17 +8909,17 @@ msgstr ""
 "relocate_gitdir für Submodul '%s' mit mehr als einem Arbeitsverzeichnis\n"
 "wird nicht unterstützt"
 
-#: submodule.c:2081 submodule.c:2140
+#: submodule.c:2082 submodule.c:2141
 #, c-format
 msgid "could not lookup name for submodule '%s'"
 msgstr "Konnte Name für Submodul '%s' nicht nachschlagen."
 
-#: submodule.c:2085
+#: submodule.c:2086
 #, c-format
 msgid "refusing to move '%s' into an existing git dir"
 msgstr "Verschieben von '%s' in ein existierendes Git-Verzeichnis verweigert."
 
-#: submodule.c:2092
+#: submodule.c:2093
 #, c-format
 msgid ""
 "Migrating git directory of '%s%s' from\n"
@@ -8816,65 +8930,71 @@ msgstr ""
 "'%s' nach\n"
 "'%s'\n"
 
-#: submodule.c:2220
+#: submodule.c:2221
 msgid "could not start ls-files in .."
 msgstr "Konnte 'ls-files' nicht in .. starten"
 
-#: submodule.c:2260
+#: submodule.c:2261
 #, c-format
 msgid "ls-tree returned unexpected return code %d"
 msgstr "ls-tree mit unerwartetem Rückgabewert %d beendet"
 
-#: trailer.c:236
+#: symlinks.c:244
+#, fuzzy, c-format
+msgid "failed to lstat '%s'"
+msgstr "Konnte '%s' nicht lesen"
+
+#: trailer.c:244
 #, c-format
 msgid "running trailer command '%s' failed"
 msgstr "Ausführen des Anhang-Befehls '%s' fehlgeschlagen"
 
-#: trailer.c:483 trailer.c:488 trailer.c:493 trailer.c:547 trailer.c:551
-#: trailer.c:555
+#: trailer.c:493 trailer.c:498 trailer.c:503 trailer.c:562 trailer.c:566
+#: trailer.c:570
 #, c-format
 msgid "unknown value '%s' for key '%s'"
 msgstr "unbekannter Wert '%s' für Schlüssel %s"
 
-#: trailer.c:537 trailer.c:542 builtin/remote.c:299 builtin/remote.c:324
+#: trailer.c:547 trailer.c:552 trailer.c:557 builtin/remote.c:299
+#: builtin/remote.c:324
 #, c-format
 msgid "more than one %s"
 msgstr "mehr als ein %s"
 
-#: trailer.c:728
+#: trailer.c:743
 #, c-format
 msgid "empty trailer token in trailer '%.*s'"
 msgstr "leerer Anhang-Token in Anhang '%.*s'"
 
-#: trailer.c:748
+#: trailer.c:763
 #, c-format
 msgid "could not read input file '%s'"
 msgstr "Konnte Eingabe-Datei '%s' nicht lesen"
 
-#: trailer.c:751 builtin/mktag.c:91
+#: trailer.c:766 builtin/mktag.c:88
 msgid "could not read from stdin"
 msgstr "konnte nicht von der Standard-Eingabe lesen"
 
-#: trailer.c:1009 wrapper.c:676
+#: trailer.c:1024 wrapper.c:676
 #, c-format
 msgid "could not stat %s"
 msgstr "Konnte '%s' nicht lesen"
 
-#: trailer.c:1011
+#: trailer.c:1026
 #, c-format
 msgid "file %s is not a regular file"
 msgstr "Datei '%s' ist keine reguläre Datei"
 
-#: trailer.c:1013
+#: trailer.c:1028
 #, c-format
 msgid "file %s is not writable by user"
 msgstr "Datei %s ist vom Benutzer nicht beschreibbar."
 
-#: trailer.c:1025
+#: trailer.c:1040
 msgid "could not open temporary file"
 msgstr "konnte temporäre Datei '%s' nicht öffnen"
 
-#: trailer.c:1065
+#: trailer.c:1080
 #, c-format
 msgid "could not rename temporary file to %s"
 msgstr "konnte temporäre Datei nicht zu %s umbenennen"
@@ -8925,7 +9045,7 @@ msgstr "konnte \"fast-import\" nicht ausführen"
 msgid "error while running fast-import"
 msgstr "Fehler beim Ausführen von 'fast-import'."
 
-#: transport-helper.c:549 transport-helper.c:1237
+#: transport-helper.c:549 transport-helper.c:1247
 #, c-format
 msgid "could not read ref %s"
 msgstr "konnte Referenz %s nicht lesen"
@@ -8944,7 +9064,7 @@ msgstr ""
 msgid "invalid remote service path"
 msgstr "ungültiger Remote-Service Pfad."
 
-#: transport-helper.c:661 transport.c:1447
+#: transport-helper.c:661 transport.c:1471
 msgid "operation not supported by protocol"
 msgstr "die Operation wird von dem Protokoll nicht unterstützt"
 
@@ -8953,68 +9073,72 @@ msgstr "die Operation wird von dem Protokoll nicht unterstützt"
 msgid "can't connect to subservice %s"
 msgstr "kann keine Verbindung zu Subservice %s herstellen"
 
-#: transport-helper.c:745
+#: transport-helper.c:693 transport.c:397
+msgid "--negotiate-only requires protocol v2"
+msgstr ""
+
+#: transport-helper.c:755
 msgid "'option' without a matching 'ok/error' directive"
 msgstr "'option' ohne passende 'ok/error' Direktive"
 
-#: transport-helper.c:788
+#: transport-helper.c:798
 #, c-format
 msgid "expected ok/error, helper said '%s'"
 msgstr "erwartete ok/error, Remote-Helper gab '%s' aus"
 
-#: transport-helper.c:845
+#: transport-helper.c:855
 #, c-format
 msgid "helper reported unexpected status of %s"
 msgstr "Remote-Helper meldete unerwarteten Status von %s"
 
-#: transport-helper.c:928
+#: transport-helper.c:938
 #, c-format
 msgid "helper %s does not support dry-run"
 msgstr "Remote-Helper %s unterstützt kein Trockenlauf"
 
-#: transport-helper.c:931
+#: transport-helper.c:941
 #, c-format
 msgid "helper %s does not support --signed"
 msgstr "Remote-Helper %s unterstützt kein --signed"
 
-#: transport-helper.c:934
+#: transport-helper.c:944
 #, c-format
 msgid "helper %s does not support --signed=if-asked"
 msgstr "Remote-Helper %s unterstützt kein --signed=if-asked"
 
-#: transport-helper.c:939
+#: transport-helper.c:949
 #, c-format
 msgid "helper %s does not support --atomic"
 msgstr "Remote-Helper %s unterstützt kein --atomic"
 
-#: transport-helper.c:943
+#: transport-helper.c:953
 #, c-format
 msgid "helper %s does not support --%s"
 msgstr "Remote-Helper %s unterstützt kein --%s"
 
-#: transport-helper.c:950
+#: transport-helper.c:960
 #, c-format
 msgid "helper %s does not support 'push-option'"
 msgstr "Remote-Helper %s unterstützt nicht 'push-option'"
 
-#: transport-helper.c:1050
+#: transport-helper.c:1060
 msgid "remote-helper doesn't support push; refspec needed"
 msgstr "Remote-Helper unterstützt kein Push; Refspec benötigt"
 
-#: transport-helper.c:1055
+#: transport-helper.c:1065
 #, c-format
 msgid "helper %s does not support 'force'"
 msgstr "Remote-Helper %s unterstützt kein 'force'."
 
-#: transport-helper.c:1102
+#: transport-helper.c:1112
 msgid "couldn't run fast-export"
 msgstr "Konnte \"fast-export\" nicht ausführen."
 
-#: transport-helper.c:1107
+#: transport-helper.c:1117
 msgid "error while running fast-export"
 msgstr "Fehler beim Ausführen von \"fast-export\"."
 
-#: transport-helper.c:1132
+#: transport-helper.c:1142
 #, c-format
 msgid ""
 "No refs in common and none specified; doing nothing.\n"
@@ -9023,52 +9147,52 @@ msgstr ""
 "Keine gemeinsamen Referenzen und nichts spezifiziert; keine Ausführung.\n"
 "Vielleicht sollten Sie einen Branch angeben.\n"
 
-#: transport-helper.c:1214
+#: transport-helper.c:1224
 #, c-format
 msgid "unsupported object format '%s'"
 msgstr "nicht unterstütztes Objekt-Format '%s'"
 
-#: transport-helper.c:1223
+#: transport-helper.c:1233
 #, c-format
 msgid "malformed response in ref list: %s"
 msgstr "Ungültige Antwort in Referenzliste: %s"
 
-#: transport-helper.c:1375
+#: transport-helper.c:1385
 #, c-format
 msgid "read(%s) failed"
 msgstr "Lesen von %s fehlgeschlagen."
 
-#: transport-helper.c:1402
+#: transport-helper.c:1412
 #, c-format
 msgid "write(%s) failed"
 msgstr "Schreiben von %s fehlgeschlagen."
 
-#: transport-helper.c:1451
+#: transport-helper.c:1461
 #, c-format
 msgid "%s thread failed"
 msgstr "Thread %s fehlgeschlagen."
 
-#: transport-helper.c:1455
+#: transport-helper.c:1465
 #, c-format
 msgid "%s thread failed to join: %s"
 msgstr "Fehler beim Beitreten zu Thread %s: %s"
 
-#: transport-helper.c:1474 transport-helper.c:1478
+#: transport-helper.c:1484 transport-helper.c:1488
 #, c-format
 msgid "can't start thread for copying data: %s"
 msgstr "Kann Thread zum Kopieren von Daten nicht starten: %s"
 
-#: transport-helper.c:1515
+#: transport-helper.c:1525
 #, c-format
 msgid "%s process failed to wait"
 msgstr "Fehler beim Warten von Prozess %s."
 
-#: transport-helper.c:1519
+#: transport-helper.c:1529
 #, c-format
 msgid "%s process failed"
 msgstr "Prozess %s fehlgeschlagen"
 
-#: transport-helper.c:1537 transport-helper.c:1546
+#: transport-helper.c:1547 transport-helper.c:1556
 msgid "can't start thread for copying data"
 msgstr "Kann Thread zum Kopieren von Daten nicht starten."
 
@@ -9087,37 +9211,42 @@ msgstr "Konnte Paket '%s' nicht lesen."
 msgid "transport: invalid depth option '%s'"
 msgstr "transport: ungültige --depth Option '%s'"
 
-#: transport.c:269
+#: transport.c:272
 msgid "see protocol.version in 'git help config' for more details"
 msgstr "Siehe protocol.version in 'git help config' für weitere Informationen"
 
-#: transport.c:270
+#: transport.c:273
 msgid "server options require protocol version 2 or later"
 msgstr "Server-Optionen benötigen Protokoll-Version 2 oder höher"
 
-#: transport.c:727
+#: transport.c:400
+#, fuzzy
+msgid "server does not support wait-for-done"
+msgstr "Server unterstützt kein --deepen"
+
+#: transport.c:751
 msgid "could not parse transport.color.* config"
 msgstr "Konnte transport.color.* Konfiguration nicht parsen."
 
-#: transport.c:802
+#: transport.c:826
 msgid "support for protocol v2 not implemented yet"
 msgstr "Unterstützung für Protokoll v2 noch nicht implementiert."
 
-#: transport.c:936
+#: transport.c:960
 #, c-format
 msgid "unknown value for config '%s': %s"
 msgstr "Unbekannter Wert für Konfiguration '%s': %s"
 
-#: transport.c:1002
+#: transport.c:1026
 #, c-format
 msgid "transport '%s' not allowed"
 msgstr "Übertragungsart '%s' nicht erlaubt."
 
-#: transport.c:1055
+#: transport.c:1079
 msgid "git-over-rsync is no longer supported"
 msgstr "git-over-rsync wird nicht länger unterstützt."
 
-#: transport.c:1157
+#: transport.c:1181
 #, c-format
 msgid ""
 "The following submodule paths contain changes that can\n"
@@ -9126,7 +9255,7 @@ msgstr ""
 "Die folgenden Submodul-Pfade enthalten Änderungen, die in keinem\n"
 "Remote-Repository gefunden wurden:\n"
 
-#: transport.c:1161
+#: transport.c:1185
 #, c-format
 msgid ""
 "\n"
@@ -9153,11 +9282,11 @@ msgstr ""
 "zum Versenden zu einem Remote-Repository.\n"
 "\n"
 
-#: transport.c:1169
+#: transport.c:1193
 msgid "Aborting."
 msgstr "Abbruch."
 
-#: transport.c:1316
+#: transport.c:1340
 msgid "failed to push all needed submodules"
 msgstr "Fehler beim Versand aller erforderlichen Submodule."
 
@@ -9177,7 +9306,7 @@ msgstr "leerer Dateiname in Tree-Eintrag"
 msgid "too-short tree file"
 msgstr "zu kurze Tree-Datei"
 
-#: unpack-trees.c:113
+#: unpack-trees.c:115
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by checkout:\n"
@@ -9188,7 +9317,7 @@ msgstr ""
 "%%sBitte committen oder stashen Sie Ihre Änderungen, bevor Sie Branches\n"
 "wechseln."
 
-#: unpack-trees.c:115
+#: unpack-trees.c:117
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by checkout:\n"
@@ -9198,7 +9327,7 @@ msgstr ""
 "überschrieben werden:\n"
 "%%s"
 
-#: unpack-trees.c:118
+#: unpack-trees.c:120
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -9208,7 +9337,7 @@ msgstr ""
 "überschrieben werden:\n"
 "%%sBitte committen oder stashen Sie Ihre Änderungen, bevor Sie mergen."
 
-#: unpack-trees.c:120
+#: unpack-trees.c:122
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -9218,7 +9347,7 @@ msgstr ""
 "überschrieben werden:\n"
 "%%s"
 
-#: unpack-trees.c:123
+#: unpack-trees.c:125
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by %s:\n"
@@ -9228,7 +9357,7 @@ msgstr ""
 "überschrieben werden:\n"
 "%%sBitte committen oder stashen Sie Ihre Änderungen, bevor Sie %s ausführen."
 
-#: unpack-trees.c:125
+#: unpack-trees.c:127
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by %s:\n"
@@ -9237,7 +9366,7 @@ msgstr ""
 "Ihre lokalen Änderungen würden durch %s überschrieben werden.\n"
 "%%s"
 
-#: unpack-trees.c:130
+#: unpack-trees.c:132
 #, c-format
 msgid ""
 "Updating the following directories would lose untracked files in them:\n"
@@ -9247,7 +9376,7 @@ msgstr ""
 "Dateien in diesen Verzeichnissen verloren gehen:\n"
 "%s"
 
-#: unpack-trees.c:134
+#: unpack-trees.c:136
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by checkout:\n"
@@ -9257,7 +9386,7 @@ msgstr ""
 "den Checkout entfernt werden:\n"
 "%%sBitte verschieben oder entfernen Sie diese, bevor Sie Branches wechseln."
 
-#: unpack-trees.c:136
+#: unpack-trees.c:138
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by checkout:\n"
@@ -9268,7 +9397,7 @@ msgstr ""
 "Checkout entfernt werden:\n"
 "%%s"
 
-#: unpack-trees.c:139
+#: unpack-trees.c:141
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by merge:\n"
@@ -9278,7 +9407,7 @@ msgstr ""
 "den Merge entfernt werden:\n"
 "%%sBitte verschieben oder entfernen Sie diese, bevor sie mergen."
 
-#: unpack-trees.c:141
+#: unpack-trees.c:143
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by merge:\n"
@@ -9289,7 +9418,7 @@ msgstr ""
 "Merge entfernt werden:\n"
 "%%s"
 
-#: unpack-trees.c:144
+#: unpack-trees.c:146
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by %s:\n"
@@ -9299,7 +9428,7 @@ msgstr ""
 "den %s entfernt werden:\n"
 "%%sBitte verschieben oder entfernen Sie diese, bevor sie %s ausführen."
 
-#: unpack-trees.c:146
+#: unpack-trees.c:148
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by %s:\n"
@@ -9309,7 +9438,7 @@ msgstr ""
 "den %s entfernt werden:\n"
 "%%s"
 
-#: unpack-trees.c:152
+#: unpack-trees.c:154
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by "
@@ -9320,7 +9449,7 @@ msgstr ""
 "den Checkout überschrieben werden:\n"
 "%%sBitte verschieben oder entfernen Sie diese, bevor Sie Branches wechseln."
 
-#: unpack-trees.c:154
+#: unpack-trees.c:156
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by "
@@ -9332,7 +9461,7 @@ msgstr ""
 "Checkout überschrieben werden:\n"
 "%%s"
 
-#: unpack-trees.c:157
+#: unpack-trees.c:159
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by merge:\n"
@@ -9342,7 +9471,7 @@ msgstr ""
 "den Merge überschrieben werden:\n"
 "%%sBitte verschieben oder entfernen Sie diese, bevor Sie mergen."
 
-#: unpack-trees.c:159
+#: unpack-trees.c:161
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by merge:\n"
@@ -9352,7 +9481,7 @@ msgstr ""
 "den Merge überschrieben werden:\n"
 "%%s"
 
-#: unpack-trees.c:162
+#: unpack-trees.c:164
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by %s:\n"
@@ -9362,7 +9491,7 @@ msgstr ""
 "den %s überschrieben werden:\n"
 "%%sBitte verschieben oder entfernen Sie diese, bevor sie %s ausführen."
 
-#: unpack-trees.c:164
+#: unpack-trees.c:166
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by %s:\n"
@@ -9373,12 +9502,12 @@ msgstr ""
 "%s überschrieben werden:\n"
 "%%s"
 
-#: unpack-trees.c:172
+#: unpack-trees.c:174
 #, c-format
 msgid "Entry '%s' overlaps with '%s'.  Cannot bind."
 msgstr "Eintrag '%s' überschneidet sich mit '%s'. Kann nicht verbinden."
 
-#: unpack-trees.c:175
+#: unpack-trees.c:177
 #, c-format
 msgid ""
 "Cannot update submodule:\n"
@@ -9387,7 +9516,7 @@ msgstr ""
 "Kann Submodul nicht aktualisieren:\n"
 "%s"
 
-#: unpack-trees.c:178
+#: unpack-trees.c:180
 #, c-format
 msgid ""
 "The following paths are not up to date and were left despite sparse "
@@ -9398,7 +9527,7 @@ msgstr ""
 "übrig gelassen:\n"
 "%s"
 
-#: unpack-trees.c:180
+#: unpack-trees.c:182
 #, c-format
 msgid ""
 "The following paths are unmerged and were left despite sparse patterns:\n"
@@ -9408,7 +9537,7 @@ msgstr ""
 "partieller Muster übrig gelassen:\n"
 "%s"
 
-#: unpack-trees.c:182
+#: unpack-trees.c:184
 #, c-format
 msgid ""
 "The following paths were already present and thus not updated despite sparse "
@@ -9419,12 +9548,12 @@ msgstr ""
 "partieller Muster nicht aktualisiert:\n"
 "%s"
 
-#: unpack-trees.c:262
+#: unpack-trees.c:264
 #, c-format
 msgid "Aborting\n"
 msgstr "Abbruch\n"
 
-#: unpack-trees.c:289
+#: unpack-trees.c:291
 #, c-format
 msgid ""
 "After fixing the above paths, you may want to run `git sparse-checkout "
@@ -9433,11 +9562,11 @@ msgstr ""
 "Nachdem die obigen Pfade behoben sind, können Sie `git sparse-checkout "
 "reapply` ausführen.\n"
 
-#: unpack-trees.c:350
+#: unpack-trees.c:352
 msgid "Updating files"
 msgstr "Aktualisiere Dateien"
 
-#: unpack-trees.c:382
+#: unpack-trees.c:384
 msgid ""
 "the following paths have collided (e.g. case-sensitive paths\n"
 "on a case-insensitive filesystem) and only one from the same\n"
@@ -9447,11 +9576,16 @@ msgstr ""
 "auf einem case-insensitiven Dateisystem) und nur einer von der\n"
 "selben Kollissionsgruppe ist im Arbeitsverzeichnis:\n"
 
-#: unpack-trees.c:1498
+#: unpack-trees.c:1519
 msgid "Updating index flags"
 msgstr "Aktualisiere Index-Markierungen"
 
-#: upload-pack.c:1543
+#: unpack-trees.c:2608
+#, c-format
+msgid "worktree and untracked commit have duplicate entries: %s"
+msgstr ""
+
+#: upload-pack.c:1548
 msgid "expected flush after fetch arguments"
 msgstr "erwartete Flush nach Abrufen der Argumente"
 
@@ -9488,7 +9622,7 @@ msgstr "ungültiges '..' Pfadsegment"
 msgid "Fetching objects"
 msgstr "Anfordern der Objekte"
 
-#: worktree.c:238 builtin/am.c:2103
+#: worktree.c:238 builtin/am.c:2151
 #, c-format
 msgid "failed to read '%s'"
 msgstr "Fehler beim Lesen von '%s'"
@@ -9638,11 +9772,11 @@ msgid "  (use \"git rm <file>...\" to mark resolution)"
 msgstr ""
 "  (benutzen Sie \"git add/rm <Datei>...\", um die Auflösung zu markieren)"
 
-#: wt-status.c:211 wt-status.c:1072
+#: wt-status.c:211 wt-status.c:1075
 msgid "Changes to be committed:"
 msgstr "Zum Commit vorgemerkte Änderungen:"
 
-#: wt-status.c:234 wt-status.c:1081
+#: wt-status.c:234 wt-status.c:1084
 msgid "Changes not staged for commit:"
 msgstr "Änderungen, die nicht zum Commit vorgemerkt sind:"
 
@@ -9750,22 +9884,22 @@ msgstr "geänderter Inhalt, "
 msgid "untracked content, "
 msgstr "unversionierter Inhalt, "
 
-#: wt-status.c:905
+#: wt-status.c:908
 #, c-format
 msgid "Your stash currently has %d entry"
 msgid_plural "Your stash currently has %d entries"
 msgstr[0] "Ihr Stash hat gerade %d Eintrag"
 msgstr[1] "Ihr Stash hat gerade %d Einträge"
 
-#: wt-status.c:936
+#: wt-status.c:939
 msgid "Submodules changed but not updated:"
 msgstr "Submodule geändert, aber nicht aktualisiert:"
 
-#: wt-status.c:938
+#: wt-status.c:941
 msgid "Submodule changes to be committed:"
 msgstr "Änderungen in Submodul zum Committen:"
 
-#: wt-status.c:1020
+#: wt-status.c:1023
 msgid ""
 "Do not modify or remove the line above.\n"
 "Everything below it will be ignored."
@@ -9773,7 +9907,7 @@ msgstr ""
 "Ändern oder entfernen Sie nicht die obige Zeile.\n"
 "Alles unterhalb von ihr wird ignoriert."
 
-#: wt-status.c:1112
+#: wt-status.c:1115
 #, c-format
 msgid ""
 "\n"
@@ -9785,114 +9919,114 @@ msgstr ""
 "berechnen.\n"
 "Sie können '--no-ahead-behind' benutzen, um das zu verhindern.\n"
 
-#: wt-status.c:1142
+#: wt-status.c:1145
 msgid "You have unmerged paths."
 msgstr "Sie haben nicht zusammengeführte Pfade."
 
-#: wt-status.c:1145
+#: wt-status.c:1148
 msgid "  (fix conflicts and run \"git commit\")"
 msgstr "  (beheben Sie die Konflikte und führen Sie \"git commit\" aus)"
 
-#: wt-status.c:1147
+#: wt-status.c:1150
 msgid "  (use \"git merge --abort\" to abort the merge)"
 msgstr "  (benutzen Sie \"git merge --abort\", um den Merge abzubrechen)"
 
-#: wt-status.c:1151
+#: wt-status.c:1154
 msgid "All conflicts fixed but you are still merging."
 msgstr "Alle Konflikte sind behoben, aber Sie sind immer noch beim Merge."
 
-#: wt-status.c:1154
+#: wt-status.c:1157
 msgid "  (use \"git commit\" to conclude merge)"
 msgstr "  (benutzen Sie \"git commit\", um den Merge abzuschließen)"
 
-#: wt-status.c:1163
+#: wt-status.c:1166
 msgid "You are in the middle of an am session."
 msgstr "Eine \"am\"-Sitzung ist im Gange."
 
-#: wt-status.c:1166
+#: wt-status.c:1169
 msgid "The current patch is empty."
 msgstr "Der aktuelle Patch ist leer."
 
-#: wt-status.c:1170
+#: wt-status.c:1173
 msgid "  (fix conflicts and then run \"git am --continue\")"
 msgstr ""
 "  (beheben Sie die Konflikte und führen Sie dann \"git am --continue\" aus)"
 
-#: wt-status.c:1172
+#: wt-status.c:1175
 msgid "  (use \"git am --skip\" to skip this patch)"
 msgstr "  (benutzen Sie \"git am --skip\", um diesen Patch auszulassen)"
 
-#: wt-status.c:1174
+#: wt-status.c:1177
 msgid "  (use \"git am --abort\" to restore the original branch)"
 msgstr ""
 "  (benutzen Sie \"git am --abort\", um den ursprünglichen Branch "
 "wiederherzustellen)"
 
-#: wt-status.c:1307
+#: wt-status.c:1310
 msgid "git-rebase-todo is missing."
 msgstr "git-rebase-todo fehlt."
 
-#: wt-status.c:1309
+#: wt-status.c:1312
 msgid "No commands done."
 msgstr "Keine Befehle ausgeführt."
 
-#: wt-status.c:1312
+#: wt-status.c:1315
 #, c-format
 msgid "Last command done (%d command done):"
 msgid_plural "Last commands done (%d commands done):"
 msgstr[0] "Zuletzt ausgeführter Befehl (%d Befehl ausgeführt):"
 msgstr[1] "Zuletzt ausgeführte Befehle (%d Befehle ausgeführt):"
 
-#: wt-status.c:1323
+#: wt-status.c:1326
 #, c-format
 msgid "  (see more in file %s)"
 msgstr "  (mehr Informationen in Datei %s)"
 
-#: wt-status.c:1328
+#: wt-status.c:1331
 msgid "No commands remaining."
 msgstr "Keine Befehle verbleibend."
 
-#: wt-status.c:1331
+#: wt-status.c:1334
 #, c-format
 msgid "Next command to do (%d remaining command):"
 msgid_plural "Next commands to do (%d remaining commands):"
 msgstr[0] "Nächster auszuführender Befehl (%d Befehle verbleibend):"
 msgstr[1] "Nächste auszuführende Befehle (%d Befehle verbleibend):"
 
-#: wt-status.c:1339
+#: wt-status.c:1342
 msgid "  (use \"git rebase --edit-todo\" to view and edit)"
 msgstr "  (benutzen Sie \"git rebase --edit-todo\" zum Ansehen und Bearbeiten)"
 
-#: wt-status.c:1351
+#: wt-status.c:1354
 #, c-format
 msgid "You are currently rebasing branch '%s' on '%s'."
 msgstr "Sie sind gerade beim Rebase von Branch '%s' auf '%s'."
 
-#: wt-status.c:1356
+#: wt-status.c:1359
 msgid "You are currently rebasing."
 msgstr "Sie sind gerade beim Rebase."
 
-#: wt-status.c:1369
+#: wt-status.c:1372
 msgid "  (fix conflicts and then run \"git rebase --continue\")"
 msgstr ""
 "  (beheben Sie die Konflikte und führen Sie dann \"git rebase --continue\" "
 "aus)"
 
-#: wt-status.c:1371
+#: wt-status.c:1374
 msgid "  (use \"git rebase --skip\" to skip this patch)"
 msgstr "  (benutzen Sie \"git rebase --skip\", um diesen Patch auszulassen)"
 
-#: wt-status.c:1373
+#: wt-status.c:1376
 msgid "  (use \"git rebase --abort\" to check out the original branch)"
 msgstr ""
 "  (benutzen Sie \"git rebase --abort\", um den ursprünglichen Branch "
 "auszuchecken)"
 
-#: wt-status.c:1380
+#: wt-status.c:1383
 msgid "  (all conflicts fixed: run \"git rebase --continue\")"
 msgstr "  (alle Konflikte behoben: führen Sie \"git rebase --continue\" aus)"
 
-#: wt-status.c:1384
+#: wt-status.c:1387
 #, c-format
 msgid ""
 "You are currently splitting a commit while rebasing branch '%s' on '%s'."
@@ -9900,170 +10034,170 @@ msgstr ""
 "Sie teilen gerade einen Commit auf, während ein Rebase von Branch '%s' auf "
 "'%s' im Gange ist."
 
-#: wt-status.c:1389
+#: wt-status.c:1392
 msgid "You are currently splitting a commit during a rebase."
 msgstr "Sie teilen gerade einen Commit während eines Rebase auf."
 
-#: wt-status.c:1392
+#: wt-status.c:1395
 msgid "  (Once your working directory is clean, run \"git rebase --continue\")"
 msgstr ""
 "  (Sobald Ihr Arbeitsverzeichnis unverändert ist, führen Sie \"git rebase --"
 "continue\" aus)"
 
-#: wt-status.c:1396
+#: wt-status.c:1399
 #, c-format
 msgid "You are currently editing a commit while rebasing branch '%s' on '%s'."
 msgstr ""
 "Sie editieren gerade einen Commit während eines Rebase von Branch '%s' auf "
 "'%s'."
 
-#: wt-status.c:1401
+#: wt-status.c:1404
 msgid "You are currently editing a commit during a rebase."
 msgstr "Sie editieren gerade einen Commit während eines Rebase."
 
-#: wt-status.c:1404
+#: wt-status.c:1407
 msgid "  (use \"git commit --amend\" to amend the current commit)"
 msgstr ""
 "  (benutzen Sie \"git commit --amend\", um den aktuellen Commit "
 "nachzubessern)"
 
-#: wt-status.c:1406
+#: wt-status.c:1409
 msgid ""
 "  (use \"git rebase --continue\" once you are satisfied with your changes)"
 msgstr ""
 "  (benutzen Sie \"git rebase --continue\" sobald Ihre Änderungen "
 "abgeschlossen sind)"
 
-#: wt-status.c:1417
+#: wt-status.c:1420
 msgid "Cherry-pick currently in progress."
 msgstr "Cherry-pick zurzeit im Gange."
 
-#: wt-status.c:1420
+#: wt-status.c:1423
 #, c-format
 msgid "You are currently cherry-picking commit %s."
 msgstr "Sie führen gerade \"cherry-pick\" von Commit %s aus."
 
-#: wt-status.c:1427
+#: wt-status.c:1430
 msgid "  (fix conflicts and run \"git cherry-pick --continue\")"
 msgstr ""
 "  (beheben Sie die Konflikte und führen Sie dann \"git cherry-pick --continue"
 "\" aus)"
 
-#: wt-status.c:1430
+#: wt-status.c:1433
 msgid "  (run \"git cherry-pick --continue\" to continue)"
 msgstr "  (Führen Sie \"git cherry-pick --continue\" aus, um weiterzumachen)"
 
-#: wt-status.c:1433
+#: wt-status.c:1436
 msgid "  (all conflicts fixed: run \"git cherry-pick --continue\")"
 msgstr ""
 "  (alle Konflikte behoben: führen Sie \"git cherry-pick --continue\" aus)"
 
-#: wt-status.c:1435
+#: wt-status.c:1438
 msgid "  (use \"git cherry-pick --skip\" to skip this patch)"
 msgstr ""
 "  (benutzen Sie \"git cherry-pick --skip\", um diesen Patch auszulassen)"
 
-#: wt-status.c:1437
+#: wt-status.c:1440
 msgid "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)"
 msgstr ""
 "  (benutzen Sie \"git cherry-pick --abort\", um die Cherry-Pick-Operation "
 "abzubrechen)"
 
-#: wt-status.c:1447
+#: wt-status.c:1450
 msgid "Revert currently in progress."
 msgstr "Revert zurzeit im Gange."
 
-#: wt-status.c:1450
+#: wt-status.c:1453
 #, c-format
 msgid "You are currently reverting commit %s."
 msgstr "Sie sind gerade beim Revert von Commit '%s'."
 
-#: wt-status.c:1456
+#: wt-status.c:1459
 msgid "  (fix conflicts and run \"git revert --continue\")"
 msgstr ""
 "  (beheben Sie die Konflikte und führen Sie dann \"git revert --continue\" "
 "aus)"
 
-#: wt-status.c:1459
+#: wt-status.c:1462
 msgid "  (run \"git revert --continue\" to continue)"
 msgstr "  (Führen Sie \"git revert --continue\", um weiterzumachen)"
 
-#: wt-status.c:1462
+#: wt-status.c:1465
 msgid "  (all conflicts fixed: run \"git revert --continue\")"
 msgstr "  (alle Konflikte behoben: führen Sie \"git revert --continue\" aus)"
 
-#: wt-status.c:1464
+#: wt-status.c:1467
 msgid "  (use \"git revert --skip\" to skip this patch)"
 msgstr "  (benutzen Sie \"git revert --skip\", um diesen Patch auszulassen)"
 
-#: wt-status.c:1466
+#: wt-status.c:1469
 msgid "  (use \"git revert --abort\" to cancel the revert operation)"
 msgstr ""
 "  (benutzen Sie \"git revert --abort\", um die Revert-Operation abzubrechen)"
 
-#: wt-status.c:1476
+#: wt-status.c:1479
 #, c-format
 msgid "You are currently bisecting, started from branch '%s'."
 msgstr "Sie sind gerade bei einer binären Suche, gestartet von Branch '%s'."
 
-#: wt-status.c:1480
+#: wt-status.c:1483
 msgid "You are currently bisecting."
 msgstr "Sie sind gerade bei einer binären Suche."
 
-#: wt-status.c:1483
+#: wt-status.c:1486
 msgid "  (use \"git bisect reset\" to get back to the original branch)"
 msgstr ""
 "  (benutzen Sie \"git bisect reset\", um zum ursprünglichen Branch "
 "zurückzukehren)"
 
-#: wt-status.c:1494
+#: wt-status.c:1497
 #, c-format
 msgid "You are in a sparse checkout with %d%% of tracked files present."
 msgstr ""
 "Sie sind in einem partiellen Checkout mit %d%% vorhandenen versionierten "
 "Dateien."
 
-#: wt-status.c:1733
+#: wt-status.c:1736
 msgid "On branch "
 msgstr "Auf Branch "
 
-#: wt-status.c:1740
+#: wt-status.c:1743
 msgid "interactive rebase in progress; onto "
 msgstr "interaktives Rebase im Gange; auf "
 
-#: wt-status.c:1742
+#: wt-status.c:1745
 msgid "rebase in progress; onto "
 msgstr "Rebase im Gange; auf "
 
-#: wt-status.c:1747
+#: wt-status.c:1750
 msgid "HEAD detached at "
 msgstr "HEAD losgelöst bei "
 
-#: wt-status.c:1749
+#: wt-status.c:1752
 msgid "HEAD detached from "
 msgstr "HEAD losgelöst von "
 
-#: wt-status.c:1752
+#: wt-status.c:1755
 msgid "Not currently on any branch."
 msgstr "Im Moment auf keinem Branch."
 
-#: wt-status.c:1769
+#: wt-status.c:1772
 msgid "Initial commit"
 msgstr "Initialer Commit"
 
-#: wt-status.c:1770
+#: wt-status.c:1773
 msgid "No commits yet"
 msgstr "Noch keine Commits"
 
-#: wt-status.c:1784
+#: wt-status.c:1787
 msgid "Untracked files"
 msgstr "Unversionierte Dateien"
 
-#: wt-status.c:1786
+#: wt-status.c:1789
 msgid "Ignored files"
 msgstr "Ignorierte Dateien"
 
-#: wt-status.c:1790
+#: wt-status.c:1793
 #, c-format
 msgid ""
 "It took %.2f seconds to enumerate untracked files. 'status -uno'\n"
@@ -10074,32 +10208,32 @@ msgstr ""
 "'status -uno' könnte das beschleunigen, aber Sie müssen darauf achten,\n"
 "neue Dateien selbstständig hinzuzufügen (siehe 'git help status')."
 
-#: wt-status.c:1796
+#: wt-status.c:1799
 #, c-format
 msgid "Untracked files not listed%s"
 msgstr "Unversionierte Dateien nicht aufgelistet%s"
 
-#: wt-status.c:1798
+#: wt-status.c:1801
 msgid " (use -u option to show untracked files)"
 msgstr " (benutzen Sie die Option -u, um unversionierte Dateien anzuzeigen)"
 
-#: wt-status.c:1804
+#: wt-status.c:1807
 msgid "No changes"
 msgstr "Keine Änderungen"
 
-#: wt-status.c:1809
+#: wt-status.c:1812
 #, c-format
 msgid "no changes added to commit (use \"git add\" and/or \"git commit -a\")\n"
 msgstr ""
 "keine Änderungen zum Commit vorgemerkt (benutzen Sie \"git add\" und/oder "
 "\"git commit -a\")\n"
 
-#: wt-status.c:1813
+#: wt-status.c:1816
 #, c-format
 msgid "no changes added to commit\n"
 msgstr "keine Änderungen zum Commit vorgemerkt\n"
 
-#: wt-status.c:1817
+#: wt-status.c:1820
 #, c-format
 msgid ""
 "nothing added to commit but untracked files present (use \"git add\" to "
@@ -10108,73 +10242,93 @@ msgstr ""
 "nichts zum Commit vorgemerkt, aber es gibt unversionierte Dateien\n"
 "(benutzen Sie \"git add\" zum Versionieren)\n"
 
-#: wt-status.c:1821
+#: wt-status.c:1824
 #, c-format
 msgid "nothing added to commit but untracked files present\n"
 msgstr "nichts zum Commit vorgemerkt, aber es gibt unversionierte Dateien\n"
 
-#: wt-status.c:1825
+#: wt-status.c:1828
 #, c-format
 msgid "nothing to commit (create/copy files and use \"git add\" to track)\n"
 msgstr ""
 "nichts zu committen (erstellen/kopieren Sie Dateien und benutzen\n"
 "Sie \"git add\" zum Versionieren)\n"
 
-#: wt-status.c:1829 wt-status.c:1835
+#: wt-status.c:1832 wt-status.c:1838
 #, c-format
 msgid "nothing to commit\n"
 msgstr "nichts zu committen\n"
 
-#: wt-status.c:1832
+#: wt-status.c:1835
 #, c-format
 msgid "nothing to commit (use -u to show untracked files)\n"
 msgstr ""
 "nichts zu committen (benutzen Sie die Option -u, um unversionierte Dateien "
 "anzuzeigen)\n"
 
-#: wt-status.c:1837
+#: wt-status.c:1840
 #, c-format
 msgid "nothing to commit, working tree clean\n"
 msgstr "nichts zu committen, Arbeitsverzeichnis unverändert\n"
 
-#: wt-status.c:1942
+#: wt-status.c:1945
 msgid "No commits yet on "
 msgstr "Noch keine Commits in "
 
-#: wt-status.c:1946
+#: wt-status.c:1949
 msgid "HEAD (no branch)"
 msgstr "HEAD (kein Branch)"
 
-#: wt-status.c:1977
+#: wt-status.c:1980
 msgid "different"
 msgstr "unterschiedlich"
 
-#: wt-status.c:1979 wt-status.c:1987
+#: wt-status.c:1982 wt-status.c:1990
 msgid "behind "
 msgstr "hinterher "
 
-#: wt-status.c:1982 wt-status.c:1985
+#: wt-status.c:1985 wt-status.c:1988
 msgid "ahead "
 msgstr "voraus "
 
 #. TRANSLATORS: the action is e.g. "pull with rebase"
-#: wt-status.c:2507
+#: wt-status.c:2511
 #, c-format
 msgid "cannot %s: You have unstaged changes."
 msgstr ""
 "%s nicht möglich: Sie haben Änderungen, die nicht zum Commit vorgemerkt sind."
 
-#: wt-status.c:2513
+#: wt-status.c:2517
 msgid "additionally, your index contains uncommitted changes."
 msgstr "Zusätzlich enthält die Staging-Area nicht committete Änderungen."
 
-#: wt-status.c:2515
+#: wt-status.c:2519
 #, c-format
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr ""
 "%s nicht möglich: Die Staging-Area enthält nicht committete Änderungen."
 
-#: compat/precompose_utf8.c:58 builtin/clone.c:457
+#: compat/simple-ipc/ipc-unix-socket.c:178
+#, fuzzy
+msgid "could not send IPC command"
+msgstr "Konnte Commit %s nicht finden."
+
+#: compat/simple-ipc/ipc-unix-socket.c:185
+#, fuzzy
+msgid "could not read IPC response"
+msgstr "konnte Referenz %s nicht lesen"
+
+#: compat/simple-ipc/ipc-unix-socket.c:862
+#, fuzzy, c-format
+msgid "could not start accept_thread '%s'"
+msgstr "konnte Datei '%s' nicht lesen"
+
+#: compat/simple-ipc/ipc-unix-socket.c:874
+#, fuzzy, c-format
+msgid "could not start worker[0] for '%s'"
+msgstr "Konnte Log für '%s' nicht parsen."
+
+#: compat/precompose_utf8.c:58 builtin/clone.c:461
 #, c-format
 msgid "failed to unlink '%s'"
 msgstr "Konnte '%s' nicht entfernen."
@@ -10183,139 +10337,139 @@ msgstr "Konnte '%s' nicht entfernen."
 msgid "git add [<options>] [--] <pathspec>..."
 msgstr "git add [<Optionen>] [--] <Pfadspezifikation>..."
 
-#: builtin/add.c:58
+#: builtin/add.c:61
 #, c-format
 msgid "cannot chmod %cx '%s'"
 msgstr "kann chmod %cx '%s' nicht ausführen"
 
-#: builtin/add.c:96
+#: builtin/add.c:99
 #, c-format
 msgid "unexpected diff status %c"
 msgstr "unerwarteter Differenz-Status %c"
 
-#: builtin/add.c:101 builtin/commit.c:285
+#: builtin/add.c:104 builtin/commit.c:297
 msgid "updating files failed"
 msgstr "Aktualisierung der Dateien fehlgeschlagen"
 
-#: builtin/add.c:111
+#: builtin/add.c:114
 #, c-format
 msgid "remove '%s'\n"
 msgstr "lösche '%s'\n"
 
-#: builtin/add.c:186
+#: builtin/add.c:198
 msgid "Unstaged changes after refreshing the index:"
 msgstr ""
 "Nicht zum Commit vorgemerkte Änderungen nach Aktualisierung der Staging-Area:"
 
-#: builtin/add.c:280 builtin/rev-parse.c:991
+#: builtin/add.c:307 builtin/rev-parse.c:991
 msgid "Could not read the index"
 msgstr "Konnte den Index nicht lesen"
 
-#: builtin/add.c:291
+#: builtin/add.c:318
 #, c-format
 msgid "Could not open '%s' for writing."
 msgstr "Konnte '%s' nicht zum Schreiben öffnen."
 
-#: builtin/add.c:295
+#: builtin/add.c:322
 msgid "Could not write patch"
 msgstr "Konnte Patch nicht schreiben"
 
-#: builtin/add.c:298
+#: builtin/add.c:325
 msgid "editing patch failed"
 msgstr "Bearbeitung des Patches fehlgeschlagen"
 
-#: builtin/add.c:301
+#: builtin/add.c:328
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "Konnte Verzeichnis '%s' nicht lesen"
 
-#: builtin/add.c:303
+#: builtin/add.c:330
 msgid "Empty patch. Aborted."
 msgstr "Leerer Patch. Abgebrochen."
 
-#: builtin/add.c:308
+#: builtin/add.c:335
 #, c-format
 msgid "Could not apply '%s'"
 msgstr "Konnte '%s' nicht anwenden."
 
-#: builtin/add.c:316
+#: builtin/add.c:343
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr ""
 "Die folgenden Pfade werden durch eine Ihrer \".gitignore\" Dateien "
 "ignoriert:\n"
 
-#: builtin/add.c:336 builtin/clean.c:904 builtin/fetch.c:169 builtin/mv.c:124
+#: builtin/add.c:363 builtin/clean.c:904 builtin/fetch.c:173 builtin/mv.c:124
 #: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:559
-#: builtin/remote.c:1427 builtin/rm.c:242 builtin/send-pack.c:190
+#: builtin/remote.c:1427 builtin/rm.c:243 builtin/send-pack.c:190
 msgid "dry run"
 msgstr "Probelauf"
 
-#: builtin/add.c:339
+#: builtin/add.c:366
 msgid "interactive picking"
 msgstr "interaktives Auswählen"
 
-#: builtin/add.c:340 builtin/checkout.c:1546 builtin/reset.c:308
+#: builtin/add.c:367 builtin/checkout.c:1567 builtin/reset.c:308
 msgid "select hunks interactively"
 msgstr "Blöcke interaktiv auswählen"
 
-#: builtin/add.c:341
+#: builtin/add.c:368
 msgid "edit current diff and apply"
 msgstr "aktuelle Unterschiede editieren und anwenden"
 
-#: builtin/add.c:342
+#: builtin/add.c:369
 msgid "allow adding otherwise ignored files"
 msgstr "das Hinzufügen andernfalls ignorierter Dateien erlauben"
 
-#: builtin/add.c:343
+#: builtin/add.c:370
 msgid "update tracked files"
 msgstr "versionierte Dateien aktualisieren"
 
-#: builtin/add.c:344
+#: builtin/add.c:371
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr ""
 "erneutes Normalisieren der Zeilenenden von versionierten Dateien (impliziert "
 "-u)"
 
-#: builtin/add.c:345
+#: builtin/add.c:372
 msgid "record only the fact that the path will be added later"
 msgstr "nur speichern, dass der Pfad später hinzugefügt werden soll"
 
-#: builtin/add.c:346
+#: builtin/add.c:373
 msgid "add changes from all tracked and untracked files"
 msgstr ""
 "Änderungen von allen versionierten und unversionierten Dateien hinzufügen"
 
-#: builtin/add.c:349
+#: builtin/add.c:376
 msgid "ignore paths removed in the working tree (same as --no-all)"
 msgstr "gelöschte Pfade im Arbeitsverzeichnis ignorieren (genau wie --no-all)"
 
-#: builtin/add.c:351
+#: builtin/add.c:378
 msgid "don't add, only refresh the index"
 msgstr "nichts hinzufügen, nur den Index aktualisieren"
 
-#: builtin/add.c:352
+#: builtin/add.c:379
 msgid "just skip files which cannot be added because of errors"
 msgstr ""
 "Dateien überspringen, die aufgrund von Fehlern nicht hinzugefügt werden "
 "konnten"
 
-#: builtin/add.c:353
+#: builtin/add.c:380
 msgid "check if - even missing - files are ignored in dry run"
 msgstr "prüfen ob - auch fehlende - Dateien im Probelauf ignoriert werden"
 
-#: builtin/add.c:355 builtin/update-index.c:1004
+#: builtin/add.c:382 builtin/update-index.c:1006
 msgid "override the executable bit of the listed files"
 msgstr "das \"ausführbar\"-Bit der aufgelisteten Dateien überschreiben"
 
-#: builtin/add.c:357
+#: builtin/add.c:384
 msgid "warn when adding an embedded repository"
 msgstr "warnen wenn eingebettetes Repository hinzugefügt wird"
 
-#: builtin/add.c:359
+#: builtin/add.c:386
 msgid "backend for `git stash -p`"
 msgstr "Backend für `git stash -p`"
 
-#: builtin/add.c:377
+#: builtin/add.c:404
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -10349,12 +10503,12 @@ msgstr ""
 "\n"
 "Siehe \"git help submodule\" für weitere Informationen."
 
-#: builtin/add.c:405
+#: builtin/add.c:432
 #, c-format
 msgid "adding embedded git repository: %s"
 msgstr "Füge eingebettetes Repository hinzu: %s"
 
-#: builtin/add.c:424
+#: builtin/add.c:451
 msgid ""
 "Use -f if you really want to add them.\n"
 "Turn this message off by running\n"
@@ -10364,48 +10518,53 @@ msgstr ""
 "Um diese Meldung abzuschalten, führen Sie folgenden Befehl aus:\n"
 "\"git config advice.addIgnoredFile false\""
 
-#: builtin/add.c:433
+#: builtin/add.c:460
 msgid "adding files failed"
 msgstr "Hinzufügen von Dateien fehlgeschlagen"
 
-#: builtin/add.c:461 builtin/commit.c:345
+#: builtin/add.c:488
+#, fuzzy
+msgid "--dry-run is incompatible with --interactive/--patch"
+msgstr "--pathspec-from-file und --interactive/--patch sind inkompatibel"
+
+#: builtin/add.c:490 builtin/commit.c:357
 msgid "--pathspec-from-file is incompatible with --interactive/--patch"
 msgstr "--pathspec-from-file und --interactive/--patch sind inkompatibel"
 
-#: builtin/add.c:478
+#: builtin/add.c:507
 msgid "--pathspec-from-file is incompatible with --edit"
 msgstr "--pathspec-from-file und --edit sind inkompatibel"
 
-#: builtin/add.c:490
+#: builtin/add.c:519
 msgid "-A and -u are mutually incompatible"
 msgstr "-A und -u sind zueinander inkompatibel"
 
-#: builtin/add.c:493
+#: builtin/add.c:522
 msgid "Option --ignore-missing can only be used together with --dry-run"
 msgstr ""
 "Die Option --ignore-missing kann nur zusammen mit --dry-run verwendet werden"
 
-#: builtin/add.c:497
+#: builtin/add.c:526
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "--chmod Parameter '%s' muss entweder -x oder +x sein"
 
-#: builtin/add.c:515 builtin/checkout.c:1714 builtin/commit.c:351
-#: builtin/reset.c:328 builtin/rm.c:272 builtin/stash.c:1569
+#: builtin/add.c:544 builtin/checkout.c:1735 builtin/commit.c:363
+#: builtin/reset.c:328 builtin/rm.c:273 builtin/stash.c:1637
 msgid "--pathspec-from-file is incompatible with pathspec arguments"
 msgstr "--pathspec-from-file ist inkompatibel mit Pfadspezifikation-Argumenten"
 
-#: builtin/add.c:522 builtin/checkout.c:1726 builtin/commit.c:357
-#: builtin/reset.c:334 builtin/rm.c:278 builtin/stash.c:1575
+#: builtin/add.c:551 builtin/checkout.c:1747 builtin/commit.c:369
+#: builtin/reset.c:334 builtin/rm.c:279 builtin/stash.c:1643
 msgid "--pathspec-file-nul requires --pathspec-from-file"
 msgstr "--pathspec-file-nul benötigt --pathspec-from-file"
 
-#: builtin/add.c:526
+#: builtin/add.c:555
 #, c-format
 msgid "Nothing specified, nothing added.\n"
 msgstr "Nichts spezifiziert, nichts hinzugefügt.\n"
 
-#: builtin/add.c:528
+#: builtin/add.c:557
 msgid ""
 "Maybe you wanted to say 'git add .'?\n"
 "Turn this message off by running\n"
@@ -10415,116 +10574,116 @@ msgstr ""
 "Um diese Meldung abzuschalten, führen Sie folgenden Befehl aus:\n"
 "\"git config advice.addEmptyPathspec false\""
 
-#: builtin/am.c:352
+#: builtin/am.c:364
 msgid "could not parse author script"
 msgstr "konnte Autor-Skript nicht parsen"
 
-#: builtin/am.c:436
+#: builtin/am.c:454
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
 msgstr "'%s' wurde durch den applypatch-msg Hook entfernt"
 
-#: builtin/am.c:478
+#: builtin/am.c:496
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr "Fehlerhafte Eingabezeile: '%s'."
 
-#: builtin/am.c:516
+#: builtin/am.c:534
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
 msgstr "Fehler beim Kopieren der Notizen von '%s' nach '%s'"
 
-#: builtin/am.c:542
+#: builtin/am.c:560
 msgid "fseek failed"
 msgstr "\"fseek\" fehlgeschlagen"
 
-#: builtin/am.c:730
+#: builtin/am.c:748
 #, c-format
 msgid "could not parse patch '%s'"
 msgstr "konnte Patch '%s' nicht parsen"
 
-#: builtin/am.c:795
+#: builtin/am.c:813
 msgid "Only one StGIT patch series can be applied at once"
 msgstr "Es kann nur eine StGIT Patch-Serie auf einmal angewendet werden."
 
-#: builtin/am.c:843
+#: builtin/am.c:861
 msgid "invalid timestamp"
 msgstr "ungültiger Zeitstempel"
 
-#: builtin/am.c:848 builtin/am.c:860
+#: builtin/am.c:866 builtin/am.c:878
 msgid "invalid Date line"
 msgstr "Ungültige \"Date\"-Zeile"
 
-#: builtin/am.c:855
+#: builtin/am.c:873
 msgid "invalid timezone offset"
 msgstr "Ungültiger Offset in der Zeitzone"
 
-#: builtin/am.c:948
+#: builtin/am.c:966
 msgid "Patch format detection failed."
 msgstr "Patch-Formaterkennung fehlgeschlagen."
 
-#: builtin/am.c:953 builtin/clone.c:410
+#: builtin/am.c:971 builtin/clone.c:414
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "Fehler beim Erstellen von Verzeichnis '%s'"
 
-#: builtin/am.c:958
+#: builtin/am.c:976
 msgid "Failed to split patches."
 msgstr "Fehler beim Aufteilen der Patches."
 
-#: builtin/am.c:1089
+#: builtin/am.c:1125
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\"."
 msgstr ""
 "Wenn Sie das Problem aufgelöst haben, führen Sie \"%s --continue\" aus."
 
-#: builtin/am.c:1090
+#: builtin/am.c:1126
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
 msgstr ""
 "Falls Sie diesen Patch auslassen möchten, führen Sie stattdessen \"%s --skip"
 "\" aus."
 
-#: builtin/am.c:1091
+#: builtin/am.c:1127
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr ""
 "Um den ursprünglichen Branch wiederherzustellen und die Anwendung der "
 "Patches abzubrechen, führen Sie \"%s --abort\" aus."
 
-#: builtin/am.c:1174
+#: builtin/am.c:1222
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
 "Patch mit format=flowed versendet; Leerzeichen am Ende von Zeilen könnte "
 "verloren gehen."
 
-#: builtin/am.c:1202
+#: builtin/am.c:1250
 msgid "Patch is empty."
 msgstr "Patch ist leer."
 
-#: builtin/am.c:1267
+#: builtin/am.c:1315
 #, c-format
 msgid "missing author line in commit %s"
 msgstr "Autor-Zeile fehlt in Commit %s"
 
-#: builtin/am.c:1270
+#: builtin/am.c:1318
 #, c-format
 msgid "invalid ident line: %.*s"
 msgstr "Ungültige Identifikationszeile: %.*s"
 
-#: builtin/am.c:1489
+#: builtin/am.c:1537
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
 "Dem Repository fehlen notwendige Blobs um auf einen 3-Wege-Merge "
 "zurückzufallen."
 
-#: builtin/am.c:1491
+#: builtin/am.c:1539
 msgid "Using index info to reconstruct a base tree..."
 msgstr ""
 "Verwende Informationen aus der Staging-Area, um ein Basisverzeichnis "
 "nachzustellen ..."
 
-#: builtin/am.c:1510
+#: builtin/am.c:1558
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
@@ -10532,24 +10691,24 @@ msgstr ""
 "Haben Sie den Patch per Hand editiert?\n"
 "Er kann nicht auf die Blobs in seiner 'index' Zeile angewendet werden."
 
-#: builtin/am.c:1516
+#: builtin/am.c:1564
 msgid "Falling back to patching base and 3-way merge..."
 msgstr "Falle zurück zum Patchen der Basis und zum 3-Wege-Merge ..."
 
-#: builtin/am.c:1542
+#: builtin/am.c:1590
 msgid "Failed to merge in the changes."
 msgstr "Merge der Änderungen fehlgeschlagen."
 
-#: builtin/am.c:1574
+#: builtin/am.c:1622
 msgid "applying to an empty history"
 msgstr "auf leere Historie anwenden"
 
-#: builtin/am.c:1626 builtin/am.c:1630
+#: builtin/am.c:1674 builtin/am.c:1678
 #, c-format
 msgid "cannot resume: %s does not exist."
 msgstr "Kann nicht fortsetzen: %s existiert nicht"
 
-#: builtin/am.c:1648
+#: builtin/am.c:1696
 msgid "Commit Body is:"
 msgstr "Commit-Beschreibung ist:"
 
@@ -10557,41 +10716,41 @@ msgstr "Commit-Beschreibung ist:"
 #. in your translation. The program will only accept English
 #. input at this point.
 #.
-#: builtin/am.c:1658
+#: builtin/am.c:1706
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr "Anwenden? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 
-#: builtin/am.c:1704 builtin/commit.c:395
+#: builtin/am.c:1752 builtin/commit.c:408
 msgid "unable to write index file"
 msgstr "Konnte Index-Datei nicht schreiben."
 
-#: builtin/am.c:1708
+#: builtin/am.c:1756
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
 msgstr "Geänderter Index: kann Patches nicht anwenden (geändert: %s)"
 
-#: builtin/am.c:1748 builtin/am.c:1816
+#: builtin/am.c:1796 builtin/am.c:1864
 #, c-format
 msgid "Applying: %.*s"
 msgstr "Wende an: %.*s"
 
-#: builtin/am.c:1765
+#: builtin/am.c:1813
 msgid "No changes -- Patch already applied."
 msgstr "Keine Änderungen -- Patches bereits angewendet."
 
-#: builtin/am.c:1771
+#: builtin/am.c:1819
 #, c-format
 msgid "Patch failed at %s %.*s"
 msgstr "Anwendung des Patches fehlgeschlagen bei %s %.*s"
 
-#: builtin/am.c:1775
+#: builtin/am.c:1823
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr ""
 "Benutzen Sie 'git am --show-current-patch=diff', um den\n"
 "fehlgeschlagenen Patch zu sehen"
 
-#: builtin/am.c:1819
+#: builtin/am.c:1867
 msgid ""
 "No changes - did you forget to use 'git add'?\n"
 "If there is nothing left to stage, chances are that something else\n"
@@ -10602,7 +10761,7 @@ msgstr ""
 "diese bereits anderweitig eingefügt worden sein; Sie könnten diesen Patch\n"
 "auslassen."
 
-#: builtin/am.c:1826
+#: builtin/am.c:1874
 msgid ""
 "You still have unmerged paths in your index.\n"
 "You should 'git add' each file with resolved conflicts to mark them as "
@@ -10615,17 +10774,17 @@ msgstr ""
 "Sie können 'git rm' auf Dateien ausführen, um \"von denen gelöscht\" für\n"
 "diese zu akzeptieren."
 
-#: builtin/am.c:1933 builtin/am.c:1937 builtin/am.c:1949 builtin/reset.c:347
+#: builtin/am.c:1981 builtin/am.c:1985 builtin/am.c:1997 builtin/reset.c:347
 #: builtin/reset.c:355
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "Konnte Objekt '%s' nicht parsen."
 
-#: builtin/am.c:1985
+#: builtin/am.c:2033
 msgid "failed to clean index"
 msgstr "Fehler beim Bereinigen des Index"
 
-#: builtin/am.c:2029
+#: builtin/am.c:2077
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
@@ -10633,156 +10792,161 @@ msgstr ""
 "Sie scheinen seit dem letzten gescheiterten 'am' HEAD geändert zu haben.\n"
 "Keine Zurücksetzung zu ORIG_HEAD."
 
-#: builtin/am.c:2136
+#: builtin/am.c:2184
 #, c-format
 msgid "Invalid value for --patch-format: %s"
 msgstr "Ungültiger Wert für --patch-format: %s"
 
-#: builtin/am.c:2178
+#: builtin/am.c:2226
 #, c-format
 msgid "Invalid value for --show-current-patch: %s"
 msgstr "Ungültiger Wert für --show-current-patch: %s"
 
-#: builtin/am.c:2182
+#: builtin/am.c:2230
 #, c-format
 msgid "--show-current-patch=%s is incompatible with --show-current-patch=%s"
 msgstr "--show-current-patch=%s ist inkombatibel mit --show-current-patch=%s"
 
-#: builtin/am.c:2213
+#: builtin/am.c:2261
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
 msgstr "git am [<Optionen>] [(<mbox> | <E-Mail-Verzeichnis>)...]"
 
-#: builtin/am.c:2214
+#: builtin/am.c:2262
 msgid "git am [<options>] (--continue | --skip | --abort)"
 msgstr "git am [<Optionen>] (--continue | --skip | --abort)"
 
-#: builtin/am.c:2220
+#: builtin/am.c:2268
 msgid "run interactively"
 msgstr "interaktiv ausführen"
 
-#: builtin/am.c:2222
+#: builtin/am.c:2270
 msgid "historical option -- no-op"
 msgstr "historische Option -- kein Effekt"
 
-#: builtin/am.c:2224
+#: builtin/am.c:2272
 msgid "allow fall back on 3way merging if needed"
 msgstr "erlaube, falls notwendig, das Zurückfallen auf einen 3-Wege-Merge"
 
-#: builtin/am.c:2225 builtin/init-db.c:560 builtin/prune-packed.c:16
-#: builtin/repack.c:334 builtin/stash.c:882
+#: builtin/am.c:2273 builtin/init-db.c:546 builtin/prune-packed.c:16
+#: builtin/repack.c:472 builtin/stash.c:948
 msgid "be quiet"
 msgstr "weniger Ausgaben"
 
-#: builtin/am.c:2227
+#: builtin/am.c:2275
 msgid "add a Signed-off-by trailer to the commit message"
 msgstr "eine Signed-off-by Zeile der Commit-Beschreibung hinzufügen"
 
-#: builtin/am.c:2230
+#: builtin/am.c:2278
 msgid "recode into utf8 (default)"
 msgstr "nach UTF-8 umkodieren (Standard)"
 
-#: builtin/am.c:2232
+#: builtin/am.c:2280
 msgid "pass -k flag to git-mailinfo"
 msgstr "-k an git-mailinfo übergeben"
 
-#: builtin/am.c:2234
+#: builtin/am.c:2282
 msgid "pass -b flag to git-mailinfo"
 msgstr "-b an git-mailinfo übergeben"
 
-#: builtin/am.c:2236
+#: builtin/am.c:2284
 msgid "pass -m flag to git-mailinfo"
 msgstr "-m an git-mailinfo übergeben"
 
-#: builtin/am.c:2238
+#: builtin/am.c:2286
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
 msgstr "--keep-cr an git-mailsplit für mbox-Format übergeben"
 
-#: builtin/am.c:2241
+#: builtin/am.c:2289
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr "kein --keep-cr an git-mailsplit übergeben, unabhängig von am.keepcr"
 
-#: builtin/am.c:2244
+#: builtin/am.c:2292
 msgid "strip everything before a scissors line"
 msgstr "alles vor einer Scheren-Zeile entfernen"
 
-#: builtin/am.c:2246 builtin/am.c:2249 builtin/am.c:2252 builtin/am.c:2255
-#: builtin/am.c:2258 builtin/am.c:2261 builtin/am.c:2264 builtin/am.c:2267
-#: builtin/am.c:2273
+#: builtin/am.c:2294
+#, fuzzy
+msgid "pass it through git-mailinfo"
+msgstr "an git-apply übergeben"
+
+#: builtin/am.c:2297 builtin/am.c:2300 builtin/am.c:2303 builtin/am.c:2306
+#: builtin/am.c:2309 builtin/am.c:2312 builtin/am.c:2315 builtin/am.c:2318
+#: builtin/am.c:2324
 msgid "pass it through git-apply"
 msgstr "an git-apply übergeben"
 
-#: builtin/am.c:2263 builtin/commit.c:1395 builtin/fmt-merge-msg.c:17
-#: builtin/fmt-merge-msg.c:20 builtin/grep.c:904 builtin/merge.c:261
+#: builtin/am.c:2314 builtin/commit.c:1505 builtin/fmt-merge-msg.c:17
+#: builtin/fmt-merge-msg.c:20 builtin/grep.c:906 builtin/merge.c:261
 #: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
-#: builtin/rebase.c:1347 builtin/repack.c:345 builtin/repack.c:349
-#: builtin/repack.c:351 builtin/show-branch.c:650 builtin/show-ref.c:172
-#: builtin/tag.c:436 parse-options.h:154 parse-options.h:175
-#: parse-options.h:316
+#: builtin/rebase.c:1342 builtin/repack.c:483 builtin/repack.c:487
+#: builtin/repack.c:489 builtin/show-branch.c:650 builtin/show-ref.c:172
+#: builtin/tag.c:447 parse-options.h:155 parse-options.h:176
+#: parse-options.h:317
 msgid "n"
 msgstr "Anzahl"
 
-#: builtin/am.c:2269 builtin/branch.c:670 builtin/bugreport.c:136
-#: builtin/for-each-ref.c:38 builtin/replace.c:556 builtin/tag.c:470
+#: builtin/am.c:2320 builtin/branch.c:672 builtin/bugreport.c:137
+#: builtin/for-each-ref.c:40 builtin/replace.c:556 builtin/tag.c:481
 #: builtin/verify-tag.c:38
 msgid "format"
 msgstr "Format"
 
-#: builtin/am.c:2270
+#: builtin/am.c:2321
 msgid "format the patch(es) are in"
 msgstr "Patch-Format"
 
-#: builtin/am.c:2276
+#: builtin/am.c:2327
 msgid "override error message when patch failure occurs"
 msgstr "Meldung bei fehlerhafter Patch-Anwendung überschreiben"
 
-#: builtin/am.c:2278
+#: builtin/am.c:2329
 msgid "continue applying patches after resolving a conflict"
 msgstr "Anwendung der Patches nach Auflösung eines Konfliktes fortsetzen"
 
-#: builtin/am.c:2281
+#: builtin/am.c:2332
 msgid "synonyms for --continue"
 msgstr "Synonyme für --continue"
 
-#: builtin/am.c:2284
+#: builtin/am.c:2335
 msgid "skip the current patch"
 msgstr "den aktuellen Patch auslassen"
 
-#: builtin/am.c:2287
+#: builtin/am.c:2338
 msgid "restore the original branch and abort the patching operation"
 msgstr ""
 "ursprünglichen Branch wiederherstellen und Anwendung der Patches abbrechen"
 
-#: builtin/am.c:2290
+#: builtin/am.c:2341
 msgid "abort the patching operation but keep HEAD where it is"
 msgstr "Patch-Operation abbrechen, aber HEAD an aktueller Stelle belassen"
 
-#: builtin/am.c:2294
+#: builtin/am.c:2345
 msgid "show the patch being applied"
 msgstr "den Patch, der gerade angewendet wird, anzeigen"
 
-#: builtin/am.c:2299
+#: builtin/am.c:2350
 msgid "lie about committer date"
 msgstr "Autor-Datum als Commit-Datum verwenden"
 
-#: builtin/am.c:2301
+#: builtin/am.c:2352
 msgid "use current timestamp for author date"
 msgstr "aktuellen Zeitstempel als Autor-Datum verwenden"
 
-#: builtin/am.c:2303 builtin/commit-tree.c:120 builtin/commit.c:1515
-#: builtin/merge.c:298 builtin/pull.c:175 builtin/rebase.c:538
-#: builtin/rebase.c:1400 builtin/revert.c:117 builtin/tag.c:451
+#: builtin/am.c:2354 builtin/commit-tree.c:120 builtin/commit.c:1630
+#: builtin/merge.c:298 builtin/pull.c:175 builtin/rebase.c:537
+#: builtin/rebase.c:1395 builtin/revert.c:117 builtin/tag.c:462
 msgid "key-id"
 msgstr "GPG-Schlüsselkennung"
 
-#: builtin/am.c:2304 builtin/rebase.c:539 builtin/rebase.c:1401
+#: builtin/am.c:2355 builtin/rebase.c:538 builtin/rebase.c:1396
 msgid "GPG-sign commits"
 msgstr "Commits mit GPG signieren"
 
-#: builtin/am.c:2307
+#: builtin/am.c:2358
 msgid "(internal use for git-rebase)"
 msgstr "(intern für git-rebase verwendet)"
 
-#: builtin/am.c:2325
+#: builtin/am.c:2376
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
@@ -10790,16 +10954,16 @@ msgstr ""
 "Die -b/--binary Option hat seit Langem keinen Effekt und wird\n"
 "entfernt. Bitte verwenden Sie diese nicht mehr."
 
-#: builtin/am.c:2332
+#: builtin/am.c:2383
 msgid "failed to read the index"
 msgstr "Fehler beim Lesen des Index"
 
-#: builtin/am.c:2347
+#: builtin/am.c:2398
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr "Vorheriges Rebase-Verzeichnis %s existiert noch, aber mbox gegeben."
 
-#: builtin/am.c:2371
+#: builtin/am.c:2422
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
@@ -10808,11 +10972,11 @@ msgstr ""
 "Stray %s Verzeichnis gefunden.\n"
 "Benutzen Sie \"git am --abort\", um es zu entfernen."
 
-#: builtin/am.c:2377
+#: builtin/am.c:2428
 msgid "Resolve operation not in progress, we are not resuming."
 msgstr "Es ist keine Auflösung im Gange, es wird nicht fortgesetzt."
 
-#: builtin/am.c:2387
+#: builtin/am.c:2438
 msgid "interactive mode requires patches on the command line"
 msgstr "Interaktiver Modus benötigt Patches über die Kommandozeile"
 
@@ -11020,7 +11184,7 @@ msgstr ""
 "Ungültiges Argument %s für 'git bisect terms'.\n"
 "Unterstützte Optionen sind: --term-good|--term-old und --term-bad|--term-new."
 
-#: builtin/bisect--helper.c:497 builtin/bisect--helper.c:1014
+#: builtin/bisect--helper.c:497 builtin/bisect--helper.c:1021
 msgid "revision walk setup failed\n"
 msgstr "Einrichtung des Revisionsgangs fehlgeschlagen\n"
 
@@ -11089,86 +11253,91 @@ msgstr "Bitte führen Sie `--bisect-state` mit mindestens einem Argument aus"
 msgid "'git bisect %s' can take only one argument."
 msgstr "'git bisect %s' kann nur ein Argument entgegennehmen."
 
-#: builtin/bisect--helper.c:867 builtin/bisect--helper.c:878
+#: builtin/bisect--helper.c:867 builtin/bisect--helper.c:880
 #, c-format
 msgid "Bad rev input: %s"
 msgstr "Ungültige Referenz-Eingabe: %s"
 
-#: builtin/bisect--helper.c:912
+#: builtin/bisect--helper.c:887
+#, fuzzy, c-format
+msgid "Bad rev input (not a commit): %s"
+msgstr "Ungültige Referenz-Eingabe: %s"
+
+#: builtin/bisect--helper.c:919
 msgid "We are not bisecting."
 msgstr "Keine binäre Suche im Gange."
 
-#: builtin/bisect--helper.c:962
+#: builtin/bisect--helper.c:969
 #, c-format
 msgid "'%s'?? what are you talking about?"
 msgstr "'%s'?? Was reden Sie da?"
 
-#: builtin/bisect--helper.c:974
+#: builtin/bisect--helper.c:981
 #, c-format
 msgid "cannot read file '%s' for replaying"
 msgstr "kann Datei '%s' nicht für die Wiederholung lesen"
 
-#: builtin/bisect--helper.c:1047
+#: builtin/bisect--helper.c:1054
 msgid "reset the bisection state"
 msgstr "den Zustand der binären Suche zurücksetzen"
 
-#: builtin/bisect--helper.c:1049
+#: builtin/bisect--helper.c:1056
 msgid "check whether bad or good terms exist"
 msgstr "prüfen, ob Begriffe für gute und schlechte Commits existieren"
 
-#: builtin/bisect--helper.c:1051
+#: builtin/bisect--helper.c:1058
 msgid "print out the bisect terms"
 msgstr "die Begriffe für die binäre Suche ausgeben"
 
-#: builtin/bisect--helper.c:1053
+#: builtin/bisect--helper.c:1060
 msgid "start the bisect session"
 msgstr "Sitzung für binäre Suche starten"
 
-#: builtin/bisect--helper.c:1055
+#: builtin/bisect--helper.c:1062
 msgid "find the next bisection commit"
 msgstr "nächsten Commit für die binäre Suche finden"
 
-#: builtin/bisect--helper.c:1057
+#: builtin/bisect--helper.c:1064
 msgid "mark the state of ref (or refs)"
 msgstr "den Status der Referenz(en) markieren"
 
-#: builtin/bisect--helper.c:1059
+#: builtin/bisect--helper.c:1066
 msgid "list the bisection steps so far"
 msgstr "die bisherigen Schritte der binären Suche auflisten"
 
-#: builtin/bisect--helper.c:1061
+#: builtin/bisect--helper.c:1068
 msgid "replay the bisection process from the given file"
 msgstr "binäre Suche aus der angegebenen Datei wiederholen"
 
-#: builtin/bisect--helper.c:1063
+#: builtin/bisect--helper.c:1070
 msgid "skip some commits for checkout"
 msgstr "einige Commits für das Auschecken überspringen"
 
-#: builtin/bisect--helper.c:1065
+#: builtin/bisect--helper.c:1072
 msgid "no log for BISECT_WRITE"
 msgstr "kein Log für BISECT_WRITE"
 
-#: builtin/bisect--helper.c:1080
+#: builtin/bisect--helper.c:1087
 msgid "--bisect-reset requires either no argument or a commit"
 msgstr "--bisect-reset benötigt entweder kein Argument oder ein Commit"
 
-#: builtin/bisect--helper.c:1085
+#: builtin/bisect--helper.c:1092
 msgid "--bisect-next-check requires 2 or 3 arguments"
 msgstr "--bisect-next-check benötigt 2 oder 3 Argumente"
 
-#: builtin/bisect--helper.c:1091
+#: builtin/bisect--helper.c:1098
 msgid "--bisect-terms requires 0 or 1 argument"
 msgstr "--bisect-terms benötigt 0 oder 1 Argument"
 
-#: builtin/bisect--helper.c:1100
+#: builtin/bisect--helper.c:1107
 msgid "--bisect-next requires 0 arguments"
 msgstr "--bisect-next benötigt 0 Argumente"
 
-#: builtin/bisect--helper.c:1111
+#: builtin/bisect--helper.c:1118
 msgid "--bisect-log requires 0 arguments"
 msgstr "--bisect-log benötigt 0 Argumente"
 
-#: builtin/bisect--helper.c:1116
+#: builtin/bisect--helper.c:1123
 msgid "no logfile given"
 msgstr "keine Log-Datei angegeben"
 
@@ -11219,9 +11388,9 @@ msgstr "Root-Commits nicht als Grenzen behandeln (Standard: aus)"
 msgid "show work cost statistics"
 msgstr "Statistiken zum Arbeitsaufwand anzeigen"
 
-#: builtin/blame.c:871 builtin/checkout.c:1503 builtin/clone.c:92
-#: builtin/commit-graph.c:84 builtin/commit-graph.c:222 builtin/fetch.c:175
-#: builtin/merge.c:297 builtin/multi-pack-index.c:27 builtin/pull.c:119
+#: builtin/blame.c:871 builtin/checkout.c:1524 builtin/clone.c:94
+#: builtin/commit-graph.c:84 builtin/commit-graph.c:222 builtin/fetch.c:179
+#: builtin/merge.c:297 builtin/multi-pack-index.c:55 builtin/pull.c:119
 #: builtin/push.c:575 builtin/send-pack.c:198
 msgid "force progress reporting"
 msgstr "Fortschrittsanzeige erzwingen"
@@ -11273,7 +11442,7 @@ msgstr ""
 msgid "ignore whitespace differences"
 msgstr "Whitespace-Unterschiede ignorieren"
 
-#: builtin/blame.c:883 builtin/log.c:1812
+#: builtin/blame.c:883 builtin/log.c:1820
 msgid "rev"
 msgstr "Commit"
 
@@ -11455,81 +11624,81 @@ msgstr "Remote-Tracking-Branch %s entfernt (war %s).\n"
 msgid "Deleted branch %s (was %s).\n"
 msgstr "Branch %s entfernt (war %s).\n"
 
-#: builtin/branch.c:438 builtin/tag.c:61
+#: builtin/branch.c:440 builtin/tag.c:63
 msgid "unable to parse format string"
 msgstr "Konnte Formatierungsstring nicht parsen."
 
-#: builtin/branch.c:469
+#: builtin/branch.c:471
 msgid "could not resolve HEAD"
 msgstr "Konnte HEAD-Commit nicht auflösen."
 
-#: builtin/branch.c:475
+#: builtin/branch.c:477
 #, c-format
 msgid "HEAD (%s) points outside of refs/heads/"
 msgstr "HEAD (%s) wurde nicht unter \"refs/heads/\" gefunden!"
 
-#: builtin/branch.c:490
+#: builtin/branch.c:492
 #, c-format
 msgid "Branch %s is being rebased at %s"
 msgstr "Branch %s wird auf %s umgesetzt"
 
-#: builtin/branch.c:494
+#: builtin/branch.c:496
 #, c-format
 msgid "Branch %s is being bisected at %s"
 msgstr "Binäre Suche von Branch %s zu %s im Gange"
 
-#: builtin/branch.c:511
+#: builtin/branch.c:513
 msgid "cannot copy the current branch while not on any."
 msgstr ""
 "Kann den aktuellen Branch nicht kopieren, solange Sie sich auf keinem "
 "befinden."
 
-#: builtin/branch.c:513
+#: builtin/branch.c:515
 msgid "cannot rename the current branch while not on any."
 msgstr ""
 "Kann aktuellen Branch nicht umbenennen, solange Sie sich auf keinem befinden."
 
-#: builtin/branch.c:524
+#: builtin/branch.c:526
 #, c-format
 msgid "Invalid branch name: '%s'"
 msgstr "Ungültiger Branchname: '%s'"
 
-#: builtin/branch.c:553
+#: builtin/branch.c:555
 msgid "Branch rename failed"
 msgstr "Umbenennung des Branches fehlgeschlagen"
 
-#: builtin/branch.c:555
+#: builtin/branch.c:557
 msgid "Branch copy failed"
 msgstr "Kopie des Branches fehlgeschlagen"
 
-#: builtin/branch.c:559
+#: builtin/branch.c:561
 #, c-format
 msgid "Created a copy of a misnamed branch '%s'"
 msgstr "Kopie eines falsch benannten Branches '%s' erstellt."
 
-#: builtin/branch.c:562
+#: builtin/branch.c:564
 #, c-format
 msgid "Renamed a misnamed branch '%s' away"
 msgstr "falsch benannten Branch '%s' umbenannt"
 
-#: builtin/branch.c:568
+#: builtin/branch.c:570
 #, c-format
 msgid "Branch renamed to %s, but HEAD is not updated!"
 msgstr "Branch umbenannt zu %s, aber HEAD ist nicht aktualisiert!"
 
-#: builtin/branch.c:577
+#: builtin/branch.c:579
 msgid "Branch is renamed, but update of config-file failed"
 msgstr ""
 "Branch ist umbenannt, aber die Aktualisierung der Konfigurationsdatei ist "
 "fehlgeschlagen."
 
-#: builtin/branch.c:579
+#: builtin/branch.c:581
 msgid "Branch is copied, but update of config-file failed"
 msgstr ""
 "Branch wurde kopiert, aber die Aktualisierung der Konfigurationsdatei ist\n"
 "fehlgeschlagen."
 
-#: builtin/branch.c:595
+#: builtin/branch.c:597
 #, c-format
 msgid ""
 "Please edit the description for the branch\n"
@@ -11540,181 +11709,181 @@ msgstr ""
 "  %s\n"
 "Zeilen, die mit '%c' beginnen, werden entfernt.\n"
 
-#: builtin/branch.c:629
+#: builtin/branch.c:631
 msgid "Generic options"
 msgstr "Allgemeine Optionen"
 
-#: builtin/branch.c:631
+#: builtin/branch.c:633
 msgid "show hash and subject, give twice for upstream branch"
 msgstr "Hash und Betreff anzeigen; -vv: zusätzlich Upstream-Branch"
 
-#: builtin/branch.c:632
+#: builtin/branch.c:634
 msgid "suppress informational messages"
 msgstr "Informationsmeldungen unterdrücken"
 
-#: builtin/branch.c:633
+#: builtin/branch.c:635
 msgid "set up tracking mode (see git-pull(1))"
 msgstr "Modus zum Folgen von Branches einstellen (siehe git-pull(1))"
 
-#: builtin/branch.c:635
+#: builtin/branch.c:637
 msgid "do not use"
 msgstr "nicht verwenden"
 
-#: builtin/branch.c:637 builtin/rebase.c:534
+#: builtin/branch.c:639 builtin/rebase.c:533
 msgid "upstream"
 msgstr "Upstream"
 
-#: builtin/branch.c:637
+#: builtin/branch.c:639
 msgid "change the upstream info"
 msgstr "Informationen zum Upstream-Branch ändern"
 
-#: builtin/branch.c:638
+#: builtin/branch.c:640
 msgid "unset the upstream info"
 msgstr "Informationen zum Upstream-Branch entfernen"
 
-#: builtin/branch.c:639
+#: builtin/branch.c:641
 msgid "use colored output"
 msgstr "farbige Ausgaben verwenden"
 
-#: builtin/branch.c:640
+#: builtin/branch.c:642
 msgid "act on remote-tracking branches"
 msgstr "auf Remote-Tracking-Branches wirken"
 
-#: builtin/branch.c:642 builtin/branch.c:644
+#: builtin/branch.c:644 builtin/branch.c:646
 msgid "print only branches that contain the commit"
 msgstr "nur Branches ausgeben, die diesen Commit enthalten"
 
-#: builtin/branch.c:643 builtin/branch.c:645
+#: builtin/branch.c:645 builtin/branch.c:647
 msgid "print only branches that don't contain the commit"
 msgstr "nur Branches ausgeben, die diesen Commit nicht enthalten"
 
-#: builtin/branch.c:648
+#: builtin/branch.c:650
 msgid "Specific git-branch actions:"
 msgstr "spezifische Aktionen für \"git-branch\":"
 
-#: builtin/branch.c:649
+#: builtin/branch.c:651
 msgid "list both remote-tracking and local branches"
 msgstr "Remote-Tracking und lokale Branches auflisten"
 
-#: builtin/branch.c:651
+#: builtin/branch.c:653
 msgid "delete fully merged branch"
 msgstr "vollständig zusammengeführten Branch entfernen"
 
-#: builtin/branch.c:652
+#: builtin/branch.c:654
 msgid "delete branch (even if not merged)"
 msgstr "Branch löschen (auch wenn nicht zusammengeführt)"
 
-#: builtin/branch.c:653
+#: builtin/branch.c:655
 msgid "move/rename a branch and its reflog"
 msgstr "einen Branch und dessen Reflog verschieben/umbenennen"
 
-#: builtin/branch.c:654
+#: builtin/branch.c:656
 msgid "move/rename a branch, even if target exists"
 msgstr ""
 "einen Branch verschieben/umbenennen, auch wenn das Ziel bereits existiert"
 
-#: builtin/branch.c:655
+#: builtin/branch.c:657
 msgid "copy a branch and its reflog"
 msgstr "einen Branch und dessen Reflog kopieren"
 
-#: builtin/branch.c:656
+#: builtin/branch.c:658
 msgid "copy a branch, even if target exists"
 msgstr "einen Branch kopieren, auch wenn das Ziel bereits existiert"
 
-#: builtin/branch.c:657
+#: builtin/branch.c:659
 msgid "list branch names"
 msgstr "Branchnamen auflisten"
 
-#: builtin/branch.c:658
+#: builtin/branch.c:660
 msgid "show current branch name"
 msgstr "Zeige aktuellen Branch-Namen."
 
-#: builtin/branch.c:659
+#: builtin/branch.c:661
 msgid "create the branch's reflog"
 msgstr "das Reflog des Branches erzeugen"
 
-#: builtin/branch.c:661
+#: builtin/branch.c:663
 msgid "edit the description for the branch"
 msgstr "die Beschreibung für den Branch bearbeiten"
 
-#: builtin/branch.c:662
+#: builtin/branch.c:664
 msgid "force creation, move/rename, deletion"
 msgstr "Erstellung, Verschiebung/Umbenennung oder Löschung erzwingen"
 
-#: builtin/branch.c:663
+#: builtin/branch.c:665
 msgid "print only branches that are merged"
 msgstr "nur zusammengeführte Branches ausgeben"
 
-#: builtin/branch.c:664
+#: builtin/branch.c:666
 msgid "print only branches that are not merged"
 msgstr "nur nicht zusammengeführte Branches ausgeben"
 
-#: builtin/branch.c:665
+#: builtin/branch.c:667
 msgid "list branches in columns"
 msgstr "Branches in Spalten auflisten"
 
-#: builtin/branch.c:667 builtin/for-each-ref.c:42 builtin/notes.c:415
+#: builtin/branch.c:669 builtin/for-each-ref.c:44 builtin/notes.c:415
 #: builtin/notes.c:418 builtin/notes.c:581 builtin/notes.c:584
-#: builtin/tag.c:466
+#: builtin/tag.c:477
 msgid "object"
 msgstr "Objekt"
 
-#: builtin/branch.c:668
+#: builtin/branch.c:670
 msgid "print only branches of the object"
 msgstr "nur Branches von diesem Objekt ausgeben"
 
-#: builtin/branch.c:669 builtin/for-each-ref.c:48 builtin/tag.c:473
+#: builtin/branch.c:671 builtin/for-each-ref.c:50 builtin/tag.c:484
 msgid "sorting and filtering are case insensitive"
 msgstr "Sortierung und Filterung sind unabhängig von Groß- und Kleinschreibung"
 
-#: builtin/branch.c:670 builtin/for-each-ref.c:38 builtin/tag.c:471
+#: builtin/branch.c:672 builtin/for-each-ref.c:40 builtin/tag.c:482
 #: builtin/verify-tag.c:38
 msgid "format to use for the output"
 msgstr "für die Ausgabe zu verwendendes Format"
 
-#: builtin/branch.c:693 builtin/clone.c:790
+#: builtin/branch.c:695 builtin/clone.c:794
 msgid "HEAD not found below refs/heads!"
 msgstr "HEAD wurde nicht unter \"refs/heads\" gefunden!"
 
-#: builtin/branch.c:717
+#: builtin/branch.c:719
 msgid "--column and --verbose are incompatible"
 msgstr "--column und --verbose sind inkompatibel"
 
-#: builtin/branch.c:732 builtin/branch.c:788 builtin/branch.c:797
+#: builtin/branch.c:734 builtin/branch.c:790 builtin/branch.c:799
 msgid "branch name required"
 msgstr "Branchname erforderlich"
 
-#: builtin/branch.c:764
+#: builtin/branch.c:766
 msgid "Cannot give description to detached HEAD"
 msgstr "zu losgelöstem HEAD kann keine Beschreibung hinterlegt werden"
 
-#: builtin/branch.c:769
+#: builtin/branch.c:771
 msgid "cannot edit description of more than one branch"
 msgstr "Beschreibung von mehr als einem Branch kann nicht bearbeitet werden"
 
-#: builtin/branch.c:776
+#: builtin/branch.c:778
 #, c-format
 msgid "No commit on branch '%s' yet."
 msgstr "Noch kein Commit in Branch '%s'."
 
-#: builtin/branch.c:779
+#: builtin/branch.c:781
 #, c-format
 msgid "No branch named '%s'."
 msgstr "Branch '%s' nicht vorhanden."
 
-#: builtin/branch.c:794
+#: builtin/branch.c:796
 msgid "too many branches for a copy operation"
 msgstr "zu viele Branches für eine Kopieroperation angegeben"
 
-#: builtin/branch.c:803
+#: builtin/branch.c:805
 msgid "too many arguments for a rename operation"
 msgstr "zu viele Argumente für eine Umbenennen-Operation angegeben"
 
-#: builtin/branch.c:808
+#: builtin/branch.c:810
 msgid "too many arguments to set new upstream"
 msgstr "zu viele Argumente angegeben, um Upstream-Branch zu setzen"
 
-#: builtin/branch.c:812
+#: builtin/branch.c:814
 #, c-format
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch."
@@ -11722,34 +11891,34 @@ msgstr ""
 "Konnte keinen neuen Upstream-Branch von HEAD zu %s setzen, da dieser auf\n"
 "keinen Branch zeigt."
 
-#: builtin/branch.c:815 builtin/branch.c:838
+#: builtin/branch.c:817 builtin/branch.c:840
 #, c-format
 msgid "no such branch '%s'"
 msgstr "Branch '%s' nicht gefunden"
 
-#: builtin/branch.c:819
+#: builtin/branch.c:821
 #, c-format
 msgid "branch '%s' does not exist"
 msgstr "Branch '%s' existiert nicht"
 
-#: builtin/branch.c:832
+#: builtin/branch.c:834
 msgid "too many arguments to unset upstream"
 msgstr ""
 "zu viele Argumente angegeben, um Konfiguration zu Upstream-Branch zu "
 "entfernen"
 
-#: builtin/branch.c:836
+#: builtin/branch.c:838
 msgid "could not unset upstream of HEAD when it does not point to any branch."
 msgstr ""
 "Konnte Konfiguration zu Upstream-Branch von HEAD nicht entfernen, da dieser\n"
 "auf keinen Branch zeigt."
 
-#: builtin/branch.c:842
+#: builtin/branch.c:844
 #, c-format
 msgid "Branch '%s' has no upstream information"
 msgstr "Branch '%s' hat keinen Upstream-Branch gesetzt"
 
-#: builtin/branch.c:852
+#: builtin/branch.c:854
 msgid ""
 "The -a, and -r, options to 'git branch' do not take a branch name.\n"
 "Did you mean to use: -a|-r --list <pattern>?"
@@ -11758,7 +11927,7 @@ msgstr ""
 "verwendet werden.\n"
 "Wollten Sie -a|-r --list <Muster> benutzen?"
 
-#: builtin/branch.c:856
+#: builtin/branch.c:858
 msgid ""
 "the '--set-upstream' option is no longer supported. Please use '--track' or "
 "'--set-upstream-to' instead."
@@ -11828,38 +11997,38 @@ msgstr ""
 "Bitte überprüfen Sie den restlichen Teil des Fehlerberichts unten.\n"
 "Sie können jede Zeile löschen, die Sie nicht mitteilen möchten.\n"
 
-#: builtin/bugreport.c:135
+#: builtin/bugreport.c:136
 msgid "specify a destination for the bugreport file"
 msgstr "Speicherort für die Datei des Fehlerberichts angeben"
 
-#: builtin/bugreport.c:137
+#: builtin/bugreport.c:138
 msgid "specify a strftime format suffix for the filename"
 msgstr "Dateiendung im strftime-Format für den Dateinamen angeben"
 
-#: builtin/bugreport.c:159
+#: builtin/bugreport.c:160
 #, c-format
 msgid "could not create leading directories for '%s'"
 msgstr "konnte vorangehende Verzeichnisse für '%s' nicht erstellen"
 
-#: builtin/bugreport.c:166
+#: builtin/bugreport.c:167
 msgid "System Info"
 msgstr "System Info"
 
-#: builtin/bugreport.c:169
+#: builtin/bugreport.c:170
 msgid "Enabled Hooks"
 msgstr "Aktivierte Hooks"
 
-#: builtin/bugreport.c:176
+#: builtin/bugreport.c:177
 #, c-format
 msgid "couldn't create a new file at '%s'"
 msgstr "konnte keine neue Datei unter '%s' erstellen"
 
-#: builtin/bugreport.c:179
+#: builtin/bugreport.c:180
 #, c-format
 msgid "unable to write to %s"
 msgstr "konnte nicht nach %s schreiben"
 
-#: builtin/bugreport.c:189
+#: builtin/bugreport.c:190
 #, c-format
 msgid "Created new report at '%s'.\n"
 msgstr "Neuer Bericht unter '%s' erstellt.\n"
@@ -11880,19 +12049,19 @@ msgstr "git bundle list-heads <Datei> [<Referenzname>...]"
 msgid "git bundle unbundle <file> [<refname>...]"
 msgstr "git bundle unbundle <Datei> [<Referenzname>...]"
 
-#: builtin/bundle.c:67 builtin/pack-objects.c:3495
+#: builtin/bundle.c:67 builtin/pack-objects.c:3747
 msgid "do not show progress meter"
 msgstr "keine Fortschrittsanzeige anzeigen"
 
-#: builtin/bundle.c:69 builtin/pack-objects.c:3497
+#: builtin/bundle.c:69 builtin/pack-objects.c:3749
 msgid "show progress meter"
 msgstr "Fortschrittsanzeige anzeigen"
 
-#: builtin/bundle.c:71 builtin/pack-objects.c:3499
+#: builtin/bundle.c:71 builtin/pack-objects.c:3751
 msgid "show progress meter during object writing phase"
 msgstr "Forschrittsanzeige während des Schreibens von Objekten anzeigen"
 
-#: builtin/bundle.c:74 builtin/pack-objects.c:3502
+#: builtin/bundle.c:74 builtin/pack-objects.c:3754
 msgid "similar to --all-progress when progress meter is shown"
 msgstr "ähnlich zu --all-progress wenn Fortschrittsanzeige darstellt wird"
 
@@ -12039,8 +12208,8 @@ msgstr "Dateinamen von der Standard-Eingabe lesen"
 msgid "terminate input and output records by a NUL character"
 msgstr "Einträge von Ein- und Ausgabe mit NUL-Zeichen abschließen"
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1499 builtin/gc.c:549
-#: builtin/worktree.c:489
+#: builtin/check-ignore.c:21 builtin/checkout.c:1520 builtin/gc.c:549
+#: builtin/worktree.c:491
 msgid "suppress progress reporting"
 msgstr "Fortschrittsanzeige unterdrücken"
 
@@ -12052,27 +12221,27 @@ msgstr "Eingabe-Pfade ohne Übereinstimmungen anzeigen"
 msgid "ignore index when checking"
 msgstr "Index bei der Prüfung ignorieren"
 
-#: builtin/check-ignore.c:163
+#: builtin/check-ignore.c:165
 msgid "cannot specify pathnames with --stdin"
 msgstr "Angabe von Pfadnamen kann nicht gemeinsam mit --stdin verwendet werden"
 
-#: builtin/check-ignore.c:166
+#: builtin/check-ignore.c:168
 msgid "-z only makes sense with --stdin"
 msgstr "-z kann nur mit --stdin verwendet werden"
 
-#: builtin/check-ignore.c:168
+#: builtin/check-ignore.c:170
 msgid "no path specified"
 msgstr "kein Pfad angegeben"
 
-#: builtin/check-ignore.c:172
+#: builtin/check-ignore.c:174
 msgid "--quiet is only valid with a single pathname"
 msgstr "--quiet ist nur mit einem einzelnen Pfadnamen gültig"
 
-#: builtin/check-ignore.c:174
+#: builtin/check-ignore.c:176
 msgid "cannot have both --quiet and --verbose"
 msgstr "--quiet und --verbose können nicht gemeinsam verwendet werden"
 
-#: builtin/check-ignore.c:177
+#: builtin/check-ignore.c:179
 msgid "--non-matching is only valid with --verbose"
 msgstr "--non-matching ist nur mit --verbose zulässig"
 
@@ -12093,6 +12262,23 @@ msgstr "Konnte Kontakt '%s' nicht parsen."
 msgid "no contacts specified"
 msgstr "keine Kontakte angegeben"
 
+#: builtin/checkout--worker.c:110
+#, fuzzy
+msgid "git checkout--worker [<options>]"
+msgstr "git checkout [<Optionen>] <Branch>"
+
+#: builtin/checkout--worker.c:118 builtin/checkout-index.c:201
+#: builtin/column.c:31 builtin/submodule--helper.c:1825
+#: builtin/submodule--helper.c:1828 builtin/submodule--helper.c:1836
+#: builtin/submodule--helper.c:2334 builtin/worktree.c:719
+msgid "string"
+msgstr "Zeichenkette"
+
+#: builtin/checkout--worker.c:119 builtin/checkout-index.c:202
+msgid "when creating files, prepend <string>"
+msgstr ""
+"wenn Dateien erzeugt werden, stelle <Zeichenkette> dem Dateinamen voran"
+
 #: builtin/checkout-index.c:152
 msgid "git checkout-index [<options>] [--] [<file>...]"
 msgstr "git checkout-index [<Optionen>] [--] [<Datei>...]"
@@ -12101,161 +12287,149 @@ msgstr "git checkout-index [<Optionen>] [--] [<Datei>...]"
 msgid "stage should be between 1 and 3 or all"
 msgstr "--stage sollte zwischen 1 und 3 oder 'all' sein"
 
-#: builtin/checkout-index.c:186
+#: builtin/checkout-index.c:187
 msgid "check out all files in the index"
 msgstr "alle Dateien im Index auschecken"
 
-#: builtin/checkout-index.c:187
+#: builtin/checkout-index.c:188
 msgid "force overwrite of existing files"
 msgstr "das Überschreiben bereits existierender Dateien erzwingen"
 
-#: builtin/checkout-index.c:189
+#: builtin/checkout-index.c:190
 msgid "no warning for existing files and files not in index"
 msgstr ""
 "keine Warnung für existierende Dateien, und Dateien, die sich nicht im Index "
 "befinden"
 
-#: builtin/checkout-index.c:191
+#: builtin/checkout-index.c:192
 msgid "don't checkout new files"
 msgstr "keine neuen Dateien auschecken"
 
-#: builtin/checkout-index.c:193
+#: builtin/checkout-index.c:194
 msgid "update stat information in the index file"
 msgstr "Dateiinformationen in der Index-Datei aktualisieren"
 
-#: builtin/checkout-index.c:197
+#: builtin/checkout-index.c:198
 msgid "read list of paths from the standard input"
 msgstr "eine Liste von Pfaden von der Standard-Eingabe lesen"
 
-#: builtin/checkout-index.c:199
+#: builtin/checkout-index.c:200
 msgid "write the content to temporary files"
 msgstr "den Inhalt in temporäre Dateien schreiben"
 
-#: builtin/checkout-index.c:200 builtin/column.c:31
-#: builtin/submodule--helper.c:1824 builtin/submodule--helper.c:1827
-#: builtin/submodule--helper.c:1835 builtin/submodule--helper.c:2333
-#: builtin/worktree.c:717
-msgid "string"
-msgstr "Zeichenkette"
-
-#: builtin/checkout-index.c:201
-msgid "when creating files, prepend <string>"
-msgstr ""
-"wenn Dateien erzeugt werden, stelle <Zeichenkette> dem Dateinamen voran"
-
-#: builtin/checkout-index.c:203
+#: builtin/checkout-index.c:204
 msgid "copy out the files from named stage"
 msgstr "Dateien von dem benannten Stand kopieren"
 
-#: builtin/checkout.c:31
+#: builtin/checkout.c:33
 msgid "git checkout [<options>] <branch>"
 msgstr "git checkout [<Optionen>] <Branch>"
 
-#: builtin/checkout.c:32
+#: builtin/checkout.c:34
 msgid "git checkout [<options>] [<branch>] -- <file>..."
 msgstr "git checkout [<Optionen>] [<Branch>] -- <Datei>..."
 
-#: builtin/checkout.c:37
+#: builtin/checkout.c:39
 msgid "git switch [<options>] [<branch>]"
 msgstr "git switch [<Optionen>] [<Branch>]"
 
-#: builtin/checkout.c:42
+#: builtin/checkout.c:44
 msgid "git restore [<options>] [--source=<branch>] <file>..."
 msgstr "git restore [<Optionen>] [--source=<Branch>] <Datei>..."
 
-#: builtin/checkout.c:188 builtin/checkout.c:227
+#: builtin/checkout.c:190 builtin/checkout.c:229
 #, c-format
 msgid "path '%s' does not have our version"
 msgstr "Pfad '%s' hat nicht unsere Version."
 
-#: builtin/checkout.c:190 builtin/checkout.c:229
+#: builtin/checkout.c:192 builtin/checkout.c:231
 #, c-format
 msgid "path '%s' does not have their version"
 msgstr "Pfad '%s' hat nicht deren Version."
 
-#: builtin/checkout.c:206
+#: builtin/checkout.c:208
 #, c-format
 msgid "path '%s' does not have all necessary versions"
 msgstr "Pfad '%s' hat nicht alle notwendigen Versionen."
 
-#: builtin/checkout.c:258
+#: builtin/checkout.c:261
 #, c-format
 msgid "path '%s' does not have necessary versions"
 msgstr "Pfad '%s' hat nicht die notwendigen Versionen."
 
-#: builtin/checkout.c:275
+#: builtin/checkout.c:278
 #, c-format
 msgid "path '%s': cannot merge"
 msgstr "Pfad '%s': kann nicht zusammenführen"
 
-#: builtin/checkout.c:291
+#: builtin/checkout.c:294
 #, c-format
 msgid "Unable to add merge result for '%s'"
 msgstr "Konnte Merge-Ergebnis von '%s' nicht hinzufügen."
 
-#: builtin/checkout.c:396
+#: builtin/checkout.c:414
 #, c-format
 msgid "Recreated %d merge conflict"
 msgid_plural "Recreated %d merge conflicts"
 msgstr[0] "%d Merge-Konflikt wieder erstellt"
 msgstr[1] "%d Merge-Konflikte wieder erstellt"
 
-#: builtin/checkout.c:401
+#: builtin/checkout.c:419
 #, c-format
 msgid "Updated %d path from %s"
 msgid_plural "Updated %d paths from %s"
 msgstr[0] "%d Pfad von %s aktualisiert"
 msgstr[1] "%d Pfade von %s aktualisiert"
 
-#: builtin/checkout.c:408
+#: builtin/checkout.c:426
 #, c-format
 msgid "Updated %d path from the index"
 msgid_plural "Updated %d paths from the index"
 msgstr[0] "%d Pfad vom Index aktualisiert"
 msgstr[1] "%d Pfade vom Index aktualisiert"
 
-#: builtin/checkout.c:431 builtin/checkout.c:434 builtin/checkout.c:437
-#: builtin/checkout.c:441
+#: builtin/checkout.c:449 builtin/checkout.c:452 builtin/checkout.c:455
+#: builtin/checkout.c:459
 #, c-format
 msgid "'%s' cannot be used with updating paths"
 msgstr "'%s' kann nicht mit der Aktualisierung von Pfaden verwendet werden"
 
-#: builtin/checkout.c:444 builtin/checkout.c:447
+#: builtin/checkout.c:462 builtin/checkout.c:465
 #, c-format
 msgid "'%s' cannot be used with %s"
 msgstr "'%s' kann nicht mit '%s' verwendet werden"
 
-#: builtin/checkout.c:451
+#: builtin/checkout.c:469
 #, c-format
 msgid "Cannot update paths and switch to branch '%s' at the same time."
 msgstr ""
 "Kann nicht gleichzeitig Pfade aktualisieren und zu Branch '%s' wechseln"
 
-#: builtin/checkout.c:455
+#: builtin/checkout.c:473
 #, c-format
 msgid "neither '%s' or '%s' is specified"
 msgstr "Weder '%s' noch '%s' ist angegeben"
 
-#: builtin/checkout.c:459
+#: builtin/checkout.c:477
 #, c-format
 msgid "'%s' must be used when '%s' is not specified"
 msgstr "'%s' kann nur genutzt werden, wenn '%s' nicht verwendet wird"
 
-#: builtin/checkout.c:464 builtin/checkout.c:469
+#: builtin/checkout.c:482 builtin/checkout.c:487
 #, c-format
 msgid "'%s' or '%s' cannot be used with %s"
 msgstr "'%s' oder '%s' kann nicht mit %s verwendet werden"
 
-#: builtin/checkout.c:543 builtin/checkout.c:550
+#: builtin/checkout.c:563 builtin/checkout.c:570
 #, c-format
 msgid "path '%s' is unmerged"
 msgstr "Pfad '%s' ist nicht zusammengeführt."
 
-#: builtin/checkout.c:718
+#: builtin/checkout.c:739
 msgid "you need to resolve your current index first"
 msgstr "Sie müssen zuerst die Konflikte in Ihrem aktuellen Index auflösen."
 
-#: builtin/checkout.c:772
+#: builtin/checkout.c:793
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -12264,50 +12438,50 @@ msgstr ""
 "Kann nicht mit vorgemerkten Änderungen in folgenden Dateien fortsetzen:\n"
 "%s"
 
-#: builtin/checkout.c:865
+#: builtin/checkout.c:886
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Kann \"reflog\" für '%s' nicht durchführen: %s\n"
 
-#: builtin/checkout.c:907
+#: builtin/checkout.c:928
 msgid "HEAD is now at"
 msgstr "HEAD ist jetzt bei"
 
-#: builtin/checkout.c:911 builtin/clone.c:721 t/helper/test-fast-rebase.c:202
+#: builtin/checkout.c:932 builtin/clone.c:725 t/helper/test-fast-rebase.c:202
 msgid "unable to update HEAD"
 msgstr "Konnte HEAD nicht aktualisieren."
 
-#: builtin/checkout.c:915
+#: builtin/checkout.c:936
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Setze Branch '%s' neu\n"
 
-#: builtin/checkout.c:918
+#: builtin/checkout.c:939
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Bereits auf '%s'\n"
 
-#: builtin/checkout.c:922
+#: builtin/checkout.c:943
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Zu umgesetztem Branch '%s' gewechselt\n"
 
-#: builtin/checkout.c:924 builtin/checkout.c:1355
+#: builtin/checkout.c:945 builtin/checkout.c:1376
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Zu neuem Branch '%s' gewechselt\n"
 
-#: builtin/checkout.c:926
+#: builtin/checkout.c:947
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Zu Branch '%s' gewechselt\n"
 
-#: builtin/checkout.c:977
+#: builtin/checkout.c:998
 #, c-format
 msgid " ... and %d more.\n"
 msgstr " ... und %d weitere.\n"
 
-#: builtin/checkout.c:983
+#: builtin/checkout.c:1004
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -12330,7 +12504,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:1002
+#: builtin/checkout.c:1023
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -12357,19 +12531,19 @@ msgstr[1] ""
 " git branch <neuer-Branchname> %s\n"
 "\n"
 
-#: builtin/checkout.c:1037
+#: builtin/checkout.c:1058
 msgid "internal error in revision walk"
 msgstr "interner Fehler im Revisionsgang"
 
-#: builtin/checkout.c:1041
+#: builtin/checkout.c:1062
 msgid "Previous HEAD position was"
 msgstr "Vorherige Position von HEAD war"
 
-#: builtin/checkout.c:1081 builtin/checkout.c:1350
+#: builtin/checkout.c:1102 builtin/checkout.c:1371
 msgid "You are on a branch yet to be born"
 msgstr "Sie sind auf einem Branch, der noch nicht geboren ist"
 
-#: builtin/checkout.c:1163
+#: builtin/checkout.c:1184
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
@@ -12379,7 +12553,7 @@ msgstr ""
 "Bitte benutzen Sie -- (und optional --no-guess), um diese\n"
 "eindeutig voneinander zu unterscheiden."
 
-#: builtin/checkout.c:1170
+#: builtin/checkout.c:1191
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -12402,51 +12576,51 @@ msgstr ""
 "bevorzugen möchten, z.B. 'origin', können Sie die Einstellung\n"
 "checkout.defaultRemote=origin in Ihrer Konfiguration setzen."
 
-#: builtin/checkout.c:1180
+#: builtin/checkout.c:1201
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "'%s' entspricht mehreren (%d) Remote-Tracking-Branches"
 
-#: builtin/checkout.c:1246
+#: builtin/checkout.c:1267
 msgid "only one reference expected"
 msgstr "nur eine Referenz erwartet"
 
-#: builtin/checkout.c:1263
+#: builtin/checkout.c:1284
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "nur eine Referenz erwartet, %d gegeben."
 
-#: builtin/checkout.c:1309 builtin/worktree.c:270 builtin/worktree.c:438
+#: builtin/checkout.c:1330 builtin/worktree.c:270 builtin/worktree.c:438
 #, c-format
 msgid "invalid reference: %s"
 msgstr "Ungültige Referenz: %s"
 
-#: builtin/checkout.c:1322 builtin/checkout.c:1688
+#: builtin/checkout.c:1343 builtin/checkout.c:1709
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "Referenz ist kein \"Tree\"-Objekt: %s"
 
-#: builtin/checkout.c:1369
+#: builtin/checkout.c:1390
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "Ein Branch wird erwartet, Tag '%s' bekommen"
 
-#: builtin/checkout.c:1371
+#: builtin/checkout.c:1392
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "Ein Branch wird erwartet, Remote-Branch '%s' bekommen"
 
-#: builtin/checkout.c:1372 builtin/checkout.c:1380
+#: builtin/checkout.c:1393 builtin/checkout.c:1401
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "Ein Branch wird erwartet, '%s' bekommen"
 
-#: builtin/checkout.c:1375
+#: builtin/checkout.c:1396
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "Ein Branch wird erwartet, Commit '%s' bekommen"
 
-#: builtin/checkout.c:1391
+#: builtin/checkout.c:1412
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -12454,7 +12628,7 @@ msgstr ""
 "Der Branch kann nicht während eines Merges gewechselt werden.\n"
 "Ziehen Sie \"git merge --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1395
+#: builtin/checkout.c:1416
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
@@ -12463,7 +12637,7 @@ msgstr ""
 "werden.\n"
 "Ziehen Sie \"git am --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1399
+#: builtin/checkout.c:1420
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
@@ -12472,7 +12646,7 @@ msgstr ""
 "werden.\n"
 "Ziehen Sie \"git rebase --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1403
+#: builtin/checkout.c:1424
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
@@ -12481,7 +12655,7 @@ msgstr ""
 "gewechselt werden.\n"
 "Ziehen Sie \"git cherry-pick --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1407
+#: builtin/checkout.c:1428
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -12490,140 +12664,140 @@ msgstr ""
 "werden.\n"
 "Ziehen Sie \"git revert --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1411
+#: builtin/checkout.c:1432
 msgid "you are switching branch while bisecting"
 msgstr "Sie wechseln den Branch während einer binären Suche"
 
-#: builtin/checkout.c:1418
+#: builtin/checkout.c:1439
 msgid "paths cannot be used with switching branches"
 msgstr "Pfade können nicht beim Wechseln von Branches verwendet werden"
 
-#: builtin/checkout.c:1421 builtin/checkout.c:1425 builtin/checkout.c:1429
+#: builtin/checkout.c:1442 builtin/checkout.c:1446 builtin/checkout.c:1450
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "'%s' kann nicht beim Wechseln von Branches verwendet werden"
 
-#: builtin/checkout.c:1433 builtin/checkout.c:1436 builtin/checkout.c:1439
-#: builtin/checkout.c:1444 builtin/checkout.c:1449
+#: builtin/checkout.c:1454 builtin/checkout.c:1457 builtin/checkout.c:1460
+#: builtin/checkout.c:1465 builtin/checkout.c:1470
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "'%s' kann nicht mit '%s' verwendet werden"
 
-#: builtin/checkout.c:1446
+#: builtin/checkout.c:1467
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "'%s' kann nicht <Startpunkt> bekommen"
 
-#: builtin/checkout.c:1454
+#: builtin/checkout.c:1475
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "Kann Branch nicht zu Nicht-Commit '%s' wechseln"
 
-#: builtin/checkout.c:1461
+#: builtin/checkout.c:1482
 msgid "missing branch or commit argument"
 msgstr "Branch- oder Commit-Argument fehlt"
 
-#: builtin/checkout.c:1504
+#: builtin/checkout.c:1525
 msgid "perform a 3-way merge with the new branch"
 msgstr "einen 3-Wege-Merge mit dem neuen Branch ausführen"
 
-#: builtin/checkout.c:1505 builtin/log.c:1799 parse-options.h:322
+#: builtin/checkout.c:1526 builtin/log.c:1807 parse-options.h:323
 msgid "style"
 msgstr "Stil"
 
-#: builtin/checkout.c:1506
+#: builtin/checkout.c:1527
 msgid "conflict style (merge or diff3)"
 msgstr "Konfliktstil (merge oder diff3)"
 
-#: builtin/checkout.c:1518 builtin/worktree.c:486
+#: builtin/checkout.c:1539 builtin/worktree.c:488
 msgid "detach HEAD at named commit"
 msgstr "HEAD bei benanntem Commit loslösen"
 
-#: builtin/checkout.c:1519
+#: builtin/checkout.c:1540
 msgid "set upstream info for new branch"
 msgstr "Informationen zum Upstream-Branch für den neuen Branch setzen"
 
-#: builtin/checkout.c:1521
+#: builtin/checkout.c:1542
 msgid "force checkout (throw away local modifications)"
 msgstr "Auschecken erzwingen (verwirft lokale Änderungen)"
 
-#: builtin/checkout.c:1523
+#: builtin/checkout.c:1544
 msgid "new-branch"
 msgstr "neuer Branch"
 
-#: builtin/checkout.c:1523
+#: builtin/checkout.c:1544
 msgid "new unparented branch"
 msgstr "neuer Branch ohne Eltern-Commit"
 
-#: builtin/checkout.c:1525 builtin/merge.c:301
+#: builtin/checkout.c:1546 builtin/merge.c:301
 msgid "update ignored files (default)"
 msgstr "ignorierte Dateien aktualisieren (Standard)"
 
-#: builtin/checkout.c:1528
+#: builtin/checkout.c:1549
 msgid "do not check if another worktree is holding the given ref"
 msgstr ""
 "Prüfung, ob die Referenz bereits in einem anderen Arbeitsverzeichnis "
 "ausgecheckt wurde, deaktivieren"
 
-#: builtin/checkout.c:1541
+#: builtin/checkout.c:1562
 msgid "checkout our version for unmerged files"
 msgstr "unsere Variante für nicht zusammengeführte Dateien auschecken"
 
-#: builtin/checkout.c:1544
+#: builtin/checkout.c:1565
 msgid "checkout their version for unmerged files"
 msgstr "ihre Variante für nicht zusammengeführte Dateien auschecken"
 
-#: builtin/checkout.c:1548
+#: builtin/checkout.c:1569
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "keine Einschränkung bei Pfadspezifikationen zum partiellen Auschecken"
 
-#: builtin/checkout.c:1603
+#: builtin/checkout.c:1624
 #, c-format
 msgid "-%c, -%c and --orphan are mutually exclusive"
 msgstr "-%c, -%c und --orphan schließen sich gegenseitig aus"
 
-#: builtin/checkout.c:1607
+#: builtin/checkout.c:1628
 msgid "-p and --overlay are mutually exclusive"
 msgstr "-p und --overlay schließen sich gegenseitig aus"
 
-#: builtin/checkout.c:1644
+#: builtin/checkout.c:1665
 msgid "--track needs a branch name"
 msgstr "--track benötigt ein Branchname"
 
-#: builtin/checkout.c:1649
+#: builtin/checkout.c:1670
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "kein Branchname; versuchen Sie -%c"
 
-#: builtin/checkout.c:1681
+#: builtin/checkout.c:1702
 #, c-format
 msgid "could not resolve %s"
 msgstr "konnte %s nicht auflösen"
 
-#: builtin/checkout.c:1697
+#: builtin/checkout.c:1718
 msgid "invalid path specification"
 msgstr "ungültige Pfadspezifikation"
 
-#: builtin/checkout.c:1704
+#: builtin/checkout.c:1725
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr ""
 "'%s' ist kein Commit und es kann kein Branch '%s' aus diesem erstellt werden."
 
-#: builtin/checkout.c:1708
+#: builtin/checkout.c:1729
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach nimmt kein Pfad-Argument '%s'"
 
-#: builtin/checkout.c:1717
+#: builtin/checkout.c:1738
 msgid "--pathspec-from-file is incompatible with --detach"
 msgstr "--pathspec-from-file und --detach sind inkompatibel"
 
-#: builtin/checkout.c:1720 builtin/reset.c:325 builtin/stash.c:1566
+#: builtin/checkout.c:1741 builtin/reset.c:325 builtin/stash.c:1634
 msgid "--pathspec-from-file is incompatible with --patch"
 msgstr "--pathspec-from-file und --patch sind inkompatibel"
 
-#: builtin/checkout.c:1733
+#: builtin/checkout.c:1754
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -12631,70 +12805,70 @@ msgstr ""
 "git checkout: --ours/--theirs, --force und --merge sind inkompatibel wenn\n"
 "Sie aus dem Index auschecken."
 
-#: builtin/checkout.c:1738
+#: builtin/checkout.c:1759
 msgid "you must specify path(s) to restore"
 msgstr "Sie müssen Pfad(e) zur Wiederherstellung angeben."
 
-#: builtin/checkout.c:1764 builtin/checkout.c:1766 builtin/checkout.c:1815
-#: builtin/checkout.c:1817 builtin/clone.c:122 builtin/remote.c:170
-#: builtin/remote.c:172 builtin/submodule--helper.c:2719 builtin/worktree.c:482
-#: builtin/worktree.c:484
+#: builtin/checkout.c:1785 builtin/checkout.c:1787 builtin/checkout.c:1836
+#: builtin/checkout.c:1838 builtin/clone.c:126 builtin/remote.c:170
+#: builtin/remote.c:172 builtin/submodule--helper.c:2720 builtin/worktree.c:484
+#: builtin/worktree.c:486
 msgid "branch"
 msgstr "Branch"
 
-#: builtin/checkout.c:1765
+#: builtin/checkout.c:1786
 msgid "create and checkout a new branch"
 msgstr "einen neuen Branch erzeugen und auschecken"
 
-#: builtin/checkout.c:1767
+#: builtin/checkout.c:1788
 msgid "create/reset and checkout a branch"
 msgstr "einen Branch erstellen/umsetzen und auschecken"
 
-#: builtin/checkout.c:1768
+#: builtin/checkout.c:1789
 msgid "create reflog for new branch"
 msgstr "das Reflog für den neuen Branch erzeugen"
 
-#: builtin/checkout.c:1770
+#: builtin/checkout.c:1791
 msgid "second guess 'git checkout <no-such-branch>' (default)"
 msgstr "Zweite Vermutung 'git checkout <kein-solcher-Branch>' (Standard)"
 
-#: builtin/checkout.c:1771
+#: builtin/checkout.c:1792
 msgid "use overlay mode (default)"
 msgstr "benutze Overlay-Modus (Standard)"
 
-#: builtin/checkout.c:1816
+#: builtin/checkout.c:1837
 msgid "create and switch to a new branch"
 msgstr "einen neuen Branch erzeugen und dahin wechseln"
 
-#: builtin/checkout.c:1818
+#: builtin/checkout.c:1839
 msgid "create/reset and switch to a branch"
 msgstr "einen Branch erstellen/umsetzen und dahin wechseln"
 
-#: builtin/checkout.c:1820
+#: builtin/checkout.c:1841
 msgid "second guess 'git switch <no-such-branch>'"
 msgstr "Zweite Vermutung 'git switch <kein-solcher-Branch>'"
 
-#: builtin/checkout.c:1822
+#: builtin/checkout.c:1843
 msgid "throw away local modifications"
 msgstr "lokale Änderungen verwerfen"
 
-#: builtin/checkout.c:1856
+#: builtin/checkout.c:1877
 msgid "which tree-ish to checkout from"
 msgstr "Von welcher Commit-Referenz ausgecheckt werden soll"
 
-#: builtin/checkout.c:1858
+#: builtin/checkout.c:1879
 msgid "restore the index"
 msgstr "Index wiederherstellen"
 
-#: builtin/checkout.c:1860
+#: builtin/checkout.c:1881
 msgid "restore the working tree (default)"
 msgstr "das Arbeitsverzeichnis wiederherstellen (Standard)"
 
-#: builtin/checkout.c:1862
+#: builtin/checkout.c:1883
 msgid "ignore unmerged entries"
 msgstr "ignoriere nicht zusammengeführte Einträge"
 
-#: builtin/checkout.c:1863
+#: builtin/checkout.c:1884
 msgid "use overlay mode"
 msgstr "benutze Overlay-Modus"
 
@@ -12723,11 +12897,6 @@ msgstr "Überspringe Repository %s\n"
 #, c-format
 msgid "Would skip repository %s\n"
 msgstr "Würde Repository %s überspringen\n"
-
-#: builtin/clean.c:37
-#, c-format
-msgid "failed to remove %s"
-msgstr "Fehler beim Löschen von %s"
 
 #: builtin/clean.c:38
 #, c-format
@@ -12839,8 +13008,8 @@ msgid "remove whole directories"
 msgstr "ganze Verzeichnisse löschen"
 
 #: builtin/clean.c:909 builtin/describe.c:565 builtin/describe.c:567
-#: builtin/grep.c:922 builtin/log.c:184 builtin/log.c:186
-#: builtin/ls-files.c:573 builtin/name-rev.c:526 builtin/name-rev.c:528
+#: builtin/grep.c:924 builtin/log.c:184 builtin/log.c:186
+#: builtin/ls-files.c:650 builtin/name-rev.c:526 builtin/name-rev.c:528
 #: builtin/show-ref.c:179
 msgid "pattern"
 msgstr "Muster"
@@ -12881,170 +13050,176 @@ msgstr "-x und -X können nicht gemeinsam verwendet werden"
 msgid "git clone [<options>] [--] <repo> [<dir>]"
 msgstr "git clone [<Optionen>] [--] <Repository> [<Verzeichnis>]"
 
-#: builtin/clone.c:94
+#: builtin/clone.c:96
+#, fuzzy
+msgid "don't clone shallow repository"
+msgstr "von einem lokalen Repository klonen"
+
+#: builtin/clone.c:98
 msgid "don't create a checkout"
 msgstr "kein Auschecken"
 
-#: builtin/clone.c:95 builtin/clone.c:97 builtin/init-db.c:555
+#: builtin/clone.c:99 builtin/clone.c:101 builtin/init-db.c:541
 msgid "create a bare repository"
 msgstr "ein Bare-Repository erstellen"
 
-#: builtin/clone.c:99
+#: builtin/clone.c:103
 msgid "create a mirror repository (implies bare)"
 msgstr "ein Spiegelarchiv erstellen (impliziert --bare)"
 
-#: builtin/clone.c:101
+#: builtin/clone.c:105
 msgid "to clone from a local repository"
 msgstr "von einem lokalen Repository klonen"
 
-#: builtin/clone.c:103
+#: builtin/clone.c:107
 msgid "don't use local hardlinks, always copy"
 msgstr "lokal keine harten Verweise verwenden, immer Kopien"
 
-#: builtin/clone.c:105
+#: builtin/clone.c:109
 msgid "setup as shared repository"
 msgstr "als verteiltes Repository einrichten"
 
-#: builtin/clone.c:107
+#: builtin/clone.c:111
 msgid "pathspec"
 msgstr "Pfadspezifikation"
 
-#: builtin/clone.c:107
+#: builtin/clone.c:111
 msgid "initialize submodules in the clone"
 msgstr "Submodule im Klon initialisieren"
 
-#: builtin/clone.c:111
+#: builtin/clone.c:115
 msgid "number of submodules cloned in parallel"
 msgstr "Anzahl der parallel zu klonenden Submodule"
 
-#: builtin/clone.c:112 builtin/init-db.c:552
+#: builtin/clone.c:116 builtin/init-db.c:538
 msgid "template-directory"
 msgstr "Vorlagenverzeichnis"
 
-#: builtin/clone.c:113 builtin/init-db.c:553
+#: builtin/clone.c:117 builtin/init-db.c:539
 msgid "directory from which templates will be used"
 msgstr "Verzeichnis, von welchem die Vorlagen verwendet werden"
 
-#: builtin/clone.c:115 builtin/clone.c:117 builtin/submodule--helper.c:1831
-#: builtin/submodule--helper.c:2336
+#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1832
+#: builtin/submodule--helper.c:2337
 msgid "reference repository"
 msgstr "Repository referenzieren"
 
-#: builtin/clone.c:119 builtin/submodule--helper.c:1833
-#: builtin/submodule--helper.c:2338
+#: builtin/clone.c:123 builtin/submodule--helper.c:1834
+#: builtin/submodule--helper.c:2339
 msgid "use --reference only while cloning"
 msgstr "--reference nur während des Klonens benutzen"
 
-#: builtin/clone.c:120 builtin/column.c:27 builtin/init-db.c:563
-#: builtin/merge-file.c:46 builtin/pack-objects.c:3561 builtin/repack.c:357
+#: builtin/clone.c:124 builtin/column.c:27 builtin/init-db.c:549
+#: builtin/merge-file.c:46 builtin/pack-objects.c:3815 builtin/repack.c:495
+#: t/helper/test-simple-ipc.c:696 t/helper/test-simple-ipc.c:698
 msgid "name"
 msgstr "Name"
 
-#: builtin/clone.c:121
+#: builtin/clone.c:125
 msgid "use <name> instead of 'origin' to track upstream"
 msgstr "<Name> statt 'origin' für Upstream-Repository verwenden"
 
-#: builtin/clone.c:123
+#: builtin/clone.c:127
 msgid "checkout <branch> instead of the remote's HEAD"
 msgstr "<Branch> auschecken, anstatt HEAD des Remote-Repositories"
 
-#: builtin/clone.c:125
+#: builtin/clone.c:129
 msgid "path to git-upload-pack on the remote"
 msgstr "Pfad zu \"git-upload-pack\" auf der Gegenseite"
 
-#: builtin/clone.c:126 builtin/fetch.c:176 builtin/grep.c:861
+#: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:863
 #: builtin/pull.c:208
 msgid "depth"
 msgstr "Tiefe"
 
-#: builtin/clone.c:127
+#: builtin/clone.c:131
 msgid "create a shallow clone of that depth"
 msgstr ""
 "einen Klon mit unvollständiger Historie (shallow) in dieser Tiefe erstellen"
 
-#: builtin/clone.c:128 builtin/fetch.c:178 builtin/pack-objects.c:3550
+#: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3804
 #: builtin/pull.c:211
 msgid "time"
 msgstr "Zeit"
 
-#: builtin/clone.c:129
+#: builtin/clone.c:133
 msgid "create a shallow clone since a specific time"
 msgstr ""
 "einen Klon mit unvollständiger Historie (shallow) seit einer bestimmten "
 "Zeit\n"
 "erstellen"
 
-#: builtin/clone.c:130 builtin/fetch.c:180 builtin/fetch.c:203
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1323
+#: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
+#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1318
 msgid "revision"
 msgstr "Commit"
 
-#: builtin/clone.c:131 builtin/fetch.c:181 builtin/pull.c:215
+#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:215
 msgid "deepen history of shallow clone, excluding rev"
 msgstr ""
 "die Historie eines Klons mit unvollständiger Historie (shallow) mittels\n"
 "Ausschluss eines Commits vertiefen"
 
-#: builtin/clone.c:133 builtin/submodule--helper.c:1843
-#: builtin/submodule--helper.c:2352
+#: builtin/clone.c:137 builtin/submodule--helper.c:1844
+#: builtin/submodule--helper.c:2353
 msgid "clone only one branch, HEAD or --branch"
 msgstr "nur einen Branch klonen, HEAD oder --branch"
 
-#: builtin/clone.c:135
+#: builtin/clone.c:139
 msgid "don't clone any tags, and make later fetches not to follow them"
 msgstr "keine Tags klonen, und auch bei späteren Abrufen nicht beachten"
 
-#: builtin/clone.c:137
+#: builtin/clone.c:141
 msgid "any cloned submodules will be shallow"
 msgstr "jedes geklonte Submodul mit unvollständiger Historie (shallow)"
 
-#: builtin/clone.c:138 builtin/init-db.c:561
+#: builtin/clone.c:142 builtin/init-db.c:547
 msgid "gitdir"
 msgstr ".git-Verzeichnis"
 
-#: builtin/clone.c:139 builtin/init-db.c:562
+#: builtin/clone.c:143 builtin/init-db.c:548
 msgid "separate git dir from working tree"
 msgstr "Git-Verzeichnis vom Arbeitsverzeichnis separieren"
 
-#: builtin/clone.c:140
+#: builtin/clone.c:144
 msgid "key=value"
 msgstr "Schlüssel=Wert"
 
-#: builtin/clone.c:141
+#: builtin/clone.c:145
 msgid "set config inside the new repository"
 msgstr "Konfiguration innerhalb des neuen Repositories setzen"
 
-#: builtin/clone.c:143 builtin/fetch.c:198 builtin/ls-remote.c:77
+#: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
 #: builtin/pull.c:230 builtin/push.c:584 builtin/send-pack.c:196
 msgid "server-specific"
 msgstr "serverspezifisch"
 
-#: builtin/clone.c:143 builtin/fetch.c:198 builtin/ls-remote.c:77
+#: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
 #: builtin/pull.c:231 builtin/push.c:584 builtin/send-pack.c:197
 msgid "option to transmit"
 msgstr "Option übertragen"
 
-#: builtin/clone.c:144 builtin/fetch.c:199 builtin/pull.c:234
+#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:234
 #: builtin/push.c:585
 msgid "use IPv4 addresses only"
 msgstr "nur IPv4-Adressen benutzen"
 
-#: builtin/clone.c:146 builtin/fetch.c:201 builtin/pull.c:237
+#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:237
 #: builtin/push.c:587
 msgid "use IPv6 addresses only"
 msgstr "nur IPv6-Adressen benutzen"
 
-#: builtin/clone.c:150
+#: builtin/clone.c:154
 msgid "any cloned submodules will use their remote-tracking branch"
 msgstr "jedes geklonte Submodul nutzt seinen Remote-Tracking-Branch"
 
-#: builtin/clone.c:152
+#: builtin/clone.c:156
 msgid "initialize sparse-checkout file to include only files at root"
 msgstr ""
 "Initialisiere Datei für partiellen Checkout, um nur Dateien im\n"
 "Root-Verzeichnis einzubeziehen"
 
-#: builtin/clone.c:288
+#: builtin/clone.c:292
 msgid ""
 "No directory name could be guessed.\n"
 "Please specify a directory on the command line"
@@ -13052,42 +13227,42 @@ msgstr ""
 "Konnte keinen Verzeichnisnamen erraten.\n"
 "Bitte geben Sie ein Verzeichnis auf der Befehlszeile an."
 
-#: builtin/clone.c:341
+#: builtin/clone.c:345
 #, c-format
 msgid "info: Could not add alternate for '%s': %s\n"
 msgstr "info: Konnte Alternative für '%s' nicht hinzufügen: %s\n"
 
-#: builtin/clone.c:414
+#: builtin/clone.c:418
 #, c-format
 msgid "%s exists and is not a directory"
 msgstr "%s existiert und ist kein Verzeichnis"
 
-#: builtin/clone.c:432
+#: builtin/clone.c:436
 #, c-format
 msgid "failed to start iterator over '%s'"
 msgstr "Fehler beim Starten der Iteration über '%s'"
 
-#: builtin/clone.c:463
+#: builtin/clone.c:467
 #, c-format
 msgid "failed to create link '%s'"
 msgstr "Konnte Verweis '%s' nicht erstellen"
 
-#: builtin/clone.c:467
+#: builtin/clone.c:471
 #, c-format
 msgid "failed to copy file to '%s'"
 msgstr "Konnte Datei nicht nach '%s' kopieren"
 
-#: builtin/clone.c:472
+#: builtin/clone.c:476
 #, c-format
 msgid "failed to iterate over '%s'"
 msgstr "Fehler beim Iterieren über '%s'"
 
-#: builtin/clone.c:499
+#: builtin/clone.c:503
 #, c-format
 msgid "done.\n"
 msgstr "Fertig.\n"
 
-#: builtin/clone.c:513
+#: builtin/clone.c:517
 msgid ""
 "Clone succeeded, but checkout failed.\n"
 "You can inspect what was checked out with 'git status'\n"
@@ -13097,107 +13272,107 @@ msgstr ""
 "Sie können mit 'git status' prüfen, was ausgecheckt worden ist\n"
 "und das Auschecken mit 'git restore --source=HEAD :/' erneut versuchen.\n"
 
-#: builtin/clone.c:590
+#: builtin/clone.c:594
 #, c-format
 msgid "Could not find remote branch %s to clone."
 msgstr "Konnte zu klonenden Remote-Branch %s nicht finden."
 
-#: builtin/clone.c:709
+#: builtin/clone.c:713
 #, c-format
 msgid "unable to update %s"
 msgstr "kann %s nicht aktualisieren"
 
-#: builtin/clone.c:757
+#: builtin/clone.c:761
 msgid "failed to initialize sparse-checkout"
 msgstr "Fehler beim Initialisieren vom partiellen Checkout."
 
-#: builtin/clone.c:780
+#: builtin/clone.c:784
 msgid "remote HEAD refers to nonexistent ref, unable to checkout.\n"
 msgstr ""
 "Externer HEAD bezieht sich auf eine nicht existierende Referenz und kann "
 "nicht ausgecheckt werden.\n"
 
-#: builtin/clone.c:812
+#: builtin/clone.c:816
 msgid "unable to checkout working tree"
 msgstr "Arbeitsverzeichnis konnte nicht ausgecheckt werden"
 
-#: builtin/clone.c:887
+#: builtin/clone.c:894
 msgid "unable to write parameters to config file"
 msgstr "konnte Parameter nicht in Konfigurationsdatei schreiben"
 
-#: builtin/clone.c:950
+#: builtin/clone.c:957
 msgid "cannot repack to clean up"
 msgstr "Kann \"repack\" zum Aufräumen nicht aufrufen"
 
-#: builtin/clone.c:952
+#: builtin/clone.c:959
 msgid "cannot unlink temporary alternates file"
 msgstr "Kann temporäre \"alternates\"-Datei nicht entfernen"
 
-#: builtin/clone.c:993 builtin/receive-pack.c:2493
+#: builtin/clone.c:1001 builtin/receive-pack.c:2491
 msgid "Too many arguments."
 msgstr "Zu viele Argumente."
 
-#: builtin/clone.c:997
+#: builtin/clone.c:1005
 msgid "You must specify a repository to clone."
 msgstr "Sie müssen ein Repository zum Klonen angeben."
 
-#: builtin/clone.c:1010
+#: builtin/clone.c:1018
 #, c-format
 msgid "--bare and --origin %s options are incompatible."
 msgstr "--bare und --origin %s sind inkompatibel."
 
-#: builtin/clone.c:1013
+#: builtin/clone.c:1021
 msgid "--bare and --separate-git-dir are incompatible."
 msgstr "--bare und --separate-git-dir sind inkompatibel."
 
-#: builtin/clone.c:1026
+#: builtin/clone.c:1035
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "Repository '%s' existiert nicht"
 
-#: builtin/clone.c:1030 builtin/fetch.c:1951
+#: builtin/clone.c:1039 builtin/fetch.c:2011
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "Tiefe %s ist keine positive Zahl"
 
-#: builtin/clone.c:1040
+#: builtin/clone.c:1049
 #, c-format
 msgid "destination path '%s' already exists and is not an empty directory."
 msgstr "Zielpfad '%s' existiert bereits und ist kein leeres Verzeichnis."
 
-#: builtin/clone.c:1046
+#: builtin/clone.c:1055
 #, c-format
 msgid "repository path '%s' already exists and is not an empty directory."
 msgstr ""
 "Pfad des Repositories '%s' existiert bereits und ist kein leeres Verzeichnis."
 
-#: builtin/clone.c:1060
+#: builtin/clone.c:1069
 #, c-format
 msgid "working tree '%s' already exists."
 msgstr "Arbeitsverzeichnis '%s' existiert bereits."
 
-#: builtin/clone.c:1075 builtin/clone.c:1096 builtin/difftool.c:271
-#: builtin/log.c:1986 builtin/worktree.c:282 builtin/worktree.c:314
+#: builtin/clone.c:1084 builtin/clone.c:1105 builtin/difftool.c:272
+#: builtin/log.c:1995 builtin/worktree.c:282 builtin/worktree.c:314
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "Konnte führende Verzeichnisse von '%s' nicht erstellen."
 
-#: builtin/clone.c:1080
+#: builtin/clone.c:1089
 #, c-format
 msgid "could not create work tree dir '%s'"
 msgstr "Konnte Arbeitsverzeichnis '%s' nicht erstellen"
 
-#: builtin/clone.c:1100
+#: builtin/clone.c:1109
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
 msgstr "Klone in Bare-Repository '%s' ...\n"
 
-#: builtin/clone.c:1102
+#: builtin/clone.c:1111
 #, c-format
 msgid "Cloning into '%s'...\n"
 msgstr "Klone nach '%s' ...\n"
 
-#: builtin/clone.c:1126
+#: builtin/clone.c:1135
 msgid ""
 "clone --recursive is not compatible with both --reference and --reference-if-"
 "able"
@@ -13205,51 +13380,51 @@ msgstr ""
 "'clone --recursive' ist nicht kompatibel mit --reference und --reference-if-"
 "able"
 
-#: builtin/clone.c:1170 builtin/remote.c:200 builtin/remote.c:705
+#: builtin/clone.c:1188 builtin/remote.c:200 builtin/remote.c:705
 #, c-format
 msgid "'%s' is not a valid remote name"
 msgstr "'%s' ist kein gültiger Name für ein Remote-Repository"
 
-#: builtin/clone.c:1211
+#: builtin/clone.c:1229
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr ""
 "--depth wird in lokalen Klonen ignoriert; benutzen Sie stattdessen \"file://"
 "\"."
 
-#: builtin/clone.c:1213
+#: builtin/clone.c:1231
 msgid "--shallow-since is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-since wird in lokalen Klonen ignoriert; benutzen Sie stattdessen "
 "\"file://\"."
 
-#: builtin/clone.c:1215
+#: builtin/clone.c:1233
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-exclude wird in lokalen Klonen ignoriert; benutzen Sie stattdessen "
 "\"file://\"."
 
-#: builtin/clone.c:1217
+#: builtin/clone.c:1235
 msgid "--filter is ignored in local clones; use file:// instead."
 msgstr ""
 "--filter wird in lokalen Klonen ignoriert; benutzen Sie stattdessen \"file://"
 "\"."
 
-#: builtin/clone.c:1220
+#: builtin/clone.c:1240
 msgid "source repository is shallow, ignoring --local"
 msgstr ""
 "Quelle ist ein Repository mit unvollständiger Historie (shallow),\n"
 "ignoriere --local"
 
-#: builtin/clone.c:1225
+#: builtin/clone.c:1245
 msgid "--local is ignored"
 msgstr "--local wird ignoriert"
 
-#: builtin/clone.c:1315 builtin/clone.c:1323
+#: builtin/clone.c:1337 builtin/clone.c:1345
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "Remote-Branch %s nicht im Upstream-Repository %s gefunden"
 
-#: builtin/clone.c:1326
+#: builtin/clone.c:1348
 msgid "You appear to have cloned an empty repository."
 msgstr "Sie scheinen ein leeres Repository geklont zu haben."
 
@@ -13266,19 +13441,23 @@ msgid "layout to use"
 msgstr "zu verwendende Anordnung"
 
 #: builtin/column.c:30
-msgid "Maximum width"
+#, fuzzy
+msgid "maximum width"
 msgstr "maximale Breite"
 
 #: builtin/column.c:31
-msgid "Padding space on left border"
+#, fuzzy
+msgid "padding space on left border"
 msgstr "Abstand zum linken Rand"
 
 #: builtin/column.c:32
-msgid "Padding space on right border"
+#, fuzzy
+msgid "padding space on right border"
 msgstr "Abstand zum rechten Rand"
 
 #: builtin/column.c:33
-msgid "Padding space between columns"
+#, fuzzy
+msgid "padding space between columns"
 msgstr "Abstand zwischen Spalten"
 
 #: builtin/column.c:51
@@ -13308,7 +13487,7 @@ msgid "could not find object directory matching %s"
 msgstr "konnte Objekt-Verzeichnis nicht finden, dass '%s' entsprechen soll"
 
 #: builtin/commit-graph.c:80 builtin/commit-graph.c:210
-#: builtin/commit-graph.c:316 builtin/fetch.c:187 builtin/log.c:1768
+#: builtin/commit-graph.c:316 builtin/fetch.c:191 builtin/log.c:1776
 msgid "dir"
 msgstr "Verzeichnis"
 
@@ -13409,7 +13588,7 @@ msgstr ""
 msgid "duplicate parent %s ignored"
 msgstr "doppelter Vorgänger %s ignoriert"
 
-#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:557
+#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:559
 #, c-format
 msgid "not a valid object name %s"
 msgstr "Kein gültiger Objektname: %s"
@@ -13437,13 +13616,13 @@ msgstr "Eltern-Commit"
 msgid "id of a parent commit object"
 msgstr "ID eines Eltern-Commit-Objektes."
 
-#: builtin/commit-tree.c:114 builtin/commit.c:1504 builtin/merge.c:282
-#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1537
-#: builtin/tag.c:445
+#: builtin/commit-tree.c:114 builtin/commit.c:1614 builtin/merge.c:282
+#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1605
+#: builtin/tag.c:456
 msgid "message"
 msgstr "Beschreibung"
 
-#: builtin/commit-tree.c:115 builtin/commit.c:1504
+#: builtin/commit-tree.c:115 builtin/commit.c:1614
 msgid "commit message"
 msgstr "Commit-Beschreibung"
 
@@ -13451,7 +13630,7 @@ msgstr "Commit-Beschreibung"
 msgid "read commit log message from file"
 msgstr "Commit-Beschreibung von Datei lesen"
 
-#: builtin/commit-tree.c:121 builtin/commit.c:1516 builtin/merge.c:299
+#: builtin/commit-tree.c:121 builtin/commit.c:1631 builtin/merge.c:299
 #: builtin/pull.c:176 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "Commit mit GPG signieren"
@@ -13527,74 +13706,74 @@ msgstr ""
 "    git cherry-pick --skip\n"
 "\n"
 
-#: builtin/commit.c:312
+#: builtin/commit.c:324
 msgid "failed to unpack HEAD tree object"
 msgstr "Fehler beim Entpacken des Tree-Objektes von HEAD."
 
-#: builtin/commit.c:348
+#: builtin/commit.c:360
 msgid "--pathspec-from-file with -a does not make sense"
 msgstr "Option --pathspec-from-file mit -a ist nicht sinnvoll."
 
-#: builtin/commit.c:361
+#: builtin/commit.c:374
 msgid "No paths with --include/--only does not make sense."
 msgstr "Keine Pfade mit der Option --include/--only ist nicht sinnvoll."
 
-#: builtin/commit.c:373
+#: builtin/commit.c:386
 msgid "unable to create temporary index"
 msgstr "Konnte temporären Index nicht erstellen."
 
-#: builtin/commit.c:382
+#: builtin/commit.c:395
 msgid "interactive add failed"
 msgstr "interaktives Hinzufügen fehlgeschlagen"
 
-#: builtin/commit.c:397
+#: builtin/commit.c:410
 msgid "unable to update temporary index"
 msgstr "Konnte temporären Index nicht aktualisieren."
 
-#: builtin/commit.c:399
+#: builtin/commit.c:412
 msgid "Failed to update main cache tree"
 msgstr "Konnte Haupt-Cache-Verzeichnis nicht aktualisieren"
 
-#: builtin/commit.c:424 builtin/commit.c:447 builtin/commit.c:495
+#: builtin/commit.c:437 builtin/commit.c:460 builtin/commit.c:508
 msgid "unable to write new_index file"
 msgstr "Konnte new_index Datei nicht schreiben"
 
-#: builtin/commit.c:476
+#: builtin/commit.c:489
 msgid "cannot do a partial commit during a merge."
 msgstr "Kann keinen Teil-Commit durchführen, während ein Merge im Gange ist."
 
-#: builtin/commit.c:478
+#: builtin/commit.c:491
 msgid "cannot do a partial commit during a cherry-pick."
 msgstr ""
 "Kann keinen Teil-Commit durchführen, während \"cherry-pick\" im Gange ist."
 
-#: builtin/commit.c:480
+#: builtin/commit.c:493
 msgid "cannot do a partial commit during a rebase."
 msgstr "kann keinen Teil-Commit durchführen, während ein Rebase im Gange ist."
 
-#: builtin/commit.c:488
+#: builtin/commit.c:501
 msgid "cannot read the index"
 msgstr "Kann Index nicht lesen"
 
-#: builtin/commit.c:507
+#: builtin/commit.c:520
 msgid "unable to write temporary index file"
 msgstr "Konnte temporäre Index-Datei nicht schreiben."
 
-#: builtin/commit.c:605
+#: builtin/commit.c:618
 #, c-format
 msgid "commit '%s' lacks author header"
 msgstr "Commit '%s' fehlt Autor-Kopfbereich"
 
-#: builtin/commit.c:607
+#: builtin/commit.c:620
 #, c-format
 msgid "commit '%s' has malformed author line"
 msgstr "Commit '%s' hat fehlerhafte Autor-Zeile"
 
-#: builtin/commit.c:626
+#: builtin/commit.c:639
 msgid "malformed --author parameter"
 msgstr "Fehlerhafter --author Parameter"
 
-#: builtin/commit.c:679
+#: builtin/commit.c:692
 msgid ""
 "unable to select a comment character that is not used\n"
 "in the current commit message"
@@ -13602,38 +13781,43 @@ msgstr ""
 "Konnte kein Kommentar-Zeichen auswählen, das nicht in\n"
 "der aktuellen Commit-Beschreibung verwendet wird."
 
-#: builtin/commit.c:717 builtin/commit.c:750 builtin/commit.c:1097
+#: builtin/commit.c:746 builtin/commit.c:780 builtin/commit.c:1158
 #, c-format
 msgid "could not lookup commit %s"
 msgstr "Konnte Commit %s nicht nachschlagen"
 
-#: builtin/commit.c:729 builtin/shortlog.c:413
+#: builtin/commit.c:758 builtin/shortlog.c:413
 #, c-format
 msgid "(reading log message from standard input)\n"
 msgstr "(lese Log-Nachricht von Standard-Eingabe)\n"
 
-#: builtin/commit.c:731
+#: builtin/commit.c:760
 msgid "could not read log from standard input"
 msgstr "Konnte Log nicht von Standard-Eingabe lesen."
 
-#: builtin/commit.c:735
+#: builtin/commit.c:764
 #, c-format
 msgid "could not read log file '%s'"
 msgstr "Konnte Log-Datei '%s' nicht lesen"
 
-#: builtin/commit.c:766 builtin/commit.c:782
+#: builtin/commit.c:801
+#, fuzzy, c-format
+msgid "cannot combine -m with --fixup:%s"
+msgstr "'--root' kann nicht mit '--fork-point' kombiniert werden"
+
+#: builtin/commit.c:813 builtin/commit.c:829
 msgid "could not read SQUASH_MSG"
 msgstr "Konnte SQUASH_MSG nicht lesen"
 
-#: builtin/commit.c:773
+#: builtin/commit.c:820
 msgid "could not read MERGE_MSG"
 msgstr "Konnte MERGE_MSG nicht lesen"
 
-#: builtin/commit.c:833
+#: builtin/commit.c:880
 msgid "could not write commit template"
 msgstr "Konnte Commit-Vorlage nicht schreiben"
 
-#: builtin/commit.c:853
+#: builtin/commit.c:900
 msgid ""
 "\n"
 "It looks like you may be committing a merge.\n"
@@ -13647,7 +13831,7 @@ msgstr ""
 "\tgit update-ref -d MERGE_HEAD\n"
 "aus und versuchen Sie es erneut.\n"
 
-#: builtin/commit.c:858
+#: builtin/commit.c:905
 msgid ""
 "\n"
 "It looks like you may be committing a cherry-pick.\n"
@@ -13661,7 +13845,7 @@ msgstr ""
 "\tgit update-ref -d CHERRY_PICK_HEAD\n"
 "aus und versuchen Sie es erneut.\n"
 
-#: builtin/commit.c:868
+#: builtin/commit.c:915
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13671,7 +13855,7 @@ msgstr ""
 "die mit '%c' beginnen, werden ignoriert, und eine leere Beschreibung\n"
 "bricht den Commit ab.\n"
 
-#: builtin/commit.c:876
+#: builtin/commit.c:923
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13684,150 +13868,183 @@ msgstr ""
 "entfernen.\n"
 "Eine leere Beschreibung bricht den Commit ab.\n"
 
-#: builtin/commit.c:893
+#: builtin/commit.c:940
 #, c-format
 msgid "%sAuthor:    %.*s <%.*s>"
 msgstr "%sAutor:           %.*s <%.*s>"
 
-#: builtin/commit.c:901
+#: builtin/commit.c:948
 #, c-format
 msgid "%sDate:      %s"
 msgstr "%sDatum:            %s"
 
-#: builtin/commit.c:908
+#: builtin/commit.c:955
 #, c-format
 msgid "%sCommitter: %.*s <%.*s>"
 msgstr "%sCommit-Ersteller: %.*s <%.*s>"
 
-#: builtin/commit.c:926
+#: builtin/commit.c:973
 msgid "Cannot read index"
 msgstr "Kann Index nicht lesen"
 
-#: builtin/commit.c:997
+#: builtin/commit.c:1018
+#, fuzzy
+msgid "unable to pass trailers to --trailers"
+msgstr "Konnte Kopfbereich von %s nicht parsen."
+
+#: builtin/commit.c:1058
 msgid "Error building trees"
 msgstr "Fehler beim Erzeugen der \"Tree\"-Objekte"
 
-#: builtin/commit.c:1011 builtin/tag.c:308
+#: builtin/commit.c:1072 builtin/tag.c:319
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr ""
 "Bitte liefern Sie eine Beschreibung entweder mit der Option -m oder -F.\n"
 
-#: builtin/commit.c:1055
+#: builtin/commit.c:1116
 #, c-format
 msgid "--author '%s' is not 'Name <email>' and matches no existing author"
 msgstr ""
 "--author '%s' ist nicht im Format 'Name <E-Mail>' und stimmt mit keinem "
 "vorhandenen Autor überein"
 
-#: builtin/commit.c:1069
+#: builtin/commit.c:1130
 #, c-format
 msgid "Invalid ignored mode '%s'"
 msgstr "Ungültiger ignored-Modus '%s'."
 
-#: builtin/commit.c:1087 builtin/commit.c:1331
+#: builtin/commit.c:1148 builtin/commit.c:1441
 #, c-format
 msgid "Invalid untracked files mode '%s'"
 msgstr "Ungültiger Modus '%s' für unversionierte Dateien"
 
-#: builtin/commit.c:1127
+#: builtin/commit.c:1188
 msgid "--long and -z are incompatible"
 msgstr "--long und -z sind inkompatibel"
 
-#: builtin/commit.c:1171
+#: builtin/commit.c:1219
+#, fuzzy
+msgid "You are in the middle of a merge -- cannot reword."
+msgstr "Ein Merge ist im Gange -- kann \"--amend\" nicht ausführen."
+
+#: builtin/commit.c:1221
+#, fuzzy
+msgid "You are in the middle of a cherry-pick -- cannot reword."
+msgstr "\"cherry-pick\" ist im Gange -- kann \"--amend\" nicht ausführen."
+
+#: builtin/commit.c:1224
+#, fuzzy, c-format
+msgid "cannot combine reword option of --fixup with path '%s'"
+msgstr ""
+"Optionen für \"am\" können nicht mit Optionen für \"merge\" kombiniert "
+"werden."
+
+#: builtin/commit.c:1226
+msgid ""
+"reword option of --fixup is mutually exclusive with --patch/--interactive/--"
+"all/--include/--only"
+msgstr ""
+
+#: builtin/commit.c:1245
 msgid "Using both --reset-author and --author does not make sense"
 msgstr "--reset-author und --author können nicht gemeinsam verwendet werden"
 
-#: builtin/commit.c:1180
+#: builtin/commit.c:1254
 msgid "You have nothing to amend."
 msgstr "Sie haben nichts für \"--amend\"."
 
-#: builtin/commit.c:1183
+#: builtin/commit.c:1257
 msgid "You are in the middle of a merge -- cannot amend."
 msgstr "Ein Merge ist im Gange -- kann \"--amend\" nicht ausführen."
 
-#: builtin/commit.c:1185
+#: builtin/commit.c:1259
 msgid "You are in the middle of a cherry-pick -- cannot amend."
 msgstr "\"cherry-pick\" ist im Gange -- kann \"--amend\" nicht ausführen."
 
-#: builtin/commit.c:1187
+#: builtin/commit.c:1261
 msgid "You are in the middle of a rebase -- cannot amend."
 msgstr "Ein Rebase ist im Gange -- kann \"--amend\" nicht ausführen."
 
-#: builtin/commit.c:1190
+#: builtin/commit.c:1264
 msgid "Options --squash and --fixup cannot be used together"
 msgstr ""
 "Die Optionen --squash und --fixup können nicht gemeinsam verwendet werden"
 
-#: builtin/commit.c:1200
+#: builtin/commit.c:1274
 msgid "Only one of -c/-C/-F/--fixup can be used."
 msgstr "Es kann nur eine Option von -c/-C/-F/--fixup verwendet werden."
 
-#: builtin/commit.c:1202
+#: builtin/commit.c:1276
 msgid "Option -m cannot be combined with -c/-C/-F."
 msgstr "Die Option -m kann nicht mit -c/-C/-F kombiniert werden."
 
-#: builtin/commit.c:1211
+#: builtin/commit.c:1285
 msgid "--reset-author can be used only with -C, -c or --amend."
 msgstr "--reset--author kann nur mit -C, -c oder --amend verwendet werden"
 
-#: builtin/commit.c:1229
+#: builtin/commit.c:1303
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
 msgstr ""
 "Es kann nur eine Option von --include/--only/--all/--interactive/--patch "
 "verwendet werden."
 
-#: builtin/commit.c:1235
+#: builtin/commit.c:1331
+#, fuzzy, c-format
+msgid "unknown option: --fixup=%s:%s"
+msgstr "Unbekannte Option: %s\n"
+
+#: builtin/commit.c:1345
 #, c-format
 msgid "paths '%s ...' with -a does not make sense"
 msgstr "Pfade '%s ...' mit -a sind nicht sinnvoll"
 
-#: builtin/commit.c:1366 builtin/commit.c:1527
+#: builtin/commit.c:1476 builtin/commit.c:1642
 msgid "show status concisely"
 msgstr "Status im Kurzformat anzeigen"
 
-#: builtin/commit.c:1368 builtin/commit.c:1529
+#: builtin/commit.c:1478 builtin/commit.c:1644
 msgid "show branch information"
 msgstr "Branchinformationen anzeigen"
 
-#: builtin/commit.c:1370
+#: builtin/commit.c:1480
 msgid "show stash information"
 msgstr "Stashinformationen anzeigen"
 
-#: builtin/commit.c:1372 builtin/commit.c:1531
+#: builtin/commit.c:1482 builtin/commit.c:1646
 msgid "compute full ahead/behind values"
 msgstr "voraus/hinterher-Werte berechnen"
 
-#: builtin/commit.c:1374
+#: builtin/commit.c:1484
 msgid "version"
 msgstr "Version"
 
-#: builtin/commit.c:1374 builtin/commit.c:1533 builtin/push.c:560
-#: builtin/worktree.c:679
+#: builtin/commit.c:1484 builtin/commit.c:1648 builtin/push.c:560
+#: builtin/worktree.c:681
 msgid "machine-readable output"
 msgstr "maschinenlesbare Ausgabe"
 
-#: builtin/commit.c:1377 builtin/commit.c:1535
+#: builtin/commit.c:1487 builtin/commit.c:1650
 msgid "show status in long format (default)"
 msgstr "Status im Langformat anzeigen (Standard)"
 
-#: builtin/commit.c:1380 builtin/commit.c:1538
+#: builtin/commit.c:1490 builtin/commit.c:1653
 msgid "terminate entries with NUL"
 msgstr "Einträge mit NUL-Zeichen abschließen"
 
-#: builtin/commit.c:1382 builtin/commit.c:1386 builtin/commit.c:1541
+#: builtin/commit.c:1492 builtin/commit.c:1496 builtin/commit.c:1656
 #: builtin/fast-export.c:1198 builtin/fast-export.c:1201
-#: builtin/fast-export.c:1204 builtin/rebase.c:1412 parse-options.h:336
+#: builtin/fast-export.c:1204 builtin/rebase.c:1407 parse-options.h:337
 msgid "mode"
 msgstr "Modus"
 
-#: builtin/commit.c:1383 builtin/commit.c:1541
+#: builtin/commit.c:1493 builtin/commit.c:1656
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
 "unversionierte Dateien anzeigen, optionale Modi: all, normal, no. (Standard: "
 "all)"
 
-#: builtin/commit.c:1387
+#: builtin/commit.c:1497
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
@@ -13835,11 +14052,11 @@ msgstr ""
 "ignorierte Dateien anzeigen, optionale Modi: traditional, matching, no. "
 "(Standard: traditional)"
 
-#: builtin/commit.c:1389 parse-options.h:192
+#: builtin/commit.c:1499 parse-options.h:193
 msgid "when"
 msgstr "wann"
 
-#: builtin/commit.c:1390
+#: builtin/commit.c:1500
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
@@ -13847,174 +14064,197 @@ msgstr ""
 "Änderungen in Submodulen ignorieren, optional wenn: all, dirty, untracked. "
 "(Standard: all)"
 
-#: builtin/commit.c:1392
+#: builtin/commit.c:1502
 msgid "list untracked files in columns"
 msgstr "unversionierte Dateien in Spalten auflisten"
 
-#: builtin/commit.c:1393
+#: builtin/commit.c:1503
 msgid "do not detect renames"
 msgstr "keine Umbenennungen ermitteln"
 
-#: builtin/commit.c:1395
+#: builtin/commit.c:1505
 msgid "detect renames, optionally set similarity index"
 msgstr "Umbenennungen erkennen, optional Index für Gleichheit setzen"
 
-#: builtin/commit.c:1415
+#: builtin/commit.c:1525
 msgid "Unsupported combination of ignored and untracked-files arguments"
 msgstr ""
 "Nicht unterstützte Kombination von ignored und untracked-files Argumenten."
 
-#: builtin/commit.c:1497
+#: builtin/commit.c:1607
 msgid "suppress summary after successful commit"
 msgstr "Zusammenfassung nach erfolgreichem Commit unterdrücken"
 
-#: builtin/commit.c:1498
+#: builtin/commit.c:1608
 msgid "show diff in commit message template"
 msgstr "Unterschiede in Commit-Beschreibungsvorlage anzeigen"
 
-#: builtin/commit.c:1500
+#: builtin/commit.c:1610
 msgid "Commit message options"
 msgstr "Optionen für Commit-Beschreibung"
 
-#: builtin/commit.c:1501 builtin/merge.c:286 builtin/tag.c:447
+#: builtin/commit.c:1611 builtin/merge.c:286 builtin/tag.c:458
 msgid "read message from file"
 msgstr "Beschreibung von Datei lesen"
 
-#: builtin/commit.c:1502
+#: builtin/commit.c:1612
 msgid "author"
 msgstr "Autor"
 
-#: builtin/commit.c:1502
+#: builtin/commit.c:1612
 msgid "override author for commit"
 msgstr "Autor eines Commits überschreiben"
 
-#: builtin/commit.c:1503 builtin/gc.c:550
+#: builtin/commit.c:1613 builtin/gc.c:550
 msgid "date"
 msgstr "Datum"
 
-#: builtin/commit.c:1503
+#: builtin/commit.c:1613
 msgid "override date for commit"
 msgstr "Datum eines Commits überschreiben"
 
-#: builtin/commit.c:1505 builtin/commit.c:1506 builtin/commit.c:1507
-#: builtin/commit.c:1508 parse-options.h:328 ref-filter.h:90
+#: builtin/commit.c:1615 builtin/commit.c:1616 builtin/commit.c:1622
+#: parse-options.h:329 ref-filter.h:90
 msgid "commit"
 msgstr "Commit"
 
-#: builtin/commit.c:1505
+#: builtin/commit.c:1615
 msgid "reuse and edit message from specified commit"
 msgstr "Beschreibung des angegebenen Commits wiederverwenden und editieren"
 
-#: builtin/commit.c:1506
+#: builtin/commit.c:1616
 msgid "reuse message from specified commit"
 msgstr "Beschreibung des angegebenen Commits wiederverwenden"
 
-#: builtin/commit.c:1507
-msgid "use autosquash formatted message to fixup specified commit"
+#. TRANSLATORS: Leave "[(amend|reword):]" as-is,
+#. and only translate <commit>.
+#.
+#: builtin/commit.c:1621
+#, fuzzy
+msgid "[(amend|reword):]commit"
+msgstr "vorherigen Commit ändern"
+
+#: builtin/commit.c:1621
+#, fuzzy
+msgid ""
+"use autosquash formatted message to fixup or amend/reword specified commit"
 msgstr ""
 "eine automatisch zusammengesetzte Beschreibung zum Nachbessern des "
 "angegebenen Commits verwenden"
 
-#: builtin/commit.c:1508
+#: builtin/commit.c:1622
 msgid "use autosquash formatted message to squash specified commit"
 msgstr ""
 "eine automatisch zusammengesetzte Beschreibung beim \"squash\" des "
 "angegebenen Commits verwenden"
 
-#: builtin/commit.c:1509
+#: builtin/commit.c:1623
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr "Sie als Autor des Commits setzen (verwendet mit -C/-c/--amend)"
 
-#: builtin/commit.c:1510 builtin/log.c:1743 builtin/merge.c:302
+#: builtin/commit.c:1624 builtin/interpret-trailers.c:111
+msgid "trailer"
+msgstr "Anhang"
+
+#: builtin/commit.c:1624
+msgid "add custom trailer(s)"
+msgstr ""
+
+#: builtin/commit.c:1625 builtin/log.c:1751 builtin/merge.c:302
 #: builtin/pull.c:145 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "eine Signed-off-by Zeile hinzufügen"
 
-#: builtin/commit.c:1511
+#: builtin/commit.c:1626
 msgid "use specified template file"
 msgstr "angegebene Vorlagendatei verwenden"
 
-#: builtin/commit.c:1512
+#: builtin/commit.c:1627
 msgid "force edit of commit"
 msgstr "Bearbeitung des Commits erzwingen"
 
-#: builtin/commit.c:1514
+#: builtin/commit.c:1629
 msgid "include status in commit message template"
 msgstr "Status in die Commit-Beschreibungsvorlage einfügen"
 
-#: builtin/commit.c:1519
+#: builtin/commit.c:1634
 msgid "Commit contents options"
 msgstr "Optionen für Commit-Inhalt"
 
-#: builtin/commit.c:1520
+#: builtin/commit.c:1635
 msgid "commit all changed files"
 msgstr "alle geänderten Dateien committen"
 
-#: builtin/commit.c:1521
+#: builtin/commit.c:1636
 msgid "add specified files to index for commit"
 msgstr "die angegebenen Dateien zusätzlich zum Commit vormerken"
 
-#: builtin/commit.c:1522
+#: builtin/commit.c:1637
 msgid "interactively add files"
 msgstr "interaktives Hinzufügen von Dateien"
 
-#: builtin/commit.c:1523
+#: builtin/commit.c:1638
 msgid "interactively add changes"
 msgstr "interaktives Hinzufügen von Änderungen"
 
-#: builtin/commit.c:1524
+#: builtin/commit.c:1639
 msgid "commit only specified files"
 msgstr "nur die angegebenen Dateien committen"
 
-#: builtin/commit.c:1525
+#: builtin/commit.c:1640
 msgid "bypass pre-commit and commit-msg hooks"
 msgstr "Hooks pre-commit und commit-msg umgehen"
 
-#: builtin/commit.c:1526
+#: builtin/commit.c:1641
 msgid "show what would be committed"
 msgstr "anzeigen, was committet werden würde"
 
-#: builtin/commit.c:1539
+#: builtin/commit.c:1654
 msgid "amend previous commit"
 msgstr "vorherigen Commit ändern"
 
-#: builtin/commit.c:1540
+#: builtin/commit.c:1655
 msgid "bypass post-rewrite hook"
 msgstr "\"post-rewrite hook\" umgehen"
 
-#: builtin/commit.c:1547
+#: builtin/commit.c:1662
 msgid "ok to record an empty change"
 msgstr "Aufzeichnung einer leeren Änderung erlauben"
 
-#: builtin/commit.c:1549
+#: builtin/commit.c:1664
 msgid "ok to record a change with an empty message"
 msgstr "Aufzeichnung einer Änderung mit einer leeren Beschreibung erlauben"
 
-#: builtin/commit.c:1622
+#: builtin/commit.c:1737
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
 msgstr "Beschädigte MERGE_HEAD-Datei (%s)"
 
-#: builtin/commit.c:1629
+#: builtin/commit.c:1744
 msgid "could not read MERGE_MODE"
 msgstr "Konnte MERGE_MODE nicht lesen"
 
-#: builtin/commit.c:1650
+#: builtin/commit.c:1765
 #, c-format
 msgid "could not read commit message: %s"
 msgstr "Konnte Commit-Beschreibung nicht lesen: %s"
 
-#: builtin/commit.c:1657
+#: builtin/commit.c:1772
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
 msgstr "Commit aufgrund leerer Beschreibung abgebrochen.\n"
 
-#: builtin/commit.c:1662
+#: builtin/commit.c:1777
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
 msgstr "Commit abgebrochen; Sie haben die Beschreibung nicht editiert.\n"
 
-#: builtin/commit.c:1696
+#: builtin/commit.c:1788
+#, fuzzy, c-format
+msgid "Aborting commit due to empty commit message body.\n"
+msgstr "Commit aufgrund leerer Beschreibung abgebrochen.\n"
+
+#: builtin/commit.c:1824
 msgid ""
 "repository has been updated, but unable to write\n"
 "new_index file. Check that disk is not full and quota is\n"
@@ -14363,7 +14603,7 @@ msgstr "git count-objects [-v] [-H | --human-readable]"
 msgid "print sizes in human readable format"
 msgstr "gibt Größenangaben in menschenlesbaren Format aus"
 
-#: builtin/credential-cache--daemon.c:226
+#: builtin/credential-cache--daemon.c:227
 #, c-format
 msgid ""
 "The permissions on your socket directory are too loose; other\n"
@@ -14379,11 +14619,11 @@ msgstr ""
 "\n"
 "auszuführen."
 
-#: builtin/credential-cache--daemon.c:275
+#: builtin/credential-cache--daemon.c:276
 msgid "print debugging messages to stderr"
 msgstr "Meldungen zur Fehlersuche in Standard-Fehlerausgabe ausgeben"
 
-#: builtin/credential-cache--daemon.c:315
+#: builtin/credential-cache--daemon.c:316
 msgid "credential-cache--daemon unavailable; no unix socket support"
 msgstr ""
 "credential-cache--daemon nicht verfügbar; Unix-Socket wird nicht unterstützt"
@@ -14593,7 +14833,7 @@ msgstr "%s...%s: keine Merge-Basis"
 msgid "Not a git repository"
 msgstr "Kein Git-Repository"
 
-#: builtin/diff.c:532 builtin/grep.c:682
+#: builtin/diff.c:532 builtin/grep.c:684
 #, c-format
 msgid "invalid object '%s' given."
 msgstr "Objekt '%s' ist ungültig."
@@ -14613,31 +14853,31 @@ msgstr "unbehandeltes Objekt '%s' angegeben"
 msgid "%s...%s: multiple merge bases, using %s"
 msgstr "%s...%s: mehrere Merge-Basen, nutze %s"
 
-#: builtin/difftool.c:30
+#: builtin/difftool.c:31
 msgid "git difftool [<options>] [<commit> [<commit>]] [--] [<path>...]"
 msgstr "git difftool [<Optionen>] [<Commit> [<Commit>]] [--] [<Pfad>...]"
 
-#: builtin/difftool.c:260
+#: builtin/difftool.c:261
 #, c-format
 msgid "failed: %d"
 msgstr "fehlgeschlagen: %d"
 
-#: builtin/difftool.c:302
+#: builtin/difftool.c:303
 #, c-format
 msgid "could not read symlink %s"
 msgstr "konnte symbolische Verknüpfung %s nicht lesen"
 
-#: builtin/difftool.c:304
+#: builtin/difftool.c:305
 #, c-format
 msgid "could not read symlink file %s"
 msgstr "Konnte Datei von symbolischer Verknüpfung '%s' nicht lesen."
 
-#: builtin/difftool.c:312
+#: builtin/difftool.c:313
 #, c-format
 msgid "could not read object %s for symlink %s"
 msgstr "Konnte Objekt '%s' für symbolische Verknüpfung '%s' nicht lesen."
 
-#: builtin/difftool.c:412
+#: builtin/difftool.c:413
 msgid ""
 "combined diff formats('-c' and '--cc') are not supported in\n"
 "directory diff mode('-d' and '--dir-diff')."
@@ -14645,54 +14885,54 @@ msgstr ""
 "Kombinierte Diff-Formate('-c' und '--cc') werden im Verzeichnis-\n"
 "Diff-Modus('-d' und '--dir-diff') nicht unterstützt."
 
-#: builtin/difftool.c:633
+#: builtin/difftool.c:637
 #, c-format
 msgid "both files modified: '%s' and '%s'."
 msgstr "beide Dateien geändert: '%s' und '%s'."
 
-#: builtin/difftool.c:635
+#: builtin/difftool.c:639
 msgid "working tree file has been left."
 msgstr "Datei im Arbeitsverzeichnis belassen."
 
-#: builtin/difftool.c:646
+#: builtin/difftool.c:650
 #, c-format
 msgid "temporary files exist in '%s'."
 msgstr "Es existieren temporäre Dateien in '%s'."
 
-#: builtin/difftool.c:647
+#: builtin/difftool.c:651
 msgid "you may want to cleanup or recover these."
 msgstr "Sie könnten diese aufräumen oder wiederherstellen."
 
-#: builtin/difftool.c:696
+#: builtin/difftool.c:700
 msgid "use `diff.guitool` instead of `diff.tool`"
 msgstr "`diff.guitool` statt `diff.tool` benutzen"
 
-#: builtin/difftool.c:698
+#: builtin/difftool.c:702
 msgid "perform a full-directory diff"
 msgstr "Diff über ganzes Verzeichnis ausführen"
 
-#: builtin/difftool.c:700
+#: builtin/difftool.c:704
 msgid "do not prompt before launching a diff tool"
 msgstr "keine Eingabeaufforderung vor Ausführung eines Diff-Tools"
 
-#: builtin/difftool.c:705
+#: builtin/difftool.c:709
 msgid "use symlinks in dir-diff mode"
 msgstr "symbolische Verknüpfungen im dir-diff Modus verwenden"
 
-#: builtin/difftool.c:706
+#: builtin/difftool.c:710
 msgid "tool"
 msgstr "Tool"
 
-#: builtin/difftool.c:707
+#: builtin/difftool.c:711
 msgid "use the specified diff tool"
 msgstr "das angegebene Diff-Tool benutzen"
 
-#: builtin/difftool.c:709
+#: builtin/difftool.c:713
 msgid "print a list of diff tools that may be used with `--tool`"
 msgstr ""
 "eine Liste mit Diff-Tools darstellen, die mit `--tool` benutzt werden können"
 
-#: builtin/difftool.c:712
+#: builtin/difftool.c:716
 msgid ""
 "make 'git-difftool' exit when an invoked diff tool returns a non - zero exit "
 "code"
@@ -14701,31 +14941,31 @@ msgstr ""
 "Rückkehrwert\n"
 "verschieden 0 ausgeführt wurde"
 
-#: builtin/difftool.c:715
+#: builtin/difftool.c:719
 msgid "specify a custom command for viewing diffs"
 msgstr "eigenen Befehl zur Anzeige von Unterschieden angeben"
 
-#: builtin/difftool.c:716
+#: builtin/difftool.c:720
 msgid "passed to `diff`"
 msgstr "an 'diff' übergeben"
 
-#: builtin/difftool.c:731
+#: builtin/difftool.c:735
 msgid "difftool requires worktree or --no-index"
 msgstr "difftool benötigt Arbeitsverzeichnis oder --no-index"
 
-#: builtin/difftool.c:738
+#: builtin/difftool.c:742
 msgid "--dir-diff is incompatible with --no-index"
 msgstr "--dir-diff kann nicht mit --no-index verwendet werden"
 
-#: builtin/difftool.c:741
+#: builtin/difftool.c:745
 msgid "--gui, --tool and --extcmd are mutually exclusive"
 msgstr "--gui, --tool und --extcmd schließen sich gegenseitig aus"
 
-#: builtin/difftool.c:749
+#: builtin/difftool.c:753
 msgid "no <tool> given for --tool=<tool>"
 msgstr "kein <Tool> für --tool=<Tool> angegeben"
 
-#: builtin/difftool.c:756
+#: builtin/difftool.c:760
 msgid "no <cmd> given for --extcmd=<cmd>"
 msgstr "kein <Programm> für --extcmd=<Programm> angegeben"
 
@@ -14820,7 +15060,7 @@ msgstr "die \"done\"-Funktion benutzen, um den Datenstrom abzuschließen"
 msgid "skip output of blob data"
 msgstr "Ausgabe von Blob-Daten überspringen"
 
-#: builtin/fast-export.c:1222 builtin/log.c:1815
+#: builtin/fast-export.c:1222 builtin/log.c:1823
 msgid "refspec"
 msgstr "Refspec"
 
@@ -14914,104 +15154,108 @@ msgstr "git fetch --multiple [<Optionen>] [(<Repository> | <Gruppe>)...]"
 msgid "git fetch --all [<options>]"
 msgstr "git fetch --all [<Optionen>]"
 
-#: builtin/fetch.c:120
+#: builtin/fetch.c:122
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel kann nicht negativ sein"
 
-#: builtin/fetch.c:143 builtin/pull.c:185
+#: builtin/fetch.c:145 builtin/pull.c:185
 msgid "fetch from all remotes"
 msgstr "fordert von allen Remote-Repositories an"
 
-#: builtin/fetch.c:145 builtin/pull.c:245
+#: builtin/fetch.c:147 builtin/pull.c:245
 msgid "set upstream for git pull/fetch"
 msgstr "Upstream für \"git pull/fetch\" setzen"
 
-#: builtin/fetch.c:147 builtin/pull.c:188
+#: builtin/fetch.c:149 builtin/pull.c:188
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "an .git/FETCH_HEAD anhängen statt zu überschreiben"
 
-#: builtin/fetch.c:149
+#: builtin/fetch.c:151
 msgid "use atomic transaction to update references"
 msgstr "atomare Transaktionen nutzen, um Referenzen zu aktualisieren"
 
-#: builtin/fetch.c:151 builtin/pull.c:191
+#: builtin/fetch.c:153 builtin/pull.c:191
 msgid "path to upload pack on remote end"
 msgstr "Pfad des Programms zum Hochladen von Paketen auf der Gegenseite"
 
-#: builtin/fetch.c:152
+#: builtin/fetch.c:154
 msgid "force overwrite of local reference"
 msgstr "das Überschreiben einer lokalen Referenz erzwingen"
 
-#: builtin/fetch.c:154
+#: builtin/fetch.c:156
 msgid "fetch from multiple remotes"
 msgstr "von mehreren Remote-Repositories anfordern"
 
-#: builtin/fetch.c:156 builtin/pull.c:195
+#: builtin/fetch.c:158 builtin/pull.c:195
 msgid "fetch all tags and associated objects"
 msgstr "alle Tags und verbundene Objekte anfordern"
 
-#: builtin/fetch.c:158
+#: builtin/fetch.c:160
 msgid "do not fetch all tags (--no-tags)"
 msgstr "nicht alle Tags anfordern (--no-tags)"
 
-#: builtin/fetch.c:160
+#: builtin/fetch.c:162
 msgid "number of submodules fetched in parallel"
 msgstr "Anzahl der parallel anzufordernden Submodule"
 
-#: builtin/fetch.c:162 builtin/pull.c:198
+#: builtin/fetch.c:164
+msgid "modify the refspec to place all refs within refs/prefetch/"
+msgstr ""
+
+#: builtin/fetch.c:166 builtin/pull.c:198
 msgid "prune remote-tracking branches no longer on remote"
 msgstr ""
 "Remote-Tracking-Branches entfernen, die sich nicht mehr im Remote-Repository "
 "befinden"
 
-#: builtin/fetch.c:164
+#: builtin/fetch.c:168
 msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr ""
 "lokale Tags entfernen, die sich nicht mehr im Remote-Repository befinden, "
 "und geänderte Tags aktualisieren"
 
-#: builtin/fetch.c:165 builtin/fetch.c:190 builtin/pull.c:122
+#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:122
 msgid "on-demand"
 msgstr "bei-Bedarf"
 
-#: builtin/fetch.c:166
+#: builtin/fetch.c:170
 msgid "control recursive fetching of submodules"
 msgstr "rekursive Anforderungen von Submodulen kontrollieren"
 
-#: builtin/fetch.c:171
+#: builtin/fetch.c:175
 msgid "write fetched references to the FETCH_HEAD file"
 msgstr "schreibe angeforderte Referenzen in die FETCH_HEAD-Datei"
 
-#: builtin/fetch.c:172 builtin/pull.c:206
+#: builtin/fetch.c:176 builtin/pull.c:206
 msgid "keep downloaded pack"
 msgstr "heruntergeladenes Paket behalten"
 
-#: builtin/fetch.c:174
+#: builtin/fetch.c:178
 msgid "allow updating of HEAD ref"
 msgstr "Aktualisierung der \"HEAD\"-Referenz erlauben"
 
-#: builtin/fetch.c:177 builtin/fetch.c:183 builtin/pull.c:209
+#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:209
 #: builtin/pull.c:218
 msgid "deepen history of shallow clone"
 msgstr ""
 "die Historie eines Klons mit unvollständiger Historie (shallow) vertiefen"
 
-#: builtin/fetch.c:179 builtin/pull.c:212
+#: builtin/fetch.c:183 builtin/pull.c:212
 msgid "deepen history of shallow repository based on time"
 msgstr ""
 "die Historie eines Klons mit unvollständiger Historie (shallow) auf "
 "Zeitbasis\n"
 "vertiefen"
 
-#: builtin/fetch.c:185 builtin/pull.c:221
+#: builtin/fetch.c:189 builtin/pull.c:221
 msgid "convert to a complete repository"
 msgstr "zu einem vollständigen Repository konvertieren"
 
-#: builtin/fetch.c:188
+#: builtin/fetch.c:192
 msgid "prepend this to submodule path output"
 msgstr "dies an die Ausgabe der Submodul-Pfade voranstellen"
 
-#: builtin/fetch.c:191
+#: builtin/fetch.c:195
 msgid ""
 "default for recursive fetching of submodules (lower priority than config "
 "files)"
@@ -15019,100 +15263,104 @@ msgstr ""
 "Standard für die rekursive Anforderung von Submodulen (geringere Priorität\n"
 "als Konfigurationsdateien)"
 
-#: builtin/fetch.c:195 builtin/pull.c:224
+#: builtin/fetch.c:199 builtin/pull.c:224
 msgid "accept refs that update .git/shallow"
 msgstr "Referenzen, die .git/shallow aktualisieren, akzeptieren"
 
-#: builtin/fetch.c:196 builtin/pull.c:226
+#: builtin/fetch.c:200 builtin/pull.c:226
 msgid "refmap"
 msgstr "Refmap"
 
-#: builtin/fetch.c:197 builtin/pull.c:227
+#: builtin/fetch.c:201 builtin/pull.c:227
 msgid "specify fetch refmap"
 msgstr "Refmap für 'fetch' angeben"
 
-#: builtin/fetch.c:204 builtin/pull.c:240
+#: builtin/fetch.c:208 builtin/pull.c:240
 msgid "report that we have only objects reachable from this object"
 msgstr ""
 "ausgeben, dass wir nur Objekte haben, die von diesem Objekt aus erreichbar "
 "sind"
 
-#: builtin/fetch.c:207 builtin/fetch.c:209
+#: builtin/fetch.c:210
+msgid "do not fetch a packfile; instead, print ancestors of negotiation tips"
+msgstr ""
+
+#: builtin/fetch.c:213 builtin/fetch.c:215
 msgid "run 'maintenance --auto' after fetching"
 msgstr "führe 'maintenance --auto' nach \"fetch\" aus"
 
-#: builtin/fetch.c:211 builtin/pull.c:243
+#: builtin/fetch.c:217 builtin/pull.c:243
 msgid "check for forced-updates on all updated branches"
 msgstr "Prüfe auf erzwungene Aktualisierungen in allen aktualisierten Branches"
 
-#: builtin/fetch.c:213
+#: builtin/fetch.c:219
 msgid "write the commit-graph after fetching"
 msgstr "Schreibe den Commit-Graph nach \"fetch\""
 
-#: builtin/fetch.c:215
+#: builtin/fetch.c:221
 msgid "accept refspecs from stdin"
 msgstr "akzeptiere Refspecs von der Standard-Eingabe"
 
-#: builtin/fetch.c:526
+#: builtin/fetch.c:586
 msgid "Couldn't find remote ref HEAD"
 msgstr "Konnte Remote-Referenz von HEAD nicht finden."
 
-#: builtin/fetch.c:697
+#: builtin/fetch.c:757
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "Konfiguration fetch.output enthält ungültigen Wert %s"
 
-#: builtin/fetch.c:796
+#: builtin/fetch.c:856
 #, c-format
 msgid "object %s not found"
 msgstr "Objekt %s nicht gefunden"
 
-#: builtin/fetch.c:800
+#: builtin/fetch.c:860
 msgid "[up to date]"
 msgstr "[aktuell]"
 
-#: builtin/fetch.c:813 builtin/fetch.c:829 builtin/fetch.c:901
+#: builtin/fetch.c:873 builtin/fetch.c:889 builtin/fetch.c:961
 msgid "[rejected]"
 msgstr "[zurückgewiesen]"
 
-#: builtin/fetch.c:814
+#: builtin/fetch.c:874
 msgid "can't fetch in current branch"
 msgstr "kann \"fetch\" im aktuellen Branch nicht ausführen"
 
-#: builtin/fetch.c:824
+#: builtin/fetch.c:884
 msgid "[tag update]"
 msgstr "[Tag Aktualisierung]"
 
-#: builtin/fetch.c:825 builtin/fetch.c:862 builtin/fetch.c:884
-#: builtin/fetch.c:896
+#: builtin/fetch.c:885 builtin/fetch.c:922 builtin/fetch.c:944
+#: builtin/fetch.c:956
 msgid "unable to update local ref"
 msgstr "kann lokale Referenz nicht aktualisieren"
 
-#: builtin/fetch.c:829
+#: builtin/fetch.c:889
 msgid "would clobber existing tag"
 msgstr "würde bestehende Tags verändern"
 
-#: builtin/fetch.c:851
+#: builtin/fetch.c:911
 msgid "[new tag]"
 msgstr "[neues Tag]"
 
-#: builtin/fetch.c:854
+#: builtin/fetch.c:914
 msgid "[new branch]"
 msgstr "[neuer Branch]"
 
-#: builtin/fetch.c:857
+#: builtin/fetch.c:917
 msgid "[new ref]"
 msgstr "[neue Referenz]"
 
-#: builtin/fetch.c:896
+#: builtin/fetch.c:956
 msgid "forced update"
 msgstr "Aktualisierung erzwungen"
 
-#: builtin/fetch.c:901
+#: builtin/fetch.c:961
 msgid "non-fast-forward"
 msgstr "kein Vorspulen"
 
-#: builtin/fetch.c:1005
+#: builtin/fetch.c:1065
 msgid ""
 "Fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled. To re-enable, use '--show-forced-updates'\n"
@@ -15123,7 +15371,7 @@ msgstr ""
 "aktivieren, nutzen Sie die Option '--show-forced-updated' oder führen\n"
 "Sie 'git config fetch.showForcedUpdates true' aus."
 
-#: builtin/fetch.c:1009
+#: builtin/fetch.c:1069
 #, c-format
 msgid ""
 "It took %.2f seconds to check forced updates. You can use\n"
@@ -15136,12 +15384,12 @@ msgstr ""
 "'git config fetch.showForcedUpdates false' ausführen, um diese Überprüfung\n"
 "zu umgehen.\n"
 
-#: builtin/fetch.c:1041
+#: builtin/fetch.c:1101
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s hat nicht alle erforderlichen Objekte gesendet\n"
 
-#: builtin/fetch.c:1069
+#: builtin/fetch.c:1129
 #, c-format
 msgid "reject %s because shallow roots are not allowed to be updated"
 msgstr ""
@@ -15149,12 +15397,12 @@ msgstr ""
 "unvollständiger\n"
 "Historie (shallow) nicht aktualisiert werden dürfen."
 
-#: builtin/fetch.c:1146 builtin/fetch.c:1297
+#: builtin/fetch.c:1206 builtin/fetch.c:1357
 #, c-format
 msgid "From %.*s\n"
 msgstr "Von %.*s\n"
 
-#: builtin/fetch.c:1168
+#: builtin/fetch.c:1228
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -15163,58 +15411,58 @@ msgstr ""
 "Einige lokale Referenzen konnten nicht aktualisiert werden; versuchen Sie\n"
 "'git remote prune %s', um jeden älteren, widersprüchlichen Branch zu löschen."
 
-#: builtin/fetch.c:1267
+#: builtin/fetch.c:1327
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s wird unreferenziert)"
 
-#: builtin/fetch.c:1268
+#: builtin/fetch.c:1328
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s wurde unreferenziert)"
 
-#: builtin/fetch.c:1300
+#: builtin/fetch.c:1360
 msgid "[deleted]"
 msgstr "[gelöscht]"
 
-#: builtin/fetch.c:1301 builtin/remote.c:1118
+#: builtin/fetch.c:1361 builtin/remote.c:1118
 msgid "(none)"
 msgstr "(nichts)"
 
-#: builtin/fetch.c:1324
+#: builtin/fetch.c:1384
 #, c-format
 msgid "Refusing to fetch into current branch %s of non-bare repository"
 msgstr ""
 "Der \"fetch\" in den aktuellen Branch %s von einem Nicht-Bare-Repository "
 "wurde verweigert."
 
-#: builtin/fetch.c:1343
+#: builtin/fetch.c:1403
 #, c-format
 msgid "Option \"%s\" value \"%s\" is not valid for %s"
 msgstr "Option \"%s\" Wert \"%s\" ist nicht gültig für %s"
 
-#: builtin/fetch.c:1346
+#: builtin/fetch.c:1406
 #, c-format
 msgid "Option \"%s\" is ignored for %s\n"
 msgstr "Option \"%s\" wird ignoriert für %s\n"
 
-#: builtin/fetch.c:1558
+#: builtin/fetch.c:1618
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "Mehrere Branches erkannt, inkompatibel mit --set-upstream"
 
-#: builtin/fetch.c:1573
+#: builtin/fetch.c:1633
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "Setze keinen Upstream für einen entfernten Remote-Tracking-Branch."
 
-#: builtin/fetch.c:1575
+#: builtin/fetch.c:1635
 msgid "not setting upstream for a remote tag"
 msgstr "Setze keinen Upstream für einen Tag eines Remote-Repositories."
 
-#: builtin/fetch.c:1577
+#: builtin/fetch.c:1637
 msgid "unknown branch type"
 msgstr "Unbekannter Branch-Typ"
 
-#: builtin/fetch.c:1579
+#: builtin/fetch.c:1639
 msgid ""
 "no source branch found.\n"
 "you need to specify exactly one branch with the --set-upstream option."
@@ -15222,22 +15470,22 @@ msgstr ""
 "Keinen Quell-Branch gefunden.\n"
 "Sie müssen bei der Option --set-upstream genau einen Branch angeben."
 
-#: builtin/fetch.c:1708 builtin/fetch.c:1771
+#: builtin/fetch.c:1768 builtin/fetch.c:1831
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Fordere an von %s\n"
 
-#: builtin/fetch.c:1718 builtin/fetch.c:1773 builtin/remote.c:101
+#: builtin/fetch.c:1778 builtin/fetch.c:1833 builtin/remote.c:101
 #, c-format
 msgid "Could not fetch %s"
 msgstr "Konnte nicht von %s anfordern"
 
-#: builtin/fetch.c:1730
+#: builtin/fetch.c:1790
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "Konnte '%s' nicht anfordern (Exit-Code: %d)\n"
 
-#: builtin/fetch.c:1834
+#: builtin/fetch.c:1894
 msgid ""
 "No remote repository specified.  Please, specify either a URL or a\n"
 "remote name from which new revisions should be fetched."
@@ -15246,48 +15494,56 @@ msgstr ""
 "oder den Namen des Remote-Repositories an, von welchem neue\n"
 "Commits angefordert werden sollen."
 
-#: builtin/fetch.c:1870
+#: builtin/fetch.c:1930
 msgid "You need to specify a tag name."
 msgstr "Sie müssen den Namen des Tags angeben."
 
-#: builtin/fetch.c:1935
+#: builtin/fetch.c:1995
 msgid "Negative depth in --deepen is not supported"
 msgstr "Negative Tiefe wird von --deepen nicht unterstützt."
 
-#: builtin/fetch.c:1937
+#: builtin/fetch.c:1997
 msgid "--deepen and --depth are mutually exclusive"
 msgstr "--deepen und --depth schließen sich gegenseitig aus"
 
-#: builtin/fetch.c:1942
+#: builtin/fetch.c:2002
 msgid "--depth and --unshallow cannot be used together"
 msgstr "--depth und --unshallow können nicht gemeinsam verwendet werden"
 
-#: builtin/fetch.c:1944
+#: builtin/fetch.c:2004
 msgid "--unshallow on a complete repository does not make sense"
 msgstr ""
 "--unshallow kann nicht in einem Repository mit vollständiger Historie "
 "verwendet werden"
 
-#: builtin/fetch.c:1961
+#: builtin/fetch.c:2021
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all akzeptiert kein Repository als Argument"
 
-#: builtin/fetch.c:1963
+#: builtin/fetch.c:2023
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all kann nicht mit Refspecs verwendet werden"
 
-#: builtin/fetch.c:1972
+#: builtin/fetch.c:2032
 #, c-format
 msgid "No such remote or remote group: %s"
 msgstr "Remote-Repository (einzeln oder Gruppe) nicht gefunden: %s"
 
-#: builtin/fetch.c:1979
+#: builtin/fetch.c:2039
 msgid "Fetching a group and specifying refspecs does not make sense"
 msgstr ""
 "Das Abholen einer Gruppe von Remote-Repositories kann nicht mit der Angabe\n"
 "von Refspecs verwendet werden."
 
-#: builtin/fetch.c:1997
+#: builtin/fetch.c:2055
+msgid "must supply remote when using --negotiate-only"
+msgstr ""
+
+#: builtin/fetch.c:2060
+msgid "Protocol does not support --negotiate-only, exiting."
+msgstr ""
+
+#: builtin/fetch.c:2079
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -15295,13 +15551,13 @@ msgstr ""
 "--filter kann nur mit den Remote-Repositories verwendet werden,\n"
 "die in extensions.partialclone konfiguriert sind"
 
-#: builtin/fetch.c:2001
+#: builtin/fetch.c:2083
 msgid "--atomic can only be used when fetching from one remote"
 msgstr ""
 "--atomic kann nur verwendet werden, wenn nur von einem Remote-Repository "
 "abgefragt wird"
 
-#: builtin/fetch.c:2005
+#: builtin/fetch.c:2087
 msgid "--stdin can only be used when fetching from one remote"
 msgstr ""
 "--stdin kann nur verwendet werden, wenn nur von einem Remote-Repository "
@@ -15350,47 +15606,47 @@ msgstr "git for-each-ref [--merged [<Commit>]] [--no-merged [<Commit>]]"
 msgid "git for-each-ref [--contains [<commit>]] [--no-contains [<commit>]]"
 msgstr "git for-each-ref [--contains [<Objekt>]] [--no-contains [<Commit>]]"
 
-#: builtin/for-each-ref.c:28
+#: builtin/for-each-ref.c:30
 msgid "quote placeholders suitably for shells"
 msgstr "Platzhalter als Shell-String formatieren"
 
-#: builtin/for-each-ref.c:30
+#: builtin/for-each-ref.c:32
 msgid "quote placeholders suitably for perl"
 msgstr "Platzhalter als Perl-String formatieren"
 
-#: builtin/for-each-ref.c:32
+#: builtin/for-each-ref.c:34
 msgid "quote placeholders suitably for python"
 msgstr "Platzhalter als Python-String formatieren"
 
-#: builtin/for-each-ref.c:34
+#: builtin/for-each-ref.c:36
 msgid "quote placeholders suitably for Tcl"
 msgstr "Platzhalter als Tcl-String formatieren"
 
-#: builtin/for-each-ref.c:37
+#: builtin/for-each-ref.c:39
 msgid "show only <n> matched refs"
 msgstr "nur <n> passende Referenzen anzeigen"
 
-#: builtin/for-each-ref.c:39 builtin/tag.c:472
+#: builtin/for-each-ref.c:41 builtin/tag.c:483
 msgid "respect format colors"
 msgstr "Formatfarben beachten"
 
-#: builtin/for-each-ref.c:42
+#: builtin/for-each-ref.c:44
 msgid "print only refs which points at the given object"
 msgstr "nur auf dieses Objekt zeigende Referenzen ausgeben"
 
-#: builtin/for-each-ref.c:44
+#: builtin/for-each-ref.c:46
 msgid "print only refs that are merged"
 msgstr "nur zusammengeführte Referenzen ausgeben"
 
-#: builtin/for-each-ref.c:45
+#: builtin/for-each-ref.c:47
 msgid "print only refs that are not merged"
 msgstr "nur nicht zusammengeführte Referenzen ausgeben"
 
-#: builtin/for-each-ref.c:46
+#: builtin/for-each-ref.c:48
 msgid "print only refs which contain the commit"
 msgstr "nur Referenzen ausgeben, die diesen Commit enthalten"
 
-#: builtin/for-each-ref.c:47
+#: builtin/for-each-ref.c:49
 msgid "print only refs which don't contain the commit"
 msgstr "nur Referenzen ausgeben, die diesen Commit nicht enthalten"
 
@@ -15410,32 +15666,32 @@ msgstr "Konfigurationsschlüssel für eine Liste von Repository-Pfaden"
 msgid "missing --config=<config>"
 msgstr "Option --config=<Konfiguration> fehlt"
 
-#: builtin/fsck.c:69 builtin/fsck.c:130 builtin/fsck.c:131
+#: builtin/fsck.c:69 builtin/fsck.c:127 builtin/fsck.c:128
 msgid "unknown"
 msgstr "unbekannt"
 
 #. TRANSLATORS: e.g. error in tree 01bfda: <more explanation>
-#: builtin/fsck.c:83 builtin/fsck.c:103
+#: builtin/fsck.c:78 builtin/fsck.c:100
 #, c-format
 msgid "error in %s %s: %s"
 msgstr "Fehler in %s %s: %s"
 
 #. TRANSLATORS: e.g. warning in tree 01bfda: <more explanation>
-#: builtin/fsck.c:97
+#: builtin/fsck.c:94
 #, c-format
 msgid "warning in %s %s: %s"
 msgstr "Warnung in %s %s: %s"
 
-#: builtin/fsck.c:126 builtin/fsck.c:129
+#: builtin/fsck.c:123 builtin/fsck.c:126
 #, c-format
 msgid "broken link from %7s %s"
 msgstr "fehlerhafte Verknüpfung von %7s %s"
 
-#: builtin/fsck.c:138
+#: builtin/fsck.c:135
 msgid "wrong object type in link"
 msgstr "falscher Objekttyp in Verknüpfung"
 
-#: builtin/fsck.c:154
+#: builtin/fsck.c:151
 #, c-format
 msgid ""
 "broken link from %7s %s\n"
@@ -15444,211 +15700,211 @@ msgstr ""
 "fehlerhafte Verknüpfung von %7s %s\n"
 "                       nach %7s %s"
 
-#: builtin/fsck.c:265
+#: builtin/fsck.c:263
 #, c-format
 msgid "missing %s %s"
 msgstr "%s %s fehlt"
 
-#: builtin/fsck.c:292
+#: builtin/fsck.c:290
 #, c-format
 msgid "unreachable %s %s"
 msgstr "%s %s nicht erreichbar"
 
-#: builtin/fsck.c:312
+#: builtin/fsck.c:310
 #, c-format
 msgid "dangling %s %s"
 msgstr "%s %s unreferenziert"
 
-#: builtin/fsck.c:322
+#: builtin/fsck.c:320
 msgid "could not create lost-found"
 msgstr "Konnte lost-found nicht erstellen."
 
-#: builtin/fsck.c:333
+#: builtin/fsck.c:331
 #, c-format
 msgid "could not finish '%s'"
 msgstr "Konnte '%s' nicht abschließen."
 
-#: builtin/fsck.c:350
+#: builtin/fsck.c:348
 #, c-format
 msgid "Checking %s"
 msgstr "Prüfe %s"
 
-#: builtin/fsck.c:388
+#: builtin/fsck.c:386
 #, c-format
 msgid "Checking connectivity (%d objects)"
 msgstr "Prüfe Konnektivität (%d Objekte)"
 
-#: builtin/fsck.c:407
+#: builtin/fsck.c:405
 #, c-format
 msgid "Checking %s %s"
 msgstr "Prüfe %s %s"
 
-#: builtin/fsck.c:412
+#: builtin/fsck.c:410
 msgid "broken links"
 msgstr "Fehlerhafte Verknüpfungen"
 
-#: builtin/fsck.c:421
+#: builtin/fsck.c:419
 #, c-format
 msgid "root %s"
 msgstr "Wurzel %s"
 
-#: builtin/fsck.c:429
+#: builtin/fsck.c:427
 #, c-format
 msgid "tagged %s %s (%s) in %s"
 msgstr "%s %s (%s) in %s getaggt"
 
-#: builtin/fsck.c:458
+#: builtin/fsck.c:456
 #, c-format
 msgid "%s: object corrupt or missing"
 msgstr "%s: Objekt fehlerhaft oder nicht vorhanden"
 
-#: builtin/fsck.c:483
+#: builtin/fsck.c:481
 #, c-format
 msgid "%s: invalid reflog entry %s"
 msgstr "%s: Ungültiger Reflog-Eintrag %s"
 
-#: builtin/fsck.c:497
+#: builtin/fsck.c:495
 #, c-format
 msgid "Checking reflog %s->%s"
 msgstr "Prüfe Reflog %s->%s"
 
-#: builtin/fsck.c:531
+#: builtin/fsck.c:529
 #, c-format
 msgid "%s: invalid sha1 pointer %s"
 msgstr "%s: Ungültiger SHA1-Zeiger %s"
 
-#: builtin/fsck.c:538
+#: builtin/fsck.c:536
 #, c-format
 msgid "%s: not a commit"
 msgstr "%s: kein Commit"
 
-#: builtin/fsck.c:592
+#: builtin/fsck.c:590
 msgid "notice: No default references"
 msgstr "Notiz: Keine Standardreferenzen"
 
-#: builtin/fsck.c:607
+#: builtin/fsck.c:605
 #, c-format
 msgid "%s: object corrupt or missing: %s"
 msgstr "%s: Objekt fehlerhaft oder nicht vorhanden: %s"
 
-#: builtin/fsck.c:620
+#: builtin/fsck.c:618
 #, c-format
 msgid "%s: object could not be parsed: %s"
 msgstr "%s: Objekt konnte nicht geparst werden: %s"
 
-#: builtin/fsck.c:640
+#: builtin/fsck.c:638
 #, c-format
 msgid "bad sha1 file: %s"
 msgstr "Ungültige SHA1-Datei: %s"
 
-#: builtin/fsck.c:655
+#: builtin/fsck.c:653
 msgid "Checking object directory"
 msgstr "Prüfe Objekt-Verzeichnis"
 
-#: builtin/fsck.c:658
+#: builtin/fsck.c:656
 msgid "Checking object directories"
 msgstr "Prüfe Objekt-Verzeichnisse"
 
-#: builtin/fsck.c:673
+#: builtin/fsck.c:671
 #, c-format
 msgid "Checking %s link"
 msgstr "Prüfe %s Verknüpfung"
 
-#: builtin/fsck.c:678 builtin/index-pack.c:865
+#: builtin/fsck.c:676 builtin/index-pack.c:866
 #, c-format
 msgid "invalid %s"
 msgstr "Ungültiger Objekt-Typ %s"
 
-#: builtin/fsck.c:685
+#: builtin/fsck.c:683
 #, c-format
 msgid "%s points to something strange (%s)"
 msgstr "%s zeigt auf etwas seltsames (%s)"
 
-#: builtin/fsck.c:691
+#: builtin/fsck.c:689
 #, c-format
 msgid "%s: detached HEAD points at nothing"
 msgstr "%s: losgelöster HEAD zeigt auf nichts"
 
-#: builtin/fsck.c:695
+#: builtin/fsck.c:693
 #, c-format
 msgid "notice: %s points to an unborn branch (%s)"
 msgstr "Notiz: %s zeigt auf einen ungeborenen Branch (%s)"
 
-#: builtin/fsck.c:707
+#: builtin/fsck.c:705
 msgid "Checking cache tree"
 msgstr "Prüfe Cache-Verzeichnis"
 
-#: builtin/fsck.c:712
+#: builtin/fsck.c:710
 #, c-format
 msgid "%s: invalid sha1 pointer in cache-tree"
 msgstr "%s: Ungültiger SHA1-Zeiger in Cache-Verzeichnis"
 
-#: builtin/fsck.c:721
+#: builtin/fsck.c:719
 msgid "non-tree in cache-tree"
 msgstr "non-tree in Cache-Verzeichnis"
 
-#: builtin/fsck.c:752
+#: builtin/fsck.c:750
 msgid "git fsck [<options>] [<object>...]"
 msgstr "git fsck [<Optionen>] [<Objekt>...]"
 
-#: builtin/fsck.c:758
+#: builtin/fsck.c:756
 msgid "show unreachable objects"
 msgstr "unerreichbare Objekte anzeigen"
 
-#: builtin/fsck.c:759
+#: builtin/fsck.c:757
 msgid "show dangling objects"
 msgstr "unreferenzierte Objekte anzeigen"
 
-#: builtin/fsck.c:760
+#: builtin/fsck.c:758
 msgid "report tags"
 msgstr "Tags melden"
 
-#: builtin/fsck.c:761
+#: builtin/fsck.c:759
 msgid "report root nodes"
 msgstr "Hauptwurzeln melden"
 
-#: builtin/fsck.c:762
+#: builtin/fsck.c:760
 msgid "make index objects head nodes"
 msgstr "Index-Objekte in Erreichbarkeitsprüfung einbeziehen"
 
-#: builtin/fsck.c:763
+#: builtin/fsck.c:761
 msgid "make reflogs head nodes (default)"
 msgstr "Reflogs in Erreichbarkeitsprüfung einbeziehen (Standard)"
 
-#: builtin/fsck.c:764
+#: builtin/fsck.c:762
 msgid "also consider packs and alternate objects"
 msgstr "ebenso Pakete und alternative Objekte betrachten"
 
-#: builtin/fsck.c:765
+#: builtin/fsck.c:763
 msgid "check only connectivity"
 msgstr "nur Konnektivität prüfen"
 
-#: builtin/fsck.c:766 builtin/mktag.c:78
+#: builtin/fsck.c:764 builtin/mktag.c:75
 msgid "enable more strict checking"
 msgstr "genauere Prüfung aktivieren"
 
-#: builtin/fsck.c:768
+#: builtin/fsck.c:766
 msgid "write dangling objects in .git/lost-found"
 msgstr "unreferenzierte Objekte nach .git/lost-found schreiben"
 
-#: builtin/fsck.c:769 builtin/prune.c:134
+#: builtin/fsck.c:767 builtin/prune.c:134
 msgid "show progress"
 msgstr "Fortschrittsanzeige anzeigen"
 
-#: builtin/fsck.c:770
+#: builtin/fsck.c:768
 msgid "show verbose names for reachable objects"
 msgstr "ausführliche Namen für erreichbare Objekte anzeigen"
 
-#: builtin/fsck.c:829 builtin/index-pack.c:261
+#: builtin/fsck.c:827 builtin/index-pack.c:262
 msgid "Checking objects"
 msgstr "Prüfe Objekte"
 
-#: builtin/fsck.c:857
+#: builtin/fsck.c:855
 #, c-format
 msgid "%s: object missing"
 msgstr "%s: Objekt nicht vorhanden"
 
-#: builtin/fsck.c:868
+#: builtin/fsck.c:866
 #, c-format
 msgid "invalid parameter: expected sha1, got '%s'"
 msgstr "Ungültiger Parameter: SHA-1 erwartet, '%s' bekommen"
@@ -15667,12 +15923,12 @@ msgstr "Konnte '%s' nicht lesen: %s"
 msgid "failed to parse '%s' value '%s'"
 msgstr "Fehler beim Parsen von '%s' mit dem Wert '%s'"
 
-#: builtin/gc.c:487 builtin/init-db.c:58
+#: builtin/gc.c:487 builtin/init-db.c:57
 #, c-format
 msgid "cannot stat '%s'"
 msgstr "Kann '%s' nicht lesen"
 
-#: builtin/gc.c:496 builtin/notes.c:240 builtin/tag.c:562
+#: builtin/gc.c:496 builtin/notes.c:240 builtin/tag.c:573
 #, c-format
 msgid "cannot read '%s'"
 msgstr "kann '%s' nicht lesen"
@@ -15778,150 +16034,151 @@ msgstr "nicht erkanntes --schedule Argument '%s'"
 msgid "failed to write commit-graph"
 msgstr "Fehler beim Schreiben des Commit-Graph"
 
-#: builtin/gc.c:914
-msgid "failed to fill remotes"
+#: builtin/gc.c:905
+#, fuzzy
+msgid "failed to prefetch remotes"
 msgstr "Fehler beim Eintragen der Remote-Repositories"
 
-#: builtin/gc.c:1037
+#: builtin/gc.c:1022
 msgid "failed to start 'git pack-objects' process"
 msgstr "konnte 'git pack-objects' Prozess nicht starten"
 
-#: builtin/gc.c:1054
+#: builtin/gc.c:1039
 msgid "failed to finish 'git pack-objects' process"
 msgstr "konnte 'git pack-objects' Prozess nicht beenden"
 
-#: builtin/gc.c:1106
+#: builtin/gc.c:1091
 msgid "failed to write multi-pack-index"
 msgstr "Fehler beim Schreiben des multi-pack-index"
 
-#: builtin/gc.c:1124
+#: builtin/gc.c:1109
 msgid "'git multi-pack-index expire' failed"
 msgstr "Fehler beim Ausführen von 'git multi-pack-index expire'"
 
-#: builtin/gc.c:1185
+#: builtin/gc.c:1170
 msgid "'git multi-pack-index repack' failed"
 msgstr "Fehler beim Ausführen von 'git multi-pack-index repack'"
 
-#: builtin/gc.c:1194
+#: builtin/gc.c:1179
 msgid ""
 "skipping incremental-repack task because core.multiPackIndex is disabled"
 msgstr ""
 "Überspringen der Aufgabe 'incremental-repack', weil core.multiPackIndex "
 "deaktiviert ist"
 
-#: builtin/gc.c:1298
+#: builtin/gc.c:1283
 #, c-format
 msgid "lock file '%s' exists, skipping maintenance"
 msgstr "Sperrdatei '%s' existiert, Wartung wird übersprungen"
 
-#: builtin/gc.c:1328
+#: builtin/gc.c:1313
 #, c-format
 msgid "task '%s' failed"
 msgstr "Aufgabe '%s' fehlgeschlagen"
 
-#: builtin/gc.c:1410
+#: builtin/gc.c:1395
 #, c-format
 msgid "'%s' is not a valid task"
 msgstr "'%s' ist keine gültige Aufgabe"
 
-#: builtin/gc.c:1415
+#: builtin/gc.c:1400
 #, c-format
 msgid "task '%s' cannot be selected multiple times"
 msgstr "Aufgabe '%s' kann nicht mehrfach ausgewählt werden"
 
-#: builtin/gc.c:1430
+#: builtin/gc.c:1415
 msgid "run tasks based on the state of the repository"
 msgstr "Aufgaben abhängig vom Zustand des Repositories ausführen"
 
-#: builtin/gc.c:1431
+#: builtin/gc.c:1416
 msgid "frequency"
 msgstr "Häufigkeit"
 
-#: builtin/gc.c:1432
+#: builtin/gc.c:1417
 msgid "run tasks based on frequency"
 msgstr "Aufgaben abhängig von der Häufigkeit ausführen"
 
-#: builtin/gc.c:1435
+#: builtin/gc.c:1420
 msgid "do not report progress or other information over stderr"
 msgstr "zeige keinen Fortschritt oder andere Informationen über stderr"
 
-#: builtin/gc.c:1436
+#: builtin/gc.c:1421
 msgid "task"
 msgstr "Aufgabe"
 
-#: builtin/gc.c:1437
+#: builtin/gc.c:1422
 msgid "run a specific task"
 msgstr "eine bestimmte Aufgabe ausführen"
 
-#: builtin/gc.c:1454
+#: builtin/gc.c:1439
 msgid "use at most one of --auto and --schedule=<frequency>"
 msgstr ""
 "nutzen Sie höchstens eine der Optionen --auto oder --schedule=<Häufigkeit>"
 
-#: builtin/gc.c:1497
+#: builtin/gc.c:1482
 msgid "failed to run 'git config'"
 msgstr "Fehler beim Ausführen von 'git config'"
 
-#: builtin/gc.c:1562
+#: builtin/gc.c:1547
 #, c-format
 msgid "failed to expand path '%s'"
 msgstr "Fehler beim Erweitern des Pfades '%s'"
 
-#: builtin/gc.c:1591
+#: builtin/gc.c:1576
 msgid "failed to start launchctl"
 msgstr "konnte launchctl nicht starten"
 
-#: builtin/gc.c:1628
+#: builtin/gc.c:1613
 #, c-format
 msgid "failed to create directories for '%s'"
 msgstr "Fehler beim Erstellen von Verzeichnissen für '%s'"
 
-#: builtin/gc.c:1689
+#: builtin/gc.c:1674
 #, c-format
 msgid "failed to bootstrap service %s"
 msgstr "Fehler beim Laden des Services %s"
 
-#: builtin/gc.c:1760
+#: builtin/gc.c:1745
 msgid "failed to create temp xml file"
 msgstr "Fehler beim Erstellen der temporären XML-Datei"
 
-#: builtin/gc.c:1850
+#: builtin/gc.c:1835
 msgid "failed to start schtasks"
 msgstr "Fehler beim Starten von schtasks"
 
-#: builtin/gc.c:1894
+#: builtin/gc.c:1879
 msgid "failed to run 'crontab -l'; your system might not support 'cron'"
 msgstr ""
 "Fehler beim Ausführen von 'crontab -l'; Ihr System unterstützt eventuell "
 "'cron' nicht"
 
-#: builtin/gc.c:1911
+#: builtin/gc.c:1896
 msgid "failed to run 'crontab'; your system might not support 'cron'"
 msgstr ""
 "Fehler beim Ausführen von 'crontab'; Ihr System unterstützt eventuell 'cron' "
 "nicht"
 
-#: builtin/gc.c:1915
+#: builtin/gc.c:1900
 msgid "failed to open stdin of 'crontab'"
 msgstr "Fehler beim Öffnen der Standard-Eingabe von 'crontab'"
 
-#: builtin/gc.c:1956
+#: builtin/gc.c:1942
 msgid "'crontab' died"
 msgstr "'crontab' abgebrochen"
 
-#: builtin/gc.c:1990
+#: builtin/gc.c:1976
 msgid "another process is scheduling background maintenance"
 msgstr "ein anderer Prozess plant die Hintergrundwartung"
 
-#: builtin/gc.c:2009
+#: builtin/gc.c:2000
 msgid "failed to add repo to global config"
 msgstr "Repository konnte nicht zur globalen Konfiguration hinzugefügt werden"
 
-#: builtin/gc.c:2019
+#: builtin/gc.c:2010
 msgid "git maintenance <subcommand> [<options>]"
 msgstr "git maintenance <Unterbefehl> [<Optionen>]"
 
-#: builtin/gc.c:2038
+#: builtin/gc.c:2029
 #, c-format
 msgid "invalid subcommand: %s"
 msgstr "ungültiger Unterbefehl: %s"
@@ -15944,266 +16201,266 @@ msgstr "ungültige Anzahl von Threads (%d) für %s angegeben"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:285 builtin/index-pack.c:1589 builtin/index-pack.c:1808
-#: builtin/pack-objects.c:2944
+#: builtin/grep.c:285 builtin/index-pack.c:1590 builtin/index-pack.c:1793
+#: builtin/pack-objects.c:2969
 #, c-format
 msgid "no threads support, ignoring %s"
 msgstr "keine Unterstützung von Threads, '%s' wird ignoriert"
 
-#: builtin/grep.c:473 builtin/grep.c:601 builtin/grep.c:641
+#: builtin/grep.c:473 builtin/grep.c:603 builtin/grep.c:643
 #, c-format
 msgid "unable to read tree (%s)"
 msgstr "konnte \"Tree\"-Objekt (%s) nicht lesen"
 
-#: builtin/grep.c:656
+#: builtin/grep.c:658
 #, c-format
 msgid "unable to grep from object of type %s"
 msgstr "kann \"grep\" nicht mit Objekten des Typs %s durchführen"
 
-#: builtin/grep.c:737
+#: builtin/grep.c:739
 #, c-format
 msgid "switch `%c' expects a numerical value"
 msgstr "Schalter '%c' erwartet einen numerischen Wert"
 
-#: builtin/grep.c:836
+#: builtin/grep.c:838
 msgid "search in index instead of in the work tree"
 msgstr "im Index statt im Arbeitsverzeichnis suchen"
 
-#: builtin/grep.c:838
+#: builtin/grep.c:840
 msgid "find in contents not managed by git"
 msgstr "auch in Inhalten finden, die nicht von Git verwaltet werden"
 
-#: builtin/grep.c:840
+#: builtin/grep.c:842
 msgid "search in both tracked and untracked files"
 msgstr "in versionierten und unversionierten Dateien suchen"
 
-#: builtin/grep.c:842
+#: builtin/grep.c:844
 msgid "ignore files specified via '.gitignore'"
 msgstr "Dateien, die über '.gitignore' angegeben sind, ignorieren"
 
-#: builtin/grep.c:844
+#: builtin/grep.c:846
 msgid "recursively search in each submodule"
 msgstr "rekursive Suche in jedem Submodul"
 
-#: builtin/grep.c:847
+#: builtin/grep.c:849
 msgid "show non-matching lines"
 msgstr "Zeilen ohne Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:849
+#: builtin/grep.c:851
 msgid "case insensitive matching"
 msgstr "Übereinstimmungen unabhängig von Groß- und Kleinschreibung finden"
 
-#: builtin/grep.c:851
+#: builtin/grep.c:853
 msgid "match patterns only at word boundaries"
 msgstr "nur ganze Wörter suchen"
 
-#: builtin/grep.c:853
+#: builtin/grep.c:855
 msgid "process binary files as text"
 msgstr "binäre Dateien als Text verarbeiten"
 
-#: builtin/grep.c:855
+#: builtin/grep.c:857
 msgid "don't match patterns in binary files"
 msgstr "keine Muster in Binärdateien finden"
 
-#: builtin/grep.c:858
+#: builtin/grep.c:860
 msgid "process binary files with textconv filters"
 msgstr "binäre Dateien mit \"textconv\"-Filtern verarbeiten"
 
-#: builtin/grep.c:860
+#: builtin/grep.c:862
 msgid "search in subdirectories (default)"
 msgstr "in Unterverzeichnissen suchen (Standard)"
 
-#: builtin/grep.c:862
+#: builtin/grep.c:864
 msgid "descend at most <depth> levels"
 msgstr "höchstens <Tiefe> Ebenen durchlaufen"
 
-#: builtin/grep.c:866
+#: builtin/grep.c:868
 msgid "use extended POSIX regular expressions"
 msgstr "erweiterte reguläre Ausdrücke aus POSIX verwenden"
 
-#: builtin/grep.c:869
+#: builtin/grep.c:871
 msgid "use basic POSIX regular expressions (default)"
 msgstr "grundlegende reguläre Ausdrücke aus POSIX verwenden (Standard)"
 
-#: builtin/grep.c:872
+#: builtin/grep.c:874
 msgid "interpret patterns as fixed strings"
 msgstr "Muster als feste Zeichenketten interpretieren"
 
-#: builtin/grep.c:875
+#: builtin/grep.c:877
 msgid "use Perl-compatible regular expressions"
 msgstr "Perl-kompatible reguläre Ausdrücke verwenden"
 
-#: builtin/grep.c:878
+#: builtin/grep.c:880
 msgid "show line numbers"
 msgstr "Zeilennummern anzeigen"
 
-#: builtin/grep.c:879
+#: builtin/grep.c:881
 msgid "show column number of first match"
 msgstr "Nummer der Spalte des ersten Treffers anzeigen"
 
-#: builtin/grep.c:880
+#: builtin/grep.c:882
 msgid "don't show filenames"
 msgstr "keine Dateinamen anzeigen"
 
-#: builtin/grep.c:881
+#: builtin/grep.c:883
 msgid "show filenames"
 msgstr "Dateinamen anzeigen"
 
-#: builtin/grep.c:883
+#: builtin/grep.c:885
 msgid "show filenames relative to top directory"
 msgstr "Dateinamen relativ zum Projektverzeichnis anzeigen"
 
-#: builtin/grep.c:885
+#: builtin/grep.c:887
 msgid "show only filenames instead of matching lines"
 msgstr "nur Dateinamen anzeigen anstatt übereinstimmende Zeilen"
 
-#: builtin/grep.c:887
+#: builtin/grep.c:889
 msgid "synonym for --files-with-matches"
 msgstr "Synonym für --files-with-matches"
 
-#: builtin/grep.c:890
+#: builtin/grep.c:892
 msgid "show only the names of files without match"
 msgstr "nur die Dateinamen ohne Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:892
+#: builtin/grep.c:894
 msgid "print NUL after filenames"
 msgstr "NUL-Zeichen nach Dateinamen ausgeben"
 
-#: builtin/grep.c:895
+#: builtin/grep.c:897
 msgid "show only matching parts of a line"
 msgstr "nur übereinstimmende Teile der Zeile anzeigen"
 
-#: builtin/grep.c:897
+#: builtin/grep.c:899
 msgid "show the number of matches instead of matching lines"
 msgstr "anstatt der Zeilen, die Anzahl der übereinstimmenden Zeilen anzeigen"
 
-#: builtin/grep.c:898
+#: builtin/grep.c:900
 msgid "highlight matches"
 msgstr "Übereinstimmungen hervorheben"
 
-#: builtin/grep.c:900
+#: builtin/grep.c:902
 msgid "print empty line between matches from different files"
 msgstr ""
 "eine Leerzeile zwischen Übereinstimmungen in verschiedenen Dateien ausgeben"
 
-#: builtin/grep.c:902
+#: builtin/grep.c:904
 msgid "show filename only once above matches from same file"
 msgstr ""
 "den Dateinamen nur einmal oberhalb der Übereinstimmungen aus dieser Datei "
 "anzeigen"
 
-#: builtin/grep.c:905
+#: builtin/grep.c:907
 msgid "show <n> context lines before and after matches"
 msgstr "<n> Zeilen vor und nach den Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:908
+#: builtin/grep.c:910
 msgid "show <n> context lines before matches"
 msgstr "<n> Zeilen vor den Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:910
+#: builtin/grep.c:912
 msgid "show <n> context lines after matches"
 msgstr "<n> Zeilen nach den Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:912
+#: builtin/grep.c:914
 msgid "use <n> worker threads"
 msgstr "<n> Threads benutzen"
 
-#: builtin/grep.c:913
+#: builtin/grep.c:915
 msgid "shortcut for -C NUM"
 msgstr "Kurzform für -C NUM"
 
-#: builtin/grep.c:916
+#: builtin/grep.c:918
 msgid "show a line with the function name before matches"
 msgstr "eine Zeile mit dem Funktionsnamen vor Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:918
+#: builtin/grep.c:920
 msgid "show the surrounding function"
 msgstr "die umgebende Funktion anzeigen"
 
-#: builtin/grep.c:921
+#: builtin/grep.c:923
 msgid "read patterns from file"
 msgstr "Muster von einer Datei lesen"
 
-#: builtin/grep.c:923
+#: builtin/grep.c:925
 msgid "match <pattern>"
 msgstr "<Muster> finden"
 
-#: builtin/grep.c:925
+#: builtin/grep.c:927
 msgid "combine patterns specified with -e"
 msgstr "Muster kombinieren, die mit -e angegeben wurden"
 
-#: builtin/grep.c:937
+#: builtin/grep.c:939
 msgid "indicate hit with exit status without output"
 msgstr "Übereinstimmungen nur durch Beendigungsstatus anzeigen"
 
-#: builtin/grep.c:939
+#: builtin/grep.c:941
 msgid "show only matches from files that match all patterns"
 msgstr ""
 "nur Übereinstimmungen von Dateien anzeigen, die allen Mustern entsprechen"
 
-#: builtin/grep.c:942
+#: builtin/grep.c:944
 msgid "pager"
 msgstr "Anzeigeprogramm"
 
-#: builtin/grep.c:942
+#: builtin/grep.c:944
 msgid "show matching files in the pager"
 msgstr "Dateien mit Übereinstimmungen im Anzeigeprogramm anzeigen"
 
-#: builtin/grep.c:946
+#: builtin/grep.c:948
 msgid "allow calling of grep(1) (ignored by this build)"
 msgstr "den Aufruf von grep(1) erlauben (von dieser Programmversion ignoriert)"
 
-#: builtin/grep.c:1012
+#: builtin/grep.c:1014
 msgid "no pattern given"
 msgstr "Kein Muster angegeben."
 
-#: builtin/grep.c:1048
+#: builtin/grep.c:1050
 msgid "--no-index or --untracked cannot be used with revs"
 msgstr "--no-index oder --untracked können nicht mit Commits verwendet werden"
 
-#: builtin/grep.c:1056
+#: builtin/grep.c:1058
 #, c-format
 msgid "unable to resolve revision: %s"
 msgstr "Konnte Commit nicht auflösen: %s"
 
-#: builtin/grep.c:1086
+#: builtin/grep.c:1088
 msgid "--untracked not supported with --recurse-submodules"
 msgstr "--untracked zusammen mit --recurse-submodules wird nicht unterstützt"
 
-#: builtin/grep.c:1090
+#: builtin/grep.c:1092
 msgid "invalid option combination, ignoring --threads"
 msgstr "Ungültige Kombination von Optionen, --threads wird ignoriert."
 
-#: builtin/grep.c:1093 builtin/pack-objects.c:3672
+#: builtin/grep.c:1095 builtin/pack-objects.c:3930
 msgid "no threads support, ignoring --threads"
 msgstr "Keine Unterstützung für Threads, --threads wird ignoriert."
 
-#: builtin/grep.c:1096 builtin/index-pack.c:1586 builtin/pack-objects.c:2941
+#: builtin/grep.c:1098 builtin/index-pack.c:1587 builtin/pack-objects.c:2966
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "ungültige Anzahl von Threads angegeben (%d)"
 
-#: builtin/grep.c:1130
+#: builtin/grep.c:1132
 msgid "--open-files-in-pager only works on the worktree"
 msgstr ""
 "--open-files-in-pager kann nur innerhalb des Arbeitsverzeichnisses verwendet "
 "werden"
 
-#: builtin/grep.c:1156
+#: builtin/grep.c:1158
 msgid "--cached or --untracked cannot be used with --no-index"
 msgstr "--cached und --untracked können nicht mit --no-index verwendet werden"
 
-#: builtin/grep.c:1159
+#: builtin/grep.c:1161
 msgid "--untracked cannot be used with --cached"
 msgstr "--untracked kann nicht mit --cached verwendet werden"
 
-#: builtin/grep.c:1165
+#: builtin/grep.c:1167
 msgid "--[no-]exclude-standard cannot be used for tracked contents"
 msgstr ""
 "--[no-]exclude-standard kann nicht mit versionierten Inhalten verwendet "
 "werden"
 
-#: builtin/grep.c:1173
+#: builtin/grep.c:1175
 msgid "both --cached and trees are given"
 msgstr "--cached und \"Tree\"-Objekte angegeben"
 
@@ -16336,12 +16593,12 @@ msgstr "kein Handbuch-Betrachter konnte mit dieser Anfrage umgehen"
 msgid "no info viewer handled the request"
 msgstr "kein Informations-Betrachter konnte mit dieser Anfrage umgehen"
 
-#: builtin/help.c:520 builtin/help.c:531 git.c:340
+#: builtin/help.c:520 builtin/help.c:531 git.c:348
 #, c-format
 msgid "'%s' is aliased to '%s'"
 msgstr "Für '%s' wurde der Alias '%s' angelegt."
 
-#: builtin/help.c:534 git.c:372
+#: builtin/help.c:534 git.c:380
 #, c-format
 msgid "bad alias.%s string: %s"
 msgstr "Ungültiger alias.%s String: %s"
@@ -16355,397 +16612,393 @@ msgstr "Verwendung: %s%s"
 msgid "'git help config' for more information"
 msgstr "'git help config' für weitere Informationen"
 
-#: builtin/index-pack.c:221
+#: builtin/index-pack.c:222
 #, c-format
 msgid "object type mismatch at %s"
 msgstr "Objekt-Typen passen bei %s nicht zusammen"
 
-#: builtin/index-pack.c:241
+#: builtin/index-pack.c:242
 #, c-format
 msgid "did not receive expected object %s"
 msgstr "konnte erwartetes Objekt %s nicht empfangen"
 
-#: builtin/index-pack.c:244
+#: builtin/index-pack.c:245
 #, c-format
 msgid "object %s: expected type %s, found %s"
 msgstr "Objekt %s: erwarteter Typ %s, %s gefunden"
 
-#: builtin/index-pack.c:294
+#: builtin/index-pack.c:295
 #, c-format
 msgid "cannot fill %d byte"
 msgid_plural "cannot fill %d bytes"
 msgstr[0] "kann %d Byte nicht lesen"
 msgstr[1] "kann %d Bytes nicht lesen"
 
-#: builtin/index-pack.c:304
+#: builtin/index-pack.c:305
 msgid "early EOF"
 msgstr "zu frühes Dateiende"
 
-#: builtin/index-pack.c:305
+#: builtin/index-pack.c:306
 msgid "read error on input"
 msgstr "Fehler beim Lesen der Eingabe"
 
-#: builtin/index-pack.c:317
+#: builtin/index-pack.c:318
 msgid "used more bytes than were available"
 msgstr "verwendete mehr Bytes als verfügbar waren"
 
-#: builtin/index-pack.c:324 builtin/pack-objects.c:624
+#: builtin/index-pack.c:325 builtin/pack-objects.c:624
 msgid "pack too large for current definition of off_t"
 msgstr "Paket ist zu groß für die aktuelle Definition von off_t"
 
-#: builtin/index-pack.c:327 builtin/unpack-objects.c:95
+#: builtin/index-pack.c:328 builtin/unpack-objects.c:95
 msgid "pack exceeds maximum allowed size"
 msgstr "Paket überschreitet die maximal erlaubte Größe"
 
-#: builtin/index-pack.c:342
+#: builtin/index-pack.c:343
 #, c-format
 msgid "unable to create '%s'"
 msgstr "konnte '%s' nicht erstellen"
 
-#: builtin/index-pack.c:348
+#: builtin/index-pack.c:349
 #, c-format
 msgid "cannot open packfile '%s'"
 msgstr "Kann Paketdatei '%s' nicht öffnen"
 
-#: builtin/index-pack.c:362
+#: builtin/index-pack.c:363
 msgid "pack signature mismatch"
 msgstr "Paketsignatur stimmt nicht überein"
 
-#: builtin/index-pack.c:364
+#: builtin/index-pack.c:365
 #, c-format
 msgid "pack version %<PRIu32> unsupported"
 msgstr "Paketversion %<PRIu32> nicht unterstützt"
 
-#: builtin/index-pack.c:382
+#: builtin/index-pack.c:383
 #, c-format
 msgid "pack has bad object at offset %<PRIuMAX>: %s"
 msgstr "Paket hat ein ungültiges Objekt bei Versatz %<PRIuMAX>: %s"
 
-#: builtin/index-pack.c:488
+#: builtin/index-pack.c:489
 #, c-format
 msgid "inflate returned %d"
 msgstr "Dekomprimierung gab %d zurück"
 
-#: builtin/index-pack.c:537
+#: builtin/index-pack.c:538
 msgid "offset value overflow for delta base object"
 msgstr "Wert für Versatz bei Differenzobjekt übergelaufen"
 
-#: builtin/index-pack.c:545
+#: builtin/index-pack.c:546
 msgid "delta base offset is out of bound"
 msgstr ""
 "Wert für Versatz bei Differenzobjekt liegt außerhalb des gültigen Bereichs"
 
-#: builtin/index-pack.c:553
+#: builtin/index-pack.c:554
 #, c-format
 msgid "unknown object type %d"
 msgstr "Unbekannter Objekt-Typ %d"
 
-#: builtin/index-pack.c:584
+#: builtin/index-pack.c:585
 msgid "cannot pread pack file"
 msgstr "Kann Paketdatei %s nicht lesen"
 
-#: builtin/index-pack.c:586
+#: builtin/index-pack.c:587
 #, c-format
 msgid "premature end of pack file, %<PRIuMAX> byte missing"
 msgid_plural "premature end of pack file, %<PRIuMAX> bytes missing"
 msgstr[0] "frühzeitiges Ende der Paketdatei, vermisse %<PRIuMAX> Byte"
 msgstr[1] "frühzeitiges Ende der Paketdatei, vermisse %<PRIuMAX> Bytes"
 
-#: builtin/index-pack.c:612
+#: builtin/index-pack.c:613
 msgid "serious inflate inconsistency"
 msgstr "ernsthafte Inkonsistenz nach Dekomprimierung"
 
-#: builtin/index-pack.c:757 builtin/index-pack.c:763 builtin/index-pack.c:787
-#: builtin/index-pack.c:826 builtin/index-pack.c:835
+#: builtin/index-pack.c:758 builtin/index-pack.c:764 builtin/index-pack.c:788
+#: builtin/index-pack.c:827 builtin/index-pack.c:836
 #, c-format
 msgid "SHA1 COLLISION FOUND WITH %s !"
 msgstr "SHA1 KOLLISION MIT %s GEFUNDEN !"
 
-#: builtin/index-pack.c:760 builtin/pack-objects.c:171
+#: builtin/index-pack.c:761 builtin/pack-objects.c:171
 #: builtin/pack-objects.c:231 builtin/pack-objects.c:326
 #, c-format
 msgid "unable to read %s"
 msgstr "kann %s nicht lesen"
 
-#: builtin/index-pack.c:824
+#: builtin/index-pack.c:825
 #, c-format
 msgid "cannot read existing object info %s"
 msgstr "Kann existierende Informationen zu Objekt %s nicht lesen."
 
-#: builtin/index-pack.c:832
+#: builtin/index-pack.c:833
 #, c-format
 msgid "cannot read existing object %s"
 msgstr "Kann existierendes Objekt %s nicht lesen."
 
-#: builtin/index-pack.c:846
+#: builtin/index-pack.c:847
 #, c-format
 msgid "invalid blob object %s"
 msgstr "ungültiges Blob-Objekt %s"
 
-#: builtin/index-pack.c:849 builtin/index-pack.c:868
+#: builtin/index-pack.c:850 builtin/index-pack.c:869
 msgid "fsck error in packed object"
 msgstr "fsck Fehler in gepacktem Objekt"
 
-#: builtin/index-pack.c:870
+#: builtin/index-pack.c:871
 #, c-format
 msgid "Not all child objects of %s are reachable"
 msgstr "Nicht alle Kind-Objekte von %s sind erreichbar"
 
-#: builtin/index-pack.c:931 builtin/index-pack.c:978
+#: builtin/index-pack.c:932 builtin/index-pack.c:979
 msgid "failed to apply delta"
 msgstr "Konnte Dateiunterschied nicht anwenden"
 
-#: builtin/index-pack.c:1161
+#: builtin/index-pack.c:1162
 msgid "Receiving objects"
 msgstr "Empfange Objekte"
 
-#: builtin/index-pack.c:1161
+#: builtin/index-pack.c:1162
 msgid "Indexing objects"
 msgstr "Indiziere Objekte"
 
-#: builtin/index-pack.c:1195
+#: builtin/index-pack.c:1196
 msgid "pack is corrupted (SHA1 mismatch)"
 msgstr "Paket ist beschädigt (SHA1 unterschiedlich)"
 
-#: builtin/index-pack.c:1200
+#: builtin/index-pack.c:1201
 msgid "cannot fstat packfile"
 msgstr "kann Paketdatei nicht lesen"
 
-#: builtin/index-pack.c:1203
+#: builtin/index-pack.c:1204
 msgid "pack has junk at the end"
 msgstr "Paketende enthält nicht verwendbaren Inhalt"
 
-#: builtin/index-pack.c:1215
+#: builtin/index-pack.c:1216
 msgid "confusion beyond insanity in parse_pack_objects()"
 msgstr "Fehler beim Ausführen von \"parse_pack_objects()\""
 
-#: builtin/index-pack.c:1238
+#: builtin/index-pack.c:1239
 msgid "Resolving deltas"
 msgstr "Löse Unterschiede auf"
 
-#: builtin/index-pack.c:1249 builtin/pack-objects.c:2707
+#: builtin/index-pack.c:1250 builtin/pack-objects.c:2732
 #, c-format
 msgid "unable to create thread: %s"
 msgstr "kann Thread nicht erzeugen: %s"
 
-#: builtin/index-pack.c:1282
+#: builtin/index-pack.c:1283
 msgid "confusion beyond insanity"
 msgstr "Fehler beim Auflösen der Unterschiede"
 
-#: builtin/index-pack.c:1288
+#: builtin/index-pack.c:1289
 #, c-format
 msgid "completed with %d local object"
 msgid_plural "completed with %d local objects"
 msgstr[0] "abgeschlossen mit %d lokalem Objekt"
 msgstr[1] "abgeschlossen mit %d lokalen Objekten"
 
-#: builtin/index-pack.c:1300
+#: builtin/index-pack.c:1301
 #, c-format
 msgid "Unexpected tail checksum for %s (disk corruption?)"
 msgstr "unerwartete Prüfsumme für %s (Festplattenfehler?)"
 
-#: builtin/index-pack.c:1304
+#: builtin/index-pack.c:1305
 #, c-format
 msgid "pack has %d unresolved delta"
 msgid_plural "pack has %d unresolved deltas"
 msgstr[0] "Paket hat %d unaufgelösten Unterschied"
 msgstr[1] "Paket hat %d unaufgelöste Unterschiede"
 
-#: builtin/index-pack.c:1328
+#: builtin/index-pack.c:1329
 #, c-format
 msgid "unable to deflate appended object (%d)"
 msgstr "Konnte angehängtes Objekt (%d) nicht komprimieren"
 
-#: builtin/index-pack.c:1424
+#: builtin/index-pack.c:1425
 #, c-format
 msgid "local object %s is corrupt"
 msgstr "lokales Objekt %s ist beschädigt"
 
-#: builtin/index-pack.c:1445
+#: builtin/index-pack.c:1446
 #, c-format
 msgid "packfile name '%s' does not end with '.%s'"
 msgstr "Name der Paketdatei '%s' endet nicht mit '.%s'"
 
-#: builtin/index-pack.c:1469
+#: builtin/index-pack.c:1470
 #, c-format
 msgid "cannot write %s file '%s'"
 msgstr "Kann %s Datei '%s' nicht schreiben."
 
-#: builtin/index-pack.c:1477
+#: builtin/index-pack.c:1478
 #, c-format
 msgid "cannot close written %s file '%s'"
 msgstr "Kann eben geschriebene %s Datei '%s' nicht schließen."
 
-#: builtin/index-pack.c:1503
+#: builtin/index-pack.c:1504
 msgid "error while closing pack file"
 msgstr "Fehler beim Schließen der Paketdatei"
 
-#: builtin/index-pack.c:1517
+#: builtin/index-pack.c:1518
 msgid "cannot store pack file"
 msgstr "Kann Paketdatei nicht speichern"
 
-#: builtin/index-pack.c:1525
+#: builtin/index-pack.c:1526
 msgid "cannot store index file"
 msgstr "Kann Indexdatei nicht speichern"
 
-#: builtin/index-pack.c:1534
-msgid "cannot store reverse index file"
-msgstr "kann Reverse-Index-Datei nicht speichern"
-
-#: builtin/index-pack.c:1580 builtin/pack-objects.c:2952
+#: builtin/index-pack.c:1581 builtin/pack-objects.c:2977
 #, c-format
 msgid "bad pack.indexversion=%<PRIu32>"
 msgstr "\"pack.indexversion=%<PRIu32>\" ist ungültig"
 
-#: builtin/index-pack.c:1650
+#: builtin/index-pack.c:1651
 #, c-format
 msgid "Cannot open existing pack file '%s'"
 msgstr "Kann existierende Paketdatei '%s' nicht öffnen"
 
-#: builtin/index-pack.c:1652
+#: builtin/index-pack.c:1653
 #, c-format
 msgid "Cannot open existing pack idx file for '%s'"
 msgstr "Kann existierende Indexdatei für Paket '%s' nicht öffnen"
 
-#: builtin/index-pack.c:1700
+#: builtin/index-pack.c:1701
 #, c-format
 msgid "non delta: %d object"
 msgid_plural "non delta: %d objects"
 msgstr[0] "kein Unterschied: %d Objekt"
 msgstr[1] "kein Unterschied: %d Objekte"
 
-#: builtin/index-pack.c:1707
+#: builtin/index-pack.c:1708
 #, c-format
 msgid "chain length = %d: %lu object"
 msgid_plural "chain length = %d: %lu objects"
 msgstr[0] "Länge der Objekt-Liste = %d: %lu Objekt"
 msgstr[1] "Länge der Objekt-Liste = %d: %lu Objekte"
 
-#: builtin/index-pack.c:1765
+#: builtin/index-pack.c:1750
 msgid "Cannot come back to cwd"
 msgstr "Kann nicht zurück zum Arbeitsverzeichnis wechseln"
 
-#: builtin/index-pack.c:1819 builtin/index-pack.c:1822
-#: builtin/index-pack.c:1838 builtin/index-pack.c:1842
+#: builtin/index-pack.c:1804 builtin/index-pack.c:1807
+#: builtin/index-pack.c:1823 builtin/index-pack.c:1827
 #, c-format
 msgid "bad %s"
 msgstr "%s ist ungültig"
 
-#: builtin/index-pack.c:1848 builtin/init-db.c:392 builtin/init-db.c:625
+#: builtin/index-pack.c:1833 builtin/init-db.c:378 builtin/init-db.c:613
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "unbekannter Hash-Algorithmus '%s'"
 
-#: builtin/index-pack.c:1867
+#: builtin/index-pack.c:1852
 msgid "--fix-thin cannot be used without --stdin"
 msgstr "--fix-thin kann nicht ohne --stdin verwendet werden"
 
-#: builtin/index-pack.c:1869
+#: builtin/index-pack.c:1854
 msgid "--stdin requires a git repository"
 msgstr "--stdin erfordert ein Git-Repository"
 
-#: builtin/index-pack.c:1871
+#: builtin/index-pack.c:1856
 msgid "--object-format cannot be used with --stdin"
 msgstr "--object-format kann nicht mit --stdin verwendet werden"
 
-#: builtin/index-pack.c:1886
+#: builtin/index-pack.c:1871
 msgid "--verify with no packfile name given"
 msgstr "--verify wurde ohne Namen der Paketdatei angegeben"
 
-#: builtin/index-pack.c:1956 builtin/unpack-objects.c:582
+#: builtin/index-pack.c:1937 builtin/unpack-objects.c:584
 msgid "fsck error in pack objects"
 msgstr "fsck Fehler beim Packen von Objekten"
 
-#: builtin/init-db.c:64
+#: builtin/init-db.c:63
 #, c-format
 msgid "cannot stat template '%s'"
 msgstr "kann Vorlage '%s' nicht lesen"
 
-#: builtin/init-db.c:69
+#: builtin/init-db.c:68
 #, c-format
 msgid "cannot opendir '%s'"
 msgstr "kann Verzeichnis '%s' nicht öffnen"
 
-#: builtin/init-db.c:81
+#: builtin/init-db.c:80
 #, c-format
 msgid "cannot readlink '%s'"
 msgstr "kann Verweis '%s' nicht lesen"
 
-#: builtin/init-db.c:83
+#: builtin/init-db.c:82
 #, c-format
 msgid "cannot symlink '%s' '%s'"
 msgstr "kann symbolische Verknüpfung '%s' auf '%s' nicht erstellen"
 
-#: builtin/init-db.c:89
+#: builtin/init-db.c:88
 #, c-format
 msgid "cannot copy '%s' to '%s'"
 msgstr "kann '%s' nicht nach '%s' kopieren"
 
-#: builtin/init-db.c:93
+#: builtin/init-db.c:92
 #, c-format
 msgid "ignoring template %s"
 msgstr "ignoriere Vorlage %s"
 
-#: builtin/init-db.c:124
+#: builtin/init-db.c:123
 #, c-format
 msgid "templates not found in %s"
 msgstr "Keine Vorlagen in %s gefunden."
 
-#: builtin/init-db.c:139
+#: builtin/init-db.c:138
 #, c-format
 msgid "not copying templates from '%s': %s"
 msgstr "kopiere keine Vorlagen von '%s': %s"
 
-#: builtin/init-db.c:275
+#: builtin/init-db.c:262
 #, c-format
 msgid "invalid initial branch name: '%s'"
 msgstr "ungültiger initialer Branchname: '%s'"
 
-#: builtin/init-db.c:367
+#: builtin/init-db.c:353
 #, c-format
 msgid "unable to handle file type %d"
 msgstr "kann nicht mit Dateityp %d umgehen"
 
-#: builtin/init-db.c:370
+#: builtin/init-db.c:356
 #, c-format
 msgid "unable to move %s to %s"
 msgstr "Konnte %s nicht nach %s verschieben"
 
-#: builtin/init-db.c:386
+#: builtin/init-db.c:372
 msgid "attempt to reinitialize repository with different hash"
 msgstr "Versuch, das Repository mit einem anderen Hash zu reinitialisieren"
 
-#: builtin/init-db.c:410 builtin/init-db.c:413
+#: builtin/init-db.c:396 builtin/init-db.c:399
 #, c-format
 msgid "%s already exists"
 msgstr "%s existiert bereits"
 
-#: builtin/init-db.c:445
+#: builtin/init-db.c:431
 #, c-format
 msgid "re-init: ignored --initial-branch=%s"
 msgstr "Neu-Initialisierung: --initial-branch=%s ignoriert"
 
-#: builtin/init-db.c:476
+#: builtin/init-db.c:462
 #, c-format
 msgid "Reinitialized existing shared Git repository in %s%s\n"
 msgstr "Bestehendes verteiltes Git-Repository in %s%s neuinitialisiert\n"
 
-#: builtin/init-db.c:477
+#: builtin/init-db.c:463
 #, c-format
 msgid "Reinitialized existing Git repository in %s%s\n"
 msgstr "Bestehendes Git-Repository in %s%s neuinitialisiert\n"
 
-#: builtin/init-db.c:481
+#: builtin/init-db.c:467
 #, c-format
 msgid "Initialized empty shared Git repository in %s%s\n"
 msgstr "Leeres verteiltes Git-Repository in %s%s initialisiert\n"
 
-#: builtin/init-db.c:482
+#: builtin/init-db.c:468
 #, c-format
 msgid "Initialized empty Git repository in %s%s\n"
 msgstr "Leeres Git-Repository in %s%s initialisiert\n"
 
-#: builtin/init-db.c:531
+#: builtin/init-db.c:517
 msgid ""
 "git init [-q | --quiet] [--bare] [--template=<template-directory>] [--"
 "shared[=<permissions>]] [<directory>]"
@@ -16753,41 +17006,41 @@ msgstr ""
 "git init [-q | --quiet] [--bare] [--template=<Vorlagenverzeichnis>] [--"
 "shared[=<Berechtigungen>]] [<Verzeichnis>]"
 
-#: builtin/init-db.c:557
+#: builtin/init-db.c:543
 msgid "permissions"
 msgstr "Berechtigungen"
 
-#: builtin/init-db.c:558
+#: builtin/init-db.c:544
 msgid "specify that the git repository is to be shared amongst several users"
 msgstr "angeben, dass das Git-Repository mit mehreren Benutzern geteilt wird"
 
-#: builtin/init-db.c:564
+#: builtin/init-db.c:550
 msgid "override the name of the initial branch"
 msgstr "den Namen des initialen Branches überschreiben"
 
-#: builtin/init-db.c:565 builtin/verify-pack.c:74
+#: builtin/init-db.c:551 builtin/verify-pack.c:74
 msgid "hash"
 msgstr "Hash"
 
-#: builtin/init-db.c:566 builtin/show-index.c:22 builtin/verify-pack.c:75
+#: builtin/init-db.c:552 builtin/show-index.c:22 builtin/verify-pack.c:75
 msgid "specify the hash algorithm to use"
 msgstr "den zu verwendenen Hash-Algorithmus angeben"
 
-#: builtin/init-db.c:573
+#: builtin/init-db.c:559
 msgid "--separate-git-dir and --bare are mutually exclusive"
 msgstr "--separate-git-dir und --bare schließen sich gegenseitig aus"
 
-#: builtin/init-db.c:602 builtin/init-db.c:607
+#: builtin/init-db.c:590 builtin/init-db.c:595
 #, c-format
 msgid "cannot mkdir %s"
 msgstr "kann Verzeichnis %s nicht erstellen"
 
-#: builtin/init-db.c:611 builtin/init-db.c:666
+#: builtin/init-db.c:599 builtin/init-db.c:654
 #, c-format
 msgid "cannot chdir to %s"
 msgstr "kann nicht in Verzeichnis %s wechseln"
 
-#: builtin/init-db.c:638
+#: builtin/init-db.c:626
 #, c-format
 msgid ""
 "%s (or --work-tree=<directory>) not allowed without specifying %s (or --git-"
@@ -16796,12 +17049,12 @@ msgstr ""
 "%s (oder --work-tree=<Verzeichnis>) nicht erlaubt ohne Spezifizierung von %s "
 "(oder --git-dir=<Verzeichnis>)"
 
-#: builtin/init-db.c:690
+#: builtin/init-db.c:678
 #, c-format
 msgid "Cannot access work tree '%s'"
 msgstr "Kann nicht auf Arbeitsverzeichnis '%s' zugreifen."
 
-#: builtin/init-db.c:695
+#: builtin/init-db.c:683
 msgid "--separate-git-dir incompatible with bare repository"
 msgstr "--separate-git-dir nicht kompatibel mit Bare-Repository"
 
@@ -16852,10 +17105,6 @@ msgstr "Optionen für das Parsen setzen"
 #: builtin/interpret-trailers.c:110
 msgid "do not treat --- specially"
 msgstr "--- nicht speziell behandeln"
-
-#: builtin/interpret-trailers.c:111
-msgid "trailer"
-msgstr "Anhang"
 
 #: builtin/interpret-trailers.c:112
 msgid "trailer(s) to add"
@@ -16919,81 +17168,81 @@ msgstr "-L<Bereich>:<Datei> kann nicht mit Pfadspezifikation verwendet werden"
 msgid "Final output: %d %s\n"
 msgstr "letzte Ausgabe: %d %s\n"
 
-#: builtin/log.c:566
+#: builtin/log.c:568
 #, c-format
 msgid "git show %s: bad file"
 msgstr "git show %s: ungültige Datei"
 
-#: builtin/log.c:581 builtin/log.c:671
+#: builtin/log.c:583 builtin/log.c:673
 #, c-format
 msgid "could not read object %s"
 msgstr "Konnte Objekt %s nicht lesen."
 
-#: builtin/log.c:696
+#: builtin/log.c:698
 #, c-format
 msgid "unknown type: %d"
 msgstr "Unbekannter Typ: %d"
 
-#: builtin/log.c:841
+#: builtin/log.c:843
 #, c-format
 msgid "%s: invalid cover from description mode"
 msgstr ""
 "%s: Ungültiger Modus für Erstellung des Deckblattes aus der Beschreibung"
 
-#: builtin/log.c:848
+#: builtin/log.c:850
 msgid "format.headers without value"
 msgstr "format.headers ohne Wert"
 
-#: builtin/log.c:977
+#: builtin/log.c:979
 #, c-format
 msgid "cannot open patch file %s"
 msgstr "Kann Patch-Datei %s nicht öffnen"
 
-#: builtin/log.c:994
+#: builtin/log.c:996
 msgid "need exactly one range"
 msgstr "Brauche genau einen Commit-Bereich."
 
-#: builtin/log.c:1004
+#: builtin/log.c:1006
 msgid "not a range"
 msgstr "Kein Commit-Bereich."
 
-#: builtin/log.c:1168
+#: builtin/log.c:1170
 msgid "cover letter needs email format"
 msgstr "Anschreiben benötigt E-Mail-Format"
 
-#: builtin/log.c:1174
+#: builtin/log.c:1176
 msgid "failed to create cover-letter file"
 msgstr "Fehler beim Erstellen der Datei für das Anschreiben."
 
-#: builtin/log.c:1261
+#: builtin/log.c:1263
 #, c-format
 msgid "insane in-reply-to: %s"
 msgstr "ungültiges in-reply-to: %s"
 
-#: builtin/log.c:1288
+#: builtin/log.c:1290
 msgid "git format-patch [<options>] [<since> | <revision-range>]"
 msgstr "git format-patch [<Optionen>] [<seit> | <Commitbereich>]"
 
-#: builtin/log.c:1346
+#: builtin/log.c:1348
 msgid "two output directories?"
 msgstr "Zwei Ausgabeverzeichnisse?"
 
-#: builtin/log.c:1497 builtin/log.c:2317 builtin/log.c:2319 builtin/log.c:2331
+#: builtin/log.c:1499 builtin/log.c:2326 builtin/log.c:2328 builtin/log.c:2340
 #, c-format
 msgid "unknown commit %s"
 msgstr "Unbekannter Commit %s"
 
-#: builtin/log.c:1508 builtin/replace.c:58 builtin/replace.c:207
+#: builtin/log.c:1510 builtin/replace.c:58 builtin/replace.c:207
 #: builtin/replace.c:210
 #, c-format
 msgid "failed to resolve '%s' as a valid ref"
 msgstr "Konnte '%s' nicht als gültige Referenz auflösen."
 
-#: builtin/log.c:1517
+#: builtin/log.c:1519
 msgid "could not find exact merge base"
 msgstr "Konnte keine exakte Merge-Basis finden."
 
-#: builtin/log.c:1527
+#: builtin/log.c:1529
 msgid ""
 "failed to get upstream, if you want to record base commit automatically,\n"
 "please use git branch --set-upstream-to to track a remote branch.\n"
@@ -17004,291 +17253,295 @@ msgstr ""
 "'git branch --set-upstream-to', um einem Remote-Branch zu folgen.\n"
 "Oder geben Sie den Basis-Commit mit '--base=<Basis-Commit-Id>' manuell an."
 
-#: builtin/log.c:1550
+#: builtin/log.c:1552
 msgid "failed to find exact merge base"
 msgstr "Fehler beim Finden einer exakten Merge-Basis."
 
-#: builtin/log.c:1567
+#: builtin/log.c:1569
 msgid "base commit should be the ancestor of revision list"
 msgstr "Basis-Commit sollte der Vorgänger der Revisionsliste sein."
 
-#: builtin/log.c:1577
+#: builtin/log.c:1579
 msgid "base commit shouldn't be in revision list"
 msgstr "Basis-Commit sollte nicht in der Revisionsliste enthalten sein."
 
-#: builtin/log.c:1635
+#: builtin/log.c:1637
 msgid "cannot get patch id"
 msgstr "kann Patch-Id nicht lesen"
 
-#: builtin/log.c:1692
+#: builtin/log.c:1700
 msgid "failed to infer range-diff origin of current series"
 msgstr "Fehler beim Ableiten des range-diff Ursprungs der aktuellen Serie"
 
-#: builtin/log.c:1694
+#: builtin/log.c:1702
 #, c-format
 msgid "using '%s' as range-diff origin of current series"
 msgstr "nutze '%s' als range-diff Ursprung der aktuellen Serie"
 
-#: builtin/log.c:1738
+#: builtin/log.c:1746
 msgid "use [PATCH n/m] even with a single patch"
 msgstr "[PATCH n/m] auch mit einzelnem Patch verwenden"
 
-#: builtin/log.c:1741
+#: builtin/log.c:1749
 msgid "use [PATCH] even with multiple patches"
 msgstr "[PATCH] auch mit mehreren Patches verwenden"
 
-#: builtin/log.c:1745
+#: builtin/log.c:1753
 msgid "print patches to standard out"
 msgstr "Ausgabe der Patches in Standard-Ausgabe"
 
-#: builtin/log.c:1747
+#: builtin/log.c:1755
 msgid "generate a cover letter"
 msgstr "ein Deckblatt erzeugen"
 
-#: builtin/log.c:1749
+#: builtin/log.c:1757
 msgid "use simple number sequence for output file names"
 msgstr "einfache Nummernfolge für die Namen der Ausgabedateien verwenden"
 
-#: builtin/log.c:1750
+#: builtin/log.c:1758
 msgid "sfx"
 msgstr "Dateiendung"
 
-#: builtin/log.c:1751
+#: builtin/log.c:1759
 msgid "use <sfx> instead of '.patch'"
 msgstr "<Dateiendung> statt '.patch' verwenden"
 
-#: builtin/log.c:1753
+#: builtin/log.c:1761
 msgid "start numbering patches at <n> instead of 1"
 msgstr "die Nummerierung der Patches bei <n> statt bei 1 beginnen"
 
-#: builtin/log.c:1755
+#: builtin/log.c:1762
+msgid "reroll-count"
+msgstr ""
+
+#: builtin/log.c:1763
 msgid "mark the series as Nth re-roll"
 msgstr "die Serie als n-te Fassung kennzeichnen"
 
-#: builtin/log.c:1757
+#: builtin/log.c:1765
 msgid "max length of output filename"
 msgstr "maximale Länge des Dateinamens für die Ausgabe"
 
-#: builtin/log.c:1759
+#: builtin/log.c:1767
 msgid "use [RFC PATCH] instead of [PATCH]"
 msgstr "[RFC PATCH] statt [PATCH] verwenden"
 
-#: builtin/log.c:1762
+#: builtin/log.c:1770
 msgid "cover-from-description-mode"
 msgstr "Modus für Erstellung des Deckblattes aus der Beschreibung"
 
-#: builtin/log.c:1763
+#: builtin/log.c:1771
 msgid "generate parts of a cover letter based on a branch's description"
 msgstr ""
 "Erzeuge Teile des Deckblattes basierend auf der Beschreibung des Branches"
 
-#: builtin/log.c:1765
+#: builtin/log.c:1773
 msgid "use [<prefix>] instead of [PATCH]"
 msgstr "nutze [<Präfix>] statt [PATCH]"
 
-#: builtin/log.c:1768
+#: builtin/log.c:1776
 msgid "store resulting files in <dir>"
 msgstr "erzeugte Dateien in <Verzeichnis> speichern"
 
-#: builtin/log.c:1771
+#: builtin/log.c:1779
 msgid "don't strip/add [PATCH]"
 msgstr "[PATCH] nicht entfernen/hinzufügen"
 
-#: builtin/log.c:1774
+#: builtin/log.c:1782
 msgid "don't output binary diffs"
 msgstr "keine binären Unterschiede ausgeben"
 
-#: builtin/log.c:1776
+#: builtin/log.c:1784
 msgid "output all-zero hash in From header"
 msgstr "Hash mit Nullen in \"From\"-Header ausgeben"
 
-#: builtin/log.c:1778
+#: builtin/log.c:1786
 msgid "don't include a patch matching a commit upstream"
 msgstr ""
 "keine Patches einschließen, die einem Commit im Upstream-Branch entsprechen"
 
-#: builtin/log.c:1780
+#: builtin/log.c:1788
 msgid "show patch format instead of default (patch + stat)"
 msgstr "Patchformat anstatt des Standards anzeigen (Patch + Zusammenfassung)"
 
-#: builtin/log.c:1782
+#: builtin/log.c:1790
 msgid "Messaging"
 msgstr "E-Mail-Einstellungen"
 
-#: builtin/log.c:1783
+#: builtin/log.c:1791
 msgid "header"
 msgstr "Header"
 
-#: builtin/log.c:1784
+#: builtin/log.c:1792
 msgid "add email header"
 msgstr "E-Mail-Header hinzufügen"
 
-#: builtin/log.c:1785 builtin/log.c:1786
+#: builtin/log.c:1793 builtin/log.c:1794
 msgid "email"
 msgstr "E-Mail"
 
-#: builtin/log.c:1785
+#: builtin/log.c:1793
 msgid "add To: header"
 msgstr "\"To:\"-Header hinzufügen"
 
-#: builtin/log.c:1786
+#: builtin/log.c:1794
 msgid "add Cc: header"
 msgstr "\"Cc:\"-Header hinzufügen"
 
-#: builtin/log.c:1787
+#: builtin/log.c:1795
 msgid "ident"
 msgstr "Ident"
 
-#: builtin/log.c:1788
+#: builtin/log.c:1796
 msgid "set From address to <ident> (or committer ident if absent)"
 msgstr ""
 "\"From\"-Adresse auf <Ident> setzen (oder Ident des Commit-Erstellers, wenn "
 "fehlend)"
 
-#: builtin/log.c:1790
+#: builtin/log.c:1798
 msgid "message-id"
 msgstr "message-id"
 
-#: builtin/log.c:1791
+#: builtin/log.c:1799
 msgid "make first mail a reply to <message-id>"
 msgstr "aus erster E-Mail eine Antwort zu <message-id> machen"
 
-#: builtin/log.c:1792 builtin/log.c:1795
+#: builtin/log.c:1800 builtin/log.c:1803
 msgid "boundary"
 msgstr "Grenze"
 
-#: builtin/log.c:1793
+#: builtin/log.c:1801
 msgid "attach the patch"
 msgstr "den Patch anhängen"
 
-#: builtin/log.c:1796
+#: builtin/log.c:1804
 msgid "inline the patch"
 msgstr "den Patch direkt in die Nachricht einfügen"
 
-#: builtin/log.c:1800
+#: builtin/log.c:1808
 msgid "enable message threading, styles: shallow, deep"
 msgstr "Nachrichtenverkettung aktivieren, Stile: shallow, deep"
 
-#: builtin/log.c:1802
+#: builtin/log.c:1810
 msgid "signature"
 msgstr "Signatur"
 
-#: builtin/log.c:1803
+#: builtin/log.c:1811
 msgid "add a signature"
 msgstr "eine Signatur hinzufügen"
 
-#: builtin/log.c:1804
+#: builtin/log.c:1812
 msgid "base-commit"
 msgstr "Basis-Commit"
 
-#: builtin/log.c:1805
+#: builtin/log.c:1813
 msgid "add prerequisite tree info to the patch series"
 msgstr "erforderliche Revisions-Informationen der Patch-Serie hinzufügen"
 
-#: builtin/log.c:1808
+#: builtin/log.c:1816
 msgid "add a signature from a file"
 msgstr "eine Signatur aus einer Datei hinzufügen"
 
-#: builtin/log.c:1809
+#: builtin/log.c:1817
 msgid "don't print the patch filenames"
 msgstr "keine Dateinamen der Patches anzeigen"
 
-#: builtin/log.c:1811
+#: builtin/log.c:1819
 msgid "show progress while generating patches"
 msgstr "Forschrittsanzeige während der Erzeugung der Patches"
 
-#: builtin/log.c:1813
+#: builtin/log.c:1821
 msgid "show changes against <rev> in cover letter or single patch"
 msgstr ""
 "Änderungen gegenüber <Commit> im Deckblatt oder einzelnem Patch anzeigen"
 
-#: builtin/log.c:1816
+#: builtin/log.c:1824
 msgid "show changes against <refspec> in cover letter or single patch"
 msgstr ""
 "Änderungen gegenüber <Refspec> im Deckblatt oder einzelnem Patch anzeigen"
 
-#: builtin/log.c:1818
+#: builtin/log.c:1826 builtin/range-diff.c:28
 msgid "percentage by which creation is weighted"
 msgstr "Prozentsatz mit welchem Erzeugung gewichtet wird"
 
-#: builtin/log.c:1904
+#: builtin/log.c:1913
 #, c-format
 msgid "invalid ident line: %s"
 msgstr "Ungültige Identifikationszeile: %s"
 
-#: builtin/log.c:1919
+#: builtin/log.c:1928
 msgid "-n and -k are mutually exclusive"
 msgstr "-n und -k schließen sich gegenseitig aus"
 
-#: builtin/log.c:1921
+#: builtin/log.c:1930
 msgid "--subject-prefix/--rfc and -k are mutually exclusive"
 msgstr "--subject-prefix/--rfc und -k schließen sich gegenseitig aus"
 
-#: builtin/log.c:1929
+#: builtin/log.c:1938
 msgid "--name-only does not make sense"
 msgstr "--name-only kann nicht verwendet werden"
 
-#: builtin/log.c:1931
+#: builtin/log.c:1940
 msgid "--name-status does not make sense"
 msgstr "--name-status kann nicht verwendet werden"
 
-#: builtin/log.c:1933
+#: builtin/log.c:1942
 msgid "--check does not make sense"
 msgstr "--check kann nicht verwendet werden"
 
-#: builtin/log.c:1955
+#: builtin/log.c:1964
 msgid "--stdout, --output, and --output-directory are mutually exclusive"
 msgstr ""
 "--stdout, --output und --output-directory schließen sich gegenseitig aus"
 
-#: builtin/log.c:2078
+#: builtin/log.c:2087
 msgid "--interdiff requires --cover-letter or single patch"
 msgstr "--interdiff erfordert --cover-letter oder einzelnen Patch"
 
-#: builtin/log.c:2082
+#: builtin/log.c:2091
 msgid "Interdiff:"
 msgstr "Interdiff:"
 
-#: builtin/log.c:2083
+#: builtin/log.c:2092
 #, c-format
 msgid "Interdiff against v%d:"
 msgstr "Interdiff gegen v%d:"
 
-#: builtin/log.c:2089
+#: builtin/log.c:2098
 msgid "--creation-factor requires --range-diff"
 msgstr "--creation-factor erfordert --range-diff"
 
-#: builtin/log.c:2093
+#: builtin/log.c:2102
 msgid "--range-diff requires --cover-letter or single patch"
 msgstr "--range-diff erfordert --cover-letter oder einzelnen Patch."
 
-#: builtin/log.c:2101
+#: builtin/log.c:2110
 msgid "Range-diff:"
 msgstr "Range-Diff:"
 
-#: builtin/log.c:2102
+#: builtin/log.c:2111
 #, c-format
 msgid "Range-diff against v%d:"
 msgstr "Range-Diff gegen v%d:"
 
-#: builtin/log.c:2113
+#: builtin/log.c:2122
 #, c-format
 msgid "unable to read signature file '%s'"
 msgstr "Konnte Signatur-Datei '%s' nicht lesen"
 
-#: builtin/log.c:2149
+#: builtin/log.c:2158
 msgid "Generating patches"
 msgstr "Erzeuge Patches"
 
-#: builtin/log.c:2193
+#: builtin/log.c:2202
 msgid "failed to create output files"
 msgstr "Fehler beim Erstellen der Ausgabedateien."
 
-#: builtin/log.c:2252
+#: builtin/log.c:2261
 msgid "git cherry [-v] [<upstream> [<head> [<limit>]]]"
 msgstr "git cherry [-v] [<Upstream> [<Branch> [<Limit>]]]"
 
-#: builtin/log.c:2306
+#: builtin/log.c:2315
 #, c-format
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> manually.\n"
@@ -17296,116 +17549,116 @@ msgstr ""
 "Konnte gefolgten Remote-Branch nicht finden, bitte geben Sie <Upstream> "
 "manuell an.\n"
 
-#: builtin/ls-files.c:486
+#: builtin/ls-files.c:563
 msgid "git ls-files [<options>] [<file>...]"
 msgstr "git ls-files [<Optionen>] [<Datei>...]"
 
-#: builtin/ls-files.c:542
+#: builtin/ls-files.c:619
 msgid "identify the file status with tags"
 msgstr "den Dateistatus mit Tags anzeigen"
 
-#: builtin/ls-files.c:544
+#: builtin/ls-files.c:621
 msgid "use lowercase letters for 'assume unchanged' files"
 msgstr ""
 "Kleinbuchstaben für Dateien mit 'assume unchanged' Markierung verwenden"
 
-#: builtin/ls-files.c:546
+#: builtin/ls-files.c:623
 msgid "use lowercase letters for 'fsmonitor clean' files"
 msgstr "Kleinbuchstaben für 'fsmonitor clean' Dateien verwenden"
 
-#: builtin/ls-files.c:548
+#: builtin/ls-files.c:625
 msgid "show cached files in the output (default)"
 msgstr "zwischengespeicherte Dateien in der Ausgabe anzeigen (Standard)"
 
-#: builtin/ls-files.c:550
+#: builtin/ls-files.c:627
 msgid "show deleted files in the output"
 msgstr "entfernte Dateien in der Ausgabe anzeigen"
 
-#: builtin/ls-files.c:552
+#: builtin/ls-files.c:629
 msgid "show modified files in the output"
 msgstr "geänderte Dateien in der Ausgabe anzeigen"
 
-#: builtin/ls-files.c:554
+#: builtin/ls-files.c:631
 msgid "show other files in the output"
 msgstr "sonstige Dateien in der Ausgabe anzeigen"
 
-#: builtin/ls-files.c:556
+#: builtin/ls-files.c:633
 msgid "show ignored files in the output"
 msgstr "ignorierte Dateien in der Ausgabe anzeigen"
 
-#: builtin/ls-files.c:559
+#: builtin/ls-files.c:636
 msgid "show staged contents' object name in the output"
 msgstr ""
 "Objektnamen von Inhalten, die zum Commit vorgemerkt sind, in der Ausgabe "
 "anzeigen"
 
-#: builtin/ls-files.c:561
+#: builtin/ls-files.c:638
 msgid "show files on the filesystem that need to be removed"
 msgstr "Dateien im Dateisystem, die gelöscht werden müssen, anzeigen"
 
-#: builtin/ls-files.c:563
+#: builtin/ls-files.c:640
 msgid "show 'other' directories' names only"
 msgstr "nur Namen von 'sonstigen' Verzeichnissen anzeigen"
 
-#: builtin/ls-files.c:565
+#: builtin/ls-files.c:642
 msgid "show line endings of files"
 msgstr "Zeilenenden von Dateien anzeigen"
 
-#: builtin/ls-files.c:567
+#: builtin/ls-files.c:644
 msgid "don't show empty directories"
 msgstr "keine leeren Verzeichnisse anzeigen"
 
-#: builtin/ls-files.c:570
+#: builtin/ls-files.c:647
 msgid "show unmerged files in the output"
 msgstr "nicht zusammengeführte Dateien in der Ausgabe anzeigen"
 
-#: builtin/ls-files.c:572
+#: builtin/ls-files.c:649
 msgid "show resolve-undo information"
 msgstr "'resolve-undo' Informationen anzeigen"
 
-#: builtin/ls-files.c:574
+#: builtin/ls-files.c:651
 msgid "skip files matching pattern"
 msgstr "Dateien auslassen, die einem Muster entsprechen"
 
-#: builtin/ls-files.c:577
+#: builtin/ls-files.c:654
 msgid "exclude patterns are read from <file>"
 msgstr "Muster, gelesen von <Datei>, ausschließen"
 
-#: builtin/ls-files.c:580
+#: builtin/ls-files.c:657
 msgid "read additional per-directory exclude patterns in <file>"
 msgstr "zusätzliche pro-Verzeichnis Auschlussmuster aus <Datei> auslesen"
 
-#: builtin/ls-files.c:582
+#: builtin/ls-files.c:659
 msgid "add the standard git exclusions"
 msgstr "die standardmäßigen Git-Ausschlüsse hinzufügen"
 
-#: builtin/ls-files.c:586
+#: builtin/ls-files.c:663
 msgid "make the output relative to the project top directory"
 msgstr "Ausgabe relativ zum Projektverzeichnis"
 
-#: builtin/ls-files.c:589
+#: builtin/ls-files.c:666
 msgid "recurse through submodules"
 msgstr "Rekursion in Submodulen durchführen"
 
-#: builtin/ls-files.c:591
+#: builtin/ls-files.c:668
 msgid "if any <file> is not in the index, treat this as an error"
 msgstr "als Fehler behandeln, wenn sich eine <Datei> nicht im Index befindet"
 
-#: builtin/ls-files.c:592
+#: builtin/ls-files.c:669
 msgid "tree-ish"
 msgstr "Commit-Referenz"
 
-#: builtin/ls-files.c:593
+#: builtin/ls-files.c:670
 msgid "pretend that paths removed since <tree-ish> are still present"
 msgstr ""
 "vorgeben, dass Pfade, die seit <Commit-Referenz> gelöscht wurden, immer noch "
 "vorhanden sind"
 
-#: builtin/ls-files.c:595
+#: builtin/ls-files.c:672
 msgid "show debugging data"
 msgstr "Ausgaben zur Fehlersuche anzeigen"
 
-#: builtin/ls-files.c:597
+#: builtin/ls-files.c:674
 msgid "suppress duplicate entries"
 msgstr "doppelte Einträge unterdrücken"
 
@@ -17423,7 +17676,7 @@ msgstr ""
 msgid "do not print remote URL"
 msgstr "URL des Remote-Repositories nicht ausgeben"
 
-#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1404
+#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1399
 msgid "exec"
 msgstr "Programm"
 
@@ -17494,6 +17747,59 @@ msgid "list entire tree; not just current directory (implies --full-name)"
 msgstr ""
 "das gesamte Verzeichnis auflisten; nicht nur das aktuelle Verzeichnis "
 "(impliziert --full-name)"
+
+#. TRANSLATORS: keep <> in "<" mail ">" info.
+#: builtin/mailinfo.c:14
+#, fuzzy
+msgid "git mailinfo [<options>] <msg> <patch> < mail >info"
+msgstr "git diff --no-index [<Optionen>] <Pfad> <Pfad>"
+
+#: builtin/mailinfo.c:58
+#, fuzzy
+msgid "keep subject"
+msgstr "nicht erreichbare Objekte behalten"
+
+#: builtin/mailinfo.c:60
+msgid "keep non patch brackets in subject"
+msgstr ""
+
+#: builtin/mailinfo.c:62
+#, fuzzy
+msgid "copy Message-ID to the end of commit message"
+msgstr "Commit-Beschreibung bearbeiten"
+
+#: builtin/mailinfo.c:64
+msgid "re-code metadata to i18n.commitEncoding"
+msgstr ""
+
+#: builtin/mailinfo.c:67
+msgid "disable charset re-coding of metadata"
+msgstr ""
+
+#: builtin/mailinfo.c:69
+msgid "encoding"
+msgstr ""
+
+#: builtin/mailinfo.c:70
+msgid "re-code metadata to this encoding"
+msgstr ""
+
+#: builtin/mailinfo.c:72
+msgid "use scissors"
+msgstr ""
+
+#: builtin/mailinfo.c:73
+#, fuzzy
+msgid "<action>"
+msgstr "Aktion"
+
+#: builtin/mailinfo.c:74
+msgid "action when quoted CR is found"
+msgstr ""
+
+#: builtin/mailinfo.c:77
+msgid "use headers in message's body"
+msgstr ""
 
 #: builtin/mailsplit.c:241
 #, c-format
@@ -17690,7 +17996,7 @@ msgid "verify that the named commit has a valid GPG signature"
 msgstr "den genannten Commit auf eine gültige GPG-Signatur überprüfen"
 
 #: builtin/merge.c:278 builtin/notes.c:787 builtin/pull.c:168
-#: builtin/rebase.c:541 builtin/rebase.c:1418 builtin/revert.c:114
+#: builtin/rebase.c:540 builtin/rebase.c:1413 builtin/revert.c:114
 msgid "strategy"
 msgstr "Strategie"
 
@@ -17748,57 +18054,58 @@ msgstr "kein gültiges Objekt: %s"
 msgid "read-tree failed"
 msgstr "read-tree fehlgeschlagen"
 
-#: builtin/merge.c:399
-msgid " (nothing to squash)"
+#: builtin/merge.c:400
+#, fuzzy
+msgid "Already up to date. (nothing to squash)"
 msgstr " (nichts zu quetschen)"
 
-#: builtin/merge.c:410
+#: builtin/merge.c:414
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
 msgstr "Quetsche Commit -- HEAD wird nicht aktualisiert\n"
 
-#: builtin/merge.c:460
+#: builtin/merge.c:464
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
 msgstr "Keine Merge-Commit-Beschreibung -- HEAD wird nicht aktualisiert\n"
 
-#: builtin/merge.c:511
+#: builtin/merge.c:515
 #, c-format
 msgid "'%s' does not point to a commit"
 msgstr "'%s' zeigt auf keinen Commit"
 
-#: builtin/merge.c:598
+#: builtin/merge.c:602
 #, c-format
 msgid "Bad branch.%s.mergeoptions string: %s"
 msgstr "Ungültiger branch.%s.mergeoptions String: %s"
 
-#: builtin/merge.c:724
+#: builtin/merge.c:728
 msgid "Not handling anything other than two heads merge."
 msgstr "Es wird nur der Merge von zwei Branches behandelt."
 
-#: builtin/merge.c:737
+#: builtin/merge.c:741
 #, c-format
 msgid "Unknown option for merge-recursive: -X%s"
 msgstr "Unbekannte Option für merge-recursive: -X%s"
 
-#: builtin/merge.c:756 t/helper/test-fast-rebase.c:209
+#: builtin/merge.c:760 t/helper/test-fast-rebase.c:209
 #, c-format
 msgid "unable to write %s"
 msgstr "konnte %s nicht schreiben"
 
-#: builtin/merge.c:808
+#: builtin/merge.c:812
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "konnte nicht von '%s' lesen"
 
-#: builtin/merge.c:817
+#: builtin/merge.c:821
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
 "Merge wurde nicht committet; benutzen Sie 'git commit', um den Merge "
 "abzuschließen.\n"
 
-#: builtin/merge.c:823
+#: builtin/merge.c:827
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
@@ -17809,11 +18116,11 @@ msgstr ""
 "Upstream-Branch mit einem Thema-Branch zusammenführt.\n"
 "\n"
 
-#: builtin/merge.c:828
+#: builtin/merge.c:832
 msgid "An empty message aborts the commit.\n"
 msgstr "Eine leere Commit-Beschreibung bricht den Commit ab.\n"
 
-#: builtin/merge.c:831
+#: builtin/merge.c:835
 #, c-format
 msgid ""
 "Lines starting with '%c' will be ignored, and an empty message aborts\n"
@@ -17822,75 +18129,75 @@ msgstr ""
 "Zeilen, die mit '%c' beginnen, werden ignoriert,\n"
 "und eine leere Beschreibung bricht den Commit ab.\n"
 
-#: builtin/merge.c:884
+#: builtin/merge.c:888
 msgid "Empty commit message."
 msgstr "Leere Commit-Beschreibung"
 
-#: builtin/merge.c:899
+#: builtin/merge.c:903
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Wunderbar.\n"
 
-#: builtin/merge.c:960
+#: builtin/merge.c:964
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
 "Automatischer Merge fehlgeschlagen; beheben Sie die Konflikte und committen "
 "Sie dann das Ergebnis.\n"
 
-#: builtin/merge.c:999
+#: builtin/merge.c:1003
 msgid "No current branch."
 msgstr "Sie befinden sich auf keinem Branch."
 
-#: builtin/merge.c:1001
+#: builtin/merge.c:1005
 msgid "No remote for the current branch."
 msgstr "Kein Remote-Repository für den aktuellen Branch."
 
-#: builtin/merge.c:1003
+#: builtin/merge.c:1007
 msgid "No default upstream defined for the current branch."
 msgstr ""
 "Es ist kein Standard-Upstream-Branch für den aktuellen Branch definiert."
 
-#: builtin/merge.c:1008
+#: builtin/merge.c:1012
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "Kein Remote-Tracking-Branch für %s von %s"
 
-#: builtin/merge.c:1065
+#: builtin/merge.c:1069
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Fehlerhafter Wert '%s' in Umgebungsvariable '%s'"
 
-#: builtin/merge.c:1168
+#: builtin/merge.c:1172
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "nichts was wir in %s zusammenführen können: %s"
 
-#: builtin/merge.c:1202
+#: builtin/merge.c:1206
 msgid "not something we can merge"
 msgstr "nichts was wir zusammenführen können"
 
-#: builtin/merge.c:1312
+#: builtin/merge.c:1316
 msgid "--abort expects no arguments"
 msgstr "--abort akzeptiert keine Argumente"
 
-#: builtin/merge.c:1316
+#: builtin/merge.c:1320
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr "Es gibt keinen Merge abzubrechen (MERGE_HEAD fehlt)"
 
-#: builtin/merge.c:1334
+#: builtin/merge.c:1338
 msgid "--quit expects no arguments"
 msgstr "--quit erwartet keine Argumente"
 
-#: builtin/merge.c:1347
+#: builtin/merge.c:1351
 msgid "--continue expects no arguments"
 msgstr "--continue erwartet keine Argumente"
 
-#: builtin/merge.c:1351
+#: builtin/merge.c:1355
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "Es ist kein Merge im Gange (MERGE_HEAD fehlt)."
 
-#: builtin/merge.c:1367
+#: builtin/merge.c:1371
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17898,7 +18205,7 @@ msgstr ""
 "Sie haben Ihren Merge nicht abgeschlossen (MERGE_HEAD existiert).\n"
 "Bitte committen Sie Ihre Änderungen, bevor Sie den Merge ausführen."
 
-#: builtin/merge.c:1374
+#: builtin/merge.c:1378
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17906,100 +18213,92 @@ msgstr ""
 "Sie haben \"cherry-pick\" nicht abgeschlossen (CHERRY_PICK_HEAD existiert).\n"
 "Bitte committen Sie Ihre Änderungen, bevor Sie den Merge ausführen."
 
-#: builtin/merge.c:1377
+#: builtin/merge.c:1381
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr ""
 "Sie haben \"cherry-pick\" nicht abgeschlossen (CHERRY_PICK_HEAD existiert)."
 
-#: builtin/merge.c:1391
+#: builtin/merge.c:1395
 msgid "You cannot combine --squash with --no-ff."
 msgstr "Sie können --squash nicht mit --no-ff kombinieren."
 
-#: builtin/merge.c:1393
+#: builtin/merge.c:1397
 msgid "You cannot combine --squash with --commit."
 msgstr "Sie können --squash nicht mit --commit kombinieren."
 
-#: builtin/merge.c:1409
+#: builtin/merge.c:1413
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr "Kein Commit angegeben und merge.defaultToUpstream ist nicht gesetzt."
 
-#: builtin/merge.c:1426
+#: builtin/merge.c:1430
 msgid "Squash commit into empty head not supported yet"
 msgstr ""
 "Bin auf einem Commit, der noch geboren wird; kann \"squash\" nicht ausführen."
 
-#: builtin/merge.c:1428
+#: builtin/merge.c:1432
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr ""
 "Nicht vorzuspulender Commit kann nicht in einem leeren Branch verwendet "
 "werden."
 
-#: builtin/merge.c:1433
+#: builtin/merge.c:1437
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "%s - nichts was wir zusammenführen können"
 
-#: builtin/merge.c:1435
+#: builtin/merge.c:1439
 msgid "Can merge only exactly one commit into empty head"
 msgstr "Kann nur exakt einen Commit in einem leeren Branch zusammenführen."
 
-#: builtin/merge.c:1516
+#: builtin/merge.c:1520
 msgid "refusing to merge unrelated histories"
 msgstr "Verweigere den Merge von nicht zusammenhängenden Historien."
 
-#: builtin/merge.c:1525
-msgid "Already up to date."
-msgstr "Bereits aktuell."
-
-#: builtin/merge.c:1535
+#: builtin/merge.c:1539
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "Aktualisiere %s..%s\n"
 
-#: builtin/merge.c:1581
+#: builtin/merge.c:1585
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "Probiere wirklich trivialen \"in-index\"-Merge ...\n"
 
-#: builtin/merge.c:1588
+#: builtin/merge.c:1592
 #, c-format
 msgid "Nope.\n"
 msgstr "Nein.\n"
 
-#: builtin/merge.c:1613
-msgid "Already up to date. Yeeah!"
-msgstr "Bereits aktuell."
-
-#: builtin/merge.c:1619
+#: builtin/merge.c:1623
 msgid "Not possible to fast-forward, aborting."
 msgstr "Vorspulen nicht möglich, breche ab."
 
-#: builtin/merge.c:1647 builtin/merge.c:1712
+#: builtin/merge.c:1651 builtin/merge.c:1716
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "Rücklauf des Verzeichnisses bis zum Ursprung ...\n"
 
-#: builtin/merge.c:1651
+#: builtin/merge.c:1655
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Probiere Merge-Strategie %s ...\n"
 
-#: builtin/merge.c:1703
+#: builtin/merge.c:1707
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Keine Merge-Strategie behandelt diesen Merge.\n"
 
-#: builtin/merge.c:1705
+#: builtin/merge.c:1709
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "Merge mit Strategie %s fehlgeschlagen.\n"
 
-#: builtin/merge.c:1714
+#: builtin/merge.c:1718
 #, c-format
 msgid "Using the %s to prepare resolving by hand.\n"
 msgstr "Benutzen Sie \"%s\", um die Auflösung per Hand vorzubereiten.\n"
 
-#: builtin/merge.c:1728
+#: builtin/merge.c:1732
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
@@ -18009,41 +18308,41 @@ msgstr ""
 msgid "git mktag"
 msgstr "git mktag"
 
-#: builtin/mktag.c:30
+#: builtin/mktag.c:27
 #, c-format
 msgid "warning: tag input does not pass fsck: %s"
 msgstr "Warnung: Tag-Eingabe ungültig für fsck: %s"
 
-#: builtin/mktag.c:41
+#: builtin/mktag.c:38
 #, c-format
 msgid "error: tag input does not pass fsck: %s"
 msgstr "Fehler: Tag-Eingabe ungültig für fsck: %s"
 
-#: builtin/mktag.c:44
+#: builtin/mktag.c:41
 #, c-format
 msgid "%d (FSCK_IGNORE?) should never trigger this callback"
 msgstr "%d (FSCK_IGNORE?) sollte diesen Aufruf niemals auslösen"
 
-#: builtin/mktag.c:59
+#: builtin/mktag.c:56
 #, c-format
 msgid "could not read tagged object '%s'"
 msgstr "konnte getaggtes Objekt '%s' nicht lesen"
 
-#: builtin/mktag.c:62
+#: builtin/mktag.c:59
 #, c-format
 msgid "object '%s' tagged as '%s', but is a '%s' type"
 msgstr "Objekt '%s' als '%s' getaggt, aber ist ein '%s' Typ"
 
-#: builtin/mktag.c:99
+#: builtin/mktag.c:97
 msgid "tag on stdin did not pass our strict fsck check"
 msgstr ""
 "Tag von der Standardeingabe für unsere strenge Überprüfung bei fsck ungültig"
 
-#: builtin/mktag.c:102
+#: builtin/mktag.c:100
 msgid "tag on stdin did not refer to a valid object"
 msgstr "Tag von der Standard-Eingabe verweiste nicht auf gültiges Objekt"
 
-#: builtin/mktag.c:105 builtin/tag.c:232
+#: builtin/mktag.c:103 builtin/tag.c:243
 msgid "unable to write tag file"
 msgstr "konnte Tag-Datei nicht schreiben"
 
@@ -18063,20 +18362,44 @@ msgstr "fehlende Objekte erlauben"
 msgid "allow creation of more than one tree"
 msgstr "die Erstellung von mehr als einem \"Tree\"-Objekt erlauben"
 
-#: builtin/multi-pack-index.c:9
-msgid ""
-"git multi-pack-index [<options>] (write|verify|expire|repack --batch-"
-"size=<size>)"
+#: builtin/multi-pack-index.c:10
+#, fuzzy
+msgid "git multi-pack-index [<options>] write [--preferred-pack=<pack>]"
 msgstr ""
 "git multi-pack-index [<Optionen>] (write|verify|expire|repack --batch-"
 "size=<Größe>)"
 
-#: builtin/multi-pack-index.c:26
+#: builtin/multi-pack-index.c:13
+#, fuzzy
+msgid "git multi-pack-index [<options>] verify"
+msgstr "git upload-pack [<Optionen>] <Verzeichnis>"
+
+#: builtin/multi-pack-index.c:16
+#, fuzzy
+msgid "git multi-pack-index [<options>] expire"
+msgstr "git upload-pack [<Optionen>] <Verzeichnis>"
+
+#: builtin/multi-pack-index.c:19
+#, fuzzy
+msgid "git multi-pack-index [<options>] repack [--batch-size=<size>]"
+msgstr ""
+"git multi-pack-index [<Optionen>] (write|verify|expire|repack --batch-"
+"size=<Größe>)"
+
+#: builtin/multi-pack-index.c:54
 msgid "object directory containing set of packfile and pack-index pairs"
 msgstr ""
 "Objekt-Verzeichnis, welches Paare von Packdateien und pack-index enthält"
 
-#: builtin/multi-pack-index.c:29
+#: builtin/multi-pack-index.c:69
+msgid "preferred-pack"
+msgstr ""
+
+#: builtin/multi-pack-index.c:70
+msgid "pack for reuse when computing a multi-pack bitmap"
+msgstr ""
+
+#: builtin/multi-pack-index.c:128
 msgid ""
 "during repack, collect pack-files of smaller size into a batch that is "
 "larger than this size"
@@ -18084,18 +18407,7 @@ msgstr ""
 "Während des Umpackens, sammle Paket-Dateien von geringerer Größe in "
 "einenStapel, welcher größer ist als diese Größe"
 
-#: builtin/multi-pack-index.c:50 builtin/notes.c:376 builtin/notes.c:431
-#: builtin/notes.c:509 builtin/notes.c:521 builtin/notes.c:598
-#: builtin/notes.c:665 builtin/notes.c:815 builtin/notes.c:963
-#: builtin/notes.c:985 builtin/prune-packed.c:25 builtin/tag.c:575
-msgid "too many arguments"
-msgstr "Zu viele Argumente."
-
-#: builtin/multi-pack-index.c:60
-msgid "--batch-size option is only for 'repack' subcommand"
-msgstr "Option --batch-size ist nur für den Unterbefehl 'repack'"
-
-#: builtin/multi-pack-index.c:69
+#: builtin/multi-pack-index.c:180
 #, c-format
 msgid "unrecognized subcommand: %s"
 msgstr "Nicht erkannter Unterbefehl: %s"
@@ -18194,7 +18506,7 @@ msgstr "%s, Quelle=%s, Ziel=%s"
 msgid "Renaming %s to %s\n"
 msgstr "Benenne %s nach %s um\n"
 
-#: builtin/mv.c:280 builtin/remote.c:785 builtin/repack.c:483
+#: builtin/mv.c:280 builtin/remote.c:785 builtin/repack.c:667
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "Umbenennung von '%s' fehlgeschlagen"
@@ -18387,7 +18699,7 @@ msgstr "Konnte Notiz-Objekt nicht schreiben"
 msgid "the note contents have been left in %s"
 msgstr "Die Notiz-Inhalte wurden in %s belassen."
 
-#: builtin/notes.c:242 builtin/tag.c:565
+#: builtin/notes.c:242 builtin/tag.c:576
 #, c-format
 msgid "could not open or read '%s'"
 msgstr "konnte '%s' nicht öffnen oder lesen"
@@ -18428,6 +18740,13 @@ msgid "refusing to %s notes in %s (outside of refs/notes/)"
 msgstr ""
 "Ausführung von %s auf Notizen in %s (außerhalb von refs/notes/) "
 "zurückgewiesen"
+
+#: builtin/notes.c:376 builtin/notes.c:431 builtin/notes.c:509
+#: builtin/notes.c:521 builtin/notes.c:598 builtin/notes.c:665
+#: builtin/notes.c:815 builtin/notes.c:963 builtin/notes.c:985
+#: builtin/prune-packed.c:25 builtin/tag.c:586
+msgid "too many arguments"
+msgstr "Zu viele Argumente."
 
 #: builtin/notes.c:389 builtin/notes.c:678
 #, c-format
@@ -18621,7 +18940,7 @@ msgstr ""
 "commit',\n"
 "oder brechen Sie den Merge mit 'git notes merge --abort' ab.\n"
 
-#: builtin/notes.c:897 builtin/tag.c:578
+#: builtin/notes.c:897 builtin/tag.c:589
 #, c-format
 msgid "Failed to resolve '%s' as a valid ref."
 msgstr "Konnte '%s' nicht als gültige Referenz auflösen."
@@ -18655,7 +18974,7 @@ msgstr "Notiz-Referenz"
 msgid "use notes from <notes-ref>"
 msgstr "Notizen von <Notiz-Referenz> verwenden"
 
-#: builtin/notes.c:1034 builtin/stash.c:1671
+#: builtin/notes.c:1034 builtin/stash.c:1739
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr "Unbekannter Unterbefehl: %s"
@@ -18728,66 +19047,66 @@ msgstr "Konnte '%s' nicht lesen"
 msgid "wrote %<PRIu32> objects while expecting %<PRIu32>"
 msgstr "Schrieb %<PRIu32> Objekte während %<PRIu32> erwartet waren."
 
-#: builtin/pack-objects.c:1358
+#: builtin/pack-objects.c:1383
 msgid "disabling bitmap writing, as some objects are not being packed"
 msgstr ""
 "Deaktiviere Schreiben der Bitmap, da einige Objekte nicht in eine Pack-"
 "Datei\n"
 "geschrieben wurden."
 
-#: builtin/pack-objects.c:1806
+#: builtin/pack-objects.c:1831
 #, c-format
 msgid "delta base offset overflow in pack for %s"
 msgstr "\"delta base offset\" Überlauf in Paket für %s"
 
-#: builtin/pack-objects.c:1815
+#: builtin/pack-objects.c:1840
 #, c-format
 msgid "delta base offset out of bound for %s"
 msgstr "\"delta base offset\" liegt außerhalb des gültigen Bereichs für %s"
 
-#: builtin/pack-objects.c:2096
+#: builtin/pack-objects.c:2121
 msgid "Counting objects"
 msgstr "Zähle Objekte"
 
-#: builtin/pack-objects.c:2241
+#: builtin/pack-objects.c:2266
 #, c-format
 msgid "unable to parse object header of %s"
 msgstr "Konnte Kopfbereich von Objekt '%s' nicht parsen."
 
-#: builtin/pack-objects.c:2311 builtin/pack-objects.c:2327
-#: builtin/pack-objects.c:2337
+#: builtin/pack-objects.c:2336 builtin/pack-objects.c:2352
+#: builtin/pack-objects.c:2362
 #, c-format
 msgid "object %s cannot be read"
 msgstr "Objekt %s kann nicht gelesen werden."
 
-#: builtin/pack-objects.c:2314 builtin/pack-objects.c:2341
+#: builtin/pack-objects.c:2339 builtin/pack-objects.c:2366
 #, c-format
 msgid "object %s inconsistent object length (%<PRIuMAX> vs %<PRIuMAX>)"
 msgstr "Inkonsistente Objektlänge bei Objekt %s (%<PRIuMAX> vs %<PRIuMAX>)"
 
-#: builtin/pack-objects.c:2351
+#: builtin/pack-objects.c:2376
 msgid "suboptimal pack - out of memory"
 msgstr "ungünstiges Packet - Speicher voll"
 
-#: builtin/pack-objects.c:2666
+#: builtin/pack-objects.c:2691
 #, c-format
 msgid "Delta compression using up to %d threads"
 msgstr "Delta-Kompression verwendet bis zu %d Threads."
 
-#: builtin/pack-objects.c:2805
+#: builtin/pack-objects.c:2830
 #, c-format
 msgid "unable to pack objects reachable from tag %s"
 msgstr "Konnte keine Objekte packen, die von Tag %s erreichbar sind."
 
-#: builtin/pack-objects.c:2891
+#: builtin/pack-objects.c:2916
 msgid "Compressing objects"
 msgstr "Komprimiere Objekte"
 
-#: builtin/pack-objects.c:2897
+#: builtin/pack-objects.c:2922
 msgid "inconsistency with delta count"
 msgstr "Inkonsistenz mit der Anzahl von Deltas"
 
-#: builtin/pack-objects.c:2976
+#: builtin/pack-objects.c:3001
 #, c-format
 msgid ""
 "value of uploadpack.blobpackfileuri must be of the form '<object-hash> <pack-"
@@ -18796,7 +19115,7 @@ msgstr ""
 "Wert für uploadpack.blobpackfileuri muss in der Form '<Objekt-Hash> <Pack-"
 "Hash> <URI>' vorliegen ('%s' erhalten)"
 
-#: builtin/pack-objects.c:2979
+#: builtin/pack-objects.c:3004
 #, c-format
 msgid ""
 "object already configured in another uploadpack.blobpackfileuri (got '%s')"
@@ -18804,7 +19123,17 @@ msgstr ""
 "Objekt bereits in einem anderen uploadpack.blobpackfileuri konfiguriert "
 "('%s' erhalten)"
 
-#: builtin/pack-objects.c:3008
+#: builtin/pack-objects.c:3039
+#, fuzzy, c-format
+msgid "could not get type of object %s in pack %s"
+msgstr "Konnte Art von Objekt '%s' nicht bestimmen."
+
+#: builtin/pack-objects.c:3161 builtin/pack-objects.c:3175
+#, fuzzy, c-format
+msgid "could not find pack '%s'"
+msgstr "Konnte '%s' nicht abschließen."
+
+#: builtin/pack-objects.c:3218
 #, c-format
 msgid ""
 "expected edge object ID, got garbage:\n"
@@ -18813,7 +19142,7 @@ msgstr ""
 "erwartete Randobjekt-ID, erhielt nutzlose Daten:\n"
 " %s"
 
-#: builtin/pack-objects.c:3014
+#: builtin/pack-objects.c:3224
 #, c-format
 msgid ""
 "expected object ID, got garbage:\n"
@@ -18822,250 +19151,265 @@ msgstr ""
 "erwartete Objekt-ID, erhielt nutzlose Daten:\n"
 " %s"
 
-#: builtin/pack-objects.c:3112
+#: builtin/pack-objects.c:3322
 msgid "invalid value for --missing"
 msgstr "ungültiger Wert für --missing"
 
-#: builtin/pack-objects.c:3171 builtin/pack-objects.c:3279
+#: builtin/pack-objects.c:3381 builtin/pack-objects.c:3490
 msgid "cannot open pack index"
 msgstr "kann Paketindex nicht öffnen"
 
-#: builtin/pack-objects.c:3202
+#: builtin/pack-objects.c:3412
 #, c-format
 msgid "loose object at %s could not be examined"
 msgstr "loses Objekt bei %s konnte nicht untersucht werden"
 
-#: builtin/pack-objects.c:3287
+#: builtin/pack-objects.c:3498
 msgid "unable to force loose object"
 msgstr "konnte loses Objekt nicht erzwingen"
 
-#: builtin/pack-objects.c:3380
+#: builtin/pack-objects.c:3628
 #, c-format
 msgid "not a rev '%s'"
 msgstr "'%s' ist kein Commit"
 
-#: builtin/pack-objects.c:3383
+#: builtin/pack-objects.c:3631
 #, c-format
 msgid "bad revision '%s'"
 msgstr "ungültiger Commit '%s'"
 
-#: builtin/pack-objects.c:3408
+#: builtin/pack-objects.c:3659
 msgid "unable to add recent objects"
 msgstr "konnte neuere Objekte nicht hinzufügen"
 
-#: builtin/pack-objects.c:3461
+#: builtin/pack-objects.c:3712
 #, c-format
 msgid "unsupported index version %s"
 msgstr "nicht unterstützte Index-Version %s"
 
-#: builtin/pack-objects.c:3465
+#: builtin/pack-objects.c:3716
 #, c-format
 msgid "bad index version '%s'"
 msgstr "ungültige Index-Version '%s'"
 
-#: builtin/pack-objects.c:3503
+#: builtin/pack-objects.c:3755
 msgid "<version>[,<offset>]"
 msgstr "<Version>[,<Offset>]"
 
-#: builtin/pack-objects.c:3504
+#: builtin/pack-objects.c:3756
 msgid "write the pack index file in the specified idx format version"
 msgstr ""
 "die Index-Datei des Paketes in der angegebenen Indexformat-Version schreiben"
 
-#: builtin/pack-objects.c:3507
+#: builtin/pack-objects.c:3759
 msgid "maximum size of each output pack file"
 msgstr "maximale Größe für jede ausgegebene Paketdatei"
 
-#: builtin/pack-objects.c:3509
+#: builtin/pack-objects.c:3761
 msgid "ignore borrowed objects from alternate object store"
 msgstr "geliehene Objekte von alternativem Objektspeicher ignorieren"
 
-#: builtin/pack-objects.c:3511
+#: builtin/pack-objects.c:3763
 msgid "ignore packed objects"
 msgstr "gepackte Objekte ignorieren"
 
-#: builtin/pack-objects.c:3513
+#: builtin/pack-objects.c:3765
 msgid "limit pack window by objects"
 msgstr "Paketfenster durch Objekte begrenzen"
 
-#: builtin/pack-objects.c:3515
+#: builtin/pack-objects.c:3767
 msgid "limit pack window by memory in addition to object limit"
 msgstr ""
 "Paketfenster, zusätzlich zur Objektbegrenzung, durch Speicher begrenzen"
 
-#: builtin/pack-objects.c:3517
+#: builtin/pack-objects.c:3769
 msgid "maximum length of delta chain allowed in the resulting pack"
 msgstr ""
 "maximale Länge der erlaubten Differenzverkettung im resultierenden Paket"
 
-#: builtin/pack-objects.c:3519
+#: builtin/pack-objects.c:3771
 msgid "reuse existing deltas"
 msgstr "existierende Unterschiede wiederverwenden"
 
-#: builtin/pack-objects.c:3521
+#: builtin/pack-objects.c:3773
 msgid "reuse existing objects"
 msgstr "existierende Objekte wiederverwenden"
 
-#: builtin/pack-objects.c:3523
+#: builtin/pack-objects.c:3775
 msgid "use OFS_DELTA objects"
 msgstr "OFS_DELTA Objekte verwenden"
 
-#: builtin/pack-objects.c:3525
+#: builtin/pack-objects.c:3777
 msgid "use threads when searching for best delta matches"
 msgstr ""
 "Threads bei der Suche nach den besten Übereinstimmungen bei Unterschieden "
 "verwenden"
 
-#: builtin/pack-objects.c:3527
+#: builtin/pack-objects.c:3779
 msgid "do not create an empty pack output"
 msgstr "keine leeren Pakete erzeugen"
 
-#: builtin/pack-objects.c:3529
+#: builtin/pack-objects.c:3781
 msgid "read revision arguments from standard input"
 msgstr "Argumente bezüglich Commits von der Standard-Eingabe lesen"
 
-#: builtin/pack-objects.c:3531
+#: builtin/pack-objects.c:3783
 msgid "limit the objects to those that are not yet packed"
 msgstr "die Objekte zu solchen, die noch nicht gepackt wurden, begrenzen"
 
-#: builtin/pack-objects.c:3534
+#: builtin/pack-objects.c:3786
 msgid "include objects reachable from any reference"
 msgstr "Objekte einschließen, die von jeder Referenz erreichbar sind"
 
-#: builtin/pack-objects.c:3537
+#: builtin/pack-objects.c:3789
 msgid "include objects referred by reflog entries"
 msgstr ""
 "Objekte einschließen, die von Einträgen des Reflogs referenziert werden"
 
-#: builtin/pack-objects.c:3540
+#: builtin/pack-objects.c:3792
 msgid "include objects referred to by the index"
 msgstr "Objekte einschließen, die vom Index referenziert werden"
 
-#: builtin/pack-objects.c:3543
+#: builtin/pack-objects.c:3795
+#, fuzzy
+msgid "read packs from stdin"
+msgstr "Aktualisierungen von der Standard-Eingabe lesen"
+
+#: builtin/pack-objects.c:3797
 msgid "output pack to stdout"
 msgstr "Paket in die Standard-Ausgabe schreiben"
 
-#: builtin/pack-objects.c:3545
+#: builtin/pack-objects.c:3799
 msgid "include tag objects that refer to objects to be packed"
 msgstr "Tag-Objekte einschließen, die auf gepackte Objekte referenzieren"
 
-#: builtin/pack-objects.c:3547
+#: builtin/pack-objects.c:3801
 msgid "keep unreachable objects"
 msgstr "nicht erreichbare Objekte behalten"
 
-#: builtin/pack-objects.c:3549
+#: builtin/pack-objects.c:3803
 msgid "pack loose unreachable objects"
 msgstr "nicht erreichbare lose Objekte packen"
 
-#: builtin/pack-objects.c:3551
+#: builtin/pack-objects.c:3805
 msgid "unpack unreachable objects newer than <time>"
 msgstr "nicht erreichbare Objekte entpacken, die neuer als <Zeit> sind"
 
-#: builtin/pack-objects.c:3554
+#: builtin/pack-objects.c:3808
 msgid "use the sparse reachability algorithm"
 msgstr "den \"sparse\" Algorithmus zur Bestimmung der Erreichbarkeit benutzen"
 
-#: builtin/pack-objects.c:3556
+#: builtin/pack-objects.c:3810
 msgid "create thin packs"
 msgstr "dünnere Pakete erzeugen"
 
-#: builtin/pack-objects.c:3558
+#: builtin/pack-objects.c:3812
 msgid "create packs suitable for shallow fetches"
 msgstr ""
 "Pakete geeignet für Abholung mit unvollständiger Historie (shallow) erzeugen"
 
-#: builtin/pack-objects.c:3560
+#: builtin/pack-objects.c:3814
 msgid "ignore packs that have companion .keep file"
 msgstr "Pakete ignorieren, die .keep Dateien haben"
 
-#: builtin/pack-objects.c:3562
+#: builtin/pack-objects.c:3816
 msgid "ignore this pack"
 msgstr "dieses Paket ignorieren"
 
-#: builtin/pack-objects.c:3564
+#: builtin/pack-objects.c:3818
 msgid "pack compression level"
 msgstr "Komprimierungsgrad für Paketierung"
 
-#: builtin/pack-objects.c:3566
+#: builtin/pack-objects.c:3820
 msgid "do not hide commits by grafts"
 msgstr "keine künstlichen Vorgänger-Commits (\"grafts\") verbergen"
 
-#: builtin/pack-objects.c:3568
+#: builtin/pack-objects.c:3822
 msgid "use a bitmap index if available to speed up counting objects"
 msgstr ""
 "Bitmap-Index (falls verfügbar) zur Optimierung der Objektzählung benutzen"
 
-#: builtin/pack-objects.c:3570
+#: builtin/pack-objects.c:3824
 msgid "write a bitmap index together with the pack index"
 msgstr "Bitmap-Index zusammen mit Pack-Index schreiben"
 
-#: builtin/pack-objects.c:3574
+#: builtin/pack-objects.c:3828
 msgid "write a bitmap index if possible"
 msgstr "Bitmap-Index schreiben, wenn möglich"
 
-#: builtin/pack-objects.c:3578
+#: builtin/pack-objects.c:3832
 msgid "handling for missing objects"
 msgstr "Behandlung für fehlende Objekte"
 
-#: builtin/pack-objects.c:3581
+#: builtin/pack-objects.c:3835
 msgid "do not pack objects in promisor packfiles"
 msgstr ""
 "keine Objekte aus Packdateien von partiell geklonten Remote-Repositories "
 "packen"
 
-#: builtin/pack-objects.c:3583
+#: builtin/pack-objects.c:3837
 msgid "respect islands during delta compression"
 msgstr "Delta-Islands bei Delta-Kompression beachten"
 
-#: builtin/pack-objects.c:3585
+#: builtin/pack-objects.c:3839
 msgid "protocol"
 msgstr "Protokoll"
 
-#: builtin/pack-objects.c:3586
+#: builtin/pack-objects.c:3840
 msgid "exclude any configured uploadpack.blobpackfileuri with this protocol"
 msgstr ""
 "jegliche konfigurierte uploadpack.blobpackfileuri für dieses Protkoll "
 "ausschließen"
 
-#: builtin/pack-objects.c:3617
+#: builtin/pack-objects.c:3873
 #, c-format
 msgid "delta chain depth %d is too deep, forcing %d"
 msgstr "Tiefe für Verkettung von Unterschieden %d ist zu tief, erzwinge %d"
 
-#: builtin/pack-objects.c:3622
+#: builtin/pack-objects.c:3878
 #, c-format
 msgid "pack.deltaCacheLimit is too high, forcing %d"
 msgstr "pack.deltaCacheLimit ist zu hoch, erzwinge %d"
 
-#: builtin/pack-objects.c:3676
+#: builtin/pack-objects.c:3934
 msgid "--max-pack-size cannot be used to build a pack for transfer"
 msgstr ""
 "--max-pack-size kann nicht für die Erstellung eines Pakets für eine "
 "Übertragung\n"
 "benutzt werden."
 
-#: builtin/pack-objects.c:3678
+#: builtin/pack-objects.c:3936
 msgid "minimum pack size limit is 1 MiB"
 msgstr "Minimales Limit für die Paketgröße ist 1 MiB."
 
-#: builtin/pack-objects.c:3683
+#: builtin/pack-objects.c:3941
 msgid "--thin cannot be used to build an indexable pack"
 msgstr ""
 "--thin kann nicht benutzt werden, um ein indizierbares Paket zu erstellen."
 
-#: builtin/pack-objects.c:3686
+#: builtin/pack-objects.c:3944
 msgid "--keep-unreachable and --unpack-unreachable are incompatible"
 msgstr "--keep-unreachable und --unpack-unreachable sind inkompatibel"
 
-#: builtin/pack-objects.c:3692
+#: builtin/pack-objects.c:3950
 msgid "cannot use --filter without --stdout"
 msgstr "Kann --filter nicht ohne --stdout benutzen."
 
-#: builtin/pack-objects.c:3752
+#: builtin/pack-objects.c:3952
+#, fuzzy
+msgid "cannot use --filter with --stdin-packs"
+msgstr "Kann --filter nicht ohne --stdout benutzen."
+
+#: builtin/pack-objects.c:3956
+#, fuzzy
+msgid "cannot use internal rev list with --stdin-packs"
+msgstr "Angabe von Pfadnamen kann nicht gemeinsam mit --stdin verwendet werden"
+
+#: builtin/pack-objects.c:4015
 msgid "Enumerating objects"
 msgstr "Objekte aufzählen"
 
-#: builtin/pack-objects.c:3783
+#: builtin/pack-objects.c:4052
 #, c-format
 msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
@@ -19148,11 +19492,11 @@ msgstr "Optionen bezogen auf Merge"
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "Integration von Änderungen durch Rebase statt Merge"
 
-#: builtin/pull.c:158 builtin/rebase.c:492 builtin/revert.c:126
+#: builtin/pull.c:158 builtin/rebase.c:491 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "Vorspulen erlauben"
 
-#: builtin/pull.c:167 parse-options.h:339
+#: builtin/pull.c:167 parse-options.h:340
 msgid "automatically stash/stash pop before and after"
 msgstr "automatischer Stash/Stash-Pop davor und danach"
 
@@ -19208,7 +19552,7 @@ msgstr ""
 "Repository für den aktuellen Branch ist, müssen Sie einen Branch auf\n"
 "der Befehlszeile angeben."
 
-#: builtin/pull.c:456 builtin/rebase.c:1253
+#: builtin/pull.c:456 builtin/rebase.c:1248
 msgid "You are not currently on a branch."
 msgstr "Im Moment auf keinem Branch."
 
@@ -19227,7 +19571,7 @@ msgid "See git-pull(1) for details."
 msgstr "Siehe git-pull(1) für weitere Details."
 
 #: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
-#: builtin/rebase.c:1259
+#: builtin/rebase.c:1254
 msgid "<remote>"
 msgstr "<Remote-Repository>"
 
@@ -19235,7 +19579,7 @@ msgstr "<Remote-Repository>"
 msgid "<branch>"
 msgstr "<Branch>"
 
-#: builtin/pull.c:471 builtin/rebase.c:1251
+#: builtin/pull.c:471 builtin/rebase.c:1246
 msgid "There is no tracking information for the current branch."
 msgstr "Es gibt keine Tracking-Informationen für den aktuellen Branch."
 
@@ -19682,10 +20026,6 @@ msgstr "git range-diff [<Optionen>] <alte-Spitze>...<neue-Spitze>"
 msgid "git range-diff [<options>] <base> <old-tip> <new-tip>"
 msgstr "git range-diff [<Optionen>] <Basis> <alte-Spitze> <neue-Spitze>"
 
-#: builtin/range-diff.c:28
-msgid "Percentage by which creation is weighted"
-msgstr "Prozentsatz mit welchem Erzeugung gewichtet wird"
-
 #: builtin/range-diff.c:30
 msgid "use simple diff colors"
 msgstr "einfache Diff-Farben benutzen"
@@ -19821,189 +20161,189 @@ msgstr ""
 msgid "git rebase --continue | --abort | --skip | --edit-todo"
 msgstr "git rebase --continue | --abort | --skip | --edit-todo"
 
-#: builtin/rebase.c:195 builtin/rebase.c:219 builtin/rebase.c:246
+#: builtin/rebase.c:194 builtin/rebase.c:218 builtin/rebase.c:245
 #, c-format
 msgid "unusable todo list: '%s'"
 msgstr "Unbenutzbare TODO-Liste: '%s'"
 
-#: builtin/rebase.c:312
+#: builtin/rebase.c:311
 #, c-format
 msgid "could not create temporary %s"
 msgstr "Konnte temporäres Verzeichnis '%s' nicht erstellen."
 
-#: builtin/rebase.c:318
+#: builtin/rebase.c:317
 msgid "could not mark as interactive"
 msgstr "Markierung auf interaktiven Rebase fehlgeschlagen."
 
-#: builtin/rebase.c:371
+#: builtin/rebase.c:370
 msgid "could not generate todo list"
 msgstr "Konnte TODO-Liste nicht erzeugen."
 
-#: builtin/rebase.c:413
+#: builtin/rebase.c:412
 msgid "a base commit must be provided with --upstream or --onto"
 msgstr "Ein Basis-Commit muss mit --upstream oder --onto angegeben werden."
 
-#: builtin/rebase.c:482
+#: builtin/rebase.c:481
 msgid "git rebase--interactive [<options>]"
 msgstr "git rebase--interactive [<Optionen>]"
 
-#: builtin/rebase.c:495 builtin/rebase.c:1394
+#: builtin/rebase.c:494 builtin/rebase.c:1389
 msgid "keep commits which start empty"
 msgstr "behalte Commits, die leer beginnen"
 
-#: builtin/rebase.c:499 builtin/revert.c:128
+#: builtin/rebase.c:498 builtin/revert.c:128
 msgid "allow commits with empty messages"
 msgstr "Commits mit leerer Beschreibung erlauben"
 
-#: builtin/rebase.c:501
+#: builtin/rebase.c:500
 msgid "rebase merge commits"
 msgstr "Rebase auf Merge-Commits ausführen"
 
-#: builtin/rebase.c:503
+#: builtin/rebase.c:502
 msgid "keep original branch points of cousins"
 msgstr "originale Branch-Punkte der Cousins behalten"
 
-#: builtin/rebase.c:505
+#: builtin/rebase.c:504
 msgid "move commits that begin with squash!/fixup!"
 msgstr "Commits verschieben, die mit squash!/fixup! beginnen"
 
-#: builtin/rebase.c:506
+#: builtin/rebase.c:505
 msgid "sign commits"
 msgstr "Commits signieren"
 
-#: builtin/rebase.c:508 builtin/rebase.c:1333
+#: builtin/rebase.c:507 builtin/rebase.c:1328
 msgid "display a diffstat of what changed upstream"
 msgstr ""
 "Zusammenfassung der Unterschiede gegenüber dem Upstream-Branch anzeigen"
 
-#: builtin/rebase.c:510
+#: builtin/rebase.c:509
 msgid "continue rebase"
 msgstr "Rebase fortsetzen"
 
-#: builtin/rebase.c:512
+#: builtin/rebase.c:511
 msgid "skip commit"
 msgstr "Commit auslassen"
 
-#: builtin/rebase.c:513
+#: builtin/rebase.c:512
 msgid "edit the todo list"
 msgstr "die TODO-Liste bearbeiten"
 
-#: builtin/rebase.c:515
+#: builtin/rebase.c:514
 msgid "show the current patch"
 msgstr "den aktuellen Patch anzeigen"
 
-#: builtin/rebase.c:518
+#: builtin/rebase.c:517
 msgid "shorten commit ids in the todo list"
 msgstr "Commit-IDs in der TODO-Liste verkürzen"
 
-#: builtin/rebase.c:520
+#: builtin/rebase.c:519
 msgid "expand commit ids in the todo list"
 msgstr "Commit-IDs in der TODO-Liste erweitern"
 
-#: builtin/rebase.c:522
+#: builtin/rebase.c:521
 msgid "check the todo list"
 msgstr "die TODO-Liste prüfen"
 
-#: builtin/rebase.c:524
+#: builtin/rebase.c:523
 msgid "rearrange fixup/squash lines"
 msgstr "fixup/squash-Zeilen umordnen"
 
-#: builtin/rebase.c:526
+#: builtin/rebase.c:525
 msgid "insert exec commands in todo list"
 msgstr "\"exec\"-Befehle in TODO-Liste einfügen"
 
-#: builtin/rebase.c:527
+#: builtin/rebase.c:526
 msgid "onto"
 msgstr "auf"
 
-#: builtin/rebase.c:530
+#: builtin/rebase.c:529
 msgid "restrict-revision"
 msgstr "Begrenzungscommit"
 
-#: builtin/rebase.c:530
+#: builtin/rebase.c:529
 msgid "restrict revision"
 msgstr "Begrenzungscommit"
 
-#: builtin/rebase.c:532
+#: builtin/rebase.c:531
 msgid "squash-onto"
 msgstr "squash-onto"
 
-#: builtin/rebase.c:533
+#: builtin/rebase.c:532
 msgid "squash onto"
 msgstr "squash onto"
 
-#: builtin/rebase.c:535
+#: builtin/rebase.c:534
 msgid "the upstream commit"
 msgstr "der Upstream-Commit"
 
-#: builtin/rebase.c:537
+#: builtin/rebase.c:536
 msgid "head-name"
 msgstr "head-Name"
 
-#: builtin/rebase.c:537
+#: builtin/rebase.c:536
 msgid "head name"
 msgstr "head-Name"
 
-#: builtin/rebase.c:542
+#: builtin/rebase.c:541
 msgid "rebase strategy"
 msgstr "Rebase-Strategie"
 
-#: builtin/rebase.c:543
+#: builtin/rebase.c:542
 msgid "strategy-opts"
 msgstr "Strategie-Optionen"
 
-#: builtin/rebase.c:544
+#: builtin/rebase.c:543
 msgid "strategy options"
 msgstr "Strategie-Optionen"
 
-#: builtin/rebase.c:545
+#: builtin/rebase.c:544
 msgid "switch-to"
 msgstr "wechseln zu"
 
-#: builtin/rebase.c:546
+#: builtin/rebase.c:545
 msgid "the branch or commit to checkout"
 msgstr "der Branch oder Commit zum Auschecken"
 
-#: builtin/rebase.c:547
+#: builtin/rebase.c:546
 msgid "onto-name"
 msgstr "onto-Name"
 
-#: builtin/rebase.c:547
+#: builtin/rebase.c:546
 msgid "onto name"
 msgstr "onto-Name"
 
-#: builtin/rebase.c:548
+#: builtin/rebase.c:547
 msgid "cmd"
 msgstr "Befehl"
 
-#: builtin/rebase.c:548
+#: builtin/rebase.c:547
 msgid "the command to run"
 msgstr "auszuführender Befehl"
 
-#: builtin/rebase.c:551 builtin/rebase.c:1427
+#: builtin/rebase.c:550 builtin/rebase.c:1422
 msgid "automatically re-schedule any `exec` that fails"
 msgstr "jeden fehlgeschlagenen `exec`-Befehl neu ansetzen"
 
-#: builtin/rebase.c:567
+#: builtin/rebase.c:566
 msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
 msgstr "--[no-]rebase-cousins hat ohne --rebase-merges keine Auswirkung"
 
-#: builtin/rebase.c:583
+#: builtin/rebase.c:582
 #, c-format
 msgid "%s requires the merge backend"
 msgstr "%s erfordert das Merge-Backend"
 
-#: builtin/rebase.c:626
+#: builtin/rebase.c:625
 #, c-format
 msgid "could not get 'onto': '%s'"
 msgstr "Konnte 'onto' nicht bestimmen: '%s'"
 
-#: builtin/rebase.c:643
+#: builtin/rebase.c:642
 #, c-format
 msgid "invalid orig-head: '%s'"
 msgstr "Ungültiges orig-head: '%s'"
 
-#: builtin/rebase.c:668
+#: builtin/rebase.c:667
 #, c-format
 msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
 msgstr "Ignoriere ungültiges allow_rerere_autoupdate: '%s'"
@@ -20044,7 +20384,7 @@ msgstr ""
 "Infolge dessen kann Git auf diesen Revisionen Rebase nicht\n"
 "ausführen."
 
-#: builtin/rebase.c:1227
+#: builtin/rebase.c:1222
 #, c-format
 msgid ""
 "unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and \"ask"
@@ -20053,7 +20393,7 @@ msgstr ""
 "nicht erkannter leerer Typ '%s'; Gültige Werte sind \"drop\", \"keep\", und "
 "\"ask\"."
 
-#: builtin/rebase.c:1245
+#: builtin/rebase.c:1240
 #, c-format
 msgid ""
 "%s\n"
@@ -20071,7 +20411,7 @@ msgstr ""
 "    git rebase '<Branch>'\n"
 "\n"
 
-#: builtin/rebase.c:1261
+#: builtin/rebase.c:1256
 #, c-format
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:\n"
@@ -20085,197 +20425,189 @@ msgstr ""
 "    git branch --set-upstream-to=%s/<Branch> %s\n"
 "\n"
 
-#: builtin/rebase.c:1291
+#: builtin/rebase.c:1286
 msgid "exec commands cannot contain newlines"
 msgstr "\"exec\"-Befehle können keine neuen Zeilen enthalten"
 
-#: builtin/rebase.c:1295
+#: builtin/rebase.c:1290
 msgid "empty exec command"
 msgstr "Leerer \"exec\"-Befehl."
 
-#: builtin/rebase.c:1324
+#: builtin/rebase.c:1319
 msgid "rebase onto given branch instead of upstream"
 msgstr "Rebase auf angegebenen Branch anstelle des Upstream-Branches ausführen"
 
-#: builtin/rebase.c:1326
+#: builtin/rebase.c:1321
 msgid "use the merge-base of upstream and branch as the current base"
 msgstr "Nutze die Merge-Basis von Upstream und Branch als die aktuelle Basis"
 
-#: builtin/rebase.c:1328
+#: builtin/rebase.c:1323
 msgid "allow pre-rebase hook to run"
 msgstr "Ausführung des pre-rebase-Hooks erlauben"
 
-#: builtin/rebase.c:1330
+#: builtin/rebase.c:1325
 msgid "be quiet. implies --no-stat"
 msgstr "weniger Ausgaben (impliziert --no-stat)"
 
-#: builtin/rebase.c:1336
+#: builtin/rebase.c:1331
 msgid "do not show diffstat of what changed upstream"
 msgstr ""
 "Zusammenfassung der Unterschiede gegenüber dem Upstream-Branch verbergen"
 
-#: builtin/rebase.c:1339
+#: builtin/rebase.c:1334
 msgid "add a Signed-off-by trailer to each commit"
 msgstr "eine Signed-off-by Zeile zu jedem Commit hinzufügen"
 
-#: builtin/rebase.c:1342
+#: builtin/rebase.c:1337
 msgid "make committer date match author date"
 msgstr "Datum des Commit-Erstellers soll mit Datum des Autors übereinstimmen"
 
-#: builtin/rebase.c:1344
+#: builtin/rebase.c:1339
 msgid "ignore author date and use current date"
 msgstr "ignoriere Autor-Datum und nutze aktuelles Datum"
 
-#: builtin/rebase.c:1346
+#: builtin/rebase.c:1341
 msgid "synonym of --reset-author-date"
 msgstr "Synonym für --reset-author-date"
 
-#: builtin/rebase.c:1348 builtin/rebase.c:1352
+#: builtin/rebase.c:1343 builtin/rebase.c:1347
 msgid "passed to 'git apply'"
 msgstr "an 'git apply' übergeben"
 
-#: builtin/rebase.c:1350
+#: builtin/rebase.c:1345
 msgid "ignore changes in whitespace"
 msgstr "Whitespace-Änderungen ignorieren"
 
-#: builtin/rebase.c:1354 builtin/rebase.c:1357
+#: builtin/rebase.c:1349 builtin/rebase.c:1352
 msgid "cherry-pick all commits, even if unchanged"
 msgstr ""
 "Cherry-Pick auf alle Commits ausführen, auch wenn diese unverändert sind"
 
-#: builtin/rebase.c:1359
+#: builtin/rebase.c:1354
 msgid "continue"
 msgstr "fortsetzen"
 
-#: builtin/rebase.c:1362
+#: builtin/rebase.c:1357
 msgid "skip current patch and continue"
 msgstr "den aktuellen Patch auslassen und fortfahren"
 
-#: builtin/rebase.c:1364
+#: builtin/rebase.c:1359
 msgid "abort and check out the original branch"
 msgstr "abbrechen und den ursprünglichen Branch auschecken"
 
-#: builtin/rebase.c:1367
+#: builtin/rebase.c:1362
 msgid "abort but keep HEAD where it is"
 msgstr "abbrechen, aber HEAD an aktueller Stelle belassen"
 
-#: builtin/rebase.c:1368
+#: builtin/rebase.c:1363
 msgid "edit the todo list during an interactive rebase"
 msgstr "TODO-Liste während eines interaktiven Rebase bearbeiten"
 
-#: builtin/rebase.c:1371
+#: builtin/rebase.c:1366
 msgid "show the patch file being applied or merged"
 msgstr "den Patch, der gerade angewendet oder zusammengeführt wird, anzeigen"
 
-#: builtin/rebase.c:1374
+#: builtin/rebase.c:1369
 msgid "use apply strategies to rebase"
 msgstr "Strategien von 'git am' bei Rebase verwenden"
 
-#: builtin/rebase.c:1378
+#: builtin/rebase.c:1373
 msgid "use merging strategies to rebase"
 msgstr "Merge-Strategien beim Rebase verwenden"
 
-#: builtin/rebase.c:1382
+#: builtin/rebase.c:1377
 msgid "let the user edit the list of commits to rebase"
 msgstr "den Benutzer die Liste der Commits für den Rebase bearbeiten lassen"
 
-#: builtin/rebase.c:1386
+#: builtin/rebase.c:1381
 msgid "(DEPRECATED) try to recreate merges instead of ignoring them"
 msgstr "(VERALTET) Versuche, Merges wiederherzustellen statt sie zu ignorieren"
 
-#: builtin/rebase.c:1391
+#: builtin/rebase.c:1386
 msgid "how to handle commits that become empty"
 msgstr "wie sollen Commits behandelt werden, die leer werden"
 
-#: builtin/rebase.c:1398
+#: builtin/rebase.c:1393
 msgid "move commits that begin with squash!/fixup! under -i"
 msgstr "bei -i Commits verschieben, die mit squash!/fixup! beginnen"
 
-#: builtin/rebase.c:1405
+#: builtin/rebase.c:1400
 msgid "add exec lines after each commit of the editable list"
 msgstr "exec-Zeilen nach jedem Commit der editierbaren Liste hinzufügen"
 
-#: builtin/rebase.c:1409
+#: builtin/rebase.c:1404
 msgid "allow rebasing commits with empty messages"
 msgstr "Rebase von Commits mit leerer Beschreibung erlauben"
 
-#: builtin/rebase.c:1413
+#: builtin/rebase.c:1408
 msgid "try to rebase merges instead of skipping them"
 msgstr "versuchen, Rebase mit Merges auszuführen, statt diese zu überspringen"
 
-#: builtin/rebase.c:1416
+#: builtin/rebase.c:1411
 msgid "use 'merge-base --fork-point' to refine upstream"
 msgstr ""
 "'git merge-base --fork-point' benutzen, um Upstream-Branch zu bestimmen"
 
-#: builtin/rebase.c:1418
+#: builtin/rebase.c:1413
 msgid "use the given merge strategy"
 msgstr "angegebene Merge-Strategie verwenden"
 
-#: builtin/rebase.c:1420 builtin/revert.c:115
+#: builtin/rebase.c:1415 builtin/revert.c:115
 msgid "option"
 msgstr "Option"
 
-#: builtin/rebase.c:1421
+#: builtin/rebase.c:1416
 msgid "pass the argument through to the merge strategy"
 msgstr "Argument zur Merge-Strategie durchreichen"
 
-#: builtin/rebase.c:1424
+#: builtin/rebase.c:1419
 msgid "rebase all reachable commits up to the root(s)"
 msgstr "Rebase auf alle erreichbaren Commits bis zum Root-Commit ausführen"
 
-#: builtin/rebase.c:1429
+#: builtin/rebase.c:1424
 msgid "apply all changes, even those already present upstream"
 msgstr ""
 "alle Änderungen anwenden, auch jene, die bereits im Upstream-Branch "
 "vorhanden sind"
 
-#: builtin/rebase.c:1446
-msgid ""
-"the rebase.useBuiltin support has been removed!\n"
-"See its entry in 'git help config' for details."
-msgstr ""
-"Die Unterstützung für rebase.useBuiltin wurde entfernt!\n"
-"Siehe dessen Eintrag in 'git help config' für Details."
-
-#: builtin/rebase.c:1452
+#: builtin/rebase.c:1442
 msgid "It looks like 'git am' is in progress. Cannot rebase."
 msgstr "'git-am' scheint im Gange zu sein. Kann Rebase nicht durchführen."
 
-#: builtin/rebase.c:1493
+#: builtin/rebase.c:1483
 msgid ""
 "git rebase --preserve-merges is deprecated. Use --rebase-merges instead."
 msgstr ""
 "'git rebase --preserve-merges' ist veraltet. Benutzen Sie stattdessen '--"
 "rebase-merges'."
 
-#: builtin/rebase.c:1498
+#: builtin/rebase.c:1488
 msgid "cannot combine '--keep-base' with '--onto'"
 msgstr "'--keep-base' kann nicht mit '--onto' kombiniert werden"
 
-#: builtin/rebase.c:1500
+#: builtin/rebase.c:1490
 msgid "cannot combine '--keep-base' with '--root'"
 msgstr "'--keep-base' kann nicht mit '--root' kombiniert werden"
 
-#: builtin/rebase.c:1504
+#: builtin/rebase.c:1494
 msgid "cannot combine '--root' with '--fork-point'"
 msgstr "'--root' kann nicht mit '--fork-point' kombiniert werden"
 
-#: builtin/rebase.c:1507
+#: builtin/rebase.c:1497
 msgid "No rebase in progress?"
 msgstr "Kein Rebase im Gange?"
 
-#: builtin/rebase.c:1511
+#: builtin/rebase.c:1501
 msgid "The --edit-todo action can only be used during interactive rebase."
 msgstr ""
 "Die --edit-todo Aktion kann nur während eines interaktiven Rebase verwendet "
 "werden."
 
-#: builtin/rebase.c:1534 t/helper/test-fast-rebase.c:123
+#: builtin/rebase.c:1524 t/helper/test-fast-rebase.c:123
 msgid "Cannot read HEAD"
 msgstr "Kann HEAD nicht lesen"
 
-#: builtin/rebase.c:1546
+#: builtin/rebase.c:1536
 msgid ""
 "You must edit all merge conflicts and then\n"
 "mark them as resolved using git add"
@@ -20283,16 +20615,16 @@ msgstr ""
 "Sie müssen alle Merge-Konflikte editieren und diese dann\n"
 "mittels \"git add\" als aufgelöst markieren"
 
-#: builtin/rebase.c:1565
+#: builtin/rebase.c:1555
 msgid "could not discard worktree changes"
 msgstr "Konnte Änderungen im Arbeitsverzeichnis nicht verwerfen."
 
-#: builtin/rebase.c:1584
+#: builtin/rebase.c:1574
 #, c-format
 msgid "could not move back to %s"
 msgstr "Konnte nicht zu %s zurückgehen."
 
-#: builtin/rebase.c:1630
+#: builtin/rebase.c:1620
 #, c-format
 msgid ""
 "It seems that there is already a %s directory, and\n"
@@ -20313,138 +20645,138 @@ msgstr ""
 "und führen Sie diesen Befehl nochmal aus. Es wird angehalten, falls noch\n"
 "etwas Schützenswertes vorhanden ist.\n"
 
-#: builtin/rebase.c:1658
+#: builtin/rebase.c:1648
 msgid "switch `C' expects a numerical value"
 msgstr "Schalter `C' erwartet einen numerischen Wert."
 
-#: builtin/rebase.c:1700
+#: builtin/rebase.c:1690
 #, c-format
 msgid "Unknown mode: %s"
 msgstr "Unbekannter Modus: %s"
 
-#: builtin/rebase.c:1739
+#: builtin/rebase.c:1729
 msgid "--strategy requires --merge or --interactive"
 msgstr "--strategy erfordert --merge oder --interactive"
 
-#: builtin/rebase.c:1769
+#: builtin/rebase.c:1759
 msgid "cannot combine apply options with merge options"
 msgstr ""
 "Optionen für \"am\" können nicht mit Optionen für \"merge\" kombiniert "
 "werden."
 
-#: builtin/rebase.c:1782
+#: builtin/rebase.c:1772
 #, c-format
 msgid "Unknown rebase backend: %s"
 msgstr "Unbekanntes Rebase-Backend: %s"
 
-#: builtin/rebase.c:1812
+#: builtin/rebase.c:1802
 msgid "--reschedule-failed-exec requires --exec or --interactive"
 msgstr "--reschedule-failed-exec erfordert --exec oder --interactive"
 
-#: builtin/rebase.c:1832
+#: builtin/rebase.c:1822
 msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
 msgstr ""
 "'--preserve-merges' kann nicht mit '--rebase-merges' kombiniert werden."
 
-#: builtin/rebase.c:1836
+#: builtin/rebase.c:1826
 msgid ""
 "error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
 msgstr ""
 "Fehler: '--preserve-merges' kann nicht mit '--reschedule-failed-exec' "
 "kombiniert werden."
 
-#: builtin/rebase.c:1860
+#: builtin/rebase.c:1850
 #, c-format
 msgid "invalid upstream '%s'"
 msgstr "Ungültiger Upstream '%s'"
 
-#: builtin/rebase.c:1866
+#: builtin/rebase.c:1856
 msgid "Could not create new root commit"
 msgstr "Konnte neuen Root-Commit nicht erstellen."
 
-#: builtin/rebase.c:1892
+#: builtin/rebase.c:1882
 #, c-format
 msgid "'%s': need exactly one merge base with branch"
 msgstr "'%s': benötige genau eine Merge-Basis mit dem Branch"
 
-#: builtin/rebase.c:1895
+#: builtin/rebase.c:1885
 #, c-format
 msgid "'%s': need exactly one merge base"
 msgstr "'%s': benötige genau eine Merge-Basis"
 
-#: builtin/rebase.c:1903
+#: builtin/rebase.c:1893
 #, c-format
 msgid "Does not point to a valid commit '%s'"
 msgstr "'%s' zeigt auf keinen gültigen Commit."
 
-#: builtin/rebase.c:1931
+#: builtin/rebase.c:1921
 #, c-format
 msgid "fatal: no such branch/commit '%s'"
 msgstr "fatal: Branch/Commit '%s' nicht gefunden"
 
-#: builtin/rebase.c:1939 builtin/submodule--helper.c:40
-#: builtin/submodule--helper.c:2414
+#: builtin/rebase.c:1929 builtin/submodule--helper.c:40
+#: builtin/submodule--helper.c:2415
 #, c-format
 msgid "No such ref: %s"
 msgstr "Referenz nicht gefunden: %s"
 
-#: builtin/rebase.c:1950
+#: builtin/rebase.c:1940
 msgid "Could not resolve HEAD to a revision"
 msgstr "Konnte HEAD zu keinem Commit auflösen."
 
-#: builtin/rebase.c:1971
+#: builtin/rebase.c:1961
 msgid "Please commit or stash them."
 msgstr "Bitte committen Sie die Änderungen oder benutzen Sie \"stash\"."
 
-#: builtin/rebase.c:2007
+#: builtin/rebase.c:1997
 #, c-format
 msgid "could not switch to %s"
 msgstr "Konnte nicht zu %s wechseln."
 
-#: builtin/rebase.c:2018
+#: builtin/rebase.c:2008
 msgid "HEAD is up to date."
 msgstr "HEAD ist aktuell."
 
-#: builtin/rebase.c:2020
+#: builtin/rebase.c:2010
 #, c-format
 msgid "Current branch %s is up to date.\n"
 msgstr "Aktueller Branch %s ist auf dem neuesten Stand.\n"
 
-#: builtin/rebase.c:2028
+#: builtin/rebase.c:2018
 msgid "HEAD is up to date, rebase forced."
 msgstr "HEAD ist aktuell, Rebase erzwungen."
 
-#: builtin/rebase.c:2030
+#: builtin/rebase.c:2020
 #, c-format
 msgid "Current branch %s is up to date, rebase forced.\n"
 msgstr "Aktueller Branch %s ist auf dem neuesten Stand, Rebase erzwungen.\n"
 
-#: builtin/rebase.c:2038
+#: builtin/rebase.c:2028
 msgid "The pre-rebase hook refused to rebase."
 msgstr "Der \"pre-rebase hook\" hat den Rebase zurückgewiesen."
 
-#: builtin/rebase.c:2045
+#: builtin/rebase.c:2035
 #, c-format
 msgid "Changes to %s:\n"
 msgstr "Änderungen zu %s:\n"
 
-#: builtin/rebase.c:2048
+#: builtin/rebase.c:2038
 #, c-format
 msgid "Changes from %s to %s:\n"
 msgstr "Änderungen von %s zu %s:\n"
 
-#: builtin/rebase.c:2073
+#: builtin/rebase.c:2063
 #, c-format
 msgid "First, rewinding head to replay your work on top of it...\n"
 msgstr ""
 "Zunächst wird der Branch zurückgespult, um Ihre Änderungen darauf neu "
 "anzuwenden...\n"
 
-#: builtin/rebase.c:2082
+#: builtin/rebase.c:2072
 msgid "Could not detach HEAD"
 msgstr "Konnte HEAD nicht loslösen."
 
-#: builtin/rebase.c:2091
+#: builtin/rebase.c:2081
 #, c-format
 msgid "Fast-forwarded %s to %s.\n"
 msgstr "Spule %s vor zu %s.\n"
@@ -20506,11 +20838,11 @@ msgstr ""
 "\n"
 "Um diese Meldung zu unterdrücken, setzen Sie die Variable auf 'refuse'."
 
-#: builtin/receive-pack.c:2481
+#: builtin/receive-pack.c:2479
 msgid "quiet"
 msgstr "weniger Ausgaben"
 
-#: builtin/receive-pack.c:2495
+#: builtin/receive-pack.c:2493
 msgid "You must specify a directory."
 msgstr "Sie müssen ein Repository angeben."
 
@@ -20750,7 +21082,7 @@ msgstr ""
 "\t%s:%d\n"
 "benennt jetzt das nicht existierende Remote-Repository '%s'"
 
-#: builtin/remote.c:691 builtin/remote.c:836 builtin/remote.c:946
+#: builtin/remote.c:691 builtin/remote.c:836 builtin/remote.c:943
 #, c-format
 msgid "No such remote: '%s'"
 msgstr "Remote-Repository nicht gefunden: '%s'"
@@ -21112,7 +21444,7 @@ msgstr ""
 "Konnte 'pack-objects' für das Neupacken von Objekten aus partiell geklonten\n"
 "Remote-Repositories nicht starten."
 
-#: builtin/repack.c:270 builtin/repack.c:446
+#: builtin/repack.c:270 builtin/repack.c:630
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
 msgstr ""
 "repack: Erwarte Zeilen mit vollständiger Hex-Objekt-ID nur von pack-objects."
@@ -21123,107 +21455,131 @@ msgstr ""
 "Konnte 'pack-objects' für das Neupacken von Objekten aus partiell geklonten\n"
 "Remote-Repositories nicht abschließen."
 
-#: builtin/repack.c:322
+#: builtin/repack.c:309
+#, fuzzy, c-format
+msgid "cannot open index for %s"
+msgstr "Fehler beim Öffnen des Index für %s."
+
+#: builtin/repack.c:368
+#, c-format
+msgid "pack %s too large to consider in geometric progression"
+msgstr ""
+
+#: builtin/repack.c:401 builtin/repack.c:408 builtin/repack.c:413
+#, c-format
+msgid "pack %s too large to roll up"
+msgstr ""
+
+#: builtin/repack.c:460
 msgid "pack everything in a single pack"
 msgstr "alles in eine einzige Pack-Datei packen"
 
-#: builtin/repack.c:324
+#: builtin/repack.c:462
 msgid "same as -a, and turn unreachable objects loose"
 msgstr "genau wie -a, unerreichbare Objekte werden aber nicht gelöscht"
 
-#: builtin/repack.c:327
+#: builtin/repack.c:465
 msgid "remove redundant packs, and run git-prune-packed"
 msgstr "redundante Pakete entfernen und \"git-prune-packed\" ausführen"
 
-#: builtin/repack.c:329
+#: builtin/repack.c:467
 msgid "pass --no-reuse-delta to git-pack-objects"
 msgstr "--no-reuse-delta an git-pack-objects übergeben"
 
-#: builtin/repack.c:331
+#: builtin/repack.c:469
 msgid "pass --no-reuse-object to git-pack-objects"
 msgstr "--no-reuse-object an git-pack-objects übergeben"
 
-#: builtin/repack.c:333
+#: builtin/repack.c:471
 msgid "do not run git-update-server-info"
 msgstr "git-update-server-info nicht ausführen"
 
-#: builtin/repack.c:336
+#: builtin/repack.c:474
 msgid "pass --local to git-pack-objects"
 msgstr "--local an git-pack-objects übergeben"
 
-#: builtin/repack.c:338
+#: builtin/repack.c:476
 msgid "write bitmap index"
 msgstr "Bitmap-Index schreiben"
 
-#: builtin/repack.c:340
+#: builtin/repack.c:478
 msgid "pass --delta-islands to git-pack-objects"
 msgstr "--delta-islands an git-pack-objects übergeben"
 
-#: builtin/repack.c:341
+#: builtin/repack.c:479
 msgid "approxidate"
 msgstr "Datumsangabe"
 
-#: builtin/repack.c:342
+#: builtin/repack.c:480
 msgid "with -A, do not loosen objects older than this"
 msgstr "mit -A, keine Objekte älter als dieses Datum löschen"
 
-#: builtin/repack.c:344
+#: builtin/repack.c:482
 msgid "with -a, repack unreachable objects"
 msgstr "mit -a, nicht erreichbare Objekte neu packen"
 
-#: builtin/repack.c:346
+#: builtin/repack.c:484
 msgid "size of the window used for delta compression"
 msgstr "Größe des Fensters für die Delta-Kompression"
 
-#: builtin/repack.c:347 builtin/repack.c:353
+#: builtin/repack.c:485 builtin/repack.c:491
 msgid "bytes"
 msgstr "Bytes"
 
-#: builtin/repack.c:348
+#: builtin/repack.c:486
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr ""
 "gleiches wie oben, aber die Speichergröße statt der Anzahl der Einträge "
 "limitieren"
 
-#: builtin/repack.c:350
+#: builtin/repack.c:488
 msgid "limits the maximum delta depth"
 msgstr "die maximale Delta-Tiefe limitieren"
 
-#: builtin/repack.c:352
+#: builtin/repack.c:490
 msgid "limits the maximum number of threads"
 msgstr "maximale Anzahl von Threads limitieren"
 
-#: builtin/repack.c:354
+#: builtin/repack.c:492
 msgid "maximum size of each packfile"
 msgstr "maximale Größe für jede Paketdatei"
 
-#: builtin/repack.c:356
+#: builtin/repack.c:494
 msgid "repack objects in packs marked with .keep"
 msgstr ""
 "Objekte umpacken, die sich in mit .keep markierten Pack-Dateien befinden"
 
-#: builtin/repack.c:358
+#: builtin/repack.c:496
 msgid "do not repack this pack"
 msgstr "dieses Paket nicht neu packen"
 
-#: builtin/repack.c:368
+#: builtin/repack.c:498
+msgid "find a geometric progression with factor <N>"
+msgstr ""
+
+#: builtin/repack.c:508
 msgid "cannot delete packs in a precious-objects repo"
 msgstr "kann Pack-Dateien in precious-objects Repository nicht löschen"
 
-#: builtin/repack.c:372
+#: builtin/repack.c:512
 msgid "--keep-unreachable and -A are incompatible"
 msgstr "--keep-unreachable und -A sind inkompatibel"
 
-#: builtin/repack.c:455
+#: builtin/repack.c:527
+#, fuzzy
+msgid "--geometric is incompatible with -A, -a"
+msgstr "--long und --abbrev=0 sind inkompatibel"
+
+#: builtin/repack.c:639
 msgid "Nothing new to pack."
 msgstr "Nichts Neues zum Packen."
 
-#: builtin/repack.c:485
+#: builtin/repack.c:669
 #, c-format
 msgid "missing required file: %s"
 msgstr "benötigte Datei fehlt: %s"
 
-#: builtin/repack.c:487
+#: builtin/repack.c:671
 #, c-format
 msgid "could not unlink: %s"
 msgstr "konnte nicht löschen: %s"
@@ -21558,8 +21914,8 @@ msgstr "HEAD ist jetzt bei %s"
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "Kann keinen '%s'-Reset durchführen, während ein Merge im Gange ist."
 
-#: builtin/reset.c:295 builtin/stash.c:587 builtin/stash.c:661
-#: builtin/stash.c:685
+#: builtin/reset.c:295 builtin/stash.c:589 builtin/stash.c:663
+#: builtin/stash.c:687
 msgid "be quiet, only report errors"
 msgstr "weniger Ausgaben, nur Fehler melden"
 
@@ -21644,20 +22000,20 @@ msgstr "Konnte Index-Datei nicht zu Commit '%s' setzen."
 msgid "Could not write new index file."
 msgstr "Konnte neue Index-Datei nicht schreiben."
 
-#: builtin/rev-list.c:534
+#: builtin/rev-list.c:538
 msgid "cannot combine --exclude-promisor-objects and --missing"
 msgstr ""
 "--exclude-promisor-objects und --missing können nicht kombiniert werden."
 
-#: builtin/rev-list.c:595
+#: builtin/rev-list.c:599
 msgid "object filtering requires --objects"
 msgstr "Das Filtern von Objekten erfordert --objects."
 
-#: builtin/rev-list.c:651
+#: builtin/rev-list.c:659
 msgid "rev-list does not support display of notes"
 msgstr "rev-list unterstützt keine Anzeige von Notizen"
 
-#: builtin/rev-list.c:656
+#: builtin/rev-list.c:664
 msgid "marked counting is incompatible with --objects"
 msgstr "markiertes Zählen ist inkompatibel mit der Option --objects"
 
@@ -21771,19 +22127,19 @@ msgstr "ursprüngliche, leere Commits erhalten"
 msgid "keep redundant, empty commits"
 msgstr "redundante, leere Commits behalten"
 
-#: builtin/revert.c:239
+#: builtin/revert.c:237
 msgid "revert failed"
 msgstr "\"revert\" fehlgeschlagen"
 
-#: builtin/revert.c:252
+#: builtin/revert.c:250
 msgid "cherry-pick failed"
 msgstr "\"cherry-pick\" fehlgeschlagen"
 
-#: builtin/rm.c:19
+#: builtin/rm.c:20
 msgid "git rm [<options>] [--] <file>..."
 msgstr "git rm [<Optionen>] [--] <Datei>..."
 
-#: builtin/rm.c:207
+#: builtin/rm.c:208
 msgid ""
 "the following file has staged content different from both the\n"
 "file and the HEAD:"
@@ -21798,7 +22154,7 @@ msgstr[1] ""
 "unterschiedlich\n"
 "zu der Datei und HEAD:"
 
-#: builtin/rm.c:212
+#: builtin/rm.c:213
 msgid ""
 "\n"
 "(use -f to force removal)"
@@ -21806,13 +22162,13 @@ msgstr ""
 "\n"
 "(benutzen Sie -f, um die Löschung zu erzwingen)"
 
-#: builtin/rm.c:216
+#: builtin/rm.c:217
 msgid "the following file has changes staged in the index:"
 msgid_plural "the following files have changes staged in the index:"
 msgstr[0] "die folgende Datei hat zum Commit vorgemerkte Änderungen:"
 msgstr[1] "die folgenden Dateien haben zum Commit vorgemerkte Änderungen:"
 
-#: builtin/rm.c:220 builtin/rm.c:229
+#: builtin/rm.c:221 builtin/rm.c:230
 msgid ""
 "\n"
 "(use --cached to keep the file, or -f to force removal)"
@@ -21821,50 +22177,50 @@ msgstr ""
 "(benutzen Sie --cached, um die Datei zu behalten, oder -f, um das Entfernen "
 "zu erzwingen)"
 
-#: builtin/rm.c:226
+#: builtin/rm.c:227
 msgid "the following file has local modifications:"
 msgid_plural "the following files have local modifications:"
 msgstr[0] "die folgende Datei hat lokale Änderungen:"
 msgstr[1] "die folgenden Dateien haben lokale Änderungen:"
 
-#: builtin/rm.c:243
+#: builtin/rm.c:244
 msgid "do not list removed files"
 msgstr "keine gelöschten Dateien auflisten"
 
-#: builtin/rm.c:244
+#: builtin/rm.c:245
 msgid "only remove from the index"
 msgstr "nur aus dem Index entfernen"
 
-#: builtin/rm.c:245
+#: builtin/rm.c:246
 msgid "override the up-to-date check"
 msgstr "die \"up-to-date\" Prüfung überschreiben"
 
-#: builtin/rm.c:246
+#: builtin/rm.c:247
 msgid "allow recursive removal"
 msgstr "rekursives Entfernen erlauben"
 
-#: builtin/rm.c:248
+#: builtin/rm.c:249
 msgid "exit with a zero status even if nothing matched"
 msgstr "mit Rückgabewert 0 beenden, wenn keine Übereinstimmung gefunden wurde"
 
-#: builtin/rm.c:282
+#: builtin/rm.c:283
 msgid "No pathspec was given. Which files should I remove?"
 msgstr ""
 "Es wurde keine Pfadspezifikation angegeben. Welche Dateien sollen entfernt "
 "werden?"
 
-#: builtin/rm.c:305
+#: builtin/rm.c:310
 msgid "please stage your changes to .gitmodules or stash them to proceed"
 msgstr ""
 "Bitte merken Sie Ihre Änderungen in .gitmodules zum Commit vor oder\n"
 "benutzen Sie \"stash\", um fortzufahren."
 
-#: builtin/rm.c:323
+#: builtin/rm.c:331
 #, c-format
 msgid "not removing '%s' recursively without -r"
 msgstr "'%s' wird nicht ohne -r rekursiv entfernt"
 
-#: builtin/rm.c:362
+#: builtin/rm.c:379
 #, c-format
 msgid "git rm: unable to remove %s"
 msgstr "git rm: konnte %s nicht löschen"
@@ -22149,108 +22505,118 @@ msgstr ""
 "Referenzen von der Standard-Eingabe anzeigen, die sich nicht im lokalen "
 "Repository befinden"
 
-#: builtin/sparse-checkout.c:21
+#: builtin/sparse-checkout.c:22
 msgid "git sparse-checkout (init|list|set|add|reapply|disable) <options>"
 msgstr "git sparse-checkout (init|list|set|add|reapply|disable) <Optionen>"
 
-#: builtin/sparse-checkout.c:45
+#: builtin/sparse-checkout.c:46
 msgid "git sparse-checkout list"
 msgstr "git sparse-checkout list"
 
-#: builtin/sparse-checkout.c:71
+#: builtin/sparse-checkout.c:72
 msgid "this worktree is not sparse (sparse-checkout file may not exist)"
 msgstr ""
 "dieses Arbeitsverzeichnis ist nicht partiell (Datei für partieller Checkout "
 "existiert eventuell nicht)"
 
-#: builtin/sparse-checkout.c:223
+#: builtin/sparse-checkout.c:227
 msgid "failed to create directory for sparse-checkout file"
 msgstr ""
 "Fehler beim Erstellen eines Verzeichnisses für Datei eines partiellen "
 "Checkouts"
 
-#: builtin/sparse-checkout.c:264
+#: builtin/sparse-checkout.c:268
 msgid "unable to upgrade repository format to enable worktreeConfig"
 msgstr ""
 "Repository-Format konnte nicht erweitert werden, um worktreeConfig zu "
 "aktivieren"
 
-#: builtin/sparse-checkout.c:266
+#: builtin/sparse-checkout.c:270
 msgid "failed to set extensions.worktreeConfig setting"
 msgstr "Einstellung für extensions.worktreeConfig konnte nicht gesetzt werden"
 
-#: builtin/sparse-checkout.c:283
-msgid "git sparse-checkout init [--cone]"
+#: builtin/sparse-checkout.c:290
+#, fuzzy
+msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
 msgstr "git sparse-checkout init [--cone]"
 
-#: builtin/sparse-checkout.c:302
+#: builtin/sparse-checkout.c:310
 msgid "initialize the sparse-checkout in cone mode"
 msgstr "initialisiere den partiellen Checkout im Cone-Modus"
 
-#: builtin/sparse-checkout.c:339
+#: builtin/sparse-checkout.c:312
+msgid "toggle the use of a sparse index"
+msgstr ""
+
+#: builtin/sparse-checkout.c:340
+#, fuzzy
+msgid "failed to modify sparse-index config"
+msgstr "Fehler beim Laden des Pack-Index für Packdatei %s"
+
+#: builtin/sparse-checkout.c:361
 #, c-format
 msgid "failed to open '%s'"
 msgstr "Fehler beim Öffnen von '%s'"
 
-#: builtin/sparse-checkout.c:396
+#: builtin/sparse-checkout.c:419
 #, c-format
 msgid "could not normalize path %s"
 msgstr "konnte Pfad '%s' nicht normalisieren"
 
-#: builtin/sparse-checkout.c:408
+#: builtin/sparse-checkout.c:431
 msgid "git sparse-checkout (set|add) (--stdin | <patterns>)"
 msgstr "git sparse-checkout (set|add) (--stdin | <Muster>)"
 
-#: builtin/sparse-checkout.c:433
+#: builtin/sparse-checkout.c:456
 #, c-format
 msgid "unable to unquote C-style string '%s'"
 msgstr "konnte Anführungszeichen von C-Style Zeichenkette '%s' nicht entfernen"
 
-#: builtin/sparse-checkout.c:487 builtin/sparse-checkout.c:511
+#: builtin/sparse-checkout.c:510 builtin/sparse-checkout.c:534
 msgid "unable to load existing sparse-checkout patterns"
 msgstr "konnte die existierenden Muster des partiellen Checkouts nicht laden"
 
-#: builtin/sparse-checkout.c:556
+#: builtin/sparse-checkout.c:579
 msgid "read patterns from standard in"
 msgstr "Muster von der Standard-Eingabe lesen"
 
-#: builtin/sparse-checkout.c:571
+#: builtin/sparse-checkout.c:594
 msgid "git sparse-checkout reapply"
 msgstr "git sparse-checkout reapply"
 
-#: builtin/sparse-checkout.c:590
+#: builtin/sparse-checkout.c:613
 msgid "git sparse-checkout disable"
 msgstr "git sparse-checkout disable"
 
-#: builtin/sparse-checkout.c:618
+#: builtin/sparse-checkout.c:644
 msgid "error while refreshing working directory"
 msgstr "Fehler während der Aktualisierung des Arbeitsverzeichnisses."
 
-#: builtin/stash.c:22 builtin/stash.c:38
+#: builtin/stash.c:24 builtin/stash.c:40
 msgid "git stash list [<options>]"
 msgstr "git stash list [<Optionen>]"
 
-#: builtin/stash.c:23 builtin/stash.c:43
+#: builtin/stash.c:25 builtin/stash.c:45
 msgid "git stash show [<options>] [<stash>]"
 msgstr "git stash show [<Optionen>] [<Stash>]"
 
-#: builtin/stash.c:24 builtin/stash.c:48
+#: builtin/stash.c:26 builtin/stash.c:50
 msgid "git stash drop [-q|--quiet] [<stash>]"
 msgstr "git stash drop [-q|--quiet] [<Stash>]"
 
-#: builtin/stash.c:25
+#: builtin/stash.c:27
 msgid "git stash ( pop | apply ) [--index] [-q|--quiet] [<stash>]"
 msgstr "git stash ( pop | apply ) [--index] [-q|--quiet] [<Stash>]"
 
-#: builtin/stash.c:26 builtin/stash.c:63
+#: builtin/stash.c:28 builtin/stash.c:65
 msgid "git stash branch <branchname> [<stash>]"
 msgstr "git stash branch <Branch> [<Stash>]"
 
-#: builtin/stash.c:27 builtin/stash.c:68
+#: builtin/stash.c:29 builtin/stash.c:70
 msgid "git stash clear"
 msgstr "git stash clear"
 
-#: builtin/stash.c:28
+#: builtin/stash.c:30
 msgid ""
 "git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [-m|--message <message>]\n"
@@ -22262,7 +22628,7 @@ msgstr ""
 "          [--pathspec-from-file=<Datei> [--pathspec-file-nul]]\n"
 "          [--] [<Pfadspezifikation>...]]"
 
-#: builtin/stash.c:32 builtin/stash.c:85
+#: builtin/stash.c:34 builtin/stash.c:87
 msgid ""
 "git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [<message>]"
@@ -22270,19 +22636,19 @@ msgstr ""
 "git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [<Nachricht>]"
 
-#: builtin/stash.c:53
+#: builtin/stash.c:55
 msgid "git stash pop [--index] [-q|--quiet] [<stash>]"
 msgstr "git stash pop [--index] [-q|--quiet] [<Stash>]"
 
-#: builtin/stash.c:58
+#: builtin/stash.c:60
 msgid "git stash apply [--index] [-q|--quiet] [<stash>]"
 msgstr "git stash apply [--index] [-q|--quiet] [<Stash>]"
 
-#: builtin/stash.c:73
+#: builtin/stash.c:75
 msgid "git stash store [-m|--message <message>] [-q|--quiet] <commit>"
 msgstr "git stash store [-m|--message <Nachricht>] [-q|--quiet] <Commit>"
 
-#: builtin/stash.c:78
+#: builtin/stash.c:80
 msgid ""
 "git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [-m|--message <message>]\n"
@@ -22292,30 +22658,30 @@ msgstr ""
 "          [-u|--include-untracked] [-a|--all] [-m|--message <Nachricht>]\n"
 "          [--] [<Pfadspezifikation>...]]"
 
-#: builtin/stash.c:128
+#: builtin/stash.c:130
 #, c-format
 msgid "'%s' is not a stash-like commit"
 msgstr "'%s' ist kein \"stash\"-artiger Commit"
 
-#: builtin/stash.c:148
+#: builtin/stash.c:150
 #, c-format
 msgid "Too many revisions specified:%s"
 msgstr "Zu viele Commits angegeben:%s"
 
-#: builtin/stash.c:162
+#: builtin/stash.c:164
 msgid "No stash entries found."
 msgstr "Keine Stash-Einträge gefunden."
 
-#: builtin/stash.c:176
+#: builtin/stash.c:178
 #, c-format
 msgid "%s is not a valid reference"
 msgstr "'%s' ist kein gültiger Referenzname."
 
-#: builtin/stash.c:225
+#: builtin/stash.c:227
 msgid "git stash clear with arguments is unimplemented"
 msgstr "git stash clear mit Parametern ist nicht implementiert"
 
-#: builtin/stash.c:429
+#: builtin/stash.c:431
 #, c-format
 msgid ""
 "WARNING: Untracked file in way of tracked file!  Renaming\n"
@@ -22327,153 +22693,173 @@ msgstr ""
 "            %s -> %s\n"
 "         um Platz zu schaffen.\n"
 
-#: builtin/stash.c:490
+#: builtin/stash.c:492
 msgid "cannot apply a stash in the middle of a merge"
 msgstr "Kann Stash nicht anwenden, solange ein Merge im Gange ist"
 
-#: builtin/stash.c:501
+#: builtin/stash.c:503
 #, c-format
 msgid "could not generate diff %s^!."
 msgstr "Konnte keinen Diff erzeugen %s^!."
 
-#: builtin/stash.c:508
+#: builtin/stash.c:510
 msgid "conflicts in index. Try without --index."
 msgstr "Konflikte im Index. Versuchen Sie es ohne --index."
 
-#: builtin/stash.c:514
+#: builtin/stash.c:516
 msgid "could not save index tree"
 msgstr "Konnte Index-Verzeichnis nicht speichern"
 
-#: builtin/stash.c:523
+#: builtin/stash.c:525
 msgid "could not restore untracked files from stash"
 msgstr "Konnte unversionierte Dateien vom Stash nicht wiederherstellen."
 
-#: builtin/stash.c:537
+#: builtin/stash.c:539
 #, c-format
 msgid "Merging %s with %s"
 msgstr "Führe %s mit %s zusammen"
 
-#: builtin/stash.c:547
+#: builtin/stash.c:549
 msgid "Index was not unstashed."
 msgstr "Index wurde nicht aus dem Stash zurückgeladen."
 
-#: builtin/stash.c:589 builtin/stash.c:687
+#: builtin/stash.c:591 builtin/stash.c:689
 msgid "attempt to recreate the index"
 msgstr "Versuche Index wiederherzustellen."
 
-#: builtin/stash.c:633
+#: builtin/stash.c:635
 #, c-format
 msgid "Dropped %s (%s)"
 msgstr "%s (%s) gelöscht"
 
-#: builtin/stash.c:636
+#: builtin/stash.c:638
 #, c-format
 msgid "%s: Could not drop stash entry"
 msgstr "%s: Konnte Stash-Eintrag nicht löschen"
 
-#: builtin/stash.c:649
+#: builtin/stash.c:651
 #, c-format
 msgid "'%s' is not a stash reference"
 msgstr "'%s' ist keine Stash-Referenz"
 
-#: builtin/stash.c:699
+#: builtin/stash.c:701
 msgid "The stash entry is kept in case you need it again."
 msgstr ""
 "Der Stash-Eintrag wird für den Fall behalten, dass Sie diesen nochmal "
 "benötigen."
 
-#: builtin/stash.c:722
+#: builtin/stash.c:724
 msgid "No branch name specified"
 msgstr "Kein Branchname spezifiziert"
 
-#: builtin/stash.c:866 builtin/stash.c:903
+#: builtin/stash.c:808
+#, fuzzy
+msgid "failed to parse tree"
+msgstr "Fehler beim Parsen von %s."
+
+#: builtin/stash.c:819
+#, fuzzy
+msgid "failed to unpack trees"
+msgstr "Fehler beim Entpacken des Tree-Objektes von HEAD."
+
+#: builtin/stash.c:839
+#, fuzzy
+msgid "include untracked files in the stash"
+msgstr "unversionierte Dateien in Stash einbeziehen"
+
+#: builtin/stash.c:842
+#, fuzzy
+msgid "only show untracked files in the stash"
+msgstr "unversionierte Dateien in Stash einbeziehen"
+
+#: builtin/stash.c:932 builtin/stash.c:969
 #, c-format
 msgid "Cannot update %s with %s"
 msgstr "Kann nicht %s mit %s aktualisieren."
 
-#: builtin/stash.c:884 builtin/stash.c:1538 builtin/stash.c:1603
+#: builtin/stash.c:950 builtin/stash.c:1606 builtin/stash.c:1671
 msgid "stash message"
 msgstr "Stash-Beschreibung"
 
-#: builtin/stash.c:894
+#: builtin/stash.c:960
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "\"git stash store\" erwartet ein Argument <Commit>"
 
-#: builtin/stash.c:1109
+#: builtin/stash.c:1175
 msgid "No changes selected"
 msgstr "Keine Änderungen ausgewählt"
 
-#: builtin/stash.c:1209
+#: builtin/stash.c:1275
 msgid "You do not have the initial commit yet"
 msgstr "Sie haben bisher noch keinen initialen Commit"
 
-#: builtin/stash.c:1236
+#: builtin/stash.c:1302
 msgid "Cannot save the current index state"
 msgstr "Kann den aktuellen Zustand des Index nicht speichern"
 
-#: builtin/stash.c:1245
+#: builtin/stash.c:1311
 msgid "Cannot save the untracked files"
 msgstr "Kann die unversionierten Dateien nicht speichern"
 
-#: builtin/stash.c:1256 builtin/stash.c:1265
+#: builtin/stash.c:1322 builtin/stash.c:1331
 msgid "Cannot save the current worktree state"
 msgstr "Kann den aktuellen Zustand des Arbeitsverzeichnisses nicht speichern"
 
-#: builtin/stash.c:1293
+#: builtin/stash.c:1359
 msgid "Cannot record working tree state"
 msgstr "Kann Zustand des Arbeitsverzeichnisses nicht aufzeichnen"
 
-#: builtin/stash.c:1342
+#: builtin/stash.c:1408
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr ""
 "Kann nicht gleichzeitig --patch und --include-untracked oder --all verwenden"
 
-#: builtin/stash.c:1358
+#: builtin/stash.c:1426
 msgid "Did you forget to 'git add'?"
 msgstr "Haben Sie vielleicht 'git add' vergessen?"
 
-#: builtin/stash.c:1373
+#: builtin/stash.c:1441
 msgid "No local changes to save"
 msgstr "Keine lokalen Änderungen zum Speichern"
 
-#: builtin/stash.c:1380
+#: builtin/stash.c:1448
 msgid "Cannot initialize stash"
 msgstr "Kann \"stash\" nicht initialisieren"
 
-#: builtin/stash.c:1395
+#: builtin/stash.c:1463
 msgid "Cannot save the current status"
 msgstr "Kann den aktuellen Status nicht speichern"
 
-#: builtin/stash.c:1400
+#: builtin/stash.c:1468
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "Arbeitsverzeichnis und Index-Status %s gespeichert."
 
-#: builtin/stash.c:1490
+#: builtin/stash.c:1558
 msgid "Cannot remove worktree changes"
 msgstr "Kann Änderungen im Arbeitsverzeichnis nicht löschen"
 
-#: builtin/stash.c:1529 builtin/stash.c:1594
+#: builtin/stash.c:1597 builtin/stash.c:1662
 msgid "keep index"
 msgstr "behalte Index"
 
-#: builtin/stash.c:1531 builtin/stash.c:1596
+#: builtin/stash.c:1599 builtin/stash.c:1664
 msgid "stash in patch mode"
 msgstr "Stash in Patch-Modus"
 
-#: builtin/stash.c:1532 builtin/stash.c:1597
+#: builtin/stash.c:1600 builtin/stash.c:1665
 msgid "quiet mode"
 msgstr "weniger Ausgaben"
 
-#: builtin/stash.c:1534 builtin/stash.c:1599
+#: builtin/stash.c:1602 builtin/stash.c:1667
 msgid "include untracked files in stash"
 msgstr "unversionierte Dateien in Stash einbeziehen"
 
-#: builtin/stash.c:1536 builtin/stash.c:1601
+#: builtin/stash.c:1604 builtin/stash.c:1669
 msgid "include ignore files"
 msgstr "ignorierte Dateien einbeziehen"
 
-#: builtin/stash.c:1636
+#: builtin/stash.c:1704
 msgid ""
 "the stash.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -22499,7 +22885,7 @@ msgstr ""
 msgid "prepend comment character and space to each line"
 msgstr "Kommentarzeichen mit Leerzeichen an jede Zeile voranstellen"
 
-#: builtin/submodule--helper.c:47 builtin/submodule--helper.c:2423
+#: builtin/submodule--helper.c:47 builtin/submodule--helper.c:2424
 #, c-format
 msgid "Expecting a full ref name, got %s"
 msgstr "Vollständiger Referenzname erwartet, %s erhalten"
@@ -22513,7 +22899,7 @@ msgstr "'submodule--helper print-default-remote' erwartet keine Argumente."
 msgid "cannot strip one component off url '%s'"
 msgstr "Kann eine Komponente von URL '%s' nicht extrahieren"
 
-#: builtin/submodule--helper.c:410 builtin/submodule--helper.c:1819
+#: builtin/submodule--helper.c:410 builtin/submodule--helper.c:1820
 msgid "alternative anchor for relative paths"
 msgstr "Alternativer Anker für relative Pfade"
 
@@ -22521,18 +22907,18 @@ msgstr "Alternativer Anker für relative Pfade"
 msgid "git submodule--helper list [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper list [--prefix=<Pfad>] [<Pfad>...]"
 
-#: builtin/submodule--helper.c:472 builtin/submodule--helper.c:629
-#: builtin/submodule--helper.c:652
+#: builtin/submodule--helper.c:473 builtin/submodule--helper.c:630
+#: builtin/submodule--helper.c:653
 #, c-format
 msgid "No url found for submodule path '%s' in .gitmodules"
 msgstr "Keine URL für Submodul-Pfad '%s' in .gitmodules gefunden"
 
-#: builtin/submodule--helper.c:524
+#: builtin/submodule--helper.c:525
 #, c-format
 msgid "Entering '%s'\n"
 msgstr "Betrete '%s'\n"
 
-#: builtin/submodule--helper.c:527
+#: builtin/submodule--helper.c:528
 #, c-format
 msgid ""
 "run_command returned non-zero status for %s\n"
@@ -22541,7 +22927,7 @@ msgstr ""
 "run_command gab nicht-Null Status für '%s' zurück.\n"
 "."
 
-#: builtin/submodule--helper.c:549
+#: builtin/submodule--helper.c:550
 #, c-format
 msgid ""
 "run_command returned non-zero status while recursing in the nested "
@@ -22553,20 +22939,20 @@ msgstr ""
 "nicht-Null Status zurück.\n"
 "."
 
-#: builtin/submodule--helper.c:565
+#: builtin/submodule--helper.c:566
 msgid "suppress output of entering each submodule command"
 msgstr "Ausgaben beim Betreten eines Submodul-Befehls unterdrücken"
 
-#: builtin/submodule--helper.c:567 builtin/submodule--helper.c:888
-#: builtin/submodule--helper.c:1487
+#: builtin/submodule--helper.c:568 builtin/submodule--helper.c:889
+#: builtin/submodule--helper.c:1488
 msgid "recurse into nested submodules"
 msgstr "Rekursion in verschachtelte Submodule durchführen"
 
-#: builtin/submodule--helper.c:572
+#: builtin/submodule--helper.c:573
 msgid "git submodule--helper foreach [--quiet] [--recursive] [--] <command>"
 msgstr "git submodule--helper foreach [--quiet] [--recursive] [--] <Befehl>"
 
-#: builtin/submodule--helper.c:599
+#: builtin/submodule--helper.c:600
 #, c-format
 msgid ""
 "could not look up configuration '%s'. Assuming this repository is its own "
@@ -22575,155 +22961,155 @@ msgstr ""
 "Konnte Konfiguration '%s' nicht nachschlagen. Nehme an, dass dieses\n"
 "Repository sein eigenes verbindliches Upstream-Repository ist."
 
-#: builtin/submodule--helper.c:666
+#: builtin/submodule--helper.c:667
 #, c-format
 msgid "Failed to register url for submodule path '%s'"
 msgstr ""
 "Fehler beim Eintragen der URL für Submodul-Pfad '%s' in die Konfiguration."
 
-#: builtin/submodule--helper.c:670
+#: builtin/submodule--helper.c:671
 #, c-format
 msgid "Submodule '%s' (%s) registered for path '%s'\n"
 msgstr "Submodul '%s' (%s) für Pfad '%s' in die Konfiguration eingetragen.\n"
 
-#: builtin/submodule--helper.c:680
+#: builtin/submodule--helper.c:681
 #, c-format
 msgid "warning: command update mode suggested for submodule '%s'\n"
 msgstr "Warnung: 'update'-Modus für Submodul '%s' vorgeschlagen\n"
 
-#: builtin/submodule--helper.c:687
+#: builtin/submodule--helper.c:688
 #, c-format
 msgid "Failed to register update mode for submodule path '%s'"
 msgstr ""
 "Fehler bei Änderung des Aktualisierungsmodus für Submodul-Pfad '%s' in der\n"
 "Konfiguration."
 
-#: builtin/submodule--helper.c:709
+#: builtin/submodule--helper.c:710
 msgid "suppress output for initializing a submodule"
 msgstr "Ausgaben bei Initialisierung eines Submoduls unterdrücken"
 
-#: builtin/submodule--helper.c:714
+#: builtin/submodule--helper.c:715
 msgid "git submodule--helper init [<options>] [<path>]"
 msgstr "git submodule--helper init [<Optionen>] [<Pfad>]"
 
-#: builtin/submodule--helper.c:787 builtin/submodule--helper.c:922
+#: builtin/submodule--helper.c:788 builtin/submodule--helper.c:923
 #, c-format
 msgid "no submodule mapping found in .gitmodules for path '%s'"
 msgstr "Keine Submodul-Zuordnung in .gitmodules für Pfad '%s' gefunden"
 
-#: builtin/submodule--helper.c:835
+#: builtin/submodule--helper.c:836
 #, c-format
 msgid "could not resolve HEAD ref inside the submodule '%s'"
 msgstr "Konnte HEAD-Referenz nicht innerhalb des Submodul-Pfads '%s' auflösen."
 
-#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1457
+#: builtin/submodule--helper.c:863 builtin/submodule--helper.c:1458
 #, c-format
 msgid "failed to recurse into submodule '%s'"
 msgstr "Fehler bei Rekursion in Submodul '%s'."
 
-#: builtin/submodule--helper.c:886 builtin/submodule--helper.c:1623
+#: builtin/submodule--helper.c:887 builtin/submodule--helper.c:1624
 msgid "suppress submodule status output"
 msgstr "Ausgabe des Submodul-Status unterdrücken"
 
-#: builtin/submodule--helper.c:887
+#: builtin/submodule--helper.c:888
 msgid ""
 "use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
 msgstr ""
 "den Commit benutzen, der im Index gespeichert ist, statt den im Submodul HEAD"
 
-#: builtin/submodule--helper.c:893
+#: builtin/submodule--helper.c:894
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
 msgstr "git submodule status [--quiet] [--cached] [--recursive] [<Pfad>...]"
 
-#: builtin/submodule--helper.c:917
+#: builtin/submodule--helper.c:918
 msgid "git submodule--helper name <path>"
 msgstr "git submodule--helper name <Pfad>"
 
-#: builtin/submodule--helper.c:989
+#: builtin/submodule--helper.c:990
 #, c-format
 msgid "* %s %s(blob)->%s(submodule)"
 msgstr "* %s %s(blob)->%s(submodule)"
 
-#: builtin/submodule--helper.c:992
+#: builtin/submodule--helper.c:993
 #, c-format
 msgid "* %s %s(submodule)->%s(blob)"
 msgstr "* %s %s(submodule)->%s(blob)"
 
-#: builtin/submodule--helper.c:1005
+#: builtin/submodule--helper.c:1006
 #, c-format
 msgid "%s"
 msgstr "%s"
 
-#: builtin/submodule--helper.c:1055
+#: builtin/submodule--helper.c:1056
 #, c-format
 msgid "couldn't hash object from '%s'"
 msgstr "Hash eines Objektes von '%s' konnte nicht erzeugt werden"
 
-#: builtin/submodule--helper.c:1059
+#: builtin/submodule--helper.c:1060
 #, c-format
 msgid "unexpected mode %o\n"
 msgstr "unerwarteter Modus %o\n"
 
-#: builtin/submodule--helper.c:1300
+#: builtin/submodule--helper.c:1301
 msgid "use the commit stored in the index instead of the submodule HEAD"
 msgstr ""
 "benutze den Commit, der im Index gespeichert ist, statt vom Submodul HEAD"
 
-#: builtin/submodule--helper.c:1302
+#: builtin/submodule--helper.c:1303
 msgid "to compare the commit in the index with that in the submodule HEAD"
 msgstr "um den Commit aus dem Index mit dem im Submodul HEAD zu vergleichen"
 
-#: builtin/submodule--helper.c:1304
+#: builtin/submodule--helper.c:1305
 msgid "skip submodules with 'ignore_config' value set to 'all'"
 msgstr ""
 "überspringe Submodule, wo der 'ignore_config' Wert auf 'all' gesetzt ist"
 
-#: builtin/submodule--helper.c:1306
+#: builtin/submodule--helper.c:1307
 msgid "limit the summary size"
 msgstr "Größe der Zusammenfassung begrenzen"
 
-#: builtin/submodule--helper.c:1311
+#: builtin/submodule--helper.c:1312
 msgid "git submodule--helper summary [<options>] [<commit>] [--] [<path>]"
 msgstr "git submodule--helper summary [<Optionen>] [<Commit>] [--] [<Pfad>]"
 
-#: builtin/submodule--helper.c:1335
+#: builtin/submodule--helper.c:1336
 msgid "could not fetch a revision for HEAD"
 msgstr "konnte keinen Commit für HEAD holen"
 
-#: builtin/submodule--helper.c:1340
+#: builtin/submodule--helper.c:1341
 msgid "--cached and --files are mutually exclusive"
 msgstr "--cached und --files schließen sich gegenseitig aus"
 
-#: builtin/submodule--helper.c:1407
+#: builtin/submodule--helper.c:1408
 #, c-format
 msgid "Synchronizing submodule url for '%s'\n"
 msgstr "Synchronisiere Submodul-URL für '%s'\n"
 
-#: builtin/submodule--helper.c:1413
+#: builtin/submodule--helper.c:1414
 #, c-format
 msgid "failed to register url for submodule path '%s'"
 msgstr "Fehler beim Registrieren der URL für Submodul-Pfad '%s'"
 
-#: builtin/submodule--helper.c:1427
+#: builtin/submodule--helper.c:1428
 #, c-format
 msgid "failed to get the default remote for submodule '%s'"
 msgstr "Fehler beim Lesen des Standard-Remote-Repositories für Submodul '%s'"
 
-#: builtin/submodule--helper.c:1438
+#: builtin/submodule--helper.c:1439
 #, c-format
 msgid "failed to update remote for submodule '%s'"
 msgstr "Fehler beim Aktualisieren des Remote-Repositories für Submodul '%s'"
 
-#: builtin/submodule--helper.c:1485
+#: builtin/submodule--helper.c:1486
 msgid "suppress output of synchronizing submodule url"
 msgstr "Ausgaben bei der Synchronisierung der Submodul-URLs unterdrücken"
 
-#: builtin/submodule--helper.c:1492
+#: builtin/submodule--helper.c:1493
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
 msgstr "git submodule--helper sync [--quiet] [--recursive] [<Pfad>]"
 
-#: builtin/submodule--helper.c:1546
+#: builtin/submodule--helper.c:1547
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains a .git directory (use 'rm -rf' if you "
@@ -22733,7 +23119,7 @@ msgstr ""
 "(benutzen Sie 'rm -rf', wenn Sie dieses wirklich mitsamt seiner Historie\n"
 "löschen möchten)"
 
-#: builtin/submodule--helper.c:1558
+#: builtin/submodule--helper.c:1559
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
@@ -22742,49 +23128,49 @@ msgstr ""
 "Arbeitsverzeichnis von Submodul in '%s' enthält lokale Änderungen;\n"
 "verwenden Sie '-f', um diese zu verwerfen."
 
-#: builtin/submodule--helper.c:1566
+#: builtin/submodule--helper.c:1567
 #, c-format
 msgid "Cleared directory '%s'\n"
 msgstr "Verzeichnis '%s' bereinigt.\n"
 
-#: builtin/submodule--helper.c:1568
+#: builtin/submodule--helper.c:1569
 #, c-format
 msgid "Could not remove submodule work tree '%s'\n"
 msgstr "Konnte Arbeitsverzeichnis des Submoduls in '%s' nicht löschen.\n"
 
-#: builtin/submodule--helper.c:1579
+#: builtin/submodule--helper.c:1580
 #, c-format
 msgid "could not create empty submodule directory %s"
 msgstr "Konnte kein leeres Verzeichnis für Submodul in '%s' erstellen."
 
-#: builtin/submodule--helper.c:1595
+#: builtin/submodule--helper.c:1596
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "Submodul '%s' (%s) für Pfad '%s' ausgetragen.\n"
 
-#: builtin/submodule--helper.c:1624
+#: builtin/submodule--helper.c:1625
 msgid "remove submodule working trees even if they contain local changes"
 msgstr ""
 "Arbeitsverzeichnisse von Submodulen löschen, auch wenn lokale Änderungen "
 "vorliegen"
 
-#: builtin/submodule--helper.c:1625
+#: builtin/submodule--helper.c:1626
 msgid "unregister all submodules"
 msgstr "alle Submodule austragen"
 
-#: builtin/submodule--helper.c:1630
+#: builtin/submodule--helper.c:1631
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<Pfad>...]]"
 
-#: builtin/submodule--helper.c:1644
+#: builtin/submodule--helper.c:1645
 msgid "Use '--all' if you really want to deinitialize all submodules"
 msgstr ""
 "Verwenden Sie '--all', wenn Sie wirklich alle Submodule deinitialisieren\n"
 "möchten."
 
-#: builtin/submodule--helper.c:1713
+#: builtin/submodule--helper.c:1714
 msgid ""
 "An alternate computed from a superproject's alternate is invalid.\n"
 "To allow Git to clone without an alternate in such a case, set\n"
@@ -22797,46 +23183,46 @@ msgstr ""
 "submodule.alternateErrorStrategy auf 'info' oder klone mit der Option\n"
 "'--reference-if-able' statt '--reference'."
 
-#: builtin/submodule--helper.c:1752 builtin/submodule--helper.c:1755
+#: builtin/submodule--helper.c:1753 builtin/submodule--helper.c:1756
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
 msgstr "Submodul '%s' kann Alternative nicht hinzufügen: %s"
 
-#: builtin/submodule--helper.c:1791
+#: builtin/submodule--helper.c:1792
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
 msgstr "Wert '%s' für submodule.alternateErrorStrategy wird nicht erkannt"
 
-#: builtin/submodule--helper.c:1798
+#: builtin/submodule--helper.c:1799
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
 msgstr "Wert '%s' für submodule.alternateLocation wird nicht erkannt."
 
-#: builtin/submodule--helper.c:1822
+#: builtin/submodule--helper.c:1823
 msgid "where the new submodule will be cloned to"
 msgstr "Pfad für neues Submodul"
 
-#: builtin/submodule--helper.c:1825
+#: builtin/submodule--helper.c:1826
 msgid "name of the new submodule"
 msgstr "Name des neuen Submoduls"
 
-#: builtin/submodule--helper.c:1828
+#: builtin/submodule--helper.c:1829
 msgid "url where to clone the submodule from"
 msgstr "URL von der das Submodul geklont wird"
 
-#: builtin/submodule--helper.c:1836
+#: builtin/submodule--helper.c:1837
 msgid "depth for shallow clones"
 msgstr "Tiefe des Klons mit unvollständiger Historie (shallow)"
 
-#: builtin/submodule--helper.c:1839 builtin/submodule--helper.c:2348
+#: builtin/submodule--helper.c:1840 builtin/submodule--helper.c:2349
 msgid "force cloning progress"
 msgstr "Fortschrittsanzeige beim Klonen erzwingen"
 
-#: builtin/submodule--helper.c:1841 builtin/submodule--helper.c:2350
+#: builtin/submodule--helper.c:1842 builtin/submodule--helper.c:2351
 msgid "disallow cloning into non-empty directory"
 msgstr "Klonen in ein nicht leeres Verzeichnis verbieten"
 
-#: builtin/submodule--helper.c:1848
+#: builtin/submodule--helper.c:1849
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
 "<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
@@ -22846,110 +23232,110 @@ msgstr ""
 "<Repository>] [--name <Name>] [--depth <Tiefe>] [--single-branch] --url "
 "<URL> --path <Pfad>"
 
-#: builtin/submodule--helper.c:1873
+#: builtin/submodule--helper.c:1874
 #, c-format
 msgid "refusing to create/use '%s' in another submodule's git dir"
 msgstr ""
 "Erstellung/Benutzung von '%s' in einem anderen Submodul-Git-Verzeichnis\n"
 "verweigert."
 
-#: builtin/submodule--helper.c:1884
+#: builtin/submodule--helper.c:1885
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
 msgstr "Klonen von '%s' in Submodul-Pfad '%s' fehlgeschlagen."
 
-#: builtin/submodule--helper.c:1888
+#: builtin/submodule--helper.c:1889
 #, c-format
 msgid "directory not empty: '%s'"
 msgstr "Verzeichnis ist nicht leer: '%s'"
 
-#: builtin/submodule--helper.c:1900
+#: builtin/submodule--helper.c:1901
 #, c-format
 msgid "could not get submodule directory for '%s'"
 msgstr "Konnte Submodul-Verzeichnis '%s' nicht finden."
 
-#: builtin/submodule--helper.c:1936
+#: builtin/submodule--helper.c:1937
 #, c-format
 msgid "Invalid update mode '%s' for submodule path '%s'"
 msgstr "Ungültiger Aktualisierungsmodus '%s' für Submodul-Pfad '%s'."
 
-#: builtin/submodule--helper.c:1940
+#: builtin/submodule--helper.c:1941
 #, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
 msgstr ""
 "Ungültiger Aktualisierungsmodus '%s' für Submodul-Pfad '%s' konfiguriert."
 
-#: builtin/submodule--helper.c:2041
+#: builtin/submodule--helper.c:2042
 #, c-format
 msgid "Submodule path '%s' not initialized"
 msgstr "Submodul-Pfad '%s' nicht initialisiert"
 
-#: builtin/submodule--helper.c:2045
+#: builtin/submodule--helper.c:2046
 msgid "Maybe you want to use 'update --init'?"
 msgstr "Meinten Sie vielleicht 'update --init'?"
 
-#: builtin/submodule--helper.c:2075
+#: builtin/submodule--helper.c:2076
 #, c-format
 msgid "Skipping unmerged submodule %s"
 msgstr "Überspringe nicht zusammengeführtes Submodul %s"
 
-#: builtin/submodule--helper.c:2104
+#: builtin/submodule--helper.c:2105
 #, c-format
 msgid "Skipping submodule '%s'"
 msgstr "Überspringe Submodul '%s'"
 
-#: builtin/submodule--helper.c:2254
+#: builtin/submodule--helper.c:2255
 #, c-format
 msgid "Failed to clone '%s'. Retry scheduled"
 msgstr "Fehler beim Klonen von '%s'. Weiterer Versuch geplant"
 
-#: builtin/submodule--helper.c:2265
+#: builtin/submodule--helper.c:2266
 #, c-format
 msgid "Failed to clone '%s' a second time, aborting"
 msgstr "Zweiter Versuch '%s' zu klonen fehlgeschlagen, breche ab."
 
-#: builtin/submodule--helper.c:2327 builtin/submodule--helper.c:2573
+#: builtin/submodule--helper.c:2328 builtin/submodule--helper.c:2574
 msgid "path into the working tree"
 msgstr "Pfad zum Arbeitsverzeichnis"
 
-#: builtin/submodule--helper.c:2330
+#: builtin/submodule--helper.c:2331
 msgid "path into the working tree, across nested submodule boundaries"
 msgstr ""
 "Pfad zum Arbeitsverzeichnis, über verschachtelte Submodul-Grenzen hinweg"
 
-#: builtin/submodule--helper.c:2334
+#: builtin/submodule--helper.c:2335
 msgid "rebase, merge, checkout or none"
 msgstr "rebase, merge, checkout oder none"
 
-#: builtin/submodule--helper.c:2340
+#: builtin/submodule--helper.c:2341
 msgid "create a shallow clone truncated to the specified number of revisions"
 msgstr ""
 "einen Klon mit unvollständiger Historie (shallow) erstellen, abgeschnitten "
 "bei der angegebenen Anzahl von Commits"
 
-#: builtin/submodule--helper.c:2343
+#: builtin/submodule--helper.c:2344
 msgid "parallel jobs"
 msgstr "Parallele Ausführungen"
 
-#: builtin/submodule--helper.c:2345
+#: builtin/submodule--helper.c:2346
 msgid "whether the initial clone should follow the shallow recommendation"
 msgstr ""
 "ob das initiale Klonen den Empfehlungen für eine unvollständige\n"
 "Historie (shallow) folgen soll"
 
-#: builtin/submodule--helper.c:2346
+#: builtin/submodule--helper.c:2347
 msgid "don't print cloning progress"
 msgstr "keine Fortschrittsanzeige beim Klonen"
 
-#: builtin/submodule--helper.c:2357
+#: builtin/submodule--helper.c:2358
 msgid "git submodule--helper update-clone [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper update-clone [--prefix=<Pfad>] [<Pfad>...]"
 
-#: builtin/submodule--helper.c:2370
+#: builtin/submodule--helper.c:2371
 msgid "bad value for update parameter"
 msgstr "Fehlerhafter Wert für --update Parameter"
 
-#: builtin/submodule--helper.c:2418
+#: builtin/submodule--helper.c:2419
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
@@ -22958,86 +23344,86 @@ msgstr ""
 "Branch von Submodul (%s) ist konfiguriert, den Branch des Hauptprojektes\n"
 "zu erben, aber das Hauptprojekt befindet sich auf keinem Branch."
 
-#: builtin/submodule--helper.c:2541
+#: builtin/submodule--helper.c:2542
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
 msgstr "Konnte kein Repository-Handle für Submodul '%s' erhalten."
 
-#: builtin/submodule--helper.c:2574
+#: builtin/submodule--helper.c:2575
 msgid "recurse into submodules"
 msgstr "Rekursion in Submodule durchführen"
 
-#: builtin/submodule--helper.c:2580
+#: builtin/submodule--helper.c:2581
 msgid "git submodule--helper absorb-git-dirs [<options>] [<path>...]"
 msgstr "git submodule--helper absorb-git-dirs [<Optionen>] [<Pfad>...]"
 
-#: builtin/submodule--helper.c:2636
+#: builtin/submodule--helper.c:2637
 msgid "check if it is safe to write to the .gitmodules file"
 msgstr "prüfen, ob es sicher ist, in die Datei .gitmodules zu schreiben"
 
-#: builtin/submodule--helper.c:2639
+#: builtin/submodule--helper.c:2640
 msgid "unset the config in the .gitmodules file"
 msgstr "Konfiguration in der .gitmodules-Datei entfernen"
 
-#: builtin/submodule--helper.c:2644
+#: builtin/submodule--helper.c:2645
 msgid "git submodule--helper config <name> [<value>]"
 msgstr "git submodule--helper config <name> [<Wert>]"
 
-#: builtin/submodule--helper.c:2645
+#: builtin/submodule--helper.c:2646
 msgid "git submodule--helper config --unset <name>"
 msgstr "git submodule--helper config --unset <Name>"
 
-#: builtin/submodule--helper.c:2646
+#: builtin/submodule--helper.c:2647
 msgid "git submodule--helper config --check-writeable"
 msgstr "git submodule--helper config --check-writeable"
 
-#: builtin/submodule--helper.c:2665 git-submodule.sh:150
+#: builtin/submodule--helper.c:2666 git-submodule.sh:150
 #, sh-format
 msgid "please make sure that the .gitmodules file is in the working tree"
 msgstr ""
 "Bitte stellen Sie sicher, dass sich die Datei .gitmodules im "
 "Arbeitsverzeichnis befindet."
 
-#: builtin/submodule--helper.c:2681
+#: builtin/submodule--helper.c:2682
 msgid "suppress output for setting url of a submodule"
 msgstr "Ausgaben beim Setzen der URL eines Submoduls unterdrücken"
 
-#: builtin/submodule--helper.c:2685
+#: builtin/submodule--helper.c:2686
 msgid "git submodule--helper set-url [--quiet] <path> <newurl>"
 msgstr "git submodule--helper set-url [--quiet] <Pfad> <neue URL>"
 
-#: builtin/submodule--helper.c:2718
+#: builtin/submodule--helper.c:2719
 msgid "set the default tracking branch to master"
 msgstr "Standard-Tracking-Branch auf master setzen"
 
-#: builtin/submodule--helper.c:2720
+#: builtin/submodule--helper.c:2721
 msgid "set the default tracking branch"
 msgstr "Standard-Tracking-Branch setzen"
 
-#: builtin/submodule--helper.c:2724
+#: builtin/submodule--helper.c:2725
 msgid "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
 msgstr "git submodule--helper set-branch [-q|--quiet] (-d|--default) [<Pfad>]"
 
-#: builtin/submodule--helper.c:2725
+#: builtin/submodule--helper.c:2726
 msgid ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
 msgstr ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <Branch> <Pfad>"
 
-#: builtin/submodule--helper.c:2732
+#: builtin/submodule--helper.c:2733
 msgid "--branch or --default required"
 msgstr "Option --branch oder --default erforderlich"
 
-#: builtin/submodule--helper.c:2735
+#: builtin/submodule--helper.c:2736
 msgid "--branch and --default are mutually exclusive"
 msgstr "--branch und --default schließen sich gegenseitig aus"
 
-#: builtin/submodule--helper.c:2792 git.c:441 git.c:714
+#: builtin/submodule--helper.c:2793 git.c:449 git.c:724
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s unterstützt kein --super-prefix"
 
-#: builtin/submodule--helper.c:2798
+#: builtin/submodule--helper.c:2799
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
 msgstr "'%s' ist kein gültiger Unterbefehl von submodule--helper"
@@ -23050,24 +23436,24 @@ msgstr "git symbolic-ref [<Optionen>] <Name> [<Referenz>]"
 msgid "git symbolic-ref -d [-q] <name>"
 msgstr "git symbolic-ref -d [-q] <Name>"
 
-#: builtin/symbolic-ref.c:40
+#: builtin/symbolic-ref.c:42
 msgid "suppress error message for non-symbolic (detached) refs"
 msgstr ""
 "Fehlermeldungen für nicht-symbolische (losgelöste) Referenzen unterdrücken"
 
-#: builtin/symbolic-ref.c:41
+#: builtin/symbolic-ref.c:43
 msgid "delete symbolic ref"
 msgstr "symbolische Referenzen löschen"
 
-#: builtin/symbolic-ref.c:42
+#: builtin/symbolic-ref.c:44
 msgid "shorten ref output"
 msgstr "verkürzte Ausgabe der Referenzen"
 
-#: builtin/symbolic-ref.c:43 builtin/update-ref.c:499
+#: builtin/symbolic-ref.c:45 builtin/update-ref.c:499
 msgid "reason"
 msgstr "Grund"
 
-#: builtin/symbolic-ref.c:43 builtin/update-ref.c:499
+#: builtin/symbolic-ref.c:45 builtin/update-ref.c:499
 msgid "reason of the update"
 msgstr "Grund für die Aktualisierung"
 
@@ -23099,17 +23485,17 @@ msgstr ""
 msgid "git tag -v [--format=<format>] <tagname>..."
 msgstr "git tag -v [--format=<Format>] <Tagname>..."
 
-#: builtin/tag.c:89
+#: builtin/tag.c:100
 #, c-format
 msgid "tag '%s' not found."
 msgstr "Tag '%s' nicht gefunden."
 
-#: builtin/tag.c:124
+#: builtin/tag.c:135
 #, c-format
 msgid "Deleted tag '%s' (was %s)\n"
 msgstr "Tag '%s' gelöscht (war %s)\n"
 
-#: builtin/tag.c:159
+#: builtin/tag.c:170
 #, c-format
 msgid ""
 "\n"
@@ -23122,7 +23508,7 @@ msgstr ""
 "  %s\n"
 "ein. Zeilen, die mit '%c' beginnen, werden ignoriert.\n"
 
-#: builtin/tag.c:163
+#: builtin/tag.c:174
 #, c-format
 msgid ""
 "\n"
@@ -23137,11 +23523,11 @@ msgstr ""
 "ein. Zeilen, die mit '%c' beginnen, werden behalten; Sie dürfen diese\n"
 "selbst entfernen wenn Sie möchten.\n"
 
-#: builtin/tag.c:230
+#: builtin/tag.c:241
 msgid "unable to sign the tag"
 msgstr "konnte Tag nicht signieren"
 
-#: builtin/tag.c:248
+#: builtin/tag.c:259
 #, c-format
 msgid ""
 "You have created a nested tag. The object referred to by your new tag is\n"
@@ -23155,139 +23541,139 @@ msgstr ""
 "\n"
 "\tgit tag -f %s %s^{}"
 
-#: builtin/tag.c:264
+#: builtin/tag.c:275
 msgid "bad object type."
 msgstr "ungültiger Objekt-Typ"
 
-#: builtin/tag.c:317
+#: builtin/tag.c:328
 msgid "no tag message?"
 msgstr "keine Tag-Beschreibung?"
 
-#: builtin/tag.c:324
+#: builtin/tag.c:335
 #, c-format
 msgid "The tag message has been left in %s\n"
 msgstr "Die Tag-Beschreibung wurde in %s gelassen\n"
 
-#: builtin/tag.c:435
+#: builtin/tag.c:446
 msgid "list tag names"
 msgstr "Tagnamen auflisten"
 
-#: builtin/tag.c:437
+#: builtin/tag.c:448
 msgid "print <n> lines of each tag message"
 msgstr "<n> Zeilen jeder Tag-Beschreibung anzeigen"
 
-#: builtin/tag.c:439
+#: builtin/tag.c:450
 msgid "delete tags"
 msgstr "Tags löschen"
 
-#: builtin/tag.c:440
+#: builtin/tag.c:451
 msgid "verify tags"
 msgstr "Tags überprüfen"
 
-#: builtin/tag.c:442
+#: builtin/tag.c:453
 msgid "Tag creation options"
 msgstr "Optionen für Erstellung von Tags"
 
-#: builtin/tag.c:444
+#: builtin/tag.c:455
 msgid "annotated tag, needs a message"
 msgstr "annotiertes Tag, benötigt eine Beschreibung"
 
-#: builtin/tag.c:446
+#: builtin/tag.c:457
 msgid "tag message"
 msgstr "Tag-Beschreibung"
 
-#: builtin/tag.c:448
+#: builtin/tag.c:459
 msgid "force edit of tag message"
 msgstr "Bearbeitung der Tag-Beschreibung erzwingen"
 
-#: builtin/tag.c:449
+#: builtin/tag.c:460
 msgid "annotated and GPG-signed tag"
 msgstr "annotiertes und GPG-signiertes Tag"
 
-#: builtin/tag.c:452
+#: builtin/tag.c:463
 msgid "use another key to sign the tag"
 msgstr "einen anderen Schlüssel verwenden, um das Tag zu signieren"
 
-#: builtin/tag.c:453
+#: builtin/tag.c:464
 msgid "replace the tag if exists"
 msgstr "das Tag ersetzen, wenn es existiert"
 
-#: builtin/tag.c:454 builtin/update-ref.c:505
+#: builtin/tag.c:465 builtin/update-ref.c:505
 msgid "create a reflog"
 msgstr "Reflog erstellen"
 
-#: builtin/tag.c:456
+#: builtin/tag.c:467
 msgid "Tag listing options"
 msgstr "Optionen für Auflistung der Tags"
 
-#: builtin/tag.c:457
+#: builtin/tag.c:468
 msgid "show tag list in columns"
 msgstr "Liste der Tags in Spalten anzeigen"
 
-#: builtin/tag.c:458 builtin/tag.c:460
+#: builtin/tag.c:469 builtin/tag.c:471
 msgid "print only tags that contain the commit"
 msgstr "nur Tags ausgeben, die diesen Commit beinhalten"
 
-#: builtin/tag.c:459 builtin/tag.c:461
+#: builtin/tag.c:470 builtin/tag.c:472
 msgid "print only tags that don't contain the commit"
 msgstr "nur Tags ausgeben, die diesen Commit nicht enthalten"
 
-#: builtin/tag.c:462
+#: builtin/tag.c:473
 msgid "print only tags that are merged"
 msgstr "nur Tags ausgeben, die gemerged wurden"
 
-#: builtin/tag.c:463
+#: builtin/tag.c:474
 msgid "print only tags that are not merged"
 msgstr "nur Tags ausgeben, die nicht gemerged wurden"
 
-#: builtin/tag.c:467
+#: builtin/tag.c:478
 msgid "print only tags of the object"
 msgstr "nur Tags von dem Objekt ausgeben"
 
-#: builtin/tag.c:515
+#: builtin/tag.c:526
 msgid "--column and -n are incompatible"
 msgstr "--column und -n sind inkompatibel"
 
-#: builtin/tag.c:537
+#: builtin/tag.c:548
 msgid "-n option is only allowed in list mode"
 msgstr "die Option -n ist nur im Listenmodus erlaubt"
 
-#: builtin/tag.c:539
+#: builtin/tag.c:550
 msgid "--contains option is only allowed in list mode"
 msgstr "--contains ist nur im Listenmodus erlaubt"
 
-#: builtin/tag.c:541
+#: builtin/tag.c:552
 msgid "--no-contains option is only allowed in list mode"
 msgstr "--no-contains ist nur im Listenmodus erlaubt"
 
-#: builtin/tag.c:543
+#: builtin/tag.c:554
 msgid "--points-at option is only allowed in list mode"
 msgstr "--points-at ist nur im Listenmodus erlaubt"
 
-#: builtin/tag.c:545
+#: builtin/tag.c:556
 msgid "--merged and --no-merged options are only allowed in list mode"
 msgstr "--merged und --no-merged sind nur im Listenmodus erlaubt"
 
-#: builtin/tag.c:556
+#: builtin/tag.c:567
 msgid "only one -F or -m option is allowed."
 msgstr "nur eine -F oder -m Option ist erlaubt."
 
-#: builtin/tag.c:581
+#: builtin/tag.c:592
 #, c-format
 msgid "'%s' is not a valid tag name."
 msgstr "'%s' ist kein gültiger Tagname."
 
-#: builtin/tag.c:586
+#: builtin/tag.c:597
 #, c-format
 msgid "tag '%s' already exists"
 msgstr "Tag '%s' existiert bereits"
 
-#: builtin/tag.c:617
+#: builtin/tag.c:628
 #, c-format
 msgid "Updated tag '%s' (was %s)\n"
 msgstr "Tag '%s' aktualisiert (war %s)\n"
 
-#: builtin/unpack-objects.c:502
+#: builtin/unpack-objects.c:504
 msgid "Unpacking objects"
 msgstr "Entpacke Objekte"
 
@@ -23359,151 +23745,151 @@ msgstr " OK"
 msgid "git update-index [<options>] [--] [<file>...]"
 msgstr "git update-index [<Optionen>] [--] [<Datei>...]"
 
-#: builtin/update-index.c:974
+#: builtin/update-index.c:976
 msgid "continue refresh even when index needs update"
 msgstr ""
 "Aktualisierung fortsetzen, auch wenn der Index aktualisiert werden muss"
 
-#: builtin/update-index.c:977
+#: builtin/update-index.c:979
 msgid "refresh: ignore submodules"
 msgstr "Aktualisierung: ignoriert Submodule"
 
-#: builtin/update-index.c:980
+#: builtin/update-index.c:982
 msgid "do not ignore new files"
 msgstr "keine neuen Dateien ignorieren"
 
-#: builtin/update-index.c:982
+#: builtin/update-index.c:984
 msgid "let files replace directories and vice-versa"
 msgstr "Dateien Verzeichnisse ersetzen lassen, und umgedreht"
 
-#: builtin/update-index.c:984
+#: builtin/update-index.c:986
 msgid "notice files missing from worktree"
 msgstr "fehlende Dateien im Arbeitsverzeichnis beachten"
 
-#: builtin/update-index.c:986
+#: builtin/update-index.c:988
 msgid "refresh even if index contains unmerged entries"
 msgstr ""
 "aktualisieren, auch wenn der Index nicht zusammengeführte Einträge beinhaltet"
 
-#: builtin/update-index.c:989
+#: builtin/update-index.c:991
 msgid "refresh stat information"
 msgstr "Dateiinformationen aktualisieren"
 
-#: builtin/update-index.c:993
+#: builtin/update-index.c:995
 msgid "like --refresh, but ignore assume-unchanged setting"
 msgstr "wie --refresh, ignoriert aber \"assume-unchanged\" Einstellung"
 
-#: builtin/update-index.c:997
+#: builtin/update-index.c:999
 msgid "<mode>,<object>,<path>"
 msgstr "<Modus>,<Objekt>,<Pfad>"
 
-#: builtin/update-index.c:998
+#: builtin/update-index.c:1000
 msgid "add the specified entry to the index"
 msgstr "den angegebenen Eintrag zum Commit vormerken"
 
-#: builtin/update-index.c:1008
+#: builtin/update-index.c:1010
 msgid "mark files as \"not changing\""
 msgstr "diese Datei immer als unverändert betrachten"
 
-#: builtin/update-index.c:1011
+#: builtin/update-index.c:1013
 msgid "clear assumed-unchanged bit"
 msgstr "\"assumed-unchanged\"-Bit löschen"
 
-#: builtin/update-index.c:1014
+#: builtin/update-index.c:1016
 msgid "mark files as \"index-only\""
 msgstr "Dateien als \"index-only\" markieren"
 
-#: builtin/update-index.c:1017
+#: builtin/update-index.c:1019
 msgid "clear skip-worktree bit"
 msgstr "\"skip-worktree\"-Bit löschen"
 
-#: builtin/update-index.c:1020
+#: builtin/update-index.c:1022
 msgid "do not touch index-only entries"
 msgstr "\"index-only\" Einträge überspringen"
 
-#: builtin/update-index.c:1022
+#: builtin/update-index.c:1024
 msgid "add to index only; do not add content to object database"
 msgstr ""
 "die Änderungen nur zum Commit vormerken; Inhalt wird nicht der Objekt-"
 "Datenbank hinzugefügt"
 
-#: builtin/update-index.c:1024
+#: builtin/update-index.c:1026
 msgid "remove named paths even if present in worktree"
 msgstr ""
 "benannte Pfade löschen, auch wenn sie sich im Arbeitsverzeichnis befinden"
 
-#: builtin/update-index.c:1026
+#: builtin/update-index.c:1028
 msgid "with --stdin: input lines are terminated by null bytes"
 msgstr "mit --stdin: eingegebene Zeilen sind durch NUL-Bytes abgeschlossen"
 
-#: builtin/update-index.c:1028
+#: builtin/update-index.c:1030
 msgid "read list of paths to be updated from standard input"
 msgstr "Liste der zu aktualisierenden Pfade von der Standard-Eingabe lesen"
 
-#: builtin/update-index.c:1032
+#: builtin/update-index.c:1034
 msgid "add entries from standard input to the index"
 msgstr "Einträge von der Standard-Eingabe zum Commit vormerken"
 
-#: builtin/update-index.c:1036
+#: builtin/update-index.c:1038
 msgid "repopulate stages #2 and #3 for the listed paths"
 msgstr ""
 "wiederholtes Einpflegen der Zustände #2 und #3 für die aufgelisteten Pfade"
 
-#: builtin/update-index.c:1040
+#: builtin/update-index.c:1042
 msgid "only update entries that differ from HEAD"
 msgstr "nur Einträge aktualisieren, die unterschiedlich zu HEAD sind"
 
-#: builtin/update-index.c:1044
+#: builtin/update-index.c:1046
 msgid "ignore files missing from worktree"
 msgstr "fehlende Dateien im Arbeitsverzeichnis ignorieren"
 
-#: builtin/update-index.c:1047
+#: builtin/update-index.c:1049
 msgid "report actions to standard output"
 msgstr "die Aktionen in der Standard-Ausgabe ausgeben"
 
-#: builtin/update-index.c:1049
+#: builtin/update-index.c:1051
 msgid "(for porcelains) forget saved unresolved conflicts"
 msgstr "(für Fremdprogramme) keine gespeicherten, nicht aufgelöste Konflikte"
 
-#: builtin/update-index.c:1053
+#: builtin/update-index.c:1055
 msgid "write index in this format"
 msgstr "Index-Datei in diesem Format schreiben"
 
-#: builtin/update-index.c:1055
+#: builtin/update-index.c:1057
 msgid "enable or disable split index"
 msgstr "Splitting des Index aktivieren oder deaktivieren"
 
-#: builtin/update-index.c:1057
+#: builtin/update-index.c:1059
 msgid "enable/disable untracked cache"
 msgstr "Cache für unversionierte Dateien aktivieren oder deaktivieren"
 
-#: builtin/update-index.c:1059
+#: builtin/update-index.c:1061
 msgid "test if the filesystem supports untracked cache"
 msgstr ""
 "prüfen, ob das Dateisystem einen Cache für unversionierte Dateien unterstützt"
 
-#: builtin/update-index.c:1061
+#: builtin/update-index.c:1063
 msgid "enable untracked cache without testing the filesystem"
 msgstr ""
 "Cache für unversionierte Dateien ohne Prüfung des Dateisystems aktivieren"
 
-#: builtin/update-index.c:1063
+#: builtin/update-index.c:1065
 msgid "write out the index even if is not flagged as changed"
 msgstr "Index rausschreiben, auch wenn dieser nicht als geändert markiert ist"
 
-#: builtin/update-index.c:1065
+#: builtin/update-index.c:1067
 msgid "enable or disable file system monitor"
 msgstr "Dateisystem-Monitor aktivieren oder deaktivieren"
 
-#: builtin/update-index.c:1067
+#: builtin/update-index.c:1069
 msgid "mark files as fsmonitor valid"
 msgstr "Dateien als \"fsmonitor valid\" markieren"
 
-#: builtin/update-index.c:1070
+#: builtin/update-index.c:1072
 msgid "clear fsmonitor valid bit"
 msgstr "\"fsmonitor valid\"-Bit löschen"
 
-#: builtin/update-index.c:1173
+#: builtin/update-index.c:1175
 msgid ""
 "core.splitIndex is set to false; remove or change it, if you really want to "
 "enable split index"
@@ -23511,7 +23897,7 @@ msgstr ""
 "core.splitIndex ist auf 'false' gesetzt; entfernen oder ändern Sie dies,\n"
 "wenn sie wirklich das Splitting des Index aktivieren möchten"
 
-#: builtin/update-index.c:1182
+#: builtin/update-index.c:1184
 msgid ""
 "core.splitIndex is set to true; remove or change it, if you really want to "
 "disable split index"
@@ -23519,7 +23905,7 @@ msgstr ""
 "core.splitIndex ist auf 'true' gesetzt; entfernen oder ändern Sie dies,\n"
 "wenn Sie wirklich das Splitting des Index deaktivieren möchten"
 
-#: builtin/update-index.c:1194
+#: builtin/update-index.c:1196
 msgid ""
 "core.untrackedCache is set to true; remove or change it, if you really want "
 "to disable the untracked cache"
@@ -23527,11 +23913,11 @@ msgstr ""
 "core.untrackedCache ist auf 'true' gesetzt; entfernen oder ändern Sie dies,\n"
 "wenn Sie wirklich den Cache für unversionierte Dateien deaktivieren möchten"
 
-#: builtin/update-index.c:1198
+#: builtin/update-index.c:1200
 msgid "Untracked cache disabled"
 msgstr "Cache für unversionierte Dateien deaktiviert"
 
-#: builtin/update-index.c:1206
+#: builtin/update-index.c:1208
 msgid ""
 "core.untrackedCache is set to false; remove or change it, if you really want "
 "to enable the untracked cache"
@@ -23540,23 +23926,23 @@ msgstr ""
 "dies,\n"
 "wenn sie wirklich den Cache für unversionierte Dateien aktivieren möchten"
 
-#: builtin/update-index.c:1210
+#: builtin/update-index.c:1212
 #, c-format
 msgid "Untracked cache enabled for '%s'"
 msgstr "Cache für unversionierte Dateien für '%s' aktiviert"
 
-#: builtin/update-index.c:1218
+#: builtin/update-index.c:1220
 msgid "core.fsmonitor is unset; set it if you really want to enable fsmonitor"
 msgstr ""
 "core.fsmonitor nicht gesetzt; setzen Sie es, wenn Sie den Dateisystem-"
 "Monitor\n"
 "wirklich aktivieren möchten"
 
-#: builtin/update-index.c:1222
+#: builtin/update-index.c:1224
 msgid "fsmonitor enabled"
 msgstr "Dateisystem-Monitor aktiviert"
 
-#: builtin/update-index.c:1225
+#: builtin/update-index.c:1227
 msgid ""
 "core.fsmonitor is set; remove it if you really want to disable fsmonitor"
 msgstr ""
@@ -23564,7 +23950,7 @@ msgstr ""
 "Monitor\n"
 "wirklich deaktivieren möchten."
 
-#: builtin/update-index.c:1229
+#: builtin/update-index.c:1231
 msgid "fsmonitor disabled"
 msgstr "Dateisystem-Monitor deaktiviert"
 
@@ -23687,7 +24073,7 @@ msgstr "git worktree remove [<Optionen>] <Arbeitsverzeichnis>"
 msgid "git worktree unlock <path>"
 msgstr "git worktree unlock <Pfad>"
 
-#: builtin/worktree.c:61 builtin/worktree.c:933
+#: builtin/worktree.c:61 builtin/worktree.c:935
 #, c-format
 msgid "failed to delete '%s'"
 msgstr "Fehler beim Löschen von '%s'"
@@ -23760,112 +24146,112 @@ msgstr "Bereite Arbeitsverzeichnis vor (checke '%s' aus)"
 msgid "Preparing worktree (detached HEAD %s)"
 msgstr "Bereite Arbeitsverzeichnis vor (losgelöster HEAD %s)"
 
-#: builtin/worktree.c:480
+#: builtin/worktree.c:482
 msgid "checkout <branch> even if already checked out in other worktree"
 msgstr ""
 "<Branch> auschecken, auch wenn dieser bereits in einem anderen "
 "Arbeitsverzeichnis ausgecheckt ist"
 
-#: builtin/worktree.c:483
+#: builtin/worktree.c:485
 msgid "create a new branch"
 msgstr "neuen Branch erstellen"
 
-#: builtin/worktree.c:485
+#: builtin/worktree.c:487
 msgid "create or reset a branch"
 msgstr "Branch erstellen oder umsetzen"
 
-#: builtin/worktree.c:487
+#: builtin/worktree.c:489
 msgid "populate the new working tree"
 msgstr "das neue Arbeitsverzeichnis auschecken"
 
-#: builtin/worktree.c:488
+#: builtin/worktree.c:490
 msgid "keep the new working tree locked"
 msgstr "das neue Arbeitsverzeichnis gesperrt lassen"
 
-#: builtin/worktree.c:491
+#: builtin/worktree.c:493
 msgid "set up tracking mode (see git-branch(1))"
 msgstr "Modus zum Folgen von Branches einstellen (siehe git-branch(1))"
 
-#: builtin/worktree.c:494
+#: builtin/worktree.c:496
 msgid "try to match the new branch name with a remote-tracking branch"
 msgstr ""
 "versuchen, eine Übereinstimmung des Branch-Namens mit einem\n"
 "Remote-Tracking-Branch herzustellen"
 
-#: builtin/worktree.c:502
+#: builtin/worktree.c:504
 msgid "-b, -B, and --detach are mutually exclusive"
 msgstr "-b, -B und --detach schließen sich gegenseitig aus"
 
-#: builtin/worktree.c:563
+#: builtin/worktree.c:565
 msgid "--[no-]track can only be used if a new branch is created"
 msgstr ""
 "--[no]-track kann nur verwendet werden, wenn ein neuer Branch erstellt wird."
 
-#: builtin/worktree.c:680
+#: builtin/worktree.c:682
 msgid "show extended annotations and reasons, if available"
 msgstr "erweiterte Anmerkungen und Gründe anzeigen, falls vorhanden"
 
-#: builtin/worktree.c:682
+#: builtin/worktree.c:684
 msgid "add 'prunable' annotation to worktrees older than <time>"
 msgstr ""
 "'prunable'-Anmerkung zu Arbeitsverzeichnissen älter als <Zeit> hinzufügen"
 
-#: builtin/worktree.c:691
+#: builtin/worktree.c:693
 msgid "--verbose and --porcelain are mutually exclusive"
 msgstr "--verbose und --porcelain schließen sich gegenseitig aus"
 
-#: builtin/worktree.c:718
+#: builtin/worktree.c:720
 msgid "reason for locking"
 msgstr "Sperrgrund"
 
-#: builtin/worktree.c:730 builtin/worktree.c:763 builtin/worktree.c:837
-#: builtin/worktree.c:961
+#: builtin/worktree.c:732 builtin/worktree.c:765 builtin/worktree.c:839
+#: builtin/worktree.c:963
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr "'%s' ist kein Arbeitsverzeichnis"
 
-#: builtin/worktree.c:732 builtin/worktree.c:765
+#: builtin/worktree.c:734 builtin/worktree.c:767
 msgid "The main working tree cannot be locked or unlocked"
 msgstr "Das Hauptarbeitsverzeichnis kann nicht gesperrt oder entsperrt werden."
 
-#: builtin/worktree.c:737
+#: builtin/worktree.c:739
 #, c-format
 msgid "'%s' is already locked, reason: %s"
 msgstr "'%s' ist bereits gesperrt, Grund: %s"
 
-#: builtin/worktree.c:739
+#: builtin/worktree.c:741
 #, c-format
 msgid "'%s' is already locked"
 msgstr "'%s' ist bereits gesperrt"
 
-#: builtin/worktree.c:767
+#: builtin/worktree.c:769
 #, c-format
 msgid "'%s' is not locked"
 msgstr "'%s' ist nicht gesperrt"
 
-#: builtin/worktree.c:808
+#: builtin/worktree.c:810
 msgid "working trees containing submodules cannot be moved or removed"
 msgstr ""
 "Arbeitsverzeichnisse, die Submodule enthalten, können nicht verschoben oder\n"
 "entfernt werden."
 
-#: builtin/worktree.c:816
+#: builtin/worktree.c:818
 msgid "force move even if worktree is dirty or locked"
 msgstr ""
 "Verschieben erzwingen, auch wenn das Arbeitsverzeichnis geändert oder "
 "gesperrt ist"
 
-#: builtin/worktree.c:839 builtin/worktree.c:963
+#: builtin/worktree.c:841 builtin/worktree.c:965
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr "'%s' ist ein Hauptarbeitsverzeichnis"
 
-#: builtin/worktree.c:844
+#: builtin/worktree.c:846
 #, c-format
 msgid "could not figure out destination name from '%s'"
 msgstr "Konnte Zielname aus '%s' nicht bestimmen."
 
-#: builtin/worktree.c:857
+#: builtin/worktree.c:859
 #, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
@@ -23875,7 +24261,7 @@ msgstr ""
 "Benutzen Sie 'move -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:859
+#: builtin/worktree.c:861
 msgid ""
 "cannot move a locked working tree;\n"
 "use 'move -f -f' to override or unlock first"
@@ -23884,40 +24270,40 @@ msgstr ""
 "Benutzen Sie 'move -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:862
+#: builtin/worktree.c:864
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
 msgstr "Validierung fehlgeschlagen, kann Arbeitszeichnis nicht verschieben: %s"
 
-#: builtin/worktree.c:867
+#: builtin/worktree.c:869
 #, c-format
 msgid "failed to move '%s' to '%s'"
 msgstr "Fehler beim Verschieben von '%s' nach '%s'"
 
-#: builtin/worktree.c:913
+#: builtin/worktree.c:915
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr "Fehler beim Ausführen von 'git status' auf '%s'"
 
-#: builtin/worktree.c:917
+#: builtin/worktree.c:919
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
 "'%s' enthält geänderte oder nicht versionierte Dateien, benutzen Sie --force "
 "zum Löschen"
 
-#: builtin/worktree.c:922
+#: builtin/worktree.c:924
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr "Fehler beim Ausführen von 'git status' auf '%s'. Code: %d"
 
-#: builtin/worktree.c:945
+#: builtin/worktree.c:947
 msgid "force removal even if worktree is dirty or locked"
 msgstr ""
 "Löschen erzwingen, auch wenn das Arbeitsverzeichnis geändert oder gesperrt "
 "ist"
 
-#: builtin/worktree.c:968
+#: builtin/worktree.c:970
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
@@ -23927,7 +24313,7 @@ msgstr ""
 "Benutzen Sie 'remove -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:970
+#: builtin/worktree.c:972
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
@@ -23936,17 +24322,17 @@ msgstr ""
 "Benutzen Sie 'remove -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:973
+#: builtin/worktree.c:975
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr "Validierung fehlgeschlagen, kann Arbeitsverzeichnis nicht löschen: %s"
 
-#: builtin/worktree.c:997
+#: builtin/worktree.c:999
 #, c-format
 msgid "repair: %s: %s"
 msgstr "repariere: %s: %s"
 
-#: builtin/worktree.c:1000
+#: builtin/worktree.c:1002
 #, c-format
 msgid "error: %s: %s"
 msgstr "Fehler: %s: %s"
@@ -23966,48 +24352,6 @@ msgstr "das Tree-Objekt für ein Unterverzeichnis <Präfix> schreiben"
 #: builtin/write-tree.c:31
 msgid "only useful for debugging"
 msgstr "nur nützlich für Fehlersuche"
-
-#: http-fetch.c:118
-#, c-format
-msgid "argument to --packfile must be a valid hash (got '%s')"
-msgstr "Argument für --packfile muss ein gültiger Hash sein ('%s' erhalten)"
-
-#: http-fetch.c:128
-msgid "not a git repository"
-msgstr "kein Git-Repository"
-
-#: http-fetch.c:134
-msgid "--packfile requires --index-pack-args"
-msgstr "--packfile benötigt --index-pack-args"
-
-#: http-fetch.c:143
-msgid "--index-pack-args can only be used with --packfile"
-msgstr "--index-pack-args kann nur mit --packfile benutzt werden"
-
-#: t/helper/test-fast-rebase.c:141
-msgid "unhandled options"
-msgstr "unbehandelte Optionen"
-
-#: t/helper/test-fast-rebase.c:146
-msgid "error preparing revisions"
-msgstr "Fehler beim Vorbereiten der Commits"
-
-#: t/helper/test-reach.c:154
-#, c-format
-msgid "commit %s is not marked reachable"
-msgstr "Commit %s ist nicht als erreichbar gekennzeichnet."
-
-#: t/helper/test-reach.c:164
-msgid "too many commits marked reachable"
-msgstr "Zu viele Commits als erreichbar gekennzeichnet."
-
-#: t/helper/test-serve-v2.c:7
-msgid "test-tool serve-v2 [<options>]"
-msgstr "test-tool serve-v2 [<Optionen>]"
-
-#: t/helper/test-serve-v2.c:19
-msgid "exit immediately after advertising capabilities"
-msgstr "direkt nach Anzeige der angebotenen Fähigkeiten beenden"
 
 #: git.c:28
 msgid ""
@@ -24065,22 +24409,27 @@ msgstr "Kein Präfix für --super-prefix angegeben.\n"
 msgid "-c expects a configuration string\n"
 msgstr "-c erwartet einen Konfigurationsstring.\n"
 
-#: git.c:292
+#: git.c:260
+#, fuzzy, c-format
+msgid "no config key given for --config-env\n"
+msgstr "Kein Verzeichnis für --work-tree angegeben.\n"
+
+#: git.c:300
 #, c-format
 msgid "no directory given for -C\n"
 msgstr "Kein Verzeichnis für -C angegeben.\n"
 
-#: git.c:318
+#: git.c:326
 #, c-format
 msgid "unknown option: %s\n"
 msgstr "Unbekannte Option: %s\n"
 
-#: git.c:367
+#: git.c:375
 #, c-format
 msgid "while expanding alias '%s': '%s'"
 msgstr "beim Erweitern von Alias '%s': '%s'"
 
-#: git.c:376
+#: git.c:384
 #, c-format
 msgid ""
 "alias '%s' changes environment variables.\n"
@@ -24089,39 +24438,39 @@ msgstr ""
 "Alias '%s' ändert Umgebungsvariablen.\n"
 "Sie können '!git' im Alias benutzen, um dies zu tun."
 
-#: git.c:383
+#: git.c:391
 #, c-format
 msgid "empty alias for %s"
 msgstr "leerer Alias für %s"
 
-#: git.c:386
+#: git.c:394
 #, c-format
 msgid "recursive alias: %s"
 msgstr "rekursiver Alias: %s"
 
-#: git.c:468
+#: git.c:476
 msgid "write failure on standard output"
 msgstr "Fehler beim Schreiben in die Standard-Ausgabe."
 
-#: git.c:470
+#: git.c:478
 msgid "unknown write failure on standard output"
 msgstr "Unbekannter Fehler beim Schreiben in die Standard-Ausgabe."
 
-#: git.c:472
+#: git.c:480
 msgid "close failed on standard output"
 msgstr "Fehler beim Schließen der Standard-Ausgabe."
 
-#: git.c:823
+#: git.c:833
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr "Alias-Schleife erkannt: Erweiterung von '%s' schließt nicht ab:%s"
 
-#: git.c:873
+#: git.c:883
 #, c-format
 msgid "cannot handle %s as a builtin"
 msgstr "Kann %s nicht als eingebauten Befehl behandeln."
 
-#: git.c:886
+#: git.c:896
 #, c-format
 msgid ""
 "usage: %s\n"
@@ -24130,15 +24479,166 @@ msgstr ""
 "Verwendung: %s\n"
 "\n"
 
-#: git.c:906
+#: git.c:916
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr "Erweiterung von Alias '%s' fehlgeschlagen; '%s' ist kein Git-Befehl\n"
 
-#: git.c:918
+#: git.c:928
 #, c-format
 msgid "failed to run command '%s': %s\n"
 msgstr "Fehler beim Ausführen von Befehl '%s': %s\n"
+
+#: http-fetch.c:118
+#, c-format
+msgid "argument to --packfile must be a valid hash (got '%s')"
+msgstr "Argument für --packfile muss ein gültiger Hash sein ('%s' erhalten)"
+
+#: http-fetch.c:128
+msgid "not a git repository"
+msgstr "kein Git-Repository"
+
+#: http-fetch.c:134
+msgid "--packfile requires --index-pack-args"
+msgstr "--packfile benötigt --index-pack-args"
+
+#: http-fetch.c:143
+msgid "--index-pack-args can only be used with --packfile"
+msgstr "--index-pack-args kann nur mit --packfile benutzt werden"
+
+#: t/helper/test-fast-rebase.c:141
+msgid "unhandled options"
+msgstr "unbehandelte Optionen"
+
+#: t/helper/test-fast-rebase.c:146
+msgid "error preparing revisions"
+msgstr "Fehler beim Vorbereiten der Commits"
+
+#: t/helper/test-reach.c:154
+#, c-format
+msgid "commit %s is not marked reachable"
+msgstr "Commit %s ist nicht als erreichbar gekennzeichnet."
+
+#: t/helper/test-reach.c:164
+msgid "too many commits marked reachable"
+msgstr "Zu viele Commits als erreichbar gekennzeichnet."
+
+#: t/helper/test-serve-v2.c:7
+msgid "test-tool serve-v2 [<options>]"
+msgstr "test-tool serve-v2 [<Optionen>]"
+
+#: t/helper/test-serve-v2.c:19
+msgid "exit immediately after advertising capabilities"
+msgstr "direkt nach Anzeige der angebotenen Fähigkeiten beenden"
+
+#: t/helper/test-simple-ipc.c:262
+#, c-format
+msgid "socket/pipe already in use: '%s'"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:264
+#, fuzzy, c-format
+msgid "could not start server on: '%s'"
+msgstr "konnte Datei '%s' nicht lesen"
+
+#: t/helper/test-simple-ipc.c:295 t/helper/test-simple-ipc.c:331
+msgid "could not spawn daemon in the background"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:356
+#, fuzzy
+msgid "waitpid failed"
+msgstr "setsid fehlgeschlagen"
+
+#: t/helper/test-simple-ipc.c:376
+msgid "daemon not online yet"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:406
+#, fuzzy
+msgid "daemon failed to start"
+msgstr "Konnte '%s' nicht lesen"
+
+#: t/helper/test-simple-ipc.c:410
+msgid "waitpid is confused"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:541
+msgid "daemon has not shutdown yet"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:682
+msgid "test-helper simple-ipc is-active    [<name>] [<options>]"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:683
+msgid "test-helper simple-ipc run-daemon   [<name>] [<threads>]"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:684
+msgid "test-helper simple-ipc start-daemon [<name>] [<threads>] [<max-wait>]"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:685
+msgid "test-helper simple-ipc stop-daemon  [<name>] [<max-wait>]"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:686
+msgid "test-helper simple-ipc send         [<name>] [<token>]"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:687
+msgid "test-helper simple-ipc sendbytes    [<name>] [<bytecount>] [<byte>]"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:688
+msgid ""
+"test-helper simple-ipc multiple     [<name>] [<threads>] [<bytecount>] "
+"[<batchsize>]"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:696
+msgid "name or pathname of unix domain socket"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:698
+msgid "named-pipe name"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:700
+msgid "number of threads in server thread pool"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:701
+msgid "seconds to wait for daemon to start or stop"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:703
+#, fuzzy
+msgid "number of bytes"
+msgstr "Ungültige Anzahl von Argumenten."
+
+#: t/helper/test-simple-ipc.c:704
+#, fuzzy
+msgid "number of requests per thread"
+msgstr "kann Thread nicht erzeugen: %s"
+
+#: t/helper/test-simple-ipc.c:706
+#, fuzzy
+msgid "byte"
+msgstr "Bytes"
+
+#: t/helper/test-simple-ipc.c:706
+msgid "ballast character"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:707
+msgid "token"
+msgstr ""
+
+#: t/helper/test-simple-ipc.c:707
+msgid "command token to send to the server"
+msgstr ""
 
 #: http.c:399
 #, c-format
@@ -24179,7 +24679,7 @@ msgstr ""
 msgid "Could not set SSL backend to '%s': already set"
 msgstr "Konnte SSL-Backend nicht zu '%s' setzen: bereits gesetzt"
 
-#: http.c:2025
+#: http.c:2035
 #, c-format
 msgid ""
 "unable to update url base from redirection:\n"
@@ -24332,44 +24832,44 @@ msgstr "keine Compiler-Information verfügbar\n"
 msgid "no libc information available\n"
 msgstr "keine libc Informationen verfügbar\n"
 
-#: list-objects-filter-options.h:91
+#: list-objects-filter-options.h:94
 msgid "args"
 msgstr "Argumente"
 
-#: list-objects-filter-options.h:92
+#: list-objects-filter-options.h:95
 msgid "object filtering"
 msgstr "Filtern nach Objekten"
 
-#: parse-options.h:183
+#: parse-options.h:184
 msgid "expiry-date"
 msgstr "Verfallsdatum"
 
-#: parse-options.h:197
+#: parse-options.h:198
 msgid "no-op (backward compatibility)"
 msgstr "Kein Effekt (Rückwärtskompatibilität)"
 
-#: parse-options.h:309
+#: parse-options.h:310
 msgid "be more verbose"
 msgstr "erweiterte Ausgaben"
 
-#: parse-options.h:311
+#: parse-options.h:312
 msgid "be more quiet"
 msgstr "weniger Ausgaben"
 
-#: parse-options.h:317
+#: parse-options.h:318
 msgid "use <n> digits to display object names"
 msgstr "benutze <Anzahl> Ziffern zur Anzeige von Objektnamen"
 
-#: parse-options.h:336
+#: parse-options.h:337
 msgid "how to strip spaces and #comments from message"
 msgstr ""
 "wie Leerzeichen und #Kommentare von der Beschreibung getrennt werden sollen"
 
-#: parse-options.h:337
+#: parse-options.h:338
 msgid "read pathspec from file"
 msgstr "Pfadspezifikation aus einer Datei lesen"
 
-#: parse-options.h:338
+#: parse-options.h:339
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""
@@ -26107,27 +26607,32 @@ msgstr ""
 msgid "local time offset greater than or equal to 24 hours\n"
 msgstr "lokaler Zeit-Offset größer oder gleich 24 Stunden\n"
 
-#: git-send-email.perl:223 git-send-email.perl:229
+#: git-send-email.perl:222
+#, perl-format
+msgid "fatal: command '%s' died with exit code %d"
+msgstr ""
+
+#: git-send-email.perl:235
 msgid "the editor exited uncleanly, aborting everything"
 msgstr "Der Editor wurde unsauber beendet, breche alles ab."
 
-#: git-send-email.perl:312
+#: git-send-email.perl:321
 #, perl-format
 msgid ""
 "'%s' contains an intermediate version of the email you were composing.\n"
 msgstr ""
 "'%s' enthält eine Zwischenversion der E-Mail, die Sie gerade verfassen.\n"
 
-#: git-send-email.perl:317
+#: git-send-email.perl:326
 #, perl-format
 msgid "'%s.final' contains the composed email.\n"
 msgstr "'%s.final' enthält die verfasste E-Mail.\n"
 
-#: git-send-email.perl:410
+#: git-send-email.perl:419
 msgid "--dump-aliases incompatible with other options\n"
 msgstr "--dump-aliases ist mit anderen Optionen inkompatibel\n"
 
-#: git-send-email.perl:484
+#: git-send-email.perl:493
 msgid ""
 "fatal: found configuration options for 'sendmail'\n"
 "git-send-email is configured with the sendemail.* options - note the 'e'.\n"
@@ -26139,12 +26644,12 @@ msgstr ""
 "Setzen Sie sendemail.forbidSendmailVariables auf 'false', um diese Prüfung "
 "zu deaktivieren.\n"
 
-#: git-send-email.perl:489 git-send-email.perl:691
+#: git-send-email.perl:498 git-send-email.perl:700
 msgid "Cannot run git format-patch from outside a repository\n"
 msgstr ""
 "Kann 'git format-patch' nicht außerhalb eines Repositories ausführen.\n"
 
-#: git-send-email.perl:492
+#: git-send-email.perl:501
 msgid ""
 "`batch-size` and `relogin` must be specified together (via command-line or "
 "configuration option)\n"
@@ -26153,38 +26658,38 @@ msgstr ""
 "Kommandozeile\n"
 "oder Konfigurationsoption)\n"
 
-#: git-send-email.perl:505
+#: git-send-email.perl:514
 #, perl-format
 msgid "Unknown --suppress-cc field: '%s'\n"
 msgstr "Unbekanntes --suppress-cc Feld: '%s'\n"
 
-#: git-send-email.perl:536
+#: git-send-email.perl:545
 #, perl-format
 msgid "Unknown --confirm setting: '%s'\n"
 msgstr "Unbekannte --confirm Einstellung: '%s'\n"
 
-#: git-send-email.perl:564
+#: git-send-email.perl:573
 #, perl-format
 msgid "warning: sendmail alias with quotes is not supported: %s\n"
 msgstr ""
 "Warnung: sendemail-Alias mit Anführungszeichen wird nicht unterstützt: %s\n"
 
-#: git-send-email.perl:566
+#: git-send-email.perl:575
 #, perl-format
 msgid "warning: `:include:` not supported: %s\n"
 msgstr "Warnung: `:include:` wird nicht unterstützt: %s\n"
 
-#: git-send-email.perl:568
+#: git-send-email.perl:577
 #, perl-format
 msgid "warning: `/file` or `|pipe` redirection not supported: %s\n"
 msgstr "Warnung: `/file` oder `|pipe` Umleitung wird nicht unterstützt: %s\n"
 
-#: git-send-email.perl:573
+#: git-send-email.perl:582
 #, perl-format
 msgid "warning: sendmail line is not recognized: %s\n"
 msgstr "Warnung: sendmail Zeile wird nicht erkannt: %s\n"
 
-#: git-send-email.perl:657
+#: git-send-email.perl:666
 #, perl-format
 msgid ""
 "File '%s' exists but it could also be the range of commits\n"
@@ -26201,21 +26706,12 @@ msgstr ""
 "    * die Option --format-patch angeben, wenn Sie einen Commit-Bereich "
 "meinen.\n"
 
-#: git-send-email.perl:678
+#: git-send-email.perl:687
 #, perl-format
 msgid "Failed to opendir %s: %s"
 msgstr "Fehler beim Öffnen von %s: %s"
 
-#: git-send-email.perl:702
-#, perl-format
-msgid ""
-"fatal: %s: %s\n"
-"warning: no patches were sent\n"
-msgstr ""
-"fatal: %s: %s\n"
-"Warnung: Es wurden keine Patches versendet\n"
-
-#: git-send-email.perl:713
+#: git-send-email.perl:720
 msgid ""
 "\n"
 "No patch files specified!\n"
@@ -26225,17 +26721,17 @@ msgstr ""
 "Keine Patch-Dateien angegeben!\n"
 "\n"
 
-#: git-send-email.perl:726
+#: git-send-email.perl:733
 #, perl-format
 msgid "No subject line in %s?"
 msgstr "Keine Betreffzeile in %s?"
 
-#: git-send-email.perl:736
+#: git-send-email.perl:743
 #, perl-format
 msgid "Failed to open for writing %s: %s"
 msgstr "Fehler beim Öffnen von '%s' zum Schreiben: %s"
 
-#: git-send-email.perl:747
+#: git-send-email.perl:754
 msgid ""
 "Lines beginning in \"GIT:\" will be removed.\n"
 "Consider including an overall diffstat or table of contents\n"
@@ -26250,27 +26746,27 @@ msgstr ""
 "Leeren Sie den Inhalt des Bodys, wenn Sie keine Zusammenfassung senden "
 "möchten.\n"
 
-#: git-send-email.perl:771
+#: git-send-email.perl:778
 #, perl-format
 msgid "Failed to open %s: %s"
 msgstr "Fehler beim Öffnen von %s: %s"
 
-#: git-send-email.perl:788
+#: git-send-email.perl:795
 #, perl-format
 msgid "Failed to open %s.final: %s"
 msgstr "Fehler beim Öffnen von %s.final: %s"
 
-#: git-send-email.perl:831
+#: git-send-email.perl:838
 msgid "Summary email is empty, skipping it\n"
 msgstr "E-Mail mit Zusammenfassung ist leer, wird ausgelassen\n"
 
 #. TRANSLATORS: please keep [y/N] as is.
-#: git-send-email.perl:866
+#: git-send-email.perl:873
 #, perl-format
 msgid "Are you sure you want to use <%s> [y/N]? "
 msgstr "Sind Sie sich sicher, <%s> zu benutzen [y/N]? "
 
-#: git-send-email.perl:921
+#: git-send-email.perl:928
 msgid ""
 "The following files are 8bit, but do not declare a Content-Transfer-"
 "Encoding.\n"
@@ -26278,11 +26774,11 @@ msgstr ""
 "Die folgenden Dateien sind 8-Bit, aber deklarieren kein\n"
 "Content-Transfer-Encoding.\n"
 
-#: git-send-email.perl:926
+#: git-send-email.perl:933
 msgid "Which 8bit encoding should I declare [UTF-8]? "
 msgstr "Welches 8-Bit-Encoding soll deklariert werden [UTF-8]? "
 
-#: git-send-email.perl:934
+#: git-send-email.perl:941
 #, perl-format
 msgid ""
 "Refusing to send because the patch\n"
@@ -26296,22 +26792,22 @@ msgstr ""
 "an,\n"
 "wenn Sie den Patch wirklich versenden wollen.\n"
 
-#: git-send-email.perl:953
+#: git-send-email.perl:960
 msgid "To whom should the emails be sent (if anyone)?"
 msgstr "An wen sollen die E-Mails versendet werden (wenn überhaupt jemand)?"
 
-#: git-send-email.perl:971
+#: git-send-email.perl:978
 #, perl-format
 msgid "fatal: alias '%s' expands to itself\n"
 msgstr "fatal: Alias '%s' erweitert sich zu sich selbst\n"
 
-#: git-send-email.perl:983
+#: git-send-email.perl:990
 msgid "Message-ID to be used as In-Reply-To for the first email (if any)? "
 msgstr ""
 "Message-ID zur Verwendung als In-Reply-To für die erste E-Mail (wenn eine "
 "existiert)? "
 
-#: git-send-email.perl:1041 git-send-email.perl:1049
+#: git-send-email.perl:1048 git-send-email.perl:1056
 #, perl-format
 msgid "error: unable to extract a valid address from: %s\n"
 msgstr "Fehler: konnte keine gültige Adresse aus %s extrahieren\n"
@@ -26319,18 +26815,18 @@ msgstr "Fehler: konnte keine gültige Adresse aus %s extrahieren\n"
 #. TRANSLATORS: Make sure to include [q] [d] [e] in your
 #. translation. The program will only accept English input
 #. at this point.
-#: git-send-email.perl:1053
+#: git-send-email.perl:1060
 msgid "What to do with this address? ([q]uit|[d]rop|[e]dit): "
 msgstr ""
 "Was soll mit dieser Adresse geschehen? (Beenden [q]|Löschen [d]|Bearbeiten "
 "[e]): "
 
-#: git-send-email.perl:1370
+#: git-send-email.perl:1377
 #, perl-format
 msgid "CA path \"%s\" does not exist"
 msgstr "CA Pfad \"%s\" existiert nicht"
 
-#: git-send-email.perl:1453
+#: git-send-email.perl:1460
 msgid ""
 "    The Cc list above has been expanded by additional\n"
 "    addresses found in the patch commit message. By default\n"
@@ -26359,133 +26855,147 @@ msgstr ""
 #. TRANSLATORS: Make sure to include [y] [n] [e] [q] [a] in your
 #. translation. The program will only accept English input
 #. at this point.
-#: git-send-email.perl:1468
+#: git-send-email.perl:1475
 msgid "Send this email? ([y]es|[n]o|[e]dit|[q]uit|[a]ll): "
 msgstr ""
 "Diese E-Mail versenden? (Ja [y]|Nein [n]|Bearbeiten [e]|Beenden [q]|Alle "
 "[a]): "
 
-#: git-send-email.perl:1471
+#: git-send-email.perl:1478
 msgid "Send this email reply required"
 msgstr "Zum Versenden dieser E-Mail ist eine Antwort erforderlich."
 
-#: git-send-email.perl:1499
+#: git-send-email.perl:1506
 msgid "The required SMTP server is not properly defined."
 msgstr "Der erforderliche SMTP-Server ist nicht korrekt definiert."
 
-#: git-send-email.perl:1546
+#: git-send-email.perl:1553
 #, perl-format
 msgid "Server does not support STARTTLS! %s"
 msgstr "Server unterstützt kein STARTTLS! %s"
 
-#: git-send-email.perl:1551 git-send-email.perl:1555
+#: git-send-email.perl:1558 git-send-email.perl:1562
 #, perl-format
 msgid "STARTTLS failed! %s"
 msgstr "STARTTLS fehlgeschlagen! %s"
 
-#: git-send-email.perl:1564
+#: git-send-email.perl:1571
 msgid "Unable to initialize SMTP properly. Check config and use --smtp-debug."
 msgstr ""
 "Konnte SMTP nicht korrekt initialisieren. Bitte prüfen Sie Ihre "
 "Konfiguration\n"
 "und benutzen Sie --smtp-debug."
 
-#: git-send-email.perl:1582
+#: git-send-email.perl:1589
 #, perl-format
 msgid "Failed to send %s\n"
 msgstr "Fehler beim Senden %s\n"
 
-#: git-send-email.perl:1585
+#: git-send-email.perl:1592
 #, perl-format
 msgid "Dry-Sent %s\n"
 msgstr "Probeversand %s\n"
 
-#: git-send-email.perl:1585
+#: git-send-email.perl:1592
 #, perl-format
 msgid "Sent %s\n"
 msgstr "%s gesendet\n"
 
-#: git-send-email.perl:1587
+#: git-send-email.perl:1594
 msgid "Dry-OK. Log says:\n"
 msgstr "Probeversand OK. Log enthält:\n"
 
-#: git-send-email.perl:1587
+#: git-send-email.perl:1594
 msgid "OK. Log says:\n"
 msgstr "OK. Log enthält:\n"
 
-#: git-send-email.perl:1599
+#: git-send-email.perl:1606
 msgid "Result: "
 msgstr "Ergebnis: "
 
-#: git-send-email.perl:1602
+#: git-send-email.perl:1609
 msgid "Result: OK\n"
 msgstr "Ergebnis: OK\n"
 
-#: git-send-email.perl:1620
+#: git-send-email.perl:1627
 #, perl-format
 msgid "can't open file %s"
 msgstr "Kann Datei %s nicht öffnen"
 
-#: git-send-email.perl:1667 git-send-email.perl:1687
+#: git-send-email.perl:1674 git-send-email.perl:1694
 #, perl-format
 msgid "(mbox) Adding cc: %s from line '%s'\n"
 msgstr "(mbox) Füge cc: hinzu: %s von Zeile '%s'\n"
 
-#: git-send-email.perl:1673
+#: git-send-email.perl:1680
 #, perl-format
 msgid "(mbox) Adding to: %s from line '%s'\n"
 msgstr "(mbox) Füge to: hinzu: %s von Zeile '%s'\n"
 
-#: git-send-email.perl:1730
+#: git-send-email.perl:1737
 #, perl-format
 msgid "(non-mbox) Adding cc: %s from line '%s'\n"
 msgstr "(non-mbox) Füge cc: hinzu: %s von Zeile '%s'\n"
 
-#: git-send-email.perl:1765
+#: git-send-email.perl:1772
 #, perl-format
 msgid "(body) Adding cc: %s from line '%s'\n"
 msgstr "(body) Füge cc: hinzu: %s von Zeile '%s'\n"
 
-#: git-send-email.perl:1876
+#: git-send-email.perl:1883
 #, perl-format
 msgid "(%s) Could not execute '%s'"
 msgstr "(%s) Konnte '%s' nicht ausführen"
 
-#: git-send-email.perl:1883
+#: git-send-email.perl:1890
 #, perl-format
 msgid "(%s) Adding %s: %s from: '%s'\n"
 msgstr "(%s) Füge %s: %s hinzu von: '%s'\n"
 
-#: git-send-email.perl:1887
+#: git-send-email.perl:1894
 #, perl-format
 msgid "(%s) failed to close pipe to '%s'"
 msgstr "(%s) Fehler beim Schließen der Pipe nach '%s'"
 
-#: git-send-email.perl:1917
+#: git-send-email.perl:1924
 msgid "cannot send message as 7bit"
 msgstr "Kann Nachricht nicht als 7bit versenden."
 
-#: git-send-email.perl:1925
+#: git-send-email.perl:1932
 msgid "invalid transfer encoding"
 msgstr "Ungültiges Transfer-Encoding"
 
-#: git-send-email.perl:1966 git-send-email.perl:2018 git-send-email.perl:2028
+#: git-send-email.perl:1966
+#, fuzzy, perl-format
+msgid ""
+"fatal: %s: rejected by sendemail-validate hook\n"
+"%s\n"
+"warning: no patches were sent\n"
+msgstr ""
+"fatal: %s: %s\n"
+"Warnung: Es wurden keine Patches versendet\n"
+
+#: git-send-email.perl:1976 git-send-email.perl:2029 git-send-email.perl:2039
 #, perl-format
 msgid "unable to open %s: %s\n"
 msgstr "konnte %s nicht öffnen: %s\n"
 
-#: git-send-email.perl:1969
-#, perl-format
-msgid "%s: patch contains a line longer than 998 characters"
-msgstr "%s: Patch enthält eine Zeile, die länger als 998 Zeichen ist"
+#: git-send-email.perl:1979
+#, fuzzy, perl-format
+msgid ""
+"fatal: %s:%d is longer than 998 characters\n"
+"warning: no patches were sent\n"
+msgstr ""
+"fatal: %s: %s\n"
+"Warnung: Es wurden keine Patches versendet\n"
 
-#: git-send-email.perl:1986
+#: git-send-email.perl:1997
 #, perl-format
 msgid "Skipping %s with backup suffix '%s'.\n"
 msgstr "Lasse %s mit Backup-Suffix '%s' aus.\n"
 
 #. TRANSLATORS: please keep "[y|N]" as is.
-#: git-send-email.perl:1990
+#: git-send-email.perl:2001
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Wollen Sie %s wirklich versenden? [y|N]: "


### PR DESCRIPTION
@ralfth and @PhillipSz: please have a look at my suggestions for the German translation of Git v2.32.0. Only the commit 77434b6492 needs to be reviewed, the first commit is the automatically generated one to update the po file.

I had some troubles with "squash" and "sparse-index" as it is translated differently depending on the context. I want to establish "Squash-Merge" as a preferred German translation for "squash" as it is also used here: https://www.atlassian.com/de/git/tutorials/using-branches/merge-strategy

As always I also cleaned up some other translations that were not related to the current update. Some of these changes are proposed as best practises by the software poedit (which is also used by some other translation teams).