### PR TITLE
Review: Update German translation for Git v2.34.0

### DIFF
--- a/Documentation/RelNotes/2.34.0.txt
+++ b/Documentation/RelNotes/2.34.0.txt
@@ -383,7 +383,7 @@ Fixes since v2.33
    compression level for both zip and tar.gz format.
    (merge c4b208c309 bs/archive-doc-compression-level later to maint).
 
- * Drop "git sparse-index" from the list of common commands.
+ * Drop "git sparse-checkout" from the list of common commands.
    (merge 6a9a50a8af sg/sparse-index-not-that-common-a-command later to maint).
 
  * "git branch -c/-m new old" was not described to copy config, which

--- a/Documentation/RelNotes/2.34.0.txt
+++ b/Documentation/RelNotes/2.34.0.txt
@@ -401,6 +401,13 @@ Fixes since v2.33
    object replacement.
    (merge 095d112f8c ab/ignore-replace-while-working-on-commit-graph later to maint).
 
+ * "git pull --no-verify" did not affect the underlying "git merge".
+   (merge 47bfdfb3fd ar/fix-git-pull-no-verify later to maint).
+
+ * One CI task based on Fedora image noticed a not-quite-kosher
+   consturct recently, which has been corrected.
+   (merge 4b540cf913 vd/pthread-setspecific-g11-fix later to maint).
+
  * Other code cleanup, docfix, build fix, etc.
    (merge f188160be9 ab/bundle-remove-verbose-option later to maint).
    (merge 8c6b4332b4 rs/close-pack-leakfix later to maint).

--- a/Documentation/git-commit.txt
+++ b/Documentation/git-commit.txt
@@ -212,8 +212,9 @@ include::signoff-option.txt[]
 	each trailer would appear, and other details.
 
 -n::
---no-verify::
-	This option bypasses the pre-commit and commit-msg hooks.
+--[no-]verify::
+	By default, the pre-commit and commit-msg hooks are run.
+	When any of `--no-verify` or `-n` is given, these are bypassed.
 	See also linkgit:githooks[5].
 
 --allow-empty::

--- a/Documentation/merge-options.txt
+++ b/Documentation/merge-options.txt
@@ -132,8 +132,9 @@ ifdef::git-pull[]
 Only useful when merging.
 endif::git-pull[]
 
---no-verify::
-	This option bypasses the pre-merge and commit-msg hooks.
+--[no-]verify::
+	By default, the pre-merge and commit-msg hooks are run.
+	When `--no-verify` is given, these are bypassed.
 	See also linkgit:githooks[5].
 ifdef::git-pull[]
 	Only useful when merging.

--- a/GIT-VERSION-GEN
+++ b/GIT-VERSION-GEN
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 GVF=GIT-VERSION-FILE
-DEF_VER=v2.34.0-rc1
+DEF_VER=v2.34.0-rc2
 
 LF='
 '

--- a/builtin/pull.c
+++ b/builtin/pull.c
@@ -84,6 +84,7 @@ static char *opt_edit;
 static char *cleanup_arg;
 static char *opt_ff;
 static char *opt_verify_signatures;
+static char *opt_verify;
 static int opt_autostash = -1;
 static int config_autostash;
 static int check_trust_level = 1;
@@ -160,6 +161,9 @@ static struct option pull_options[] = {
 	OPT_PASSTHRU(0, "ff-only", &opt_ff, NULL,
 		N_("abort if fast-forward is not possible"),
 		PARSE_OPT_NOARG | PARSE_OPT_NONEG),
+	OPT_PASSTHRU(0, "verify", &opt_verify, NULL,
+		N_("control use of pre-merge-commit and commit-msg hooks"),
+		PARSE_OPT_NOARG),
 	OPT_PASSTHRU(0, "verify-signatures", &opt_verify_signatures, NULL,
 		N_("verify that the named commit has a valid GPG signature"),
 		PARSE_OPT_NOARG),
@@ -675,6 +679,8 @@ static int run_merge(void)
 		strvec_pushf(&args, "--cleanup=%s", cleanup_arg);
 	if (opt_ff)
 		strvec_push(&args, opt_ff);
+	if (opt_verify)
+		strvec_push(&args, opt_verify);
 	if (opt_verify_signatures)
 		strvec_push(&args, opt_verify_signatures);
 	strvec_pushv(&args, opt_strategies.v);

--- a/http-backend.c
+++ b/http-backend.c
@@ -466,9 +466,7 @@ static void run_service(const char **argv, int buffer_input)
 	struct child_process cld = CHILD_PROCESS_INIT;
 	ssize_t req_len = get_content_length();
 
-	if (encoding && !strcmp(encoding, "gzip"))
-		gzipped_request = 1;
-	else if (encoding && !strcmp(encoding, "x-gzip"))
+	if (encoding && (!strcmp(encoding, "gzip") || !strcmp(encoding, "x-gzip")))
 		gzipped_request = 1;
 
 	if (!user || !*user)

--- a/parse-options.c
+++ b/parse-options.c
@@ -860,11 +860,11 @@ int parse_options_end(struct parse_opt_ctx_t *ctx)
 	return ctx->cpidx + ctx->argc;
 }
 
-enum parse_opt_result parse_options(int argc, const char **argv,
-				    const char *prefix,
-				    const struct option *options,
-				    const char * const usagestr[],
-				    enum parse_opt_flags flags)
+int parse_options(int argc, const char **argv,
+		  const char *prefix,
+		  const struct option *options,
+		  const char * const usagestr[],
+		  enum parse_opt_flags flags)
 {
 	struct parse_opt_ctx_t ctx;
 	struct option *real_options;

--- a/parse-options.h
+++ b/parse-options.h
@@ -211,11 +211,10 @@ struct option {
  * untouched and parse_options() returns the number of options
  * processed.
  */
-enum parse_opt_result parse_options(int argc, const char **argv,
-				    const char *prefix,
-				    const struct option *options,
-				    const char * const usagestr[],
-				    enum parse_opt_flags flags);
+int parse_options(int argc, const char **argv, const char *prefix,
+		  const struct option *options,
+		  const char * const usagestr[],
+		  enum parse_opt_flags flags);
 
 NORETURN void usage_with_options(const char * const *usagestr,
 				 const struct option *options);

--- a/po/bg.po
+++ b/po/bg.po
@@ -62,6 +62,7 @@
 # fallback резервен вариант
 # pathspec magic опция за магически пътища
 # bitmap index индекс на база битови маски
+# multi-pack bitmap многопакетната битова маска
 # mark маркер
 # plumbing команди от системно ниво
 # porcelain команди от потребителско ниво
@@ -143,9 +144,10 @@
 # blame извеждане на авторство
 # refname име на указател
 # cone pattern matching пътеводно напасване
+# sparse-checkout cone пътеводен сегмент на частичното изтегляне
 # negative pattern отрицателен шаблон
 # colored hunk/diff оцветено парче/разлика
-# up to date обновен, освен като самостотелва дума - актуален или completely up to date - напълно актуален
+# up to date обновен, освен като самостоятелна дума - актуален или completely up to date - напълно актуален
 # stateless без запазване на състоянието
 # end packet пакет за край
 # identity самоличност, информация за
@@ -157,8 +159,10 @@
 # expired остарял
 # reroll-count номер на редакция
 # Nth re-roll N-та поредна редакция
-# fetch доставам
+# fetch доставям
 # prefetch предварително доставяне
+# scheduler планиращ модул
+# snapshot снимка
 # ------------------------
 # „$var“ - може да не сработва за shell има gettext и eval_gettext - проверка - намират се лесно по „$
 # ------------------------
@@ -175,10 +179,10 @@
 # for i in `sort -u FILES`; do cnt=`grep $i FILES | wc -l`; echo $cnt $i ;done | sort -n
 msgid ""
 msgstr ""
-"Project-Id-Version: git 2.31\n"
+"Project-Id-Version: git 2.34\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-08-14 07:56+0800\n"
-"PO-Revision-Date: 2021-08-21 18:19+0200\n"
+"POT-Creation-Date: 2021-11-04 08:34+0800\n"
+"PO-Revision-Date: 2021-11-06 12:17+0100\n"
 "Last-Translator: Alexander Shopov <ash@kambanaria.org>\n"
 "Language-Team: Bulgarian <dict@fsa-bg.org>\n"
 "Language: bg\n"
@@ -187,214 +191,214 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: add-interactive.c:376
+#: add-interactive.c:380
 #, c-format
 msgid "Huh (%s)?"
 msgstr "Неуспешен анализ — „%s“."
 
-#: add-interactive.c:529 add-interactive.c:830 reset.c:64 sequencer.c:3493
-#: sequencer.c:3964 sequencer.c:4119 builtin/rebase.c:1528
-#: builtin/rebase.c:1953
+#: add-interactive.c:533 add-interactive.c:834 reset.c:65 sequencer.c:3512
+#: sequencer.c:3979 sequencer.c:4141 builtin/rebase.c:1233
+#: builtin/rebase.c:1642
 msgid "could not read index"
 msgstr "индексът не може да бъде прочетен"
 
-#: add-interactive.c:584 git-add--interactive.perl:269
+#: add-interactive.c:588 git-add--interactive.perl:269
 #: git-add--interactive.perl:294
 msgid "binary"
 msgstr "двоично"
 
-#: add-interactive.c:642 git-add--interactive.perl:278
+#: add-interactive.c:646 git-add--interactive.perl:278
 #: git-add--interactive.perl:332
 msgid "nothing"
 msgstr "нищо"
 
-#: add-interactive.c:643 git-add--interactive.perl:314
+#: add-interactive.c:647 git-add--interactive.perl:314
 #: git-add--interactive.perl:329
 msgid "unchanged"
 msgstr "няма промени"
 
-#: add-interactive.c:680 git-add--interactive.perl:641
+#: add-interactive.c:684 git-add--interactive.perl:641
 msgid "Update"
 msgstr "Обновяване"
 
-#: add-interactive.c:697 add-interactive.c:885
+#: add-interactive.c:701 add-interactive.c:889
 #, c-format
 msgid "could not stage '%s'"
 msgstr "неуспешно добавяне в индекса на „%s“"
 
-#: add-interactive.c:703 add-interactive.c:892 reset.c:88 sequencer.c:3707
+#: add-interactive.c:707 add-interactive.c:896 reset.c:89 sequencer.c:3718
 msgid "could not write index"
 msgstr "индексът не може да бъде записан"
 
-#: add-interactive.c:706 git-add--interactive.perl:626
+#: add-interactive.c:710 git-add--interactive.perl:626
 #, c-format, perl-format
 msgid "updated %d path\n"
 msgid_plural "updated %d paths\n"
 msgstr[0] "%d файл обновен\n"
 msgstr[1] "%d файла обновени\n"
 
-#: add-interactive.c:724 git-add--interactive.perl:676
+#: add-interactive.c:728 git-add--interactive.perl:676
 #, c-format, perl-format
 msgid "note: %s is untracked now.\n"
 msgstr "БЕЛЕЖКА: „%s“ вече не се следи.\n"
 
-#: add-interactive.c:729 apply.c:4127 builtin/checkout.c:298
-#: builtin/reset.c:145
+#: add-interactive.c:733 apply.c:4149 builtin/checkout.c:298
+#: builtin/reset.c:151
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
 msgstr "неуспешно създаване на запис в кеша чрез „make_cache_entry“ за „%s“"
 
-#: add-interactive.c:759 git-add--interactive.perl:653
+#: add-interactive.c:763 git-add--interactive.perl:653
 msgid "Revert"
 msgstr "Отмяна"
 
-#: add-interactive.c:775
+#: add-interactive.c:779
 msgid "Could not parse HEAD^{tree}"
 msgstr "Указателят „HEAD^{tree}“ не може да бъде анализиран"
 
-#: add-interactive.c:813 git-add--interactive.perl:629
+#: add-interactive.c:817 git-add--interactive.perl:629
 #, c-format, perl-format
 msgid "reverted %d path\n"
 msgid_plural "reverted %d paths\n"
 msgstr[0] "%d файл с отменени промени\n"
 msgstr[1] "%d файла с отменени промени\n"
 
-#: add-interactive.c:864 git-add--interactive.perl:693
+#: add-interactive.c:868 git-add--interactive.perl:693
 #, c-format
 msgid "No untracked files.\n"
 msgstr "Няма неследени файлове.\n"
 
-#: add-interactive.c:868 git-add--interactive.perl:687
+#: add-interactive.c:872 git-add--interactive.perl:687
 msgid "Add untracked"
 msgstr "Добавяне на неследени"
 
-#: add-interactive.c:895 git-add--interactive.perl:623
+#: add-interactive.c:899 git-add--interactive.perl:623
 #, c-format, perl-format
 msgid "added %d path\n"
 msgid_plural "added %d paths\n"
 msgstr[0] "%d файл добавен\n"
 msgstr[1] "%d файла добавени\n"
 
-#: add-interactive.c:925
+#: add-interactive.c:929
 #, c-format
 msgid "ignoring unmerged: %s"
 msgstr "пренебрегване на неслятото: „%s“"
 
-#: add-interactive.c:937 add-patch.c:1752 git-add--interactive.perl:1369
+#: add-interactive.c:941 add-patch.c:1752 git-add--interactive.perl:1369
 #, c-format
 msgid "Only binary files changed.\n"
 msgstr "Само двоични файлове са променени.\n"
 
-#: add-interactive.c:939 add-patch.c:1750 git-add--interactive.perl:1371
+#: add-interactive.c:943 add-patch.c:1750 git-add--interactive.perl:1371
 #, c-format
 msgid "No changes.\n"
 msgstr "Няма промени.\n"
 
-#: add-interactive.c:943 git-add--interactive.perl:1379
+#: add-interactive.c:947 git-add--interactive.perl:1379
 msgid "Patch update"
 msgstr "Обновяване на кръпка"
 
-#: add-interactive.c:982 git-add--interactive.perl:1792
+#: add-interactive.c:986 git-add--interactive.perl:1792
 msgid "Review diff"
 msgstr "Преглед на разликата"
 
-#: add-interactive.c:1010
+#: add-interactive.c:1014
 msgid "show paths with changes"
 msgstr "извеждане на пътищата с промени"
 
-#: add-interactive.c:1012
+#: add-interactive.c:1016
 msgid "add working tree state to the staged set of changes"
 msgstr "добавяне на състоянието на работното дърво към промените в индекса"
 
-#: add-interactive.c:1014
+#: add-interactive.c:1018
 msgid "revert staged set of changes back to the HEAD version"
 msgstr "връщане на състоянието на индекса към соченото от „HEAD“"
 
-#: add-interactive.c:1016
+#: add-interactive.c:1020
 msgid "pick hunks and update selectively"
 msgstr "интерактивни избор и промяна на парчета код"
 
-#: add-interactive.c:1018
+#: add-interactive.c:1022
 msgid "view diff between HEAD and index"
 msgstr "разлика между соченото от „HEAD“ и индекса"
 
-#: add-interactive.c:1020
+#: add-interactive.c:1024
 msgid "add contents of untracked files to the staged set of changes"
 msgstr "добавяне на съдържанието на неследените файлове към индекса"
 
-#: add-interactive.c:1028 add-interactive.c:1077
+#: add-interactive.c:1032 add-interactive.c:1081
 msgid "Prompt help:"
 msgstr "Помощ:"
 
-#: add-interactive.c:1030
+#: add-interactive.c:1034
 msgid "select a single item"
 msgstr "избор на eдин елемент"
 
-#: add-interactive.c:1032
+#: add-interactive.c:1036
 msgid "select a range of items"
 msgstr "избор на поредица от елементи"
 
-#: add-interactive.c:1034
+#: add-interactive.c:1038
 msgid "select multiple ranges"
 msgstr "избор на няколко поредици от елементи"
 
-#: add-interactive.c:1036 add-interactive.c:1081
+#: add-interactive.c:1040 add-interactive.c:1085
 msgid "select item based on unique prefix"
 msgstr "избор на базата на уникален префикс"
 
-#: add-interactive.c:1038
+#: add-interactive.c:1042
 msgid "unselect specified items"
 msgstr "изваждане на указаното от избора"
 
-#: add-interactive.c:1040
+#: add-interactive.c:1044
 msgid "choose all items"
 msgstr "избор на всички елементи"
 
-#: add-interactive.c:1042
+#: add-interactive.c:1046
 msgid "(empty) finish selecting"
 msgstr "(празно) приключване на избирането"
 
-#: add-interactive.c:1079
+#: add-interactive.c:1083
 msgid "select a numbered item"
 msgstr "избор на номериран елемент"
 
-#: add-interactive.c:1083
+#: add-interactive.c:1087
 msgid "(empty) select nothing"
 msgstr "(празно) без избор на нищо"
 
-#: add-interactive.c:1091 builtin/clean.c:813 git-add--interactive.perl:1896
+#: add-interactive.c:1095 builtin/clean.c:813 git-add--interactive.perl:1896
 msgid "*** Commands ***"
 msgstr "●●● Команди ●●●"
 
-#: add-interactive.c:1092 builtin/clean.c:814 git-add--interactive.perl:1893
+#: add-interactive.c:1096 builtin/clean.c:814 git-add--interactive.perl:1893
 msgid "What now"
 msgstr "Избор на следващо действие"
 
-#: add-interactive.c:1144 git-add--interactive.perl:213
+#: add-interactive.c:1148 git-add--interactive.perl:213
 msgid "staged"
 msgstr "в индекса"
 
-#: add-interactive.c:1144 git-add--interactive.perl:213
+#: add-interactive.c:1148 git-add--interactive.perl:213
 msgid "unstaged"
 msgstr "извън индекса"
 
-#: add-interactive.c:1144 apply.c:4994 apply.c:4997 builtin/am.c:2309
-#: builtin/am.c:2312 builtin/bugreport.c:135 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:285 builtin/pull.c:190
-#: builtin/submodule--helper.c:410 builtin/submodule--helper.c:1886
-#: builtin/submodule--helper.c:1889 builtin/submodule--helper.c:2343
-#: builtin/submodule--helper.c:2346 builtin/submodule--helper.c:2589
-#: builtin/submodule--helper.c:2890 builtin/submodule--helper.c:2893
+#: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
+#: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
+#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:190
+#: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
+#: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
+#: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
+#: builtin/submodule--helper.c:2578 builtin/submodule--helper.c:2811
 #: git-add--interactive.perl:213
 msgid "path"
 msgstr "път"
 
-#: add-interactive.c:1151
+#: add-interactive.c:1155
 msgid "could not refresh index"
 msgstr "индексът не може да бъде обновен"
 
 #
-#: add-interactive.c:1165 builtin/clean.c:778 git-add--interactive.perl:1803
+#: add-interactive.c:1169 builtin/clean.c:778 git-add--interactive.perl:1803
 #, c-format
 msgid "Bye.\n"
 msgstr "Изход.\n"
@@ -928,7 +932,7 @@ msgstr "Това парче не може да бъде редактирано"
 msgid "'git apply' failed"
 msgstr "неуспешно изпълнение на „git apply“"
 
-#: advice.c:145
+#: advice.c:78
 #, c-format
 msgid ""
 "\n"
@@ -938,37 +942,37 @@ msgstr ""
 "За да изключите това предупреждение, изпълнете:\n"
 "    git config advice.%s false"
 
-#: advice.c:161
+#: advice.c:94
 #, c-format
 msgid "%shint: %.*s%s\n"
 msgstr "%sподсказка: %.*s%s\n"
 
-#: advice.c:252
+#: advice.c:178
 msgid "Cherry-picking is not possible because you have unmerged files."
 msgstr "Отбирането на подавания е блокирано от неслети файлове."
 
-#: advice.c:254
+#: advice.c:180
 msgid "Committing is not possible because you have unmerged files."
 msgstr "Подаването е блокирано от неслети файлове."
 
-#: advice.c:256
+#: advice.c:182
 msgid "Merging is not possible because you have unmerged files."
 msgstr "Сливането е блокирано от неслети файлове."
 
-#: advice.c:258
+#: advice.c:184
 msgid "Pulling is not possible because you have unmerged files."
 msgstr "Издърпването е блокирано от неслети файлове."
 
-#: advice.c:260
+#: advice.c:186
 msgid "Reverting is not possible because you have unmerged files."
 msgstr "Отмяната е блокирана от неслети файлове."
 
-#: advice.c:262
+#: advice.c:188
 #, c-format
 msgid "It is not possible to %s because you have unmerged files."
 msgstr "Действието „%s“ е блокирано от неслети файлове."
 
-#: advice.c:270
+#: advice.c:196
 msgid ""
 "Fix them up in the work tree, and then use 'git add/rm <file>'\n"
 "as appropriate to mark resolution and make a commit."
@@ -976,40 +980,47 @@ msgstr ""
 "Редактирайте ги в работното дърво, и тогава ползвайте „git add/rm ФАЙЛ“,\n"
 "за да отбележите коригирането им.  След това извършете подаването."
 
-#: advice.c:278
+#: advice.c:204
 msgid "Exiting because of an unresolved conflict."
 msgstr "Изход от програмата заради некоригиран конфликт."
 
-#: advice.c:283 builtin/merge.c:1375
+#: advice.c:209 builtin/merge.c:1379
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "Не сте завършили сливане.  (Указателят „MERGE_HEAD“ съществува)."
 
-#: advice.c:285
+#: advice.c:211
 msgid "Please, commit your changes before merging."
 msgstr "Промените трябва да се подадат преди сливане."
 
-#: advice.c:286
+#: advice.c:212
 msgid "Exiting because of unfinished merge."
 msgstr "Изход от програмата заради незавършено сливане."
 
-#: advice.c:296
+#: advice.c:217
+msgid "Not possible to fast-forward, aborting."
+msgstr "Не може да се извърши превъртане, преустановяване на действието."
+
+#: advice.c:227
 #, c-format
 msgid ""
-"The following pathspecs didn't match any eligible path, but they do match "
-"index\n"
-"entries outside the current sparse checkout:\n"
+"The following paths and/or pathspecs matched paths that exist\n"
+"outside of your sparse-checkout definition, so will not be\n"
+"updated in the index:\n"
 msgstr ""
-"Следните пътища не съвпадат с никой от настроените, но съвпадат с обекти\n"
-"в индекса, които са извън текущото частично изтегляне:\n"
+"Следните пътища напасват с пътища извън дефиницията за частично\n"
+"изтегляне и няма да се обновят в индекса:\n"
 
-#: advice.c:303
+#: advice.c:234
 msgid ""
-"Disable or modify the sparsity rules if you intend to update such entries."
+"If you intend to update such entries, try one of the following:\n"
+"* Use the --sparse option.\n"
+"* Disable or modify the sparsity rules."
 msgstr ""
-"Изключете или променете правилата за частичност, ако искате до обновявате "
-"такива обекти."
+"Ако искате да ги обновите, пробвайте едно от следните:\n"
+"  ⁃ ползвайте опцията „--sparse“\n"
+"  ⁃ изключете или променете правилата за частичност."
 
-#: advice.c:310
+#: advice.c:242
 #, c-format
 msgid ""
 "Note: switching to '%s'.\n"
@@ -1198,37 +1209,37 @@ msgstr "изтритият файл „%s“ не е празен"
 msgid "** warning: file %s becomes empty but is not deleted"
 msgstr "● предупреждение: файлът „%s“ вече е празен, но не е изтрит"
 
-#: apply.c:1977
+#: apply.c:1978
 #, c-format
 msgid "corrupt binary patch at line %d: %.*s"
 msgstr "грешка в двоичната кръпка на ред %d: %.*s"
 
-#: apply.c:2014
+#: apply.c:2015
 #, c-format
 msgid "unrecognized binary patch at line %d"
 msgstr "неразпозната двоичната кръпка на ред %d"
 
-#: apply.c:2176
+#: apply.c:2177
 #, c-format
 msgid "patch with only garbage at line %d"
 msgstr "кръпката е с изцяло повредени данни на ред %d"
 
-#: apply.c:2262
+#: apply.c:2263
 #, c-format
 msgid "unable to read symlink %s"
 msgstr "символната връзка „%s“ не може да бъде прочетена"
 
-#: apply.c:2266
+#: apply.c:2267
 #, c-format
 msgid "unable to open or read %s"
 msgstr "файлът „%s“ не може да бъде отворен или прочетен"
 
-#: apply.c:2935
+#: apply.c:2936
 #, c-format
 msgid "invalid start of line: '%c'"
 msgstr "неправилно начало на ред: „%c“"
 
-#: apply.c:3056
+#: apply.c:3057
 #, c-format
 msgid "Hunk #%d succeeded at %d (offset %d line)."
 msgid_plural "Hunk #%d succeeded at %d (offset %d lines)."
@@ -1237,13 +1248,13 @@ msgstr[0] ""
 msgstr[1] ""
 "%d-то парче код бе успешно приложено на ред %d (отместване от %d реда)."
 
-#: apply.c:3068
+#: apply.c:3069
 #, c-format
 msgid "Context reduced to (%ld/%ld) to apply fragment at %d"
 msgstr ""
 "Контекстът е намален на (%ld/%ld) за прилагането на парчето код на ред %d"
 
-#: apply.c:3074
+#: apply.c:3075
 #, c-format
 msgid ""
 "while searching for:\n"
@@ -1252,316 +1263,317 @@ msgstr ""
 "при търсене за:\n"
 "%.*s"
 
-#: apply.c:3096
+#: apply.c:3097
 #, c-format
 msgid "missing binary patch data for '%s'"
 msgstr "липсват данните за двоичната кръпка за „%s“"
 
-#: apply.c:3104
+#: apply.c:3105
 #, c-format
 msgid "cannot reverse-apply a binary patch without the reverse hunk to '%s'"
 msgstr ""
 "двоичната кръпка не може да се приложи в обратна посока, когато обратното "
 "парче за „%s“ липсва"
 
-#: apply.c:3151
+#: apply.c:3152
 #, c-format
 msgid "cannot apply binary patch to '%s' without full index line"
 msgstr "към „%s“ не може да се приложи двоична кръпка без пълен индекс"
 
-#: apply.c:3162
+#: apply.c:3163
 #, c-format
 msgid ""
 "the patch applies to '%s' (%s), which does not match the current contents."
 msgstr "кръпката съответства на „%s“ (%s), който не съвпада по съдържание."
 
-#: apply.c:3170
+#: apply.c:3171
 #, c-format
 msgid "the patch applies to an empty '%s' but it is not empty"
 msgstr "кръпката съответства на „%s“, който трябва да е празен, но не е"
 
-#: apply.c:3188
+#: apply.c:3189
 #, c-format
 msgid "the necessary postimage %s for '%s' cannot be read"
 msgstr ""
 "необходимият резултат след операцията  — „%s“ за „%s“ не може да бъде "
 "прочетен"
 
-#: apply.c:3201
+#: apply.c:3202
 #, c-format
 msgid "binary patch does not apply to '%s'"
 msgstr "двоичната кръпка не може да бъде приложена върху „%s“"
 
-#: apply.c:3208
+#: apply.c:3209
 #, c-format
 msgid "binary patch to '%s' creates incorrect result (expecting %s, got %s)"
 msgstr ""
 "двоичната кръпка за „%s“ води до неправилни резултати (очакваше се: „%s“, а "
 "бе получено: „%s“)"
 
-#: apply.c:3229
+#: apply.c:3230
 #, c-format
 msgid "patch failed: %s:%ld"
 msgstr "неуспешно прилагане на кръпка: „%s:%ld“"
 
-#: apply.c:3352
+#: apply.c:3353
 #, c-format
 msgid "cannot checkout %s"
 msgstr "„%s“ не може да се изтегли"
 
-#: apply.c:3404 apply.c:3415 apply.c:3461 midx.c:98 pack-revindex.c:214
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:102 pack-revindex.c:214
 #: setup.c:308
 #, c-format
 msgid "failed to read %s"
 msgstr "файлът „%s“ не може да бъде прочетен"
 
-#: apply.c:3412
+#: apply.c:3413
 #, c-format
 msgid "reading from '%s' beyond a symbolic link"
 msgstr "изчитане на „%s“ след проследяване на символна връзка"
 
-#: apply.c:3441 apply.c:3687
+#: apply.c:3442 apply.c:3709
 #, c-format
 msgid "path %s has been renamed/deleted"
 msgstr "обектът с път „%s“ е преименуван или изтрит"
 
-#: apply.c:3527 apply.c:3702
+#: apply.c:3549 apply.c:3724
 #, c-format
 msgid "%s: does not exist in index"
 msgstr "„%s“ не съществува в индекса"
 
-#: apply.c:3536 apply.c:3710 apply.c:3954
+#: apply.c:3558 apply.c:3732 apply.c:3976
 #, c-format
 msgid "%s: does not match index"
 msgstr "„%s“ не съответства на индекса"
 
-#: apply.c:3571
+#: apply.c:3593
 msgid "repository lacks the necessary blob to perform 3-way merge."
 msgstr "в хранилището липсват необходимите обекти-BLOB, за тройно сливане."
 
-#: apply.c:3574
+#: apply.c:3596
 #, c-format
 msgid "Performing three-way merge...\n"
 msgstr "Тройно сливане…\n"
 
-#: apply.c:3590 apply.c:3594
+#: apply.c:3612 apply.c:3616
 #, c-format
 msgid "cannot read the current contents of '%s'"
 msgstr "текущото съдържание на „%s“ не може да бъде прочетено"
 
-#: apply.c:3606
+#: apply.c:3628
 #, c-format
 msgid "Failed to perform three-way merge...\n"
 msgstr "Неуспешно тройно сливане…\n"
 
-#: apply.c:3620
+#: apply.c:3642
 #, c-format
 msgid "Applied patch to '%s' with conflicts.\n"
 msgstr "Конфликти при прилагането на кръпката към „%s“.\n"
 
-#: apply.c:3625
+#: apply.c:3647
 #, c-format
 msgid "Applied patch to '%s' cleanly.\n"
 msgstr "Кръпката бе приложена чисто към „%s“.\n"
 
-#: apply.c:3642
+#: apply.c:3664
 #, c-format
 msgid "Falling back to direct application...\n"
 msgstr "Преминаване към пряко прилагане…\n"
 
-#: apply.c:3654
+#: apply.c:3676
 msgid "removal patch leaves file contents"
 msgstr "изтриващата кръпка оставя файла непразен"
 
-#: apply.c:3727
+#: apply.c:3749
 #, c-format
 msgid "%s: wrong type"
 msgstr "„%s“: неправилен вид"
 
-#: apply.c:3729
+#: apply.c:3751
 #, c-format
 msgid "%s has type %o, expected %o"
 msgstr "„%s“ е от вид „%o“, а се очакваше „%o“"
 
-#: apply.c:3894 apply.c:3896 read-cache.c:863 read-cache.c:892
-#: read-cache.c:1353
+#: apply.c:3916 apply.c:3918 read-cache.c:876 read-cache.c:905
+#: read-cache.c:1368
 #, c-format
 msgid "invalid path '%s'"
 msgstr "неправилен път: „%s“"
 
-#: apply.c:3952
+#: apply.c:3974
 #, c-format
 msgid "%s: already exists in index"
 msgstr "„%s“: вече съществува в индекса"
 
-#: apply.c:3956
+#: apply.c:3978
 #, c-format
 msgid "%s: already exists in working directory"
 msgstr "„%s“: вече съществува в работното дърво"
 
-#: apply.c:3976
+#: apply.c:3998
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
 msgstr "новите права за достъп (%o) на „%s“ не съвпадат със старите (%o)"
 
-#: apply.c:3981
+#: apply.c:4003
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
 msgstr ""
 "новите права за достъп (%o) на „%s“ не съвпадат със старите (%o) на „%s“"
 
-#: apply.c:4001
+#: apply.c:4023
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
 msgstr "засегнатият файл „%s“ е след символна връзка"
 
-#: apply.c:4005
+#: apply.c:4027
 #, c-format
 msgid "%s: patch does not apply"
 msgstr "Кръпката „%s“ не може да бъде приложена"
 
-#: apply.c:4020
+#: apply.c:4042
 #, c-format
 msgid "Checking patch %s..."
 msgstr "Проверяване на кръпката „%s“…"
 
-#: apply.c:4112
+#: apply.c:4134
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
 msgstr ""
 "информацията за сумата по SHA1 за подмодула липсва или не е достатъчна (%s)."
 
-#: apply.c:4119
+#: apply.c:4141
 #, c-format
 msgid "mode change for %s, which is not in current HEAD"
 msgstr "смяна на режима на достъпа на „%s“, който не е в текущия връх „HEAD“"
 
-#: apply.c:4122
+#: apply.c:4144
 #, c-format
 msgid "sha1 information is lacking or useless (%s)."
 msgstr "информацията за сумата по SHA1 липсва или не е достатъчна (%s)."
 
-#: apply.c:4131
+#: apply.c:4153
 #, c-format
 msgid "could not add %s to temporary index"
 msgstr "„%s“ не може да се добави към временния индекс"
 
-#: apply.c:4141
+#: apply.c:4163
 #, c-format
 msgid "could not write temporary index to %s"
 msgstr "временният индекс не може да се запази в „%s“"
 
-#: apply.c:4279
+#: apply.c:4301
 #, c-format
 msgid "unable to remove %s from index"
 msgstr "„%s“ не може да се извади от индекса"
 
-#: apply.c:4313
+#: apply.c:4335
 #, c-format
 msgid "corrupt patch for submodule %s"
 msgstr "повредена кръпка за модула „%s“"
 
-#: apply.c:4319
+#: apply.c:4341
 #, c-format
 msgid "unable to stat newly created file '%s'"
 msgstr ""
 "не може да се получи информация чрез „stat“ за новосъздадения файл „%s“"
 
-#: apply.c:4327
+#: apply.c:4349
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr ""
 "не може да се за създаде мястото за съхранение на новосъздадения файл „%s“"
 
-#: apply.c:4333 apply.c:4478
+#: apply.c:4355 apply.c:4500
 #, c-format
 msgid "unable to add cache entry for %s"
 msgstr "не може да се добави запис в кеша за „%s“"
 
-#: apply.c:4376 builtin/bisect--helper.c:525
+#: apply.c:4398 builtin/bisect--helper.c:540 builtin/gc.c:2241
+#: builtin/gc.c:2276
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "в „%s“ не може да се пише"
 
-#: apply.c:4380
+#: apply.c:4402
 #, c-format
 msgid "closing file '%s'"
 msgstr "затваряне на файла „%s“"
 
-#: apply.c:4450
+#: apply.c:4472
 #, c-format
 msgid "unable to write file '%s' mode %o"
 msgstr "файлът „%s“ не може да се запише с режим на достъп „%o“"
 
-#: apply.c:4548
+#: apply.c:4570
 #, c-format
 msgid "Applied patch %s cleanly."
 msgstr "Кръпката „%s“ бе приложена чисто."
 
-#: apply.c:4556
+#: apply.c:4578
 msgid "internal error"
 msgstr "вътрешна грешка"
 
-#: apply.c:4559
+#: apply.c:4581
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
 msgstr[0] "Прилагане на кръпката „%%s“ с %d отхвърлено парче…"
 msgstr[1] "Прилагане на кръпката „%%s“ с %d отхвърлени парчета…"
 
-#: apply.c:4570
+#: apply.c:4592
 #, c-format
 msgid "truncating .rej filename to %.*s.rej"
 msgstr "съкращаване на името на файла с отхвърлените парчета на „ %.*s.rej“"
 
-#: apply.c:4578 builtin/fetch.c:993 builtin/fetch.c:1394
+#: apply.c:4600 builtin/fetch.c:998 builtin/fetch.c:1408
 #, c-format
 msgid "cannot open %s"
 msgstr "„%s“ не може да бъде отворен"
 
-#: apply.c:4592
+#: apply.c:4614
 #, c-format
 msgid "Hunk #%d applied cleanly."
 msgstr "%d-то парче бе успешно приложено."
 
-#: apply.c:4596
+#: apply.c:4618
 #, c-format
 msgid "Rejected hunk #%d."
 msgstr "%d-то парче бе отхвърлено."
 
-#: apply.c:4725
+#: apply.c:4747
 #, c-format
 msgid "Skipped patch '%s'."
 msgstr "Пропусната кръпка: „%s“"
 
-#: apply.c:4733
+#: apply.c:4755
 msgid "unrecognized input"
 msgstr "непознат вход"
 
-#: apply.c:4753
+#: apply.c:4775
 msgid "unable to read index file"
 msgstr "индексът не може да бъде записан"
 
-#: apply.c:4910
+#: apply.c:4932
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr "кръпката „%s“ не може да бъде отворена: %s"
 
-#: apply.c:4937
+#: apply.c:4959
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "пренебрегната е %d грешка в знаците за интервали"
 msgstr[1] "пренебрегнати са %d грешки в знаците за интервали"
 
-#: apply.c:4943 apply.c:4958
+#: apply.c:4965 apply.c:4980
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] "%d ред добавя грешки в знаците за интервали."
 msgstr[1] "%d реда добавят грешки в знаците за интервали."
 
-#: apply.c:4951
+#: apply.c:4973
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
@@ -1570,138 +1582,138 @@ msgstr[0] ""
 msgstr[1] ""
 "Добавени са %d реда след корекцията на грешките в знаците за интервали."
 
-#: apply.c:4967 builtin/add.c:678 builtin/mv.c:304 builtin/rm.c:423
+#: apply.c:4989 builtin/add.c:707 builtin/mv.c:338 builtin/rm.c:429
 msgid "Unable to write new index file"
 msgstr "Новият индекс не може да бъде записан"
 
-#: apply.c:4995
+#: apply.c:5017
 msgid "don't apply changes matching the given path"
 msgstr "без прилагане на промените напасващи на дадения път"
 
-#: apply.c:4998
+#: apply.c:5020
 msgid "apply changes matching the given path"
 msgstr "прилагане на промените напасващи на дадения път"
 
-#: apply.c:5000 builtin/am.c:2318
+#: apply.c:5022 builtin/am.c:2320
 msgid "num"
 msgstr "БРОЙ"
 
-#: apply.c:5001
+#: apply.c:5023
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr "премахване на този БРОЙ водещи елементи от пътищата в разликата"
 
-#: apply.c:5004
+#: apply.c:5026
 msgid "ignore additions made by the patch"
 msgstr "игнориране на редовете добавени от тази кръпка"
 
-#: apply.c:5006
+#: apply.c:5028
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr "извеждане на статистика на промените без прилагане на кръпката"
 
-#: apply.c:5010
+#: apply.c:5032
 msgid "show number of added and deleted lines in decimal notation"
 msgstr "извеждане на броя на добавените и изтритите редове"
 
-#: apply.c:5012
+#: apply.c:5034
 msgid "instead of applying the patch, output a summary for the input"
 msgstr "извеждане на статистика на входните данни без прилагане на кръпката"
 
-#: apply.c:5014
+#: apply.c:5036
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr "проверка дали кръпката може да се приложи, без действително прилагане"
 
-#: apply.c:5016
+#: apply.c:5038
 msgid "make sure the patch is applicable to the current index"
 msgstr "проверка дали кръпката може да бъде приложена към текущия индекс"
 
-#: apply.c:5018
+#: apply.c:5040
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "отбелязване на новите файлове с „git add --intent-to-add“"
 
-#: apply.c:5020
+#: apply.c:5042
 msgid "apply a patch without touching the working tree"
 msgstr "прилагане на кръпката без промяна на работното дърво"
 
-#: apply.c:5022
+#: apply.c:5044
 msgid "accept a patch that touches outside the working area"
 msgstr "прилагане на кръпка, която променя и файлове извън работното дърво"
 
-#: apply.c:5025
+#: apply.c:5047
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr ""
 "кръпката да бъде приложена.  Опцията се комбинира с „--check“/„--stat“/„--"
 "summary“"
 
-#: apply.c:5027
+#: apply.c:5049
 msgid "attempt three-way merge, fall back on normal patch if that fails"
 msgstr ""
 "пробване с тройно сливане, ако това не сработи — стандартно прилагане на "
 "кръпка"
 
-#: apply.c:5029
+#: apply.c:5051
 msgid "build a temporary index based on embedded index information"
 msgstr ""
 "създаване на временен индекс на база на включената информация за индекса"
 
-#: apply.c:5032 builtin/checkout-index.c:196 builtin/ls-files.c:617
+#: apply.c:5054 builtin/checkout-index.c:196
 msgid "paths are separated with NUL character"
 msgstr "разделяне на пътищата с нулевия знак „NUL“"
 
-#: apply.c:5034
+#: apply.c:5056
 msgid "ensure at least <n> lines of context match"
 msgstr "да се осигури контекст от поне такъв БРОЙ съвпадащи редове"
 
-#: apply.c:5035 builtin/am.c:2294 builtin/am.c:2297
+#: apply.c:5057 builtin/am.c:2296 builtin/am.c:2299
 #: builtin/interpret-trailers.c:98 builtin/interpret-trailers.c:100
-#: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3991
-#: builtin/rebase.c:1347
+#: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3960
+#: builtin/rebase.c:1051
 msgid "action"
 msgstr "действие"
 
-#: apply.c:5036
+#: apply.c:5058
 msgid "detect new or modified lines that have whitespace errors"
 msgstr "засичане на нови или променени редове с грешки в знаците за интервали"
 
-#: apply.c:5039 apply.c:5042
+#: apply.c:5061 apply.c:5064
 msgid "ignore changes in whitespace when finding context"
 msgstr ""
 "игнориране на промените в знаците за интервали при откриване на контекста"
 
-#: apply.c:5045
+#: apply.c:5067
 msgid "apply the patch in reverse"
 msgstr "прилагане на кръпката в обратна посока"
 
-#: apply.c:5047
+#: apply.c:5069
 msgid "don't expect at least one line of context"
 msgstr "без изискване на дори и един ред контекст"
 
-#: apply.c:5049
+#: apply.c:5071
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr "оставяне на отхвърлените парчета във файлове с разширение „.rej“"
 
-#: apply.c:5051
+#: apply.c:5073
 msgid "allow overlapping hunks"
 msgstr "позволяване на застъпващи се парчета"
 
-#: apply.c:5052 builtin/add.c:364 builtin/check-ignore.c:22
-#: builtin/commit.c:1481 builtin/count-objects.c:98 builtin/fsck.c:756
-#: builtin/log.c:2297 builtin/mv.c:123 builtin/read-tree.c:128
+#: apply.c:5074 builtin/add.c:372 builtin/check-ignore.c:22
+#: builtin/commit.c:1483 builtin/count-objects.c:98 builtin/fsck.c:788
+#: builtin/log.c:2297 builtin/mv.c:123 builtin/read-tree.c:120
 msgid "be verbose"
 msgstr "повече подробности"
 
-#: apply.c:5054
+#: apply.c:5076
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr "пренебрегване на неправилно липсващ знак за нов ред в края на файл"
 
-#: apply.c:5057
+#: apply.c:5079
 msgid "do not trust the line counts in the hunk headers"
 msgstr "без доверяване на номерата на редовете в заглавните части на парчетата"
 
-#: apply.c:5059 builtin/am.c:2306
+#: apply.c:5081 builtin/am.c:2308
 msgid "root"
 msgstr "НАЧАЛНА_ДИРЕКТОРИЯ"
 
-#: apply.c:5060
+#: apply.c:5082
 msgid "prepend <root> to all filenames"
 msgstr "добавяне на тази НАЧАЛНА_ДИРЕКТОРИЯ към имената на всички файлове"
 
@@ -1773,152 +1785,151 @@ msgstr "git archive --remote ХРАНИЛИЩЕ [--exec КОМАНДА] --list"
 msgid "cannot read %s"
 msgstr "обектът „%s“ не може да бъде прочетен"
 
-#: archive.c:342 sequencer.c:460 sequencer.c:1915 sequencer.c:3095
-#: sequencer.c:3537 sequencer.c:3665 builtin/am.c:262 builtin/commit.c:833
-#: builtin/merge.c:1144
+#: archive.c:341 sequencer.c:473 sequencer.c:1932 sequencer.c:3114
+#: sequencer.c:3556 sequencer.c:3684 builtin/am.c:263 builtin/commit.c:834
+#: builtin/merge.c:1145
 #, c-format
 msgid "could not read '%s'"
 msgstr "файлът „%s“ не може да бъде прочетен"
 
-#: archive.c:427 builtin/add.c:205 builtin/add.c:645 builtin/rm.c:328
+#: archive.c:426 builtin/add.c:215 builtin/add.c:674 builtin/rm.c:334
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "пътят „%s“ не съвпада с никой файл"
 
-#: archive.c:451
+#: archive.c:450
 #, c-format
 msgid "no such ref: %.*s"
 msgstr "такъв указател няма: %.*s"
 
-#: archive.c:457
+#: archive.c:456
 #, c-format
 msgid "not a valid object name: %s"
 msgstr "неправилно име на обект: „%s“"
 
-#: archive.c:470
+#: archive.c:469
 #, c-format
 msgid "not a tree object: %s"
 msgstr "не е обект-дърво: %s"
 
-#: archive.c:482
+#: archive.c:481
 msgid "current working directory is untracked"
 msgstr "текущата работна директория не е следена"
 
-#: archive.c:523
+#: archive.c:522
 #, c-format
 msgid "File not found: %s"
 msgstr "Файлът „%s“ липсва"
 
-#: archive.c:525
+#: archive.c:524
 #, c-format
 msgid "Not a regular file: %s"
 msgstr "„%s“ не е обикновен файл"
 
-#: archive.c:552
+#: archive.c:551
 msgid "fmt"
 msgstr "ФОРМАТ"
 
-#: archive.c:552
+#: archive.c:551
 msgid "archive format"
 msgstr "ФОРМАТ на архива"
 
-#: archive.c:553 builtin/log.c:1775
+#: archive.c:552 builtin/log.c:1775
 msgid "prefix"
 msgstr "ПРЕФИКС"
 
-#: archive.c:554
+#: archive.c:553
 msgid "prepend prefix to each pathname in the archive"
 msgstr "добавяне на този ПРЕФИКС към всеки път в архива"
 
-#: archive.c:555 archive.c:558 builtin/blame.c:884 builtin/blame.c:888
-#: builtin/blame.c:889 builtin/commit-tree.c:117 builtin/config.c:135
-#: builtin/fast-export.c:1207 builtin/fast-export.c:1209
-#: builtin/fast-export.c:1213 builtin/grep.c:921 builtin/hash-object.c:105
-#: builtin/ls-files.c:653 builtin/ls-files.c:656 builtin/notes.c:412
-#: builtin/notes.c:578 builtin/read-tree.c:123 parse-options.h:191
+#: archive.c:554 archive.c:557 builtin/blame.c:880 builtin/blame.c:884
+#: builtin/blame.c:885 builtin/commit-tree.c:115 builtin/config.c:135
+#: builtin/fast-export.c:1208 builtin/fast-export.c:1210
+#: builtin/fast-export.c:1214 builtin/grep.c:935 builtin/hash-object.c:103
+#: builtin/ls-files.c:651 builtin/ls-files.c:654 builtin/notes.c:410
+#: builtin/notes.c:576 builtin/read-tree.c:115 parse-options.h:190
 msgid "file"
 msgstr "ФАЙЛ"
 
-#: archive.c:556
+#: archive.c:555
 msgid "add untracked file to archive"
 msgstr "добавяне на неследените файлове към архива"
 
-#: archive.c:559 builtin/archive.c:90
+#: archive.c:558 builtin/archive.c:88
 msgid "write the archive to this file"
 msgstr "запазване на архива в този ФАЙЛ"
 
-#: archive.c:561
+#: archive.c:560
 msgid "read .gitattributes in working directory"
 msgstr "изчитане на „.gitattributes“ в работната директория"
 
-#: archive.c:562
+#: archive.c:561
 msgid "report archived files on stderr"
 msgstr "извеждане на архивираните файлове на стандартната грешка"
 
-#: archive.c:564
+#: archive.c:563
 msgid "set compression level"
 msgstr "задаване на нивото на компресиране"
 
-#: archive.c:567
+#: archive.c:566
 msgid "list supported archive formats"
 msgstr "извеждане на списъка с поддържаните формати"
 
-#: archive.c:569 builtin/archive.c:91 builtin/clone.c:118 builtin/clone.c:121
-#: builtin/submodule--helper.c:1898 builtin/submodule--helper.c:2352
-#: builtin/submodule--helper.c:2902
+#: archive.c:568 builtin/archive.c:89 builtin/clone.c:118 builtin/clone.c:121
+#: builtin/submodule--helper.c:1869 builtin/submodule--helper.c:2512
 msgid "repo"
 msgstr "хранилище"
 
-#: archive.c:570 builtin/archive.c:92
+#: archive.c:569 builtin/archive.c:90
 msgid "retrieve the archive from remote repository <repo>"
 msgstr "получаване на архива от отдалеченото ХРАНИЛИЩЕ"
 
-#: archive.c:571 builtin/archive.c:93 builtin/difftool.c:717
-#: builtin/notes.c:498
+#: archive.c:570 builtin/archive.c:91 builtin/difftool.c:714
+#: builtin/notes.c:496
 msgid "command"
 msgstr "команда"
 
-#: archive.c:572 builtin/archive.c:94
+#: archive.c:571 builtin/archive.c:92
 msgid "path to the remote git-upload-archive command"
 msgstr "път към отдалечената команда „git-upload-archive“"
 
-#: archive.c:579
+#: archive.c:578
 msgid "Unexpected option --remote"
 msgstr "Неочаквана опция „--remote“"
 
-#: archive.c:581
+#: archive.c:580
 msgid "Option --exec can only be used together with --remote"
 msgstr "опцията „--exec“ изисква „--remote“"
 
-#: archive.c:583
+#: archive.c:582
 msgid "Unexpected option --output"
 msgstr "Неочаквана опция „--output“"
 
-#: archive.c:585
+#: archive.c:584
 msgid "Options --add-file and --remote cannot be used together"
 msgstr "опциите „--add-file“ и „--remote“ са несъвместими"
 
-#: archive.c:607
+#: archive.c:606
 #, c-format
 msgid "Unknown archive format '%s'"
 msgstr "Непознат формат на архив: „%s“"
 
-#: archive.c:616
+#: archive.c:615
 #, c-format
 msgid "Argument not supported for format '%s': -%d"
 msgstr "Аргументът не се поддържа за форма̀та „%s“: -%d"
 
-#: attr.c:202
+#: attr.c:203
 #, c-format
 msgid "%.*s is not a valid attribute name"
 msgstr "„%.*s“ е неправилно име за атрибут"
 
-#: attr.c:363
+#: attr.c:364
 #, c-format
 msgid "%s not allowed: %s:%d"
 msgstr "%s: командата не е позволена: „%s:%d“"
 
-#: attr.c:403
+#: attr.c:404
 msgid ""
 "Negative patterns are ignored in git attributes\n"
 "Use '\\!' for literal leading exclamation."
@@ -1926,22 +1937,22 @@ msgstr ""
 "Отрицателните шаблони се игнорират в атрибутите на git.\n"
 "Ако ви трябва начална удивителна, ползвайте „\\!“."
 
-#: bisect.c:489
+#: bisect.c:488
 #, c-format
 msgid "Badly quoted content in file '%s': %s"
 msgstr "Неправилно цитирано съдържание във файла „%s“: %s"
 
-#: bisect.c:699
+#: bisect.c:698
 #, c-format
 msgid "We cannot bisect more!\n"
 msgstr "Повече не може да се търси двоично!\n"
 
-#: bisect.c:766
+#: bisect.c:764
 #, c-format
 msgid "Not a valid commit name %s"
 msgstr "Неправилно име на подаване „%s“"
 
-#: bisect.c:791
+#: bisect.c:789
 #, c-format
 msgid ""
 "The merge base %s is bad.\n"
@@ -1950,7 +1961,7 @@ msgstr ""
 "Неправилна база за сливане: %s.\n"
 "Следователно грешката е коригирана между „%s“ и [%s].\n"
 
-#: bisect.c:796
+#: bisect.c:794
 #, c-format
 msgid ""
 "The merge base %s is new.\n"
@@ -1959,7 +1970,7 @@ msgstr ""
 "Нова база за сливане: %s.\n"
 "Свойството е променено между „%s“ и [%s].\n"
 
-#: bisect.c:801
+#: bisect.c:799
 #, c-format
 msgid ""
 "The merge base %s is %s.\n"
@@ -1968,7 +1979,7 @@ msgstr ""
 "Базата за сливане „%s“ е %s.\n"
 "Следователно първото %s подаване е между „%s“ и [%s].\n"
 
-#: bisect.c:809
+#: bisect.c:807
 #, c-format
 msgid ""
 "Some %s revs are not ancestors of the %s rev.\n"
@@ -1979,7 +1990,7 @@ msgstr ""
 "Двоичното търсене с git bisect няма да работи правилно.\n"
 "Дали не сте объркали указателите „%s“ и „%s“?\n"
 
-#: bisect.c:822
+#: bisect.c:820
 #, c-format
 msgid ""
 "the merge base between %s and [%s] must be skipped.\n"
@@ -1990,36 +2001,36 @@ msgstr ""
 "Не може да сме сигурни, че първото %s подаване е между „%s“ и „%s“.\n"
 "Двоичното търсене продължава."
 
-#: bisect.c:861
+#: bisect.c:859
 #, c-format
 msgid "Bisecting: a merge base must be tested\n"
 msgstr "Двоично търсене: трябва да се провери база за сливане\n"
 
-#: bisect.c:911
+#: bisect.c:909
 #, c-format
 msgid "a %s revision is needed"
 msgstr "необходима е версия „%s“"
 
-#: bisect.c:941 builtin/notes.c:177 builtin/tag.c:298
+#: bisect.c:939
 #, c-format
 msgid "could not create file '%s'"
 msgstr "файлът „%s“ не може да бъде създаден"
 
-#: bisect.c:987 builtin/merge.c:153
+#: bisect.c:985 builtin/merge.c:154
 #, c-format
 msgid "could not read file '%s'"
 msgstr "файлът „%s“ не може да бъде прочетен"
 
-#: bisect.c:1027
+#: bisect.c:1025
 msgid "reading bisect refs failed"
 msgstr "неуспешно прочитане на указателите за двоично търсене"
 
-#: bisect.c:1057
+#: bisect.c:1055
 #, c-format
 msgid "%s was both %s and %s\n"
 msgstr "„%s“ e както „%s“, така и „%s“\n"
 
-#: bisect.c:1066
+#: bisect.c:1064
 #, c-format
 msgid ""
 "No testable commit found.\n"
@@ -2028,7 +2039,7 @@ msgstr ""
 "Липсва подходящо за тестване подаване.\n"
 "Проверете параметрите за пътищата.\n"
 
-#: bisect.c:1095
+#: bisect.c:1093
 #, c-format
 msgid "(roughly %d step)"
 msgid_plural "(roughly %d steps)"
@@ -2038,7 +2049,7 @@ msgstr[1] "(приблизително %d стъпки)"
 #. TRANSLATORS: the last %s will be replaced with "(roughly %d
 #. steps)" translation.
 #.
-#: bisect.c:1101
+#: bisect.c:1099
 #, c-format
 msgid "Bisecting: %d revision left to test after this %s\n"
 msgid_plural "Bisecting: %d revisions left to test after this %s\n"
@@ -2059,11 +2070,12 @@ msgstr ""
 "Едновременното задаване на опциите „--reverse“ и „--first-parent“ изисква "
 "указването на крайно подаване"
 
-#: blame.c:2820 bundle.c:224 ref-filter.c:2278 remote.c:2041 sequencer.c:2333
-#: sequencer.c:4865 submodule.c:844 builtin/commit.c:1113 builtin/log.c:414
-#: builtin/log.c:1021 builtin/log.c:1629 builtin/log.c:2056 builtin/log.c:2346
-#: builtin/merge.c:428 builtin/pack-objects.c:3343 builtin/pack-objects.c:3806
-#: builtin/pack-objects.c:3821 builtin/shortlog.c:255
+#: blame.c:2820 bundle.c:224 midx.c:1039 ref-filter.c:2370 remote.c:2041
+#: sequencer.c:2350 sequencer.c:4902 submodule.c:883 builtin/commit.c:1114
+#: builtin/log.c:414 builtin/log.c:1021 builtin/log.c:1629 builtin/log.c:2056
+#: builtin/log.c:2346 builtin/merge.c:429 builtin/pack-objects.c:3373
+#: builtin/pack-objects.c:3775 builtin/pack-objects.c:3790
+#: builtin/shortlog.c:255
 msgid "revision walk setup failed"
 msgstr "неуспешно настройване на обхождането на версиите"
 
@@ -2242,8 +2254,8 @@ msgstr "Файлът „%s“ не изглежда да е пратка на gi
 msgid "unrecognized header: %s%s (%d)"
 msgstr "непозната заглавна част: %s%s (%d)"
 
-#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2593 sequencer.c:3385
-#: builtin/commit.c:861
+#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2618 sequencer.c:3404
+#: builtin/commit.c:862
 #, c-format
 msgid "could not open '%s'"
 msgstr "„%s“ не може да се отвори"
@@ -2302,7 +2314,7 @@ msgstr "неподдържана версия на индекса %d"
 msgid "cannot write bundle version %d with algorithm %s"
 msgstr "пратка %d не може да се запише с алгоритъм %s"
 
-#: bundle.c:524 builtin/log.c:210 builtin/log.c:1938 builtin/shortlog.c:396
+#: bundle.c:524 builtin/log.c:210 builtin/log.c:1938 builtin/shortlog.c:399
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr "непознат аргумент: %s"
@@ -2344,7 +2356,7 @@ msgstr "ненулев идентификатор за краен откъс %<P
 msgid "invalid color value: %.*s"
 msgstr "неправилна стойност за цвят: %.*s"
 
-#: commit-graph.c:204 midx.c:47
+#: commit-graph.c:204 midx.c:51
 msgid "invalid hash version"
 msgstr "неправилна версия на контролна сума"
 
@@ -2390,197 +2402,197 @@ msgstr ""
 msgid "unable to find all commit-graph files"
 msgstr "някои файлове на гра̀фа с подаванията не може да бъдат открити"
 
-#: commit-graph.c:745 commit-graph.c:782
+#: commit-graph.c:746 commit-graph.c:783
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr ""
 "неправилна позиция на подаването.  Вероятно графът с подаванията е повреден"
 
-#: commit-graph.c:766
+#: commit-graph.c:767
 #, c-format
 msgid "could not find commit %s"
 msgstr "подаването „%s“ не може да бъде открито"
 
-#: commit-graph.c:799
+#: commit-graph.c:800
 msgid "commit-graph requires overflow generation data but has none"
 msgstr ""
 "графът с подаванията изисква генериране на данни за отместването, но такива "
 "липсват"
 
-#: commit-graph.c:1075 builtin/am.c:1341
+#: commit-graph.c:1105 builtin/am.c:1342
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "подаването не може да бъде анализирано: %s"
 
-#: commit-graph.c:1337 builtin/pack-objects.c:3057
+#: commit-graph.c:1367 builtin/pack-objects.c:3070
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "видът на обекта „%s“ не може да бъде определен"
 
-#: commit-graph.c:1368
+#: commit-graph.c:1398
 msgid "Loading known commits in commit graph"
 msgstr "Зареждане на познатите подавания в гра̀фа с подаванията"
 
-#: commit-graph.c:1385
+#: commit-graph.c:1415
 msgid "Expanding reachable commits in commit graph"
 msgstr "Разширяване на достижимите подавания в гра̀фа"
 
-#: commit-graph.c:1405
+#: commit-graph.c:1435
 msgid "Clearing commit marks in commit graph"
 msgstr "Изчистване на отбелязванията на подаванията в гра̀фа с подаванията"
 
-#: commit-graph.c:1424
+#: commit-graph.c:1454
 msgid "Computing commit graph topological levels"
 msgstr "Изчисляване на топологичните нива в гра̀фа с подаванията"
 
-#: commit-graph.c:1477
+#: commit-graph.c:1507
 msgid "Computing commit graph generation numbers"
 msgstr "Изчисляване на номерата на поколенията в гра̀фа с подаванията"
 
-#: commit-graph.c:1558
+#: commit-graph.c:1588
 msgid "Computing commit changed paths Bloom filters"
 msgstr "Изчисляване на филтрите на Блум на пътищата с промяна при подаването"
 
-#: commit-graph.c:1635
+#: commit-graph.c:1665
 msgid "Collecting referenced commits"
 msgstr "Събиране на свързаните подавания"
 
-#: commit-graph.c:1660
+#: commit-graph.c:1690
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] "Откриване на подаванията в гра̀фа в %d пакетен файл"
 msgstr[1] "Откриване на подаванията в гра̀фа в %d пакетни файла"
 
-#: commit-graph.c:1673
+#: commit-graph.c:1703
 #, c-format
 msgid "error adding pack %s"
 msgstr "грешка при добавяне на пакетен файл „%s“"
 
-#: commit-graph.c:1677
+#: commit-graph.c:1707
 #, c-format
 msgid "error opening index for %s"
 msgstr "грешка при отваряне на индекса на „%s“"
 
-#: commit-graph.c:1714
+#: commit-graph.c:1744
 msgid "Finding commits for commit graph among packed objects"
 msgstr "Откриване на подаванията в гра̀фа измежду пакетираните обекти"
 
-#: commit-graph.c:1732
+#: commit-graph.c:1762
 msgid "Finding extra edges in commit graph"
 msgstr "Откриване на още върхове в гра̀фа с подаванията"
 
-#: commit-graph.c:1781
+#: commit-graph.c:1811
 msgid "failed to write correct number of base graph ids"
 msgstr "правилният брой на базовите идентификатори не може да се запише"
 
-#: commit-graph.c:1812 midx.c:911
+#: commit-graph.c:1842 midx.c:1146
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "родителските директории на „%s“ не може да бъдат създадени"
 
-#: commit-graph.c:1825
+#: commit-graph.c:1855
 msgid "unable to create temporary graph layer"
 msgstr "не може да бъде създаден временен слой за гра̀фа с подаванията"
 
-#: commit-graph.c:1830
+#: commit-graph.c:1860
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "правата за споделен достъп до „%s“ не може да бъдат зададени"
 
-#: commit-graph.c:1887
+#: commit-graph.c:1917
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "Запазване на гра̀фа с подаванията в %d пас"
 msgstr[1] "Запазване на гра̀фа с подаванията в %d паса"
 
-#: commit-graph.c:1923
+#: commit-graph.c:1953
 msgid "unable to open commit-graph chain file"
 msgstr "файлът с веригата на гра̀фа с подаванията не може да се отвори"
 
-#: commit-graph.c:1939
+#: commit-graph.c:1969
 msgid "failed to rename base commit-graph file"
 msgstr "основният файл на гра̀фа с подаванията не може да бъде преименуван"
 
-#: commit-graph.c:1959
+#: commit-graph.c:1989
 msgid "failed to rename temporary commit-graph file"
 msgstr "временният файл на гра̀фа с подаванията не може да бъде преименуван"
 
-#: commit-graph.c:2092
+#: commit-graph.c:2122
 msgid "Scanning merged commits"
 msgstr "Търсене на подаванията със сливания"
 
-#: commit-graph.c:2136
+#: commit-graph.c:2166
 msgid "Merging commit-graph"
 msgstr "Сливане на гра̀фа с подаванията"
 
-#: commit-graph.c:2244
+#: commit-graph.c:2274
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 "опит за запис на гра̀фа с подаванията, но настройката „core.commitGraph“ е "
 "изключена"
 
-#: commit-graph.c:2351
+#: commit-graph.c:2381
 msgid "too many commits to write graph"
 msgstr "прекалено много подавания за записване на гра̀фа"
 
-#: commit-graph.c:2449
+#: commit-graph.c:2479
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr "графът с подаванията е с грешна сума за проверка — вероятно е повреден"
 
-#: commit-graph.c:2459
+#: commit-graph.c:2489
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr ""
 "неправилна подредба на обектите по идентификатор в гра̀фа с подаванията: „%s“ "
 "е преди „%s“, а не трябва"
 
-#: commit-graph.c:2469 commit-graph.c:2484
+#: commit-graph.c:2499 commit-graph.c:2514
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr ""
 "неправилна стойност за откъс в гра̀фа с подаванията: fanout[%d] = %u, а "
 "трябва да е %u"
 
-#: commit-graph.c:2476
+#: commit-graph.c:2506
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "подаване „%s“ в гра̀фа с подаванията не може да се анализира"
 
-#: commit-graph.c:2494
+#: commit-graph.c:2524
 msgid "Verifying commits in commit graph"
 msgstr "Проверка на подаванията в гра̀фа"
 
-#: commit-graph.c:2509
+#: commit-graph.c:2539
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "подаване „%s“ в базата от данни към гра̀фа с подаванията не може да се "
 "анализира"
 
-#: commit-graph.c:2516
+#: commit-graph.c:2546
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 "идентификаторът на обект за кореновото дърво за подаване „%s“ в гра̀фа с "
 "подаванията е „%s“, а трябва да е „%s“"
 
-#: commit-graph.c:2526
+#: commit-graph.c:2556
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr "списъкът с родители на „%s“ в гра̀фа с подаванията е прекалено дълъг"
 
-#: commit-graph.c:2535
+#: commit-graph.c:2565
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "родителят на „%s“ в гра̀фа с подаванията е „%s“, а трябва да е „%s“"
 
-#: commit-graph.c:2549
+#: commit-graph.c:2579
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr "списъкът с родители на „%s“ в гра̀фа с подаванията е прекалено къс"
 
-#: commit-graph.c:2554
+#: commit-graph.c:2584
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2588,7 +2600,7 @@ msgstr ""
 "номерът на поколението на подаване „%s“ в гра̀фа с подаванията е 0, а другаде "
 "не е"
 
-#: commit-graph.c:2558
+#: commit-graph.c:2588
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2596,32 +2608,32 @@ msgstr ""
 "номерът на поколението на подаване „%s“ в гра̀фа с подаванията не е 0, а "
 "другаде е"
 
-#: commit-graph.c:2575
+#: commit-graph.c:2605
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr ""
 "номерът на поколението на подаване „%s“ в гра̀фа с подаванията е %<PRIuMAX> < "
 "%<PRIuMAX>"
 
-#: commit-graph.c:2581
+#: commit-graph.c:2611
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 "датата на подаване на „%s“ в гра̀фа с подаванията е %<PRIuMAX>, а трябва да е "
 "%<PRIuMAX>"
 
-#: commit.c:52 sequencer.c:3088 builtin/am.c:372 builtin/am.c:417
-#: builtin/am.c:422 builtin/am.c:1420 builtin/am.c:2067 builtin/replace.c:457
+#: commit.c:53 sequencer.c:3107 builtin/am.c:373 builtin/am.c:418
+#: builtin/am.c:423 builtin/am.c:1421 builtin/am.c:2068 builtin/replace.c:457
 #, c-format
 msgid "could not parse %s"
 msgstr "„%s“ не може да се анализира"
 
-#: commit.c:54
+#: commit.c:55
 #, c-format
 msgid "%s %s is not a commit!"
 msgstr "%s %s не е подаване!"
 
-#: commit.c:194
+#: commit.c:196
 msgid ""
 "Support for <GIT_DIR>/info/grafts is deprecated\n"
 "and will be removed in a future Git version.\n"
@@ -2644,29 +2656,29 @@ msgstr ""
 "\n"
 "    git config advice.graftFileDeprecated false"
 
-#: commit.c:1237
+#: commit.c:1239
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
 msgstr ""
 "Подаването „%s“ е с недоверен подпис от GPG, който твърди, че е на „%s“."
 
-#: commit.c:1241
+#: commit.c:1243
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
 msgstr ""
 "Подаването „%s“ е с неправилен подпис от GPG, който твърди, че е на „%s“."
 
-#: commit.c:1244
+#: commit.c:1246
 #, c-format
 msgid "Commit %s does not have a GPG signature."
 msgstr "Подаването „%s“ е без подпис от GPG."
 
-#: commit.c:1247
+#: commit.c:1249
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
 msgstr "Подаването „%s“ е с коректен подпис от GPG на „%s“.\n"
 
-#: commit.c:1501
+#: commit.c:1503
 msgid ""
 "Warning: commit message did not conform to UTF-8.\n"
 "You may want to amend it after fixing the message, or set the config\n"
@@ -2680,7 +2692,7 @@ msgstr ""
 msgid "memory exhausted"
 msgstr "паметта свърши"
 
-#: config.c:126
+#: config.c:125
 #, c-format
 msgid ""
 "exceeded maximum include depth (%d) while including\n"
@@ -2695,35 +2707,35 @@ msgstr ""
 "    %s\n"
 "Това може да се дължи на зацикляне при вмъкването."
 
-#: config.c:142
+#: config.c:141
 #, c-format
 msgid "could not expand include path '%s'"
 msgstr "пътят за вмъкване „%s“не може да бъде разширен"
 
-#: config.c:153
+#: config.c:152
 msgid "relative config includes must come from files"
 msgstr "относителните вмъквания на конфигурации трябва да идват от файлове"
 
-#: config.c:199
+#: config.c:201
 msgid "relative config include conditionals must come from files"
 msgstr "относителните условни изрази за вмъкване трябва да идват от файлове"
 
-#: config.c:396
+#: config.c:398
 #, c-format
 msgid "invalid config format: %s"
 msgstr "неправилен формат на настройка: %s"
 
-#: config.c:400
+#: config.c:402
 #, c-format
 msgid "missing environment variable name for configuration '%.*s'"
 msgstr "липсва име на променлива на средата за настройката „%.*s“"
 
-#: config.c:405
+#: config.c:407
 #, c-format
 msgid "missing environment variable '%s' for configuration '%.*s'"
 msgstr "липсва променлива на средата „%s“ за настройката „%.*s“"
 
-#: config.c:442
+#: config.c:443
 #, c-format
 msgid "key does not contain a section: %s"
 msgstr "ключът не съдържа раздел: „%s“"
@@ -2733,168 +2745,168 @@ msgstr "ключът не съдържа раздел: „%s“"
 msgid "key does not contain variable name: %s"
 msgstr "ключът не съдържа име на променлива: „%s“"
 
-#: config.c:472 sequencer.c:2785
+#: config.c:470 sequencer.c:2804
 #, c-format
 msgid "invalid key: %s"
 msgstr "неправилен ключ: „%s“"
 
-#: config.c:478
+#: config.c:475
 #, c-format
 msgid "invalid key (newline): %s"
 msgstr "неправилен ключ (нов ред): „%s“"
 
-#: config.c:511
+#: config.c:495
 msgid "empty config key"
 msgstr "празен ключ за настройка"
 
-#: config.c:529 config.c:541
+#: config.c:513 config.c:525
 #, c-format
 msgid "bogus config parameter: %s"
 msgstr "неправилен конфигурационен параметър: „%s“"
 
-#: config.c:555 config.c:572 config.c:579 config.c:588
+#: config.c:539 config.c:556 config.c:563 config.c:572
 #, c-format
 msgid "bogus format in %s"
 msgstr "неправилен формат в „%s“"
 
-#: config.c:622
+#: config.c:606
 #, c-format
 msgid "bogus count in %s"
 msgstr "неправилен брой в „%s“"
 
-#: config.c:626
+#: config.c:610
 #, c-format
 msgid "too many entries in %s"
 msgstr "прекалено много записи в „%s“"
 
-#: config.c:636
+#: config.c:620
 #, c-format
 msgid "missing config key %s"
 msgstr "ключът за настройка „%s“ липсва"
 
-#: config.c:644
+#: config.c:628
 #, c-format
 msgid "missing config value %s"
 msgstr "стойността за настройка „%s“ липсва"
 
-#: config.c:995
+#: config.c:979
 #, c-format
 msgid "bad config line %d in blob %s"
 msgstr "неправилен ред за настройки %d в BLOB „%s“"
 
-#: config.c:999
+#: config.c:983
 #, c-format
 msgid "bad config line %d in file %s"
 msgstr "неправилен ред за настройки %d във файла „%s“"
 
-#: config.c:1003
+#: config.c:987
 #, c-format
 msgid "bad config line %d in standard input"
 msgstr "неправилен ред за настройки %d на стандартния вход"
 
-#: config.c:1007
+#: config.c:991
 #, c-format
 msgid "bad config line %d in submodule-blob %s"
 msgstr "неправилен ред за настройки %d в BLOB за подмодул „%s“"
 
-#: config.c:1011
+#: config.c:995
 #, c-format
 msgid "bad config line %d in command line %s"
 msgstr "неправилен ред за настройки %d на командния ред „%s“"
 
-#: config.c:1015
+#: config.c:999
 #, c-format
 msgid "bad config line %d in %s"
 msgstr "неправилен ред за настройки %d в „%s“"
 
-#: config.c:1152
+#: config.c:1136
 msgid "out of range"
 msgstr "извън диапазона"
 
-#: config.c:1152
+#: config.c:1136
 msgid "invalid unit"
 msgstr "неправилна мерна единица"
 
-#: config.c:1153
+#: config.c:1137
 #, c-format
 msgid "bad numeric config value '%s' for '%s': %s"
 msgstr "неправилна числова стойност „%s“ за „%s“: %s"
 
-#: config.c:1163
+#: config.c:1147
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in blob %s: %s"
 msgstr "неправилна числова стойност „%s“ за „%s“ в BLOB „%s“: %s"
 
-#: config.c:1166
+#: config.c:1150
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in file %s: %s"
 msgstr "неправилна числова стойност „%s“ за „%s“ във файла „%s“: %s"
 
-#: config.c:1169
+#: config.c:1153
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in standard input: %s"
 msgstr "неправилна числова стойност „%s“ за „%s“ на стандартния вход: %s"
 
-#: config.c:1172
+#: config.c:1156
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in submodule-blob %s: %s"
 msgstr "неправилна числова стойност „%s“ за „%s“ в BLOB от подмодул „%s“: %s"
 
-#: config.c:1175
+#: config.c:1159
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in command line %s: %s"
 msgstr "неправилна числова стойност „%s“ за „%s“ на командния ред „%s“: %s"
 
-#: config.c:1178
+#: config.c:1162
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in %s: %s"
 msgstr "неправилна числова стойност „%s“ за „%s“ в %s: %s"
 
-#: config.c:1257
+#: config.c:1241
 #, c-format
 msgid "bad boolean config value '%s' for '%s'"
 msgstr "неправилна булева стойност „%s“ за „%s“"
 
-#: config.c:1275
+#: config.c:1259
 #, c-format
 msgid "failed to expand user dir in: '%s'"
 msgstr "домашната папка на потребителя не може да бъде открита: „%s“"
 
-#: config.c:1284
+#: config.c:1268
 #, c-format
 msgid "'%s' for '%s' is not a valid timestamp"
 msgstr "„%s“ не е правилна стойност за време за „%s“"
 
-#: config.c:1377
+#: config.c:1361
 #, c-format
 msgid "abbrev length out of range: %d"
 msgstr "дължината на съкращаване е извън интервала ([4; 40]): %d"
 
-#: config.c:1391 config.c:1402
+#: config.c:1375 config.c:1386
 #, c-format
 msgid "bad zlib compression level %d"
 msgstr "неправилно ниво на компресиране: %d"
 
-#: config.c:1494
+#: config.c:1476
 msgid "core.commentChar should only be one character"
 msgstr "настройката „core.commentChar“ трябва да е само един знак"
 
-#: config.c:1527
+#: config.c:1509
 #, c-format
 msgid "invalid mode for object creation: %s"
 msgstr "неправилен режим за създаването на обекти: %s"
 
-#: config.c:1599
+#: config.c:1581
 #, c-format
 msgid "malformed value for %s"
 msgstr "неправилна стойност за „%s“"
 
-#: config.c:1625
+#: config.c:1607
 #, c-format
 msgid "malformed value for %s: %s"
 msgstr "неправилна стойност за „%s“: „%s“"
 
-#: config.c:1626
+#: config.c:1608
 msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr ""
 "трябва да е една от следните стойности: „nothing“ (без изтласкване при липса "
@@ -2902,132 +2914,132 @@ msgstr ""
 "„simple“ (клонът със същото име, от който се издърпва), „upstream“ (клонът, "
 "от който се издърпва) или „current“ (клонът със същото име)"
 
-#: config.c:1687 builtin/pack-objects.c:4084
+#: config.c:1669 builtin/pack-objects.c:4053
 #, c-format
 msgid "bad pack compression level %d"
 msgstr "неправилно ниво на компресиране при пакетиране: %d"
 
-#: config.c:1809
+#: config.c:1792
 #, c-format
 msgid "unable to load config blob object '%s'"
 msgstr "обектът-BLOB „%s“ с конфигурации не може да се зареди"
 
-#: config.c:1812
+#: config.c:1795
 #, c-format
 msgid "reference '%s' does not point to a blob"
 msgstr "указателят „%s“ не сочи към обект-BLOB"
 
-#: config.c:1829
+#: config.c:1813
 #, c-format
 msgid "unable to resolve config blob '%s'"
 msgstr "обектът-BLOB „%s“ с конфигурации не може да бъде открит"
 
-#: config.c:1874
+#: config.c:1858
 #, c-format
 msgid "failed to parse %s"
 msgstr "„%s“ не може да бъде анализиран"
 
-#: config.c:1930
+#: config.c:1914
 msgid "unable to parse command-line config"
 msgstr "неправилни настройки от командния ред"
 
-#: config.c:2294
+#: config.c:2282
 msgid "unknown error occurred while reading the configuration files"
 msgstr "неочаквана грешка при изчитането на конфигурационните файлове"
 
-#: config.c:2468
+#: config.c:2456
 #, c-format
 msgid "Invalid %s: '%s'"
 msgstr "Неправилен %s: „%s“"
 
-#: config.c:2513
+#: config.c:2501
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
 msgstr ""
 "стойността на „splitIndex.maxPercentChange“ трябва да е между 1 и 100, а не "
 "%d"
 
-#: config.c:2559
+#: config.c:2547
 #, c-format
 msgid "unable to parse '%s' from command-line config"
 msgstr "неразпозната стойност „%s“ от командния ред"
 
-#: config.c:2561
+#: config.c:2549
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
 msgstr "неправилна настройка „%s“ във файла „%s“ на ред №%d"
 
-#: config.c:2645
+#: config.c:2633
 #, c-format
 msgid "invalid section name '%s'"
 msgstr "неправилно име на раздел: „%s“"
 
-#: config.c:2677
+#: config.c:2665
 #, c-format
 msgid "%s has multiple values"
 msgstr "зададени са няколко стойности за „%s“"
 
-#: config.c:2706
+#: config.c:2694
 #, c-format
 msgid "failed to write new configuration file %s"
 msgstr "новият конфигурационен файл „%s“ не може да бъде запазен"
 
-#: config.c:2958 config.c:3285
+#: config.c:2946 config.c:3273
 #, c-format
 msgid "could not lock config file %s"
 msgstr "конфигурационният файл „%s“ не може да бъде заключен"
 
-#: config.c:2969
+#: config.c:2957
 #, c-format
 msgid "opening %s"
 msgstr "отваряне на „%s“"
 
-#: config.c:3006 builtin/config.c:361
+#: config.c:2994 builtin/config.c:361
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "неправилен шаблон: %s"
 
-#: config.c:3031
+#: config.c:3019
 #, c-format
 msgid "invalid config file %s"
 msgstr "неправилен конфигурационен файл: „%s“"
 
-#: config.c:3044 config.c:3298
+#: config.c:3032 config.c:3286
 #, c-format
 msgid "fstat on %s failed"
 msgstr "неуспешно изпълнение на „fstat“ върху „%s“"
 
-#: config.c:3055
+#: config.c:3043
 #, c-format
 msgid "unable to mmap '%s'%s"
 msgstr "неуспешно изпълнение на „mmap“ върху „%s“%s"
 
-#: config.c:3065 config.c:3303
+#: config.c:3053 config.c:3291
 #, c-format
 msgid "chmod on %s failed"
 msgstr "неуспешна смяна на права с „chmod“ върху „%s“"
 
-#: config.c:3150 config.c:3400
+#: config.c:3138 config.c:3388
 #, c-format
 msgid "could not write config file %s"
 msgstr "конфигурационният файл „%s“ не може да бъде записан"
 
-#: config.c:3184
+#: config.c:3172
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "„%s“ не може да се зададе да е „%s“"
 
-#: config.c:3186 builtin/remote.c:657 builtin/remote.c:855 builtin/remote.c:863
+#: config.c:3174 builtin/remote.c:662 builtin/remote.c:860 builtin/remote.c:868
 #, c-format
 msgid "could not unset '%s'"
 msgstr "„%s“ не може да се премахне"
 
-#: config.c:3276
+#: config.c:3264
 #, c-format
 msgid "invalid section name: %s"
 msgstr "неправилно име на раздел: %s"
 
-#: config.c:3443
+#: config.c:3431
 #, c-format
 msgid "missing value for '%s'"
 msgstr "липсва стойност за „%s“"
@@ -3063,72 +3075,72 @@ msgid "expected flush after capabilities"
 msgstr ""
 "след първоначалната обява на възможностите се очаква изчистване на буферите"
 
-#: connect.c:263
+#: connect.c:265
 #, c-format
 msgid "ignoring capabilities after first line '%s'"
 msgstr "пропускане на възможностите след първия ред „%s“"
 
-#: connect.c:284
+#: connect.c:286
 msgid "protocol error: unexpected capabilities^{}"
 msgstr "протоколна грешка: неочаквани възможности^{}"
 
-#: connect.c:306
+#: connect.c:308
 #, c-format
 msgid "protocol error: expected shallow sha-1, got '%s'"
 msgstr "протоколна грешка: очаква се SHA1 на плитък обект, а бе получено: „%s“"
 
-#: connect.c:308
+#: connect.c:310
 msgid "repository on the other end cannot be shallow"
 msgstr "отсрещното хранилище не може да е плитко"
 
-#: connect.c:347
+#: connect.c:349
 msgid "invalid packet"
 msgstr "неправилен пакет"
 
-#: connect.c:367
+#: connect.c:369
 #, c-format
 msgid "protocol error: unexpected '%s'"
 msgstr "протоколна грешка: неочаквано „%s“"
 
-#: connect.c:497
+#: connect.c:499
 #, c-format
 msgid "unknown object format '%s' specified by server"
 msgstr "сървърът указа непознат формат на обект: „%s“"
 
-#: connect.c:526
+#: connect.c:528
 #, c-format
 msgid "invalid ls-refs response: %s"
 msgstr "неправилен отговор на „ls-refs“: „%s“"
 
-#: connect.c:530
+#: connect.c:532
 msgid "expected flush after ref listing"
 msgstr "след изброяването на указателите се очаква изчистване на буферите"
 
-#: connect.c:533
+#: connect.c:535
 msgid "expected response end packet after ref listing"
 msgstr "след изброяването на указателите се очаква пакет за край"
 
-#: connect.c:666
+#: connect.c:670
 #, c-format
 msgid "protocol '%s' is not supported"
 msgstr "протокол „%s“ не се поддържа"
 
-#: connect.c:717
+#: connect.c:721
 msgid "unable to set SO_KEEPALIVE on socket"
 msgstr "неуспешно задаване на „SO_KEEPALIVE“ на гнездо"
 
-#: connect.c:757 connect.c:820
+#: connect.c:761 connect.c:824
 #, c-format
 msgid "Looking up %s ... "
 msgstr "Търсене на „%s“… "
 
-#: connect.c:761
+#: connect.c:765
 #, c-format
 msgid "unable to look up %s (port %s) (%s)"
 msgstr "„%s“ (порт %s) не може да се открие („%s“)"
 
 #. TRANSLATORS: this is the end of "Looking up %s ... "
-#: connect.c:765 connect.c:836
+#: connect.c:769 connect.c:840
 #, c-format
 msgid ""
 "done.\n"
@@ -3137,7 +3149,7 @@ msgstr ""
 "готово.\n"
 "Свързване към „%s“ (порт %s)…"
 
-#: connect.c:787 connect.c:864
+#: connect.c:791 connect.c:868
 #, c-format
 msgid ""
 "unable to connect to %s:\n"
@@ -3147,83 +3159,83 @@ msgstr ""
 "%s"
 
 #. TRANSLATORS: this is the end of "Connecting to %s (port %s) ... "
-#: connect.c:793 connect.c:870
+#: connect.c:797 connect.c:874
 msgid "done."
 msgstr "действието завърши."
 
-#: connect.c:824
+#: connect.c:828
 #, c-format
 msgid "unable to look up %s (%s)"
 msgstr "„%s“ не може да се открие (%s)"
 
-#: connect.c:830
+#: connect.c:834
 #, c-format
 msgid "unknown port %s"
 msgstr "непознат порт „%s“"
 
-#: connect.c:967 connect.c:1299
+#: connect.c:971 connect.c:1303
 #, c-format
 msgid "strange hostname '%s' blocked"
 msgstr "необичайното име на хост „%s“ е блокирано"
 
-#: connect.c:969
+#: connect.c:973
 #, c-format
 msgid "strange port '%s' blocked"
 msgstr "необичайният порт „%s“ е блокиран"
 
-#: connect.c:979
+#: connect.c:983
 #, c-format
 msgid "cannot start proxy %s"
 msgstr "посредникът „%s“ не може да се стартира"
 
-#: connect.c:1050
+#: connect.c:1054
 msgid "no path specified; see 'git help pull' for valid url syntax"
 msgstr ""
 "не е указан път. Проверете синтаксиса с командата:\n"
 "\n"
 "    git help pull"
 
-#: connect.c:1190
+#: connect.c:1194
 msgid "newline is forbidden in git:// hosts and repo paths"
 msgstr ""
 "знакът за нов ред не е позволен в адресите и в пътищата до хранилищата "
 "„git://“"
 
-#: connect.c:1247
+#: connect.c:1251
 msgid "ssh variant 'simple' does not support -4"
 msgstr "вариантът за „ssh“ — „simple“ (опростен), не поддържа опцията „-4“"
 
-#: connect.c:1259
+#: connect.c:1263
 msgid "ssh variant 'simple' does not support -6"
 msgstr "вариантът за „ssh“ — „simple“ (опростен), не поддържа опцията „-6“"
 
-#: connect.c:1276
+#: connect.c:1280
 msgid "ssh variant 'simple' does not support setting port"
 msgstr ""
 "вариантът за „ssh“ — „simple“ (опростен), не поддържа задаването на порт"
 
-#: connect.c:1388
+#: connect.c:1392
 #, c-format
 msgid "strange pathname '%s' blocked"
 msgstr "необичайният път „%s“ е блокиран"
 
-#: connect.c:1436
+#: connect.c:1440
 msgid "unable to fork"
 msgstr "неуспешно създаване на процес"
 
-#: connected.c:108 builtin/fsck.c:189 builtin/prune.c:45
+#: connected.c:109 builtin/fsck.c:189 builtin/prune.c:45
 msgid "Checking connectivity"
 msgstr "Проверка на свързаността"
 
-#: connected.c:120
+#: connected.c:122
 msgid "Could not run 'git rev-list'"
 msgstr "Командата „git rev-list“ не може да бъде изпълнена."
 
-#: connected.c:144
+#: connected.c:146
 msgid "failed write to rev-list"
 msgstr "неуспешен запис на списъка с версиите"
 
-#: connected.c:149
+#: connected.c:151
 msgid "failed to close rev-list's stdin"
 msgstr "стандартният вход на списъка с версиите не може да бъде затворен"
 
@@ -3377,17 +3389,17 @@ msgstr "адресът трябва задължително да съдържа
 msgid "refusing to work with credential missing protocol field"
 msgstr "адресът трябва задължително да съдържа протокол"
 
-#: credential.c:394
+#: credential.c:395
 #, c-format
 msgid "url contains a newline in its %s component: %s"
 msgstr "адресът съдържа нов ред в частта за %s: %s"
 
-#: credential.c:438
+#: credential.c:439
 #, c-format
 msgid "url has no scheme: %s"
 msgstr "адресът е без схема: %s"
 
-#: credential.c:511
+#: credential.c:512
 #, c-format
 msgid "credential url cannot be parsed: %s"
 msgstr "адресът за идентификация не може да се анализира: „%s“"
@@ -3491,23 +3503,23 @@ msgstr "Отбелязани са %d групи, работата приключ
 msgid "unknown value for --diff-merges: %s"
 msgstr "непозната стойност за опцията „--diff-merges“: „%s“"
 
-#: diff-lib.c:557
+#: diff-lib.c:561
 msgid "--merge-base does not work with ranges"
 msgstr "опцията „--merge-base“ не работи с диапазони"
 
-#: diff-lib.c:559
+#: diff-lib.c:563
 msgid "--merge-base only works with commits"
 msgstr "опцията „--merge-base“ работи само с подавания"
 
-#: diff-lib.c:576
+#: diff-lib.c:580
 msgid "unable to get HEAD"
 msgstr "Указателят „HEAD“ не може да бъде получен"
 
-#: diff-lib.c:583
+#: diff-lib.c:587
 msgid "no merge base found"
 msgstr "липсва база за сливане"
 
-#: diff-lib.c:585
+#: diff-lib.c:589
 msgid "multiple merge bases found"
 msgstr "много бази за сливане"
 
@@ -3523,19 +3535,19 @@ msgstr ""
 "Не е хранилище на git.  Ползвайте опцията „--no-index“, за да сравните "
 "пътища извън работно дърво"
 
-#: diff.c:156
+#: diff.c:157
 #, c-format
 msgid "  Failed to parse dirstat cut-off percentage '%s'\n"
 msgstr ""
 "  Неуспешно разпознаване на „%s“ като процент-праг за статистиката по "
 "директории\n"
 
-#: diff.c:161
+#: diff.c:162
 #, c-format
 msgid "  Unknown dirstat parameter '%s'\n"
 msgstr "  Непознат параметър „%s“ за статистиката по директории'\n"
 
-#: diff.c:297
+#: diff.c:298
 msgid ""
 "color moved setting must be one of 'no', 'default', 'blocks', 'zebra', "
 "'dimmed-zebra', 'plain'"
@@ -3544,7 +3556,7 @@ msgstr ""
 "„default“ (стандартно), „blocks“ (парчета), „zebra“ (райе), „dimmed-"
 "zebra“ (тъмно райе), „plain“ (обикновено)"
 
-#: diff.c:325
+#: diff.c:326
 #, c-format
 msgid ""
 "unknown color-moved-ws mode '%s', possible values are 'ignore-space-change', "
@@ -3557,7 +3569,7 @@ msgstr ""
 "„allow-indentation-change“ (позволяване на промените в празните знаци за "
 "форматиране)"
 
-#: diff.c:333
+#: diff.c:334
 msgid ""
 "color-moved-ws: allow-indentation-change cannot be combined with other "
 "whitespace modes"
@@ -3565,12 +3577,12 @@ msgstr ""
 "„color-moved-ws“: „allow-indentation-change“ е несъвместима с другите режими "
 "за празни знаци"
 
-#: diff.c:410
+#: diff.c:411
 #, c-format
 msgid "Unknown value for 'diff.submodule' config variable: '%s'"
 msgstr "Непозната стойност „%s“ за настройката „diff.submodule“"
 
-#: diff.c:470
+#: diff.c:471
 #, c-format
 msgid ""
 "Found errors in 'diff.dirstat' config variable:\n"
@@ -3579,30 +3591,30 @@ msgstr ""
 "Грешки в настройката „diff.dirstat“:\n"
 "%s"
 
-#: diff.c:4282
+#: diff.c:4290
 #, c-format
 msgid "external diff died, stopping at %s"
 msgstr ""
 "външната програма за разлики завърши неуспешно.  Спиране на работата при „%s“"
 
-#: diff.c:4634
+#: diff.c:4642
 msgid "--name-only, --name-status, --check and -s are mutually exclusive"
 msgstr ""
 "опциите „--name-only“, „--name-status“, „--check“ и „-s“ са несъвместими "
 "една с друга"
 
-#: diff.c:4637
+#: diff.c:4645
 msgid "-G, -S and --find-object are mutually exclusive"
 msgstr "опциите „-G“, „-S“ и „--find-object“ са несъвместими една с друга"
 
-#: diff.c:4640
+#: diff.c:4648
 msgid ""
 "-G and --pickaxe-regex are mutually exclusive, use --pickaxe-regex with -S"
 msgstr ""
 "опциите „-G“ и „--pickaxe-regex“ са несъвместими една с друга.  Пробвайте „--"
 "pickaxe-regex“ със „-S“"
 
-#: diff.c:4643
+#: diff.c:4651
 msgid ""
 "--pickaxe-all and --find-object are mutually exclusive, use --pickaxe-all "
 "with -G and -S"
@@ -3610,22 +3622,22 @@ msgstr ""
 "опциите „--pickaxe-all“ и „--find-object“ са несъвместими една с друга.  "
 "Пробвайте „--pickaxe-all“ с „-G“ и „-S“"
 
-#: diff.c:4722
+#: diff.c:4730
 msgid "--follow requires exactly one pathspec"
 msgstr "опцията „--follow“ изисква точно един път"
 
-#: diff.c:4770
+#: diff.c:4778
 #, c-format
 msgid "invalid --stat value: %s"
 msgstr "неправилна стойност за „--stat“: %s"
 
-#: diff.c:4775 diff.c:4780 diff.c:4785 diff.c:4790 diff.c:5318
-#: parse-options.c:197 parse-options.c:201 builtin/commit-graph.c:180
+#: diff.c:4783 diff.c:4788 diff.c:4793 diff.c:4798 diff.c:5326
+#: parse-options.c:217 parse-options.c:221
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "опцията „%s“ очаква число за аргумент"
 
-#: diff.c:4807
+#: diff.c:4815
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -3634,44 +3646,44 @@ msgstr ""
 "Неразпознат параметър към опцията „--dirstat/-X“:\n"
 "%s"
 
-#: diff.c:4892
+#: diff.c:4900
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
 msgstr "непознат вид промяна: „%c“ в „--diff-filter=%s“"
 
-#: diff.c:4916
+#: diff.c:4924
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
 msgstr "непозната стойност след „ws-error-highlight=%.*s“"
 
-#: diff.c:4930
+#: diff.c:4938
 #, c-format
 msgid "unable to resolve '%s'"
 msgstr "„%s“ не може да се открие"
 
-#: diff.c:4980 diff.c:4986
+#: diff.c:4988 diff.c:4994
 #, c-format
 msgid "%s expects <n>/<m> form"
 msgstr ""
 "опцията „%s“ изисква стойности за МИНИМАЛЕН_%%_ПРОМЯНА_ЗА_ИЗТОЧНИК_/"
 "МАКСИМАЛЕН_%%_ПРОМЯНА_ЗА_ЗАМЯНА от"
 
-#: diff.c:4998
+#: diff.c:5006
 #, c-format
 msgid "%s expects a character, got '%s'"
 msgstr "опцията „%s“ изисква знак, а не: „%s“"
 
-#: diff.c:5019
+#: diff.c:5027
 #, c-format
 msgid "bad --color-moved argument: %s"
 msgstr "неправилен аргумент за „--color-moved“: „%s“"
 
-#: diff.c:5038
+#: diff.c:5046
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
 msgstr "неправилен режим „%s“ за „ --color-moved-ws“"
 
-#: diff.c:5078
+#: diff.c:5086
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
@@ -3680,158 +3692,158 @@ msgstr ""
 "Майерс), „minimal“ (минимизиране на разликите), „patience“ (пасианс) и "
 "„histogram“ (хистограмен)"
 
-#: diff.c:5114 diff.c:5134
+#: diff.c:5122 diff.c:5142
 #, c-format
 msgid "invalid argument to %s"
 msgstr "неправилен аргумент към „%s“"
 
-#: diff.c:5238
+#: diff.c:5246
 #, c-format
 msgid "invalid regex given to -I: '%s'"
 msgstr "неправилен регулярен израз подаден към „-I“: „%s“"
 
-#: diff.c:5287
+#: diff.c:5295
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
 msgstr "неразпознат параметър към опцията „--submodule“: „%s“"
 
-#: diff.c:5343
+#: diff.c:5351
 #, c-format
 msgid "bad --word-diff argument: %s"
 msgstr "неправилен аргумент към „--word-diff“: „%s“"
 
-#: diff.c:5379
+#: diff.c:5387
 msgid "Diff output format options"
 msgstr "Формат на изхода за разликите"
 
-#: diff.c:5381 diff.c:5387
+#: diff.c:5389 diff.c:5395
 msgid "generate patch"
 msgstr "създаване на кръпки"
 
-#: diff.c:5384 builtin/log.c:179
+#: diff.c:5392 builtin/log.c:179
 msgid "suppress diff output"
 msgstr "без извеждане на разликите"
 
-#: diff.c:5389 diff.c:5503 diff.c:5510
+#: diff.c:5397 diff.c:5511 diff.c:5518
 msgid "<n>"
 msgstr "БРОЙ"
 
-#: diff.c:5390 diff.c:5393
+#: diff.c:5398 diff.c:5401
 msgid "generate diffs with <n> lines context"
 msgstr "файловете с разлики да са с контекст с такъв БРОЙ редове"
 
-#: diff.c:5395
+#: diff.c:5403
 msgid "generate the diff in raw format"
 msgstr "файловете с разлики да са в суров формат"
 
-#: diff.c:5398
+#: diff.c:5406
 msgid "synonym for '-p --raw'"
 msgstr "псевдоним на „-p --raw“"
 
-#: diff.c:5402
+#: diff.c:5410
 msgid "synonym for '-p --stat'"
 msgstr "псевдоним на „-p --stat“"
 
-#: diff.c:5406
+#: diff.c:5414
 msgid "machine friendly --stat"
 msgstr "„--stat“ във формат за четене от програма"
 
-#: diff.c:5409
+#: diff.c:5417
 msgid "output only the last line of --stat"
 msgstr "извеждане само на последния ред на „--stat“"
 
-#: diff.c:5411 diff.c:5419
+#: diff.c:5419 diff.c:5427
 msgid "<param1,param2>..."
 msgstr "ПАРАМЕТЪР_1, ПАРАМЕТЪР_2, …"
 
-#: diff.c:5412
+#: diff.c:5420
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr "извеждане на разпределението на промените за всяка поддиректория"
 
-#: diff.c:5416
+#: diff.c:5424
 msgid "synonym for --dirstat=cumulative"
 msgstr "псевдоним на „--dirstat=cumulative“"
 
-#: diff.c:5420
+#: diff.c:5428
 msgid "synonym for --dirstat=files,param1,param2..."
 msgstr "псевдоним на „--dirstat=ФАЙЛ…,ПАРАМЕТЪР_1,ПАРАМЕТЪР_2,…“"
 
-#: diff.c:5424
+#: diff.c:5432
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
 "предупреждаване, ако промените водят до маркери за конфликт или грешки в "
 "празните знаци"
 
-#: diff.c:5427
+#: diff.c:5435
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr ""
 "съкратено резюме на създадените, преименуваните и файловете с промяна на "
 "режима на достъп"
 
-#: diff.c:5430
+#: diff.c:5438
 msgid "show only names of changed files"
 msgstr "извеждане само на имената на променените файлове"
 
-#: diff.c:5433
+#: diff.c:5441
 msgid "show only names and status of changed files"
 msgstr "извеждане само на имената и статистиката за променените файлове"
 
-#: diff.c:5435
+#: diff.c:5443
 msgid "<width>[,<name-width>[,<count>]]"
 msgstr "ШИРОЧИНА[,ИМЕ-ШИРОЧИНА[,БРОЙ]]"
 
-#: diff.c:5436
+#: diff.c:5444
 msgid "generate diffstat"
 msgstr "извеждане на статистика за промените"
 
-#: diff.c:5438 diff.c:5441 diff.c:5444
+#: diff.c:5446 diff.c:5449 diff.c:5452
 msgid "<width>"
 msgstr "ШИРОЧИНА"
 
-#: diff.c:5439
+#: diff.c:5447
 msgid "generate diffstat with a given width"
 msgstr "статистика с такава ШИРОЧИНА за промените"
 
-#: diff.c:5442
+#: diff.c:5450
 msgid "generate diffstat with a given name width"
 msgstr "статистика за промените с такава ШИРОЧИНА на имената"
 
-#: diff.c:5445
+#: diff.c:5453
 msgid "generate diffstat with a given graph width"
 msgstr "статистика за промените с такава ШИРОЧИНА на гра̀фа"
 
-#: diff.c:5447
+#: diff.c:5455
 msgid "<count>"
 msgstr "БРОЙ"
 
-#: diff.c:5448
+#: diff.c:5456
 msgid "generate diffstat with limited lines"
 msgstr "ограничаване на БРОя на редовете в статистиката за промените"
 
-#: diff.c:5451
+#: diff.c:5459
 msgid "generate compact summary in diffstat"
 msgstr "кратко резюме в статистиката за промените"
 
-#: diff.c:5454
+#: diff.c:5462
 msgid "output a binary diff that can be applied"
 msgstr "извеждане на двоична разлика във вид за прилагане"
 
-#: diff.c:5457
+#: diff.c:5465
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr ""
 "показване на пълните имена на обекти в редовете за индекса при вариантите "
 "преди и след промяната"
 
-#: diff.c:5459
+#: diff.c:5467
 msgid "show colored diff"
 msgstr "разлики в цвят"
 
-#: diff.c:5460
+#: diff.c:5468
 msgid "<kind>"
 msgstr "ВИД"
 
-#: diff.c:5461
+#: diff.c:5469
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
@@ -3839,7 +3851,7 @@ msgstr ""
 "грешките в празните знаци да се указват в редовете за контекста, вариантите "
 "преди и след разликата,"
 
-#: diff.c:5464
+#: diff.c:5472
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
@@ -3847,261 +3859,261 @@ msgstr ""
 "без преименуване на пътищата.  Да се използват нулеви байтове за разделители "
 "на полета в изхода при ползване на опцията „--raw“ или „--numstat“"
 
-#: diff.c:5467 diff.c:5470 diff.c:5473 diff.c:5582
+#: diff.c:5475 diff.c:5478 diff.c:5481 diff.c:5590
 msgid "<prefix>"
 msgstr "ПРЕФИКС"
 
-#: diff.c:5468
+#: diff.c:5476
 msgid "show the given source prefix instead of \"a/\""
 msgstr "префикс вместо „a/“ за източник"
 
-#: diff.c:5471
+#: diff.c:5479
 msgid "show the given destination prefix instead of \"b/\""
 msgstr "префикс вместо „b/“ за цел"
 
-#: diff.c:5474
+#: diff.c:5482
 msgid "prepend an additional prefix to every line of output"
 msgstr "добавяне на допълнителен префикс за всеки ред на изхода"
 
-#: diff.c:5477
+#: diff.c:5485
 msgid "do not show any source or destination prefix"
 msgstr "без префикс за източника и целта"
 
-#: diff.c:5480
+#: diff.c:5488
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
 "извеждане на контекст между последователните парчета с разлики от указания "
 "БРОЙ редове"
 
-#: diff.c:5484 diff.c:5489 diff.c:5494
+#: diff.c:5492 diff.c:5497 diff.c:5502
 msgid "<char>"
 msgstr "ЗНАК"
 
-#: diff.c:5485
+#: diff.c:5493
 msgid "specify the character to indicate a new line instead of '+'"
 msgstr "знак вместо „+“ за нов вариант на ред"
 
-#: diff.c:5490
+#: diff.c:5498
 msgid "specify the character to indicate an old line instead of '-'"
 msgstr "знак вместо „-“ за стар вариант на ред"
 
-#: diff.c:5495
+#: diff.c:5503
 msgid "specify the character to indicate a context instead of ' '"
 msgstr "знак вместо „ “ за контекст"
 
-#: diff.c:5498
+#: diff.c:5506
 msgid "Diff rename options"
 msgstr "Настройки за разлики с преименуване"
 
-#: diff.c:5499
+#: diff.c:5507
 msgid "<n>[/<m>]"
 msgstr "МИНИМАЛЕН_%_ПРОМЯНА_ЗА_ИЗТОЧНИК[/МАКСИМАЛEН_%_ПРОМЯНА_ЗА_ЗАМЯНА]"
 
-#: diff.c:5500
+#: diff.c:5508
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr ""
 "заместване на пълните промени с последователност от изтриване и създаване"
 
-#: diff.c:5504
+#: diff.c:5512
 msgid "detect renames"
 msgstr "засичане на преименуванията"
 
-#: diff.c:5508
+#: diff.c:5516
 msgid "omit the preimage for deletes"
 msgstr "без предварителен вариант при изтриване"
 
-#: diff.c:5511
+#: diff.c:5519
 msgid "detect copies"
 msgstr "засичане на копиранията"
 
-#: diff.c:5515
+#: diff.c:5523
 msgid "use unmodified files as source to find copies"
 msgstr "търсене на копирано и от непроменените файлове"
 
-#: diff.c:5517
+#: diff.c:5525
 msgid "disable rename detection"
 msgstr "без търсене на преименувания"
 
-#: diff.c:5520
+#: diff.c:5528
 msgid "use empty blobs as rename source"
 msgstr "празни обекти като източник при преименувания"
 
-#: diff.c:5522
+#: diff.c:5530
 msgid "continue listing the history of a file beyond renames"
 msgstr ""
 "продължаване на извеждането на историята — без отрязването при преименувания "
 "на файл"
 
-#: diff.c:5525
+#: diff.c:5533
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
 msgstr ""
 "без засичане на преименувания/копирания, ако броят им надвишава тази стойност"
 
-#: diff.c:5527
+#: diff.c:5535
 msgid "Diff algorithm options"
 msgstr "Опции към алгоритъма за разлики"
 
-#: diff.c:5529
+#: diff.c:5537
 msgid "produce the smallest possible diff"
 msgstr "търсене на възможно най-малка разлика"
 
-#: diff.c:5532
+#: diff.c:5540
 msgid "ignore whitespace when comparing lines"
 msgstr "без промени в празните знаци при сравняване на редове"
 
-#: diff.c:5535
+#: diff.c:5543
 msgid "ignore changes in amount of whitespace"
 msgstr "без промени в празните знаци"
 
-#: diff.c:5538
+#: diff.c:5546
 msgid "ignore changes in whitespace at EOL"
 msgstr "без промени в празните знаци в края на редовете"
 
-#: diff.c:5541
+#: diff.c:5549
 msgid "ignore carrier-return at the end of line"
 msgstr "без промени в знаците за край на ред"
 
-#: diff.c:5544
+#: diff.c:5552
 msgid "ignore changes whose lines are all blank"
 msgstr "без промени в редовете, които са изцяло от празни знаци"
 
-#: diff.c:5546 diff.c:5568 diff.c:5571 diff.c:5616
+#: diff.c:5554 diff.c:5576 diff.c:5579 diff.c:5624
 msgid "<regex>"
 msgstr "РЕГУЛЯРЕН_ИЗРАЗ"
 
-#: diff.c:5547
+#: diff.c:5555
 msgid "ignore changes whose all lines match <regex>"
 msgstr "без промени в редовете, които напасват РЕГУЛЯРНия_ИЗРАЗ"
 
-#: diff.c:5550
+#: diff.c:5558
 msgid "heuristic to shift diff hunk boundaries for easy reading"
 msgstr ""
 "евристика за преместване на границите на парчетата за улесняване на четенето"
 
-#: diff.c:5553
+#: diff.c:5561
 msgid "generate diff using the \"patience diff\" algorithm"
 msgstr "разлика чрез алгоритъм за подредба като пасианс"
 
-#: diff.c:5557
+#: diff.c:5565
 msgid "generate diff using the \"histogram diff\" algorithm"
 msgstr "разлика по хистограмния алгоритъм"
 
-#: diff.c:5559
+#: diff.c:5567
 msgid "<algorithm>"
 msgstr "АЛГОРИТЪМ"
 
-#: diff.c:5560
+#: diff.c:5568
 msgid "choose a diff algorithm"
 msgstr "избор на АЛГОРИТЪМа за разлики"
 
-#: diff.c:5562
+#: diff.c:5570
 msgid "<text>"
 msgstr "ТЕКСТ"
 
-#: diff.c:5563
+#: diff.c:5571
 msgid "generate diff using the \"anchored diff\" algorithm"
 msgstr "разлика чрез алгоритъма със закотвяне"
 
-#: diff.c:5565 diff.c:5574 diff.c:5577
+#: diff.c:5573 diff.c:5582 diff.c:5585
 msgid "<mode>"
 msgstr "РЕЖИМ"
 
-#: diff.c:5566
+#: diff.c:5574
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr ""
 "разлика по думи, като се ползва този РЕЖИМ за отделянето на променените думи"
 
-#: diff.c:5569
+#: diff.c:5577
 msgid "use <regex> to decide what a word is"
 msgstr "РЕГУЛЯРЕН_ИЗРАЗ за разделяне по думи"
 
-#: diff.c:5572
+#: diff.c:5580
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
 msgstr "псевдоним на „--word-diff=color --word-diff-regex=РЕГУЛЯРЕН_ИЗРАЗ“"
 
-#: diff.c:5575
+#: diff.c:5583
 msgid "moved lines of code are colored differently"
 msgstr "различен цвят за извеждане на преместените редове"
 
-#: diff.c:5578
+#: diff.c:5586
 msgid "how white spaces are ignored in --color-moved"
 msgstr ""
 "режим за прескачането на празните знаци при задаването на „--color-moved“"
 
-#: diff.c:5581
+#: diff.c:5589
 msgid "Other diff options"
 msgstr "Други опции за разлики"
 
-#: diff.c:5583
+#: diff.c:5591
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
 "при изпълнение от поддиректория да се пренебрегват разликите извън нея и да "
 "се ползват относителни пътища"
 
-#: diff.c:5587
+#: diff.c:5595
 msgid "treat all files as text"
 msgstr "обработка на всички файлове като текстови"
 
-#: diff.c:5589
+#: diff.c:5597
 msgid "swap two inputs, reverse the diff"
 msgstr "размяна на двата входа — обръщане на разликата"
 
-#: diff.c:5591
+#: diff.c:5599
 msgid "exit with 1 if there were differences, 0 otherwise"
 msgstr ""
 "завършване с код за състояние 1 при наличието на разлики, а в противен "
 "случай — с 0"
 
-#: diff.c:5593
+#: diff.c:5601
 msgid "disable all output of the program"
 msgstr "без всякакъв изход от програмата"
 
-#: diff.c:5595
+#: diff.c:5603
 msgid "allow an external diff helper to be executed"
 msgstr "позволяване на изпълнение на външна помощна програма за разлики"
 
-#: diff.c:5597
+#: diff.c:5605
 msgid "run external text conversion filters when comparing binary files"
 msgstr ""
 "изпълнение на външни програми-филтри при сравнението на двоични файлове"
 
-#: diff.c:5599
+#: diff.c:5607
 msgid "<when>"
 msgstr "КОГА"
 
-#: diff.c:5600
+#: diff.c:5608
 msgid "ignore changes to submodules in the diff generation"
 msgstr "игнориране на промените в подмодулите при извеждането на разликите"
 
-#: diff.c:5603
+#: diff.c:5611
 msgid "<format>"
 msgstr "ФОРМАТ"
 
-#: diff.c:5604
+#: diff.c:5612
 msgid "specify how differences in submodules are shown"
 msgstr "начин за извеждане на промените в подмодулите"
 
-#: diff.c:5608
+#: diff.c:5616
 msgid "hide 'git add -N' entries from the index"
 msgstr "без включване в индекса на записите, добавени с „git add -N“"
 
-#: diff.c:5611
+#: diff.c:5619
 msgid "treat 'git add -N' entries as real in the index"
 msgstr "включване в индекса на записите, добавени с „git add -N“"
 
-#: diff.c:5613
+#: diff.c:5621
 msgid "<string>"
 msgstr "НИЗ"
 
-#: diff.c:5614
+#: diff.c:5622
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
 msgstr "търсене на разлики, които променят броя на поява на указаните низове"
 
-#: diff.c:5617
+#: diff.c:5625
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
@@ -4109,69 +4121,69 @@ msgstr ""
 "търсене на разлики, които променят броя на поява на низовете, които напасват "
 "на регулярния израз"
 
-#: diff.c:5620
+#: diff.c:5628
 msgid "show all changes in the changeset with -S or -G"
 msgstr "извеждане на всички промени с „-G“/„-S“"
 
-#: diff.c:5623
+#: diff.c:5631
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr "НИЗът към „-S“ да се тълкува като разширен регулярен израз по POSIX"
 
-#: diff.c:5626
+#: diff.c:5634
 msgid "control the order in which files appear in the output"
 msgstr "управление на подредбата на файловете в изхода"
 
-#: diff.c:5627 diff.c:5630
+#: diff.c:5635 diff.c:5638
 msgid "<path>"
 msgstr "ПЪТ"
 
-#: diff.c:5628
+#: diff.c:5636
 msgid "show the change in the specified path first"
 msgstr "първо извеждане на промяната в указания път"
 
-#: diff.c:5631
+#: diff.c:5639
 msgid "skip the output to the specified path"
 msgstr "прескачане на изхода към указания път"
 
-#: diff.c:5633
+#: diff.c:5641
 msgid "<object-id>"
 msgstr "ИДЕНТИФИКАТОР_НА_ОБЕКТ"
 
-#: diff.c:5634
+#: diff.c:5642
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
 msgstr "търсене на разлики, които променят броя на поява на указания обект"
 
-#: diff.c:5636
+#: diff.c:5644
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "[(A|C|D|M|R|T|U|X|B)…[*]]"
 
-#: diff.c:5637
+#: diff.c:5645
 msgid "select files by diff type"
 msgstr "избор на файловете по вид разлика"
 
-#: diff.c:5639
+#: diff.c:5647
 msgid "<file>"
 msgstr "ФАЙЛ"
 
-#: diff.c:5640
+#: diff.c:5648
 msgid "Output to a specific file"
 msgstr "Изход към указания файл"
 
-#: diff.c:6298
+#: diff.c:6306
 msgid "exhaustive rename detection was skipped due to too many files."
 msgstr ""
 "пълното търсене на преименувания на обекти се прескача поради многото "
 "файлове."
 
-#: diff.c:6301
+#: diff.c:6309
 msgid "only found copies from modified paths due to too many files."
 msgstr ""
 "установени са само точните копия на променените пътища поради многото "
 "файлове."
 
-#: diff.c:6304
+#: diff.c:6312
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
@@ -4182,7 +4194,7 @@ msgstr "задайте променливата „%s“ да е поне %d и 
 msgid "failed to read orderfile '%s'"
 msgstr "файлът с подредбата на съответствията „%s“ не може да бъде прочетен"
 
-#: diffcore-rename.c:1514
+#: diffcore-rename.c:1564
 msgid "Performing inexact rename detection"
 msgstr "Търсене на преименувания на обекти съчетани с промени"
 
@@ -4222,342 +4234,430 @@ msgstr "изключване на пътеводното напасване"
 msgid "cannot use %s as an exclude file"
 msgstr "„%s“ не може да се ползва за игнорираните файлове (като gitignore)"
 
-#: dir.c:2351
+#: dir.c:2464
 #, c-format
 msgid "could not open directory '%s'"
 msgstr "директорията „%s“ не може да бъде отворена"
 
-#: dir.c:2653
+#: dir.c:2766
 msgid "failed to get kernel name and information"
 msgstr "името и версията на ядрото не бяха получени"
 
-#: dir.c:2777
+#: dir.c:2890
 msgid "untracked cache is disabled on this system or location"
 msgstr ""
 "кешът за неследените файлове е изключен на тази система или местоположение"
 
-#: dir.c:3610
+#: dir.c:3158
+msgid ""
+"No directory name could be guessed.\n"
+"Please specify a directory on the command line"
+msgstr ""
+"Името на директорията не може да бъде отгатнато.\n"
+"Задайте директорията изрично на командния ред"
+
+#: dir.c:3837
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "файлът с индекса е повреден в хранилището „%s“"
 
-#: dir.c:3657 dir.c:3662
+#: dir.c:3884 dir.c:3889
 #, c-format
 msgid "could not create directories for %s"
 msgstr "директориите за „%s“ не може да бъдат създадени"
 
-#: dir.c:3691
+#: dir.c:3918
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "директорията на git не може да се мигрира от „%s“ до „%s“"
 
-#: editor.c:74
+#: editor.c:77
 #, c-format
 msgid "hint: Waiting for your editor to close the file...%c"
 msgstr "Подсказка: чака се редакторът ви да затвори файла …%c"
 
-#: entry.c:176
+#: entry.c:177
 msgid "Filtering content"
 msgstr "Филтриране на съдържанието"
 
-#: entry.c:497
+#: entry.c:498
 #, c-format
 msgid "could not stat file '%s'"
 msgstr "неуспешно изпълнение на „stat“ върху файла „%s“"
 
-#: environment.c:152
+#: environment.c:143
 #, c-format
 msgid "bad git namespace path \"%s\""
 msgstr "неправилен път към пространства от имена „%s“"
-
-#: environment.c:334
-#, c-format
-msgid "could not set GIT_DIR to '%s'"
-msgstr "GIT_DIR не може да се зададе да е „%s“"
 
 #: exec-cmd.c:363
 #, c-format
 msgid "too many args to run %s"
 msgstr "прекалено много аргументи за изпълнение „%s“"
 
-#: fetch-pack.c:182
+#: fetch-pack.c:193
 msgid "git fetch-pack: expected shallow list"
 msgstr "git fetch-pack: очаква се плитък списък"
 
-#: fetch-pack.c:185
+#: fetch-pack.c:196
 msgid "git fetch-pack: expected a flush packet after shallow list"
 msgstr "git fetch-pack: след плитък списък се очаква изчистващ пакет „flush“"
 
-#: fetch-pack.c:196
+#: fetch-pack.c:207
 msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
 msgstr ""
 "git fetch-pack: очаква се „ACK“/„NAK“, а бе получен изчистващ пакет „flush“"
 
-#: fetch-pack.c:216
+#: fetch-pack.c:227
 #, c-format
 msgid "git fetch-pack: expected ACK/NAK, got '%s'"
 msgstr "git fetch-pack: очаква се „ACK“/„NAK“, а бе получено „%s“"
 
-#: fetch-pack.c:227
+#: fetch-pack.c:238
 msgid "unable to write to remote"
 msgstr "невъзможно писане към отдалечено хранилище"
 
-#: fetch-pack.c:288
+#: fetch-pack.c:299
 msgid "--stateless-rpc requires multi_ack_detailed"
 msgstr "опцията „--stateless-rpc“ изисква  „multi_ack_detailed“"
 
-#: fetch-pack.c:383 fetch-pack.c:1423
+#: fetch-pack.c:394 fetch-pack.c:1434
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "неправилен плитък ред: „%s“"
 
-#: fetch-pack.c:389 fetch-pack.c:1429
+#: fetch-pack.c:400 fetch-pack.c:1440
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "неправилен неплитък ред: „%s“"
 
-#: fetch-pack.c:391 fetch-pack.c:1431
+#: fetch-pack.c:402 fetch-pack.c:1442
 #, c-format
 msgid "object not found: %s"
 msgstr "обектът „%s“ липсва"
 
-#: fetch-pack.c:394 fetch-pack.c:1434
+#: fetch-pack.c:405 fetch-pack.c:1445
 #, c-format
 msgid "error in object: %s"
 msgstr "грешка в обекта: „%s“"
 
-#: fetch-pack.c:396 fetch-pack.c:1436
+#: fetch-pack.c:407 fetch-pack.c:1447
 #, c-format
 msgid "no shallow found: %s"
 msgstr "не е открит плитък обект: %s"
 
-#: fetch-pack.c:399 fetch-pack.c:1440
+#: fetch-pack.c:410 fetch-pack.c:1451
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "очаква се плитък или не обект, а бе получено: „%s“"
 
-#: fetch-pack.c:439
+#: fetch-pack.c:450
 #, c-format
 msgid "got %s %d %s"
 msgstr "получено бе %s %d %s"
 
-#: fetch-pack.c:456
+#: fetch-pack.c:467
 #, c-format
 msgid "invalid commit %s"
 msgstr "неправилно подаване: „%s“"
 
-#: fetch-pack.c:487
+#: fetch-pack.c:498
 msgid "giving up"
 msgstr "преустановяване"
 
-#: fetch-pack.c:500 progress.c:339
+#: fetch-pack.c:511 progress.c:339
 msgid "done"
 msgstr "действието завърши"
 
-#: fetch-pack.c:512
+#: fetch-pack.c:523
 #, c-format
 msgid "got %s (%d) %s"
 msgstr "получено бе %s (%d) %s"
 
-#: fetch-pack.c:548
+#: fetch-pack.c:559
 #, c-format
 msgid "Marking %s as complete"
 msgstr "Отбелязване на „%s“ като пълно"
 
-#: fetch-pack.c:763
+#: fetch-pack.c:774
 #, c-format
 msgid "already have %s (%s)"
 msgstr "вече има „%s“ (%s)"
 
-#: fetch-pack.c:849
+#: fetch-pack.c:860
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-pack: не може да се създаде процес за демултиплексора"
 
-#: fetch-pack.c:857
+#: fetch-pack.c:868
 msgid "protocol error: bad pack header"
 msgstr "протоколна грешка: неправилна заглавна част на пакет"
 
-#: fetch-pack.c:951
+#: fetch-pack.c:962
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-pack: не може да се създаде процес за „%s“"
 
-#: fetch-pack.c:957
+#: fetch-pack.c:968
 msgid "fetch-pack: invalid index-pack output"
 msgstr "fetch-pack: неправилен изход от командата „index-pack“"
 
-#: fetch-pack.c:974
+#: fetch-pack.c:985
 #, c-format
 msgid "%s failed"
 msgstr "неуспешно изпълнение на „%s“"
 
-#: fetch-pack.c:976
+#: fetch-pack.c:987
 msgid "error in sideband demultiplexer"
 msgstr "грешка в демултиплексора"
 
-#: fetch-pack.c:1019
+#: fetch-pack.c:1030
 #, c-format
 msgid "Server version is %.*s"
 msgstr "Версията на сървъра е: %.*s"
 
-#: fetch-pack.c:1027 fetch-pack.c:1033 fetch-pack.c:1036 fetch-pack.c:1042
-#: fetch-pack.c:1046 fetch-pack.c:1050 fetch-pack.c:1054 fetch-pack.c:1058
-#: fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070 fetch-pack.c:1074
-#: fetch-pack.c:1080 fetch-pack.c:1086 fetch-pack.c:1091 fetch-pack.c:1096
+#: fetch-pack.c:1038 fetch-pack.c:1044 fetch-pack.c:1047 fetch-pack.c:1053
+#: fetch-pack.c:1057 fetch-pack.c:1061 fetch-pack.c:1065 fetch-pack.c:1069
+#: fetch-pack.c:1073 fetch-pack.c:1077 fetch-pack.c:1081 fetch-pack.c:1085
+#: fetch-pack.c:1091 fetch-pack.c:1097 fetch-pack.c:1102 fetch-pack.c:1107
 #, c-format
 msgid "Server supports %s"
 msgstr "Сървърът поддържа „%s“"
 
-#: fetch-pack.c:1029
+#: fetch-pack.c:1040
 msgid "Server does not support shallow clients"
 msgstr "Сървърът не поддържа плитки клиенти"
 
-#: fetch-pack.c:1089
+#: fetch-pack.c:1100
 msgid "Server does not support --shallow-since"
 msgstr "Сървърът не поддържа опцията „--shallow-since“"
 
-#: fetch-pack.c:1094
+#: fetch-pack.c:1105
 msgid "Server does not support --shallow-exclude"
 msgstr "Сървърът не поддържа опцията „--shallow-exclude“"
 
-#: fetch-pack.c:1098
+#: fetch-pack.c:1109
 msgid "Server does not support --deepen"
 msgstr "Сървърът не поддържа опцията „--deepen“"
 
-#: fetch-pack.c:1100
+#: fetch-pack.c:1111
 msgid "Server does not support this repository's object format"
 msgstr "Сървърът не поддържа форма̀та на обектите на това хранилище"
 
-#: fetch-pack.c:1113
+#: fetch-pack.c:1124
 msgid "no common commits"
 msgstr "няма общи подавания"
 
-#: fetch-pack.c:1122 fetch-pack.c:1469 builtin/clone.c:1238
+#: fetch-pack.c:1133 fetch-pack.c:1480 builtin/clone.c:1130
 msgid "source repository is shallow, reject to clone."
 msgstr "клонираното хранилище е плитко, затова няма да се клонира."
 
-#: fetch-pack.c:1128 fetch-pack.c:1660
+#: fetch-pack.c:1139 fetch-pack.c:1671
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack: неуспешно доставяне."
 
-#: fetch-pack.c:1242
+#: fetch-pack.c:1253
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "различни алгоритми — на клиента: „%s“, на сървъра: „%s“"
 
-#: fetch-pack.c:1246
+#: fetch-pack.c:1257
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "сървърът не поддържа алгоритъм „%s“"
 
-#: fetch-pack.c:1279
+#: fetch-pack.c:1290
 msgid "Server does not support shallow requests"
 msgstr "Сървърът не поддържа плитки заявки"
 
-#: fetch-pack.c:1286
+#: fetch-pack.c:1297
 msgid "Server supports filter"
 msgstr "Сървърът поддържа филтри"
 
-#: fetch-pack.c:1329 fetch-pack.c:2043
+#: fetch-pack.c:1340 fetch-pack.c:2053
 msgid "unable to write request to remote"
 msgstr "невъзможно писане към отдалечено хранилище"
 
-#: fetch-pack.c:1347
+#: fetch-pack.c:1358
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "грешка при прочитане на заглавната част на раздел „%s“"
 
-#: fetch-pack.c:1353
+#: fetch-pack.c:1364
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "очаква се „%s“, а бе получено „%s“"
 
-#: fetch-pack.c:1387
+#: fetch-pack.c:1398
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "неочакван ред за потвърждение: „%s“"
 
-#: fetch-pack.c:1392
+#: fetch-pack.c:1403
 #, c-format
 msgid "error processing acks: %d"
 msgstr "грешка при обработка на потвържденията: %d"
 
-#: fetch-pack.c:1402
+#: fetch-pack.c:1413
 msgid "expected packfile to be sent after 'ready'"
 msgstr ""
 "очакваше се пакетният файл да бъде изпратен след отговор за готовност (ready)"
 
-#: fetch-pack.c:1404
+#: fetch-pack.c:1415
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr ""
 "очакваше се след липса на отговор за готовност (ready) да не се се пращат "
 "други раздели"
 
-#: fetch-pack.c:1445
+#: fetch-pack.c:1456
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "грешка при обработка на информация за дълбочината/плиткостта: %d"
 
-#: fetch-pack.c:1494
+#: fetch-pack.c:1505
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "очаква се искан указател, а бе получено: „%s“"
 
-#: fetch-pack.c:1499
+#: fetch-pack.c:1510
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "неочакван искан указател: „%s“"
 
-#: fetch-pack.c:1504
+#: fetch-pack.c:1515
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "грешка при обработката на исканите указатели: %d"
 
-#: fetch-pack.c:1534
+#: fetch-pack.c:1545
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: очаква се пакет за край на отговора"
 
-#: fetch-pack.c:1939
+#: fetch-pack.c:1949
 msgid "no matching remote head"
 msgstr "не може да бъде открит подходящ връх от отдалеченото хранилище"
 
-#: fetch-pack.c:1962 builtin/clone.c:697
+#: fetch-pack.c:1972 builtin/clone.c:581
 msgid "remote did not send all necessary objects"
 msgstr "отдалеченото хранилище не изпрати всички необходими обекти."
 
-#: fetch-pack.c:2065
+#: fetch-pack.c:2075
 msgid "unexpected 'ready' from remote"
 msgstr "неочаквано състояние за готовност от отдалечено хранилище"
 
-#: fetch-pack.c:2088
+#: fetch-pack.c:2098
 #, c-format
 msgid "no such remote ref %s"
 msgstr "такъв отдалечен указател няма: %s"
 
-#: fetch-pack.c:2091
+#: fetch-pack.c:2101
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Сървърът не позволява заявка за необявен обект „%s“"
 
-#: gpg-interface.c:273
+#: gpg-interface.c:329 gpg-interface.c:451 gpg-interface.c:902
+#: gpg-interface.c:918
 msgid "could not create temporary file"
 msgstr "не може да се създаде временен файл"
 
-#: gpg-interface.c:276
+#: gpg-interface.c:332 gpg-interface.c:454
 #, c-format
 msgid "failed writing detached signature to '%s'"
 msgstr "Програмата не успя да запише самостоятелния подпис в „%s“"
 
-#: gpg-interface.c:470
+#: gpg-interface.c:445
+msgid ""
+"gpg.ssh.allowedSignersFile needs to be configured and exist for ssh "
+"signature verification"
+msgstr ""
+"настройката „gpg.ssh.allowedSignersFile“ трябва да е зададена за проверка на "
+"подписите на ssh"
+
+#: gpg-interface.c:469
+msgid ""
+"ssh-keygen -Y find-principals/verify is needed for ssh signature "
+"verification (available in openssh version 8.2p1+)"
+msgstr ""
+"За проверка на подписите е необходима командата (достъпна от openssh ≥ "
+"8.2p1+):\n"
+"\n"
+"    ssh-keygen -Y find-principals/verify"
+
+#: gpg-interface.c:523
+#, c-format
+msgid "ssh signing revocation file configured but not found: %s"
+msgstr ""
+"файлът за отхвърляне на подписи на ssh е настроен, но не може да се открие: "
+"%s"
+
+#: gpg-interface.c:576
+#, c-format
+msgid "bad/incompatible signature '%s'"
+msgstr "лош/несъвместим подпис „%s“"
+
+#: gpg-interface.c:735 gpg-interface.c:740
+#, c-format
+msgid "failed to get the ssh fingerprint for key '%s'"
+msgstr "отпечатъкът по ssh на ключа „%s“ не може да бъде получен"
+
+#: gpg-interface.c:762
+msgid ""
+"either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured"
+msgstr ""
+"Поне една от настройките „user.signingkey“ или „gpg.ssh.defaultKeyCommand“ "
+"трябва да е зададена"
+
+#: gpg-interface.c:780
+#, c-format
+msgid "gpg.ssh.defaultKeyCommand succeeded but returned no keys: %s %s"
+msgstr ""
+"командата „gpg.ssh.defaultKeyCommand“ завърши успешно, но не върна никакви "
+"ключове: %s %s"
+
+#: gpg-interface.c:786
+#, c-format
+msgid "gpg.ssh.defaultKeyCommand failed: %s %s"
+msgstr "неуспешно изпълнение на „gpg.ssh.defaultKeyCommand“: %s %s"
+
+#: gpg-interface.c:874
 msgid "gpg failed to sign the data"
-msgstr "Програмата „gpg“ не подписа данните."
+msgstr "Програмата „gpg“ не подписа данните"
+
+#: gpg-interface.c:895
+msgid "user.signingkey needs to be set for ssh signing"
+msgstr ""
+"за подписване със ssh е необходимо да зададете настройката „user.signingkey“"
+
+#: gpg-interface.c:906
+#, c-format
+msgid "failed writing ssh signing key to '%s'"
+msgstr "неуспешно запазване на ключа за подписване на ssh в „%s“"
+
+#: gpg-interface.c:924
+#, c-format
+msgid "failed writing ssh signing key buffer to '%s'"
+msgstr "неуспешно запазване на буфера за подписване на ssh в „%s“"
+
+#: gpg-interface.c:942
+msgid ""
+"ssh-keygen -Y sign is needed for ssh signing (available in openssh version "
+"8.2p1+)"
+msgstr ""
+"За подписване със ssh е необходима командата (достъпна от openssh ≥ "
+"8.2p1+):\n"
+"\n"
+"    ssh-keygen -Y"
+
+#: gpg-interface.c:954
+#, c-format
+msgid "failed reading ssh signing data buffer from '%s'"
+msgstr "неуспешно прочитане на буфера за подписване на ssh от „%s“"
 
 #: graph.c:98
 #, c-format
 msgid "ignored invalid color '%.*s' in log.graphColors"
 msgstr "прескачане на неправилния цвят „%.*s“ в „log.graphColors“"
 
-#: grep.c:531
+#: grep.c:533
 msgid ""
 "given pattern contains NULL byte (via -f <file>). This is only supported "
 "with -P under PCRE v2"
@@ -4565,109 +4665,109 @@ msgstr ""
 "зададеният шаблон съдържа нулев знак (идва от -f „ФАЙЛ“).  Това се поддържа "
 "в комбинация с „-P“ само при ползването на „PCRE v2“"
 
-#: grep.c:1895
+#: grep.c:1928
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr "„%s“: файлът сочен от „%s“ не може да бъде прочетен"
 
-#: grep.c:1912 setup.c:176 builtin/clone.c:416 builtin/diff.c:90
+#: grep.c:1945 setup.c:176 builtin/clone.c:302 builtin/diff.c:90
 #: builtin/rm.c:136
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "не може да бъде получена информация чрез „stat“ за „%s“"
 
-#: grep.c:1923
+#: grep.c:1956
 #, c-format
 msgid "'%s': short read"
 msgstr "„%s“: изчитането върна по-малко байтове от очакваното"
 
-#: help.c:23
+#: help.c:24
 msgid "start a working area (see also: git help tutorial)"
 msgstr "създаване на работно дърво (погледнете: „git help tutorial“)"
 
-#: help.c:24
+#: help.c:25
 msgid "work on the current change (see also: git help everyday)"
 msgstr "работа по текущата промяна (погледнете: „git help everyday“)"
 
-#: help.c:25
+#: help.c:26
 msgid "examine the history and state (see also: git help revisions)"
 msgstr "преглед на историята и състоянието (погледнете: „git help revisions“)"
 
-#: help.c:26
+#: help.c:27
 msgid "grow, mark and tweak your common history"
 msgstr "увеличаване, отбелязване и промяна на общата история"
 
-#: help.c:27
+#: help.c:28
 msgid "collaborate (see also: git help workflows)"
 msgstr "съвместна работа (погледнете: „git help workflows“)"
 
-#: help.c:31
+#: help.c:32
 msgid "Main Porcelain Commands"
 msgstr "Основни команди от потребителско ниво"
 
-#: help.c:32
+#: help.c:33
 msgid "Ancillary Commands / Manipulators"
 msgstr "Помощни команди / Променящи"
 
-#: help.c:33
+#: help.c:34
 msgid "Ancillary Commands / Interrogators"
 msgstr "Помощни команди / Запитващи"
 
-#: help.c:34
+#: help.c:35
 msgid "Interacting with Others"
 msgstr "Съвместна работа с други хора"
 
-#: help.c:35
+#: help.c:36
 msgid "Low-level Commands / Manipulators"
 msgstr "Команди от ниско ниво / Променящи"
 
-#: help.c:36
+#: help.c:37
 msgid "Low-level Commands / Interrogators"
 msgstr "Команди от ниско ниво / Запитващи"
 
-#: help.c:37
+#: help.c:38
 msgid "Low-level Commands / Syncing Repositories"
 msgstr "Команди от ниско ниво / Синхронизация на хранилища"
 
-#: help.c:38
+#: help.c:39
 msgid "Low-level Commands / Internal Helpers"
 msgstr "Команди от ниско ниво / Допълнителни инструменти"
 
-#: help.c:300
+#: help.c:313
 #, c-format
 msgid "available git commands in '%s'"
 msgstr "налични команди на git от „%s“"
 
-#: help.c:307
+#: help.c:320
 msgid "git commands available from elsewhere on your $PATH"
 msgstr "команди на git от други директории от „$PATH“"
 
-#: help.c:316
+#: help.c:329
 msgid "These are common Git commands used in various situations:"
 msgstr "Това са най-често използваните команди на Git:"
 
-#: help.c:365 git.c:100
+#: help.c:378 git.c:100
 #, c-format
 msgid "unsupported command listing type '%s'"
 msgstr "неподдържан списък от команди „%s“"
 
-#: help.c:405
+#: help.c:418
 msgid "The Git concept guides are:"
 msgstr "Ръководствата за концепциите в Git са:"
 
-#: help.c:429
+#: help.c:442
 msgid "See 'git help <command>' to read about a specific subcommand"
 msgstr "За повече информация за КОМАНДА изпълнете „git help КОМАНДА“"
 
-#: help.c:434
+#: help.c:447
 msgid "External commands"
 msgstr "Външни команди"
 
-#: help.c:449
+#: help.c:462
 msgid "Command aliases"
 msgstr "Псевдоними на командите"
 
-#: help.c:527
+#: help.c:543
 #, c-format
 msgid ""
 "'%s' appears to be a git command, but we were not\n"
@@ -4676,36 +4776,41 @@ msgstr ""
 "Изглежда, че „%s“ е команда на git, но тя не може да\n"
 "бъде изпълнена.  Вероятно пакетът „git-%s“ е повреден."
 
-#: help.c:543 help.c:631
+#: help.c:565 help.c:662
 #, c-format
 msgid "git: '%s' is not a git command. See 'git --help'."
 msgstr "git: „%s“ не е команда на git.  Погледнете изхода от „git --help“."
 
-#: help.c:591
+#: help.c:613
 msgid "Uh oh. Your system reports no Git commands at all."
 msgstr "Странно, изглежда, че на системата ви няма нито една команда на git."
 
-#: help.c:613
+#: help.c:635
 #, c-format
 msgid "WARNING: You called a Git command named '%s', which does not exist."
 msgstr ""
 "ПРЕДУПРЕЖДЕНИЕ: Пробвахте да изпълните команда на Git на име „%s“, а такава "
 "не съществува."
 
-#: help.c:618
+#: help.c:640
 #, c-format
 msgid "Continuing under the assumption that you meant '%s'."
 msgstr ""
 "Изпълнението автоматично продължава, като се счита, че имате предвид „%s“."
 
-#: help.c:623
+#: help.c:646
+#, c-format
+msgid "Run '%s' instead? (y/N)"
+msgstr "Да се изпълни „%s“ вместо това? (y/N)"
+
+#: help.c:654
 #, c-format
 msgid "Continuing in %0.1f seconds, assuming that you meant '%s'."
 msgstr ""
 "Изпълнението автоматично ще продължи след %0.1f сек., като се счита, че "
 "имате предвид „%s“."
 
-#: help.c:635
+#: help.c:666
 msgid ""
 "\n"
 "The most similar command is"
@@ -4719,16 +4824,16 @@ msgstr[1] ""
 "\n"
 "Най-близките команди са"
 
-#: help.c:675
+#: help.c:706
 msgid "git version [<options>]"
 msgstr "git version [ОПЦИЯ…]"
 
-#: help.c:730
+#: help.c:761
 #, c-format
 msgid "%s: %s - %s"
 msgstr "%s: %s — %s"
 
-#: help.c:734
+#: help.c:765
 msgid ""
 "\n"
 "Did you mean this?"
@@ -4741,6 +4846,16 @@ msgstr[0] ""
 msgstr[1] ""
 "\n"
 "Команди с подобно име са:"
+
+#: hook.c:27
+#, c-format
+msgid ""
+"The '%s' hook was ignored because it's not set as executable.\n"
+"You can disable this warning with `git config advice.ignoredHook false`."
+msgstr ""
+"Куката „%s“ се прескача, защото липсват права за изпълнение.\n"
+"За да изключите това предупреждение, изпълнете:\n"
+"    git config advice.ignoredHook false"
 
 #: ident.c:353
 msgid "Author identity unknown\n"
@@ -4807,7 +4922,7 @@ msgstr "не може да се ползва празно име като иде
 msgid "name consists only of disallowed characters: %s"
 msgstr "името съдържа само непозволени знаци: „%s“"
 
-#: ident.c:454 builtin/commit.c:647
+#: ident.c:454 builtin/commit.c:648
 #, c-format
 msgid "invalid date format: %s"
 msgstr "неправилен формат на дата: %s"
@@ -4904,7 +5019,12 @@ msgstr "Файлът-ключалка „%s.lock“ не може да бъде 
 msgid "invalid value '%s' for lsrefs.unborn"
 msgstr "неправилна стойност „%s“ за „lsrefs.unborn“"
 
-#: ls-refs.c:167
+#: ls-refs.c:174
+#, c-format
+msgid "unexpected line: '%s'"
+msgstr "неочакван ред: „%s“"
+
+#: ls-refs.c:178
 msgid "expected flush after ls-refs arguments"
 msgstr "след аргументите към „ls-refs“ се очаква изчистване на буферите"
 
@@ -4912,39 +5032,39 @@ msgstr "след аргументите към „ls-refs“ се очаква �
 msgid "quoted CRLF detected"
 msgstr "цитирани знаци CRLF"
 
-#: mailinfo.c:1254 builtin/am.c:176 builtin/mailinfo.c:46
+#: mailinfo.c:1254 builtin/am.c:177 builtin/mailinfo.c:46
 #, c-format
 msgid "bad action '%s' for '%s'"
 msgstr "неправилно действие „%s“ за „%s“"
 
-#: merge-ort.c:1569 merge-recursive.c:1201
+#: merge-ort.c:1584 merge-recursive.c:1211
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
 msgstr "Неуспешно сливане на подмодула „%s“ (не е изтеглен)"
 
-#: merge-ort.c:1578 merge-recursive.c:1208
+#: merge-ort.c:1593 merge-recursive.c:1218
 #, c-format
 msgid "Failed to merge submodule %s (commits not present)"
 msgstr "Неуспешно сливане на подмодула „%s“ (няма подавания)"
 
-#: merge-ort.c:1587 merge-recursive.c:1215
+#: merge-ort.c:1602 merge-recursive.c:1225
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
 msgstr ""
 "Подмодулът „%s“ не може да бъде слят (базата за сливане не предшества "
 "подаванията)"
 
-#: merge-ort.c:1597 merge-ort.c:1604
+#: merge-ort.c:1612 merge-ort.c:1620
 #, c-format
 msgid "Note: Fast-forwarding submodule %s to %s"
 msgstr "Бележка: Превъртане на подмодула „%s“ към „%s“"
 
-#: merge-ort.c:1625
+#: merge-ort.c:1642
 #, c-format
 msgid "Failed to merge submodule %s"
 msgstr "Неуспешно сливане на подмодула „%s“"
 
-#: merge-ort.c:1632
+#: merge-ort.c:1649
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but a possible merge resolution exists:\n"
@@ -4953,7 +5073,7 @@ msgstr ""
 "Неуспешно сливане на подмодула „%s“, но е открито възможно решение:\n"
 "%s\n"
 
-#: merge-ort.c:1636 merge-recursive.c:1269
+#: merge-ort.c:1653 merge-recursive.c:1281
 #, c-format
 msgid ""
 "If this is correct simply add it to the index for example\n"
@@ -4969,7 +5089,7 @@ msgstr ""
 "\n"
 "Това приема предложеното.\n"
 
-#: merge-ort.c:1649
+#: merge-ort.c:1666
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but multiple possible merges exist:\n"
@@ -4978,21 +5098,21 @@ msgstr ""
 "Неуспешно сливане на подмодула „%s“, но са открити множество решения:\n"
 "%s"
 
-#: merge-ort.c:1868 merge-recursive.c:1358
+#: merge-ort.c:1887 merge-recursive.c:1372
 msgid "Failed to execute internal merge"
 msgstr "Неуспешно вътрешно сливане"
 
-#: merge-ort.c:1873 merge-recursive.c:1363
+#: merge-ort.c:1892 merge-recursive.c:1377
 #, c-format
 msgid "Unable to add %s to database"
 msgstr "„%s“ не може да се добави в базата с данни"
 
-#: merge-ort.c:1880 merge-recursive.c:1396
+#: merge-ort.c:1899 merge-recursive.c:1410
 #, c-format
 msgid "Auto-merging %s"
 msgstr "Автоматично сливане на „%s“"
 
-#: merge-ort.c:2019 merge-recursive.c:2118
+#: merge-ort.c:2038 merge-recursive.c:2132
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
@@ -5001,7 +5121,7 @@ msgstr ""
 "КОНФЛИКТ (косвено преименуване на директория): следният файл или директория "
 "„%s“ не позволяват косвеното преименуване на следния път/ища: %s."
 
-#: merge-ort.c:2029 merge-recursive.c:2128
+#: merge-ort.c:2048 merge-recursive.c:2142
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
@@ -5011,7 +5131,7 @@ msgstr ""
 "съответства на „%s“.  Косвено преименуване на директория води до поставянето "
 "на тези пътища там: %s."
 
-#: merge-ort.c:2087
+#: merge-ort.c:2106
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to rename %s to; it was "
@@ -5022,7 +5142,7 @@ msgstr ""
 "да се преименува „%s“, защото е преместен в няколко нови директории, без "
 "никоя от тях да е по-честа цел."
 
-#: merge-ort.c:2241 merge-recursive.c:2464
+#: merge-ort.c:2260 merge-recursive.c:2478
 #, c-format
 msgid ""
 "WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
@@ -5031,7 +5151,7 @@ msgstr ""
 "ПРЕДУПРЕЖДЕНИЕ: прескачане на преименуването на „%s“ на „%s“ в „%s“, защото "
 "„%s“ също е с променено име."
 
-#: merge-ort.c:2385 merge-recursive.c:3247
+#: merge-ort.c:2400 merge-recursive.c:3261
 #, c-format
 msgid ""
 "Path updated: %s added in %s inside a directory that was renamed in %s; "
@@ -5040,7 +5160,7 @@ msgstr ""
 "Обновен път: „%s“ е добавен в „%s“ в директория, която е преименувана в "
 "„%s“.  Обектът се мести в „%s“."
 
-#: merge-ort.c:2392 merge-recursive.c:3254
+#: merge-ort.c:2407 merge-recursive.c:3268
 #, c-format
 msgid ""
 "Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
@@ -5049,7 +5169,7 @@ msgstr ""
 "Обновен път: „%s“ е преименуван на „%s“ в „%s“ в директория, която е "
 "преименувана в „%s“.  Обектът се мести в „%s“."
 
-#: merge-ort.c:2405 merge-recursive.c:3250
+#: merge-ort.c:2420 merge-recursive.c:3264
 #, c-format
 msgid ""
 "CONFLICT (file location): %s added in %s inside a directory that was renamed "
@@ -5058,7 +5178,7 @@ msgstr ""
 "КОНФЛИКТ (места на файлове): „%s“ е добавен в „%s“ в директория, която е "
 "преименувана в „%s“.  Предложението е да преместите обекта в „%s“."
 
-#: merge-ort.c:2413 merge-recursive.c:3257
+#: merge-ort.c:2428 merge-recursive.c:3271
 #, c-format
 msgid ""
 "CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
@@ -5067,14 +5187,14 @@ msgstr ""
 "КОНФЛИКТ (места на файлове): „%s“ е преименуван на „%s“ в „%s“ в директория, "
 "която е преименувана в „%s“.  Предложението е да преместите обекта в „%s“."
 
-#: merge-ort.c:2569
+#: merge-ort.c:2584
 #, c-format
 msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
 msgstr ""
 "КОНФЛИКТ (преименуване/преименуване): „%s“ е преименуван на „%s“ в клон „%s“ "
 "и на „%s“ в „%s“."
 
-#: merge-ort.c:2664
+#: merge-ort.c:2679
 #, c-format
 msgid ""
 "CONFLICT (rename involved in collision): rename of %s -> %s has content "
@@ -5085,24 +5205,24 @@ msgstr ""
 "има и промени в съдържанието, а и има съвпадение на пътя.  Може да се "
 "получат вложени маркери за конфликт."
 
-#: merge-ort.c:2683 merge-ort.c:2707
+#: merge-ort.c:2698 merge-ort.c:2722
 #, c-format
 msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
 msgstr ""
 "КОНФЛИКТ (преименуване/добавяне): „%s“ е преименуван на „%s“ в клон „%s“, а "
 "е изтрит в „%s“."
 
-#: merge-ort.c:3182 merge-recursive.c:3008
+#: merge-ort.c:3212 merge-recursive.c:3022
 #, c-format
 msgid "cannot read object %s"
 msgstr "обектът „%s“ не може да се прочете"
 
-#: merge-ort.c:3185 merge-recursive.c:3011
+#: merge-ort.c:3215 merge-recursive.c:3025
 #, c-format
 msgid "object %s is not a blob"
 msgstr "обектът „%s“ не е BLOB"
 
-#: merge-ort.c:3613
+#: merge-ort.c:3644
 #, c-format
 msgid ""
 "CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
@@ -5111,7 +5231,7 @@ msgstr ""
 "КОНФЛИКТ (файл/директория): директория на мястото на „%s“ от „%s“, вместо "
 "това се извършва преместване в „%s“."
 
-#: merge-ort.c:3689
+#: merge-ort.c:3721
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed both "
@@ -5120,7 +5240,7 @@ msgstr ""
 "КОНФЛИКТ (различни видове): „%s“ е различен вид обект в двата варианта.  И "
 "двата се преименуват, за да може всичко да е отразено."
 
-#: merge-ort.c:3696
+#: merge-ort.c:3728
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed one "
@@ -5129,24 +5249,24 @@ msgstr ""
 "КОНФЛИКТ (различни видове): „%s“ е различен вид обект в двата варианта.  "
 "Извършва се преименуване в единия, за да може всичко да е отразено."
 
-#: merge-ort.c:3796 merge-recursive.c:3087
+#: merge-ort.c:3819 merge-recursive.c:3101
 msgid "content"
 msgstr "съдържание"
 
-#: merge-ort.c:3798 merge-recursive.c:3091
+#: merge-ort.c:3821 merge-recursive.c:3105
 msgid "add/add"
 msgstr "добавяне/добавяне"
 
-#: merge-ort.c:3800 merge-recursive.c:3136
+#: merge-ort.c:3823 merge-recursive.c:3150
 msgid "submodule"
 msgstr "ПОДМОДУЛ"
 
-#: merge-ort.c:3802 merge-recursive.c:3137
+#: merge-ort.c:3825 merge-recursive.c:3151
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "КОНФЛИКТ (%s): Конфликт при сливане на „%s“"
 
-#: merge-ort.c:3833
+#: merge-ort.c:3856
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
@@ -5155,7 +5275,7 @@ msgstr ""
 "КОНФЛИКТ (промяна/изтриване): „%s“ е изтрит в %s, а е променен в %s.  Версия "
 "%s на „%s“ е оставена в дървото."
 
-#: merge-ort.c:4120
+#: merge-ort.c:4152
 #, c-format
 msgid ""
 "Note: %s not up to date and in way of checking out conflicted version; old "
@@ -5167,12 +5287,12 @@ msgstr ""
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
-#: merge-ort.c:4487
+#: merge-ort.c:4521
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
 msgstr "неуспешно събиране на информацията за сливането на „%s“, „%s“ и „%s“"
 
-#: merge-ort-wrappers.c:13 merge-recursive.c:3702
+#: merge-ort-wrappers.c:13 merge-recursive.c:3716
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -5181,113 +5301,113 @@ msgstr ""
 "Сливането ще презапише локалните промени на тези файлове:\n"
 "    %s"
 
-#: merge-ort-wrappers.c:33 merge-recursive.c:3468 builtin/merge.c:402
+#: merge-ort-wrappers.c:33 merge-recursive.c:3482 builtin/merge.c:403
 msgid "Already up to date."
 msgstr "Вече е обновено."
 
-#: merge-recursive.c:352
+#: merge-recursive.c:353
 msgid "(bad commit)\n"
 msgstr "(лошо подаване)\n"
 
-#: merge-recursive.c:375
+#: merge-recursive.c:381
 #, c-format
 msgid "add_cacheinfo failed for path '%s'; merge aborting."
 msgstr ""
 "неуспешно изпълнение на „add_cacheinfo“ за пътя „%s“.  Сливането е "
 "преустановено."
 
-#: merge-recursive.c:384
+#: merge-recursive.c:390
 #, c-format
 msgid "add_cacheinfo failed to refresh for path '%s'; merge aborting."
 msgstr ""
 "неуспешно изпълнение на „add_cacheinfo“ за обновяването на пътя „%s“.  "
 "Сливането е преустановено."
 
-#: merge-recursive.c:872
+#: merge-recursive.c:881
 #, c-format
 msgid "failed to create path '%s'%s"
 msgstr "грешка при създаването на пътя „%s“%s"
 
-#: merge-recursive.c:883
+#: merge-recursive.c:892
 #, c-format
 msgid "Removing %s to make room for subdirectory\n"
 msgstr "Изтриване на „%s“, за да се освободи място за поддиректория\n"
 
-#: merge-recursive.c:897 merge-recursive.c:916
+#: merge-recursive.c:906 merge-recursive.c:925
 msgid ": perhaps a D/F conflict?"
 msgstr ": възможно е да има конфликт директория/файл."
 
-#: merge-recursive.c:906
+#: merge-recursive.c:915
 #, c-format
 msgid "refusing to lose untracked file at '%s'"
 msgstr ""
 "преустановяване на действието, за да не се изтрие неследеният файл „%s“"
 
-#: merge-recursive.c:947 builtin/cat-file.c:41
+#: merge-recursive.c:956 builtin/cat-file.c:41
 #, c-format
 msgid "cannot read object %s '%s'"
 msgstr "обектът „%s“ (%s) не може да бъде прочетен"
 
-#: merge-recursive.c:952
+#: merge-recursive.c:961
 #, c-format
 msgid "blob expected for %s '%s'"
 msgstr "обектът „%s“ (%s) се очакваше да е BLOB, а не е"
 
-#: merge-recursive.c:977
+#: merge-recursive.c:986
 #, c-format
 msgid "failed to open '%s': %s"
 msgstr "„%s“ не може да се отвори: %s"
 
-#: merge-recursive.c:988
+#: merge-recursive.c:997
 #, c-format
 msgid "failed to symlink '%s': %s"
 msgstr "неуспешно създаване на символната връзка „%s“: %s"
 
-#: merge-recursive.c:993
+#: merge-recursive.c:1002
 #, c-format
 msgid "do not know what to do with %06o %s '%s'"
 msgstr ""
 "не е ясно какво да се прави с обекта „%2$s“ (%3$s) с права за достъп „%1$06o“"
 
-#: merge-recursive.c:1223 merge-recursive.c:1235
+#: merge-recursive.c:1233 merge-recursive.c:1246
 #, c-format
 msgid "Fast-forwarding submodule %s to the following commit:"
 msgstr "Превъртане на подмодула „%s“ до следното подаване:"
 
-#: merge-recursive.c:1226 merge-recursive.c:1238
+#: merge-recursive.c:1236 merge-recursive.c:1249
 #, c-format
 msgid "Fast-forwarding submodule %s"
 msgstr "Превъртане на подмодула „%s“"
 
-#: merge-recursive.c:1261
+#: merge-recursive.c:1273
 #, c-format
 msgid "Failed to merge submodule %s (merge following commits not found)"
 msgstr ""
 "Неуспешно сливане на подмодула „%s“ (липсва сливането, което се предшества "
 "от подаванията)"
 
-#: merge-recursive.c:1265
+#: merge-recursive.c:1277
 #, c-format
 msgid "Failed to merge submodule %s (not fast-forward)"
 msgstr "Неуспешно сливане на подмодула „%s“ (не е превъртане)"
 
-#: merge-recursive.c:1266
+#: merge-recursive.c:1278
 msgid "Found a possible merge resolution for the submodule:\n"
 msgstr ""
 "Открито е сливане, което може да решава проблема със сливането на "
 "подмодула:\n"
 
-#: merge-recursive.c:1278
+#: merge-recursive.c:1290
 #, c-format
 msgid "Failed to merge submodule %s (multiple merges found)"
 msgstr "Неуспешно сливане на подмодула „%s“ (открити са множество сливания)"
 
-#: merge-recursive.c:1420
+#: merge-recursive.c:1434
 #, c-format
 msgid "Error: Refusing to lose untracked file at %s; writing to %s instead."
 msgstr "Грешка: за да не се изтрие неследеният файл „%s“, се записва в „%s“."
 
-#: merge-recursive.c:1492
+#: merge-recursive.c:1506
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
@@ -5296,7 +5416,7 @@ msgstr ""
 "КОНФЛИКТ (%s/изтриване): „%s“ е изтрит в %s, а „%s“ в %s.  Версия %s на „%s“ "
 "е оставена в дървото."
 
-#: merge-recursive.c:1497
+#: merge-recursive.c:1511
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
@@ -5305,7 +5425,7 @@ msgstr ""
 "КОНФЛИКТ (%s/изтриване): „%s“ е изтрит в %s, а „%s“ е преименуван на „%s“ в "
 "%s.  Версия %s на „%s“ е оставена в дървото."
 
-#: merge-recursive.c:1504
+#: merge-recursive.c:1518
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
@@ -5314,7 +5434,7 @@ msgstr ""
 "КОНФЛИКТ (%s/изтриване): „%s“ е изтрит в %s, а „%s“ в %s.  Версия %s на „%s“ "
 "е оставена в дървото: %s."
 
-#: merge-recursive.c:1509
+#: merge-recursive.c:1523
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
@@ -5323,45 +5443,45 @@ msgstr ""
 "КОНФЛИКТ (%s/изтриване): „%s“ е изтрит в %s, а „%s“ е преименуван на „%s“ в "
 "%s.  Версия %s на „%s“ е оставена в дървото: %s."
 
-#: merge-recursive.c:1544
+#: merge-recursive.c:1558
 msgid "rename"
 msgstr "преименуване"
 
-#: merge-recursive.c:1544
+#: merge-recursive.c:1558
 msgid "renamed"
 msgstr "преименуван"
 
-#: merge-recursive.c:1595 merge-recursive.c:2501 merge-recursive.c:3164
+#: merge-recursive.c:1609 merge-recursive.c:2515 merge-recursive.c:3178
 #, c-format
 msgid "Refusing to lose dirty file at %s"
 msgstr "Преустановяване на действието, за да не се изгуби промененият „%s“"
 
-#: merge-recursive.c:1605
+#: merge-recursive.c:1619
 #, c-format
 msgid "Refusing to lose untracked file at %s, even though it's in the way."
 msgstr ""
 "Отказ да се загуби неследеният файл „%s“, защото е на място, където пречи."
 
-#: merge-recursive.c:1663
+#: merge-recursive.c:1677
 #, c-format
 msgid "CONFLICT (rename/add): Rename %s->%s in %s.  Added %s in %s"
 msgstr ""
 "КОНФЛИКТ (преименуване/добавяне): „%s“ е преименуван на „%s“ в клон „%s“, а "
 "„%s“ е добавен в „%s“"
 
-#: merge-recursive.c:1694
+#: merge-recursive.c:1708
 #, c-format
 msgid "%s is a directory in %s adding as %s instead"
 msgstr "„%s“ е директория в „%s“, затова се добавя като „%s“"
 
-#: merge-recursive.c:1699
+#: merge-recursive.c:1713
 #, c-format
 msgid "Refusing to lose untracked file at %s; adding as %s instead"
 msgstr ""
 "Преустановяване на действието, за да не се изгуби неследеният файл „%s“.  "
 "Вместо него се добавя „%s“"
 
-#: merge-recursive.c:1726
+#: merge-recursive.c:1740
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename \"%s\"->\"%s\" in branch \"%s\" rename \"%s"
@@ -5370,18 +5490,18 @@ msgstr ""
 "КОНФЛИКТ (преименуване/преименуване): „%s“ е преименуван на „%s“ в клон "
 "„%s“, а „%s“ е преименуван на „%s“ в „%s“/%s."
 
-#: merge-recursive.c:1731
+#: merge-recursive.c:1745
 msgid " (left unresolved)"
 msgstr " (некоригиран конфликт)"
 
-#: merge-recursive.c:1823
+#: merge-recursive.c:1837
 #, c-format
 msgid "CONFLICT (rename/rename): Rename %s->%s in %s. Rename %s->%s in %s"
 msgstr ""
 "КОНФЛИКТ (преименуване/преименуване): „%s“ е преименуван на „%s“ в клон "
 "„%s“, а „%s“ е преименуван на „%s“ в „%s“"
 
-#: merge-recursive.c:2086
+#: merge-recursive.c:2100
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to place %s because "
@@ -5392,7 +5512,7 @@ msgstr ""
 "постави „%s“, защото няколко нови директории поделят съдържанието на "
 "директория „%s“, като никоя не съдържа мнозинство от файловете ѝ."
 
-#: merge-recursive.c:2220
+#: merge-recursive.c:2234
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename directory %s->%s in %s. Rename directory %s-"
@@ -5401,81 +5521,81 @@ msgstr ""
 "КОНФЛИКТ (преименуване/преименуване): „%s“ е преименуван на „%s“ в клон "
 "„%s“, а „%s“ е преименуван на „%s“ в „%s“"
 
-#: merge-recursive.c:3075
+#: merge-recursive.c:3089
 msgid "modify"
 msgstr "промяна"
 
-#: merge-recursive.c:3075
+#: merge-recursive.c:3089
 msgid "modified"
 msgstr "променен"
 
-#: merge-recursive.c:3114
+#: merge-recursive.c:3128
 #, c-format
 msgid "Skipped %s (merged same as existing)"
 msgstr "Прескачане на „%s“ (слетият резултат е идентичен със сегашния)"
 
-#: merge-recursive.c:3167
+#: merge-recursive.c:3181
 #, c-format
 msgid "Adding as %s instead"
 msgstr "Добавяне като „%s“"
 
-#: merge-recursive.c:3371
+#: merge-recursive.c:3385
 #, c-format
 msgid "Removing %s"
 msgstr "Изтриване на „%s“"
 
-#: merge-recursive.c:3394
+#: merge-recursive.c:3408
 msgid "file/directory"
 msgstr "файл/директория"
 
-#: merge-recursive.c:3399
+#: merge-recursive.c:3413
 msgid "directory/file"
 msgstr "директория/файл"
 
-#: merge-recursive.c:3406
+#: merge-recursive.c:3420
 #, c-format
 msgid "CONFLICT (%s): There is a directory with name %s in %s. Adding %s as %s"
 msgstr ""
 "КОНФЛИКТ (%s): Съществува директория на име „%s“ в „%s“.  Добавяне на „%s“ "
 "като „%s“"
 
-#: merge-recursive.c:3415
+#: merge-recursive.c:3429
 #, c-format
 msgid "Adding %s"
 msgstr "Добавяне на „%s“"
 
-#: merge-recursive.c:3424
+#: merge-recursive.c:3438
 #, c-format
 msgid "CONFLICT (add/add): Merge conflict in %s"
 msgstr "КОНФЛИКТ (добавяне/добавяне): Конфликт при сливане на „%s“"
 
-#: merge-recursive.c:3477
+#: merge-recursive.c:3491
 #, c-format
 msgid "merging of trees %s and %s failed"
 msgstr "неуспешно сливане на дърветата „%s“ и „%s“"
 
-#: merge-recursive.c:3571
+#: merge-recursive.c:3585
 msgid "Merging:"
 msgstr "Сливане:"
 
-#: merge-recursive.c:3584
+#: merge-recursive.c:3598
 #, c-format
 msgid "found %u common ancestor:"
 msgid_plural "found %u common ancestors:"
 msgstr[0] "открит е %u общ предшественик:"
 msgstr[1] "открити са %u общи предшественици:"
 
-#: merge-recursive.c:3634
+#: merge-recursive.c:3648
 msgid "merge returned no commit"
 msgstr "сливането не върна подаване"
 
-#: merge-recursive.c:3799
+#: merge-recursive.c:3816
 #, c-format
 msgid "Could not parse object '%s'"
 msgstr "Неуспешен анализ на обекта „%s“"
 
-#: merge-recursive.c:3817 builtin/merge.c:717 builtin/merge.c:901
-#: builtin/stash.c:473
+#: merge-recursive.c:3834 builtin/merge.c:718 builtin/merge.c:904
+#: builtin/stash.c:489
 msgid "Unable to write index."
 msgstr "Индексът не може да бъде прочетен"
 
@@ -5483,143 +5603,176 @@ msgstr "Индексът не може да бъде прочетен"
 msgid "failed to read the cache"
 msgstr "кешът не може да бъде прочетен"
 
-#: merge.c:108 rerere.c:704 builtin/am.c:1932 builtin/am.c:1966
-#: builtin/checkout.c:590 builtin/checkout.c:844 builtin/clone.c:821
-#: builtin/stash.c:267
+#: merge.c:102 rerere.c:704 builtin/am.c:1933 builtin/am.c:1967
+#: builtin/checkout.c:590 builtin/checkout.c:842 builtin/clone.c:706
+#: builtin/stash.c:269
 msgid "unable to write new index file"
 msgstr "неуспешно записване на новия индекс"
 
-#: midx.c:74
+#: midx.c:78
 msgid "multi-pack-index OID fanout is of the wrong size"
 msgstr "неправилен размер на откъс (OID fanout) на индекса за множество пакети"
 
-#: midx.c:105
+#: midx.c:109
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "файлът с индекса за множество пакети „%s“ е твърде малък"
 
-#: midx.c:121
+#: midx.c:125
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr "отпечатъкът на индекса за множество пакети 0x%08x не съвпада с 0x%08x"
 
-#: midx.c:126
+#: midx.c:130
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "непозната версия на индекс за множество пакети — %d"
 
-#: midx.c:131
+#: midx.c:135
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr ""
 "версията на контролната сума на индекса за множество пакети %u не съвпада с "
 "%u"
 
-#: midx.c:148
+#: midx.c:152
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "липсва откъс (pack-name) от индекс за множество пакети"
 
-#: midx.c:150
+#: midx.c:154
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "липсва откъс (OID fanout) от индекс за множество пакети"
 
-#: midx.c:152
+#: midx.c:156
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr "липсва откъс (OID lookup) от индекс за множество пакети"
 
-#: midx.c:154
+#: midx.c:158
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr "липсва откъс за отместванията на обекти от индекс за множество пакети"
 
-#: midx.c:170
+#: midx.c:174
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr ""
 "неправилна подредба на имената в индекс за множество пакети: „%s“ се появи "
 "преди „%s“"
 
-#: midx.c:214
+#: midx.c:221
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr ""
 "неправилен идентификатор на пакет (pack-int-id): %u (от общо %u пакети)"
 
-#: midx.c:264
+#: midx.c:271
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr ""
 "индексът за множество пакети съдържа 64-битови отмествания, но размерът на "
 "„off_t“ е недостатъчен"
 
-#: midx.c:490
+#: midx.c:502
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "пакетният файл „%s“ не може да бъде добавен"
 
-#: midx.c:496
+#: midx.c:508
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "индексът за пакети „%s“ не може да бъде отворен"
 
-#: midx.c:564
+#: midx.c:576
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "обект %d в пакетния файл липсва"
 
-#: midx.c:880 builtin/index-pack.c:1533
+#: midx.c:892
 msgid "cannot store reverse index file"
 msgstr "файлът за индекса не може да бъде съхранен"
 
-#: midx.c:920
+#: midx.c:990
+#, c-format
+msgid "could not parse line: %s"
+msgstr "редът не може да се анализира: „%s“"
+
+#: midx.c:992
+#, c-format
+msgid "malformed line: %s"
+msgstr "неправилен ред: „%s“."
+
+#: midx.c:1159
 msgid "ignoring existing multi-pack-index; checksum mismatch"
 msgstr ""
 "индексът за множество пакети се прескача, защото контролната сума не съвпада"
 
-#: midx.c:943
+#: midx.c:1184
+msgid "could not load pack"
+msgstr "пакетът не може да се зареди"
+
+#: midx.c:1190
+#, c-format
+msgid "could not open index for %s"
+msgstr "индексът за „%s“ не може да се отвори"
+
+#: midx.c:1201
 msgid "Adding packfiles to multi-pack-index"
 msgstr "Добавяне на пакетни файлове към индекс за множество пакети"
 
-#: midx.c:989
-#, c-format
-msgid "did not see pack-file %s to drop"
-msgstr "пакетният файл за триене „%s“ не може да се открие"
-
-#: midx.c:1034
+#: midx.c:1244
 #, c-format
 msgid "unknown preferred pack: '%s'"
 msgstr "непознат предпочитан пакет: %s"
 
-#: midx.c:1039
+#: midx.c:1289
+#, c-format
+msgid "cannot select preferred pack %s with no objects"
+msgstr ""
+"не може да изберете „%s“, който не съдържа обекти, за предпочитан пакет"
+
+#: midx.c:1321
+#, c-format
+msgid "did not see pack-file %s to drop"
+msgstr "пакетният файл за триене „%s“ не може да се открие"
+
+#: midx.c:1367
 #, c-format
 msgid "preferred pack '%s' is expired"
 msgstr "предпочитаният пакет „%s“ е остарял"
 
-#: midx.c:1055
+#: midx.c:1380
 msgid "no pack files to index."
 msgstr "няма пакетни файлове за индексиране"
 
-#: midx.c:1135 builtin/clean.c:37
+#: midx.c:1417
+msgid "could not write multi-pack bitmap"
+msgstr "многопакетната битова маска не може да бъде запазена"
+
+#: midx.c:1427
+msgid "could not write multi-pack-index"
+msgstr "индексът за множество пакети не може да бъде запазен"
+
+#: midx.c:1486 builtin/clean.c:37
 #, c-format
 msgid "failed to remove %s"
 msgstr "файлът „%s“ не може да бъде изтрит"
 
-#: midx.c:1166
+#: midx.c:1517
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "индексът за множество пакети не може да бъде изчистен при „%s“"
 
-#: midx.c:1225
+#: midx.c:1577
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr "файлът с индекса за множество пакети, но не може да бъде анализиран"
 
-#: midx.c:1233
+#: midx.c:1585
 msgid "incorrect checksum"
 msgstr "неправилна контролна сума"
 
-#: midx.c:1236
+#: midx.c:1588
 msgid "Looking for referenced packfiles"
 msgstr "Търсене на указаните пакетни файлове"
 
-#: midx.c:1251
+#: midx.c:1603
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
@@ -5627,58 +5780,58 @@ msgstr ""
 "неправилна подредба на откъси (OID fanout): fanout[%d] = %<PRIx32> > "
 "%<PRIx32> = fanout[%d]"
 
-#: midx.c:1256
+#: midx.c:1608
 msgid "the midx contains no oid"
 msgstr "във файла с индекса за множество пакети няма идентификатори на обекти"
 
-#: midx.c:1265
+#: midx.c:1617
 msgid "Verifying OID order in multi-pack-index"
 msgstr ""
 "Проверка на подредбата на идентификатори на обекти във файл с индекс към "
 "множество пакетни файлове"
 
-#: midx.c:1274
+#: midx.c:1626
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr ""
 "неправилна подредба на откъси (OID lookup): oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1294
+#: midx.c:1646
 msgid "Sorting objects by packfile"
 msgstr "Подредба на обектите по пакетни файлове"
 
-#: midx.c:1301
+#: midx.c:1653
 msgid "Verifying object offsets"
 msgstr "Проверка на отместването на обекти"
 
-#: midx.c:1317
+#: midx.c:1669
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "записът в пакета за обекта oid[%d] = %s не може да бъде зареден"
 
-#: midx.c:1323
+#: midx.c:1675
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "индексът на пакета „%s“ не може да бъде зареден"
 
-#: midx.c:1332
+#: midx.c:1684
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr "неправилно отместване на обект за oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#: midx.c:1357
+#: midx.c:1709
 msgid "Counting referenced objects"
 msgstr "Преброяване на свързаните обекти"
 
-#: midx.c:1367
+#: midx.c:1719
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "Търсене и изтриване на несвързаните пакетни файлове"
 
-#: midx.c:1558
+#: midx.c:1911
 msgid "could not start pack-objects"
 msgstr "командата „pack-objects“ не може да бъде стартирана"
 
-#: midx.c:1578
+#: midx.c:1931
 msgid "could not finish pack-objects"
 msgstr "командата „pack-objects“ не може да бъде завършена"
 
@@ -5745,266 +5898,263 @@ msgstr ""
 msgid "Bad %s value: '%s'"
 msgstr "Зададена е лоша стойност на променливата „%s“: „%s“"
 
-#: object-file.c:526
+#: object-file.c:459
 #, c-format
 msgid "object directory %s does not exist; check .git/objects/info/alternates"
 msgstr ""
 "директорията за обекти „%s“ не съществува, проверете „.git/objects/info/"
 "alternates“"
 
-#: object-file.c:584
+#: object-file.c:517
 #, c-format
 msgid "unable to normalize alternate object path: %s"
 msgstr "алтернативният път към обекти не може да бъде нормализиран: „%s“"
 
-#: object-file.c:658
+#: object-file.c:591
 #, c-format
 msgid "%s: ignoring alternate object stores, nesting too deep"
 msgstr ""
 "%s: алтернативните хранилища за обекти се пренебрегват поради прекалено "
 "дълбоко влагане"
 
-#: object-file.c:665
+#: object-file.c:598
 #, c-format
 msgid "unable to normalize object directory: %s"
 msgstr "директорията за обекти „%s“ не може да бъде нормализирана"
 
-#: object-file.c:708
+#: object-file.c:641
 msgid "unable to fdopen alternates lockfile"
 msgstr "заключващият файл за алтернативите не може да се отвори с „fdopen“"
 
-#: object-file.c:726
+#: object-file.c:659
 msgid "unable to read alternates file"
 msgstr "файлът с алтернативите не може да бъде прочетен"
 
-#: object-file.c:733
+#: object-file.c:666
 msgid "unable to move new alternates file into place"
 msgstr "новият файл с алтернативите не може да бъде преместен на мястото му"
 
-#: object-file.c:768
+#: object-file.c:701
 #, c-format
 msgid "path '%s' does not exist"
 msgstr "пътят „%s“ не съществува."
 
-#: object-file.c:789
+#: object-file.c:722
 #, c-format
 msgid "reference repository '%s' as a linked checkout is not supported yet."
 msgstr "все още не се поддържа еталонно хранилище „%s“ като свързано."
 
-#: object-file.c:795
+#: object-file.c:728
 #, c-format
 msgid "reference repository '%s' is not a local repository."
 msgstr "еталонното хранилище „%s“ не е локално"
 
-#: object-file.c:801
+#: object-file.c:734
 #, c-format
 msgid "reference repository '%s' is shallow"
 msgstr "еталонното хранилище „%s“ е плитко"
 
-#: object-file.c:809
+#: object-file.c:742
 #, c-format
 msgid "reference repository '%s' is grafted"
 msgstr "еталонното хранилище „%s“ е с присаждане"
 
-#: object-file.c:869
+#: object-file.c:773
+#, c-format
+msgid "could not find object directory matching %s"
+msgstr "директорията с обекти, която отговаря на „%s“, не може да бъде открита"
+
+#: object-file.c:823
 #, c-format
 msgid "invalid line while parsing alternate refs: %s"
 msgstr "неправилен ред при анализа на алтернативните указатели: „%s“"
 
-#: object-file.c:1019
+#: object-file.c:973
 #, c-format
 msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
 msgstr ""
 "неуспешен опит за „mmap“ %<PRIuMAX>, което е над позволеното %<PRIuMAX>"
 
-#: object-file.c:1054
+#: object-file.c:1008
 #, c-format
 msgid "mmap failed%s"
 msgstr "неуспешно изпълнение на „mmap“%s"
 
-#: object-file.c:1218
+#: object-file.c:1174
 #, c-format
 msgid "object file %s is empty"
 msgstr "файлът с обектите „%s“ е празен"
 
-#: object-file.c:1353 object-file.c:2548
+#: object-file.c:1293 object-file.c:2499
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr "непакетираният обект „%s“ е повреден"
 
-#: object-file.c:1355 object-file.c:2552
+#: object-file.c:1295 object-file.c:2503
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr "грешни данни в края на непакетирания обект „%s“"
 
-#: object-file.c:1397
-msgid "invalid object type"
-msgstr "неправилен вид обект"
-
-#: object-file.c:1481
-#, c-format
-msgid "unable to unpack %s header with --allow-unknown-type"
-msgstr ""
-"заглавната част „%s“ не може да се разпакетира с опцията „--allow-unknown-"
-"type“"
-
-#: object-file.c:1484
-#, c-format
-msgid "unable to unpack %s header"
-msgstr "заглавната част на „%s“ не може да бъде разпакетирана"
-
-#: object-file.c:1490
-#, c-format
-msgid "unable to parse %s header with --allow-unknown-type"
-msgstr ""
-"заглавната част „%s“ не може да се анализира с опцията „--allow-unknown-type“"
-
-#: object-file.c:1493
+#: object-file.c:1417
 #, c-format
 msgid "unable to parse %s header"
 msgstr "заглавната част на „%s“ не може да бъде анализирана"
 
-#: object-file.c:1717
+#: object-file.c:1419
+msgid "invalid object type"
+msgstr "неправилен вид обект"
+
+#: object-file.c:1430
+#, c-format
+msgid "unable to unpack %s header"
+msgstr "заглавната част на „%s“ не може да бъде разпакетирана"
+
+#: object-file.c:1434
+#, c-format
+msgid "header for %s too long, exceeds %d bytes"
+msgstr "заглавната част на „%s“ е прекалено дълга — надхвърля %d байта"
+
+#: object-file.c:1664
 #, c-format
 msgid "failed to read object %s"
 msgstr "обектът „%s“ не може да бъде прочетен"
 
-#: object-file.c:1721
+#: object-file.c:1668
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr "заместителят „%s“ на „%s“ не може да бъде открит"
 
-#: object-file.c:1725
+#: object-file.c:1672
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr "непакетираният обект „%s“ (в „%s“) е повреден"
 
-#: object-file.c:1729
+#: object-file.c:1676
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr "пакетираният обект „%s“ (в „%s“) е повреден"
 
-#: object-file.c:1834
+#: object-file.c:1781
 #, c-format
 msgid "unable to write file %s"
 msgstr "файлът „%s“ не може да бъде записан"
 
-#: object-file.c:1841
+#: object-file.c:1788
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr "правата за достъп до „%s“ не може да бъдат зададени"
 
-#: object-file.c:1848
+#: object-file.c:1795
 msgid "file write error"
 msgstr "грешка при запис на файл"
 
-#: object-file.c:1868
+#: object-file.c:1815
 msgid "error when closing loose object file"
 msgstr "грешка при затварянето на файла с непакетиран обект"
 
-#: object-file.c:1933
+#: object-file.c:1882
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 "няма права за добавяне на обект към базата от данни на хранилището „%s“"
 
-#: object-file.c:1935
+#: object-file.c:1884
 msgid "unable to create temporary file"
 msgstr "не може да бъде създаден временен файл"
 
-#: object-file.c:1959
+#: object-file.c:1908
 msgid "unable to write loose object file"
 msgstr "грешка при записа на файла с непакетиран обект"
 
-#: object-file.c:1965
+#: object-file.c:1914
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr "новият обект „%s“ не може да се компресира с „deflate“: %d"
 
-#: object-file.c:1969
+#: object-file.c:1918
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr "неуспешно приключване на „deflate“ върху „%s“: %d"
 
-#: object-file.c:1973
+#: object-file.c:1922
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr "грешка поради нестабилния източник данни за обектите „%s“"
 
-#: object-file.c:1983 builtin/pack-objects.c:1237
+#: object-file.c:1933 builtin/pack-objects.c:1243
 #, c-format
 msgid "failed utime() on %s"
 msgstr "неуспешно задаване на време на достъп/създаване чрез „utime“ на „%s“"
 
-#: object-file.c:2060
+#: object-file.c:2011
 #, c-format
 msgid "cannot read object for %s"
 msgstr "обектът за „%s“ не може да се прочете"
 
-#: object-file.c:2111
+#: object-file.c:2062
 msgid "corrupt commit"
 msgstr "повредено подаване"
 
-#: object-file.c:2119
+#: object-file.c:2070
 msgid "corrupt tag"
 msgstr "повреден етикет"
 
-#: object-file.c:2219
+#: object-file.c:2170
 #, c-format
 msgid "read error while indexing %s"
 msgstr "грешка при четене по време на индексиране на „%s“"
 
-#: object-file.c:2222
+#: object-file.c:2173
 #, c-format
 msgid "short read while indexing %s"
 msgstr "непълно прочитане по време на индексиране на „%s“"
 
-#: object-file.c:2295 object-file.c:2305
+#: object-file.c:2246 object-file.c:2256
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr "„%s“ не може да се вмъкне в базата от данни"
 
-#: object-file.c:2311
+#: object-file.c:2262
 #, c-format
 msgid "%s: unsupported file type"
 msgstr "неподдържан вид файл: „%s“"
 
-#: object-file.c:2335
+#: object-file.c:2286 builtin/fetch.c:1445
 #, c-format
 msgid "%s is not a valid object"
 msgstr "„%s“ е неправилен обект"
 
-#: object-file.c:2337
+#: object-file.c:2288
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr "„%s“ е неправилен обект от вид „%s“"
 
-#: object-file.c:2364 builtin/index-pack.c:192
+#: object-file.c:2315
 #, c-format
 msgid "unable to open %s"
 msgstr "обектът „%s“ не може да бъде отворен"
 
-#: object-file.c:2559 object-file.c:2612
+#: object-file.c:2510
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
 msgstr "неправилна контролна сума за „%s“ (трябва да е %s)"
 
-#: object-file.c:2583
+#: object-file.c:2533
 #, c-format
 msgid "unable to mmap %s"
 msgstr "неуспешно изпълнение на „mmap“ върху „%s“"
 
-#: object-file.c:2588
+#: object-file.c:2539
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr "заглавната част на „%s“ не може да бъде разпакетирана"
 
-#: object-file.c:2594
+#: object-file.c:2544
 #, c-format
 msgid "unable to parse header of %s"
 msgstr "заглавната част на „%s“ не може да бъде анализирана"
 
-#: object-file.c:2605
+#: object-file.c:2555
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr "съдържанието на „%s“ не може да бъде разпакетирано"
@@ -6133,12 +6283,27 @@ msgstr "обектът „%s“ не може да бъде анализиран
 msgid "hash mismatch %s"
 msgstr "разлика в контролната сума: „%s“"
 
-#: pack-bitmap.c:868 pack-bitmap.c:874 builtin/pack-objects.c:2411
+#: pack-bitmap.c:348
+msgid "multi-pack bitmap is missing required reverse index"
+msgstr "задължителният обратен индекс липсва в многопакетната битова маска"
+
+#: pack-bitmap.c:424
+msgid "load_reverse_index: could not open pack"
+msgstr ""
+"load_reverse_index: пакетът не може да се отвори (при зареждане на обратния "
+"индекс)"
+
+#: pack-bitmap.c:1064 pack-bitmap.c:1070 builtin/pack-objects.c:2424
 #, c-format
 msgid "unable to get size of %s"
 msgstr "размерът на „%s“ не може да бъде получен"
 
-#: pack-bitmap.c:1571 builtin/rev-list.c:92
+#: pack-bitmap.c:1916
+#, c-format
+msgid "could not find %s in pack %s at offset %<PRIuMAX>"
+msgstr "„%s“ липсва в пакет „%s“ при отместване %<PRIuMAX>"
+
+#: pack-bitmap.c:1952 builtin/rev-list.c:92
 #, c-format
 msgid "unable to get disk usage of %s"
 msgstr "използваното място за „%s“ не може да бъде получено"
@@ -6170,50 +6335,50 @@ msgstr ""
 "идентификатор на контролна сума %2$<PRIu32> на файла с обратен индекс „%1$s“ "
 "не се поддържа"
 
-#: pack-write.c:250
+#: pack-write.c:251
 msgid "cannot both write and verify reverse index"
 msgstr "обратният индекс не може едновременно да се записва и да се проверява"
 
-#: pack-write.c:271
+#: pack-write.c:270
 #, c-format
 msgid "could not stat: %s"
 msgstr "не може да се получи информация чрез „stat“ за „%s“"
 
-#: pack-write.c:283
+#: pack-write.c:282
 #, c-format
 msgid "failed to make %s readable"
 msgstr "не може да се дадат права за четене на „%s“"
 
-#: pack-write.c:522
+#: pack-write.c:520
 #, c-format
 msgid "could not write '%s' promisor file"
 msgstr "гарантиращият файл „%s“ не може да се запише"
 
-#: packfile.c:625
+#: packfile.c:626
 msgid "offset before end of packfile (broken .idx?)"
 msgstr ""
 "отместване преди края на пакетния файл (възможно е индексът да е повреден)"
 
-#: packfile.c:655
+#: packfile.c:656
 #, c-format
 msgid "packfile %s cannot be mapped%s"
 msgstr "не може да се изпълни „mmap“ върху пакетния файл „%s“%s"
 
-#: packfile.c:1934
+#: packfile.c:1923
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr ""
 "отместване преди началото на индекса на пакетния файл „%s“ (възможно е "
 "индексът да е повреден)"
 
-#: packfile.c:1938
+#: packfile.c:1927
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr ""
 "отместване преди края на индекса на пакетния файл „%s“ (възможно е индексът "
 "да е отрязан)"
 
-#: parse-options-cb.c:20 parse-options-cb.c:24
+#: parse-options-cb.c:20 parse-options-cb.c:24 builtin/commit-graph.c:175
 #, c-format
 msgid "option `%s' expects a numerical value"
 msgstr "опцията „%s“ очаква число за аргумент"
@@ -6235,72 +6400,72 @@ msgstr ""
 msgid "malformed object name '%s'"
 msgstr "неправилно име на обект „%s“"
 
-#: parse-options.c:38
+#: parse-options.c:58
 #, c-format
 msgid "%s requires a value"
 msgstr "опцията „%s“ изисква аргумент"
 
-#: parse-options.c:73
+#: parse-options.c:93
 #, c-format
 msgid "%s is incompatible with %s"
 msgstr "опциите „%s“ и „%s“ са несъвместими"
 
-#: parse-options.c:78
+#: parse-options.c:98
 #, c-format
 msgid "%s : incompatible with something else"
 msgstr "опцията „%s“ е несъвместима с нещо"
 
-#: parse-options.c:92 parse-options.c:96 parse-options.c:317
+#: parse-options.c:112 parse-options.c:116
 #, c-format
 msgid "%s takes no value"
 msgstr "опцията „%s“ не приема аргументи"
 
-#: parse-options.c:94
+#: parse-options.c:114
 #, c-format
 msgid "%s isn't available"
 msgstr "опцията „%s“ не е налична"
 
-#: parse-options.c:217
+#: parse-options.c:237
 #, c-format
 msgid "%s expects a non-negative integer value with an optional k/m/g suffix"
 msgstr ""
 "„%s“ очаква неотрицателно цяло число, евентуално със суфикс „k“/„m“/„g“"
 
-#: parse-options.c:386
+#: parse-options.c:393
 #, c-format
 msgid "ambiguous option: %s (could be --%s%s or --%s%s)"
 msgstr "нееднозначна опция: „%s“ (може да е „--%s%s“ или „--%s%s“)"
 
-#: parse-options.c:420 parse-options.c:428
+#: parse-options.c:427 parse-options.c:435
 #, c-format
 msgid "did you mean `--%s` (with two dashes)?"
 msgstr "„--%s“ (с 2 тирета) ли имахте предвид?"
 
-#: parse-options.c:668 parse-options.c:988
+#: parse-options.c:677 parse-options.c:1053
 #, c-format
 msgid "alias of --%s"
 msgstr "псевдоним на „--%s“"
 
-#: parse-options.c:879
+#: parse-options.c:891
 #, c-format
 msgid "unknown option `%s'"
 msgstr "непозната опция: „%s“"
 
-#: parse-options.c:881
+#: parse-options.c:893
 #, c-format
 msgid "unknown switch `%c'"
 msgstr "непознат флаг „%c“"
 
-#: parse-options.c:883
+#: parse-options.c:895
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
 msgstr "непозната стойност извън „ascii“ в низа: „%s“"
 
-#: parse-options.c:907
+#: parse-options.c:919
 msgid "..."
 msgstr "…"
 
-#: parse-options.c:926
+#: parse-options.c:933
 #, c-format
 msgid "usage: %s"
 msgstr "употреба: %s"
@@ -6308,48 +6473,72 @@ msgstr "употреба: %s"
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
 #.
-#: parse-options.c:932
+#: parse-options.c:948
 #, c-format
 msgid "   or: %s"
 msgstr "     или: %s"
 
-#: parse-options.c:935
+#. TRANSLATORS: You should only need to translate this format
+#. string if your language is a RTL language (e.g. Arabic,
+#. Hebrew etc.), not if it's a LTR language (e.g. German,
+#. Russian, Chinese etc.).
+#. *
+#. When a translated usage string has an embedded "\n" it's
+#. because options have wrapped to the next line. The line
+#. after the "\n" will then be padded to align with the
+#. command name, such as N_("git cmd [opt]\n<8
+#. spaces>[opt2]"), where the 8 spaces are the same length as
+#. "git cmd ".
+#. *
+#. This format string prints out that already-translated
+#. line. The "%*s" is whitespace padding to account for the
+#. padding at the start of the line that we add in this
+#. function. The "%s" is a line in the (hopefully already
+#. translated) N_() usage string, which contained embedded
+#. newlines before we split it up.
+#.
+#: parse-options.c:969
+#, c-format
+msgid "%*s%s"
+msgstr "%*s%s"
+
+#: parse-options.c:992
 #, c-format
 msgid "    %s"
 msgstr "    %s"
 
-#: parse-options.c:974
+#: parse-options.c:1039
 msgid "-NUM"
 msgstr "-ЧИСЛО"
 
-#: path.c:915
+#: path.c:922
 #, c-format
 msgid "Could not make %s writable by group"
 msgstr "Не може да се дадат права за запис в директорията „%s“ на групата"
 
-#: pathspec.c:151
+#: pathspec.c:150
 msgid "Escape character '\\' not allowed as last character in attr value"
 msgstr ""
 "Екраниращият знак „\\“не може да е последен знак в стойността на атрибут"
 
-#: pathspec.c:169
+#: pathspec.c:168
 msgid "Only one 'attr:' specification is allowed."
 msgstr "Позволено е само едно указване на „attr:“."
 
-#: pathspec.c:172
+#: pathspec.c:171
 msgid "attr spec must not be empty"
 msgstr "„attr:“ трябва да указва стойност"
 
-#: pathspec.c:215
+#: pathspec.c:214
 #, c-format
 msgid "invalid attribute name %s"
 msgstr "неправилно име на атрибут: „%s“"
 
-#: pathspec.c:280
+#: pathspec.c:279
 msgid "global 'glob' and 'noglob' pathspec settings are incompatible"
 msgstr "глобалните настройки за пътища „glob“ и „noglob“ са несъвместими"
 
-#: pathspec.c:287
+#: pathspec.c:286
 msgid ""
 "global 'literal' pathspec setting is incompatible with all other global "
 "pathspec settings"
@@ -6357,51 +6546,51 @@ msgstr ""
 "глобалната настройка за дословни пътища „literal“ е несъвместима с всички "
 "други глобални настройки за пътища"
 
-#: pathspec.c:327
+#: pathspec.c:326
 msgid "invalid parameter for pathspec magic 'prefix'"
 msgstr "неправилен параметър за опцията за магически пътища „prefix“"
 
-#: pathspec.c:348
+#: pathspec.c:347
 #, c-format
 msgid "Invalid pathspec magic '%.*s' in '%s'"
 msgstr "Неправилна стойност за опцията за магически пътища „%.*s“ в „%s“"
 
-#: pathspec.c:353
+#: pathspec.c:352
 #, c-format
 msgid "Missing ')' at the end of pathspec magic in '%s'"
 msgstr "Знакът „)“ липсва в опцията за магически пътища в „%s“"
 
-#: pathspec.c:391
+#: pathspec.c:390
 #, c-format
 msgid "Unimplemented pathspec magic '%c' in '%s'"
 msgstr "Магическите пътища „%c“ са без реализация за „%s“"
 
-#: pathspec.c:450
+#: pathspec.c:449
 #, c-format
 msgid "%s: 'literal' and 'glob' are incompatible"
 msgstr "%s: опциите „literal“ и „glob“ са несъвместими"
 
-#: pathspec.c:466
+#: pathspec.c:465
 #, c-format
 msgid "%s: '%s' is outside repository at '%s'"
 msgstr "%s: „%s“ е извън хранилището при „%s“"
 
-#: pathspec.c:542
+#: pathspec.c:541
 #, c-format
 msgid "'%s' (mnemonic: '%c')"
 msgstr "„%s“ (клавиш: „%c“)"
 
-#: pathspec.c:552
+#: pathspec.c:551
 #, c-format
 msgid "%s: pathspec magic not supported by this command: %s"
 msgstr "%s: магическите пътища не се поддържат от командата „%s“"
 
-#: pathspec.c:619
+#: pathspec.c:618
 #, c-format
 msgid "pathspec '%s' is beyond a symbolic link"
 msgstr "пътят „%s“ е след символна връзка"
 
-#: pathspec.c:664
+#: pathspec.c:663
 #, c-format
 msgid "line is badly quoted: %s"
 msgstr "неправилно цитиран ред: %s"
@@ -6422,7 +6611,7 @@ msgstr "пакетът за край на отговора не може да с
 msgid "flush packet write failed"
 msgstr "неуспешно изчистване на буферите при запис на пакет"
 
-#: pkt-line.c:153 pkt-line.c:265
+#: pkt-line.c:153
 msgid "protocol error: impossibly long line"
 msgstr "протоколна грешка: прекалено дълъг ред"
 
@@ -6430,7 +6619,7 @@ msgstr "протоколна грешка: прекалено дълъг ред"
 msgid "packet write with format failed"
 msgstr "неуспешен запис на пакет с формат"
 
-#: pkt-line.c:204
+#: pkt-line.c:204 pkt-line.c:252
 msgid "packet write failed - data exceeds max packet size"
 msgstr ""
 "неуспешен запис на пакетен файл — данните надвишават максималният размер на "
@@ -6441,25 +6630,25 @@ msgstr ""
 msgid "packet write failed: %s"
 msgstr "неуспешен запис на пакет: %s"
 
-#: pkt-line.c:328 pkt-line.c:329
+#: pkt-line.c:349 pkt-line.c:350
 msgid "read error"
 msgstr "грешка при четене"
 
-#: pkt-line.c:339 pkt-line.c:340
+#: pkt-line.c:360 pkt-line.c:361
 msgid "the remote end hung up unexpectedly"
 msgstr "отдалеченото хранилище неочаквано прекъсна връзката"
 
-#: pkt-line.c:369 pkt-line.c:371
+#: pkt-line.c:390 pkt-line.c:392
 #, c-format
 msgid "protocol error: bad line length character: %.4s"
 msgstr "протоколна грешка: неправилeн знак за дължина на ред: %.4s"
 
-#: pkt-line.c:386 pkt-line.c:388 pkt-line.c:394 pkt-line.c:396
+#: pkt-line.c:407 pkt-line.c:409 pkt-line.c:415 pkt-line.c:417
 #, c-format
 msgid "protocol error: bad line length %d"
 msgstr "протоколна грешка: неправилна дължина на ред: %d"
 
-#: pkt-line.c:413 sideband.c:165
+#: pkt-line.c:434 sideband.c:165
 #, c-format
 msgid "remote error: %s"
 msgstr "отдалечена грешка: %s"
@@ -6473,7 +6662,7 @@ msgstr "Обновяване на индекса"
 msgid "unable to create threaded lstat: %s"
 msgstr "не може да се създаде нишка за изпълнението на „lstat“: %s"
 
-#: pretty.c:988
+#: pretty.c:1051
 msgid "unable to parse --pretty format"
 msgstr "аргументът към опцията „--pretty“ не може да се анализира"
 
@@ -6505,21 +6694,21 @@ msgstr "object-info: след аргументите се очаква изчи�
 msgid "Removing duplicate objects"
 msgstr "Изтриване на повтарящите се обекти"
 
-#: range-diff.c:78
+#: range-diff.c:67
 msgid "could not start `log`"
 msgstr "командата за журнала с подавания „log“ не може да се стартира"
 
-#: range-diff.c:80
+#: range-diff.c:69
 msgid "could not read `log` output"
 msgstr ""
 "изходът от командата за журнала с подавания „log“ не може да се прочете"
 
-#: range-diff.c:101 sequencer.c:5550
+#: range-diff.c:97 sequencer.c:5605
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr "подаването „%s“ не може да бъде анализирано"
 
-#: range-diff.c:115
+#: range-diff.c:111
 #, c-format
 msgid ""
 "could not parse first line of `log` output: did not start with 'commit ': "
@@ -6528,12 +6717,12 @@ msgstr ""
 "първият ред от изхода на командата „log“ не може да се анализира, защото не "
 "започва с „commit “: „%s“"
 
-#: range-diff.c:140
+#: range-diff.c:137
 #, c-format
 msgid "could not parse git header '%.*s'"
 msgstr "заглавната част на git „%.*s“ не може да се анализира"
 
-#: range-diff.c:307
+#: range-diff.c:304
 msgid "failed to generate diff"
 msgstr "неуспешно търсене на разлика"
 
@@ -6563,7 +6752,7 @@ msgstr ""
 "%s: може да добавяте само обикновени файлове, символни връзки и директории "
 "на git"
 
-#: read-cache.c:753
+#: read-cache.c:753 builtin/submodule--helper.c:3241
 #, c-format
 msgid "'%s' does not have a commit checked out"
 msgstr "не е изтеглено подаване в „%s“"
@@ -6583,16 +6772,16 @@ msgstr "„%s“ не може да се добави в индекса"
 msgid "unable to stat '%s'"
 msgstr "„stat“ не може да се изпълни върху „%s“"
 
-#: read-cache.c:1358
+#: read-cache.c:1373
 #, c-format
 msgid "'%s' appears as both a file and as a directory"
 msgstr "„%s“ съществува и като файл, и като директория"
 
-#: read-cache.c:1573
+#: read-cache.c:1588
 msgid "Refresh index"
 msgstr "Обновяване на индекса"
 
-#: read-cache.c:1705
+#: read-cache.c:1720
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -6601,7 +6790,7 @@ msgstr ""
 "Зададена е неправилна стойност на настройката „index.version“.\n"
 "Ще се ползва версия %i"
 
-#: read-cache.c:1715
+#: read-cache.c:1730
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -6611,152 +6800,152 @@ msgstr ""
 "„GIT_INDEX_VERSION“.\n"
 "Ще се ползва версия %i"
 
-#: read-cache.c:1771
+#: read-cache.c:1786
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr "неправилен подпис: „0x%08x“"
 
-#: read-cache.c:1774
+#: read-cache.c:1789
 #, c-format
 msgid "bad index version %d"
 msgstr "неправилна версия на индекса %d"
 
-#: read-cache.c:1783
+#: read-cache.c:1798
 msgid "bad index file sha1 signature"
 msgstr "неправилен подпис за контролна сума по SHA1 на файла на индекса"
 
-#: read-cache.c:1817
+#: read-cache.c:1832
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr ""
 "индексът ползва разширение „%.4s“, което не се поддържа от тази версия на git"
 
-#: read-cache.c:1819
+#: read-cache.c:1834
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr "игнориране на разширението „%.4s“"
 
-#: read-cache.c:1856
+#: read-cache.c:1871
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr "непознат формат на запис в индекса: „0x%08x“"
 
-#: read-cache.c:1872
+#: read-cache.c:1887
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "неправилно име на поле в индекса близо до пътя „%s“"
 
-#: read-cache.c:1929
+#: read-cache.c:1944
 msgid "unordered stage entries in index"
 msgstr "неподредени записи в индекса"
 
-#: read-cache.c:1932
+#: read-cache.c:1947
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr "множество записи за слетия файл „%s“"
 
-#: read-cache.c:1935
+#: read-cache.c:1950
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr "неподредени записи за „%s“"
 
-#: read-cache.c:2041 read-cache.c:2339 rerere.c:549 rerere.c:583 rerere.c:1095
-#: submodule.c:1622 builtin/add.c:575 builtin/check-ignore.c:183
-#: builtin/checkout.c:519 builtin/checkout.c:706 builtin/clean.c:987
-#: builtin/commit.c:377 builtin/diff-tree.c:122 builtin/grep.c:505
-#: builtin/mv.c:146 builtin/reset.c:247 builtin/rm.c:291
-#: builtin/submodule--helper.c:333
+#: read-cache.c:2065 read-cache.c:2363 rerere.c:549 rerere.c:583 rerere.c:1095
+#: submodule.c:1662 builtin/add.c:603 builtin/check-ignore.c:183
+#: builtin/checkout.c:519 builtin/checkout.c:708 builtin/clean.c:987
+#: builtin/commit.c:378 builtin/diff-tree.c:122 builtin/grep.c:519
+#: builtin/mv.c:148 builtin/reset.c:253 builtin/rm.c:293
+#: builtin/submodule--helper.c:327 builtin/submodule--helper.c:3201
 msgid "index file corrupt"
 msgstr "файлът с индекса е повреден"
 
-#: read-cache.c:2185
+#: read-cache.c:2209
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr ""
 "не може да се създаде нишка за зареждане на обектите от кеша "
 "(load_cache_entries): %s"
 
-#: read-cache.c:2198
+#: read-cache.c:2222
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr ""
 "не може да се изчака нишка за зареждане на обектите от кеша "
 "(load_cache_entries): %s"
 
-#: read-cache.c:2231
+#: read-cache.c:2255
 #, c-format
 msgid "%s: index file open failed"
 msgstr "%s: неуспешно отваряне на файла на индекса"
 
-#: read-cache.c:2235
+#: read-cache.c:2259
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr "%s: не може да се получи информация за отворения индекс със „stat“"
 
-#: read-cache.c:2239
+#: read-cache.c:2263
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr "%s: файлът на индекса е по-малък от очакваното"
 
-#: read-cache.c:2243
+#: read-cache.c:2267
 #, c-format
 msgid "%s: unable to map index file%s"
 msgstr "%s: неуспешно изпълнение на „mmap“ върху индексния файл%s"
 
-#: read-cache.c:2286
+#: read-cache.c:2310
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr ""
 "не може да се създаде нишка за зареждане на разширенията на индекса "
 "(load_index_extensions): %s"
 
-#: read-cache.c:2313
+#: read-cache.c:2337
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr ""
 "не може да се създаде нишка за зареждане на разширенията на индекса "
 "(load_index_extensions): %s"
 
-#: read-cache.c:2351
+#: read-cache.c:2375
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr "споделеният индекс „%s“ не може да се обнови"
 
-#: read-cache.c:2398
+#: read-cache.c:2434
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr "грешки в индекса — в „%2$s“ се очаква „%1$s“, а бе получено „%3$s“"
 
-#: read-cache.c:3032 strbuf.c:1173 wrapper.c:633 builtin/merge.c:1146
+#: read-cache.c:3065 strbuf.c:1179 wrapper.c:641 builtin/merge.c:1147
 #, c-format
 msgid "could not close '%s'"
 msgstr "„%s“ не може да се затвори"
 
-#: read-cache.c:3075
+#: read-cache.c:3108
 msgid "failed to convert to a sparse-index"
 msgstr "индексът не може да бъде превърнат в частичен"
 
-#: read-cache.c:3146 sequencer.c:2684 sequencer.c:4440
+#: read-cache.c:3179
 #, c-format
 msgid "could not stat '%s'"
 msgstr "неуспешно изпълнение на „stat“ върху „%s“"
 
-#: read-cache.c:3159
+#: read-cache.c:3192
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "не може да се отвори директорията на git: %s"
 
-#: read-cache.c:3171
+#: read-cache.c:3204
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "неуспешно изтриване на „%s“"
 
-#: read-cache.c:3200
+#: read-cache.c:3233
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr "правата за достъп до „%s“ не може да бъдат поправени"
 
-#: read-cache.c:3349
+#: read-cache.c:3390
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr "%s: не може да се премине към етап №0"
@@ -6838,7 +7027,7 @@ msgid_plural "Rebase %s onto %s (%d commands)"
 msgstr[0] "Пребазиране на „%s“ върху „%s“ (%d команди)"
 msgstr[1] "Пребазиране на „%s“ върху „%s“ (%d команда)"
 
-#: rebase-interactive.c:75 git-rebase--preserve-merges.sh:218
+#: rebase-interactive.c:75
 msgid ""
 "\n"
 "Do not remove any line. Use 'drop' explicitly to remove a commit.\n"
@@ -6846,7 +7035,7 @@ msgstr ""
 "\n"
 "Не изтривайте редове.  Подаванията може да се прескачат с командата „drop“.\n"
 
-#: rebase-interactive.c:78 git-rebase--preserve-merges.sh:222
+#: rebase-interactive.c:78
 msgid ""
 "\n"
 "If you remove a line here THAT COMMIT WILL BE LOST.\n"
@@ -6854,7 +7043,7 @@ msgstr ""
 "\n"
 "Ако изтриете ред, съответстващото му подаване ще бъде ИЗТРИТО.\n"
 
-#: rebase-interactive.c:84 git-rebase--preserve-merges.sh:861
+#: rebase-interactive.c:84
 msgid ""
 "\n"
 "You are editing the todo file of an ongoing interactive rebase.\n"
@@ -6869,7 +7058,7 @@ msgstr ""
 "    git rebase --continue\n"
 "\n"
 
-#: rebase-interactive.c:89 git-rebase--preserve-merges.sh:938
+#: rebase-interactive.c:89
 msgid ""
 "\n"
 "However, if you remove everything, the rebase will be aborted.\n"
@@ -6879,14 +7068,14 @@ msgstr ""
 "Ако изтриете всичко, пребазирането ще бъде преустановено.\n"
 "\n"
 
-#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3836
-#: sequencer.c:3862 sequencer.c:5656 builtin/fsck.c:328 builtin/rebase.c:271
+#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3888
+#: sequencer.c:3914 sequencer.c:5711 builtin/fsck.c:328 builtin/gc.c:1789
+#: builtin/rebase.c:190
 #, c-format
 msgid "could not write '%s'"
 msgstr "„%s“ не може да се запише"
 
-#: rebase-interactive.c:119 builtin/rebase.c:203 builtin/rebase.c:229
-#: builtin/rebase.c:253
+#: rebase-interactive.c:119
 #, c-format
 msgid "could not write '%s'."
 msgstr "„%s“ не може да се запише."
@@ -6917,12 +7106,10 @@ msgstr ""
 "предупреждение)\n"
 "или „error“ (считане за грешка).\n"
 
-#: rebase-interactive.c:236 rebase-interactive.c:241 sequencer.c:2597
-#: builtin/rebase.c:189 builtin/rebase.c:214 builtin/rebase.c:240
-#: builtin/rebase.c:265
+#: rebase.c:29
 #, c-format
-msgid "could not read '%s'."
-msgstr "от „%s“ не може да се чете."
+msgid "%s: 'preserve' superseded by 'merges'"
+msgstr "%s: „merges“ заменя „preserve“"
 
 #: ref-filter.c:42 wt-status.c:2036
 msgid "gone"
@@ -6943,257 +7130,278 @@ msgstr "назад с %d"
 msgid "ahead %d, behind %d"
 msgstr "напред с %d, назад с %d"
 
-#: ref-filter.c:230
+#: ref-filter.c:235
 #, c-format
 msgid "expected format: %%(color:<color>)"
 msgstr "очакван формат: %%(color:ЦВЯТ)"
 
-#: ref-filter.c:232
+#: ref-filter.c:237
 #, c-format
 msgid "unrecognized color: %%(color:%s)"
 msgstr "непознат цвят: %%(color:%s)"
 
-#: ref-filter.c:254
+#: ref-filter.c:259
 #, c-format
 msgid "Integer value expected refname:lstrip=%s"
 msgstr "очаква се цяло число за „refname:lstrip=%s“"
 
-#: ref-filter.c:258
+#: ref-filter.c:263
 #, c-format
 msgid "Integer value expected refname:rstrip=%s"
 msgstr "очаква се цяло число за „refname:rstrip=%s“"
 
-#: ref-filter.c:260
+#: ref-filter.c:265
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
 msgstr "непознат аргумент за „%%(%s)“: %s"
 
-#: ref-filter.c:315
+#: ref-filter.c:320
 #, c-format
 msgid "%%(objecttype) does not take arguments"
 msgstr "%%(objecttype) не приема аргументи"
 
-#: ref-filter.c:339
+#: ref-filter.c:344
 #, c-format
 msgid "unrecognized %%(objectsize) argument: %s"
 msgstr "непознат аргумент за %%(objectsize): %s"
 
-#: ref-filter.c:347
+#: ref-filter.c:352
 #, c-format
 msgid "%%(deltabase) does not take arguments"
 msgstr "%%(deltabase) не приема аргументи"
 
-#: ref-filter.c:359
+#: ref-filter.c:364
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr "%%(body) не приема аргументи"
 
-#: ref-filter.c:372
+#: ref-filter.c:377
 #, c-format
 msgid "unrecognized %%(subject) argument: %s"
 msgstr "непознат аргумент за %%(subject): %s"
 
-#: ref-filter.c:391
+#: ref-filter.c:396
 #, c-format
 msgid "expected %%(trailers:key=<value>)"
 msgstr "очаква се %%(trailers:КЛЮЧ=СТОЙНОСТ)"
 
-#: ref-filter.c:393
+#: ref-filter.c:398
 #, c-format
 msgid "unknown %%(trailers) argument: %s"
 msgstr "непознат аргумент „%%(trailers)“: %s"
 
-#: ref-filter.c:424
+#: ref-filter.c:429
 #, c-format
 msgid "positive value expected contents:lines=%s"
 msgstr "очаква се положителна стойност за „contents:lines=%s“"
 
-#: ref-filter.c:426
+#: ref-filter.c:431
 #, c-format
 msgid "unrecognized %%(contents) argument: %s"
 msgstr "непознат аргумент за %%(contents): %s"
 
-#: ref-filter.c:441
+#: ref-filter.c:443
+#, c-format
+msgid "unrecognized %%(raw) argument: %s"
+msgstr "непознат аргумент за „%%(raw)“: %s"
+
+#: ref-filter.c:458
 #, c-format
 msgid "positive value expected '%s' in %%(%s)"
 msgstr "очаква се положителна стойност за „%s“ в %%(%s)"
 
-#: ref-filter.c:445
+#: ref-filter.c:462
 #, c-format
 msgid "unrecognized argument '%s' in %%(%s)"
 msgstr "непознат аргумент „%s“ в %%(%s)"
 
-#: ref-filter.c:459
+#: ref-filter.c:476
 #, c-format
 msgid "unrecognized email option: %s"
 msgstr "непозната опция за е-поща: %s"
 
-#: ref-filter.c:489
+#: ref-filter.c:506
 #, c-format
 msgid "expected format: %%(align:<width>,<position>)"
 msgstr "очакван формат: %%(align:ШИРОЧИНА,ПОЗИЦИЯ)"
 
-#: ref-filter.c:501
+#: ref-filter.c:518
 #, c-format
 msgid "unrecognized position:%s"
 msgstr "непозната позиция: %s"
 
-#: ref-filter.c:508
+#: ref-filter.c:525
 #, c-format
 msgid "unrecognized width:%s"
 msgstr "непозната широчина: %s"
 
-#: ref-filter.c:517
+#: ref-filter.c:534
 #, c-format
 msgid "unrecognized %%(align) argument: %s"
 msgstr "непознат аргумент за %%(align): %s"
 
-#: ref-filter.c:525
+#: ref-filter.c:542
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr "очаква се положителна широчина с лексемата „%%(align)“"
 
-#: ref-filter.c:543
+#: ref-filter.c:560
 #, c-format
 msgid "unrecognized %%(if) argument: %s"
 msgstr "непознат аргумент за „%%(if)“: %s"
 
-#: ref-filter.c:645
+#: ref-filter.c:568
+#, c-format
+msgid "%%(rest) does not take arguments"
+msgstr "%%(rest) не приема аргументи"
+
+#: ref-filter.c:680
 #, c-format
 msgid "malformed field name: %.*s"
 msgstr "неправилно име на обект: „%.*s“"
 
-#: ref-filter.c:672
+#: ref-filter.c:707
 #, c-format
 msgid "unknown field name: %.*s"
 msgstr "непознато име на обект: „%.*s“"
 
-#: ref-filter.c:676
+#: ref-filter.c:711
 #, c-format
 msgid ""
 "not a git repository, but the field '%.*s' requires access to object data"
 msgstr "не е хранилище на git, а полето „%.*s“ изисква достъп данни на обектни"
 
-#: ref-filter.c:801
+#: ref-filter.c:844
 #, c-format
 msgid "format: %%(if) atom used without a %%(then) atom"
 msgstr "формат: лексемата %%(if) е използвана без съответната ѝ %%(then)"
 
-#: ref-filter.c:865
+#: ref-filter.c:910
 #, c-format
 msgid "format: %%(then) atom used without an %%(if) atom"
 msgstr "формат: лексемата %%(then) е използвана без съответната ѝ %%(if)"
 
-#: ref-filter.c:867
+#: ref-filter.c:912
 #, c-format
 msgid "format: %%(then) atom used more than once"
 msgstr "формат: лексемата %%(then) е използвана повече от един път"
 
-#: ref-filter.c:869
+#: ref-filter.c:914
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr "формат: лексемата %%(then) е използвана след %%(else)"
 
-#: ref-filter.c:897
+#: ref-filter.c:946
 #, c-format
 msgid "format: %%(else) atom used without an %%(if) atom"
 msgstr "формат: лексемата %%(else) е използвана без съответната ѝ %%(if)"
 
-#: ref-filter.c:899
+#: ref-filter.c:948
 #, c-format
 msgid "format: %%(else) atom used without a %%(then) atom"
 msgstr "формат: лексемата %%(else) е използвана без съответната ѝ %%(then)"
 
-#: ref-filter.c:901
+#: ref-filter.c:950
 #, c-format
 msgid "format: %%(else) atom used more than once"
 msgstr "формат: лексемата %%(else) е използвана повече от един път"
 
-#: ref-filter.c:916
+#: ref-filter.c:965
 #, c-format
 msgid "format: %%(end) atom used without corresponding atom"
 msgstr "формат: лексемата %%(end) е използвана без съответната ѝ"
 
-#: ref-filter.c:973
+#: ref-filter.c:1027
 #, c-format
 msgid "malformed format string %s"
 msgstr "неправилен форматиращ низ „%s“"
 
-#: ref-filter.c:1621
+#: ref-filter.c:1033
+#, c-format
+msgid "this command reject atom %%(%.*s)"
+msgstr "тази команда отхвърли лексемата %%(%.*s)"
+
+#: ref-filter.c:1040
+#, c-format
+msgid "--format=%.*s cannot be used with --python, --shell, --tcl"
+msgstr ""
+"опцията „--format=%.*s“ е несъвместима с „--python“, „--shell“, „--tcl“"
+
+#: ref-filter.c:1706
 #, c-format
 msgid "(no branch, rebasing %s)"
 msgstr "(извън клон, пребазиране на „%s“)"
 
-#: ref-filter.c:1624
+#: ref-filter.c:1709
 #, c-format
 msgid "(no branch, rebasing detached HEAD %s)"
 msgstr "(извън клон, пребазиране на несвързан указател „HEAD“ при „%s“)"
 
-#: ref-filter.c:1627
+#: ref-filter.c:1712
 #, c-format
 msgid "(no branch, bisect started on %s)"
 msgstr "(извън клон, двоично търсене от „%s“)"
 
-#: ref-filter.c:1631
+#: ref-filter.c:1716
 #, c-format
 msgid "(HEAD detached at %s)"
 msgstr "(указателят „HEAD“ не е свързан и е при „%s“)"
 
-#: ref-filter.c:1634
+#: ref-filter.c:1719
 #, c-format
 msgid "(HEAD detached from %s)"
 msgstr "(указателят „HEAD“ не е свързан и е отделѐн от „%s“)"
 
-#: ref-filter.c:1637
+#: ref-filter.c:1722
 msgid "(no branch)"
 msgstr "(извън клон)"
 
-#: ref-filter.c:1669 ref-filter.c:1880
+#: ref-filter.c:1754 ref-filter.c:1972
 #, c-format
 msgid "missing object %s for %s"
 msgstr "обектът „%s“ липсва за „%s“"
 
-#: ref-filter.c:1679
+#: ref-filter.c:1764
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr "неуспешно анализиране чрез „parse_object_buffer“ на „%s“ за „%s“"
 
-#: ref-filter.c:2064
+#: ref-filter.c:2155
 #, c-format
 msgid "malformed object at '%s'"
 msgstr "обект със сгрешен формат при „%s“"
 
-#: ref-filter.c:2153
+#: ref-filter.c:2245
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr "игнориране на указателя с грешно име „%s“"
 
-#: ref-filter.c:2158 refs.c:676
+#: ref-filter.c:2250 refs.c:673
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "игнориране на повредения указател „%s“"
 
-#: ref-filter.c:2502
+#: ref-filter.c:2623
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "грешка във форма̀та: липсва лексемата %%(end)"
 
-#: ref-filter.c:2596
+#: ref-filter.c:2726
 #, c-format
 msgid "malformed object name %s"
 msgstr "неправилно име на обект „%s“"
 
-#: ref-filter.c:2601
+#: ref-filter.c:2731
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "опцията „%s“ не сочи към подаване"
 
-#: refs.c:264
+#: refs.c:261
 #, c-format
 msgid "%s does not point to a valid object!"
 msgstr "„%s“ не сочи към позволен обект!"
 
-#: refs.c:566
+#: refs.c:563
 #, c-format
 msgid ""
 "Using '%s' as the name for the initial branch. This default branch name\n"
@@ -7218,81 +7426,81 @@ msgstr ""
 "\n"
 "    git branch -m ИМЕ\n"
 
-#: refs.c:588
+#: refs.c:585
 #, c-format
 msgid "could not retrieve `%s`"
 msgstr "„%s“ не може да бъде получен"
 
-#: refs.c:598
+#: refs.c:595
 #, c-format
 msgid "invalid branch name: %s = %s"
 msgstr "неправилно име на клон: „%s = %s“"
 
-#: refs.c:674
+#: refs.c:671
 #, c-format
 msgid "ignoring dangling symref %s"
 msgstr "игнориране на указател на обект извън клон „%s“"
 
-#: refs.c:922
+#: refs.c:920
 #, c-format
 msgid "log for ref %s has gap after %s"
 msgstr "има пропуски в журнала с подаванията за указателя „%s“ след „%s“"
 
-#: refs.c:929
+#: refs.c:927
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
 msgstr "журналът с подаванията за указателя „%s“ свършва неочаквано след „%s“"
 
-#: refs.c:994
+#: refs.c:992
 #, c-format
 msgid "log for %s is empty"
 msgstr "журналът с подаванията за указателя „%s“ е празен"
 
-#: refs.c:1086
+#: refs.c:1084
 #, c-format
 msgid "refusing to update ref with bad name '%s'"
 msgstr "указател не може да се обнови с грешно име „%s“"
 
-#: refs.c:1157
+#: refs.c:1155
 #, c-format
 msgid "update_ref failed for ref '%s': %s"
 msgstr "неуспешно обновяване на указателя (update_ref) „%s“: %s"
 
-#: refs.c:2051
+#: refs.c:2062
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "не са позволени повече от една промени на указателя „%s“"
 
-#: refs.c:2131
+#: refs.c:2142
 msgid "ref updates forbidden inside quarantine environment"
 msgstr "обновяванията на указатели са забранени в среди под карантина"
 
-#: refs.c:2142
+#: refs.c:2153
 msgid "ref updates aborted by hook"
 msgstr "обновяванията на указатели са преустановени от кука"
 
-#: refs.c:2242 refs.c:2272
+#: refs.c:2253 refs.c:2283
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "„%s“ съществува, не може да се създаде „%s“"
 
-#: refs.c:2248 refs.c:2283
+#: refs.c:2259 refs.c:2294
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "невъзможно е едновременно да се обработват „%s“ и „%s“"
 
-#: refs/files-backend.c:1228
+#: refs/files-backend.c:1271
 #, c-format
 msgid "could not remove reference %s"
 msgstr "Указателят „%s“ не може да бъде изтрит"
 
-#: refs/files-backend.c:1242 refs/packed-backend.c:1542
-#: refs/packed-backend.c:1552
+#: refs/files-backend.c:1285 refs/packed-backend.c:1549
+#: refs/packed-backend.c:1559
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr "Указателят „%s“ не може да бъде изтрит: %s"
 
-#: refs/files-backend.c:1245 refs/packed-backend.c:1555
+#: refs/files-backend.c:1288 refs/packed-backend.c:1562
 #, c-format
 msgid "could not delete references: %s"
 msgstr "Указателите не може да бъдат изтрити: %s"
@@ -7596,7 +7804,7 @@ msgstr "приложеното коригиране на конфликт не �
 msgid "there were errors while writing '%s' (%s)"
 msgstr "грешки при записването на „%s“ (%s)"
 
-#: rerere.c:482
+#: rerere.c:482 builtin/gc.c:2246 builtin/gc.c:2281
 #, c-format
 msgid "failed to flush '%s'"
 msgstr "грешка при изчистването на буферите при записването на „%s“"
@@ -7644,8 +7852,8 @@ msgstr "излишният обект „%s“ не може да се изтр�
 msgid "Recorded preimage for '%s'"
 msgstr "Предварителният вариант на „%s“ е запазен"
 
-#: rerere.c:865 submodule.c:2076 builtin/log.c:2002
-#: builtin/submodule--helper.c:1805 builtin/submodule--helper.c:1848
+#: rerere.c:865 submodule.c:2121 builtin/log.c:2002
+#: builtin/submodule--helper.c:1776 builtin/submodule--helper.c:1819
 #, c-format
 msgid "could not create directory '%s'"
 msgstr "Директорията „%s“ не може да бъде създадена"
@@ -7683,48 +7891,42 @@ msgstr "директорията „rr-cache“ не може да се отво
 msgid "could not determine HEAD revision"
 msgstr "не може да се определи към какво да сочи указателят „HEAD“"
 
-#: reset.c:69 reset.c:75 sequencer.c:3689
+#: reset.c:70 reset.c:76 sequencer.c:3705
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "дървото, сочено от „%s“, не може да бъде открито"
 
-#: revision.c:2344
+#: revision.c:2259
+msgid "--unsorted-input is incompatible with --no-walk"
+msgstr "опциите „--unsorted-input“ и „--no-walk“ са несъвместими"
+
+#: revision.c:2346
 msgid "--unpacked=<packfile> no longer supported"
 msgstr "опцията „--unpacked=ПАКЕТЕН_ФАЙЛ“ вече не се поддържа"
 
-#: revision.c:2684
+#: revision.c:2655 revision.c:2659
+msgid "--no-walk is incompatible with --unsorted-input"
+msgstr "опциите „--no-walk“ и „--unsorted-input“ са несъвместими"
+
+#: revision.c:2690
 msgid "your current branch appears to be broken"
 msgstr "Текущият клон е повреден"
 
-#: revision.c:2687
+#: revision.c:2693
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
 msgstr "Текущият клон „%s“ е без подавания "
 
-#: revision.c:2893
+#: revision.c:2895
 msgid "-L does not yet support diff formats besides -p and -s"
 msgstr ""
 "опцията „-L“ поддържа единствено форматирането на разликите според опциите „-"
 "p“ и „-s“"
 
-#: run-command.c:766
-msgid "open /dev/null failed"
-msgstr "неуспешно отваряне на „/dev/null“"
-
-#: run-command.c:1274
+#: run-command.c:1278
 #, c-format
 msgid "cannot create async thread: %s"
 msgstr "не може да се създаде асинхронна нишка: %s"
-
-#: run-command.c:1344
-#, c-format
-msgid ""
-"The '%s' hook was ignored because it's not set as executable.\n"
-"You can disable this warning with `git config advice.ignoredHook false`."
-msgstr ""
-"Куката „%s“ се прескача, защото липсват права за изпълнение.\n"
-"За да изключите това предупреждение, изпълнете:\n"
-"    git config advice.ignoredHook false"
 
 #: send-pack.c:150
 msgid "unexpected flush packet while reading remote unpack status"
@@ -7747,24 +7949,24 @@ msgstr "неуспешно отдалечено разпакетиране: %s"
 msgid "failed to sign the push certificate"
 msgstr "сертификатът за изтласкване не може да бъде подписан"
 
-#: send-pack.c:433
+#: send-pack.c:435
 msgid "send-pack: unable to fork off fetch subprocess"
 msgstr "send-pack: неуспешно създаване на процес"
 
-#: send-pack.c:455
+#: send-pack.c:457
 msgid "push negotiation failed; proceeding anyway with push"
 msgstr "неуспешно договаряне на изтласкване, но се продължава с изтласкването"
 
-#: send-pack.c:526
+#: send-pack.c:528
 msgid "the receiving end does not support this repository's hash algorithm"
 msgstr ""
 "отсрещната страна не поддържа алгоритъма за контролни суми на това хранилище"
 
-#: send-pack.c:535
+#: send-pack.c:537
 msgid "the receiving end does not support --signed push"
 msgstr "отсрещната страна не поддържа изтласкване с опцията „--signed“"
 
-#: send-pack.c:537
+#: send-pack.c:539
 msgid ""
 "not sending a push certificate since the receiving end does not support --"
 "signed push"
@@ -7772,101 +7974,149 @@ msgstr ""
 "отсрещната страна не поддържа изтласкване с опцията „--signed“, затова не се "
 "използва сертификат"
 
-#: send-pack.c:544
+#: send-pack.c:546
 msgid "the receiving end does not support --atomic push"
 msgstr "получаващата страна не поддържа изтласкване с опцията „--atomic“"
 
-#: send-pack.c:549
+#: send-pack.c:551
 msgid "the receiving end does not support push options"
 msgstr "отсрещната страна не поддържа опции при изтласкване"
 
-#: sequencer.c:196
+#: sequencer.c:197
 #, c-format
 msgid "invalid commit message cleanup mode '%s'"
 msgstr "несъществуващ режим на изчистване „%s“ на съобщение при подаване"
 
-#: sequencer.c:324
+#: sequencer.c:325
 #, c-format
 msgid "could not delete '%s'"
 msgstr "„%s“ не може да бъде изтрит"
 
-#: sequencer.c:344 builtin/rebase.c:757 builtin/rebase.c:1592 builtin/rm.c:402
+#: sequencer.c:345 sequencer.c:4754 builtin/rebase.c:563 builtin/rebase.c:1297
+#: builtin/rm.c:408
 #, c-format
 msgid "could not remove '%s'"
 msgstr "„%s“ не може да бъде изтрит"
 
-#: sequencer.c:354
+#: sequencer.c:355
 msgid "revert"
 msgstr "отмяна"
 
-#: sequencer.c:356
+#: sequencer.c:357
 msgid "cherry-pick"
 msgstr "отбиране"
 
-#: sequencer.c:358
+#: sequencer.c:359
 msgid "rebase"
 msgstr "пребазиране"
 
-#: sequencer.c:360
+#: sequencer.c:361
 #, c-format
 msgid "unknown action: %d"
 msgstr "неизвестно действие: %d"
 
-#: sequencer.c:419
+#: sequencer.c:420
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'"
 msgstr ""
-"след коригирането на конфликтите, отбележете съответните\n"
-"пътища с „git add ПЪТ…“ или „git rm ПЪТ…“."
+"след коригирането на конфликтите, отбележете съответните пътища с:\n"
+"\n"
+"    git add ПЪТ…\n"
+"\n"
+"или\n"
+"\n"
+"    git rm ПЪТ…"
 
-#: sequencer.c:422
+#: sequencer.c:423
 msgid ""
-"after resolving the conflicts, mark the corrected paths\n"
-"with 'git add <paths>' or 'git rm <paths>'\n"
-"and commit the result with 'git commit'"
+"After resolving the conflicts, mark them with\n"
+"\"git add/rm <pathspec>\", then run\n"
+"\"git cherry-pick --continue\".\n"
+"You can instead skip this commit with \"git cherry-pick --skip\".\n"
+"To abort and get back to the state before \"git cherry-pick\",\n"
+"run \"git cherry-pick --abort\"."
 msgstr ""
-"след коригирането на конфликтите, отбележете съответните\n"
-"пътища с „git add ПЪТ…“ или „git rm ПЪТ…“, след което\n"
-"подайте резултата с командата „git commit'“."
+"След коригирането на конфликтите отбележете решаването им чрез:\n"
+"\n"
+"    git add/rm ПЪТ…\n"
+"\n"
+"и изпълнете:\n"
+"\n"
+"    git cherry-pick --continue\n"
+"\n"
+"Ако предпочитате да прескочите тази кръпка, изпълнете:\n"
+"\n"
+"    git cherry-pick --skip\n"
+"\n"
+"За да откажете пребазирането и да се върнете към първоначалното състояние,\n"
+"изпълнете:\n"
+"\n"
+"    git cherry-pick --abort"
 
-#: sequencer.c:435 sequencer.c:3271
+#: sequencer.c:430
+msgid ""
+"After resolving the conflicts, mark them with\n"
+"\"git add/rm <pathspec>\", then run\n"
+"\"git revert --continue\".\n"
+"You can instead skip this commit with \"git revert --skip\".\n"
+"To abort and get back to the state before \"git revert\",\n"
+"run \"git revert --abort\"."
+msgstr ""
+"След коригирането на конфликтите отбележете решаването им чрез:\n"
+"\n"
+"    git add/rm ПЪТ…\n"
+"\n"
+"и изпълнете:\n"
+"\n"
+"    git revert --continue\n"
+"\n"
+"Ако предпочитате да прескочите тази кръпка, изпълнете:\n"
+"\n"
+"    git revert --skip\n"
+"\n"
+"За да откажете пребазирането и да се върнете към първоначалното състояние,\n"
+"изпълнете:\n"
+"\n"
+"    git revert --abort"
+
+#: sequencer.c:448 sequencer.c:3290
 #, c-format
 msgid "could not lock '%s'"
 msgstr "„%s“ не може да се заключи"
 
-#: sequencer.c:437 sequencer.c:3070 sequencer.c:3275 sequencer.c:3289
-#: sequencer.c:3547 sequencer.c:5566 strbuf.c:1170 wrapper.c:631
+#: sequencer.c:450 sequencer.c:3089 sequencer.c:3294 sequencer.c:3308
+#: sequencer.c:3566 sequencer.c:5621 strbuf.c:1176 wrapper.c:639
 #, c-format
 msgid "could not write to '%s'"
 msgstr "в „%s“ не може да се пише"
 
-#: sequencer.c:442
+#: sequencer.c:455
 #, c-format
 msgid "could not write eol to '%s'"
 msgstr "краят на ред не може да се запише в „%s“"
 
-#: sequencer.c:447 sequencer.c:3075 sequencer.c:3277 sequencer.c:3291
-#: sequencer.c:3555
+#: sequencer.c:460 sequencer.c:3094 sequencer.c:3296 sequencer.c:3310
+#: sequencer.c:3574
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "„%s“ не може да се завърши"
 
-#: sequencer.c:486
+#: sequencer.c:499
 #, c-format
 msgid "your local changes would be overwritten by %s."
 msgstr "локалните ви промени ще бъдат презаписани при %s."
 
-#: sequencer.c:490
+#: sequencer.c:503
 msgid "commit your changes or stash them to proceed."
 msgstr "подайте или скатайте промените, за да продължите"
 
-#: sequencer.c:522
+#: sequencer.c:535
 #, c-format
 msgid "%s: fast-forward"
 msgstr "%s: превъртане"
 
-#: sequencer.c:561 builtin/tag.c:609
+#: sequencer.c:574 builtin/tag.c:610
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Несъществуващ режим на изчистване „%s“"
@@ -7874,65 +8124,65 @@ msgstr "Несъществуващ режим на изчистване „%s“
 #. TRANSLATORS: %s will be "revert", "cherry-pick" or
 #. "rebase".
 #.
-#: sequencer.c:671
+#: sequencer.c:685
 #, c-format
 msgid "%s: Unable to write new index file"
 msgstr "%s: новият индекс не може да бъде запазен"
 
-#: sequencer.c:685
+#: sequencer.c:699
 msgid "unable to update cache tree"
 msgstr "дървото на кеша не може да бъде обновено"
 
-#: sequencer.c:699
+#: sequencer.c:713
 msgid "could not resolve HEAD commit"
 msgstr "подаването, сочено от указателя „HEAD“, не може да бъде открито"
 
-#: sequencer.c:779
+#: sequencer.c:793
 #, c-format
 msgid "no key present in '%.*s'"
 msgstr "в „%.*s“ няма ключове"
 
-#: sequencer.c:790
+#: sequencer.c:804
 #, c-format
 msgid "unable to dequote value of '%s'"
 msgstr "цитирането на стойността на „%s“ не може да бъде изчистено"
 
-#: sequencer.c:827 wrapper.c:201 wrapper.c:371 builtin/am.c:729
-#: builtin/am.c:821 builtin/merge.c:1141 builtin/rebase.c:910
+#: sequencer.c:841 wrapper.c:209 wrapper.c:379 builtin/am.c:730
+#: builtin/am.c:822 builtin/rebase.c:694
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "файлът не може да бъде прочетен: „%s“"
 
-#: sequencer.c:837
+#: sequencer.c:851
 msgid "'GIT_AUTHOR_NAME' already given"
 msgstr "настройката за автор „GIT_AUTHOR_NAME“ вече е зададена"
 
-#: sequencer.c:842
+#: sequencer.c:856
 msgid "'GIT_AUTHOR_EMAIL' already given"
 msgstr "настройката за е-поща „GIT_AUTHOR_EMAIL“ вече е зададена"
 
-#: sequencer.c:847
+#: sequencer.c:861
 msgid "'GIT_AUTHOR_DATE' already given"
 msgstr "настройката за дата „GIT_AUTHOR_DATE“ вече е зададена"
 
-#: sequencer.c:851
+#: sequencer.c:865
 #, c-format
 msgid "unknown variable '%s'"
 msgstr "непозната променлива „%s“"
 
-#: sequencer.c:856
+#: sequencer.c:870
 msgid "missing 'GIT_AUTHOR_NAME'"
 msgstr "настройката за автор „GIT_AUTHOR_NAME“ липсва"
 
-#: sequencer.c:858
+#: sequencer.c:872
 msgid "missing 'GIT_AUTHOR_EMAIL'"
 msgstr "настройката за е-поща „GIT_AUTHOR_EMAIL“ липсва"
 
-#: sequencer.c:860
+#: sequencer.c:874
 msgid "missing 'GIT_AUTHOR_DATE'"
 msgstr "настройката за дата „GIT_AUTHOR_DATE“ липсва"
 
-#: sequencer.c:925
+#: sequencer.c:939
 #, c-format
 msgid ""
 "you have staged changes in your working tree\n"
@@ -7961,13 +8211,13 @@ msgstr ""
 "\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:1212
+#: sequencer.c:1229
 msgid "'prepare-commit-msg' hook failed"
 msgstr ""
 "неуспешно изпълнение на куката при промяна на съобщението при подаване "
 "(prepare-commit-msg)"
 
-#: sequencer.c:1218
+#: sequencer.c:1235
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7995,7 +8245,7 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1231
+#: sequencer.c:1248
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -8020,356 +8270,361 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1273
+#: sequencer.c:1290
 msgid "couldn't look up newly created commit"
 msgstr "току що създаденото подаване не може да бъде открито"
 
-#: sequencer.c:1275
+#: sequencer.c:1292
 msgid "could not parse newly created commit"
 msgstr "току що създаденото подаване не може да бъде анализирано"
 
-#: sequencer.c:1321
+#: sequencer.c:1338
 msgid "unable to resolve HEAD after creating commit"
 msgstr ""
 "състоянието сочено от указателя „HEAD“ не може да бъде открито след "
 "подаването"
 
-#: sequencer.c:1323
+#: sequencer.c:1340
 msgid "detached HEAD"
 msgstr "несвързан връх „HEAD“"
 
-#: sequencer.c:1327
+#: sequencer.c:1344
 msgid " (root-commit)"
 msgstr " (начално подаване)"
 
-#: sequencer.c:1348
+#: sequencer.c:1365
 msgid "could not parse HEAD"
 msgstr "указателят „HEAD“ не може да бъде анализиран"
 
-#: sequencer.c:1350
+#: sequencer.c:1367
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "указателят „HEAD“ „%s“ сочи към нещо, което не е подаване!"
 
-#: sequencer.c:1354 sequencer.c:1432 builtin/commit.c:1705
+#: sequencer.c:1371 sequencer.c:1449 builtin/commit.c:1707
 msgid "could not parse HEAD commit"
 msgstr "върховото подаване „HEAD“ не може да бъде прочетено"
 
-#: sequencer.c:1410 sequencer.c:2295
+#: sequencer.c:1427 sequencer.c:2312
 msgid "unable to parse commit author"
 msgstr "авторът на подаването не може да бъде анализиран"
 
-#: sequencer.c:1421 builtin/am.c:1615 builtin/merge.c:707
+#: sequencer.c:1438 builtin/am.c:1616 builtin/merge.c:708
 msgid "git write-tree failed to write a tree"
 msgstr "Командата „git write-tree“ не успя да запише обект-дърво"
 
-#: sequencer.c:1454 sequencer.c:1574
+#: sequencer.c:1471 sequencer.c:1591
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "съобщението за подаване не може да бъде прочетено от „%s“"
 
-#: sequencer.c:1485 sequencer.c:1517
+#: sequencer.c:1502 sequencer.c:1534
 #, c-format
 msgid "invalid author identity '%s'"
 msgstr "неправилна самоличност за автор: „%s“"
 
-#: sequencer.c:1491
+#: sequencer.c:1508
 msgid "corrupt author: missing date information"
 msgstr "повредена информация за автор: липсва дата"
 
-#: sequencer.c:1530 builtin/am.c:1642 builtin/commit.c:1819 builtin/merge.c:910
-#: builtin/merge.c:935 t/helper/test-fast-rebase.c:78
+#: sequencer.c:1547 builtin/am.c:1643 builtin/commit.c:1821 builtin/merge.c:913
+#: builtin/merge.c:938 t/helper/test-fast-rebase.c:78
 msgid "failed to write commit object"
 msgstr "обектът за подаването не може да бъде записан"
 
-#: sequencer.c:1557 sequencer.c:4492 t/helper/test-fast-rebase.c:199
+#: sequencer.c:1574 sequencer.c:4526 t/helper/test-fast-rebase.c:199
 #: t/helper/test-fast-rebase.c:217
 #, c-format
 msgid "could not update %s"
 msgstr "„%s“ не може да се обнови"
 
-#: sequencer.c:1606
+#: sequencer.c:1623
 #, c-format
 msgid "could not parse commit %s"
 msgstr "подаването „%s“ не може да бъде анализирано"
 
-#: sequencer.c:1611
+#: sequencer.c:1628
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "родителското подаване „%s“ не може да бъде анализирано"
 
-#: sequencer.c:1694 sequencer.c:1975
+#: sequencer.c:1711 sequencer.c:1992
 #, c-format
 msgid "unknown command: %d"
 msgstr "непозната команда: %d"
 
-#: sequencer.c:1736 git-rebase--preserve-merges.sh:486
+#: sequencer.c:1753
 msgid "This is the 1st commit message:"
 msgstr "Това е 1-то съобщение при подаване:"
 
-#: sequencer.c:1737
+#: sequencer.c:1754
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "Това е съобщение при подаване №%d:"
 
-#: sequencer.c:1738
+#: sequencer.c:1755
 msgid "The 1st commit message will be skipped:"
 msgstr "Съобщението при подаване №1 ще бъде прескочено:"
 
-#: sequencer.c:1739
+#: sequencer.c:1756
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "Съобщението при подаване №%d ще бъде прескочено:"
 
-#: sequencer.c:1740
+#: sequencer.c:1757
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr "Това е обединение от %d подавания"
 
-#: sequencer.c:1887 sequencer.c:1944
+#: sequencer.c:1904 sequencer.c:1961
 #, c-format
 msgid "cannot write '%s'"
 msgstr "„%s“ не може да се запази"
 
-#: sequencer.c:1934
+#: sequencer.c:1951
 msgid "need a HEAD to fixup"
 msgstr "За вкарване в предходното подаване ви трябва указател „HEAD“"
 
-#: sequencer.c:1936 sequencer.c:3582
+#: sequencer.c:1953 sequencer.c:3601
 msgid "could not read HEAD"
 msgstr "указателят „HEAD“ не може да се прочете"
 
-#: sequencer.c:1938
+#: sequencer.c:1955
 msgid "could not read HEAD's commit message"
 msgstr ""
 "съобщението за подаване към указателя „HEAD“ не може да бъде прочетено: %s"
 
-#: sequencer.c:1962
+#: sequencer.c:1979
 #, c-format
 msgid "could not read commit message of %s"
 msgstr "съобщението за подаване към „%s“ не може да бъде прочетено"
 
-#: sequencer.c:2072
+#: sequencer.c:2089
 msgid "your index file is unmerged."
 msgstr "индексът не е слят."
 
-#: sequencer.c:2079
+#: sequencer.c:2096
 msgid "cannot fixup root commit"
 msgstr "началното подаване не може да се вкара в предходното му"
 
-#: sequencer.c:2098
+#: sequencer.c:2115
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "подаването „%s“ е сливане, но не е дадена опцията „-m“"
 
-#: sequencer.c:2106 sequencer.c:2114
+#: sequencer.c:2123 sequencer.c:2131
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "подаването „%s“ няма родител %d"
 
-#: sequencer.c:2120
+#: sequencer.c:2137
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "неуспешно извличане на съобщението за подаване на „%s“"
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:2139
+#: sequencer.c:2156
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: неразпозната стойност за родителското подаване „%s“"
 
-#: sequencer.c:2205
+#: sequencer.c:2222
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "„%s“ не може да се преименува на „%s“"
 
-#: sequencer.c:2265
+#: sequencer.c:2282
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "подаването „%s“… не може да бъде отменено: „%s“"
 
-#: sequencer.c:2266
+#: sequencer.c:2283
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "подаването „%s“… не може да бъде приложено: „%s“"
 
-#: sequencer.c:2287
+#: sequencer.c:2304
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr "прескачане на %s %s — кръпката вече е приложена\n"
 
-#: sequencer.c:2345
+#: sequencer.c:2362
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: неуспешно изчитане на индекса"
 
-#: sequencer.c:2352
+#: sequencer.c:2370
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: неуспешно обновяване на индекса"
 
-#: sequencer.c:2425
+#: sequencer.c:2450
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "„%s“ не приема аргументи: „%s“"
 
-#: sequencer.c:2434
+#: sequencer.c:2459
 #, c-format
 msgid "missing arguments for %s"
 msgstr "„%s“ изисква аргументи"
 
-#: sequencer.c:2477
+#: sequencer.c:2502
 #, c-format
 msgid "could not parse '%s'"
 msgstr "„%s“ не може да се анализира"
 
-#: sequencer.c:2538
+#: sequencer.c:2563
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "неправилен ред %d: %.*s"
 
-#: sequencer.c:2549
+#: sequencer.c:2574
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "Без предишно подаване не може да се изпълни „%s“"
 
-#: sequencer.c:2635
+#: sequencer.c:2622 builtin/rebase.c:184
+#, c-format
+msgid "could not read '%s'."
+msgstr "от „%s“ не може да се чете."
+
+#: sequencer.c:2660
 msgid "cancelling a cherry picking in progress"
 msgstr "преустановяване на извършваното в момента отбиране на подавания"
 
-#: sequencer.c:2644
+#: sequencer.c:2669
 msgid "cancelling a revert in progress"
 msgstr "преустановяване на извършваното в момента отмяна на подаване"
 
-#: sequencer.c:2690
+#: sequencer.c:2709
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr "коригирайте това чрез „git rebase --edit-todo“."
 
-#: sequencer.c:2692
+#: sequencer.c:2711
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "неизползваем файл с описание на предстоящите действия: „%s“"
 
-#: sequencer.c:2697
+#: sequencer.c:2716
 msgid "no commits parsed."
 msgstr "никое от подаванията не може да се разпознае."
 
-#: sequencer.c:2708
+#: sequencer.c:2727
 msgid "cannot cherry-pick during a revert."
 msgstr ""
 "по време на отмяна на подаване не може да се извърши отбиране на подаване."
 
-#: sequencer.c:2710
+#: sequencer.c:2729
 msgid "cannot revert during a cherry-pick."
 msgstr "по време на отбиране не може да се извърши отмяна на подаване."
 
-#: sequencer.c:2788
+#: sequencer.c:2807
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr "неправилна стойност за „%s“: „%s“"
 
-#: sequencer.c:2897
+#: sequencer.c:2916
 msgid "unusable squash-onto"
 msgstr "подаването, в което другите да се вкарат, не може да се използва"
 
-#: sequencer.c:2917
+#: sequencer.c:2936
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "неправилен файл с опции: „%s“"
 
-#: sequencer.c:3012 sequencer.c:4868
+#: sequencer.c:3031 sequencer.c:4905
 msgid "empty commit set passed"
 msgstr "зададено е празно множество от подавания"
 
-#: sequencer.c:3029
+#: sequencer.c:3048
 msgid "revert is already in progress"
 msgstr "в момента вече се извършва отмяна на подавания"
 
-#: sequencer.c:3031
+#: sequencer.c:3050
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr "използвайте „git revert (--continue | %s--abort | --quit)“"
 
-#: sequencer.c:3034
+#: sequencer.c:3053
 msgid "cherry-pick is already in progress"
 msgstr "в момента вече се извършва отбиране на подавания"
 
-#: sequencer.c:3036
+#: sequencer.c:3055
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr "използвайте „git cherry-pick (--continue | %s--abort | --quit)“"
 
-#: sequencer.c:3050
+#: sequencer.c:3069
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr ""
 "директорията за определянето на последователността „%s“ не може да бъде "
 "създадена"
 
-#: sequencer.c:3065
+#: sequencer.c:3084
 msgid "could not lock HEAD"
 msgstr "указателят „HEAD“ не може да се заключи"
 
-#: sequencer.c:3125 sequencer.c:4581
+#: sequencer.c:3144 sequencer.c:4615
 msgid "no cherry-pick or revert in progress"
 msgstr ""
 "в момента не се извършва отбиране на подавания или пребазиране на клона"
 
-#: sequencer.c:3127 sequencer.c:3138
+#: sequencer.c:3146 sequencer.c:3157
 msgid "cannot resolve HEAD"
 msgstr "Подаването сочено от указателя „HEAD“ не може да бъде открито"
 
-#: sequencer.c:3129 sequencer.c:3173
+#: sequencer.c:3148 sequencer.c:3192
 msgid "cannot abort from a branch yet to be born"
 msgstr ""
 "действието не може да бъде преустановено, когато сте на клон, който тепърва "
 "предстои да бъде създаден"
 
-#: sequencer.c:3159 builtin/grep.c:758
+#: sequencer.c:3178 builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr "„%s“ не може да бъде отворен"
 
-#: sequencer.c:3161
+#: sequencer.c:3180
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "„%s“ не може да бъде прочетен: %s"
 
-#: sequencer.c:3162
+#: sequencer.c:3181
 msgid "unexpected end of file"
 msgstr "неочакван край на файл"
 
-#: sequencer.c:3168
+#: sequencer.c:3187
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr ""
 "запазеният преди започването на отбирането файл за указателя „HEAD“ — „%s“ е "
 "повреден"
 
-#: sequencer.c:3179
+#: sequencer.c:3198
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr ""
 "Изглежда указателят „HEAD“ е променен.  Проверете към какво сочи.\n"
 "Не се правят промени."
 
-#: sequencer.c:3220
+#: sequencer.c:3239
 msgid "no revert in progress"
 msgstr "в момента не тече пребазиране"
 
-#: sequencer.c:3229
+#: sequencer.c:3248
 msgid "no cherry-pick in progress"
 msgstr "в момента не се извършва отбиране на подавания"
 
-#: sequencer.c:3239
+#: sequencer.c:3258
 msgid "failed to skip the commit"
 msgstr "неуспешно прескачане на подаването"
 
-#: sequencer.c:3246
+#: sequencer.c:3265
 msgid "there is nothing to skip"
 msgstr "няма какво да се прескочи"
 
-#: sequencer.c:3249
+#: sequencer.c:3268
 #, c-format
 msgid ""
 "have you committed already?\n"
@@ -8379,16 +8634,16 @@ msgstr ""
 "\n"
 "    git %s --continue"
 
-#: sequencer.c:3411 sequencer.c:4472
+#: sequencer.c:3430 sequencer.c:4506
 msgid "cannot read HEAD"
 msgstr "указателят „HEAD“ не може да бъде прочетен"
 
-#: sequencer.c:3428
+#: sequencer.c:3447
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "„%s“ не може да се копира като „%s“"
 
-#: sequencer.c:3436
+#: sequencer.c:3455
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -8407,27 +8662,27 @@ msgstr ""
 "\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:3446
+#: sequencer.c:3465
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "Подаването „%s“… не може да бъде приложено: „%.*s“"
 
-#: sequencer.c:3453
+#: sequencer.c:3472
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "Невъзможно сливане на „%.*s“"
 
-#: sequencer.c:3467 sequencer.c:3471 builtin/difftool.c:644
+#: sequencer.c:3486 sequencer.c:3490 builtin/difftool.c:639
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "„%s“ не може да се копира като „%s“"
 
-#: sequencer.c:3483
+#: sequencer.c:3502
 #, c-format
 msgid "Executing: %s\n"
 msgstr "В момента се изпълнява: %s\n"
 
-#: sequencer.c:3498
+#: sequencer.c:3517
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -8442,11 +8697,11 @@ msgstr ""
 "    git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3504
+#: sequencer.c:3523
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "и променѝ индекса и/или работното дърво\n"
 
-#: sequencer.c:3510
+#: sequencer.c:3529
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -8463,90 +8718,90 @@ msgstr ""
 "    git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3572
+#: sequencer.c:3591
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "неправилно име на етикет: „%.*s“"
 
-#: sequencer.c:3645
+#: sequencer.c:3664
 msgid "writing fake root commit"
 msgstr "запазване на фалшиво начално подаване"
 
-#: sequencer.c:3650
+#: sequencer.c:3669
 msgid "writing squash-onto"
 msgstr "запазване на подаването, в което другите да се вкарат"
 
-#: sequencer.c:3734
+#: sequencer.c:3748
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "„%s“ не може да бъде открит"
 
-#: sequencer.c:3767
+#: sequencer.c:3780
 msgid "cannot merge without a current revision"
 msgstr "без текущо подаване не може да се слива"
 
-#: sequencer.c:3789
+#: sequencer.c:3802
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "„%.*s“ не може да се анализира"
 
-#: sequencer.c:3798
+#: sequencer.c:3811
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "няма нищо за сливане: „%.*s“"
 
-#: sequencer.c:3810
+#: sequencer.c:3823
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr "върху начално подаване не може да се извърши множествено сливане"
 
-#: sequencer.c:3826
+#: sequencer.c:3878
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "съобщението за подаване към „%s“ не може да бъде получено"
 
-#: sequencer.c:4009
+#: sequencer.c:4024
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "сливането на „%.*s“ не може даже да започне"
 
-#: sequencer.c:4025
+#: sequencer.c:4040
 msgid "merge: Unable to write new index file"
 msgstr "сливане: новият индекс не може да бъде запазен"
 
-#: sequencer.c:4099
+#: sequencer.c:4121
 msgid "Cannot autostash"
 msgstr "Не може да се скатае автоматично"
 
-#: sequencer.c:4102
+#: sequencer.c:4124
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Неочакван резултат при скатаване: „%s“"
 
-#: sequencer.c:4108
+#: sequencer.c:4130
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "Директорията за „%s“ не може да бъде създадена"
 
-#: sequencer.c:4111
+#: sequencer.c:4133
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "Автоматично скатано: „%s“\n"
 
-#: sequencer.c:4115
+#: sequencer.c:4137
 msgid "could not reset --hard"
 msgstr "неуспешно изпълнение на „git reset --hard“"
 
-#: sequencer.c:4140
+#: sequencer.c:4162
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "Автоматично скатаното е приложено.\n"
 
-#: sequencer.c:4152
+#: sequencer.c:4174
 #, c-format
 msgid "cannot store %s"
 msgstr "„%s“ не може да бъде запазен"
 
-#: sequencer.c:4155
+#: sequencer.c:4177
 #, c-format
 msgid ""
 "%s\n"
@@ -8558,29 +8813,29 @@ msgstr ""
 "„git stash pop“ или да ги изхвърлите чрез „git stash drop“, когато "
 "поискате.\n"
 
-#: sequencer.c:4160
+#: sequencer.c:4182
 msgid "Applying autostash resulted in conflicts."
 msgstr "Конфликти при прилагането на автоматично скатаното."
 
-#: sequencer.c:4161
+#: sequencer.c:4183
 msgid "Autostash exists; creating a new stash entry."
 msgstr "Вече има запис за автоматично скатано, затова се създава нов запис."
 
-#: sequencer.c:4233 git-rebase--preserve-merges.sh:769
+#: sequencer.c:4255
 msgid "could not detach HEAD"
 msgstr "указателят „HEAD“ не може да се отдели"
 
-#: sequencer.c:4248
+#: sequencer.c:4270
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Бе спряно при „HEAD“\n"
 
-#: sequencer.c:4250
+#: sequencer.c:4272
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Бе спряно при „%s“\n"
 
-#: sequencer.c:4258
+#: sequencer.c:4304
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -8603,58 +8858,58 @@ msgstr ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:4304
+#: sequencer.c:4350
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr "Пребазиране (%d/%d)%s"
 
-#: sequencer.c:4350
+#: sequencer.c:4396
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Спиране при „%s“…  %.*s\n"
 
-#: sequencer.c:4421
+#: sequencer.c:4466
 #, c-format
 msgid "unknown command %d"
 msgstr "непозната команда %d"
 
-#: sequencer.c:4480
+#: sequencer.c:4514
 msgid "could not read orig-head"
 msgstr "указателят за „orig-head“ не може да се прочете"
 
-#: sequencer.c:4485
+#: sequencer.c:4519
 msgid "could not read 'onto'"
 msgstr "указателят за „onto“ не може да се прочете"
 
-#: sequencer.c:4499
+#: sequencer.c:4533
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "„HEAD“ не може да бъде обновен до „%s“"
 
-#: sequencer.c:4559
+#: sequencer.c:4593
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr "Успешно пребазиране и обновяване на „%s“.\n"
 
-#: sequencer.c:4611
+#: sequencer.c:4645
 msgid "cannot rebase: You have unstaged changes."
 msgstr "не може да пребазирате, защото има промени, които не са в индекса."
 
-#: sequencer.c:4620
+#: sequencer.c:4654
 msgid "cannot amend non-existing commit"
 msgstr "несъществуващо подаване не може да се поправи"
 
-#: sequencer.c:4622
+#: sequencer.c:4656
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "неправилен файл: „%s“"
 
-#: sequencer.c:4624
+#: sequencer.c:4658
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "неправилно съдържание: „%s“"
 
-#: sequencer.c:4627
+#: sequencer.c:4661
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -8664,50 +8919,60 @@ msgstr ""
 "В работното дърво има неподадени промени.  Първо ги подайте, а след това\n"
 "отново изпълнете „git rebase --continue“."
 
-#: sequencer.c:4663 sequencer.c:4702
+#: sequencer.c:4697 sequencer.c:4736
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "файлът „%s“ не може да бъде записан"
 
-#: sequencer.c:4718
+#: sequencer.c:4752
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "указателят „CHERRY_PICK_HEAD“ не може да бъде изтрит"
 
-#: sequencer.c:4725
+#: sequencer.c:4762
 msgid "could not commit staged changes."
 msgstr "промените в индекса не може да бъдат подадени."
 
-#: sequencer.c:4845
+#: sequencer.c:4882
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: не може да се отбере „%s“"
 
-#: sequencer.c:4849
+#: sequencer.c:4886
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: неправилна версия"
 
-#: sequencer.c:4884
+#: sequencer.c:4921
 msgid "can't revert as initial commit"
 msgstr "първоначалното подаване не може да бъде отменено"
 
-#: sequencer.c:5361
+#: sequencer.c:5192 sequencer.c:5421
+#, c-format
+msgid "skipped previously applied commit %s"
+msgstr "прескачане на вече приложеното подаване „%s“"
+
+#: sequencer.c:5262 sequencer.c:5437
+msgid "use --reapply-cherry-picks to include skipped commits"
+msgstr ""
+"може да включите пропуснатите подавания с опцията „--reapply-cherry-picks“"
+
+#: sequencer.c:5408
 msgid "make_script: unhandled options"
 msgstr "make_script: неподдържани опции"
 
-#: sequencer.c:5364
+#: sequencer.c:5411
 msgid "make_script: error preparing revisions"
 msgstr "make_script: грешка при подготовката на версии"
 
-#: sequencer.c:5614 sequencer.c:5631
+#: sequencer.c:5669 sequencer.c:5686
 msgid "nothing to do"
 msgstr "няма какво да се прави"
 
-#: sequencer.c:5650
+#: sequencer.c:5705
 msgid "could not skip unnecessary pick commands"
 msgstr "излишните команди за отбиране не бяха прескочени"
 
-#: sequencer.c:5750
+#: sequencer.c:5805
 msgid "the script was already rearranged."
 msgstr "скриптът вече е преподреден."
 
@@ -8874,27 +9139,15 @@ msgstr ""
 "(0%.3o).\n"
 "Собственикът на файла трябва да има права за писане и четене."
 
-#: setup.c:1430
-msgid "open /dev/null or dup failed"
-msgstr "неуспешно изпълнение на „open“ или „dup“ върху „/dev/null“"
-
-#: setup.c:1445
+#: setup.c:1443
 msgid "fork failed"
 msgstr "неуспешно създаване на процес чрез „fork“"
 
-#: setup.c:1450 t/helper/test-simple-ipc.c:285
+#: setup.c:1448
 msgid "setsid failed"
 msgstr "неуспешно изпълнение на „setsid“"
 
-#: sparse-index.c:162
-msgid "attempting to use sparse-index without cone mode"
-msgstr "опит за ползване на частичен индекс без пътеводен режим"
-
-#: sparse-index.c:176
-msgid "unable to update cache-tree, staying full"
-msgstr "дървото на кеша не може да бъде обновено и остава пълно"
-
-#: sparse-index.c:263
+#: sparse-index.c:273
 #, c-format
 msgid "index entry is a directory, but not sparse (%08x)"
 msgstr "обектът в индекса е директория, но не частично изтеглена (%08x)"
@@ -8951,13 +9204,13 @@ msgid_plural "%u bytes/s"
 msgstr[0] "%u байт/сек."
 msgstr[1] "%u байта/сек."
 
-#: strbuf.c:1168 wrapper.c:199 wrapper.c:369 builtin/am.c:738
-#: builtin/rebase.c:866
+#: strbuf.c:1174 wrapper.c:207 wrapper.c:377 builtin/am.c:739
+#: builtin/rebase.c:650
 #, c-format
 msgid "could not open '%s' for writing"
 msgstr "„%s“ не може да бъде отворен за запис"
 
-#: strbuf.c:1177
+#: strbuf.c:1183
 #, c-format
 msgid "could not edit '%s'"
 msgstr "„%s“ не може да се редактира"
@@ -8983,7 +9236,7 @@ msgstr ""
 msgid "invalid value for %s"
 msgstr "Неправилна стойност за „%s“"
 
-#: submodule-config.c:766
+#: submodule-config.c:767
 #, c-format
 msgid "Could not update .gitmodules entry %s"
 msgstr "Записът „%s“ във файла „.gitmodules“ не може да бъде променен"
@@ -9008,22 +9261,22 @@ msgstr "Записът „%s“ във файла „.gitmodules“ не мож�
 msgid "staging updated .gitmodules failed"
 msgstr "неуспешно добавяне на променения файл „.gitmodules“ в индекса"
 
-#: submodule.c:328
+#: submodule.c:358
 #, c-format
 msgid "in unpopulated submodule '%s'"
 msgstr "в неподготвения подмодул „%s“"
 
-#: submodule.c:359
+#: submodule.c:389
 #, c-format
 msgid "Pathspec '%s' is in submodule '%.*s'"
 msgstr "Пътят „%s“ е в подмодула „%.*s“"
 
-#: submodule.c:436
+#: submodule.c:466
 #, c-format
 msgid "bad --ignore-submodules argument: %s"
 msgstr "неправилен аргумент за „--ignore-submodules“: „%s“"
 
-#: submodule.c:805
+#: submodule.c:844
 #, c-format
 msgid ""
 "Submodule in commit %s at path: '%s' collides with a submodule named the "
@@ -9032,12 +9285,12 @@ msgstr ""
 "Подмодулът при подаване %s на пътя „%s“ е различен от другия модул със "
 "същото име, затова първият се прескача."
 
-#: submodule.c:908
+#: submodule.c:954
 #, c-format
 msgid "submodule entry '%s' (%s) is a %s, not a commit"
 msgstr "записът за подмодула „%s“ (%s) е %s, а не подаване!"
 
-#: submodule.c:993
+#: submodule.c:1042
 #, c-format
 msgid ""
 "Could not run 'git rev-list <commits> --not --remotes -n 1' command in "
@@ -9046,36 +9299,36 @@ msgstr ""
 "Командата „git rev-list ПОДАВАНИЯ --not --remotes -n 1“ не може да се "
 "изпълни в подмодула „%s“"
 
-#: submodule.c:1116
+#: submodule.c:1165
 #, c-format
 msgid "process for submodule '%s' failed"
 msgstr "процесът за подмодула „%s“ завърши неуспешно"
 
-#: submodule.c:1145 builtin/branch.c:691 builtin/submodule--helper.c:2486
+#: submodule.c:1194 builtin/branch.c:692 builtin/submodule--helper.c:2713
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "Не може да се открие към какво сочи указателят „HEAD“"
 
-#: submodule.c:1156
+#: submodule.c:1205
 #, c-format
 msgid "Pushing submodule '%s'\n"
 msgstr "Изтласкване на подмодула „%s“\n"
 
-#: submodule.c:1159
+#: submodule.c:1208
 #, c-format
 msgid "Unable to push submodule '%s'\n"
 msgstr "Подмодулът „%s“ не може да бъде изтласкан\n"
 
-#: submodule.c:1451
+#: submodule.c:1491
 #, c-format
 msgid "Fetching submodule %s%s\n"
 msgstr "Доставяне на подмодула „%s%s“\n"
 
-#: submodule.c:1485
+#: submodule.c:1525
 #, c-format
 msgid "Could not access submodule '%s'\n"
 msgstr "Подмодулът „%s“ не може да бъде достъпен\n"
 
-#: submodule.c:1640
+#: submodule.c:1680
 #, c-format
 msgid ""
 "Errors during submodule fetch:\n"
@@ -9084,63 +9337,63 @@ msgstr ""
 "Грешки при доставяне на подмодул:\n"
 "%s"
 
-#: submodule.c:1665
+#: submodule.c:1705
 #, c-format
 msgid "'%s' not recognized as a git repository"
 msgstr "„%s“ не е хранилище на git"
 
-#: submodule.c:1682
+#: submodule.c:1722
 #, c-format
 msgid "Could not run 'git status --porcelain=2' in submodule %s"
 msgstr ""
 "Командата „git status --porcelain=2“ не може да се изпълни в подмодула „%s“"
 
-#: submodule.c:1723
+#: submodule.c:1763
 #, c-format
 msgid "'git status --porcelain=2' failed in submodule %s"
 msgstr ""
 "командата „git status --porcelain=2“ не може да се изпълни в подмодула „%s“"
 
-#: submodule.c:1798
+#: submodule.c:1838
 #, c-format
 msgid "could not start 'git status' in submodule '%s'"
 msgstr "командата „git status“ не може да се изпълни в подмодула „%s“"
 
-#: submodule.c:1811
+#: submodule.c:1851
 #, c-format
 msgid "could not run 'git status' in submodule '%s'"
 msgstr "командата „git status“ не може да се изпълни в подмодула „%s“"
 
-#: submodule.c:1826
+#: submodule.c:1868
 #, c-format
 msgid "Could not unset core.worktree setting in submodule '%s'"
 msgstr "Настройката „core.worktree“ не може да се изтрие в подмодула „%s“"
 
-#: submodule.c:1853 submodule.c:2163
+#: submodule.c:1895 submodule.c:2210
 #, c-format
 msgid "could not recurse into submodule '%s'"
 msgstr "неуспешна обработка на поддиректориите в подмодула „%s“"
 
-#: submodule.c:1874
+#: submodule.c:1917
 msgid "could not reset submodule index"
 msgstr "неуспешно зануляване на индекса на подмодула"
 
-#: submodule.c:1916
+#: submodule.c:1959
 #, c-format
 msgid "submodule '%s' has dirty index"
 msgstr "индексът на подмодула „%s“ не е чист"
 
-#: submodule.c:1968
+#: submodule.c:2013
 #, c-format
 msgid "Submodule '%s' could not be updated."
 msgstr "Подмодулът „%s“ не може да се обнови."
 
-#: submodule.c:2036
+#: submodule.c:2081
 #, c-format
 msgid "submodule git dir '%s' is inside git dir '%.*s'"
 msgstr "„%s“ (директория на подмодул) е в директорията на git: „%.*s“"
 
-#: submodule.c:2057
+#: submodule.c:2102
 #, c-format
 msgid ""
 "relocate_gitdir for submodule '%s' with more than one worktree not supported"
@@ -9148,17 +9401,17 @@ msgstr ""
 "не се поддържа „relocate_gitdir“ за подмодула „%s“, който има повече от едно "
 "работно дърво"
 
-#: submodule.c:2069 submodule.c:2128
+#: submodule.c:2114 submodule.c:2174
 #, c-format
 msgid "could not lookup name for submodule '%s'"
 msgstr "името на подмодула „%s“ не може да бъде намерено"
 
-#: submodule.c:2073
+#: submodule.c:2118
 #, c-format
 msgid "refusing to move '%s' into an existing git dir"
 msgstr "„%s“ не може да се премести в съществуваща директория на git"
 
-#: submodule.c:2080
+#: submodule.c:2124
 #, c-format
 msgid ""
 "Migrating git directory of '%s%s' from\n"
@@ -9169,11 +9422,11 @@ msgstr ""
 "„%s“ към\n"
 "„%s“\n"
 
-#: submodule.c:2208
+#: submodule.c:2255
 msgid "could not start ls-files in .."
 msgstr "„ls-stat“ не може да се стартира в „..“"
 
-#: submodule.c:2248
+#: submodule.c:2295
 #, c-format
 msgid "ls-tree returned unexpected return code %d"
 msgstr "„ls-tree“ завърши с неочакван изходен код: %d"
@@ -9195,7 +9448,7 @@ msgid "unknown value '%s' for key '%s'"
 msgstr "непозната стойност „%s“ за настройката „%s“"
 
 #: trailer.c:547 trailer.c:552 trailer.c:557 builtin/remote.c:299
-#: builtin/remote.c:324
+#: builtin/remote.c:327
 #, c-format
 msgid "more than one %s"
 msgstr "стойността „%s“ се повтаря в настройките"
@@ -9210,11 +9463,11 @@ msgstr "празна завършваща лексема в епилога „%.
 msgid "could not read input file '%s'"
 msgstr "входният файл „%s“ не може да бъде прочетен"
 
-#: trailer.c:766 builtin/mktag.c:88 imap-send.c:1577
+#: trailer.c:766 builtin/mktag.c:89 imap-send.c:1573
 msgid "could not read from stdin"
 msgstr "от стандартния вход не може да се чете"
 
-#: trailer.c:1024 wrapper.c:676
+#: trailer.c:1024 wrapper.c:684
 #, c-format
 msgid "could not stat %s"
 msgstr "Не може да се получи информация чрез „stat“ за „%s“"
@@ -9286,7 +9539,7 @@ msgstr "неуспешно изпълнение на бързо внасяне"
 msgid "error while running fast-import"
 msgstr "грешка при изпълнението на бързо внасяне"
 
-#: transport-helper.c:549 transport-helper.c:1247
+#: transport-helper.c:549 transport-helper.c:1251
 #, c-format
 msgid "could not read ref %s"
 msgstr "указателят „%s“ не може да се прочете"
@@ -9304,7 +9557,7 @@ msgstr "протоколът не поддържа задаването на п�
 msgid "invalid remote service path"
 msgstr "неправилен път на отдалечената услуга"
 
-#: transport-helper.c:661 transport.c:1477
+#: transport-helper.c:661 transport.c:1475
 msgid "operation not supported by protocol"
 msgstr "опцията не се поддържа от протокола"
 
@@ -9313,7 +9566,7 @@ msgstr "опцията не се поддържа от протокола"
 msgid "can't connect to subservice %s"
 msgstr "неуспешно свързване към подуслугата „%s“"
 
-#: transport-helper.c:693 transport.c:400
+#: transport-helper.c:693 transport.c:404
 msgid "--negotiate-only requires protocol v2"
 msgstr "опцията „--negotiate-only“ изисква версия 2 на протокола"
 
@@ -9327,63 +9580,62 @@ msgid "expected ok/error, helper said '%s'"
 msgstr ""
 "очаква се или успех, или грешка, но насрещната помощна програма върна „%s“"
 
-#: transport-helper.c:855
+#: transport-helper.c:859
 #, c-format
 msgid "helper reported unexpected status of %s"
 msgstr "насрещната помощна програма завърши с неочакван изходен код: „%s“"
 
-#: transport-helper.c:938
+#: transport-helper.c:942
 #, c-format
 msgid "helper %s does not support dry-run"
 msgstr "насрещната помощна програма „%s“ не поддържа проби „dry-run“"
 
-#: transport-helper.c:941
+#: transport-helper.c:945
 #, c-format
 msgid "helper %s does not support --signed"
 msgstr "насрещната помощна програма „%s“ не поддържа опцията „--signed“"
 
-#: transport-helper.c:944
+#: transport-helper.c:948
 #, c-format
 msgid "helper %s does not support --signed=if-asked"
 msgstr ""
 "насрещната помощна програма „%s“ не поддържа опцията „--signed=if-asked“"
 
-#: transport-helper.c:949
+#: transport-helper.c:953
 #, c-format
 msgid "helper %s does not support --atomic"
 msgstr "насрещната помощна програма „%s“ не поддържа опцията „--atomic“"
 
-#: transport-helper.c:953
+#: transport-helper.c:957
 #, c-format
 msgid "helper %s does not support --%s"
 msgstr "насрещната помощна програма „%s“ не поддържа опцията „%s“"
 
-#: transport-helper.c:960
+#: transport-helper.c:964
 #, c-format
 msgid "helper %s does not support 'push-option'"
 msgstr "насрещната помощна програма „%s“ не поддържа опции за изтласкване"
 
-#: transport-helper.c:1060
+#: transport-helper.c:1064
 msgid "remote-helper doesn't support push; refspec needed"
 msgstr ""
 "насрещната помощна програма не поддържа изтласкване.  Необходимо е "
 "изброяване на указателите"
 
-#: transport-helper.c:1065
+#: transport-helper.c:1069
 #, c-format
 msgid "helper %s does not support 'force'"
-msgstr ""
-"насрещната помощна програма не поддържа „%s“ поддържа опцията „--force“"
+msgstr "насрещната помощна програма „%s“ не поддържа опцията „--force“"
 
-#: transport-helper.c:1112
+#: transport-helper.c:1116
 msgid "couldn't run fast-export"
 msgstr "не може да се извърши бързо изнасяне"
 
-#: transport-helper.c:1117
+#: transport-helper.c:1121
 msgid "error while running fast-export"
 msgstr "грешка при изпълнението на командата за бързо изнасяне"
 
-#: transport-helper.c:1142
+#: transport-helper.c:1146
 #, c-format
 msgid ""
 "No refs in common and none specified; doing nothing.\n"
@@ -9392,52 +9644,52 @@ msgstr ""
 "Няма общи указатели, не са указани никакви указатели —\n"
 "нищо няма да бъде направено.  Пробвайте да укажете клон.\n"
 
-#: transport-helper.c:1224
+#: transport-helper.c:1228
 #, c-format
 msgid "unsupported object format '%s'"
 msgstr "обект с неподдържан формат „%s“"
 
-#: transport-helper.c:1233
+#: transport-helper.c:1237
 #, c-format
 msgid "malformed response in ref list: %s"
 msgstr "неправилен отговор в списъка с указатели: „%s“"
 
-#: transport-helper.c:1385
+#: transport-helper.c:1389
 #, c-format
 msgid "read(%s) failed"
 msgstr "неуспешно четене на „%s“"
 
-#: transport-helper.c:1412
+#: transport-helper.c:1416
 #, c-format
 msgid "write(%s) failed"
 msgstr "неуспешен запис в „%s“"
 
-#: transport-helper.c:1461
+#: transport-helper.c:1465
 #, c-format
 msgid "%s thread failed"
 msgstr "неуспешно изпълнение на нишката „%s“"
 
-#: transport-helper.c:1465
+#: transport-helper.c:1469
 #, c-format
 msgid "%s thread failed to join: %s"
 msgstr "завършването на нишката „%s“ не може да се изчака: „%s“"
 
-#: transport-helper.c:1484 transport-helper.c:1488
+#: transport-helper.c:1488 transport-helper.c:1492
 #, c-format
 msgid "can't start thread for copying data: %s"
 msgstr "неуспешно стартиране на нишка за копиране на данните: „%s“"
 
-#: transport-helper.c:1525
+#: transport-helper.c:1529
 #, c-format
 msgid "%s process failed to wait"
 msgstr "процесът на „%s“ не успя да изчака чрез „waitpid“"
 
-#: transport-helper.c:1529
+#: transport-helper.c:1533
 #, c-format
 msgid "%s process failed"
 msgstr "неуспешно изпълнение на „%s“"
 
-#: transport-helper.c:1547 transport-helper.c:1556
+#: transport-helper.c:1551 transport-helper.c:1560
 msgid "can't start thread for copying data"
 msgstr "неуспешно стартиране на нишка за копиране на данните"
 
@@ -9451,47 +9703,47 @@ msgstr "Клонът „%s“ ще следи „%s“ от „%s“\n"
 msgid "could not read bundle '%s'"
 msgstr "пратката на git „%s“ не може да бъде прочетена"
 
-#: transport.c:223
+#: transport.c:227
 #, c-format
 msgid "transport: invalid depth option '%s'"
 msgstr "transport: неправилна опция за дълбочина: %s"
 
-#: transport.c:275
+#: transport.c:279
 msgid "see protocol.version in 'git help config' for more details"
 msgstr ""
 "За повече информация вижте раздела „protocol.version“ в „git help config“"
 
-#: transport.c:276
+#: transport.c:280
 msgid "server options require protocol version 2 or later"
 msgstr "опциите на сървъра изискват поне версия 2 на протокола"
 
-#: transport.c:403
+#: transport.c:407
 msgid "server does not support wait-for-done"
 msgstr "сървърът не поддържа „wait-for-done“"
 
-#: transport.c:755
+#: transport.c:759
 msgid "could not parse transport.color.* config"
 msgstr "стойността на настройката „transport.color.*“ не може да се разпознае"
 
-#: transport.c:830
+#: transport.c:834
 msgid "support for protocol v2 not implemented yet"
 msgstr "протокол версия 2 все още не се поддържа"
 
-#: transport.c:965
+#: transport.c:967
 #, c-format
 msgid "unknown value for config '%s': %s"
 msgstr "непозната стойност за настройката „%s“: „%s“"
 
-#: transport.c:1031
+#: transport.c:1033
 #, c-format
 msgid "transport '%s' not allowed"
 msgstr "преносът по „%s“ не е позволен"
 
-#: transport.c:1084
+#: transport.c:1082
 msgid "git-over-rsync is no longer supported"
 msgstr "командата „git-over-rsync“ вече не се поддържа"
 
-#: transport.c:1187
+#: transport.c:1185
 #, c-format
 msgid ""
 "The following submodule paths contain changes that can\n"
@@ -9500,7 +9752,7 @@ msgstr ""
 "Следните пътища за подмодули съдържат промени,\n"
 "които липсват от всички отдалечени хранилища:\n"
 
-#: transport.c:1191
+#: transport.c:1189
 #, c-format
 msgid ""
 "\n"
@@ -9525,11 +9777,11 @@ msgstr ""
 "    git push\n"
 "\n"
 
-#: transport.c:1199
+#: transport.c:1197
 msgid "Aborting."
 msgstr "Преустановяване на действието."
 
-#: transport.c:1346
+#: transport.c:1344
 msgid "failed to push all needed submodules"
 msgstr "неуспешно изтласкване на всички необходими подмодули"
 
@@ -9798,17 +10050,17 @@ msgstr ""
 "във файлови системи, които не различават главни от малки букви)\n"
 "и само един от участниците в конфликта е в работното дърво:\n"
 
-#: unpack-trees.c:1618
+#: unpack-trees.c:1620
 msgid "Updating index flags"
 msgstr "Обновяване на флаговете на индекса"
 
-#: unpack-trees.c:2718
+#: unpack-trees.c:2772
 #, c-format
 msgid "worktree and untracked commit have duplicate entries: %s"
 msgstr ""
 "работното дърво и неследеното подаване съдържат повтарящи се обекти: %s"
 
-#: upload-pack.c:1548
+#: upload-pack.c:1561
 msgid "expected flush after fetch arguments"
 msgstr "след аргументите на „fetch“ се очаква изчистване на буферите"
 
@@ -9845,7 +10097,7 @@ msgstr "неправилна част от пътя „..“"
 msgid "Fetching objects"
 msgstr "Доставяне на обектите"
 
-#: worktree.c:236 builtin/am.c:2152
+#: worktree.c:236 builtin/am.c:2154 builtin/bisect--helper.c:156
 #, c-format
 msgid "failed to read '%s'"
 msgstr "„%s“ не може да бъде прочетен"
@@ -9944,17 +10196,27 @@ msgstr "неправилен файл „gitdir“"
 msgid "gitdir file points to non-existent location"
 msgstr "файлът „gitdir“ сочи несъществуващо местоположение"
 
-#: wrapper.c:197 wrapper.c:367
+#: wrapper.c:151
+#, c-format
+msgid "could not setenv '%s'"
+msgstr "променливата на средата „%s“ не може да се зададе чрез „setenv“"
+
+#: wrapper.c:203
+#, c-format
+msgid "unable to create '%s'"
+msgstr "пакетният файл „%s“ не може да бъде създаден"
+
+#: wrapper.c:205 wrapper.c:375
 #, c-format
 msgid "could not open '%s' for reading and writing"
 msgstr "„%s“ не може да бъде отворен и за четене, и за запис"
 
-#: wrapper.c:398 wrapper.c:599
+#: wrapper.c:406 wrapper.c:607
 #, c-format
 msgid "unable to access '%s'"
 msgstr "няма достъп до „%s“"
 
-#: wrapper.c:607
+#: wrapper.c:615
 msgid "unable to get current working directory"
 msgstr "текущата работна директория е недостъпна"
 
@@ -10516,25 +10778,25 @@ msgstr "освен това в индекса има неподадени про
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr "не може да извършите „%s“, защото в индекса има неподадени промени."
 
-#: compat/simple-ipc/ipc-unix-socket.c:182
+#: compat/simple-ipc/ipc-unix-socket.c:183
 msgid "could not send IPC command"
 msgstr "командата за комуникация между процеси не може да бъде пратена"
 
-#: compat/simple-ipc/ipc-unix-socket.c:189
+#: compat/simple-ipc/ipc-unix-socket.c:190
 msgid "could not read IPC response"
 msgstr "отговорът за комуникацията между процеси не може да бъде прочетен"
 
-#: compat/simple-ipc/ipc-unix-socket.c:866
+#: compat/simple-ipc/ipc-unix-socket.c:870
 #, c-format
 msgid "could not start accept_thread '%s'"
 msgstr "неуспешно изпълнение на „accept_thread“ върху нишката „%s“"
 
-#: compat/simple-ipc/ipc-unix-socket.c:878
+#: compat/simple-ipc/ipc-unix-socket.c:882
 #, c-format
 msgid "could not start worker[0] for '%s'"
 msgstr "не може да се стартира нишката worker[0] за „%s“"
 
-#: compat/precompose_utf8.c:58 builtin/clone.c:461
+#: compat/precompose_utf8.c:58 builtin/clone.c:347
 #, c-format
 msgid "failed to unlink '%s'"
 msgstr "неуспешно изтриване на „%s“"
@@ -10543,136 +10805,136 @@ msgstr "неуспешно изтриване на „%s“"
 msgid "git add [<options>] [--] <pathspec>..."
 msgstr "git add [ОПЦИЯ…] [--] ПЪТ…"
 
-#: builtin/add.c:61
+#: builtin/add.c:64
 #, c-format
 msgid "cannot chmod %cx '%s'"
 msgstr "правата на „%2$s“ не може да се зададат да са %1$cx"
 
-#: builtin/add.c:99
+#: builtin/add.c:106
 #, c-format
 msgid "unexpected diff status %c"
 msgstr "неочакван изходен код при генериране на разлика: %c"
 
-#: builtin/add.c:104 builtin/commit.c:297
+#: builtin/add.c:111 builtin/commit.c:298
 msgid "updating files failed"
 msgstr "неуспешно обновяване на файловете"
 
-#: builtin/add.c:114
+#: builtin/add.c:121
 #, c-format
 msgid "remove '%s'\n"
 msgstr "изтриване на „%s“\n"
 
-#: builtin/add.c:198
+#: builtin/add.c:205
 msgid "Unstaged changes after refreshing the index:"
 msgstr "Промени, които и след обновяването на индекса не са добавени към него:"
 
-#: builtin/add.c:307 builtin/rev-parse.c:993
+#: builtin/add.c:317 builtin/rev-parse.c:993
 msgid "Could not read the index"
 msgstr "Индексът не може да бъде прочетен"
 
-#: builtin/add.c:318
-#, c-format
-msgid "Could not open '%s' for writing."
-msgstr "Файлът „%s“ не може да бъде отворен за запис."
-
-#: builtin/add.c:322
+#: builtin/add.c:330
 msgid "Could not write patch"
 msgstr "Кръпката не може да бъде записана"
 
-#: builtin/add.c:325
+#: builtin/add.c:333
 msgid "editing patch failed"
 msgstr "неуспешно редактиране на кръпка"
 
-#: builtin/add.c:328
+#: builtin/add.c:336
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "Не може да се получи информация чрез „stat“ за файла „%s“"
 
-#: builtin/add.c:330
+#: builtin/add.c:338
 msgid "Empty patch. Aborted."
 msgstr "Празна кръпка, преустановяване на действието."
 
-#: builtin/add.c:335
+#: builtin/add.c:343
 #, c-format
 msgid "Could not apply '%s'"
 msgstr "Кръпката „%s“ не може да бъде приложена"
 
-#: builtin/add.c:343
+#: builtin/add.c:351
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr ""
 "Следните пътища ще бъдат игнорирани според някой от файловете „.gitignore“:\n"
 
-#: builtin/add.c:363 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
+#: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
 #: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:550
-#: builtin/remote.c:1427 builtin/rm.c:243 builtin/send-pack.c:190
+#: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr "пробно изпълнение"
 
-#: builtin/add.c:366
+#: builtin/add.c:374
 msgid "interactive picking"
 msgstr "интерактивно отбиране на промени"
 
-#: builtin/add.c:367 builtin/checkout.c:1562 builtin/reset.c:308
+#: builtin/add.c:375 builtin/checkout.c:1560 builtin/reset.c:314
 msgid "select hunks interactively"
 msgstr "интерактивен избор на парчета код"
 
-#: builtin/add.c:368
+#: builtin/add.c:376
 msgid "edit current diff and apply"
 msgstr "редактиране на текущата разлика и прилагане"
 
-#: builtin/add.c:369
+#: builtin/add.c:377
 msgid "allow adding otherwise ignored files"
 msgstr "добавяне и на иначе игнорираните файлове"
 
-#: builtin/add.c:370
+#: builtin/add.c:378
 msgid "update tracked files"
 msgstr "обновяване на следените файлове"
 
-#: builtin/add.c:371
+#: builtin/add.c:379
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr "уеднаквяване на знаците за край на файл (включва опцията „-u“)"
 
-#: builtin/add.c:372
+#: builtin/add.c:380
 msgid "record only the fact that the path will be added later"
 msgstr "отбелязване само на факта, че пътят ще бъде добавен по-късно"
 
-#: builtin/add.c:373
+#: builtin/add.c:381
 msgid "add changes from all tracked and untracked files"
 msgstr "добавяне на всички промени в следените и неследените файлове"
 
-#: builtin/add.c:376
+#: builtin/add.c:384
 msgid "ignore paths removed in the working tree (same as --no-all)"
 msgstr ""
 "игнориране на пътищата, които са изтрити от работното дърво (същото като „--"
 "no-all“)"
 
-#: builtin/add.c:378
+#: builtin/add.c:386
 msgid "don't add, only refresh the index"
 msgstr "без добавяне на нови файлове, само обновяване на индекса"
 
-#: builtin/add.c:379
+#: builtin/add.c:387
 msgid "just skip files which cannot be added because of errors"
 msgstr "прескачане на файловете, които не може да бъдат добавени поради грешки"
 
-#: builtin/add.c:380
+#: builtin/add.c:388
 msgid "check if - even missing - files are ignored in dry run"
 msgstr ""
 "проверка, че при пробно изпълнение всички файлове, дори и изтритите, се "
 "игнорират"
 
-#: builtin/add.c:382 builtin/update-index.c:1006
+#: builtin/add.c:389 builtin/mv.c:128 builtin/rm.c:251
+msgid "allow updating entries outside of the sparse-checkout cone"
+msgstr ""
+"обновяване и на записите извън пътеводния сегмент на частичното изтегляне"
+
+#: builtin/add.c:391 builtin/update-index.c:1004
 msgid "override the executable bit of the listed files"
 msgstr "изрично задаване на стойността на флага дали файлът е изпълним"
 
-#: builtin/add.c:384
+#: builtin/add.c:393
 msgid "warn when adding an embedded repository"
 msgstr "предупреждаване при добавяне на вградено хранилище"
 
-#: builtin/add.c:386
+#: builtin/add.c:395
 msgid "backend for `git stash -p`"
 msgstr "реализация на „git stash -p“"
 
-#: builtin/add.c:404
+#: builtin/add.c:413
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -10703,12 +10965,12 @@ msgstr ""
 "\n"
 "За повече информация погледнете „git help submodule“."
 
-#: builtin/add.c:432
+#: builtin/add.c:442
 #, c-format
 msgid "adding embedded git repository: %s"
 msgstr "добавяне на вградено хранилище: %s"
 
-#: builtin/add.c:451
+#: builtin/add.c:462
 msgid ""
 "Use -f if you really want to add them.\n"
 "Turn this message off by running\n"
@@ -10719,56 +10981,56 @@ msgstr ""
 "\n"
 "    git config advice.addIgnoredFile false"
 
-#: builtin/add.c:460
+#: builtin/add.c:477
 msgid "adding files failed"
 msgstr "неуспешно добавяне на файлове"
 
-#: builtin/add.c:488
+#: builtin/add.c:513
 msgid "--dry-run is incompatible with --interactive/--patch"
 msgstr ""
 "опцията „--dry-run“ е несъвместима с всяка от опциите „--interactive“/„--"
 "patch“"
 
-#: builtin/add.c:490 builtin/commit.c:357
+#: builtin/add.c:515 builtin/commit.c:358
 msgid "--pathspec-from-file is incompatible with --interactive/--patch"
 msgstr ""
 "опцията „--pathspec-from-file“ е несъвместима с всяка от опциите „--"
 "interactive“/„--patch“"
 
-#: builtin/add.c:507
+#: builtin/add.c:532
 msgid "--pathspec-from-file is incompatible with --edit"
 msgstr "опциите „--pathspec-from-file“ и „--edit“ са несъвместими"
 
-#: builtin/add.c:519
+#: builtin/add.c:544
 msgid "-A and -u are mutually incompatible"
 msgstr "опциите „-A“ и „-u“ са несъвместими"
 
-#: builtin/add.c:522
+#: builtin/add.c:547
 msgid "Option --ignore-missing can only be used together with --dry-run"
 msgstr "опцията „--ignore-missing“ изисква „--dry-run“"
 
-#: builtin/add.c:526
+#: builtin/add.c:551
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "параметърът към „--chmod“ — „%s“ може да е или „-x“, или „+x“"
 
-#: builtin/add.c:544 builtin/checkout.c:1733 builtin/commit.c:363
-#: builtin/reset.c:328 builtin/rm.c:273 builtin/stash.c:1633
+#: builtin/add.c:572 builtin/checkout.c:1731 builtin/commit.c:364
+#: builtin/reset.c:334 builtin/rm.c:275 builtin/stash.c:1650
 msgid "--pathspec-from-file is incompatible with pathspec arguments"
 msgstr ""
 "опцията „--pathspec-from-file“ е несъвместима с аргументи, указващи пътища"
 
-#: builtin/add.c:551 builtin/checkout.c:1745 builtin/commit.c:369
-#: builtin/reset.c:334 builtin/rm.c:279 builtin/stash.c:1639
+#: builtin/add.c:579 builtin/checkout.c:1743 builtin/commit.c:370
+#: builtin/reset.c:340 builtin/rm.c:281 builtin/stash.c:1656
 msgid "--pathspec-file-nul requires --pathspec-from-file"
 msgstr "опцията „--pathspec-file-nul“ изисква опция „--pathspec-from-file“"
 
-#: builtin/add.c:555
+#: builtin/add.c:583
 #, c-format
 msgid "Nothing specified, nothing added.\n"
 msgstr "Нищо не е зададено и нищо не е добавено.\n"
 
-#: builtin/add.c:557
+#: builtin/add.c:585
 msgid ""
 "Maybe you wanted to say 'git add .'?\n"
 "Turn this message off by running\n"
@@ -10779,110 +11041,110 @@ msgstr ""
 "\n"
 "    git config advice.addEmptyPathspec false"
 
-#: builtin/am.c:365
+#: builtin/am.c:366
 msgid "could not parse author script"
 msgstr "скриптът за автор не може да се анализира"
 
-#: builtin/am.c:455
+#: builtin/am.c:456
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
 msgstr "„%s“ бе изтрит от куката „applypatch-msg“"
 
-#: builtin/am.c:497
+#: builtin/am.c:498
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr "Даденият входен ред е с неправилен формат: „%s“."
 
-#: builtin/am.c:535
+#: builtin/am.c:536
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
 msgstr "Бележката не може да се копира от „%s“ към „%s“"
 
-#: builtin/am.c:561
+#: builtin/am.c:562
 msgid "fseek failed"
 msgstr "неуспешно изпълнение на „fseek“"
 
-#: builtin/am.c:749
+#: builtin/am.c:750
 #, c-format
 msgid "could not parse patch '%s'"
 msgstr "кръпката „%s“ не може да се анализира"
 
-#: builtin/am.c:814
+#: builtin/am.c:815
 msgid "Only one StGIT patch series can be applied at once"
 msgstr ""
 "Само една поредица от кръпки от „StGIT“ може да бъде прилагана в даден момент"
 
-#: builtin/am.c:862
+#: builtin/am.c:863
 msgid "invalid timestamp"
 msgstr "неправилна стойност за време"
 
-#: builtin/am.c:867 builtin/am.c:879
+#: builtin/am.c:868 builtin/am.c:880
 msgid "invalid Date line"
 msgstr "неправилен ред за дата „Date“"
 
-#: builtin/am.c:874
+#: builtin/am.c:875
 msgid "invalid timezone offset"
 msgstr "неправилно отместване на часовия пояс"
 
-#: builtin/am.c:967
+#: builtin/am.c:968
 msgid "Patch format detection failed."
 msgstr "Форматът на кръпката не може да бъде определен."
 
-#: builtin/am.c:972 builtin/clone.c:414
+#: builtin/am.c:973 builtin/clone.c:300
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "директорията „%s“ не може да бъде създадена"
 
-#: builtin/am.c:977
+#: builtin/am.c:978
 msgid "Failed to split patches."
 msgstr "Кръпките не може да бъдат разделени."
 
-#: builtin/am.c:1126
+#: builtin/am.c:1127
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\"."
 msgstr "След коригирането на този проблем изпълнете „%s --continue“."
 
-#: builtin/am.c:1127
+#: builtin/am.c:1128
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
 msgstr "Ако предпочитате да прескочите тази кръпка, изпълнете „%s --skip“."
 
-#: builtin/am.c:1128
+#: builtin/am.c:1129
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr "За да се върнете към първоначалното състояние, изпълнете „%s --abort“."
 
-#: builtin/am.c:1223
+#: builtin/am.c:1224
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
 "Кръпката е пратена с форматиране „format=flowed“.  Празните знаци в края на "
 "редовете може да се загубят."
 
-#: builtin/am.c:1251
+#: builtin/am.c:1252
 msgid "Patch is empty."
 msgstr "Кръпката е празна."
 
-#: builtin/am.c:1316
+#: builtin/am.c:1317
 #, c-format
 msgid "missing author line in commit %s"
 msgstr "липсва ред за авторство в подаването „%s“"
 
-#: builtin/am.c:1319
+#: builtin/am.c:1320
 #, c-format
 msgid "invalid ident line: %.*s"
 msgstr "грешен ред с идентичност: %.*s"
 
-#: builtin/am.c:1538
+#: builtin/am.c:1539
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
 "В хранилището липсват необходимите обекти-BLOB, за да се премине към тройно "
 "сливане."
 
-#: builtin/am.c:1540
+#: builtin/am.c:1541
 msgid "Using index info to reconstruct a base tree..."
 msgstr "Базовото дърво се реконструира от информацията в индекса…"
 
-#: builtin/am.c:1559
+#: builtin/am.c:1560
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
@@ -10890,24 +11152,24 @@ msgstr ""
 "Кръпката не може да се приложи към обектите-BLOB в индекса.\n"
 "Да не би да сте я редактирали на ръка?"
 
-#: builtin/am.c:1565
+#: builtin/am.c:1566
 msgid "Falling back to patching base and 3-way merge..."
 msgstr "Преминаване към прилагане на кръпка към базата и тройно сливане…"
 
-#: builtin/am.c:1591
+#: builtin/am.c:1592
 msgid "Failed to merge in the changes."
 msgstr "Неуспешно сливане на промените."
 
-#: builtin/am.c:1623
+#: builtin/am.c:1624
 msgid "applying to an empty history"
 msgstr "прилагане върху празна история"
 
-#: builtin/am.c:1675 builtin/am.c:1679
+#: builtin/am.c:1676 builtin/am.c:1680
 #, c-format
 msgid "cannot resume: %s does not exist."
 msgstr "не може да се продължи — „%s“ не съществува."
 
-#: builtin/am.c:1697
+#: builtin/am.c:1698
 msgid "Commit Body is:"
 msgstr "Тялото на кръпката за прилагане е:"
 
@@ -10915,38 +11177,38 @@ msgstr "Тялото на кръпката за прилагане е:"
 #. in your translation. The program will only accept English
 #. input at this point.
 #.
-#: builtin/am.c:1707
+#: builtin/am.c:1708
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr ""
 "Прилагане? „y“ — да/„n“ — не/„e“ — редактиране/„v“ — преглед/„a“ — приемане "
 "на всичко:"
 
-#: builtin/am.c:1753 builtin/commit.c:408
+#: builtin/am.c:1754 builtin/commit.c:409
 msgid "unable to write index file"
 msgstr "индексът не може да бъде записан"
 
-#: builtin/am.c:1757
+#: builtin/am.c:1758
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
 msgstr ""
 "Индексът не е чист: кръпките не може да бъдат приложени (замърсени са: %s)"
 
-#: builtin/am.c:1797 builtin/am.c:1865
+#: builtin/am.c:1798 builtin/am.c:1865
 #, c-format
 msgid "Applying: %.*s"
 msgstr "Прилагане: %.*s"
 
-#: builtin/am.c:1814
+#: builtin/am.c:1815
 msgid "No changes -- Patch already applied."
 msgstr "Без промени — кръпката вече е приложена."
 
-#: builtin/am.c:1820
+#: builtin/am.c:1821
 #, c-format
 msgid "Patch failed at %s %.*s"
 msgstr "Неуспешно прилагане на кръпка при %s %.*s“"
 
-#: builtin/am.c:1824
+#: builtin/am.c:1825
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr ""
 "За да видите неуспешно приложени кръпки, използвайте:\n"
@@ -10974,17 +11236,17 @@ msgstr ""
 "След корекция на конфликтите изпълнете „git add“ върху поправените файлове.\n"
 "За да приемете „изтрити от тях“, изпълнете „git rm“ върху изтритите файлове."
 
-#: builtin/am.c:1982 builtin/am.c:1986 builtin/am.c:1998 builtin/reset.c:347
-#: builtin/reset.c:355
+#: builtin/am.c:1983 builtin/am.c:1987 builtin/am.c:1999 builtin/reset.c:353
+#: builtin/reset.c:361
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "„%s“ не е разпознат като обект."
 
-#: builtin/am.c:2034
+#: builtin/am.c:2035 builtin/am.c:2111
 msgid "failed to clean index"
 msgstr "индексът не може да бъде изчистен"
 
-#: builtin/am.c:2078
+#: builtin/am.c:2079
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
@@ -10995,166 +11257,166 @@ msgstr ""
 "сочи към\n"
 "„ORIG_HEAD“"
 
-#: builtin/am.c:2185
+#: builtin/am.c:2187
 #, c-format
 msgid "Invalid value for --patch-format: %s"
 msgstr "Неправилна стойност за „--patch-format“: „%s“"
 
-#: builtin/am.c:2227
+#: builtin/am.c:2229
 #, c-format
 msgid "Invalid value for --show-current-patch: %s"
 msgstr "Неправилна стойност за „--show-current-patch“: „%s“"
 
-#: builtin/am.c:2231
+#: builtin/am.c:2233
 #, c-format
 msgid "--show-current-patch=%s is incompatible with --show-current-patch=%s"
 msgstr ""
 "опциите „--show-current-patch=%s“ и „--show-current-patch=%s“ са несъвместими"
 
-#: builtin/am.c:2262
+#: builtin/am.c:2264
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
 msgstr "git am [ОПЦИЯ…] [(ФАЙЛ_С_ПОЩА|ДИРЕКТОРИЯ_С_ПОЩА)…]"
 
-#: builtin/am.c:2263
+#: builtin/am.c:2265
 msgid "git am [<options>] (--continue | --skip | --abort)"
 msgstr "git am [ОПЦИЯ…] (--continue | --skip | --abort)"
 
-#: builtin/am.c:2269
+#: builtin/am.c:2271
 msgid "run interactively"
 msgstr "интерактивна работа"
 
-#: builtin/am.c:2271
+#: builtin/am.c:2273
 msgid "historical option -- no-op"
 msgstr "изоставена опция, съществува по исторически причини, нищо не прави"
 
-#: builtin/am.c:2273
+#: builtin/am.c:2275
 msgid "allow fall back on 3way merging if needed"
 msgstr "да се преминава към тройно сливане при нужда."
 
-#: builtin/am.c:2274 builtin/init-db.c:547 builtin/prune-packed.c:16
-#: builtin/repack.c:472 builtin/stash.c:945
+#: builtin/am.c:2276 builtin/init-db.c:547 builtin/prune-packed.c:16
+#: builtin/repack.c:640 builtin/stash.c:961
 msgid "be quiet"
 msgstr "без извеждане на информация"
 
-#: builtin/am.c:2276
+#: builtin/am.c:2278
 msgid "add a Signed-off-by trailer to the commit message"
 msgstr "добавяне на епилог за подпис „Signed-off-by“ в съобщението за подаване"
 
-#: builtin/am.c:2279
+#: builtin/am.c:2281
 msgid "recode into utf8 (default)"
 msgstr "прекодиране в UTF-8 (стандартно)"
 
-#: builtin/am.c:2281
+#: builtin/am.c:2283
 msgid "pass -k flag to git-mailinfo"
 msgstr "подаване на опцията „-k“ на командата „git-mailinfo“"
 
-#: builtin/am.c:2283
+#: builtin/am.c:2285
 msgid "pass -b flag to git-mailinfo"
 msgstr "подаване на опцията „-b“ на командата „git-mailinfo“"
 
-#: builtin/am.c:2285
+#: builtin/am.c:2287
 msgid "pass -m flag to git-mailinfo"
 msgstr "подаване на опцията „-m“ на командата „git-mailinfo“"
 
-#: builtin/am.c:2287
+#: builtin/am.c:2289
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
 msgstr ""
 "подаване на опцията „--keep-cr“ на командата „git-mailsplit“ за формат „mbox“"
 
-#: builtin/am.c:2290
+#: builtin/am.c:2292
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr ""
 "без подаване на опцията „--keep-cr“ на командата „git-mailsplit“ независимо "
 "от „am.keepcr“"
 
-#: builtin/am.c:2293
+#: builtin/am.c:2295
 msgid "strip everything before a scissors line"
 msgstr "пропускане на всичко преди реда за отрязване"
 
-#: builtin/am.c:2295
+#: builtin/am.c:2297
 msgid "pass it through git-mailinfo"
 msgstr "прекарване през „git-mailinfo“"
 
-#: builtin/am.c:2298 builtin/am.c:2301 builtin/am.c:2304 builtin/am.c:2307
-#: builtin/am.c:2310 builtin/am.c:2313 builtin/am.c:2316 builtin/am.c:2319
-#: builtin/am.c:2325
+#: builtin/am.c:2300 builtin/am.c:2303 builtin/am.c:2306 builtin/am.c:2309
+#: builtin/am.c:2312 builtin/am.c:2315 builtin/am.c:2318 builtin/am.c:2321
+#: builtin/am.c:2327
 msgid "pass it through git-apply"
 msgstr "прекарване през „git-apply“"
 
-#: builtin/am.c:2315 builtin/commit.c:1512 builtin/fmt-merge-msg.c:17
-#: builtin/fmt-merge-msg.c:20 builtin/grep.c:905 builtin/merge.c:261
+#: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
+#: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
 #: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
-#: builtin/rebase.c:1342 builtin/repack.c:483 builtin/repack.c:487
-#: builtin/repack.c:489 builtin/show-branch.c:650 builtin/show-ref.c:172
-#: builtin/tag.c:447 parse-options.h:155 parse-options.h:176
-#: parse-options.h:317
+#: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
+#: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
+#: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
+#: parse-options.h:316
 msgid "n"
 msgstr "БРОЙ"
 
-#: builtin/am.c:2321 builtin/branch.c:672 builtin/bugreport.c:137
-#: builtin/for-each-ref.c:40 builtin/replace.c:556 builtin/tag.c:481
+#: builtin/am.c:2323 builtin/branch.c:673 builtin/bugreport.c:109
+#: builtin/for-each-ref.c:40 builtin/replace.c:556 builtin/tag.c:479
 #: builtin/verify-tag.c:38
 msgid "format"
 msgstr "ФОРМАТ"
 
-#: builtin/am.c:2322
+#: builtin/am.c:2324
 msgid "format the patch(es) are in"
 msgstr "формат на кръпките"
 
-#: builtin/am.c:2328
+#: builtin/am.c:2330
 msgid "override error message when patch failure occurs"
 msgstr "избрано от вас съобщение за грешка при прилагане на кръпки"
 
-#: builtin/am.c:2330
+#: builtin/am.c:2332
 msgid "continue applying patches after resolving a conflict"
 msgstr "продължаване на прилагането на кръпки след коригирането на конфликт"
 
-#: builtin/am.c:2333
+#: builtin/am.c:2335
 msgid "synonyms for --continue"
 msgstr "псевдоними на „--continue“"
 
-#: builtin/am.c:2336
+#: builtin/am.c:2338
 msgid "skip the current patch"
 msgstr "прескачане на текущата кръпка"
 
-#: builtin/am.c:2339
+#: builtin/am.c:2341
 msgid "restore the original branch and abort the patching operation"
 msgstr ""
 "възстановяване на първоначалното състояние на клона и преустановяване на "
 "прилагането на кръпката"
 
-#: builtin/am.c:2342
+#: builtin/am.c:2344
 msgid "abort the patching operation but keep HEAD where it is"
 msgstr ""
 "преустановяване на прилагането на кръпката без промяна към кое сочи „HEAD“"
 
-#: builtin/am.c:2346
+#: builtin/am.c:2348
 msgid "show the patch being applied"
 msgstr "показване на прилаганата кръпка"
 
-#: builtin/am.c:2351
+#: builtin/am.c:2353
 msgid "lie about committer date"
 msgstr "дата за подаване различна от първоначалната"
 
-#: builtin/am.c:2353
+#: builtin/am.c:2355
 msgid "use current timestamp for author date"
 msgstr "използване на текущото време като това за автор"
 
-#: builtin/am.c:2355 builtin/commit-tree.c:120 builtin/commit.c:1640
-#: builtin/merge.c:298 builtin/pull.c:175 builtin/rebase.c:537
-#: builtin/rebase.c:1395 builtin/revert.c:117 builtin/tag.c:462
+#: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
+#: builtin/merge.c:299 builtin/pull.c:175 builtin/rebase.c:1099
+#: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
 msgstr "ИДЕНТИФИКАТОР_НА_КЛЮЧ"
 
-#: builtin/am.c:2356 builtin/rebase.c:538 builtin/rebase.c:1396
+#: builtin/am.c:2358 builtin/rebase.c:1100
 msgid "GPG-sign commits"
 msgstr "подписване на подаванията с GPG"
 
-#: builtin/am.c:2359
+#: builtin/am.c:2361
 msgid "(internal use for git-rebase)"
 msgstr "(ползва се вътрешно за „git-rebase“)"
 
-#: builtin/am.c:2377
+#: builtin/am.c:2379
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
@@ -11162,18 +11424,18 @@ msgstr ""
 "Опциите „-b“/„--binary“ отдавна не правят нищо и\n"
 "ще бъдат премахнати в бъдеще.  Не ги ползвайте."
 
-#: builtin/am.c:2384
+#: builtin/am.c:2386
 msgid "failed to read the index"
 msgstr "неуспешно изчитане на индекса"
 
-#: builtin/am.c:2399
+#: builtin/am.c:2401
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr ""
 "предишната директория за пребазиране „%s“ все още съществува, а е зададен "
 "файл „mbox“."
 
-#: builtin/am.c:2423
+#: builtin/am.c:2425
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
@@ -11182,11 +11444,11 @@ msgstr ""
 "Открита е излишна директория „%s“.\n"
 "Може да я изтриете с командата „git am --abort“."
 
-#: builtin/am.c:2429
+#: builtin/am.c:2431
 msgid "Resolve operation not in progress, we are not resuming."
 msgstr "В момента не тече операция по коригиране и няма как да се продължи."
 
-#: builtin/am.c:2439
+#: builtin/am.c:2441
 msgid "interactive mode requires patches on the command line"
 msgstr "интерактивният режим изисква кръпки на командния ред"
 
@@ -11194,44 +11456,35 @@ msgstr "интерактивният режим изисква кръпки на
 msgid "git apply [<options>] [<patch>...]"
 msgstr "git apply [ОПЦИЯ…] [КРЪПКА…]"
 
-#: builtin/archive.c:17
-#, c-format
-msgid "could not create archive file '%s'"
-msgstr "архивният файл „%s“ не може да бъде създаден"
-
-#: builtin/archive.c:20
+#: builtin/archive.c:18
 msgid "could not redirect output"
 msgstr "изходът не може да бъде пренасочен"
 
-#: builtin/archive.c:37
+#: builtin/archive.c:35
 msgid "git archive: Remote with no URL"
 msgstr "git archive: Липсва адрес за отдалеченото хранилище"
 
-#: builtin/archive.c:61
+#: builtin/archive.c:59
 msgid "git archive: expected ACK/NAK, got a flush packet"
 msgstr ""
 "git archive: очакваше се „ACK“/„NAK“, а бе получен изчистващ пакет „flush“"
 
-#: builtin/archive.c:64
+#: builtin/archive.c:62
 #, c-format
 msgid "git archive: NACK %s"
 msgstr "git archive: получен е „NACK“ — %s"
 
-#: builtin/archive.c:65
+#: builtin/archive.c:63
 msgid "git archive: protocol error"
 msgstr "git archive: протоколна грешка"
 
-#: builtin/archive.c:69
+#: builtin/archive.c:67
 msgid "git archive: expected a flush"
 msgstr "git archive: очакваше се изчистване на буферите чрез „flush“"
 
-#: builtin/bisect--helper.c:23
+#: builtin/bisect--helper.c:24
 msgid "git bisect--helper --bisect-reset [<commit>]"
 msgstr "git bisect--helper --bisect-reset [ПОДАВАНЕ]"
-
-#: builtin/bisect--helper.c:24
-msgid "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
-msgstr "git bisect--helper --bisect-next-check ЛОШО ДОБРО УПРАВЛЯВАЩА_ДУМА"
 
 #: builtin/bisect--helper.c:25
 msgid ""
@@ -11270,46 +11523,59 @@ msgstr "git bisect--helper --bisect-replay ИМЕ_НА_ФАЙЛ"
 msgid "git bisect--helper --bisect-skip [(<rev>|<range>)...]"
 msgstr "git bisect--helper --bisect-skip [(ВЕРСИЯ|ДИАПАЗОН)…]"
 
-#: builtin/bisect--helper.c:107
+#: builtin/bisect--helper.c:33
+msgid "git bisect--helper --bisect-visualize"
+msgstr "git bisect--helper --bisect-visualize"
+
+#: builtin/bisect--helper.c:34
+msgid "git bisect--helper --bisect-run <cmd>..."
+msgstr "git bisect--helper --bisect-run КОМАНДА…"
+
+#: builtin/bisect--helper.c:109
 #, c-format
 msgid "cannot open file '%s' in mode '%s'"
 msgstr "файлът „%s“ не може да се отвори в режим „%s“"
 
-#: builtin/bisect--helper.c:114
+#: builtin/bisect--helper.c:116
 #, c-format
 msgid "could not write to file '%s'"
 msgstr "във файла „%s“ не може да се пише"
 
-#: builtin/bisect--helper.c:155
+#: builtin/bisect--helper.c:154
+#, c-format
+msgid "cannot open file '%s' for reading"
+msgstr "файлът „%s“ не може да бъде отворен за четене"
+
+#: builtin/bisect--helper.c:170
 #, c-format
 msgid "'%s' is not a valid term"
 msgstr "„%s“ е неправилна управляваща дума"
 
-#: builtin/bisect--helper.c:159
+#: builtin/bisect--helper.c:174
 #, c-format
 msgid "can't use the builtin command '%s' as a term"
 msgstr "„%s“ е вградена команда и не може да се използва като управляваща дума"
 
-#: builtin/bisect--helper.c:169
+#: builtin/bisect--helper.c:184
 #, c-format
 msgid "can't change the meaning of the term '%s'"
 msgstr "не може да смените значението на управляващата дума „%s“"
 
-#: builtin/bisect--helper.c:179
+#: builtin/bisect--helper.c:194
 msgid "please use two different terms"
 msgstr "използвайте две различни управляващи думи"
 
-#: builtin/bisect--helper.c:195
+#: builtin/bisect--helper.c:210
 #, c-format
 msgid "We are not bisecting.\n"
 msgstr "В момента не се извършва двоично търсене.\n"
 
-#: builtin/bisect--helper.c:203
+#: builtin/bisect--helper.c:218
 #, c-format
 msgid "'%s' is not a valid commit"
 msgstr "„%s“ не е подаване"
 
-#: builtin/bisect--helper.c:212
+#: builtin/bisect--helper.c:227
 #, c-format
 msgid ""
 "could not check out original HEAD '%s'. Try 'git bisect reset <commit>'."
@@ -11317,27 +11583,27 @@ msgstr ""
 "първоначално указаното „%s“ в указателя „HEAD“ не може да бъде\n"
 "изтеглено.  Пробвайте да изпълните командата „git bisect reset ПОДАВАНЕ“."
 
-#: builtin/bisect--helper.c:256
+#: builtin/bisect--helper.c:271
 #, c-format
 msgid "Bad bisect_write argument: %s"
 msgstr "Неправилен аргумент на функцията „bisect_write“: „%s“"
 
-#: builtin/bisect--helper.c:261
+#: builtin/bisect--helper.c:276
 #, c-format
 msgid "couldn't get the oid of the rev '%s'"
 msgstr "идентификаторът на обект на версия „%s“ не може да бъде получен"
 
-#: builtin/bisect--helper.c:273
+#: builtin/bisect--helper.c:288
 #, c-format
 msgid "couldn't open the file '%s'"
 msgstr "файлът „%s“ не може да бъде отворен"
 
-#: builtin/bisect--helper.c:299
+#: builtin/bisect--helper.c:314
 #, c-format
 msgid "Invalid command: you're currently in a %s/%s bisect"
 msgstr "Неправилна команда: в момента се изпълнява двоично търсене по %s/%s."
 
-#: builtin/bisect--helper.c:326
+#: builtin/bisect--helper.c:341
 #, c-format
 msgid ""
 "You need to give me at least one %s and %s revision.\n"
@@ -11346,7 +11612,7 @@ msgstr ""
 "Трябва да зададете поне една „%s“ и една „%s“ версия.  (Това може да се\n"
 "направи съответно и чрез командите „git bisect %s“ и „git bisect %s“.)"
 
-#: builtin/bisect--helper.c:330
+#: builtin/bisect--helper.c:345
 #, c-format
 msgid ""
 "You need to start by \"git bisect start\".\n"
@@ -11357,7 +11623,7 @@ msgstr ""
 "Трябва да зададете поне една „%s“ и една „%s“ версия.  (Това може да се\n"
 "направи съответно и чрез командите „git bisect %s“ и „git bisect %s“.)"
 
-#: builtin/bisect--helper.c:350
+#: builtin/bisect--helper.c:365
 #, c-format
 msgid "bisecting only with a %s commit"
 msgstr "двоично търсене само по „%s“ подаване."
@@ -11366,15 +11632,15 @@ msgstr "двоично търсене само по „%s“ подаване."
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:358
+#: builtin/bisect--helper.c:373
 msgid "Are you sure [Y/n]? "
 msgstr "Да се продължи ли? „Y“ —  ДА, „n“ — не"
 
-#: builtin/bisect--helper.c:419
+#: builtin/bisect--helper.c:434
 msgid "no terms defined"
 msgstr "не са указани управляващи думи"
 
-#: builtin/bisect--helper.c:422
+#: builtin/bisect--helper.c:437
 #, c-format
 msgid ""
 "Your current terms are %s for the old state\n"
@@ -11383,7 +11649,7 @@ msgstr ""
 "Текущите управляващи думи са: %s за старото състояние\n"
 "и %s за новото състояние.\n"
 
-#: builtin/bisect--helper.c:432
+#: builtin/bisect--helper.c:447
 #, c-format
 msgid ""
 "invalid argument %s for 'git bisect terms'.\n"
@@ -11392,56 +11658,56 @@ msgstr ""
 "на „git bisect terms“ е подаден неправилен аргумент „%s“\n"
 "Поддържат се опциите „--term-good“/„--term-old“ и „--term-bad„/„--term-new“."
 
-#: builtin/bisect--helper.c:499 builtin/bisect--helper.c:1023
+#: builtin/bisect--helper.c:514 builtin/bisect--helper.c:1038
 msgid "revision walk setup failed\n"
 msgstr "неуспешно настройване на обхождането на версиите\n"
 
-#: builtin/bisect--helper.c:521
+#: builtin/bisect--helper.c:536
 #, c-format
 msgid "could not open '%s' for appending"
 msgstr "файлът „%s“ не може да се отвори за добавяне"
 
-#: builtin/bisect--helper.c:640 builtin/bisect--helper.c:653
+#: builtin/bisect--helper.c:655 builtin/bisect--helper.c:668
 msgid "'' is not a valid term"
 msgstr "„“ е неправилна управляваща дума"
 
-#: builtin/bisect--helper.c:663
+#: builtin/bisect--helper.c:678
 #, c-format
 msgid "unrecognized option: '%s'"
 msgstr "непозната опция: %s"
 
-#: builtin/bisect--helper.c:667
+#: builtin/bisect--helper.c:682
 #, c-format
 msgid "'%s' does not appear to be a valid revision"
 msgstr "„%s“ не изглежда като указател към версия"
 
-#: builtin/bisect--helper.c:698
+#: builtin/bisect--helper.c:713
 msgid "bad HEAD - I need a HEAD"
 msgstr "Неправилен указател „HEAD“"
 
-#: builtin/bisect--helper.c:713
+#: builtin/bisect--helper.c:728
 #, c-format
 msgid "checking out '%s' failed. Try 'git bisect start <valid-branch>'."
 msgstr ""
 "Неуспешно преминаване към „%s“.  Изпълнете командата „git bisect start "
 "СЪЩЕСТВУВАЩ_КЛОН“."
 
-#: builtin/bisect--helper.c:734
+#: builtin/bisect--helper.c:749
 msgid "won't bisect on cg-seek'ed tree"
 msgstr ""
 "не може да се търси двоично, когато е изпълнена командата „cg-seek“ от "
 "„cogito“"
 
-#: builtin/bisect--helper.c:737
+#: builtin/bisect--helper.c:752
 msgid "bad HEAD - strange symbolic ref"
 msgstr "Неправилен указател „HEAD“ — необичаен символен указател"
 
-#: builtin/bisect--helper.c:757
+#: builtin/bisect--helper.c:772
 #, c-format
 msgid "invalid ref: '%s'"
 msgstr "неправилен указател: „%s“"
 
-#: builtin/bisect--helper.c:815
+#: builtin/bisect--helper.c:830
 msgid "You need to start by \"git bisect start\"\n"
 msgstr "Започнете като изпълните командата „git bisect start“\n"
 
@@ -11449,108 +11715,158 @@ msgstr "Започнете като изпълните командата „git
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:826
+#: builtin/bisect--helper.c:841
 msgid "Do you want me to do it for you [Y/n]? "
 msgstr "Да се извърши ли автоматично? „Y“ —  ДА, „n“ — не"
 
-#: builtin/bisect--helper.c:844
+#: builtin/bisect--helper.c:859
 msgid "Please call `--bisect-state` with at least one argument"
 msgstr "опцията „--bisect-state“ изисква поне един аргумент"
 
-#: builtin/bisect--helper.c:857
+#: builtin/bisect--helper.c:872
 #, c-format
 msgid "'git bisect %s' can take only one argument."
 msgstr "Командата „git bisect %s“ приема само един аргумент."
 
-#: builtin/bisect--helper.c:869 builtin/bisect--helper.c:882
+#: builtin/bisect--helper.c:884 builtin/bisect--helper.c:897
 #, c-format
 msgid "Bad rev input: %s"
 msgstr "Неправилна версия: „%s“"
 
-#: builtin/bisect--helper.c:889
+#: builtin/bisect--helper.c:904
 #, c-format
 msgid "Bad rev input (not a commit): %s"
 msgstr "Неправилна версия (не е подаване): „%s“"
 
-#: builtin/bisect--helper.c:921
+#: builtin/bisect--helper.c:936
 msgid "We are not bisecting."
 msgstr "В момента не се извършва двоично търсене."
 
-#: builtin/bisect--helper.c:971
+#: builtin/bisect--helper.c:986
 #, c-format
 msgid "'%s'?? what are you talking about?"
 msgstr ""
 "Непозната команда „%s“.  Възможностите са: „start“, „skip“, „good“, „bad“ (и "
 "вариантите им)"
 
-#: builtin/bisect--helper.c:983
+#: builtin/bisect--helper.c:998
 #, c-format
 msgid "cannot read file '%s' for replaying"
 msgstr ""
 "файлът „%s“ не може да бъде прочетен, за да се изпълнят командите от него "
 "наново"
 
-#: builtin/bisect--helper.c:1056
+#: builtin/bisect--helper.c:1107 builtin/bisect--helper.c:1274
+msgid "bisect run failed: no command provided."
+msgstr "неуспешно двоично търсене, не е зададена команда."
+
+#: builtin/bisect--helper.c:1116
+#, c-format
+msgid "running %s\n"
+msgstr "изпълнение на %s\n"
+
+#: builtin/bisect--helper.c:1120
+#, c-format
+msgid "bisect run failed: exit code %d from '%s' is < 0 or >= 128"
+msgstr ""
+"неуспешно двоично търсене: изходният код от командата „%2$s“ е %1$d — това е "
+"извън интервала [0, 128)"
+
+#: builtin/bisect--helper.c:1136
+#, c-format
+msgid "cannot open file '%s' for writing"
+msgstr "файлът „%s“ не може да бъде отворен за запис"
+
+#: builtin/bisect--helper.c:1152
+msgid "bisect run cannot continue any more"
+msgstr "двоичното търсене не може да продължи"
+
+#: builtin/bisect--helper.c:1154
+#, c-format
+msgid "bisect run success"
+msgstr "успешно двоично търсене"
+
+#: builtin/bisect--helper.c:1157
+#, c-format
+msgid "bisect found first bad commit"
+msgstr "двоичното търсене откри първото лошо подаване"
+
+#: builtin/bisect--helper.c:1160
+#, c-format
+msgid ""
+"bisect run failed: 'git bisect--helper --bisect-state %s' exited with error "
+"code %d"
+msgstr ""
+"неуспешно двоично търсене: „git bisect--helper bisect-state %s“ завърши с "
+"код за грешка: %d"
+
+#: builtin/bisect--helper.c:1192
 msgid "reset the bisection state"
 msgstr "изчистване на състоянието на двоичното търсене"
 
-#: builtin/bisect--helper.c:1058
+#: builtin/bisect--helper.c:1194
 msgid "check whether bad or good terms exist"
 msgstr "проверка дали съществуват одобряващи/отхвърлящи управляващи думи"
 
-#: builtin/bisect--helper.c:1060
+#: builtin/bisect--helper.c:1196
 msgid "print out the bisect terms"
 msgstr "извеждане на управляващите думи"
 
-#: builtin/bisect--helper.c:1062
+#: builtin/bisect--helper.c:1198
 msgid "start the bisect session"
 msgstr "начало на двоично търсене"
 
-#: builtin/bisect--helper.c:1064
+#: builtin/bisect--helper.c:1200
 msgid "find the next bisection commit"
 msgstr "откриване на следващото подаване при двоично търсене"
 
-#: builtin/bisect--helper.c:1066
+#: builtin/bisect--helper.c:1202
 msgid "mark the state of ref (or refs)"
 msgstr "задаване на състоянието на указателя/ите"
 
-#: builtin/bisect--helper.c:1068
+#: builtin/bisect--helper.c:1204
 msgid "list the bisection steps so far"
 msgstr "извеждане на стъпките на двоичното търсене досега"
 
-#: builtin/bisect--helper.c:1070
+#: builtin/bisect--helper.c:1206
 msgid "replay the bisection process from the given file"
 msgstr "наново изпълнение на двоичното търсене чрез дадения файл"
 
-#: builtin/bisect--helper.c:1072
+#: builtin/bisect--helper.c:1208
 msgid "skip some commits for checkout"
 msgstr "прескачане на някои подавания при изтегляне"
 
-#: builtin/bisect--helper.c:1074
+#: builtin/bisect--helper.c:1210
+msgid "visualize the bisection"
+msgstr "визуализиране на двоичното търсене"
+
+#: builtin/bisect--helper.c:1212
+msgid "use <cmd>... to automatically bisect."
+msgstr ""
+"за автоматично определяне на състоянието при двоичното търсене да се ползва "
+"тази КОМАНДА…"
+
+#: builtin/bisect--helper.c:1214
 msgid "no log for BISECT_WRITE"
 msgstr "липсва запис за „BISECT_WRITE“"
 
-#: builtin/bisect--helper.c:1089
+#: builtin/bisect--helper.c:1229
 msgid "--bisect-reset requires either no argument or a commit"
 msgstr "опцията „--bisect-reset“ изисква или 0 аргументи, или 1 — подаване"
 
-#: builtin/bisect--helper.c:1094
-msgid "--bisect-next-check requires 2 or 3 arguments"
-msgstr "опцията „--bisect-next-check“ изисква 2 или 3 аргумента"
-
-#: builtin/bisect--helper.c:1100
+#: builtin/bisect--helper.c:1234
 msgid "--bisect-terms requires 0 or 1 argument"
 msgstr "опцията „--bisect-terms“ изисква 0 или 1 аргумента"
 
-#: builtin/bisect--helper.c:1109
+#: builtin/bisect--helper.c:1243
 msgid "--bisect-next requires 0 arguments"
 msgstr "опцията „--bisect-next“ не приема аргументи"
 
-#: builtin/bisect--helper.c:1120
+#: builtin/bisect--helper.c:1254
 msgid "--bisect-log requires 0 arguments"
 msgstr "опцията „--bisect-log“ не приема аргументи"
 
-#: builtin/bisect--helper.c:1125
+#: builtin/bisect--helper.c:1259
 msgid "no logfile given"
 msgstr "не е зададен журнален файл"
 
@@ -11562,167 +11878,169 @@ msgstr "git blame [ОПЦИЯ…] [ОПЦИЯ_ЗА_ВЕРСИЯТА…] [ВЕР�
 msgid "<rev-opts> are documented in git-rev-list(1)"
 msgstr "ОПЦИИте_ЗА_ВЕРСИЯТА са документирани в ръководството git-rev-list(1)"
 
-#: builtin/blame.c:410
+#: builtin/blame.c:406
 #, c-format
 msgid "expecting a color: %s"
 msgstr "трябва да е цвят: %s"
 
-#: builtin/blame.c:417
+#: builtin/blame.c:413
 msgid "must end with a color"
 msgstr "трябва да завършва с цвят"
 
-#: builtin/blame.c:728
+#: builtin/blame.c:724
 #, c-format
 msgid "invalid color '%s' in color.blame.repeatedLines"
 msgstr "неправилен цвят „%s“ в „color.blame.repeatedLines“"
 
-#: builtin/blame.c:746
+#: builtin/blame.c:742
 msgid "invalid value for blame.coloring"
 msgstr "неправилна стойност за „blame.coloring“"
 
-#: builtin/blame.c:845
+#: builtin/blame.c:841
 #, c-format
 msgid "cannot find revision %s to ignore"
 msgstr "версията за прескачане „%s“ не може да бъде открита"
 
-#: builtin/blame.c:867
+#: builtin/blame.c:863
 msgid "show blame entries as we find them, incrementally"
 msgstr "извеждане на авторството с намирането му, последователно"
 
-#: builtin/blame.c:868
+#: builtin/blame.c:864
 msgid "do not show object names of boundary commits (Default: off)"
 msgstr ""
 "без извеждане на имената на обектите за граничните подавания (стандартно "
 "опцията е изключена)"
 
-#: builtin/blame.c:869
+#: builtin/blame.c:865
 msgid "do not treat root commits as boundaries (Default: off)"
 msgstr ""
 "началните подавания да не се считат за гранични (стандартно опцията е "
 "изключена)"
 
-#: builtin/blame.c:870
+#: builtin/blame.c:866
 msgid "show work cost statistics"
 msgstr "извеждане на статистика за извършените действия"
 
-#: builtin/blame.c:871 builtin/checkout.c:1519 builtin/clone.c:94
-#: builtin/commit-graph.c:84 builtin/commit-graph.c:222 builtin/fetch.c:179
-#: builtin/merge.c:297 builtin/multi-pack-index.c:55 builtin/pull.c:119
-#: builtin/push.c:566 builtin/send-pack.c:198
+#: builtin/blame.c:867 builtin/checkout.c:1517 builtin/clone.c:94
+#: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
+#: builtin/merge.c:298 builtin/multi-pack-index.c:103
+#: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
+#: builtin/multi-pack-index.c:204 builtin/pull.c:119 builtin/push.c:566
+#: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "извеждане на напредъка"
 
-#: builtin/blame.c:872
+#: builtin/blame.c:868
 msgid "show output score for blame entries"
 msgstr "извеждане на допълнителна информация за определянето на авторството"
 
-#: builtin/blame.c:873
+#: builtin/blame.c:869
 msgid "show original filename (Default: auto)"
 msgstr ""
 "извеждане на първоначалното име на файл (стандартно това е автоматично)"
 
-#: builtin/blame.c:874
+#: builtin/blame.c:870
 msgid "show original linenumber (Default: off)"
 msgstr ""
 "извеждане на първоначалния номер на ред (стандартно опцията е изключена)"
 
-#: builtin/blame.c:875
+#: builtin/blame.c:871
 msgid "show in a format designed for machine consumption"
 msgstr "извеждане във формат за по-нататъшна обработка"
 
-#: builtin/blame.c:876
+#: builtin/blame.c:872
 msgid "show porcelain format with per-line commit information"
 msgstr ""
 "извеждане във формат за команди от потребителско ниво с информация на всеки "
 "ред"
 
-#: builtin/blame.c:877
+#: builtin/blame.c:873
 msgid "use the same output mode as git-annotate (Default: off)"
 msgstr ""
 "използване на същия формат като „git-annotate“ (стандартно опцията е "
 "изключена)"
 
-#: builtin/blame.c:878
+#: builtin/blame.c:874
 msgid "show raw timestamp (Default: off)"
 msgstr "извеждане на неформатирани времена (стандартно опцията е изключена)"
 
-#: builtin/blame.c:879
+#: builtin/blame.c:875
 msgid "show long commit SHA1 (Default: off)"
 msgstr "извеждане на пълните суми по SHA1 (стандартно опцията е изключена)"
 
-#: builtin/blame.c:880
+#: builtin/blame.c:876
 msgid "suppress author name and timestamp (Default: off)"
 msgstr "без име на автор и време на промяна (стандартно опцията е изключена)"
 
-#: builtin/blame.c:881
+#: builtin/blame.c:877
 msgid "show author email instead of name (Default: off)"
 msgstr ""
 "извеждане на е-пощата на автора, а не името му (стандартно опцията е "
 "изключена)"
 
-#: builtin/blame.c:882
+#: builtin/blame.c:878
 msgid "ignore whitespace differences"
 msgstr "без разлики в знаците за интервали"
 
-#: builtin/blame.c:883 builtin/log.c:1823
+#: builtin/blame.c:879 builtin/log.c:1823
 msgid "rev"
 msgstr "ВЕРС"
 
-#: builtin/blame.c:883
+#: builtin/blame.c:879
 msgid "ignore <rev> when blaming"
 msgstr "прескачане на ВЕРСията при извеждане на авторството"
 
-#: builtin/blame.c:884
+#: builtin/blame.c:880
 msgid "ignore revisions from <file>"
 msgstr "прескачане на версиите указани във ФАЙЛа"
 
-#: builtin/blame.c:885
+#: builtin/blame.c:881
 msgid "color redundant metadata from previous line differently"
 msgstr ""
 "оцветяване на повтарящите се метаданни от предишния ред в различен цвят"
 
-#: builtin/blame.c:886
+#: builtin/blame.c:882
 msgid "color lines by age"
 msgstr "оцветяване на редовете по възраст"
 
-#: builtin/blame.c:887
+#: builtin/blame.c:883
 msgid "spend extra cycles to find better match"
 msgstr "допълнителни изчисления за по-добри резултати"
 
-#: builtin/blame.c:888
+#: builtin/blame.c:884
 msgid "use revisions from <file> instead of calling git-rev-list"
 msgstr "изчитане на версиите от ФАЙЛа, а не чрез изпълнение на „git-rev-list“"
 
-#: builtin/blame.c:889
+#: builtin/blame.c:885
 msgid "use <file>'s contents as the final image"
 msgstr "използване на съдържанието на ФАЙЛа като крайно положение"
 
-#: builtin/blame.c:890 builtin/blame.c:891
+#: builtin/blame.c:886 builtin/blame.c:887
 msgid "score"
 msgstr "напасване на редовете"
 
-#: builtin/blame.c:890
+#: builtin/blame.c:886
 msgid "find line copies within and across files"
 msgstr ""
 "търсене на копирани редове както в рамките на един файл, така и от един файл "
 "към друг"
 
-#: builtin/blame.c:891
+#: builtin/blame.c:887
 msgid "find line movements within and across files"
 msgstr ""
 "търсене на преместени редове както в рамките на един файл, така и от един "
 "файл към друг"
 
-#: builtin/blame.c:892
+#: builtin/blame.c:888
 msgid "range"
 msgstr "диапазон"
 
-#: builtin/blame.c:893
+#: builtin/blame.c:889
 msgid "process only line range <start>,<end> or function :<funcname>"
 msgstr ""
 "информация само за редовете в диапазона НАЧАЛО,КРАЙ или само на :ФУНКЦИЯта"
 
-#: builtin/blame.c:945
+#: builtin/blame.c:944
 msgid "--progress can't be used with --incremental or porcelain formats"
 msgstr ""
 "опцията „--progress“ е несъвместима с „--incremental“ и форма̀та на командите "
@@ -11736,18 +12054,18 @@ msgstr ""
 #. your language may need more or fewer display
 #. columns.
 #.
-#: builtin/blame.c:996
+#: builtin/blame.c:995
 msgid "4 years, 11 months ago"
 msgstr "преди 4 години и 11 месеца"
 
-#: builtin/blame.c:1112
+#: builtin/blame.c:1111
 #, c-format
 msgid "file %s has only %lu line"
 msgid_plural "file %s has only %lu lines"
 msgstr[0] "има само %2$lu ред във файла „%1$s“"
 msgstr[1] "има само %2$lu реда във файла „%1$s“"
 
-#: builtin/blame.c:1157
+#: builtin/blame.c:1156
 msgid "Blaming lines"
 msgstr "Редове с авторство"
 
@@ -11848,75 +12166,75 @@ msgstr "Изтрит следящ клон „%s“ (той сочеше към 
 msgid "Deleted branch %s (was %s).\n"
 msgstr "Изтрит клон „%s“ (той сочеше към „%s“).\n"
 
-#: builtin/branch.c:440 builtin/tag.c:63
+#: builtin/branch.c:441 builtin/tag.c:63
 msgid "unable to parse format string"
 msgstr "форматиращият низ не може да бъде анализиран: %s"
 
-#: builtin/branch.c:471
+#: builtin/branch.c:472
 msgid "could not resolve HEAD"
 msgstr "подаването, сочено от указателя „HEAD“, не може да се установи"
 
-#: builtin/branch.c:477
+#: builtin/branch.c:478
 #, c-format
 msgid "HEAD (%s) points outside of refs/heads/"
 msgstr "„HEAD“ (%s) сочи извън директорията „refs/heads“"
 
-#: builtin/branch.c:492
+#: builtin/branch.c:493
 #, c-format
 msgid "Branch %s is being rebased at %s"
 msgstr "Клонът „%s“ се пребазира върху „%s“"
 
-#: builtin/branch.c:496
+#: builtin/branch.c:497
 #, c-format
 msgid "Branch %s is being bisected at %s"
 msgstr "Търси се двоично в клона „%s“ при „%s“"
 
-#: builtin/branch.c:513
+#: builtin/branch.c:514
 msgid "cannot copy the current branch while not on any."
 msgstr "не може да копирате текущия клон, защото сте извън който и да е клон"
 
-#: builtin/branch.c:515
+#: builtin/branch.c:516
 msgid "cannot rename the current branch while not on any."
 msgstr ""
 "не може да преименувате текущия клон, защото сте извън който и да е клон"
 
-#: builtin/branch.c:526
+#: builtin/branch.c:527
 #, c-format
 msgid "Invalid branch name: '%s'"
 msgstr "Неправилно име на клон: „%s“"
 
-#: builtin/branch.c:555
+#: builtin/branch.c:556
 msgid "Branch rename failed"
 msgstr "Неуспешно преименуване на клон"
 
-#: builtin/branch.c:557
+#: builtin/branch.c:558
 msgid "Branch copy failed"
 msgstr "Неуспешно копиране на клон"
 
-#: builtin/branch.c:561
+#: builtin/branch.c:562
 #, c-format
 msgid "Created a copy of a misnamed branch '%s'"
 msgstr "Клонът с неправилно име „%s“ е копиран"
 
-#: builtin/branch.c:564
+#: builtin/branch.c:565
 #, c-format
 msgid "Renamed a misnamed branch '%s' away"
 msgstr "Клонът с неправилно име „%s“ е преименуван"
 
-#: builtin/branch.c:570
+#: builtin/branch.c:571
 #, c-format
 msgid "Branch renamed to %s, but HEAD is not updated!"
 msgstr "Клонът е преименуван на „%s“, но указателят „HEAD“ не е обновен"
 
-#: builtin/branch.c:579
+#: builtin/branch.c:580
 msgid "Branch is renamed, but update of config-file failed"
 msgstr "Клонът е преименуван, но конфигурационният файл не е обновен"
 
-#: builtin/branch.c:581
+#: builtin/branch.c:582
 msgid "Branch is copied, but update of config-file failed"
 msgstr "Клонът е копиран, но конфигурационният файл не е обновен"
 
-#: builtin/branch.c:597
+#: builtin/branch.c:598
 #, c-format
 msgid ""
 "Please edit the description for the branch\n"
@@ -11927,183 +12245,183 @@ msgstr ""
 "    %s\n"
 "Редовете, които започват с „%c“, ще бъдат пропуснати.\n"
 
-#: builtin/branch.c:631
+#: builtin/branch.c:632
 msgid "Generic options"
 msgstr "Общи настройки"
 
-#: builtin/branch.c:633
+#: builtin/branch.c:634
 msgid "show hash and subject, give twice for upstream branch"
 msgstr ""
 "извеждане на контролната сума и темата.  Повтарянето на опцията прибавя "
 "отдалечените клони"
 
-#: builtin/branch.c:634
+#: builtin/branch.c:635
 msgid "suppress informational messages"
 msgstr "без информационни съобщения"
 
-#: builtin/branch.c:635
+#: builtin/branch.c:636
 msgid "set up tracking mode (see git-pull(1))"
 msgstr "задаване на режима на следене (виж git-pull(1))"
 
-#: builtin/branch.c:637
+#: builtin/branch.c:638
 msgid "do not use"
 msgstr "да не се ползва"
 
-#: builtin/branch.c:639 builtin/rebase.c:533
+#: builtin/branch.c:640
 msgid "upstream"
 msgstr "клон-източник"
 
-#: builtin/branch.c:639
+#: builtin/branch.c:640
 msgid "change the upstream info"
 msgstr "смяна на клона-източник"
 
-#: builtin/branch.c:640
+#: builtin/branch.c:641
 msgid "unset the upstream info"
 msgstr "изчистване на информацията за клон-източник"
 
-#: builtin/branch.c:641
+#: builtin/branch.c:642
 msgid "use colored output"
 msgstr "цветен изход"
 
-#: builtin/branch.c:642
+#: builtin/branch.c:643
 msgid "act on remote-tracking branches"
 msgstr "действие върху следящите клони"
 
-#: builtin/branch.c:644 builtin/branch.c:646
+#: builtin/branch.c:645 builtin/branch.c:647
 msgid "print only branches that contain the commit"
 msgstr "извеждане само на клоните, които съдържат това ПОДАВАНЕ"
 
-#: builtin/branch.c:645 builtin/branch.c:647
+#: builtin/branch.c:646 builtin/branch.c:648
 msgid "print only branches that don't contain the commit"
 msgstr "извеждане само на клоните, които не съдържат това ПОДАВАНЕ"
 
-#: builtin/branch.c:650
+#: builtin/branch.c:651
 msgid "Specific git-branch actions:"
 msgstr "Специални действия на „git-branch“:"
 
-#: builtin/branch.c:651
+#: builtin/branch.c:652
 msgid "list both remote-tracking and local branches"
 msgstr "извеждане както на следящите, така и на локалните клони"
 
-#: builtin/branch.c:653
+#: builtin/branch.c:654
 msgid "delete fully merged branch"
 msgstr "изтриване на клони, които са напълно слети"
 
-#: builtin/branch.c:654
+#: builtin/branch.c:655
 msgid "delete branch (even if not merged)"
 msgstr "изтриване и на клони, които не са напълно слети"
 
-#: builtin/branch.c:655
+#: builtin/branch.c:656
 msgid "move/rename a branch and its reflog"
 msgstr ""
 "преместване/преименуване на клон и принадлежащият му журнал на указателите"
 
-#: builtin/branch.c:656
+#: builtin/branch.c:657
 msgid "move/rename a branch, even if target exists"
 msgstr "преместване/преименуване на клон, дори ако има вече клон с такова име"
 
-#: builtin/branch.c:657
+#: builtin/branch.c:658
 msgid "copy a branch and its reflog"
 msgstr "копиране на клон и принадлежащия му журнал на указателите"
 
-#: builtin/branch.c:658
+#: builtin/branch.c:659
 msgid "copy a branch, even if target exists"
 msgstr "копиране на клон, дори ако има вече клон с такова име"
 
-#: builtin/branch.c:659
+#: builtin/branch.c:660
 msgid "list branch names"
 msgstr "извеждане на имената на клоните"
 
-#: builtin/branch.c:660
+#: builtin/branch.c:661
 msgid "show current branch name"
 msgstr "извеждане на името на текущия клон"
 
-#: builtin/branch.c:661
+#: builtin/branch.c:662
 msgid "create the branch's reflog"
 msgstr "създаване на журнала на указателите на клона"
 
-#: builtin/branch.c:663
+#: builtin/branch.c:664
 msgid "edit the description for the branch"
 msgstr "редактиране на описанието на клона"
 
-#: builtin/branch.c:664
+#: builtin/branch.c:665
 msgid "force creation, move/rename, deletion"
 msgstr "принудително създаване, преместване, преименуване, изтриване"
 
-#: builtin/branch.c:665
+#: builtin/branch.c:666
 msgid "print only branches that are merged"
 msgstr "извеждане само на слетите клони"
 
-#: builtin/branch.c:666
+#: builtin/branch.c:667
 msgid "print only branches that are not merged"
 msgstr "извеждане само на неслетите клони"
 
-#: builtin/branch.c:667
+#: builtin/branch.c:668
 msgid "list branches in columns"
 msgstr "извеждане по колони"
 
-#: builtin/branch.c:669 builtin/for-each-ref.c:44 builtin/notes.c:415
-#: builtin/notes.c:418 builtin/notes.c:581 builtin/notes.c:584
-#: builtin/tag.c:477
+#: builtin/branch.c:670 builtin/for-each-ref.c:44 builtin/notes.c:413
+#: builtin/notes.c:416 builtin/notes.c:579 builtin/notes.c:582
+#: builtin/tag.c:475
 msgid "object"
 msgstr "ОБЕКТ"
 
-#: builtin/branch.c:670
+#: builtin/branch.c:671
 msgid "print only branches of the object"
 msgstr "извеждане само на клоните на ОБЕКТА"
 
-#: builtin/branch.c:671 builtin/for-each-ref.c:50 builtin/tag.c:484
+#: builtin/branch.c:672 builtin/for-each-ref.c:50 builtin/tag.c:482
 msgid "sorting and filtering are case insensitive"
 msgstr "подредбата и филтрирането третират еднакво малките и главните букви"
 
-#: builtin/branch.c:672 builtin/for-each-ref.c:40 builtin/tag.c:482
+#: builtin/branch.c:673 builtin/for-each-ref.c:40 builtin/tag.c:480
 #: builtin/verify-tag.c:38
 msgid "format to use for the output"
 msgstr "ФОРМАТ за изхода"
 
-#: builtin/branch.c:695 builtin/clone.c:794
+#: builtin/branch.c:696 builtin/clone.c:678
 msgid "HEAD not found below refs/heads!"
 msgstr "В директорията „refs/heads“ липсва файл „HEAD“"
 
-#: builtin/branch.c:719
+#: builtin/branch.c:720
 msgid "--column and --verbose are incompatible"
 msgstr "опциите „--column“ и „--verbose“ са несъвместими"
 
-#: builtin/branch.c:734 builtin/branch.c:790 builtin/branch.c:799
+#: builtin/branch.c:735 builtin/branch.c:792 builtin/branch.c:801
 msgid "branch name required"
 msgstr "Необходимо е име на клон"
 
-#: builtin/branch.c:766
+#: builtin/branch.c:768
 msgid "Cannot give description to detached HEAD"
 msgstr "Не може да зададете описание на несвързан „HEAD“"
 
-#: builtin/branch.c:771
+#: builtin/branch.c:773
 msgid "cannot edit description of more than one branch"
 msgstr "Не може да редактирате описанието на повече от един клон едновременно"
 
-#: builtin/branch.c:778
+#: builtin/branch.c:780
 #, c-format
 msgid "No commit on branch '%s' yet."
 msgstr "В клона „%s“ все още няма подавания."
 
-#: builtin/branch.c:781
+#: builtin/branch.c:783
 #, c-format
 msgid "No branch named '%s'."
 msgstr "Липсва клон на име „%s“."
 
-#: builtin/branch.c:796
+#: builtin/branch.c:798
 msgid "too many branches for a copy operation"
 msgstr "прекалено много клони за копиране"
 
-#: builtin/branch.c:805
+#: builtin/branch.c:807
 msgid "too many arguments for a rename operation"
 msgstr "прекалено много аргументи към командата за преименуване"
 
-#: builtin/branch.c:810
+#: builtin/branch.c:812
 msgid "too many arguments to set new upstream"
 msgstr "прекалено много аргументи към командата за следене"
 
-#: builtin/branch.c:814
+#: builtin/branch.c:816
 #, c-format
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch."
@@ -12111,31 +12429,31 @@ msgstr ""
 "Следеното от „HEAD“ не може да се зададе да е „%s“, защото то не сочи към "
 "никой клон."
 
-#: builtin/branch.c:817 builtin/branch.c:840
+#: builtin/branch.c:819 builtin/branch.c:842
 #, c-format
 msgid "no such branch '%s'"
 msgstr "Няма клон на име „%s“."
 
-#: builtin/branch.c:821
+#: builtin/branch.c:823
 #, c-format
 msgid "branch '%s' does not exist"
 msgstr "Не съществува клон на име „%s“."
 
-#: builtin/branch.c:834
+#: builtin/branch.c:836
 msgid "too many arguments to unset upstream"
 msgstr "прекалено много аргументи към командата за спиране на следене"
 
-#: builtin/branch.c:838
+#: builtin/branch.c:840
 msgid "could not unset upstream of HEAD when it does not point to any branch."
 msgstr ""
 "Следеното от „HEAD“ не може да махне, защото то не сочи към никой клон."
 
-#: builtin/branch.c:844
+#: builtin/branch.c:846
 #, c-format
 msgid "Branch '%s' has no upstream information"
 msgstr "Няма информация клонът „%s“ да следи някой друг"
 
-#: builtin/branch.c:854
+#: builtin/branch.c:856
 msgid ""
 "The -a, and -r, options to 'git branch' do not take a branch name.\n"
 "Did you mean to use: -a|-r --list <pattern>?"
@@ -12143,7 +12461,7 @@ msgstr ""
 "опциите „-a“ и „-r“ на „git branch“ са несъвместими с име на клон.\n"
 "Пробвайте с: „-a|-r --list ШАБЛОН“"
 
-#: builtin/branch.c:858
+#: builtin/branch.c:860
 msgid ""
 "the '--set-upstream' option is no longer supported. Please use '--track' or "
 "'--set-upstream-to' instead."
@@ -12151,32 +12469,32 @@ msgstr ""
 "опцията „--set-upstream“ вече не се поддържа.  Използвайте „--track“ или „--"
 "set-upstream-to“"
 
-#: builtin/bugreport.c:15
+#: builtin/bugreport.c:16
 msgid "git version:\n"
 msgstr "версия на git:\n"
 
-#: builtin/bugreport.c:21
+#: builtin/bugreport.c:22
 #, c-format
 msgid "uname() failed with error '%s' (%d)\n"
 msgstr "грешка при изпълнението на „uname()“ — „%s“ (%d)\n"
 
-#: builtin/bugreport.c:31
+#: builtin/bugreport.c:32
 msgid "compiler info: "
 msgstr "компилатор: "
 
-#: builtin/bugreport.c:34
+#: builtin/bugreport.c:35
 msgid "libc info: "
 msgstr "библиотека на C: "
 
-#: builtin/bugreport.c:80
+#: builtin/bugreport.c:49
 msgid "not run from a git repository - no hooks to show\n"
 msgstr "командата е стартирана извън хранилище на Git, затова няма куки\n"
 
-#: builtin/bugreport.c:90
+#: builtin/bugreport.c:62
 msgid "git bugreport [-o|--output-directory <file>] [-s|--suffix <format>]"
 msgstr "git bugreport [-o|--output-directory ФАЙЛ] [-s|--suffix ФОРМАТ]"
 
-#: builtin/bugreport.c:97
+#: builtin/bugreport.c:69
 msgid ""
 "Thank you for filling out a Git bug report!\n"
 "Please answer the following questions to help us understand your issue.\n"
@@ -12212,38 +12530,33 @@ msgstr ""
 "Разгледайте останалата част от доклада за грешка по-долу.\n"
 "Може да изтриете редовете, които не искате да споделите.\n"
 
-#: builtin/bugreport.c:136
+#: builtin/bugreport.c:108
 msgid "specify a destination for the bugreport file"
 msgstr "укажете файла, в който да се запази докладът за грешка"
 
-#: builtin/bugreport.c:138
+#: builtin/bugreport.c:110
 msgid "specify a strftime format suffix for the filename"
 msgstr "укажете суфикса на файла във формат за „strftime“"
 
-#: builtin/bugreport.c:160
+#: builtin/bugreport.c:132
 #, c-format
 msgid "could not create leading directories for '%s'"
 msgstr "родителските директории на „%s“ не може да бъдат създадени"
 
-#: builtin/bugreport.c:167
+#: builtin/bugreport.c:139
 msgid "System Info"
 msgstr "Информация за системата"
 
-#: builtin/bugreport.c:170
+#: builtin/bugreport.c:142
 msgid "Enabled Hooks"
 msgstr "Включени куки"
 
-#: builtin/bugreport.c:177
-#, c-format
-msgid "couldn't create a new file at '%s'"
-msgstr "новият файл „%s“ не може да бъде създаден"
-
-#: builtin/bugreport.c:180
+#: builtin/bugreport.c:149
 #, c-format
 msgid "unable to write to %s"
 msgstr "в „%s“ не може да се пише"
 
-#: builtin/bugreport.c:190
+#: builtin/bugreport.c:159
 #, c-format
 msgid "Created new report at '%s'.\n"
 msgstr "Новият доклад е създаден в „%s“.\n"
@@ -12264,54 +12577,54 @@ msgstr "git bundle list-heads ФАЙЛ [ИМЕ_НА_УКАЗАТЕЛ…]"
 msgid "git bundle unbundle <file> [<refname>...]"
 msgstr "git bundle unbundle ФАЙЛ [ИМЕ_НА_УКАЗАТЕЛ…]"
 
-#: builtin/bundle.c:67 builtin/pack-objects.c:3907
+#: builtin/bundle.c:65 builtin/pack-objects.c:3876
 msgid "do not show progress meter"
 msgstr "без извеждане на напредъка"
 
-#: builtin/bundle.c:69 builtin/pack-objects.c:3909
+#: builtin/bundle.c:67 builtin/bundle.c:167 builtin/pack-objects.c:3878
 msgid "show progress meter"
 msgstr "извеждане на напредъка"
 
-#: builtin/bundle.c:71 builtin/pack-objects.c:3911
+#: builtin/bundle.c:69 builtin/pack-objects.c:3880
 msgid "show progress meter during object writing phase"
 msgstr "извеждане на напредъка във фазата на запазване на обектите"
 
-#: builtin/bundle.c:74 builtin/pack-objects.c:3914
+#: builtin/bundle.c:72 builtin/pack-objects.c:3883
 msgid "similar to --all-progress when progress meter is shown"
 msgstr ""
 "същото действие като опцията „--all-progress“ при извеждането на напредъка"
 
-#: builtin/bundle.c:76
+#: builtin/bundle.c:74
 msgid "specify bundle format version"
 msgstr "версия на пратката"
 
-#: builtin/bundle.c:96
+#: builtin/bundle.c:94
 msgid "Need a repository to create a bundle."
 msgstr "За създаването на пратка е необходимо хранилище."
 
-#: builtin/bundle.c:109
+#: builtin/bundle.c:107
 msgid "do not show bundle details"
 msgstr "без подробна информация за пратките"
 
-#: builtin/bundle.c:128
+#: builtin/bundle.c:126
 #, c-format
 msgid "%s is okay\n"
 msgstr "Пратката „%s“ е наред\n"
 
-#: builtin/bundle.c:179
+#: builtin/bundle.c:182
 msgid "Need a repository to unbundle."
 msgstr "За приемането на пратка е необходимо хранилище."
 
-#: builtin/bundle.c:191 builtin/remote.c:1700
-msgid "be verbose; must be placed before a subcommand"
-msgstr "повече подробности.  Поставя се пред подкоманда"
+#: builtin/bundle.c:185
+msgid "Unbundling objects"
+msgstr "Разпакетиране на пратки от обекти"
 
-#: builtin/bundle.c:213 builtin/remote.c:1731
+#: builtin/bundle.c:219 builtin/remote.c:1733
 #, c-format
 msgid "Unknown subcommand: %s"
 msgstr "Непозната подкоманда: %s"
 
-#: builtin/cat-file.c:596
+#: builtin/cat-file.c:622
 msgid ""
 "git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e | -"
 "p | <type> | --textconv | --filters) [--path=<path>] <object>"
@@ -12319,7 +12632,7 @@ msgstr ""
 "git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e | -"
 "p | ВИД | --textconv --filters) [--path=ПЪТ] ОБЕКТ"
 
-#: builtin/cat-file.c:597
+#: builtin/cat-file.c:623
 msgid ""
 "git cat-file (--batch[=<format>] | --batch-check[=<format>]) [--follow-"
 "symlinks] [--textconv | --filters]"
@@ -12327,79 +12640,79 @@ msgstr ""
 "git cat-file (--batch[=ФОРМАТ] | --batch-check[=ФОРМАТ]) [--follow-symlinks] "
 "[--textconv | --filters]"
 
-#: builtin/cat-file.c:618
+#: builtin/cat-file.c:644
 msgid "only one batch option may be specified"
 msgstr "може да укажете само една пакетна опция"
 
-#: builtin/cat-file.c:636
+#: builtin/cat-file.c:662
 msgid "<type> can be one of: blob, tree, commit, tag"
 msgstr ""
 "ВИДът може да е: „blob“ (BLOB), „tree“ (дърво), „commit“ (подаване), "
 "„tag“ (етикет)"
 
-#: builtin/cat-file.c:637
+#: builtin/cat-file.c:663
 msgid "show object type"
 msgstr "извеждане на вида на обект"
 
-#: builtin/cat-file.c:638
+#: builtin/cat-file.c:664
 msgid "show object size"
 msgstr "извеждане на размера на обект"
 
-#: builtin/cat-file.c:640
+#: builtin/cat-file.c:666
 msgid "exit with zero when there's no error"
 msgstr "изход с 0, когато няма грешка"
 
-#: builtin/cat-file.c:641
+#: builtin/cat-file.c:667
 msgid "pretty-print object's content"
 msgstr "форматирано извеждане на съдържанието на обекта"
 
-#: builtin/cat-file.c:643
+#: builtin/cat-file.c:669
 msgid "for blob objects, run textconv on object's content"
 msgstr ""
 "да се стартира програмата зададена в настройката „textconv“ за преобразуване "
 "на съдържанието на обекта-BLOB"
 
-#: builtin/cat-file.c:645
+#: builtin/cat-file.c:671
 msgid "for blob objects, run filters on object's content"
 msgstr ""
 "да се стартират програмите за преобразуване на съдържанието на обектите-BLOB"
 
-#: builtin/cat-file.c:646
+#: builtin/cat-file.c:672
 msgid "blob"
 msgstr "обект-BLOB"
 
-#: builtin/cat-file.c:647
+#: builtin/cat-file.c:673
 msgid "use a specific path for --textconv/--filters"
 msgstr "опциите „--textconv“/„--filters“ изискват път"
 
-#: builtin/cat-file.c:649
+#: builtin/cat-file.c:675
 msgid "allow -s and -t to work with broken/corrupt objects"
 msgstr "позволяване на опциите „-s“ и „-t“ да работят с повредени обекти"
 
-#: builtin/cat-file.c:650
+#: builtin/cat-file.c:676
 msgid "buffer --batch output"
 msgstr "буфериране на изхода от „--batch“"
 
-#: builtin/cat-file.c:652
+#: builtin/cat-file.c:678
 msgid "show info and content of objects fed from the standard input"
 msgstr ""
 "извеждане на информация и съдържание на обектите подадени на стандартния вход"
 
-#: builtin/cat-file.c:656
+#: builtin/cat-file.c:682
 msgid "show info about objects fed from the standard input"
 msgstr "извеждане на информация за обектите подадени на стандартния вход"
 
-#: builtin/cat-file.c:660
+#: builtin/cat-file.c:686
 msgid "follow in-tree symlinks (used with --batch or --batch-check)"
 msgstr ""
 "следване на символните връзки сочещи в дървото (ползва се с „--batch“ или „--"
 "batch-check“)"
 
-#: builtin/cat-file.c:662
+#: builtin/cat-file.c:688
 msgid "show all objects with --batch or --batch-check"
 msgstr "извеждане на всички обекти с „--batch“ или „--batch-check“"
 
-#: builtin/cat-file.c:664
+#: builtin/cat-file.c:690
 msgid "do not order --batch-all-objects output"
 msgstr "без подреждане на изхода от „--batch-all-objects“"
 
@@ -12419,7 +12732,7 @@ msgstr "извеждане на всички атрибути, зададени 
 msgid "use .gitattributes only from the index"
 msgstr "използване на файла „.gitattributes“ само от индекса"
 
-#: builtin/check-attr.c:23 builtin/check-ignore.c:25 builtin/hash-object.c:102
+#: builtin/check-attr.c:23 builtin/check-ignore.c:25 builtin/hash-object.c:100
 msgid "read file names from stdin"
 msgstr "изчитане на имената на файловете от стандартния вход"
 
@@ -12427,8 +12740,8 @@ msgstr "изчитане на имената на файловете от ста
 msgid "terminate input and output records by a NUL character"
 msgstr "разделяне на входните и изходните записи с нулевия знак „NUL“"
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1515 builtin/gc.c:549
-#: builtin/worktree.c:493
+#: builtin/check-ignore.c:21 builtin/checkout.c:1513 builtin/gc.c:549
+#: builtin/worktree.c:494
 msgid "suppress progress reporting"
 msgstr "без показване на напредъка"
 
@@ -12486,11 +12799,10 @@ msgid "git checkout--worker [<options>]"
 msgstr "git checkout--worker [ОПЦИЯ…]"
 
 #: builtin/checkout--worker.c:118 builtin/checkout-index.c:201
-#: builtin/column.c:31 builtin/submodule--helper.c:1892
-#: builtin/submodule--helper.c:1895 builtin/submodule--helper.c:1903
-#: builtin/submodule--helper.c:2350 builtin/submodule--helper.c:2896
-#: builtin/submodule--helper.c:2899 builtin/worktree.c:491
-#: builtin/worktree.c:728
+#: builtin/column.c:31 builtin/column.c:32 builtin/submodule--helper.c:1863
+#: builtin/submodule--helper.c:1866 builtin/submodule--helper.c:1874
+#: builtin/submodule--helper.c:2510 builtin/submodule--helper.c:2576
+#: builtin/worktree.c:492 builtin/worktree.c:729
 msgid "string"
 msgstr "НИЗ"
 
@@ -12642,11 +12954,11 @@ msgstr "опцията „%3$s“ е несъвместима както с „%
 msgid "path '%s' is unmerged"
 msgstr "пътят „%s“ не е слят"
 
-#: builtin/checkout.c:734
+#: builtin/checkout.c:736
 msgid "you need to resolve your current index first"
 msgstr "първо трябва да коригирате индекса си"
 
-#: builtin/checkout.c:788
+#: builtin/checkout.c:786
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -12656,50 +12968,50 @@ msgstr ""
 "индекса:\n"
 "%s"
 
-#: builtin/checkout.c:881
+#: builtin/checkout.c:879
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Журналът на указателите за „%s“ не може да се проследи: %s\n"
 
-#: builtin/checkout.c:923
+#: builtin/checkout.c:921
 msgid "HEAD is now at"
 msgstr "Указателят „HEAD“ в момента сочи към"
 
-#: builtin/checkout.c:927 builtin/clone.c:725 t/helper/test-fast-rebase.c:203
+#: builtin/checkout.c:925 builtin/clone.c:609 t/helper/test-fast-rebase.c:203
 msgid "unable to update HEAD"
 msgstr "Указателят „HEAD“ не може да бъде обновен"
 
-#: builtin/checkout.c:931
+#: builtin/checkout.c:929
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Зануляване на клона „%s“\n"
 
-#: builtin/checkout.c:934
+#: builtin/checkout.c:932
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Вече сте на „%s“\n"
 
-#: builtin/checkout.c:938
+#: builtin/checkout.c:936
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Преминаване към клона „%s“ и зануляване на промените\n"
 
-#: builtin/checkout.c:940 builtin/checkout.c:1371
+#: builtin/checkout.c:938 builtin/checkout.c:1369
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Преминахте към новия клон „%s“\n"
 
-#: builtin/checkout.c:942
+#: builtin/checkout.c:940
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Преминахте към клона „%s“\n"
 
-#: builtin/checkout.c:993
+#: builtin/checkout.c:991
 #, c-format
 msgid " ... and %d more.\n"
 msgstr "… и още %d.\n"
 
-#: builtin/checkout.c:999
+#: builtin/checkout.c:997
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -12721,7 +13033,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:1018
+#: builtin/checkout.c:1016
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -12748,19 +13060,19 @@ msgstr[1] ""
 "    git branch ИМЕ_НА_НОВИЯ_КЛОН %s\n"
 "\n"
 
-#: builtin/checkout.c:1053
+#: builtin/checkout.c:1051
 msgid "internal error in revision walk"
 msgstr "вътрешна грешка при обхождането на версиите"
 
-#: builtin/checkout.c:1057
+#: builtin/checkout.c:1055
 msgid "Previous HEAD position was"
 msgstr "Преди това „HEAD“ сочеше към"
 
-#: builtin/checkout.c:1097 builtin/checkout.c:1366
+#: builtin/checkout.c:1095 builtin/checkout.c:1364
 msgid "You are on a branch yet to be born"
 msgstr "В момента сте на клон, който все още не е създаден"
 
-#: builtin/checkout.c:1179
+#: builtin/checkout.c:1177
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
@@ -12769,7 +13081,7 @@ msgstr ""
 "„%s“ може да е както локален файл, така и следящ клон.  За уточняване\n"
 "ползвайте разделителя „--“ (и евентуално опцията „--no-guess“)"
 
-#: builtin/checkout.c:1186
+#: builtin/checkout.c:1184
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -12791,51 +13103,51 @@ msgstr ""
 "\n"
 "    checkout.defaultRemote=origin"
 
-#: builtin/checkout.c:1196
+#: builtin/checkout.c:1194
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "„%s“ напасва с множество (%d) отдалечени клони"
 
-#: builtin/checkout.c:1262
+#: builtin/checkout.c:1260
 msgid "only one reference expected"
 msgstr "очаква се само един указател"
 
-#: builtin/checkout.c:1279
+#: builtin/checkout.c:1277
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "очаква се един указател, а сте подали %d."
 
-#: builtin/checkout.c:1325 builtin/worktree.c:268 builtin/worktree.c:436
+#: builtin/checkout.c:1323 builtin/worktree.c:269 builtin/worktree.c:437
 #, c-format
 msgid "invalid reference: %s"
 msgstr "неправилен указател: %s"
 
-#: builtin/checkout.c:1338 builtin/checkout.c:1707
+#: builtin/checkout.c:1336 builtin/checkout.c:1705
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "указателят не сочи към обект-дърво: %s"
 
-#: builtin/checkout.c:1385
+#: builtin/checkout.c:1383
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "очаква се клон, а не етикет — „%s“"
 
-#: builtin/checkout.c:1387
+#: builtin/checkout.c:1385
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "очаква се локален, а не отдалечен клон — „%s“"
 
-#: builtin/checkout.c:1388 builtin/checkout.c:1396
+#: builtin/checkout.c:1386 builtin/checkout.c:1394
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "очаква се клон, а не „%s“"
 
-#: builtin/checkout.c:1391
+#: builtin/checkout.c:1389
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "очаква се клон, а не подаване — „%s“"
 
-#: builtin/checkout.c:1407
+#: builtin/checkout.c:1405
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -12843,7 +13155,7 @@ msgstr ""
 "по време на сливане не може да преминете към друг клон.\n"
 "Пробвайте с „git merge --quit“ или „git worktree add“."
 
-#: builtin/checkout.c:1411
+#: builtin/checkout.c:1409
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
@@ -12852,7 +13164,7 @@ msgstr ""
 "клон.\n"
 "Пробвайте с „git am --quit“ или „git worktree add“."
 
-#: builtin/checkout.c:1415
+#: builtin/checkout.c:1413
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
@@ -12860,7 +13172,7 @@ msgstr ""
 "по време на пребазиране не може да преминете към друг клон.\n"
 "Пробвайте с „git rebase --quit“ или „git worktree add“."
 
-#: builtin/checkout.c:1419
+#: builtin/checkout.c:1417
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
@@ -12868,7 +13180,7 @@ msgstr ""
 "по време на отбиране на подавания не може да преминете към друг клон.\n"
 "Пробвайте с „git cherry-pick --quit“ или „git worktree add“."
 
-#: builtin/checkout.c:1423
+#: builtin/checkout.c:1421
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -12876,139 +13188,139 @@ msgstr ""
 "по време на отмяна на подавания не може да преминете към друг клон.\n"
 "Пробвайте с „git revert --quit“ или „git worktree add“."
 
-#: builtin/checkout.c:1427
+#: builtin/checkout.c:1425
 msgid "you are switching branch while bisecting"
 msgstr "преминаване към друг клон по време на двоично търсене"
 
-#: builtin/checkout.c:1434
+#: builtin/checkout.c:1432
 msgid "paths cannot be used with switching branches"
 msgstr "задаването на път е несъвместимо с преминаването от един клон към друг"
 
-#: builtin/checkout.c:1437 builtin/checkout.c:1441 builtin/checkout.c:1445
+#: builtin/checkout.c:1435 builtin/checkout.c:1439 builtin/checkout.c:1443
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "опцията „%s“ е несъвместима с преминаването от един клон към друг"
 
-#: builtin/checkout.c:1449 builtin/checkout.c:1452 builtin/checkout.c:1455
-#: builtin/checkout.c:1460 builtin/checkout.c:1465
+#: builtin/checkout.c:1447 builtin/checkout.c:1450 builtin/checkout.c:1453
+#: builtin/checkout.c:1458 builtin/checkout.c:1463
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "опцията „%s“ е несъвместима с „%s“"
 
-#: builtin/checkout.c:1462
+#: builtin/checkout.c:1460
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "опцията „%s“ е несъвместима със задаването на НАЧАЛО"
 
-#: builtin/checkout.c:1470
+#: builtin/checkout.c:1468
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr ""
 "За да преминете към клон, подайте указател, който сочи към подаване.  „%s“ "
 "не е такъв"
 
-#: builtin/checkout.c:1477
+#: builtin/checkout.c:1475
 msgid "missing branch or commit argument"
 msgstr "липсва аргумент — клон или подаване"
 
-#: builtin/checkout.c:1520
+#: builtin/checkout.c:1518
 msgid "perform a 3-way merge with the new branch"
 msgstr "извършване на тройно сливане с новия клон"
 
-#: builtin/checkout.c:1521 builtin/log.c:1810 parse-options.h:323
+#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:322
 msgid "style"
 msgstr "СТИЛ"
 
-#: builtin/checkout.c:1522
+#: builtin/checkout.c:1520
 msgid "conflict style (merge or diff3)"
 msgstr "действие при конфликт (сливане или тройна разлика)"
 
-#: builtin/checkout.c:1534 builtin/worktree.c:488
+#: builtin/checkout.c:1532 builtin/worktree.c:489
 msgid "detach HEAD at named commit"
 msgstr "отделяне на указателя „HEAD“ към указаното подаване"
 
-#: builtin/checkout.c:1535
+#: builtin/checkout.c:1533
 msgid "set upstream info for new branch"
 msgstr "задаване на кой клон бива следен при създаването на новия клон"
 
-#: builtin/checkout.c:1537
+#: builtin/checkout.c:1535
 msgid "force checkout (throw away local modifications)"
 msgstr "принудително изтегляне (вашите промени ще бъдат занулени)"
 
-#: builtin/checkout.c:1539
+#: builtin/checkout.c:1537
 msgid "new-branch"
 msgstr "НОВ_КЛОН"
 
-#: builtin/checkout.c:1539
+#: builtin/checkout.c:1537
 msgid "new unparented branch"
 msgstr "нов клон без родител"
 
-#: builtin/checkout.c:1541 builtin/merge.c:301
+#: builtin/checkout.c:1539 builtin/merge.c:302
 msgid "update ignored files (default)"
 msgstr "обновяване на игнорираните файлове (стандартно)"
 
-#: builtin/checkout.c:1544
+#: builtin/checkout.c:1542
 msgid "do not check if another worktree is holding the given ref"
 msgstr "без проверка дали друго работно дърво държи указателя"
 
-#: builtin/checkout.c:1557
+#: builtin/checkout.c:1555
 msgid "checkout our version for unmerged files"
 msgstr "изтегляне на вашата версия на неслетите файлове"
 
-#: builtin/checkout.c:1560
+#: builtin/checkout.c:1558
 msgid "checkout their version for unmerged files"
 msgstr "изтегляне на чуждата версия на неслетите файлове"
 
-#: builtin/checkout.c:1564
+#: builtin/checkout.c:1562
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "без ограничаване на изброените пътища само до частично изтеглените"
 
-#: builtin/checkout.c:1622
+#: builtin/checkout.c:1620
 #, c-format
 msgid "-%c, -%c and --orphan are mutually exclusive"
 msgstr "опциите „-%c“, „-%c“ и „--orphan“ са несъвместими една с друга"
 
-#: builtin/checkout.c:1626
+#: builtin/checkout.c:1624
 msgid "-p and --overlay are mutually exclusive"
 msgstr "опциите „-p“ и „--overlay“ са несъвместими"
 
-#: builtin/checkout.c:1663
+#: builtin/checkout.c:1661
 msgid "--track needs a branch name"
 msgstr "опцията „--track“ изисква име на клон"
 
-#: builtin/checkout.c:1668
+#: builtin/checkout.c:1666
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "липсва име на клон, използвайте опцията „-%c“"
 
-#: builtin/checkout.c:1700
+#: builtin/checkout.c:1698
 #, c-format
 msgid "could not resolve %s"
 msgstr "„%s“ не може да бъде открит"
 
-#: builtin/checkout.c:1716
+#: builtin/checkout.c:1714
 msgid "invalid path specification"
 msgstr "указан е неправилен път"
 
-#: builtin/checkout.c:1723
+#: builtin/checkout.c:1721
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr "„%s“ не е подаване, затова от него не може да се създаде клон „%s“"
 
-#: builtin/checkout.c:1727
+#: builtin/checkout.c:1725
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: опцията „--detach“ не приема аргумент-път „%s“"
 
-#: builtin/checkout.c:1736
+#: builtin/checkout.c:1734
 msgid "--pathspec-from-file is incompatible with --detach"
 msgstr "опциите „--pathspec-from-file“ и „--detach“ са несъвместими"
 
-#: builtin/checkout.c:1739 builtin/reset.c:325 builtin/stash.c:1630
+#: builtin/checkout.c:1737 builtin/reset.c:331 builtin/stash.c:1647
 msgid "--pathspec-from-file is incompatible with --patch"
 msgstr "опциите „--pathspec-from-file“ и „--patch“ са несъвместими"
 
-#: builtin/checkout.c:1752
+#: builtin/checkout.c:1750
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -13016,75 +13328,75 @@ msgstr ""
 "git checkout: опциите „--ours“/„--theirs“, „--force“ и „--merge“\n"
 "са несъвместими с изтегляне от индекса."
 
-#: builtin/checkout.c:1757
+#: builtin/checkout.c:1755
 msgid "you must specify path(s) to restore"
 msgstr "трябва да укажете поне един път за възстановяване"
 
-#: builtin/checkout.c:1783 builtin/checkout.c:1785 builtin/checkout.c:1834
-#: builtin/checkout.c:1836 builtin/clone.c:126 builtin/remote.c:170
-#: builtin/remote.c:172 builtin/submodule--helper.c:2736
-#: builtin/submodule--helper.c:2887 builtin/worktree.c:484
-#: builtin/worktree.c:486
+#: builtin/checkout.c:1781 builtin/checkout.c:1783 builtin/checkout.c:1832
+#: builtin/checkout.c:1834 builtin/clone.c:126 builtin/remote.c:170
+#: builtin/remote.c:172 builtin/submodule--helper.c:2958
+#: builtin/submodule--helper.c:3252 builtin/worktree.c:485
+#: builtin/worktree.c:487
 msgid "branch"
 msgstr "клон"
 
-#: builtin/checkout.c:1784
+#: builtin/checkout.c:1782
 msgid "create and checkout a new branch"
 msgstr "създаване и преминаване към нов клон"
 
-#: builtin/checkout.c:1786
+#: builtin/checkout.c:1784
 msgid "create/reset and checkout a branch"
 msgstr "създаване/зануляване на клон и преминаване към него"
 
-#: builtin/checkout.c:1787
+#: builtin/checkout.c:1785
 msgid "create reflog for new branch"
 msgstr "създаване на журнал на указателите за нов клон"
 
-#: builtin/checkout.c:1789
+#: builtin/checkout.c:1787
 msgid "second guess 'git checkout <no-such-branch>' (default)"
 msgstr ""
 "опит за отгатване на име на клон след неуспешен опит с „git checkout "
 "НЕСЪЩЕСТВУВАЩ_КЛОН“ (стандартно)"
 
-#: builtin/checkout.c:1790
+#: builtin/checkout.c:1788
 msgid "use overlay mode (default)"
 msgstr "използване на припокриващ режим (стандартно)"
 
-#: builtin/checkout.c:1835
+#: builtin/checkout.c:1833
 msgid "create and switch to a new branch"
 msgstr "създаване и преминаване към нов клон"
 
-#: builtin/checkout.c:1837
+#: builtin/checkout.c:1835
 msgid "create/reset and switch to a branch"
 msgstr "създаване/зануляване на клон и преминаване към него"
 
-#: builtin/checkout.c:1839
+#: builtin/checkout.c:1837
 msgid "second guess 'git switch <no-such-branch>'"
 msgstr ""
 "опит за отгатване на име на клон след неуспешен опит с „git switch "
 "НЕСЪЩЕСТВУВАЩ_КЛОН“"
 
-#: builtin/checkout.c:1841
+#: builtin/checkout.c:1839
 msgid "throw away local modifications"
 msgstr "зануляване на локалните промени"
 
-#: builtin/checkout.c:1875
+#: builtin/checkout.c:1873
 msgid "which tree-ish to checkout from"
 msgstr "към кой указател към дърво да се премине"
 
-#: builtin/checkout.c:1877
+#: builtin/checkout.c:1875
 msgid "restore the index"
 msgstr "възстановяване на индекса"
 
-#: builtin/checkout.c:1879
+#: builtin/checkout.c:1877
 msgid "restore the working tree (default)"
 msgstr "възстановяване на работното дърво (стандартно)"
 
-#: builtin/checkout.c:1881
+#: builtin/checkout.c:1879
 msgid "ignore unmerged entries"
 msgstr "пренебрегване на неслетите елементи"
 
-#: builtin/checkout.c:1882
+#: builtin/checkout.c:1880
 msgid "use overlay mode"
 msgstr "използване на припокриващ режим"
 
@@ -13223,8 +13535,8 @@ msgid "remove whole directories"
 msgstr "изтриване на цели директории"
 
 #: builtin/clean.c:906 builtin/describe.c:565 builtin/describe.c:567
-#: builtin/grep.c:923 builtin/log.c:184 builtin/log.c:186
-#: builtin/ls-files.c:650 builtin/name-rev.c:526 builtin/name-rev.c:528
+#: builtin/grep.c:937 builtin/log.c:184 builtin/log.c:186
+#: builtin/ls-files.c:648 builtin/name-rev.c:526 builtin/name-rev.c:528
 #: builtin/show-ref.c:179
 msgid "pattern"
 msgstr "ШАБЛОН"
@@ -13315,19 +13627,20 @@ msgstr "директория с шаблони"
 msgid "directory from which templates will be used"
 msgstr "директория, която съдържа шаблоните, които да се ползват"
 
-#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1899
-#: builtin/submodule--helper.c:2353 builtin/submodule--helper.c:2903
+#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1870
+#: builtin/submodule--helper.c:2513 builtin/submodule--helper.c:3259
 msgid "reference repository"
 msgstr "еталонно хранилище"
 
-#: builtin/clone.c:123 builtin/submodule--helper.c:1901
-#: builtin/submodule--helper.c:2355 builtin/submodule--helper.c:2905
+#: builtin/clone.c:123 builtin/submodule--helper.c:1872
+#: builtin/submodule--helper.c:2515
 msgid "use --reference only while cloning"
 msgstr "опцията „--reference“ може да се използва само при клониране"
 
 #: builtin/clone.c:124 builtin/column.c:27 builtin/init-db.c:550
-#: builtin/merge-file.c:46 builtin/pack-objects.c:3975 builtin/repack.c:495
-#: t/helper/test-simple-ipc.c:696 t/helper/test-simple-ipc.c:698
+#: builtin/merge-file.c:46 builtin/pack-objects.c:3944 builtin/repack.c:663
+#: builtin/submodule--helper.c:3261 t/helper/test-simple-ipc.c:595
+#: t/helper/test-simple-ipc.c:597
 msgid "name"
 msgstr "ИМЕ"
 
@@ -13343,7 +13656,7 @@ msgstr "изтегляне на този КЛОН, а не соченият от
 msgid "path to git-upload-pack on the remote"
 msgstr "път към командата „git-upload-pack“ на отдалеченото хранилище"
 
-#: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:862
+#: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
 #: builtin/pull.c:208
 msgid "depth"
 msgstr "ДЪЛБОЧИНА"
@@ -13352,7 +13665,7 @@ msgstr "ДЪЛБОЧИНА"
 msgid "create a shallow clone of that depth"
 msgstr "плитко клониране до тази ДЪЛБОЧИНА"
 
-#: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3964
+#: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
 #: builtin/pull.c:211
 msgid "time"
 msgstr "ВРЕМЕ"
@@ -13362,7 +13675,7 @@ msgid "create a shallow clone since a specific time"
 msgstr "плитко клониране до момент във времето"
 
 #: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1318
+#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1022
 msgid "revision"
 msgstr "ВЕРСИЯ"
 
@@ -13370,8 +13683,8 @@ msgstr "ВЕРСИЯ"
 msgid "deepen history of shallow clone, excluding rev"
 msgstr "задълбочаване на историята на плитко хранилище до изключващ указател"
 
-#: builtin/clone.c:137 builtin/submodule--helper.c:1911
-#: builtin/submodule--helper.c:2369
+#: builtin/clone.c:137 builtin/submodule--helper.c:1882
+#: builtin/submodule--helper.c:2529
 msgid "clone only one branch, HEAD or --branch"
 msgstr ""
 "клониране само на един клон — или сочения от отдалечения „HEAD“, или изрично "
@@ -13403,12 +13716,12 @@ msgid "set config inside the new repository"
 msgstr "задаване на настройките на новото хранилище"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:196
+#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "специфични за сървъра"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:197
+#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr "опция за пренос"
 
@@ -13432,51 +13745,43 @@ msgstr ""
 "инициализиране на файла за частично изтегляне („.git/info/sparse-checkout“) "
 "да съдържа само файловете в основната директория"
 
-#: builtin/clone.c:292
-msgid ""
-"No directory name could be guessed.\n"
-"Please specify a directory on the command line"
-msgstr ""
-"Името на директорията не може да бъде отгатнато.\n"
-"Задайте директорията изрично на командния ред"
-
-#: builtin/clone.c:345
+#: builtin/clone.c:231
 #, c-format
 msgid "info: Could not add alternate for '%s': %s\n"
 msgstr ""
 "ПРЕДУПРЕЖДЕНИЕ: не може да се добави алтернативен източник на „%s“: %s\n"
 
-#: builtin/clone.c:418
+#: builtin/clone.c:304
 #, c-format
 msgid "%s exists and is not a directory"
 msgstr "„%s“ съществува и не е директория"
 
-#: builtin/clone.c:436
+#: builtin/clone.c:322
 #, c-format
 msgid "failed to start iterator over '%s'"
 msgstr "неуспешно итериране по „%s“"
 
-#: builtin/clone.c:467
+#: builtin/clone.c:353
 #, c-format
 msgid "failed to create link '%s'"
 msgstr "връзката „%s“ не може да бъде създадена"
 
-#: builtin/clone.c:471
+#: builtin/clone.c:357
 #, c-format
 msgid "failed to copy file to '%s'"
 msgstr "файлът не може да бъде копиран като „%s“"
 
-#: builtin/clone.c:476
+#: builtin/clone.c:362
 #, c-format
 msgid "failed to iterate over '%s'"
 msgstr "неуспешно итериране по „%s“"
 
-#: builtin/clone.c:503
+#: builtin/clone.c:389
 #, c-format
 msgid "done.\n"
 msgstr "действието завърши.\n"
 
-#: builtin/clone.c:517
+#: builtin/clone.c:403
 msgid ""
 "Clone succeeded, but checkout failed.\n"
 "You can inspect what was checked out with 'git status'\n"
@@ -13489,108 +13794,108 @@ msgstr ""
 "\n"
 "    git restore --source=HEAD :/\n"
 
-#: builtin/clone.c:594
+#: builtin/clone.c:480
 #, c-format
 msgid "Could not find remote branch %s to clone."
 msgstr ""
 "Клонът „%s“ от отдалеченото хранилище, което клонирате,\n"
 "и който следва да бъде изтеглен, не съществува."
 
-#: builtin/clone.c:713
+#: builtin/clone.c:597
 #, c-format
 msgid "unable to update %s"
 msgstr "обектът „%s“ не може да бъде обновен"
 
-#: builtin/clone.c:761
+#: builtin/clone.c:645
 msgid "failed to initialize sparse-checkout"
 msgstr "частичното изтегляне не може да се инициализира"
 
-#: builtin/clone.c:784
+#: builtin/clone.c:668
 msgid "remote HEAD refers to nonexistent ref, unable to checkout.\n"
 msgstr ""
 "указателят „HEAD“ от отдалеченото хранилище сочи към нещо,\n"
 "което не съществува.  Не може да се изтегли определен клон.\n"
 
-#: builtin/clone.c:816
+#: builtin/clone.c:701
 msgid "unable to checkout working tree"
 msgstr "работното дърво не може да бъде подготвено"
 
-#: builtin/clone.c:894
+#: builtin/clone.c:779
 msgid "unable to write parameters to config file"
 msgstr "настройките не може да бъдат записани в конфигурационния файл"
 
-#: builtin/clone.c:957
+#: builtin/clone.c:842
 msgid "cannot repack to clean up"
 msgstr "не може да се извърши пакетиране за изчистване на файловете"
 
-#: builtin/clone.c:959
+#: builtin/clone.c:844
 msgid "cannot unlink temporary alternates file"
 msgstr "временният файл за алтернативни обекти не може да бъде изтрит"
 
-#: builtin/clone.c:1001 builtin/receive-pack.c:2490
+#: builtin/clone.c:886 builtin/receive-pack.c:2493
 msgid "Too many arguments."
 msgstr "Прекалено много аргументи."
 
-#: builtin/clone.c:1005
+#: builtin/clone.c:890
 msgid "You must specify a repository to clone."
 msgstr "Трябва да укажете кое хранилище искате да клонирате."
 
-#: builtin/clone.c:1018
+#: builtin/clone.c:903
 #, c-format
 msgid "--bare and --origin %s options are incompatible."
 msgstr "опциите „--bare“ и „--origin %s“ са несъвместими."
 
-#: builtin/clone.c:1021
+#: builtin/clone.c:906
 msgid "--bare and --separate-git-dir are incompatible."
 msgstr "опциите „--bare“ и „--separate-git-dir“ са несъвместими."
 
-#: builtin/clone.c:1035
+#: builtin/clone.c:920
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "не съществува хранилище „%s“"
 
-#: builtin/clone.c:1039 builtin/fetch.c:2014
+#: builtin/clone.c:924 builtin/fetch.c:2029
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "дълбочината трябва да е положително цяло число, а не „%s“"
 
-#: builtin/clone.c:1049
+#: builtin/clone.c:934
 #, c-format
 msgid "destination path '%s' already exists and is not an empty directory."
 msgstr "целевият път „%s“ съществува и не е празна директория."
 
-#: builtin/clone.c:1055
+#: builtin/clone.c:940
 #, c-format
 msgid "repository path '%s' already exists and is not an empty directory."
 msgstr "пътят в хранилището „%s“ съществува и не е празна директория."
 
-#: builtin/clone.c:1069
+#: builtin/clone.c:954
 #, c-format
 msgid "working tree '%s' already exists."
 msgstr "в „%s“ вече съществува работно дърво."
 
-#: builtin/clone.c:1084 builtin/clone.c:1105 builtin/difftool.c:272
-#: builtin/log.c:1997 builtin/worktree.c:280 builtin/worktree.c:312
+#: builtin/clone.c:969 builtin/clone.c:990 builtin/difftool.c:262
+#: builtin/log.c:1997 builtin/worktree.c:281 builtin/worktree.c:313
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "родителските директории на „%s“ не може да бъдат създадени"
 
-#: builtin/clone.c:1089
+#: builtin/clone.c:974
 #, c-format
 msgid "could not create work tree dir '%s'"
 msgstr "работното дърво в „%s“ не може да бъде създадено."
 
-#: builtin/clone.c:1109
+#: builtin/clone.c:994
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
 msgstr "Клониране и създаване на голо хранилище в „%s“…\n"
 
-#: builtin/clone.c:1111
+#: builtin/clone.c:996
 #, c-format
 msgid "Cloning into '%s'...\n"
 msgstr "Клониране и създаване на хранилище в „%s“…\n"
 
-#: builtin/clone.c:1135
+#: builtin/clone.c:1025
 msgid ""
 "clone --recursive is not compatible with both --reference and --reference-if-"
 "able"
@@ -13598,53 +13903,53 @@ msgstr ""
 "опцията „--recursive“ е несъвместима с опциите „--reference“ и „--reference-"
 "if-able“"
 
-#: builtin/clone.c:1188 builtin/remote.c:200 builtin/remote.c:705
+#: builtin/clone.c:1080 builtin/remote.c:200 builtin/remote.c:710
 #, c-format
 msgid "'%s' is not a valid remote name"
 msgstr "„%s“ е неправилно име за отдалечено хранилище"
 
-#: builtin/clone.c:1229
+#: builtin/clone.c:1121
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr ""
 "При локално клониране опцията „--depth“ се прескача.  Ползвайте схемата "
 "„file://“."
 
-#: builtin/clone.c:1231
+#: builtin/clone.c:1123
 msgid "--shallow-since is ignored in local clones; use file:// instead."
 msgstr ""
 "При локално клониране опцията „--shallow-since“ се прескача.  Ползвайте "
 "схемата „file://“."
 
-#: builtin/clone.c:1233
+#: builtin/clone.c:1125
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
 msgstr ""
 "При локално клониране опцията „--shallow-exclude“ се прескача.  Ползвайте "
 "схемата „file://“."
 
-#: builtin/clone.c:1235
+#: builtin/clone.c:1127
 msgid "--filter is ignored in local clones; use file:// instead."
 msgstr ""
 "При локално клониране опцията „--filter“ се прескача.  Ползвайте схемата "
 "„file://“."
 
-#: builtin/clone.c:1240
+#: builtin/clone.c:1132
 msgid "source repository is shallow, ignoring --local"
 msgstr "клонираното хранилище е плитко, затова опцията „--local“ се прескача"
 
-#: builtin/clone.c:1245
+#: builtin/clone.c:1137
 msgid "--local is ignored"
 msgstr "опцията „--local“ се прескача"
 
-#: builtin/clone.c:1324 builtin/clone.c:1383
+#: builtin/clone.c:1216 builtin/clone.c:1276
 msgid "remote transport reported error"
 msgstr "отдалеченият транспорт върна грешка"
 
-#: builtin/clone.c:1336 builtin/clone.c:1344
+#: builtin/clone.c:1228 builtin/clone.c:1239
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "Отдалеченият клон „%s“ липсва в клонираното хранилище „%s“"
 
-#: builtin/clone.c:1347
+#: builtin/clone.c:1242
 msgid "You appear to have cloned an empty repository."
 msgstr "Изглежда клонирахте празно хранилище."
 
@@ -13680,14 +13985,14 @@ msgstr "поле в знаци между колоните"
 msgid "--command must be the first argument"
 msgstr "опцията „--command“ трябва да е първият аргумент"
 
-#: builtin/commit-graph.c:13 builtin/commit-graph.c:22
+#: builtin/commit-graph.c:13
 msgid ""
 "git commit-graph verify [--object-dir <objdir>] [--shallow] [--[no-]progress]"
 msgstr ""
 "git commit-graph verify [--object-dir ДИР_ОБЕКТИ] [--shallow] [--"
 "[no-]progress]"
 
-#: builtin/commit-graph.c:14 builtin/commit-graph.c:27
+#: builtin/commit-graph.c:16
 msgid ""
 "git commit-graph write [--object-dir <objdir>] [--append] [--"
 "split[=<strategy>]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
@@ -13697,98 +14002,96 @@ msgstr ""
 "split[=СТРАТЕГИЯ]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
 "paths] [--[no-]max-new-filters <n>] [--[no-]progress] ОПЦИИ_ЗА_РАЗДЕЛЯНЕ"
 
-#: builtin/commit-graph.c:64
-#, c-format
-msgid "could not find object directory matching %s"
-msgstr "директорията с обекти, която отговаря на „%s“, не може да бъде открита"
-
-#: builtin/commit-graph.c:80 builtin/commit-graph.c:210
-#: builtin/commit-graph.c:316 builtin/fetch.c:191 builtin/log.c:1779
+#: builtin/commit-graph.c:51 builtin/fetch.c:191 builtin/log.c:1779
 msgid "dir"
 msgstr "директория"
 
-#: builtin/commit-graph.c:81 builtin/commit-graph.c:211
-#: builtin/commit-graph.c:317
+#: builtin/commit-graph.c:52
 msgid "the object directory to store the graph"
 msgstr "ДИРекторията_с_ОБЕКТИ за запазване на гра̀фа"
 
-#: builtin/commit-graph.c:83
+#: builtin/commit-graph.c:73
 msgid "if the commit-graph is split, only verify the tip file"
 msgstr ""
 "ако гра̀фа с подаванията е раздробен, да се проверява само файлът на върха"
 
-#: builtin/commit-graph.c:106
+#: builtin/commit-graph.c:100
 #, c-format
 msgid "Could not open commit-graph '%s'"
 msgstr "Графът с подаванията не може да се отвори: „%s“"
 
-#: builtin/commit-graph.c:142
+#: builtin/commit-graph.c:137
 #, c-format
 msgid "unrecognized --split argument, %s"
 msgstr "непознат аргумент към „--split“: %s"
 
-#: builtin/commit-graph.c:155
+#: builtin/commit-graph.c:150
 #, c-format
 msgid "unexpected non-hex object ID: %s"
 msgstr "неочакван, нешестнайсетичен идентификатор на обект:  %s"
 
-#: builtin/commit-graph.c:160
+#: builtin/commit-graph.c:155
 #, c-format
 msgid "invalid object: %s"
 msgstr "неправилен обект: „%s“"
 
-#: builtin/commit-graph.c:213
+#: builtin/commit-graph.c:205
 msgid "start walk at all refs"
 msgstr "обхождането да започне от всички указатели"
 
-#: builtin/commit-graph.c:215
+#: builtin/commit-graph.c:207
 msgid "scan pack-indexes listed by stdin for commits"
 msgstr ""
 "проверка на подаванията за индексите на пакетите изброени на командния ред"
 
-#: builtin/commit-graph.c:217
+#: builtin/commit-graph.c:209
 msgid "start walk at commits listed by stdin"
 msgstr "започване на обхождането при подаванията подадени на стандартния вход"
 
-#: builtin/commit-graph.c:219
+#: builtin/commit-graph.c:211
 msgid "include all commits already in the commit-graph file"
 msgstr ""
 "включване на всички подавания, които вече са във файла с гра̀фа на подаванията"
 
-#: builtin/commit-graph.c:221
+#: builtin/commit-graph.c:213
 msgid "enable computation for changed paths"
 msgstr "включване на изчисленията за променените пътища"
 
-#: builtin/commit-graph.c:224
+#: builtin/commit-graph.c:215
 msgid "allow writing an incremental commit-graph file"
 msgstr "позволяване на запис на нарастващ файл с гра̀фа на подаванията"
 
-#: builtin/commit-graph.c:228
+#: builtin/commit-graph.c:219
 msgid "maximum number of commits in a non-base split commit-graph"
 msgstr "максимален брой подавания в небазово ниво на раздробен граф"
 
-#: builtin/commit-graph.c:230
+#: builtin/commit-graph.c:221
 msgid "maximum ratio between two levels of a split commit-graph"
 msgstr ""
 "максимално отношение на броя подавания в две последователни нива в раздробен "
 "граф"
 
-#: builtin/commit-graph.c:232
+#: builtin/commit-graph.c:223
 msgid "only expire files older than a given date-time"
 msgstr "обявяване за остарели само на файловете по-стари от това ВРЕМЕ"
 
-#: builtin/commit-graph.c:234
+#: builtin/commit-graph.c:225
 msgid "maximum number of changed-path Bloom filters to compute"
 msgstr "максимален брой промени в пътищата следени от филтрите на Блум"
 
-#: builtin/commit-graph.c:255
+#: builtin/commit-graph.c:251
 msgid "use at most one of --reachable, --stdin-commits, or --stdin-packs"
 msgstr ""
 "опциите „--reachable“, „--stdin-commits“ и „--stdin-packs“ са несъвместими"
 
-#: builtin/commit-graph.c:287
+#: builtin/commit-graph.c:282
 msgid "Collecting commits from input"
 msgstr "Получаване на подаванията от входа"
+
+#: builtin/commit-graph.c:328 builtin/multi-pack-index.c:255
+#, c-format
+msgid "unrecognized subcommand: %s"
+msgstr "непозната подкоманда: %s"
 
 #: builtin/commit-tree.c:18
 msgid ""
@@ -13803,70 +14106,65 @@ msgstr ""
 msgid "duplicate parent %s ignored"
 msgstr "прескачане на повтарящ се родител: „%s“"
 
-#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:562
+#: builtin/commit-tree.c:56 builtin/commit-tree.c:134 builtin/log.c:562
 #, c-format
 msgid "not a valid object name %s"
 msgstr "неправилно име на обект: „%s“"
 
-#: builtin/commit-tree.c:93
-#, c-format
-msgid "git commit-tree: failed to open '%s'"
-msgstr "git commit-tree: „%s“ не може да се отвори"
-
-#: builtin/commit-tree.c:96
+#: builtin/commit-tree.c:94
 #, c-format
 msgid "git commit-tree: failed to read '%s'"
 msgstr "git commit-tree: „%s“ не може да се прочете"
 
-#: builtin/commit-tree.c:98
+#: builtin/commit-tree.c:96
 #, c-format
 msgid "git commit-tree: failed to close '%s'"
 msgstr "git commit-tree: „%s“ не може да се затвори"
 
-#: builtin/commit-tree.c:111
+#: builtin/commit-tree.c:109
 msgid "parent"
 msgstr "родител"
 
-#: builtin/commit-tree.c:112
+#: builtin/commit-tree.c:110
 msgid "id of a parent commit object"
 msgstr "ИДЕНТИФИКАТОР на обекта за подаването-родител"
 
-#: builtin/commit-tree.c:114 builtin/commit.c:1624 builtin/merge.c:282
-#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1601
-#: builtin/tag.c:456
+#: builtin/commit-tree.c:112 builtin/commit.c:1626 builtin/merge.c:283
+#: builtin/notes.c:407 builtin/notes.c:573 builtin/stash.c:1618
+#: builtin/tag.c:454
 msgid "message"
 msgstr "СЪОБЩЕНИЕ"
 
-#: builtin/commit-tree.c:115 builtin/commit.c:1624
+#: builtin/commit-tree.c:113 builtin/commit.c:1626
 msgid "commit message"
 msgstr "СЪОБЩЕНИЕ при подаване"
 
-#: builtin/commit-tree.c:118
+#: builtin/commit-tree.c:116
 msgid "read commit log message from file"
 msgstr "изчитане на съобщението за подаване от ФАЙЛ"
 
-#: builtin/commit-tree.c:121 builtin/commit.c:1641 builtin/merge.c:299
+#: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
 #: builtin/pull.c:176 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "подписване на подаването с GPG"
 
-#: builtin/commit-tree.c:133
+#: builtin/commit-tree.c:131
 msgid "must give exactly one tree"
 msgstr "трябва да е точно едно дърво"
 
-#: builtin/commit-tree.c:140
+#: builtin/commit-tree.c:138
 msgid "git commit-tree: failed to read"
 msgstr "git commit-tree: не може да се прочете"
 
-#: builtin/commit.c:41
+#: builtin/commit.c:42
 msgid "git commit [<options>] [--] <pathspec>..."
 msgstr "git commit [ОПЦИЯ…] [--] ПЪТ…"
 
-#: builtin/commit.c:46
+#: builtin/commit.c:47
 msgid "git status [<options>] [--] <pathspec>..."
 msgstr "git status [ОПЦИЯ…] [--] ПЪТ…"
 
-#: builtin/commit.c:51
+#: builtin/commit.c:52
 msgid ""
 "You asked to amend the most recent commit, but doing so would make\n"
 "it empty. You can repeat your command with --allow-empty, or you can\n"
@@ -13878,7 +14176,7 @@ msgstr ""
 "с опцията „--allow-empty“, или да го изтриете от историята с командата:\n"
 "„git reset HEAD^“.\n"
 
-#: builtin/commit.c:56
+#: builtin/commit.c:57
 msgid ""
 "The previous cherry-pick is now empty, possibly due to conflict resolution.\n"
 "If you wish to commit it anyway, use:\n"
@@ -13893,21 +14191,21 @@ msgstr ""
 "    git commit --allow-empty\n"
 "\n"
 
-#: builtin/commit.c:63
+#: builtin/commit.c:64
 msgid "Otherwise, please use 'git rebase --skip'\n"
 msgstr ""
 "В противен случай използвайте командата:\n"
 "\n"
 "    git rebase --skip\n"
 
-#: builtin/commit.c:66
+#: builtin/commit.c:67
 msgid "Otherwise, please use 'git cherry-pick --skip'\n"
 msgstr ""
 "В противен случай използвайте командата:\n"
 "\n"
 "    git cherry-pick --skip\n"
 
-#: builtin/commit.c:69
+#: builtin/commit.c:70
 msgid ""
 "and then use:\n"
 "\n"
@@ -13929,73 +14227,73 @@ msgstr ""
 "    git cherry-pick --skip\n"
 "\n"
 
-#: builtin/commit.c:324
+#: builtin/commit.c:325
 msgid "failed to unpack HEAD tree object"
 msgstr "върховото дърво (HEAD tree object) не може да бъде извадено от пакет"
 
-#: builtin/commit.c:360
+#: builtin/commit.c:361
 msgid "--pathspec-from-file with -a does not make sense"
 msgstr "опциите „-a“ и „--pathspec-from-file“ са несъвместими"
 
-#: builtin/commit.c:374
+#: builtin/commit.c:375
 msgid "No paths with --include/--only does not make sense."
 msgstr "опциите „--include“ и „--only“ изискват аргументи."
 
-#: builtin/commit.c:386
+#: builtin/commit.c:387
 msgid "unable to create temporary index"
 msgstr "временният индекс не може да бъде създаден"
 
-#: builtin/commit.c:395
+#: builtin/commit.c:396
 msgid "interactive add failed"
 msgstr "неуспешно интерактивно добавяне"
 
-#: builtin/commit.c:410
+#: builtin/commit.c:411
 msgid "unable to update temporary index"
 msgstr "временният индекс не може да бъде обновен"
 
-#: builtin/commit.c:412
+#: builtin/commit.c:413
 msgid "Failed to update main cache tree"
 msgstr "Дървото на основния кеш не може да бъде обновено"
 
-#: builtin/commit.c:437 builtin/commit.c:460 builtin/commit.c:508
+#: builtin/commit.c:438 builtin/commit.c:461 builtin/commit.c:509
 msgid "unable to write new_index file"
 msgstr "новият индекс (new_index) не може да бъде записан"
 
-#: builtin/commit.c:489
+#: builtin/commit.c:490
 msgid "cannot do a partial commit during a merge."
 msgstr "по време на сливане не може да се извърши частично подаване."
 
-#: builtin/commit.c:491
+#: builtin/commit.c:492
 msgid "cannot do a partial commit during a cherry-pick."
 msgstr "по време на отбиране не може да се извърши частично подаване."
 
-#: builtin/commit.c:493
+#: builtin/commit.c:494
 msgid "cannot do a partial commit during a rebase."
 msgstr "по време на пребазиране не може да се извърши частично подаване."
 
-#: builtin/commit.c:501
+#: builtin/commit.c:502
 msgid "cannot read the index"
 msgstr "индексът не може да бъде прочетен"
 
-#: builtin/commit.c:520
+#: builtin/commit.c:521
 msgid "unable to write temporary index file"
 msgstr "временният индекс не може да бъде записан"
 
-#: builtin/commit.c:618
+#: builtin/commit.c:619
 #, c-format
 msgid "commit '%s' lacks author header"
 msgstr "заглавната част за автор в подаването „%s“ липсва"
 
-#: builtin/commit.c:620
+#: builtin/commit.c:621
 #, c-format
 msgid "commit '%s' has malformed author line"
 msgstr "заглавната част за автор в подаването „%s“ е неправилна"
 
-#: builtin/commit.c:639
+#: builtin/commit.c:640
 msgid "malformed --author parameter"
 msgstr "неправилен параметър към опцията „--author“"
 
-#: builtin/commit.c:692
+#: builtin/commit.c:693
 msgid ""
 "unable to select a comment character that is not used\n"
 "in the current commit message"
@@ -14003,43 +14301,43 @@ msgstr ""
 "не може да се избере знак за коментар — в текущото съобщение за подаване са "
 "използвани всички подобни знаци"
 
-#: builtin/commit.c:746 builtin/commit.c:780 builtin/commit.c:1165
+#: builtin/commit.c:747 builtin/commit.c:781 builtin/commit.c:1166
 #, c-format
 msgid "could not lookup commit %s"
 msgstr "следното подаване не може да бъде открито: %s"
 
-#: builtin/commit.c:758 builtin/shortlog.c:413
+#: builtin/commit.c:759 builtin/shortlog.c:416
 #, c-format
 msgid "(reading log message from standard input)\n"
 msgstr "(изчитане на съобщението за подаване от стандартния вход)\n"
 
-#: builtin/commit.c:760
+#: builtin/commit.c:761
 msgid "could not read log from standard input"
 msgstr "съобщението за подаване не бе прочетено стандартния вход"
 
-#: builtin/commit.c:764
+#: builtin/commit.c:765
 #, c-format
 msgid "could not read log file '%s'"
 msgstr "файлът със съобщението за подаване „%s“ не може да бъде прочетен"
 
-#: builtin/commit.c:801
+#: builtin/commit.c:802
 #, c-format
 msgid "cannot combine -m with --fixup:%s"
 msgstr "опциите „-m“ и „--fixup“ са несъвместими:%s"
 
-#: builtin/commit.c:813 builtin/commit.c:829
+#: builtin/commit.c:814 builtin/commit.c:830
 msgid "could not read SQUASH_MSG"
 msgstr "съобщението за вкарване SQUASH_MSG не може да бъде прочетено"
 
-#: builtin/commit.c:820
+#: builtin/commit.c:821
 msgid "could not read MERGE_MSG"
 msgstr "съобщението за сливане MERGE_MSG не може да бъде прочетено"
 
-#: builtin/commit.c:880
+#: builtin/commit.c:881
 msgid "could not write commit template"
 msgstr "шаблонът за подаване не може да бъде запазен"
 
-#: builtin/commit.c:893
+#: builtin/commit.c:894
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -14048,7 +14346,7 @@ msgstr ""
 "Въведете съобщението за подаване на промените.  Редовете, които започват\n"
 "с „%c“, ще бъдат пропуснати.\n"
 
-#: builtin/commit.c:895
+#: builtin/commit.c:896
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -14057,7 +14355,7 @@ msgstr ""
 "Въведете съобщението за подаване на промените.  Редовете, които започват\n"
 "с „%c“, ще бъдат пропуснати, а празно съобщение преустановява подаването.\n"
 
-#: builtin/commit.c:899
+#: builtin/commit.c:900
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -14066,7 +14364,7 @@ msgstr ""
 "Въведете съобщението за подаване на промените.  Редовете, които започват\n"
 "с „%c“, също ще бъдат включени — може да ги изтриете вие.\n"
 
-#: builtin/commit.c:903
+#: builtin/commit.c:904
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -14077,7 +14375,7 @@ msgstr ""
 "с „%c“, също ще бъдат включени — може да ги изтриете вие.  Празно \n"
 "съобщение преустановява подаването.\n"
 
-#: builtin/commit.c:915
+#: builtin/commit.c:916
 msgid ""
 "\n"
 "It looks like you may be committing a merge.\n"
@@ -14092,7 +14390,7 @@ msgstr ""
 "    git update-ref -d MERGE_HEAD\n"
 "и опитайте отново.\n"
 
-#: builtin/commit.c:920
+#: builtin/commit.c:921
 msgid ""
 "\n"
 "It looks like you may be committing a cherry-pick.\n"
@@ -14107,78 +14405,78 @@ msgstr ""
 "    git update-ref -d CHERRY_PICK_HEAD\n"
 "и опитайте отново.\n"
 
-#: builtin/commit.c:947
+#: builtin/commit.c:948
 #, c-format
 msgid "%sAuthor:    %.*s <%.*s>"
 msgstr "%sАвтор:   %.*s <%.*s>"
 
-#: builtin/commit.c:955
+#: builtin/commit.c:956
 #, c-format
 msgid "%sDate:      %s"
 msgstr "%sДата:    %s"
 
-#: builtin/commit.c:962
+#: builtin/commit.c:963
 #, c-format
 msgid "%sCommitter: %.*s <%.*s>"
 msgstr "%sПодаващ: %.*s <%.*s>"
 
-#: builtin/commit.c:980
+#: builtin/commit.c:981
 msgid "Cannot read index"
 msgstr "Индексът не може да бъде прочетен"
 
-#: builtin/commit.c:1025
+#: builtin/commit.c:1026
 msgid "unable to pass trailers to --trailers"
 msgstr "епилогът не може да се подаде на „--trailers“"
 
-#: builtin/commit.c:1065
+#: builtin/commit.c:1066
 msgid "Error building trees"
 msgstr "Грешка при изграждане на дърветата"
 
-#: builtin/commit.c:1079 builtin/tag.c:319
+#: builtin/commit.c:1080 builtin/tag.c:317
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr "Подайте съобщението с някоя от опциите „-m“ или „-F“.\n"
 
-#: builtin/commit.c:1123
+#: builtin/commit.c:1124
 #, c-format
 msgid "--author '%s' is not 'Name <email>' and matches no existing author"
 msgstr ""
 "опцията „--author '%s'“ не отговаря на форма̀та „Име <е-поща>“ и не съвпада с "
 "никой автор"
 
-#: builtin/commit.c:1137
+#: builtin/commit.c:1138
 #, c-format
 msgid "Invalid ignored mode '%s'"
 msgstr "Неправилен режим за игнорираните файлове: „%s“"
 
-#: builtin/commit.c:1155 builtin/commit.c:1448
+#: builtin/commit.c:1156 builtin/commit.c:1450
 #, c-format
 msgid "Invalid untracked files mode '%s'"
 msgstr "Неправилен режим за неследените файлове: „%s“"
 
-#: builtin/commit.c:1195
+#: builtin/commit.c:1196
 msgid "--long and -z are incompatible"
 msgstr "опциите „--long“ и „-z“ са несъвместими."
 
-#: builtin/commit.c:1226
+#: builtin/commit.c:1227
 msgid "You are in the middle of a merge -- cannot reword."
 msgstr ""
 "В момента се извършва сливане, не може да промените съобщение при подаване."
 
-#: builtin/commit.c:1228
+#: builtin/commit.c:1229
 msgid "You are in the middle of a cherry-pick -- cannot reword."
 msgstr ""
 "В момента се извършва отбиране на подаване, не може да промените съобщение "
 "при подаване."
 
-#: builtin/commit.c:1231
+#: builtin/commit.c:1232
 #, c-format
 msgid "cannot combine reword option of --fixup with path '%s'"
 msgstr ""
 "опцията за промяна на съобщението на „--fixup“ и указването на път „%s“ са "
 "несъвместими"
 
-#: builtin/commit.c:1233
+#: builtin/commit.c:1234
 msgid ""
 "reword option of --fixup is mutually exclusive with --patch/--interactive/--"
 "all/--include/--only"
@@ -14186,107 +14484,107 @@ msgstr ""
 "опцията за промяна на съобщението на „--fixup“ и „--patch“/„--interactive“/"
 "„--all“/„--include“/„--only“ са несъвместими"
 
-#: builtin/commit.c:1252
+#: builtin/commit.c:1253
 msgid "Using both --reset-author and --author does not make sense"
 msgstr "опциите „--reset-author“ и „--author“ са несъвместими."
 
-#: builtin/commit.c:1261
+#: builtin/commit.c:1260
 msgid "You have nothing to amend."
 msgstr "Няма какво да бъде поправено."
 
-#: builtin/commit.c:1264
+#: builtin/commit.c:1263
 msgid "You are in the middle of a merge -- cannot amend."
 msgstr "В момента се извършва сливане, не може да поправяте."
 
-#: builtin/commit.c:1266
+#: builtin/commit.c:1265
 msgid "You are in the middle of a cherry-pick -- cannot amend."
 msgstr "В момента се извършва отбиране на подаване, не може да поправяте."
 
-#: builtin/commit.c:1268
+#: builtin/commit.c:1267
 msgid "You are in the middle of a rebase -- cannot amend."
 msgstr "В момента се извършва пребазиране, не може да поправяте."
 
-#: builtin/commit.c:1271
+#: builtin/commit.c:1270
 msgid "Options --squash and --fixup cannot be used together"
 msgstr "опциите „--squash“ и „--fixup“ са несъвместими."
 
-#: builtin/commit.c:1281
+#: builtin/commit.c:1280
 msgid "Only one of -c/-C/-F/--fixup can be used."
 msgstr "опциите „-c“, „-C“, „-F“ и „--fixup““ са несъвместими."
 
-#: builtin/commit.c:1283
+#: builtin/commit.c:1282
 msgid "Option -m cannot be combined with -c/-C/-F."
 msgstr "опцията „-m“ е несъвместима с „-c“, „-C“ и „-F“."
 
-#: builtin/commit.c:1292
+#: builtin/commit.c:1291
 msgid "--reset-author can be used only with -C, -c or --amend."
 msgstr ""
 "опцията „--reset-author“ може да се използва само заедно с „-C“, „-c“ или\n"
 "„--amend“."
 
-#: builtin/commit.c:1310
+#: builtin/commit.c:1309
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
 msgstr ""
 "опциите „--include“, „--only“, „--all“, „--interactive“ и „--patch“ са\n"
 "несъвместими."
 
-#: builtin/commit.c:1338
+#: builtin/commit.c:1337
 #, c-format
 msgid "unknown option: --fixup=%s:%s"
 msgstr "непозната опция: --fixup=%s:%s"
 
-#: builtin/commit.c:1352
+#: builtin/commit.c:1354
 #, c-format
 msgid "paths '%s ...' with -a does not make sense"
 msgstr "опцията „-a“ е несъвместима със задаването на пътища: „%s…“"
 
-#: builtin/commit.c:1483 builtin/commit.c:1652
+#: builtin/commit.c:1485 builtin/commit.c:1654
 msgid "show status concisely"
 msgstr "кратка информация за състоянието"
 
-#: builtin/commit.c:1485 builtin/commit.c:1654
+#: builtin/commit.c:1487 builtin/commit.c:1656
 msgid "show branch information"
 msgstr "информация за клоните"
 
-#: builtin/commit.c:1487
+#: builtin/commit.c:1489
 msgid "show stash information"
 msgstr "информация за скатаното"
 
-#: builtin/commit.c:1489 builtin/commit.c:1656
+#: builtin/commit.c:1491 builtin/commit.c:1658
 msgid "compute full ahead/behind values"
 msgstr "изчисляване на точните стойности напред/назад"
 
-#: builtin/commit.c:1491
+#: builtin/commit.c:1493
 msgid "version"
 msgstr "версия"
 
-#: builtin/commit.c:1491 builtin/commit.c:1658 builtin/push.c:551
-#: builtin/worktree.c:690
+#: builtin/commit.c:1493 builtin/commit.c:1660 builtin/push.c:551
+#: builtin/worktree.c:691
 msgid "machine-readable output"
 msgstr "формат на изхода за четене от програма"
 
-#: builtin/commit.c:1494 builtin/commit.c:1660
+#: builtin/commit.c:1496 builtin/commit.c:1662
 msgid "show status in long format (default)"
 msgstr "подробна информация за състоянието (стандартно)"
 
-#: builtin/commit.c:1497 builtin/commit.c:1663
+#: builtin/commit.c:1499 builtin/commit.c:1665
 msgid "terminate entries with NUL"
 msgstr "разделяне на елементите с нулевия знак „NUL“"
 
-#: builtin/commit.c:1499 builtin/commit.c:1503 builtin/commit.c:1666
-#: builtin/fast-export.c:1198 builtin/fast-export.c:1201
-#: builtin/fast-export.c:1204 builtin/rebase.c:1407 parse-options.h:337
+#: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
+#: builtin/fast-export.c:1199 builtin/fast-export.c:1202
+#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:336
 msgid "mode"
 msgstr "РЕЖИМ"
 
-#: builtin/commit.c:1500 builtin/commit.c:1666
+#: builtin/commit.c:1502 builtin/commit.c:1668
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
 "извеждане на неследените файлове.  Възможните РЕЖИМи са „all“ (подробна "
 "информация), „normal“ (кратка информация), „no“ (без неследените файлове).  "
 "Стандартният РЕЖИМ е: „all“."
 
-#: builtin/commit.c:1504
+#: builtin/commit.c:1506
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
@@ -14295,11 +14593,11 @@ msgstr ""
 "„traditional“ (традиционен), „matching“ (напасващи), „no“ (без игнорираните "
 "файлове).  Стандартният РЕЖИМ е: „traditional“."
 
-#: builtin/commit.c:1506 parse-options.h:193
+#: builtin/commit.c:1508 parse-options.h:192
 msgid "when"
 msgstr "КОГА"
 
-#: builtin/commit.c:1507
+#: builtin/commit.c:1509
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
@@ -14308,197 +14606,197 @@ msgstr ""
 "една от „all“ (всички), „dirty“ (тези с неподадени промени), "
 "„untracked“ (неследени)"
 
-#: builtin/commit.c:1509
+#: builtin/commit.c:1511
 msgid "list untracked files in columns"
 msgstr "извеждане на неследените файлове в колони"
 
-#: builtin/commit.c:1510
+#: builtin/commit.c:1512
 msgid "do not detect renames"
 msgstr "без засичане на преименуванията"
 
-#: builtin/commit.c:1512
+#: builtin/commit.c:1514
 msgid "detect renames, optionally set similarity index"
 msgstr "засичане на преименуванията, може да се зададе коефициент на прилика"
 
-#: builtin/commit.c:1535
+#: builtin/commit.c:1537
 msgid "Unsupported combination of ignored and untracked-files arguments"
 msgstr "Неподдържана комбинация от аргументи за игнорирани и неследени файлове"
 
-#: builtin/commit.c:1617
+#: builtin/commit.c:1619
 msgid "suppress summary after successful commit"
 msgstr "без информация след успешно подаване"
 
-#: builtin/commit.c:1618
+#: builtin/commit.c:1620
 msgid "show diff in commit message template"
 msgstr "добавяне на разликата към шаблона за съобщението при подаване"
 
-#: builtin/commit.c:1620
+#: builtin/commit.c:1622
 msgid "Commit message options"
 msgstr "Опции за съобщението при подаване"
 
-#: builtin/commit.c:1621 builtin/merge.c:286 builtin/tag.c:458
+#: builtin/commit.c:1623 builtin/merge.c:287 builtin/tag.c:456
 msgid "read message from file"
 msgstr "взимане на съобщението от ФАЙЛ"
 
-#: builtin/commit.c:1622
+#: builtin/commit.c:1624
 msgid "author"
 msgstr "АВТОР"
 
-#: builtin/commit.c:1622
+#: builtin/commit.c:1624
 msgid "override author for commit"
 msgstr "задаване на АВТОР за подаването"
 
-#: builtin/commit.c:1623 builtin/gc.c:550
+#: builtin/commit.c:1625 builtin/gc.c:550
 msgid "date"
 msgstr "ДАТА"
 
-#: builtin/commit.c:1623
+#: builtin/commit.c:1625
 msgid "override date for commit"
 msgstr "задаване на ДАТА за подаването"
 
-#: builtin/commit.c:1625 builtin/commit.c:1626 builtin/commit.c:1632
-#: parse-options.h:329 ref-filter.h:90
+#: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
+#: parse-options.h:328 ref-filter.h:92
 msgid "commit"
 msgstr "ПОДАВАНЕ"
 
-#: builtin/commit.c:1625
+#: builtin/commit.c:1627
 msgid "reuse and edit message from specified commit"
 msgstr "преизползване и редактиране на съобщението от указаното ПОДАВАНЕ"
 
-#: builtin/commit.c:1626
+#: builtin/commit.c:1628
 msgid "reuse message from specified commit"
 msgstr "преизползване на съобщението от указаното ПОДАВАНЕ"
 
 #. TRANSLATORS: Leave "[(amend|reword):]" as-is,
 #. and only translate <commit>.
 #.
-#: builtin/commit.c:1631
+#: builtin/commit.c:1633
 msgid "[(amend|reword):]commit"
 msgstr "[(amend|reword):]подаване"
 
-#: builtin/commit.c:1631
+#: builtin/commit.c:1633
 msgid ""
 "use autosquash formatted message to fixup or amend/reword specified commit"
 msgstr ""
 "използване на автоматичното съобщение за вкарване на указаното ПОДАВАНЕ в "
 "предходното без следа или за промяна на подаването или съобщението"
 
-#: builtin/commit.c:1632
+#: builtin/commit.c:1634
 msgid "use autosquash formatted message to squash specified commit"
 msgstr ""
 "използване на автоматичното съобщение за вкарване на указаното ПОДАВАНЕ в "
 "предното"
 
-#: builtin/commit.c:1633
+#: builtin/commit.c:1635
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr ""
 "смяна на автора да съвпада с подаващия (използва се с „-C“/„-c“/„--amend“)"
 
-#: builtin/commit.c:1634 builtin/interpret-trailers.c:111
+#: builtin/commit.c:1636 builtin/interpret-trailers.c:111
 msgid "trailer"
 msgstr "епилог"
 
-#: builtin/commit.c:1634
+#: builtin/commit.c:1636
 msgid "add custom trailer(s)"
-msgstr "добовяне на друг епилог"
+msgstr "добавяне на друг епилог"
 
-#: builtin/commit.c:1635 builtin/log.c:1754 builtin/merge.c:302
+#: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
 #: builtin/pull.c:145 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "добавяне на епилог за подпис „Signed-off-by“"
 
-#: builtin/commit.c:1636
+#: builtin/commit.c:1638
 msgid "use specified template file"
 msgstr "използване на указания шаблонен ФАЙЛ"
 
-#: builtin/commit.c:1637
+#: builtin/commit.c:1639
 msgid "force edit of commit"
 msgstr "редактиране на подаване"
 
-#: builtin/commit.c:1639
+#: builtin/commit.c:1641
 msgid "include status in commit message template"
 msgstr "вмъкване на състоянието в шаблона за съобщението при подаване"
 
-#: builtin/commit.c:1644
+#: builtin/commit.c:1646
 msgid "Commit contents options"
 msgstr "Опции за избор на файлове при подаване"
 
-#: builtin/commit.c:1645
+#: builtin/commit.c:1647
 msgid "commit all changed files"
 msgstr "подаване на всички променени файлове"
 
-#: builtin/commit.c:1646
+#: builtin/commit.c:1648
 msgid "add specified files to index for commit"
 msgstr "добавяне на указаните файлове към индекса за подаване"
 
-#: builtin/commit.c:1647
+#: builtin/commit.c:1649
 msgid "interactively add files"
 msgstr "интерактивно добавяне на файлове"
 
-#: builtin/commit.c:1648
+#: builtin/commit.c:1650
 msgid "interactively add changes"
 msgstr "интерактивно добавяне на промени"
 
-#: builtin/commit.c:1649
+#: builtin/commit.c:1651
 msgid "commit only specified files"
 msgstr "подаване само на указаните файлове"
 
-#: builtin/commit.c:1650
+#: builtin/commit.c:1652
 msgid "bypass pre-commit and commit-msg hooks"
 msgstr ""
 "без изпълнение на куките преди подаване и при промяна на съобщението за "
 "подаване (pre-commit и commit-msg)"
 
-#: builtin/commit.c:1651
+#: builtin/commit.c:1653
 msgid "show what would be committed"
 msgstr "отпечатване на това, което би било подадено"
 
-#: builtin/commit.c:1664
+#: builtin/commit.c:1666
 msgid "amend previous commit"
 msgstr "поправяне на предишното подаване"
 
-#: builtin/commit.c:1665
+#: builtin/commit.c:1667
 msgid "bypass post-rewrite hook"
 msgstr "без изпълнение на куката след презаписване (post-rewrite)"
 
-#: builtin/commit.c:1672
+#: builtin/commit.c:1674
 msgid "ok to record an empty change"
 msgstr "позволяване на празни подавания"
 
-#: builtin/commit.c:1674
+#: builtin/commit.c:1676
 msgid "ok to record a change with an empty message"
 msgstr "позволяване на подавания с празни съобщения"
 
-#: builtin/commit.c:1750
+#: builtin/commit.c:1752
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
 msgstr "Повреден файл за върха за сливането „MERGE_HEAD“ (%s)"
 
-#: builtin/commit.c:1757
+#: builtin/commit.c:1759
 msgid "could not read MERGE_MODE"
 msgstr "режимът на сливане „MERGE_MODE“ не може да бъде прочетен"
 
-#: builtin/commit.c:1778
+#: builtin/commit.c:1780
 #, c-format
 msgid "could not read commit message: %s"
 msgstr "съобщението за подаване не може да бъде прочетено: %s"
 
-#: builtin/commit.c:1785
+#: builtin/commit.c:1787
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
 msgstr "Неизвършване на подаване поради празно съобщение.\n"
 
-#: builtin/commit.c:1790
+#: builtin/commit.c:1792
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
 msgstr "Неизвършване на подаване поради нередактирано съобщение.\n"
 
-#: builtin/commit.c:1801
+#: builtin/commit.c:1803
 #, c-format
 msgid "Aborting commit due to empty commit message body.\n"
 msgstr "Неизвършване на подаване поради празно съобщение.\n"
 
-#: builtin/commit.c:1837
+#: builtin/commit.c:1839
 msgid ""
 "repository has been updated, but unable to write\n"
 "new_index file. Check that disk is not full and quota is\n"
@@ -14878,7 +15176,7 @@ msgstr ""
 "демонът за кеша с идентификациите е недостъпен (credential-cache--daemon) — "
 "липсва поддръжка на гнезда на unix"
 
-#: builtin/credential-cache.c:154
+#: builtin/credential-cache.c:180
 msgid "credential-cache unavailable; no unix socket support"
 msgstr ""
 "кешът с идентификациите е недостъпен — липсва поддръжка на гнезда на unix"
@@ -15084,7 +15382,7 @@ msgstr "„%s..%s“: липсва база за сливане"
 msgid "Not a git repository"
 msgstr "Не е хранилище на Git"
 
-#: builtin/diff.c:532 builtin/grep.c:684
+#: builtin/diff.c:532 builtin/grep.c:698
 #, c-format
 msgid "invalid object '%s' given."
 msgstr "зададен е неправилен обект „%s“."
@@ -15108,115 +15406,115 @@ msgstr "%s...%s: много бази за сливане, ще се ползва
 msgid "git difftool [<options>] [<commit> [<commit>]] [--] [<path>...]"
 msgstr "git difftool [ОПЦИЯ…] [ПОДАВАНЕ [ПОДАВАНЕ]] [[--] ПЪТ…]"
 
-#: builtin/difftool.c:261
-#, c-format
-msgid "failed: %d"
-msgstr "неуспешно действие с изходен код: %d"
-
-#: builtin/difftool.c:303
+#: builtin/difftool.c:293
 #, c-format
 msgid "could not read symlink %s"
 msgstr "символната връзка „%s“ не може да бъде прочетена"
 
-#: builtin/difftool.c:305
+#: builtin/difftool.c:295
 #, c-format
 msgid "could not read symlink file %s"
 msgstr "файлът, сочен от символната връзка „%s“, не може да бъде прочетен"
 
-#: builtin/difftool.c:313
+#: builtin/difftool.c:303
 #, c-format
 msgid "could not read object %s for symlink %s"
 msgstr "обектът „%s“ за символната връзка „%s“ не може да бъде прочетен"
 
-#: builtin/difftool.c:413
+#: builtin/difftool.c:427
 msgid ""
-"combined diff formats('-c' and '--cc') are not supported in\n"
-"directory diff mode('-d' and '--dir-diff')."
+"combined diff formats ('-c' and '--cc') are not supported in\n"
+"directory diff mode ('-d' and '--dir-diff')."
 msgstr ""
 "комбинираните формати на разликите („-c“ и „--cc“) не се поддържат\n"
 "в режима за разлики върху директории („-d“ и „--dir-diff“)."
 
-#: builtin/difftool.c:637
+#: builtin/difftool.c:632
 #, c-format
 msgid "both files modified: '%s' and '%s'."
 msgstr "и двата файла са променени: „%s“ и „%s“."
 
-#: builtin/difftool.c:639
+#: builtin/difftool.c:634
 msgid "working tree file has been left."
 msgstr "работното дърво е изоставено."
 
-#: builtin/difftool.c:650
+#: builtin/difftool.c:645
 #, c-format
 msgid "temporary files exist in '%s'."
 msgstr "в „%s“ има временни файлове."
 
-#: builtin/difftool.c:651
+#: builtin/difftool.c:646
 msgid "you may want to cleanup or recover these."
 msgstr "възможно е да ги изчистите или възстановите"
 
-#: builtin/difftool.c:699
+#: builtin/difftool.c:651
+#, c-format
+msgid "failed: %d"
+msgstr "неуспешно действие с изходен код: %d"
+
+#: builtin/difftool.c:696
 msgid "use `diff.guitool` instead of `diff.tool`"
 msgstr "използвайте „diff.guitool“ вместо „diff.tool“"
 
-#: builtin/difftool.c:701
+#: builtin/difftool.c:698
 msgid "perform a full-directory diff"
 msgstr "разлика по директории"
 
-#: builtin/difftool.c:703
+#: builtin/difftool.c:700
 msgid "do not prompt before launching a diff tool"
 msgstr "стартиране на ПРОГРАМАта за разлики без предупреждение"
 
-#: builtin/difftool.c:708
+#: builtin/difftool.c:705
 msgid "use symlinks in dir-diff mode"
 msgstr "следване на символните връзки при разлика по директории"
 
-#: builtin/difftool.c:709
+#: builtin/difftool.c:706
 msgid "tool"
 msgstr "ПРОГРАМА"
 
-#: builtin/difftool.c:710
+#: builtin/difftool.c:707
 msgid "use the specified diff tool"
 msgstr "използване на указаната ПРОГРАМА"
 
-#: builtin/difftool.c:712
+#: builtin/difftool.c:709
 msgid "print a list of diff tools that may be used with `--tool`"
 msgstr ""
 "извеждане на списък с всички ПРОГРАМи, които може да се ползват с опцията „--"
 "tool“"
 
-#: builtin/difftool.c:715
+#: builtin/difftool.c:712
 msgid ""
-"make 'git-difftool' exit when an invoked diff tool returns a non - zero exit "
+"make 'git-difftool' exit when an invoked diff tool returns a non-zero exit "
 "code"
 msgstr ""
-"„git-difftool“ да спре работа, когато стартираната ПРОГРАМА завърши с "
-"ненулев код"
+"„git-difftool“ да спре работа, когато стартираната ПРОГРАМА за разлики "
+"завърши с ненулев код"
 
-#: builtin/difftool.c:718
+#: builtin/difftool.c:715
 msgid "specify a custom command for viewing diffs"
 msgstr "команда за разглеждане на разлики"
 
-#: builtin/difftool.c:719
+#: builtin/difftool.c:716
 msgid "passed to `diff`"
 msgstr "подава се към „diff“"
 
-#: builtin/difftool.c:734
+#: builtin/difftool.c:732
 msgid "difftool requires worktree or --no-index"
 msgstr "„git-difftool“ изисква работно дърво или опцията „--no-index“"
 
-#: builtin/difftool.c:741
+#: builtin/difftool.c:739
 msgid "--dir-diff is incompatible with --no-index"
 msgstr "опциите „--dir-diff“ и „--no-index“ са несъвместими"
 
-#: builtin/difftool.c:744
+#: builtin/difftool.c:742
 msgid "--gui, --tool and --extcmd are mutually exclusive"
 msgstr "опциите „--gui“, „--tool“ и „--extcmd“ са несъвместими една с друга"
 
-#: builtin/difftool.c:752
+#: builtin/difftool.c:750
 msgid "no <tool> given for --tool=<tool>"
 msgstr "не е зададена програма за „--tool=ПРОГРАМА“"
 
-#: builtin/difftool.c:759
+#: builtin/difftool.c:757
 msgid "no <cmd> given for --extcmd=<cmd>"
 msgstr "не е зададена команда за „--extcmd=КОМАНДА“"
 
@@ -15224,7 +15522,7 @@ msgstr "не е зададена команда за „--extcmd=КОМАНДА�
 msgid "git env--helper --type=[bool|ulong] <options> <env-var>"
 msgstr "git env--helper --type=[bool|ulong] ОПЦИИ ПРОМЕНЛИВИ"
 
-#: builtin/env--helper.c:42 builtin/hash-object.c:98
+#: builtin/env--helper.c:42 builtin/hash-object.c:96
 msgid "type"
 msgstr "ВИД"
 
@@ -15256,100 +15554,100 @@ msgstr ""
 msgid "git fast-export [rev-list-opts]"
 msgstr "git fast-export [ОПЦИИ_ЗА_СПИСЪКА_С_ВЕРСИИ]"
 
-#: builtin/fast-export.c:868
+#: builtin/fast-export.c:869
 msgid "Error: Cannot export nested tags unless --mark-tags is specified."
 msgstr ""
 "Грешка: непреките етикети не се изнасят, освен ако не зададете „--mark-tags“."
 
-#: builtin/fast-export.c:1177
+#: builtin/fast-export.c:1178
 msgid "--anonymize-map token cannot be empty"
 msgstr "опцията „--anonymize-map“ изисква аргумент"
 
-#: builtin/fast-export.c:1197
+#: builtin/fast-export.c:1198
 msgid "show progress after <n> objects"
 msgstr "Съобщение за напредъка на всеки такъв БРОЙ обекта"
 
-#: builtin/fast-export.c:1199
+#: builtin/fast-export.c:1200
 msgid "select handling of signed tags"
 msgstr "Как да се обработват подписаните етикети"
 
-#: builtin/fast-export.c:1202
+#: builtin/fast-export.c:1203
 msgid "select handling of tags that tag filtered objects"
 msgstr "Как да се обработват етикетите на филтрираните обекти"
 
-#: builtin/fast-export.c:1205
+#: builtin/fast-export.c:1206
 msgid "select handling of commit messages in an alternate encoding"
 msgstr ""
 "как да се обработват съобщенията за подаване, които са в друго кодиране"
 
-#: builtin/fast-export.c:1208
+#: builtin/fast-export.c:1209
 msgid "dump marks to this file"
 msgstr "запазване на маркерите в този ФАЙЛ"
 
-#: builtin/fast-export.c:1210
+#: builtin/fast-export.c:1211
 msgid "import marks from this file"
 msgstr "внасяне на маркерите от този ФАЙЛ"
 
-#: builtin/fast-export.c:1214
+#: builtin/fast-export.c:1215
 msgid "import marks from this file if it exists"
 msgstr "внасяне на маркерите от този ФАЙЛ, ако съществува"
 
-#: builtin/fast-export.c:1216
+#: builtin/fast-export.c:1217
 msgid "fake a tagger when tags lack one"
 msgstr ""
 "да се използва изкуствено име на човек при липса на създател на етикета"
 
-#: builtin/fast-export.c:1218
+#: builtin/fast-export.c:1219
 msgid "output full tree for each commit"
 msgstr "извеждане на цялото дърво за всяко подаване"
 
-#: builtin/fast-export.c:1220
+#: builtin/fast-export.c:1221
 msgid "use the done feature to terminate the stream"
 msgstr "използване на маркер за завършване на потока"
 
-#: builtin/fast-export.c:1221
+#: builtin/fast-export.c:1222
 msgid "skip output of blob data"
 msgstr "без извеждане на съдържанието на обектите-BLOB"
 
-#: builtin/fast-export.c:1222 builtin/log.c:1826
+#: builtin/fast-export.c:1223 builtin/log.c:1826
 msgid "refspec"
 msgstr "УКАЗАТЕЛ_НА_ВЕРСИЯ"
 
-#: builtin/fast-export.c:1223
+#: builtin/fast-export.c:1224
 msgid "apply refspec to exported refs"
 msgstr "прилагане на УКАЗАТЕЛя_НА_ВЕРСИЯ към изнесените указатели"
 
-#: builtin/fast-export.c:1224
+#: builtin/fast-export.c:1225
 msgid "anonymize output"
 msgstr "анонимизиране на извежданата информация"
 
-#: builtin/fast-export.c:1225
+#: builtin/fast-export.c:1226
 msgid "from:to"
 msgstr "ОТ:КЪМ"
 
-#: builtin/fast-export.c:1226
+#: builtin/fast-export.c:1227
 msgid "convert <from> to <to> in anonymized output"
 msgstr "заместване ОТ със КЪМ в анонимизирания изход"
 
-#: builtin/fast-export.c:1229
+#: builtin/fast-export.c:1230
 msgid "reference parents which are not in fast-export stream by object id"
 msgstr ""
 "указване на родителите, които не са в потока на бързо изнасяне, с "
 "идентификатор на обект"
 
-#: builtin/fast-export.c:1231
+#: builtin/fast-export.c:1232
 msgid "show original object ids of blobs/commits"
 msgstr "извеждане на първоначалните идентификатори на обектите BLOB/подавяния"
 
-#: builtin/fast-export.c:1233
+#: builtin/fast-export.c:1234
 msgid "label tags with mark ids"
 msgstr "задаване на идентификатори на маркери на етикетите"
 
-#: builtin/fast-export.c:1256
+#: builtin/fast-export.c:1257
 msgid "--anonymize-map without --anonymize does not make sense"
 msgstr "опцията „--anonymize-map“ изисква „--anonymize“"
 
-#: builtin/fast-export.c:1271
+#: builtin/fast-export.c:1272
 msgid "Cannot pass both --import-marks and --import-marks-if-exists"
 msgstr "опциите „--import-marks“ и „--import-marks-if-exists“ са несъвместими"
 
@@ -15550,62 +15848,62 @@ msgstr "четене на указателите от стандартния в�
 msgid "Couldn't find remote ref HEAD"
 msgstr "Указателят „HEAD“ в отдалеченото хранилище не може да бъде открит"
 
-#: builtin/fetch.c:757
+#: builtin/fetch.c:760
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "настройката „fetch.output“ е с неправилна стойност „%s“"
 
-#: builtin/fetch.c:856
+#: builtin/fetch.c:862
 #, c-format
 msgid "object %s not found"
 msgstr "обектът „%s“ липсва"
 
-#: builtin/fetch.c:860
+#: builtin/fetch.c:866
 msgid "[up to date]"
 msgstr "[актуален]"
 
-#: builtin/fetch.c:873 builtin/fetch.c:889 builtin/fetch.c:961
+#: builtin/fetch.c:879 builtin/fetch.c:895 builtin/fetch.c:967
 msgid "[rejected]"
 msgstr "[отхвърлен]"
 
-#: builtin/fetch.c:874
+#: builtin/fetch.c:880
 msgid "can't fetch in current branch"
 msgstr "в текущия клон не може да се доставя"
 
-#: builtin/fetch.c:884
+#: builtin/fetch.c:890
 msgid "[tag update]"
 msgstr "[обновяване на етикетите]"
 
-#: builtin/fetch.c:885 builtin/fetch.c:922 builtin/fetch.c:944
-#: builtin/fetch.c:956
+#: builtin/fetch.c:891 builtin/fetch.c:928 builtin/fetch.c:950
+#: builtin/fetch.c:962
 msgid "unable to update local ref"
 msgstr "локален указател не може да бъде обновен"
 
-#: builtin/fetch.c:889
+#: builtin/fetch.c:895
 msgid "would clobber existing tag"
 msgstr "съществуващ етикет ще бъде презаписан"
 
-#: builtin/fetch.c:911
+#: builtin/fetch.c:917
 msgid "[new tag]"
 msgstr "[нов етикет]"
 
-#: builtin/fetch.c:914
+#: builtin/fetch.c:920
 msgid "[new branch]"
 msgstr "[нов клон]"
 
-#: builtin/fetch.c:917
+#: builtin/fetch.c:923
 msgid "[new ref]"
 msgstr "[нов указател]"
 
-#: builtin/fetch.c:956
+#: builtin/fetch.c:962
 msgid "forced update"
 msgstr "принудително обновяване"
 
-#: builtin/fetch.c:961
+#: builtin/fetch.c:967
 msgid "non-fast-forward"
 msgstr "същинско сливане"
 
-#: builtin/fetch.c:1065
+#: builtin/fetch.c:1070
 msgid ""
 "Fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled. To re-enable, use '--show-forced-updates'\n"
@@ -15616,7 +15914,7 @@ msgstr ""
 "\n"
 "    git config fetch.showForcedUpdates true"
 
-#: builtin/fetch.c:1069
+#: builtin/fetch.c:1074
 #, c-format
 msgid ""
 "It took %.2f seconds to check forced updates. You can use\n"
@@ -15630,23 +15928,23 @@ msgstr ""
 "\n"
 "    git config fetch.showForcedUpdates false\n"
 
-#: builtin/fetch.c:1101
+#: builtin/fetch.c:1105
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "хранилището „%s“ не изпрати всички необходими обекти\n"
 
-#: builtin/fetch.c:1129
+#: builtin/fetch.c:1134
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr ""
 "отхвърляне на „%s“, защото плитките върхове не може да бъдат обновявани"
 
-#: builtin/fetch.c:1206 builtin/fetch.c:1357
+#: builtin/fetch.c:1223 builtin/fetch.c:1371
 #, c-format
 msgid "From %.*s\n"
 msgstr "От %.*s\n"
 
-#: builtin/fetch.c:1228
+#: builtin/fetch.c:1244
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -15656,57 +15954,62 @@ msgstr ""
 "„git remote prune %s“, за да премахнете остарелите клони, които\n"
 "предизвикват конфликта"
 
-#: builtin/fetch.c:1327
+#: builtin/fetch.c:1341
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (обектът „%s“ ще се окаже извън клон)"
 
-#: builtin/fetch.c:1328
+#: builtin/fetch.c:1342
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (обектът „%s“ вече е извън клон)"
 
-#: builtin/fetch.c:1360
+#: builtin/fetch.c:1374
 msgid "[deleted]"
 msgstr "[изтрит]"
 
-#: builtin/fetch.c:1361 builtin/remote.c:1118
+#: builtin/fetch.c:1375 builtin/remote.c:1128
 msgid "(none)"
 msgstr "(нищо)"
 
-#: builtin/fetch.c:1384
+#: builtin/fetch.c:1398
 #, c-format
 msgid "Refusing to fetch into current branch %s of non-bare repository"
 msgstr "Не може да доставите в текущия клон „%s“ на хранилище, което не е голо"
 
-#: builtin/fetch.c:1403
+#: builtin/fetch.c:1417
 #, c-format
 msgid "Option \"%s\" value \"%s\" is not valid for %s"
 msgstr "Стойността „%2$s“ за опцията „%1$s“ не е съвместима с „%3$s“"
 
-#: builtin/fetch.c:1406
+#: builtin/fetch.c:1420
 #, c-format
 msgid "Option \"%s\" is ignored for %s\n"
 msgstr "опцията „%s“ се прескача при „%s“\n"
 
-#: builtin/fetch.c:1618
+#: builtin/fetch.c:1447
+#, c-format
+msgid "the object %s does not exist"
+msgstr "обектът „%s“ не съществува"
+
+#: builtin/fetch.c:1633
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr ""
 "засечени са множество клони, това е несъвместимо с опцията „--set-upstream“"
 
-#: builtin/fetch.c:1633
+#: builtin/fetch.c:1648
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "не може да указвате клон за следене на отдалечен етикет"
 
-#: builtin/fetch.c:1635
+#: builtin/fetch.c:1650
 msgid "not setting upstream for a remote tag"
 msgstr "не може да указвате клон за следене на отдалечен етикет"
 
-#: builtin/fetch.c:1637
+#: builtin/fetch.c:1652
 msgid "unknown branch type"
 msgstr "непознат вид клон"
 
-#: builtin/fetch.c:1639
+#: builtin/fetch.c:1654
 msgid ""
 "no source branch found.\n"
 "you need to specify exactly one branch with the --set-upstream option."
@@ -15714,22 +16017,22 @@ msgstr ""
 "не е открит клон за следене.\n"
 "Трябва изрично да зададете един клон с опцията „--set-upstream option“."
 
-#: builtin/fetch.c:1768 builtin/fetch.c:1831
+#: builtin/fetch.c:1783 builtin/fetch.c:1846
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Доставяне на „%s“\n"
 
-#: builtin/fetch.c:1778 builtin/fetch.c:1833 builtin/remote.c:101
+#: builtin/fetch.c:1793 builtin/fetch.c:1848 builtin/remote.c:101
 #, c-format
 msgid "Could not fetch %s"
 msgstr "„%s“ не може да се достави"
 
-#: builtin/fetch.c:1790
+#: builtin/fetch.c:1805
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "„%s“ не може да се достави (изходният код е: %d)\n"
 
-#: builtin/fetch.c:1894
+#: builtin/fetch.c:1909
 msgid ""
 "No remote repository specified.  Please, specify either a URL or a\n"
 "remote name from which new revisions should be fetched."
@@ -15737,57 +16040,57 @@ msgstr ""
 "Не сте указали отдалечено хранилище.  Задайте или адрес, или име\n"
 "на отдалечено хранилище, откъдето да се доставят новите версии."
 
-#: builtin/fetch.c:1930
+#: builtin/fetch.c:1945
 msgid "You need to specify a tag name."
 msgstr "Трябва да укажете име на етикет."
 
-#: builtin/fetch.c:1994
+#: builtin/fetch.c:2009
 msgid "--negotiate-only needs one or more --negotiate-tip=*"
 msgstr ""
 "Опцията „--negotiate-only“ изисква една или повече опции „--negotiate-tip=*“"
 
-#: builtin/fetch.c:1998
+#: builtin/fetch.c:2013
 msgid "Negative depth in --deepen is not supported"
 msgstr "Отрицателна дълбочина като аргумент на „--deepen“ не се поддържа"
 
-#: builtin/fetch.c:2000
+#: builtin/fetch.c:2015
 msgid "--deepen and --depth are mutually exclusive"
 msgstr "опциите „--deepen“ и „--depth“ са несъвместими"
 
-#: builtin/fetch.c:2005
+#: builtin/fetch.c:2020
 msgid "--depth and --unshallow cannot be used together"
 msgstr "опциите „--depth“ и „--unshallow“ са несъвместими"
 
-#: builtin/fetch.c:2007
+#: builtin/fetch.c:2022
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "не може да използвате опцията „--unshallow“ върху пълно хранилище"
 
-#: builtin/fetch.c:2024
+#: builtin/fetch.c:2039
 msgid "fetch --all does not take a repository argument"
 msgstr "към „git fetch --all“ не може да добавите аргумент-хранилище"
 
-#: builtin/fetch.c:2026
+#: builtin/fetch.c:2041
 msgid "fetch --all does not make sense with refspecs"
 msgstr "към „git fetch --all“ не може да добавите аргумент-указател на версия"
 
-#: builtin/fetch.c:2035
+#: builtin/fetch.c:2050
 #, c-format
 msgid "No such remote or remote group: %s"
 msgstr "Няма нито отдалечено хранилище, нито група от хранилища на име „%s“"
 
-#: builtin/fetch.c:2042
+#: builtin/fetch.c:2057
 msgid "Fetching a group and specifying refspecs does not make sense"
 msgstr "Указването на група и указването на версия са несъвместими"
 
-#: builtin/fetch.c:2058
+#: builtin/fetch.c:2073
 msgid "must supply remote when using --negotiate-only"
 msgstr "опцията „--negotiate-only“ изисква хранилище"
 
-#: builtin/fetch.c:2063
+#: builtin/fetch.c:2078
 msgid "Protocol does not support --negotiate-only, exiting."
 msgstr "Протоколът не поддържа опцията „--negotiate-only“, изход от прогамата."
 
-#: builtin/fetch.c:2082
+#: builtin/fetch.c:2097
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -15795,12 +16098,12 @@ msgstr ""
 "опцията „--filter“ може да се ползва само с отдалеченото хранилище указано в "
 "настройката „extensions.partialclone“"
 
-#: builtin/fetch.c:2086
+#: builtin/fetch.c:2101
 msgid "--atomic can only be used when fetching from one remote"
 msgstr ""
 "опцията „--atomic“ поддържа доставяне само от едно отдалечено хранилище"
 
-#: builtin/fetch.c:2090
+#: builtin/fetch.c:2105
 msgid "--stdin can only be used when fetching from one remote"
 msgstr "опцията „--stdin“ поддържа доставяне само от едно отдалечено хранилище"
 
@@ -15868,7 +16171,7 @@ msgstr "цитиране подходящо за tcl"
 msgid "show only <n> matched refs"
 msgstr "извеждане само на този БРОЙ напаснати указатели"
 
-#: builtin/for-each-ref.c:41 builtin/tag.c:483
+#: builtin/for-each-ref.c:41 builtin/tag.c:481
 msgid "respect format colors"
 msgstr "спазване на цветовете на форма̀та"
 
@@ -16024,130 +16327,140 @@ msgstr "%s: не е подаване!"
 msgid "notice: No default references"
 msgstr "внимание: няма указатели по подразбиране"
 
-#: builtin/fsck.c:606
+#: builtin/fsck.c:621
+#, c-format
+msgid "%s: hash-path mismatch, found at: %s"
+msgstr "%s: разлика в контролната сума при: %s"
+
+#: builtin/fsck.c:624
 #, c-format
 msgid "%s: object corrupt or missing: %s"
-msgstr "„%s“: липсващ обект: „%s“"
+msgstr "%s: развален или липсващ обект: %s"
 
-#: builtin/fsck.c:619
+#: builtin/fsck.c:628
+#, c-format
+msgid "%s: object is of unknown type '%s': %s"
+msgstr "%s: обектът е непознат вид „%s“: %s"
+
+#: builtin/fsck.c:644
 #, c-format
 msgid "%s: object could not be parsed: %s"
 msgstr "„%s“: не може да се анализира: „%s“"
 
-#: builtin/fsck.c:639
+#: builtin/fsck.c:664
 #, c-format
 msgid "bad sha1 file: %s"
 msgstr "неправилен ред с контролна сума по SHA1: „%s“"
 
-#: builtin/fsck.c:654
+#: builtin/fsck.c:685
 msgid "Checking object directory"
 msgstr "Проверка на директория с обекти"
 
-#: builtin/fsck.c:657
+#: builtin/fsck.c:688
 msgid "Checking object directories"
 msgstr "Проверка на директориите с обекти"
 
-#: builtin/fsck.c:672
+#: builtin/fsck.c:704
 #, c-format
 msgid "Checking %s link"
 msgstr "Проверка на връзките на „%s“"
 
 #
-#: builtin/fsck.c:677 builtin/index-pack.c:864
+#: builtin/fsck.c:709 builtin/index-pack.c:859
 #, c-format
 msgid "invalid %s"
 msgstr "неправилен указател „%s“"
 
-#: builtin/fsck.c:684
+#: builtin/fsck.c:716
 #, c-format
 msgid "%s points to something strange (%s)"
 msgstr "„%s“ сочи към нещо необичайно (%s)"
 
-#: builtin/fsck.c:690
+#: builtin/fsck.c:722
 #, c-format
 msgid "%s: detached HEAD points at nothing"
 msgstr "%s: несвързаният връх „HEAD“ не сочи към нищо"
 
-#: builtin/fsck.c:694
+#: builtin/fsck.c:726
 #, c-format
 msgid "notice: %s points to an unborn branch (%s)"
 msgstr "предупреждение: „%s“ сочи към все още несъществуващ клон (%s)"
 
-#: builtin/fsck.c:706
+#: builtin/fsck.c:738
 msgid "Checking cache tree"
 msgstr "Проверка на дървото на кеша"
 
-#: builtin/fsck.c:711
+#: builtin/fsck.c:743
 #, c-format
 msgid "%s: invalid sha1 pointer in cache-tree"
 msgstr "„%s“: неправилен указател за SHA1 в дървото на кеша"
 
-#: builtin/fsck.c:720
+#: builtin/fsck.c:752
 msgid "non-tree in cache-tree"
 msgstr "в дървото на кеша има нещо, което не е дърво"
 
-#: builtin/fsck.c:751
+#: builtin/fsck.c:783
 msgid "git fsck [<options>] [<object>...]"
 msgstr "git fsck [ОПЦИЯ…] [ОБЕКТ…]"
 
-#: builtin/fsck.c:757
+#: builtin/fsck.c:789
 msgid "show unreachable objects"
 msgstr "показване на недостижимите обекти"
 
-#: builtin/fsck.c:758
+#: builtin/fsck.c:790
 msgid "show dangling objects"
 msgstr "показване на обектите извън клоните"
 
-#: builtin/fsck.c:759
+#: builtin/fsck.c:791
 msgid "report tags"
 msgstr "показване на етикетите"
 
-#: builtin/fsck.c:760
+#: builtin/fsck.c:792
 msgid "report root nodes"
 msgstr "показване на кореновите възли"
 
-#: builtin/fsck.c:761
+#: builtin/fsck.c:793
 msgid "make index objects head nodes"
 msgstr "задаване на обекти от индекса да са коренови"
 
-#: builtin/fsck.c:762
+#: builtin/fsck.c:794
 msgid "make reflogs head nodes (default)"
 msgstr "проследяване и на указателите от журнала с указателите (стандартно)"
 
-#: builtin/fsck.c:763
+#: builtin/fsck.c:795
 msgid "also consider packs and alternate objects"
 msgstr "допълнително да се проверяват пакетите и алтернативните обекти"
 
-#: builtin/fsck.c:764
+#: builtin/fsck.c:796
 msgid "check only connectivity"
 msgstr "проверка само на връзката"
 
-#: builtin/fsck.c:765 builtin/mktag.c:75
+#: builtin/fsck.c:797 builtin/mktag.c:76
 msgid "enable more strict checking"
 msgstr "по-строги проверки"
 
-#: builtin/fsck.c:767
+#: builtin/fsck.c:799
 msgid "write dangling objects in .git/lost-found"
 msgstr "запазване на обектите извън клоните в директорията „.git/lost-found“"
 
-#: builtin/fsck.c:768 builtin/prune.c:134
+#: builtin/fsck.c:800 builtin/prune.c:134
 msgid "show progress"
 msgstr "показване на напредъка"
 
-#: builtin/fsck.c:769
+#: builtin/fsck.c:801
 msgid "show verbose names for reachable objects"
 msgstr "показване на подробни имена на достижимите обекти"
 
-#: builtin/fsck.c:828 builtin/index-pack.c:262
+#: builtin/fsck.c:861 builtin/index-pack.c:261
 msgid "Checking objects"
 msgstr "Проверка на обектите"
 
-#: builtin/fsck.c:856
+#: builtin/fsck.c:889
 #, c-format
 msgid "%s: object missing"
 msgstr "„%s“: липсващ обект"
 
-#: builtin/fsck.c:867
+#: builtin/fsck.c:900
 #, c-format
 msgid "invalid parameter: expected sha1, got '%s'"
 msgstr "неправилен параметър: очаква се SHA1, а бе получено: „%s“"
@@ -16171,7 +16484,7 @@ msgstr "стойността на „%s“ — „%s“ не може да се 
 msgid "cannot stat '%s'"
 msgstr "не може да се получи информация чрез „stat“ за директорията „%s“"
 
-#: builtin/gc.c:496 builtin/notes.c:240 builtin/tag.c:573
+#: builtin/gc.c:496 builtin/notes.c:238 builtin/tag.c:574
 #, c-format
 msgid "cannot read '%s'"
 msgstr "файлът „%s“ не може да бъде прочетен"
@@ -16180,14 +16493,13 @@ msgstr "файлът „%s“ не може да бъде прочетен"
 #, c-format
 msgid ""
 "The last gc run reported the following. Please correct the root cause\n"
-"and remove %s.\n"
+"and remove %s\n"
 "Automatic cleanup will not be performed until the file is removed.\n"
 "\n"
 "%s"
 msgstr ""
-"При последното изпълнение на „git gc“ бе докладвана грешка.  Коригирайте "
-"причината за\n"
-"нея и изтрийте „%s“.\n"
+"При последното изпълнение на „git gc“ бе докладвано следното — коригирайте\n"
+"причината за него и изтрийте „%s“.\n"
 "Автоматичното изчистване на боклука няма да работи, преди да изтриете "
 "файла.\n"
 "\n"
@@ -16275,153 +16587,192 @@ msgstr "опцията „--no-schedule“ не е позволена"
 msgid "unrecognized --schedule argument '%s'"
 msgstr "непознат аргумент към „--schedule“: %s"
 
-#: builtin/gc.c:869
+#: builtin/gc.c:868
 msgid "failed to write commit-graph"
 msgstr "графът с подаванията не може да бъде записан"
 
-#: builtin/gc.c:905
+#: builtin/gc.c:904
 msgid "failed to prefetch remotes"
 msgstr "неуспешно предварително доставяне на отдалечените клони"
 
-#: builtin/gc.c:1022
+#: builtin/gc.c:1020
 msgid "failed to start 'git pack-objects' process"
 msgstr "процесът за командата „git pack-objects“ не може да бъде стартиран"
 
-#: builtin/gc.c:1039
+#: builtin/gc.c:1037
 msgid "failed to finish 'git pack-objects' process"
 msgstr "процесът за командата „git pack-objects“ не може да завърши"
 
-#: builtin/gc.c:1091
+#: builtin/gc.c:1088
 msgid "failed to write multi-pack-index"
 msgstr "индексът за множество пакети не може да бъде записан"
 
-#: builtin/gc.c:1109
+#: builtin/gc.c:1104
 msgid "'git multi-pack-index expire' failed"
 msgstr "неуспешно изпълнение на „git multi-pack-index expire“"
 
-#: builtin/gc.c:1170
+#: builtin/gc.c:1163
 msgid "'git multi-pack-index repack' failed"
 msgstr "неуспешно изпълнение на „git multi-pack-index repack“"
 
-#: builtin/gc.c:1179
+#: builtin/gc.c:1172
 msgid ""
 "skipping incremental-repack task because core.multiPackIndex is disabled"
 msgstr ""
 "задачата „incremental-repack“ се прескача, защото настройката „core."
 "multiPackIndex“ е изключена"
 
-#: builtin/gc.c:1283
+#: builtin/gc.c:1276
 #, c-format
 msgid "lock file '%s' exists, skipping maintenance"
 msgstr "заключващият файл „%s“ съществува.  Действието се прескача"
 
-#: builtin/gc.c:1313
+#: builtin/gc.c:1306
 #, c-format
 msgid "task '%s' failed"
 msgstr "неуспешно изпълнение на задачата „%s“"
 
-#: builtin/gc.c:1395
+#: builtin/gc.c:1388
 #, c-format
 msgid "'%s' is not a valid task"
 msgstr "„%s“ не е правилна задача"
 
-#: builtin/gc.c:1400
+#: builtin/gc.c:1393
 #, c-format
 msgid "task '%s' cannot be selected multiple times"
 msgstr "задачата „%s“ не може да се избере повече от веднъж"
 
-#: builtin/gc.c:1415
+#: builtin/gc.c:1408
 msgid "run tasks based on the state of the repository"
 msgstr "изпълняване на задачи според състоянието на хранилището"
 
-#: builtin/gc.c:1416
+#: builtin/gc.c:1409
 msgid "frequency"
 msgstr "честота"
 
-#: builtin/gc.c:1417
+#: builtin/gc.c:1410
 msgid "run tasks based on frequency"
 msgstr "изпълняване на задачи по график"
 
-#: builtin/gc.c:1420
+#: builtin/gc.c:1413
 msgid "do not report progress or other information over stderr"
 msgstr "без извеждане на напредъка и друга информация на стандартния изход"
 
-#: builtin/gc.c:1421
+#: builtin/gc.c:1414
 msgid "task"
 msgstr "задача"
 
-#: builtin/gc.c:1422
+#: builtin/gc.c:1415
 msgid "run a specific task"
 msgstr "изпълнение на определена задача"
 
-#: builtin/gc.c:1439
+#: builtin/gc.c:1432
 msgid "use at most one of --auto and --schedule=<frequency>"
-msgstr ""
-"може да се указва максимум една от опциите „--auto“ и „--schedule=ЧЕСТОТА“"
+msgstr "опциите „--auto“ и „--schedule=ЧЕСТОТА“ са несъвместими"
 
-#: builtin/gc.c:1482
+#: builtin/gc.c:1475
 msgid "failed to run 'git config'"
 msgstr "неуспешно изпълнение на „git config“"
 
-#: builtin/gc.c:1547
+#: builtin/gc.c:1627
 #, c-format
 msgid "failed to expand path '%s'"
 msgstr "грешка при заместването на пътя „%s“"
 
-#: builtin/gc.c:1576
+#: builtin/gc.c:1654 builtin/gc.c:1692
 msgid "failed to start launchctl"
 msgstr "неуспешно стартиране на „launchctl“."
 
-#: builtin/gc.c:1613
+#: builtin/gc.c:1767 builtin/gc.c:2220
 #, c-format
 msgid "failed to create directories for '%s'"
 msgstr "директориите за „%s“ не може да бъдат създадени"
 
-#: builtin/gc.c:1674
+#: builtin/gc.c:1794
 #, c-format
 msgid "failed to bootstrap service %s"
 msgstr "услугата „%s“ не може се настрои първоначално"
 
-#: builtin/gc.c:1745
+#: builtin/gc.c:1887
 msgid "failed to create temp xml file"
 msgstr "неуспешно създаване на временен файл за xml"
 
-#: builtin/gc.c:1835
+#: builtin/gc.c:1977
 msgid "failed to start schtasks"
 msgstr "задачите за периодично изпълнение не може да се стартират"
 
-#: builtin/gc.c:1879
+#: builtin/gc.c:2046
 msgid "failed to run 'crontab -l'; your system might not support 'cron'"
 msgstr ""
 "неуспешно изпълнение на „crontab -l“.  Системата ви може да не поддържа "
 "„cron“"
 
-#: builtin/gc.c:1896
+#: builtin/gc.c:2063
 msgid "failed to run 'crontab'; your system might not support 'cron'"
 msgstr ""
 "неуспешно изпълнение на „crontab“.  Системата ви може да не поддържа „cron“"
 
-#: builtin/gc.c:1900
+#: builtin/gc.c:2067
 msgid "failed to open stdin of 'crontab'"
 msgstr "стандартният вход на „crontab“ не може да се отвори"
 
-#: builtin/gc.c:1942
+#: builtin/gc.c:2109
 msgid "'crontab' died"
 msgstr "процесът на „crontab“ умря"
 
-#: builtin/gc.c:1976
+#: builtin/gc.c:2174
+msgid "failed to start systemctl"
+msgstr "неуспешно стартиране на „systemctl“"
+
+#: builtin/gc.c:2184
+msgid "failed to run systemctl"
+msgstr "неуспешно изпълнение на „systemctl“"
+
+#: builtin/gc.c:2193 builtin/gc.c:2198 builtin/worktree.c:62
+#: builtin/worktree.c:945
+#, c-format
+msgid "failed to delete '%s'"
+msgstr "неуспешно изтриване на „%s“"
+
+#: builtin/gc.c:2378
+#, c-format
+msgid "unrecognized --scheduler argument '%s'"
+msgstr "непознат аргумент към „--scheduler“: %s"
+
+#: builtin/gc.c:2403
+msgid "neither systemd timers nor crontab are available"
+msgstr "липсват както таймери на systemd, така и crontab"
+
+#: builtin/gc.c:2418
+#, c-format
+msgid "%s scheduler is not available"
+msgstr "планиращият модул „%s“ липсва"
+
+#: builtin/gc.c:2432
 msgid "another process is scheduling background maintenance"
 msgstr "друг процес задава поддръжката на заден фон"
 
-#: builtin/gc.c:2000
+#: builtin/gc.c:2454
+msgid "git maintenance start [--scheduler=<scheduler>]"
+msgstr "git maintenance start [--scheduler=ПЛАНИРАЩ_МОДУЛ]"
+
+#: builtin/gc.c:2463
+msgid "scheduler"
+msgstr "ПЛАНИРАЩ_МОДУЛ"
+
+#: builtin/gc.c:2464
+msgid "scheduler to trigger git maintenance run"
+msgstr "ПЛАНИРАЩият_МОДУЛ, който да изпълнява задачите"
+
+#: builtin/gc.c:2478
 msgid "failed to add repo to global config"
 msgstr "неуспешно добавяне на хранилище към файла с глобални настройки"
 
-#: builtin/gc.c:2010
+#: builtin/gc.c:2487
 msgid "git maintenance <subcommand> [<options>]"
 msgstr "git maintenance ПОДКОМАНДА [ОПЦИЯ…]"
 
-#: builtin/gc.c:2029
+#: builtin/gc.c:2506
 #, c-format
 msgid "invalid subcommand: %s"
 msgstr "неправилна подкоманда: „%s“"
@@ -16430,12 +16781,12 @@ msgstr "неправилна подкоманда: „%s“"
 msgid "git grep [<options>] [-e] <pattern> [<rev>...] [[--] <path>...]"
 msgstr "git grep [ОПЦИЯ…] [-e] ШАБЛОН [ВЕРСИЯ…] [[--] ПЪТ…]"
 
-#: builtin/grep.c:223
+#: builtin/grep.c:239
 #, c-format
 msgid "grep: failed to create thread: %s"
 msgstr "grep: неуспешно създаване на нишка: %s"
 
-#: builtin/grep.c:277
+#: builtin/grep.c:293
 #, c-format
 msgid "invalid number of threads specified (%d) for %s"
 msgstr "зададен е неправилен брой нишки (%d) за %s"
@@ -16444,275 +16795,275 @@ msgstr "зададен е неправилен брой нишки (%d) за %s"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:285 builtin/index-pack.c:1588 builtin/index-pack.c:1791
-#: builtin/pack-objects.c:3129
+#: builtin/grep.c:301 builtin/index-pack.c:1582 builtin/index-pack.c:1785
+#: builtin/pack-objects.c:3142
 #, c-format
 msgid "no threads support, ignoring %s"
 msgstr "липсва поддръжка за нишки.  „%s“ ще се пренебрегне"
 
-#: builtin/grep.c:473 builtin/grep.c:603 builtin/grep.c:643
+#: builtin/grep.c:488 builtin/grep.c:617 builtin/grep.c:657
 #, c-format
 msgid "unable to read tree (%s)"
 msgstr "дървото не може да бъде прочетено (%s)"
 
-#: builtin/grep.c:658
+#: builtin/grep.c:672
 #, c-format
 msgid "unable to grep from object of type %s"
 msgstr "не може да се изпълни „grep“ от обект от вида %s"
 
-#: builtin/grep.c:738
+#: builtin/grep.c:752
 #, c-format
 msgid "switch `%c' expects a numerical value"
 msgstr "опцията „%c“ очаква число за аргумент"
 
-#: builtin/grep.c:837
+#: builtin/grep.c:851
 msgid "search in index instead of in the work tree"
 msgstr "търсене в индекса, а не в работното дърво"
 
-#: builtin/grep.c:839
+#: builtin/grep.c:853
 msgid "find in contents not managed by git"
 msgstr "търсене и във файловете, които не са под управлението на git"
 
-#: builtin/grep.c:841
+#: builtin/grep.c:855
 msgid "search in both tracked and untracked files"
 msgstr "търсене и в следените, и в неследените файлове"
 
-#: builtin/grep.c:843
+#: builtin/grep.c:857
 msgid "ignore files specified via '.gitignore'"
 msgstr "игнориране на файловете указани в „.gitignore“"
 
-#: builtin/grep.c:845
+#: builtin/grep.c:859
 msgid "recursively search in each submodule"
 msgstr "рекурсивно търсене във всички подмодули"
 
-#: builtin/grep.c:848
+#: builtin/grep.c:862
 msgid "show non-matching lines"
 msgstr "извеждане на редовете, които не съвпадат"
 
-#: builtin/grep.c:850
+#: builtin/grep.c:864
 msgid "case insensitive matching"
 msgstr "без значение на регистъра на буквите (главни/малки)"
 
-#: builtin/grep.c:852
+#: builtin/grep.c:866
 msgid "match patterns only at word boundaries"
 msgstr "напасване на шаблоните само по границите на думите"
 
-#: builtin/grep.c:854
+#: builtin/grep.c:868
 msgid "process binary files as text"
 msgstr "обработване на двоичните файлове като текстови"
 
-#: builtin/grep.c:856
+#: builtin/grep.c:870
 msgid "don't match patterns in binary files"
 msgstr "прескачане на двоичните файлове"
 
-#: builtin/grep.c:859
+#: builtin/grep.c:873
 msgid "process binary files with textconv filters"
 msgstr ""
 "обработване на двоичните файлове чрез филтри за преобразуване към текст"
 
-#: builtin/grep.c:861
+#: builtin/grep.c:875
 msgid "search in subdirectories (default)"
 msgstr "търсене в поддиректориите (стандартно)"
 
-#: builtin/grep.c:863
+#: builtin/grep.c:877
 msgid "descend at most <depth> levels"
 msgstr "навлизане максимално на тази ДЪЛБОЧИНА в дървото"
 
-#: builtin/grep.c:867
+#: builtin/grep.c:881
 msgid "use extended POSIX regular expressions"
 msgstr "разширени регулярни изрази по POSIX"
 
-#: builtin/grep.c:870
+#: builtin/grep.c:884
 msgid "use basic POSIX regular expressions (default)"
 msgstr "основни регулярни изрази по POSIX (стандартно)"
 
-#: builtin/grep.c:873
+#: builtin/grep.c:887
 msgid "interpret patterns as fixed strings"
 msgstr "шаблоните са дословни низове"
 
-#: builtin/grep.c:876
+#: builtin/grep.c:890
 msgid "use Perl-compatible regular expressions"
 msgstr "регулярни изрази на Perl"
 
-#: builtin/grep.c:879
+#: builtin/grep.c:893
 msgid "show line numbers"
 msgstr "извеждане на номерата на редовете"
 
-#: builtin/grep.c:880
+#: builtin/grep.c:894
 msgid "show column number of first match"
 msgstr "извеждане на номера на колоната на първото напасване"
 
-#: builtin/grep.c:881
+#: builtin/grep.c:895
 msgid "don't show filenames"
 msgstr "без извеждане на имената на файловете"
 
-#: builtin/grep.c:882
+#: builtin/grep.c:896
 msgid "show filenames"
 msgstr "извеждане на имената на файловете"
 
-#: builtin/grep.c:884
+#: builtin/grep.c:898
 msgid "show filenames relative to top directory"
 msgstr ""
 "извеждане на относителните имена на файловете спрямо основната директория на "
 "хранилището"
 
-#: builtin/grep.c:886
+#: builtin/grep.c:900
 msgid "show only filenames instead of matching lines"
 msgstr "извеждане само на имената на файловете без напасващите редове"
 
-#: builtin/grep.c:888
+#: builtin/grep.c:902
 msgid "synonym for --files-with-matches"
 msgstr "псевдоним на „--files-with-matches“"
 
-#: builtin/grep.c:891
+#: builtin/grep.c:905
 msgid "show only the names of files without match"
 msgstr ""
 "извеждане само на имената на файловете, които не съдържат ред, напасващ на "
 "шаблона"
 
-#: builtin/grep.c:893
+#: builtin/grep.c:907
 msgid "print NUL after filenames"
 msgstr "извеждане на нулевия знак „NUL“ след всяко име на файл"
 
-#: builtin/grep.c:896
+#: builtin/grep.c:910
 msgid "show only matching parts of a line"
 msgstr "извеждане само на частите на редовете, които съвпадат"
 
-#: builtin/grep.c:898
+#: builtin/grep.c:912
 msgid "show the number of matches instead of matching lines"
 msgstr "извеждане на броя на съвпаденията вместо напасващите редове"
 
-#: builtin/grep.c:899
+#: builtin/grep.c:913
 msgid "highlight matches"
 msgstr "оцветяване на напасванията"
 
-#: builtin/grep.c:901
+#: builtin/grep.c:915
 msgid "print empty line between matches from different files"
 msgstr "извеждане на празен ред между напасванията от различни файлове"
 
-#: builtin/grep.c:903
+#: builtin/grep.c:917
 msgid "show filename only once above matches from same file"
 msgstr ""
 "извеждане на името на файла само веднъж за всички напасвания от този файл"
 
-#: builtin/grep.c:906
+#: builtin/grep.c:920
 msgid "show <n> context lines before and after matches"
 msgstr "извеждане на такъв БРОЙ редове преди и след напасванията"
 
-#: builtin/grep.c:909
+#: builtin/grep.c:923
 msgid "show <n> context lines before matches"
 msgstr "извеждане на такъв БРОЙ редове преди напасванията"
 
-#: builtin/grep.c:911
+#: builtin/grep.c:925
 msgid "show <n> context lines after matches"
 msgstr "извеждане на такъв БРОЙ редове след напасванията"
 
-#: builtin/grep.c:913
+#: builtin/grep.c:927
 msgid "use <n> worker threads"
 msgstr "използване на такъв БРОЙ работещи нишки"
 
-#: builtin/grep.c:914
+#: builtin/grep.c:928
 msgid "shortcut for -C NUM"
 msgstr "псевдоним на „-C БРОЙ“"
 
-#: builtin/grep.c:917
+#: builtin/grep.c:931
 msgid "show a line with the function name before matches"
 msgstr "извеждане на ред с името на функцията, в която е напаснат шаблона"
 
-#: builtin/grep.c:919
+#: builtin/grep.c:933
 msgid "show the surrounding function"
 msgstr "извеждане на обхващащата функция"
 
-#: builtin/grep.c:922
+#: builtin/grep.c:936
 msgid "read patterns from file"
 msgstr "изчитане на шаблоните от ФАЙЛ"
 
-#: builtin/grep.c:924
+#: builtin/grep.c:938
 msgid "match <pattern>"
 msgstr "напасване на ШАБЛОН"
 
-#: builtin/grep.c:926
+#: builtin/grep.c:940
 msgid "combine patterns specified with -e"
 msgstr "комбиниране на шаблоните указани с опцията „-e“"
 
-#: builtin/grep.c:938
+#: builtin/grep.c:952
 msgid "indicate hit with exit status without output"
 msgstr ""
 "без извеждане на стандартния изход.  Изходният код указва наличието на "
 "напасване"
 
-#: builtin/grep.c:940
+#: builtin/grep.c:954
 msgid "show only matches from files that match all patterns"
 msgstr ""
 "извеждане на редове само от файловете, които напасват на всички шаблони"
 
-#: builtin/grep.c:943
+#: builtin/grep.c:957
 msgid "pager"
 msgstr "програма за преглед по страници"
 
-#: builtin/grep.c:943
+#: builtin/grep.c:957
 msgid "show matching files in the pager"
 msgstr "извеждане на съвпадащите файлове в програма за преглед по страници"
 
-#: builtin/grep.c:947
+#: builtin/grep.c:961
 msgid "allow calling of grep(1) (ignored by this build)"
 msgstr ""
 "позволяване на стартирането на grep(1) (текущият компилат пренебрегва тази "
 "опция)"
 
-#: builtin/grep.c:1013
+#: builtin/grep.c:1027
 msgid "no pattern given"
 msgstr "не сте задали шаблон"
 
-#: builtin/grep.c:1049
+#: builtin/grep.c:1063
 msgid "--no-index or --untracked cannot be used with revs"
 msgstr "опциите „--no-index“ и „--untracked“ са несъвместими с версии."
 
-#: builtin/grep.c:1057
+#: builtin/grep.c:1071
 #, c-format
 msgid "unable to resolve revision: %s"
 msgstr "версията „%s“ не може бъде открита"
 
-#: builtin/grep.c:1087
+#: builtin/grep.c:1101
 msgid "--untracked not supported with --recurse-submodules"
 msgstr "опциите „--untracked“ и „--recurse-submodules“ са несъвместими"
 
-#: builtin/grep.c:1091
+#: builtin/grep.c:1105
 msgid "invalid option combination, ignoring --threads"
 msgstr "неправилна комбинация от опции, „--threads“ ще се пренебрегне"
 
-#: builtin/grep.c:1094 builtin/pack-objects.c:4090
+#: builtin/grep.c:1108 builtin/pack-objects.c:4059
 msgid "no threads support, ignoring --threads"
 msgstr "липсва поддръжка за нишки.  „--threads“ ще се пренебрегне"
 
-#: builtin/grep.c:1097 builtin/index-pack.c:1585 builtin/pack-objects.c:3126
+#: builtin/grep.c:1111 builtin/index-pack.c:1579 builtin/pack-objects.c:3139
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "зададен е неправилен брой нишки: %d"
 
-#: builtin/grep.c:1131
+#: builtin/grep.c:1145
 msgid "--open-files-in-pager only works on the worktree"
 msgstr "опцията „--open-files-in-pager“ изисква търсене в работното дърво"
 
-#: builtin/grep.c:1157
+#: builtin/grep.c:1171
 msgid "--cached or --untracked cannot be used with --no-index"
 msgstr "опциите „--cached“ и „--untracked“ са несъвместими с „--no-index“"
 
-#: builtin/grep.c:1160
+#: builtin/grep.c:1174
 msgid "--untracked cannot be used with --cached"
 msgstr "опциите „--untracked“ и „--cached“ са несъвместими"
 
-#: builtin/grep.c:1166
+#: builtin/grep.c:1180
 msgid "--[no-]exclude-standard cannot be used for tracked contents"
 msgstr ""
 "опциите „--(no-)exclude-standard“ са несъвместими с търсене по следени "
 "файлове"
 
-#: builtin/grep.c:1174
+#: builtin/grep.c:1188
 msgid "both --cached and trees are given"
 msgstr "опцията „--cached“ е несъвместима със задаване на дърво"
 
-#: builtin/hash-object.c:85
+#: builtin/hash-object.c:83
 msgid ""
 "git hash-object [-t <type>] [-w] [--path=<file> | --no-filters] [--stdin] "
 "[--] <file>..."
@@ -16720,97 +17071,109 @@ msgstr ""
 "git hash-object [-t ВИД] [-w] [--path=ФАЙЛ | --no-filters] [--stdin] [--] "
 "ФАЙЛ…"
 
-#: builtin/hash-object.c:86
+#: builtin/hash-object.c:84
 msgid "git hash-object  --stdin-paths"
 msgstr "git hash-object --stdin-paths"
 
-#: builtin/hash-object.c:98
+#: builtin/hash-object.c:96
 msgid "object type"
 msgstr "ВИД на обекта"
 
-#: builtin/hash-object.c:99
+#: builtin/hash-object.c:97
 msgid "write the object into the object database"
 msgstr "записване на обекта в базата от данни за обектите"
 
-#: builtin/hash-object.c:101
+#: builtin/hash-object.c:99
 msgid "read the object from stdin"
 msgstr "изчитане на обекта от стандартния вход"
 
-#: builtin/hash-object.c:103
+#: builtin/hash-object.c:101
 msgid "store file as is without filters"
 msgstr "запазване на файла както е — без филтри"
 
-#: builtin/hash-object.c:104
+#: builtin/hash-object.c:102
 msgid ""
 "just hash any random garbage to create corrupt objects for debugging Git"
 msgstr ""
 "създаване и изчисляване на контролни суми на произволни данни за повредени "
 "обекти за трасиране на Git"
 
-#: builtin/hash-object.c:105
+#: builtin/hash-object.c:103
 msgid "process file as it were from this path"
 msgstr "обработване на ФАЙЛа все едно е с този път"
 
-#: builtin/help.c:47
+#: builtin/help.c:55
 msgid "print all available commands"
 msgstr "показване на всички налични команди"
 
-#: builtin/help.c:48
+#: builtin/help.c:57
 msgid "exclude guides"
 msgstr "без въведения"
 
-#: builtin/help.c:49
-msgid "print list of useful guides"
-msgstr "показване на списък с въведения"
-
-#: builtin/help.c:50
-msgid "print all configuration variable names"
-msgstr "показване на имената на всички конфигуриращи променливи"
-
-#: builtin/help.c:52
+#: builtin/help.c:58
 msgid "show man page"
 msgstr "показване на страница от ръководството"
 
-#: builtin/help.c:53
+#: builtin/help.c:59
 msgid "show manual in web browser"
 msgstr "показване на страница от ръководството в уеб браузър"
 
-#: builtin/help.c:55
+#: builtin/help.c:61
 msgid "show info page"
 msgstr "показване на информационна страница"
 
-#: builtin/help.c:57
+#: builtin/help.c:63
 msgid "print command description"
 msgstr "извеждане на описанието на команда"
 
-#: builtin/help.c:62
-msgid "git help [--all] [--guides] [--man | --web | --info] [<command>]"
-msgstr "git help [--all] [--guides] [--man | --web | --info] [КОМАНДА]"
+#: builtin/help.c:65
+msgid "print list of useful guides"
+msgstr "показване на списък с въведения"
 
-#: builtin/help.c:163
+#: builtin/help.c:67
+msgid "print all configuration variable names"
+msgstr "показване на имената на всички конфигуриращи променливи"
+
+#: builtin/help.c:78
+msgid ""
+"git help [-a|--all] [--[no-]verbose]]\n"
+"         [[-i|--info] [-m|--man] [-w|--web]] [<command>]"
+msgstr ""
+"git help [-a|--all] [--[no-]verbose]]\n"
+"         [[-i|--info] [-m|--man] [-w|--web]] [КОМАНДА]"
+
+#: builtin/help.c:80
+msgid "git help [-g|--guides]"
+msgstr "git help [-g|--guides]"
+
+#: builtin/help.c:81
+msgid "git help [-c|--config]"
+msgstr "git help [-c|--config]"
+
+#: builtin/help.c:196
 #, c-format
 msgid "unrecognized help format '%s'"
 msgstr "непознат формат на помощта „%s“"
 
-#: builtin/help.c:190
+#: builtin/help.c:223
 msgid "Failed to start emacsclient."
 msgstr "Неуспешно стартиране на „emacsclient“."
 
-#: builtin/help.c:203
+#: builtin/help.c:236
 msgid "Failed to parse emacsclient version."
 msgstr "Версията на „emacsclient“ не може да се анализира."
 
-#: builtin/help.c:211
+#: builtin/help.c:244
 #, c-format
 msgid "emacsclient version '%d' too old (< 22)."
 msgstr "Прекалено стара версия на „emacsclient“ — %d (< 22)."
 
-#: builtin/help.c:229 builtin/help.c:251 builtin/help.c:261 builtin/help.c:269
+#: builtin/help.c:262 builtin/help.c:284 builtin/help.c:294 builtin/help.c:302
 #, c-format
 msgid "failed to exec '%s'"
 msgstr "неуспешно изпълнение на „%s“"
 
-#: builtin/help.c:307
+#: builtin/help.c:340
 #, c-format
 msgid ""
 "'%s': path for unsupported man viewer.\n"
@@ -16819,7 +17182,7 @@ msgstr ""
 "„%s“: път към неподдържана програма за преглед на\n"
 " ръководството.  Вместо нея пробвайте „man.<tool>.cmd“."
 
-#: builtin/help.c:319
+#: builtin/help.c:352
 #, c-format
 msgid ""
 "'%s': cmd for supported man viewer.\n"
@@ -16828,339 +17191,330 @@ msgstr ""
 "„%s“: команда за поддържана програма за преглед на\n"
 " ръководството.  Вместо нея пробвайте „man.<tool>.path“."
 
-#: builtin/help.c:436
+#: builtin/help.c:467
 #, c-format
 msgid "'%s': unknown man viewer."
 msgstr "„%s“: непозната програма за преглед на ръководството."
 
-#: builtin/help.c:452
+#: builtin/help.c:483
 msgid "no man viewer handled the request"
 msgstr "никоя програма за преглед на ръководство не успя да обработи заявката"
 
-#: builtin/help.c:459
+#: builtin/help.c:490
 msgid "no info viewer handled the request"
 msgstr ""
 "никоя програма за преглед на информационните страници не успя да обработи "
 "заявката"
 
-#: builtin/help.c:517 builtin/help.c:528 git.c:348
+#: builtin/help.c:551 builtin/help.c:562 git.c:348
 #, c-format
 msgid "'%s' is aliased to '%s'"
 msgstr "„%s“ е псевдоним на „%s“"
 
-#: builtin/help.c:531 git.c:380
+#: builtin/help.c:565 git.c:380
 #, c-format
 msgid "bad alias.%s string: %s"
 msgstr "неправилен низ за настройката „alias.%s“: „%s“"
 
-#: builtin/help.c:561 builtin/help.c:591
+#: builtin/help.c:581
+msgid "this option doesn't take any other arguments"
+msgstr "опцията не приема аргументи"
+
+#: builtin/help.c:602 builtin/help.c:629
 #, c-format
 msgid "usage: %s%s"
 msgstr "употреба: %s%s"
 
-#: builtin/help.c:575
+#: builtin/help.c:624
 msgid "'git help config' for more information"
 msgstr "За повече информация изпълнете „git help config“"
 
-#: builtin/index-pack.c:222
+#: builtin/index-pack.c:221
 #, c-format
 msgid "object type mismatch at %s"
 msgstr "неправилен вид на обекта „%s“"
 
-#: builtin/index-pack.c:242
+#: builtin/index-pack.c:241
 #, c-format
 msgid "did not receive expected object %s"
 msgstr "очакваният обект „%s“ не бе получен"
 
-#: builtin/index-pack.c:245
+#: builtin/index-pack.c:244
 #, c-format
 msgid "object %s: expected type %s, found %s"
 msgstr "неправилен вид на обекта „%s“: очакваше се „%s“, а бе получен „%s“"
 
-#: builtin/index-pack.c:295
+#: builtin/index-pack.c:294
 #, c-format
 msgid "cannot fill %d byte"
 msgid_plural "cannot fill %d bytes"
 msgstr[0] "не може да се запълни %d байт"
 msgstr[1] "не може да се запълнят %d байта"
 
-#: builtin/index-pack.c:305
+#: builtin/index-pack.c:304
 msgid "early EOF"
 msgstr "неочакван край на файл"
 
-#: builtin/index-pack.c:306
+#: builtin/index-pack.c:305
 msgid "read error on input"
 msgstr "грешка при четене на входните данни"
 
-#: builtin/index-pack.c:318
+#: builtin/index-pack.c:317
 msgid "used more bytes than were available"
 msgstr "използвани са повече от наличните байтове"
 
-#: builtin/index-pack.c:325 builtin/pack-objects.c:756
+#: builtin/index-pack.c:324 builtin/pack-objects.c:756
 msgid "pack too large for current definition of off_t"
 msgstr "пакетният файл е прекалено голям за текущата стойност на типа „off_t“"
 
-#: builtin/index-pack.c:328 builtin/unpack-objects.c:95
+#: builtin/index-pack.c:327 builtin/unpack-objects.c:95
 msgid "pack exceeds maximum allowed size"
 msgstr "пакетният файл надвишава максималния възможен размер"
 
-#: builtin/index-pack.c:343
-#, c-format
-msgid "unable to create '%s'"
-msgstr "пакетният файл „%s“ не може да бъде създаден"
-
-#: builtin/index-pack.c:349
-#, c-format
-msgid "cannot open packfile '%s'"
-msgstr "пакетният файл „%s“ не може да бъде отворен"
-
-#: builtin/index-pack.c:363
+#: builtin/index-pack.c:358
 msgid "pack signature mismatch"
 msgstr "несъответствие в подписа към пакетния файл"
 
-#: builtin/index-pack.c:365
+#: builtin/index-pack.c:360
 #, c-format
 msgid "pack version %<PRIu32> unsupported"
 msgstr "не се поддържа пакетиране вeрсия „%<PRIu32>“"
 
-#: builtin/index-pack.c:381
+#: builtin/index-pack.c:376
 #, c-format
 msgid "pack has bad object at offset %<PRIuMAX>: %s"
 msgstr "повреден обект в пакетния файл при отместване %<PRIuMAX>: %s"
 
-#: builtin/index-pack.c:487
+#: builtin/index-pack.c:482
 #, c-format
 msgid "inflate returned %d"
 msgstr "декомпресирането с „inflate“ върна %d"
 
-#: builtin/index-pack.c:536
+#: builtin/index-pack.c:531
 msgid "offset value overflow for delta base object"
 msgstr "стойността на отместването за обекта-разлика води до препълване"
 
-#: builtin/index-pack.c:544
+#: builtin/index-pack.c:539
 msgid "delta base offset is out of bound"
 msgstr "стойността на отместването за обекта-разлика е извън диапазона"
 
-#: builtin/index-pack.c:552
+#: builtin/index-pack.c:547
 #, c-format
 msgid "unknown object type %d"
 msgstr "непознат вид обект %d"
 
-#: builtin/index-pack.c:583
+#: builtin/index-pack.c:578
 msgid "cannot pread pack file"
 msgstr "пакетният файл не може да бъде прочетен"
 
-#: builtin/index-pack.c:585
+#: builtin/index-pack.c:580
 #, c-format
 msgid "premature end of pack file, %<PRIuMAX> byte missing"
 msgid_plural "premature end of pack file, %<PRIuMAX> bytes missing"
 msgstr[0] "неочакван край на файл, липсва %<PRIuMAX> байт"
 msgstr[1] "неочакван край на файл, липсват %<PRIuMAX> байта"
 
-#: builtin/index-pack.c:611
+#: builtin/index-pack.c:606
 msgid "serious inflate inconsistency"
 msgstr "сериозна грешка при декомпресиране с „inflate“"
 
-#: builtin/index-pack.c:756 builtin/index-pack.c:762 builtin/index-pack.c:786
-#: builtin/index-pack.c:825 builtin/index-pack.c:834
+#: builtin/index-pack.c:751 builtin/index-pack.c:757 builtin/index-pack.c:781
+#: builtin/index-pack.c:820 builtin/index-pack.c:829
 #, c-format
 msgid "SHA1 COLLISION FOUND WITH %s !"
 msgstr ""
 "СЪВПАДЕНИЕ НА СТОЙНОСТИТЕ ЗА СУМИТЕ ЗА SHA1: „%s“ НА ДВА РАЗЛИЧНИ ОБЕКТА!"
 
-#: builtin/index-pack.c:759 builtin/pack-objects.c:292
+#: builtin/index-pack.c:754 builtin/pack-objects.c:292
 #: builtin/pack-objects.c:352 builtin/pack-objects.c:458
 #, c-format
 msgid "unable to read %s"
 msgstr "обектът „%s“ не може да бъде прочетен"
 
-#: builtin/index-pack.c:823
+#: builtin/index-pack.c:818
 #, c-format
 msgid "cannot read existing object info %s"
 msgstr "съществуващият обект в „%s“ не може да бъде прочетен"
 
-#: builtin/index-pack.c:831
+#: builtin/index-pack.c:826
 #, c-format
 msgid "cannot read existing object %s"
 msgstr "съществуващият обект „%s“ не може да бъде прочетен"
 
-#: builtin/index-pack.c:845
+#: builtin/index-pack.c:840
 #, c-format
 msgid "invalid blob object %s"
 msgstr "неправилен обект-BLOB „%s“"
 
-#: builtin/index-pack.c:848 builtin/index-pack.c:867
+#: builtin/index-pack.c:843 builtin/index-pack.c:862
 msgid "fsck error in packed object"
 msgstr "грешка при проверката на пакетирани обекти"
 
-#: builtin/index-pack.c:869
+#: builtin/index-pack.c:864
 #, c-format
 msgid "Not all child objects of %s are reachable"
 msgstr "Някои обекти, наследници на „%s“, не може да бъдат достигнати"
 
-#: builtin/index-pack.c:930 builtin/index-pack.c:977
+#: builtin/index-pack.c:925 builtin/index-pack.c:972
 msgid "failed to apply delta"
 msgstr "разликата не може да бъде приложена"
 
-#: builtin/index-pack.c:1160
+#: builtin/index-pack.c:1156
 msgid "Receiving objects"
 msgstr "Получаване на обекти"
 
-#: builtin/index-pack.c:1160
+#: builtin/index-pack.c:1156
 msgid "Indexing objects"
 msgstr "Индексиране на обекти"
 
-#: builtin/index-pack.c:1194
+#: builtin/index-pack.c:1190
 msgid "pack is corrupted (SHA1 mismatch)"
 msgstr "пакетният файл е повреден (нееднакви суми по SHA1)"
 
-#: builtin/index-pack.c:1199
+#: builtin/index-pack.c:1195
 msgid "cannot fstat packfile"
 msgstr "не може да се получи информация за пакетния файл с „fstat“"
 
-#: builtin/index-pack.c:1202
+#: builtin/index-pack.c:1198
 msgid "pack has junk at the end"
 msgstr "в края на пакетния файл има повредени данни"
 
-#: builtin/index-pack.c:1214
+#: builtin/index-pack.c:1210
 msgid "confusion beyond insanity in parse_pack_objects()"
 msgstr ""
 "фатална грешка във функцията „parse_pack_objects“.  Това е грешка в Git, "
 "докладвайте я на разработчиците, като пратите е-писмо на адрес: „git@vger."
 "kernel.org“."
 
-#: builtin/index-pack.c:1237
+#: builtin/index-pack.c:1233
 msgid "Resolving deltas"
 msgstr "Откриване на съответните разлики"
 
-#: builtin/index-pack.c:1248 builtin/pack-objects.c:2892
+#: builtin/index-pack.c:1244 builtin/pack-objects.c:2905
 #, c-format
 msgid "unable to create thread: %s"
 msgstr "не може да се създаде нишка: %s"
 
-#: builtin/index-pack.c:1281
+#: builtin/index-pack.c:1277
 msgid "confusion beyond insanity"
 msgstr "фатална грешка"
 
-#: builtin/index-pack.c:1287
+#: builtin/index-pack.c:1283
 #, c-format
 msgid "completed with %d local object"
 msgid_plural "completed with %d local objects"
 msgstr[0] "действието завърши с %d локален обект"
 msgstr[1] "действието завърши с %d локални обекта"
 
-#: builtin/index-pack.c:1299
+#: builtin/index-pack.c:1295
 #, c-format
 msgid "Unexpected tail checksum for %s (disk corruption?)"
 msgstr ""
 "Неочаквана последваща сума за грешки за „%s“ (причината може да е грешка в "
 "диска)"
 
-#: builtin/index-pack.c:1303
+#: builtin/index-pack.c:1299
 #, c-format
 msgid "pack has %d unresolved delta"
 msgid_plural "pack has %d unresolved deltas"
 msgstr[0] "в пакета има %d ненапасваща разлика"
 msgstr[1] "в пакета има %d ненапасващи разлики"
 
-#: builtin/index-pack.c:1327
+#: builtin/index-pack.c:1323
 #, c-format
 msgid "unable to deflate appended object (%d)"
 msgstr "добавеният обект не може да се компресира с „deflate“: %d"
 
-#: builtin/index-pack.c:1423
+#: builtin/index-pack.c:1419
 #, c-format
 msgid "local object %s is corrupt"
 msgstr "локалният обект „%s“ е повреден"
 
-#: builtin/index-pack.c:1444
+#: builtin/index-pack.c:1440
 #, c-format
 msgid "packfile name '%s' does not end with '.%s'"
 msgstr "името на пакетния файл „%s“ не завършва с „%s“"
 
-#: builtin/index-pack.c:1468
+#: builtin/index-pack.c:1464
 #, c-format
 msgid "cannot write %s file '%s'"
 msgstr "грешка при запис на файла „%s“ „%s“"
 
-#: builtin/index-pack.c:1476
+#: builtin/index-pack.c:1472
 #, c-format
 msgid "cannot close written %s file '%s'"
 msgstr "грешка при затварянето на записания файл „%s“ „%s“"
 
-#: builtin/index-pack.c:1502
+#: builtin/index-pack.c:1489
+#, c-format
+msgid "unable to rename temporary '*.%s' file to '%s'"
+msgstr "временният файл „*.%s“ не може да се преименува на „%s“"
+
+#: builtin/index-pack.c:1514
 msgid "error while closing pack file"
 msgstr "грешка при затварянето на пакетния файл"
 
-#: builtin/index-pack.c:1516
-msgid "cannot store pack file"
-msgstr "пакетният файл не може да бъде запазен"
-
-#: builtin/index-pack.c:1524
-msgid "cannot store index file"
-msgstr "файлът за индекса не може да бъде съхранен"
-
-#: builtin/index-pack.c:1579 builtin/pack-objects.c:3137
+#: builtin/index-pack.c:1573 builtin/pack-objects.c:3150
 #, c-format
 msgid "bad pack.indexversion=%<PRIu32>"
 msgstr "зададена е неправилна версия пакетиране: „pack.indexversion=%<PRIu32>“"
 
-#: builtin/index-pack.c:1649
+#: builtin/index-pack.c:1643
 #, c-format
 msgid "Cannot open existing pack file '%s'"
 msgstr "Съществуващият пакетен файл „%s“ не може да бъде отворен"
 
-#: builtin/index-pack.c:1651
+#: builtin/index-pack.c:1645
 #, c-format
 msgid "Cannot open existing pack idx file for '%s'"
 msgstr "Съществуващият индекс за пакетния файл „%s“ не може да бъде отворен"
 
-#: builtin/index-pack.c:1699
+#: builtin/index-pack.c:1693
 #, c-format
 msgid "non delta: %d object"
 msgid_plural "non delta: %d objects"
 msgstr[0] "%d обект не е разлика"
 msgstr[1] "%d обекта не са разлика"
 
-#: builtin/index-pack.c:1706
+#: builtin/index-pack.c:1700
 #, c-format
 msgid "chain length = %d: %lu object"
 msgid_plural "chain length = %d: %lu objects"
 msgstr[0] "дължината на веригата е %d: %lu обект"
 msgstr[1] "дължината на веригата е %d: %lu обекта"
 
-#: builtin/index-pack.c:1748
+#: builtin/index-pack.c:1742
 msgid "Cannot come back to cwd"
 msgstr "Процесът не може да се върне към предишната работна директория"
 
-#: builtin/index-pack.c:1802 builtin/index-pack.c:1805
-#: builtin/index-pack.c:1821 builtin/index-pack.c:1825
+#: builtin/index-pack.c:1796 builtin/index-pack.c:1799
+#: builtin/index-pack.c:1819 builtin/index-pack.c:1823
 #, c-format
 msgid "bad %s"
 msgstr "неправилна стойност „%s“"
 
-#: builtin/index-pack.c:1831 builtin/init-db.c:379 builtin/init-db.c:614
+#: builtin/index-pack.c:1829 builtin/init-db.c:379 builtin/init-db.c:614
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "непознат алгоритъм за контролни суми „%s“"
 
-#: builtin/index-pack.c:1850
+#: builtin/index-pack.c:1848
 msgid "--fix-thin cannot be used without --stdin"
 msgstr "опцията „--fix-thin“ изисква „--stdin“"
 
-#: builtin/index-pack.c:1852
+#: builtin/index-pack.c:1850
 msgid "--stdin requires a git repository"
 msgstr "„--stdin“ изисква хранилище на git"
 
-#: builtin/index-pack.c:1854
+#: builtin/index-pack.c:1852
 msgid "--object-format cannot be used with --stdin"
 msgstr "опцията „--object-format“ и „--stdin“ са несъвместими"
 
-#: builtin/index-pack.c:1869
+#: builtin/index-pack.c:1867
 msgid "--verify with no packfile name given"
 msgstr "опцията „--verify“ изисква име на пакетен файл"
 
-#: builtin/index-pack.c:1935 builtin/unpack-objects.c:584
+#: builtin/index-pack.c:1933 builtin/unpack-objects.c:584
 msgid "fsck error in pack objects"
 msgstr "грешка при проверка с „fsck“ на пакетните обекти"
 
@@ -17822,131 +18176,135 @@ msgstr ""
 "Следеният отдалечен клон не бе открит, затова изрично задайте "
 "ОТДАЛЕЧЕН_КЛОН.\n"
 
-#: builtin/ls-files.c:563
+#: builtin/ls-files.c:561
 msgid "git ls-files [<options>] [<file>...]"
 msgstr "git ls-files [ОПЦИЯ…] [ФАЙЛ…]"
 
-#: builtin/ls-files.c:619
+#: builtin/ls-files.c:615
+msgid "separate paths with the NUL character"
+msgstr "разделяне на пътищата с нулевия знак „NUL“"
+
+#: builtin/ls-files.c:617
 msgid "identify the file status with tags"
 msgstr "извеждане на състоянието на файловете с еднобуквени флагове"
 
-#: builtin/ls-files.c:621
+#: builtin/ls-files.c:619
 msgid "use lowercase letters for 'assume unchanged' files"
 msgstr "малки букви за файловете, които да се счетат за непроменени"
 
-#: builtin/ls-files.c:623
+#: builtin/ls-files.c:621
 msgid "use lowercase letters for 'fsmonitor clean' files"
 msgstr "малки букви за файловете за командата „fsmonitor clean“"
 
-#: builtin/ls-files.c:625
+#: builtin/ls-files.c:623
 msgid "show cached files in the output (default)"
 msgstr "извеждане на кешираните файлове (стандартно)"
 
-#: builtin/ls-files.c:627
+#: builtin/ls-files.c:625
 msgid "show deleted files in the output"
 msgstr "извеждане на изтритите файлове"
 
-#: builtin/ls-files.c:629
+#: builtin/ls-files.c:627
 msgid "show modified files in the output"
 msgstr "извеждане на променените файлове"
 
-#: builtin/ls-files.c:631
+#: builtin/ls-files.c:629
 msgid "show other files in the output"
 msgstr "извеждане на другите файлове"
 
-#: builtin/ls-files.c:633
+#: builtin/ls-files.c:631
 msgid "show ignored files in the output"
 msgstr "извеждане на игнорираните файлове"
 
-#: builtin/ls-files.c:636
+#: builtin/ls-files.c:634
 msgid "show staged contents' object name in the output"
 msgstr "извеждане на името на обекта за съдържанието на индекса"
 
-#: builtin/ls-files.c:638
+#: builtin/ls-files.c:636
 msgid "show files on the filesystem that need to be removed"
 msgstr "извеждане на файловете, които трябва да бъдат изтрити"
 
-#: builtin/ls-files.c:640
+#: builtin/ls-files.c:638
 msgid "show 'other' directories' names only"
 msgstr "извеждане само на името на другите (неследените) директории"
 
-#: builtin/ls-files.c:642
+#: builtin/ls-files.c:640
 msgid "show line endings of files"
 msgstr "извеждане на знаците за край на ред във файловете"
 
-#: builtin/ls-files.c:644
+#: builtin/ls-files.c:642
 msgid "don't show empty directories"
 msgstr "без извеждане на празните директории"
 
-#: builtin/ls-files.c:647
+#: builtin/ls-files.c:645
 msgid "show unmerged files in the output"
 msgstr "извеждане на неслетите файлове"
 
-#: builtin/ls-files.c:649
+#: builtin/ls-files.c:647
 msgid "show resolve-undo information"
 msgstr "извеждане на информацията за отмяна на разрешените подавания"
 
-#: builtin/ls-files.c:651
+#: builtin/ls-files.c:649
 msgid "skip files matching pattern"
 msgstr "прескачане на файловете напасващи ШАБЛОНа"
 
-#: builtin/ls-files.c:654
-msgid "exclude patterns are read from <file>"
-msgstr "шаблоните за игнориране да се прочетат от този ФАЙЛ"
+#: builtin/ls-files.c:652
+msgid "read exclude patterns from <file>"
+msgstr "изчитане на шаблоните за игнориране от ФАЙЛ"
 
-#: builtin/ls-files.c:657
+#: builtin/ls-files.c:655
 msgid "read additional per-directory exclude patterns in <file>"
 msgstr ""
 "изчитане на допълнителните шаблони за игнориране по директория от този ФАЙЛ"
 
-#: builtin/ls-files.c:659
+#: builtin/ls-files.c:657
 msgid "add the standard git exclusions"
 msgstr "добавяне на стандартно игнорираните от Git файлове"
 
-#: builtin/ls-files.c:663
+#: builtin/ls-files.c:661
 msgid "make the output relative to the project top directory"
 msgstr "пътищата да са относителни спрямо основната директория на проекта"
 
-#: builtin/ls-files.c:666
+#: builtin/ls-files.c:664
 msgid "recurse through submodules"
 msgstr "рекурсивно обхождане подмодулите"
 
-#: builtin/ls-files.c:668
+#: builtin/ls-files.c:666
 msgid "if any <file> is not in the index, treat this as an error"
 msgstr "грешка, ако някой от тези ФАЙЛове не е в индекса"
 
-#: builtin/ls-files.c:669
+#: builtin/ls-files.c:667
 msgid "tree-ish"
 msgstr "УКАЗАТЕЛ_КЪМ_ДЪРВО"
 
-#: builtin/ls-files.c:670
+#: builtin/ls-files.c:668
 msgid "pretend that paths removed since <tree-ish> are still present"
 msgstr ""
 "считане, че пътищата изтрити след УКАЗАТЕЛя_КЪМ_ДЪРВО все още съществуват"
 
-#: builtin/ls-files.c:672
+#: builtin/ls-files.c:670
 msgid "show debugging data"
 msgstr "извеждане на информацията за изчистване на грешки"
 
-#: builtin/ls-files.c:674
+#: builtin/ls-files.c:672
 msgid "suppress duplicate entries"
 msgstr "без повтаряне на записите"
 
 #: builtin/ls-remote.c:9
 msgid ""
 "git ls-remote [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
-"                     [-q | --quiet] [--exit-code] [--get-url]\n"
-"                     [--symref] [<repository> [<refs>...]]"
+"              [-q | --quiet] [--exit-code] [--get-url]\n"
+"              [--symref] [<repository> [<refs>...]]"
 msgstr ""
-"git ls-remote [--heads] [--tags] [--refs] [--upload-pack=КОМАНДА]\n"
-"                     [-q | --quiet] [--exit-code] [--get-url]\n"
-"                     [--symref] [ХРАНИЛИЩЕ [УКАЗАТЕЛ…]]"
+"git ls-remote [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
+"              [-q | --quiet] [--exit-code] [--get-url]\n"
+"              [--symref] [ХРАНИЛИЩЕ [УКАЗАТЕЛ…]]"
 
 #: builtin/ls-remote.c:60
 msgid "do not print remote URL"
 msgstr "без извеждане на адресите на отдалечените хранилища"
 
-#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1399
+#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1103
 msgid "exec"
 msgstr "КОМАНДА"
 
@@ -18068,7 +18426,7 @@ msgstr "ДЕЙСТВИЕ при намирането на цитиран зна�
 msgid "use headers in message's body"
 msgstr "заглавни части в тялото на писмото"
 
-#: builtin/mailsplit.c:241
+#: builtin/mailsplit.c:239
 #, c-format
 msgid "empty mbox: '%s'"
 msgstr "празна пощенска кутия mbox: „%s“"
@@ -18185,146 +18543,146 @@ msgstr "указателят „%s“ не може да бъде изтрит"
 msgid "Merging %s with %s\n"
 msgstr "Сливане на „%s“ с „%s“\n"
 
-#: builtin/merge.c:58
+#: builtin/merge.c:59
 msgid "git merge [<options>] [<commit>...]"
 msgstr "git merge [ОПЦИЯ…] [ПОДАВАНЕ…]"
 
-#: builtin/merge.c:123
+#: builtin/merge.c:124
 msgid "switch `m' requires a value"
 msgstr "опцията „-m“ изисква стойност"
 
-#: builtin/merge.c:146
+#: builtin/merge.c:147
 #, c-format
 msgid "option `%s' requires a value"
 msgstr "опцията „%s“ изисква стойност"
 
-#: builtin/merge.c:199
+#: builtin/merge.c:200
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
 msgstr "Няма такава стратегия за сливане: „%s“.\n"
 
-#: builtin/merge.c:200
+#: builtin/merge.c:201
 #, c-format
 msgid "Available strategies are:"
 msgstr "Наличните стратегии са:"
 
-#: builtin/merge.c:205
+#: builtin/merge.c:206
 #, c-format
 msgid "Available custom strategies are:"
 msgstr "Допълнителните стратегии са:"
 
-#: builtin/merge.c:256 builtin/pull.c:133
+#: builtin/merge.c:257 builtin/pull.c:133
 msgid "do not show a diffstat at the end of the merge"
 msgstr "без извеждане на статистиката след завършване на сливане"
 
-#: builtin/merge.c:259 builtin/pull.c:136
+#: builtin/merge.c:260 builtin/pull.c:136
 msgid "show a diffstat at the end of the merge"
 msgstr "извеждане на статистиката след завършване на сливане"
 
-#: builtin/merge.c:260 builtin/pull.c:139
+#: builtin/merge.c:261 builtin/pull.c:139
 msgid "(synonym to --stat)"
 msgstr "(псевдоним на „--stat“)"
 
-#: builtin/merge.c:262 builtin/pull.c:142
+#: builtin/merge.c:263 builtin/pull.c:142
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "добавяне (на максимум такъв БРОЙ) записи от съкратения журнал в съобщението "
 "за подаване"
 
-#: builtin/merge.c:265 builtin/pull.c:148
+#: builtin/merge.c:266 builtin/pull.c:148
 msgid "create a single commit instead of doing a merge"
 msgstr "създаване на едно подаване вместо извършване на сливане"
 
-#: builtin/merge.c:267 builtin/pull.c:151
+#: builtin/merge.c:268 builtin/pull.c:151
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "извършване на подаване при успешно сливане (стандартно действие)"
 
-#: builtin/merge.c:269 builtin/pull.c:154
+#: builtin/merge.c:270 builtin/pull.c:154
 msgid "edit message before committing"
 msgstr "редактиране на съобщението преди подаване"
 
-#: builtin/merge.c:271
+#: builtin/merge.c:272
 msgid "allow fast-forward (default)"
 msgstr "позволяване на превъртане (стандартно действие)"
 
-#: builtin/merge.c:273 builtin/pull.c:161
+#: builtin/merge.c:274 builtin/pull.c:161
 msgid "abort if fast-forward is not possible"
 msgstr "преустановяване, ако превъртането е невъзможно"
 
-#: builtin/merge.c:277 builtin/pull.c:164
+#: builtin/merge.c:278 builtin/pull.c:164
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "проверка, че указаното подаване е с правилен подпис на GPG"
 
-#: builtin/merge.c:278 builtin/notes.c:787 builtin/pull.c:168
-#: builtin/rebase.c:540 builtin/rebase.c:1413 builtin/revert.c:114
+#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:168
+#: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr "СТРАТЕГИЯ"
 
-#: builtin/merge.c:279 builtin/pull.c:169
+#: builtin/merge.c:280 builtin/pull.c:169
 msgid "merge strategy to use"
 msgstr "СТРАТЕГИЯ за сливане, която да се ползва"
 
-#: builtin/merge.c:280 builtin/pull.c:172
+#: builtin/merge.c:281 builtin/pull.c:172
 msgid "option=value"
 msgstr "ОПЦИЯ=СТОЙНОСТ"
 
-#: builtin/merge.c:281 builtin/pull.c:173
+#: builtin/merge.c:282 builtin/pull.c:173
 msgid "option for selected merge strategy"
 msgstr "ОПЦИЯ за избраната стратегия за сливане"
 
-#: builtin/merge.c:283
+#: builtin/merge.c:284
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr "СЪОБЩЕНИЕ при подаването със сливане (при същински сливания)"
 
-#: builtin/merge.c:290
+#: builtin/merge.c:291
 msgid "abort the current in-progress merge"
 msgstr "преустановяване на текущото сливане"
 
-#: builtin/merge.c:292
+#: builtin/merge.c:293
 msgid "--abort but leave index and working tree alone"
 msgstr "преустановяване (--abort) без промяна на индекса и работното дърво"
 
-#: builtin/merge.c:294
+#: builtin/merge.c:295
 msgid "continue the current in-progress merge"
 msgstr "продължаване на текущото сливане"
 
-#: builtin/merge.c:296 builtin/pull.c:180
+#: builtin/merge.c:297 builtin/pull.c:180
 msgid "allow merging unrelated histories"
 msgstr "позволяване на сливане на независими истории"
 
-#: builtin/merge.c:303
+#: builtin/merge.c:304
 msgid "bypass pre-merge-commit and commit-msg hooks"
 msgstr ""
 "без изпълнение на куките преди подаване и сливане и при промяна на "
 "съобщението за подаване (pre-merge-commit и commit-msg)"
 
-#: builtin/merge.c:320
+#: builtin/merge.c:321
 msgid "could not run stash."
 msgstr "не може да се извърши скатаване"
 
-#: builtin/merge.c:325
+#: builtin/merge.c:326
 msgid "stash failed"
 msgstr "неуспешно скатаване"
 
-#: builtin/merge.c:330
+#: builtin/merge.c:331
 #, c-format
 msgid "not a valid object: %s"
 msgstr "неправилен обект: „%s“"
 
-#: builtin/merge.c:352 builtin/merge.c:369
+#: builtin/merge.c:353 builtin/merge.c:370
 msgid "read-tree failed"
 msgstr "неуспешно прочитане на обект-дърво"
 
-#: builtin/merge.c:400
+#: builtin/merge.c:401
 msgid "Already up to date. (nothing to squash)"
 msgstr "Вече е обновено (няма какво да се вкара)"
 
-#: builtin/merge.c:414
+#: builtin/merge.c:415
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
 msgstr "Вкарано подаване — указателят „HEAD“ няма да бъде обновен\n"
 
-#: builtin/merge.c:464
+#: builtin/merge.c:465
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
 msgstr ""
@@ -18340,33 +18698,33 @@ msgstr "„%s“ не сочи към подаване"
 msgid "Bad branch.%s.mergeoptions string: %s"
 msgstr "Неправилен низ за настройката „branch.%s.mergeoptions“: „%s“"
 
-#: builtin/merge.c:729
+#: builtin/merge.c:730
 msgid "Not handling anything other than two heads merge."
 msgstr "Поддържа се само сливане на точно две истории."
 
-#: builtin/merge.c:742
+#: builtin/merge.c:743
 #, c-format
-msgid "Unknown option for merge-recursive: -X%s"
-msgstr "Непозната опция за рекурсивното сливане „merge-recursive“: „-X%s“"
+msgid "unknown strategy option: -X%s"
+msgstr "непозната опция за стратегия: -X%s"
 
-#: builtin/merge.c:761 t/helper/test-fast-rebase.c:223
+#: builtin/merge.c:762 t/helper/test-fast-rebase.c:223
 #, c-format
 msgid "unable to write %s"
 msgstr "„%s“ не може да бъде записан"
 
-#: builtin/merge.c:813
+#: builtin/merge.c:814
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "От „%s“ не може да се чете"
 
-#: builtin/merge.c:822
+#: builtin/merge.c:823
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
 "Сливането няма да бъде подадено.  За завършването му и подаването му "
 "използвайте командата „git commit“.\n"
 
-#: builtin/merge.c:828
+#: builtin/merge.c:829
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
@@ -18375,11 +18733,11 @@ msgstr ""
 "В съобщението при подаване добавете информация за причината за\n"
 "сливането, особено ако сливате обновен отдалечен клон в тематичен клон.\n"
 
-#: builtin/merge.c:833
+#: builtin/merge.c:834
 msgid "An empty message aborts the commit.\n"
 msgstr "Празно съобщение предотвратява подаването.\n"
 
-#: builtin/merge.c:836
+#: builtin/merge.c:837
 #, c-format
 msgid ""
 "Lines starting with '%c' will be ignored, and an empty message aborts\n"
@@ -18388,76 +18746,76 @@ msgstr ""
 "Редовете, които започват с „%c“, ще бъдат пропуснати, а празно\n"
 "съобщение преустановява подаването.\n"
 
-#: builtin/merge.c:889
+#: builtin/merge.c:892
 msgid "Empty commit message."
 msgstr "Празно съобщение при подаване."
 
-#: builtin/merge.c:904
+#: builtin/merge.c:907
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Първият етап на сливането завърши.\n"
 
-#: builtin/merge.c:965
+#: builtin/merge.c:968
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
 "Неуспешно автоматично сливане — коригирайте конфликтите и подайте "
 "резултата.\n"
 
-#: builtin/merge.c:1004
+#: builtin/merge.c:1007
 msgid "No current branch."
 msgstr "Няма текущ клон."
 
-#: builtin/merge.c:1006
+#: builtin/merge.c:1009
 msgid "No remote for the current branch."
 msgstr "Текущият клон не следи никой."
 
-#: builtin/merge.c:1008
+#: builtin/merge.c:1011
 msgid "No default upstream defined for the current branch."
 msgstr "Текущият клон не следи никой клон."
 
-#: builtin/merge.c:1013
+#: builtin/merge.c:1016
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "Никой клон не следи клона „%s“ от хранилището „%s“"
 
-#: builtin/merge.c:1070
+#: builtin/merge.c:1073
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Неправилна стойност „%s“ в средата „%s“"
 
-#: builtin/merge.c:1173
+#: builtin/merge.c:1174
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "не може да се слее в „%s“: %s"
 
-#: builtin/merge.c:1207
+#: builtin/merge.c:1208
 msgid "not something we can merge"
 msgstr "не може да се слее"
 
-#: builtin/merge.c:1317
+#: builtin/merge.c:1321
 msgid "--abort expects no arguments"
 msgstr "опцията „--abort“ не приема аргументи"
 
-#: builtin/merge.c:1321
+#: builtin/merge.c:1325
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr ""
 "Не може да преустановите сливане, защото в момента не се извършва такова "
 "(липсва указател „MERGE_HEAD“)."
 
-#: builtin/merge.c:1339
+#: builtin/merge.c:1343
 msgid "--quit expects no arguments"
 msgstr "опцията „--quit“ не приема аргументи"
 
-#: builtin/merge.c:1352
+#: builtin/merge.c:1356
 msgid "--continue expects no arguments"
 msgstr "опцията „--continue“ не приема аргументи"
 
-#: builtin/merge.c:1356
+#: builtin/merge.c:1360
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "В момента не се извършва сливане (липсва указател „MERGE_HEAD“)."
 
-#: builtin/merge.c:1372
+#: builtin/merge.c:1376
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -18465,7 +18823,7 @@ msgstr ""
 "Не сте завършили сливане.  (Указателят „MERGE_HEAD“ съществува).\n"
 "Подайте промените си, преди да започнете ново сливане."
 
-#: builtin/merge.c:1379
+#: builtin/merge.c:1383
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -18473,94 +18831,90 @@ msgstr ""
 "Не сте завършили отбиране на подаване (указателят „CHERRY_PICK_HEAD“\n"
 "съществува).  Подайте промените си, преди да започнете ново сливане."
 
-#: builtin/merge.c:1382
+#: builtin/merge.c:1386
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr ""
 "Не сте завършили отбиране на подаване (указателят „CHERRY_PICK_HEAD“\n"
 "съществува)."
 
-#: builtin/merge.c:1396
+#: builtin/merge.c:1400
 msgid "You cannot combine --squash with --no-ff."
 msgstr "опциите „--squash“ и „--no-ff“ са несъвместими."
 
-#: builtin/merge.c:1398
+#: builtin/merge.c:1402
 msgid "You cannot combine --squash with --commit."
 msgstr "опциите „--squash“ и „--commit“ са несъвместими."
 
-#: builtin/merge.c:1414
+#: builtin/merge.c:1418
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr ""
 "Не е указано подаване и настройката „merge.defaultToUpstream“ не е зададена."
 
-#: builtin/merge.c:1431
+#: builtin/merge.c:1435
 msgid "Squash commit into empty head not supported yet"
 msgstr "Вкарване на подаване във връх без история все още не се поддържа"
 
-#: builtin/merge.c:1433
+#: builtin/merge.c:1437
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr ""
 "Понеже върхът е без история, сливания, които не са превъртания, са невъзможни"
 
-#: builtin/merge.c:1438
+#: builtin/merge.c:1442
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "„%s“ — не е нещо, което може да се слее"
 
-#: builtin/merge.c:1440
+#: builtin/merge.c:1444
 msgid "Can merge only exactly one commit into empty head"
 msgstr "Може да слеете точно едно подаване във връх без история"
 
-#: builtin/merge.c:1521
+#: builtin/merge.c:1531
 msgid "refusing to merge unrelated histories"
 msgstr "независими истории не може да се слеят"
 
-#: builtin/merge.c:1540
+#: builtin/merge.c:1550
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "Обновяване „%s..%s“\n"
 
-#: builtin/merge.c:1587
+#: builtin/merge.c:1598
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "Проба със сливане в рамките на индекса…\n"
 
-#: builtin/merge.c:1594
+#: builtin/merge.c:1605
 #, c-format
 msgid "Nope.\n"
 msgstr "Неуспешно сливане.\n"
 
-#: builtin/merge.c:1625
-msgid "Not possible to fast-forward, aborting."
-msgstr "Не може да се извърши превъртане, преустановяване на действието."
-
-#: builtin/merge.c:1653 builtin/merge.c:1719
+#: builtin/merge.c:1664 builtin/merge.c:1730
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "Привеждане на дървото към първоначалното…\n"
 
-#: builtin/merge.c:1657
+#: builtin/merge.c:1668
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Пробване със стратегията за сливане „%s“…\n"
 
-#: builtin/merge.c:1709
+#: builtin/merge.c:1720
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Никоя стратегия за сливане не може да извърши сливането.\n"
 
-#: builtin/merge.c:1711
+#: builtin/merge.c:1722
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "Неуспешно сливане със стратегия „%s“.\n"
 
-#: builtin/merge.c:1721
+#: builtin/merge.c:1732
 #, c-format
 msgid "Using the %s strategy to prepare resolving by hand.\n"
 msgstr ""
 "Ползва се стратегията „%s“, която ще подготви дървото за коригиране на "
 "ръка.\n"
 
-#: builtin/merge.c:1735
+#: builtin/merge.c:1746
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
@@ -18595,15 +18949,15 @@ msgstr "обектът с етикет не може да бъде прочет�
 msgid "object '%s' tagged as '%s', but is a '%s' type"
 msgstr "обектът „%s“ е с етикет за %s, но е %s"
 
-#: builtin/mktag.c:97
+#: builtin/mktag.c:98
 msgid "tag on stdin did not pass our strict fsck check"
 msgstr "етикетът на стандартния вход не преминава строгата проверка с „fsck“"
 
-#: builtin/mktag.c:100
+#: builtin/mktag.c:101
 msgid "tag on stdin did not refer to a valid object"
 msgstr "етикетът на стандартния вход не сочи към правилен обект"
 
-#: builtin/mktag.c:103 builtin/tag.c:243
+#: builtin/mktag.c:104 builtin/tag.c:243
 msgid "unable to write tag file"
 msgstr "файлът за етикета не може да бъде запазен"
 
@@ -18624,48 +18978,61 @@ msgid "allow creation of more than one tree"
 msgstr "разрешаване на създаването на повече от едно дърво"
 
 #: builtin/multi-pack-index.c:10
-msgid "git multi-pack-index [<options>] write [--preferred-pack=<pack>]"
-msgstr "git multi-pack-index [ОПЦИЯ…] write [--preferred-pack=ПАКЕТ]"
+msgid ""
+"git multi-pack-index [<options>] write [--preferred-pack=<pack>][--refs-"
+"snapshot=<path>]"
+msgstr ""
+"git multi-pack-index [ОПЦИЯ…] write [--preferred-pack=ПАКЕТ] [--refs-"
+"snapshot=ПЪТ]"
 
-#: builtin/multi-pack-index.c:13
+#: builtin/multi-pack-index.c:14
 msgid "git multi-pack-index [<options>] verify"
 msgstr "git multi-pack-index [ОПЦИЯ…] verify"
 
-#: builtin/multi-pack-index.c:16
+#: builtin/multi-pack-index.c:17
 msgid "git multi-pack-index [<options>] expire"
 msgstr "git multi-pack-index [ОПЦИЯ…] expire"
 
-#: builtin/multi-pack-index.c:19
+#: builtin/multi-pack-index.c:20
 msgid "git multi-pack-index [<options>] repack [--batch-size=<size>]"
 msgstr "git multi-pack-index [ОПЦИЯ…] repack [--batch-size=РАЗМЕР]"
 
-#: builtin/multi-pack-index.c:54
+#: builtin/multi-pack-index.c:57
 msgid "object directory containing set of packfile and pack-index pairs"
 msgstr ""
 "ДИРекторията_с_ОБЕКТи съдържа множество двойки пакетни файлове със "
 "съответния им индекс"
 
-#: builtin/multi-pack-index.c:69
+#: builtin/multi-pack-index.c:98
 msgid "preferred-pack"
 msgstr "предпочитан_пакет"
 
-#: builtin/multi-pack-index.c:70
+#: builtin/multi-pack-index.c:99
 msgid "pack for reuse when computing a multi-pack bitmap"
 msgstr ""
 "пакет, който да се преизползва при изчисляване на многопакетна битовата маска"
 
-#: builtin/multi-pack-index.c:128
+#: builtin/multi-pack-index.c:100
+msgid "write multi-pack bitmap"
+msgstr "запазване на многопакетната битова маска"
+
+#: builtin/multi-pack-index.c:105
+msgid "write multi-pack index containing only given indexes"
+msgstr ""
+"запазване на битовата маска за множество пакети, съдържаща само дадените "
+"индекси"
+
+#: builtin/multi-pack-index.c:107
+msgid "refs snapshot for selecting bitmap commits"
+msgstr "снимка на указателите за избор на подавания по битова маска"
+
+#: builtin/multi-pack-index.c:202
 msgid ""
 "during repack, collect pack-files of smaller size into a batch that is "
 "larger than this size"
 msgstr ""
 "при препакетиране пакетните файлове, които са с по-малък от този размер, да "
 "се обединяват в пакети с по-голям от този размер"
-
-#: builtin/multi-pack-index.c:179
-#, c-format
-msgid "unrecognized subcommand: %s"
-msgstr "непозната подкоманда: %s"
 
 #: builtin/mv.c:18
 msgid "git mv [<options>] <source>... <destination>"
@@ -18695,72 +19062,72 @@ msgstr "принудително преместване/преименуване
 msgid "skip move/rename errors"
 msgstr "прескачане на грешките при преместване/преименуване"
 
-#: builtin/mv.c:170
+#: builtin/mv.c:172
 #, c-format
 msgid "destination '%s' is not a directory"
 msgstr "целта „%s“ съществува и не е директория"
 
-#: builtin/mv.c:181
+#: builtin/mv.c:184
 #, c-format
 msgid "Checking rename of '%s' to '%s'\n"
 msgstr "Проверка на преименуването на обект от „%s“ на „%s“\n"
 
-#: builtin/mv.c:185
+#: builtin/mv.c:190
 msgid "bad source"
 msgstr "неправилен обект"
 
-#: builtin/mv.c:188
+#: builtin/mv.c:193
 msgid "can not move directory into itself"
 msgstr "директория не може да се премести в себе си"
 
-#: builtin/mv.c:191
+#: builtin/mv.c:196
 msgid "cannot move directory over file"
 msgstr "директория не може да се премести върху файл"
 
-#: builtin/mv.c:200
+#: builtin/mv.c:205
 msgid "source directory is empty"
 msgstr "първоначалната директория е празна"
 
-#: builtin/mv.c:225
+#: builtin/mv.c:231
 msgid "not under version control"
 msgstr "не е под контрола на Git"
 
-#: builtin/mv.c:227
+#: builtin/mv.c:233
 msgid "conflicted"
 msgstr "конфликт"
 
-#: builtin/mv.c:230
+#: builtin/mv.c:236
 msgid "destination exists"
 msgstr "целта съществува"
 
-#: builtin/mv.c:238
+#: builtin/mv.c:244
 #, c-format
 msgid "overwriting '%s'"
 msgstr "презаписване на „%s“"
 
-#: builtin/mv.c:241
+#: builtin/mv.c:247
 msgid "Cannot overwrite"
 msgstr "Презаписването е невъзможно"
 
-#: builtin/mv.c:244
+#: builtin/mv.c:250
 msgid "multiple sources for the same target"
 msgstr "множество източници за една цел"
 
-#: builtin/mv.c:246
+#: builtin/mv.c:252
 msgid "destination directory does not exist"
 msgstr "целевата директория не съществува"
 
-#: builtin/mv.c:253
+#: builtin/mv.c:280
 #, c-format
 msgid "%s, source=%s, destination=%s"
 msgstr "%s, обект: „%s“, цел: „%s“"
 
-#: builtin/mv.c:274
+#: builtin/mv.c:308
 #, c-format
 msgid "Renaming %s to %s\n"
 msgstr "Преименуване на „%s“ на „%s“\n"
 
-#: builtin/mv.c:280 builtin/remote.c:785 builtin/repack.c:667
+#: builtin/mv.c:314 builtin/remote.c:790 builtin/repack.c:853
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "неуспешно преименуване на „%s“"
@@ -18941,48 +19308,48 @@ msgstr "изведената информация от действието „s
 msgid "failed to finish 'show' for object '%s'"
 msgstr "действието „show“ не може да се завърши за обект „%s“"
 
-#: builtin/notes.c:197
+#: builtin/notes.c:195
 msgid "please supply the note contents using either -m or -F option"
 msgstr "задайте съдържанието на бележката с някоя от опциите „-m“ или „-F“"
 
-#: builtin/notes.c:206
+#: builtin/notes.c:204
 msgid "unable to write note object"
 msgstr "обектът-бележка не може да бъде записан"
 
-#: builtin/notes.c:208
+#: builtin/notes.c:206
 #, c-format
 msgid "the note contents have been left in %s"
 msgstr "съдържанието на бележката е във файла „%s“"
 
-#: builtin/notes.c:242 builtin/tag.c:576
+#: builtin/notes.c:240 builtin/tag.c:577
 #, c-format
 msgid "could not open or read '%s'"
 msgstr "файлът „%s“ не може да бъде отворен или прочетен"
 
-#: builtin/notes.c:263 builtin/notes.c:313 builtin/notes.c:315
-#: builtin/notes.c:383 builtin/notes.c:438 builtin/notes.c:526
-#: builtin/notes.c:531 builtin/notes.c:610 builtin/notes.c:672
+#: builtin/notes.c:261 builtin/notes.c:311 builtin/notes.c:313
+#: builtin/notes.c:381 builtin/notes.c:436 builtin/notes.c:524
+#: builtin/notes.c:529 builtin/notes.c:608 builtin/notes.c:670
 #, c-format
 msgid "failed to resolve '%s' as a valid ref."
 msgstr "не може да се открие към какво сочи „%s“."
 
-#: builtin/notes.c:265
+#: builtin/notes.c:263
 #, c-format
 msgid "failed to read object '%s'."
 msgstr "обектът „%s“ не може да бъде прочетен."
 
-#: builtin/notes.c:268
+#: builtin/notes.c:266
 #, c-format
 msgid "cannot read note data from non-blob object '%s'."
 msgstr ""
 "съдържанието на бележка не може да се вземе от обект, който не е BLOB: „%s“."
 
-#: builtin/notes.c:309
+#: builtin/notes.c:307
 #, c-format
 msgid "malformed input line: '%s'."
 msgstr "входен ред с неправилен формат: „%s“."
 
-#: builtin/notes.c:324
+#: builtin/notes.c:322
 #, c-format
 msgid "failed to copy notes from '%s' to '%s'"
 msgstr "бележката не може да се копира от „%s“ към „%s“"
@@ -18990,50 +19357,50 @@ msgstr "бележката не може да се копира от „%s“ к
 #. TRANSLATORS: the first %s will be replaced by a git
 #. notes command: 'add', 'merge', 'remove', etc.
 #.
-#: builtin/notes.c:356
+#: builtin/notes.c:354
 #, c-format
 msgid "refusing to %s notes in %s (outside of refs/notes/)"
 msgstr ""
 "няма да се извърши „%s“ върху бележките в „%s“, защото са извън „refs/"
 "notes/“."
 
-#: builtin/notes.c:376 builtin/notes.c:431 builtin/notes.c:509
-#: builtin/notes.c:521 builtin/notes.c:598 builtin/notes.c:665
-#: builtin/notes.c:815 builtin/notes.c:963 builtin/notes.c:985
-#: builtin/prune-packed.c:25 builtin/tag.c:586
+#: builtin/notes.c:374 builtin/notes.c:429 builtin/notes.c:507
+#: builtin/notes.c:519 builtin/notes.c:596 builtin/notes.c:663
+#: builtin/notes.c:813 builtin/notes.c:961 builtin/notes.c:983
+#: builtin/prune-packed.c:25 builtin/tag.c:587
 msgid "too many arguments"
 msgstr "прекалено много аргументи"
 
-#: builtin/notes.c:389 builtin/notes.c:678
+#: builtin/notes.c:387 builtin/notes.c:676
 #, c-format
 msgid "no note found for object %s."
 msgstr "няма бележки за обекта „%s“."
 
-#: builtin/notes.c:410 builtin/notes.c:576
+#: builtin/notes.c:408 builtin/notes.c:574
 msgid "note contents as a string"
 msgstr "низ, който е съдържанието на бележката"
 
-#: builtin/notes.c:413 builtin/notes.c:579
+#: builtin/notes.c:411 builtin/notes.c:577
 msgid "note contents in a file"
 msgstr "ФАЙЛ със съдържанието на бележката"
 
-#: builtin/notes.c:416 builtin/notes.c:582
+#: builtin/notes.c:414 builtin/notes.c:580
 msgid "reuse and edit specified note object"
 msgstr "преизползване и редактиране на указания ОБЕКТ-бележка"
 
-#: builtin/notes.c:419 builtin/notes.c:585
+#: builtin/notes.c:417 builtin/notes.c:583
 msgid "reuse specified note object"
 msgstr "преизползване на указания ОБЕКТ-бележка"
 
-#: builtin/notes.c:422 builtin/notes.c:588
+#: builtin/notes.c:420 builtin/notes.c:586
 msgid "allow storing empty note"
 msgstr "приемане и на празни бележки"
 
-#: builtin/notes.c:423 builtin/notes.c:496
+#: builtin/notes.c:421 builtin/notes.c:494
 msgid "replace existing notes"
 msgstr "замяна на съществуващите бележки"
 
-#: builtin/notes.c:448
+#: builtin/notes.c:446
 #, c-format
 msgid ""
 "Cannot add notes. Found existing notes for object %s. Use '-f' to overwrite "
@@ -19042,31 +19409,31 @@ msgstr ""
 "Не може да се добави бележка, защото такава вече съществува за обекта „%s“.  "
 "Използвайте опцията „-f“, за да презапишете съществуващи бележки."
 
-#: builtin/notes.c:463 builtin/notes.c:544
+#: builtin/notes.c:461 builtin/notes.c:542
 #, c-format
 msgid "Overwriting existing notes for object %s\n"
 msgstr "Презаписване на съществуващите бележки за обекта „%s“\n"
 
-#: builtin/notes.c:475 builtin/notes.c:637 builtin/notes.c:902
+#: builtin/notes.c:473 builtin/notes.c:635 builtin/notes.c:900
 #, c-format
 msgid "Removing note for object %s\n"
 msgstr "Изтриване на бележката за обекта „%s“\n"
 
-#: builtin/notes.c:497
+#: builtin/notes.c:495
 msgid "read objects from stdin"
 msgstr "изчитане на обектите от стандартния вход"
 
-#: builtin/notes.c:499
+#: builtin/notes.c:497
 msgid "load rewriting config for <command> (implies --stdin)"
 msgstr ""
 "зареждане на настройките за КОМАНДАта, която презаписва подавания (включва "
 "опцията „--stdin“)"
 
-#: builtin/notes.c:517
+#: builtin/notes.c:515
 msgid "too few arguments"
 msgstr "прекалено малко аргументи"
 
-#: builtin/notes.c:538
+#: builtin/notes.c:536
 #, c-format
 msgid ""
 "Cannot copy notes. Found existing notes for object %s. Use '-f' to overwrite "
@@ -19075,12 +19442,12 @@ msgstr ""
 "Не може да се копира бележка, защото такава вече съществува за обекта „%s“.  "
 "Използвайте опцията „-f“, за да презапишете съществуващи бележки."
 
-#: builtin/notes.c:550
+#: builtin/notes.c:548
 #, c-format
 msgid "missing notes on source object %s. Cannot copy."
 msgstr "няма бележки за обекта-източник „%s“.  Не може да се копира."
 
-#: builtin/notes.c:603
+#: builtin/notes.c:601
 #, c-format
 msgid ""
 "The -m/-F/-c/-C options have been deprecated for the 'edit' subcommand.\n"
@@ -19091,52 +19458,52 @@ msgstr ""
 "Вместо това ги използвайте с подкомандата „add“: „git notes add -f -m/-F/-c/-"
 "C“.\n"
 
-#: builtin/notes.c:698
+#: builtin/notes.c:696
 msgid "failed to delete ref NOTES_MERGE_PARTIAL"
 msgstr "указателят „NOTES_MERGE_PARTIAL“ не може да бъде изтрит"
 
-#: builtin/notes.c:700
+#: builtin/notes.c:698
 msgid "failed to delete ref NOTES_MERGE_REF"
 msgstr "указателят „NOTES_MERGE_REF“ не може да бъде изтрит"
 
-#: builtin/notes.c:702
+#: builtin/notes.c:700
 msgid "failed to remove 'git notes merge' worktree"
 msgstr "работната директория на „git notes merge“ не може да бъде изтрита"
 
-#: builtin/notes.c:722
+#: builtin/notes.c:720
 msgid "failed to read ref NOTES_MERGE_PARTIAL"
 msgstr "указателят „NOTES_MERGE_PARTIAL“ не може да бъде прочетен"
 
-#: builtin/notes.c:724
+#: builtin/notes.c:722
 msgid "could not find commit from NOTES_MERGE_PARTIAL."
 msgstr "подаването от „NOTES_MERGE_PARTIAL“ не може да се открие."
 
-#: builtin/notes.c:726
+#: builtin/notes.c:724
 msgid "could not parse commit from NOTES_MERGE_PARTIAL."
 msgstr "подаването от „NOTES_MERGE_PARTIAL“ не може да се анализира."
 
-#: builtin/notes.c:739
+#: builtin/notes.c:737
 msgid "failed to resolve NOTES_MERGE_REF"
 msgstr "не може да се открие към какво сочи „NOTES_MERGE_REF“"
 
-#: builtin/notes.c:742
+#: builtin/notes.c:740
 msgid "failed to finalize notes merge"
 msgstr "неуспешно сливане на бележките"
 
-#: builtin/notes.c:768
+#: builtin/notes.c:766
 #, c-format
 msgid "unknown notes merge strategy %s"
 msgstr "непозната стратегия за сливане на бележки „%s“"
 
-#: builtin/notes.c:784
+#: builtin/notes.c:782
 msgid "General options"
 msgstr "Общи опции"
 
-#: builtin/notes.c:786
+#: builtin/notes.c:784
 msgid "Merge options"
 msgstr "Опции при сливане"
 
-#: builtin/notes.c:788
+#: builtin/notes.c:786
 msgid ""
 "resolve notes conflicts using the given strategy (manual/ours/theirs/union/"
 "cat_sort_uniq)"
@@ -19146,46 +19513,46 @@ msgstr ""
 "„union“ (обединяване), „cat_sort_uniq“ (обединяване, подреждане, уникални "
 "резултати)"
 
-#: builtin/notes.c:790
+#: builtin/notes.c:788
 msgid "Committing unmerged notes"
 msgstr "Подаване на неслети бележки"
 
-#: builtin/notes.c:792
+#: builtin/notes.c:790
 msgid "finalize notes merge by committing unmerged notes"
 msgstr "завършване на сливането чрез подаване на неслети бележки"
 
-#: builtin/notes.c:794
+#: builtin/notes.c:792
 msgid "Aborting notes merge resolution"
 msgstr "Преустановяване на корекцията при сливането на бележки"
 
-#: builtin/notes.c:796
+#: builtin/notes.c:794
 msgid "abort notes merge"
 msgstr "преустановяване на сливането на бележки"
 
-#: builtin/notes.c:807
+#: builtin/notes.c:805
 msgid "cannot mix --commit, --abort or -s/--strategy"
 msgstr "опциите „--commit“, „--abort“ и „-s“/„--strategy“ са несъвместими"
 
-#: builtin/notes.c:812
+#: builtin/notes.c:810
 msgid "must specify a notes ref to merge"
 msgstr "трябва да укажете указател към бележка за сливане."
 
-#: builtin/notes.c:836
+#: builtin/notes.c:834
 #, c-format
 msgid "unknown -s/--strategy: %s"
 msgstr "неизвестна стратегия към опцията „-s“/„--strategy“: „%s“"
 
-#: builtin/notes.c:873
+#: builtin/notes.c:871
 #, c-format
 msgid "a notes merge into %s is already in-progress at %s"
 msgstr "в момента се извършва сливане на бележките в „%s“ при „%s“"
 
-#: builtin/notes.c:876
+#: builtin/notes.c:874
 #, c-format
 msgid "failed to store link to current notes ref (%s)"
 msgstr "не може да се запази връзка към указателя на текущата бележка („%s“)."
 
-#: builtin/notes.c:878
+#: builtin/notes.c:876
 #, c-format
 msgid ""
 "Automatic notes merge failed. Fix conflicts in %s and commit the result with "
@@ -19196,41 +19563,41 @@ msgstr ""
 "резултата с „git notes merge --commit“ или преустановете сливането с "
 "командата „git notes merge --abort“.\n"
 
-#: builtin/notes.c:897 builtin/tag.c:589
+#: builtin/notes.c:895 builtin/tag.c:590
 #, c-format
 msgid "Failed to resolve '%s' as a valid ref."
 msgstr "Не може да се открие към какво сочи „%s“."
 
-#: builtin/notes.c:900
+#: builtin/notes.c:898
 #, c-format
 msgid "Object %s has no note\n"
 msgstr "Няма бележки за обекта „%s“\n"
 
-#: builtin/notes.c:912
+#: builtin/notes.c:910
 msgid "attempt to remove non-existent note is not an error"
 msgstr "опитът за изтриването на несъществуваща бележка не се счита за грешка"
 
-#: builtin/notes.c:915
+#: builtin/notes.c:913
 msgid "read object names from the standard input"
 msgstr "изчитане на имената на обектите от стандартния вход"
 
-#: builtin/notes.c:954 builtin/prune.c:132 builtin/worktree.c:146
+#: builtin/notes.c:952 builtin/prune.c:132 builtin/worktree.c:147
 msgid "do not remove, show only"
 msgstr "само извеждане без действително окастряне"
 
-#: builtin/notes.c:955
+#: builtin/notes.c:953
 msgid "report pruned notes"
 msgstr "докладване на окастрените обекти"
 
-#: builtin/notes.c:998
+#: builtin/notes.c:996
 msgid "notes-ref"
 msgstr "УКАЗАТЕЛ_ЗА_БЕЛЕЖКА"
 
-#: builtin/notes.c:999
+#: builtin/notes.c:997
 msgid "use notes from <notes-ref>"
 msgstr "да се използва бележката сочена от този УКАЗАТЕЛ_ЗА_БЕЛЕЖКА"
 
-#: builtin/notes.c:1034 builtin/stash.c:1735
+#: builtin/notes.c:1032 builtin/stash.c:1752
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr "непозната подкоманда: %s"
@@ -19282,87 +19649,91 @@ msgstr "подредени бяха %u обекта, а се очакваха %<
 msgid "expected object at offset %<PRIuMAX> in pack %s"
 msgstr "очаква се обект при отместване %<PRIuMAX> в пакетния файл „%s“"
 
-#: builtin/pack-objects.c:1155
+#: builtin/pack-objects.c:1160
 msgid "disabling bitmap writing, packs are split due to pack.packSizeLimit"
 msgstr ""
 "изключване на записването на битовата маска, пакетите са разделени поради "
 "стойността на „pack.packSizeLimit“"
 
-#: builtin/pack-objects.c:1168
+#: builtin/pack-objects.c:1173
 msgid "Writing objects"
 msgstr "Записване на обектите"
 
-#: builtin/pack-objects.c:1229 builtin/update-index.c:90
+#: builtin/pack-objects.c:1235 builtin/update-index.c:90
 #, c-format
 msgid "failed to stat %s"
 msgstr "не може да бъде получена информация чрез „stat“ за „%s“"
 
-#: builtin/pack-objects.c:1281
+#: builtin/pack-objects.c:1268
+msgid "failed to write bitmap index"
+msgstr "неуспешно записване на индекси на база битови маски"
+
+#: builtin/pack-objects.c:1294
 #, c-format
 msgid "wrote %<PRIu32> objects while expecting %<PRIu32>"
 msgstr "бяха записани %<PRIu32> обекти, а се очакваха %<PRIu32>"
 
-#: builtin/pack-objects.c:1523
+#: builtin/pack-objects.c:1536
 msgid "disabling bitmap writing, as some objects are not being packed"
 msgstr ""
 "изключване на записването на битовата маска, защото някои обекти няма да се "
 "пакетират"
 
-#: builtin/pack-objects.c:1971
+#: builtin/pack-objects.c:1984
 #, c-format
 msgid "delta base offset overflow in pack for %s"
 msgstr "прекалено далечно начало на отместването за обектите-разлика за „%s“"
 
-#: builtin/pack-objects.c:1980
+#: builtin/pack-objects.c:1993
 #, c-format
 msgid "delta base offset out of bound for %s"
 msgstr "недостижимо начало на отместването за обектите-разлика за „%s“"
 
-#: builtin/pack-objects.c:2261
+#: builtin/pack-objects.c:2274
 msgid "Counting objects"
 msgstr "Преброяване на обектите"
 
-#: builtin/pack-objects.c:2426
+#: builtin/pack-objects.c:2439
 #, c-format
 msgid "unable to parse object header of %s"
 msgstr "заглавната част на „%s“ не може да бъде анализирана"
 
-#: builtin/pack-objects.c:2496 builtin/pack-objects.c:2512
-#: builtin/pack-objects.c:2522
+#: builtin/pack-objects.c:2509 builtin/pack-objects.c:2525
+#: builtin/pack-objects.c:2535
 #, c-format
 msgid "object %s cannot be read"
 msgstr "обектът „%s“ не може да се прочете"
 
-#: builtin/pack-objects.c:2499 builtin/pack-objects.c:2526
+#: builtin/pack-objects.c:2512 builtin/pack-objects.c:2539
 #, c-format
 msgid "object %s inconsistent object length (%<PRIuMAX> vs %<PRIuMAX>)"
 msgstr "обектът „%s“ е с неправилна дължина (%<PRIuMAX>, а не %<PRIuMAX>)"
 
-#: builtin/pack-objects.c:2536
+#: builtin/pack-objects.c:2549
 msgid "suboptimal pack - out of memory"
 msgstr "неоптимизиран пакет — паметта свърши"
 
-#: builtin/pack-objects.c:2851
+#: builtin/pack-objects.c:2864
 #, c-format
 msgid "Delta compression using up to %d threads"
 msgstr "Делта компресията ще използва до %d нишки"
 
-#: builtin/pack-objects.c:2990
+#: builtin/pack-objects.c:3003
 #, c-format
 msgid "unable to pack objects reachable from tag %s"
 msgstr ""
 "обектите, които може да бъдат достигнати от етикета „%s“, не може да бъдат "
 "пакетирани"
 
-#: builtin/pack-objects.c:3076
+#: builtin/pack-objects.c:3089
 msgid "Compressing objects"
 msgstr "Компресиране на обектите"
 
-#: builtin/pack-objects.c:3082
+#: builtin/pack-objects.c:3095
 msgid "inconsistency with delta count"
 msgstr "неправилен брой разлики"
 
-#: builtin/pack-objects.c:3161
+#: builtin/pack-objects.c:3174
 #, c-format
 msgid ""
 "value of uploadpack.blobpackfileuri must be of the form '<object-hash> <pack-"
@@ -19371,7 +19742,7 @@ msgstr ""
 "стойността на „uploadpack.blobpackfileuri“ трябва да е във формат "
 "„СУМА_НА_ОБЕКТ СУМА_НА_ПАКЕТ АДРЕС“ (получена е „%s“)"
 
-#: builtin/pack-objects.c:3164
+#: builtin/pack-objects.c:3177
 #, c-format
 msgid ""
 "object already configured in another uploadpack.blobpackfileuri (got '%s')"
@@ -19379,17 +19750,18 @@ msgstr ""
 "вече има настройка за обекта в друг ред „uploadpack."
 "blobpackfileuri“ (получена е „%s“)"
 
-#: builtin/pack-objects.c:3199
+#: builtin/pack-objects.c:3212
 #, c-format
 msgid "could not get type of object %s in pack %s"
 msgstr "видът на обекта „%s“ в пакет „%s“ не може да бъде определен"
 
-#: builtin/pack-objects.c:3321 builtin/pack-objects.c:3335
+#: builtin/pack-objects.c:3340 builtin/pack-objects.c:3351
+#: builtin/pack-objects.c:3365
 #, c-format
 msgid "could not find pack '%s'"
 msgstr "пакетът „%s“ не може да се открие"
 
-#: builtin/pack-objects.c:3378
+#: builtin/pack-objects.c:3408
 #, c-format
 msgid ""
 "expected edge object ID, got garbage:\n"
@@ -19398,7 +19770,7 @@ msgstr ""
 "очаква се идентификатор на краен обект, а не:\n"
 " %s"
 
-#: builtin/pack-objects.c:3384
+#: builtin/pack-objects.c:3414
 #, c-format
 msgid ""
 "expected object ID, got garbage:\n"
@@ -19407,264 +19779,264 @@ msgstr ""
 "очаква се идентификатор на обект, а не:\n"
 " %s"
 
-#: builtin/pack-objects.c:3482
+#: builtin/pack-objects.c:3507
 msgid "invalid value for --missing"
 msgstr "неправилна стойност за „--missing“"
 
-#: builtin/pack-objects.c:3541 builtin/pack-objects.c:3650
+#: builtin/pack-objects.c:3532 builtin/pack-objects.c:3619
 msgid "cannot open pack index"
 msgstr "индексът на пакетния файл не може да бъде отворен"
 
-#: builtin/pack-objects.c:3572
+#: builtin/pack-objects.c:3541
 #, c-format
 msgid "loose object at %s could not be examined"
 msgstr "непакетираният обект в „%s“ не може да бъде анализиран"
 
-#: builtin/pack-objects.c:3658
+#: builtin/pack-objects.c:3627
 msgid "unable to force loose object"
 msgstr "оставането на обекта непакетиран не може да бъде наложено"
 
-#: builtin/pack-objects.c:3788
+#: builtin/pack-objects.c:3757
 #, c-format
 msgid "not a rev '%s'"
 msgstr "„%s“ не е версия"
 
-#: builtin/pack-objects.c:3791 builtin/rev-parse.c:1061
+#: builtin/pack-objects.c:3760 builtin/rev-parse.c:1061
 #, c-format
 msgid "bad revision '%s'"
 msgstr "неправилна версия „%s“"
 
-#: builtin/pack-objects.c:3819
+#: builtin/pack-objects.c:3788
 msgid "unable to add recent objects"
 msgstr "скорошните обекти не може да бъдат добавени"
 
-#: builtin/pack-objects.c:3872
+#: builtin/pack-objects.c:3841
 #, c-format
 msgid "unsupported index version %s"
 msgstr "неподдържана версия на индекса „%s“"
 
-#: builtin/pack-objects.c:3876
+#: builtin/pack-objects.c:3845
 #, c-format
 msgid "bad index version '%s'"
 msgstr "неправилна версия на индекса „%s“"
 
-#: builtin/pack-objects.c:3915
+#: builtin/pack-objects.c:3884
 msgid "<version>[,<offset>]"
 msgstr "ВЕРСИЯ[,ОТМЕСТВАНЕ]"
 
-#: builtin/pack-objects.c:3916
+#: builtin/pack-objects.c:3885
 msgid "write the pack index file in the specified idx format version"
 msgstr ""
 "запазване на индекса на пакетните файлове във форма̀та с указаната версия"
 
-#: builtin/pack-objects.c:3919
+#: builtin/pack-objects.c:3888
 msgid "maximum size of each output pack file"
 msgstr "максимален размер на всеки пакетен файл"
 
-#: builtin/pack-objects.c:3921
+#: builtin/pack-objects.c:3890
 msgid "ignore borrowed objects from alternate object store"
 msgstr "игнориране на обектите заети от други хранилища на обекти"
 
-#: builtin/pack-objects.c:3923
+#: builtin/pack-objects.c:3892
 msgid "ignore packed objects"
 msgstr "игнориране на пакетираните обекти"
 
-#: builtin/pack-objects.c:3925
+#: builtin/pack-objects.c:3894
 msgid "limit pack window by objects"
 msgstr "ограничаване на прозореца за пакетиране по брой обекти"
 
-#: builtin/pack-objects.c:3927
+#: builtin/pack-objects.c:3896
 msgid "limit pack window by memory in addition to object limit"
 msgstr ""
 "ограничаване на прозореца за пакетиране и по памет освен по брой обекти"
 
-#: builtin/pack-objects.c:3929
+#: builtin/pack-objects.c:3898
 msgid "maximum length of delta chain allowed in the resulting pack"
 msgstr ""
 "максимална дължина на веригата от разлики, която е позволена в пакетния файл"
 
-#: builtin/pack-objects.c:3931
+#: builtin/pack-objects.c:3900
 msgid "reuse existing deltas"
 msgstr "преизползване на съществуващите разлики"
 
-#: builtin/pack-objects.c:3933
+#: builtin/pack-objects.c:3902
 msgid "reuse existing objects"
 msgstr "преизползване на съществуващите обекти"
 
-#: builtin/pack-objects.c:3935
+#: builtin/pack-objects.c:3904
 msgid "use OFS_DELTA objects"
 msgstr "използване на обекти „OFS_DELTA“"
 
-#: builtin/pack-objects.c:3937
+#: builtin/pack-objects.c:3906
 msgid "use threads when searching for best delta matches"
 msgstr ""
 "стартиране на нишки за претърсване на най-добрите съвпадения на разликите"
 
-#: builtin/pack-objects.c:3939
+#: builtin/pack-objects.c:3908
 msgid "do not create an empty pack output"
 msgstr "без създаване на празен пакетен файл"
 
-#: builtin/pack-objects.c:3941
+#: builtin/pack-objects.c:3910
 msgid "read revision arguments from standard input"
 msgstr "изчитане на версиите от стандартния вход"
 
-#: builtin/pack-objects.c:3943
+#: builtin/pack-objects.c:3912
 msgid "limit the objects to those that are not yet packed"
 msgstr "ограничаване до все още непакетираните обекти"
 
-#: builtin/pack-objects.c:3946
+#: builtin/pack-objects.c:3915
 msgid "include objects reachable from any reference"
 msgstr ""
 "включване на всички обекти, които може да се достигнат от произволен указател"
 
-#: builtin/pack-objects.c:3949
+#: builtin/pack-objects.c:3918
 msgid "include objects referred by reflog entries"
 msgstr "включване и на обектите сочени от записите в журнала на указателите"
 
-#: builtin/pack-objects.c:3952
+#: builtin/pack-objects.c:3921
 msgid "include objects referred to by the index"
 msgstr "включване и на обектите сочени от индекса"
 
-#: builtin/pack-objects.c:3955
+#: builtin/pack-objects.c:3924
 msgid "read packs from stdin"
 msgstr "изчитане на пакетите от стандартния вход"
 
-#: builtin/pack-objects.c:3957
+#: builtin/pack-objects.c:3926
 msgid "output pack to stdout"
 msgstr "извеждане на пакета на стандартния изход"
 
-#: builtin/pack-objects.c:3959
+#: builtin/pack-objects.c:3928
 msgid "include tag objects that refer to objects to be packed"
 msgstr ""
 "включване и на обектите-етикети, които сочат към обектите, които ще бъдат "
 "пакетирани"
 
-#: builtin/pack-objects.c:3961
+#: builtin/pack-objects.c:3930
 msgid "keep unreachable objects"
 msgstr "запазване на недостижимите обекти"
 
-#: builtin/pack-objects.c:3963
+#: builtin/pack-objects.c:3932
 msgid "pack loose unreachable objects"
 msgstr "пакетиране и на недостижимите обекти"
 
-#: builtin/pack-objects.c:3965
+#: builtin/pack-objects.c:3934
 msgid "unpack unreachable objects newer than <time>"
 msgstr "разпакетиране на недостижимите обекти, които са по-нови от това ВРЕМЕ"
 
-#: builtin/pack-objects.c:3968
+#: builtin/pack-objects.c:3937
 msgid "use the sparse reachability algorithm"
 msgstr "използване на алгоритъм за частична достижимост"
 
-#: builtin/pack-objects.c:3970
+#: builtin/pack-objects.c:3939
 msgid "create thin packs"
 msgstr "създаване на съкратени пакети"
 
-#: builtin/pack-objects.c:3972
+#: builtin/pack-objects.c:3941
 msgid "create packs suitable for shallow fetches"
 msgstr "пакетиране подходящо за плитко доставяне"
 
-#: builtin/pack-objects.c:3974
+#: builtin/pack-objects.c:3943
 msgid "ignore packs that have companion .keep file"
 msgstr "игнориране на пакетите, които са придружени от файл „.keep“"
 
-#: builtin/pack-objects.c:3976
+#: builtin/pack-objects.c:3945
 msgid "ignore this pack"
 msgstr "пропускане на този пакет"
 
-#: builtin/pack-objects.c:3978
+#: builtin/pack-objects.c:3947
 msgid "pack compression level"
 msgstr "ниво на компресиране при пакетиране"
 
-#: builtin/pack-objects.c:3980
+#: builtin/pack-objects.c:3949
 msgid "do not hide commits by grafts"
 msgstr ""
 "извеждане на всички родители — дори и тези, които нормално са скрити при "
 "присажданията"
 
-#: builtin/pack-objects.c:3982
+#: builtin/pack-objects.c:3951
 msgid "use a bitmap index if available to speed up counting objects"
 msgstr ""
 "използване на съществуващи индекси на база битови маски за ускоряване на "
 "преброяването на обектите"
 
-#: builtin/pack-objects.c:3984
+#: builtin/pack-objects.c:3953
 msgid "write a bitmap index together with the pack index"
 msgstr "запазване и на индекс на база битова маска, заедно с индекса за пакета"
 
-#: builtin/pack-objects.c:3988
+#: builtin/pack-objects.c:3957
 msgid "write a bitmap index if possible"
 msgstr "записване на индекси на база битови маски при възможност"
 
-#: builtin/pack-objects.c:3992
+#: builtin/pack-objects.c:3961
 msgid "handling for missing objects"
 msgstr "как да се обработват липсващите обекти"
 
-#: builtin/pack-objects.c:3995
+#: builtin/pack-objects.c:3964
 msgid "do not pack objects in promisor packfiles"
 msgstr "без пакетиране на обекти в гарантиращи пакети"
 
-#: builtin/pack-objects.c:3997
+#: builtin/pack-objects.c:3966
 msgid "respect islands during delta compression"
 msgstr "без промяна на групите при делта компресия"
 
-#: builtin/pack-objects.c:3999
+#: builtin/pack-objects.c:3968
 msgid "protocol"
 msgstr "протокол"
 
-#: builtin/pack-objects.c:4000
+#: builtin/pack-objects.c:3969
 msgid "exclude any configured uploadpack.blobpackfileuri with this protocol"
 msgstr "без ползване на настройки „uploadpack.blobpackfileuri“ с този протокол"
 
-#: builtin/pack-objects.c:4033
+#: builtin/pack-objects.c:4002
 #, c-format
 msgid "delta chain depth %d is too deep, forcing %d"
 msgstr "веригата с разлики е прекалено дълбока — %d, ще се ползва %d"
 
-#: builtin/pack-objects.c:4038
+#: builtin/pack-objects.c:4007
 #, c-format
 msgid "pack.deltaCacheLimit is too high, forcing %d"
 msgstr ""
 "Стойността на настройката „pack.deltaCacheLimit“ е прекалено голяма.  Ще се "
 "ползва %d"
 
-#: builtin/pack-objects.c:4094
+#: builtin/pack-objects.c:4063
 msgid "--max-pack-size cannot be used to build a pack for transfer"
 msgstr ""
 "опцията „--max-pack-size“ не може да се използва за създаване на пакетни "
 "файлове за пренос"
 
-#: builtin/pack-objects.c:4096
+#: builtin/pack-objects.c:4065
 msgid "minimum pack size limit is 1 MiB"
 msgstr "минималният размер на пакетите е 1 MiB"
 
-#: builtin/pack-objects.c:4101
+#: builtin/pack-objects.c:4070
 msgid "--thin cannot be used to build an indexable pack"
 msgstr ""
 "опцията „--thin“не може да се използва за създаване на пакетни файлове с "
 "индекс"
 
-#: builtin/pack-objects.c:4104
+#: builtin/pack-objects.c:4073
 msgid "--keep-unreachable and --unpack-unreachable are incompatible"
 msgstr "опциите „--keep-unreachable“ и „--unpack-unreachable“ са несъвместими"
 
-#: builtin/pack-objects.c:4110
+#: builtin/pack-objects.c:4079
 msgid "cannot use --filter without --stdout"
 msgstr "опцията „--filter“ изисква „--stdout“"
 
-#: builtin/pack-objects.c:4112
+#: builtin/pack-objects.c:4081
 msgid "cannot use --filter with --stdin-packs"
 msgstr "опциите „--filter“ и „--stdin-packs“ са несъвместими"
 
-#: builtin/pack-objects.c:4116
+#: builtin/pack-objects.c:4085
 msgid "cannot use internal rev list with --stdin-packs"
 msgstr ""
 "вътрешният списък на указатели и опцията „--stdin-packs“ са несъвместими"
 
-#: builtin/pack-objects.c:4175
+#: builtin/pack-objects.c:4144
 msgid "Enumerating objects"
 msgstr "Изброяване на обектите"
 
-#: builtin/pack-objects.c:4212
+#: builtin/pack-objects.c:4181
 #, c-format
 msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
@@ -19719,7 +20091,7 @@ msgstr "обявяване на обектите по-стари от това �
 msgid "limit traversal to objects outside promisor packfiles"
 msgstr "ограничаване на обхождането до обекти извън гарантиращи пакети"
 
-#: builtin/prune.c:152
+#: builtin/prune.c:151
 msgid "cannot prune in a precious-objects repo"
 msgstr "хранилище с важни обекти не може да се окастря"
 
@@ -19744,11 +20116,11 @@ msgstr "Опции при сливане"
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "внасяне на промените чрез пребазиране, а не чрез сливане"
 
-#: builtin/pull.c:158 builtin/rebase.c:491 builtin/revert.c:126
+#: builtin/pull.c:158 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "позволяване на превъртания"
 
-#: builtin/pull.c:167 parse-options.h:340
+#: builtin/pull.c:167 parse-options.h:339
 msgid "automatically stash/stash pop before and after"
 msgstr "автоматично скатаване/прилагане на скатаното преди и след пребазиране"
 
@@ -19803,7 +20175,7 @@ msgstr ""
 "Понеже това не е хранилището по подразбиране на текущия клон, трябва\n"
 "да укажете отдалечения клон на командния ред."
 
-#: builtin/pull.c:456 builtin/rebase.c:1248
+#: builtin/pull.c:456 builtin/rebase.c:951
 msgid "You are not currently on a branch."
 msgstr "Извън всички клони."
 
@@ -19820,7 +20192,7 @@ msgid "See git-pull(1) for details."
 msgstr "За повече информация погледнете ръководството „git-pull(1)“"
 
 #: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
-#: builtin/rebase.c:1254
+#: builtin/rebase.c:957
 msgid "<remote>"
 msgstr "ОТДАЛЕЧЕНО_ХРАНИЛИЩЕ"
 
@@ -19828,7 +20200,7 @@ msgstr "ОТДАЛЕЧЕНО_ХРАНИЛИЩЕ"
 msgid "<branch>"
 msgstr "КЛОН"
 
-#: builtin/pull.c:471 builtin/rebase.c:1246
+#: builtin/pull.c:471 builtin/rebase.c:949
 msgid "There is no tracking information for the current branch."
 msgstr "Текущият клон не следи никой."
 
@@ -19857,11 +20229,11 @@ msgstr "недостъпно подаване: %s"
 msgid "ignoring --verify-signatures for rebase"
 msgstr "без „--verify-signatures“ при пребазиране"
 
-#: builtin/pull.c:930
+#: builtin/pull.c:936
 msgid ""
-"Pulling without specifying how to reconcile divergent branches is\n"
-"discouraged. You can squelch this message by running one of the following\n"
-"commands sometime before your next pull:\n"
+"You have divergent branches and need to specify how to reconcile them.\n"
+"You can do so by running one of the following commands sometime before\n"
+"your next pull:\n"
 "\n"
 "  git config pull.rebase false  # merge (the default strategy)\n"
 "  git config pull.rebase true   # rebase\n"
@@ -19873,8 +20245,8 @@ msgid ""
 "or --ff-only on the command line to override the configured default per\n"
 "invocation.\n"
 msgstr ""
-"Не се насърчава издърпване без указване на стратегията за съгласуване на\n"
-"клоните.  За да заглушите това съобщение, изпълнете някоя от следните\n"
+"Някои от клоните са се раздалечили и трябва да укажете как да се решава\n"
+"това.  За да заглушите това съобщение, изпълнете някоя от следните\n"
 "команди преди следващото издърпване:\n"
 "\n"
 "  git config pull.rebase false  # сливане (стандартна стратегия)\n"
@@ -19886,19 +20258,19 @@ msgstr ""
 "използвайте опциите „--rebase“, „--no-rebase“, „--ff-only“.  Те са с\n"
 "приоритет пред настройките.\n"
 
-#: builtin/pull.c:990
+#: builtin/pull.c:1010
 msgid "Updating an unborn branch with changes added to the index."
 msgstr "Обновяване на все още несъздаден клон с промените от индекса"
 
-#: builtin/pull.c:994
+#: builtin/pull.c:1014
 msgid "pull with rebase"
 msgstr "издърпване с пребазиране"
 
-#: builtin/pull.c:995
+#: builtin/pull.c:1015
 msgid "please commit or stash them."
 msgstr "трябва да подадете или скатаете промените."
 
-#: builtin/pull.c:1020
+#: builtin/pull.c:1040
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -19908,7 +20280,7 @@ msgstr ""
 "доставянето обнови върха на текущия клон.  Работното\n"
 "ви копие бе превъртяно от подаване „%s“."
 
-#: builtin/pull.c:1026
+#: builtin/pull.c:1046
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -19925,15 +20297,24 @@ msgstr ""
 "    git reset --hard\n"
 "за връщане към нормално състояние."
 
-#: builtin/pull.c:1041
+#: builtin/pull.c:1061
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Не може да сливате множество клони в празен върхов указател."
 
-#: builtin/pull.c:1045
+#: builtin/pull.c:1066
 msgid "Cannot rebase onto multiple branches."
 msgstr "Не може да пребазирате върху повече от един клон."
 
-#: builtin/pull.c:1065
+#: builtin/pull.c:1068
+msgid "Cannot fast-forward to multiple branches."
+msgstr "Не може да превъртите към повече от един клон."
+
+#: builtin/pull.c:1082
+msgid "Need to specify how to reconcile divergent branches."
+msgstr ""
+"Трябва да укажете как да се решават разликите при разминаване на клоните."
+
+#: builtin/pull.c:1096
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "пребазирането е невъзможно заради локално записаните промени по подмодулите"
@@ -20123,15 +20504,15 @@ msgstr "Изтласкване към „%s“\n"
 msgid "failed to push some refs to '%s'"
 msgstr "част от указателите не бяха изтласкани към „%s“"
 
-#: builtin/push.c:544
+#: builtin/push.c:544 builtin/submodule--helper.c:3258
 msgid "repository"
 msgstr "хранилище"
 
-#: builtin/push.c:545 builtin/send-pack.c:189
+#: builtin/push.c:545 builtin/send-pack.c:193
 msgid "push all refs"
 msgstr "изтласкване на всички указатели"
 
-#: builtin/push.c:546 builtin/send-pack.c:191
+#: builtin/push.c:546 builtin/send-pack.c:195
 msgid "mirror all refs"
 msgstr "огледално копие на всички указатели"
 
@@ -20143,19 +20524,19 @@ msgstr "изтриване на указателите"
 msgid "push tags (can't be used with --all or --mirror)"
 msgstr "изтласкване на етикетите (несъвместимо с опциите „--all“ и „--mirror“)"
 
-#: builtin/push.c:552 builtin/send-pack.c:192
+#: builtin/push.c:552 builtin/send-pack.c:196
 msgid "force updates"
 msgstr "принудително обновяване"
 
-#: builtin/push.c:553 builtin/send-pack.c:204
+#: builtin/push.c:553 builtin/send-pack.c:208
 msgid "<refname>:<expect>"
 msgstr "ИМЕ_НА_УКАЗАТЕЛ:ОЧАКВАНА_СТОЙНОСТ"
 
-#: builtin/push.c:554 builtin/send-pack.c:205
+#: builtin/push.c:554 builtin/send-pack.c:209
 msgid "require old value of ref to be at this value"
 msgstr "УКАЗАТЕЛят трябва първоначално да е с тази ОЧАКВАНА_СТОЙНОСТ"
 
-#: builtin/push.c:557 builtin/send-pack.c:208
+#: builtin/push.c:557 builtin/send-pack.c:212
 msgid "require remote updates to be integrated locally"
 msgstr ""
 "изискване обновяванията в отдалечените хранилища да се внасят и в локалното"
@@ -20164,12 +20545,12 @@ msgstr ""
 msgid "control recursive pushing of submodules"
 msgstr "управление на рекурсивното изтласкване на подмодулите"
 
-#: builtin/push.c:561 builtin/send-pack.c:199
+#: builtin/push.c:561 builtin/send-pack.c:203
 msgid "use thin pack"
 msgstr "използване на съкратени пакети"
 
-#: builtin/push.c:562 builtin/push.c:563 builtin/send-pack.c:186
-#: builtin/send-pack.c:187
+#: builtin/push.c:562 builtin/push.c:563 builtin/send-pack.c:190
+#: builtin/send-pack.c:191
 msgid "receive pack program"
 msgstr "програма за получаването на пакети"
 
@@ -20191,11 +20572,11 @@ msgstr ""
 "изтласкване на липсващите в отдалеченото хранилище, но свързани с текущото "
 "изтласкване, етикети"
 
-#: builtin/push.c:572 builtin/send-pack.c:193
+#: builtin/push.c:572 builtin/send-pack.c:197
 msgid "GPG sign the push"
 msgstr "подписване на изтласкването с GPG"
 
-#: builtin/push.c:574 builtin/send-pack.c:200
+#: builtin/push.c:574 builtin/send-pack.c:204
 msgid "request atomic transaction on remote side"
 msgstr "изискване на атомарни операции от отсрещната страна"
 
@@ -20307,83 +20688,82 @@ msgstr "необходими са два диапазона с подавани�
 #: builtin/read-tree.c:41
 msgid ""
 "git read-tree [(-m [--trivial] [--aggressive] | --reset | --prefix=<prefix>) "
-"[-u [--exclude-per-directory=<gitignore>] | -i]] [--no-sparse-checkout] [--"
-"index-output=<file>] (--empty | <tree-ish1> [<tree-ish2> [<tree-ish3>]])"
+"[-u | -i]] [--no-sparse-checkout] [--index-output=<file>] (--empty | <tree-"
+"ish1> [<tree-ish2> [<tree-ish3>]])"
 msgstr ""
 "git read-tree [(-m [--trivial] [--aggressive] | --reset | --prefix=ПРЕФИКС) "
-"[-u [--exclude-per-directory=ФАЙЛ_С_ИЗКЛЮЧЕНИЯ] | -i]] [--no-sparse-"
-"checkout] [--index-output=ФАЙЛ] (--empty | УКАЗАТЕЛ_КЪМ_ДЪРВО_1 "
-"[УКАЗАТЕЛ_КЪМ_ДЪРВО_2 [УКАЗАТЕЛ_КЪМ_ДЪРВО_3]])"
+"[-u | -i]] [--no-sparse-checkout] [--index-output=ФАЙЛ] (--empty | "
+"УКАЗАТЕЛ_КЪМ_ДЪРВО_1 [УКАЗАТЕЛ_КЪМ_ДЪРВО_2 [УКАЗАТЕЛ_КЪМ_ДЪРВО_3]])"
 
-#: builtin/read-tree.c:124
+#: builtin/read-tree.c:116
 msgid "write resulting index to <file>"
 msgstr "запазване на индекса в този ФАЙЛ"
 
-#: builtin/read-tree.c:127
+#: builtin/read-tree.c:119
 msgid "only empty the index"
 msgstr "само зануляване на индекса"
 
-#: builtin/read-tree.c:129
+#: builtin/read-tree.c:121
 msgid "Merging"
 msgstr "Сливане"
 
-#: builtin/read-tree.c:131
+#: builtin/read-tree.c:123
 msgid "perform a merge in addition to a read"
 msgstr "да се извърши и сливане след освен изчитането"
 
-#: builtin/read-tree.c:133
+#: builtin/read-tree.c:125
 msgid "3-way merge if no file level merging required"
 msgstr "тройно сливане, ако не се налага пофайлово сливане"
 
-#: builtin/read-tree.c:135
+#: builtin/read-tree.c:127
 msgid "3-way merge in presence of adds and removes"
 msgstr "тройно сливане при добавяне на добавяне и изтриване на файлове"
 
-#: builtin/read-tree.c:137
+#: builtin/read-tree.c:129
 msgid "same as -m, but discard unmerged entries"
 msgstr "същото като опцията „-m“, но неслетите обекти се пренебрегват"
 
-#: builtin/read-tree.c:138
+#: builtin/read-tree.c:130
 msgid "<subdirectory>/"
 msgstr "ПОДДИРЕКТОРИЯ/"
 
-#: builtin/read-tree.c:139
+#: builtin/read-tree.c:131
 msgid "read the tree into the index under <subdirectory>/"
 msgstr "изчитане на дървото към индекса като да е в тази ПОДДИРЕКТОРИЯ/"
 
-#: builtin/read-tree.c:142
+#: builtin/read-tree.c:134
 msgid "update working tree with merge result"
 msgstr "обновяване на работното дърво с резултата от сливането"
 
-#: builtin/read-tree.c:144
+#: builtin/read-tree.c:136
 msgid "gitignore"
 msgstr "ФАЙЛ_С_ИЗКЛЮЧЕНИЯ"
 
-#: builtin/read-tree.c:145
+#: builtin/read-tree.c:137
 msgid "allow explicitly ignored files to be overwritten"
 msgstr "позволяване на презаписването на изрично пренебрегваните файлове"
 
-#: builtin/read-tree.c:148
+#: builtin/read-tree.c:140
 msgid "don't check the working tree after merging"
 msgstr "без проверка на работното дърво след сливането"
 
-#: builtin/read-tree.c:149
+#: builtin/read-tree.c:141
 msgid "don't update the index or the work tree"
 msgstr "без обновяване и на индекса, и на работното дърво"
 
-#: builtin/read-tree.c:151
+#: builtin/read-tree.c:143
 msgid "skip applying sparse checkout filter"
 msgstr "без прилагане на филтъра за частично изтегляне"
 
-#: builtin/read-tree.c:153
+#: builtin/read-tree.c:145
 msgid "debug unpack-trees"
 msgstr "изчистване на грешки в командата „unpack-trees“"
 
-#: builtin/read-tree.c:157
+#: builtin/read-tree.c:149
 msgid "suppress feedback messages"
 msgstr "без информационни съобщения"
 
-#: builtin/read-tree.c:188
+#: builtin/read-tree.c:183
 msgid "You need to resolve your current index first"
 msgstr "Първо трябва да коригирате индекса си"
 
@@ -20405,197 +20785,44 @@ msgstr ""
 msgid "git rebase --continue | --abort | --skip | --edit-todo"
 msgstr "git rebase --continue | --abort | --skip | --edit-todo"
 
-#: builtin/rebase.c:194 builtin/rebase.c:218 builtin/rebase.c:245
-#, c-format
-msgid "unusable todo list: '%s'"
-msgstr "неуспешно изтриване на списъка за изпълнение: „%s“"
-
-#: builtin/rebase.c:311
+#: builtin/rebase.c:230
 #, c-format
 msgid "could not create temporary %s"
 msgstr "не може да се създаде временна директория „%s“"
 
-#: builtin/rebase.c:317
+#: builtin/rebase.c:236
 msgid "could not mark as interactive"
 msgstr "невъзможно задаване на интерактивна работа"
 
-#: builtin/rebase.c:370
+#: builtin/rebase.c:289
 msgid "could not generate todo list"
 msgstr "файлът с командите не може да се генерира"
 
-#: builtin/rebase.c:412
+#: builtin/rebase.c:331
 msgid "a base commit must be provided with --upstream or --onto"
 msgstr "опциите „--upstream“ и „--onto“ изискват базово подаване"
 
-#: builtin/rebase.c:481
-msgid "git rebase--interactive [<options>]"
-msgstr "git rebase--interactive [ОПЦИЯ…]"
-
-#: builtin/rebase.c:494 builtin/rebase.c:1389
-msgid "keep commits which start empty"
-msgstr "запазванe на първоначално празните подавания"
-
-#: builtin/rebase.c:498 builtin/revert.c:128
-msgid "allow commits with empty messages"
-msgstr "позволяване на празни съобщения при подаване"
-
-#: builtin/rebase.c:500
-msgid "rebase merge commits"
-msgstr "пребазиране на подаванията със сливания"
-
-#: builtin/rebase.c:502
-msgid "keep original branch points of cousins"
-msgstr ""
-"запазване на първоначалните точки на разклоняване на сестринските клони"
-
-#: builtin/rebase.c:504
-msgid "move commits that begin with squash!/fixup!"
-msgstr "преместване на подаванията, които започват със „squash!“/“fixup!“"
-
-#: builtin/rebase.c:505
-msgid "sign commits"
-msgstr "подписване на подаванията"
-
-#: builtin/rebase.c:507 builtin/rebase.c:1328
-msgid "display a diffstat of what changed upstream"
-msgstr "извеждане на статистика с промените в следения клон"
-
-#: builtin/rebase.c:509
-msgid "continue rebase"
-msgstr "продължаване на пребазирането"
-
-#: builtin/rebase.c:511
-msgid "skip commit"
-msgstr "прескачане на подаване"
-
-#: builtin/rebase.c:512
-msgid "edit the todo list"
-msgstr "редактиране на списъка с команди за изпълнение"
-
-#: builtin/rebase.c:514
-msgid "show the current patch"
-msgstr "извеждане на текущата кръпка"
-
-#: builtin/rebase.c:517
-msgid "shorten commit ids in the todo list"
-msgstr "съкратени идентификатори в списъка за изпълнение"
-
-#: builtin/rebase.c:519
-msgid "expand commit ids in the todo list"
-msgstr "пълни идентификатори в списъка за изпълнение"
-
-#: builtin/rebase.c:521
-msgid "check the todo list"
-msgstr "проверка на списъка за изпълнение"
-
-#: builtin/rebase.c:523
-msgid "rearrange fixup/squash lines"
-msgstr ""
-"преподреждане на редовете за вкарване на подаванията подаванията в "
-"предходните им със и без смени на съобщението"
-
-#: builtin/rebase.c:525
-msgid "insert exec commands in todo list"
-msgstr "вмъкване на командите за изпълнение в списъка за изпълнение"
-
-#: builtin/rebase.c:526
-msgid "onto"
-msgstr "върху"
-
-#: builtin/rebase.c:529
-msgid "restrict-revision"
-msgstr "ограничена версия"
-
-#: builtin/rebase.c:529
-msgid "restrict revision"
-msgstr "ограничена версия"
-
-#: builtin/rebase.c:531
-msgid "squash-onto"
-msgstr "подаване, в което другите да се вкарат"
-
-#: builtin/rebase.c:532
-msgid "squash onto"
-msgstr "подаване, в което другите да се вкарат"
-
-#: builtin/rebase.c:534
-msgid "the upstream commit"
-msgstr "подаване на източника"
-
-#: builtin/rebase.c:536
-msgid "head-name"
-msgstr "име на върха"
-
-#: builtin/rebase.c:536
-msgid "head name"
-msgstr "име на върха"
-
-#: builtin/rebase.c:541
-msgid "rebase strategy"
-msgstr "стратегия на пребазиране"
-
-#: builtin/rebase.c:542
-msgid "strategy-opts"
-msgstr "опции на стратегията"
-
-#: builtin/rebase.c:543
-msgid "strategy options"
-msgstr "опции на стратегията"
-
-#: builtin/rebase.c:544
-msgid "switch-to"
-msgstr "преминаване към"
-
-#: builtin/rebase.c:545
-msgid "the branch or commit to checkout"
-msgstr "клонът, към който да се премине"
-
-#: builtin/rebase.c:546
-msgid "onto-name"
-msgstr "име на база"
-
-#: builtin/rebase.c:546
-msgid "onto name"
-msgstr "име на база"
-
-#: builtin/rebase.c:547
-msgid "cmd"
-msgstr "команда"
-
-#: builtin/rebase.c:547
-msgid "the command to run"
-msgstr "команда за изпълнение"
-
-#: builtin/rebase.c:550 builtin/rebase.c:1422
-msgid "automatically re-schedule any `exec` that fails"
-msgstr ""
-"автоматично подаване за повторно изпълнение на командите завършили с неуспех"
-
-#: builtin/rebase.c:566
-msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
-msgstr "опциите „--[no-]rebase-cousins“ изискват опцията „--rebase-merges“"
-
-#: builtin/rebase.c:582
+#: builtin/rebase.c:390
 #, c-format
 msgid "%s requires the merge backend"
 msgstr "„%s“ изисква пребазиране"
 
-#: builtin/rebase.c:625
+#: builtin/rebase.c:432
 #, c-format
 msgid "could not get 'onto': '%s'"
 msgstr "не може да се премине към новата база, зададена с „onto“: „%s“"
 
-#: builtin/rebase.c:642
+#: builtin/rebase.c:449
 #, c-format
 msgid "invalid orig-head: '%s'"
 msgstr "неправилен указател към първоначален връх „orig-head“: „%s“"
 
-#: builtin/rebase.c:667
+#: builtin/rebase.c:474
 #, c-format
 msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
 msgstr "неправилната стойност на „allow_rerere_autoupdate“ се прескача: „%s“"
 
-#: builtin/rebase.c:813 git-rebase--preserve-merges.sh:81
+#: builtin/rebase.c:597
 msgid ""
 "Resolve all conflicts manually, mark them as resolved with\n"
 "\"git add/rm <conflicted_files>\", then run \"git rebase --continue\".\n"
@@ -20609,7 +20836,7 @@ msgstr ""
 "За да откажете пребазирането и да се върнете към първоначалното състояние,\n"
 "изпълнете „git rebase --abort“."
 
-#: builtin/rebase.c:896
+#: builtin/rebase.c:680
 #, c-format
 msgid ""
 "\n"
@@ -20627,7 +20854,7 @@ msgstr ""
 "\n"
 "В резултат те не може да се пребазират."
 
-#: builtin/rebase.c:1222
+#: builtin/rebase.c:925
 #, c-format
 msgid ""
 "unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and \"ask"
@@ -20636,7 +20863,7 @@ msgstr ""
 "неправилна стойност „%s“: вариантите са „drop“ (прескачане), "
 "„keep“ (запазване) и „ask“ (питане)"
 
-#: builtin/rebase.c:1240
+#: builtin/rebase.c:943
 #, c-format
 msgid ""
 "%s\n"
@@ -20653,7 +20880,7 @@ msgstr ""
 "    git rebase КЛОН\n"
 "\n"
 
-#: builtin/rebase.c:1256
+#: builtin/rebase.c:959
 #, c-format
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:\n"
@@ -20666,192 +20893,202 @@ msgstr ""
 "\n"
 "    git branch --set-upstream-to=%s/КЛОН %s\n"
 
-#: builtin/rebase.c:1286
+#: builtin/rebase.c:989
 msgid "exec commands cannot contain newlines"
 msgstr "командите за изпълнение не може да съдържат нови редове"
 
-#: builtin/rebase.c:1290
+#: builtin/rebase.c:993
 msgid "empty exec command"
 msgstr "празна команда за изпълнение"
 
-#: builtin/rebase.c:1319
+#: builtin/rebase.c:1023
 msgid "rebase onto given branch instead of upstream"
 msgstr "пребазиране върху зададения, а не следения клон"
 
-#: builtin/rebase.c:1321
+#: builtin/rebase.c:1025
 msgid "use the merge-base of upstream and branch as the current base"
 msgstr "за текуща база да се ползва базата за сливане на клона и следеното"
 
-#: builtin/rebase.c:1323
+#: builtin/rebase.c:1027
 msgid "allow pre-rebase hook to run"
 msgstr "позволяване на куката преди пребазиране да се изпълни"
 
-#: builtin/rebase.c:1325
+#: builtin/rebase.c:1029
 msgid "be quiet. implies --no-stat"
 msgstr "без извеждане на информация.  Включва опцията „--no-stat“"
 
-#: builtin/rebase.c:1331
+#: builtin/rebase.c:1032
+msgid "display a diffstat of what changed upstream"
+msgstr "извеждане на статистика с промените в следения клон"
+
+#: builtin/rebase.c:1035
 msgid "do not show diffstat of what changed upstream"
 msgstr "без извеждане на статистика с промените в следения клон"
 
-#: builtin/rebase.c:1334
+#: builtin/rebase.c:1038
 msgid "add a Signed-off-by trailer to each commit"
 msgstr "добавяне на епилог за подпис „Signed-off-by“ към всяко подаване"
 
-#: builtin/rebase.c:1337
+#: builtin/rebase.c:1041
 msgid "make committer date match author date"
 msgstr "датата на подаващия да отговаря на датата на автора"
 
-#: builtin/rebase.c:1339
+#: builtin/rebase.c:1043
 msgid "ignore author date and use current date"
 msgstr "да се ползва днешна дата, а не тази на автора"
 
-#: builtin/rebase.c:1341
+#: builtin/rebase.c:1045
 msgid "synonym of --reset-author-date"
 msgstr "псевдоним на „--reset-author-date“"
 
-#: builtin/rebase.c:1343 builtin/rebase.c:1347
+#: builtin/rebase.c:1047 builtin/rebase.c:1051
 msgid "passed to 'git apply'"
 msgstr "подава се на командата „git apply“"
 
-#: builtin/rebase.c:1345
+#: builtin/rebase.c:1049
 msgid "ignore changes in whitespace"
 msgstr "без промени в празните знаци"
 
-#: builtin/rebase.c:1349 builtin/rebase.c:1352
+#: builtin/rebase.c:1053 builtin/rebase.c:1056
 msgid "cherry-pick all commits, even if unchanged"
 msgstr "отбиране на всички подавания дори да няма промени"
 
-#: builtin/rebase.c:1354
+#: builtin/rebase.c:1058
 msgid "continue"
 msgstr "продължаване"
 
-#: builtin/rebase.c:1357
+#: builtin/rebase.c:1061
 msgid "skip current patch and continue"
 msgstr "прескачане на текущата кръпка и продължаване"
 
-#: builtin/rebase.c:1359
+#: builtin/rebase.c:1063
 msgid "abort and check out the original branch"
 msgstr "преустановяване и възстановяване на първоначалния клон"
 
-#: builtin/rebase.c:1362
+#: builtin/rebase.c:1066
 msgid "abort but keep HEAD where it is"
 msgstr "преустановяване без промяна към какво сочи „HEAD“"
 
-#: builtin/rebase.c:1363
+#: builtin/rebase.c:1067
 msgid "edit the todo list during an interactive rebase"
 msgstr "редактиране на файла с команди при интерактивно пребазиране"
 
-#: builtin/rebase.c:1366
+#: builtin/rebase.c:1070
 msgid "show the patch file being applied or merged"
 msgstr "показване на кръпката, която се прилага или слива"
 
-#: builtin/rebase.c:1369
+#: builtin/rebase.c:1073
 msgid "use apply strategies to rebase"
 msgstr "при пребазиране да се ползва стратегия с прилагане"
 
-#: builtin/rebase.c:1373
+#: builtin/rebase.c:1077
 msgid "use merging strategies to rebase"
 msgstr "при пребазиране да се ползва стратегия със сливане"
 
-#: builtin/rebase.c:1377
+#: builtin/rebase.c:1081
 msgid "let the user edit the list of commits to rebase"
 msgstr ""
 "позволяване на потребителя да редактира списъка с подавания за пребазиране"
 
-#: builtin/rebase.c:1381
+#: builtin/rebase.c:1085
 msgid "(DEPRECATED) try to recreate merges instead of ignoring them"
 msgstr "(ОСТАРЯЛО) пресъздаване на сливанията вместо да се прескачат"
 
-#: builtin/rebase.c:1386
+#: builtin/rebase.c:1090
 msgid "how to handle commits that become empty"
 msgstr "как да се обработват оказалите се празни подавания"
 
-#: builtin/rebase.c:1393
+#: builtin/rebase.c:1093
+msgid "keep commits which start empty"
+msgstr "запазванe на първоначално празните подавания"
+
+#: builtin/rebase.c:1097
 msgid "move commits that begin with squash!/fixup! under -i"
 msgstr ""
 "преместване на подаванията, които започват със „squash!“/“fixup!“ при „-i“"
 
-#: builtin/rebase.c:1400
+#: builtin/rebase.c:1104
 msgid "add exec lines after each commit of the editable list"
 msgstr ""
 "добавяне на редове с команди за изпълнение след всяко подаване в "
 "редактирания списък"
 
-#: builtin/rebase.c:1404
+#: builtin/rebase.c:1108
 msgid "allow rebasing commits with empty messages"
 msgstr "позволяване на пребазиране на подавания с празни съобщения"
 
-#: builtin/rebase.c:1408
+#: builtin/rebase.c:1112
 msgid "try to rebase merges instead of skipping them"
 msgstr "опит за пребазиране на сливанията вместо те да се прескачат"
 
-#: builtin/rebase.c:1411
+#: builtin/rebase.c:1115
 msgid "use 'merge-base --fork-point' to refine upstream"
 msgstr ""
 "за доуточняването на следения клон, използвайте:\n"
 "\n"
 "    git merge-base --fork-point"
 
-#: builtin/rebase.c:1413
+#: builtin/rebase.c:1117
 msgid "use the given merge strategy"
 msgstr "използване на зададената стратегията на сливане"
 
-#: builtin/rebase.c:1415 builtin/revert.c:115
+#: builtin/rebase.c:1119 builtin/revert.c:115
 msgid "option"
 msgstr "опция"
 
-#: builtin/rebase.c:1416
+#: builtin/rebase.c:1120
 msgid "pass the argument through to the merge strategy"
 msgstr "аргументът да се подаде на стратегията за сливане"
 
-#: builtin/rebase.c:1419
+#: builtin/rebase.c:1123
 msgid "rebase all reachable commits up to the root(s)"
 msgstr "пребазиране на всички достижими подавания до началното им подаване"
 
-#: builtin/rebase.c:1424
+#: builtin/rebase.c:1126
+msgid "automatically re-schedule any `exec` that fails"
+msgstr ""
+"автоматично подаване за повторно изпълнение на командите завършили с неуспех"
+
+#: builtin/rebase.c:1128
 msgid "apply all changes, even those already present upstream"
 msgstr "прилагане на всички промени, дори и наличните вече в следеното"
 
-#: builtin/rebase.c:1442
+#: builtin/rebase.c:1149
 msgid "It looks like 'git am' is in progress. Cannot rebase."
 msgstr ""
 "Изглежда, че сега се прилагат кръпки чрез командата „git am“.  Не може да "
 "пребазирате в момента."
 
-#: builtin/rebase.c:1483
-msgid ""
-"git rebase --preserve-merges is deprecated. Use --rebase-merges instead."
-msgstr ""
-"Опцията „--preserve-merges“ е остаряла.  Ползвайте „--rebase-merges“ вместо "
-"нея."
+#: builtin/rebase.c:1180
+msgid "--preserve-merges was replaced by --rebase-merges"
+msgstr "Опцията „--preserve-merges“ е заменена с „--rebase-merges“."
 
-#: builtin/rebase.c:1488
+#: builtin/rebase.c:1193
 msgid "cannot combine '--keep-base' with '--onto'"
 msgstr "опциите „--keep-base“ и „--onto“ са несъвместими"
 
-#: builtin/rebase.c:1490
+#: builtin/rebase.c:1195
 msgid "cannot combine '--keep-base' with '--root'"
 msgstr "опциите „--keep-base“ и „--root“ са несъвместими"
 
-#: builtin/rebase.c:1494
+#: builtin/rebase.c:1199
 msgid "cannot combine '--root' with '--fork-point'"
 msgstr "опциите „--root“ и „--fork-point“ са несъвместими"
 
-#: builtin/rebase.c:1497
+#: builtin/rebase.c:1202
 msgid "No rebase in progress?"
 msgstr "Изглежда в момента не тече пребазиране"
 
-#: builtin/rebase.c:1501
+#: builtin/rebase.c:1206
 msgid "The --edit-todo action can only be used during interactive rebase."
 msgstr ""
 "Опцията „--edit-todo“ е достъпна само по време на интерактивно пребазиране."
 
-#: builtin/rebase.c:1524 t/helper/test-fast-rebase.c:122
+#: builtin/rebase.c:1229 t/helper/test-fast-rebase.c:122
 msgid "Cannot read HEAD"
 msgstr "Указателят „HEAD“ не може да бъде прочетен"
 
-#: builtin/rebase.c:1536
+#: builtin/rebase.c:1241
 msgid ""
 "You must edit all merge conflicts and then\n"
 "mark them as resolved using git add"
@@ -20859,16 +21096,16 @@ msgstr ""
 "Трябва да редактирате всички конфликти при сливането.  След това\n"
 "отбележете коригирането им чрез командата „git add“"
 
-#: builtin/rebase.c:1555
+#: builtin/rebase.c:1260
 msgid "could not discard worktree changes"
 msgstr "промените в работното дърво не може да бъдат занулени"
 
-#: builtin/rebase.c:1574
+#: builtin/rebase.c:1279
 #, c-format
 msgid "could not move back to %s"
 msgstr "връщането към „%s“ е невъзможно"
 
-#: builtin/rebase.c:1620
+#: builtin/rebase.c:1325
 #, c-format
 msgid ""
 "It seems that there is already a %s directory, and\n"
@@ -20889,147 +21126,136 @@ msgstr ""
 "за\n"
 "да не загубите случайно промени.\n"
 
-#: builtin/rebase.c:1648
+#: builtin/rebase.c:1353
 msgid "switch `C' expects a numerical value"
 msgstr "опцията „C“ очаква число за аргумент"
 
-#: builtin/rebase.c:1690
+#: builtin/rebase.c:1395
 #, c-format
 msgid "Unknown mode: %s"
 msgstr "Неизвестна стратегия: „%s“"
 
-#: builtin/rebase.c:1729
+#: builtin/rebase.c:1434
 msgid "--strategy requires --merge or --interactive"
 msgstr ""
 "опцията „--strategy“ изисква някоя от опциите „--merge“ или „--interactive“"
 
-#: builtin/rebase.c:1759
+#: builtin/rebase.c:1463
 msgid "cannot combine apply options with merge options"
 msgstr "опциите за „apply“ са несъвместими с опциите за сливане"
 
-#: builtin/rebase.c:1772
+#: builtin/rebase.c:1476
 #, c-format
 msgid "Unknown rebase backend: %s"
 msgstr "Непозната реализация на пребазиране: %s"
 
-#: builtin/rebase.c:1802
+#: builtin/rebase.c:1505
 msgid "--reschedule-failed-exec requires --exec or --interactive"
 msgstr ""
 "опцията „--reschedule-failed-exec“ изисква някоя от опциите „--exec“ или „--"
 "interactive“"
 
-#: builtin/rebase.c:1822
-msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
-msgstr "опциите „--preserve-merges“ и „--rebase-merges“ са несъвместими"
-
-#: builtin/rebase.c:1826
-msgid ""
-"error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
-msgstr ""
-"ГРЕШКА: опциите „--preserve-merges“ и „--reschedule-failed-exec“ са "
-"несъвместими"
-
-#: builtin/rebase.c:1850
+#: builtin/rebase.c:1536
 #, c-format
 msgid "invalid upstream '%s'"
 msgstr "неправилен следен клон: „%s“"
 
-#: builtin/rebase.c:1856
+#: builtin/rebase.c:1542
 msgid "Could not create new root commit"
 msgstr "Не може да се създаде ново начално подаване"
 
-#: builtin/rebase.c:1882
+#: builtin/rebase.c:1568
 #, c-format
 msgid "'%s': need exactly one merge base with branch"
 msgstr "„%s“: изисква се точно една база за сливане с клона"
 
-#: builtin/rebase.c:1885
+#: builtin/rebase.c:1571
 #, c-format
 msgid "'%s': need exactly one merge base"
 msgstr "„%s“: изисква се точно една база за пребазиране"
 
-#: builtin/rebase.c:1893
+#: builtin/rebase.c:1580
 #, c-format
 msgid "Does not point to a valid commit '%s'"
 msgstr "Указателят „%s“ не сочи към подаване"
 
-#: builtin/rebase.c:1921
+#: builtin/rebase.c:1607
 #, c-format
-msgid "fatal: no such branch/commit '%s'"
-msgstr "ФАТАЛНА ГРЕШКА: не съществува клон „%s“"
+msgid "no such branch/commit '%s'"
+msgstr "не съществува клон/подаване „%s“"
 
-#: builtin/rebase.c:1929 builtin/submodule--helper.c:39
-#: builtin/submodule--helper.c:2431
+#: builtin/rebase.c:1618 builtin/submodule--helper.c:39
+#: builtin/submodule--helper.c:2658
 #, c-format
 msgid "No such ref: %s"
 msgstr "Такъв указател няма: %s"
 
-#: builtin/rebase.c:1940
+#: builtin/rebase.c:1629
 msgid "Could not resolve HEAD to a revision"
 msgstr "Подаването, сочено от указателя „HEAD“, не може да бъде открито"
 
-#: builtin/rebase.c:1961
+#: builtin/rebase.c:1650
 msgid "Please commit or stash them."
 msgstr "Промените трябва или да се подадат, или да се скатаят."
 
-#: builtin/rebase.c:1997
+#: builtin/rebase.c:1686
 #, c-format
 msgid "could not switch to %s"
 msgstr "не може да се премине към „%s“"
 
-#: builtin/rebase.c:2008
+#: builtin/rebase.c:1697
 msgid "HEAD is up to date."
 msgstr "Указателят „HEAD“ е напълно актуален."
 
-#: builtin/rebase.c:2010
+#: builtin/rebase.c:1699
 #, c-format
 msgid "Current branch %s is up to date.\n"
 msgstr "Текущият клон „%s“ е напълно актуален.\n"
 
-#: builtin/rebase.c:2018
+#: builtin/rebase.c:1707
 msgid "HEAD is up to date, rebase forced."
 msgstr "Указателят „HEAD“ е напълно актуален — принудително пребазиране"
 
-#: builtin/rebase.c:2020
+#: builtin/rebase.c:1709
 #, c-format
 msgid "Current branch %s is up to date, rebase forced.\n"
 msgstr "Текущият клон „%s“ е напълно актуален — принудително пребазиране\n"
 
-#: builtin/rebase.c:2028
+#: builtin/rebase.c:1717
 msgid "The pre-rebase hook refused to rebase."
 msgstr "Куката за изпълнение преди пребазиране отхвърли пребазирането."
 
-#: builtin/rebase.c:2035
+#: builtin/rebase.c:1724
 #, c-format
 msgid "Changes to %s:\n"
 msgstr "Промените в „%s“:\n"
 
-#: builtin/rebase.c:2038
+#: builtin/rebase.c:1727
 #, c-format
 msgid "Changes from %s to %s:\n"
 msgstr "Промените от „%s“ към „%s“:\n"
 
-#: builtin/rebase.c:2063
+#: builtin/rebase.c:1752
 #, c-format
 msgid "First, rewinding head to replay your work on top of it...\n"
 msgstr ""
 "Първо, указателят „HEAD“ започва да сочи към базата, върху която "
 "пребазирате…\n"
 
-#: builtin/rebase.c:2072
+#: builtin/rebase.c:1761
 msgid "Could not detach HEAD"
 msgstr "Указателят „HEAD“ не може да се отделѝ"
 
-#: builtin/rebase.c:2081
+#: builtin/rebase.c:1770
 #, c-format
 msgid "Fast-forwarded %s to %s.\n"
 msgstr "Превъртане на „%s“ към „%s“.\n"
 
-#: builtin/receive-pack.c:34
+#: builtin/receive-pack.c:35
 msgid "git receive-pack <git-dir>"
 msgstr "git receive-pack ДИРЕКТОРИЯ_НА_GIT"
 
-#: builtin/receive-pack.c:1275
+#: builtin/receive-pack.c:1280
 msgid ""
 "By default, updating the current branch in a non-bare repository\n"
 "is denied, because it will make the index and work tree inconsistent\n"
@@ -21062,7 +21288,7 @@ msgstr ""
 "За да заглушите това съобщение, като запазите стандартното поведение,\n"
 "задайте настройката „receive.denyCurrentBranch“ да е „refuse“ (отказ)."
 
-#: builtin/receive-pack.c:1295
+#: builtin/receive-pack.c:1300
 msgid ""
 "By default, deleting the current branch is denied, because the next\n"
 "'git clone' won't result in any file checked out, causing confusion.\n"
@@ -21083,11 +21309,11 @@ msgstr ""
 "За да заглушите това съобщение, задайте настройката\n"
 "„receive.denyDeleteCurrent“ да е „refuse“ (отказ)."
 
-#: builtin/receive-pack.c:2478
+#: builtin/receive-pack.c:2480
 msgid "quiet"
 msgstr "без извеждане на информация"
 
-#: builtin/receive-pack.c:2492
+#: builtin/receive-pack.c:2495
 msgid "You must specify a directory."
 msgstr "Трябва да укажете директория."
 
@@ -21127,7 +21353,7 @@ msgstr "Отбелязване на достижимите обекти…"
 msgid "%s points nowhere!"
 msgstr "„%s“ не сочи наникъде!"
 
-#: builtin/reflog.c:699
+#: builtin/reflog.c:700
 msgid "no reflog specified to delete"
 msgstr "не е указан журнал с подавания за изтриване"
 
@@ -21287,7 +21513,7 @@ msgstr ""
 "указването на следени клони е смислено само за отдалечени хранилища, от "
 "които се доставя"
 
-#: builtin/remote.c:195 builtin/remote.c:700
+#: builtin/remote.c:195 builtin/remote.c:705
 #, c-format
 msgid "remote %s already exists."
 msgstr "вече съществува отдалечено хранилище с име „%s“."
@@ -21297,25 +21523,30 @@ msgstr "вече съществува отдалечено хранилище с
 msgid "Could not setup master '%s'"
 msgstr "Основният клон „%s“ не може да бъде настроен"
 
-#: builtin/remote.c:355
+#: builtin/remote.c:322
+#, c-format
+msgid "unhandled branch.%s.rebase=%s; assuming 'true'"
+msgstr "„branch.%s.rebase=%s“ не се поддържа.  Приема се „true“ (истина)"
+
+#: builtin/remote.c:366
 #, c-format
 msgid "Could not get fetch map for refspec %s"
 msgstr "Обектите за доставяне за указателя „%s“ не може да бъдат получени"
 
-#: builtin/remote.c:454 builtin/remote.c:462
+#: builtin/remote.c:460 builtin/remote.c:468
 msgid "(matching)"
 msgstr "(съвпадащи)"
 
-#: builtin/remote.c:466
+#: builtin/remote.c:472
 msgid "(delete)"
 msgstr "(за изтриване)"
 
-#: builtin/remote.c:655
+#: builtin/remote.c:660
 #, c-format
 msgid "could not set '%s'"
 msgstr "„%s“ не може да се зададе"
 
-#: builtin/remote.c:660
+#: builtin/remote.c:665
 #, c-format
 msgid ""
 "The %s configuration remote.pushDefault in:\n"
@@ -21326,17 +21557,17 @@ msgstr ""
 "    %s:%d\n"
 "използва отдалечено хранилище, което вече не съществува: „%s“"
 
-#: builtin/remote.c:691 builtin/remote.c:836 builtin/remote.c:943
+#: builtin/remote.c:696 builtin/remote.c:841 builtin/remote.c:948
 #, c-format
 msgid "No such remote: '%s'"
 msgstr "Няма отдалечено хранилище на име „%s“"
 
-#: builtin/remote.c:710
+#: builtin/remote.c:715
 #, c-format
 msgid "Could not rename config section '%s' to '%s'"
 msgstr "Разделът „%s“ в настройките не може да бъде преименуван на „%s“"
 
-#: builtin/remote.c:730
+#: builtin/remote.c:735
 #, c-format
 msgid ""
 "Not updating non-default fetch refspec\n"
@@ -21347,17 +21578,17 @@ msgstr ""
 "    %s\n"
 "  Променете настройките ръчно, ако е необходимо."
 
-#: builtin/remote.c:770
+#: builtin/remote.c:775
 #, c-format
 msgid "deleting '%s' failed"
 msgstr "неуспешно изтриване на „%s“"
 
-#: builtin/remote.c:804
+#: builtin/remote.c:809
 #, c-format
 msgid "creating '%s' failed"
 msgstr "неуспешно създаване на „%s“"
 
-#: builtin/remote.c:882
+#: builtin/remote.c:887
 msgid ""
 "Note: A branch outside the refs/remotes/ hierarchy was not removed;\n"
 "to delete it, use:"
@@ -21371,121 +21602,121 @@ msgstr[1] ""
 "Бележка: Няколко клона извън йерархията „refs/remotes/“ не бяха изтрити.\n"
 "Изтрийте ги чрез командата:"
 
-#: builtin/remote.c:896
+#: builtin/remote.c:901
 #, c-format
 msgid "Could not remove config section '%s'"
 msgstr "Разделът „%s“ в настройките не може да бъде изтрит"
 
-#: builtin/remote.c:999
+#: builtin/remote.c:1009
 #, c-format
 msgid " new (next fetch will store in remotes/%s)"
 msgstr " нов (следващото доставяне ще го разположи в „remotes/%s“)"
 
-#: builtin/remote.c:1002
+#: builtin/remote.c:1012
 msgid " tracked"
 msgstr " следен"
 
-#: builtin/remote.c:1004
+#: builtin/remote.c:1014
 msgid " stale (use 'git remote prune' to remove)"
 msgstr " стар (изтрийте чрез „git remote prune“)"
 
-#: builtin/remote.c:1006
+#: builtin/remote.c:1016
 msgid " ???"
 msgstr " неясно състояние"
 
 # CHECK
-#: builtin/remote.c:1047
+#: builtin/remote.c:1057
 #, c-format
 msgid "invalid branch.%s.merge; cannot rebase onto > 1 branch"
 msgstr ""
 "неправилен клон за сливане „branch.%s.merge“.  Невъзможно е да пребазирате "
 "върху повече от 1 клон"
 
-#: builtin/remote.c:1056
+#: builtin/remote.c:1066
 #, c-format
 msgid "rebases interactively onto remote %s"
 msgstr "интерактивно пребазиране върху отдалечения клон „%s“"
 
-#: builtin/remote.c:1058
+#: builtin/remote.c:1068
 #, c-format
 msgid "rebases interactively (with merges) onto remote %s"
 msgstr "интерактивно пребазиране (със сливания) върху отдалечения клон „%s“"
 
-#: builtin/remote.c:1061
+#: builtin/remote.c:1071
 #, c-format
 msgid "rebases onto remote %s"
 msgstr "пребазиране върху отдалечения клон „%s“"
 
-#: builtin/remote.c:1065
+#: builtin/remote.c:1075
 #, c-format
 msgid " merges with remote %s"
 msgstr " сливане с отдалечения клон „%s“"
 
-#: builtin/remote.c:1068
+#: builtin/remote.c:1078
 #, c-format
 msgid "merges with remote %s"
 msgstr "сливане с отдалечения клон „%s“"
 
-#: builtin/remote.c:1071
+#: builtin/remote.c:1081
 #, c-format
 msgid "%-*s    and with remote %s\n"
 msgstr "%-*s    и с отдалечения клон „%s“\n"
 
-#: builtin/remote.c:1114
+#: builtin/remote.c:1124
 msgid "create"
 msgstr "създаден"
 
-#: builtin/remote.c:1117
+#: builtin/remote.c:1127
 msgid "delete"
 msgstr "изтрит"
 
-#: builtin/remote.c:1121
+#: builtin/remote.c:1131
 msgid "up to date"
 msgstr "актуален"
 
-#: builtin/remote.c:1124
+#: builtin/remote.c:1134
 msgid "fast-forwardable"
 msgstr "може да се превърти"
 
-#: builtin/remote.c:1127
+#: builtin/remote.c:1137
 msgid "local out of date"
 msgstr "локалният е изостанал"
 
-#: builtin/remote.c:1134
+#: builtin/remote.c:1144
 #, c-format
 msgid "    %-*s forces to %-*s (%s)"
 msgstr "    %-*s принудително изтласква към %-*s (%s)"
 
-#: builtin/remote.c:1137
+#: builtin/remote.c:1147
 #, c-format
 msgid "    %-*s pushes to %-*s (%s)"
 msgstr "    %-*s изтласква към %-*s (%s)"
 
-#: builtin/remote.c:1141
+#: builtin/remote.c:1151
 #, c-format
 msgid "    %-*s forces to %s"
 msgstr "    %-*s принудително изтласква към %s"
 
-#: builtin/remote.c:1144
+#: builtin/remote.c:1154
 #, c-format
 msgid "    %-*s pushes to %s"
 msgstr "    %-*s изтласква към %s"
 
-#: builtin/remote.c:1212
+#: builtin/remote.c:1222
 msgid "do not query remotes"
 msgstr "без заявки към отдалечените хранилища"
 
-#: builtin/remote.c:1239
+#: builtin/remote.c:1243
 #, c-format
 msgid "* remote %s"
 msgstr "● отдалечено хранилище „%s“"
 
-#: builtin/remote.c:1240
+#: builtin/remote.c:1244
 #, c-format
 msgid "  Fetch URL: %s"
 msgstr "  Адрес за доставяне: %s"
 
-#: builtin/remote.c:1241 builtin/remote.c:1257 builtin/remote.c:1396
+#: builtin/remote.c:1245 builtin/remote.c:1261 builtin/remote.c:1398
 msgid "(no URL)"
 msgstr "(без адрес)"
 
@@ -21493,25 +21724,25 @@ msgstr "(без адрес)"
 #. with the one in " Fetch URL: %s"
 #. translation.
 #.
-#: builtin/remote.c:1255 builtin/remote.c:1257
+#: builtin/remote.c:1259 builtin/remote.c:1261
 #, c-format
 msgid "  Push  URL: %s"
 msgstr "  Адрес за изтласкване: %s"
 
-#: builtin/remote.c:1259 builtin/remote.c:1261 builtin/remote.c:1263
+#: builtin/remote.c:1263 builtin/remote.c:1265 builtin/remote.c:1267
 #, c-format
 msgid "  HEAD branch: %s"
 msgstr "  клон сочен от HEAD: %s"
 
-#: builtin/remote.c:1259
+#: builtin/remote.c:1263
 msgid "(not queried)"
 msgstr "(без проверка)"
 
-#: builtin/remote.c:1261
+#: builtin/remote.c:1265
 msgid "(unknown)"
 msgstr "(непознат)"
 
-#: builtin/remote.c:1265
+#: builtin/remote.c:1269
 #, c-format
 msgid ""
 "  HEAD branch (remote HEAD is ambiguous, may be one of the following):\n"
@@ -21520,161 +21751,165 @@ msgstr ""
 "хранилище\n"
 "  не е еднозначен и е някой от следните):\n"
 
-#: builtin/remote.c:1277
+#: builtin/remote.c:1281
 #, c-format
 msgid "  Remote branch:%s"
 msgid_plural "  Remote branches:%s"
 msgstr[0] "  Отдалечен клон:%s"
 msgstr[1] "  Отдалечени клони:%s"
 
-#: builtin/remote.c:1280 builtin/remote.c:1306
+#: builtin/remote.c:1284 builtin/remote.c:1310
 msgid " (status not queried)"
 msgstr " (състоянието не бе проверено)"
 
-#: builtin/remote.c:1289
+#: builtin/remote.c:1293
 msgid "  Local branch configured for 'git pull':"
 msgid_plural "  Local branches configured for 'git pull':"
 msgstr[0] "  Локален клон настроен за издърпване чрез „git pull“:"
 msgstr[1] "  Локални клони настроени за издърпване чрез „git pull“:"
 
-#: builtin/remote.c:1297
+#: builtin/remote.c:1301
 msgid "  Local refs will be mirrored by 'git push'"
 msgstr "  Локалните указатели ще бъдат пренесени чрез „ push“"
 
-#: builtin/remote.c:1303
+#: builtin/remote.c:1307
 #, c-format
 msgid "  Local ref configured for 'git push'%s:"
 msgid_plural "  Local refs configured for 'git push'%s:"
 msgstr[0] "  Локалният указател, настроен за „git push“%s:"
 msgstr[1] "  Локалните указатели, настроени за „git push“%s:"
 
-#: builtin/remote.c:1324
+#: builtin/remote.c:1328
 msgid "set refs/remotes/<name>/HEAD according to remote"
 msgstr "задаване на refs/remotes/ИМЕ/HEAD според отдалеченото хранилище"
 
-#: builtin/remote.c:1326
+#: builtin/remote.c:1330
 msgid "delete refs/remotes/<name>/HEAD"
 msgstr "изтриване на refs/remotes/ИМЕ/HEAD"
 
-#: builtin/remote.c:1341
+#: builtin/remote.c:1344
 msgid "Cannot determine remote HEAD"
 msgstr "Не може да се установи отдалеченият връх"
 
-#: builtin/remote.c:1343
+#: builtin/remote.c:1346
 msgid "Multiple remote HEAD branches. Please choose one explicitly with:"
 msgstr ""
 "Множество клони с върхове.  Изберете изрично някой от тях чрез командата:"
 
-#: builtin/remote.c:1353
+#: builtin/remote.c:1356
 #, c-format
 msgid "Could not delete %s"
 msgstr "„%s“ не може да бъде изтрит"
 
-#: builtin/remote.c:1361
+#: builtin/remote.c:1364
 #, c-format
 msgid "Not a valid ref: %s"
 msgstr "Неправилен указател: %s"
 
-#: builtin/remote.c:1363
+#: builtin/remote.c:1366
 #, c-format
 msgid "Could not setup %s"
 msgstr "„%s“ не може да се настрои"
 
-#: builtin/remote.c:1381
+#: builtin/remote.c:1384
 #, c-format
 msgid " %s will become dangling!"
 msgstr "„%s“ ще се превърне в обект извън клоните!"
 
-#: builtin/remote.c:1382
+#: builtin/remote.c:1385
 #, c-format
 msgid " %s has become dangling!"
 msgstr "„%s“ се превърна в обект извън клоните!"
 
-#: builtin/remote.c:1392
+#: builtin/remote.c:1394
 #, c-format
 msgid "Pruning %s"
 msgstr "Окастряне на „%s“"
 
-#: builtin/remote.c:1393
+#: builtin/remote.c:1395
 #, c-format
 msgid "URL: %s"
 msgstr "адрес: %s"
 
-#: builtin/remote.c:1409
+#: builtin/remote.c:1411
 #, c-format
 msgid " * [would prune] %s"
 msgstr " ● [ще бъде окастрено] %s"
 
-#: builtin/remote.c:1412
+#: builtin/remote.c:1414
 #, c-format
 msgid " * [pruned] %s"
 msgstr " ● [окастрено] %s"
 
-#: builtin/remote.c:1457
+#: builtin/remote.c:1459
 msgid "prune remotes after fetching"
 msgstr "окастряне на огледалата на отдалечените хранилища след доставяне"
 
-#: builtin/remote.c:1521 builtin/remote.c:1577 builtin/remote.c:1647
+#: builtin/remote.c:1523 builtin/remote.c:1579 builtin/remote.c:1649
 #, c-format
 msgid "No such remote '%s'"
 msgstr "Няма отдалечено хранилище на име „%s“"
 
-#: builtin/remote.c:1539
+#: builtin/remote.c:1541
 msgid "add branch"
 msgstr "добавяне на клон"
 
-#: builtin/remote.c:1546
+#: builtin/remote.c:1548
 msgid "no remote specified"
 msgstr "не е указано отдалечено хранилище"
 
-#: builtin/remote.c:1563
+#: builtin/remote.c:1565
 msgid "query push URLs rather than fetch URLs"
 msgstr "запитване към адресите за изтласкване, а не за доставяне"
 
-#: builtin/remote.c:1565
+#: builtin/remote.c:1567
 msgid "return all URLs"
 msgstr "извеждане на всички адреси"
 
-#: builtin/remote.c:1595
+#: builtin/remote.c:1597
 #, c-format
 msgid "no URLs configured for remote '%s'"
 msgstr "не е зададен адрес за отдалеченото хранилище „%s“"
 
-#: builtin/remote.c:1621
+#: builtin/remote.c:1623
 msgid "manipulate push URLs"
 msgstr "промяна на адресите за изтласкване"
 
-#: builtin/remote.c:1623
+#: builtin/remote.c:1625
 msgid "add URL"
 msgstr "добавяне на адреси"
 
-#: builtin/remote.c:1625
+#: builtin/remote.c:1627
 msgid "delete URLs"
 msgstr "изтриване на адреси"
 
-#: builtin/remote.c:1632
+#: builtin/remote.c:1634
 msgid "--add --delete doesn't make sense"
 msgstr "опциите „--add“ и „--delete“ са несъвместими"
 
-#: builtin/remote.c:1673
+#: builtin/remote.c:1675
 #, c-format
 msgid "Invalid old URL pattern: %s"
 msgstr "Неправилен (стар) формат за адрес: %s"
 
-#: builtin/remote.c:1681
+#: builtin/remote.c:1683
 #, c-format
 msgid "No such URL found: %s"
 msgstr "Такъв адрес не е открит: %s"
 
-#: builtin/remote.c:1683
+#: builtin/remote.c:1685
 msgid "Will not delete all non-push URLs"
 msgstr "Никой от адресите, които не са за изтласкване, няма да се изтрие"
 
-#: builtin/repack.c:26
+#: builtin/remote.c:1702
+msgid "be verbose; must be placed before a subcommand"
+msgstr "повече подробности.  Поставя се пред подкоманда"
+
+#: builtin/repack.c:28
 msgid "git repack [<options>]"
 msgstr "git repack [ОПЦИЯ…]"
 
-#: builtin/repack.c:31
+#: builtin/repack.c:33
 msgid ""
 "Incremental repacks are incompatible with bitmap indexes.  Use\n"
 "--no-write-bitmap-index or disable the pack.writebitmaps configuration."
@@ -21683,154 +21918,167 @@ msgstr ""
 "Ползвайте опцията --no-write-bitmap-index или изключете настройката\n"
 "„pack.writebitmaps“."
 
-#: builtin/repack.c:198
+#: builtin/repack.c:201
 msgid "could not start pack-objects to repack promisor objects"
 msgstr ""
 "командата „pack-objects“ не може да се стартира за препакетирането на "
 "гарантиращите обекти"
 
-#: builtin/repack.c:270 builtin/repack.c:630
+#: builtin/repack.c:273 builtin/repack.c:816
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
 msgstr ""
 "repack: от „pack-objects“ се изискват редове само с пълни шестнайсетични "
 "указатели."
 
-#: builtin/repack.c:294
+#: builtin/repack.c:297
 msgid "could not finish pack-objects to repack promisor objects"
 msgstr ""
 "командата „pack-objects“ не може да завърши за препакетирането на "
 "гарантиращите обекти"
 
-#: builtin/repack.c:309
+#: builtin/repack.c:312
 #, c-format
 msgid "cannot open index for %s"
 msgstr "грешка при отваряне на индекса за „%s“"
 
-#: builtin/repack.c:368
+#: builtin/repack.c:371
 #, c-format
 msgid "pack %s too large to consider in geometric progression"
 msgstr "пакет „%s“ е твърде голям, за да е част от геометрична прогресия"
 
-#: builtin/repack.c:401 builtin/repack.c:408 builtin/repack.c:413
+#: builtin/repack.c:404 builtin/repack.c:411 builtin/repack.c:416
 #, c-format
 msgid "pack %s too large to roll up"
 msgstr "пакет „%s“ е твърде голям за свиване"
 
-#: builtin/repack.c:460
+#: builtin/repack.c:496
+#, c-format
+msgid "could not open tempfile %s for writing"
+msgstr "временният файл „%s“ не може да бъде отворен за запис"
+
+#: builtin/repack.c:514
+msgid "could not close refs snapshot tempfile"
+msgstr "временният файл със снимка на указателите не може да се затвори"
+
+#: builtin/repack.c:628
 msgid "pack everything in a single pack"
 msgstr "пакетиране на всичко в пакет"
 
-#: builtin/repack.c:462
+#: builtin/repack.c:630
 msgid "same as -a, and turn unreachable objects loose"
 msgstr ""
 "същото като опцията „-a“.  Допълнително — недостижимите обекти да станат "
 "непакетирани"
 
-#: builtin/repack.c:465
+#: builtin/repack.c:633
 msgid "remove redundant packs, and run git-prune-packed"
 msgstr ""
 "премахване на ненужните пакетирани файлове и изпълнение на командата „git-"
 "prune-packed“"
 
-#: builtin/repack.c:467
+#: builtin/repack.c:635
 msgid "pass --no-reuse-delta to git-pack-objects"
 msgstr "подаване на опцията „--no-reuse-delta“ на командата „git-pack-objects“"
 
-#: builtin/repack.c:469
+#: builtin/repack.c:637
 msgid "pass --no-reuse-object to git-pack-objects"
 msgstr ""
 "подаване на опцията „--no-reuse-object“ на командата „git-pack-objects“"
 
-#: builtin/repack.c:471
+#: builtin/repack.c:639
 msgid "do not run git-update-server-info"
 msgstr "без изпълнение на командата „git-update-server-info“"
 
-#: builtin/repack.c:474
+#: builtin/repack.c:642
 msgid "pass --local to git-pack-objects"
 msgstr "подаване на опцията „--local“ на командата „git-pack-objects“"
 
-#: builtin/repack.c:476
+#: builtin/repack.c:644
 msgid "write bitmap index"
 msgstr "създаване и записване на индекси на база битови маски"
 
-#: builtin/repack.c:478
+#: builtin/repack.c:646
 msgid "pass --delta-islands to git-pack-objects"
 msgstr "подаване на опцията „--delta-islands“ на командата „git-pack-objects“"
 
-#: builtin/repack.c:479
+#: builtin/repack.c:647
 msgid "approxidate"
 msgstr "евристична дата"
 
-#: builtin/repack.c:480
+#: builtin/repack.c:648
 msgid "with -A, do not loosen objects older than this"
 msgstr ""
 "при комбинирането с опцията „-A“ — без разпакетиране на обектите по стари от "
 "това"
 
-#: builtin/repack.c:482
+#: builtin/repack.c:650
 msgid "with -a, repack unreachable objects"
 msgstr "с „-a“ — препакетиране на недостижимите обекти"
 
-#: builtin/repack.c:484
+#: builtin/repack.c:652
 msgid "size of the window used for delta compression"
 msgstr "размер на прозореца за делта компресията"
 
-#: builtin/repack.c:485 builtin/repack.c:491
+#: builtin/repack.c:653 builtin/repack.c:659
 msgid "bytes"
 msgstr "байтове"
 
-#: builtin/repack.c:486
+#: builtin/repack.c:654
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr ""
 "същото като горната опция, но ограничението да е по размер на паметта, а не "
 "по броя на обектите"
 
-#: builtin/repack.c:488
+#: builtin/repack.c:656
 msgid "limits the maximum delta depth"
 msgstr "ограничаване на максималната дълбочина на делтата"
 
-#: builtin/repack.c:490
+#: builtin/repack.c:658
 msgid "limits the maximum number of threads"
 msgstr "ограничаване на максималния брой нишки"
 
-#: builtin/repack.c:492
+#: builtin/repack.c:660
 msgid "maximum size of each packfile"
 msgstr "максимален размер на всеки пакет"
 
-#: builtin/repack.c:494
+#: builtin/repack.c:662
 msgid "repack objects in packs marked with .keep"
 msgstr "препакетиране на обектите в пакети белязани с „.keep“"
 
-#: builtin/repack.c:496
+#: builtin/repack.c:664
 msgid "do not repack this pack"
 msgstr "без препакетиране на този пакет"
 
-#: builtin/repack.c:498
+#: builtin/repack.c:666
 msgid "find a geometric progression with factor <N>"
 msgstr "откриване на геометрична прогресия с частно <N>"
 
-#: builtin/repack.c:508
+#: builtin/repack.c:668
+msgid "write a multi-pack index of the resulting packs"
+msgstr "запазване на многопакетен индекс за създадените пакети"
+
+#: builtin/repack.c:678
 msgid "cannot delete packs in a precious-objects repo"
 msgstr "пакетите в хранилище с важни обекти не може да се трият"
 
-#: builtin/repack.c:512
+#: builtin/repack.c:682
 msgid "--keep-unreachable and -A are incompatible"
 msgstr "опциите „--keep-unreachable“ и „-A“ са несъвместими"
 
-#: builtin/repack.c:527
+#: builtin/repack.c:713
 msgid "--geometric is incompatible with -A, -a"
 msgstr "опциите „--geometric“ и „-A“/„-a“ са несъвместими"
 
-#: builtin/repack.c:639
+#: builtin/repack.c:825
 msgid "Nothing new to pack."
 msgstr "Нищо ново за пакетиране"
 
-#: builtin/repack.c:669
+#: builtin/repack.c:855
 #, c-format
 msgid "missing required file: %s"
 msgstr "липсва задължителния файл „%s“"
 
-#: builtin/repack.c:671
+#: builtin/repack.c:857
 #, c-format
 msgid "could not unlink: %s"
 msgstr "неуспешно изтриване на „%s“"
@@ -22141,96 +22389,96 @@ msgstr "слято (merge)"
 msgid "keep"
 msgstr "запазващо (keep)"
 
-#: builtin/reset.c:83
+#: builtin/reset.c:89
 msgid "You do not have a valid HEAD."
 msgstr "Указателят „HEAD“ е повреден."
 
-#: builtin/reset.c:85
+#: builtin/reset.c:91
 msgid "Failed to find tree of HEAD."
 msgstr "Дървото, сочено от указателя „HEAD“, не може да бъде открито."
 
-#: builtin/reset.c:91
+#: builtin/reset.c:97
 #, c-format
 msgid "Failed to find tree of %s."
 msgstr "Дървото, сочено от „%s“, не може да бъде открито."
 
-#: builtin/reset.c:116
+#: builtin/reset.c:122
 #, c-format
 msgid "HEAD is now at %s"
 msgstr "Указателят „HEAD“ сочи към „%s“"
 
-#: builtin/reset.c:195
+#: builtin/reset.c:201
 #, c-format
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "Не може да се извърши %s зануляване по време на сливане."
 
-#: builtin/reset.c:295 builtin/stash.c:589 builtin/stash.c:663
-#: builtin/stash.c:687
+#: builtin/reset.c:301 builtin/stash.c:605 builtin/stash.c:679
+#: builtin/stash.c:703
 msgid "be quiet, only report errors"
 msgstr "по-малко подробности, да се извеждат само грешките"
 
-#: builtin/reset.c:297
+#: builtin/reset.c:303
 msgid "reset HEAD and index"
 msgstr "индекса и указателя „HEAD“, без работното дърво"
 
-#: builtin/reset.c:298
+#: builtin/reset.c:304
 msgid "reset only HEAD"
 msgstr "само указателя „HEAD“, без индекса и работното дърво"
 
-#: builtin/reset.c:300 builtin/reset.c:302
+#: builtin/reset.c:306 builtin/reset.c:308
 msgid "reset HEAD, index and working tree"
 msgstr "указателя „HEAD“, индекса и работното дърво"
 
-#: builtin/reset.c:304
+#: builtin/reset.c:310
 msgid "reset HEAD but keep local changes"
 msgstr "зануляване на указателя „HEAD“, но запазване на локалните промени"
 
-#: builtin/reset.c:310
+#: builtin/reset.c:316
 msgid "record only the fact that removed paths will be added later"
 msgstr ""
 "отбелязване само на факта, че изтритите пътища ще бъдат добавени по-късно"
 
-#: builtin/reset.c:344
+#: builtin/reset.c:350
 #, c-format
 msgid "Failed to resolve '%s' as a valid revision."
 msgstr "Стойността „%s“ не е разпозната като съществуваща версия."
 
-#: builtin/reset.c:352
+#: builtin/reset.c:358
 #, c-format
 msgid "Failed to resolve '%s' as a valid tree."
 msgstr "„%s“ не е разпознат като дърво."
 
-#: builtin/reset.c:361
+#: builtin/reset.c:367
 msgid "--patch is incompatible with --{hard,mixed,soft}"
 msgstr ""
 "опцията „--patch“ е несъвместима с всяка от опциите „--hard“/„--mixed“/„--"
 "soft“"
 
-#: builtin/reset.c:371
+#: builtin/reset.c:377
 msgid "--mixed with paths is deprecated; use 'git reset -- <paths>' instead."
 msgstr ""
 "опцията „--mixed“ не бива да се използва заедно с пътища.  Вместо това "
 "изпълнете „git reset -- ПЪТ…“."
 
-#: builtin/reset.c:373
+#: builtin/reset.c:379
 #, c-format
 msgid "Cannot do %s reset with paths."
 msgstr "Не може да извършите %s зануляване, когато сте задали ПЪТ."
 
-#: builtin/reset.c:388
+#: builtin/reset.c:394
 #, c-format
 msgid "%s reset is not allowed in a bare repository"
 msgstr "В голо хранилище не може да извършите %s зануляване"
 
-#: builtin/reset.c:392
+#: builtin/reset.c:398
 msgid "-N can only be used with --mixed"
 msgstr "опцията „-N“ изисква опцията „--mixed“"
 
-#: builtin/reset.c:413
+#: builtin/reset.c:419
 msgid "Unstaged changes after reset:"
 msgstr "Промени извън индекса след зануляването:"
 
-#: builtin/reset.c:416
+#: builtin/reset.c:422
 #, c-format
 msgid ""
 "\n"
@@ -22243,12 +22491,12 @@ msgstr ""
 "Опцията „--quiet“ заглушава това съобщение еднократно.  За постоянно\n"
 "заглушаване задайте настройката „reset.quiet“ да е „true“ (истина).\n"
 
-#: builtin/reset.c:434
+#: builtin/reset.c:440
 #, c-format
 msgid "Could not reset index file to revision '%s'."
 msgstr "Индексът не може да бъде занулен към версия „%s“."
 
-#: builtin/reset.c:439
+#: builtin/reset.c:445
 msgid "Could not write new index file."
 msgstr "Новият индекс не може да бъде записан."
 
@@ -22429,15 +22677,19 @@ msgstr "добавяне на името на подаването"
 msgid "preserve initially empty commits"
 msgstr "запазване на първоначално празните подавания"
 
+#: builtin/revert.c:128
+msgid "allow commits with empty messages"
+msgstr "позволяване на празни съобщения при подаване"
+
 #: builtin/revert.c:129
 msgid "keep redundant, empty commits"
 msgstr "запазване на излишните, празни подавания"
 
-#: builtin/revert.c:237
+#: builtin/revert.c:241
 msgid "revert failed"
 msgstr "неуспешна отмяна"
 
-#: builtin/revert.c:250
+#: builtin/revert.c:254
 msgid "cherry-pick failed"
 msgstr "неуспешно отбиране"
 
@@ -22490,72 +22742,73 @@ msgid_plural "the following files have local modifications:"
 msgstr[0] "следният файл е с променено съдържание"
 msgstr[1] "следните файлове са с променено съдържание"
 
-#: builtin/rm.c:244
+#: builtin/rm.c:245
 msgid "do not list removed files"
 msgstr "да не се извеждат изтритите файлове"
 
-#: builtin/rm.c:245
+#: builtin/rm.c:246
 msgid "only remove from the index"
 msgstr "изтриване само от индекса"
 
-#: builtin/rm.c:246
+#: builtin/rm.c:247
 msgid "override the up-to-date check"
 msgstr "въпреки проверката за актуалността на съдържанието"
 
-#: builtin/rm.c:247
+#: builtin/rm.c:248
 msgid "allow recursive removal"
 msgstr "рекурсивно изтриване"
 
-#: builtin/rm.c:249
+#: builtin/rm.c:250
 msgid "exit with a zero status even if nothing matched"
 msgstr ""
 "изходният код да е 0, дори ако никой файл нe e напаснал с шаблона за "
 "изтриване"
 
-#: builtin/rm.c:283
+#: builtin/rm.c:285
 msgid "No pathspec was given. Which files should I remove?"
 msgstr "Не са зададени пътища.  Кои файлове да се изтрият?"
 
-#: builtin/rm.c:310
+#: builtin/rm.c:315
 msgid "please stage your changes to .gitmodules or stash them to proceed"
 msgstr ""
 "за да продължите, или вкарайте промените по файла „.gitmodules“ в индекса,\n"
 "или ги скатайте"
 
-#: builtin/rm.c:331
+#: builtin/rm.c:337
 #, c-format
 msgid "not removing '%s' recursively without -r"
 msgstr "без използването на опцията „-r“ „%s“ няма да се изтрие рекурсивно"
 
-#: builtin/rm.c:379
+#: builtin/rm.c:385
 #, c-format
 msgid "git rm: unable to remove %s"
 msgstr "git rm: „%s“ не може да се изтрие"
 
 #: builtin/send-pack.c:20
 msgid ""
-"git send-pack [--all | --mirror] [--dry-run] [--force] [--receive-pack=<git-"
-"receive-pack>] [--verbose] [--thin] [--atomic] [<host>:]<directory> "
-"[<ref>...]\n"
-"  --all and explicit <ref> specification are mutually exclusive."
+"git send-pack [--mirror] [--dry-run] [--force]\n"
+"              [--receive-pack=<git-receive-pack>]\n"
+"              [--verbose] [--thin] [--atomic]\n"
+"              [<host>:]<directory> (--all | <ref>...)"
 msgstr ""
-"git send-pack [--all | --mirror] [--dry-run] [--force] [--receive-"
-"pack=ПАКЕТ] [--verbose] [--thin] [--atomic] [ХОСТ:]ДИРЕКТОРИЯ [УКАЗАТЕЛ…]\n"
-"  опцията „--all“ и изричното посочване на УКАЗАТЕЛ са взаимно несъвместими."
+"git send-pack [--mirror] [--dry-run] [--force]\n"
+"              [--receive-pack=ПАКЕТ]\n"
+"              [--verbose] [--thin] [--atomic]\n"
+"              [ХОСТ:]ДИРЕКТОРИЯ (--all | УКАЗАТЕЛ…])"
 
-#: builtin/send-pack.c:188
+#: builtin/send-pack.c:192
 msgid "remote name"
 msgstr "име на отдалечено хранилище"
 
-#: builtin/send-pack.c:201
+#: builtin/send-pack.c:205
 msgid "use stateless RPC protocol"
 msgstr "използване на протокол без запазване на състоянието за RPC"
 
-#: builtin/send-pack.c:202
+#: builtin/send-pack.c:206
 msgid "read refs from stdin"
 msgstr "четене на указателите от стандартния вход"
 
-#: builtin/send-pack.c:203
+#: builtin/send-pack.c:207
 msgid "print status from remote helper"
 msgstr "извеждане на състоянието от отдалечената помощна функция"
 
@@ -22612,21 +22865,21 @@ msgstr "поле"
 msgid "group by field"
 msgstr "групиране по поле"
 
-#: builtin/shortlog.c:391
+#: builtin/shortlog.c:394
 msgid "too many arguments given outside repository"
 msgstr "прекалено много аргументи извън хранилище"
 
 #: builtin/show-branch.c:13
 msgid ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
-"\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
-"\t\t[--more=<n> | --list | --independent | --merge-base]\n"
-"\t\t[--no-name | --sha1-name] [--topics] [(<rev> | <glob>)...]"
+"                [--current] [--color[=<when>] | --no-color] [--sparse]\n"
+"                [--more=<n> | --list | --independent | --merge-base]\n"
+"                [--no-name | --sha1-name] [--topics] [(<rev> | <glob>)...]"
 msgstr ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
-"    [--current] [--color[=КОГА] | --no-color] [--sparse]\n"
-"    [--more=БРОЙ | --list | --independent | --merge-base]\n"
-"    [--no-name | --sha1-name] [--topics] [(РЕВИЗИЯ | УКАЗАТЕЛ)…]"
+"                [--current] [--color[=КОГА] | --no-color] [--sparse]\n"
+"                [--more=БРОЙ | --list | --independent | --merge-base]\n"
+"                [--no-name | --sha1-name] [--topics] [(РЕВИЗИЯ | УКАЗАТЕЛ)…]"
 
 #: builtin/show-branch.c:17
 msgid "git show-branch (-g | --reflog)[=<n>[,<base>]] [--list] [<ref>]"
@@ -22639,117 +22892,117 @@ msgid_plural "ignoring %s; cannot handle more than %d refs"
 msgstr[0] "„%s“ се прескача — не може да се обработят повече от %d указател"
 msgstr[1] "„%s“ се прескача — не може да се обработят повече от %d указатели"
 
-#: builtin/show-branch.c:548
+#: builtin/show-branch.c:547
 #, c-format
 msgid "no matching refs with %s"
 msgstr "никой указател не съвпада с „%s“"
 
-#: builtin/show-branch.c:645
+#: builtin/show-branch.c:644
 msgid "show remote-tracking and local branches"
 msgstr "извеждане на следящите и локалните клони"
 
-#: builtin/show-branch.c:647
+#: builtin/show-branch.c:646
 msgid "show remote-tracking branches"
 msgstr "извеждане на следящите клони"
 
-#: builtin/show-branch.c:649
+#: builtin/show-branch.c:648
 msgid "color '*!+-' corresponding to the branch"
 msgstr "оцветяване на „*!+-“ според клоните"
 
-#: builtin/show-branch.c:651
+#: builtin/show-branch.c:650
 msgid "show <n> more commits after the common ancestor"
 msgstr "извеждане на такъв БРОЙ подавания от общия предшественик"
 
-#: builtin/show-branch.c:653
+#: builtin/show-branch.c:652
 msgid "synonym to more=-1"
 msgstr "псевдоним на „more=-1“"
 
-#: builtin/show-branch.c:654
+#: builtin/show-branch.c:653
 msgid "suppress naming strings"
 msgstr "без низове за имената на клоните"
 
-#: builtin/show-branch.c:656
+#: builtin/show-branch.c:655
 msgid "include the current branch"
 msgstr "включване и на текущия клон"
 
-#: builtin/show-branch.c:658
+#: builtin/show-branch.c:657
 msgid "name commits with their object names"
 msgstr "именуване на подаванията с имената им на обекти"
 
-#: builtin/show-branch.c:660
+#: builtin/show-branch.c:659
 msgid "show possible merge bases"
 msgstr "извеждане на възможните бази за сливания"
 
-#: builtin/show-branch.c:662
+#: builtin/show-branch.c:661
 msgid "show refs unreachable from any other ref"
 msgstr "извеждане на недостижимите указатели"
 
-#: builtin/show-branch.c:664
+#: builtin/show-branch.c:663
 msgid "show commits in topological order"
 msgstr "извеждане на подаванията в топологическа подредба"
 
-#: builtin/show-branch.c:667
+#: builtin/show-branch.c:666
 msgid "show only commits not on the first branch"
 msgstr "извеждане само на подаванията, които не са от първия клон"
 
-#: builtin/show-branch.c:669
+#: builtin/show-branch.c:668
 msgid "show merges reachable from only one tip"
 msgstr "извеждане на сливанията, които може да се достигнат само от един връх"
 
-#: builtin/show-branch.c:671
+#: builtin/show-branch.c:670
 msgid "topologically sort, maintaining date order where possible"
 msgstr ""
 "топологическа подредба, при запазване на подредбата по дата, доколкото е\n"
 "възможно"
 
-#: builtin/show-branch.c:674
+#: builtin/show-branch.c:673
 msgid "<n>[,<base>]"
 msgstr "БРОЙ[,БАЗА]"
 
-#: builtin/show-branch.c:675
+#: builtin/show-branch.c:674
 msgid "show <n> most recent ref-log entries starting at base"
 msgstr "показване на най-много БРОЙ журнални записа с начало съответната БАЗА"
 
-#: builtin/show-branch.c:711
+#: builtin/show-branch.c:710
 msgid ""
 "--reflog is incompatible with --all, --remotes, --independent or --merge-base"
 msgstr ""
 "опцията „--reflog“ е несъвместима с опциите  „--all“, „--remotes“, „--"
 "independent“ и „--merge-base“"
 
-#: builtin/show-branch.c:735
+#: builtin/show-branch.c:734
 msgid "no branches given, and HEAD is not valid"
 msgstr "не е зададен клон, а указателят „HEAD“ е неправилен"
 
-#: builtin/show-branch.c:738
+#: builtin/show-branch.c:737
 msgid "--reflog option needs one branch name"
 msgstr "опцията „--reflog“ изисква точно едно име на клон"
 
-#: builtin/show-branch.c:741
+#: builtin/show-branch.c:740
 #, c-format
 msgid "only %d entry can be shown at one time."
 msgid_plural "only %d entries can be shown at one time."
 msgstr[0] "само %d запис може да бъде показан наведнъж."
 msgstr[1] "само %d записа може да бъде показани наведнъж."
 
-#: builtin/show-branch.c:745
+#: builtin/show-branch.c:744
 #, c-format
 msgid "no such ref %s"
 msgstr "такъв указател няма: %s"
 
-#: builtin/show-branch.c:831
+#: builtin/show-branch.c:828
 #, c-format
 msgid "cannot handle more than %d rev."
 msgid_plural "cannot handle more than %d revs."
 msgstr[0] "не може да се обработи повече от %d указател."
 msgstr[1] "не може да се обработят повече от %d указатели."
 
-#: builtin/show-branch.c:835
+#: builtin/show-branch.c:832
 #, c-format
 msgid "'%s' is not a valid ref."
 msgstr "„%s“ е неправилен указател."
 
-#: builtin/show-branch.c:838
+#: builtin/show-branch.c:835
 #, c-format
 msgid "cannot find commit %s (%s)"
 msgstr "подаването „%s“ (%s) липсва"
@@ -22823,72 +23076,86 @@ msgid "this worktree is not sparse (sparse-checkout file may not exist)"
 msgstr ""
 "това не е частично работно дърво (вероятно липсва файл „sparse-checkout“)"
 
-#: builtin/sparse-checkout.c:227
+#: builtin/sparse-checkout.c:173
+#, c-format
+msgid ""
+"directory '%s' contains untracked files, but is not in the sparse-checkout "
+"cone"
+msgstr ""
+"директорията „%s“ съдържа неследени файлове, но не е в пътищата на "
+"пътеводното напасване на частичното изтегляне"
+
+#: builtin/sparse-checkout.c:181
+#, c-format
+msgid "failed to remove directory '%s'"
+msgstr "директорията „%s“ не може да бъде изтрита"
+
+#: builtin/sparse-checkout.c:321
 msgid "failed to create directory for sparse-checkout file"
 msgstr "директорията за частично изтегляне „%s“ не може да бъде създадена"
 
-#: builtin/sparse-checkout.c:268
+#: builtin/sparse-checkout.c:362
 msgid "unable to upgrade repository format to enable worktreeConfig"
 msgstr ""
 "настройката „worktreeConfig“ не може да се включи, защото форматът на "
 "хранилището не може да се обнови"
 
-#: builtin/sparse-checkout.c:270
+#: builtin/sparse-checkout.c:364
 msgid "failed to set extensions.worktreeConfig setting"
 msgstr "неуспешно задаване на настройката „extensions.worktreeConfig“"
 
-#: builtin/sparse-checkout.c:290
+#: builtin/sparse-checkout.c:384
 msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
 msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
 
-#: builtin/sparse-checkout.c:310
+#: builtin/sparse-checkout.c:404
 msgid "initialize the sparse-checkout in cone mode"
 msgstr "инициализиране на частичното изтегляне в пътеводен режим"
 
-#: builtin/sparse-checkout.c:312
+#: builtin/sparse-checkout.c:406
 msgid "toggle the use of a sparse index"
 msgstr "превключване на ползването на частичен индекс"
 
-#: builtin/sparse-checkout.c:340
+#: builtin/sparse-checkout.c:434
 msgid "failed to modify sparse-index config"
 msgstr "настройките на частичния индекс не може да се променят"
 
-#: builtin/sparse-checkout.c:361
+#: builtin/sparse-checkout.c:455
 #, c-format
 msgid "failed to open '%s'"
 msgstr "„%s“ не може да се отвори"
 
-#: builtin/sparse-checkout.c:413
+#: builtin/sparse-checkout.c:507
 #, c-format
 msgid "could not normalize path %s"
 msgstr "пътят „%s“  не може да се нормализира"
 
-#: builtin/sparse-checkout.c:425
+#: builtin/sparse-checkout.c:519
 msgid "git sparse-checkout (set|add) (--stdin | <patterns>)"
 msgstr "git sparse-checkout (set|add) (--stdin | ШАБЛОН…)"
 
-#: builtin/sparse-checkout.c:450
+#: builtin/sparse-checkout.c:544
 #, c-format
 msgid "unable to unquote C-style string '%s'"
 msgstr "цитирането на низ, форматиран за C — „%s“ не може да бъде изчистено"
 
-#: builtin/sparse-checkout.c:504 builtin/sparse-checkout.c:528
+#: builtin/sparse-checkout.c:598 builtin/sparse-checkout.c:622
 msgid "unable to load existing sparse-checkout patterns"
 msgstr "шаблоните за частично изтегляне не може да се заредят"
 
-#: builtin/sparse-checkout.c:573
+#: builtin/sparse-checkout.c:667
 msgid "read patterns from standard in"
 msgstr "изчитане на шаблоните от стандартния вход"
 
-#: builtin/sparse-checkout.c:588
+#: builtin/sparse-checkout.c:682
 msgid "git sparse-checkout reapply"
 msgstr "git sparse-checkout reapply"
 
-#: builtin/sparse-checkout.c:607
+#: builtin/sparse-checkout.c:701
 msgid "git sparse-checkout disable"
 msgstr "git sparse-checkout disable"
 
-#: builtin/sparse-checkout.c:638
+#: builtin/sparse-checkout.c:732
 msgid "error while refreshing working directory"
 msgstr "грешка при обновяване на работната директория"
 
@@ -22924,7 +23191,7 @@ msgstr ""
 "          [--pathspec-from-file=ФАЙЛ [--pathspec-file-nul]]\n"
 "          [--] [ПЪТ…]]"
 
-#: builtin/stash.c:34 builtin/stash.c:87
+#: builtin/stash.c:34
 msgid ""
 "git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [<message>]"
@@ -22954,6 +23221,14 @@ msgstr ""
 "          [-u|--include-untracked] [-a|--all] [-m|--message СЪОБЩЕНИЕ]\n"
 "          [--] [ПЪТ…]]"
 
+#: builtin/stash.c:87
+msgid ""
+"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"               [-u|--include-untracked] [-a|--all] [<message>]"
+msgstr ""
+"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"               [-u|--include-untracked] [-a|--all] [СЪОБЩЕНИЕ]]"
+
 #: builtin/stash.c:130
 #, c-format
 msgid "'%s' is not a stash-like commit"
@@ -22977,7 +23252,7 @@ msgstr "„%s“ е неправилно име за указател"
 msgid "git stash clear with arguments is unimplemented"
 msgstr "командата „git stash clear“ не поддържа аргументи"
 
-#: builtin/stash.c:431
+#: builtin/stash.c:447
 #, c-format
 msgid ""
 "WARNING: Untracked file in way of tracked file!  Renaming\n"
@@ -22988,168 +23263,168 @@ msgstr ""
 "            „%s“ на „%s“\n"
 "         за да се направи място.\n"
 
-#: builtin/stash.c:492
+#: builtin/stash.c:508
 msgid "cannot apply a stash in the middle of a merge"
 msgstr "по време на сливане не може да приложите нещо скатано"
 
-#: builtin/stash.c:503
+#: builtin/stash.c:519
 #, c-format
 msgid "could not generate diff %s^!."
 msgstr "файлът с разликите „%s^!“ не може да се генерира"
 
-#: builtin/stash.c:510
+#: builtin/stash.c:526
 msgid "conflicts in index. Try without --index."
 msgstr ""
 "в индекса има конфликти.  Пробвайте да изпълните командата без опцията „--"
 "index“."
 
-#: builtin/stash.c:516
+#: builtin/stash.c:532
 msgid "could not save index tree"
 msgstr "дървото сочено от индекса не може да бъде запазено"
 
-#: builtin/stash.c:525
-msgid "could not restore untracked files from stash"
-msgstr "неследени файлове не може да се възстановят от скатаното"
-
-#: builtin/stash.c:539
+#: builtin/stash.c:552
 #, c-format
 msgid "Merging %s with %s"
 msgstr "Сливане на „%s“ с „%s“"
 
-#: builtin/stash.c:549
+#: builtin/stash.c:562
 msgid "Index was not unstashed."
 msgstr "Индексът не е изваден от скатаното."
 
-#: builtin/stash.c:591 builtin/stash.c:689
+#: builtin/stash.c:575
+msgid "could not restore untracked files from stash"
+msgstr "неследени файлове не може да се възстановят от скатаното"
+
+#: builtin/stash.c:607 builtin/stash.c:705
 msgid "attempt to recreate the index"
 msgstr "опит за повторно създаване на индекса"
 
-#: builtin/stash.c:635
+#: builtin/stash.c:651
 #, c-format
 msgid "Dropped %s (%s)"
 msgstr "Изтрито: „%s“ (%s)"
 
-#: builtin/stash.c:638
+#: builtin/stash.c:654
 #, c-format
 msgid "%s: Could not drop stash entry"
 msgstr "Скатаното „%s“ не може да бъде изтрито"
 
-#: builtin/stash.c:651
+#: builtin/stash.c:667
 #, c-format
 msgid "'%s' is not a stash reference"
 msgstr "„%s“ не е указател към нещо скатано"
 
-#: builtin/stash.c:701
+#: builtin/stash.c:717
 msgid "The stash entry is kept in case you need it again."
 msgstr "Скатаното е запазено в случай, че ви потрябва отново."
 
-#: builtin/stash.c:724
+#: builtin/stash.c:740
 msgid "No branch name specified"
 msgstr "Не е указано име на клон"
 
-#: builtin/stash.c:808
+#: builtin/stash.c:824
 msgid "failed to parse tree"
 msgstr "дървото не може да бъде анализирано"
 
-#: builtin/stash.c:819
+#: builtin/stash.c:835
 msgid "failed to unpack trees"
 msgstr "дървото не може да бъде разпакетирано"
 
-#: builtin/stash.c:839
+#: builtin/stash.c:855
 msgid "include untracked files in the stash"
 msgstr "скатаване и на неследените файлове"
 
-#: builtin/stash.c:842
+#: builtin/stash.c:858
 msgid "only show untracked files in the stash"
 msgstr "извеждане само на неследените файлове в скатаното"
 
-#: builtin/stash.c:929 builtin/stash.c:966
+#: builtin/stash.c:945 builtin/stash.c:982
 #, c-format
 msgid "Cannot update %s with %s"
 msgstr "Указателят „%s“ не може да бъде обновен да сочи към „%s“"
 
-#: builtin/stash.c:947 builtin/stash.c:1602 builtin/stash.c:1667
+#: builtin/stash.c:963 builtin/stash.c:1619 builtin/stash.c:1684
 msgid "stash message"
 msgstr "съобщение при скатаване"
 
-#: builtin/stash.c:957
+#: builtin/stash.c:973
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "командата „git stash store“ изисква точно един аргумент-ПОДАВАНЕ"
 
-#: builtin/stash.c:1171
+#: builtin/stash.c:1187
 msgid "No changes selected"
 msgstr "Не са избрани никакви промени"
 
-#: builtin/stash.c:1271
+#: builtin/stash.c:1287
 msgid "You do not have the initial commit yet"
 msgstr "Все още липсва първоначално подаване"
 
-#: builtin/stash.c:1298
+#: builtin/stash.c:1314
 msgid "Cannot save the current index state"
 msgstr "Състоянието на текущия индекс не може да бъде запазено"
 
-#: builtin/stash.c:1307
+#: builtin/stash.c:1323
 msgid "Cannot save the untracked files"
 msgstr "Неследените файлове не може да се запазят"
 
-#: builtin/stash.c:1318 builtin/stash.c:1327
+#: builtin/stash.c:1334 builtin/stash.c:1343
 msgid "Cannot save the current worktree state"
 msgstr "Състоянието на работното дърво не може да бъде запазено"
 
-#: builtin/stash.c:1355
+#: builtin/stash.c:1371
 msgid "Cannot record working tree state"
 msgstr "Състоянието на работното дърво не може да бъде запазено"
 
-#: builtin/stash.c:1404
+#: builtin/stash.c:1420
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr "опцията „--patch“ е несъвместима с „--include-untracked“ и „--all“"
 
-#: builtin/stash.c:1422
+#: builtin/stash.c:1438
 msgid "Did you forget to 'git add'?"
 msgstr "Пробвайте да използвате „git add“"
 
-#: builtin/stash.c:1437
+#: builtin/stash.c:1453
 msgid "No local changes to save"
 msgstr "Няма никакви локални промени за скатаване"
 
-#: builtin/stash.c:1444
+#: builtin/stash.c:1460
 msgid "Cannot initialize stash"
 msgstr "Скатаването не може да стартира"
 
-#: builtin/stash.c:1459
+#: builtin/stash.c:1475
 msgid "Cannot save the current status"
 msgstr "Текущото състояние не може да бъде запазено"
 
-#: builtin/stash.c:1464
+#: builtin/stash.c:1480
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "Състоянието на работната директория и индекса e запазено: „%s“"
 
-#: builtin/stash.c:1554
+#: builtin/stash.c:1571
 msgid "Cannot remove worktree changes"
 msgstr "Промените в работното дърво не може да бъдат занулени"
 
-#: builtin/stash.c:1593 builtin/stash.c:1658
+#: builtin/stash.c:1610 builtin/stash.c:1675
 msgid "keep index"
 msgstr "запазване на индекса"
 
-#: builtin/stash.c:1595 builtin/stash.c:1660
+#: builtin/stash.c:1612 builtin/stash.c:1677
 msgid "stash in patch mode"
 msgstr "скатаване в режим за кръпки"
 
-#: builtin/stash.c:1596 builtin/stash.c:1661
+#: builtin/stash.c:1613 builtin/stash.c:1678
 msgid "quiet mode"
 msgstr "без извеждане на информация"
 
-#: builtin/stash.c:1598 builtin/stash.c:1663
+#: builtin/stash.c:1615 builtin/stash.c:1680
 msgid "include untracked files in stash"
 msgstr "скатаване и на неследените файлове"
 
-#: builtin/stash.c:1600 builtin/stash.c:1665
+#: builtin/stash.c:1617 builtin/stash.c:1682
 msgid "include ignore files"
 msgstr "скатаване и на игнорираните файлове"
 
-#: builtin/stash.c:1700
+#: builtin/stash.c:1717
 msgid ""
 "the stash.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -23173,7 +23448,7 @@ msgstr "пропускане на всички редове, които запо
 msgid "prepend comment character and space to each line"
 msgstr "добавяне на „# “ в началото на всеки ред"
 
-#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2440
+#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2667
 #, c-format
 msgid "Expecting a full ref name, got %s"
 msgstr "Очаква се пълно име на указател, а не „%s“"
@@ -23188,27 +23463,35 @@ msgstr ""
 msgid "cannot strip one component off url '%s'"
 msgstr "не може да се махне компонент от адреса „%s“"
 
-#: builtin/submodule--helper.c:411 builtin/submodule--helper.c:1887
-#: builtin/submodule--helper.c:2891
+#: builtin/submodule--helper.c:211
+#, c-format
+msgid ""
+"could not look up configuration '%s'. Assuming this repository is its own "
+"authoritative upstream."
+msgstr ""
+"настройката „%s“ липсва.  Приема се, че това хранилище е правилният източник "
+"за себе си."
+
+#: builtin/submodule--helper.c:405 builtin/submodule--helper.c:1858
 msgid "alternative anchor for relative paths"
 msgstr "директория за определянето на относителните пътища"
 
-#: builtin/submodule--helper.c:416
+#: builtin/submodule--helper.c:410
 msgid "git submodule--helper list [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper list [--prefix=ПЪТ] [ПЪТ…]"
 
-#: builtin/submodule--helper.c:474 builtin/submodule--helper.c:631
-#: builtin/submodule--helper.c:654
+#: builtin/submodule--helper.c:468 builtin/submodule--helper.c:605
+#: builtin/submodule--helper.c:628
 #, c-format
 msgid "No url found for submodule path '%s' in .gitmodules"
 msgstr "Във файла „.gitmodules“ не е открит адрес за пътя към подмодул „%s“"
 
-#: builtin/submodule--helper.c:526
+#: builtin/submodule--helper.c:520
 #, c-format
 msgid "Entering '%s'\n"
 msgstr "Влизане в „%s“\n"
 
-#: builtin/submodule--helper.c:529
+#: builtin/submodule--helper.c:523
 #, c-format
 msgid ""
 "run_command returned non-zero status for %s\n"
@@ -23217,7 +23500,7 @@ msgstr ""
 "изпълнената команда (run_command) завърши с ненулев изход за „%s“\n"
 "."
 
-#: builtin/submodule--helper.c:551
+#: builtin/submodule--helper.c:545
 #, c-format
 msgid ""
 "run_command returned non-zero status while recursing in the nested "
@@ -23228,77 +23511,68 @@ msgstr ""
 "подмодулите, вложени в „%s“\n"
 "."
 
-#: builtin/submodule--helper.c:567
+#: builtin/submodule--helper.c:561
 msgid "suppress output of entering each submodule command"
 msgstr "без извеждане на изход при въвеждането на всяка команда за подмодули"
 
-#: builtin/submodule--helper.c:569 builtin/submodule--helper.c:890
-#: builtin/submodule--helper.c:1489
+#: builtin/submodule--helper.c:563 builtin/submodule--helper.c:864
+#: builtin/submodule--helper.c:1453
 msgid "recurse into nested submodules"
 msgstr "рекурсивно обхождане на подмодулите"
 
-#: builtin/submodule--helper.c:574
+#: builtin/submodule--helper.c:568
 msgid "git submodule--helper foreach [--quiet] [--recursive] [--] <command>"
 msgstr "git submodule--helper foreach [--quiet] [--recursive] [--] КОМАНДА"
 
-#: builtin/submodule--helper.c:601
-#, c-format
-msgid ""
-"could not look up configuration '%s'. Assuming this repository is its own "
-"authoritative upstream."
-msgstr ""
-"настройката „%s“ липсва.  Приема се, че това хранилище е правилният източник "
-"за себе си."
-
-#: builtin/submodule--helper.c:668
+#: builtin/submodule--helper.c:642
 #, c-format
 msgid "Failed to register url for submodule path '%s'"
 msgstr "Неуспешно регистриране на адрес за пътя към подмодул „%s“"
 
-#: builtin/submodule--helper.c:672
+#: builtin/submodule--helper.c:646
 #, c-format
 msgid "Submodule '%s' (%s) registered for path '%s'\n"
 msgstr "Регистриран е подмодул „%s“ (%s) за пътя към подмодул „%s“\n"
 
-#: builtin/submodule--helper.c:682
+#: builtin/submodule--helper.c:656
 #, c-format
 msgid "warning: command update mode suggested for submodule '%s'\n"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: препоръчва се режим на обновяване за подмодула „%s“\n"
 
-#: builtin/submodule--helper.c:689
+#: builtin/submodule--helper.c:663
 #, c-format
 msgid "Failed to register update mode for submodule path '%s'"
 msgstr ""
 "Неуспешно регистриране на режима на обновяване за пътя към подмодул „%s“"
 
-#: builtin/submodule--helper.c:711
+#: builtin/submodule--helper.c:685
 msgid "suppress output for initializing a submodule"
 msgstr "без извеждане на информация при инициализирането на подмодул"
 
-#: builtin/submodule--helper.c:716
+#: builtin/submodule--helper.c:690
 msgid "git submodule--helper init [<options>] [<path>]"
 msgstr "git submodule--helper init [ОПЦИЯ…] [ПЪТ]"
 
-#: builtin/submodule--helper.c:789 builtin/submodule--helper.c:924
+#: builtin/submodule--helper.c:763 builtin/submodule--helper.c:898
 #, c-format
 msgid "no submodule mapping found in .gitmodules for path '%s'"
 msgstr "Във файла „.gitmodules“ липсва информация за пътя „%s“"
 
-#: builtin/submodule--helper.c:837
+#: builtin/submodule--helper.c:811
 #, c-format
 msgid "could not resolve HEAD ref inside the submodule '%s'"
 msgstr "указателят сочен от „HEAD“ в подмодула „%s“ не може да бъде открит"
 
-#: builtin/submodule--helper.c:864 builtin/submodule--helper.c:1459
+#: builtin/submodule--helper.c:838 builtin/submodule--helper.c:1423
 #, c-format
 msgid "failed to recurse into submodule '%s'"
 msgstr "неуспешно рекурсивно обхождане на подмодула „%s“"
 
-#: builtin/submodule--helper.c:888 builtin/submodule--helper.c:1625
+#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1589
 msgid "suppress submodule status output"
 msgstr "без изход за състоянието на подмодула"
 
-#: builtin/submodule--helper.c:889
+#: builtin/submodule--helper.c:863
 msgid ""
 "use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
@@ -23306,100 +23580,100 @@ msgstr ""
 "използване на подаването указано в индекса, а не това от указателя „HEAD“ на "
 "подмодула"
 
-#: builtin/submodule--helper.c:895
+#: builtin/submodule--helper.c:869
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
 msgstr "git submodule status [--quiet] [--cached] [--recursive] [ПЪТ…]"
 
-#: builtin/submodule--helper.c:919
+#: builtin/submodule--helper.c:893
 msgid "git submodule--helper name <path>"
 msgstr "git submodule--helper name ПЪТ"
 
-#: builtin/submodule--helper.c:991
+#: builtin/submodule--helper.c:965
 #, c-format
 msgid "* %s %s(blob)->%s(submodule)"
 msgstr "● %s %s(обект-BLOB)→%s(подмодул)"
 
-#: builtin/submodule--helper.c:994
+#: builtin/submodule--helper.c:968
 #, c-format
 msgid "* %s %s(submodule)->%s(blob)"
 msgstr "● %s %s(подмодул)→%s(обект-BLOB)"
 
-#: builtin/submodule--helper.c:1007
+#: builtin/submodule--helper.c:981
 #, c-format
 msgid "%s"
 msgstr "%s"
 
-#: builtin/submodule--helper.c:1057
+#: builtin/submodule--helper.c:1031
 #, c-format
 msgid "couldn't hash object from '%s'"
 msgstr "неуспешно изчисляване на контролната сума на обект от „%s“"
 
-#: builtin/submodule--helper.c:1061
+#: builtin/submodule--helper.c:1035
 #, c-format
 msgid "unexpected mode %o\n"
 msgstr "неочакван режим „%o“\n"
 
-#: builtin/submodule--helper.c:1302
+#: builtin/submodule--helper.c:1276
 msgid "use the commit stored in the index instead of the submodule HEAD"
 msgstr ""
 "използване на подаването указано в индекса, а не това от указателя „HEAD“ на "
 "подмодула"
 
-#: builtin/submodule--helper.c:1304
+#: builtin/submodule--helper.c:1278
 msgid "compare the commit in the index with that in the submodule HEAD"
 msgstr ""
 "сравнение на подаването указано в индекса с това от указателя „HEAD“ на "
 "подмодула"
 
-#: builtin/submodule--helper.c:1306
+#: builtin/submodule--helper.c:1280
 msgid "skip submodules with 'ignore_config' value set to 'all'"
 msgstr "прескачане на подмодули, чиято настройка „ignore_config“ е „all“"
 
-#: builtin/submodule--helper.c:1308
+#: builtin/submodule--helper.c:1282
 msgid "limit the summary size"
 msgstr "ограничаване на размера на обобщението"
 
-#: builtin/submodule--helper.c:1313
+#: builtin/submodule--helper.c:1287
 msgid "git submodule--helper summary [<options>] [<commit>] [--] [<path>]"
-msgstr "git submodule--helper summary [ОПЦИЯ…] [ПОДАВАНЕ] -- [ПЪТ]"
+msgstr "git submodule--helper summary [ОПЦИЯ…] [ПОДАВАНЕ] [--] [ПЪТ]"
 
-#: builtin/submodule--helper.c:1337
+#: builtin/submodule--helper.c:1311
 msgid "could not fetch a revision for HEAD"
 msgstr "не може да се достави версия за „HEAD“"
 
-#: builtin/submodule--helper.c:1342
+#: builtin/submodule--helper.c:1316
 msgid "--cached and --files are mutually exclusive"
 msgstr "опциите „--cached“ и „--files“ са несъвместими"
 
-#: builtin/submodule--helper.c:1409
+#: builtin/submodule--helper.c:1373
 #, c-format
 msgid "Synchronizing submodule url for '%s'\n"
 msgstr "Синхронизиране на адреса на подмодул за „%s“\n"
 
-#: builtin/submodule--helper.c:1415
+#: builtin/submodule--helper.c:1379
 #, c-format
 msgid "failed to register url for submodule path '%s'"
 msgstr "неуспешно регистриране на адрес за пътя към подмодул „%s“"
 
-#: builtin/submodule--helper.c:1429
+#: builtin/submodule--helper.c:1393
 #, c-format
 msgid "failed to get the default remote for submodule '%s'"
 msgstr "отдалеченият адрес на подмодула „%s“ не може да бъде получен"
 
-#: builtin/submodule--helper.c:1440
+#: builtin/submodule--helper.c:1404
 #, c-format
 msgid "failed to update remote for submodule '%s'"
 msgstr "отдалеченият адрес на подмодула „%s“ не може да бъде променен"
 
-#: builtin/submodule--helper.c:1487
+#: builtin/submodule--helper.c:1451
 msgid "suppress output of synchronizing submodule url"
 msgstr "без извеждане на информация при синхронизирането на подмодул"
 
-#: builtin/submodule--helper.c:1494
+#: builtin/submodule--helper.c:1458
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
 msgstr "git submodule--helper sync [--quiet] [--recursive] [ПЪТ]"
 
-#: builtin/submodule--helper.c:1548
+#: builtin/submodule--helper.c:1512
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains a .git directory (use 'rm -rf' if you "
@@ -23408,7 +23682,7 @@ msgstr ""
 "Работното дърво на подмодул „%s“ съдържа директория „.git“.\n"
 "(ако искате да ги изтриете заедно с цялата им история, използвайте „rm -rf“)"
 
-#: builtin/submodule--helper.c:1560
+#: builtin/submodule--helper.c:1524
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
@@ -23417,47 +23691,47 @@ msgstr ""
 "Работното дърво на подмодул „%s“ съдържа локални промени.  Може да ги "
 "отхвърлите с опцията „-f“"
 
-#: builtin/submodule--helper.c:1568
+#: builtin/submodule--helper.c:1532
 #, c-format
 msgid "Cleared directory '%s'\n"
 msgstr "Директорията „%s“ е изчистена\n"
 
-#: builtin/submodule--helper.c:1570
+#: builtin/submodule--helper.c:1534
 #, c-format
 msgid "Could not remove submodule work tree '%s'\n"
 msgstr ""
 "Директорията към работното дърво на подмодула „%s“ не може да бъде изтрита\n"
 
-#: builtin/submodule--helper.c:1581
+#: builtin/submodule--helper.c:1545
 #, c-format
 msgid "could not create empty submodule directory %s"
 msgstr "празната директория за подмодула „%s“ не може да бъде създадена"
 
-#: builtin/submodule--helper.c:1597
+#: builtin/submodule--helper.c:1561
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "Регистрацията на подмодула „%s“ (%s) за пътя „%s“ е премахната\n"
 
-#: builtin/submodule--helper.c:1626
+#: builtin/submodule--helper.c:1590
 msgid "remove submodule working trees even if they contain local changes"
 msgstr ""
 "изтриване на работните дървета на подмодулите, дори когато те съдържат "
 "локални промени"
 
-#: builtin/submodule--helper.c:1627
+#: builtin/submodule--helper.c:1591
 msgid "unregister all submodules"
 msgstr "премахване на регистрациите на всички подмодули"
 
-#: builtin/submodule--helper.c:1632
+#: builtin/submodule--helper.c:1596
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr "git submodule deinit [--quiet] [-f | --force] [--all | [--] [ПЪТ…]]"
 
-#: builtin/submodule--helper.c:1646
+#: builtin/submodule--helper.c:1610
 msgid "Use '--all' if you really want to deinitialize all submodules"
 msgstr "Използвайте „--all“, за да премахнете всички подмодули"
 
-#: builtin/submodule--helper.c:1690
+#: builtin/submodule--helper.c:1655
 msgid ""
 "An alternate computed from a superproject's alternate is invalid.\n"
 "To allow Git to clone without an alternate in such a case, set\n"
@@ -23469,70 +23743,70 @@ msgstr ""
 "задайте настройката „submodule.alternateErrorStrategy“ да е „info“ или\n"
 "при клониране ползвайте опцията „--reference-if-able“ вместо „--reference“."
 
-#: builtin/submodule--helper.c:1729 builtin/submodule--helper.c:1732
+#: builtin/submodule--helper.c:1700 builtin/submodule--helper.c:1703
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
 msgstr "към подмодула „%s“ не може да се добави алтернативен източник: %s"
 
-#: builtin/submodule--helper.c:1768
+#: builtin/submodule--helper.c:1739
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
 msgstr ""
 "Непозната стойност „%s“ за настройката „submodule.alternateErrorStrategy“"
 
-#: builtin/submodule--helper.c:1775
+#: builtin/submodule--helper.c:1746
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
 msgstr "Непозната стойност „%s“ за настройката „submodule.alternateLocation“"
 
-#: builtin/submodule--helper.c:1800
+#: builtin/submodule--helper.c:1771
 #, c-format
 msgid "refusing to create/use '%s' in another submodule's git dir"
 msgstr ""
 "„%s“ не може нито да се създаде, нито да се ползва в директорията на git на "
 "друг подмодул"
 
-#: builtin/submodule--helper.c:1841
+#: builtin/submodule--helper.c:1812
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
 msgstr "Неуспешно клониране на адреса „%s“ в пътя „%s“ като подмодул"
 
-#: builtin/submodule--helper.c:1846
+#: builtin/submodule--helper.c:1817
 #, c-format
 msgid "directory not empty: '%s'"
 msgstr "директорията не е празна: „%s“"
 
-#: builtin/submodule--helper.c:1858
+#: builtin/submodule--helper.c:1829
 #, c-format
 msgid "could not get submodule directory for '%s'"
 msgstr "директорията на подмодула „%s“ не може да бъде получена"
 
-#: builtin/submodule--helper.c:1890 builtin/submodule--helper.c:2894
+#: builtin/submodule--helper.c:1861
 msgid "where the new submodule will be cloned to"
 msgstr "къде да се клонира новият подмодул"
 
-#: builtin/submodule--helper.c:1893 builtin/submodule--helper.c:2897
+#: builtin/submodule--helper.c:1864
 msgid "name of the new submodule"
 msgstr "име на новия подмодул"
 
-#: builtin/submodule--helper.c:1896 builtin/submodule--helper.c:2900
+#: builtin/submodule--helper.c:1867
 msgid "url where to clone the submodule from"
 msgstr "адрес, от който да се клонира новият подмодул"
 
-#: builtin/submodule--helper.c:1904 builtin/submodule--helper.c:2907
+#: builtin/submodule--helper.c:1875 builtin/submodule--helper.c:3264
 msgid "depth for shallow clones"
 msgstr "дълбочина на плитките хранилища"
 
-#: builtin/submodule--helper.c:1907 builtin/submodule--helper.c:2365
-#: builtin/submodule--helper.c:2909
+#: builtin/submodule--helper.c:1878 builtin/submodule--helper.c:2525
+#: builtin/submodule--helper.c:3257
 msgid "force cloning progress"
 msgstr "извеждане на напредъка на клонирането"
 
-#: builtin/submodule--helper.c:1909 builtin/submodule--helper.c:2367
+#: builtin/submodule--helper.c:1880 builtin/submodule--helper.c:2527
 msgid "disallow cloning into non-empty directory"
 msgstr "предотвратяване на клониране в непразна история"
 
-#: builtin/submodule--helper.c:1916
+#: builtin/submodule--helper.c:1887
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
 "<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
@@ -23541,86 +23815,185 @@ msgstr ""
 "git submodule--helper clone [--prefix=ПЪТ] [--quiet] [--reference ХРАНИЛИЩЕ] "
 "[--name ИМЕ] [--depth ДЪЛБОЧИНА] [--single-branch] --url АДРЕС --path ПЪТ"
 
-#: builtin/submodule--helper.c:1953
+#: builtin/submodule--helper.c:1924
 #, c-format
 msgid "Invalid update mode '%s' for submodule path '%s'"
 msgstr "Неправилен режим на обновяване „%s“ за пътя към подмодул „%s“"
 
-#: builtin/submodule--helper.c:1957
+#: builtin/submodule--helper.c:1928
 #, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
 msgstr ""
 "Настроен е неправилен режим на обновяване „%s“ за пътя към подмодул „%s“"
 
-#: builtin/submodule--helper.c:2058
+#: builtin/submodule--helper.c:2043
 #, c-format
 msgid "Submodule path '%s' not initialized"
 msgstr "Пътят на подмодула „%s“ не е инициализиран"
 
-#: builtin/submodule--helper.c:2062
+#: builtin/submodule--helper.c:2047
 msgid "Maybe you want to use 'update --init'?"
 msgstr "Вероятно искахте да използвате „update --init“?"
 
-#: builtin/submodule--helper.c:2092
+#: builtin/submodule--helper.c:2077
 #, c-format
 msgid "Skipping unmerged submodule %s"
 msgstr "Прескачане на неслетия подмодул „%s“"
 
-#: builtin/submodule--helper.c:2121
+#: builtin/submodule--helper.c:2106
 #, c-format
 msgid "Skipping submodule '%s'"
 msgstr "Прескачане на подмодула „%s“"
 
-#: builtin/submodule--helper.c:2271
+#: builtin/submodule--helper.c:2256
 #, c-format
 msgid "Failed to clone '%s'. Retry scheduled"
 msgstr "Неуспешен опит за клониране на „%s“.  Насрочен е втори опит"
 
-#: builtin/submodule--helper.c:2282
+#: builtin/submodule--helper.c:2267
 #, c-format
 msgid "Failed to clone '%s' a second time, aborting"
 msgstr ""
 "Втори неуспешен опит за клониране на „%s“.  Действието се преустановява"
 
-#: builtin/submodule--helper.c:2344 builtin/submodule--helper.c:2590
+#: builtin/submodule--helper.c:2372
+#, c-format
+msgid "Unable to checkout '%s' in submodule path '%s'"
+msgstr "Неуспешно изтегляне на версия „%s“ в пътя към подмодул „%s“'"
+
+#: builtin/submodule--helper.c:2376
+#, c-format
+msgid "Unable to rebase '%s' in submodule path '%s'"
+msgstr "Неуспешно пребазиране на версия „%s“ в пътя към подмодул „%s“"
+
+#: builtin/submodule--helper.c:2380
+#, c-format
+msgid "Unable to merge '%s' in submodule path '%s'"
+msgstr "Неуспешно сливане на версия „%s“ в пътя към подмодул „%s“"
+
+#: builtin/submodule--helper.c:2384
+#, c-format
+msgid "Execution of '%s %s' failed in submodule path '%s'"
+msgstr "Неуспешно изпълнение на командата „%s %s“ в пътя към подмодул „%s“"
+
+#: builtin/submodule--helper.c:2408
+#, c-format
+msgid "Submodule path '%s': checked out '%s'\n"
+msgstr "Път към подмодул „%s“: изтеглена е версия „%s“\n"
+
+#: builtin/submodule--helper.c:2412
+#, c-format
+msgid "Submodule path '%s': rebased into '%s'\n"
+msgstr "Път към подмодул „%s“: пребазиран към „%s“\n"
+
+#: builtin/submodule--helper.c:2416
+#, c-format
+msgid "Submodule path '%s': merged in '%s'\n"
+msgstr "Път към подмодул „%s“: слят в „%s“\n"
+
+#: builtin/submodule--helper.c:2420
+#, c-format
+msgid "Submodule path '%s': '%s %s'\n"
+msgstr "Пътят на подмодула „%s“: „%s %s“\n"
+
+#: builtin/submodule--helper.c:2444
+#, c-format
+msgid "Unable to fetch in submodule path '%s'; trying to directly fetch %s:"
+msgstr ""
+"Неуспешно доставяне в пътя към подмодул „%s“, опит за директно доставяне на "
+"„%s“"
+
+#: builtin/submodule--helper.c:2453
+#, c-format
+msgid ""
+"Fetched in submodule path '%s', but it did not contain %s. Direct fetching "
+"of that commit failed."
+msgstr ""
+"Подмодулът в пътя „%s“ е доставен, но не съдържа обекта със сума\n"
+"„%s“.  Директното доставяне на това подаване е неуспешно."
+
+#: builtin/submodule--helper.c:2504 builtin/submodule--helper.c:2574
+#: builtin/submodule--helper.c:2812
 msgid "path into the working tree"
 msgstr "път към работното дърво"
 
-#: builtin/submodule--helper.c:2347
+#: builtin/submodule--helper.c:2507 builtin/submodule--helper.c:2579
 msgid "path into the working tree, across nested submodule boundaries"
 msgstr "път към работното дърво, през границите на вложените подмодули"
 
-#: builtin/submodule--helper.c:2351
+#: builtin/submodule--helper.c:2511 builtin/submodule--helper.c:2577
 msgid "rebase, merge, checkout or none"
 msgstr ""
 "„rebase“ (пребазиране), „merge“ (сливане), „checkout“ (изтегляне) или "
 "„none“ (нищо да не се прави)"
 
-#: builtin/submodule--helper.c:2357
+#: builtin/submodule--helper.c:2517
 msgid "create a shallow clone truncated to the specified number of revisions"
 msgstr "извършване на плитко клониране, отрязано до указания брой версии"
 
-#: builtin/submodule--helper.c:2360
+#: builtin/submodule--helper.c:2520
 msgid "parallel jobs"
 msgstr "брой паралелни процеси"
 
-#: builtin/submodule--helper.c:2362
+#: builtin/submodule--helper.c:2522
 msgid "whether the initial clone should follow the shallow recommendation"
 msgstr "дали първоначалното клониране да е плитко, както се препоръчва"
 
-#: builtin/submodule--helper.c:2363
+#: builtin/submodule--helper.c:2523
 msgid "don't print cloning progress"
 msgstr "без извеждане на напредъка на клонирането"
 
-#: builtin/submodule--helper.c:2374
+#: builtin/submodule--helper.c:2534
 msgid "git submodule--helper update-clone [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper update-clone [--prefix=ПЪТ] [ПЪТ…]"
 
-#: builtin/submodule--helper.c:2387
+#: builtin/submodule--helper.c:2547
 msgid "bad value for update parameter"
 msgstr "неправилен параметър към опцията „--update“"
 
-#: builtin/submodule--helper.c:2435
+#: builtin/submodule--helper.c:2565
+msgid "suppress output for update by rebase or merge"
+msgstr ""
+"без извеждане на информация при обновяване чрез пребазиране или сливане"
+
+#: builtin/submodule--helper.c:2566
+msgid "force checkout updates"
+msgstr "принудително изтегляне на обновленията"
+
+#: builtin/submodule--helper.c:2568
+msgid "don't fetch new objects from the remote site"
+msgstr "без доставяне на новите обекти от отдалеченото хранилище"
+
+#: builtin/submodule--helper.c:2570
+msgid "overrides update mode in case the repository is a fresh clone"
+msgstr ""
+"различен режим на обновяване, когато хранилището е чисто ново изтеглено"
+
+#: builtin/submodule--helper.c:2571
+msgid "depth for shallow fetch"
+msgstr "дълбочина на плиткото доставяне"
+
+#: builtin/submodule--helper.c:2581
+msgid "sha1"
+msgstr "сума по SHA1"
+
+#: builtin/submodule--helper.c:2582
+msgid "SHA1 expected by superproject"
+msgstr "сумата по SHA1, очаквана от обхващащия модул"
+
+#: builtin/submodule--helper.c:2584
+msgid "subsha1"
+msgstr "сумата по SHA1 на подмодула"
+
+#: builtin/submodule--helper.c:2585
+msgid "SHA1 of submodule's HEAD"
+msgstr "сумата по SHA1 за указателя HEAD на подмодула"
+
+#: builtin/submodule--helper.c:2591
+msgid "git submodule--helper run-update-procedure [<options>] <path>"
+msgstr "git submodule--helper run-update-procedure [ОПЦИЯ…] [ПЪТ]"
+
+#: builtin/submodule--helper.c:2662
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
@@ -23629,142 +24002,192 @@ msgstr ""
 "Клонът на подмодула „%s“ е настроен да наследява клона от обхващащия проект, "
 "но той не е на никой клон"
 
-#: builtin/submodule--helper.c:2558
+#: builtin/submodule--helper.c:2780
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
 msgstr "не може да се получи връзка към хранилище за подмодула „%s“"
 
-#: builtin/submodule--helper.c:2591
+#: builtin/submodule--helper.c:2813
 msgid "recurse into submodules"
 msgstr "рекурсивно обхождане подмодулите"
 
-#: builtin/submodule--helper.c:2597
+#: builtin/submodule--helper.c:2819
 msgid "git submodule--helper absorb-git-dirs [<options>] [<path>...]"
 msgstr "git submodule--helper absorb-git-dirs [ОПЦИЯ…] [ПЪТ…]"
 
-#: builtin/submodule--helper.c:2653
+#: builtin/submodule--helper.c:2875
 msgid "check if it is safe to write to the .gitmodules file"
 msgstr "проверка дали писането във файла „.gitmodules“ е безопасно"
 
-#: builtin/submodule--helper.c:2656
+#: builtin/submodule--helper.c:2878
 msgid "unset the config in the .gitmodules file"
 msgstr "изтриване на настройка във файла „.gitmodules“"
 
-#: builtin/submodule--helper.c:2661
+#: builtin/submodule--helper.c:2883
 msgid "git submodule--helper config <name> [<value>]"
 msgstr "git submodule--helper config ИМЕ [СТОЙНОСТ]"
 
-#: builtin/submodule--helper.c:2662
+#: builtin/submodule--helper.c:2884
 msgid "git submodule--helper config --unset <name>"
 msgstr "git submodule--helper config --unset ИМЕ"
 
-#: builtin/submodule--helper.c:2663
+#: builtin/submodule--helper.c:2885
 msgid "git submodule--helper config --check-writeable"
 msgstr "git submodule--helper config --check-writeable"
 
-#: builtin/submodule--helper.c:2682 git-submodule.sh:150
-#, sh-format
+#: builtin/submodule--helper.c:2904 builtin/submodule--helper.c:3120
+#: builtin/submodule--helper.c:3276
 msgid "please make sure that the .gitmodules file is in the working tree"
 msgstr "файлът „.gitmodules“ трябва да е в работното дърво"
 
-#: builtin/submodule--helper.c:2698
+#: builtin/submodule--helper.c:2920
 msgid "suppress output for setting url of a submodule"
 msgstr "без извеждане на информация при задаването на адреса на подмодул"
 
-#: builtin/submodule--helper.c:2702
+#: builtin/submodule--helper.c:2924
 msgid "git submodule--helper set-url [--quiet] <path> <newurl>"
 msgstr "git submodule--helper set-url [--quiet] [ПЪТ] [НОВ_ПЪТ]"
 
-#: builtin/submodule--helper.c:2735
+#: builtin/submodule--helper.c:2957
 msgid "set the default tracking branch to master"
 msgstr "задаване на стандартния следящ клон да е „master“"
 
-#: builtin/submodule--helper.c:2737
+#: builtin/submodule--helper.c:2959
 msgid "set the default tracking branch"
 msgstr "задаване на стандартния следящ клон"
 
-#: builtin/submodule--helper.c:2741
+#: builtin/submodule--helper.c:2963
 msgid "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
 msgstr "git submodule--helper set-branch [-q|--quiet] (-d|--default) ПЪТ"
 
-#: builtin/submodule--helper.c:2742
+#: builtin/submodule--helper.c:2964
 msgid ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
 msgstr "git submodule--helper set-branch [-q|--quiet] (-b|--branch) КЛОН ПЪТ"
 
-#: builtin/submodule--helper.c:2749
+#: builtin/submodule--helper.c:2971
 msgid "--branch or --default required"
 msgstr "необходимо е една от опциите „--branch“ и „--default“"
 
-#: builtin/submodule--helper.c:2752
+#: builtin/submodule--helper.c:2974
 msgid "--branch and --default are mutually exclusive"
 msgstr "опциите „--branch“ и „--default“ са несъвместими"
 
-#: builtin/submodule--helper.c:2815
+#: builtin/submodule--helper.c:3037
 #, c-format
 msgid "Adding existing repo at '%s' to the index\n"
 msgstr "Добавяне на съществуващото хранилище в „%s“ към индекса\n"
 
-#: builtin/submodule--helper.c:2818
+#: builtin/submodule--helper.c:3040
 #, c-format
 msgid "'%s' already exists and is not a valid git repo"
 msgstr "„%s“ съществува, а не е хранилище на Git"
 
-#: builtin/submodule--helper.c:2828
+#: builtin/submodule--helper.c:3053
 #, c-format
-msgid "A git directory for '%s' is found locally with remote(s):"
+msgid "A git directory for '%s' is found locally with remote(s):\n"
 msgstr ""
 "Открита е локална директория на Git — „%s“, която сочи към отдалечените "
-"хранилища:"
+"хранилища:\n"
 
-#: builtin/submodule--helper.c:2833
+#: builtin/submodule--helper.c:3060
 #, c-format
 msgid ""
 "If you want to reuse this local git directory instead of cloning again from\n"
 "  %s\n"
 "use the '--force' option. If the local git directory is not the correct "
 "repo\n"
-"or if you are unsure what this means, choose another name with the '--name' "
-"option.\n"
+"or you are unsure what this means choose another name with the '--name' "
+"option."
 msgstr ""
-"Ако искате да преизползвате тази директория на git, вместо да клонирате "
-"отново\n"
+"Ако искате да преизползвате тази локална директория на git, вместо да\n"
+"клонирате отново:\n"
 "    %s\n"
-"използвайте опцията „--force“.  Ако локалната директория на git не е за\n"
+"използвайте опцията „--force“.  Ако локалната директория на git не е\n"
 "правилното хранилище или ако не знаете какво означава това, използвайте\n"
-"друго име като аргумент към опцията „--name“.\n"
+"друго име като аргумент към опцията „--name“."
 
-#: builtin/submodule--helper.c:2842
+#: builtin/submodule--helper.c:3072
 #, c-format
 msgid "Reactivating local git directory for submodule '%s'\n"
 msgstr "Активиране на локалното хранилище за подмодула „%s“ наново.\n"
 
-#: builtin/submodule--helper.c:2875
+#: builtin/submodule--helper.c:3109
 #, c-format
 msgid "unable to checkout submodule '%s'"
 msgstr "Подмодулът „%s“ не може да бъде изтеглен"
 
-#: builtin/submodule--helper.c:2888
-msgid "branch of repository to checkout on cloning"
-msgstr "клонът, към който да се премине при клониране"
+#: builtin/submodule--helper.c:3148
+#, c-format
+msgid "Failed to add submodule '%s'"
+msgstr "Неуспешно добавяне на подмодула „%s“"
 
-#: builtin/submodule--helper.c:2910
+#: builtin/submodule--helper.c:3152 builtin/submodule--helper.c:3157
+#: builtin/submodule--helper.c:3165
+#, c-format
+msgid "Failed to register submodule '%s'"
+msgstr "Неуспешно регистриране на подмодула „%s“"
+
+#: builtin/submodule--helper.c:3221
+#, c-format
+msgid "'%s' already exists in the index"
+msgstr "„%s“ вече съществува в индекса"
+
+#: builtin/submodule--helper.c:3224
+#, c-format
+msgid "'%s' already exists in the index and is not a submodule"
+msgstr "„%s“ вече съществува в индекса и не е подмодул"
+
+#: builtin/submodule--helper.c:3253
+msgid "branch of repository to add as submodule"
+msgstr "клон на хранилище, който да се добави като подмодул"
+
+#: builtin/submodule--helper.c:3254
 msgid "allow adding an otherwise ignored submodule path"
 msgstr "позволяване на добавяне и на иначе игнорираните файлове"
 
-#: builtin/submodule--helper.c:2917
-msgid ""
-"git submodule--helper add-clone [<options>...] --url <url> --path <path> --"
-"name <name>"
-msgstr ""
-"git submodule--helper add-clone [ОПЦИЯ…] --url АДРЕС --path ПЪТ --name ИМЕ"
+#: builtin/submodule--helper.c:3256
+msgid "print only error messages"
+msgstr "извеждане само на съобщенията за грешка"
 
-#: builtin/submodule--helper.c:2985 git.c:449 git.c:724
+#: builtin/submodule--helper.c:3260
+msgid "borrow the objects from reference repositories"
+msgstr "заемане на обектите от еталонните хранилища"
+
+#: builtin/submodule--helper.c:3262
+msgid ""
+"sets the submodule’s name to the given string instead of defaulting to its "
+"path"
+msgstr "името на подмодула да е указаното, а не да е същото като пътя"
+
+#: builtin/submodule--helper.c:3269
+msgid "git submodule--helper add [<options>] [--] <repository> [<path>]"
+msgstr "git submodule--helper add [ОПЦИЯ…] [--] ХРАНИЛИЩЕ [ПЪТ]"
+
+#: builtin/submodule--helper.c:3297
+msgid "Relative path can only be used from the toplevel of the working tree"
+msgstr ""
+"Относителен път може да се ползва само от основната директория на работното "
+"дърво"
+
+#: builtin/submodule--helper.c:3305
+#, c-format
+msgid "repo URL: '%s' must be absolute or begin with ./|../"
+msgstr ""
+"адрес на хранилище: „%s“ трябва или да е абсолютен, или да започва с „./“ "
+"или „../“"
+
+#: builtin/submodule--helper.c:3340
+#, c-format
+msgid "'%s' is not a valid submodule name"
+msgstr "„%s“ е неправилно име за подмодул"
+
+#: builtin/submodule--helper.c:3404 git.c:449 git.c:723
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "„%s“ не поддържа опцията „--super-prefix“"
 
-#: builtin/submodule--helper.c:2991
+#: builtin/submodule--helper.c:3410
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
 msgstr "„%s“ не е подкоманда на „submodule--helper“"
@@ -23789,18 +24212,18 @@ msgstr "изтриване на символен указател"
 msgid "shorten ref output"
 msgstr "кратка информация за указателя"
 
-#: builtin/symbolic-ref.c:45 builtin/update-ref.c:499
+#: builtin/symbolic-ref.c:45 builtin/update-ref.c:505
 msgid "reason"
 msgstr "причина"
 
-#: builtin/symbolic-ref.c:45 builtin/update-ref.c:499
+#: builtin/symbolic-ref.c:45 builtin/update-ref.c:505
 msgid "reason of the update"
 msgstr "причина за обновяването"
 
 #: builtin/tag.c:25
 msgid ""
 "git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <file>]\n"
-"\t\t<tagname> [<head>]"
+"        <tagname> [<head>]"
 msgstr ""
 "git tag [-a | -s | -u ИДЕНТИФИКАТОР_НА_КЛЮЧ] [-f] [-m СЪОБЩЕНИЕ | -F ФАЙЛ]\n"
 "        ЕТИКЕТ [ВРЪХ]"
@@ -23813,7 +24236,7 @@ msgstr "git tag -d ЕТИКЕТ…"
 msgid ""
 "git tag -l [-n[<num>]] [--contains <commit>] [--no-contains <commit>] [--"
 "points-at <object>]\n"
-"\t\t[--format=<format>] [--merged <commit>] [--no-merged <commit>] "
+"        [--format=<format>] [--merged <commit>] [--no-merged <commit>] "
 "[<pattern>...]"
 msgstr ""
 "git tag -l [-n[БРОЙ]] [--contains ПОДАВАНЕ] [--no-contains ПОДАВАНЕ]\n"
@@ -23884,130 +24307,130 @@ msgstr ""
 msgid "bad object type."
 msgstr "неправилен вид обект."
 
-#: builtin/tag.c:328
+#: builtin/tag.c:326
 msgid "no tag message?"
 msgstr "липсва съобщение за етикета"
 
-#: builtin/tag.c:335
+#: builtin/tag.c:333
 #, c-format
 msgid "The tag message has been left in %s\n"
 msgstr "Съобщението за етикета е запазено във файла „%s“\n"
 
-#: builtin/tag.c:446
+#: builtin/tag.c:444
 msgid "list tag names"
 msgstr "извеждане на имената на етикетите"
 
-#: builtin/tag.c:448
+#: builtin/tag.c:446
 msgid "print <n> lines of each tag message"
 msgstr "извеждане на този БРОЙ редове от всяко съобщение за етикет"
 
-#: builtin/tag.c:450
+#: builtin/tag.c:448
 msgid "delete tags"
 msgstr "изтриване на етикети"
 
-#: builtin/tag.c:451
+#: builtin/tag.c:449
 msgid "verify tags"
 msgstr "проверка на етикети"
 
-#: builtin/tag.c:453
+#: builtin/tag.c:451
 msgid "Tag creation options"
 msgstr "Опции при създаването на етикети"
 
-#: builtin/tag.c:455
+#: builtin/tag.c:453
 msgid "annotated tag, needs a message"
 msgstr "анотирането на етикети изисква съобщение"
 
-#: builtin/tag.c:457
+#: builtin/tag.c:455
 msgid "tag message"
 msgstr "СЪОБЩЕНИЕ за етикет"
 
-#: builtin/tag.c:459
+#: builtin/tag.c:457
 msgid "force edit of tag message"
 msgstr "принудително редактиране на съобщение за етикет"
 
-#: builtin/tag.c:460
+#: builtin/tag.c:458
 msgid "annotated and GPG-signed tag"
 msgstr "анотиран етикет с подпис по GPG"
 
-#: builtin/tag.c:463
+#: builtin/tag.c:461
 msgid "use another key to sign the tag"
 msgstr "използване на друг ключ за подписването на етикет"
 
-#: builtin/tag.c:464
+#: builtin/tag.c:462
 msgid "replace the tag if exists"
 msgstr "замяна на етикета, ако съществува"
 
-#: builtin/tag.c:465 builtin/update-ref.c:505
+#: builtin/tag.c:463 builtin/update-ref.c:511
 msgid "create a reflog"
 msgstr "създаване на журнал на указателите"
 
-#: builtin/tag.c:467
+#: builtin/tag.c:465
 msgid "Tag listing options"
 msgstr "Опции за извеждането на етикети"
 
-#: builtin/tag.c:468
+#: builtin/tag.c:466
 msgid "show tag list in columns"
 msgstr "извеждане на списъка на етикетите по колони"
 
-#: builtin/tag.c:469 builtin/tag.c:471
+#: builtin/tag.c:467 builtin/tag.c:469
 msgid "print only tags that contain the commit"
 msgstr "извеждане само на етикетите, които съдържат подаването"
 
-#: builtin/tag.c:470 builtin/tag.c:472
+#: builtin/tag.c:468 builtin/tag.c:470
 msgid "print only tags that don't contain the commit"
 msgstr "извеждане само на етикетите, които не съдържат подаването"
 
-#: builtin/tag.c:473
+#: builtin/tag.c:471
 msgid "print only tags that are merged"
 msgstr "извеждане само на слетите етикети"
 
-#: builtin/tag.c:474
+#: builtin/tag.c:472
 msgid "print only tags that are not merged"
 msgstr "извеждане само на неслетите етикети"
 
-#: builtin/tag.c:478
+#: builtin/tag.c:476
 msgid "print only tags of the object"
 msgstr "извеждане само на етикетите на ОБЕКТА"
 
-#: builtin/tag.c:526
+#: builtin/tag.c:525
 msgid "--column and -n are incompatible"
 msgstr "опциите „--column“ и „-n“ са несъвместими"
 
-#: builtin/tag.c:548
+#: builtin/tag.c:546
 msgid "-n option is only allowed in list mode"
 msgstr "опцията „-n“ изисква режим на списък."
 
-#: builtin/tag.c:550
+#: builtin/tag.c:548
 msgid "--contains option is only allowed in list mode"
 msgstr "опцията „--contains“ изисква режим на списък."
 
-#: builtin/tag.c:552
+#: builtin/tag.c:550
 msgid "--no-contains option is only allowed in list mode"
 msgstr "опцията „--no-contains“ изисква  режим на списък."
 
-#: builtin/tag.c:554
+#: builtin/tag.c:552
 msgid "--points-at option is only allowed in list mode"
 msgstr "опцията „--points-at“ изисква режим на списък."
 
-#: builtin/tag.c:556
+#: builtin/tag.c:554
 msgid "--merged and --no-merged options are only allowed in list mode"
 msgstr "опциите „--merged“ и „--no-merged“ изискват режим на списък."
 
-#: builtin/tag.c:567
+#: builtin/tag.c:568
 msgid "only one -F or -m option is allowed."
 msgstr "опциите „-F“ и „-m“ са несъвместими."
 
-#: builtin/tag.c:592
+#: builtin/tag.c:593
 #, c-format
 msgid "'%s' is not a valid tag name."
 msgstr "„%s“ е неправилно име за етикет."
 
-#: builtin/tag.c:597
+#: builtin/tag.c:598
 #, c-format
 msgid "tag '%s' already exists"
 msgstr "етикетът „%s“ вече съществува"
 
-#: builtin/tag.c:628
+#: builtin/tag.c:629
 #, c-format
 msgid "Updated tag '%s' (was %s)\n"
 msgstr "Обновен етикет „%s“ (бе „%s“)\n"
@@ -24021,217 +24444,212 @@ msgstr "Разпакетиране на обектите"
 msgid "failed to create directory %s"
 msgstr "директорията „%s“ не може да бъде създадена"
 
-#: builtin/update-index.c:100
-#, c-format
-msgid "failed to create file %s"
-msgstr "файлът „%s“ не може да бъде създаден"
-
-#: builtin/update-index.c:108
+#: builtin/update-index.c:106
 #, c-format
 msgid "failed to delete file %s"
 msgstr "файлът „%s“ не може да бъде изтрит"
 
-#: builtin/update-index.c:115 builtin/update-index.c:221
+#: builtin/update-index.c:113 builtin/update-index.c:219
 #, c-format
 msgid "failed to delete directory %s"
 msgstr "директорията „%s“ не може да бъде изтрита"
 
-#: builtin/update-index.c:140
+#: builtin/update-index.c:138
 #, c-format
 msgid "Testing mtime in '%s' "
 msgstr "Проверка на времето на промяна (mtime) на файла „%s“"
 
-#: builtin/update-index.c:154
+#: builtin/update-index.c:152
 msgid "directory stat info does not change after adding a new file"
 msgstr ""
 "информацията получена чрез „stat“ за директорията не се променя след "
 "добавянето на нов файл"
 
-#: builtin/update-index.c:167
+#: builtin/update-index.c:165
 msgid "directory stat info does not change after adding a new directory"
 msgstr ""
 "информацията получена чрез „stat“ за директорията не се променя след "
 "добавянето на нова директория"
 
-#: builtin/update-index.c:180
+#: builtin/update-index.c:178
 msgid "directory stat info changes after updating a file"
 msgstr ""
 "информацията получена чрез „stat“ за директорията се променя след "
 "обновяването на нов файл"
 
-#: builtin/update-index.c:191
+#: builtin/update-index.c:189
 msgid "directory stat info changes after adding a file inside subdirectory"
 msgstr ""
 "информацията получена чрез „stat“ за директорията се променя след добавянето "
 "на файл в поддиректория"
 
-#: builtin/update-index.c:202
+#: builtin/update-index.c:200
 msgid "directory stat info does not change after deleting a file"
 msgstr ""
 "информацията получена чрез „stat“ за директорията не се променя след "
 "изтриването на файл"
 
-#: builtin/update-index.c:215
+#: builtin/update-index.c:213
 msgid "directory stat info does not change after deleting a directory"
 msgstr ""
 "информацията получена чрез „stat“ за директорията не се променя след "
 "изтриването на директория"
 
-#: builtin/update-index.c:222
+#: builtin/update-index.c:220
 msgid " OK"
 msgstr " Добре"
 
-#: builtin/update-index.c:591
+#: builtin/update-index.c:589
 msgid "git update-index [<options>] [--] [<file>...]"
 msgstr "git update-index [ОПЦИЯ…] [--] [ФАЙЛ…]"
 
-#: builtin/update-index.c:976
+#: builtin/update-index.c:974
 msgid "continue refresh even when index needs update"
 msgstr ""
 "продължаване с обновяването, дори когато индексът трябва да бъде обновен"
 
-#: builtin/update-index.c:979
+#: builtin/update-index.c:977
 msgid "refresh: ignore submodules"
 msgstr "подмодулите да се игнорират при обновяването"
 
-#: builtin/update-index.c:982
+#: builtin/update-index.c:980
 msgid "do not ignore new files"
 msgstr "новите файлове да не се игнорират"
 
-#: builtin/update-index.c:984
+#: builtin/update-index.c:982
 msgid "let files replace directories and vice-versa"
 msgstr "файлове да може да заменят директории и обратно"
 
-#: builtin/update-index.c:986
+#: builtin/update-index.c:984
 msgid "notice files missing from worktree"
 msgstr "предупреждаване при липсващи в работното дърво файлове"
 
-#: builtin/update-index.c:988
+#: builtin/update-index.c:986
 msgid "refresh even if index contains unmerged entries"
 msgstr "обновяване дори и индексът да съдържа неслети обекти"
 
-#: builtin/update-index.c:991
+#: builtin/update-index.c:989
 msgid "refresh stat information"
 msgstr "обновяване на информацията от функцията „stat“"
 
-#: builtin/update-index.c:995
+#: builtin/update-index.c:993
 msgid "like --refresh, but ignore assume-unchanged setting"
 msgstr ""
 "като опцията „--refresh“, но да се проверят и обектите, които са били приети "
 "за непроменени"
 
-#: builtin/update-index.c:999
+#: builtin/update-index.c:997
 msgid "<mode>,<object>,<path>"
 msgstr "РЕЖИМ,ОБЕКТ,ПЪТ"
 
-#: builtin/update-index.c:1000
+#: builtin/update-index.c:998
 msgid "add the specified entry to the index"
 msgstr "добавяне на изброените обекти към индекса"
 
-#: builtin/update-index.c:1010
+#: builtin/update-index.c:1008
 msgid "mark files as \"not changing\""
 msgstr "задаване на флаг, че файлът не се променя"
 
-#: builtin/update-index.c:1013
+#: builtin/update-index.c:1011
 msgid "clear assumed-unchanged bit"
 msgstr "изчистване на флага, че файлът не се променя"
 
-#: builtin/update-index.c:1016
+#: builtin/update-index.c:1014
 msgid "mark files as \"index-only\""
 msgstr "задаване на флаг, че файловете са само за индекса"
 
-#: builtin/update-index.c:1019
+#: builtin/update-index.c:1017
 msgid "clear skip-worktree bit"
 msgstr "изчистване на флага, че файловете са само за индекса"
 
-#: builtin/update-index.c:1022
+#: builtin/update-index.c:1020
 msgid "do not touch index-only entries"
 msgstr "без промяна на файловете само за индекса"
 
-#: builtin/update-index.c:1024
+#: builtin/update-index.c:1022
 msgid "add to index only; do not add content to object database"
 msgstr "добавяне само към индекса без добавяне към базата от данни за обектите"
 
-#: builtin/update-index.c:1026
+#: builtin/update-index.c:1024
 msgid "remove named paths even if present in worktree"
 msgstr "изтриване на указаните пътища, дори и да съществуват в работното дърво"
 
-#: builtin/update-index.c:1028
+#: builtin/update-index.c:1026
 msgid "with --stdin: input lines are terminated by null bytes"
 msgstr ""
 "при комбиниране с опцията „--stdin“ — входните редове са разделени с нулевия "
 "байт"
 
-#: builtin/update-index.c:1030
+#: builtin/update-index.c:1028
 msgid "read list of paths to be updated from standard input"
 msgstr "изчитане на списъка с пътища за обновяване от стандартния вход"
 
-#: builtin/update-index.c:1034
+#: builtin/update-index.c:1032
 msgid "add entries from standard input to the index"
 msgstr "добавяне на елементите от стандартния вход към индекса"
 
-#: builtin/update-index.c:1038
+#: builtin/update-index.c:1036
 msgid "repopulate stages #2 and #3 for the listed paths"
 msgstr ""
 "възстановяване на състоянието преди сливане или нужда от обновяване за "
 "изброените пътища"
 
-#: builtin/update-index.c:1042
+#: builtin/update-index.c:1040
 msgid "only update entries that differ from HEAD"
 msgstr "добавяне само на съдържанието, което се различава от това в „HEAD“"
 
-#: builtin/update-index.c:1046
+#: builtin/update-index.c:1044
 msgid "ignore files missing from worktree"
 msgstr "игнориране на файловете, които липсват в работното дърво"
 
-#: builtin/update-index.c:1049
+#: builtin/update-index.c:1047
 msgid "report actions to standard output"
 msgstr "извеждане на действията на стандартния изход"
 
-#: builtin/update-index.c:1051
+#: builtin/update-index.c:1049
 msgid "(for porcelains) forget saved unresolved conflicts"
 msgstr ""
 "забравяне на записаната информация за неразрешени конфликти — за командите "
 "от потребителско ниво"
 
-#: builtin/update-index.c:1055
+#: builtin/update-index.c:1053
 msgid "write index in this format"
 msgstr "записване на индекса в този формат"
 
-#: builtin/update-index.c:1057
+#: builtin/update-index.c:1055
 msgid "enable or disable split index"
 msgstr "включване или изключване на разделянето на индекса"
 
-#: builtin/update-index.c:1059
+#: builtin/update-index.c:1057
 msgid "enable/disable untracked cache"
 msgstr "включване/изключване на кеша за неследените файлове"
 
-#: builtin/update-index.c:1061
+#: builtin/update-index.c:1059
 msgid "test if the filesystem supports untracked cache"
 msgstr "проверка дали файловата система поддържа кеш за неследени файлове"
 
-#: builtin/update-index.c:1063
+#: builtin/update-index.c:1061
 msgid "enable untracked cache without testing the filesystem"
 msgstr ""
 "включване на кеша за неследените файлове без проверка на файловата система"
 
-#: builtin/update-index.c:1065
+#: builtin/update-index.c:1063
 msgid "write out the index even if is not flagged as changed"
 msgstr "запис на индекса, дори да не е отбелязан като променен"
 
-#: builtin/update-index.c:1067
+#: builtin/update-index.c:1065
 msgid "enable or disable file system monitor"
 msgstr "включване или изключване на наблюдението на файловата система"
 
-#: builtin/update-index.c:1069
+#: builtin/update-index.c:1067
 msgid "mark files as fsmonitor valid"
 msgstr "отбелязване на файловете, че може да се следят чрез файловата система"
 
-#: builtin/update-index.c:1072
+#: builtin/update-index.c:1070
 msgid "clear fsmonitor valid bit"
 msgstr "изчистване на флага за следенето чрез файловата система"
 
-#: builtin/update-index.c:1175
+#: builtin/update-index.c:1173
 msgid ""
 "core.splitIndex is set to false; remove or change it, if you really want to "
 "enable split index"
@@ -24239,7 +24657,7 @@ msgstr ""
 "Настройката „core.splitIndex“ е зададена на „false“ (лъжа̀).  Сменете я или я "
 "изтрийте, за да включите разделянето на индекса"
 
-#: builtin/update-index.c:1184
+#: builtin/update-index.c:1182
 msgid ""
 "core.splitIndex is set to true; remove or change it, if you really want to "
 "disable split index"
@@ -24247,7 +24665,7 @@ msgstr ""
 "Настройката „core.splitIndex“ е зададена на „true“ (истина).  Сменете я или "
 "я изтрийте, за да изключите разделянето на индекса."
 
-#: builtin/update-index.c:1196
+#: builtin/update-index.c:1194
 msgid ""
 "core.untrackedCache is set to true; remove or change it, if you really want "
 "to disable the untracked cache"
@@ -24255,11 +24673,11 @@ msgstr ""
 "Настройката „core.untrackedCache“ е зададена на „true“ (истина).  Сменете я "
 "или я изтрийте, за да изключите кеша за неследените файлове"
 
-#: builtin/update-index.c:1200
+#: builtin/update-index.c:1198
 msgid "Untracked cache disabled"
 msgstr "Кешът за неследените файлове е изключен"
 
-#: builtin/update-index.c:1208
+#: builtin/update-index.c:1206
 msgid ""
 "core.untrackedCache is set to false; remove or change it, if you really want "
 "to enable the untracked cache"
@@ -24267,29 +24685,29 @@ msgstr ""
 "Настройката „core.untrackedCache“ е зададена на „false“ (лъжа̀).  Сменете я "
 "или я изтрийте, за да включите кеша за неследените файлове"
 
-#: builtin/update-index.c:1212
+#: builtin/update-index.c:1210
 #, c-format
 msgid "Untracked cache enabled for '%s'"
 msgstr "Кешът за неследените файлове е включен за „%s“"
 
-#: builtin/update-index.c:1220
+#: builtin/update-index.c:1218
 msgid "core.fsmonitor is unset; set it if you really want to enable fsmonitor"
 msgstr ""
 "Настройката „core.fsmonitor“ не е зададена.  Задайте я, за да включите "
 "следенето чрез файловата система."
 
-#: builtin/update-index.c:1224
+#: builtin/update-index.c:1222
 msgid "fsmonitor enabled"
 msgstr "следенето чрез файловата система е включено"
 
-#: builtin/update-index.c:1227
+#: builtin/update-index.c:1225
 msgid ""
 "core.fsmonitor is set; remove it if you really want to disable fsmonitor"
 msgstr ""
 "Настройката „core.fsmonitor“ е зададена.  Изтрийте я, за да изключите "
 "следенето чрез файловата система."
 
-#: builtin/update-index.c:1231
+#: builtin/update-index.c:1229
 msgid "fsmonitor disabled"
 msgstr "следенето чрез файловата система е изключено"
 
@@ -24305,21 +24723,21 @@ msgstr "git update-ref [ОПЦИЯ…] ИМЕ_НА_УКАЗАТЕЛ НОВА_С�
 msgid "git update-ref [<options>] --stdin [-z]"
 msgstr "git update-ref [ОПЦИЯ…] --stdin [-z]"
 
-#: builtin/update-ref.c:500
+#: builtin/update-ref.c:506
 msgid "delete the reference"
 msgstr "изтриване на указателя"
 
-#: builtin/update-ref.c:502
+#: builtin/update-ref.c:508
 msgid "update <refname> not the one it points to"
 msgstr "обновяване на ИМЕто_НА_УКАЗАТЕЛя, а не това, към което сочи"
 
-#: builtin/update-ref.c:503
+#: builtin/update-ref.c:509
 msgid "stdin has NUL-terminated arguments"
 msgstr ""
 "някои от елементите подадени на стандартния вход завършват с нулевия знак "
 "„NUL“"
 
-#: builtin/update-ref.c:504
+#: builtin/update-ref.c:510
 msgid "read updates from stdin"
 msgstr "изчитане на указателите от стандартния вход"
 
@@ -24335,20 +24753,20 @@ msgstr "обновяване на информационните файлове 
 msgid "git upload-pack [<options>] <dir>"
 msgstr "git upload-pack [ОПЦИЯ…] ДИРЕКТОРИЯ"
 
-#: builtin/upload-pack.c:23 t/helper/test-serve-v2.c:17
+#: builtin/upload-pack.c:24 t/helper/test-serve-v2.c:17
 msgid "quit after a single request/response exchange"
 msgstr "изход след първоначалната размяна на заявка и отговор"
 
-#: builtin/upload-pack.c:25
-msgid "exit immediately after initial ref advertisement"
-msgstr "изход след първоначалната обява на указатели"
+#: builtin/upload-pack.c:26
+msgid "serve up the info/refs for git-http-backend"
+msgstr "доставяне на информацията/указателите за „git-http-backend“"
 
-#: builtin/upload-pack.c:27
+#: builtin/upload-pack.c:29
 msgid "do not try <directory>/.git/ if <directory> is no Git directory"
 msgstr ""
 "да не се търси „ДИРЕКТОРИЯ/.git/“, ако ДИРЕКТОРИЯта не е под контрола на Git"
 
-#: builtin/upload-pack.c:29
+#: builtin/upload-pack.c:31
 msgid "interrupt transfer after <n> seconds of inactivity"
 msgstr "трансферът да се преустанови след този БРОЙ секунди"
 
@@ -24384,63 +24802,58 @@ msgstr "git verify-tag [-v | --verbose] [--format=ФОРМАТ] ЕТИКЕТ…"
 msgid "print tag contents"
 msgstr "извеждане на съдържанието на ЕТИКЕТи"
 
-#: builtin/worktree.c:18
+#: builtin/worktree.c:19
 msgid "git worktree add [<options>] <path> [<commit-ish>]"
 msgstr "git worktree add [ОПЦИЯ…] ПЪТ [УКАЗАТЕЛ_КЪМ_ПОДАВАНЕ]"
 
-#: builtin/worktree.c:19
+#: builtin/worktree.c:20
 msgid "git worktree list [<options>]"
 msgstr "git worktree list [ОПЦИЯ…]"
 
-#: builtin/worktree.c:20
+#: builtin/worktree.c:21
 msgid "git worktree lock [<options>] <path>"
 msgstr "git worktree lock [ОПЦИЯ…] [ПЪТ]"
 
-#: builtin/worktree.c:21
+#: builtin/worktree.c:22
 msgid "git worktree move <worktree> <new-path>"
 msgstr "git worktree move [ДЪРВО] [НОВ_ПЪТ]"
 
-#: builtin/worktree.c:22
+#: builtin/worktree.c:23
 msgid "git worktree prune [<options>]"
 msgstr "git worktree prune [ОПЦИЯ…]"
 
-#: builtin/worktree.c:23
+#: builtin/worktree.c:24
 msgid "git worktree remove [<options>] <worktree>"
 msgstr "git worktree remove [ОПЦИЯ…] [ДЪРВО]"
 
-#: builtin/worktree.c:24
+#: builtin/worktree.c:25
 msgid "git worktree unlock <path>"
 msgstr "git worktree unlock [ПЪТ]"
 
-#: builtin/worktree.c:61 builtin/worktree.c:944
-#, c-format
-msgid "failed to delete '%s'"
-msgstr "неуспешно изтриване на „%s“"
-
-#: builtin/worktree.c:74
+#: builtin/worktree.c:75
 #, c-format
 msgid "Removing %s/%s: %s"
 msgstr "Изтриване на „%s/%s“: %s"
 
-#: builtin/worktree.c:147
+#: builtin/worktree.c:148
 msgid "report pruned working trees"
 msgstr "докладване на окастрените работни дървета"
 
-#: builtin/worktree.c:149
+#: builtin/worktree.c:150
 msgid "expire working trees older than <time>"
 msgstr "обявяване на работните копия по-стари от това ВРЕМЕ за остарели"
 
-#: builtin/worktree.c:219
+#: builtin/worktree.c:220
 #, c-format
 msgid "'%s' already exists"
 msgstr "„%s“ вече съществува"
 
-#: builtin/worktree.c:228
+#: builtin/worktree.c:229
 #, c-format
 msgid "unusable worktree destination '%s'"
 msgstr "целта не може да се ползва за работно дърво: „%s“"
 
-#: builtin/worktree.c:233
+#: builtin/worktree.c:234
 #, c-format
 msgid ""
 "'%s' is a missing but locked worktree;\n"
@@ -24450,7 +24863,7 @@ msgstr ""
 "За изрично задаване ползвайте „%s -f -f“, а за изчистване —\n"
 "„unlock“, „prune“ или „remove“"
 
-#: builtin/worktree.c:235
+#: builtin/worktree.c:236
 #, c-format
 msgid ""
 "'%s' is a missing but already registered worktree;\n"
@@ -24460,145 +24873,145 @@ msgstr ""
 "За изрично задаване ползвайте „%s -f“, а за изчистване —\n"
 "„prune“ или „remove“"
 
-#: builtin/worktree.c:286
+#: builtin/worktree.c:287
 #, c-format
 msgid "could not create directory of '%s'"
 msgstr "директорията „%s“ не може да бъде създадена"
 
-#: builtin/worktree.c:308
+#: builtin/worktree.c:309
 msgid "initializing"
 msgstr "инициализация"
 
-#: builtin/worktree.c:420 builtin/worktree.c:426
+#: builtin/worktree.c:421 builtin/worktree.c:427
 #, c-format
 msgid "Preparing worktree (new branch '%s')"
 msgstr "Приготвяне на работното дърво (нов клон „%s“)"
 
-#: builtin/worktree.c:422
+#: builtin/worktree.c:423
 #, c-format
 msgid "Preparing worktree (resetting branch '%s'; was at %s)"
 msgstr ""
 "Приготвяне на работното дърво (зануляване на клона „%s“, който сочеше към "
 "„%s“)"
 
-#: builtin/worktree.c:431
+#: builtin/worktree.c:432
 #, c-format
 msgid "Preparing worktree (checking out '%s')"
 msgstr "Приготвяне на работното дърво (изтегляне на „%s“)"
 
-#: builtin/worktree.c:437
+#: builtin/worktree.c:438
 #, c-format
 msgid "Preparing worktree (detached HEAD %s)"
 msgstr "Подготвяне на работно дърво (указателят „HEAD“ не свързан: %s)"
 
-#: builtin/worktree.c:482
+#: builtin/worktree.c:483
 msgid "checkout <branch> even if already checked out in other worktree"
 msgstr "Изтегляне КЛОНа, дори и да е изтеглен в друго работно дърво"
 
-#: builtin/worktree.c:485
+#: builtin/worktree.c:486
 msgid "create a new branch"
 msgstr "създаване на нов клон"
 
-#: builtin/worktree.c:487
+#: builtin/worktree.c:488
 msgid "create or reset a branch"
 msgstr "създаване или зануляване на клони"
 
-#: builtin/worktree.c:489
+#: builtin/worktree.c:490
 msgid "populate the new working tree"
 msgstr "подготвяне на новото работно дърво"
 
-#: builtin/worktree.c:490
+#: builtin/worktree.c:491
 msgid "keep the new working tree locked"
 msgstr "новото работно дърво да остане заключено"
 
-#: builtin/worktree.c:492 builtin/worktree.c:729
+#: builtin/worktree.c:493 builtin/worktree.c:730
 msgid "reason for locking"
 msgstr "причина за заключване"
 
-#: builtin/worktree.c:495
+#: builtin/worktree.c:496
 msgid "set up tracking mode (see git-branch(1))"
 msgstr "задаване на режима на следене (виж git-branch(1))"
 
-#: builtin/worktree.c:498
+#: builtin/worktree.c:499
 msgid "try to match the new branch name with a remote-tracking branch"
 msgstr "опит за напасване на името на новия клон с това на следящ клон"
 
-#: builtin/worktree.c:506
+#: builtin/worktree.c:507
 msgid "-b, -B, and --detach are mutually exclusive"
 msgstr "опциите „-b“, „-B“ и „--detach“ са несъвместими една с друга"
 
-#: builtin/worktree.c:508
+#: builtin/worktree.c:509
 msgid "--reason requires --lock"
 msgstr "опцията „--reason“ изисква „--lock“"
 
-#: builtin/worktree.c:512
+#: builtin/worktree.c:513
 msgid "added with --lock"
 msgstr "добавена с „--lock“"
 
-#: builtin/worktree.c:574
+#: builtin/worktree.c:575
 msgid "--[no-]track can only be used if a new branch is created"
 msgstr "„--[no-]track“ може да се използва само при създаването на нов клон"
 
-#: builtin/worktree.c:691
+#: builtin/worktree.c:692
 msgid "show extended annotations and reasons, if available"
 msgstr "извеждане на подробни анотации и обяснения, ако такива са налични"
 
-#: builtin/worktree.c:693
+#: builtin/worktree.c:694
 msgid "add 'prunable' annotation to worktrees older than <time>"
 msgstr ""
 "добавяне на анотация за окастряне на работните копия по-стари от това ВРЕМЕ"
 
-#: builtin/worktree.c:702
+#: builtin/worktree.c:703
 msgid "--verbose and --porcelain are mutually exclusive"
 msgstr "опциите „--verbose“ и „--porcelain“ са несъвместими"
 
-#: builtin/worktree.c:741 builtin/worktree.c:774 builtin/worktree.c:848
-#: builtin/worktree.c:972
+#: builtin/worktree.c:742 builtin/worktree.c:775 builtin/worktree.c:849
+#: builtin/worktree.c:973
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr "„%s“ не е работно дърво"
 
-#: builtin/worktree.c:743 builtin/worktree.c:776
+#: builtin/worktree.c:744 builtin/worktree.c:777
 msgid "The main working tree cannot be locked or unlocked"
 msgstr "Основното дърво не може да се отключи или заключи"
 
-#: builtin/worktree.c:748
+#: builtin/worktree.c:749
 #, c-format
 msgid "'%s' is already locked, reason: %s"
 msgstr "„%s“ вече е заключено, защото „%s“"
 
-#: builtin/worktree.c:750
+#: builtin/worktree.c:751
 #, c-format
 msgid "'%s' is already locked"
 msgstr "„%s“ вече е заключено"
 
-#: builtin/worktree.c:778
+#: builtin/worktree.c:779
 #, c-format
 msgid "'%s' is not locked"
 msgstr "„%s“ не е заключено"
 
-#: builtin/worktree.c:819
+#: builtin/worktree.c:820
 msgid "working trees containing submodules cannot be moved or removed"
 msgstr ""
 "не може да местите или изтривате работни дървета, в които има подмодули"
 
-#: builtin/worktree.c:827
+#: builtin/worktree.c:828
 msgid "force move even if worktree is dirty or locked"
 msgstr ""
 "принудително преместване, дори работното дърво да не е чисто или да е "
 "заключено"
 
-#: builtin/worktree.c:850 builtin/worktree.c:974
+#: builtin/worktree.c:851 builtin/worktree.c:975
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr "„%s“ е основно работно дърво"
 
-#: builtin/worktree.c:855
+#: builtin/worktree.c:856
 #, c-format
 msgid "could not figure out destination name from '%s'"
 msgstr "името на целта не може да се определи от „%s“"
 
-#: builtin/worktree.c:868
+#: builtin/worktree.c:869
 #, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
@@ -24607,7 +25020,7 @@ msgstr ""
 "не може да преместите заключено работно дърво, причина за заключването: %s\n"
 "или го отключете, или го преместете принудително с „move -f -f“"
 
-#: builtin/worktree.c:870
+#: builtin/worktree.c:871
 msgid ""
 "cannot move a locked working tree;\n"
 "use 'move -f -f' to override or unlock first"
@@ -24615,41 +25028,41 @@ msgstr ""
 "не може да преместите заключено работно дърво:\n"
 "или го отключете, или го преместете принудително с „move -f -f“"
 
-#: builtin/worktree.c:873
+#: builtin/worktree.c:874
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
 msgstr ""
 "проверките са неуспешни, работното дърво не може да бъде преместено: %s"
 
-#: builtin/worktree.c:878
+#: builtin/worktree.c:879
 #, c-format
 msgid "failed to move '%s' to '%s'"
 msgstr "„%s“ не може да се премести в „%s“"
 
-#: builtin/worktree.c:924
+#: builtin/worktree.c:925
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr "неуспешно изпълнение на „git status“ върху „%s“"
 
-#: builtin/worktree.c:928
+#: builtin/worktree.c:929
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
 "„%s“ съдържа променени или нови файлове, за принудително изтриване е "
 "необходима опцията „--force“"
 
-#: builtin/worktree.c:933
+#: builtin/worktree.c:934
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr ""
 "командата „git status“ не може да се изпълни за „%s“, код за грешка: %d"
 
-#: builtin/worktree.c:956
+#: builtin/worktree.c:957
 msgid "force removal even if worktree is dirty or locked"
 msgstr ""
 "принудително изтриване, дори работното дърво да не е чисто или да е заключено"
 
-#: builtin/worktree.c:979
+#: builtin/worktree.c:980
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
@@ -24658,7 +25071,7 @@ msgstr ""
 "не може да изтриете заключено работно дърво, причина за заключването: %s\n"
 "или го отключете, или го изтрийте принудително с „remove -f -f“"
 
-#: builtin/worktree.c:981
+#: builtin/worktree.c:982
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
@@ -24666,17 +25079,17 @@ msgstr ""
 "не може да изтриете заключено работно дърво:\n"
 "или го отключете, или го изтрийте принудително с „remove -f -f“"
 
-#: builtin/worktree.c:984
+#: builtin/worktree.c:985
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr "проверките са неуспешни, работното дърво не може да бъде изтрито: %s"
 
-#: builtin/worktree.c:1008
+#: builtin/worktree.c:1009
 #, c-format
 msgid "repair: %s: %s"
 msgstr "поправяне: %s: „%s“"
 
-#: builtin/worktree.c:1011
+#: builtin/worktree.c:1012
 #, c-format
 msgid "error: %s: %s"
 msgstr "грешка: %s: „%s“"
@@ -24805,17 +25218,17 @@ msgstr "неизвестна грешка при запис на стандар�
 msgid "close failed on standard output"
 msgstr "грешка при затваряне на стандартния изход"
 
-#: git.c:833
+#: git.c:832
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr "зацикляне в псевдонимите: заместванията на „%s“ не приключват:%s"
 
-#: git.c:883
+#: git.c:882
 #, c-format
 msgid "cannot handle %s as a builtin"
 msgstr "„%s“ не може да се обработи като вградена команда"
 
-#: git.c:896
+#: git.c:895
 #, c-format
 msgid ""
 "usage: %s\n"
@@ -24824,14 +25237,14 @@ msgstr ""
 "употреба: %s\n"
 "\n"
 
-#: git.c:916
+#: git.c:915
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr ""
 "неуспешно заместване на псевдонима „%s“ — резултатът „%s“ не е команда на "
 "git\n"
 
-#: git.c:928
+#: git.c:927
 #, c-format
 msgid "failed to run command '%s': %s\n"
 msgstr "командата „%s“ не може да се изпълни: %s\n"
@@ -24878,65 +25291,31 @@ msgstr "test-tool serve-v2 [ОПЦИЯ…]"
 msgid "exit immediately after advertising capabilities"
 msgstr "изход след първоначалната обява на възможностите"
 
-#: t/helper/test-simple-ipc.c:262
-#, c-format
-msgid "socket/pipe already in use: '%s'"
-msgstr "гнездото/каналът вече се ползват: „%s“"
-
-#: t/helper/test-simple-ipc.c:264
-#, c-format
-msgid "could not start server on: '%s'"
-msgstr "сървърът не стартира на гнездо/канал „%s“"
-
-#: t/helper/test-simple-ipc.c:295 t/helper/test-simple-ipc.c:331
-msgid "could not spawn daemon in the background"
-msgstr "демонът не може да се стартира във фонов режим"
-
-#: t/helper/test-simple-ipc.c:356
-msgid "waitpid failed"
-msgstr "неуспешно изпълнение на „waitpid“"
-
-#: t/helper/test-simple-ipc.c:376
-msgid "daemon not online yet"
-msgstr "демонът още не отговаря на заявки"
-
-#: t/helper/test-simple-ipc.c:406
-msgid "daemon failed to start"
-msgstr "демонът не е стартирал"
-
-#: t/helper/test-simple-ipc.c:410
-msgid "waitpid is confused"
-msgstr "„waitpid“ върна неочаквана стойност"
-
-#: t/helper/test-simple-ipc.c:541
-msgid "daemon has not shutdown yet"
-msgstr "демонът не е спрял"
-
-#: t/helper/test-simple-ipc.c:682
+#: t/helper/test-simple-ipc.c:581
 msgid "test-helper simple-ipc is-active    [<name>] [<options>]"
 msgstr "test-helper simple-ipc is-active    [ИМЕ] [ОПЦИЯ…]"
 
-#: t/helper/test-simple-ipc.c:683
+#: t/helper/test-simple-ipc.c:582
 msgid "test-helper simple-ipc run-daemon   [<name>] [<threads>]"
 msgstr "test-helper simple-ipc run-daemon   [ИМЕ] [НИШКИ]"
 
-#: t/helper/test-simple-ipc.c:684
+#: t/helper/test-simple-ipc.c:583
 msgid "test-helper simple-ipc start-daemon [<name>] [<threads>] [<max-wait>]"
 msgstr "test-helper simple-ipc start-daemon [ИМЕ] [НИШКИ] [ИЗЧАКВАНЕ]"
 
-#: t/helper/test-simple-ipc.c:685
+#: t/helper/test-simple-ipc.c:584
 msgid "test-helper simple-ipc stop-daemon  [<name>] [<max-wait>]"
 msgstr "test-helper simple-ipc stop-daemon  [ИМЕ] [ИЗЧАКВАНЕ]"
 
-#: t/helper/test-simple-ipc.c:686
+#: t/helper/test-simple-ipc.c:585
 msgid "test-helper simple-ipc send         [<name>] [<token>]"
 msgstr "test-helper simple-ipc send         [ИМЕ] [ЛЕКСЕМА]"
 
-#: t/helper/test-simple-ipc.c:687
+#: t/helper/test-simple-ipc.c:586
 msgid "test-helper simple-ipc sendbytes    [<name>] [<bytecount>] [<byte>]"
 msgstr "test-helper simple-ipc sendbytes    [ИМЕ] [БРОЙ_БАЙТОВЕ] [РАЗМЕР]"
 
-#: t/helper/test-simple-ipc.c:688
+#: t/helper/test-simple-ipc.c:587
 msgid ""
 "test-helper simple-ipc multiple     [<name>] [<threads>] [<bytecount>] "
 "[<batchsize>]"
@@ -24944,88 +25323,84 @@ msgstr ""
 "test-helper simple-ipc multiple     [ИМЕ] [НИШКИ] [БРОЙ_БАЙТОВЕ] "
 "[РАЗМЕР_НА_ПАКЕТА]"
 
-#: t/helper/test-simple-ipc.c:696
+#: t/helper/test-simple-ipc.c:595
 msgid "name or pathname of unix domain socket"
 msgstr "име или път за гнездото на Unix"
 
-#: t/helper/test-simple-ipc.c:698
+#: t/helper/test-simple-ipc.c:597
 msgid "named-pipe name"
 msgstr "име на именован канал"
 
-#: t/helper/test-simple-ipc.c:700
+#: t/helper/test-simple-ipc.c:599
 msgid "number of threads in server thread pool"
 msgstr "брой нишки в запаса нишки"
 
-#: t/helper/test-simple-ipc.c:701
+#: t/helper/test-simple-ipc.c:600
 msgid "seconds to wait for daemon to start or stop"
 msgstr "секунди изчакване на демона да стартира или спре"
 
-#: t/helper/test-simple-ipc.c:703
+#: t/helper/test-simple-ipc.c:602
 msgid "number of bytes"
 msgstr "брой байтове"
 
-#: t/helper/test-simple-ipc.c:704
+#: t/helper/test-simple-ipc.c:603
 msgid "number of requests per thread"
 msgstr "брой заявки на нишка"
 
-#: t/helper/test-simple-ipc.c:706
+#: t/helper/test-simple-ipc.c:605
 msgid "byte"
 msgstr "байта"
 
-#: t/helper/test-simple-ipc.c:706
+#: t/helper/test-simple-ipc.c:605
 msgid "ballast character"
 msgstr "знаци за пращане"
 
-#: t/helper/test-simple-ipc.c:707
+#: t/helper/test-simple-ipc.c:606
 msgid "token"
 msgstr "лексема"
 
-#: t/helper/test-simple-ipc.c:707
+#: t/helper/test-simple-ipc.c:606
 msgid "command token to send to the server"
 msgstr "командна лексема за пращане"
 
-#: http.c:399
+#: http.c:350
 #, c-format
 msgid "negative value for http.postbuffer; defaulting to %d"
 msgstr ""
 "отрицателна стойност за „http.postbuffer“.  Ще се ползва стандартната: %d"
 
-#: http.c:420
+#: http.c:371
 msgid "Delegation control is not supported with cURL < 7.22.0"
 msgstr "Управлението на делегирането не се поддържа от cURL < 7.22.0"
 
-#: http.c:429
-msgid "Public key pinning not supported with cURL < 7.44.0"
-msgstr "Задаването на постоянен публичен ключ не се поддържа от cURL < 7.44.0"
+#: http.c:380
+msgid "Public key pinning not supported with cURL < 7.39.0"
+msgstr "Задаването на постоянен публичен ключ не се поддържа от cURL < 7.39.0"
 
-#: http.c:910
+#: http.c:812
 msgid "CURLSSLOPT_NO_REVOKE not supported with cURL < 7.44.0"
 msgstr "„CURLSSLOPT_NO_REVOKE“ не се поддържа от cURL < 7.44.0"
 
-#: http.c:989
-msgid "Protocol restrictions not supported with cURL < 7.19.4"
-msgstr "Ограничаването на протоколите не се поддържа от cURL < 7.44.0"
-
-#: http.c:1132
+#: http.c:1016
 #, c-format
 msgid "Unsupported SSL backend '%s'. Supported SSL backends:"
 msgstr "Неподдържана реализация на SSL „%s“. Поддържат се:"
 
-#: http.c:1139
+#: http.c:1023
 #, c-format
 msgid "Could not set SSL backend to '%s': cURL was built without SSL backends"
 msgstr ""
 "Реализацията на SSL не може да се зададе да е „%s“: cURL е компилиран без "
 "поддръжка на SSL"
 
-#: http.c:1143
+#: http.c:1027
 #, c-format
 msgid "Could not set SSL backend to '%s': already set"
 msgstr ""
 "Реализацията на SSL не може да се зададе да е „%s“, защото вече е зададена "
 "друга"
 
-#: http.c:2034
+#: http.c:1876
 #, c-format
 msgid ""
 "unable to update url base from redirection:\n"
@@ -25043,47 +25418,52 @@ msgstr ""
 "неправилно екраниране или цитиране в стойността към опция за изтласкване: "
 "„%s“"
 
-#: remote-curl.c:307
+#: remote-curl.c:304
 #, c-format
 msgid "%sinfo/refs not valid: is this a git repository?"
 msgstr "„%sinfo/refs“ е неизползваемо, проверете дали е хранилище на git"
 
-#: remote-curl.c:408
+#: remote-curl.c:405
 msgid "invalid server response; expected service, got flush packet"
 msgstr ""
 "неправилен отговор от сървъра: очакваше се услуга, а бе получен изчистващ "
 "пакет „flush“"
 
-#: remote-curl.c:439
+#: remote-curl.c:436
 #, c-format
 msgid "invalid server response; got '%s'"
 msgstr "неправилен отговор от сървъра, бе получено: „%s“"
 
-#: remote-curl.c:499
+#: remote-curl.c:496
 #, c-format
 msgid "repository '%s' not found"
 msgstr "хранилището „%s“ липсва"
 
-#: remote-curl.c:503
+#: remote-curl.c:500
 #, c-format
 msgid "Authentication failed for '%s'"
 msgstr "Неуспешна идентификация към „%s“"
 
-#: remote-curl.c:507
+#: remote-curl.c:504
+#, c-format
+msgid "unable to access '%s' with http.pinnedPubkey configuration: %s"
+msgstr "няма достъп до „%s“ със следната настройка на „http.pinnedPubkey“: %s"
+
+#: remote-curl.c:508
 #, c-format
 msgid "unable to access '%s': %s"
 msgstr "няма достъп до „%s“: %s"
 
-#: remote-curl.c:513
+#: remote-curl.c:514
 #, c-format
 msgid "redirecting to %s"
 msgstr "пренасочване към „%s“"
 
-#: remote-curl.c:644
+#: remote-curl.c:645
 msgid "shouldn't have EOF when not gentle on EOF"
 msgstr "получен е EOF, в режим без поддръжка за това"
 
-#: remote-curl.c:656
+#: remote-curl.c:657
 msgid "remote server sent unexpected response end packet"
 msgstr "отдалеченият сървър прати неочакван пакет за край на отговор"
 
@@ -25093,86 +25473,86 @@ msgstr ""
 "данните за POST не може да се прочетат наново, пробвайте да увеличите "
 "настройката „http.postBuffer“"
 
-#: remote-curl.c:756
+#: remote-curl.c:755
 #, c-format
 msgid "remote-curl: bad line length character: %.4s"
 msgstr "remote-curl: неправилeн знак за дължина на ред: %.4s"
 
-#: remote-curl.c:758
+#: remote-curl.c:757
 msgid "remote-curl: unexpected response end packet"
 msgstr "remote-curl: неочакван пакет за край на отговор"
 
-#: remote-curl.c:834
+#: remote-curl.c:833
 #, c-format
 msgid "RPC failed; %s"
 msgstr "Неуспешно отдалечено извикване.  %s"
 
-#: remote-curl.c:874
+#: remote-curl.c:873
 msgid "cannot handle pushes this big"
 msgstr "толкова големи изтласквания не може да се изпълнят"
 
-#: remote-curl.c:989
+#: remote-curl.c:986
 #, c-format
 msgid "cannot deflate request; zlib deflate error %d"
 msgstr ""
 "заявката не може да бъде декомпресирана, грешка от „zlib“ при "
 "декомпресиране: %d"
 
-#: remote-curl.c:993
+#: remote-curl.c:990
 #, c-format
 msgid "cannot deflate request; zlib end error %d"
 msgstr ""
 "заявката не може да бъде декомпресирана; грешка от „zlib“ при завършване: %d<"
 
-#: remote-curl.c:1043
+#: remote-curl.c:1040
 #, c-format
 msgid "%d bytes of length header were received"
 msgstr "получени са %d байта от заглавна част"
 
-#: remote-curl.c:1045
+#: remote-curl.c:1042
 #, c-format
 msgid "%d bytes of body are still expected"
 msgstr "очакват се още %d байта от тялото на отговора"
 
-#: remote-curl.c:1134
+#: remote-curl.c:1131
 msgid "dumb http transport does not support shallow capabilities"
 msgstr "опростеният транспорт по http не поддържа плитки клиенти"
 
-#: remote-curl.c:1149
+#: remote-curl.c:1146
 msgid "fetch failed."
 msgstr "неуспешно доставяне."
 
-#: remote-curl.c:1195
+#: remote-curl.c:1192
 msgid "cannot fetch by sha1 over smart http"
 msgstr "умният вариант на http не може да доставя по SHA1"
 
-#: remote-curl.c:1239 remote-curl.c:1245
+#: remote-curl.c:1236 remote-curl.c:1242
 #, c-format
 msgid "protocol error: expected sha/ref, got '%s'"
 msgstr "протоколна грешка: очаква се SHA1 или указател, а бе получено: „%s“"
 
-#: remote-curl.c:1257 remote-curl.c:1375
+#: remote-curl.c:1254 remote-curl.c:1372
 #, c-format
 msgid "http transport does not support %s"
 msgstr "транспортът по http не поддържа „%s“"
 
-#: remote-curl.c:1293
+#: remote-curl.c:1290
 msgid "git-http-push failed"
 msgstr "неуспешно изпълнение на „git-http-push“"
 
-#: remote-curl.c:1481
+#: remote-curl.c:1478
 msgid "remote-curl: usage: git remote-curl <remote> [<url>]"
 msgstr "remote-curl: употреба: git remote-curl ХРАНИЛИЩЕ [АДРЕС]"
 
-#: remote-curl.c:1513
+#: remote-curl.c:1510
 msgid "remote-curl: error reading command stream from git"
 msgstr "remote-curl: грешка при изчитането на потока команди от git"
 
-#: remote-curl.c:1520
+#: remote-curl.c:1517
 msgid "remote-curl: fetch attempted without a local repo"
 msgstr "remote-curl: опит за доставяне без локално хранилище"
 
-#: remote-curl.c:1561
+#: remote-curl.c:1558
 #, c-format
 msgid "remote-curl: unknown command '%s' from git"
 msgstr "remote-curl: непозната команда „%s“ от git"
@@ -25193,46 +25573,46 @@ msgstr "АРГУМЕНТИ"
 msgid "object filtering"
 msgstr "филтриране по вид на обекта"
 
-#: parse-options.h:184
+#: parse-options.h:183
 msgid "expiry-date"
 msgstr "период на валидност/запазване"
 
-#: parse-options.h:198
+#: parse-options.h:197
 msgid "no-op (backward compatibility)"
 msgstr "нулева операция (за съвместимост с предишни версии)"
 
-#: parse-options.h:310
+#: parse-options.h:309
 msgid "be more verbose"
 msgstr "повече подробности"
 
-#: parse-options.h:312
+#: parse-options.h:311
 msgid "be more quiet"
 msgstr "по-малко подробности"
 
-#: parse-options.h:318
+#: parse-options.h:317
 msgid "use <n> digits to display object names"
 msgstr "да се показват такъв БРОЙ цифри от имената на обектите"
 
-#: parse-options.h:337
+#: parse-options.h:336
 msgid "how to strip spaces and #comments from message"
 msgstr "кои празни знаци и #коментари да се махат от съобщенията"
 
-#: parse-options.h:338
+#: parse-options.h:337
 msgid "read pathspec from file"
 msgstr "изчитане на пътищата от ФАЙЛ"
 
-#: parse-options.h:339
+#: parse-options.h:338
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""
 "при ползването на „--pathspec-from-file“, пътищата са разделени с нулевия "
 "знак „NUL“"
 
-#: ref-filter.h:99
+#: ref-filter.h:101
 msgid "key"
 msgstr "КЛЮЧ"
 
-#: ref-filter.h:99
+#: ref-filter.h:101
 msgid "field name to sort on"
 msgstr "име на полето, по което да е подредбата"
 
@@ -25935,42 +26315,6 @@ msgstr "Въвеждащ урок за Git"
 msgid "An overview of recommended workflows with Git"
 msgstr "Общ преглед на препоръчваните начини за работа с Git"
 
-#: git-bisect.sh:68
-msgid "bisect run failed: no command provided."
-msgstr "неуспешно двоично търсене, не е зададена команда."
-
-#: git-bisect.sh:73
-#, sh-format
-msgid "running $command"
-msgstr "изпълнение на командата „${command}“"
-
-#: git-bisect.sh:80
-#, sh-format
-msgid ""
-"bisect run failed:\n"
-"exit code $res from '$command' is < 0 or >= 128"
-msgstr ""
-"неуспешно двоично търсене:\n"
-"изходният код от командата „${command}“ е ${res} — това е извън интервала "
-"[0, 128)"
-
-#: git-bisect.sh:105
-msgid "bisect run cannot continue any more"
-msgstr "двоичното търсене не може да продължи"
-
-#: git-bisect.sh:111
-#, sh-format
-msgid ""
-"bisect run failed:\n"
-"'bisect-state $state' exited with error code $res"
-msgstr ""
-"неуспешно двоично търсене:\n"
-"функцията „bisect-state ${state}“ завърши с код за грешка ${res}"
-
-#: git-bisect.sh:118
-msgid "bisect run success"
-msgstr "успешно двоично търсене"
-
 #: git-merge-octopus.sh:46
 msgid ""
 "Error: Your local changes to the following files would be overwritten by "
@@ -26009,55 +26353,17 @@ msgstr "Опит за просто сливане с „$pretty_name“"
 msgid "Simple merge did not work, trying automatic merge."
 msgstr "Простото сливане не сработи, пробва се автоматично сливане."
 
-#: git-submodule.sh:179
-msgid "Relative path can only be used from the toplevel of the working tree"
-msgstr ""
-"Относителен път може да се ползва само от основната директория на работното "
-"дърво"
-
-#: git-submodule.sh:189
-#, sh-format
-msgid "repo URL: '$repo' must be absolute or begin with ./|../"
-msgstr ""
-"адрес на хранилище: „${repo}“ трябва или да е абсолютен, или да започва с "
-"„./“ или „../“"
-
-#: git-submodule.sh:208
-#, sh-format
-msgid "'$sm_path' already exists in the index"
-msgstr "„${sm_path}“ вече съществува в индекса"
-
-#: git-submodule.sh:211
-#, sh-format
-msgid "'$sm_path' already exists in the index and is not a submodule"
-msgstr "„${sm_path}“ вече съществува в индекса и не е подмодул"
-
-#: git-submodule.sh:218
-#, sh-format
-msgid "'$sm_path' does not have a commit checked out"
-msgstr "в „${sm_path}“ не е изтеглено подаване"
-
-#: git-submodule.sh:248
-#, sh-format
-msgid "Failed to add submodule '$sm_path'"
-msgstr "Неуспешно добавяне на подмодула „${sm_path}“"
-
-#: git-submodule.sh:257
-#, sh-format
-msgid "Failed to register submodule '$sm_path'"
-msgstr "Неуспешно регистриране на подмодула „${sm_path}“"
-
-#: git-submodule.sh:532
+#: git-submodule.sh:401
 #, sh-format
 msgid "Unable to find current revision in submodule path '$displaypath'"
 msgstr "Текущата версия за подмодула в „${displaypath}“ липсва"
 
-#: git-submodule.sh:542
+#: git-submodule.sh:411
 #, sh-format
 msgid "Unable to fetch in submodule path '$sm_path'"
 msgstr "Неуспешно доставяне в пътя към подмодул „${sm_path}“"
 
-#: git-submodule.sh:547
+#: git-submodule.sh:416
 #, sh-format
 msgid ""
 "Unable to find current ${remote_name}/${branch} revision in submodule path "
@@ -26066,408 +26372,11 @@ msgstr ""
 "Текущата версия „${remote_name}/${branch}“ в пътя към подмодул „${sm_path}“ "
 "липсва"
 
-#: git-submodule.sh:565
-#, sh-format
-msgid ""
-"Unable to fetch in submodule path '$displaypath'; trying to directly fetch "
-"$sha1:"
-msgstr ""
-"Неуспешно доставяне в пътя към подмодул „${displaypath}“, опит за директно "
-"доставяне на „${sha1}“"
-
-#: git-submodule.sh:571
-#, sh-format
-msgid ""
-"Fetched in submodule path '$displaypath', but it did not contain $sha1. "
-"Direct fetching of that commit failed."
-msgstr ""
-"Подмодулът в пътя „$displaypath“ е доставен, но не съдържа обекта със сума\n"
-"„${sha1}“.  Директното доставяне на това подаване е неуспешно."
-
-#: git-submodule.sh:578
-#, sh-format
-msgid "Unable to checkout '$sha1' in submodule path '$displaypath'"
-msgstr ""
-"Неуспешно изтегляне на версия „${sha1}“ в пътя към подмодул „${displaypath}“'"
-
-#: git-submodule.sh:579
-#, sh-format
-msgid "Submodule path '$displaypath': checked out '$sha1'"
-msgstr "Път към подмодул „${displaypath}“: изтеглена е версия „${sha1}“"
-
-#: git-submodule.sh:583
-#, sh-format
-msgid "Unable to rebase '$sha1' in submodule path '$displaypath'"
-msgstr ""
-"Неуспешно пребазиране на версия „${sha1}“ в пътя към подмодул "
-"„${displaypath}“"
-
-#: git-submodule.sh:584
-#, sh-format
-msgid "Submodule path '$displaypath': rebased into '$sha1'"
-msgstr "Път към подмодул „${displaypath}“: пребазиране върху версия „${sha1}“"
-
-#: git-submodule.sh:589
-#, sh-format
-msgid "Unable to merge '$sha1' in submodule path '$displaypath'"
-msgstr ""
-"Неуспешно сливане на версия „${sha1}“ в пътя към подмодул „${displaypath}“"
-
-#: git-submodule.sh:590
-#, sh-format
-msgid "Submodule path '$displaypath': merged in '$sha1'"
-msgstr "Път към подмодул „${displaypath}“: сливане с версия „${sha1}“"
-
-#: git-submodule.sh:595
-#, sh-format
-msgid "Execution of '$command $sha1' failed in submodule path '$displaypath'"
-msgstr ""
-"Неуспешно изпълнение на командата „${command} ${sha1}“ в пътя към подмодул "
-"„${displaypath}“"
-
-#: git-submodule.sh:596
-#, sh-format
-msgid "Submodule path '$displaypath': '$command $sha1'"
-msgstr "Път към подмодул „${displaypath}“: „${command} ${sha1}“"
-
-#: git-submodule.sh:627
+#: git-submodule.sh:464
 #, sh-format
 msgid "Failed to recurse into submodule path '$displaypath'"
 msgstr ""
 "Неуспешна обработка на поддиректориите в пътя към подмодул „${displaypath}“"
-
-#: git-rebase--preserve-merges.sh:109
-msgid "Applied autostash."
-msgstr "Автоматично скатаното е приложено."
-
-#: git-rebase--preserve-merges.sh:112
-#, sh-format
-msgid "Cannot store $stash_sha1"
-msgstr "„$stash_sha1“ не може да бъде запазен"
-
-#: git-rebase--preserve-merges.sh:113
-msgid ""
-"Applying autostash resulted in conflicts.\n"
-"Your changes are safe in the stash.\n"
-"You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
-msgstr ""
-"Прилагането на автоматично скатаното доведе до конфликти.  Промените ви са\n"
-"надеждно скатани.  Може да пробвате да ги приложите чрез „git stash pop“\n"
-"или да ги изхвърлите чрез „git stash drop“, когато поискате.\n"
-
-#: git-rebase--preserve-merges.sh:191
-#, sh-format
-msgid "Rebasing ($new_count/$total)"
-msgstr "Пребазиране ($new_count/$total)"
-
-#: git-rebase--preserve-merges.sh:197
-msgid ""
-"\n"
-"Commands:\n"
-"p, pick <commit> = use commit\n"
-"r, reword <commit> = use commit, but edit the commit message\n"
-"e, edit <commit> = use commit, but stop for amending\n"
-"s, squash <commit> = use commit, but meld into previous commit\n"
-"f, fixup <commit> = like \"squash\", but discard this commit's log message\n"
-"x, exec <commit> = run command (the rest of the line) using shell\n"
-"d, drop <commit> = remove commit\n"
-"l, label <label> = label current HEAD with a name\n"
-"t, reset <label> = reset HEAD to a label\n"
-"m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
-".       create a merge commit using the original merge commit's\n"
-".       message (or the oneline, if no original merge commit was\n"
-".       specified). Use -c <commit> to reword the commit message.\n"
-"\n"
-"These lines can be re-ordered; they are executed from top to bottom.\n"
-msgstr ""
-"\n"
-"Команди:\n"
-" p, pick ПОДАВАНЕ   — прилагане на подаването\n"
-" r, reword ПОДАВАНЕ — прилагане на подаването, но промяна на съобщението му\n"
-" e, edit ПОДАВАНЕ   — прилагане на подаването и спиране при него за още "
-"промени\n"
-" s, squash ПОДАВАНЕ — вкарване на подаването в предходното му\n"
-" f, fixup ПОДАВАНЕ  — вкарване на подаването в предходното му, без смяна на\n"
-"                      съобщението\n"
-" x, exec ПОДАВАНЕ   — изпълнение на команда към обвивката: останалата част "
-"на\n"
-"                      реда\n"
-" d, drop ПОДАВАНЕ   — прескачане на подаването\n"
-" l, label ЕТИКЕТ    — задаване на етикет на указаното от HEAD\n"
-" t, reset ЕТИКЕТ    — зануляване на HEAD към ЕТИКЕТа\n"
-" m, merge [-C ПОДАВАНЕ | -c ПОДАВАНЕ] ЕТИКЕТ [# ЕДИН_РЕД]\n"
-"                    — създаване на подаване със сливане със съобщението от\n"
-"                      първоначалното подаване (или съобщението от ЕДИН_РЕД,\n"
-"                      ако не е зададено подаване със сливане.  С опцията\n"
-"                      „-c ПОДАВАНЕ“, може да смените съобщението.\n"
-"\n"
-"Може да променяте последователността на редовете — те се изпълняват\n"
-"последователно отгоре-надолу.\n"
-
-#: git-rebase--preserve-merges.sh:260
-#, sh-format
-msgid ""
-"You can amend the commit now, with\n"
-"\n"
-"\tgit commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"Once you are satisfied with your changes, run\n"
-"\n"
-"\tgit rebase --continue"
-msgstr ""
-"Може да промените подаването с командата:\n"
-"\n"
-"    git commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"След като привършите, продължете с командата:\n"
-"\n"
-"    git rebase --continue"
-
-#: git-rebase--preserve-merges.sh:285
-#, sh-format
-msgid "$sha1: not a commit that can be picked"
-msgstr "$sha1: това не е подаване, което може да бъде отбрано"
-
-#: git-rebase--preserve-merges.sh:324
-#, sh-format
-msgid "Invalid commit name: $sha1"
-msgstr "Неправилно име на подаване: „$sha1“"
-
-#: git-rebase--preserve-merges.sh:354
-msgid "Cannot write current commit's replacement sha1"
-msgstr ""
-"Заместващата сума по SHA1 за текущото подаване не може да бъде запазена"
-
-#: git-rebase--preserve-merges.sh:405
-#, sh-format
-msgid "Fast-forward to $sha1"
-msgstr "Превъртане до „$sha1“"
-
-#: git-rebase--preserve-merges.sh:407
-#, sh-format
-msgid "Cannot fast-forward to $sha1"
-msgstr "Не може да се превърти до „$sha1“"
-
-#: git-rebase--preserve-merges.sh:416
-#, sh-format
-msgid "Cannot move HEAD to $first_parent"
-msgstr "Указателят „HEAD“ не може да се насочи към „$first_parent“"
-
-#: git-rebase--preserve-merges.sh:421
-#, sh-format
-msgid "Refusing to squash a merge: $sha1"
-msgstr "Подаването не може да се смачка: „$sha1“"
-
-#: git-rebase--preserve-merges.sh:439
-#, sh-format
-msgid "Error redoing merge $sha1"
-msgstr "Грешка при повтарянето на сливането на „$sha1“"
-
-#: git-rebase--preserve-merges.sh:448
-#, sh-format
-msgid "Could not pick $sha1"
-msgstr "„$sha1“ не може да се отбере."
-
-#: git-rebase--preserve-merges.sh:457
-#, sh-format
-msgid "This is the commit message #${n}:"
-msgstr "Това е съобщение при подаване №${n}:"
-
-#: git-rebase--preserve-merges.sh:462
-#, sh-format
-msgid "The commit message #${n} will be skipped:"
-msgstr "Съобщение при подаване №${n} ще бъде прескочено."
-
-#: git-rebase--preserve-merges.sh:473
-#, sh-format
-msgid "This is a combination of $count commit."
-msgid_plural "This is a combination of $count commits."
-msgstr[0] "Това е обединение от $count подаване."
-msgstr[1] "Това е обединение от $count подавания."
-
-#: git-rebase--preserve-merges.sh:482
-#, sh-format
-msgid "Cannot write $fixup_msg"
-msgstr "Новото съобщение при подаване „$fixup_msg“ не може да бъде запазено"
-
-#: git-rebase--preserve-merges.sh:485
-msgid "This is a combination of 2 commits."
-msgstr "Това е обединение от 2 подавания"
-
-#: git-rebase--preserve-merges.sh:526 git-rebase--preserve-merges.sh:569
-#: git-rebase--preserve-merges.sh:572
-#, sh-format
-msgid "Could not apply $sha1... $rest"
-msgstr "Не може да се подаде $sha1… $rest"
-
-#: git-rebase--preserve-merges.sh:601
-#, sh-format
-msgid ""
-"Could not amend commit after successfully picking $sha1... $rest\n"
-"This is most likely due to an empty commit message, or the pre-commit hook\n"
-"failed. If the pre-commit hook failed, you may need to resolve the issue "
-"before\n"
-"you are able to reword the commit."
-msgstr ""
-"Подаването не може за де промени след успешното отбиране на „$sha1…“ $rest.\n"
-"Най-вероятните причини са празно съобщение при подаване или неуспешно "
-"изпълнение\n"
-"на куката преди подаване.  Ако имате проблем с куката, ще трябва да го "
-"коригирате,\n"
-"преди да може да промените съобщението на подаването."
-
-#: git-rebase--preserve-merges.sh:616
-#, sh-format
-msgid "Stopped at $sha1_abbrev... $rest"
-msgstr "Спиране при „$sha1_abbrev…“ $rest"
-
-#: git-rebase--preserve-merges.sh:631
-#, sh-format
-msgid "Cannot '$squash_style' without a previous commit"
-msgstr "Без предходно подаване не може да се изпълни „$squash_style“"
-
-#: git-rebase--preserve-merges.sh:673
-#, sh-format
-msgid "Executing: $rest"
-msgstr "В момента се изпълнява: $rest"
-
-#: git-rebase--preserve-merges.sh:681
-#, sh-format
-msgid "Execution failed: $rest"
-msgstr "Неуспешно изпълнение: $rest"
-
-#: git-rebase--preserve-merges.sh:683
-msgid "and made changes to the index and/or the working tree"
-msgstr "и промени индекса и/или работното дърво"
-
-#: git-rebase--preserve-merges.sh:685
-msgid ""
-"You can fix the problem, and then run\n"
-"\n"
-"\tgit rebase --continue"
-msgstr ""
-"Може да коригирате проблема, след което изпълнете:\n"
-"\n"
-"    git rebase --continue"
-
-#. TRANSLATORS: after these lines is a command to be issued by the user
-#: git-rebase--preserve-merges.sh:698
-#, sh-format
-msgid ""
-"Execution succeeded: $rest\n"
-"but left changes to the index and/or the working tree\n"
-"Commit or stash your changes, and then run\n"
-"\n"
-"\tgit rebase --continue"
-msgstr ""
-"Успешно изпълнение: $rest\n"
-"Остават още промени в индекса или работното дърво.\n"
-"Трябва да ги подадете или скатаете и след това изпълнете:\n"
-"\n"
-"    git rebase --continue"
-
-#: git-rebase--preserve-merges.sh:709
-#, sh-format
-msgid "Unknown command: $command $sha1 $rest"
-msgstr "Непозната команда: $command $sha1 $rest"
-
-#: git-rebase--preserve-merges.sh:710
-msgid "Please fix this using 'git rebase --edit-todo'."
-msgstr "Коригирайте това чрез „git rebase --edit-todo“."
-
-#: git-rebase--preserve-merges.sh:745
-#, sh-format
-msgid "Successfully rebased and updated $head_name."
-msgstr "Успешно пребазиране и обновяване на „$head_name“."
-
-#: git-rebase--preserve-merges.sh:802
-msgid "Could not remove CHERRY_PICK_HEAD"
-msgstr "Указателят „CHERRY_PICK_HEAD“ не може да бъде изтрит"
-
-#: git-rebase--preserve-merges.sh:807
-#, sh-format
-msgid ""
-"You have staged changes in your working tree.\n"
-"If these changes are meant to be\n"
-"squashed into the previous commit, run:\n"
-"\n"
-"  git commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"If they are meant to go into a new commit, run:\n"
-"\n"
-"  git commit $gpg_sign_opt_quoted\n"
-"\n"
-"In both cases, once you're done, continue with:\n"
-"\n"
-"  git rebase --continue\n"
-msgstr ""
-"В индекса има промени.  Ако искате да ги вкарате в\n"
-"предишното подаване, изпълнете:\n"
-"\n"
-"    git commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"Ако искате да създадете ново подаване, изпълнете:\n"
-"\n"
-"    git commit $gpg_sign_opt_quoted\n"
-"\n"
-"И в двата случая след като привършите, продължете с командата:\n"
-"\n"
-"    git rebase --continue\n"
-
-#: git-rebase--preserve-merges.sh:824
-msgid "Error trying to find the author identity to amend commit"
-msgstr "Не може да бъде открит автор за поправянето на подаването"
-
-#: git-rebase--preserve-merges.sh:829
-msgid ""
-"You have uncommitted changes in your working tree. Please commit them\n"
-"first and then run 'git rebase --continue' again."
-msgstr ""
-"В работното дърво има неподадени промени.  Първо ги подайте, а след това\n"
-"отново изпълнете „git rebase --continue“."
-
-#: git-rebase--preserve-merges.sh:834 git-rebase--preserve-merges.sh:838
-msgid "Could not commit staged changes."
-msgstr "Промените в индекса не може да бъдат подадени."
-
-#: git-rebase--preserve-merges.sh:869 git-rebase--preserve-merges.sh:955
-msgid "Could not execute editor"
-msgstr "Текстовият редактор не може да бъде стартиран"
-
-#: git-rebase--preserve-merges.sh:890
-#, sh-format
-msgid "Could not checkout $switch_to"
-msgstr "„$switch_to“ не може да се изтегли"
-
-#: git-rebase--preserve-merges.sh:897
-msgid "No HEAD?"
-msgstr "Липсва указател „HEAD“"
-
-#: git-rebase--preserve-merges.sh:898
-#, sh-format
-msgid "Could not create temporary $state_dir"
-msgstr "Временната директория „$state_dir“ не може да бъде създадена"
-
-#: git-rebase--preserve-merges.sh:901
-msgid "Could not mark as interactive"
-msgstr "Пребазирането не е интерактивно"
-
-#: git-rebase--preserve-merges.sh:933
-#, sh-format
-msgid "Rebase $shortrevisions onto $shortonto ($todocount command)"
-msgid_plural "Rebase $shortrevisions onto $shortonto ($todocount commands)"
-msgstr[0] ""
-"Пребазиране на $shortrevisions върху $shortonto ($todocount команда)"
-msgstr[1] ""
-"Пребазиране на $shortrevisions върху $shortonto ($todocount команди)"
-
-#: git-rebase--preserve-merges.sh:945
-msgid "Note that empty commits are commented out"
-msgstr "Празните подавания са коментирани"
-
-#: git-rebase--preserve-merges.sh:987 git-rebase--preserve-merges.sh:992
-msgid "Could not init rewritten commits"
-msgstr "Списъкът с презаписаните подавания не може да бъде създаден"
 
 #: git-sh-setup.sh:89 git-sh-setup.sh:94
 #, sh-format
@@ -26487,52 +26396,32 @@ msgstr ""
 "ФАТАЛНА ГРЕШКА: „$program_name“ не може да се ползва без работно дърво."
 
 #: git-sh-setup.sh:221
-msgid "Cannot rebase: You have unstaged changes."
-msgstr "Не може да пребазирате, защото има промени, които не са в индекса."
-
-#: git-sh-setup.sh:224
 msgid "Cannot rewrite branches: You have unstaged changes."
 msgstr ""
 "Не може да презапишете клоните, защото има промени, които не са в индекса."
 
-#: git-sh-setup.sh:227
-msgid "Cannot pull with rebase: You have unstaged changes."
-msgstr ""
-"Не може да издърпвате при това пребазиране, защото има промени, които не са "
-"в индекса."
-
-#: git-sh-setup.sh:230
+#: git-sh-setup.sh:224
 #, sh-format
 msgid "Cannot $action: You have unstaged changes."
 msgstr ""
 "Не може да изпълните „$action“, защото има промени, които не са в индекса."
 
-#: git-sh-setup.sh:243
-msgid "Cannot rebase: Your index contains uncommitted changes."
-msgstr "Не може да пребазирате, защото в индекса има неподадени промени."
-
-#: git-sh-setup.sh:246
-msgid "Cannot pull with rebase: Your index contains uncommitted changes."
-msgstr ""
-"Не може да издърпвате при това пребазиране, защото в индекса има неподадени "
-"промени."
-
-#: git-sh-setup.sh:249
+#: git-sh-setup.sh:235
 #, sh-format
 msgid "Cannot $action: Your index contains uncommitted changes."
 msgstr ""
 "Не може да изпълните „$action“, защото в индекса има неподадени промени."
 
-#: git-sh-setup.sh:253
+#: git-sh-setup.sh:237
 msgid "Additionally, your index contains uncommitted changes."
 msgstr "Освен това в индекса има неподадени промени."
 
-#: git-sh-setup.sh:373
+#: git-sh-setup.sh:357
 msgid "You need to run this command from the toplevel of the working tree."
 msgstr ""
 "Тази команда трябва да се изпълни от основната директория на работното дърво"
 
-#: git-sh-setup.sh:378
+#: git-sh-setup.sh:362
 msgid "Unable to determine absolute path of git directory"
 msgstr "Абсолютният път на работното дърво не може да се определи"
 
@@ -27201,7 +27090,7 @@ msgstr "Резултат: "
 msgid "Result: OK\n"
 msgstr "Резултат: успех\n"
 
-#: git-send-email.perl:1709
+#: git-send-email.perl:1708
 #, perl-format
 msgid "can't open file %s"
 msgstr "файлът „%s“ не може да бъде отворен"
@@ -27226,30 +27115,30 @@ msgstr "(не-mbox) Добавяне на „як: %s“ от ред „%s“\n"
 msgid "(body) Adding cc: %s from line '%s'\n"
 msgstr "(тяло) Добавяне на „як: %s“ от ред „%s“\n"
 
-#: git-send-email.perl:1965
+#: git-send-email.perl:1973
 #, perl-format
 msgid "(%s) Could not execute '%s'"
 msgstr "(%s) Не може да бъде се изпълни „%s“"
 
-#: git-send-email.perl:1972
+#: git-send-email.perl:1980
 #, perl-format
 msgid "(%s) Adding %s: %s from: '%s'\n"
 msgstr "(%s) Добавяне на „%s: %s“ от: „%s“\n"
 
-#: git-send-email.perl:1976
+#: git-send-email.perl:1984
 #, perl-format
 msgid "(%s) failed to close pipe to '%s'"
 msgstr "(%s) програмният канал не може да се затвори за изпълнението на „%s“"
 
-#: git-send-email.perl:2006
+#: git-send-email.perl:2014
 msgid "cannot send message as 7bit"
 msgstr "съобщението не може да се изпрати чрез 7 битови знаци"
 
-#: git-send-email.perl:2014
+#: git-send-email.perl:2022
 msgid "invalid transfer encoding"
 msgstr "неправилно кодиране за пренос"
 
-#: git-send-email.perl:2051
+#: git-send-email.perl:2059
 #, perl-format
 msgid ""
 "fatal: %s: rejected by sendemail-validate hook\n"
@@ -27260,12 +27149,12 @@ msgstr ""
 "%s\n"
 "ПРЕДУПРЕЖДЕНИЕ: не са пратени никакви кръпки\n"
 
-#: git-send-email.perl:2061 git-send-email.perl:2114 git-send-email.perl:2124
+#: git-send-email.perl:2069 git-send-email.perl:2122 git-send-email.perl:2132
 #, perl-format
 msgid "unable to open %s: %s\n"
 msgstr "„%s“ не може да се отвори: %s\n"
 
-#: git-send-email.perl:2064
+#: git-send-email.perl:2072
 #, perl-format
 msgid ""
 "fatal: %s:%d is longer than 998 characters\n"
@@ -27274,13 +27163,13 @@ msgstr ""
 "ФАТАЛНА ГРЕШКА: %s: %d е повече от 998 знака\n"
 "ПРЕДУПРЕЖДЕНИЕ: не са пратени никакви кръпки\n"
 
-#: git-send-email.perl:2082
+#: git-send-email.perl:2090
 #, perl-format
 msgid "Skipping %s with backup suffix '%s'.\n"
 msgstr "„%s“ се пропуска, защото е с разширение за архивен файл: „%s“.\n"
 
 #. TRANSLATORS: please keep "[y|N]" as is.
-#: git-send-email.perl:2086
+#: git-send-email.perl:2094
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Наистина ли искате да изпратите „%s“? [y|N]: "

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-08-14 07:56+0800\n"
+"POT-Creation-Date: 2021-11-04 08:34+0800\n"
 "PO-Revision-Date: 2021-05-23 18:32+0200\n"
 "Last-Translator: Matthias Rüster <matthias.ruester@gmail.com>\n"
 "Language-Team: Matthias Rüster <matthias.ruester@gmail.com>\n"
@@ -19,213 +19,213 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n!=1);\n"
 "X-Generator: Poedit 2.4.3\n"
 
-#: add-interactive.c:376
+#: add-interactive.c:380
 #, c-format
 msgid "Huh (%s)?"
 msgstr "Wie bitte (%s)?"
 
-#: add-interactive.c:529 add-interactive.c:830 reset.c:64 sequencer.c:3493
-#: sequencer.c:3964 sequencer.c:4119 builtin/rebase.c:1528
-#: builtin/rebase.c:1953
+#: add-interactive.c:533 add-interactive.c:834 reset.c:65 sequencer.c:3512
+#: sequencer.c:3979 sequencer.c:4141 builtin/rebase.c:1233
+#: builtin/rebase.c:1642
 msgid "could not read index"
 msgstr "Index konnte nicht gelesen werden"
 
-#: add-interactive.c:584 git-add--interactive.perl:269
+#: add-interactive.c:588 git-add--interactive.perl:269
 #: git-add--interactive.perl:294
 msgid "binary"
 msgstr "Binär"
 
-#: add-interactive.c:642 git-add--interactive.perl:278
+#: add-interactive.c:646 git-add--interactive.perl:278
 #: git-add--interactive.perl:332
 msgid "nothing"
 msgstr "Nichts"
 
-#: add-interactive.c:643 git-add--interactive.perl:314
+#: add-interactive.c:647 git-add--interactive.perl:314
 #: git-add--interactive.perl:329
 msgid "unchanged"
 msgstr "unverändert"
 
-#: add-interactive.c:680 git-add--interactive.perl:641
+#: add-interactive.c:684 git-add--interactive.perl:641
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: add-interactive.c:697 add-interactive.c:885
+#: add-interactive.c:701 add-interactive.c:889
 #, c-format
 msgid "could not stage '%s'"
 msgstr "Konnte '%s' nicht zum Commit vormerken."
 
-#: add-interactive.c:703 add-interactive.c:892 reset.c:88 sequencer.c:3707
+#: add-interactive.c:707 add-interactive.c:896 reset.c:89 sequencer.c:3718
 msgid "could not write index"
 msgstr "konnte Index nicht schreiben"
 
-#: add-interactive.c:706 git-add--interactive.perl:626
+#: add-interactive.c:710 git-add--interactive.perl:626
 #, c-format, perl-format
 msgid "updated %d path\n"
 msgid_plural "updated %d paths\n"
 msgstr[0] "%d Pfad aktualisiert\n"
 msgstr[1] "%d Pfade aktualisiert\n"
 
-#: add-interactive.c:724 git-add--interactive.perl:676
+#: add-interactive.c:728 git-add--interactive.perl:676
 #, c-format, perl-format
 msgid "note: %s is untracked now.\n"
 msgstr "Hinweis: %s ist nun unversioniert.\n"
 
-#: add-interactive.c:729 apply.c:4127 builtin/checkout.c:298
-#: builtin/reset.c:145
+#: add-interactive.c:733 apply.c:4149 builtin/checkout.c:298
+#: builtin/reset.c:151
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
 msgstr "make_cache_entry für Pfad '%s' fehlgeschlagen"
 
-#: add-interactive.c:759 git-add--interactive.perl:653
+#: add-interactive.c:763 git-add--interactive.perl:653
 msgid "Revert"
 msgstr "Revert"
 
-#: add-interactive.c:775
+#: add-interactive.c:779
 msgid "Could not parse HEAD^{tree}"
 msgstr "Konnte HEAD^{tree} nicht parsen."
 
-#: add-interactive.c:813 git-add--interactive.perl:629
+#: add-interactive.c:817 git-add--interactive.perl:629
 #, c-format, perl-format
 msgid "reverted %d path\n"
 msgid_plural "reverted %d paths\n"
 msgstr[0] "%d Pfad wiederhergestellt\n"
 msgstr[1] "%d Pfade wiederhergestellt\n"
 
-#: add-interactive.c:864 git-add--interactive.perl:693
+#: add-interactive.c:868 git-add--interactive.perl:693
 #, c-format
 msgid "No untracked files.\n"
 msgstr "Keine unversionierten Dateien.\n"
 
-#: add-interactive.c:868 git-add--interactive.perl:687
+#: add-interactive.c:872 git-add--interactive.perl:687
 msgid "Add untracked"
 msgstr "Unversionierte Dateien hinzufügen"
 
-#: add-interactive.c:895 git-add--interactive.perl:623
+#: add-interactive.c:899 git-add--interactive.perl:623
 #, c-format, perl-format
 msgid "added %d path\n"
 msgid_plural "added %d paths\n"
 msgstr[0] "%d Pfad hinzugefügt\n"
 msgstr[1] "%d Pfade hinzugefügt\n"
 
-#: add-interactive.c:925
+#: add-interactive.c:929
 #, c-format
 msgid "ignoring unmerged: %s"
 msgstr "Ignoriere nicht zusammengeführte Datei: %s"
 
-#: add-interactive.c:937 add-patch.c:1752 git-add--interactive.perl:1369
+#: add-interactive.c:941 add-patch.c:1752 git-add--interactive.perl:1369
 #, c-format
 msgid "Only binary files changed.\n"
 msgstr "Nur Binärdateien geändert.\n"
 
-#: add-interactive.c:939 add-patch.c:1750 git-add--interactive.perl:1371
+#: add-interactive.c:943 add-patch.c:1750 git-add--interactive.perl:1371
 #, c-format
 msgid "No changes.\n"
 msgstr "Keine Änderungen.\n"
 
-#: add-interactive.c:943 git-add--interactive.perl:1379
+#: add-interactive.c:947 git-add--interactive.perl:1379
 msgid "Patch update"
 msgstr "Patch Aktualisierung"
 
-#: add-interactive.c:982 git-add--interactive.perl:1792
+#: add-interactive.c:986 git-add--interactive.perl:1792
 msgid "Review diff"
 msgstr "Diff überprüfen"
 
-#: add-interactive.c:1010
+#: add-interactive.c:1014
 msgid "show paths with changes"
 msgstr "Zeige Pfade mit Änderungen"
 
-#: add-interactive.c:1012
+#: add-interactive.c:1016
 msgid "add working tree state to the staged set of changes"
 msgstr "Zustand des Arbeitsverzeichnisses zum Commit vormerken"
 
-#: add-interactive.c:1014
+#: add-interactive.c:1018
 msgid "revert staged set of changes back to the HEAD version"
 msgstr "Zum Commit vorgemerkte Änderungen auf HEAD-Version zurücksetzen"
 
-#: add-interactive.c:1016
+#: add-interactive.c:1020
 msgid "pick hunks and update selectively"
 msgstr "Blöcke und Änderung gezielt auswählen"
 
-#: add-interactive.c:1018
+#: add-interactive.c:1022
 msgid "view diff between HEAD and index"
 msgstr "Differenz zwischen HEAD und Index ansehen"
 
-#: add-interactive.c:1020
+#: add-interactive.c:1024
 msgid "add contents of untracked files to the staged set of changes"
 msgstr "Inhalte von unversionierten Dateien zum Commit vormerken"
 
-#: add-interactive.c:1028 add-interactive.c:1077
+#: add-interactive.c:1032 add-interactive.c:1081
 msgid "Prompt help:"
 msgstr "Hilfe für Eingaben:"
 
-#: add-interactive.c:1030
+#: add-interactive.c:1034
 msgid "select a single item"
 msgstr "Ein einzelnes Element auswählen"
 
-#: add-interactive.c:1032
+#: add-interactive.c:1036
 msgid "select a range of items"
 msgstr "Eine Reihe von Elementen auswählen"
 
-#: add-interactive.c:1034
+#: add-interactive.c:1038
 msgid "select multiple ranges"
 msgstr "Mehrere Reihen auswählen"
 
-#: add-interactive.c:1036 add-interactive.c:1081
+#: add-interactive.c:1040 add-interactive.c:1085
 msgid "select item based on unique prefix"
 msgstr "Element basierend auf eindeutigen Präfix auswählen"
 
-#: add-interactive.c:1038
+#: add-interactive.c:1042
 msgid "unselect specified items"
 msgstr "Angegebene Elemente abwählen"
 
-#: add-interactive.c:1040
+#: add-interactive.c:1044
 msgid "choose all items"
 msgstr "Alle Elemente auswählen"
 
-#: add-interactive.c:1042
+#: add-interactive.c:1046
 msgid "(empty) finish selecting"
 msgstr "(leer) Auswählen beenden"
 
-#: add-interactive.c:1079
+#: add-interactive.c:1083
 msgid "select a numbered item"
 msgstr "Ein nummeriertes Element auswählen"
 
-#: add-interactive.c:1083
+#: add-interactive.c:1087
 msgid "(empty) select nothing"
 msgstr "(leer) nichts auswählen"
 
-#: add-interactive.c:1091 builtin/clean.c:813 git-add--interactive.perl:1896
+#: add-interactive.c:1095 builtin/clean.c:813 git-add--interactive.perl:1896
 msgid "*** Commands ***"
 msgstr "*** Befehle ***"
 
-#: add-interactive.c:1092 builtin/clean.c:814 git-add--interactive.perl:1893
+#: add-interactive.c:1096 builtin/clean.c:814 git-add--interactive.perl:1893
 msgid "What now"
 msgstr "Was nun"
 
-#: add-interactive.c:1144 git-add--interactive.perl:213
+#: add-interactive.c:1148 git-add--interactive.perl:213
 msgid "staged"
 msgstr "zur Staging-Area hinzugefügt"
 
-#: add-interactive.c:1144 git-add--interactive.perl:213
+#: add-interactive.c:1148 git-add--interactive.perl:213
 msgid "unstaged"
 msgstr "aus Staging-Area entfernt"
 
-#: add-interactive.c:1144 apply.c:4994 apply.c:4997 builtin/am.c:2309
-#: builtin/am.c:2312 builtin/bugreport.c:135 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:285 builtin/pull.c:190
-#: builtin/submodule--helper.c:410 builtin/submodule--helper.c:1886
-#: builtin/submodule--helper.c:1889 builtin/submodule--helper.c:2343
-#: builtin/submodule--helper.c:2346 builtin/submodule--helper.c:2589
-#: builtin/submodule--helper.c:2890 builtin/submodule--helper.c:2893
+#: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
+#: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
+#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:190
+#: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
+#: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
+#: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
+#: builtin/submodule--helper.c:2578 builtin/submodule--helper.c:2811
 #: git-add--interactive.perl:213
 msgid "path"
 msgstr "Pfad"
 
-#: add-interactive.c:1151
+#: add-interactive.c:1155
 msgid "could not refresh index"
 msgstr "Index konnte nicht aktualisiert werden"
 
-#: add-interactive.c:1165 builtin/clean.c:778 git-add--interactive.perl:1803
+#: add-interactive.c:1169 builtin/clean.c:778 git-add--interactive.perl:1803
 #, c-format
 msgid "Bye.\n"
 msgstr "Tschüss.\n"
@@ -762,7 +762,7 @@ msgstr "Entschuldigung, kann diesen Patch-Block nicht bearbeiten"
 msgid "'git apply' failed"
 msgstr "'git apply' schlug fehl"
 
-#: advice.c:145
+#: advice.c:78
 #, c-format
 msgid ""
 "\n"
@@ -771,43 +771,43 @@ msgstr ""
 "\n"
 "Deaktivieren Sie diese Nachricht mit \"git config advice.%s false\""
 
-#: advice.c:161
+#: advice.c:94
 #, c-format
 msgid "%shint: %.*s%s\n"
 msgstr "%sHinweis: %.*s%s\n"
 
-#: advice.c:252
+#: advice.c:178
 msgid "Cherry-picking is not possible because you have unmerged files."
 msgstr ""
 "Cherry-Picken ist nicht möglich, weil Sie nicht zusammengeführte Dateien "
 "haben."
 
-#: advice.c:254
+#: advice.c:180
 msgid "Committing is not possible because you have unmerged files."
 msgstr ""
 "Committen ist nicht möglich, weil Sie nicht zusammengeführte Dateien haben."
 
-#: advice.c:256
+#: advice.c:182
 msgid "Merging is not possible because you have unmerged files."
 msgstr ""
 "Mergen ist nicht möglich, weil Sie nicht zusammengeführte Dateien haben."
 
-#: advice.c:258
+#: advice.c:184
 msgid "Pulling is not possible because you have unmerged files."
 msgstr ""
 "Pullen ist nicht möglich, weil Sie nicht zusammengeführte Dateien haben."
 
-#: advice.c:260
+#: advice.c:186
 msgid "Reverting is not possible because you have unmerged files."
 msgstr ""
 "Reverten ist nicht möglich, weil Sie nicht zusammengeführte Dateien haben."
 
-#: advice.c:262
+#: advice.c:188
 #, c-format
 msgid "It is not possible to %s because you have unmerged files."
 msgstr "%s ist nicht möglich, weil Sie nicht zusammengeführte Dateien haben."
 
-#: advice.c:270
+#: advice.c:196
 msgid ""
 "Fix them up in the work tree, and then use 'git add/rm <file>'\n"
 "as appropriate to mark resolution and make a commit."
@@ -816,40 +816,42 @@ msgstr ""
 "dann 'git add/rm <Datei>', um die Auflösung entsprechend zu markieren\n"
 "und zu committen."
 
-#: advice.c:278
+#: advice.c:204
 msgid "Exiting because of an unresolved conflict."
 msgstr "Beende wegen unaufgelöstem Konflikt."
 
-#: advice.c:283 builtin/merge.c:1375
+#: advice.c:209 builtin/merge.c:1379
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "Sie haben Ihren Merge nicht abgeschlossen (MERGE_HEAD existiert)."
 
-#: advice.c:285
+#: advice.c:211
 msgid "Please, commit your changes before merging."
 msgstr "Bitte committen Sie Ihre Änderungen, bevor Sie mergen."
 
-#: advice.c:286
+#: advice.c:212
 msgid "Exiting because of unfinished merge."
 msgstr "Beende wegen nicht abgeschlossenem Merge."
 
-#: advice.c:296
+#: advice.c:217
+msgid "Not possible to fast-forward, aborting."
+msgstr "Vorspulen nicht möglich, breche ab."
+
+#: advice.c:227
 #, c-format
 msgid ""
-"The following pathspecs didn't match any eligible path, but they do match "
-"index\n"
-"entries outside the current sparse checkout:\n"
+"The following paths and/or pathspecs matched paths that exist\n"
+"outside of your sparse-checkout definition, so will not be\n"
+"updated in the index:\n"
 msgstr ""
-"Die folgenden Pfadspezifikationen entsprachen keinem geeigneten Pfad, aber\n"
-"entsprechen Index-Einträgen außerhalb des aktuellen partiellen Checkouts:\n"
 
-#: advice.c:303
+#: advice.c:234
 msgid ""
-"Disable or modify the sparsity rules if you intend to update such entries."
+"If you intend to update such entries, try one of the following:\n"
+"* Use the --sparse option.\n"
+"* Disable or modify the sparsity rules."
 msgstr ""
-"Deaktivieren oder verändern Sie die Regeln für partielle Checkouts, wenn Sie "
-"solche Einträge aktualisieren möchten."
 
-#: advice.c:310
+#: advice.c:242
 #, c-format
 msgid ""
 "Note: switching to '%s'.\n"
@@ -1035,37 +1037,37 @@ msgstr "entfernte Datei %s hat noch Inhalte"
 msgid "** warning: file %s becomes empty but is not deleted"
 msgstr "** Warnung: Datei %s wird leer, aber nicht entfernt."
 
-#: apply.c:1977
+#: apply.c:1978
 #, c-format
 msgid "corrupt binary patch at line %d: %.*s"
 msgstr "fehlerhafter Binär-Patch bei Zeile %d: %.*s"
 
-#: apply.c:2014
+#: apply.c:2015
 #, c-format
 msgid "unrecognized binary patch at line %d"
 msgstr "nicht erkannter Binär-Patch bei Zeile %d"
 
-#: apply.c:2176
+#: apply.c:2177
 #, c-format
 msgid "patch with only garbage at line %d"
 msgstr "Patch mit nutzlosen Informationen bei Zeile %d"
 
-#: apply.c:2262
+#: apply.c:2263
 #, c-format
 msgid "unable to read symlink %s"
 msgstr "konnte symbolische Verknüpfung %s nicht lesen"
 
-#: apply.c:2266
+#: apply.c:2267
 #, c-format
 msgid "unable to open or read %s"
 msgstr "konnte %s nicht öffnen oder lesen"
 
-#: apply.c:2935
+#: apply.c:2936
 #, c-format
 msgid "invalid start of line: '%c'"
 msgstr "Ungültiger Zeilenanfang: '%c'"
 
-#: apply.c:3056
+#: apply.c:3057
 #, c-format
 msgid "Hunk #%d succeeded at %d (offset %d line)."
 msgid_plural "Hunk #%d succeeded at %d (offset %d lines)."
@@ -1073,12 +1075,12 @@ msgstr[0] "Patch-Bereich #%d erfolgreich angewendet bei %d (%d Zeile versetzt)"
 msgstr[1] ""
 "Patch-Bereich #%d erfolgreich angewendet bei %d (%d Zeilen versetzt)"
 
-#: apply.c:3068
+#: apply.c:3069
 #, c-format
 msgid "Context reduced to (%ld/%ld) to apply fragment at %d"
 msgstr "Kontext reduziert zu (%ld/%ld), um Patch-Bereich bei %d anzuwenden"
 
-#: apply.c:3074
+#: apply.c:3075
 #, c-format
 msgid ""
 "while searching for:\n"
@@ -1087,25 +1089,25 @@ msgstr ""
 "bei der Suche nach:\n"
 "%.*s"
 
-#: apply.c:3096
+#: apply.c:3097
 #, c-format
 msgid "missing binary patch data for '%s'"
 msgstr "keine Daten in Binär-Patch für '%s'"
 
-#: apply.c:3104
+#: apply.c:3105
 #, c-format
 msgid "cannot reverse-apply a binary patch without the reverse hunk to '%s'"
 msgstr ""
 "kann binären Patch nicht in umgekehrter Reihenfolge anwenden ohne einen\n"
 "umgekehrten Patch-Block auf '%s'"
 
-#: apply.c:3151
+#: apply.c:3152
 #, c-format
 msgid "cannot apply binary patch to '%s' without full index line"
 msgstr ""
 "kann binären Patch auf '%s' nicht ohne eine vollständige Index-Zeile anwenden"
 
-#: apply.c:3162
+#: apply.c:3163
 #, c-format
 msgid ""
 "the patch applies to '%s' (%s), which does not match the current contents."
@@ -1113,433 +1115,434 @@ msgstr ""
 "der Patch wird angewendet auf '%s' (%s), was nicht den aktuellen Inhalten\n"
 "entspricht"
 
-#: apply.c:3170
+#: apply.c:3171
 #, c-format
 msgid "the patch applies to an empty '%s' but it is not empty"
 msgstr "der Patch wird auf ein leeres '%s' angewendet, was aber nicht leer ist"
 
-#: apply.c:3188
+#: apply.c:3189
 #, c-format
 msgid "the necessary postimage %s for '%s' cannot be read"
 msgstr "das erforderliche Postimage %s für '%s' kann nicht gelesen werden"
 
-#: apply.c:3201
+#: apply.c:3202
 #, c-format
 msgid "binary patch does not apply to '%s'"
 msgstr "Konnte Binär-Patch nicht auf '%s' anwenden"
 
-#: apply.c:3208
+#: apply.c:3209
 #, c-format
 msgid "binary patch to '%s' creates incorrect result (expecting %s, got %s)"
 msgstr ""
 "Binär-Patch für '%s' erzeugt falsches Ergebnis (erwartete %s, bekam %s)"
 
-#: apply.c:3229
+#: apply.c:3230
 #, c-format
 msgid "patch failed: %s:%ld"
 msgstr "Anwendung des Patches fehlgeschlagen: %s:%ld"
 
-#: apply.c:3352
+#: apply.c:3353
 #, c-format
 msgid "cannot checkout %s"
 msgstr "kann %s nicht auschecken"
 
-#: apply.c:3404 apply.c:3415 apply.c:3461 midx.c:98 pack-revindex.c:214
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:102 pack-revindex.c:214
 #: setup.c:308
 #, c-format
 msgid "failed to read %s"
 msgstr "Fehler beim Lesen von %s"
 
-#: apply.c:3412
+#: apply.c:3413
 #, c-format
 msgid "reading from '%s' beyond a symbolic link"
 msgstr "'%s' ist hinter einer symbolischen Verknüpfung"
 
-#: apply.c:3441 apply.c:3687
+#: apply.c:3442 apply.c:3709
 #, c-format
 msgid "path %s has been renamed/deleted"
 msgstr "Pfad %s wurde umbenannt/gelöscht"
 
-#: apply.c:3527 apply.c:3702
+#: apply.c:3549 apply.c:3724
 #, c-format
 msgid "%s: does not exist in index"
 msgstr "%s ist nicht im Index"
 
-#: apply.c:3536 apply.c:3710 apply.c:3954
+#: apply.c:3558 apply.c:3732 apply.c:3976
 #, c-format
 msgid "%s: does not match index"
 msgstr "%s entspricht nicht der Version im Index"
 
-#: apply.c:3571
+#: apply.c:3593
 msgid "repository lacks the necessary blob to perform 3-way merge."
 msgstr ""
 "Dem Repository fehlt der notwendige Blob, um einen 3-Wege-Merge "
 "durchzuführen."
 
-#: apply.c:3574
+#: apply.c:3596
 #, c-format
 msgid "Performing three-way merge...\n"
 msgstr "Führe 3-Wege-Merge durch...\n"
 
-#: apply.c:3590 apply.c:3594
+#: apply.c:3612 apply.c:3616
 #, c-format
 msgid "cannot read the current contents of '%s'"
 msgstr "kann aktuelle Inhalte von '%s' nicht lesen"
 
-#: apply.c:3606
+#: apply.c:3628
 #, c-format
 msgid "Failed to perform three-way merge...\n"
 msgstr "Fehler beim Durchführen des 3-Wege-Merges...\n"
 
-#: apply.c:3620
+#: apply.c:3642
 #, c-format
 msgid "Applied patch to '%s' with conflicts.\n"
 msgstr "Patch auf '%s' mit Konflikten angewendet.\n"
 
-#: apply.c:3625
+#: apply.c:3647
 #, c-format
 msgid "Applied patch to '%s' cleanly.\n"
 msgstr "Patch auf '%s' sauber angewendet.\n"
 
-#: apply.c:3642
+#: apply.c:3664
 #, c-format
 msgid "Falling back to direct application...\n"
 msgstr "Ausweichen auf direkte Anwendung...\n"
 
-#: apply.c:3654
+#: apply.c:3676
 msgid "removal patch leaves file contents"
 msgstr "Lösch-Patch hinterlässt Dateiinhalte"
 
-#: apply.c:3727
+#: apply.c:3749
 #, c-format
 msgid "%s: wrong type"
 msgstr "%s: falscher Typ"
 
-#: apply.c:3729
+#: apply.c:3751
 #, c-format
 msgid "%s has type %o, expected %o"
 msgstr "%s ist vom Typ %o, erwartete %o"
 
-#: apply.c:3894 apply.c:3896 read-cache.c:863 read-cache.c:892
-#: read-cache.c:1353
+#: apply.c:3916 apply.c:3918 read-cache.c:876 read-cache.c:905
+#: read-cache.c:1368
 #, c-format
 msgid "invalid path '%s'"
 msgstr "Ungültiger Pfad '%s'"
 
-#: apply.c:3952
+#: apply.c:3974
 #, c-format
 msgid "%s: already exists in index"
 msgstr "%s ist bereits bereitgestellt"
 
-#: apply.c:3956
+#: apply.c:3978
 #, c-format
 msgid "%s: already exists in working directory"
 msgstr "%s existiert bereits im Arbeitsverzeichnis"
 
-#: apply.c:3976
+#: apply.c:3998
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
 msgstr "neuer Modus (%o) von %s entspricht nicht dem alten Modus (%o)"
 
-#: apply.c:3981
+#: apply.c:4003
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
 msgstr "neuer Modus (%o) von %s entspricht nicht dem alten Modus (%o) von %s"
 
-#: apply.c:4001
+#: apply.c:4023
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
 msgstr "betroffene Datei '%s' ist hinter einer symbolischen Verknüpfung"
 
-#: apply.c:4005
+#: apply.c:4027
 #, c-format
 msgid "%s: patch does not apply"
 msgstr "%s: Patch konnte nicht angewendet werden"
 
-#: apply.c:4020
+#: apply.c:4042
 #, c-format
 msgid "Checking patch %s..."
 msgstr "Prüfe Patch %s ..."
 
-#: apply.c:4112
+#: apply.c:4134
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
 msgstr "SHA-1 Information fehlt oder ist unbrauchbar für Submodul %s"
 
-#: apply.c:4119
+#: apply.c:4141
 #, c-format
 msgid "mode change for %s, which is not in current HEAD"
 msgstr "Modusänderung für %s, was sich nicht im aktuellen HEAD befindet"
 
-#: apply.c:4122
+#: apply.c:4144
 #, c-format
 msgid "sha1 information is lacking or useless (%s)."
 msgstr "SHA-1 Information fehlt oder ist unbrauchbar (%s)."
 
-#: apply.c:4131
+#: apply.c:4153
 #, c-format
 msgid "could not add %s to temporary index"
 msgstr "konnte %s nicht zum temporären Index hinzufügen"
 
-#: apply.c:4141
+#: apply.c:4163
 #, c-format
 msgid "could not write temporary index to %s"
 msgstr "konnte temporären Index nicht nach %s schreiben"
 
-#: apply.c:4279
+#: apply.c:4301
 #, c-format
 msgid "unable to remove %s from index"
 msgstr "konnte %s nicht aus dem Index entfernen"
 
-#: apply.c:4313
+#: apply.c:4335
 #, c-format
 msgid "corrupt patch for submodule %s"
 msgstr "fehlerhafter Patch für Submodul %s"
 
-#: apply.c:4319
+#: apply.c:4341
 #, c-format
 msgid "unable to stat newly created file '%s'"
 msgstr "konnte neu erstellte Datei '%s' nicht lesen"
 
-#: apply.c:4327
+#: apply.c:4349
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr "kann internen Speicher für eben erstellte Datei %s nicht erzeugen"
 
-#: apply.c:4333 apply.c:4478
+#: apply.c:4355 apply.c:4500
 #, c-format
 msgid "unable to add cache entry for %s"
 msgstr "kann für %s keinen Eintrag in den Zwischenspeicher hinzufügen"
 
-#: apply.c:4376 builtin/bisect--helper.c:525
+#: apply.c:4398 builtin/bisect--helper.c:540 builtin/gc.c:2241
+#: builtin/gc.c:2276
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "Fehler beim Schreiben nach '%s'"
 
-#: apply.c:4380
+#: apply.c:4402
 #, c-format
 msgid "closing file '%s'"
 msgstr "schließe Datei '%s'"
 
-#: apply.c:4450
+#: apply.c:4472
 #, c-format
 msgid "unable to write file '%s' mode %o"
 msgstr "konnte Datei '%s' mit Modus %o nicht schreiben"
 
-#: apply.c:4548
+#: apply.c:4570
 #, c-format
 msgid "Applied patch %s cleanly."
 msgstr "Patch %s sauber angewendet"
 
-#: apply.c:4556
+#: apply.c:4578
 msgid "internal error"
 msgstr "interner Fehler"
 
-#: apply.c:4559
+#: apply.c:4581
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
 msgstr[0] "Wende Patch %%s mit %d Zurückweisung an..."
 msgstr[1] "Wende Patch %%s mit %d Zurückweisungen an..."
 
-#: apply.c:4570
+#: apply.c:4592
 #, c-format
 msgid "truncating .rej filename to %.*s.rej"
 msgstr "Verkürze Name von .rej Datei zu %.*s.rej"
 
-#: apply.c:4578 builtin/fetch.c:993 builtin/fetch.c:1394
+#: apply.c:4600 builtin/fetch.c:998 builtin/fetch.c:1408
 #, c-format
 msgid "cannot open %s"
 msgstr "kann '%s' nicht öffnen"
 
-#: apply.c:4592
+#: apply.c:4614
 #, c-format
 msgid "Hunk #%d applied cleanly."
 msgstr "Patch-Bereich #%d sauber angewendet."
 
-#: apply.c:4596
+#: apply.c:4618
 #, c-format
 msgid "Rejected hunk #%d."
 msgstr "Patch-Block #%d zurückgewiesen."
 
-#: apply.c:4725
+#: apply.c:4747
 #, c-format
 msgid "Skipped patch '%s'."
 msgstr "Patch '%s' ausgelassen."
 
-#: apply.c:4733
+#: apply.c:4755
 msgid "unrecognized input"
 msgstr "nicht erkannte Eingabe"
 
-#: apply.c:4753
+#: apply.c:4775
 msgid "unable to read index file"
 msgstr "Konnte Index-Datei nicht lesen"
 
-#: apply.c:4910
+#: apply.c:4932
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr "kann Patch '%s' nicht öffnen: %s"
 
-#: apply.c:4937
+#: apply.c:4959
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "unterdrückte %d Whitespace-Fehler"
 msgstr[1] "unterdrückte %d Whitespace-Fehler"
 
-#: apply.c:4943 apply.c:4958
+#: apply.c:4965 apply.c:4980
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] "%d Zeile fügt Whitespace-Fehler hinzu."
 msgstr[1] "%d Zeilen fügen Whitespace-Fehler hinzu."
 
-#: apply.c:4951
+#: apply.c:4973
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
 msgstr[0] "%d Zeile nach Behebung von Whitespace-Fehlern angewendet."
 msgstr[1] "%d Zeilen nach Behebung von Whitespace-Fehlern angewendet."
 
-#: apply.c:4967 builtin/add.c:678 builtin/mv.c:304 builtin/rm.c:423
+#: apply.c:4989 builtin/add.c:707 builtin/mv.c:338 builtin/rm.c:429
 msgid "Unable to write new index file"
 msgstr "Konnte neue Index-Datei nicht schreiben."
 
-#: apply.c:4995
+#: apply.c:5017
 msgid "don't apply changes matching the given path"
 msgstr "keine Änderungen im angegebenen Pfad anwenden"
 
-#: apply.c:4998
+#: apply.c:5020
 msgid "apply changes matching the given path"
 msgstr "Änderungen nur im angegebenen Pfad anwenden"
 
-#: apply.c:5000 builtin/am.c:2318
+#: apply.c:5022 builtin/am.c:2320
 msgid "num"
 msgstr "Anzahl"
 
-#: apply.c:5001
+#: apply.c:5023
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr ""
 "<Anzahl> vorangestellte Schrägstriche von herkömmlichen Differenzpfaden "
 "entfernen"
 
-#: apply.c:5004
+#: apply.c:5026
 msgid "ignore additions made by the patch"
 msgstr "hinzugefügte Zeilen des Patches ignorieren"
 
-#: apply.c:5006
+#: apply.c:5028
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr ""
 "statt den Patch anzuwenden, den \"diffstat\" für die Eingabe ausgegeben"
 
-#: apply.c:5010
+#: apply.c:5032
 msgid "show number of added and deleted lines in decimal notation"
 msgstr ""
 "die Anzahl von hinzugefügten/entfernten Zeilen in Dezimalnotation anzeigen"
 
-#: apply.c:5012
+#: apply.c:5034
 msgid "instead of applying the patch, output a summary for the input"
 msgstr ""
 "statt den Patch anzuwenden, eine Zusammenfassung für die Eingabe ausgeben"
 
-#: apply.c:5014
+#: apply.c:5036
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr ""
 "statt den Patch anzuwenden, anzeigen ob der Patch angewendet werden kann"
 
-#: apply.c:5016
+#: apply.c:5038
 msgid "make sure the patch is applicable to the current index"
 msgstr ""
 "sicherstellen, dass der Patch mit dem aktuellen Index angewendet werden kann"
 
-#: apply.c:5018
+#: apply.c:5040
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "neue Dateien mit `git add --intent-to-add` markieren"
 
-#: apply.c:5020
+#: apply.c:5042
 msgid "apply a patch without touching the working tree"
 msgstr "Patch anwenden, ohne Änderungen im Arbeitsverzeichnis vorzunehmen"
 
-#: apply.c:5022
+#: apply.c:5044
 msgid "accept a patch that touches outside the working area"
 msgstr ""
 "Patch anwenden, der Änderungen außerhalb des Arbeitsverzeichnisses vornimmt"
 
-#: apply.c:5025
+#: apply.c:5047
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr "Patch anwenden (Benutzung mit --stat/--summary/--check)"
 
-#: apply.c:5027
+#: apply.c:5049
 msgid "attempt three-way merge, fall back on normal patch if that fails"
 msgstr ""
 "versuche 3-Wege-Merge, weiche auf normalen Patch aus, wenn dies fehlschlägt"
 
-#: apply.c:5029
+#: apply.c:5051
 msgid "build a temporary index based on embedded index information"
 msgstr ""
 "einen temporären Index, basierend auf den integrierten Index-Informationen, "
 "erstellen"
 
-#: apply.c:5032 builtin/checkout-index.c:196 builtin/ls-files.c:617
+#: apply.c:5054 builtin/checkout-index.c:196
 msgid "paths are separated with NUL character"
 msgstr "Pfade sind getrennt durch NUL Zeichen"
 
-#: apply.c:5034
+#: apply.c:5056
 msgid "ensure at least <n> lines of context match"
 msgstr ""
 "sicher stellen, dass mindestens <n> Zeilen des Kontextes übereinstimmen"
 
-#: apply.c:5035 builtin/am.c:2294 builtin/am.c:2297
+#: apply.c:5057 builtin/am.c:2296 builtin/am.c:2299
 #: builtin/interpret-trailers.c:98 builtin/interpret-trailers.c:100
-#: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3991
-#: builtin/rebase.c:1347
+#: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3960
+#: builtin/rebase.c:1051
 msgid "action"
 msgstr "Aktion"
 
-#: apply.c:5036
+#: apply.c:5058
 msgid "detect new or modified lines that have whitespace errors"
 msgstr "neue oder geänderte Zeilen, die Whitespace-Fehler haben, ermitteln"
 
-#: apply.c:5039 apply.c:5042
+#: apply.c:5061 apply.c:5064
 msgid "ignore changes in whitespace when finding context"
 msgstr "Änderungen im Whitespace bei der Suche des Kontextes ignorieren"
 
-#: apply.c:5045
+#: apply.c:5067
 msgid "apply the patch in reverse"
 msgstr "den Patch in umgekehrter Reihenfolge anwenden"
 
-#: apply.c:5047
+#: apply.c:5069
 msgid "don't expect at least one line of context"
 msgstr "keinen Kontext erwarten"
 
-#: apply.c:5049
+#: apply.c:5071
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr ""
 "zurückgewiesene Patch-Blöcke in entsprechenden *.rej Dateien hinterlassen"
 
-#: apply.c:5051
+#: apply.c:5073
 msgid "allow overlapping hunks"
 msgstr "sich überlappende Patch-Blöcke erlauben"
 
-#: apply.c:5052 builtin/add.c:364 builtin/check-ignore.c:22
-#: builtin/commit.c:1481 builtin/count-objects.c:98 builtin/fsck.c:756
-#: builtin/log.c:2297 builtin/mv.c:123 builtin/read-tree.c:128
+#: apply.c:5074 builtin/add.c:372 builtin/check-ignore.c:22
+#: builtin/commit.c:1483 builtin/count-objects.c:98 builtin/fsck.c:788
+#: builtin/log.c:2297 builtin/mv.c:123 builtin/read-tree.c:120
 msgid "be verbose"
 msgstr "erweiterte Ausgaben"
 
-#: apply.c:5054
+#: apply.c:5076
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr "fehlerhaft erkannten fehlenden Zeilenumbruch am Dateiende tolerieren"
 
-#: apply.c:5057
+#: apply.c:5079
 msgid "do not trust the line counts in the hunk headers"
 msgstr "den Zeilennummern im Kopf des Patch-Blocks nicht vertrauen"
 
-#: apply.c:5059 builtin/am.c:2306
+#: apply.c:5081 builtin/am.c:2308
 msgid "root"
 msgstr "Wurzelverzeichnis"
 
-#: apply.c:5060
+#: apply.c:5082
 msgid "prepend <root> to all filenames"
 msgstr "<Wurzelverzeichnis> vor alle Dateinamen stellen"
 
@@ -1611,153 +1614,152 @@ msgstr "git archive --remote <Repository> [--exec <Programm>] --list"
 msgid "cannot read %s"
 msgstr "Kann %s nicht lesen."
 
-#: archive.c:342 sequencer.c:460 sequencer.c:1915 sequencer.c:3095
-#: sequencer.c:3537 sequencer.c:3665 builtin/am.c:262 builtin/commit.c:833
-#: builtin/merge.c:1144
+#: archive.c:341 sequencer.c:473 sequencer.c:1932 sequencer.c:3114
+#: sequencer.c:3556 sequencer.c:3684 builtin/am.c:263 builtin/commit.c:834
+#: builtin/merge.c:1145
 #, c-format
 msgid "could not read '%s'"
 msgstr "Konnte '%s' nicht lesen"
 
-#: archive.c:427 builtin/add.c:205 builtin/add.c:645 builtin/rm.c:328
+#: archive.c:426 builtin/add.c:215 builtin/add.c:674 builtin/rm.c:334
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "Pfadspezifikation '%s' stimmt mit keinen Dateien überein"
 
-#: archive.c:451
+#: archive.c:450
 #, c-format
 msgid "no such ref: %.*s"
 msgstr "Referenz nicht gefunden: %.*s"
 
-#: archive.c:457
+#: archive.c:456
 #, c-format
 msgid "not a valid object name: %s"
 msgstr "Kein gültiger Objektname: %s"
 
-#: archive.c:470
+#: archive.c:469
 #, c-format
 msgid "not a tree object: %s"
 msgstr "Kein Tree-Objekt: %s"
 
-#: archive.c:482
+#: archive.c:481
 msgid "current working directory is untracked"
 msgstr "Aktuelles Arbeitsverzeichnis ist unversioniert."
 
-#: archive.c:523
+#: archive.c:522
 #, c-format
 msgid "File not found: %s"
 msgstr "Datei nicht gefunden: %s"
 
-#: archive.c:525
+#: archive.c:524
 #, c-format
 msgid "Not a regular file: %s"
 msgstr "Keine reguläre Datei: %s"
 
-#: archive.c:552
+#: archive.c:551
 msgid "fmt"
 msgstr "Format"
 
-#: archive.c:552
+#: archive.c:551
 msgid "archive format"
 msgstr "Archivformat"
 
-#: archive.c:553 builtin/log.c:1775
+#: archive.c:552 builtin/log.c:1775
 msgid "prefix"
 msgstr "Präfix"
 
-#: archive.c:554
+#: archive.c:553
 msgid "prepend prefix to each pathname in the archive"
 msgstr "einen Präfix vor jeden Pfadnamen in dem Archiv stellen"
 
-#: archive.c:555 archive.c:558 builtin/blame.c:884 builtin/blame.c:888
-#: builtin/blame.c:889 builtin/commit-tree.c:117 builtin/config.c:135
-#: builtin/fast-export.c:1207 builtin/fast-export.c:1209
-#: builtin/fast-export.c:1213 builtin/grep.c:921 builtin/hash-object.c:105
-#: builtin/ls-files.c:653 builtin/ls-files.c:656 builtin/notes.c:412
-#: builtin/notes.c:578 builtin/read-tree.c:123 parse-options.h:191
+#: archive.c:554 archive.c:557 builtin/blame.c:880 builtin/blame.c:884
+#: builtin/blame.c:885 builtin/commit-tree.c:115 builtin/config.c:135
+#: builtin/fast-export.c:1208 builtin/fast-export.c:1210
+#: builtin/fast-export.c:1214 builtin/grep.c:935 builtin/hash-object.c:103
+#: builtin/ls-files.c:651 builtin/ls-files.c:654 builtin/notes.c:410
+#: builtin/notes.c:576 builtin/read-tree.c:115 parse-options.h:190
 msgid "file"
 msgstr "Datei"
 
-#: archive.c:556
+#: archive.c:555
 msgid "add untracked file to archive"
 msgstr "unversionierte Datei zum Archiv hinzufügen"
 
-#: archive.c:559 builtin/archive.c:90
+#: archive.c:558 builtin/archive.c:88
 msgid "write the archive to this file"
 msgstr "das Archiv in diese Datei schreiben"
 
-#: archive.c:561
+#: archive.c:560
 msgid "read .gitattributes in working directory"
 msgstr ".gitattributes aus dem Arbeitsverzeichnis lesen"
 
-#: archive.c:562
+#: archive.c:561
 msgid "report archived files on stderr"
 msgstr "archivierte Dateien in der Standard-Fehlerausgabe ausgeben"
 
-#: archive.c:564
+#: archive.c:563
 msgid "set compression level"
 msgstr "Komprimierungsgrad setzen"
 
-#: archive.c:567
+#: archive.c:566
 msgid "list supported archive formats"
 msgstr "unterstützte Archivformate auflisten"
 
-#: archive.c:569 builtin/archive.c:91 builtin/clone.c:118 builtin/clone.c:121
-#: builtin/submodule--helper.c:1898 builtin/submodule--helper.c:2352
-#: builtin/submodule--helper.c:2902
+#: archive.c:568 builtin/archive.c:89 builtin/clone.c:118 builtin/clone.c:121
+#: builtin/submodule--helper.c:1869 builtin/submodule--helper.c:2512
 msgid "repo"
 msgstr "Repository"
 
-#: archive.c:570 builtin/archive.c:92
+#: archive.c:569 builtin/archive.c:90
 msgid "retrieve the archive from remote repository <repo>"
 msgstr "Archiv vom Remote-Repository <Repository> abrufen"
 
-#: archive.c:571 builtin/archive.c:93 builtin/difftool.c:717
-#: builtin/notes.c:498
+#: archive.c:570 builtin/archive.c:91 builtin/difftool.c:714
+#: builtin/notes.c:496
 msgid "command"
 msgstr "Programm"
 
-#: archive.c:572 builtin/archive.c:94
+#: archive.c:571 builtin/archive.c:92
 msgid "path to the remote git-upload-archive command"
 msgstr "Pfad zum externen \"git-upload-archive\"-Programm"
 
-#: archive.c:579
+#: archive.c:578
 msgid "Unexpected option --remote"
 msgstr "Unerwartete Option --remote"
 
-#: archive.c:581
+#: archive.c:580
 msgid "Option --exec can only be used together with --remote"
 msgstr "Die Option --exec kann nur zusammen mit --remote verwendet werden"
 
-#: archive.c:583
+#: archive.c:582
 msgid "Unexpected option --output"
 msgstr "Unerwartete Option --output"
 
-#: archive.c:585
+#: archive.c:584
 msgid "Options --add-file and --remote cannot be used together"
 msgstr ""
 "Die Optionen --add-file und --remote können nicht gemeinsam verwendet werden"
 
-#: archive.c:607
+#: archive.c:606
 #, c-format
 msgid "Unknown archive format '%s'"
 msgstr "Unbekanntes Archivformat '%s'"
 
-#: archive.c:616
+#: archive.c:615
 #, c-format
 msgid "Argument not supported for format '%s': -%d"
 msgstr "Argument für Format '%s' nicht unterstützt: -%d"
 
-#: attr.c:202
+#: attr.c:203
 #, c-format
 msgid "%.*s is not a valid attribute name"
 msgstr "%.*s ist kein gültiger Attributname"
 
-#: attr.c:363
+#: attr.c:364
 #, c-format
 msgid "%s not allowed: %s:%d"
 msgstr "%s nicht erlaubt: %s:%d"
 
-#: attr.c:403
+#: attr.c:404
 msgid ""
 "Negative patterns are ignored in git attributes\n"
 "Use '\\!' for literal leading exclamation."
@@ -1765,22 +1767,22 @@ msgstr ""
 "Verneinende Muster werden in Git-Attributen ignoriert.\n"
 "Benutzen Sie '\\!' für führende Ausrufezeichen."
 
-#: bisect.c:489
+#: bisect.c:488
 #, c-format
 msgid "Badly quoted content in file '%s': %s"
 msgstr "Ungültiger Inhalt bzgl. Anführungszeichen in Datei '%s': %s"
 
-#: bisect.c:699
+#: bisect.c:698
 #, c-format
 msgid "We cannot bisect more!\n"
 msgstr "Keine binäre Suche mehr möglich!\n"
 
-#: bisect.c:766
+#: bisect.c:764
 #, c-format
 msgid "Not a valid commit name %s"
 msgstr "%s ist kein gültiger Commit-Name"
 
-#: bisect.c:791
+#: bisect.c:789
 #, c-format
 msgid ""
 "The merge base %s is bad.\n"
@@ -1789,7 +1791,7 @@ msgstr ""
 "Die Merge-Basis %s ist fehlerhaft.\n"
 "Das bedeutet, der Fehler wurde zwischen %s und [%s] behoben.\n"
 
-#: bisect.c:796
+#: bisect.c:794
 #, c-format
 msgid ""
 "The merge base %s is new.\n"
@@ -1798,7 +1800,7 @@ msgstr ""
 "Die Merge-Basis %s ist neu.\n"
 "Das bedeutet, die Eigenschaft hat sich zwischen %s und [%s] geändert.\n"
 
-#: bisect.c:801
+#: bisect.c:799
 #, c-format
 msgid ""
 "The merge base %s is %s.\n"
@@ -1807,7 +1809,7 @@ msgstr ""
 "Die Merge-Basis %s ist %s.\n"
 "Das bedeutet, der erste '%s' Commit befindet sich zwischen %s und [%s].\n"
 
-#: bisect.c:809
+#: bisect.c:807
 #, c-format
 msgid ""
 "Some %s revs are not ancestors of the %s rev.\n"
@@ -1818,7 +1820,7 @@ msgstr ""
 "git bisect kann in diesem Fall nicht richtig arbeiten.\n"
 "Vielleicht verwechselten Sie %s und %s Commits?\n"
 
-#: bisect.c:822
+#: bisect.c:820
 #, c-format
 msgid ""
 "the merge base between %s and [%s] must be skipped.\n"
@@ -1830,36 +1832,36 @@ msgstr ""
 "erste %s Commit zwischen %s und %s befindet.\n"
 "Es wird dennoch fortgesetzt."
 
-#: bisect.c:861
+#: bisect.c:859
 #, c-format
 msgid "Bisecting: a merge base must be tested\n"
 msgstr "binäre Suche: eine Merge-Basis muss geprüft werden\n"
 
-#: bisect.c:911
+#: bisect.c:909
 #, c-format
 msgid "a %s revision is needed"
 msgstr "ein %s Commit wird benötigt"
 
-#: bisect.c:941 builtin/notes.c:177 builtin/tag.c:298
+#: bisect.c:939
 #, c-format
 msgid "could not create file '%s'"
 msgstr "konnte Datei '%s' nicht erstellen"
 
-#: bisect.c:987 builtin/merge.c:153
+#: bisect.c:985 builtin/merge.c:154
 #, c-format
 msgid "could not read file '%s'"
 msgstr "Konnte Datei '%s' nicht lesen"
 
-#: bisect.c:1027
+#: bisect.c:1025
 msgid "reading bisect refs failed"
 msgstr "Lesen von Referenzen für binäre Suche fehlgeschlagen"
 
-#: bisect.c:1057
+#: bisect.c:1055
 #, c-format
 msgid "%s was both %s and %s\n"
 msgstr "%s war sowohl %s als auch %s\n"
 
-#: bisect.c:1066
+#: bisect.c:1064
 #, c-format
 msgid ""
 "No testable commit found.\n"
@@ -1868,7 +1870,7 @@ msgstr ""
 "Kein testbarer Commit gefunden.\n"
 "Vielleicht starteten Sie mit schlechten Pfad-Argumenten?\n"
 
-#: bisect.c:1095
+#: bisect.c:1093
 #, c-format
 msgid "(roughly %d step)"
 msgid_plural "(roughly %d steps)"
@@ -1878,7 +1880,7 @@ msgstr[1] "(ungefähr %d Schritte)"
 #. TRANSLATORS: the last %s will be replaced with "(roughly %d
 #. steps)" translation.
 #.
-#: bisect.c:1101
+#: bisect.c:1099
 #, c-format
 msgid "Bisecting: %d revision left to test after this %s\n"
 msgid_plural "Bisecting: %d revisions left to test after this %s\n"
@@ -1901,11 +1903,12 @@ msgstr ""
 "endgültigen\n"
 "Commits"
 
-#: blame.c:2820 bundle.c:224 ref-filter.c:2278 remote.c:2041 sequencer.c:2333
-#: sequencer.c:4865 submodule.c:844 builtin/commit.c:1113 builtin/log.c:414
-#: builtin/log.c:1021 builtin/log.c:1629 builtin/log.c:2056 builtin/log.c:2346
-#: builtin/merge.c:428 builtin/pack-objects.c:3343 builtin/pack-objects.c:3806
-#: builtin/pack-objects.c:3821 builtin/shortlog.c:255
+#: blame.c:2820 bundle.c:224 midx.c:1039 ref-filter.c:2370 remote.c:2041
+#: sequencer.c:2350 sequencer.c:4902 submodule.c:883 builtin/commit.c:1114
+#: builtin/log.c:414 builtin/log.c:1021 builtin/log.c:1629 builtin/log.c:2056
+#: builtin/log.c:2346 builtin/merge.c:429 builtin/pack-objects.c:3373
+#: builtin/pack-objects.c:3775 builtin/pack-objects.c:3790
+#: builtin/shortlog.c:255
 msgid "revision walk setup failed"
 msgstr "Einrichtung des Revisionsgangs fehlgeschlagen"
 
@@ -2088,8 +2091,8 @@ msgstr "'%s' sieht nicht wie eine v2 oder v3 Paketdatei aus"
 msgid "unrecognized header: %s%s (%d)"
 msgstr "nicht erkannter Kopfbereich: %s%s (%d)"
 
-#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2593 sequencer.c:3385
-#: builtin/commit.c:861
+#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2618 sequencer.c:3404
+#: builtin/commit.c:862
 #, c-format
 msgid "could not open '%s'"
 msgstr "Konnte '%s' nicht öffnen"
@@ -2147,7 +2150,7 @@ msgstr "nicht unterstützte Paket-Version %d"
 msgid "cannot write bundle version %d with algorithm %s"
 msgstr "kann Paket-Version %d nicht mit Algorithmus %s schreiben"
 
-#: bundle.c:524 builtin/log.c:210 builtin/log.c:1938 builtin/shortlog.c:396
+#: bundle.c:524 builtin/log.c:210 builtin/log.c:1938 builtin/shortlog.c:399
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr "nicht erkanntes Argument: %s"
@@ -2189,7 +2192,7 @@ msgstr "letzter Chunk hat nicht-Null ID %<PRIx32>"
 msgid "invalid color value: %.*s"
 msgstr "Ungültiger Farbwert: %.*s"
 
-#: commit-graph.c:204 midx.c:47
+#: commit-graph.c:204 midx.c:51
 msgid "invalid hash version"
 msgstr "ungültige Hash-Version"
 
@@ -2234,190 +2237,190 @@ msgstr "Ungültige Commit-Graph Verkettung: Zeile '%s' ist kein Hash"
 msgid "unable to find all commit-graph files"
 msgstr "Konnte nicht alle Commit-Graph-Dateien finden."
 
-#: commit-graph.c:745 commit-graph.c:782
+#: commit-graph.c:746 commit-graph.c:783
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr "Ungültige Commit-Position. Commit-Graph ist wahrscheinlich beschädigt."
 
-#: commit-graph.c:766
+#: commit-graph.c:767
 #, c-format
 msgid "could not find commit %s"
 msgstr "Konnte Commit %s nicht finden."
 
-#: commit-graph.c:799
+#: commit-graph.c:800
 msgid "commit-graph requires overflow generation data but has none"
 msgstr "Commit-Graph erfordert Überlaufgenerierungsdaten, aber hat keine"
 
-#: commit-graph.c:1075 builtin/am.c:1341
+#: commit-graph.c:1105 builtin/am.c:1342
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "Konnte Commit '%s' nicht parsen."
 
-#: commit-graph.c:1337 builtin/pack-objects.c:3057
+#: commit-graph.c:1367 builtin/pack-objects.c:3070
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "Konnte Art von Objekt '%s' nicht bestimmen."
 
-#: commit-graph.c:1368
+#: commit-graph.c:1398
 msgid "Loading known commits in commit graph"
 msgstr "Lade bekannte Commits in Commit-Graph"
 
-#: commit-graph.c:1385
+#: commit-graph.c:1415
 msgid "Expanding reachable commits in commit graph"
 msgstr "Erweitere erreichbare Commits in Commit-Graph"
 
-#: commit-graph.c:1405
+#: commit-graph.c:1435
 msgid "Clearing commit marks in commit graph"
 msgstr "Lösche Commit-Markierungen in Commit-Graph"
 
-#: commit-graph.c:1424
+#: commit-graph.c:1454
 msgid "Computing commit graph topological levels"
 msgstr "Topologische Ebenen des Commit-Graph werden berechnet"
 
-#: commit-graph.c:1477
+#: commit-graph.c:1507
 msgid "Computing commit graph generation numbers"
 msgstr "Commit-Graph Generationsnummern berechnen"
 
-#: commit-graph.c:1558
+#: commit-graph.c:1588
 msgid "Computing commit changed paths Bloom filters"
 msgstr "Berechnung der Bloom-Filter für veränderte Pfade des Commits"
 
-#: commit-graph.c:1635
+#: commit-graph.c:1665
 msgid "Collecting referenced commits"
 msgstr "Sammle referenzierte Commits"
 
-#: commit-graph.c:1660
+#: commit-graph.c:1690
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] "Suche Commits für Commit-Graph in %d Paket"
 msgstr[1] "Suche Commits für Commit-Graph in %d Paketen"
 
-#: commit-graph.c:1673
+#: commit-graph.c:1703
 #, c-format
 msgid "error adding pack %s"
 msgstr "Fehler beim Hinzufügen von Paket %s."
 
-#: commit-graph.c:1677
+#: commit-graph.c:1707
 #, c-format
 msgid "error opening index for %s"
 msgstr "Fehler beim Öffnen des Index für %s."
 
-#: commit-graph.c:1714
+#: commit-graph.c:1744
 msgid "Finding commits for commit graph among packed objects"
 msgstr "Suche Commits für Commit-Graph in gepackten Objekten"
 
-#: commit-graph.c:1732
+#: commit-graph.c:1762
 msgid "Finding extra edges in commit graph"
 msgstr "Suche zusätzliche Ränder in Commit-Graph"
 
-#: commit-graph.c:1781
+#: commit-graph.c:1811
 msgid "failed to write correct number of base graph ids"
 msgstr "Fehler beim Schreiben der korrekten Anzahl von Basis-Graph-IDs."
 
-#: commit-graph.c:1812 midx.c:911
+#: commit-graph.c:1842 midx.c:1146
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "Konnte führende Verzeichnisse von '%s' nicht erstellen."
 
-#: commit-graph.c:1825
+#: commit-graph.c:1855
 msgid "unable to create temporary graph layer"
 msgstr "konnte temporäre Graphen-Schicht nicht erstellen"
 
-#: commit-graph.c:1830
+#: commit-graph.c:1860
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "konnte geteilte Zugriffsberechtigungen für '%s' nicht ändern"
 
-#: commit-graph.c:1887
+#: commit-graph.c:1917
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "Schreibe Commit-Graph in %d Durchgang"
 msgstr[1] "Schreibe Commit-Graph in %d Durchgängen"
 
-#: commit-graph.c:1923
+#: commit-graph.c:1953
 msgid "unable to open commit-graph chain file"
 msgstr "konnte Commit-Graph Chain-Datei nicht öffnen"
 
-#: commit-graph.c:1939
+#: commit-graph.c:1969
 msgid "failed to rename base commit-graph file"
 msgstr "konnte Basis-Commit-Graph-Datei nicht umbenennen"
 
-#: commit-graph.c:1959
+#: commit-graph.c:1989
 msgid "failed to rename temporary commit-graph file"
 msgstr "konnte temporäre Commit-Graph-Datei nicht umbenennen"
 
-#: commit-graph.c:2092
+#: commit-graph.c:2122
 msgid "Scanning merged commits"
 msgstr "Durchsuche zusammengeführte Commits"
 
-#: commit-graph.c:2136
+#: commit-graph.c:2166
 msgid "Merging commit-graph"
 msgstr "Zusammenführen von Commit-Graph"
 
-#: commit-graph.c:2244
+#: commit-graph.c:2274
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 "versuche einen Commit-Graph zu schreiben, aber 'core.commitGraph' ist "
 "deaktiviert"
 
-#: commit-graph.c:2351
+#: commit-graph.c:2381
 msgid "too many commits to write graph"
 msgstr "zu viele Commits zum Schreiben des Graphen"
 
-#: commit-graph.c:2449
+#: commit-graph.c:2479
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "die Commit-Graph-Datei hat eine falsche Prüfsumme und ist wahrscheinlich "
 "beschädigt"
 
-#: commit-graph.c:2459
+#: commit-graph.c:2489
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "Commit-Graph hat fehlerhafte OID-Reihenfolge: %s dann %s"
 
-#: commit-graph.c:2469 commit-graph.c:2484
+#: commit-graph.c:2499 commit-graph.c:2514
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr "Commit-Graph hat fehlerhaften Fanout-Wert: fanout[%d] = %u != %u"
 
-#: commit-graph.c:2476
+#: commit-graph.c:2506
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "konnte Commit %s von Commit-Graph nicht parsen"
 
-#: commit-graph.c:2494
+#: commit-graph.c:2524
 msgid "Verifying commits in commit graph"
 msgstr "Commit in Commit-Graph überprüfen"
 
-#: commit-graph.c:2509
+#: commit-graph.c:2539
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "Fehler beim Parsen des Commits %s von Objekt-Datenbank für Commit-Graph"
 
-#: commit-graph.c:2516
+#: commit-graph.c:2546
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 "OID des Wurzelverzeichnisses für Commit %s in Commit-Graph ist %s != %s"
 
-#: commit-graph.c:2526
+#: commit-graph.c:2556
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr "Commit-Graph Vorgänger-Liste für Commit %s ist zu lang"
 
-#: commit-graph.c:2535
+#: commit-graph.c:2565
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "Commit-Graph-Vorgänger für %s ist %s != %s"
 
-#: commit-graph.c:2549
+#: commit-graph.c:2579
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr "Commit-Graph Vorgänger-Liste für Commit %s endet zu früh"
 
-#: commit-graph.c:2554
+#: commit-graph.c:2584
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2425,7 +2428,7 @@ msgstr ""
 "Commit-Graph hat Generationsnummer null für Commit %s, aber sonst ungleich "
 "null"
 
-#: commit-graph.c:2558
+#: commit-graph.c:2588
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2433,29 +2436,29 @@ msgstr ""
 "Commit-Graph hat Generationsnummer ungleich null für Commit %s, aber sonst "
 "null"
 
-#: commit-graph.c:2575
+#: commit-graph.c:2605
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr "Commit-Graph Erstellung für Commit %s ist %<PRIuMAX> < %<PRIuMAX>"
 
-#: commit-graph.c:2581
+#: commit-graph.c:2611
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 "Commit-Datum für Commit %s in Commit-Graph ist %<PRIuMAX> != %<PRIuMAX>"
 
-#: commit.c:52 sequencer.c:3088 builtin/am.c:372 builtin/am.c:417
-#: builtin/am.c:422 builtin/am.c:1420 builtin/am.c:2067 builtin/replace.c:457
+#: commit.c:53 sequencer.c:3107 builtin/am.c:373 builtin/am.c:418
+#: builtin/am.c:423 builtin/am.c:1421 builtin/am.c:2068 builtin/replace.c:457
 #, c-format
 msgid "could not parse %s"
 msgstr "konnte %s nicht parsen"
 
-#: commit.c:54
+#: commit.c:55
 #, c-format
 msgid "%s %s is not a commit!"
 msgstr "%s %s ist kein Commit!"
 
-#: commit.c:194
+#: commit.c:196
 msgid ""
 "Support for <GIT_DIR>/info/grafts is deprecated\n"
 "and will be removed in a future Git version.\n"
@@ -2476,28 +2479,28 @@ msgstr ""
 "Sie können diese Meldung unterdrücken, indem Sie\n"
 "\"git config advice.graftFileDeprecated false\" ausführen."
 
-#: commit.c:1237
+#: commit.c:1239
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
 msgstr ""
 "Commit %s hat eine nicht vertrauenswürdige GPG-Signatur, angeblich von %s."
 
-#: commit.c:1241
+#: commit.c:1243
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
 msgstr "Commit %s hat eine ungültige GPG-Signatur, angeblich von %s."
 
-#: commit.c:1244
+#: commit.c:1246
 #, c-format
 msgid "Commit %s does not have a GPG signature."
 msgstr "Commit %s hat keine GPG-Signatur."
 
-#: commit.c:1247
+#: commit.c:1249
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
 msgstr "Commit %s hat eine gültige GPG-Signatur von %s\n"
 
-#: commit.c:1501
+#: commit.c:1503
 msgid ""
 "Warning: commit message did not conform to UTF-8.\n"
 "You may want to amend it after fixing the message, or set the config\n"
@@ -2513,7 +2516,7 @@ msgstr ""
 msgid "memory exhausted"
 msgstr "Speicher verbraucht"
 
-#: config.c:126
+#: config.c:125
 #, c-format
 msgid ""
 "exceeded maximum include depth (%d) while including\n"
@@ -2529,38 +2532,38 @@ msgstr ""
 "überschritten.\n"
 "Das könnte durch zirkulare Includes entstanden sein."
 
-#: config.c:142
+#: config.c:141
 #, c-format
 msgid "could not expand include path '%s'"
 msgstr "Konnte Include-Pfad '%s' nicht erweitern."
 
-#: config.c:153
+#: config.c:152
 msgid "relative config includes must come from files"
 msgstr "Relative Includes von Konfigurationen müssen aus Dateien kommen."
 
-#: config.c:199
+#: config.c:201
 msgid "relative config include conditionals must come from files"
 msgstr ""
 "Bedingungen für das Einbinden von Konfigurationen aus relativen Pfaden "
 "müssen\n"
 "aus Dateien kommen."
 
-#: config.c:396
+#: config.c:398
 #, c-format
 msgid "invalid config format: %s"
 msgstr "ungültiges Konfigurationsformat: %s"
 
-#: config.c:400
+#: config.c:402
 #, c-format
 msgid "missing environment variable name for configuration '%.*s'"
 msgstr "fehlender Name der Umgebungsvariable für Konfiguration '%.*s'"
 
-#: config.c:405
+#: config.c:407
 #, c-format
 msgid "missing environment variable '%s' for configuration '%.*s'"
 msgstr "fehlende Umgebungsvariable '%s' für Konfiguration '%.*s'"
 
-#: config.c:442
+#: config.c:443
 #, c-format
 msgid "key does not contain a section: %s"
 msgstr "Schlüssel enthält keine Sektion: %s"
@@ -2570,309 +2573,309 @@ msgstr "Schlüssel enthält keine Sektion: %s"
 msgid "key does not contain variable name: %s"
 msgstr "Schlüssel enthält keinen Variablennamen: %s"
 
-#: config.c:472 sequencer.c:2785
+#: config.c:470 sequencer.c:2804
 #, c-format
 msgid "invalid key: %s"
 msgstr "Ungültiger Schlüssel: %s"
 
-#: config.c:478
+#: config.c:475
 #, c-format
 msgid "invalid key (newline): %s"
 msgstr "Ungültiger Schlüssel (neue Zeile): %s"
 
-#: config.c:511
+#: config.c:495
 msgid "empty config key"
 msgstr "leerer Konfigurationsschlüssel"
 
-#: config.c:529 config.c:541
+#: config.c:513 config.c:525
 #, c-format
 msgid "bogus config parameter: %s"
 msgstr "Fehlerhafter Konfigurationsparameter: %s"
 
-#: config.c:555 config.c:572 config.c:579 config.c:588
+#: config.c:539 config.c:556 config.c:563 config.c:572
 #, c-format
 msgid "bogus format in %s"
 msgstr "Fehlerhaftes Format in %s"
 
-#: config.c:622
+#: config.c:606
 #, c-format
 msgid "bogus count in %s"
 msgstr "falsche Zählung in %s"
 
-#: config.c:626
+#: config.c:610
 #, c-format
 msgid "too many entries in %s"
 msgstr "zu viele Einträge in %s"
 
-#: config.c:636
+#: config.c:620
 #, c-format
 msgid "missing config key %s"
 msgstr "fehlender Konfigurationsschlüssel %s"
 
-#: config.c:644
+#: config.c:628
 #, c-format
 msgid "missing config value %s"
 msgstr "fehlender Konfigurationswert %s"
 
-#: config.c:995
+#: config.c:979
 #, c-format
 msgid "bad config line %d in blob %s"
 msgstr "Ungültige Konfigurationszeile %d in Blob %s"
 
-#: config.c:999
+#: config.c:983
 #, c-format
 msgid "bad config line %d in file %s"
 msgstr "Ungültige Konfigurationszeile %d in Datei %s"
 
-#: config.c:1003
+#: config.c:987
 #, c-format
 msgid "bad config line %d in standard input"
 msgstr "Ungültige Konfigurationszeile %d in Standard-Eingabe"
 
-#: config.c:1007
+#: config.c:991
 #, c-format
 msgid "bad config line %d in submodule-blob %s"
 msgstr "Ungültige Konfigurationszeile %d in Submodul-Blob %s"
 
-#: config.c:1011
+#: config.c:995
 #, c-format
 msgid "bad config line %d in command line %s"
 msgstr "Ungültige Konfigurationszeile %d in Kommandozeile %s"
 
-#: config.c:1015
+#: config.c:999
 #, c-format
 msgid "bad config line %d in %s"
 msgstr "Ungültige Konfigurationszeile %d in %s"
 
-#: config.c:1152
+#: config.c:1136
 msgid "out of range"
 msgstr "Außerhalb des Bereichs"
 
-#: config.c:1152
+#: config.c:1136
 msgid "invalid unit"
 msgstr "Ungültige Einheit"
 
-#: config.c:1153
+#: config.c:1137
 #, c-format
 msgid "bad numeric config value '%s' for '%s': %s"
 msgstr "Ungültiger numerischer Wert '%s' für Konfiguration '%s': %s"
 
-#: config.c:1163
+#: config.c:1147
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in blob %s: %s"
 msgstr "Ungültiger numerischer Wert '%s' für Konfiguration '%s' in Blob %s: %s"
 
-#: config.c:1166
+#: config.c:1150
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in file %s: %s"
 msgstr ""
 "Ungültiger numerischer Wert '%s' für Konfiguration '%s' in Datei %s: %s"
 
-#: config.c:1169
+#: config.c:1153
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in standard input: %s"
 msgstr ""
 "Ungültiger numerischer Wert '%s' für Konfiguration '%s' in Standard-Eingabe: "
 "%s"
 
-#: config.c:1172
+#: config.c:1156
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in submodule-blob %s: %s"
 msgstr ""
 "Ungültiger numerischer Wert '%s' für Konfiguration '%s' in Submodul-Blob %s: "
 "%s"
 
-#: config.c:1175
+#: config.c:1159
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in command line %s: %s"
 msgstr ""
 "Ungültiger numerischer Wert '%s' für Konfiguration '%s' in Befehlszeile %s: "
 "%s"
 
-#: config.c:1178
+#: config.c:1162
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in %s: %s"
 msgstr "Ungültiger numerischer Wert '%s' für Konfiguration '%s' in %s: %s"
 
-#: config.c:1257
+#: config.c:1241
 #, c-format
 msgid "bad boolean config value '%s' for '%s'"
 msgstr "ungültiger boolescher Konfigurationswert '%s' für '%s'"
 
-#: config.c:1275
+#: config.c:1259
 #, c-format
 msgid "failed to expand user dir in: '%s'"
 msgstr "Fehler beim Erweitern des Nutzerverzeichnisses in: '%s'"
 
-#: config.c:1284
+#: config.c:1268
 #, c-format
 msgid "'%s' for '%s' is not a valid timestamp"
 msgstr "'%s' ist kein gültiger Zeitstempel für '%s'"
 
-#: config.c:1377
+#: config.c:1361
 #, c-format
 msgid "abbrev length out of range: %d"
 msgstr "Länge für Abkürzung von Commit-IDs außerhalb des Bereichs: %d"
 
-#: config.c:1391 config.c:1402
+#: config.c:1375 config.c:1386
 #, c-format
 msgid "bad zlib compression level %d"
 msgstr "ungültiger zlib Komprimierungsgrad %d"
 
-#: config.c:1494
+#: config.c:1476
 msgid "core.commentChar should only be one character"
 msgstr "core.commentChar sollte nur ein Zeichen sein"
 
-#: config.c:1527
+#: config.c:1509
 #, c-format
 msgid "invalid mode for object creation: %s"
 msgstr "Ungültiger Modus für Objekterstellung: %s"
 
-#: config.c:1599
+#: config.c:1581
 #, c-format
 msgid "malformed value for %s"
 msgstr "Ungültiger Wert für %s."
 
-#: config.c:1625
+#: config.c:1607
 #, c-format
 msgid "malformed value for %s: %s"
 msgstr "Ungültiger Wert für %s: %s"
 
-#: config.c:1626
+#: config.c:1608
 msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr ""
 "Muss einer von diesen sein: nothing, matching, simple, upstream, current"
 
-#: config.c:1687 builtin/pack-objects.c:4084
+#: config.c:1669 builtin/pack-objects.c:4053
 #, c-format
 msgid "bad pack compression level %d"
 msgstr "ungültiger Komprimierungsgrad (%d) für Paketierung"
 
-#: config.c:1809
+#: config.c:1792
 #, c-format
 msgid "unable to load config blob object '%s'"
 msgstr "Konnte Blob-Objekt '%s' für Konfiguration nicht laden."
 
-#: config.c:1812
+#: config.c:1795
 #, c-format
 msgid "reference '%s' does not point to a blob"
 msgstr "Referenz '%s' zeigt auf keinen Blob."
 
-#: config.c:1829
+#: config.c:1813
 #, c-format
 msgid "unable to resolve config blob '%s'"
 msgstr "Konnte Blob '%s' für Konfiguration nicht auflösen."
 
-#: config.c:1874
+#: config.c:1858
 #, c-format
 msgid "failed to parse %s"
 msgstr "Fehler beim Parsen von %s."
 
-#: config.c:1930
+#: config.c:1914
 msgid "unable to parse command-line config"
 msgstr ""
 "Konnte die über die Befehlszeile angegebene Konfiguration nicht parsen."
 
-#: config.c:2294
+#: config.c:2282
 msgid "unknown error occurred while reading the configuration files"
 msgstr ""
 "Es trat ein unbekannter Fehler beim Lesen der Konfigurationsdateien auf."
 
-#: config.c:2468
+#: config.c:2456
 #, c-format
 msgid "Invalid %s: '%s'"
 msgstr "Ungültiger %s: '%s'"
 
-#: config.c:2513
+#: config.c:2501
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
 msgstr ""
 "Der Wert '%d' von splitIndex.maxPercentChange sollte zwischen 0 und 100 "
 "liegen."
 
-#: config.c:2559
+#: config.c:2547
 #, c-format
 msgid "unable to parse '%s' from command-line config"
 msgstr ""
 "Konnte Wert '%s' aus der über die Befehlszeile angegebenen Konfiguration\n"
 "nicht parsen."
 
-#: config.c:2561
+#: config.c:2549
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
 msgstr "ungültige Konfigurationsvariable '%s' in Datei '%s' bei Zeile %d"
 
-#: config.c:2645
+#: config.c:2633
 #, c-format
 msgid "invalid section name '%s'"
 msgstr "Ungültiger Sektionsname '%s'"
 
-#: config.c:2677
+#: config.c:2665
 #, c-format
 msgid "%s has multiple values"
 msgstr "%s hat mehrere Werte"
 
-#: config.c:2706
+#: config.c:2694
 #, c-format
 msgid "failed to write new configuration file %s"
 msgstr "Konnte neue Konfigurationsdatei '%s' nicht schreiben."
 
-#: config.c:2958 config.c:3285
+#: config.c:2946 config.c:3273
 #, c-format
 msgid "could not lock config file %s"
 msgstr "Konnte Konfigurationsdatei '%s' nicht sperren."
 
-#: config.c:2969
+#: config.c:2957
 #, c-format
 msgid "opening %s"
 msgstr "Öffne %s"
 
-#: config.c:3006 builtin/config.c:361
+#: config.c:2994 builtin/config.c:361
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "Ungültiges Muster: %s"
 
-#: config.c:3031
+#: config.c:3019
 #, c-format
 msgid "invalid config file %s"
 msgstr "Ungültige Konfigurationsdatei %s"
 
-#: config.c:3044 config.c:3298
+#: config.c:3032 config.c:3286
 #, c-format
 msgid "fstat on %s failed"
 msgstr "fstat auf %s fehlgeschlagen"
 
-#: config.c:3055
+#: config.c:3043
 #, c-format
 msgid "unable to mmap '%s'%s"
 msgstr "mmap für '%s'(%s) fehlgeschlagen"
 
-#: config.c:3065 config.c:3303
+#: config.c:3053 config.c:3291
 #, c-format
 msgid "chmod on %s failed"
 msgstr "chmod auf %s fehlgeschlagen"
 
-#: config.c:3150 config.c:3400
+#: config.c:3138 config.c:3388
 #, c-format
 msgid "could not write config file %s"
 msgstr "Konnte Konfigurationsdatei %s nicht schreiben."
 
-#: config.c:3184
+#: config.c:3172
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "Konnte '%s' nicht zu '%s' setzen."
 
-#: config.c:3186 builtin/remote.c:657 builtin/remote.c:855 builtin/remote.c:863
+#: config.c:3174 builtin/remote.c:662 builtin/remote.c:860 builtin/remote.c:868
 #, c-format
 msgid "could not unset '%s'"
 msgstr "Konnte '%s' nicht aufheben."
 
-#: config.c:3276
+#: config.c:3264
 #, c-format
 msgid "invalid section name: %s"
 msgstr "Ungültiger Sektionsname: %s"
 
-#: config.c:3443
+#: config.c:3431
 #, c-format
 msgid "missing value for '%s'"
 msgstr "Fehlender Wert für '%s'"
@@ -2908,74 +2911,74 @@ msgstr "Der Server unterstützt das Feature '%s' nicht."
 msgid "expected flush after capabilities"
 msgstr "Erwartete Flush nach Fähigkeiten."
 
-#: connect.c:263
+#: connect.c:265
 #, c-format
 msgid "ignoring capabilities after first line '%s'"
 msgstr "Ignoriere Fähigkeiten nach der ersten Zeile '%s'."
 
-#: connect.c:284
+#: connect.c:286
 msgid "protocol error: unexpected capabilities^{}"
 msgstr "Protokollfehler: unerwartetes capabilities^{}"
 
-#: connect.c:306
+#: connect.c:308
 #, c-format
 msgid "protocol error: expected shallow sha-1, got '%s'"
 msgstr "Protokollfehler: shallow SHA-1 erwartet, '%s' bekommen"
 
-#: connect.c:308
+#: connect.c:310
 msgid "repository on the other end cannot be shallow"
 msgstr ""
 "Repository auf der Gegenseite kann keine unvollständige Historie (shallow) "
 "enthalten"
 
-#: connect.c:347
+#: connect.c:349
 msgid "invalid packet"
 msgstr "ungültiges Paket"
 
-#: connect.c:367
+#: connect.c:369
 #, c-format
 msgid "protocol error: unexpected '%s'"
 msgstr "Protokollfehler: unerwartetes '%s'"
 
-#: connect.c:497
+#: connect.c:499
 #, c-format
 msgid "unknown object format '%s' specified by server"
 msgstr "unbekanntes Objekt-Format '%s' vom Server angegeben"
 
-#: connect.c:526
+#: connect.c:528
 #, c-format
 msgid "invalid ls-refs response: %s"
 msgstr "ungültige ls-refs Antwort: %s"
 
-#: connect.c:530
+#: connect.c:532
 msgid "expected flush after ref listing"
 msgstr "Flush nach Auflistung der Referenzen erwartet"
 
-#: connect.c:533
+#: connect.c:535
 msgid "expected response end packet after ref listing"
 msgstr "Antwort-Endpaket nach Auflistung der Referenzen erwartet"
 
-#: connect.c:666
+#: connect.c:670
 #, c-format
 msgid "protocol '%s' is not supported"
 msgstr "Protokoll '%s' wird nicht unterstützt"
 
-#: connect.c:717
+#: connect.c:721
 msgid "unable to set SO_KEEPALIVE on socket"
 msgstr "kann SO_KEEPALIVE bei Socket nicht setzen"
 
-#: connect.c:757 connect.c:820
+#: connect.c:761 connect.c:824
 #, c-format
 msgid "Looking up %s ... "
 msgstr "Suche nach %s ..."
 
-#: connect.c:761
+#: connect.c:765
 #, c-format
 msgid "unable to look up %s (port %s) (%s)"
 msgstr "Fehler bei Suche nach %s (Port %s) (%s)."
 
 #. TRANSLATORS: this is the end of "Looking up %s ... "
-#: connect.c:765 connect.c:836
+#: connect.c:769 connect.c:840
 #, c-format
 msgid ""
 "done.\n"
@@ -2984,7 +2987,7 @@ msgstr ""
 "Fertig.\n"
 "Verbinde nach %s (Port %s) ... "
 
-#: connect.c:787 connect.c:864
+#: connect.c:791 connect.c:868
 #, c-format
 msgid ""
 "unable to connect to %s:\n"
@@ -2994,77 +2997,77 @@ msgstr ""
 "%s"
 
 #. TRANSLATORS: this is the end of "Connecting to %s (port %s) ... "
-#: connect.c:793 connect.c:870
+#: connect.c:797 connect.c:874
 msgid "done."
 msgstr "Fertig."
 
-#: connect.c:824
+#: connect.c:828
 #, c-format
 msgid "unable to look up %s (%s)"
 msgstr "Fehler bei der Suche nach %s (%s)"
 
-#: connect.c:830
+#: connect.c:834
 #, c-format
 msgid "unknown port %s"
 msgstr "Unbekannter Port %s"
 
-#: connect.c:967 connect.c:1299
+#: connect.c:971 connect.c:1303
 #, c-format
 msgid "strange hostname '%s' blocked"
 msgstr "Merkwürdigen Hostnamen '%s' blockiert."
 
-#: connect.c:969
+#: connect.c:973
 #, c-format
 msgid "strange port '%s' blocked"
 msgstr "Merkwürdigen Port '%s' blockiert."
 
-#: connect.c:979
+#: connect.c:983
 #, c-format
 msgid "cannot start proxy %s"
 msgstr "Kann Proxy %s nicht starten."
 
-#: connect.c:1050
+#: connect.c:1054
 msgid "no path specified; see 'git help pull' for valid url syntax"
 msgstr "kein Pfad angegeben; siehe 'git help pull' für eine gültige URL-Syntax"
 
-#: connect.c:1190
+#: connect.c:1194
 msgid "newline is forbidden in git:// hosts and repo paths"
 msgstr "Zeilenumbruch ist in git:// Hosts und Repository-Pfaden verboten"
 
-#: connect.c:1247
+#: connect.c:1251
 msgid "ssh variant 'simple' does not support -4"
 msgstr "SSH-Variante 'simple' unterstützt kein -4"
 
-#: connect.c:1259
+#: connect.c:1263
 msgid "ssh variant 'simple' does not support -6"
 msgstr "SSH-Variante 'simple' unterstützt kein -6"
 
-#: connect.c:1276
+#: connect.c:1280
 msgid "ssh variant 'simple' does not support setting port"
 msgstr "SSH-Variante 'simple' unterstützt nicht das Setzen eines Ports"
 
-#: connect.c:1388
+#: connect.c:1392
 #, c-format
 msgid "strange pathname '%s' blocked"
 msgstr "Merkwürdigen Pfadnamen '%s' blockiert"
 
-#: connect.c:1436
+#: connect.c:1440
 msgid "unable to fork"
 msgstr "kann Prozess nicht starten"
 
-#: connected.c:108 builtin/fsck.c:189 builtin/prune.c:45
+#: connected.c:109 builtin/fsck.c:189 builtin/prune.c:45
 msgid "Checking connectivity"
 msgstr "Prüfe Konnektivität"
 
-#: connected.c:120
+#: connected.c:122
 msgid "Could not run 'git rev-list'"
 msgstr "Konnte 'git rev-list' nicht ausführen"
 
-#: connected.c:144
+#: connected.c:146
 msgid "failed write to rev-list"
 msgstr "Fehler beim Schreiben nach rev-list"
 
-#: connected.c:149
+#: connected.c:151
 msgid "failed to close rev-list's stdin"
 msgstr "Fehler beim Schließen von rev-lists Standard-Eingabe"
 
@@ -3211,17 +3214,17 @@ msgstr "Weigerung, mit fehlendem Hostnamen in Zugangsdaten zu arbeiten"
 msgid "refusing to work with credential missing protocol field"
 msgstr "Weigerung, mit fehlendem Protokoll in Zugangsdaten zu arbeiten"
 
-#: credential.c:394
+#: credential.c:395
 #, c-format
 msgid "url contains a newline in its %s component: %s"
 msgstr "URL enthält Zeilenumbruch in der %s Komponente: %s"
 
-#: credential.c:438
+#: credential.c:439
 #, c-format
 msgid "url has no scheme: %s"
 msgstr "URL hat kein Schema: %s"
 
-#: credential.c:511
+#: credential.c:512
 #, c-format
 msgid "credential url cannot be parsed: %s"
 msgstr "URL mit Zugangsdaten konnte nicht geparst werden: %s"
@@ -3326,23 +3329,23 @@ msgstr "%d Delta-Islands markiert, fertig.\n"
 msgid "unknown value for --diff-merges: %s"
 msgstr "unbekannter Wert für --diff-merges: %s"
 
-#: diff-lib.c:557
+#: diff-lib.c:561
 msgid "--merge-base does not work with ranges"
 msgstr "--merge-base funktioniert nicht mit Bereichen"
 
-#: diff-lib.c:559
+#: diff-lib.c:563
 msgid "--merge-base only works with commits"
 msgstr "--merge-base funktioniert nur mit Commits"
 
-#: diff-lib.c:576
+#: diff-lib.c:580
 msgid "unable to get HEAD"
 msgstr "konnte HEAD nicht bekommen"
 
-#: diff-lib.c:583
+#: diff-lib.c:587
 msgid "no merge base found"
 msgstr "keine Merge-Basis gefunden"
 
-#: diff-lib.c:585
+#: diff-lib.c:589
 msgid "multiple merge bases found"
 msgstr "mehrere Merge-Basen gefunden"
 
@@ -3358,18 +3361,18 @@ msgstr ""
 "Kein Git-Repository. Nutzen Sie --no-index, um zwei Pfade außerhalb des "
 "Arbeitsverzeichnisses zu vergleichen."
 
-#: diff.c:156
+#: diff.c:157
 #, c-format
 msgid "  Failed to parse dirstat cut-off percentage '%s'\n"
 msgstr ""
 "  Fehler beim Parsen des abgeschnittenen \"dirstat\" Prozentsatzes '%s'\n"
 
-#: diff.c:161
+#: diff.c:162
 #, c-format
 msgid "  Unknown dirstat parameter '%s'\n"
 msgstr "  Unbekannter \"dirstat\" Parameter '%s'\n"
 
-#: diff.c:297
+#: diff.c:298
 msgid ""
 "color moved setting must be one of 'no', 'default', 'blocks', 'zebra', "
 "'dimmed-zebra', 'plain'"
@@ -3377,7 +3380,7 @@ msgstr ""
 "\"color moved\"-Einstellung muss eines von diesen sein: 'no', 'default', "
 "'blocks', 'zebra', 'dimmed-zebra', 'plain'"
 
-#: diff.c:325
+#: diff.c:326
 #, c-format
 msgid ""
 "unknown color-moved-ws mode '%s', possible values are 'ignore-space-change', "
@@ -3386,7 +3389,7 @@ msgstr ""
 "Unbekannter color-moved-ws Modus '%s', mögliche Werte sind 'ignore-space-"
 "change', 'ignore-space-at-eol', 'ignore-all-space', 'allow-identation-change'"
 
-#: diff.c:333
+#: diff.c:334
 msgid ""
 "color-moved-ws: allow-indentation-change cannot be combined with other "
 "whitespace modes"
@@ -3394,12 +3397,12 @@ msgstr ""
 "color-moved-ws: allow-indentation-change kann nicht mit anderen\n"
 "Whitespace-Modi kombiniert werden."
 
-#: diff.c:410
+#: diff.c:411
 #, c-format
 msgid "Unknown value for 'diff.submodule' config variable: '%s'"
 msgstr "Unbekannter Wert in Konfigurationsvariable 'diff.submodule': '%s'"
 
-#: diff.c:470
+#: diff.c:471
 #, c-format
 msgid ""
 "Found errors in 'diff.dirstat' config variable:\n"
@@ -3408,28 +3411,28 @@ msgstr ""
 "Fehler in 'diff.dirstat' Konfigurationsvariable gefunden:\n"
 "%s"
 
-#: diff.c:4282
+#: diff.c:4290
 #, c-format
 msgid "external diff died, stopping at %s"
 msgstr "externes Diff-Programm unerwartet beendet, angehalten bei %s"
 
-#: diff.c:4634
+#: diff.c:4642
 msgid "--name-only, --name-status, --check and -s are mutually exclusive"
 msgstr ""
 "--name-only, --name-status, --check und -s schließen sich gegenseitig aus"
 
-#: diff.c:4637
+#: diff.c:4645
 msgid "-G, -S and --find-object are mutually exclusive"
 msgstr "-G, -S und --find-object schließen sich gegenseitig aus"
 
-#: diff.c:4640
+#: diff.c:4648
 msgid ""
 "-G and --pickaxe-regex are mutually exclusive, use --pickaxe-regex with -S"
 msgstr ""
 "-G und --pickaxe-regex schließen sich gegenseitig aus. Benutzen Sie\n"
 "--pickaxe-regex mit -S."
 
-#: diff.c:4643
+#: diff.c:4651
 msgid ""
 "--pickaxe-all and --find-object are mutually exclusive, use --pickaxe-all "
 "with -G and -S"
@@ -3437,22 +3440,22 @@ msgstr ""
 "--pickaxe-all und --find-object schließen sich gegenseitig aus. Benutzen\n"
 "Sie --pickaxe-all mit -G und -S."
 
-#: diff.c:4722
+#: diff.c:4730
 msgid "--follow requires exactly one pathspec"
 msgstr "--follow erfordert genau eine Pfadspezifikation"
 
-#: diff.c:4770
+#: diff.c:4778
 #, c-format
 msgid "invalid --stat value: %s"
 msgstr "Ungültiger --stat Wert: %s"
 
-#: diff.c:4775 diff.c:4780 diff.c:4785 diff.c:4790 diff.c:5318
-#: parse-options.c:197 parse-options.c:201 builtin/commit-graph.c:180
+#: diff.c:4783 diff.c:4788 diff.c:4793 diff.c:4798 diff.c:5326
+#: parse-options.c:217 parse-options.c:221
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "%s erwartet einen numerischen Wert."
 
-#: diff.c:4807
+#: diff.c:4815
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -3461,42 +3464,42 @@ msgstr ""
 "Fehler beim Parsen des --dirstat/-X Optionsparameters:\n"
 "%s"
 
-#: diff.c:4892
+#: diff.c:4900
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
 msgstr "unbekannte Änderungsklasse '%c' in --diff-filter=%s"
 
-#: diff.c:4916
+#: diff.c:4924
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
 msgstr "unbekannter Wert nach ws-error-highlight=%.*s"
 
-#: diff.c:4930
+#: diff.c:4938
 #, c-format
 msgid "unable to resolve '%s'"
 msgstr "konnte '%s' nicht auflösen"
 
-#: diff.c:4980 diff.c:4986
+#: diff.c:4988 diff.c:4994
 #, c-format
 msgid "%s expects <n>/<m> form"
 msgstr "%s erwartet die Form <n>/<m>"
 
-#: diff.c:4998
+#: diff.c:5006
 #, c-format
 msgid "%s expects a character, got '%s'"
 msgstr "%s erwartet ein Zeichen, '%s' bekommen"
 
-#: diff.c:5019
+#: diff.c:5027
 #, c-format
 msgid "bad --color-moved argument: %s"
 msgstr "ungültiges --color-moved Argument: %s"
 
-#: diff.c:5038
+#: diff.c:5046
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
 msgstr "ungültiger Modus '%s' in --color-moved-ws"
 
-#: diff.c:5078
+#: diff.c:5086
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
@@ -3504,157 +3507,157 @@ msgstr ""
 "Option diff-algorithm akzeptiert: \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
 
-#: diff.c:5114 diff.c:5134
+#: diff.c:5122 diff.c:5142
 #, c-format
 msgid "invalid argument to %s"
 msgstr "ungültiges Argument für %s"
 
-#: diff.c:5238
+#: diff.c:5246
 #, c-format
 msgid "invalid regex given to -I: '%s'"
 msgstr "ungültiger regulärer Ausdruck für -I gegeben: '%s'"
 
-#: diff.c:5287
+#: diff.c:5295
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
 msgstr "Fehler beim Parsen des --submodule Optionsparameters: '%s'"
 
-#: diff.c:5343
+#: diff.c:5351
 #, c-format
 msgid "bad --word-diff argument: %s"
 msgstr "ungültiges --word-diff Argument: %s"
 
-#: diff.c:5379
+#: diff.c:5387
 msgid "Diff output format options"
 msgstr "Diff-Optionen zu Ausgabeformaten"
 
-#: diff.c:5381 diff.c:5387
+#: diff.c:5389 diff.c:5395
 msgid "generate patch"
 msgstr "Patch erzeugen"
 
-#: diff.c:5384 builtin/log.c:179
+#: diff.c:5392 builtin/log.c:179
 msgid "suppress diff output"
 msgstr "Ausgabe der Unterschiede unterdrücken"
 
-#: diff.c:5389 diff.c:5503 diff.c:5510
+#: diff.c:5397 diff.c:5511 diff.c:5518
 msgid "<n>"
 msgstr "<n>"
 
-#: diff.c:5390 diff.c:5393
+#: diff.c:5398 diff.c:5401
 msgid "generate diffs with <n> lines context"
 msgstr "Unterschiede mit <n> Zeilen des Kontextes erstellen"
 
-#: diff.c:5395
+#: diff.c:5403
 msgid "generate the diff in raw format"
 msgstr "Unterschiede im Rohformat erstellen"
 
-#: diff.c:5398
+#: diff.c:5406
 msgid "synonym for '-p --raw'"
 msgstr "Synonym für '-p --raw'"
 
-#: diff.c:5402
+#: diff.c:5410
 msgid "synonym for '-p --stat'"
 msgstr "Synonym für '-p --stat'"
 
-#: diff.c:5406
+#: diff.c:5414
 msgid "machine friendly --stat"
 msgstr "maschinenlesbare Ausgabe von --stat"
 
-#: diff.c:5409
+#: diff.c:5417
 msgid "output only the last line of --stat"
 msgstr "nur die letzte Zeile von --stat ausgeben"
 
-#: diff.c:5411 diff.c:5419
+#: diff.c:5419 diff.c:5427
 msgid "<param1,param2>..."
 msgstr "<Parameter1,Parameter2>..."
 
-#: diff.c:5412
+#: diff.c:5420
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr ""
 "die Verteilung des relativen Umfangs der Änderungen für jedes "
 "Unterverzeichnis ausgeben"
 
-#: diff.c:5416
+#: diff.c:5424
 msgid "synonym for --dirstat=cumulative"
 msgstr "Synonym für --dirstat=cumulative"
 
-#: diff.c:5420
+#: diff.c:5428
 msgid "synonym for --dirstat=files,param1,param2..."
 msgstr "Synonym für --dirstat=files,Parameter1,Parameter2..."
 
-#: diff.c:5424
+#: diff.c:5432
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
 "warnen, wenn Änderungen Konfliktmarker oder Whitespace-Fehler einbringen"
 
-#: diff.c:5427
+#: diff.c:5435
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr ""
 "gekürzte Zusammenfassung, wie z.B. Erstellungen, Umbenennungen und "
 "Änderungen der Datei-Rechte"
 
-#: diff.c:5430
+#: diff.c:5438
 msgid "show only names of changed files"
 msgstr "nur Dateinamen der geänderten Dateien anzeigen"
 
-#: diff.c:5433
+#: diff.c:5441
 msgid "show only names and status of changed files"
 msgstr "nur Dateinamen und Status der geänderten Dateien anzeigen"
 
-#: diff.c:5435
+#: diff.c:5443
 msgid "<width>[,<name-width>[,<count>]]"
 msgstr "<Breite>[,<Namens-Breite>[,<Anzahl>]]"
 
-#: diff.c:5436
+#: diff.c:5444
 msgid "generate diffstat"
 msgstr "Zusammenfassung der Unterschiede erzeugen"
 
-#: diff.c:5438 diff.c:5441 diff.c:5444
+#: diff.c:5446 diff.c:5449 diff.c:5452
 msgid "<width>"
 msgstr "<Breite>"
 
-#: diff.c:5439
+#: diff.c:5447
 msgid "generate diffstat with a given width"
 msgstr "Zusammenfassung der Unterschiede mit gegebener Breite erzeugen"
 
-#: diff.c:5442
+#: diff.c:5450
 msgid "generate diffstat with a given name width"
 msgstr "Zusammenfassung der Unterschiede mit gegebener Namens-Breite erzeugen"
 
-#: diff.c:5445
+#: diff.c:5453
 msgid "generate diffstat with a given graph width"
 msgstr "Zusammenfassung der Unterschiede mit gegebener Graph-Breite erzeugen"
 
-#: diff.c:5447
+#: diff.c:5455
 msgid "<count>"
 msgstr "<Anzahl>"
 
-#: diff.c:5448
+#: diff.c:5456
 msgid "generate diffstat with limited lines"
 msgstr "Zusammenfassung der Unterschiede mit begrenzten Zeilen erzeugen"
 
-#: diff.c:5451
+#: diff.c:5459
 msgid "generate compact summary in diffstat"
 msgstr "kompakte Zusammenstellung in Zusammenfassung der Unterschiede erzeugen"
 
-#: diff.c:5454
+#: diff.c:5462
 msgid "output a binary diff that can be applied"
 msgstr "eine binäre Differenz ausgeben, dass angewendet werden kann"
 
-#: diff.c:5457
+#: diff.c:5465
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr "vollständige Objekt-Namen in den \"index\"-Zeilen anzeigen"
 
-#: diff.c:5459
+#: diff.c:5467
 msgid "show colored diff"
 msgstr "farbige Unterschiede anzeigen"
 
-#: diff.c:5460
+#: diff.c:5468
 msgid "<kind>"
 msgstr "<Art>"
 
-#: diff.c:5461
+#: diff.c:5469
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
@@ -3662,7 +3665,7 @@ msgstr ""
 "Whitespace-Fehler in den Zeilen 'context', 'old' oder 'new' bei den "
 "Unterschieden hervorheben"
 
-#: diff.c:5464
+#: diff.c:5472
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
@@ -3670,91 +3673,91 @@ msgstr ""
 "die Pfadnamen nicht verschleiern und NUL-Zeichen als Schlusszeichen in "
 "Ausgabefeldern bei --raw oder --numstat nutzen"
 
-#: diff.c:5467 diff.c:5470 diff.c:5473 diff.c:5582
+#: diff.c:5475 diff.c:5478 diff.c:5481 diff.c:5590
 msgid "<prefix>"
 msgstr "<Präfix>"
 
-#: diff.c:5468
+#: diff.c:5476
 msgid "show the given source prefix instead of \"a/\""
 msgstr "den gegebenen Quell-Präfix statt \"a/\" anzeigen"
 
-#: diff.c:5471
+#: diff.c:5479
 msgid "show the given destination prefix instead of \"b/\""
 msgstr "den gegebenen Ziel-Präfix statt \"b/\" anzeigen"
 
-#: diff.c:5474
+#: diff.c:5482
 msgid "prepend an additional prefix to every line of output"
 msgstr "einen zusätzlichen Präfix bei jeder Ausgabezeile voranstellen"
 
-#: diff.c:5477
+#: diff.c:5485
 msgid "do not show any source or destination prefix"
 msgstr "keine Quell- oder Ziel-Präfixe anzeigen"
 
-#: diff.c:5480
+#: diff.c:5488
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
 "Kontext zwischen Unterschied-Blöcken bis zur angegebenen Anzahl von Zeilen "
 "anzeigen"
 
-#: diff.c:5484 diff.c:5489 diff.c:5494
+#: diff.c:5492 diff.c:5497 diff.c:5502
 msgid "<char>"
 msgstr "<Zeichen>"
 
-#: diff.c:5485
+#: diff.c:5493
 msgid "specify the character to indicate a new line instead of '+'"
 msgstr "das Zeichen festlegen, das eine neue Zeile kennzeichnet (statt '+')"
 
-#: diff.c:5490
+#: diff.c:5498
 msgid "specify the character to indicate an old line instead of '-'"
 msgstr "das Zeichen festlegen, das eine alte Zeile kennzeichnet (statt '-')"
 
-#: diff.c:5495
+#: diff.c:5503
 msgid "specify the character to indicate a context instead of ' '"
 msgstr "das Zeichen festlegen, das den Kontext kennzeichnet (statt ' ')"
 
-#: diff.c:5498
+#: diff.c:5506
 msgid "Diff rename options"
 msgstr "Diff-Optionen zur Umbenennung"
 
-#: diff.c:5499
+#: diff.c:5507
 msgid "<n>[/<m>]"
 msgstr "<n>[/<m>]"
 
-#: diff.c:5500
+#: diff.c:5508
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr ""
 "teile komplette Rewrite-Änderungen in Änderungen mit \"löschen\" und "
 "\"erstellen\""
 
-#: diff.c:5504
+#: diff.c:5512
 msgid "detect renames"
 msgstr "Umbenennungen erkennen"
 
-#: diff.c:5508
+#: diff.c:5516
 msgid "omit the preimage for deletes"
 msgstr "Preimage für Löschungen weglassen"
 
-#: diff.c:5511
+#: diff.c:5519
 msgid "detect copies"
 msgstr "Kopien erkennen"
 
-#: diff.c:5515
+#: diff.c:5523
 msgid "use unmodified files as source to find copies"
 msgstr "ungeänderte Dateien als Quelle zum Finden von Kopien nutzen"
 
-#: diff.c:5517
+#: diff.c:5525
 msgid "disable rename detection"
 msgstr "Erkennung von Umbenennungen deaktivieren"
 
-#: diff.c:5520
+#: diff.c:5528
 msgid "use empty blobs as rename source"
 msgstr "leere Blobs als Quelle von Umbenennungen nutzen"
 
-#: diff.c:5522
+#: diff.c:5530
 msgid "continue listing the history of a file beyond renames"
 msgstr "Auflistung der Historie einer Datei nach Umbenennung fortführen"
 
-#: diff.c:5525
+#: diff.c:5533
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
@@ -3762,164 +3765,164 @@ msgstr ""
 "Erkennung von Umbenennungen und Kopien verhindern, wenn die Anzahl der Ziele "
 "für Umbenennungen und Kopien das gegebene Limit überschreitet"
 
-#: diff.c:5527
+#: diff.c:5535
 msgid "Diff algorithm options"
 msgstr "Diff Algorithmus-Optionen"
 
-#: diff.c:5529
+#: diff.c:5537
 msgid "produce the smallest possible diff"
 msgstr "die kleinstmöglichen Änderungen erzeugen"
 
-#: diff.c:5532
+#: diff.c:5540
 msgid "ignore whitespace when comparing lines"
 msgstr "Whitespace-Änderungen beim Vergleich von Zeilen ignorieren"
 
-#: diff.c:5535
+#: diff.c:5543
 msgid "ignore changes in amount of whitespace"
 msgstr "Änderungen bei der Anzahl von Whitespace ignorieren"
 
-#: diff.c:5538
+#: diff.c:5546
 msgid "ignore changes in whitespace at EOL"
 msgstr "Whitespace-Änderungen am Zeilenende ignorieren"
 
-#: diff.c:5541
+#: diff.c:5549
 msgid "ignore carrier-return at the end of line"
 msgstr "den Zeilenumbruch am Ende der Zeile ignorieren"
 
-#: diff.c:5544
+#: diff.c:5552
 msgid "ignore changes whose lines are all blank"
 msgstr "Änderungen in leeren Zeilen ignorieren"
 
-#: diff.c:5546 diff.c:5568 diff.c:5571 diff.c:5616
+#: diff.c:5554 diff.c:5576 diff.c:5579 diff.c:5624
 msgid "<regex>"
 msgstr "<Regex>"
 
-#: diff.c:5547
+#: diff.c:5555
 msgid "ignore changes whose all lines match <regex>"
 msgstr ""
 "Änderungen ignorieren, bei denen alle Zeilen mit <Regex> übereinstimmen"
 
-#: diff.c:5550
+#: diff.c:5558
 msgid "heuristic to shift diff hunk boundaries for easy reading"
 msgstr ""
 "Heuristik, um Grenzen der Änderungsblöcke für bessere Lesbarkeit zu "
 "verschieben"
 
-#: diff.c:5553
+#: diff.c:5561
 msgid "generate diff using the \"patience diff\" algorithm"
 msgstr "Änderungen durch Nutzung des Algorithmus \"Patience Diff\" erzeugen"
 
-#: diff.c:5557
+#: diff.c:5565
 msgid "generate diff using the \"histogram diff\" algorithm"
 msgstr "Änderungen durch Nutzung des Algorithmus \"Histogram Diff\" erzeugen"
 
-#: diff.c:5559
+#: diff.c:5567
 msgid "<algorithm>"
 msgstr "<Algorithmus>"
 
-#: diff.c:5560
+#: diff.c:5568
 msgid "choose a diff algorithm"
 msgstr "einen Algorithmus für Änderungen wählen"
 
-#: diff.c:5562
+#: diff.c:5570
 msgid "<text>"
 msgstr "<Text>"
 
-#: diff.c:5563
+#: diff.c:5571
 msgid "generate diff using the \"anchored diff\" algorithm"
 msgstr "Änderungen durch Nutzung des Algorithmus \"Anchored Diff\" erzeugen"
 
-#: diff.c:5565 diff.c:5574 diff.c:5577
+#: diff.c:5573 diff.c:5582 diff.c:5585
 msgid "<mode>"
 msgstr "<Modus>"
 
-#: diff.c:5566
+#: diff.c:5574
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr "Wort-Änderungen zeigen, nutze <Modus>, um Wörter abzugrenzen"
 
-#: diff.c:5569
+#: diff.c:5577
 msgid "use <regex> to decide what a word is"
 msgstr "<Regex> nutzen, um zu entscheiden, was ein Wort ist"
 
-#: diff.c:5572
+#: diff.c:5580
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
 msgstr "entsprechend wie --word-diff=color --word-diff-regex=<Regex>"
 
-#: diff.c:5575
+#: diff.c:5583
 msgid "moved lines of code are colored differently"
 msgstr "verschobene Codezeilen sind andersfarbig"
 
-#: diff.c:5578
+#: diff.c:5586
 msgid "how white spaces are ignored in --color-moved"
 msgstr "wie Whitespaces in --color-moved ignoriert werden"
 
-#: diff.c:5581
+#: diff.c:5589
 msgid "Other diff options"
 msgstr "Andere Diff-Optionen"
 
-#: diff.c:5583
+#: diff.c:5591
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
 "wenn vom Unterverzeichnis aufgerufen, schließe Änderungen außerhalb aus und "
 "zeige relative Pfade an"
 
-#: diff.c:5587
+#: diff.c:5595
 msgid "treat all files as text"
 msgstr "alle Dateien als Text behandeln"
 
-#: diff.c:5589
+#: diff.c:5597
 msgid "swap two inputs, reverse the diff"
 msgstr "die beiden Eingaben vertauschen und die Änderungen umkehren"
 
-#: diff.c:5591
+#: diff.c:5599
 msgid "exit with 1 if there were differences, 0 otherwise"
 msgstr ""
 "mit Exit-Status 1 beenden, wenn Änderungen vorhanden sind, andernfalls mit 0"
 
-#: diff.c:5593
+#: diff.c:5601
 msgid "disable all output of the program"
 msgstr "alle Ausgaben vom Programm deaktivieren"
 
-#: diff.c:5595
+#: diff.c:5603
 msgid "allow an external diff helper to be executed"
 msgstr "erlaube die Ausführung eines externes Programms für Änderungen"
 
-#: diff.c:5597
+#: diff.c:5605
 msgid "run external text conversion filters when comparing binary files"
 msgstr ""
 "Führe externe Text-Konvertierungsfilter aus, wenn binäre Dateien vergleicht "
 "werden"
 
-#: diff.c:5599
+#: diff.c:5607
 msgid "<when>"
 msgstr "<wann>"
 
-#: diff.c:5600
+#: diff.c:5608
 msgid "ignore changes to submodules in the diff generation"
 msgstr ""
 "Änderungen in Submodulen während der Erstellung der Unterschiede ignorieren"
 
-#: diff.c:5603
+#: diff.c:5611
 msgid "<format>"
 msgstr "<Format>"
 
-#: diff.c:5604
+#: diff.c:5612
 msgid "specify how differences in submodules are shown"
 msgstr "angeben, wie Unterschiede in Submodulen gezeigt werden"
 
-#: diff.c:5608
+#: diff.c:5616
 msgid "hide 'git add -N' entries from the index"
 msgstr "'git add -N' Einträge vom Index verstecken"
 
-#: diff.c:5611
+#: diff.c:5619
 msgid "treat 'git add -N' entries as real in the index"
 msgstr "'git add -N' Einträge im Index als echt behandeln"
 
-#: diff.c:5613
+#: diff.c:5621
 msgid "<string>"
 msgstr "<Zeichenkette>"
 
-#: diff.c:5614
+#: diff.c:5622
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
@@ -3927,7 +3930,7 @@ msgstr ""
 "nach Unterschieden suchen, welche die Anzahl des Vorkommens der angegebenen "
 "Zeichenkette verändern"
 
-#: diff.c:5617
+#: diff.c:5625
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
@@ -3935,37 +3938,37 @@ msgstr ""
 "nach Unterschieden suchen, welche die Anzahl des Vorkommens des angegebenen "
 "regulären Ausdrucks verändern"
 
-#: diff.c:5620
+#: diff.c:5628
 msgid "show all changes in the changeset with -S or -G"
 msgstr "alle Änderungen im Changeset mit -S oder -G anzeigen"
 
-#: diff.c:5623
+#: diff.c:5631
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr ""
 "<Zeichenkette> bei -S als erweiterten POSIX regulären Ausdruck behandeln"
 
-#: diff.c:5626
+#: diff.c:5634
 msgid "control the order in which files appear in the output"
 msgstr ""
 "die Reihenfolge kontrollieren, in der die Dateien in der Ausgabe erscheinen"
 
-#: diff.c:5627 diff.c:5630
+#: diff.c:5635 diff.c:5638
 msgid "<path>"
 msgstr "<Pfad>"
 
-#: diff.c:5628
+#: diff.c:5636
 msgid "show the change in the specified path first"
 msgstr "die Änderung des angegebenen Pfades zuerst anzeigen"
 
-#: diff.c:5631
+#: diff.c:5639
 msgid "skip the output to the specified path"
 msgstr "überspringe die Ausgabe bis zum angegebenen Pfad"
 
-#: diff.c:5633
+#: diff.c:5641
 msgid "<object-id>"
 msgstr "<Objekt-ID>"
 
-#: diff.c:5634
+#: diff.c:5642
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
@@ -3973,33 +3976,33 @@ msgstr ""
 "nach Unterschieden suchen, welche die Anzahl des Vorkommens des angegebenen "
 "Objektes verändern"
 
-#: diff.c:5636
+#: diff.c:5644
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "[(A|C|D|M|R|T|U|X|B)...[*]]"
 
-#: diff.c:5637
+#: diff.c:5645
 msgid "select files by diff type"
 msgstr "Dateien anhand der Art der Änderung wählen"
 
-#: diff.c:5639
+#: diff.c:5647
 msgid "<file>"
 msgstr "<Datei>"
 
-#: diff.c:5640
+#: diff.c:5648
 msgid "Output to a specific file"
 msgstr "Ausgabe zu einer bestimmten Datei"
 
-#: diff.c:6298
+#: diff.c:6306
 msgid "exhaustive rename detection was skipped due to too many files."
 msgstr ""
 "genaue Erkennung für Umbenennungen wurde aufgrund zu vieler Dateien\n"
 "übersprungen."
 
-#: diff.c:6301
+#: diff.c:6309
 msgid "only found copies from modified paths due to too many files."
 msgstr "nur Kopien von geänderten Pfaden, aufgrund zu vieler Dateien, gefunden"
 
-#: diff.c:6304
+#: diff.c:6312
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
@@ -4012,7 +4015,7 @@ msgstr ""
 msgid "failed to read orderfile '%s'"
 msgstr "Fehler beim Lesen der Reihenfolgedatei '%s'"
 
-#: diffcore-rename.c:1514
+#: diffcore-rename.c:1564
 msgid "Performing inexact rename detection"
 msgstr "Führe Erkennung für ungenaue Umbenennung aus"
 
@@ -4052,341 +4055,412 @@ msgstr "deaktiviere Cone-Muster-Übereinstimmung"
 msgid "cannot use %s as an exclude file"
 msgstr "kann %s nicht als exclude-Filter benutzen"
 
-#: dir.c:2351
+#: dir.c:2464
 #, c-format
 msgid "could not open directory '%s'"
 msgstr "konnte Verzeichnis '%s' nicht öffnen"
 
-#: dir.c:2653
+#: dir.c:2766
 msgid "failed to get kernel name and information"
 msgstr "Fehler beim Sammeln von Namen und Informationen zum Kernel"
 
-#: dir.c:2777
+#: dir.c:2890
 msgid "untracked cache is disabled on this system or location"
 msgstr ""
 "Cache für unversionierte Dateien ist auf diesem System oder\n"
 "für dieses Verzeichnis deaktiviert"
 
-#: dir.c:3610
+#: dir.c:3158
+msgid ""
+"No directory name could be guessed.\n"
+"Please specify a directory on the command line"
+msgstr ""
+"Konnte keinen Verzeichnisnamen erraten.\n"
+"Bitte geben Sie ein Verzeichnis auf der Befehlszeile an."
+
+#: dir.c:3837
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "Index-Datei in Repository %s beschädigt"
 
-#: dir.c:3657 dir.c:3662
+#: dir.c:3884 dir.c:3889
 #, c-format
 msgid "could not create directories for %s"
 msgstr "Konnte Verzeichnisse für '%s' nicht erstellen"
 
-#: dir.c:3691
+#: dir.c:3918
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "Konnte Git-Verzeichnis nicht von '%s' nach '%s' migrieren"
 
-#: editor.c:74
+#: editor.c:77
 #, c-format
 msgid "hint: Waiting for your editor to close the file...%c"
 msgstr "Hinweis: Warte auf das Schließen der Datei durch Ihren Editor...%c"
 
-#: entry.c:176
+#: entry.c:177
 msgid "Filtering content"
 msgstr "Filtere Inhalt"
 
-#: entry.c:497
+#: entry.c:498
 #, c-format
 msgid "could not stat file '%s'"
 msgstr "konnte Datei '%s' nicht lesen"
 
-#: environment.c:152
+#: environment.c:143
 #, c-format
 msgid "bad git namespace path \"%s\""
 msgstr "ungültiger Git-Namespace-Pfad \"%s\""
-
-#: environment.c:334
-#, c-format
-msgid "could not set GIT_DIR to '%s'"
-msgstr "konnte GIT_DIR nicht zu '%s' setzen"
 
 #: exec-cmd.c:363
 #, c-format
 msgid "too many args to run %s"
 msgstr "zu viele Argumente angegeben, um %s auszuführen"
 
-#: fetch-pack.c:182
+#: fetch-pack.c:193
 msgid "git fetch-pack: expected shallow list"
 msgstr "git fetch-pack: erwartete shallow-Liste"
 
-#: fetch-pack.c:185
+#: fetch-pack.c:196
 msgid "git fetch-pack: expected a flush packet after shallow list"
 msgstr "git fetch-pack: erwartete ein Flush-Paket nach der shallow-Liste"
 
-#: fetch-pack.c:196
+#: fetch-pack.c:207
 msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
 msgstr "git fetch-pack: ACK/NAK erwartet, Flush-Paket bekommen"
 
-#: fetch-pack.c:216
+#: fetch-pack.c:227
 #, c-format
 msgid "git fetch-pack: expected ACK/NAK, got '%s'"
 msgstr "git fetch-pack: ACK/NAK erwartet, '%s' bekommen"
 
-#: fetch-pack.c:227
+#: fetch-pack.c:238
 msgid "unable to write to remote"
 msgstr "konnte nicht zum Remote schreiben"
 
-#: fetch-pack.c:288
+#: fetch-pack.c:299
 msgid "--stateless-rpc requires multi_ack_detailed"
 msgstr "--stateless-rpc benötigt multi_ack_detailed"
 
-#: fetch-pack.c:383 fetch-pack.c:1423
+#: fetch-pack.c:394 fetch-pack.c:1434
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "ungültige shallow-Zeile: %s"
 
-#: fetch-pack.c:389 fetch-pack.c:1429
+#: fetch-pack.c:400 fetch-pack.c:1440
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "ungültige unshallow-Zeile: %s"
 
-#: fetch-pack.c:391 fetch-pack.c:1431
+#: fetch-pack.c:402 fetch-pack.c:1442
 #, c-format
 msgid "object not found: %s"
 msgstr "Objekt nicht gefunden: %s"
 
-#: fetch-pack.c:394 fetch-pack.c:1434
+#: fetch-pack.c:405 fetch-pack.c:1445
 #, c-format
 msgid "error in object: %s"
 msgstr "Fehler in Objekt: %s"
 
-#: fetch-pack.c:396 fetch-pack.c:1436
+#: fetch-pack.c:407 fetch-pack.c:1447
 #, c-format
 msgid "no shallow found: %s"
 msgstr "kein shallow-Objekt gefunden: %s"
 
-#: fetch-pack.c:399 fetch-pack.c:1440
+#: fetch-pack.c:410 fetch-pack.c:1451
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "shallow/unshallow erwartet, %s bekommen"
 
-#: fetch-pack.c:439
+#: fetch-pack.c:450
 #, c-format
 msgid "got %s %d %s"
 msgstr "%s %d %s bekommen"
 
-#: fetch-pack.c:456
+#: fetch-pack.c:467
 #, c-format
 msgid "invalid commit %s"
 msgstr "ungültiger Commit %s"
 
-#: fetch-pack.c:487
+#: fetch-pack.c:498
 msgid "giving up"
 msgstr "gebe auf"
 
-#: fetch-pack.c:500 progress.c:339
+#: fetch-pack.c:511 progress.c:339
 msgid "done"
 msgstr "fertig"
 
-#: fetch-pack.c:512
+#: fetch-pack.c:523
 #, c-format
 msgid "got %s (%d) %s"
 msgstr "%s (%d) %s bekommen"
 
-#: fetch-pack.c:548
+#: fetch-pack.c:559
 #, c-format
 msgid "Marking %s as complete"
 msgstr "Markiere %s als vollständig"
 
-#: fetch-pack.c:763
+#: fetch-pack.c:774
 #, c-format
 msgid "already have %s (%s)"
 msgstr "habe %s (%s) bereits"
 
-#: fetch-pack.c:849
+#: fetch-pack.c:860
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-pack: Fehler beim Starten des sideband demultiplexer"
 
-#: fetch-pack.c:857
+#: fetch-pack.c:868
 msgid "protocol error: bad pack header"
 msgstr "Protokollfehler: ungültiger Pack-Header"
 
-#: fetch-pack.c:951
+#: fetch-pack.c:962
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-pack: konnte %s nicht starten"
 
-#: fetch-pack.c:957
+#: fetch-pack.c:968
 msgid "fetch-pack: invalid index-pack output"
 msgstr "fetch-pack: ungültige index-pack Ausgabe"
 
-#: fetch-pack.c:974
+#: fetch-pack.c:985
 #, c-format
 msgid "%s failed"
 msgstr "%s fehlgeschlagen"
 
-#: fetch-pack.c:976
+#: fetch-pack.c:987
 msgid "error in sideband demultiplexer"
 msgstr "Fehler in sideband demultiplexer"
 
-#: fetch-pack.c:1019
+#: fetch-pack.c:1030
 #, c-format
 msgid "Server version is %.*s"
 msgstr "Server-Version ist %.*s"
 
-#: fetch-pack.c:1027 fetch-pack.c:1033 fetch-pack.c:1036 fetch-pack.c:1042
-#: fetch-pack.c:1046 fetch-pack.c:1050 fetch-pack.c:1054 fetch-pack.c:1058
-#: fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070 fetch-pack.c:1074
-#: fetch-pack.c:1080 fetch-pack.c:1086 fetch-pack.c:1091 fetch-pack.c:1096
+#: fetch-pack.c:1038 fetch-pack.c:1044 fetch-pack.c:1047 fetch-pack.c:1053
+#: fetch-pack.c:1057 fetch-pack.c:1061 fetch-pack.c:1065 fetch-pack.c:1069
+#: fetch-pack.c:1073 fetch-pack.c:1077 fetch-pack.c:1081 fetch-pack.c:1085
+#: fetch-pack.c:1091 fetch-pack.c:1097 fetch-pack.c:1102 fetch-pack.c:1107
 #, c-format
 msgid "Server supports %s"
 msgstr "Server unterstützt %s"
 
-#: fetch-pack.c:1029
+#: fetch-pack.c:1040
 msgid "Server does not support shallow clients"
 msgstr "Server unterstützt keine shallow-Clients"
 
-#: fetch-pack.c:1089
+#: fetch-pack.c:1100
 msgid "Server does not support --shallow-since"
 msgstr "Server unterstützt kein --shallow-since"
 
-#: fetch-pack.c:1094
+#: fetch-pack.c:1105
 msgid "Server does not support --shallow-exclude"
 msgstr "Server unterstützt kein --shallow-exclude"
 
-#: fetch-pack.c:1098
+#: fetch-pack.c:1109
 msgid "Server does not support --deepen"
 msgstr "Server unterstützt kein --deepen"
 
-#: fetch-pack.c:1100
+#: fetch-pack.c:1111
 msgid "Server does not support this repository's object format"
 msgstr "Server unterstützt das Objekt-Format dieses Repositories nicht"
 
-#: fetch-pack.c:1113
+#: fetch-pack.c:1124
 msgid "no common commits"
 msgstr "keine gemeinsamen Commits"
 
-#: fetch-pack.c:1122 fetch-pack.c:1469 builtin/clone.c:1238
+#: fetch-pack.c:1133 fetch-pack.c:1480 builtin/clone.c:1130
 msgid "source repository is shallow, reject to clone."
 msgstr ""
 "Quelle ist ein Repository mit unvollständiger Historie (shallow), Klonen "
 "zurückgewiesen."
 
-#: fetch-pack.c:1128 fetch-pack.c:1660
+#: fetch-pack.c:1139 fetch-pack.c:1671
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack: Abholen fehlgeschlagen."
 
-#: fetch-pack.c:1242
+#: fetch-pack.c:1253
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "Algorithmen stimmen nicht überein: Client %s; Server %s"
 
-#: fetch-pack.c:1246
+#: fetch-pack.c:1257
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "der Server unterstützt Algorithmus '%s' nicht"
 
-#: fetch-pack.c:1279
+#: fetch-pack.c:1290
 msgid "Server does not support shallow requests"
 msgstr "Server unterstützt keine shallow-Anfragen"
 
-#: fetch-pack.c:1286
+#: fetch-pack.c:1297
 msgid "Server supports filter"
 msgstr "Server unterstützt Filter"
 
-#: fetch-pack.c:1329 fetch-pack.c:2043
+#: fetch-pack.c:1340 fetch-pack.c:2053
 msgid "unable to write request to remote"
 msgstr "konnte Anfrage nicht zum Remote schreiben"
 
-#: fetch-pack.c:1347
+#: fetch-pack.c:1358
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "Fehler beim Lesen von Sektionskopf '%s'."
 
-#: fetch-pack.c:1353
+#: fetch-pack.c:1364
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "'%s' erwartet, '%s' empfangen"
 
-#: fetch-pack.c:1387
+#: fetch-pack.c:1398
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "Unerwartete Acknowledgment-Zeile: '%s'"
 
-#: fetch-pack.c:1392
+#: fetch-pack.c:1403
 #, c-format
 msgid "error processing acks: %d"
 msgstr "Fehler beim Verarbeiten von ACKS: %d"
 
-#: fetch-pack.c:1402
+#: fetch-pack.c:1413
 msgid "expected packfile to be sent after 'ready'"
 msgstr "Erwartete Versand einer Packdatei nach 'ready'."
 
-#: fetch-pack.c:1404
+#: fetch-pack.c:1415
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr "Erwartete keinen Versand einer anderen Sektion ohne 'ready'."
 
-#: fetch-pack.c:1445
+#: fetch-pack.c:1456
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "Fehler beim Verarbeiten von Shallow-Informationen: %d"
 
-#: fetch-pack.c:1494
+#: fetch-pack.c:1505
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "wanted-ref erwartet, '%s' bekommen"
 
-#: fetch-pack.c:1499
+#: fetch-pack.c:1510
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "unerwartetes wanted-ref: '%s'"
 
-#: fetch-pack.c:1504
+#: fetch-pack.c:1515
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "Fehler beim Verarbeiten von wanted-refs: %d"
 
-#: fetch-pack.c:1534
+#: fetch-pack.c:1545
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: Antwort-Endpaket erwartet"
 
-#: fetch-pack.c:1939
+#: fetch-pack.c:1949
 msgid "no matching remote head"
 msgstr "kein übereinstimmender Remote-Branch"
 
-#: fetch-pack.c:1962 builtin/clone.c:697
+#: fetch-pack.c:1972 builtin/clone.c:581
 msgid "remote did not send all necessary objects"
 msgstr "Remote-Repository hat nicht alle erforderlichen Objekte gesendet"
 
-#: fetch-pack.c:2065
+#: fetch-pack.c:2075
 msgid "unexpected 'ready' from remote"
 msgstr "unerwartetes 'ready' von Remote-Repository"
 
-#: fetch-pack.c:2088
+#: fetch-pack.c:2098
 #, c-format
 msgid "no such remote ref %s"
 msgstr "Remote-Referenz %s nicht gefunden"
 
-#: fetch-pack.c:2091
+#: fetch-pack.c:2101
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Der Server lehnt Anfrage nach nicht angebotenem Objekt %s ab."
 
-#: gpg-interface.c:273
+#: gpg-interface.c:329 gpg-interface.c:451 gpg-interface.c:902
+#: gpg-interface.c:918
 msgid "could not create temporary file"
 msgstr "konnte temporäre Datei nicht erstellen"
 
-#: gpg-interface.c:276
+#: gpg-interface.c:332 gpg-interface.c:454
 #, c-format
 msgid "failed writing detached signature to '%s'"
 msgstr "Fehler beim Schreiben der losgelösten Signatur nach '%s'"
 
-#: gpg-interface.c:470
+#: gpg-interface.c:445
+msgid ""
+"gpg.ssh.allowedSignersFile needs to be configured and exist for ssh "
+"signature verification"
+msgstr ""
+
+#: gpg-interface.c:469
+msgid ""
+"ssh-keygen -Y find-principals/verify is needed for ssh signature "
+"verification (available in openssh version 8.2p1+)"
+msgstr ""
+
+#: gpg-interface.c:523
+#, c-format
+msgid "ssh signing revocation file configured but not found: %s"
+msgstr ""
+
+#: gpg-interface.c:576
+#, fuzzy, c-format
+msgid "bad/incompatible signature '%s'"
+msgstr "%s ist inkompatibel mit %s."
+
+#: gpg-interface.c:735 gpg-interface.c:740
+#, fuzzy, c-format
+msgid "failed to get the ssh fingerprint for key '%s'"
+msgstr "Fehler beim Lesen des Standard-Remote-Repositories für Submodul '%s'"
+
+#: gpg-interface.c:762
+msgid ""
+"either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured"
+msgstr ""
+
+#: gpg-interface.c:780
+#, c-format
+msgid "gpg.ssh.defaultKeyCommand succeeded but returned no keys: %s %s"
+msgstr ""
+
+#: gpg-interface.c:786
+#, c-format
+msgid "gpg.ssh.defaultKeyCommand failed: %s %s"
+msgstr ""
+
+#: gpg-interface.c:874
 msgid "gpg failed to sign the data"
 msgstr "gpg beim Signieren der Daten fehlgeschlagen"
+
+#: gpg-interface.c:895
+msgid "user.signingkey needs to be set for ssh signing"
+msgstr ""
+
+#: gpg-interface.c:906
+#, fuzzy, c-format
+msgid "failed writing ssh signing key to '%s'"
+msgstr "Fehler beim Schreiben der losgelösten Signatur nach '%s'"
+
+#: gpg-interface.c:924
+#, fuzzy, c-format
+msgid "failed writing ssh signing key buffer to '%s'"
+msgstr "Fehler beim Schreiben der losgelösten Signatur nach '%s'"
+
+#: gpg-interface.c:942
+msgid ""
+"ssh-keygen -Y sign is needed for ssh signing (available in openssh version "
+"8.2p1+)"
+msgstr ""
+
+#: gpg-interface.c:954
+#, fuzzy, c-format
+msgid "failed reading ssh signing data buffer from '%s'"
+msgstr "Fehler beim Schreiben der losgelösten Signatur nach '%s'"
 
 #: graph.c:98
 #, c-format
 msgid "ignored invalid color '%.*s' in log.graphColors"
 msgstr "ungültige Farbe '%.*s' in log.graphColors ignoriert"
 
-#: grep.c:531
+#: grep.c:533
 msgid ""
 "given pattern contains NULL byte (via -f <file>). This is only supported "
 "with -P under PCRE v2"
@@ -4394,111 +4468,111 @@ msgstr ""
 "Angegebenes Muster enthält NULL Byte (über -f <Datei>). Das wird nur mit -"
 "Punter PCRE v2 unterstützt."
 
-#: grep.c:1895
+#: grep.c:1928
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr "'%s': konnte %s nicht lesen"
 
-#: grep.c:1912 setup.c:176 builtin/clone.c:416 builtin/diff.c:90
+#: grep.c:1945 setup.c:176 builtin/clone.c:302 builtin/diff.c:90
 #: builtin/rm.c:136
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "Konnte '%s' nicht lesen"
 
-#: grep.c:1923
+#: grep.c:1956
 #, c-format
 msgid "'%s': short read"
 msgstr "'%s': read() zu kurz"
 
-#: help.c:23
+#: help.c:24
 msgid "start a working area (see also: git help tutorial)"
 msgstr "Arbeitsverzeichnis anlegen (siehe auch: git help tutorial)"
 
-#: help.c:24
+#: help.c:25
 msgid "work on the current change (see also: git help everyday)"
 msgstr "an aktuellen Änderungen arbeiten (siehe auch: git help everyday)"
 
-#: help.c:25
+#: help.c:26
 msgid "examine the history and state (see also: git help revisions)"
 msgstr "Historie und Status untersuchen (siehe auch: git help revisions)"
 
-#: help.c:26
+#: help.c:27
 msgid "grow, mark and tweak your common history"
 msgstr "Historie erweitern und bearbeiten"
 
-#: help.c:27
+#: help.c:28
 msgid "collaborate (see also: git help workflows)"
 msgstr "mit anderen zusammenarbeiten (siehe auch: git help workflows)"
 
-#: help.c:31
+#: help.c:32
 msgid "Main Porcelain Commands"
 msgstr "Hauptbefehle"
 
-#: help.c:32
+#: help.c:33
 msgid "Ancillary Commands / Manipulators"
 msgstr "Nebenbefehle / Manipulationen"
 
-#: help.c:33
+#: help.c:34
 msgid "Ancillary Commands / Interrogators"
 msgstr "Nebenbefehle / Abfragen"
 
-#: help.c:34
+#: help.c:35
 msgid "Interacting with Others"
 msgstr "mit anderen interagieren"
 
-#: help.c:35
+#: help.c:36
 msgid "Low-level Commands / Manipulators"
 msgstr "Systembefehle / Manipulationen"
 
-#: help.c:36
+#: help.c:37
 msgid "Low-level Commands / Interrogators"
 msgstr "Systembefehle / Abfragen"
 
-#: help.c:37
+#: help.c:38
 msgid "Low-level Commands / Syncing Repositories"
 msgstr "Systembefehle / Repositories synchronisieren"
 
-#: help.c:38
+#: help.c:39
 msgid "Low-level Commands / Internal Helpers"
 msgstr "Systembefehle / Interne Hilfsbefehle"
 
-#: help.c:300
+#: help.c:313
 #, c-format
 msgid "available git commands in '%s'"
 msgstr "Vorhandene Git-Befehle in '%s'"
 
-#: help.c:307
+#: help.c:320
 msgid "git commands available from elsewhere on your $PATH"
 msgstr "Vorhandene Git-Befehle anderswo in Ihrem $PATH"
 
-#: help.c:316
+#: help.c:329
 msgid "These are common Git commands used in various situations:"
 msgstr "Allgemeine Git-Befehle, verwendet in verschiedenen Situationen:"
 
-#: help.c:365 git.c:100
+#: help.c:378 git.c:100
 #, c-format
 msgid "unsupported command listing type '%s'"
 msgstr "Nicht unterstützte Art zur Befehlsauflistung '%s'."
 
-#: help.c:405
+#: help.c:418
 msgid "The Git concept guides are:"
 msgstr "Die Git-Konzeptanleitungen sind:"
 
-#: help.c:429
+#: help.c:442
 msgid "See 'git help <command>' to read about a specific subcommand"
 msgstr ""
 "Siehe 'git help <Befehl>', um mehr über einen spezifischen Unterbefehl zu "
 "lesen."
 
-#: help.c:434
+#: help.c:447
 msgid "External commands"
 msgstr "Externe Befehle"
 
-#: help.c:449
+#: help.c:462
 msgid "Command aliases"
 msgstr "Alias-Befehle"
 
-#: help.c:527
+#: help.c:543
 #, c-format
 msgid ""
 "'%s' appears to be a git command, but we were not\n"
@@ -4507,32 +4581,37 @@ msgstr ""
 "'%s' scheint ein git-Befehl zu sein, konnte aber\n"
 "nicht ausgeführt werden. Vielleicht ist git-%s fehlerhaft?"
 
-#: help.c:543 help.c:631
+#: help.c:565 help.c:662
 #, c-format
 msgid "git: '%s' is not a git command. See 'git --help'."
 msgstr "git: '%s' ist kein Git-Befehl. Siehe 'git --help'."
 
-#: help.c:591
+#: help.c:613
 msgid "Uh oh. Your system reports no Git commands at all."
 msgstr "Uh oh. Keine Git-Befehle auf Ihrem System vorhanden."
 
-#: help.c:613
+#: help.c:635
 #, c-format
 msgid "WARNING: You called a Git command named '%s', which does not exist."
 msgstr ""
 "WARNUNG: Sie haben Git-Befehl '%s' ausgeführt, welcher nicht existiert."
 
-#: help.c:618
+#: help.c:640
 #, c-format
 msgid "Continuing under the assumption that you meant '%s'."
 msgstr "Setze fort unter der Annahme, dass Sie '%s' meinten."
 
-#: help.c:623
+#: help.c:646
+#, c-format
+msgid "Run '%s' instead? (y/N)"
+msgstr ""
+
+#: help.c:654
 #, c-format
 msgid "Continuing in %0.1f seconds, assuming that you meant '%s'."
 msgstr "Setze in %0.1f Sekunden fort unter der Annahme, dass Sie '%s' meinten."
 
-#: help.c:635
+#: help.c:666
 msgid ""
 "\n"
 "The most similar command is"
@@ -4546,16 +4625,16 @@ msgstr[1] ""
 "\n"
 "Die ähnlichsten Befehle sind"
 
-#: help.c:675
+#: help.c:706
 msgid "git version [<options>]"
 msgstr "git version [<Optionen>]"
 
-#: help.c:730
+#: help.c:761
 #, c-format
 msgid "%s: %s - %s"
 msgstr "%s: %s - %s"
 
-#: help.c:734
+#: help.c:765
 msgid ""
 "\n"
 "Did you mean this?"
@@ -4568,6 +4647,16 @@ msgstr[0] ""
 msgstr[1] ""
 "\n"
 "Haben Sie eines von diesen gemeint?"
+
+#: hook.c:27
+#, c-format
+msgid ""
+"The '%s' hook was ignored because it's not set as executable.\n"
+"You can disable this warning with `git config advice.ignoredHook false`."
+msgstr ""
+"Der '%s' Hook wurde ignoriert, weil er nicht als ausführbar markiert ist.\n"
+"Sie können diese Warnung mit `git config advice.ignoredHook false` "
+"deaktivieren."
 
 #: ident.c:353
 msgid "Author identity unknown\n"
@@ -4631,7 +4720,7 @@ msgstr "Leerer Name in Identifikation (für <%s>) nicht erlaubt."
 msgid "name consists only of disallowed characters: %s"
 msgstr "Name besteht nur aus nicht erlaubten Zeichen: %s"
 
-#: ident.c:454 builtin/commit.c:647
+#: ident.c:454 builtin/commit.c:648
 #, c-format
 msgid "invalid date format: %s"
 msgstr "Ungültiges Datumsformat: %s"
@@ -4729,7 +4818,12 @@ msgstr "Konnte '%s.lock' nicht erstellen: %s"
 msgid "invalid value '%s' for lsrefs.unborn"
 msgstr "ungültiger Wert '%s' für lsrefs.unborn"
 
-#: ls-refs.c:167
+#: ls-refs.c:174
+#, fuzzy, c-format
+msgid "unexpected line: '%s'"
+msgstr "unerwartetes wanted-ref: '%s'"
+
+#: ls-refs.c:178
 msgid "expected flush after ls-refs arguments"
 msgstr "erwartete Flush nach Argumenten für die Auflistung der Referenzen"
 
@@ -4737,37 +4831,37 @@ msgstr "erwartete Flush nach Argumenten für die Auflistung der Referenzen"
 msgid "quoted CRLF detected"
 msgstr "angeführtes CRLF entdeckt"
 
-#: mailinfo.c:1254 builtin/am.c:176 builtin/mailinfo.c:46
+#: mailinfo.c:1254 builtin/am.c:177 builtin/mailinfo.c:46
 #, c-format
 msgid "bad action '%s' for '%s'"
 msgstr "ungültige Aktion '%s' für '%s'"
 
-#: merge-ort.c:1569 merge-recursive.c:1201
+#: merge-ort.c:1584 merge-recursive.c:1211
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
 msgstr "Fehler beim Merge von Submodul %s (nicht ausgecheckt)."
 
-#: merge-ort.c:1578 merge-recursive.c:1208
+#: merge-ort.c:1593 merge-recursive.c:1218
 #, c-format
 msgid "Failed to merge submodule %s (commits not present)"
 msgstr "Fehler beim Merge von Submodul %s (Commits nicht vorhanden)."
 
-#: merge-ort.c:1587 merge-recursive.c:1215
+#: merge-ort.c:1602 merge-recursive.c:1225
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
 msgstr "Fehler beim Merge von Submodul %s (Commits folgen keiner Merge-Basis)"
 
-#: merge-ort.c:1597 merge-ort.c:1604
+#: merge-ort.c:1612 merge-ort.c:1620
 #, c-format
 msgid "Note: Fast-forwarding submodule %s to %s"
 msgstr "Hinweis: Spule Submodul %s vor zu %s"
 
-#: merge-ort.c:1625
+#: merge-ort.c:1642
 #, c-format
 msgid "Failed to merge submodule %s"
 msgstr "Fehler beim Zusammenführen von Submodul %s"
 
-#: merge-ort.c:1632
+#: merge-ort.c:1649
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but a possible merge resolution exists:\n"
@@ -4777,7 +4871,7 @@ msgstr ""
 "Auflösung des Merges vorhanden:\n"
 "%s\n"
 
-#: merge-ort.c:1636 merge-recursive.c:1269
+#: merge-ort.c:1653 merge-recursive.c:1281
 #, c-format
 msgid ""
 "If this is correct simply add it to the index for example\n"
@@ -4794,7 +4888,7 @@ msgstr ""
 "\n"
 "hinzu, um diesen Vorschlag zu akzeptieren.\n"
 
-#: merge-ort.c:1649
+#: merge-ort.c:1666
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but multiple possible merges exist:\n"
@@ -4804,21 +4898,21 @@ msgstr ""
 "sind vorhanden:\n"
 "%s"
 
-#: merge-ort.c:1868 merge-recursive.c:1358
+#: merge-ort.c:1887 merge-recursive.c:1372
 msgid "Failed to execute internal merge"
 msgstr "Fehler bei Ausführung des internen Merges"
 
-#: merge-ort.c:1873 merge-recursive.c:1363
+#: merge-ort.c:1892 merge-recursive.c:1377
 #, c-format
 msgid "Unable to add %s to database"
 msgstr "Konnte %s nicht zur Datenbank hinzufügen"
 
-#: merge-ort.c:1880 merge-recursive.c:1396
+#: merge-ort.c:1899 merge-recursive.c:1410
 #, c-format
 msgid "Auto-merging %s"
 msgstr "automatischer Merge von %s"
 
-#: merge-ort.c:2019 merge-recursive.c:2118
+#: merge-ort.c:2038 merge-recursive.c:2132
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
@@ -4829,7 +4923,7 @@ msgstr ""
 "Weg von impliziter Verzeichnisumbenennung, die versucht, einen oder mehrere\n"
 "Pfade dahin zu setzen: %s."
 
-#: merge-ort.c:2029 merge-recursive.c:2128
+#: merge-ort.c:2048 merge-recursive.c:2142
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
@@ -4840,7 +4934,7 @@ msgstr ""
 "%s mappen; implizite Verzeichnisumbenennungen versuchten diese Pfade dahin\n"
 "zu setzen: %s"
 
-#: merge-ort.c:2087
+#: merge-ort.c:2106
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to rename %s to; it was "
@@ -4851,7 +4945,7 @@ msgstr ""
 "ist; es wurde zu mehreren anderen Verzeichnissen umbenannt, ohne dass ein "
 "Ziel die Mehrheit der Dateien erhält."
 
-#: merge-ort.c:2241 merge-recursive.c:2464
+#: merge-ort.c:2260 merge-recursive.c:2478
 #, c-format
 msgid ""
 "WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
@@ -4860,7 +4954,7 @@ msgstr ""
 "WARNUNG: Vermeide Umbenennung %s -> %s von %s, weil %s selbst umbenannt "
 "wurde."
 
-#: merge-ort.c:2385 merge-recursive.c:3247
+#: merge-ort.c:2400 merge-recursive.c:3261
 #, c-format
 msgid ""
 "Path updated: %s added in %s inside a directory that was renamed in %s; "
@@ -4869,7 +4963,7 @@ msgstr ""
 "Pfad aktualisiert: %s hinzugefügt in %s innerhalb eines Verzeichnisses, das "
 "umbenannt wurde in %s; Verschiebe es nach %s."
 
-#: merge-ort.c:2392 merge-recursive.c:3254
+#: merge-ort.c:2407 merge-recursive.c:3268
 #, c-format
 msgid ""
 "Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
@@ -4878,7 +4972,7 @@ msgstr ""
 "Pfad aktualisiert: %s umbenannt nach %s in %s, innerhalb eines "
 "Verzeichnisses, das umbenannt wurde in %s; Verschiebe es nach %s."
 
-#: merge-ort.c:2405 merge-recursive.c:3250
+#: merge-ort.c:2420 merge-recursive.c:3264
 #, c-format
 msgid ""
 "CONFLICT (file location): %s added in %s inside a directory that was renamed "
@@ -4887,7 +4981,7 @@ msgstr ""
 "KONFLIKT (Speicherort): %s hinzugefügt in %s innerhalb eines Verzeichnisses, "
 "das umbenannt wurde in %s, es sollte vielleicht nach %s verschoben werden."
 
-#: merge-ort.c:2413 merge-recursive.c:3257
+#: merge-ort.c:2428 merge-recursive.c:3271
 #, c-format
 msgid ""
 "CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
@@ -4897,13 +4991,13 @@ msgstr ""
 "Verzeichnisses, das umbenannt wurde in %s, es sollte vielleicht nach %s "
 "verschoben werden."
 
-#: merge-ort.c:2569
+#: merge-ort.c:2584
 #, c-format
 msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
 msgstr ""
 "KONFLIKT (umbenennen/umbenennen): %s zu %s in %s umbenannt und zu %s in %s."
 
-#: merge-ort.c:2664
+#: merge-ort.c:2679
 #, c-format
 msgid ""
 "CONFLICT (rename involved in collision): rename of %s -> %s has content "
@@ -4914,23 +5008,23 @@ msgstr ""
 "Inhaltskonflikte UND kollidiert mit einem anderen Pfad; dies kann zu "
 "verschachtelten Konfliktmarkierungen führen."
 
-#: merge-ort.c:2683 merge-ort.c:2707
+#: merge-ort.c:2698 merge-ort.c:2722
 #, c-format
 msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
 msgstr ""
 "KONFLIKT (umbenennen/löschen): %s zu %s in %s umbenannt, aber in %s gelöscht."
 
-#: merge-ort.c:3182 merge-recursive.c:3008
+#: merge-ort.c:3212 merge-recursive.c:3022
 #, c-format
 msgid "cannot read object %s"
 msgstr "kann Objekt %s nicht lesen"
 
-#: merge-ort.c:3185 merge-recursive.c:3011
+#: merge-ort.c:3215 merge-recursive.c:3025
 #, c-format
 msgid "object %s is not a blob"
 msgstr "Objekt %s ist kein Blob"
 
-#: merge-ort.c:3613
+#: merge-ort.c:3644
 #, c-format
 msgid ""
 "CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
@@ -4939,7 +5033,7 @@ msgstr ""
 "KONFLIKT (Datei/Verzeichnis): Verzeichnis im Weg von %s aus %s; stattdessen "
 "nach %s verschieben."
 
-#: merge-ort.c:3689
+#: merge-ort.c:3721
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed both "
@@ -4949,7 +5043,7 @@ msgstr ""
 "Seite; beide wurden umbenannt, damit jeder irgendwo aufgezeichnet werden "
 "kann."
 
-#: merge-ort.c:3696
+#: merge-ort.c:3728
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed one "
@@ -4959,24 +5053,24 @@ msgstr ""
 "Seite; eines der beiden wurde umbenannt, damit jeder irgendwo aufgezeichnet "
 "werden kann."
 
-#: merge-ort.c:3796 merge-recursive.c:3087
+#: merge-ort.c:3819 merge-recursive.c:3101
 msgid "content"
 msgstr "Inhalt"
 
-#: merge-ort.c:3798 merge-recursive.c:3091
+#: merge-ort.c:3821 merge-recursive.c:3105
 msgid "add/add"
 msgstr "hinzufügen/hinzufügen"
 
-#: merge-ort.c:3800 merge-recursive.c:3136
+#: merge-ort.c:3823 merge-recursive.c:3150
 msgid "submodule"
 msgstr "Submodul"
 
-#: merge-ort.c:3802 merge-recursive.c:3137
+#: merge-ort.c:3825 merge-recursive.c:3151
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "KONFLIKT (%s): Merge-Konflikt in %s"
 
-#: merge-ort.c:3833
+#: merge-ort.c:3856
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
@@ -4985,7 +5079,7 @@ msgstr ""
 "KONFLIKT (ändern/löschen): %s gelöscht in %s und geändert in %s. Stand %s "
 "von %s wurde im Arbeitsbereich gelassen."
 
-#: merge-ort.c:4120
+#: merge-ort.c:4152
 #, c-format
 msgid ""
 "Note: %s not up to date and in way of checking out conflicted version; old "
@@ -4997,13 +5091,13 @@ msgstr ""
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
-#: merge-ort.c:4487
+#: merge-ort.c:4521
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
 msgstr ""
 "Sammeln von Merge-Informationen für die Referenzen %s, %s, %s fehlgeschlagen"
 
-#: merge-ort-wrappers.c:13 merge-recursive.c:3702
+#: merge-ort-wrappers.c:13 merge-recursive.c:3716
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -5013,109 +5107,109 @@ msgstr ""
 "überschrieben werden:\n"
 "  %s"
 
-#: merge-ort-wrappers.c:33 merge-recursive.c:3468 builtin/merge.c:402
+#: merge-ort-wrappers.c:33 merge-recursive.c:3482 builtin/merge.c:403
 msgid "Already up to date."
 msgstr "Bereits aktuell."
 
-#: merge-recursive.c:352
+#: merge-recursive.c:353
 msgid "(bad commit)\n"
 msgstr "(ungültiger Commit)\n"
 
-#: merge-recursive.c:375
+#: merge-recursive.c:381
 #, c-format
 msgid "add_cacheinfo failed for path '%s'; merge aborting."
 msgstr "add_cacheinfo für Pfad '%s' fehlgeschlagen; Merge wird abgebrochen."
 
-#: merge-recursive.c:384
+#: merge-recursive.c:390
 #, c-format
 msgid "add_cacheinfo failed to refresh for path '%s'; merge aborting."
 msgstr ""
 "add_cacheinfo zur Aktualisierung für Pfad '%s' fehlgeschlagen;\n"
 "Merge wird abgebrochen."
 
-#: merge-recursive.c:872
+#: merge-recursive.c:881
 #, c-format
 msgid "failed to create path '%s'%s"
 msgstr "Fehler beim Erstellen des Pfades '%s'%s"
 
-#: merge-recursive.c:883
+#: merge-recursive.c:892
 #, c-format
 msgid "Removing %s to make room for subdirectory\n"
 msgstr "Entferne %s, um Platz für Unterverzeichnis zu schaffen\n"
 
-#: merge-recursive.c:897 merge-recursive.c:916
+#: merge-recursive.c:906 merge-recursive.c:925
 msgid ": perhaps a D/F conflict?"
 msgstr ": vielleicht ein Verzeichnis/Datei-Konflikt?"
 
-#: merge-recursive.c:906
+#: merge-recursive.c:915
 #, c-format
 msgid "refusing to lose untracked file at '%s'"
 msgstr "verweigere, da unversionierte Dateien in '%s' verloren gehen würden"
 
-#: merge-recursive.c:947 builtin/cat-file.c:41
+#: merge-recursive.c:956 builtin/cat-file.c:41
 #, c-format
 msgid "cannot read object %s '%s'"
 msgstr "kann Objekt %s '%s' nicht lesen"
 
-#: merge-recursive.c:952
+#: merge-recursive.c:961
 #, c-format
 msgid "blob expected for %s '%s'"
 msgstr "Blob erwartet für %s '%s'"
 
-#: merge-recursive.c:977
+#: merge-recursive.c:986
 #, c-format
 msgid "failed to open '%s': %s"
 msgstr "Fehler beim Öffnen von '%s': %s"
 
-#: merge-recursive.c:988
+#: merge-recursive.c:997
 #, c-format
 msgid "failed to symlink '%s': %s"
 msgstr "Fehler beim Erstellen einer symbolischen Verknüpfung für '%s': %s"
 
-#: merge-recursive.c:993
+#: merge-recursive.c:1002
 #, c-format
 msgid "do not know what to do with %06o %s '%s'"
 msgstr "weiß nicht was mit %06o %s '%s' zu machen ist"
 
-#: merge-recursive.c:1223 merge-recursive.c:1235
+#: merge-recursive.c:1233 merge-recursive.c:1246
 #, c-format
 msgid "Fast-forwarding submodule %s to the following commit:"
 msgstr "Spule Submodul %s zu dem folgenden Commit vor:"
 
-#: merge-recursive.c:1226 merge-recursive.c:1238
+#: merge-recursive.c:1236 merge-recursive.c:1249
 #, c-format
 msgid "Fast-forwarding submodule %s"
 msgstr "Spule Submodul %s vor"
 
-#: merge-recursive.c:1261
+#: merge-recursive.c:1273
 #, c-format
 msgid "Failed to merge submodule %s (merge following commits not found)"
 msgstr ""
 "Fehler beim Merge von Submodule %s (dem Merge nachfolgende Commits nicht "
 "gefunden)"
 
-#: merge-recursive.c:1265
+#: merge-recursive.c:1277
 #, c-format
 msgid "Failed to merge submodule %s (not fast-forward)"
 msgstr "Fehler beim Merge von Submodul %s (kein Vorspulen)"
 
-#: merge-recursive.c:1266
+#: merge-recursive.c:1278
 msgid "Found a possible merge resolution for the submodule:\n"
 msgstr "Mögliche Auflösung des Merges für Submodul gefunden:\n"
 
-#: merge-recursive.c:1278
+#: merge-recursive.c:1290
 #, c-format
 msgid "Failed to merge submodule %s (multiple merges found)"
 msgstr "Fehler beim Merge von Submodul %s (mehrere Merges gefunden)"
 
-#: merge-recursive.c:1420
+#: merge-recursive.c:1434
 #, c-format
 msgid "Error: Refusing to lose untracked file at %s; writing to %s instead."
 msgstr ""
 "Fehler: Verweigere unversionierte Datei bei %s zu verlieren;\n"
 "schreibe stattdessen nach %s."
 
-#: merge-recursive.c:1492
+#: merge-recursive.c:1506
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
@@ -5124,7 +5218,7 @@ msgstr ""
 "KONFLIKT (%s/löschen): %s gelöscht in %s und %s in %s. Stand %s von %s wurde "
 "im Arbeitsbereich gelassen."
 
-#: merge-recursive.c:1497
+#: merge-recursive.c:1511
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
@@ -5133,7 +5227,7 @@ msgstr ""
 "KONFLIKT (%s/löschen): %s gelöscht in %s und %s nach %s in %s. Stand %s von "
 "%s wurde im Arbeitsbereich gelassen."
 
-#: merge-recursive.c:1504
+#: merge-recursive.c:1518
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
@@ -5142,7 +5236,7 @@ msgstr ""
 "KONFLIKT (%s/löschen): %s gelöscht in %s und %s in %s. Stand %s von %s wurde "
 "im Arbeitsbereich bei %s gelassen."
 
-#: merge-recursive.c:1509
+#: merge-recursive.c:1523
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
@@ -5151,46 +5245,46 @@ msgstr ""
 "KONFLIKT (%s/löschen): %s gelöscht in %s und %s nach %s in %s. Stand %s von "
 "%s wurde im Arbeitsbereich bei %s gelassen."
 
-#: merge-recursive.c:1544
+#: merge-recursive.c:1558
 msgid "rename"
 msgstr "umbenennen"
 
-#: merge-recursive.c:1544
+#: merge-recursive.c:1558
 msgid "renamed"
 msgstr "umbenannt"
 
-#: merge-recursive.c:1595 merge-recursive.c:2501 merge-recursive.c:3164
+#: merge-recursive.c:1609 merge-recursive.c:2515 merge-recursive.c:3178
 #, c-format
 msgid "Refusing to lose dirty file at %s"
 msgstr "Verweigere geänderte Datei bei %s zu verlieren."
 
-#: merge-recursive.c:1605
+#: merge-recursive.c:1619
 #, c-format
 msgid "Refusing to lose untracked file at %s, even though it's in the way."
 msgstr ""
 "Verweigere unversionierte Datei bei %s zu verlieren, auch wenn diese im Weg "
 "ist."
 
-#: merge-recursive.c:1663
+#: merge-recursive.c:1677
 #, c-format
 msgid "CONFLICT (rename/add): Rename %s->%s in %s.  Added %s in %s"
 msgstr ""
 "KONFLIKT (umbenennen/hinzufügen): Benenne um %s->%s in %s. %s hinzugefügt in "
 "%s"
 
-#: merge-recursive.c:1694
+#: merge-recursive.c:1708
 #, c-format
 msgid "%s is a directory in %s adding as %s instead"
 msgstr "%s ist ein Verzeichnis in %s, füge es stattdessen als %s hinzu"
 
-#: merge-recursive.c:1699
+#: merge-recursive.c:1713
 #, c-format
 msgid "Refusing to lose untracked file at %s; adding as %s instead"
 msgstr ""
 "Verweigere unversionierte Datei bei %s zu verlieren; füge stattdessen %s "
 "hinzu"
 
-#: merge-recursive.c:1726
+#: merge-recursive.c:1740
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename \"%s\"->\"%s\" in branch \"%s\" rename \"%s"
@@ -5199,18 +5293,18 @@ msgstr ""
 "KONFLIKT (umbenennen/umbenennen): Benenne um \"%s\"->\"%s\" in Branch \"%s\" "
 "und \"%s\"->\"%s\" in Branch \"%s\"%s"
 
-#: merge-recursive.c:1731
+#: merge-recursive.c:1745
 msgid " (left unresolved)"
 msgstr " (bleibt unaufgelöst)"
 
-#: merge-recursive.c:1823
+#: merge-recursive.c:1837
 #, c-format
 msgid "CONFLICT (rename/rename): Rename %s->%s in %s. Rename %s->%s in %s"
 msgstr ""
 "KONFLIKT (umbenennen/umbenennen): Benenne um %s->%s in %s. Benenne um %s->%s "
 "in %s"
 
-#: merge-recursive.c:2086
+#: merge-recursive.c:2100
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to place %s because "
@@ -5223,7 +5317,7 @@ msgstr ""
 "wobei\n"
 "keines dieser Ziele die Mehrheit der Dateien erhielt."
 
-#: merge-recursive.c:2220
+#: merge-recursive.c:2234
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename directory %s->%s in %s. Rename directory %s-"
@@ -5232,81 +5326,81 @@ msgstr ""
 "KONFLIKT (umbenennen/umbenennen): Benenne Verzeichnis um %s->%s in %s.\n"
 "Benenne Verzeichnis um %s->%s in %s"
 
-#: merge-recursive.c:3075
+#: merge-recursive.c:3089
 msgid "modify"
 msgstr "ändern"
 
-#: merge-recursive.c:3075
+#: merge-recursive.c:3089
 msgid "modified"
 msgstr "geändert"
 
-#: merge-recursive.c:3114
+#: merge-recursive.c:3128
 #, c-format
 msgid "Skipped %s (merged same as existing)"
 msgstr "%s ausgelassen (Ergebnis des Merges existiert bereits)"
 
-#: merge-recursive.c:3167
+#: merge-recursive.c:3181
 #, c-format
 msgid "Adding as %s instead"
 msgstr "Füge stattdessen als %s hinzu"
 
-#: merge-recursive.c:3371
+#: merge-recursive.c:3385
 #, c-format
 msgid "Removing %s"
 msgstr "Entferne %s"
 
-#: merge-recursive.c:3394
+#: merge-recursive.c:3408
 msgid "file/directory"
 msgstr "Datei/Verzeichnis"
 
-#: merge-recursive.c:3399
+#: merge-recursive.c:3413
 msgid "directory/file"
 msgstr "Verzeichnis/Datei"
 
-#: merge-recursive.c:3406
+#: merge-recursive.c:3420
 #, c-format
 msgid "CONFLICT (%s): There is a directory with name %s in %s. Adding %s as %s"
 msgstr ""
 "KONFLIKT (%s): Es existiert bereits ein Verzeichnis %s in %s. Füge %s als %s "
 "hinzu."
 
-#: merge-recursive.c:3415
+#: merge-recursive.c:3429
 #, c-format
 msgid "Adding %s"
 msgstr "Füge %s hinzu"
 
-#: merge-recursive.c:3424
+#: merge-recursive.c:3438
 #, c-format
 msgid "CONFLICT (add/add): Merge conflict in %s"
 msgstr "KONFLIKT (hinzufügen/hinzufügen): Merge-Konflikt in %s"
 
-#: merge-recursive.c:3477
+#: merge-recursive.c:3491
 #, c-format
 msgid "merging of trees %s and %s failed"
 msgstr "Zusammenführen der \"Tree\"-Objekte %s und %s fehlgeschlagen"
 
-#: merge-recursive.c:3571
+#: merge-recursive.c:3585
 msgid "Merging:"
 msgstr "Merge:"
 
-#: merge-recursive.c:3584
+#: merge-recursive.c:3598
 #, c-format
 msgid "found %u common ancestor:"
 msgid_plural "found %u common ancestors:"
 msgstr[0] "%u gemeinsamen Vorgänger-Commit gefunden"
 msgstr[1] "%u gemeinsame Vorgänger-Commits gefunden"
 
-#: merge-recursive.c:3634
+#: merge-recursive.c:3648
 msgid "merge returned no commit"
 msgstr "Merge hat keinen Commit zurückgegeben"
 
-#: merge-recursive.c:3799
+#: merge-recursive.c:3816
 #, c-format
 msgid "Could not parse object '%s'"
 msgstr "Konnte Objekt '%s' nicht parsen."
 
-#: merge-recursive.c:3817 builtin/merge.c:717 builtin/merge.c:901
-#: builtin/stash.c:473
+#: merge-recursive.c:3834 builtin/merge.c:718 builtin/merge.c:904
+#: builtin/stash.c:489
 msgid "Unable to write index."
 msgstr "Konnte Index nicht schreiben."
 
@@ -5314,138 +5408,173 @@ msgstr "Konnte Index nicht schreiben."
 msgid "failed to read the cache"
 msgstr "Lesen des Zwischenspeichers fehlgeschlagen"
 
-#: merge.c:108 rerere.c:704 builtin/am.c:1932 builtin/am.c:1966
-#: builtin/checkout.c:590 builtin/checkout.c:844 builtin/clone.c:821
-#: builtin/stash.c:267
+#: merge.c:102 rerere.c:704 builtin/am.c:1933 builtin/am.c:1967
+#: builtin/checkout.c:590 builtin/checkout.c:842 builtin/clone.c:706
+#: builtin/stash.c:269
 msgid "unable to write new index file"
 msgstr "Konnte neue Index-Datei nicht schreiben."
 
-#: midx.c:74
+#: midx.c:78
 msgid "multi-pack-index OID fanout is of the wrong size"
 msgstr "multi-pack-index OID fanout hat die falsche Größe"
 
-#: midx.c:105
+#: midx.c:109
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "multi-pack-index-Datei %s ist zu klein."
 
-#: midx.c:121
+#: midx.c:125
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr ""
 "multi-pack-index-Signatur 0x%08x stimmt nicht mit Signatur 0x%08x überein."
 
-#: midx.c:126
+#: midx.c:130
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "multi-pack-index-Version %d nicht erkannt."
 
-#: midx.c:131
+#: midx.c:135
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr "multi-pack-index Hash-Version %u stimmt nicht mit Version %u überein"
 
-#: midx.c:148
+#: midx.c:152
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "multi-pack-index fehlt erforderlicher Pack-Namen Chunk"
 
-#: midx.c:150
+#: midx.c:154
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "multi-pack-index fehlt erforderlicher OID fanout Chunk"
 
-#: midx.c:152
+#: midx.c:156
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr "multi-pack-index fehlt erforderlicher OID lookup Chunk"
 
-#: midx.c:154
+#: midx.c:158
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr "multi-pack-index fehlt erforderlicher Objekt offset Chunk"
 
-#: midx.c:170
+#: midx.c:174
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr "Falsche Reihenfolge bei multi-pack-index Pack-Namen: '%s' vor '%s'"
 
-#: midx.c:214
+#: midx.c:221
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr "Ungültige pack-int-id: %u (%u Pakete insgesamt)"
 
-#: midx.c:264
+#: midx.c:271
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr ""
 "multi-pack-index speichert einen 64-Bit Offset, aber off_t ist zu klein"
 
-#: midx.c:490
+#: midx.c:502
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "Fehler beim Hinzufügen von Packdatei '%s'"
 
-#: midx.c:496
+#: midx.c:508
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "Fehler beim Öffnen von pack-index '%s'"
 
-#: midx.c:564
+#: midx.c:576
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "Fehler beim Lokalisieren von Objekt %d in Packdatei"
 
-#: midx.c:880 builtin/index-pack.c:1533
+#: midx.c:892
 msgid "cannot store reverse index file"
 msgstr "kann Reverse-Index-Datei nicht speichern"
 
-#: midx.c:920
+#: midx.c:990
+#, fuzzy, c-format
+msgid "could not parse line: %s"
+msgstr "konnte %s nicht parsen"
+
+#: midx.c:992
+#, fuzzy, c-format
+msgid "malformed line: %s"
+msgstr "Fehlerhafte Eingabezeile: '%s'."
+
+#: midx.c:1159
 msgid "ignoring existing multi-pack-index; checksum mismatch"
 msgstr ""
 "ignoriere existierenden multi-pack-index; Prüfsumme stimmt nicht überein"
 
-#: midx.c:943
+#: midx.c:1184
+#, fuzzy
+msgid "could not load pack"
+msgstr "Konnte Paket '%s' nicht finden"
+
+#: midx.c:1190
+#, fuzzy, c-format
+msgid "could not open index for %s"
+msgstr "konnte Index für %s nicht öffnen"
+
+#: midx.c:1201
 msgid "Adding packfiles to multi-pack-index"
 msgstr "Packdateien zum multi-pack-index hinzufügen"
 
-#: midx.c:989
-#, c-format
-msgid "did not see pack-file %s to drop"
-msgstr "Pack-Datei %s zum Weglassen nicht gefunden"
-
-#: midx.c:1034
+#: midx.c:1244
 #, c-format
 msgid "unknown preferred pack: '%s'"
 msgstr "unbekanntes bevorzugtes Paket: '%s'"
 
-#: midx.c:1039
+#: midx.c:1289
+#, fuzzy, c-format
+msgid "cannot select preferred pack %s with no objects"
+msgstr "kann Pack-Dateien in precious-objects Repository nicht löschen"
+
+#: midx.c:1321
+#, c-format
+msgid "did not see pack-file %s to drop"
+msgstr "Pack-Datei %s zum Weglassen nicht gefunden"
+
+#: midx.c:1367
 #, c-format
 msgid "preferred pack '%s' is expired"
 msgstr "bevorzugtes Paket '%s' ist abgelaufen"
 
-#: midx.c:1055
+#: midx.c:1380
 msgid "no pack files to index."
 msgstr "keine Packdateien zum Indizieren."
 
-#: midx.c:1135 builtin/clean.c:37
+#: midx.c:1417
+#, fuzzy
+msgid "could not write multi-pack bitmap"
+msgstr "Konnte Commit-Vorlage nicht schreiben"
+
+#: midx.c:1427
+#, fuzzy
+msgid "could not write multi-pack-index"
+msgstr "Fehler beim Schreiben des multi-pack-index"
+
+#: midx.c:1486 builtin/clean.c:37
 #, c-format
 msgid "failed to remove %s"
 msgstr "Fehler beim Löschen von %s"
 
-#: midx.c:1166
+#: midx.c:1517
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "Fehler beim Löschen des multi-pack-index bei %s"
 
-#: midx.c:1225
+#: midx.c:1577
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr "multi-pack-index-Datei existiert, aber das Parsen schlug fehl"
 
-#: midx.c:1233
+#: midx.c:1585
 msgid "incorrect checksum"
 msgstr "Prüfsumme nicht korrekt"
 
-#: midx.c:1236
+#: midx.c:1588
 msgid "Looking for referenced packfiles"
 msgstr "Suche nach referenzierten Pack-Dateien"
 
-#: midx.c:1251
+#: midx.c:1603
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
@@ -5453,55 +5582,55 @@ msgstr ""
 "Ungültige oid fanout Reihenfolge: fanout[%d] = %<PRIx32> > %<PRIx32> = "
 "fanout[%d]"
 
-#: midx.c:1256
+#: midx.c:1608
 msgid "the midx contains no oid"
 msgstr "das midx enthält keine oid"
 
-#: midx.c:1265
+#: midx.c:1617
 msgid "Verifying OID order in multi-pack-index"
 msgstr "Verifiziere OID-Reihenfolge im multi-pack-index"
 
-#: midx.c:1274
+#: midx.c:1626
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr "Ungültige oid lookup Reihenfolge: oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1294
+#: midx.c:1646
 msgid "Sorting objects by packfile"
 msgstr "Sortiere Objekte nach Pack-Datei"
 
-#: midx.c:1301
+#: midx.c:1653
 msgid "Verifying object offsets"
 msgstr "Überprüfe Objekt-Offsets"
 
-#: midx.c:1317
+#: midx.c:1669
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "Fehler beim Laden des Pack-Eintrags für oid[%d] = %s"
 
-#: midx.c:1323
+#: midx.c:1675
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "Fehler beim Laden des Pack-Index für Packdatei %s"
 
-#: midx.c:1332
+#: midx.c:1684
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr "Falscher Objekt-Offset für oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#: midx.c:1357
+#: midx.c:1709
 msgid "Counting referenced objects"
 msgstr "Referenzierte Objekte zählen"
 
-#: midx.c:1367
+#: midx.c:1719
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "Suchen und Löschen von unreferenzierten Pack-Dateien"
 
-#: midx.c:1558
+#: midx.c:1911
 msgid "could not start pack-objects"
 msgstr "Konnte 'pack-objects' nicht ausführen"
 
-#: midx.c:1578
+#: midx.c:1931
 msgid "could not finish pack-objects"
 msgstr "Konnte 'pack-objects' nicht beenden"
 
@@ -5565,265 +5694,265 @@ msgstr ""
 msgid "Bad %s value: '%s'"
 msgstr "Ungültiger %s Wert: '%s'"
 
-#: object-file.c:526
+#: object-file.c:459
 #, c-format
 msgid "object directory %s does not exist; check .git/objects/info/alternates"
 msgstr ""
 "Objektverzeichnis %s existiert nicht; prüfe .git/objects/info/alternates"
 
-#: object-file.c:584
+#: object-file.c:517
 #, c-format
 msgid "unable to normalize alternate object path: %s"
 msgstr "Konnte alternativen Objektpfad '%s' nicht normalisieren."
 
-#: object-file.c:658
+#: object-file.c:591
 #, c-format
 msgid "%s: ignoring alternate object stores, nesting too deep"
 msgstr "%s: ignoriere alternative Objektspeicher - Verschachtelung zu tief"
 
-#: object-file.c:665
+#: object-file.c:598
 #, c-format
 msgid "unable to normalize object directory: %s"
 msgstr "Konnte Objektverzeichnis '%s' nicht normalisieren."
 
-#: object-file.c:708
+#: object-file.c:641
 msgid "unable to fdopen alternates lockfile"
 msgstr "Konnte fdopen nicht auf Lock-Datei für \"alternates\" aufrufen."
 
-#: object-file.c:726
+#: object-file.c:659
 msgid "unable to read alternates file"
 msgstr "Konnte \"alternates\"-Datei nicht lesen."
 
-#: object-file.c:733
+#: object-file.c:666
 msgid "unable to move new alternates file into place"
 msgstr "Konnte neue \"alternates\"-Datei nicht übernehmen."
 
-#: object-file.c:768
+#: object-file.c:701
 #, c-format
 msgid "path '%s' does not exist"
 msgstr "Pfad '%s' existiert nicht"
 
-#: object-file.c:789
+#: object-file.c:722
 #, c-format
 msgid "reference repository '%s' as a linked checkout is not supported yet."
 msgstr ""
 "Referenziertes Repository '%s' wird noch nicht als verknüpftes\n"
 "Arbeitsverzeichnis unterstützt."
 
-#: object-file.c:795
+#: object-file.c:728
 #, c-format
 msgid "reference repository '%s' is not a local repository."
 msgstr "Referenziertes Repository '%s' ist kein lokales Repository."
 
-#: object-file.c:801
+#: object-file.c:734
 #, c-format
 msgid "reference repository '%s' is shallow"
 msgstr ""
 "Referenziertes Repository '%s' hat eine unvollständige Historie (shallow)."
 
-#: object-file.c:809
+#: object-file.c:742
 #, c-format
 msgid "reference repository '%s' is grafted"
 msgstr ""
 "Referenziertes Repository '%s' ist mit künstlichen Vorgängern (\"grafts\") "
 "eingehängt."
 
-#: object-file.c:869
+#: object-file.c:773
+#, c-format
+msgid "could not find object directory matching %s"
+msgstr "konnte Objekt-Verzeichnis nicht finden, dass '%s' entsprechen soll"
+
+#: object-file.c:823
 #, c-format
 msgid "invalid line while parsing alternate refs: %s"
 msgstr "Ungültige Zeile beim Parsen alternativer Referenzen: %s"
 
-#: object-file.c:1019
+#: object-file.c:973
 #, c-format
 msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
 msgstr "Versuche mmap %<PRIuMAX> über Limit %<PRIuMAX>."
 
-#: object-file.c:1054
+#: object-file.c:1008
 #, c-format
 msgid "mmap failed%s"
 msgstr "mmap fehlgeschlagen%s"
 
-#: object-file.c:1218
+#: object-file.c:1174
 #, c-format
 msgid "object file %s is empty"
 msgstr "Objektdatei %s ist leer."
 
-#: object-file.c:1353 object-file.c:2548
+#: object-file.c:1293 object-file.c:2499
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr "Fehlerhaftes loses Objekt '%s'."
 
-#: object-file.c:1355 object-file.c:2552
+#: object-file.c:1295 object-file.c:2503
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr "Nutzlose Daten am Ende von losem Objekt '%s'."
 
-#: object-file.c:1397
-msgid "invalid object type"
-msgstr "ungültiger Objekt-Typ"
-
-#: object-file.c:1481
-#, c-format
-msgid "unable to unpack %s header with --allow-unknown-type"
-msgstr "Konnte %s Kopfbereich nicht mit --allow-unknown-type entpacken."
-
-#: object-file.c:1484
-#, c-format
-msgid "unable to unpack %s header"
-msgstr "Konnte %s Kopfbereich nicht entpacken."
-
-#: object-file.c:1490
-#, c-format
-msgid "unable to parse %s header with --allow-unknown-type"
-msgstr "Konnte %s Kopfbereich mit --allow-unknown-type nicht parsen."
-
-#: object-file.c:1493
+#: object-file.c:1417
 #, c-format
 msgid "unable to parse %s header"
 msgstr "Konnte %s Kopfbereich nicht parsen."
 
-#: object-file.c:1717
+#: object-file.c:1419
+msgid "invalid object type"
+msgstr "ungültiger Objekt-Typ"
+
+#: object-file.c:1430
+#, c-format
+msgid "unable to unpack %s header"
+msgstr "Konnte %s Kopfbereich nicht entpacken."
+
+#: object-file.c:1434
+#, c-format
+msgid "header for %s too long, exceeds %d bytes"
+msgstr ""
+
+#: object-file.c:1664
 #, c-format
 msgid "failed to read object %s"
 msgstr "Konnte Objekt %s nicht lesen."
 
-#: object-file.c:1721
+#: object-file.c:1668
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr "Ersetzung %s für %s nicht gefunden."
 
-#: object-file.c:1725
+#: object-file.c:1672
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr "Loses Objekt %s (gespeichert in %s) ist beschädigt."
 
-#: object-file.c:1729
+#: object-file.c:1676
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr "Gepacktes Objekt %s (gespeichert in %s) ist beschädigt."
 
-#: object-file.c:1834
+#: object-file.c:1781
 #, c-format
 msgid "unable to write file %s"
 msgstr "Konnte Datei %s nicht schreiben."
 
-#: object-file.c:1841
+#: object-file.c:1788
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr "Konnte Zugriffsberechtigung auf '%s' nicht setzen."
 
-#: object-file.c:1848
+#: object-file.c:1795
 msgid "file write error"
 msgstr "Fehler beim Schreiben einer Datei."
 
-#: object-file.c:1868
+#: object-file.c:1815
 msgid "error when closing loose object file"
 msgstr "Fehler beim Schließen der Datei für lose Objekte."
 
-#: object-file.c:1933
+#: object-file.c:1882
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 "Unzureichende Berechtigung zum Hinzufügen eines Objektes zur Repository-"
 "Datenbank %s"
 
-#: object-file.c:1935
+#: object-file.c:1884
 msgid "unable to create temporary file"
 msgstr "Konnte temporäre Datei nicht erstellen."
 
-#: object-file.c:1959
+#: object-file.c:1908
 msgid "unable to write loose object file"
 msgstr "Fehler beim Schreiben der Datei für lose Objekte."
 
-#: object-file.c:1965
+#: object-file.c:1914
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr "Konnte neues Objekt %s (%d) nicht komprimieren."
 
-#: object-file.c:1969
+#: object-file.c:1918
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr "deflateEnd auf Objekt %s fehlgeschlagen (%d)"
 
-#: object-file.c:1973
+#: object-file.c:1922
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr "Fehler wegen instabilen Objektquelldaten für %s"
 
-#: object-file.c:1983 builtin/pack-objects.c:1237
+#: object-file.c:1933 builtin/pack-objects.c:1243
 #, c-format
 msgid "failed utime() on %s"
 msgstr "Fehler beim Aufruf von utime() auf '%s'."
 
-#: object-file.c:2060
+#: object-file.c:2011
 #, c-format
 msgid "cannot read object for %s"
 msgstr "Kann Objekt für %s nicht lesen."
 
-#: object-file.c:2111
+#: object-file.c:2062
 msgid "corrupt commit"
 msgstr "fehlerhafter Commit"
 
-#: object-file.c:2119
+#: object-file.c:2070
 msgid "corrupt tag"
 msgstr "fehlerhaftes Tag"
 
-#: object-file.c:2219
+#: object-file.c:2170
 #, c-format
 msgid "read error while indexing %s"
 msgstr "Lesefehler beim Indizieren von '%s'."
 
-#: object-file.c:2222
+#: object-file.c:2173
 #, c-format
 msgid "short read while indexing %s"
 msgstr "read() zu kurz beim Indizieren von '%s'."
 
-#: object-file.c:2295 object-file.c:2305
+#: object-file.c:2246 object-file.c:2256
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr "%s: Fehler beim Einfügen in die Datenbank"
 
-#: object-file.c:2311
+#: object-file.c:2262
 #, c-format
 msgid "%s: unsupported file type"
 msgstr "%s: nicht unterstützte Dateiart"
 
-#: object-file.c:2335
+#: object-file.c:2286 builtin/fetch.c:1445
 #, c-format
 msgid "%s is not a valid object"
 msgstr "%s ist kein gültiges Objekt"
 
-#: object-file.c:2337
+#: object-file.c:2288
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr "%s ist kein gültiges '%s' Objekt"
 
-#: object-file.c:2364 builtin/index-pack.c:192
+#: object-file.c:2315
 #, c-format
 msgid "unable to open %s"
 msgstr "kann %s nicht öffnen"
 
-#: object-file.c:2559 object-file.c:2612
+#: object-file.c:2510
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
 msgstr "Hash für %s stimmt nicht überein (%s erwartet)."
 
-#: object-file.c:2583
+#: object-file.c:2533
 #, c-format
 msgid "unable to mmap %s"
 msgstr "Konnte mmap nicht auf %s ausführen."
 
-#: object-file.c:2588
+#: object-file.c:2539
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr "Konnte Kopfbereich von %s nicht entpacken."
 
-#: object-file.c:2594
+#: object-file.c:2544
 #, c-format
 msgid "unable to parse header of %s"
 msgstr "Konnte Kopfbereich von %s nicht parsen."
 
-#: object-file.c:2605
+#: object-file.c:2555
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr "Konnte Inhalt von %s nicht entpacken."
@@ -5955,12 +6084,26 @@ msgstr "Konnte Objekt '%s' nicht parsen."
 msgid "hash mismatch %s"
 msgstr "Hash stimmt nicht mit %s überein."
 
-#: pack-bitmap.c:868 pack-bitmap.c:874 builtin/pack-objects.c:2411
+#: pack-bitmap.c:348
+#, fuzzy
+msgid "multi-pack bitmap is missing required reverse index"
+msgstr "multi-pack-index fehlt erforderlicher Objekt offset Chunk"
+
+#: pack-bitmap.c:424
+msgid "load_reverse_index: could not open pack"
+msgstr ""
+
+#: pack-bitmap.c:1064 pack-bitmap.c:1070 builtin/pack-objects.c:2424
 #, c-format
 msgid "unable to get size of %s"
 msgstr "Konnte Größe von %s nicht bestimmen."
 
-#: pack-bitmap.c:1571 builtin/rev-list.c:92
+#: pack-bitmap.c:1916
+#, fuzzy, c-format
+msgid "could not find %s in pack %s at offset %<PRIuMAX>"
+msgstr "Konnte Paket '%s' nicht finden"
+
+#: pack-bitmap.c:1952 builtin/rev-list.c:92
 #, c-format
 msgid "unable to get disk usage of %s"
 msgstr "konnte Festplattennutzung von %s nicht bekommen"
@@ -5990,46 +6133,46 @@ msgstr "Reverse-Index-Datei %s hat nicht unterstützte Version %<PRIu32>"
 msgid "reverse-index file %s has unsupported hash id %<PRIu32>"
 msgstr "Reverse-Index-Datei %s hat nicht unterstützte Hash-ID %<PRIu32>"
 
-#: pack-write.c:250
+#: pack-write.c:251
 msgid "cannot both write and verify reverse index"
 msgstr ""
 "Reverse-Index kann nicht gleichzeitig geschrieben und verifiziert werden"
 
-#: pack-write.c:271
+#: pack-write.c:270
 #, c-format
 msgid "could not stat: %s"
 msgstr "konnte nicht lesen: %s"
 
-#: pack-write.c:283
+#: pack-write.c:282
 #, c-format
 msgid "failed to make %s readable"
 msgstr "Fehler beim lesbar machen von %s"
 
-#: pack-write.c:522
+#: pack-write.c:520
 #, c-format
 msgid "could not write '%s' promisor file"
 msgstr "konnte Promisor-Datei '%s' nicht schreiben"
 
-#: packfile.c:625
+#: packfile.c:626
 msgid "offset before end of packfile (broken .idx?)"
 msgstr "Offset vor Ende der Packdatei (fehlerhafte Indexdatei?)"
 
-#: packfile.c:655
+#: packfile.c:656
 #, c-format
 msgid "packfile %s cannot be mapped%s"
 msgstr "Packdatei %s kann nicht gemappt werden%s"
 
-#: packfile.c:1934
+#: packfile.c:1923
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr "Offset vor Beginn des Pack-Index für %s (beschädigter Index?)"
 
-#: packfile.c:1938
+#: packfile.c:1927
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr "Offset hinter Ende des Pack-Index für %s (abgeschnittener Index?)"
 
-#: parse-options-cb.c:20 parse-options-cb.c:24
+#: parse-options-cb.c:20 parse-options-cb.c:24 builtin/commit-graph.c:175
 #, c-format
 msgid "option `%s' expects a numerical value"
 msgstr "Option `%s' erwartet einen numerischen Wert."
@@ -6049,73 +6192,73 @@ msgstr "Option `%s' erwartet \"always\", \"auto\" oder \"never\"."
 msgid "malformed object name '%s'"
 msgstr "fehlerhafter Objekt-Name '%s'"
 
-#: parse-options.c:38
+#: parse-options.c:58
 #, c-format
 msgid "%s requires a value"
 msgstr "%s erfordert einen Wert."
 
-#: parse-options.c:73
+#: parse-options.c:93
 #, c-format
 msgid "%s is incompatible with %s"
 msgstr "%s ist inkompatibel mit %s."
 
-#: parse-options.c:78
+#: parse-options.c:98
 #, c-format
 msgid "%s : incompatible with something else"
 msgstr "%s: inkompatibel mit etwas anderem"
 
-#: parse-options.c:92 parse-options.c:96 parse-options.c:317
+#: parse-options.c:112 parse-options.c:116
 #, c-format
 msgid "%s takes no value"
 msgstr "%s erwartet keinen Wert"
 
-#: parse-options.c:94
+#: parse-options.c:114
 #, c-format
 msgid "%s isn't available"
 msgstr "%s ist nicht verfügbar."
 
-#: parse-options.c:217
+#: parse-options.c:237
 #, c-format
 msgid "%s expects a non-negative integer value with an optional k/m/g suffix"
 msgstr ""
 "%s erwartet einen nicht-negativen Integer-Wert mit einem optionalen k/m/g "
 "Suffix"
 
-#: parse-options.c:386
+#: parse-options.c:393
 #, c-format
 msgid "ambiguous option: %s (could be --%s%s or --%s%s)"
 msgstr "Mehrdeutige Option: %s (kann --%s%s oder --%s%s sein)"
 
-#: parse-options.c:420 parse-options.c:428
+#: parse-options.c:427 parse-options.c:435
 #, c-format
 msgid "did you mean `--%s` (with two dashes)?"
 msgstr "Meinten Sie `--%s` (mit zwei Strichen)?"
 
-#: parse-options.c:668 parse-options.c:988
+#: parse-options.c:677 parse-options.c:1053
 #, c-format
 msgid "alias of --%s"
 msgstr "Alias für --%s"
 
-#: parse-options.c:879
+#: parse-options.c:891
 #, c-format
 msgid "unknown option `%s'"
 msgstr "Unbekannte Option: `%s'"
 
-#: parse-options.c:881
+#: parse-options.c:893
 #, c-format
 msgid "unknown switch `%c'"
 msgstr "Unbekannter Schalter `%c'"
 
-#: parse-options.c:883
+#: parse-options.c:895
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
 msgstr "Unbekannte nicht-Ascii Option in String: `%s'"
 
-#: parse-options.c:907
+#: parse-options.c:919
 msgid "..."
 msgstr "..."
 
-#: parse-options.c:926
+#: parse-options.c:933
 #, c-format
 msgid "usage: %s"
 msgstr "Verwendung: %s"
@@ -6123,49 +6266,73 @@ msgstr "Verwendung: %s"
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
 #.
-#: parse-options.c:932
+#: parse-options.c:948
 #, c-format
 msgid "   or: %s"
 msgstr "      oder: %s"
 
-#: parse-options.c:935
+#. TRANSLATORS: You should only need to translate this format
+#. string if your language is a RTL language (e.g. Arabic,
+#. Hebrew etc.), not if it's a LTR language (e.g. German,
+#. Russian, Chinese etc.).
+#. *
+#. When a translated usage string has an embedded "\n" it's
+#. because options have wrapped to the next line. The line
+#. after the "\n" will then be padded to align with the
+#. command name, such as N_("git cmd [opt]\n<8
+#. spaces>[opt2]"), where the 8 spaces are the same length as
+#. "git cmd ".
+#. *
+#. This format string prints out that already-translated
+#. line. The "%*s" is whitespace padding to account for the
+#. padding at the start of the line that we add in this
+#. function. The "%s" is a line in the (hopefully already
+#. translated) N_() usage string, which contained embedded
+#. newlines before we split it up.
+#.
+#: parse-options.c:969
+#, c-format
+msgid "%*s%s"
+msgstr ""
+
+#: parse-options.c:992
 #, c-format
 msgid "    %s"
 msgstr "    %s"
 
-#: parse-options.c:974
+#: parse-options.c:1039
 msgid "-NUM"
 msgstr "-NUM"
 
-#: path.c:915
+#: path.c:922
 #, c-format
 msgid "Could not make %s writable by group"
 msgstr "Konnte Gruppenschreibrecht für %s nicht setzen."
 
-#: pathspec.c:151
+#: pathspec.c:150
 msgid "Escape character '\\' not allowed as last character in attr value"
 msgstr "Escape-Zeichen '\\' als letztes Zeichen in Attributwert nicht erlaubt"
 
-#: pathspec.c:169
+#: pathspec.c:168
 msgid "Only one 'attr:' specification is allowed."
 msgstr "Es ist nur eine Angabe von 'attr:' erlaubt."
 
-#: pathspec.c:172
+#: pathspec.c:171
 msgid "attr spec must not be empty"
 msgstr "Angabe von 'attr:' darf nicht leer sein"
 
-#: pathspec.c:215
+#: pathspec.c:214
 #, c-format
 msgid "invalid attribute name %s"
 msgstr "Ungültiger Attributname %s"
 
-#: pathspec.c:280
+#: pathspec.c:279
 msgid "global 'glob' and 'noglob' pathspec settings are incompatible"
 msgstr ""
 "Globale Einstellungen zur Pfadspezifikation 'glob' und 'noglob' sind "
 "inkompatibel."
 
-#: pathspec.c:287
+#: pathspec.c:286
 msgid ""
 "global 'literal' pathspec setting is incompatible with all other global "
 "pathspec settings"
@@ -6173,52 +6340,52 @@ msgstr ""
 "Globale Einstellung zur Pfadspezifikation 'literal' ist inkompatibel\n"
 "mit allen anderen Optionen."
 
-#: pathspec.c:327
+#: pathspec.c:326
 msgid "invalid parameter for pathspec magic 'prefix'"
 msgstr "ungültiger Parameter für Pfadspezifikationsangabe 'prefix'"
 
-#: pathspec.c:348
+#: pathspec.c:347
 #, c-format
 msgid "Invalid pathspec magic '%.*s' in '%s'"
 msgstr "ungültige Pfadspezifikationsangabe '%.*s' in '%s'"
 
-#: pathspec.c:353
+#: pathspec.c:352
 #, c-format
 msgid "Missing ')' at the end of pathspec magic in '%s'"
 msgstr "Fehlendes ')' am Ende der Pfadspezifikationsangabe in '%s'"
 
-#: pathspec.c:391
+#: pathspec.c:390
 #, c-format
 msgid "Unimplemented pathspec magic '%c' in '%s'"
 msgstr "nicht unterstützte Pfadspezifikationsangabe '%c' in '%s'"
 
-#: pathspec.c:450
+#: pathspec.c:449
 #, c-format
 msgid "%s: 'literal' and 'glob' are incompatible"
 msgstr "%s: 'literal' und 'glob' sind inkompatibel"
 
-#: pathspec.c:466
+#: pathspec.c:465
 #, c-format
 msgid "%s: '%s' is outside repository at '%s'"
 msgstr "%s: '%s' liegt außerhalb des Repositories von '%s'"
 
-#: pathspec.c:542
+#: pathspec.c:541
 #, c-format
 msgid "'%s' (mnemonic: '%c')"
 msgstr "'%s' (Kürzel: '%c')"
 
-#: pathspec.c:552
+#: pathspec.c:551
 #, c-format
 msgid "%s: pathspec magic not supported by this command: %s"
 msgstr ""
 "%s: Pfadspezifikationsangabe wird von diesem Befehl nicht unterstützt: %s"
 
-#: pathspec.c:619
+#: pathspec.c:618
 #, c-format
 msgid "pathspec '%s' is beyond a symbolic link"
 msgstr "Pfadspezifikation '%s' ist hinter einer symbolischen Verknüpfung"
 
-#: pathspec.c:664
+#: pathspec.c:663
 #, c-format
 msgid "line is badly quoted: %s"
 msgstr "Zeile enthält falsche Anführungszeichen: %s"
@@ -6239,7 +6406,7 @@ msgstr "konnte Antwort-Endpaket nicht schreiben"
 msgid "flush packet write failed"
 msgstr "Flush beim Schreiben des Pakets fehlgeschlagen."
 
-#: pkt-line.c:153 pkt-line.c:265
+#: pkt-line.c:153
 msgid "protocol error: impossibly long line"
 msgstr "Protokollfehler: unmöglich lange Zeile"
 
@@ -6247,7 +6414,7 @@ msgstr "Protokollfehler: unmöglich lange Zeile"
 msgid "packet write with format failed"
 msgstr "Schreiben des Pakets mit Format fehlgeschlagen."
 
-#: pkt-line.c:204
+#: pkt-line.c:204 pkt-line.c:252
 msgid "packet write failed - data exceeds max packet size"
 msgstr ""
 "Schreiben des Pakets fehlgeschlagen - Daten überschreiten maximale Paketgröße"
@@ -6257,25 +6424,25 @@ msgstr ""
 msgid "packet write failed: %s"
 msgstr "Schreiben des Pakets fehlgeschlagen: %s"
 
-#: pkt-line.c:328 pkt-line.c:329
+#: pkt-line.c:349 pkt-line.c:350
 msgid "read error"
 msgstr "Lesefehler"
 
-#: pkt-line.c:339 pkt-line.c:340
+#: pkt-line.c:360 pkt-line.c:361
 msgid "the remote end hung up unexpectedly"
 msgstr "Die Gegenseite hat unerwartet abgebrochen."
 
-#: pkt-line.c:369 pkt-line.c:371
+#: pkt-line.c:390 pkt-line.c:392
 #, c-format
 msgid "protocol error: bad line length character: %.4s"
 msgstr "Protokollfehler: ungültiges Zeichen für Zeilenlänge: %.4s"
 
-#: pkt-line.c:386 pkt-line.c:388 pkt-line.c:394 pkt-line.c:396
+#: pkt-line.c:407 pkt-line.c:409 pkt-line.c:415 pkt-line.c:417
 #, c-format
 msgid "protocol error: bad line length %d"
 msgstr "Protokollfehler: ungültige Zeilenlänge %d"
 
-#: pkt-line.c:413 sideband.c:165
+#: pkt-line.c:434 sideband.c:165
 #, c-format
 msgid "remote error: %s"
 msgstr "Fehler am anderen Ende: %s"
@@ -6289,7 +6456,7 @@ msgstr "Aktualisiere Index"
 msgid "unable to create threaded lstat: %s"
 msgstr "Kann Thread für lstat nicht erzeugen: %s"
 
-#: pretty.c:988
+#: pretty.c:1051
 msgid "unable to parse --pretty format"
 msgstr "Konnte --pretty Format nicht parsen."
 
@@ -6320,20 +6487,20 @@ msgstr "object-info: erwartete Flush nach Argumenten"
 msgid "Removing duplicate objects"
 msgstr "Lösche doppelte Objekte"
 
-#: range-diff.c:78
+#: range-diff.c:67
 msgid "could not start `log`"
 msgstr "Konnte `log` nicht starten."
 
-#: range-diff.c:80
+#: range-diff.c:69
 msgid "could not read `log` output"
 msgstr "Konnte Ausgabe von `log` nicht lesen."
 
-#: range-diff.c:101 sequencer.c:5550
+#: range-diff.c:97 sequencer.c:5605
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr "Konnte Commit '%s' nicht parsen."
 
-#: range-diff.c:115
+#: range-diff.c:111
 #, c-format
 msgid ""
 "could not parse first line of `log` output: did not start with 'commit ': "
@@ -6342,12 +6509,12 @@ msgstr ""
 "konnte erste Zeile der Ausgabe von `log` nicht parsen: fängt nicht mit "
 "'commit ' an: '%s'"
 
-#: range-diff.c:140
+#: range-diff.c:137
 #, c-format
 msgid "could not parse git header '%.*s'"
 msgstr "Konnte Git-Header '%.*s' nicht parsen."
 
-#: range-diff.c:307
+#: range-diff.c:304
 msgid "failed to generate diff"
 msgstr "Fehler beim Generieren des Diffs."
 
@@ -6377,7 +6544,7 @@ msgstr ""
 "%s: Kann nur reguläre Dateien, symbolische Links oder Git-Verzeichnisse "
 "hinzufügen."
 
-#: read-cache.c:753
+#: read-cache.c:753 builtin/submodule--helper.c:3241
 #, c-format
 msgid "'%s' does not have a commit checked out"
 msgstr "'%s' hat keinen Commit ausgecheckt"
@@ -6397,16 +6564,16 @@ msgstr "Konnte '%s' nicht dem Index hinzufügen."
 msgid "unable to stat '%s'"
 msgstr "konnte '%s' nicht lesen"
 
-#: read-cache.c:1358
+#: read-cache.c:1373
 #, c-format
 msgid "'%s' appears as both a file and as a directory"
 msgstr "'%s' scheint eine Datei und ein Verzeichnis zu sein"
 
-#: read-cache.c:1573
+#: read-cache.c:1588
 msgid "Refresh index"
 msgstr "Aktualisiere Index"
 
-#: read-cache.c:1705
+#: read-cache.c:1720
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -6415,7 +6582,7 @@ msgstr ""
 "index.version gesetzt, aber Wert ungültig.\n"
 "Verwende Version %i"
 
-#: read-cache.c:1715
+#: read-cache.c:1730
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -6424,143 +6591,143 @@ msgstr ""
 "GIT_INDEX_VERSION gesetzt, aber Wert ungültig.\n"
 "Verwende Version %i"
 
-#: read-cache.c:1771
+#: read-cache.c:1786
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr "Ungültige Signatur 0x%08x"
 
-#: read-cache.c:1774
+#: read-cache.c:1789
 #, c-format
 msgid "bad index version %d"
 msgstr "Ungültige Index-Version %d"
 
-#: read-cache.c:1783
+#: read-cache.c:1798
 msgid "bad index file sha1 signature"
 msgstr "Ungültige SHA1-Signatur der Index-Datei."
 
-#: read-cache.c:1817
+#: read-cache.c:1832
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr "Index verwendet Erweiterung %.4s, welche wir nicht unterstützen."
 
-#: read-cache.c:1819
+#: read-cache.c:1834
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr "Ignoriere Erweiterung %.4s"
 
-#: read-cache.c:1856
+#: read-cache.c:1871
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr "Unbekanntes Format für Index-Eintrag 0x%08x"
 
-#: read-cache.c:1872
+#: read-cache.c:1887
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "Ungültiges Namensfeld im Index, in der Nähe von Pfad '%s'."
 
-#: read-cache.c:1929
+#: read-cache.c:1944
 msgid "unordered stage entries in index"
 msgstr "Ungeordnete Stage-Einträge im Index."
 
-#: read-cache.c:1932
+#: read-cache.c:1947
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr "Mehrere Stage-Einträge für zusammengeführte Datei '%s'."
 
-#: read-cache.c:1935
+#: read-cache.c:1950
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr "Ungeordnete Stage-Einträge für '%s'."
 
-#: read-cache.c:2041 read-cache.c:2339 rerere.c:549 rerere.c:583 rerere.c:1095
-#: submodule.c:1622 builtin/add.c:575 builtin/check-ignore.c:183
-#: builtin/checkout.c:519 builtin/checkout.c:706 builtin/clean.c:987
-#: builtin/commit.c:377 builtin/diff-tree.c:122 builtin/grep.c:505
-#: builtin/mv.c:146 builtin/reset.c:247 builtin/rm.c:291
-#: builtin/submodule--helper.c:333
+#: read-cache.c:2065 read-cache.c:2363 rerere.c:549 rerere.c:583 rerere.c:1095
+#: submodule.c:1662 builtin/add.c:603 builtin/check-ignore.c:183
+#: builtin/checkout.c:519 builtin/checkout.c:708 builtin/clean.c:987
+#: builtin/commit.c:378 builtin/diff-tree.c:122 builtin/grep.c:519
+#: builtin/mv.c:148 builtin/reset.c:253 builtin/rm.c:293
+#: builtin/submodule--helper.c:327 builtin/submodule--helper.c:3201
 msgid "index file corrupt"
 msgstr "Index-Datei beschädigt"
 
-#: read-cache.c:2185
+#: read-cache.c:2209
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr "Kann Thread für load_cache_entries nicht erzeugen: %s"
 
-#: read-cache.c:2198
+#: read-cache.c:2222
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr "Kann Thread für load_cache_entries nicht erzeugen: %s"
 
-#: read-cache.c:2231
+#: read-cache.c:2255
 #, c-format
 msgid "%s: index file open failed"
 msgstr "%s: Öffnen der Index-Datei fehlgeschlagen."
 
-#: read-cache.c:2235
+#: read-cache.c:2259
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr "%s: Kann geöffneten Index nicht lesen."
 
-#: read-cache.c:2239
+#: read-cache.c:2263
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr "%s: Index-Datei ist kleiner als erwartet."
 
-#: read-cache.c:2243
+#: read-cache.c:2267
 #, c-format
 msgid "%s: unable to map index file%s"
 msgstr "%s: Konnte Index-Datei nicht mappen%s"
 
-#: read-cache.c:2286
+#: read-cache.c:2310
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr "Kann Thread für load_index_extensions nicht erzeugen: %s"
 
-#: read-cache.c:2313
+#: read-cache.c:2337
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr "Kann Thread für load_index_extensions nicht beitreten: %s"
 
-#: read-cache.c:2351
+#: read-cache.c:2375
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr "Konnte geteilten Index '%s' nicht aktualisieren."
 
-#: read-cache.c:2398
+#: read-cache.c:2434
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr "Fehlerhafter Index. Erwartete %s in %s, erhielt %s."
 
-#: read-cache.c:3032 strbuf.c:1173 wrapper.c:633 builtin/merge.c:1146
+#: read-cache.c:3065 strbuf.c:1179 wrapper.c:641 builtin/merge.c:1147
 #, c-format
 msgid "could not close '%s'"
 msgstr "Konnte '%s' nicht schließen."
 
-#: read-cache.c:3075
+#: read-cache.c:3108
 msgid "failed to convert to a sparse-index"
 msgstr "Konvertierung zu einem Sparse-Index fehlgeschlagen"
 
-#: read-cache.c:3146 sequencer.c:2684 sequencer.c:4440
+#: read-cache.c:3179
 #, c-format
 msgid "could not stat '%s'"
 msgstr "Konnte '%s' nicht lesen."
 
-#: read-cache.c:3159
+#: read-cache.c:3192
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "konnte Git-Verzeichnis nicht öffnen: %s"
 
-#: read-cache.c:3171
+#: read-cache.c:3204
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "Konnte '%s' nicht entfernen."
 
-#: read-cache.c:3200
+#: read-cache.c:3233
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr "Konnte Zugriffsberechtigung auf '%s' nicht setzen."
 
-#: read-cache.c:3349
+#: read-cache.c:3390
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr "%s: Kann nicht auf Stufe #0 wechseln."
@@ -6641,7 +6808,7 @@ msgid_plural "Rebase %s onto %s (%d commands)"
 msgstr[0] "Rebase von %s auf %s (%d Kommando)"
 msgstr[1] "Rebase von %s auf %s (%d Kommandos)"
 
-#: rebase-interactive.c:75 git-rebase--preserve-merges.sh:218
+#: rebase-interactive.c:75
 msgid ""
 "\n"
 "Do not remove any line. Use 'drop' explicitly to remove a commit.\n"
@@ -6650,7 +6817,7 @@ msgstr ""
 "Keine Zeile entfernen. Benutzen Sie 'drop', um explizit einen Commit zu\n"
 "entfernen.\n"
 
-#: rebase-interactive.c:78 git-rebase--preserve-merges.sh:222
+#: rebase-interactive.c:78
 msgid ""
 "\n"
 "If you remove a line here THAT COMMIT WILL BE LOST.\n"
@@ -6658,7 +6825,7 @@ msgstr ""
 "\n"
 "Wenn Sie hier eine Zeile entfernen, wird DIESER COMMIT VERLOREN GEHEN.\n"
 
-#: rebase-interactive.c:84 git-rebase--preserve-merges.sh:861
+#: rebase-interactive.c:84
 msgid ""
 "\n"
 "You are editing the todo file of an ongoing interactive rebase.\n"
@@ -6672,7 +6839,7 @@ msgstr ""
 "    git rebase --continue\n"
 "\n"
 
-#: rebase-interactive.c:89 git-rebase--preserve-merges.sh:938
+#: rebase-interactive.c:89
 msgid ""
 "\n"
 "However, if you remove everything, the rebase will be aborted.\n"
@@ -6682,14 +6849,14 @@ msgstr ""
 "Wenn Sie jedoch alles löschen, wird der Rebase abgebrochen.\n"
 "\n"
 
-#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3836
-#: sequencer.c:3862 sequencer.c:5656 builtin/fsck.c:328 builtin/rebase.c:271
+#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3888
+#: sequencer.c:3914 sequencer.c:5711 builtin/fsck.c:328 builtin/gc.c:1789
+#: builtin/rebase.c:190
 #, c-format
 msgid "could not write '%s'"
 msgstr "Konnte '%s' nicht schreiben."
 
-#: rebase-interactive.c:119 builtin/rebase.c:203 builtin/rebase.c:229
-#: builtin/rebase.c:253
+#: rebase-interactive.c:119
 #, c-format
 msgid "could not write '%s'."
 msgstr "Konnte '%s' nicht schreiben."
@@ -6720,12 +6887,10 @@ msgstr ""
 "Warnungen zu ändern.\n"
 "Die möglichen Verhaltensweisen sind: ignore, warn, error.\n"
 
-#: rebase-interactive.c:236 rebase-interactive.c:241 sequencer.c:2597
-#: builtin/rebase.c:189 builtin/rebase.c:214 builtin/rebase.c:240
-#: builtin/rebase.c:265
+#: rebase.c:29
 #, c-format
-msgid "could not read '%s'."
-msgstr "Konnte '%s' nicht lesen."
+msgid "%s: 'preserve' superseded by 'merges'"
+msgstr ""
 
 #: ref-filter.c:42 wt-status.c:2036
 msgid "gone"
@@ -6746,258 +6911,278 @@ msgstr "%d hinterher"
 msgid "ahead %d, behind %d"
 msgstr "%d voraus, %d hinterher"
 
-#: ref-filter.c:230
+#: ref-filter.c:235
 #, c-format
 msgid "expected format: %%(color:<color>)"
 msgstr "Erwartetes Format: %%(color:<Farbe>)"
 
-#: ref-filter.c:232
+#: ref-filter.c:237
 #, c-format
 msgid "unrecognized color: %%(color:%s)"
 msgstr "nicht erkannte Farbe: %%(color:%s)"
 
-#: ref-filter.c:254
+#: ref-filter.c:259
 #, c-format
 msgid "Integer value expected refname:lstrip=%s"
 msgstr "Positiver Wert erwartet refname:lstrip=%s"
 
-#: ref-filter.c:258
+#: ref-filter.c:263
 #, c-format
 msgid "Integer value expected refname:rstrip=%s"
 msgstr "Positiver Wert erwartet refname:rstrip=%s"
 
-#: ref-filter.c:260
+#: ref-filter.c:265
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
 msgstr "nicht erkanntes %%(%s) Argument: %s"
 
-#: ref-filter.c:315
+#: ref-filter.c:320
 #, c-format
 msgid "%%(objecttype) does not take arguments"
 msgstr "%%(objecttype) akzeptiert keine Argumente"
 
-#: ref-filter.c:339
+#: ref-filter.c:344
 #, c-format
 msgid "unrecognized %%(objectsize) argument: %s"
 msgstr "nicht erkanntes %%(objectsize) Argument: %s"
 
-#: ref-filter.c:347
+#: ref-filter.c:352
 #, c-format
 msgid "%%(deltabase) does not take arguments"
 msgstr "%%(deltabase) akzeptiert keine Argumente"
 
-#: ref-filter.c:359
+#: ref-filter.c:364
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr "%%(body) akzeptiert keine Argumente"
 
-#: ref-filter.c:372
+#: ref-filter.c:377
 #, c-format
 msgid "unrecognized %%(subject) argument: %s"
 msgstr "nicht erkanntes %%(subject) Argument: %s"
 
-#: ref-filter.c:391
+#: ref-filter.c:396
 #, c-format
 msgid "expected %%(trailers:key=<value>)"
 msgstr "%%(trailers:key=<Wert>) erwartet"
 
-#: ref-filter.c:393
+#: ref-filter.c:398
 #, c-format
 msgid "unknown %%(trailers) argument: %s"
 msgstr "unbekanntes %%(trailers) Argument: %s"
 
-#: ref-filter.c:424
+#: ref-filter.c:429
 #, c-format
 msgid "positive value expected contents:lines=%s"
 msgstr "Positiver Wert erwartet contents:lines=%s"
 
-#: ref-filter.c:426
+#: ref-filter.c:431
 #, c-format
 msgid "unrecognized %%(contents) argument: %s"
 msgstr "nicht erkanntes %%(contents) Argument: %s"
 
-#: ref-filter.c:441
+#: ref-filter.c:443
+#, fuzzy, c-format
+msgid "unrecognized %%(raw) argument: %s"
+msgstr "nicht erkanntes %%(%s) Argument: %s"
+
+#: ref-filter.c:458
 #, c-format
 msgid "positive value expected '%s' in %%(%s)"
 msgstr "positiver Wert erwartet '%s' in %%(%s)"
 
-#: ref-filter.c:445
+#: ref-filter.c:462
 #, c-format
 msgid "unrecognized argument '%s' in %%(%s)"
 msgstr "nicht erkanntes Argument '%s' in %%(%s)"
 
-#: ref-filter.c:459
+#: ref-filter.c:476
 #, c-format
 msgid "unrecognized email option: %s"
 msgstr "nicht erkannte E-Mail Option: %s"
 
-#: ref-filter.c:489
+#: ref-filter.c:506
 #, c-format
 msgid "expected format: %%(align:<width>,<position>)"
 msgstr "erwartetes Format: %%(align:<Breite>,<Position>)"
 
-#: ref-filter.c:501
+#: ref-filter.c:518
 #, c-format
 msgid "unrecognized position:%s"
 msgstr "nicht erkannte Position:%s"
 
-#: ref-filter.c:508
+#: ref-filter.c:525
 #, c-format
 msgid "unrecognized width:%s"
 msgstr "nicht erkannte Breite:%s"
 
-#: ref-filter.c:517
+#: ref-filter.c:534
 #, c-format
 msgid "unrecognized %%(align) argument: %s"
 msgstr "nicht erkanntes %%(align) Argument: %s"
 
-#: ref-filter.c:525
+#: ref-filter.c:542
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr "Positive Breitenangabe für %%(align) erwartet"
 
-#: ref-filter.c:543
+#: ref-filter.c:560
 #, c-format
 msgid "unrecognized %%(if) argument: %s"
 msgstr "nicht erkanntes %%(if) Argument: %s"
 
-#: ref-filter.c:645
+#: ref-filter.c:568
+#, fuzzy, c-format
+msgid "%%(rest) does not take arguments"
+msgstr "%%(body) akzeptiert keine Argumente"
+
+#: ref-filter.c:680
 #, c-format
 msgid "malformed field name: %.*s"
 msgstr "Fehlerhafter Feldname: %.*s"
 
-#: ref-filter.c:672
+#: ref-filter.c:707
 #, c-format
 msgid "unknown field name: %.*s"
 msgstr "Unbekannter Feldname: %.*s"
 
-#: ref-filter.c:676
+#: ref-filter.c:711
 #, c-format
 msgid ""
 "not a git repository, but the field '%.*s' requires access to object data"
 msgstr ""
 "Kein Git-Repository, aber das Feld '%.*s' erfordert Zugriff auf Objektdaten."
 
-#: ref-filter.c:801
+#: ref-filter.c:844
 #, c-format
 msgid "format: %%(if) atom used without a %%(then) atom"
 msgstr "format: %%(if) Atom ohne ein %%(then) Atom verwendet"
 
-#: ref-filter.c:865
+#: ref-filter.c:910
 #, c-format
 msgid "format: %%(then) atom used without an %%(if) atom"
 msgstr "format: %%(then) Atom ohne ein %%(if) Atom verwendet"
 
-#: ref-filter.c:867
+#: ref-filter.c:912
 #, c-format
 msgid "format: %%(then) atom used more than once"
 msgstr "format: %%(then) Atom mehr als einmal verwendet"
 
-#: ref-filter.c:869
+#: ref-filter.c:914
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr "format: %%(then) Atom nach %%(else) verwendet"
 
-#: ref-filter.c:897
+#: ref-filter.c:946
 #, c-format
 msgid "format: %%(else) atom used without an %%(if) atom"
 msgstr "format: %%(else) Atom ohne ein %%(if) Atom verwendet"
 
-#: ref-filter.c:899
+#: ref-filter.c:948
 #, c-format
 msgid "format: %%(else) atom used without a %%(then) atom"
 msgstr "Format: %%(else) Atom ohne ein %%(then) Atom verwendet"
 
-#: ref-filter.c:901
+#: ref-filter.c:950
 #, c-format
 msgid "format: %%(else) atom used more than once"
 msgstr "Format: %%(end) Atom mehr als einmal verwendet"
 
-#: ref-filter.c:916
+#: ref-filter.c:965
 #, c-format
 msgid "format: %%(end) atom used without corresponding atom"
 msgstr "Format: %%(end) Atom ohne zugehöriges Atom verwendet"
 
-#: ref-filter.c:973
+#: ref-filter.c:1027
 #, c-format
 msgid "malformed format string %s"
 msgstr "Fehlerhafter Formatierungsstring %s"
 
-#: ref-filter.c:1621
+#: ref-filter.c:1033
+#, c-format
+msgid "this command reject atom %%(%.*s)"
+msgstr ""
+
+#: ref-filter.c:1040
+#, fuzzy, c-format
+msgid "--format=%.*s cannot be used with --python, --shell, --tcl"
+msgstr "--object-format kann nicht mit --stdin verwendet werden"
+
+#: ref-filter.c:1706
 #, c-format
 msgid "(no branch, rebasing %s)"
 msgstr "(kein Branch, Rebase von %s)"
 
-#: ref-filter.c:1624
+#: ref-filter.c:1709
 #, c-format
 msgid "(no branch, rebasing detached HEAD %s)"
 msgstr "(kein Branch, Rebase von losgelöstem HEAD %s)"
 
-#: ref-filter.c:1627
+#: ref-filter.c:1712
 #, c-format
 msgid "(no branch, bisect started on %s)"
 msgstr "(kein Branch, binäre Suche begonnen bei %s)"
 
-#: ref-filter.c:1631
+#: ref-filter.c:1716
 #, c-format
 msgid "(HEAD detached at %s)"
 msgstr "(HEAD losgelöst bei %s)"
 
-#: ref-filter.c:1634
+#: ref-filter.c:1719
 #, c-format
 msgid "(HEAD detached from %s)"
 msgstr "(HEAD losgelöst von %s)"
 
-#: ref-filter.c:1637
+#: ref-filter.c:1722
 msgid "(no branch)"
 msgstr "(kein Branch)"
 
-#: ref-filter.c:1669 ref-filter.c:1880
+#: ref-filter.c:1754 ref-filter.c:1972
 #, c-format
 msgid "missing object %s for %s"
 msgstr "Objekt %s fehlt für %s"
 
-#: ref-filter.c:1679
+#: ref-filter.c:1764
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr "parse_object_buffer bei %s für %s fehlgeschlagen"
 
-#: ref-filter.c:2064
+#: ref-filter.c:2155
 #, c-format
 msgid "malformed object at '%s'"
 msgstr "fehlerhaftes Objekt bei '%s'"
 
-#: ref-filter.c:2153
+#: ref-filter.c:2245
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr "Ignoriere Referenz mit fehlerhaftem Namen %s"
 
-#: ref-filter.c:2158 refs.c:676
+#: ref-filter.c:2250 refs.c:673
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "Ignoriere fehlerhafte Referenz %s"
 
-#: ref-filter.c:2502
+#: ref-filter.c:2623
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "Format: %%(end) Atom fehlt"
 
-#: ref-filter.c:2596
+#: ref-filter.c:2726
 #, c-format
 msgid "malformed object name %s"
 msgstr "missgebildeter Objektname %s"
 
-#: ref-filter.c:2601
+#: ref-filter.c:2731
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "die Option `%s' muss auf einen Commit zeigen"
 
-#: refs.c:264
+#: refs.c:261
 #, c-format
 msgid "%s does not point to a valid object!"
 msgstr "%s zeigt auf kein gültiges Objekt!"
 
-#: refs.c:566
+#: refs.c:563
 #, c-format
 msgid ""
 "Using '%s' as the name for the initial branch. This default branch name\n"
@@ -7024,83 +7209,83 @@ msgstr ""
 "\n"
 "\tgit branch -m <Name>\n"
 
-#: refs.c:588
+#: refs.c:585
 #, c-format
 msgid "could not retrieve `%s`"
 msgstr "konnte `%s` nicht abrufen"
 
-#: refs.c:598
+#: refs.c:595
 #, c-format
 msgid "invalid branch name: %s = %s"
 msgstr "ungültiger Branchname: %s = %s"
 
-#: refs.c:674
+#: refs.c:671
 #, c-format
 msgid "ignoring dangling symref %s"
 msgstr "Ignoriere unreferenzierte symbolische Referenz %s"
 
-#: refs.c:922
+#: refs.c:920
 #, c-format
 msgid "log for ref %s has gap after %s"
 msgstr "Log für Referenz %s hat eine Lücke nach %s."
 
-#: refs.c:929
+#: refs.c:927
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
 msgstr "Log für Referenz %s unerwartet bei %s beendet."
 
-#: refs.c:994
+#: refs.c:992
 #, c-format
 msgid "log for %s is empty"
 msgstr "Log für %s ist leer."
 
-#: refs.c:1086
+#: refs.c:1084
 #, c-format
 msgid "refusing to update ref with bad name '%s'"
 msgstr "verweigere Aktualisierung einer Referenz mit fehlerhaftem Namen '%s'"
 
-#: refs.c:1157
+#: refs.c:1155
 #, c-format
 msgid "update_ref failed for ref '%s': %s"
 msgstr "update_ref für Referenz '%s' fehlgeschlagen: %s"
 
-#: refs.c:2051
+#: refs.c:2062
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "mehrere Aktualisierungen für Referenz '%s' nicht erlaubt"
 
-#: refs.c:2131
+#: refs.c:2142
 msgid "ref updates forbidden inside quarantine environment"
 msgstr ""
 "Aktualisierungen von Referenzen ist innerhalb der Quarantäne-Umgebung "
 "verboten"
 
-#: refs.c:2142
+#: refs.c:2153
 msgid "ref updates aborted by hook"
 msgstr "Aktualisierungen von Referenzen durch Hook abgebrochen"
 
-#: refs.c:2242 refs.c:2272
+#: refs.c:2253 refs.c:2283
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "'%s' existiert; kann '%s' nicht erstellen"
 
-#: refs.c:2248 refs.c:2283
+#: refs.c:2259 refs.c:2294
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "kann '%s' und '%s' nicht zur selben Zeit verarbeiten"
 
-#: refs/files-backend.c:1228
+#: refs/files-backend.c:1271
 #, c-format
 msgid "could not remove reference %s"
 msgstr "konnte Referenz %s nicht löschen"
 
-#: refs/files-backend.c:1242 refs/packed-backend.c:1542
-#: refs/packed-backend.c:1552
+#: refs/files-backend.c:1285 refs/packed-backend.c:1549
+#: refs/packed-backend.c:1559
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr "konnte Referenz %s nicht entfernen: %s"
 
-#: refs/files-backend.c:1245 refs/packed-backend.c:1555
+#: refs/files-backend.c:1288 refs/packed-backend.c:1562
 #, c-format
 msgid "could not delete references: %s"
 msgstr "konnte Referenzen nicht entfernen: %s"
@@ -7414,7 +7599,7 @@ msgstr "Konnte Rerere-Eintrag nicht schreiben."
 msgid "there were errors while writing '%s' (%s)"
 msgstr "Fehler beim Schreiben von '%s' (%s)."
 
-#: rerere.c:482
+#: rerere.c:482 builtin/gc.c:2246 builtin/gc.c:2281
 #, c-format
 msgid "failed to flush '%s'"
 msgstr "Flush bei '%s' fehlgeschlagen."
@@ -7459,8 +7644,8 @@ msgstr "Kann '%s' nicht löschen."
 msgid "Recorded preimage for '%s'"
 msgstr "Preimage für '%s' aufgezeichnet."
 
-#: rerere.c:865 submodule.c:2076 builtin/log.c:2002
-#: builtin/submodule--helper.c:1805 builtin/submodule--helper.c:1848
+#: rerere.c:865 submodule.c:2121 builtin/log.c:2002
+#: builtin/submodule--helper.c:1776 builtin/submodule--helper.c:1819
 #, c-format
 msgid "could not create directory '%s'"
 msgstr "Konnte Verzeichnis '%s' nicht erstellen."
@@ -7498,46 +7683,42 @@ msgstr "Konnte rr-cache Verzeichnis nicht öffnen."
 msgid "could not determine HEAD revision"
 msgstr "Konnte HEAD-Commit nicht bestimmen."
 
-#: reset.c:69 reset.c:75 sequencer.c:3689
+#: reset.c:70 reset.c:76 sequencer.c:3705
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "Fehler beim Finden des \"Tree\"-Objektes von %s."
 
-#: revision.c:2344
+#: revision.c:2259
+#, fuzzy
+msgid "--unsorted-input is incompatible with --no-walk"
+msgstr "--dir-diff kann nicht mit --no-index verwendet werden"
+
+#: revision.c:2346
 msgid "--unpacked=<packfile> no longer supported"
 msgstr "--unpacked=<Pack-Datei> wird nicht länger unterstützt"
 
-#: revision.c:2684
+#: revision.c:2655 revision.c:2659
+#, fuzzy
+msgid "--no-walk is incompatible with --unsorted-input"
+msgstr "--dir-diff kann nicht mit --no-index verwendet werden"
+
+#: revision.c:2690
 msgid "your current branch appears to be broken"
 msgstr "Ihr aktueller Branch scheint fehlerhaft zu sein."
 
-#: revision.c:2687
+#: revision.c:2693
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
 msgstr "Ihr aktueller Branch '%s' hat noch keine Commits."
 
-#: revision.c:2893
+#: revision.c:2895
 msgid "-L does not yet support diff formats besides -p and -s"
 msgstr "-L unterstützt noch keine anderen Diff-Formate außer -p und -s"
 
-#: run-command.c:766
-msgid "open /dev/null failed"
-msgstr "Öffnen von /dev/null fehlgeschlagen"
-
-#: run-command.c:1274
+#: run-command.c:1278
 #, c-format
 msgid "cannot create async thread: %s"
 msgstr "Konnte Thread für async nicht erzeugen: %s"
-
-#: run-command.c:1344
-#, c-format
-msgid ""
-"The '%s' hook was ignored because it's not set as executable.\n"
-"You can disable this warning with `git config advice.ignoredHook false`."
-msgstr ""
-"Der '%s' Hook wurde ignoriert, weil er nicht als ausführbar markiert ist.\n"
-"Sie können diese Warnung mit `git config advice.ignoredHook false` "
-"deaktivieren."
 
 #: send-pack.c:150
 msgid "unexpected flush packet while reading remote unpack status"
@@ -7557,25 +7738,25 @@ msgstr "Entpacken auf der Gegenseite fehlgeschlagen: %s"
 msgid "failed to sign the push certificate"
 msgstr "Fehler beim Signieren des \"push\"-Zertifikates"
 
-#: send-pack.c:433
+#: send-pack.c:435
 msgid "send-pack: unable to fork off fetch subprocess"
 msgstr "send-pack: konnte Fetch-Subprozess nicht abspalten"
 
-#: send-pack.c:455
+#: send-pack.c:457
 msgid "push negotiation failed; proceeding anyway with push"
 msgstr "Push-Verhandlung fehlgeschlagen; fahre trotzdem mit dem Push fort"
 
-#: send-pack.c:526
+#: send-pack.c:528
 msgid "the receiving end does not support this repository's hash algorithm"
 msgstr ""
 "die Gegenseite unterstützt nicht den Hash-Algorithmus dieses Repositories"
 
-#: send-pack.c:535
+#: send-pack.c:537
 msgid "the receiving end does not support --signed push"
 msgstr ""
 "die Gegenseite unterstützt keinen signierten Versand (\"--signed push\")"
 
-#: send-pack.c:537
+#: send-pack.c:539
 msgid ""
 "not sending a push certificate since the receiving end does not support --"
 "signed push"
@@ -7583,47 +7764,48 @@ msgstr ""
 "kein Versand des \"push\"-Zertifikates, da die Gegenseite keinen signierten\n"
 "Versand (\"--signed push\") unterstützt"
 
-#: send-pack.c:544
+#: send-pack.c:546
 msgid "the receiving end does not support --atomic push"
 msgstr "die Gegenseite unterstützt keinen atomaren Versand (\"--atomic push\")"
 
-#: send-pack.c:549
+#: send-pack.c:551
 msgid "the receiving end does not support push options"
 msgstr "die Gegenseite unterstützt keine Push-Optionen"
 
-#: sequencer.c:196
+#: sequencer.c:197
 #, c-format
 msgid "invalid commit message cleanup mode '%s'"
 msgstr "Ungültiger \"cleanup\"-Modus '%s' für Commit-Beschreibungen."
 
-#: sequencer.c:324
+#: sequencer.c:325
 #, c-format
 msgid "could not delete '%s'"
 msgstr "Konnte '%s' nicht löschen."
 
-#: sequencer.c:344 builtin/rebase.c:757 builtin/rebase.c:1592 builtin/rm.c:402
+#: sequencer.c:345 sequencer.c:4754 builtin/rebase.c:563 builtin/rebase.c:1297
+#: builtin/rm.c:408
 #, c-format
 msgid "could not remove '%s'"
 msgstr "Konnte '%s' nicht löschen"
 
-#: sequencer.c:354
+#: sequencer.c:355
 msgid "revert"
 msgstr "Revert"
 
-#: sequencer.c:356
+#: sequencer.c:357
 msgid "cherry-pick"
 msgstr "Cherry-Pick"
 
-#: sequencer.c:358
+#: sequencer.c:359
 msgid "rebase"
 msgstr "Rebase"
 
-#: sequencer.c:360
+#: sequencer.c:361
 #, c-format
 msgid "unknown action: %d"
 msgstr "Unbekannte Aktion: %d"
 
-#: sequencer.c:419
+#: sequencer.c:420
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'"
@@ -7631,54 +7813,80 @@ msgstr ""
 "nach Auflösung der Konflikte markieren Sie die korrigierten Pfade\n"
 "mit 'git add <Pfade>' oder 'git rm <Pfade>'"
 
-#: sequencer.c:422
+#: sequencer.c:423
+#, fuzzy
 msgid ""
-"after resolving the conflicts, mark the corrected paths\n"
-"with 'git add <paths>' or 'git rm <paths>'\n"
-"and commit the result with 'git commit'"
+"After resolving the conflicts, mark them with\n"
+"\"git add/rm <pathspec>\", then run\n"
+"\"git cherry-pick --continue\".\n"
+"You can instead skip this commit with \"git cherry-pick --skip\".\n"
+"To abort and get back to the state before \"git cherry-pick\",\n"
+"run \"git cherry-pick --abort\"."
 msgstr ""
-"nach Auflösung der Konflikte markieren Sie die korrigierten Pfade\n"
-"mit 'git add <Pfade>' oder 'git rm <Pfade>' und tragen Sie das Ergebnis mit\n"
-"'git commit' ein"
+"Lösen Sie alle Konflikte manuell auf, markieren Sie diese mit\n"
+"\"git add/rm <konfliktbehaftete_Dateien>\" und führen Sie dann\n"
+"\"git rebase --continue\" aus.\n"
+"Sie können auch stattdessen diesen Commit auslassen, indem\n"
+"Sie \"git rebase --skip\" ausführen.\n"
+"Um abzubrechen und zurück zum Zustand vor \"git rebase\" zu gelangen,\n"
+"führen Sie \"git rebase --abort\" aus."
 
-#: sequencer.c:435 sequencer.c:3271
+#: sequencer.c:430
+#, fuzzy
+msgid ""
+"After resolving the conflicts, mark them with\n"
+"\"git add/rm <pathspec>\", then run\n"
+"\"git revert --continue\".\n"
+"You can instead skip this commit with \"git revert --skip\".\n"
+"To abort and get back to the state before \"git revert\",\n"
+"run \"git revert --abort\"."
+msgstr ""
+"Lösen Sie alle Konflikte manuell auf, markieren Sie diese mit\n"
+"\"git add/rm <konfliktbehaftete_Dateien>\" und führen Sie dann\n"
+"\"git rebase --continue\" aus.\n"
+"Sie können auch stattdessen diesen Commit auslassen, indem\n"
+"Sie \"git rebase --skip\" ausführen.\n"
+"Um abzubrechen und zurück zum Zustand vor \"git rebase\" zu gelangen,\n"
+"führen Sie \"git rebase --abort\" aus."
+
+#: sequencer.c:448 sequencer.c:3290
 #, c-format
 msgid "could not lock '%s'"
 msgstr "Konnte '%s' nicht sperren"
 
-#: sequencer.c:437 sequencer.c:3070 sequencer.c:3275 sequencer.c:3289
-#: sequencer.c:3547 sequencer.c:5566 strbuf.c:1170 wrapper.c:631
+#: sequencer.c:450 sequencer.c:3089 sequencer.c:3294 sequencer.c:3308
+#: sequencer.c:3566 sequencer.c:5621 strbuf.c:1176 wrapper.c:639
 #, c-format
 msgid "could not write to '%s'"
 msgstr "Konnte nicht nach '%s' schreiben."
 
-#: sequencer.c:442
+#: sequencer.c:455
 #, c-format
 msgid "could not write eol to '%s'"
 msgstr "Konnte EOL nicht nach '%s' schreiben."
 
-#: sequencer.c:447 sequencer.c:3075 sequencer.c:3277 sequencer.c:3291
-#: sequencer.c:3555
+#: sequencer.c:460 sequencer.c:3094 sequencer.c:3296 sequencer.c:3310
+#: sequencer.c:3574
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "Fehler beim Fertigstellen von '%s'."
 
-#: sequencer.c:486
+#: sequencer.c:499
 #, c-format
 msgid "your local changes would be overwritten by %s."
 msgstr "Ihre lokalen Änderungen würden durch den %s überschrieben werden."
 
-#: sequencer.c:490
+#: sequencer.c:503
 msgid "commit your changes or stash them to proceed."
 msgstr ""
 "Committen Sie Ihre Änderungen oder benutzen Sie \"stash\", um fortzufahren."
 
-#: sequencer.c:522
+#: sequencer.c:535
 #, c-format
 msgid "%s: fast-forward"
 msgstr "%s: Vorspulen"
 
-#: sequencer.c:561 builtin/tag.c:609
+#: sequencer.c:574 builtin/tag.c:610
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Ungültiger \"cleanup\" Modus %s"
@@ -7686,65 +7894,65 @@ msgstr "Ungültiger \"cleanup\" Modus %s"
 #. TRANSLATORS: %s will be "revert", "cherry-pick" or
 #. "rebase".
 #.
-#: sequencer.c:671
+#: sequencer.c:685
 #, c-format
 msgid "%s: Unable to write new index file"
 msgstr "%s: Konnte neue Index-Datei nicht schreiben"
 
-#: sequencer.c:685
+#: sequencer.c:699
 msgid "unable to update cache tree"
 msgstr "Konnte Cache-Verzeichnis nicht aktualisieren."
 
-#: sequencer.c:699
+#: sequencer.c:713
 msgid "could not resolve HEAD commit"
 msgstr "Konnte HEAD-Commit nicht auflösen."
 
-#: sequencer.c:779
+#: sequencer.c:793
 #, c-format
 msgid "no key present in '%.*s'"
 msgstr "Kein Schlüssel in '%.*s' vorhanden."
 
-#: sequencer.c:790
+#: sequencer.c:804
 #, c-format
 msgid "unable to dequote value of '%s'"
 msgstr "Konnte Anführungszeichen von '%s' nicht entfernen."
 
-#: sequencer.c:827 wrapper.c:201 wrapper.c:371 builtin/am.c:729
-#: builtin/am.c:821 builtin/merge.c:1141 builtin/rebase.c:910
+#: sequencer.c:841 wrapper.c:209 wrapper.c:379 builtin/am.c:730
+#: builtin/am.c:822 builtin/rebase.c:694
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "Konnte '%s' nicht zum Lesen öffnen."
 
-#: sequencer.c:837
+#: sequencer.c:851
 msgid "'GIT_AUTHOR_NAME' already given"
 msgstr "'GIT_AUTHOR_NAME' bereits angegeben."
 
-#: sequencer.c:842
+#: sequencer.c:856
 msgid "'GIT_AUTHOR_EMAIL' already given"
 msgstr "'GIT_AUTHOR_EMAIL' bereits angegeben."
 
-#: sequencer.c:847
+#: sequencer.c:861
 msgid "'GIT_AUTHOR_DATE' already given"
 msgstr "'GIT_AUTHOR_DATE' bereits angegeben."
 
-#: sequencer.c:851
+#: sequencer.c:865
 #, c-format
 msgid "unknown variable '%s'"
 msgstr "Unbekannte Variable '%s'"
 
-#: sequencer.c:856
+#: sequencer.c:870
 msgid "missing 'GIT_AUTHOR_NAME'"
 msgstr "'GIT_AUTHOR_NAME' fehlt."
 
-#: sequencer.c:858
+#: sequencer.c:872
 msgid "missing 'GIT_AUTHOR_EMAIL'"
 msgstr "'GIT_AUTHOR_EMAIL' fehlt."
 
-#: sequencer.c:860
+#: sequencer.c:874
 msgid "missing 'GIT_AUTHOR_DATE'"
 msgstr "'GIT_AUTHOR_DATE' fehlt."
 
-#: sequencer.c:925
+#: sequencer.c:939
 #, c-format
 msgid ""
 "you have staged changes in your working tree\n"
@@ -7775,11 +7983,11 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:1212
+#: sequencer.c:1229
 msgid "'prepare-commit-msg' hook failed"
 msgstr "'prepare-commit-msg' Hook fehlgeschlagen."
 
-#: sequencer.c:1218
+#: sequencer.c:1235
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7807,7 +8015,7 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1231
+#: sequencer.c:1248
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7833,345 +8041,350 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1273
+#: sequencer.c:1290
 msgid "couldn't look up newly created commit"
 msgstr "Konnte neu erstellten Commit nicht nachschlagen."
 
-#: sequencer.c:1275
+#: sequencer.c:1292
 msgid "could not parse newly created commit"
 msgstr "Konnte neu erstellten Commit nicht analysieren."
 
-#: sequencer.c:1321
+#: sequencer.c:1338
 msgid "unable to resolve HEAD after creating commit"
 msgstr "Konnte HEAD nicht auflösen, nachdem der Commit erstellt wurde."
 
-#: sequencer.c:1323
+#: sequencer.c:1340
 msgid "detached HEAD"
 msgstr "losgelöster HEAD"
 
-#: sequencer.c:1327
+#: sequencer.c:1344
 msgid " (root-commit)"
 msgstr " (Root-Commit)"
 
-#: sequencer.c:1348
+#: sequencer.c:1365
 msgid "could not parse HEAD"
 msgstr "Konnte HEAD nicht parsen."
 
-#: sequencer.c:1350
+#: sequencer.c:1367
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "HEAD %s ist kein Commit!"
 
-#: sequencer.c:1354 sequencer.c:1432 builtin/commit.c:1705
+#: sequencer.c:1371 sequencer.c:1449 builtin/commit.c:1707
 msgid "could not parse HEAD commit"
 msgstr "Konnte Commit von HEAD nicht analysieren."
 
-#: sequencer.c:1410 sequencer.c:2295
+#: sequencer.c:1427 sequencer.c:2312
 msgid "unable to parse commit author"
 msgstr "Konnte Commit-Autor nicht parsen."
 
-#: sequencer.c:1421 builtin/am.c:1615 builtin/merge.c:707
+#: sequencer.c:1438 builtin/am.c:1616 builtin/merge.c:708
 msgid "git write-tree failed to write a tree"
 msgstr "\"git write-tree\" schlug beim Schreiben eines \"Tree\"-Objektes fehl"
 
-#: sequencer.c:1454 sequencer.c:1574
+#: sequencer.c:1471 sequencer.c:1591
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "Konnte Commit-Beschreibung von '%s' nicht lesen."
 
-#: sequencer.c:1485 sequencer.c:1517
+#: sequencer.c:1502 sequencer.c:1534
 #, c-format
 msgid "invalid author identity '%s'"
 msgstr "ungültige Autor-Identität '%s'"
 
-#: sequencer.c:1491
+#: sequencer.c:1508
 msgid "corrupt author: missing date information"
 msgstr "unbrauchbarer Autor: Datumsinformationen fehlen"
 
-#: sequencer.c:1530 builtin/am.c:1642 builtin/commit.c:1819 builtin/merge.c:910
-#: builtin/merge.c:935 t/helper/test-fast-rebase.c:78
+#: sequencer.c:1547 builtin/am.c:1643 builtin/commit.c:1821 builtin/merge.c:913
+#: builtin/merge.c:938 t/helper/test-fast-rebase.c:78
 msgid "failed to write commit object"
 msgstr "Fehler beim Schreiben des Commit-Objektes."
 
-#: sequencer.c:1557 sequencer.c:4492 t/helper/test-fast-rebase.c:199
+#: sequencer.c:1574 sequencer.c:4526 t/helper/test-fast-rebase.c:199
 #: t/helper/test-fast-rebase.c:217
 #, c-format
 msgid "could not update %s"
 msgstr "Konnte %s nicht aktualisieren."
 
-#: sequencer.c:1606
+#: sequencer.c:1623
 #, c-format
 msgid "could not parse commit %s"
 msgstr "Konnte Commit %s nicht parsen."
 
-#: sequencer.c:1611
+#: sequencer.c:1628
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "Konnte Eltern-Commit %s nicht parsen."
 
-#: sequencer.c:1694 sequencer.c:1975
+#: sequencer.c:1711 sequencer.c:1992
 #, c-format
 msgid "unknown command: %d"
 msgstr "Unbekannter Befehl: %d"
 
-#: sequencer.c:1736 git-rebase--preserve-merges.sh:486
+#: sequencer.c:1753
 msgid "This is the 1st commit message:"
 msgstr "Das ist die erste Commit-Beschreibung:"
 
-#: sequencer.c:1737
+#: sequencer.c:1754
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "Das ist Commit-Beschreibung #%d:"
 
-#: sequencer.c:1738
+#: sequencer.c:1755
 msgid "The 1st commit message will be skipped:"
 msgstr "Die erste Commit-Beschreibung wird übersprungen:"
 
-#: sequencer.c:1739
+#: sequencer.c:1756
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "Die Commit-Beschreibung #%d wird ausgelassen:"
 
-#: sequencer.c:1740
+#: sequencer.c:1757
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr "Das ist eine Kombination aus %d Commits."
 
-#: sequencer.c:1887 sequencer.c:1944
+#: sequencer.c:1904 sequencer.c:1961
 #, c-format
 msgid "cannot write '%s'"
 msgstr "kann '%s' nicht schreiben"
 
-#: sequencer.c:1934
+#: sequencer.c:1951
 msgid "need a HEAD to fixup"
 msgstr "benötige HEAD für fixup"
 
-#: sequencer.c:1936 sequencer.c:3582
+#: sequencer.c:1953 sequencer.c:3601
 msgid "could not read HEAD"
 msgstr "Konnte HEAD nicht lesen"
 
-#: sequencer.c:1938
+#: sequencer.c:1955
 msgid "could not read HEAD's commit message"
 msgstr "Konnte Commit-Beschreibung von HEAD nicht lesen"
 
-#: sequencer.c:1962
+#: sequencer.c:1979
 #, c-format
 msgid "could not read commit message of %s"
 msgstr "Konnte Commit-Beschreibung von %s nicht lesen."
 
-#: sequencer.c:2072
+#: sequencer.c:2089
 msgid "your index file is unmerged."
 msgstr "Ihre Index-Datei ist nicht zusammengeführt."
 
-#: sequencer.c:2079
+#: sequencer.c:2096
 msgid "cannot fixup root commit"
 msgstr "kann fixup nicht auf Root-Commit anwenden"
 
-#: sequencer.c:2098
+#: sequencer.c:2115
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "Commit %s ist ein Merge, aber die Option -m wurde nicht angegeben."
 
-#: sequencer.c:2106 sequencer.c:2114
+#: sequencer.c:2123 sequencer.c:2131
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "Commit %s hat keinen Eltern-Commit %d"
 
-#: sequencer.c:2120
+#: sequencer.c:2137
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "Kann keine Commit-Beschreibung für %s bekommen."
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:2139
+#: sequencer.c:2156
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: kann Eltern-Commit %s nicht parsen"
 
-#: sequencer.c:2205
+#: sequencer.c:2222
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "Konnte '%s' nicht zu '%s' umbenennen."
 
-#: sequencer.c:2265
+#: sequencer.c:2282
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "Konnte \"revert\" nicht auf %s... (%s) ausführen"
 
-#: sequencer.c:2266
+#: sequencer.c:2283
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "Konnte %s... (%s) nicht anwenden"
 
-#: sequencer.c:2287
+#: sequencer.c:2304
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr "Weglassen von %s %s -- Patch-Inhalte sind bereits im Upstream-Branch\n"
 
-#: sequencer.c:2345
+#: sequencer.c:2362
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: Fehler beim Lesen des Index"
 
-#: sequencer.c:2352
+#: sequencer.c:2370
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: Fehler beim Aktualisieren des Index"
 
-#: sequencer.c:2425
+#: sequencer.c:2450
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "%s akzeptiert keine Argumente: '%s'"
 
-#: sequencer.c:2434
+#: sequencer.c:2459
 #, c-format
 msgid "missing arguments for %s"
 msgstr "Fehlende Argumente für %s."
 
-#: sequencer.c:2477
+#: sequencer.c:2502
 #, c-format
 msgid "could not parse '%s'"
 msgstr "Konnte '%s' nicht parsen."
 
-#: sequencer.c:2538
+#: sequencer.c:2563
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "Ungültige Zeile %d: %.*s"
 
-#: sequencer.c:2549
+#: sequencer.c:2574
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "Kann '%s' nicht ohne vorherigen Commit ausführen"
 
-#: sequencer.c:2635
+#: sequencer.c:2622 builtin/rebase.c:184
+#, c-format
+msgid "could not read '%s'."
+msgstr "Konnte '%s' nicht lesen."
+
+#: sequencer.c:2660
 msgid "cancelling a cherry picking in progress"
 msgstr "Abbrechen eines laufenden \"cherry-pick\""
 
-#: sequencer.c:2644
+#: sequencer.c:2669
 msgid "cancelling a revert in progress"
 msgstr "Abbrechen eines laufenden \"revert\""
 
-#: sequencer.c:2690
+#: sequencer.c:2709
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr ""
 "Bitte beheben Sie dieses, indem Sie 'git rebase --edit-todo' ausführen."
 
-#: sequencer.c:2692
+#: sequencer.c:2711
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "Unbenutzbares Instruktionsblatt: '%s'"
 
-#: sequencer.c:2697
+#: sequencer.c:2716
 msgid "no commits parsed."
 msgstr "Keine Commits geparst."
 
-#: sequencer.c:2708
+#: sequencer.c:2727
 msgid "cannot cherry-pick during a revert."
 msgstr "Kann Cherry-Pick nicht während eines Reverts ausführen."
 
-#: sequencer.c:2710
+#: sequencer.c:2729
 msgid "cannot revert during a cherry-pick."
 msgstr "Kann Revert nicht während eines Cherry-Picks ausführen."
 
-#: sequencer.c:2788
+#: sequencer.c:2807
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr "ungültiger Wert für %s: %s"
 
-#: sequencer.c:2897
+#: sequencer.c:2916
 msgid "unusable squash-onto"
 msgstr "unbenutzbares squash-onto"
 
-#: sequencer.c:2917
+#: sequencer.c:2936
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "fehlerhaftes Optionsblatt: '%s'"
 
-#: sequencer.c:3012 sequencer.c:4868
+#: sequencer.c:3031 sequencer.c:4905
 msgid "empty commit set passed"
 msgstr "leere Menge von Commits übergeben"
 
-#: sequencer.c:3029
+#: sequencer.c:3048
 msgid "revert is already in progress"
 msgstr "\"revert\" ist bereits im Gange"
 
-#: sequencer.c:3031
+#: sequencer.c:3050
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr "versuchen Sie \"git revert (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:3034
+#: sequencer.c:3053
 msgid "cherry-pick is already in progress"
 msgstr "\"cherry-pick\" wird bereits durchgeführt"
 
-#: sequencer.c:3036
+#: sequencer.c:3055
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr "versuchen Sie \"git cherry-pick (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:3050
+#: sequencer.c:3069
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr "konnte \"sequencer\"-Verzeichnis '%s' nicht erstellen"
 
-#: sequencer.c:3065
+#: sequencer.c:3084
 msgid "could not lock HEAD"
 msgstr "konnte HEAD nicht sperren"
 
-#: sequencer.c:3125 sequencer.c:4581
+#: sequencer.c:3144 sequencer.c:4615
 msgid "no cherry-pick or revert in progress"
 msgstr "kein \"cherry-pick\" oder \"revert\" im Gange"
 
-#: sequencer.c:3127 sequencer.c:3138
+#: sequencer.c:3146 sequencer.c:3157
 msgid "cannot resolve HEAD"
 msgstr "kann HEAD nicht auflösen"
 
-#: sequencer.c:3129 sequencer.c:3173
+#: sequencer.c:3148 sequencer.c:3192
 msgid "cannot abort from a branch yet to be born"
 msgstr "kann nicht abbrechen: bin auf einem Branch, der noch nicht geboren ist"
 
-#: sequencer.c:3159 builtin/grep.c:758
+#: sequencer.c:3178 builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr "kann '%s' nicht öffnen"
 
-#: sequencer.c:3161
+#: sequencer.c:3180
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "kann '%s' nicht lesen: %s"
 
-#: sequencer.c:3162
+#: sequencer.c:3181
 msgid "unexpected end of file"
 msgstr "unerwartetes Dateiende"
 
-#: sequencer.c:3168
+#: sequencer.c:3187
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr "gespeicherte \"pre-cherry-pick\" HEAD Datei '%s' ist beschädigt"
 
-#: sequencer.c:3179
+#: sequencer.c:3198
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr ""
 "Sie scheinen HEAD verändert zu haben. Keine Rückspulung, prüfen Sie HEAD."
 
-#: sequencer.c:3220
+#: sequencer.c:3239
 msgid "no revert in progress"
 msgstr "kein Revert im Gange"
 
-#: sequencer.c:3229
+#: sequencer.c:3248
 msgid "no cherry-pick in progress"
 msgstr "kein \"cherry-pick\" im Gange"
 
-#: sequencer.c:3239
+#: sequencer.c:3258
 msgid "failed to skip the commit"
 msgstr "Überspringen des Commits fehlgeschlagen"
 
-#: sequencer.c:3246
+#: sequencer.c:3265
 msgid "there is nothing to skip"
 msgstr "nichts zum Überspringen vorhanden"
 
-#: sequencer.c:3249
+#: sequencer.c:3268
 #, c-format
 msgid ""
 "have you committed already?\n"
@@ -8180,16 +8393,16 @@ msgstr ""
 "Haben Sie bereits committet?\n"
 "Versuchen Sie \"git %s --continue\""
 
-#: sequencer.c:3411 sequencer.c:4472
+#: sequencer.c:3430 sequencer.c:4506
 msgid "cannot read HEAD"
 msgstr "kann HEAD nicht lesen"
 
-#: sequencer.c:3428
+#: sequencer.c:3447
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "konnte '%s' nicht nach '%s' kopieren"
 
-#: sequencer.c:3436
+#: sequencer.c:3455
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -8208,27 +8421,27 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:3446
+#: sequencer.c:3465
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "Konnte %s... (%.*s) nicht anwenden"
 
-#: sequencer.c:3453
+#: sequencer.c:3472
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "Konnte \"%.*s\" nicht zusammenführen"
 
-#: sequencer.c:3467 sequencer.c:3471 builtin/difftool.c:644
+#: sequencer.c:3486 sequencer.c:3490 builtin/difftool.c:639
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "konnte '%s' nicht nach '%s' kopieren"
 
-#: sequencer.c:3483
+#: sequencer.c:3502
 #, c-format
 msgid "Executing: %s\n"
 msgstr "Führe aus: %s\n"
 
-#: sequencer.c:3498
+#: sequencer.c:3517
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -8244,11 +8457,11 @@ msgstr ""
 "\n"
 "ausführen.\n"
 
-#: sequencer.c:3504
+#: sequencer.c:3523
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "Der Index und/oder das Arbeitsverzeichnis wurde geändert.\n"
 
-#: sequencer.c:3510
+#: sequencer.c:3529
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -8266,91 +8479,91 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3572
+#: sequencer.c:3591
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "unerlaubter Beschriftungsname: '%.*s'"
 
-#: sequencer.c:3645
+#: sequencer.c:3664
 msgid "writing fake root commit"
 msgstr "unechten Root-Commit schreiben"
 
-#: sequencer.c:3650
+#: sequencer.c:3669
 msgid "writing squash-onto"
 msgstr "squash-onto schreiben"
 
-#: sequencer.c:3734
+#: sequencer.c:3748
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "konnte '%s' nicht auflösen"
 
-#: sequencer.c:3767
+#: sequencer.c:3780
 msgid "cannot merge without a current revision"
 msgstr "kann nicht ohne einen aktuellen Commit mergen"
 
-#: sequencer.c:3789
+#: sequencer.c:3802
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "konnte '%.*s' nicht parsen"
 
-#: sequencer.c:3798
+#: sequencer.c:3811
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "nichts zum Zusammenführen: '%.*s'"
 
-#: sequencer.c:3810
+#: sequencer.c:3823
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr ""
 "Oktopus-Merge kann nicht auf Basis von [neuem Root-Commit] ausgeführt werden"
 
-#: sequencer.c:3826
+#: sequencer.c:3878
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "konnte keine Commit-Beschreibung von '%s' bekommen"
 
-#: sequencer.c:4009
+#: sequencer.c:4024
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "konnte nicht einmal versuchen '%.*s' zu mergen"
 
-#: sequencer.c:4025
+#: sequencer.c:4040
 msgid "merge: Unable to write new index file"
 msgstr "merge: Konnte neue Index-Datei nicht schreiben."
 
-#: sequencer.c:4099
+#: sequencer.c:4121
 msgid "Cannot autostash"
 msgstr "Kann automatischen Stash nicht erzeugen"
 
-#: sequencer.c:4102
+#: sequencer.c:4124
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Unerwartete 'stash'-Antwort: '%s'"
 
-#: sequencer.c:4108
+#: sequencer.c:4130
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "Konnte Verzeichnis für '%s' nicht erstellen"
 
-#: sequencer.c:4111
+#: sequencer.c:4133
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "Automatischen Stash erzeugt: %s\n"
 
-#: sequencer.c:4115
+#: sequencer.c:4137
 msgid "could not reset --hard"
 msgstr "konnte 'reset --hard' nicht ausführen"
 
-#: sequencer.c:4140
+#: sequencer.c:4162
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "Automatischen Stash angewendet.\n"
 
-#: sequencer.c:4152
+#: sequencer.c:4174
 #, c-format
 msgid "cannot store %s"
 msgstr "kann %s nicht speichern"
 
-#: sequencer.c:4155
+#: sequencer.c:4177
 #, c-format
 msgid ""
 "%s\n"
@@ -8361,29 +8574,29 @@ msgstr ""
 "Ihre Änderungen sind im Stash sicher.\n"
 "Sie können jederzeit \"git stash pop\" oder \"git stash drop\" ausführen.\n"
 
-#: sequencer.c:4160
+#: sequencer.c:4182
 msgid "Applying autostash resulted in conflicts."
 msgstr "Beim Anwenden des automatischen Stash traten Konflikte auf."
 
-#: sequencer.c:4161
+#: sequencer.c:4183
 msgid "Autostash exists; creating a new stash entry."
 msgstr "Automatischer Stash existiert; ein neuer Stash-Eintrag wird erstellt."
 
-#: sequencer.c:4233 git-rebase--preserve-merges.sh:769
+#: sequencer.c:4255
 msgid "could not detach HEAD"
 msgstr "konnte HEAD nicht loslösen"
 
-#: sequencer.c:4248
+#: sequencer.c:4270
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Angehalten bei HEAD\n"
 
-#: sequencer.c:4250
+#: sequencer.c:4272
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Angehalten bei %s\n"
 
-#: sequencer.c:4258
+#: sequencer.c:4304
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -8405,60 +8618,60 @@ msgstr ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:4304
+#: sequencer.c:4350
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr "Rebase (%d/%d)%s"
 
-#: sequencer.c:4350
+#: sequencer.c:4396
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Angehalten bei %s... %.*s\n"
 
-#: sequencer.c:4421
+#: sequencer.c:4466
 #, c-format
 msgid "unknown command %d"
 msgstr "Unbekannter Befehl %d"
 
-#: sequencer.c:4480
+#: sequencer.c:4514
 msgid "could not read orig-head"
 msgstr "Konnte orig-head nicht lesen."
 
-#: sequencer.c:4485
+#: sequencer.c:4519
 msgid "could not read 'onto'"
 msgstr "Konnte 'onto' nicht lesen."
 
-#: sequencer.c:4499
+#: sequencer.c:4533
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "Konnte HEAD nicht auf %s aktualisieren."
 
-#: sequencer.c:4559
+#: sequencer.c:4593
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr "Erfolgreich Rebase ausgeführt und %s aktualisiert.\n"
 
-#: sequencer.c:4611
+#: sequencer.c:4645
 msgid "cannot rebase: You have unstaged changes."
 msgstr ""
 "Rebase nicht möglich: Sie haben Änderungen, die nicht zum Commit\n"
 "vorgemerkt sind."
 
-#: sequencer.c:4620
+#: sequencer.c:4654
 msgid "cannot amend non-existing commit"
 msgstr "Kann nicht existierenden Commit nicht nachbessern."
 
-#: sequencer.c:4622
+#: sequencer.c:4656
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "Ungültige Datei: '%s'"
 
-#: sequencer.c:4624
+#: sequencer.c:4658
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "Ungültige Inhalte: '%s'"
 
-#: sequencer.c:4627
+#: sequencer.c:4661
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -8469,50 +8682,59 @@ msgstr ""
 "committen Sie diese zuerst und führen Sie dann 'git rebase --continue'\n"
 "erneut aus."
 
-#: sequencer.c:4663 sequencer.c:4702
+#: sequencer.c:4697 sequencer.c:4736
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "Konnte Datei nicht schreiben: '%s'"
 
-#: sequencer.c:4718
+#: sequencer.c:4752
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "Konnte CHERRY_PICK_HEAD nicht löschen."
 
-#: sequencer.c:4725
+#: sequencer.c:4762
 msgid "could not commit staged changes."
 msgstr "Konnte Änderungen aus der Staging-Area nicht committen."
 
-#: sequencer.c:4845
+#: sequencer.c:4882
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: %s kann nicht in \"cherry-pick\" benutzt werden"
 
-#: sequencer.c:4849
+#: sequencer.c:4886
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: ungültiger Commit"
 
-#: sequencer.c:4884
+#: sequencer.c:4921
 msgid "can't revert as initial commit"
 msgstr "Kann nicht als allerersten Commit einen Revert ausführen."
 
-#: sequencer.c:5361
+#: sequencer.c:5192 sequencer.c:5421
+#, fuzzy, c-format
+msgid "skipped previously applied commit %s"
+msgstr "vorherigen Commit ändern"
+
+#: sequencer.c:5262 sequencer.c:5437
+msgid "use --reapply-cherry-picks to include skipped commits"
+msgstr ""
+
+#: sequencer.c:5408
 msgid "make_script: unhandled options"
 msgstr "make_script: unbehandelte Optionen"
 
-#: sequencer.c:5364
+#: sequencer.c:5411
 msgid "make_script: error preparing revisions"
 msgstr "make_script: Fehler beim Vorbereiten der Commits"
 
-#: sequencer.c:5614 sequencer.c:5631
+#: sequencer.c:5669 sequencer.c:5686
 msgid "nothing to do"
 msgstr "Nichts zu tun."
 
-#: sequencer.c:5650
+#: sequencer.c:5705
 msgid "could not skip unnecessary pick commands"
 msgstr "Konnte unnötige \"pick\"-Befehle nicht auslassen."
 
-#: sequencer.c:5750
+#: sequencer.c:5805
 msgid "the script was already rearranged."
 msgstr "Das Script wurde bereits umgeordnet."
 
@@ -8673,27 +8895,15 @@ msgstr ""
 "Problem mit Wert für Dateimodus (0%.3o) von core.sharedRepository.\n"
 "Der Besitzer der Dateien muss immer Lese- und Schreibrechte haben."
 
-#: setup.c:1430
-msgid "open /dev/null or dup failed"
-msgstr "Öffnen von /dev/null oder dup fehlgeschlagen."
-
-#: setup.c:1445
+#: setup.c:1443
 msgid "fork failed"
 msgstr "fork fehlgeschlagen"
 
-#: setup.c:1450 t/helper/test-simple-ipc.c:285
+#: setup.c:1448
 msgid "setsid failed"
 msgstr "setsid fehlgeschlagen"
 
-#: sparse-index.c:162
-msgid "attempting to use sparse-index without cone mode"
-msgstr "versuche partiellen Index ohne Cone-Modus zu benutzen"
-
-#: sparse-index.c:176
-msgid "unable to update cache-tree, staying full"
-msgstr "konnte Cache-Verzeichnis nicht aktualisieren, bleibt voll"
-
-#: sparse-index.c:263
+#: sparse-index.c:273
 #, c-format
 msgid "index entry is a directory, but not sparse (%08x)"
 msgstr "Index-Eintrag ist ein Verzeichnis, aber nicht partiell (%08x)"
@@ -8750,13 +8960,13 @@ msgid_plural "%u bytes/s"
 msgstr[0] "%u Byte/s"
 msgstr[1] "%u Bytes/s"
 
-#: strbuf.c:1168 wrapper.c:199 wrapper.c:369 builtin/am.c:738
-#: builtin/rebase.c:866
+#: strbuf.c:1174 wrapper.c:207 wrapper.c:377 builtin/am.c:739
+#: builtin/rebase.c:650
 #, c-format
 msgid "could not open '%s' for writing"
 msgstr "Konnte '%s' nicht zum Schreiben öffnen."
 
-#: strbuf.c:1177
+#: strbuf.c:1183
 #, c-format
 msgid "could not edit '%s'"
 msgstr "Konnte '%s' nicht editieren."
@@ -8782,7 +8992,7 @@ msgstr ""
 msgid "invalid value for %s"
 msgstr "Ungültiger Wert für %s"
 
-#: submodule-config.c:766
+#: submodule-config.c:767
 #, c-format
 msgid "Could not update .gitmodules entry %s"
 msgstr "Konnte Eintrag '%s' in .gitmodules nicht aktualisieren"
@@ -8807,22 +9017,22 @@ msgstr "Konnte Eintrag '%s' nicht aus .gitmodules entfernen"
 msgid "staging updated .gitmodules failed"
 msgstr "Konnte aktualisierte .gitmodules-Datei nicht zum Commit vormerken"
 
-#: submodule.c:328
+#: submodule.c:358
 #, c-format
 msgid "in unpopulated submodule '%s'"
 msgstr "In nicht ausgechecktem Submodul '%s'."
 
-#: submodule.c:359
+#: submodule.c:389
 #, c-format
 msgid "Pathspec '%s' is in submodule '%.*s'"
 msgstr "Pfadspezifikation '%s' befindet sich in Submodul '%.*s'"
 
-#: submodule.c:436
+#: submodule.c:466
 #, c-format
 msgid "bad --ignore-submodules argument: %s"
 msgstr "ungültiges --ignore-submodules Argument: %s"
 
-#: submodule.c:805
+#: submodule.c:844
 #, c-format
 msgid ""
 "Submodule in commit %s at path: '%s' collides with a submodule named the "
@@ -8831,12 +9041,12 @@ msgstr ""
 "Submodul in Commit %s beim Pfad: '%s' hat den gleichen Namen wie ein "
 "Submodul. Wird übersprungen."
 
-#: submodule.c:908
+#: submodule.c:954
 #, c-format
 msgid "submodule entry '%s' (%s) is a %s, not a commit"
 msgstr "Submodul-Eintrag '%s' (%s) ist ein %s, kein Commit."
 
-#: submodule.c:993
+#: submodule.c:1042
 #, c-format
 msgid ""
 "Could not run 'git rev-list <commits> --not --remotes -n 1' command in "
@@ -8845,36 +9055,36 @@ msgstr ""
 "Konnte 'git rev-list <Commits> --not --remotes -n 1' nicht in Submodul '%s' "
 "ausführen."
 
-#: submodule.c:1116
+#: submodule.c:1165
 #, c-format
 msgid "process for submodule '%s' failed"
 msgstr "Prozess für Submodul '%s' fehlgeschlagen"
 
-#: submodule.c:1145 builtin/branch.c:691 builtin/submodule--helper.c:2486
+#: submodule.c:1194 builtin/branch.c:692 builtin/submodule--helper.c:2713
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "Konnte HEAD nicht als gültige Referenz auflösen."
 
-#: submodule.c:1156
+#: submodule.c:1205
 #, c-format
 msgid "Pushing submodule '%s'\n"
 msgstr "Pushe Submodul '%s'\n"
 
-#: submodule.c:1159
+#: submodule.c:1208
 #, c-format
 msgid "Unable to push submodule '%s'\n"
 msgstr "Kann Push für Submodul '%s' nicht ausführen\n"
 
-#: submodule.c:1451
+#: submodule.c:1491
 #, c-format
 msgid "Fetching submodule %s%s\n"
 msgstr "Anfordern des Submoduls %s%s\n"
 
-#: submodule.c:1485
+#: submodule.c:1525
 #, c-format
 msgid "Could not access submodule '%s'\n"
 msgstr "Konnte nicht auf Submodul '%s' zugreifen\n"
 
-#: submodule.c:1640
+#: submodule.c:1680
 #, c-format
 msgid ""
 "Errors during submodule fetch:\n"
@@ -8883,62 +9093,62 @@ msgstr ""
 "Fehler während des Anforderns der Submodule:\n"
 "%s"
 
-#: submodule.c:1665
+#: submodule.c:1705
 #, c-format
 msgid "'%s' not recognized as a git repository"
 msgstr "'%s' nicht als Git-Repository erkannt"
 
-#: submodule.c:1682
+#: submodule.c:1722
 #, c-format
 msgid "Could not run 'git status --porcelain=2' in submodule %s"
 msgstr "Konnte 'git status --porcelain=2' nicht in Submodul %s ausführen"
 
-#: submodule.c:1723
+#: submodule.c:1763
 #, c-format
 msgid "'git status --porcelain=2' failed in submodule %s"
 msgstr "'git status --porcelain=2' ist in Submodul %s fehlgeschlagen"
 
-#: submodule.c:1798
+#: submodule.c:1838
 #, c-format
 msgid "could not start 'git status' in submodule '%s'"
 msgstr "Konnte 'git status' in Submodul '%s' nicht starten."
 
-#: submodule.c:1811
+#: submodule.c:1851
 #, c-format
 msgid "could not run 'git status' in submodule '%s'"
 msgstr "Konnte 'git status' in Submodul '%s' nicht ausführen."
 
-#: submodule.c:1826
+#: submodule.c:1868
 #, c-format
 msgid "Could not unset core.worktree setting in submodule '%s'"
 msgstr "Konnte core.worktree Einstellung in Submodul '%s' nicht aufheben."
 
-#: submodule.c:1853 submodule.c:2163
+#: submodule.c:1895 submodule.c:2210
 #, c-format
 msgid "could not recurse into submodule '%s'"
 msgstr "Fehler bei Rekursion in Submodul-Pfad '%s'"
 
-#: submodule.c:1874
+#: submodule.c:1917
 msgid "could not reset submodule index"
 msgstr "konnte Index des Submoduls nicht zurücksetzen"
 
-#: submodule.c:1916
+#: submodule.c:1959
 #, c-format
 msgid "submodule '%s' has dirty index"
 msgstr "Submodul '%s' hat einen geänderten Index."
 
-#: submodule.c:1968
+#: submodule.c:2013
 #, c-format
 msgid "Submodule '%s' could not be updated."
 msgstr "Submodule '%s' konnte nicht aktualisiert werden."
 
-#: submodule.c:2036
+#: submodule.c:2081
 #, c-format
 msgid "submodule git dir '%s' is inside git dir '%.*s'"
 msgstr ""
 "Git-Verzeichnis des Submoduls '%s' ist im Git-Verzeichnis '%.*s' enthalten."
 
-#: submodule.c:2057
+#: submodule.c:2102
 #, c-format
 msgid ""
 "relocate_gitdir for submodule '%s' with more than one worktree not supported"
@@ -8946,17 +9156,17 @@ msgstr ""
 "relocate_gitdir für Submodul '%s' mit mehr als einem Arbeitsverzeichnis\n"
 "wird nicht unterstützt"
 
-#: submodule.c:2069 submodule.c:2128
+#: submodule.c:2114 submodule.c:2174
 #, c-format
 msgid "could not lookup name for submodule '%s'"
 msgstr "Konnte Name für Submodul '%s' nicht nachschlagen."
 
-#: submodule.c:2073
+#: submodule.c:2118
 #, c-format
 msgid "refusing to move '%s' into an existing git dir"
 msgstr "Verschieben von '%s' in ein existierendes Git-Verzeichnis verweigert."
 
-#: submodule.c:2080
+#: submodule.c:2124
 #, c-format
 msgid ""
 "Migrating git directory of '%s%s' from\n"
@@ -8967,11 +9177,11 @@ msgstr ""
 "'%s' nach\n"
 "'%s'\n"
 
-#: submodule.c:2208
+#: submodule.c:2255
 msgid "could not start ls-files in .."
 msgstr "Konnte 'ls-files' nicht in .. starten"
 
-#: submodule.c:2248
+#: submodule.c:2295
 #, c-format
 msgid "ls-tree returned unexpected return code %d"
 msgstr "ls-tree mit unerwartetem Rückgabewert %d beendet"
@@ -8993,7 +9203,7 @@ msgid "unknown value '%s' for key '%s'"
 msgstr "unbekannter Wert '%s' für Schlüssel %s"
 
 #: trailer.c:547 trailer.c:552 trailer.c:557 builtin/remote.c:299
-#: builtin/remote.c:324
+#: builtin/remote.c:327
 #, c-format
 msgid "more than one %s"
 msgstr "mehr als ein %s"
@@ -9008,11 +9218,11 @@ msgstr "leerer Anhang-Token in Anhang '%.*s'"
 msgid "could not read input file '%s'"
 msgstr "Konnte Eingabe-Datei '%s' nicht lesen"
 
-#: trailer.c:766 builtin/mktag.c:88 imap-send.c:1577
+#: trailer.c:766 builtin/mktag.c:89 imap-send.c:1573
 msgid "could not read from stdin"
 msgstr "konnte nicht von der Standard-Eingabe lesen"
 
-#: trailer.c:1024 wrapper.c:676
+#: trailer.c:1024 wrapper.c:684
 #, c-format
 msgid "could not stat %s"
 msgstr "Konnte '%s' nicht lesen"
@@ -9082,7 +9292,7 @@ msgstr "konnte \"fast-import\" nicht ausführen"
 msgid "error while running fast-import"
 msgstr "Fehler beim Ausführen von 'fast-import'."
 
-#: transport-helper.c:549 transport-helper.c:1247
+#: transport-helper.c:549 transport-helper.c:1251
 #, c-format
 msgid "could not read ref %s"
 msgstr "konnte Referenz %s nicht lesen"
@@ -9101,7 +9311,7 @@ msgstr ""
 msgid "invalid remote service path"
 msgstr "ungültiger Remote-Service Pfad."
 
-#: transport-helper.c:661 transport.c:1477
+#: transport-helper.c:661 transport.c:1475
 msgid "operation not supported by protocol"
 msgstr "die Operation wird von dem Protokoll nicht unterstützt"
 
@@ -9110,7 +9320,7 @@ msgstr "die Operation wird von dem Protokoll nicht unterstützt"
 msgid "can't connect to subservice %s"
 msgstr "kann keine Verbindung zu Subservice %s herstellen"
 
-#: transport-helper.c:693 transport.c:400
+#: transport-helper.c:693 transport.c:404
 msgid "--negotiate-only requires protocol v2"
 msgstr "--negotiate-only benötigt Protokoll v2"
 
@@ -9123,59 +9333,59 @@ msgstr "'option' ohne passende 'ok/error' Direktive"
 msgid "expected ok/error, helper said '%s'"
 msgstr "erwartete ok/error, Remote-Helper gab '%s' aus"
 
-#: transport-helper.c:855
+#: transport-helper.c:859
 #, c-format
 msgid "helper reported unexpected status of %s"
 msgstr "Remote-Helper meldete unerwarteten Status von %s"
 
-#: transport-helper.c:938
+#: transport-helper.c:942
 #, c-format
 msgid "helper %s does not support dry-run"
 msgstr "Remote-Helper %s unterstützt kein Trockenlauf"
 
-#: transport-helper.c:941
+#: transport-helper.c:945
 #, c-format
 msgid "helper %s does not support --signed"
 msgstr "Remote-Helper %s unterstützt kein --signed"
 
-#: transport-helper.c:944
+#: transport-helper.c:948
 #, c-format
 msgid "helper %s does not support --signed=if-asked"
 msgstr "Remote-Helper %s unterstützt kein --signed=if-asked"
 
-#: transport-helper.c:949
+#: transport-helper.c:953
 #, c-format
 msgid "helper %s does not support --atomic"
 msgstr "Remote-Helper %s unterstützt kein --atomic"
 
-#: transport-helper.c:953
+#: transport-helper.c:957
 #, c-format
 msgid "helper %s does not support --%s"
 msgstr "Remote-Helper %s unterstützt kein --%s"
 
-#: transport-helper.c:960
+#: transport-helper.c:964
 #, c-format
 msgid "helper %s does not support 'push-option'"
 msgstr "Remote-Helper %s unterstützt nicht 'push-option'"
 
-#: transport-helper.c:1060
+#: transport-helper.c:1064
 msgid "remote-helper doesn't support push; refspec needed"
 msgstr "Remote-Helper unterstützt kein Push; Refspec benötigt"
 
-#: transport-helper.c:1065
+#: transport-helper.c:1069
 #, c-format
 msgid "helper %s does not support 'force'"
 msgstr "Remote-Helper %s unterstützt kein 'force'."
 
-#: transport-helper.c:1112
+#: transport-helper.c:1116
 msgid "couldn't run fast-export"
 msgstr "Konnte \"fast-export\" nicht ausführen."
 
-#: transport-helper.c:1117
+#: transport-helper.c:1121
 msgid "error while running fast-export"
 msgstr "Fehler beim Ausführen von \"fast-export\"."
 
-#: transport-helper.c:1142
+#: transport-helper.c:1146
 #, c-format
 msgid ""
 "No refs in common and none specified; doing nothing.\n"
@@ -9184,52 +9394,52 @@ msgstr ""
 "Keine gemeinsamen Referenzen und nichts spezifiziert; keine Ausführung.\n"
 "Vielleicht sollten Sie einen Branch angeben.\n"
 
-#: transport-helper.c:1224
+#: transport-helper.c:1228
 #, c-format
 msgid "unsupported object format '%s'"
 msgstr "nicht unterstütztes Objekt-Format '%s'"
 
-#: transport-helper.c:1233
+#: transport-helper.c:1237
 #, c-format
 msgid "malformed response in ref list: %s"
 msgstr "Ungültige Antwort in Referenzliste: %s"
 
-#: transport-helper.c:1385
+#: transport-helper.c:1389
 #, c-format
 msgid "read(%s) failed"
 msgstr "Lesen von %s fehlgeschlagen."
 
-#: transport-helper.c:1412
+#: transport-helper.c:1416
 #, c-format
 msgid "write(%s) failed"
 msgstr "Schreiben von %s fehlgeschlagen."
 
-#: transport-helper.c:1461
+#: transport-helper.c:1465
 #, c-format
 msgid "%s thread failed"
 msgstr "Thread %s fehlgeschlagen."
 
-#: transport-helper.c:1465
+#: transport-helper.c:1469
 #, c-format
 msgid "%s thread failed to join: %s"
 msgstr "Fehler beim Beitreten zu Thread %s: %s"
 
-#: transport-helper.c:1484 transport-helper.c:1488
+#: transport-helper.c:1488 transport-helper.c:1492
 #, c-format
 msgid "can't start thread for copying data: %s"
 msgstr "Kann Thread zum Kopieren von Daten nicht starten: %s"
 
-#: transport-helper.c:1525
+#: transport-helper.c:1529
 #, c-format
 msgid "%s process failed to wait"
 msgstr "Fehler beim Warten von Prozess %s."
 
-#: transport-helper.c:1529
+#: transport-helper.c:1533
 #, c-format
 msgid "%s process failed"
 msgstr "Prozess %s fehlgeschlagen"
 
-#: transport-helper.c:1547 transport-helper.c:1556
+#: transport-helper.c:1551 transport-helper.c:1560
 msgid "can't start thread for copying data"
 msgstr "Kann Thread zum Kopieren von Daten nicht starten."
 
@@ -9243,46 +9453,46 @@ msgstr "Würde Upstream-Branch von '%s' zu '%s' von '%s' setzen\n"
 msgid "could not read bundle '%s'"
 msgstr "Konnte Paket '%s' nicht lesen."
 
-#: transport.c:223
+#: transport.c:227
 #, c-format
 msgid "transport: invalid depth option '%s'"
 msgstr "transport: ungültige depth Option '%s'"
 
-#: transport.c:275
+#: transport.c:279
 msgid "see protocol.version in 'git help config' for more details"
 msgstr "Siehe protocol.version in 'git help config' für weitere Informationen"
 
-#: transport.c:276
+#: transport.c:280
 msgid "server options require protocol version 2 or later"
 msgstr "Server-Optionen benötigen Protokoll-Version 2 oder höher"
 
-#: transport.c:403
+#: transport.c:407
 msgid "server does not support wait-for-done"
 msgstr "Server unterstützt nicht 'wait-for-done'"
 
-#: transport.c:755
+#: transport.c:759
 msgid "could not parse transport.color.* config"
 msgstr "Konnte transport.color.* Konfiguration nicht parsen."
 
-#: transport.c:830
+#: transport.c:834
 msgid "support for protocol v2 not implemented yet"
 msgstr "Unterstützung für Protokoll v2 noch nicht implementiert."
 
-#: transport.c:965
+#: transport.c:967
 #, c-format
 msgid "unknown value for config '%s': %s"
 msgstr "Unbekannter Wert für Konfiguration '%s': %s"
 
-#: transport.c:1031
+#: transport.c:1033
 #, c-format
 msgid "transport '%s' not allowed"
 msgstr "Übertragungsart '%s' nicht erlaubt."
 
-#: transport.c:1084
+#: transport.c:1082
 msgid "git-over-rsync is no longer supported"
 msgstr "git-over-rsync wird nicht länger unterstützt."
 
-#: transport.c:1187
+#: transport.c:1185
 #, c-format
 msgid ""
 "The following submodule paths contain changes that can\n"
@@ -9291,7 +9501,7 @@ msgstr ""
 "Die folgenden Submodul-Pfade enthalten Änderungen, die in keinem\n"
 "Remote-Repository gefunden wurden:\n"
 
-#: transport.c:1191
+#: transport.c:1189
 #, c-format
 msgid ""
 "\n"
@@ -9318,11 +9528,11 @@ msgstr ""
 "zum Versenden zu einem Remote-Repository.\n"
 "\n"
 
-#: transport.c:1199
+#: transport.c:1197
 msgid "Aborting."
 msgstr "Abbruch."
 
-#: transport.c:1346
+#: transport.c:1344
 msgid "failed to push all needed submodules"
 msgstr "Fehler beim Versand aller erforderlichen Submodule."
 
@@ -9612,17 +9822,17 @@ msgstr ""
 "auf einem case-insensitiven Dateisystem) und nur einer von der\n"
 "selben Kollissionsgruppe ist im Arbeitsverzeichnis:\n"
 
-#: unpack-trees.c:1618
+#: unpack-trees.c:1620
 msgid "Updating index flags"
 msgstr "Aktualisiere Index-Markierungen"
 
-#: unpack-trees.c:2718
+#: unpack-trees.c:2772
 #, c-format
 msgid "worktree and untracked commit have duplicate entries: %s"
 msgstr ""
 "Arbeitsverzeichnis und unversionierter Commit haben doppelte Einträge: %s"
 
-#: upload-pack.c:1548
+#: upload-pack.c:1561
 msgid "expected flush after fetch arguments"
 msgstr "erwartete Flush nach Abrufen der Argumente"
 
@@ -9659,7 +9869,7 @@ msgstr "ungültiges '..' Pfadsegment"
 msgid "Fetching objects"
 msgstr "Anfordern der Objekte"
 
-#: worktree.c:236 builtin/am.c:2152
+#: worktree.c:236 builtin/am.c:2154 builtin/bisect--helper.c:156
 #, c-format
 msgid "failed to read '%s'"
 msgstr "Fehler beim Lesen von '%s'"
@@ -9756,17 +9966,27 @@ msgstr "ungültige gitdir-Datei"
 msgid "gitdir file points to non-existent location"
 msgstr "gitdir-Datei verweist auf nicht existierenden Ort"
 
-#: wrapper.c:197 wrapper.c:367
+#: wrapper.c:151
+#, fuzzy, c-format
+msgid "could not setenv '%s'"
+msgstr "konnte '%s' nicht setzen"
+
+#: wrapper.c:203
+#, c-format
+msgid "unable to create '%s'"
+msgstr "konnte '%s' nicht erstellen"
+
+#: wrapper.c:205 wrapper.c:375
 #, c-format
 msgid "could not open '%s' for reading and writing"
 msgstr "konnte '%s' nicht zum Lesen und Schreiben öffnen"
 
-#: wrapper.c:398 wrapper.c:599
+#: wrapper.c:406 wrapper.c:607
 #, c-format
 msgid "unable to access '%s'"
 msgstr "konnte nicht auf '%s' zugreifen"
 
-#: wrapper.c:607
+#: wrapper.c:615
 msgid "unable to get current working directory"
 msgstr "konnte aktuelles Arbeitsverzeichnis nicht bekommen"
 
@@ -10349,25 +10569,25 @@ msgid "cannot %s: Your index contains uncommitted changes."
 msgstr ""
 "%s nicht möglich: Die Staging-Area enthält nicht committete Änderungen."
 
-#: compat/simple-ipc/ipc-unix-socket.c:182
+#: compat/simple-ipc/ipc-unix-socket.c:183
 msgid "could not send IPC command"
 msgstr "konnte IPC-Befehl nicht senden"
 
-#: compat/simple-ipc/ipc-unix-socket.c:189
+#: compat/simple-ipc/ipc-unix-socket.c:190
 msgid "could not read IPC response"
 msgstr "konnte IPC-Antwort nicht lesen"
 
-#: compat/simple-ipc/ipc-unix-socket.c:866
+#: compat/simple-ipc/ipc-unix-socket.c:870
 #, c-format
 msgid "could not start accept_thread '%s'"
 msgstr "konnte accept_thread nicht für '%s' starten"
 
-#: compat/simple-ipc/ipc-unix-socket.c:878
+#: compat/simple-ipc/ipc-unix-socket.c:882
 #, c-format
 msgid "could not start worker[0] for '%s'"
 msgstr "konnte worker[0] nicht für '%s' starten"
 
-#: compat/precompose_utf8.c:58 builtin/clone.c:461
+#: compat/precompose_utf8.c:58 builtin/clone.c:347
 #, c-format
 msgid "failed to unlink '%s'"
 msgstr "Konnte '%s' nicht entfernen."
@@ -10376,139 +10596,139 @@ msgstr "Konnte '%s' nicht entfernen."
 msgid "git add [<options>] [--] <pathspec>..."
 msgstr "git add [<Optionen>] [--] <Pfadspezifikation>..."
 
-#: builtin/add.c:61
+#: builtin/add.c:64
 #, c-format
 msgid "cannot chmod %cx '%s'"
 msgstr "kann chmod %cx '%s' nicht ausführen"
 
-#: builtin/add.c:99
+#: builtin/add.c:106
 #, c-format
 msgid "unexpected diff status %c"
 msgstr "unerwarteter Differenz-Status %c"
 
-#: builtin/add.c:104 builtin/commit.c:297
+#: builtin/add.c:111 builtin/commit.c:298
 msgid "updating files failed"
 msgstr "Aktualisierung der Dateien fehlgeschlagen"
 
-#: builtin/add.c:114
+#: builtin/add.c:121
 #, c-format
 msgid "remove '%s'\n"
 msgstr "lösche '%s'\n"
 
-#: builtin/add.c:198
+#: builtin/add.c:205
 msgid "Unstaged changes after refreshing the index:"
 msgstr ""
 "Nicht zum Commit vorgemerkte Änderungen nach Aktualisierung der Staging-Area:"
 
-#: builtin/add.c:307 builtin/rev-parse.c:993
+#: builtin/add.c:317 builtin/rev-parse.c:993
 msgid "Could not read the index"
 msgstr "Konnte den Index nicht lesen"
 
-#: builtin/add.c:318
-#, c-format
-msgid "Could not open '%s' for writing."
-msgstr "Konnte '%s' nicht zum Schreiben öffnen."
-
-#: builtin/add.c:322
+#: builtin/add.c:330
 msgid "Could not write patch"
 msgstr "Konnte Patch nicht schreiben"
 
-#: builtin/add.c:325
+#: builtin/add.c:333
 msgid "editing patch failed"
 msgstr "Bearbeitung des Patches fehlgeschlagen"
 
-#: builtin/add.c:328
+#: builtin/add.c:336
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "Konnte Verzeichnis '%s' nicht lesen"
 
-#: builtin/add.c:330
+#: builtin/add.c:338
 msgid "Empty patch. Aborted."
 msgstr "Leerer Patch. Abgebrochen."
 
-#: builtin/add.c:335
+#: builtin/add.c:343
 #, c-format
 msgid "Could not apply '%s'"
 msgstr "Konnte '%s' nicht anwenden."
 
-#: builtin/add.c:343
+#: builtin/add.c:351
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr ""
 "Die folgenden Pfade werden durch eine Ihrer \".gitignore\" Dateien "
 "ignoriert:\n"
 
-#: builtin/add.c:363 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
+#: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
 #: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:550
-#: builtin/remote.c:1427 builtin/rm.c:243 builtin/send-pack.c:190
+#: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr "Probelauf"
 
-#: builtin/add.c:366
+#: builtin/add.c:374
 msgid "interactive picking"
 msgstr "interaktives Auswählen"
 
-#: builtin/add.c:367 builtin/checkout.c:1562 builtin/reset.c:308
+#: builtin/add.c:375 builtin/checkout.c:1560 builtin/reset.c:314
 msgid "select hunks interactively"
 msgstr "Blöcke interaktiv auswählen"
 
-#: builtin/add.c:368
+#: builtin/add.c:376
 msgid "edit current diff and apply"
 msgstr "aktuelle Unterschiede editieren und anwenden"
 
-#: builtin/add.c:369
+#: builtin/add.c:377
 msgid "allow adding otherwise ignored files"
 msgstr "das Hinzufügen andernfalls ignorierter Dateien erlauben"
 
-#: builtin/add.c:370
+#: builtin/add.c:378
 msgid "update tracked files"
 msgstr "versionierte Dateien aktualisieren"
 
-#: builtin/add.c:371
+#: builtin/add.c:379
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr ""
 "erneutes Normalisieren der Zeilenenden von versionierten Dateien (impliziert "
 "-u)"
 
-#: builtin/add.c:372
+#: builtin/add.c:380
 msgid "record only the fact that the path will be added later"
 msgstr "nur speichern, dass der Pfad später hinzugefügt werden soll"
 
-#: builtin/add.c:373
+#: builtin/add.c:381
 msgid "add changes from all tracked and untracked files"
 msgstr ""
 "Änderungen von allen versionierten und unversionierten Dateien hinzufügen"
 
-#: builtin/add.c:376
+#: builtin/add.c:384
 msgid "ignore paths removed in the working tree (same as --no-all)"
 msgstr "gelöschte Pfade im Arbeitsverzeichnis ignorieren (genau wie --no-all)"
 
-#: builtin/add.c:378
+#: builtin/add.c:386
 msgid "don't add, only refresh the index"
 msgstr "nichts hinzufügen, nur den Index aktualisieren"
 
-#: builtin/add.c:379
+#: builtin/add.c:387
 msgid "just skip files which cannot be added because of errors"
 msgstr ""
 "Dateien überspringen, die aufgrund von Fehlern nicht hinzugefügt werden "
 "konnten"
 
-#: builtin/add.c:380
+#: builtin/add.c:388
 msgid "check if - even missing - files are ignored in dry run"
 msgstr "prüfen ob - auch fehlende - Dateien im Probelauf ignoriert werden"
 
-#: builtin/add.c:382 builtin/update-index.c:1006
+#: builtin/add.c:389 builtin/mv.c:128 builtin/rm.c:251
+#, fuzzy
+msgid "allow updating entries outside of the sparse-checkout cone"
+msgstr "initialisiere den partiellen Checkout im Cone-Modus"
+
+#: builtin/add.c:391 builtin/update-index.c:1004
 msgid "override the executable bit of the listed files"
 msgstr "das \"ausführbar\"-Bit der aufgelisteten Dateien überschreiben"
 
-#: builtin/add.c:384
+#: builtin/add.c:393
 msgid "warn when adding an embedded repository"
 msgstr "warnen wenn eingebettetes Repository hinzugefügt wird"
 
-#: builtin/add.c:386
+#: builtin/add.c:395
 msgid "backend for `git stash -p`"
 msgstr "Backend für `git stash -p`"
 
-#: builtin/add.c:404
+#: builtin/add.c:413
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -10542,12 +10762,12 @@ msgstr ""
 "\n"
 "Siehe \"git help submodule\" für weitere Informationen."
 
-#: builtin/add.c:432
+#: builtin/add.c:442
 #, c-format
 msgid "adding embedded git repository: %s"
 msgstr "Füge eingebettetes Repository hinzu: %s"
 
-#: builtin/add.c:451
+#: builtin/add.c:462
 msgid ""
 "Use -f if you really want to add them.\n"
 "Turn this message off by running\n"
@@ -10557,52 +10777,52 @@ msgstr ""
 "Um diese Meldung abzuschalten, führen Sie folgenden Befehl aus:\n"
 "\"git config advice.addIgnoredFile false\""
 
-#: builtin/add.c:460
+#: builtin/add.c:477
 msgid "adding files failed"
 msgstr "Hinzufügen von Dateien fehlgeschlagen"
 
-#: builtin/add.c:488
+#: builtin/add.c:513
 msgid "--dry-run is incompatible with --interactive/--patch"
 msgstr "--dry-run und --interactive/--patch sind inkompatibel"
 
-#: builtin/add.c:490 builtin/commit.c:357
+#: builtin/add.c:515 builtin/commit.c:358
 msgid "--pathspec-from-file is incompatible with --interactive/--patch"
 msgstr "--pathspec-from-file und --interactive/--patch sind inkompatibel"
 
-#: builtin/add.c:507
+#: builtin/add.c:532
 msgid "--pathspec-from-file is incompatible with --edit"
 msgstr "--pathspec-from-file und --edit sind inkompatibel"
 
-#: builtin/add.c:519
+#: builtin/add.c:544
 msgid "-A and -u are mutually incompatible"
 msgstr "-A und -u sind zueinander inkompatibel"
 
-#: builtin/add.c:522
+#: builtin/add.c:547
 msgid "Option --ignore-missing can only be used together with --dry-run"
 msgstr ""
 "Die Option --ignore-missing kann nur zusammen mit --dry-run verwendet werden"
 
-#: builtin/add.c:526
+#: builtin/add.c:551
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "--chmod Parameter '%s' muss entweder -x oder +x sein"
 
-#: builtin/add.c:544 builtin/checkout.c:1733 builtin/commit.c:363
-#: builtin/reset.c:328 builtin/rm.c:273 builtin/stash.c:1633
+#: builtin/add.c:572 builtin/checkout.c:1731 builtin/commit.c:364
+#: builtin/reset.c:334 builtin/rm.c:275 builtin/stash.c:1650
 msgid "--pathspec-from-file is incompatible with pathspec arguments"
 msgstr "--pathspec-from-file ist inkompatibel mit Pfadspezifikation-Argumenten"
 
-#: builtin/add.c:551 builtin/checkout.c:1745 builtin/commit.c:369
-#: builtin/reset.c:334 builtin/rm.c:279 builtin/stash.c:1639
+#: builtin/add.c:579 builtin/checkout.c:1743 builtin/commit.c:370
+#: builtin/reset.c:340 builtin/rm.c:281 builtin/stash.c:1656
 msgid "--pathspec-file-nul requires --pathspec-from-file"
 msgstr "--pathspec-file-nul benötigt --pathspec-from-file"
 
-#: builtin/add.c:555
+#: builtin/add.c:583
 #, c-format
 msgid "Nothing specified, nothing added.\n"
 msgstr "Nichts spezifiziert, nichts hinzugefügt.\n"
 
-#: builtin/add.c:557
+#: builtin/add.c:585
 msgid ""
 "Maybe you wanted to say 'git add .'?\n"
 "Turn this message off by running\n"
@@ -10612,116 +10832,116 @@ msgstr ""
 "Um diese Meldung abzuschalten, führen Sie folgenden Befehl aus:\n"
 "\"git config advice.addEmptyPathspec false\""
 
-#: builtin/am.c:365
+#: builtin/am.c:366
 msgid "could not parse author script"
 msgstr "konnte Autor-Skript nicht parsen"
 
-#: builtin/am.c:455
+#: builtin/am.c:456
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
 msgstr "'%s' wurde durch den applypatch-msg Hook entfernt"
 
-#: builtin/am.c:497
+#: builtin/am.c:498
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr "Fehlerhafte Eingabezeile: '%s'."
 
-#: builtin/am.c:535
+#: builtin/am.c:536
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
 msgstr "Fehler beim Kopieren der Notizen von '%s' nach '%s'"
 
-#: builtin/am.c:561
+#: builtin/am.c:562
 msgid "fseek failed"
 msgstr "\"fseek\" fehlgeschlagen"
 
-#: builtin/am.c:749
+#: builtin/am.c:750
 #, c-format
 msgid "could not parse patch '%s'"
 msgstr "konnte Patch '%s' nicht parsen"
 
-#: builtin/am.c:814
+#: builtin/am.c:815
 msgid "Only one StGIT patch series can be applied at once"
 msgstr "Es kann nur eine StGIT Patch-Serie auf einmal angewendet werden."
 
-#: builtin/am.c:862
+#: builtin/am.c:863
 msgid "invalid timestamp"
 msgstr "ungültiger Zeitstempel"
 
-#: builtin/am.c:867 builtin/am.c:879
+#: builtin/am.c:868 builtin/am.c:880
 msgid "invalid Date line"
 msgstr "Ungültige \"Date\"-Zeile"
 
-#: builtin/am.c:874
+#: builtin/am.c:875
 msgid "invalid timezone offset"
 msgstr "Ungültiger Offset in der Zeitzone"
 
-#: builtin/am.c:967
+#: builtin/am.c:968
 msgid "Patch format detection failed."
 msgstr "Patch-Formaterkennung fehlgeschlagen."
 
-#: builtin/am.c:972 builtin/clone.c:414
+#: builtin/am.c:973 builtin/clone.c:300
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "Fehler beim Erstellen von Verzeichnis '%s'"
 
-#: builtin/am.c:977
+#: builtin/am.c:978
 msgid "Failed to split patches."
 msgstr "Fehler beim Aufteilen der Patches."
 
-#: builtin/am.c:1126
+#: builtin/am.c:1127
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\"."
 msgstr ""
 "Wenn Sie das Problem aufgelöst haben, führen Sie \"%s --continue\" aus."
 
-#: builtin/am.c:1127
+#: builtin/am.c:1128
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
 msgstr ""
 "Falls Sie diesen Patch auslassen möchten, führen Sie stattdessen \"%s --skip"
 "\" aus."
 
-#: builtin/am.c:1128
+#: builtin/am.c:1129
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr ""
 "Um den ursprünglichen Branch wiederherzustellen und die Anwendung der "
 "Patches abzubrechen, führen Sie \"%s --abort\" aus."
 
-#: builtin/am.c:1223
+#: builtin/am.c:1224
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
 "Patch mit format=flowed versendet; Leerzeichen am Ende von Zeilen könnte "
 "verloren gehen."
 
-#: builtin/am.c:1251
+#: builtin/am.c:1252
 msgid "Patch is empty."
 msgstr "Patch ist leer."
 
-#: builtin/am.c:1316
+#: builtin/am.c:1317
 #, c-format
 msgid "missing author line in commit %s"
 msgstr "Autor-Zeile fehlt in Commit %s"
 
-#: builtin/am.c:1319
+#: builtin/am.c:1320
 #, c-format
 msgid "invalid ident line: %.*s"
 msgstr "Ungültige Identifikationszeile: %.*s"
 
-#: builtin/am.c:1538
+#: builtin/am.c:1539
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
 "Dem Repository fehlen notwendige Blobs um auf einen 3-Wege-Merge "
 "zurückzufallen."
 
-#: builtin/am.c:1540
+#: builtin/am.c:1541
 msgid "Using index info to reconstruct a base tree..."
 msgstr ""
 "Verwende Informationen aus der Staging-Area, um ein Basisverzeichnis "
 "nachzustellen ..."
 
-#: builtin/am.c:1559
+#: builtin/am.c:1560
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
@@ -10729,24 +10949,24 @@ msgstr ""
 "Haben Sie den Patch per Hand editiert?\n"
 "Er kann nicht auf die Blobs in seiner 'index' Zeile angewendet werden."
 
-#: builtin/am.c:1565
+#: builtin/am.c:1566
 msgid "Falling back to patching base and 3-way merge..."
 msgstr "Falle zurück zum Patchen der Basis und zum 3-Wege-Merge ..."
 
-#: builtin/am.c:1591
+#: builtin/am.c:1592
 msgid "Failed to merge in the changes."
 msgstr "Merge der Änderungen fehlgeschlagen."
 
-#: builtin/am.c:1623
+#: builtin/am.c:1624
 msgid "applying to an empty history"
 msgstr "auf leere Historie anwenden"
 
-#: builtin/am.c:1675 builtin/am.c:1679
+#: builtin/am.c:1676 builtin/am.c:1680
 #, c-format
 msgid "cannot resume: %s does not exist."
 msgstr "Kann nicht fortsetzen: %s existiert nicht"
 
-#: builtin/am.c:1697
+#: builtin/am.c:1698
 msgid "Commit Body is:"
 msgstr "Commit-Beschreibung ist:"
 
@@ -10754,35 +10974,35 @@ msgstr "Commit-Beschreibung ist:"
 #. in your translation. The program will only accept English
 #. input at this point.
 #.
-#: builtin/am.c:1707
+#: builtin/am.c:1708
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr "Anwenden? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 
-#: builtin/am.c:1753 builtin/commit.c:408
+#: builtin/am.c:1754 builtin/commit.c:409
 msgid "unable to write index file"
 msgstr "Konnte Index-Datei nicht schreiben."
 
-#: builtin/am.c:1757
+#: builtin/am.c:1758
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
 msgstr "Geänderter Index: kann Patches nicht anwenden (geändert: %s)"
 
-#: builtin/am.c:1797 builtin/am.c:1865
+#: builtin/am.c:1798 builtin/am.c:1865
 #, c-format
 msgid "Applying: %.*s"
 msgstr "Wende an: %.*s"
 
-#: builtin/am.c:1814
+#: builtin/am.c:1815
 msgid "No changes -- Patch already applied."
 msgstr "Keine Änderungen -- Patches bereits angewendet."
 
-#: builtin/am.c:1820
+#: builtin/am.c:1821
 #, c-format
 msgid "Patch failed at %s %.*s"
 msgstr "Anwendung des Patches fehlgeschlagen bei %s %.*s"
 
-#: builtin/am.c:1824
+#: builtin/am.c:1825
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr ""
 "Benutzen Sie 'git am --show-current-patch=diff', um den\n"
@@ -10812,17 +11032,17 @@ msgstr ""
 "Sie können 'git rm' auf Dateien ausführen, um \"von denen gelöscht\" für\n"
 "diese zu akzeptieren."
 
-#: builtin/am.c:1982 builtin/am.c:1986 builtin/am.c:1998 builtin/reset.c:347
-#: builtin/reset.c:355
+#: builtin/am.c:1983 builtin/am.c:1987 builtin/am.c:1999 builtin/reset.c:353
+#: builtin/reset.c:361
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "Konnte Objekt '%s' nicht parsen."
 
-#: builtin/am.c:2034
+#: builtin/am.c:2035 builtin/am.c:2111
 msgid "failed to clean index"
 msgstr "Fehler beim Bereinigen des Index"
 
-#: builtin/am.c:2078
+#: builtin/am.c:2079
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
@@ -10830,160 +11050,160 @@ msgstr ""
 "Sie scheinen seit dem letzten gescheiterten 'am' HEAD geändert zu haben.\n"
 "Keine Zurücksetzung zu ORIG_HEAD."
 
-#: builtin/am.c:2185
+#: builtin/am.c:2187
 #, c-format
 msgid "Invalid value for --patch-format: %s"
 msgstr "Ungültiger Wert für --patch-format: %s"
 
-#: builtin/am.c:2227
+#: builtin/am.c:2229
 #, c-format
 msgid "Invalid value for --show-current-patch: %s"
 msgstr "Ungültiger Wert für --show-current-patch: %s"
 
-#: builtin/am.c:2231
+#: builtin/am.c:2233
 #, c-format
 msgid "--show-current-patch=%s is incompatible with --show-current-patch=%s"
 msgstr "--show-current-patch=%s ist inkombatibel mit --show-current-patch=%s"
 
-#: builtin/am.c:2262
+#: builtin/am.c:2264
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
 msgstr "git am [<Optionen>] [(<mbox> | <E-Mail-Verzeichnis>)...]"
 
-#: builtin/am.c:2263
+#: builtin/am.c:2265
 msgid "git am [<options>] (--continue | --skip | --abort)"
 msgstr "git am [<Optionen>] (--continue | --skip | --abort)"
 
-#: builtin/am.c:2269
+#: builtin/am.c:2271
 msgid "run interactively"
 msgstr "interaktiv ausführen"
 
-#: builtin/am.c:2271
+#: builtin/am.c:2273
 msgid "historical option -- no-op"
 msgstr "historische Option -- kein Effekt"
 
-#: builtin/am.c:2273
+#: builtin/am.c:2275
 msgid "allow fall back on 3way merging if needed"
 msgstr "erlaube, falls notwendig, das Zurückfallen auf einen 3-Wege-Merge"
 
-#: builtin/am.c:2274 builtin/init-db.c:547 builtin/prune-packed.c:16
-#: builtin/repack.c:472 builtin/stash.c:945
+#: builtin/am.c:2276 builtin/init-db.c:547 builtin/prune-packed.c:16
+#: builtin/repack.c:640 builtin/stash.c:961
 msgid "be quiet"
 msgstr "weniger Ausgaben"
 
-#: builtin/am.c:2276
+#: builtin/am.c:2278
 msgid "add a Signed-off-by trailer to the commit message"
 msgstr "eine Signed-off-by Zeile der Commit-Beschreibung hinzufügen"
 
-#: builtin/am.c:2279
+#: builtin/am.c:2281
 msgid "recode into utf8 (default)"
 msgstr "nach UTF-8 umkodieren (Standard)"
 
-#: builtin/am.c:2281
+#: builtin/am.c:2283
 msgid "pass -k flag to git-mailinfo"
 msgstr "-k an git-mailinfo übergeben"
 
-#: builtin/am.c:2283
+#: builtin/am.c:2285
 msgid "pass -b flag to git-mailinfo"
 msgstr "-b an git-mailinfo übergeben"
 
-#: builtin/am.c:2285
+#: builtin/am.c:2287
 msgid "pass -m flag to git-mailinfo"
 msgstr "-m an git-mailinfo übergeben"
 
-#: builtin/am.c:2287
+#: builtin/am.c:2289
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
 msgstr "--keep-cr an git-mailsplit für mbox-Format übergeben"
 
-#: builtin/am.c:2290
+#: builtin/am.c:2292
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr "kein --keep-cr an git-mailsplit übergeben, unabhängig von am.keepcr"
 
-#: builtin/am.c:2293
+#: builtin/am.c:2295
 msgid "strip everything before a scissors line"
 msgstr "alles vor einer Scheren-Zeile entfernen"
 
-#: builtin/am.c:2295
+#: builtin/am.c:2297
 msgid "pass it through git-mailinfo"
 msgstr "an git-mailinfo weitergeben"
 
-#: builtin/am.c:2298 builtin/am.c:2301 builtin/am.c:2304 builtin/am.c:2307
-#: builtin/am.c:2310 builtin/am.c:2313 builtin/am.c:2316 builtin/am.c:2319
-#: builtin/am.c:2325
+#: builtin/am.c:2300 builtin/am.c:2303 builtin/am.c:2306 builtin/am.c:2309
+#: builtin/am.c:2312 builtin/am.c:2315 builtin/am.c:2318 builtin/am.c:2321
+#: builtin/am.c:2327
 msgid "pass it through git-apply"
 msgstr "an git-apply übergeben"
 
-#: builtin/am.c:2315 builtin/commit.c:1512 builtin/fmt-merge-msg.c:17
-#: builtin/fmt-merge-msg.c:20 builtin/grep.c:905 builtin/merge.c:261
+#: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
+#: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
 #: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
-#: builtin/rebase.c:1342 builtin/repack.c:483 builtin/repack.c:487
-#: builtin/repack.c:489 builtin/show-branch.c:650 builtin/show-ref.c:172
-#: builtin/tag.c:447 parse-options.h:155 parse-options.h:176
-#: parse-options.h:317
+#: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
+#: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
+#: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
+#: parse-options.h:316
 msgid "n"
 msgstr "Anzahl"
 
-#: builtin/am.c:2321 builtin/branch.c:672 builtin/bugreport.c:137
-#: builtin/for-each-ref.c:40 builtin/replace.c:556 builtin/tag.c:481
+#: builtin/am.c:2323 builtin/branch.c:673 builtin/bugreport.c:109
+#: builtin/for-each-ref.c:40 builtin/replace.c:556 builtin/tag.c:479
 #: builtin/verify-tag.c:38
 msgid "format"
 msgstr "Format"
 
-#: builtin/am.c:2322
+#: builtin/am.c:2324
 msgid "format the patch(es) are in"
 msgstr "Patch-Format"
 
-#: builtin/am.c:2328
+#: builtin/am.c:2330
 msgid "override error message when patch failure occurs"
 msgstr "Meldung bei fehlerhafter Patch-Anwendung überschreiben"
 
-#: builtin/am.c:2330
+#: builtin/am.c:2332
 msgid "continue applying patches after resolving a conflict"
 msgstr "Anwendung der Patches nach Auflösung eines Konfliktes fortsetzen"
 
-#: builtin/am.c:2333
+#: builtin/am.c:2335
 msgid "synonyms for --continue"
 msgstr "Synonyme für --continue"
 
-#: builtin/am.c:2336
+#: builtin/am.c:2338
 msgid "skip the current patch"
 msgstr "den aktuellen Patch auslassen"
 
-#: builtin/am.c:2339
+#: builtin/am.c:2341
 msgid "restore the original branch and abort the patching operation"
 msgstr ""
 "ursprünglichen Branch wiederherstellen und Anwendung der Patches abbrechen"
 
-#: builtin/am.c:2342
+#: builtin/am.c:2344
 msgid "abort the patching operation but keep HEAD where it is"
 msgstr "Patch-Operation abbrechen, aber HEAD an aktueller Stelle belassen"
 
-#: builtin/am.c:2346
+#: builtin/am.c:2348
 msgid "show the patch being applied"
 msgstr "den Patch, der gerade angewendet wird, anzeigen"
 
-#: builtin/am.c:2351
+#: builtin/am.c:2353
 msgid "lie about committer date"
 msgstr "Autor-Datum als Commit-Datum verwenden"
 
-#: builtin/am.c:2353
+#: builtin/am.c:2355
 msgid "use current timestamp for author date"
 msgstr "aktuellen Zeitstempel als Autor-Datum verwenden"
 
-#: builtin/am.c:2355 builtin/commit-tree.c:120 builtin/commit.c:1640
-#: builtin/merge.c:298 builtin/pull.c:175 builtin/rebase.c:537
-#: builtin/rebase.c:1395 builtin/revert.c:117 builtin/tag.c:462
+#: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
+#: builtin/merge.c:299 builtin/pull.c:175 builtin/rebase.c:1099
+#: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
 msgstr "GPG-Schlüsselkennung"
 
-#: builtin/am.c:2356 builtin/rebase.c:538 builtin/rebase.c:1396
+#: builtin/am.c:2358 builtin/rebase.c:1100
 msgid "GPG-sign commits"
 msgstr "Commits mit GPG signieren"
 
-#: builtin/am.c:2359
+#: builtin/am.c:2361
 msgid "(internal use for git-rebase)"
 msgstr "(intern für git-rebase verwendet)"
 
-#: builtin/am.c:2377
+#: builtin/am.c:2379
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
@@ -10991,16 +11211,16 @@ msgstr ""
 "Die -b/--binary Option hat seit Langem keinen Effekt und wird\n"
 "entfernt. Bitte verwenden Sie diese nicht mehr."
 
-#: builtin/am.c:2384
+#: builtin/am.c:2386
 msgid "failed to read the index"
 msgstr "Fehler beim Lesen des Index"
 
-#: builtin/am.c:2399
+#: builtin/am.c:2401
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr "Vorheriges Rebase-Verzeichnis %s existiert noch, aber mbox gegeben."
 
-#: builtin/am.c:2423
+#: builtin/am.c:2425
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
@@ -11009,11 +11229,11 @@ msgstr ""
 "Stray %s Verzeichnis gefunden.\n"
 "Benutzen Sie \"git am --abort\", um es zu entfernen."
 
-#: builtin/am.c:2429
+#: builtin/am.c:2431
 msgid "Resolve operation not in progress, we are not resuming."
 msgstr "Es ist keine Auflösung im Gange, es wird nicht fortgesetzt."
 
-#: builtin/am.c:2439
+#: builtin/am.c:2441
 msgid "interactive mode requires patches on the command line"
 msgstr "Interaktiver Modus benötigt Patches über die Kommandozeile"
 
@@ -11021,45 +11241,34 @@ msgstr "Interaktiver Modus benötigt Patches über die Kommandozeile"
 msgid "git apply [<options>] [<patch>...]"
 msgstr "git apply [<Optionen>] [<Patch>...]"
 
-#: builtin/archive.c:17
-#, c-format
-msgid "could not create archive file '%s'"
-msgstr "Konnte Archiv-Datei '%s' nicht erstellen."
-
-#: builtin/archive.c:20
+#: builtin/archive.c:18
 msgid "could not redirect output"
 msgstr "Konnte Ausgabe nicht umleiten."
 
-#: builtin/archive.c:37
+#: builtin/archive.c:35
 msgid "git archive: Remote with no URL"
 msgstr "git archive: Externes Archiv ohne URL"
 
-#: builtin/archive.c:61
+#: builtin/archive.c:59
 msgid "git archive: expected ACK/NAK, got a flush packet"
 msgstr "git archive: ACK/NAK erwartet, Flush-Paket bekommen"
 
-#: builtin/archive.c:64
+#: builtin/archive.c:62
 #, c-format
 msgid "git archive: NACK %s"
 msgstr "git archive: NACK %s"
 
-#: builtin/archive.c:65
+#: builtin/archive.c:63
 msgid "git archive: protocol error"
 msgstr "git archive: Protokollfehler"
 
-#: builtin/archive.c:69
+#: builtin/archive.c:67
 msgid "git archive: expected a flush"
 msgstr "git archive: erwartete eine Spülung (flush)"
 
-#: builtin/bisect--helper.c:23
+#: builtin/bisect--helper.c:24
 msgid "git bisect--helper --bisect-reset [<commit>]"
 msgstr "git bisect--helper --bisect-reset [<Commit>]"
-
-#: builtin/bisect--helper.c:24
-msgid "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
-msgstr ""
-"git bisect--helper --bisect-next-check <Begriff_gut> <Begriff_schlecht> "
-"[<Begriff>]"
 
 #: builtin/bisect--helper.c:25
 msgid ""
@@ -11099,46 +11308,61 @@ msgstr "git bisect--helper --bisect-replay <Dateiname>"
 msgid "git bisect--helper --bisect-skip [(<rev>|<range>)...]"
 msgstr "git bisect--helper --bisect-skip [(<Commit>|<Bereich>)...]"
 
-#: builtin/bisect--helper.c:107
+#: builtin/bisect--helper.c:33
+#, fuzzy
+msgid "git bisect--helper --bisect-visualize"
+msgstr "git bisect--helper --bisect-next"
+
+#: builtin/bisect--helper.c:34
+#, fuzzy
+msgid "git bisect--helper --bisect-run <cmd>..."
+msgstr "git bisect--helper --bisect-reset [<Commit>]"
+
+#: builtin/bisect--helper.c:109
 #, c-format
 msgid "cannot open file '%s' in mode '%s'"
 msgstr "kann Datei '%s' nicht im Modus '%s' öffnen"
 
-#: builtin/bisect--helper.c:114
+#: builtin/bisect--helper.c:116
 #, c-format
 msgid "could not write to file '%s'"
 msgstr "konnte nicht in Datei '%s' schreiben"
 
-#: builtin/bisect--helper.c:155
+#: builtin/bisect--helper.c:154
+#, fuzzy, c-format
+msgid "cannot open file '%s' for reading"
+msgstr "kann Datei '%s' nicht für die Wiederholung lesen"
+
+#: builtin/bisect--helper.c:170
 #, c-format
 msgid "'%s' is not a valid term"
 msgstr "'%s' ist kein gültiger Begriff"
 
-#: builtin/bisect--helper.c:159
+#: builtin/bisect--helper.c:174
 #, c-format
 msgid "can't use the builtin command '%s' as a term"
 msgstr "kann den eingebauten Befehl '%s' nicht als Begriff verwenden"
 
-#: builtin/bisect--helper.c:169
+#: builtin/bisect--helper.c:184
 #, c-format
 msgid "can't change the meaning of the term '%s'"
 msgstr "kann die Bedeutung von dem Begriff '%s' nicht ändern"
 
-#: builtin/bisect--helper.c:179
+#: builtin/bisect--helper.c:194
 msgid "please use two different terms"
 msgstr "bitte verwenden Sie zwei verschiedene Begriffe"
 
-#: builtin/bisect--helper.c:195
+#: builtin/bisect--helper.c:210
 #, c-format
 msgid "We are not bisecting.\n"
 msgstr "Keine binäre Suche im Gange.\n"
 
-#: builtin/bisect--helper.c:203
+#: builtin/bisect--helper.c:218
 #, c-format
 msgid "'%s' is not a valid commit"
 msgstr "'%s' ist kein gültiger Commit"
 
-#: builtin/bisect--helper.c:212
+#: builtin/bisect--helper.c:227
 #, c-format
 msgid ""
 "could not check out original HEAD '%s'. Try 'git bisect reset <commit>'."
@@ -11146,27 +11370,27 @@ msgstr ""
 "Konnte den ursprünglichen HEAD '%s' nicht auschecken.\n"
 "Versuchen Sie 'git bisect reset <Commit>'."
 
-#: builtin/bisect--helper.c:256
+#: builtin/bisect--helper.c:271
 #, c-format
 msgid "Bad bisect_write argument: %s"
 msgstr "Ungültiges \"bisect_write\" Argument: %s"
 
-#: builtin/bisect--helper.c:261
+#: builtin/bisect--helper.c:276
 #, c-format
 msgid "couldn't get the oid of the rev '%s'"
 msgstr "konnte die OID der Revision '%s' nicht erhalten"
 
-#: builtin/bisect--helper.c:273
+#: builtin/bisect--helper.c:288
 #, c-format
 msgid "couldn't open the file '%s'"
 msgstr "konnte die Datei '%s' nicht öffnen"
 
-#: builtin/bisect--helper.c:299
+#: builtin/bisect--helper.c:314
 #, c-format
 msgid "Invalid command: you're currently in a %s/%s bisect"
 msgstr "Ungültiger Befehl: Sie sind gerade innerhalb einer binären %s/%s Suche"
 
-#: builtin/bisect--helper.c:326
+#: builtin/bisect--helper.c:341
 #, c-format
 msgid ""
 "You need to give me at least one %s and %s revision.\n"
@@ -11175,7 +11399,7 @@ msgstr ""
 "Sie müssen mindestens einen \"%s\" und einen \"%s\" Commit angeben.\n"
 "Sie können dafür \"git bisect %s\" und \"git bisect %s\" benutzen."
 
-#: builtin/bisect--helper.c:330
+#: builtin/bisect--helper.c:345
 #, c-format
 msgid ""
 "You need to start by \"git bisect start\".\n"
@@ -11186,7 +11410,7 @@ msgstr ""
 "Danach müssen Sie mindestens einen \"%s\" und einen \"%s\" Commit angeben.\n"
 "Sie können dafür \"git bisect %s\" und \"git bisect %s\" benutzen."
 
-#: builtin/bisect--helper.c:350
+#: builtin/bisect--helper.c:365
 #, c-format
 msgid "bisecting only with a %s commit"
 msgstr "binäre Suche nur mit einem %s Commit"
@@ -11195,15 +11419,15 @@ msgstr "binäre Suche nur mit einem %s Commit"
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:358
+#: builtin/bisect--helper.c:373
 msgid "Are you sure [Y/n]? "
 msgstr "Sind Sie sicher [Y/n]? "
 
-#: builtin/bisect--helper.c:419
+#: builtin/bisect--helper.c:434
 msgid "no terms defined"
 msgstr "keine Begriffe definiert"
 
-#: builtin/bisect--helper.c:422
+#: builtin/bisect--helper.c:437
 #, c-format
 msgid ""
 "Your current terms are %s for the old state\n"
@@ -11212,7 +11436,7 @@ msgstr ""
 "Ihre aktuellen Begriffe sind %s für den alten Zustand\n"
 "und %s für den neuen Zustand.\n"
 
-#: builtin/bisect--helper.c:432
+#: builtin/bisect--helper.c:447
 #, c-format
 msgid ""
 "invalid argument %s for 'git bisect terms'.\n"
@@ -11221,55 +11445,55 @@ msgstr ""
 "Ungültiges Argument %s für 'git bisect terms'.\n"
 "Unterstützte Optionen sind: --term-good|--term-old und --term-bad|--term-new."
 
-#: builtin/bisect--helper.c:499 builtin/bisect--helper.c:1023
+#: builtin/bisect--helper.c:514 builtin/bisect--helper.c:1038
 msgid "revision walk setup failed\n"
 msgstr "Einrichtung des Revisionsgangs fehlgeschlagen\n"
 
-#: builtin/bisect--helper.c:521
+#: builtin/bisect--helper.c:536
 #, c-format
 msgid "could not open '%s' for appending"
 msgstr "konnte '%s' nicht zum Anhängen öffnen"
 
-#: builtin/bisect--helper.c:640 builtin/bisect--helper.c:653
+#: builtin/bisect--helper.c:655 builtin/bisect--helper.c:668
 msgid "'' is not a valid term"
 msgstr "'' ist kein gültiger Begriff"
 
-#: builtin/bisect--helper.c:663
+#: builtin/bisect--helper.c:678
 #, c-format
 msgid "unrecognized option: '%s'"
 msgstr "nicht erkannte Option: '%s'"
 
-#: builtin/bisect--helper.c:667
+#: builtin/bisect--helper.c:682
 #, c-format
 msgid "'%s' does not appear to be a valid revision"
 msgstr "'%s' scheint kein gültiger Commit zu sein"
 
-#: builtin/bisect--helper.c:698
+#: builtin/bisect--helper.c:713
 msgid "bad HEAD - I need a HEAD"
 msgstr "ungültiger HEAD - HEAD wird benötigt"
 
-#: builtin/bisect--helper.c:713
+#: builtin/bisect--helper.c:728
 #, c-format
 msgid "checking out '%s' failed. Try 'git bisect start <valid-branch>'."
 msgstr ""
 "Auschecken von '%s' fehlgeschlagen. Versuchen Sie 'git bisect start "
 "<gültiger-Branch>'."
 
-#: builtin/bisect--helper.c:734
+#: builtin/bisect--helper.c:749
 msgid "won't bisect on cg-seek'ed tree"
 msgstr ""
 "binäre Suche auf einem durch 'cg-seek' geändertem Verzeichnis nicht möglich"
 
-#: builtin/bisect--helper.c:737
+#: builtin/bisect--helper.c:752
 msgid "bad HEAD - strange symbolic ref"
 msgstr "ungültiger HEAD - merkwürdige symbolische Referenz"
 
-#: builtin/bisect--helper.c:757
+#: builtin/bisect--helper.c:772
 #, c-format
 msgid "invalid ref: '%s'"
 msgstr "ungültige Referenz: '%s'"
 
-#: builtin/bisect--helper.c:815
+#: builtin/bisect--helper.c:830
 msgid "You need to start by \"git bisect start\"\n"
 msgstr "Sie müssen mit \"git bisect start\" beginnen\n"
 
@@ -11277,104 +11501,154 @@ msgstr "Sie müssen mit \"git bisect start\" beginnen\n"
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:826
+#: builtin/bisect--helper.c:841
 msgid "Do you want me to do it for you [Y/n]? "
 msgstr "Wollen Sie, dass ich es für Sie mache [Y/n]? "
 
-#: builtin/bisect--helper.c:844
+#: builtin/bisect--helper.c:859
 msgid "Please call `--bisect-state` with at least one argument"
 msgstr "Bitte führen Sie `--bisect-state` mit mindestens einem Argument aus"
 
-#: builtin/bisect--helper.c:857
+#: builtin/bisect--helper.c:872
 #, c-format
 msgid "'git bisect %s' can take only one argument."
 msgstr "'git bisect %s' kann nur ein Argument entgegennehmen."
 
-#: builtin/bisect--helper.c:869 builtin/bisect--helper.c:882
+#: builtin/bisect--helper.c:884 builtin/bisect--helper.c:897
 #, c-format
 msgid "Bad rev input: %s"
 msgstr "Ungültige Referenz-Eingabe: %s"
 
-#: builtin/bisect--helper.c:889
+#: builtin/bisect--helper.c:904
 #, c-format
 msgid "Bad rev input (not a commit): %s"
 msgstr "Ungültige Referenz-Eingabe (kein Commit): %s"
 
-#: builtin/bisect--helper.c:921
+#: builtin/bisect--helper.c:936
 msgid "We are not bisecting."
 msgstr "Keine binäre Suche im Gange."
 
-#: builtin/bisect--helper.c:971
+#: builtin/bisect--helper.c:986
 #, c-format
 msgid "'%s'?? what are you talking about?"
 msgstr "'%s'?? Was reden Sie da?"
 
-#: builtin/bisect--helper.c:983
+#: builtin/bisect--helper.c:998
 #, c-format
 msgid "cannot read file '%s' for replaying"
 msgstr "kann Datei '%s' nicht für die Wiederholung lesen"
 
-#: builtin/bisect--helper.c:1056
+#: builtin/bisect--helper.c:1107 builtin/bisect--helper.c:1274
+msgid "bisect run failed: no command provided."
+msgstr "'bisect run' fehlgeschlagen: kein Befehl angegeben."
+
+#: builtin/bisect--helper.c:1116
+#, fuzzy, c-format
+msgid "running %s\n"
+msgstr "entferne veraltete Branches von %s"
+
+#: builtin/bisect--helper.c:1120
+#, fuzzy, c-format
+msgid "bisect run failed: exit code %d from '%s' is < 0 or >= 128"
+msgstr ""
+"'bisect run' fehlgeschlagen:\n"
+"Exit-Code $res von '$command' ist < 0 oder >= 128"
+
+#: builtin/bisect--helper.c:1136
+#, fuzzy, c-format
+msgid "cannot open file '%s' for writing"
+msgstr "Konnte '%s' nicht zum Schreiben öffnen."
+
+#: builtin/bisect--helper.c:1152
+msgid "bisect run cannot continue any more"
+msgstr "'bisect run' kann nicht mehr fortgesetzt werden"
+
+#: builtin/bisect--helper.c:1154
+#, c-format
+msgid "bisect run success"
+msgstr "'bisect run' erfolgreich ausgeführt"
+
+#: builtin/bisect--helper.c:1157
+#, fuzzy, c-format
+msgid "bisect found first bad commit"
+msgstr "binäre Suche nur mit einem %s Commit"
+
+#: builtin/bisect--helper.c:1160
+#, fuzzy, c-format
+msgid ""
+"bisect run failed: 'git bisect--helper --bisect-state %s' exited with error "
+"code %d"
+msgstr ""
+"'bisect run' fehlgeschlagen:\n"
+"'bisect-state $state' wurde mit Fehlerwert $res beendet"
+
+#: builtin/bisect--helper.c:1192
 msgid "reset the bisection state"
 msgstr "den Zustand der binären Suche zurücksetzen"
 
-#: builtin/bisect--helper.c:1058
+#: builtin/bisect--helper.c:1194
 msgid "check whether bad or good terms exist"
 msgstr "prüfen, ob Begriffe für gute und schlechte Commits existieren"
 
-#: builtin/bisect--helper.c:1060
+#: builtin/bisect--helper.c:1196
 msgid "print out the bisect terms"
 msgstr "die Begriffe für die binäre Suche ausgeben"
 
-#: builtin/bisect--helper.c:1062
+#: builtin/bisect--helper.c:1198
 msgid "start the bisect session"
 msgstr "Sitzung für binäre Suche starten"
 
-#: builtin/bisect--helper.c:1064
+#: builtin/bisect--helper.c:1200
 msgid "find the next bisection commit"
 msgstr "nächsten Commit für die binäre Suche finden"
 
-#: builtin/bisect--helper.c:1066
+#: builtin/bisect--helper.c:1202
 msgid "mark the state of ref (or refs)"
 msgstr "den Status der Referenz(en) markieren"
 
-#: builtin/bisect--helper.c:1068
+#: builtin/bisect--helper.c:1204
 msgid "list the bisection steps so far"
 msgstr "die bisherigen Schritte der binären Suche auflisten"
 
-#: builtin/bisect--helper.c:1070
+#: builtin/bisect--helper.c:1206
 msgid "replay the bisection process from the given file"
 msgstr "binäre Suche aus der angegebenen Datei wiederholen"
 
-#: builtin/bisect--helper.c:1072
+#: builtin/bisect--helper.c:1208
 msgid "skip some commits for checkout"
 msgstr "einige Commits für das Auschecken überspringen"
 
-#: builtin/bisect--helper.c:1074
+#: builtin/bisect--helper.c:1210
+#, fuzzy
+msgid "visualize the bisection"
+msgstr "Sitzung für binäre Suche starten"
+
+#: builtin/bisect--helper.c:1212
+#, fuzzy
+msgid "use <cmd>... to automatically bisect."
+msgstr "nicht automatisch committen"
+
+#: builtin/bisect--helper.c:1214
 msgid "no log for BISECT_WRITE"
 msgstr "kein Log für BISECT_WRITE"
 
-#: builtin/bisect--helper.c:1089
+#: builtin/bisect--helper.c:1229
 msgid "--bisect-reset requires either no argument or a commit"
 msgstr "--bisect-reset benötigt entweder kein Argument oder ein Commit"
 
-#: builtin/bisect--helper.c:1094
-msgid "--bisect-next-check requires 2 or 3 arguments"
-msgstr "--bisect-next-check benötigt 2 oder 3 Argumente"
-
-#: builtin/bisect--helper.c:1100
+#: builtin/bisect--helper.c:1234
 msgid "--bisect-terms requires 0 or 1 argument"
 msgstr "--bisect-terms benötigt 0 oder 1 Argument"
 
-#: builtin/bisect--helper.c:1109
+#: builtin/bisect--helper.c:1243
 msgid "--bisect-next requires 0 arguments"
 msgstr "--bisect-next benötigt 0 Argumente"
 
-#: builtin/bisect--helper.c:1120
+#: builtin/bisect--helper.c:1254
 msgid "--bisect-log requires 0 arguments"
 msgstr "--bisect-log benötigt 0 Argumente"
 
-#: builtin/bisect--helper.c:1125
+#: builtin/bisect--helper.c:1259
 msgid "no logfile given"
 msgstr "keine Log-Datei angegeben"
 
@@ -11386,155 +11660,157 @@ msgstr "git blame [<Optionen>] [<rev-opts>] [<Commit>] [--] <Datei>"
 msgid "<rev-opts> are documented in git-rev-list(1)"
 msgstr "<rev-opts> sind dokumentiert in git-rev-list(1)"
 
-#: builtin/blame.c:410
+#: builtin/blame.c:406
 #, c-format
 msgid "expecting a color: %s"
 msgstr "erwarte eine Farbe: %s"
 
-#: builtin/blame.c:417
+#: builtin/blame.c:413
 msgid "must end with a color"
 msgstr "muss mit einer Farbe enden"
 
-#: builtin/blame.c:728
+#: builtin/blame.c:724
 #, c-format
 msgid "invalid color '%s' in color.blame.repeatedLines"
 msgstr "ungültige Farbe '%s' in color.blame.repeatedLines"
 
-#: builtin/blame.c:746
+#: builtin/blame.c:742
 msgid "invalid value for blame.coloring"
 msgstr "ungültiger Wert für blame.coloring"
 
-#: builtin/blame.c:845
+#: builtin/blame.c:841
 #, c-format
 msgid "cannot find revision %s to ignore"
 msgstr "konnte Commit %s zum Ignorieren nicht finden"
 
-#: builtin/blame.c:867
+#: builtin/blame.c:863
 msgid "show blame entries as we find them, incrementally"
 msgstr "\"blame\"-Einträge schrittweise anzeigen, während wir sie finden"
 
-#: builtin/blame.c:868
+#: builtin/blame.c:864
 msgid "do not show object names of boundary commits (Default: off)"
 msgstr "keine Objektnamen für Grenz-Commits anzeigen (Standard: aus)"
 
-#: builtin/blame.c:869
+#: builtin/blame.c:865
 msgid "do not treat root commits as boundaries (Default: off)"
 msgstr "Root-Commits nicht als Grenzen behandeln (Standard: aus)"
 
-#: builtin/blame.c:870
+#: builtin/blame.c:866
 msgid "show work cost statistics"
 msgstr "Statistiken zum Arbeitsaufwand anzeigen"
 
-#: builtin/blame.c:871 builtin/checkout.c:1519 builtin/clone.c:94
-#: builtin/commit-graph.c:84 builtin/commit-graph.c:222 builtin/fetch.c:179
-#: builtin/merge.c:297 builtin/multi-pack-index.c:55 builtin/pull.c:119
-#: builtin/push.c:566 builtin/send-pack.c:198
+#: builtin/blame.c:867 builtin/checkout.c:1517 builtin/clone.c:94
+#: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
+#: builtin/merge.c:298 builtin/multi-pack-index.c:103
+#: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
+#: builtin/multi-pack-index.c:204 builtin/pull.c:119 builtin/push.c:566
+#: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "Fortschrittsanzeige erzwingen"
 
-#: builtin/blame.c:872
+#: builtin/blame.c:868
 msgid "show output score for blame entries"
 msgstr "Ausgabebewertung für \"blame\"-Einträge anzeigen"
 
-#: builtin/blame.c:873
+#: builtin/blame.c:869
 msgid "show original filename (Default: auto)"
 msgstr "ursprünglichen Dateinamen anzeigen (Standard: auto)"
 
-#: builtin/blame.c:874
+#: builtin/blame.c:870
 msgid "show original linenumber (Default: off)"
 msgstr "ursprüngliche Zeilennummer anzeigen (Standard: aus)"
 
-#: builtin/blame.c:875
+#: builtin/blame.c:871
 msgid "show in a format designed for machine consumption"
 msgstr "Anzeige in einem Format für maschinelle Auswertung"
 
-#: builtin/blame.c:876
+#: builtin/blame.c:872
 msgid "show porcelain format with per-line commit information"
 msgstr ""
 "Anzeige in Format für Fremdprogramme mit Commit-Informationen pro Zeile"
 
-#: builtin/blame.c:877
+#: builtin/blame.c:873
 msgid "use the same output mode as git-annotate (Default: off)"
 msgstr ""
 "den gleichen Ausgabemodus benutzen wie \"git-annotate\" (Standard: aus)"
 
-#: builtin/blame.c:878
+#: builtin/blame.c:874
 msgid "show raw timestamp (Default: off)"
 msgstr "unbearbeiteten Zeitstempel anzeigen (Standard: aus)"
 
-#: builtin/blame.c:879
+#: builtin/blame.c:875
 msgid "show long commit SHA1 (Default: off)"
 msgstr "langen Commit-SHA1 anzeigen (Standard: aus)"
 
-#: builtin/blame.c:880
+#: builtin/blame.c:876
 msgid "suppress author name and timestamp (Default: off)"
 msgstr "den Namen des Autors und den Zeitstempel unterdrücken (Standard: aus)"
 
-#: builtin/blame.c:881
+#: builtin/blame.c:877
 msgid "show author email instead of name (Default: off)"
 msgstr ""
 "statt des Namens die E-Mail-Adresse des Autors anzeigen (Standard: aus)"
 
-#: builtin/blame.c:882
+#: builtin/blame.c:878
 msgid "ignore whitespace differences"
 msgstr "Whitespace-Unterschiede ignorieren"
 
-#: builtin/blame.c:883 builtin/log.c:1823
+#: builtin/blame.c:879 builtin/log.c:1823
 msgid "rev"
 msgstr "Commit"
 
-#: builtin/blame.c:883
+#: builtin/blame.c:879
 msgid "ignore <rev> when blaming"
 msgstr "ignoriere <Commit> beim Ausführen von 'blame'"
 
-#: builtin/blame.c:884
+#: builtin/blame.c:880
 msgid "ignore revisions from <file>"
 msgstr "ignoriere Commits aus <Datei>"
 
-#: builtin/blame.c:885
+#: builtin/blame.c:881
 msgid "color redundant metadata from previous line differently"
 msgstr "redundante Metadaten der vorherigen Zeile unterschiedlich einfärben"
 
-#: builtin/blame.c:886
+#: builtin/blame.c:882
 msgid "color lines by age"
 msgstr "Zeilen nach Alter einfärben"
 
-#: builtin/blame.c:887
+#: builtin/blame.c:883
 msgid "spend extra cycles to find better match"
 msgstr ""
 "mehr Arbeitsschritte ausführen, um eine bessere Übereinstimmung zu finden"
 
-#: builtin/blame.c:888
+#: builtin/blame.c:884
 msgid "use revisions from <file> instead of calling git-rev-list"
 msgstr "Commits von <Datei> benutzen, statt \"git-rev-list\" aufzurufen"
 
-#: builtin/blame.c:889
+#: builtin/blame.c:885
 msgid "use <file>'s contents as the final image"
 msgstr "Inhalte der <Datei>en als endgültiges Abbild benutzen"
 
-#: builtin/blame.c:890 builtin/blame.c:891
+#: builtin/blame.c:886 builtin/blame.c:887
 msgid "score"
 msgstr "Bewertung"
 
-#: builtin/blame.c:890
+#: builtin/blame.c:886
 msgid "find line copies within and across files"
 msgstr "kopierte Zeilen innerhalb oder zwischen Dateien finden"
 
-#: builtin/blame.c:891
+#: builtin/blame.c:887
 msgid "find line movements within and across files"
 msgstr "verschobene Zeilen innerhalb oder zwischen Dateien finden"
 
-#: builtin/blame.c:892
+#: builtin/blame.c:888
 msgid "range"
 msgstr "Bereich"
 
-#: builtin/blame.c:893
+#: builtin/blame.c:889
 msgid "process only line range <start>,<end> or function :<funcname>"
 msgstr ""
 "nur Zeilen im Bereich <Start>,<Ende> oder Funktion :<Funktionsname> "
 "verarbeiten"
 
-#: builtin/blame.c:945
+#: builtin/blame.c:944
 msgid "--progress can't be used with --incremental or porcelain formats"
 msgstr ""
 "--progress kann nicht mit --incremental oder Formaten für Fremdprogramme\n"
@@ -11548,18 +11824,18 @@ msgstr ""
 #. your language may need more or fewer display
 #. columns.
 #.
-#: builtin/blame.c:996
+#: builtin/blame.c:995
 msgid "4 years, 11 months ago"
 msgstr "vor 4 Jahren und 11 Monaten"
 
-#: builtin/blame.c:1112
+#: builtin/blame.c:1111
 #, c-format
 msgid "file %s has only %lu line"
 msgid_plural "file %s has only %lu lines"
 msgstr[0] "Datei %s hat nur %lu Zeile"
 msgstr[1] "Datei %s hat nur %lu Zeilen"
 
-#: builtin/blame.c:1157
+#: builtin/blame.c:1156
 msgid "Blaming lines"
 msgstr "Verarbeite Zeilen"
 
@@ -11661,81 +11937,81 @@ msgstr "Remote-Tracking-Branch %s entfernt (war %s).\n"
 msgid "Deleted branch %s (was %s).\n"
 msgstr "Branch %s entfernt (war %s).\n"
 
-#: builtin/branch.c:440 builtin/tag.c:63
+#: builtin/branch.c:441 builtin/tag.c:63
 msgid "unable to parse format string"
 msgstr "Konnte Formatierungsstring nicht parsen."
 
-#: builtin/branch.c:471
+#: builtin/branch.c:472
 msgid "could not resolve HEAD"
 msgstr "Konnte HEAD-Commit nicht auflösen."
 
-#: builtin/branch.c:477
+#: builtin/branch.c:478
 #, c-format
 msgid "HEAD (%s) points outside of refs/heads/"
 msgstr "HEAD (%s) wurde nicht unter \"refs/heads/\" gefunden!"
 
-#: builtin/branch.c:492
+#: builtin/branch.c:493
 #, c-format
 msgid "Branch %s is being rebased at %s"
 msgstr "Branch %s wird auf %s umgesetzt"
 
-#: builtin/branch.c:496
+#: builtin/branch.c:497
 #, c-format
 msgid "Branch %s is being bisected at %s"
 msgstr "Binäre Suche von Branch %s zu %s im Gange"
 
-#: builtin/branch.c:513
+#: builtin/branch.c:514
 msgid "cannot copy the current branch while not on any."
 msgstr ""
 "Kann den aktuellen Branch nicht kopieren, solange Sie sich auf keinem "
 "befinden."
 
-#: builtin/branch.c:515
+#: builtin/branch.c:516
 msgid "cannot rename the current branch while not on any."
 msgstr ""
 "Kann aktuellen Branch nicht umbenennen, solange Sie sich auf keinem befinden."
 
-#: builtin/branch.c:526
+#: builtin/branch.c:527
 #, c-format
 msgid "Invalid branch name: '%s'"
 msgstr "Ungültiger Branchname: '%s'"
 
-#: builtin/branch.c:555
+#: builtin/branch.c:556
 msgid "Branch rename failed"
 msgstr "Umbenennung des Branches fehlgeschlagen"
 
-#: builtin/branch.c:557
+#: builtin/branch.c:558
 msgid "Branch copy failed"
 msgstr "Kopie des Branches fehlgeschlagen"
 
-#: builtin/branch.c:561
+#: builtin/branch.c:562
 #, c-format
 msgid "Created a copy of a misnamed branch '%s'"
 msgstr "Kopie eines falsch benannten Branches '%s' erstellt."
 
-#: builtin/branch.c:564
+#: builtin/branch.c:565
 #, c-format
 msgid "Renamed a misnamed branch '%s' away"
 msgstr "falsch benannten Branch '%s' umbenannt"
 
-#: builtin/branch.c:570
+#: builtin/branch.c:571
 #, c-format
 msgid "Branch renamed to %s, but HEAD is not updated!"
 msgstr "Branch umbenannt zu %s, aber HEAD ist nicht aktualisiert!"
 
-#: builtin/branch.c:579
+#: builtin/branch.c:580
 msgid "Branch is renamed, but update of config-file failed"
 msgstr ""
 "Branch ist umbenannt, aber die Aktualisierung der Konfigurationsdatei ist "
 "fehlgeschlagen."
 
-#: builtin/branch.c:581
+#: builtin/branch.c:582
 msgid "Branch is copied, but update of config-file failed"
 msgstr ""
 "Branch wurde kopiert, aber die Aktualisierung der Konfigurationsdatei ist\n"
 "fehlgeschlagen."
 
-#: builtin/branch.c:597
+#: builtin/branch.c:598
 #, c-format
 msgid ""
 "Please edit the description for the branch\n"
@@ -11746,181 +12022,181 @@ msgstr ""
 "  %s\n"
 "Zeilen, die mit '%c' beginnen, werden entfernt.\n"
 
-#: builtin/branch.c:631
+#: builtin/branch.c:632
 msgid "Generic options"
 msgstr "Allgemeine Optionen"
 
-#: builtin/branch.c:633
+#: builtin/branch.c:634
 msgid "show hash and subject, give twice for upstream branch"
 msgstr "Hash und Betreff anzeigen; -vv: zusätzlich Upstream-Branch"
 
-#: builtin/branch.c:634
+#: builtin/branch.c:635
 msgid "suppress informational messages"
 msgstr "Informationsmeldungen unterdrücken"
 
-#: builtin/branch.c:635
+#: builtin/branch.c:636
 msgid "set up tracking mode (see git-pull(1))"
 msgstr "Modus zum Folgen von Branches einstellen (siehe git-pull(1))"
 
-#: builtin/branch.c:637
+#: builtin/branch.c:638
 msgid "do not use"
 msgstr "nicht verwenden"
 
-#: builtin/branch.c:639 builtin/rebase.c:533
+#: builtin/branch.c:640
 msgid "upstream"
 msgstr "Upstream"
 
-#: builtin/branch.c:639
+#: builtin/branch.c:640
 msgid "change the upstream info"
 msgstr "Informationen zum Upstream-Branch ändern"
 
-#: builtin/branch.c:640
+#: builtin/branch.c:641
 msgid "unset the upstream info"
 msgstr "Informationen zum Upstream-Branch entfernen"
 
-#: builtin/branch.c:641
+#: builtin/branch.c:642
 msgid "use colored output"
 msgstr "farbige Ausgaben verwenden"
 
-#: builtin/branch.c:642
+#: builtin/branch.c:643
 msgid "act on remote-tracking branches"
 msgstr "auf Remote-Tracking-Branches wirken"
 
-#: builtin/branch.c:644 builtin/branch.c:646
+#: builtin/branch.c:645 builtin/branch.c:647
 msgid "print only branches that contain the commit"
 msgstr "nur Branches ausgeben, die diesen Commit enthalten"
 
-#: builtin/branch.c:645 builtin/branch.c:647
+#: builtin/branch.c:646 builtin/branch.c:648
 msgid "print only branches that don't contain the commit"
 msgstr "nur Branches ausgeben, die diesen Commit nicht enthalten"
 
-#: builtin/branch.c:650
+#: builtin/branch.c:651
 msgid "Specific git-branch actions:"
 msgstr "spezifische Aktionen für \"git-branch\":"
 
-#: builtin/branch.c:651
+#: builtin/branch.c:652
 msgid "list both remote-tracking and local branches"
 msgstr "Remote-Tracking und lokale Branches auflisten"
 
-#: builtin/branch.c:653
+#: builtin/branch.c:654
 msgid "delete fully merged branch"
 msgstr "vollständig zusammengeführten Branch entfernen"
 
-#: builtin/branch.c:654
+#: builtin/branch.c:655
 msgid "delete branch (even if not merged)"
 msgstr "Branch löschen (auch wenn nicht zusammengeführt)"
 
-#: builtin/branch.c:655
+#: builtin/branch.c:656
 msgid "move/rename a branch and its reflog"
 msgstr "einen Branch und dessen Reflog verschieben/umbenennen"
 
-#: builtin/branch.c:656
+#: builtin/branch.c:657
 msgid "move/rename a branch, even if target exists"
 msgstr ""
 "einen Branch verschieben/umbenennen, auch wenn das Ziel bereits existiert"
 
-#: builtin/branch.c:657
+#: builtin/branch.c:658
 msgid "copy a branch and its reflog"
 msgstr "einen Branch und dessen Reflog kopieren"
 
-#: builtin/branch.c:658
+#: builtin/branch.c:659
 msgid "copy a branch, even if target exists"
 msgstr "einen Branch kopieren, auch wenn das Ziel bereits existiert"
 
-#: builtin/branch.c:659
+#: builtin/branch.c:660
 msgid "list branch names"
 msgstr "Branchnamen auflisten"
 
-#: builtin/branch.c:660
+#: builtin/branch.c:661
 msgid "show current branch name"
 msgstr "Zeige aktuellen Branch-Namen."
 
-#: builtin/branch.c:661
+#: builtin/branch.c:662
 msgid "create the branch's reflog"
 msgstr "das Reflog des Branches erzeugen"
 
-#: builtin/branch.c:663
+#: builtin/branch.c:664
 msgid "edit the description for the branch"
 msgstr "die Beschreibung für den Branch bearbeiten"
 
-#: builtin/branch.c:664
+#: builtin/branch.c:665
 msgid "force creation, move/rename, deletion"
 msgstr "Erstellung, Verschiebung/Umbenennung oder Löschung erzwingen"
 
-#: builtin/branch.c:665
+#: builtin/branch.c:666
 msgid "print only branches that are merged"
 msgstr "nur zusammengeführte Branches ausgeben"
 
-#: builtin/branch.c:666
+#: builtin/branch.c:667
 msgid "print only branches that are not merged"
 msgstr "nur nicht zusammengeführte Branches ausgeben"
 
-#: builtin/branch.c:667
+#: builtin/branch.c:668
 msgid "list branches in columns"
 msgstr "Branches in Spalten auflisten"
 
-#: builtin/branch.c:669 builtin/for-each-ref.c:44 builtin/notes.c:415
-#: builtin/notes.c:418 builtin/notes.c:581 builtin/notes.c:584
-#: builtin/tag.c:477
+#: builtin/branch.c:670 builtin/for-each-ref.c:44 builtin/notes.c:413
+#: builtin/notes.c:416 builtin/notes.c:579 builtin/notes.c:582
+#: builtin/tag.c:475
 msgid "object"
 msgstr "Objekt"
 
-#: builtin/branch.c:670
+#: builtin/branch.c:671
 msgid "print only branches of the object"
 msgstr "nur Branches von diesem Objekt ausgeben"
 
-#: builtin/branch.c:671 builtin/for-each-ref.c:50 builtin/tag.c:484
+#: builtin/branch.c:672 builtin/for-each-ref.c:50 builtin/tag.c:482
 msgid "sorting and filtering are case insensitive"
 msgstr "Sortierung und Filterung sind unabhängig von Groß- und Kleinschreibung"
 
-#: builtin/branch.c:672 builtin/for-each-ref.c:40 builtin/tag.c:482
+#: builtin/branch.c:673 builtin/for-each-ref.c:40 builtin/tag.c:480
 #: builtin/verify-tag.c:38
 msgid "format to use for the output"
 msgstr "für die Ausgabe zu verwendendes Format"
 
-#: builtin/branch.c:695 builtin/clone.c:794
+#: builtin/branch.c:696 builtin/clone.c:678
 msgid "HEAD not found below refs/heads!"
 msgstr "HEAD wurde nicht unter \"refs/heads\" gefunden!"
 
-#: builtin/branch.c:719
+#: builtin/branch.c:720
 msgid "--column and --verbose are incompatible"
 msgstr "--column und --verbose sind inkompatibel"
 
-#: builtin/branch.c:734 builtin/branch.c:790 builtin/branch.c:799
+#: builtin/branch.c:735 builtin/branch.c:792 builtin/branch.c:801
 msgid "branch name required"
 msgstr "Branchname erforderlich"
 
-#: builtin/branch.c:766
+#: builtin/branch.c:768
 msgid "Cannot give description to detached HEAD"
 msgstr "zu losgelöstem HEAD kann keine Beschreibung hinterlegt werden"
 
-#: builtin/branch.c:771
+#: builtin/branch.c:773
 msgid "cannot edit description of more than one branch"
 msgstr "Beschreibung von mehr als einem Branch kann nicht bearbeitet werden"
 
-#: builtin/branch.c:778
+#: builtin/branch.c:780
 #, c-format
 msgid "No commit on branch '%s' yet."
 msgstr "Noch kein Commit in Branch '%s'."
 
-#: builtin/branch.c:781
+#: builtin/branch.c:783
 #, c-format
 msgid "No branch named '%s'."
 msgstr "Branch '%s' nicht vorhanden."
 
-#: builtin/branch.c:796
+#: builtin/branch.c:798
 msgid "too many branches for a copy operation"
 msgstr "zu viele Branches für eine Kopieroperation angegeben"
 
-#: builtin/branch.c:805
+#: builtin/branch.c:807
 msgid "too many arguments for a rename operation"
 msgstr "zu viele Argumente für eine Umbenennen-Operation angegeben"
 
-#: builtin/branch.c:810
+#: builtin/branch.c:812
 msgid "too many arguments to set new upstream"
 msgstr "zu viele Argumente angegeben, um Upstream-Branch zu setzen"
 
-#: builtin/branch.c:814
+#: builtin/branch.c:816
 #, c-format
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch."
@@ -11928,34 +12204,34 @@ msgstr ""
 "Konnte keinen neuen Upstream-Branch von HEAD zu %s setzen, da dieser auf\n"
 "keinen Branch zeigt."
 
-#: builtin/branch.c:817 builtin/branch.c:840
+#: builtin/branch.c:819 builtin/branch.c:842
 #, c-format
 msgid "no such branch '%s'"
 msgstr "Branch '%s' nicht gefunden"
 
-#: builtin/branch.c:821
+#: builtin/branch.c:823
 #, c-format
 msgid "branch '%s' does not exist"
 msgstr "Branch '%s' existiert nicht"
 
-#: builtin/branch.c:834
+#: builtin/branch.c:836
 msgid "too many arguments to unset upstream"
 msgstr ""
 "zu viele Argumente angegeben, um Konfiguration zu Upstream-Branch zu "
 "entfernen"
 
-#: builtin/branch.c:838
+#: builtin/branch.c:840
 msgid "could not unset upstream of HEAD when it does not point to any branch."
 msgstr ""
 "Konnte Konfiguration zu Upstream-Branch von HEAD nicht entfernen, da dieser\n"
 "auf keinen Branch zeigt."
 
-#: builtin/branch.c:844
+#: builtin/branch.c:846
 #, c-format
 msgid "Branch '%s' has no upstream information"
 msgstr "Branch '%s' hat keinen Upstream-Branch gesetzt"
 
-#: builtin/branch.c:854
+#: builtin/branch.c:856
 msgid ""
 "The -a, and -r, options to 'git branch' do not take a branch name.\n"
 "Did you mean to use: -a|-r --list <pattern>?"
@@ -11964,7 +12240,7 @@ msgstr ""
 "verwendet werden.\n"
 "Wollten Sie -a|-r --list <Muster> benutzen?"
 
-#: builtin/branch.c:858
+#: builtin/branch.c:860
 msgid ""
 "the '--set-upstream' option is no longer supported. Please use '--track' or "
 "'--set-upstream-to' instead."
@@ -11972,32 +12248,32 @@ msgstr ""
 "Die '--set-upstream' Option wird nicht länger unterstützt.\n"
 "Bitte benutzen Sie stattdessen '--track' oder '--set-upstream-to'."
 
-#: builtin/bugreport.c:15
+#: builtin/bugreport.c:16
 msgid "git version:\n"
 msgstr "git Version:\n"
 
-#: builtin/bugreport.c:21
+#: builtin/bugreport.c:22
 #, c-format
 msgid "uname() failed with error '%s' (%d)\n"
 msgstr "uname() ist fehlgeschlagen mit Fehler '%s' (%d)\n"
 
-#: builtin/bugreport.c:31
+#: builtin/bugreport.c:32
 msgid "compiler info: "
 msgstr "Compiler Info: "
 
-#: builtin/bugreport.c:34
+#: builtin/bugreport.c:35
 msgid "libc info: "
 msgstr "libc Info: "
 
-#: builtin/bugreport.c:80
+#: builtin/bugreport.c:49
 msgid "not run from a git repository - no hooks to show\n"
 msgstr "nicht in einem Git-Repository ausgeführt - keine Hooks zum Anzeigen\n"
 
-#: builtin/bugreport.c:90
+#: builtin/bugreport.c:62
 msgid "git bugreport [-o|--output-directory <file>] [-s|--suffix <format>]"
 msgstr "git bugreport [-o|--output-directory <Datei>] [-s|--suffix <Format>]"
 
-#: builtin/bugreport.c:97
+#: builtin/bugreport.c:69
 msgid ""
 "Thank you for filling out a Git bug report!\n"
 "Please answer the following questions to help us understand your issue.\n"
@@ -12034,38 +12310,33 @@ msgstr ""
 "Bitte überprüfen Sie den restlichen Teil des Fehlerberichts unten.\n"
 "Sie können jede Zeile löschen, die Sie nicht mitteilen möchten.\n"
 
-#: builtin/bugreport.c:136
+#: builtin/bugreport.c:108
 msgid "specify a destination for the bugreport file"
 msgstr "Speicherort für die Datei des Fehlerberichts angeben"
 
-#: builtin/bugreport.c:138
+#: builtin/bugreport.c:110
 msgid "specify a strftime format suffix for the filename"
 msgstr "Dateiendung im strftime-Format für den Dateinamen angeben"
 
-#: builtin/bugreport.c:160
+#: builtin/bugreport.c:132
 #, c-format
 msgid "could not create leading directories for '%s'"
 msgstr "konnte vorangehende Verzeichnisse für '%s' nicht erstellen"
 
-#: builtin/bugreport.c:167
+#: builtin/bugreport.c:139
 msgid "System Info"
 msgstr "System Info"
 
-#: builtin/bugreport.c:170
+#: builtin/bugreport.c:142
 msgid "Enabled Hooks"
 msgstr "Aktivierte Hooks"
 
-#: builtin/bugreport.c:177
-#, c-format
-msgid "couldn't create a new file at '%s'"
-msgstr "konnte keine neue Datei unter '%s' erstellen"
-
-#: builtin/bugreport.c:180
+#: builtin/bugreport.c:149
 #, c-format
 msgid "unable to write to %s"
 msgstr "konnte nicht nach %s schreiben"
 
-#: builtin/bugreport.c:190
+#: builtin/bugreport.c:159
 #, c-format
 msgid "Created new report at '%s'.\n"
 msgstr "Neuer Bericht unter '%s' erstellt.\n"
@@ -12086,53 +12357,54 @@ msgstr "git bundle list-heads <Datei> [<Referenzname>...]"
 msgid "git bundle unbundle <file> [<refname>...]"
 msgstr "git bundle unbundle <Datei> [<Referenzname>...]"
 
-#: builtin/bundle.c:67 builtin/pack-objects.c:3907
+#: builtin/bundle.c:65 builtin/pack-objects.c:3876
 msgid "do not show progress meter"
 msgstr "keine Fortschrittsanzeige anzeigen"
 
-#: builtin/bundle.c:69 builtin/pack-objects.c:3909
+#: builtin/bundle.c:67 builtin/bundle.c:167 builtin/pack-objects.c:3878
 msgid "show progress meter"
 msgstr "Fortschrittsanzeige anzeigen"
 
-#: builtin/bundle.c:71 builtin/pack-objects.c:3911
+#: builtin/bundle.c:69 builtin/pack-objects.c:3880
 msgid "show progress meter during object writing phase"
 msgstr "Forschrittsanzeige während des Schreibens von Objekten anzeigen"
 
-#: builtin/bundle.c:74 builtin/pack-objects.c:3914
+#: builtin/bundle.c:72 builtin/pack-objects.c:3883
 msgid "similar to --all-progress when progress meter is shown"
 msgstr "ähnlich zu --all-progress wenn Fortschrittsanzeige darstellt wird"
 
-#: builtin/bundle.c:76
+#: builtin/bundle.c:74
 msgid "specify bundle format version"
 msgstr "Version des Paket-Formats angeben"
 
-#: builtin/bundle.c:96
+#: builtin/bundle.c:94
 msgid "Need a repository to create a bundle."
 msgstr "Um ein Paket zu erstellen wird ein Repository benötigt."
 
-#: builtin/bundle.c:109
+#: builtin/bundle.c:107
 msgid "do not show bundle details"
 msgstr "Keine Bundle-Details anzeigen"
 
-#: builtin/bundle.c:128
+#: builtin/bundle.c:126
 #, c-format
 msgid "%s is okay\n"
 msgstr "%s ist in Ordnung\n"
 
-#: builtin/bundle.c:179
+#: builtin/bundle.c:182
 msgid "Need a repository to unbundle."
 msgstr "Zum Entpacken wird ein Repository benötigt."
 
-#: builtin/bundle.c:191 builtin/remote.c:1700
-msgid "be verbose; must be placed before a subcommand"
-msgstr "erweiterte Ausgaben; muss vor einem Unterbefehl angegeben werden"
+#: builtin/bundle.c:185
+#, fuzzy
+msgid "Unbundling objects"
+msgstr "Indiziere Objekte"
 
-#: builtin/bundle.c:213 builtin/remote.c:1731
+#: builtin/bundle.c:219 builtin/remote.c:1733
 #, c-format
 msgid "Unknown subcommand: %s"
 msgstr "Unbekannter Unterbefehl: %s"
 
-#: builtin/cat-file.c:596
+#: builtin/cat-file.c:622
 msgid ""
 "git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e | -"
 "p | <type> | --textconv | --filters) [--path=<path>] <object>"
@@ -12140,7 +12412,7 @@ msgstr ""
 "git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e | -"
 "p | <Art> | --textconv | --filters) [--path=<Pfad>] <Objekt>"
 
-#: builtin/cat-file.c:597
+#: builtin/cat-file.c:623
 msgid ""
 "git cat-file (--batch[=<format>] | --batch-check[=<format>]) [--follow-"
 "symlinks] [--textconv | --filters]"
@@ -12148,76 +12420,76 @@ msgstr ""
 "git cat-file (--batch[=<Format>] | --batch-check[=<Format>]) [--follow-"
 "symlinks] [--textconv | --filters]"
 
-#: builtin/cat-file.c:618
+#: builtin/cat-file.c:644
 msgid "only one batch option may be specified"
 msgstr "Nur eine Batch-Option erlaubt."
 
-#: builtin/cat-file.c:636
+#: builtin/cat-file.c:662
 msgid "<type> can be one of: blob, tree, commit, tag"
 msgstr "<Art> kann sein: blob, tree, commit, tag"
 
-#: builtin/cat-file.c:637
+#: builtin/cat-file.c:663
 msgid "show object type"
 msgstr "Objektart anzeigen"
 
-#: builtin/cat-file.c:638
+#: builtin/cat-file.c:664
 msgid "show object size"
 msgstr "Objektgröße anzeigen"
 
-#: builtin/cat-file.c:640
+#: builtin/cat-file.c:666
 msgid "exit with zero when there's no error"
 msgstr "mit Rückgabewert 0 beenden, wenn kein Fehler aufgetreten ist"
 
-#: builtin/cat-file.c:641
+#: builtin/cat-file.c:667
 msgid "pretty-print object's content"
 msgstr "ansprechende Anzeige des Objektinhaltes"
 
-#: builtin/cat-file.c:643
+#: builtin/cat-file.c:669
 msgid "for blob objects, run textconv on object's content"
 msgstr "eine Textkonvertierung auf den Inhalt von Blob-Objekten ausführen"
 
-#: builtin/cat-file.c:645
+#: builtin/cat-file.c:671
 msgid "for blob objects, run filters on object's content"
 msgstr "für Blob-Objekte, Filter auf Objekt-Inhalte ausführen"
 
-#: builtin/cat-file.c:646
+#: builtin/cat-file.c:672
 msgid "blob"
 msgstr "Blob"
 
-#: builtin/cat-file.c:647
+#: builtin/cat-file.c:673
 msgid "use a specific path for --textconv/--filters"
 msgstr "einen bestimmten Pfad für --textconv/--filters verwenden"
 
-#: builtin/cat-file.c:649
+#: builtin/cat-file.c:675
 msgid "allow -s and -t to work with broken/corrupt objects"
 msgstr "-s und -t mit beschädigten Objekten erlauben"
 
-#: builtin/cat-file.c:650
+#: builtin/cat-file.c:676
 msgid "buffer --batch output"
 msgstr "Ausgabe von --batch puffern"
 
-#: builtin/cat-file.c:652
+#: builtin/cat-file.c:678
 msgid "show info and content of objects fed from the standard input"
 msgstr ""
 "Anzeige von Informationen und Inhalt von Objekten, gelesen von der Standard-"
 "Eingabe"
 
-#: builtin/cat-file.c:656
+#: builtin/cat-file.c:682
 msgid "show info about objects fed from the standard input"
 msgstr ""
 "Anzeige von Informationen über Objekte, gelesen von der Standard-Eingabe"
 
-#: builtin/cat-file.c:660
+#: builtin/cat-file.c:686
 msgid "follow in-tree symlinks (used with --batch or --batch-check)"
 msgstr ""
 "symbolischen Verknüpfungen innerhalb des Repositories folgen (verwendet mit "
 "--batch oder --batch-check)"
 
-#: builtin/cat-file.c:662
+#: builtin/cat-file.c:688
 msgid "show all objects with --batch or --batch-check"
 msgstr "alle Objekte mit --batch oder --batch-check anzeigen"
 
-#: builtin/cat-file.c:664
+#: builtin/cat-file.c:690
 msgid "do not order --batch-all-objects output"
 msgstr "Ausgabe von --batch-all-objects nicht ordnen"
 
@@ -12237,7 +12509,7 @@ msgstr "alle Attribute einer Datei ausgeben"
 msgid "use .gitattributes only from the index"
 msgstr "nur .gitattributes vom Index verwenden"
 
-#: builtin/check-attr.c:23 builtin/check-ignore.c:25 builtin/hash-object.c:102
+#: builtin/check-attr.c:23 builtin/check-ignore.c:25 builtin/hash-object.c:100
 msgid "read file names from stdin"
 msgstr "Dateinamen von der Standard-Eingabe lesen"
 
@@ -12245,8 +12517,8 @@ msgstr "Dateinamen von der Standard-Eingabe lesen"
 msgid "terminate input and output records by a NUL character"
 msgstr "Einträge von Ein- und Ausgabe mit NUL-Zeichen abschließen"
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1515 builtin/gc.c:549
-#: builtin/worktree.c:493
+#: builtin/check-ignore.c:21 builtin/checkout.c:1513 builtin/gc.c:549
+#: builtin/worktree.c:494
 msgid "suppress progress reporting"
 msgstr "Fortschrittsanzeige unterdrücken"
 
@@ -12304,11 +12576,10 @@ msgid "git checkout--worker [<options>]"
 msgstr "git checkout--worker [<Optionen>]"
 
 #: builtin/checkout--worker.c:118 builtin/checkout-index.c:201
-#: builtin/column.c:31 builtin/submodule--helper.c:1892
-#: builtin/submodule--helper.c:1895 builtin/submodule--helper.c:1903
-#: builtin/submodule--helper.c:2350 builtin/submodule--helper.c:2896
-#: builtin/submodule--helper.c:2899 builtin/worktree.c:491
-#: builtin/worktree.c:728
+#: builtin/column.c:31 builtin/column.c:32 builtin/submodule--helper.c:1863
+#: builtin/submodule--helper.c:1866 builtin/submodule--helper.c:1874
+#: builtin/submodule--helper.c:2510 builtin/submodule--helper.c:2576
+#: builtin/worktree.c:492 builtin/worktree.c:729
 msgid "string"
 msgstr "Zeichenkette"
 
@@ -12463,11 +12734,11 @@ msgstr "'%s' oder '%s' kann nicht mit %s verwendet werden"
 msgid "path '%s' is unmerged"
 msgstr "Pfad '%s' ist nicht zusammengeführt."
 
-#: builtin/checkout.c:734
+#: builtin/checkout.c:736
 msgid "you need to resolve your current index first"
 msgstr "Sie müssen zuerst die Konflikte in Ihrem aktuellen Index auflösen."
 
-#: builtin/checkout.c:788
+#: builtin/checkout.c:786
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -12476,50 +12747,50 @@ msgstr ""
 "Kann nicht mit vorgemerkten Änderungen in folgenden Dateien fortsetzen:\n"
 "%s"
 
-#: builtin/checkout.c:881
+#: builtin/checkout.c:879
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Kann \"reflog\" für '%s' nicht durchführen: %s\n"
 
-#: builtin/checkout.c:923
+#: builtin/checkout.c:921
 msgid "HEAD is now at"
 msgstr "HEAD ist jetzt bei"
 
-#: builtin/checkout.c:927 builtin/clone.c:725 t/helper/test-fast-rebase.c:203
+#: builtin/checkout.c:925 builtin/clone.c:609 t/helper/test-fast-rebase.c:203
 msgid "unable to update HEAD"
 msgstr "Konnte HEAD nicht aktualisieren."
 
-#: builtin/checkout.c:931
+#: builtin/checkout.c:929
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Setze Branch '%s' neu\n"
 
-#: builtin/checkout.c:934
+#: builtin/checkout.c:932
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Bereits auf '%s'\n"
 
-#: builtin/checkout.c:938
+#: builtin/checkout.c:936
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Zu umgesetztem Branch '%s' gewechselt\n"
 
-#: builtin/checkout.c:940 builtin/checkout.c:1371
+#: builtin/checkout.c:938 builtin/checkout.c:1369
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Zu neuem Branch '%s' gewechselt\n"
 
-#: builtin/checkout.c:942
+#: builtin/checkout.c:940
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Zu Branch '%s' gewechselt\n"
 
-#: builtin/checkout.c:993
+#: builtin/checkout.c:991
 #, c-format
 msgid " ... and %d more.\n"
 msgstr " ... und %d weitere.\n"
 
-#: builtin/checkout.c:999
+#: builtin/checkout.c:997
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -12542,7 +12813,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:1018
+#: builtin/checkout.c:1016
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -12569,19 +12840,19 @@ msgstr[1] ""
 " git branch <neuer-Branchname> %s\n"
 "\n"
 
-#: builtin/checkout.c:1053
+#: builtin/checkout.c:1051
 msgid "internal error in revision walk"
 msgstr "interner Fehler im Revisionsgang"
 
-#: builtin/checkout.c:1057
+#: builtin/checkout.c:1055
 msgid "Previous HEAD position was"
 msgstr "Vorherige Position von HEAD war"
 
-#: builtin/checkout.c:1097 builtin/checkout.c:1366
+#: builtin/checkout.c:1095 builtin/checkout.c:1364
 msgid "You are on a branch yet to be born"
 msgstr "Sie sind auf einem Branch, der noch nicht geboren ist"
 
-#: builtin/checkout.c:1179
+#: builtin/checkout.c:1177
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
@@ -12591,7 +12862,7 @@ msgstr ""
 "Bitte benutzen Sie -- (und optional --no-guess), um diese\n"
 "eindeutig voneinander zu unterscheiden."
 
-#: builtin/checkout.c:1186
+#: builtin/checkout.c:1184
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -12614,51 +12885,51 @@ msgstr ""
 "bevorzugen möchten, z.B. 'origin', können Sie die Einstellung\n"
 "checkout.defaultRemote=origin in Ihrer Konfiguration setzen."
 
-#: builtin/checkout.c:1196
+#: builtin/checkout.c:1194
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "'%s' entspricht mehreren (%d) Remote-Tracking-Branches"
 
-#: builtin/checkout.c:1262
+#: builtin/checkout.c:1260
 msgid "only one reference expected"
 msgstr "nur eine Referenz erwartet"
 
-#: builtin/checkout.c:1279
+#: builtin/checkout.c:1277
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "nur eine Referenz erwartet, %d gegeben."
 
-#: builtin/checkout.c:1325 builtin/worktree.c:268 builtin/worktree.c:436
+#: builtin/checkout.c:1323 builtin/worktree.c:269 builtin/worktree.c:437
 #, c-format
 msgid "invalid reference: %s"
 msgstr "Ungültige Referenz: %s"
 
-#: builtin/checkout.c:1338 builtin/checkout.c:1707
+#: builtin/checkout.c:1336 builtin/checkout.c:1705
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "Referenz ist kein \"Tree\"-Objekt: %s"
 
-#: builtin/checkout.c:1385
+#: builtin/checkout.c:1383
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "Ein Branch wird erwartet, Tag '%s' bekommen"
 
-#: builtin/checkout.c:1387
+#: builtin/checkout.c:1385
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "Ein Branch wird erwartet, Remote-Branch '%s' bekommen"
 
-#: builtin/checkout.c:1388 builtin/checkout.c:1396
+#: builtin/checkout.c:1386 builtin/checkout.c:1394
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "Ein Branch wird erwartet, '%s' bekommen"
 
-#: builtin/checkout.c:1391
+#: builtin/checkout.c:1389
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "Ein Branch wird erwartet, Commit '%s' bekommen"
 
-#: builtin/checkout.c:1407
+#: builtin/checkout.c:1405
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -12666,7 +12937,7 @@ msgstr ""
 "Der Branch kann nicht während eines Merges gewechselt werden.\n"
 "Ziehen Sie \"git merge --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1411
+#: builtin/checkout.c:1409
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
@@ -12675,7 +12946,7 @@ msgstr ""
 "werden.\n"
 "Ziehen Sie \"git am --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1415
+#: builtin/checkout.c:1413
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
@@ -12684,7 +12955,7 @@ msgstr ""
 "werden.\n"
 "Ziehen Sie \"git rebase --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1419
+#: builtin/checkout.c:1417
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
@@ -12693,7 +12964,7 @@ msgstr ""
 "gewechselt werden.\n"
 "Ziehen Sie \"git cherry-pick --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1423
+#: builtin/checkout.c:1421
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -12702,140 +12973,140 @@ msgstr ""
 "werden.\n"
 "Ziehen Sie \"git revert --quit\" oder \"git worktree add\" in Betracht."
 
-#: builtin/checkout.c:1427
+#: builtin/checkout.c:1425
 msgid "you are switching branch while bisecting"
 msgstr "Sie wechseln den Branch während einer binären Suche"
 
-#: builtin/checkout.c:1434
+#: builtin/checkout.c:1432
 msgid "paths cannot be used with switching branches"
 msgstr "Pfade können nicht beim Wechseln von Branches verwendet werden"
 
-#: builtin/checkout.c:1437 builtin/checkout.c:1441 builtin/checkout.c:1445
+#: builtin/checkout.c:1435 builtin/checkout.c:1439 builtin/checkout.c:1443
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "'%s' kann nicht beim Wechseln von Branches verwendet werden"
 
-#: builtin/checkout.c:1449 builtin/checkout.c:1452 builtin/checkout.c:1455
-#: builtin/checkout.c:1460 builtin/checkout.c:1465
+#: builtin/checkout.c:1447 builtin/checkout.c:1450 builtin/checkout.c:1453
+#: builtin/checkout.c:1458 builtin/checkout.c:1463
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "'%s' kann nicht mit '%s' verwendet werden"
 
-#: builtin/checkout.c:1462
+#: builtin/checkout.c:1460
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "'%s' kann nicht <Startpunkt> bekommen"
 
-#: builtin/checkout.c:1470
+#: builtin/checkout.c:1468
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "Kann Branch nicht zu Nicht-Commit '%s' wechseln"
 
-#: builtin/checkout.c:1477
+#: builtin/checkout.c:1475
 msgid "missing branch or commit argument"
 msgstr "Branch- oder Commit-Argument fehlt"
 
-#: builtin/checkout.c:1520
+#: builtin/checkout.c:1518
 msgid "perform a 3-way merge with the new branch"
 msgstr "einen 3-Wege-Merge mit dem neuen Branch ausführen"
 
-#: builtin/checkout.c:1521 builtin/log.c:1810 parse-options.h:323
+#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:322
 msgid "style"
 msgstr "Stil"
 
-#: builtin/checkout.c:1522
+#: builtin/checkout.c:1520
 msgid "conflict style (merge or diff3)"
 msgstr "Konfliktstil (merge oder diff3)"
 
-#: builtin/checkout.c:1534 builtin/worktree.c:488
+#: builtin/checkout.c:1532 builtin/worktree.c:489
 msgid "detach HEAD at named commit"
 msgstr "HEAD bei benanntem Commit loslösen"
 
-#: builtin/checkout.c:1535
+#: builtin/checkout.c:1533
 msgid "set upstream info for new branch"
 msgstr "Informationen zum Upstream-Branch für den neuen Branch setzen"
 
-#: builtin/checkout.c:1537
+#: builtin/checkout.c:1535
 msgid "force checkout (throw away local modifications)"
 msgstr "Auschecken erzwingen (verwirft lokale Änderungen)"
 
-#: builtin/checkout.c:1539
+#: builtin/checkout.c:1537
 msgid "new-branch"
 msgstr "neuer Branch"
 
-#: builtin/checkout.c:1539
+#: builtin/checkout.c:1537
 msgid "new unparented branch"
 msgstr "neuer Branch ohne Eltern-Commit"
 
-#: builtin/checkout.c:1541 builtin/merge.c:301
+#: builtin/checkout.c:1539 builtin/merge.c:302
 msgid "update ignored files (default)"
 msgstr "ignorierte Dateien aktualisieren (Standard)"
 
-#: builtin/checkout.c:1544
+#: builtin/checkout.c:1542
 msgid "do not check if another worktree is holding the given ref"
 msgstr ""
 "Prüfung, ob die Referenz bereits in einem anderen Arbeitsverzeichnis "
 "ausgecheckt wurde, deaktivieren"
 
-#: builtin/checkout.c:1557
+#: builtin/checkout.c:1555
 msgid "checkout our version for unmerged files"
 msgstr "unsere Variante für nicht zusammengeführte Dateien auschecken"
 
-#: builtin/checkout.c:1560
+#: builtin/checkout.c:1558
 msgid "checkout their version for unmerged files"
 msgstr "ihre Variante für nicht zusammengeführte Dateien auschecken"
 
-#: builtin/checkout.c:1564
+#: builtin/checkout.c:1562
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "keine Einschränkung bei Pfadspezifikationen zum partiellen Auschecken"
 
-#: builtin/checkout.c:1622
+#: builtin/checkout.c:1620
 #, c-format
 msgid "-%c, -%c and --orphan are mutually exclusive"
 msgstr "-%c, -%c und --orphan schließen sich gegenseitig aus"
 
-#: builtin/checkout.c:1626
+#: builtin/checkout.c:1624
 msgid "-p and --overlay are mutually exclusive"
 msgstr "-p und --overlay schließen sich gegenseitig aus"
 
-#: builtin/checkout.c:1663
+#: builtin/checkout.c:1661
 msgid "--track needs a branch name"
 msgstr "--track benötigt ein Branchname"
 
-#: builtin/checkout.c:1668
+#: builtin/checkout.c:1666
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "kein Branchname; versuchen Sie -%c"
 
-#: builtin/checkout.c:1700
+#: builtin/checkout.c:1698
 #, c-format
 msgid "could not resolve %s"
 msgstr "konnte %s nicht auflösen"
 
-#: builtin/checkout.c:1716
+#: builtin/checkout.c:1714
 msgid "invalid path specification"
 msgstr "ungültige Pfadspezifikation"
 
-#: builtin/checkout.c:1723
+#: builtin/checkout.c:1721
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr ""
 "'%s' ist kein Commit und es kann kein Branch '%s' aus diesem erstellt werden."
 
-#: builtin/checkout.c:1727
+#: builtin/checkout.c:1725
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach nimmt kein Pfad-Argument '%s'"
 
-#: builtin/checkout.c:1736
+#: builtin/checkout.c:1734
 msgid "--pathspec-from-file is incompatible with --detach"
 msgstr "--pathspec-from-file und --detach sind inkompatibel"
 
-#: builtin/checkout.c:1739 builtin/reset.c:325 builtin/stash.c:1630
+#: builtin/checkout.c:1737 builtin/reset.c:331 builtin/stash.c:1647
 msgid "--pathspec-from-file is incompatible with --patch"
 msgstr "--pathspec-from-file und --patch sind inkompatibel"
 
-#: builtin/checkout.c:1752
+#: builtin/checkout.c:1750
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -12843,71 +13114,71 @@ msgstr ""
 "git checkout: --ours/--theirs, --force und --merge sind inkompatibel wenn\n"
 "Sie aus dem Index auschecken."
 
-#: builtin/checkout.c:1757
+#: builtin/checkout.c:1755
 msgid "you must specify path(s) to restore"
 msgstr "Sie müssen Pfad(e) zur Wiederherstellung angeben."
 
-#: builtin/checkout.c:1783 builtin/checkout.c:1785 builtin/checkout.c:1834
-#: builtin/checkout.c:1836 builtin/clone.c:126 builtin/remote.c:170
-#: builtin/remote.c:172 builtin/submodule--helper.c:2736
-#: builtin/submodule--helper.c:2887 builtin/worktree.c:484
-#: builtin/worktree.c:486
+#: builtin/checkout.c:1781 builtin/checkout.c:1783 builtin/checkout.c:1832
+#: builtin/checkout.c:1834 builtin/clone.c:126 builtin/remote.c:170
+#: builtin/remote.c:172 builtin/submodule--helper.c:2958
+#: builtin/submodule--helper.c:3252 builtin/worktree.c:485
+#: builtin/worktree.c:487
 msgid "branch"
 msgstr "Branch"
 
-#: builtin/checkout.c:1784
+#: builtin/checkout.c:1782
 msgid "create and checkout a new branch"
 msgstr "einen neuen Branch erzeugen und auschecken"
 
-#: builtin/checkout.c:1786
+#: builtin/checkout.c:1784
 msgid "create/reset and checkout a branch"
 msgstr "einen Branch erstellen/umsetzen und auschecken"
 
-#: builtin/checkout.c:1787
+#: builtin/checkout.c:1785
 msgid "create reflog for new branch"
 msgstr "das Reflog für den neuen Branch erzeugen"
 
-#: builtin/checkout.c:1789
+#: builtin/checkout.c:1787
 msgid "second guess 'git checkout <no-such-branch>' (default)"
 msgstr "Zweite Vermutung 'git checkout <kein-solcher-Branch>' (Standard)"
 
-#: builtin/checkout.c:1790
+#: builtin/checkout.c:1788
 msgid "use overlay mode (default)"
 msgstr "benutze Overlay-Modus (Standard)"
 
-#: builtin/checkout.c:1835
+#: builtin/checkout.c:1833
 msgid "create and switch to a new branch"
 msgstr "einen neuen Branch erzeugen und dahin wechseln"
 
-#: builtin/checkout.c:1837
+#: builtin/checkout.c:1835
 msgid "create/reset and switch to a branch"
 msgstr "einen Branch erstellen/umsetzen und dahin wechseln"
 
-#: builtin/checkout.c:1839
+#: builtin/checkout.c:1837
 msgid "second guess 'git switch <no-such-branch>'"
 msgstr "Zweite Vermutung 'git switch <kein-solcher-Branch>'"
 
-#: builtin/checkout.c:1841
+#: builtin/checkout.c:1839
 msgid "throw away local modifications"
 msgstr "lokale Änderungen verwerfen"
 
-#: builtin/checkout.c:1875
+#: builtin/checkout.c:1873
 msgid "which tree-ish to checkout from"
 msgstr "Von welcher Commit-Referenz ausgecheckt werden soll"
 
-#: builtin/checkout.c:1877
+#: builtin/checkout.c:1875
 msgid "restore the index"
 msgstr "Index wiederherstellen"
 
-#: builtin/checkout.c:1879
+#: builtin/checkout.c:1877
 msgid "restore the working tree (default)"
 msgstr "das Arbeitsverzeichnis wiederherstellen (Standard)"
 
-#: builtin/checkout.c:1881
+#: builtin/checkout.c:1879
 msgid "ignore unmerged entries"
 msgstr "ignoriere nicht zusammengeführte Einträge"
 
-#: builtin/checkout.c:1882
+#: builtin/checkout.c:1880
 msgid "use overlay mode"
 msgstr "benutze Overlay-Modus"
 
@@ -13047,8 +13318,8 @@ msgid "remove whole directories"
 msgstr "ganze Verzeichnisse löschen"
 
 #: builtin/clean.c:906 builtin/describe.c:565 builtin/describe.c:567
-#: builtin/grep.c:923 builtin/log.c:184 builtin/log.c:186
-#: builtin/ls-files.c:650 builtin/name-rev.c:526 builtin/name-rev.c:528
+#: builtin/grep.c:937 builtin/log.c:184 builtin/log.c:186
+#: builtin/ls-files.c:648 builtin/name-rev.c:526 builtin/name-rev.c:528
 #: builtin/show-ref.c:179
 msgid "pattern"
 msgstr "Muster"
@@ -13137,19 +13408,20 @@ msgstr "Vorlagenverzeichnis"
 msgid "directory from which templates will be used"
 msgstr "Verzeichnis, von welchem die Vorlagen verwendet werden"
 
-#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1899
-#: builtin/submodule--helper.c:2353 builtin/submodule--helper.c:2903
+#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1870
+#: builtin/submodule--helper.c:2513 builtin/submodule--helper.c:3259
 msgid "reference repository"
 msgstr "Repository referenzieren"
 
-#: builtin/clone.c:123 builtin/submodule--helper.c:1901
-#: builtin/submodule--helper.c:2355 builtin/submodule--helper.c:2905
+#: builtin/clone.c:123 builtin/submodule--helper.c:1872
+#: builtin/submodule--helper.c:2515
 msgid "use --reference only while cloning"
 msgstr "--reference nur während des Klonens benutzen"
 
 #: builtin/clone.c:124 builtin/column.c:27 builtin/init-db.c:550
-#: builtin/merge-file.c:46 builtin/pack-objects.c:3975 builtin/repack.c:495
-#: t/helper/test-simple-ipc.c:696 t/helper/test-simple-ipc.c:698
+#: builtin/merge-file.c:46 builtin/pack-objects.c:3944 builtin/repack.c:663
+#: builtin/submodule--helper.c:3261 t/helper/test-simple-ipc.c:595
+#: t/helper/test-simple-ipc.c:597
 msgid "name"
 msgstr "Name"
 
@@ -13165,7 +13437,7 @@ msgstr "<Branch> auschecken, anstatt HEAD des Remote-Repositories"
 msgid "path to git-upload-pack on the remote"
 msgstr "Pfad zu \"git-upload-pack\" auf der Gegenseite"
 
-#: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:862
+#: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
 #: builtin/pull.c:208
 msgid "depth"
 msgstr "Tiefe"
@@ -13175,7 +13447,7 @@ msgid "create a shallow clone of that depth"
 msgstr ""
 "einen Klon mit unvollständiger Historie (shallow) in dieser Tiefe erstellen"
 
-#: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3964
+#: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
 #: builtin/pull.c:211
 msgid "time"
 msgstr "Zeit"
@@ -13188,7 +13460,7 @@ msgstr ""
 "erstellen"
 
 #: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1318
+#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1022
 msgid "revision"
 msgstr "Commit"
 
@@ -13198,8 +13470,8 @@ msgstr ""
 "die Historie eines Klons mit unvollständiger Historie (shallow) mittels\n"
 "Ausschluss eines Commits vertiefen"
 
-#: builtin/clone.c:137 builtin/submodule--helper.c:1911
-#: builtin/submodule--helper.c:2369
+#: builtin/clone.c:137 builtin/submodule--helper.c:1882
+#: builtin/submodule--helper.c:2529
 msgid "clone only one branch, HEAD or --branch"
 msgstr "nur einen Branch klonen, HEAD oder --branch"
 
@@ -13228,12 +13500,12 @@ msgid "set config inside the new repository"
 msgstr "Konfiguration innerhalb des neuen Repositories setzen"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:196
+#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "serverspezifisch"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:197
+#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr "Option übertragen"
 
@@ -13257,50 +13529,42 @@ msgstr ""
 "Initialisiere Datei für partiellen Checkout, um nur Dateien im\n"
 "Root-Verzeichnis einzubeziehen"
 
-#: builtin/clone.c:292
-msgid ""
-"No directory name could be guessed.\n"
-"Please specify a directory on the command line"
-msgstr ""
-"Konnte keinen Verzeichnisnamen erraten.\n"
-"Bitte geben Sie ein Verzeichnis auf der Befehlszeile an."
-
-#: builtin/clone.c:345
+#: builtin/clone.c:231
 #, c-format
 msgid "info: Could not add alternate for '%s': %s\n"
 msgstr "info: Konnte Alternative für '%s' nicht hinzufügen: %s\n"
 
-#: builtin/clone.c:418
+#: builtin/clone.c:304
 #, c-format
 msgid "%s exists and is not a directory"
 msgstr "%s existiert und ist kein Verzeichnis"
 
-#: builtin/clone.c:436
+#: builtin/clone.c:322
 #, c-format
 msgid "failed to start iterator over '%s'"
 msgstr "Fehler beim Starten der Iteration über '%s'"
 
-#: builtin/clone.c:467
+#: builtin/clone.c:353
 #, c-format
 msgid "failed to create link '%s'"
 msgstr "Konnte Verweis '%s' nicht erstellen"
 
-#: builtin/clone.c:471
+#: builtin/clone.c:357
 #, c-format
 msgid "failed to copy file to '%s'"
 msgstr "Konnte Datei nicht nach '%s' kopieren"
 
-#: builtin/clone.c:476
+#: builtin/clone.c:362
 #, c-format
 msgid "failed to iterate over '%s'"
 msgstr "Fehler beim Iterieren über '%s'"
 
-#: builtin/clone.c:503
+#: builtin/clone.c:389
 #, c-format
 msgid "done.\n"
 msgstr "Fertig.\n"
 
-#: builtin/clone.c:517
+#: builtin/clone.c:403
 msgid ""
 "Clone succeeded, but checkout failed.\n"
 "You can inspect what was checked out with 'git status'\n"
@@ -13310,107 +13574,107 @@ msgstr ""
 "Sie können mit 'git status' prüfen, was ausgecheckt worden ist\n"
 "und das Auschecken mit 'git restore --source=HEAD :/' erneut versuchen.\n"
 
-#: builtin/clone.c:594
+#: builtin/clone.c:480
 #, c-format
 msgid "Could not find remote branch %s to clone."
 msgstr "Konnte zu klonenden Remote-Branch %s nicht finden."
 
-#: builtin/clone.c:713
+#: builtin/clone.c:597
 #, c-format
 msgid "unable to update %s"
 msgstr "kann %s nicht aktualisieren"
 
-#: builtin/clone.c:761
+#: builtin/clone.c:645
 msgid "failed to initialize sparse-checkout"
 msgstr "Fehler beim Initialisieren vom partiellen Checkout."
 
-#: builtin/clone.c:784
+#: builtin/clone.c:668
 msgid "remote HEAD refers to nonexistent ref, unable to checkout.\n"
 msgstr ""
 "Externer HEAD bezieht sich auf eine nicht existierende Referenz und kann "
 "nicht ausgecheckt werden.\n"
 
-#: builtin/clone.c:816
+#: builtin/clone.c:701
 msgid "unable to checkout working tree"
 msgstr "Arbeitsverzeichnis konnte nicht ausgecheckt werden"
 
-#: builtin/clone.c:894
+#: builtin/clone.c:779
 msgid "unable to write parameters to config file"
 msgstr "konnte Parameter nicht in Konfigurationsdatei schreiben"
 
-#: builtin/clone.c:957
+#: builtin/clone.c:842
 msgid "cannot repack to clean up"
 msgstr "Kann \"repack\" zum Aufräumen nicht aufrufen"
 
-#: builtin/clone.c:959
+#: builtin/clone.c:844
 msgid "cannot unlink temporary alternates file"
 msgstr "Kann temporäre \"alternates\"-Datei nicht entfernen"
 
-#: builtin/clone.c:1001 builtin/receive-pack.c:2490
+#: builtin/clone.c:886 builtin/receive-pack.c:2493
 msgid "Too many arguments."
 msgstr "Zu viele Argumente."
 
-#: builtin/clone.c:1005
+#: builtin/clone.c:890
 msgid "You must specify a repository to clone."
 msgstr "Sie müssen ein Repository zum Klonen angeben."
 
-#: builtin/clone.c:1018
+#: builtin/clone.c:903
 #, c-format
 msgid "--bare and --origin %s options are incompatible."
 msgstr "--bare und --origin %s sind inkompatibel."
 
-#: builtin/clone.c:1021
+#: builtin/clone.c:906
 msgid "--bare and --separate-git-dir are incompatible."
 msgstr "--bare und --separate-git-dir sind inkompatibel."
 
-#: builtin/clone.c:1035
+#: builtin/clone.c:920
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "Repository '%s' existiert nicht"
 
-#: builtin/clone.c:1039 builtin/fetch.c:2014
+#: builtin/clone.c:924 builtin/fetch.c:2029
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "Tiefe %s ist keine positive Zahl"
 
-#: builtin/clone.c:1049
+#: builtin/clone.c:934
 #, c-format
 msgid "destination path '%s' already exists and is not an empty directory."
 msgstr "Zielpfad '%s' existiert bereits und ist kein leeres Verzeichnis."
 
-#: builtin/clone.c:1055
+#: builtin/clone.c:940
 #, c-format
 msgid "repository path '%s' already exists and is not an empty directory."
 msgstr ""
 "Pfad des Repositories '%s' existiert bereits und ist kein leeres Verzeichnis."
 
-#: builtin/clone.c:1069
+#: builtin/clone.c:954
 #, c-format
 msgid "working tree '%s' already exists."
 msgstr "Arbeitsverzeichnis '%s' existiert bereits."
 
-#: builtin/clone.c:1084 builtin/clone.c:1105 builtin/difftool.c:272
-#: builtin/log.c:1997 builtin/worktree.c:280 builtin/worktree.c:312
+#: builtin/clone.c:969 builtin/clone.c:990 builtin/difftool.c:262
+#: builtin/log.c:1997 builtin/worktree.c:281 builtin/worktree.c:313
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "Konnte führende Verzeichnisse von '%s' nicht erstellen."
 
-#: builtin/clone.c:1089
+#: builtin/clone.c:974
 #, c-format
 msgid "could not create work tree dir '%s'"
 msgstr "Konnte Arbeitsverzeichnis '%s' nicht erstellen"
 
-#: builtin/clone.c:1109
+#: builtin/clone.c:994
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
 msgstr "Klone in Bare-Repository '%s' ...\n"
 
-#: builtin/clone.c:1111
+#: builtin/clone.c:996
 #, c-format
 msgid "Cloning into '%s'...\n"
 msgstr "Klone nach '%s' ...\n"
 
-#: builtin/clone.c:1135
+#: builtin/clone.c:1025
 msgid ""
 "clone --recursive is not compatible with both --reference and --reference-if-"
 "able"
@@ -13418,55 +13682,55 @@ msgstr ""
 "'clone --recursive' ist nicht kompatibel mit --reference und --reference-if-"
 "able"
 
-#: builtin/clone.c:1188 builtin/remote.c:200 builtin/remote.c:705
+#: builtin/clone.c:1080 builtin/remote.c:200 builtin/remote.c:710
 #, c-format
 msgid "'%s' is not a valid remote name"
 msgstr "'%s' ist kein gültiger Name für ein Remote-Repository"
 
-#: builtin/clone.c:1229
+#: builtin/clone.c:1121
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr ""
 "--depth wird in lokalen Klonen ignoriert; benutzen Sie stattdessen \"file://"
 "\"."
 
-#: builtin/clone.c:1231
+#: builtin/clone.c:1123
 msgid "--shallow-since is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-since wird in lokalen Klonen ignoriert; benutzen Sie stattdessen "
 "\"file://\"."
 
-#: builtin/clone.c:1233
+#: builtin/clone.c:1125
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-exclude wird in lokalen Klonen ignoriert; benutzen Sie stattdessen "
 "\"file://\"."
 
-#: builtin/clone.c:1235
+#: builtin/clone.c:1127
 msgid "--filter is ignored in local clones; use file:// instead."
 msgstr ""
 "--filter wird in lokalen Klonen ignoriert; benutzen Sie stattdessen \"file://"
 "\"."
 
-#: builtin/clone.c:1240
+#: builtin/clone.c:1132
 msgid "source repository is shallow, ignoring --local"
 msgstr ""
 "Quelle ist ein Repository mit unvollständiger Historie (shallow),\n"
 "ignoriere --local"
 
-#: builtin/clone.c:1245
+#: builtin/clone.c:1137
 msgid "--local is ignored"
 msgstr "--local wird ignoriert"
 
-#: builtin/clone.c:1324 builtin/clone.c:1383
+#: builtin/clone.c:1216 builtin/clone.c:1276
 msgid "remote transport reported error"
 msgstr "Remoteübertragung meldete Fehler"
 
-#: builtin/clone.c:1336 builtin/clone.c:1344
+#: builtin/clone.c:1228 builtin/clone.c:1239
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "Remote-Branch %s nicht im Upstream-Repository %s gefunden"
 
-#: builtin/clone.c:1347
+#: builtin/clone.c:1242
 msgid "You appear to have cloned an empty repository."
 msgstr "Sie scheinen ein leeres Repository geklont zu haben."
 
@@ -13502,14 +13766,14 @@ msgstr "Abstand zwischen Spalten auffüllen"
 msgid "--command must be the first argument"
 msgstr "--command muss an erster Stelle stehen"
 
-#: builtin/commit-graph.c:13 builtin/commit-graph.c:22
+#: builtin/commit-graph.c:13
 msgid ""
 "git commit-graph verify [--object-dir <objdir>] [--shallow] [--[no-]progress]"
 msgstr ""
 "git commit-graph verify [--object-dir <Objektverzeichnis>] [--shallow] [--"
 "[no-]progress]"
 
-#: builtin/commit-graph.c:14 builtin/commit-graph.c:27
+#: builtin/commit-graph.c:16
 msgid ""
 "git commit-graph write [--object-dir <objdir>] [--append] [--"
 "split[=<strategy>]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
@@ -13519,99 +13783,97 @@ msgstr ""
 "split[=<Strategie>]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
 "paths] [--[no-]max-new-filters <Anzahl>] [--[no-]progress] <Split-Optionen>"
 
-#: builtin/commit-graph.c:64
-#, c-format
-msgid "could not find object directory matching %s"
-msgstr "konnte Objekt-Verzeichnis nicht finden, dass '%s' entsprechen soll"
-
-#: builtin/commit-graph.c:80 builtin/commit-graph.c:210
-#: builtin/commit-graph.c:316 builtin/fetch.c:191 builtin/log.c:1779
+#: builtin/commit-graph.c:51 builtin/fetch.c:191 builtin/log.c:1779
 msgid "dir"
 msgstr "Verzeichnis"
 
-#: builtin/commit-graph.c:81 builtin/commit-graph.c:211
-#: builtin/commit-graph.c:317
+#: builtin/commit-graph.c:52
 msgid "the object directory to store the graph"
 msgstr "das Objektverzeichnis zum Speichern des Graphen"
 
-#: builtin/commit-graph.c:83
+#: builtin/commit-graph.c:73
 msgid "if the commit-graph is split, only verify the tip file"
 msgstr ""
 "Wenn der Commit-Graph aufgeteilt ist, nur die Datei an der Spitze überprüfen"
 
-#: builtin/commit-graph.c:106
+#: builtin/commit-graph.c:100
 #, c-format
 msgid "Could not open commit-graph '%s'"
 msgstr "Konnte Commit-Graph '%s' nicht öffnen."
 
-#: builtin/commit-graph.c:142
+#: builtin/commit-graph.c:137
 #, c-format
 msgid "unrecognized --split argument, %s"
 msgstr "nicht erkanntes --split Argument, %s"
 
-#: builtin/commit-graph.c:155
+#: builtin/commit-graph.c:150
 #, c-format
 msgid "unexpected non-hex object ID: %s"
 msgstr "unerwartete nicht-hexadezimale Objekt-ID: %s"
 
-#: builtin/commit-graph.c:160
+#: builtin/commit-graph.c:155
 #, c-format
 msgid "invalid object: %s"
 msgstr "ungültiges Objekt: %s"
 
-#: builtin/commit-graph.c:213
+#: builtin/commit-graph.c:205
 msgid "start walk at all refs"
 msgstr "Durchlauf auf allen Referenzen beginnen"
 
-#: builtin/commit-graph.c:215
+#: builtin/commit-graph.c:207
 msgid "scan pack-indexes listed by stdin for commits"
 msgstr "durch Standard-Eingabe gelistete Pack-Indexe nach Commits scannen"
 
-#: builtin/commit-graph.c:217
+#: builtin/commit-graph.c:209
 msgid "start walk at commits listed by stdin"
 msgstr "Lauf bei Commits beginnen, die über die Standard-Eingabe gelistet sind"
 
-#: builtin/commit-graph.c:219
+#: builtin/commit-graph.c:211
 msgid "include all commits already in the commit-graph file"
 msgstr ""
 "alle Commits einschließen, die sich bereits in der Commit-Graph-Datei "
 "befinden"
 
-#: builtin/commit-graph.c:221
+#: builtin/commit-graph.c:213
 msgid "enable computation for changed paths"
 msgstr "Berechnung für veränderte Pfade aktivieren"
 
-#: builtin/commit-graph.c:224
+#: builtin/commit-graph.c:215
 msgid "allow writing an incremental commit-graph file"
 msgstr "erlaube das Schreiben einer inkrementellen Commit-Graph-Datei"
 
-#: builtin/commit-graph.c:228
+#: builtin/commit-graph.c:219
 msgid "maximum number of commits in a non-base split commit-graph"
 msgstr ""
 "maximale Anzahl von Commits in einem aufgeteilten Commit-Graph ohne Basis"
 
-#: builtin/commit-graph.c:230
+#: builtin/commit-graph.c:221
 msgid "maximum ratio between two levels of a split commit-graph"
 msgstr ""
 "maximales Verhältnis zwischen zwei Ebenen eines aufgeteilten Commit-Graph"
 
-#: builtin/commit-graph.c:232
+#: builtin/commit-graph.c:223
 msgid "only expire files older than a given date-time"
 msgstr "nur Objekte älter als angegebene Zeit verfallen lassen"
 
-#: builtin/commit-graph.c:234
+#: builtin/commit-graph.c:225
 msgid "maximum number of changed-path Bloom filters to compute"
 msgstr "maximale Anzahl der zu berechnenden Bloom-Filter für veränderte Pfade"
 
-#: builtin/commit-graph.c:255
+#: builtin/commit-graph.c:251
 msgid "use at most one of --reachable, --stdin-commits, or --stdin-packs"
 msgstr ""
 "benutzen Sie mindestens eine der folgenden Optionen: --reachable, --stdin-"
 "commits, oder --stdin-packs"
 
-#: builtin/commit-graph.c:287
+#: builtin/commit-graph.c:282
 msgid "Collecting commits from input"
 msgstr "Sammle Commits von der Standard-Eingabe"
+
+#: builtin/commit-graph.c:328 builtin/multi-pack-index.c:255
+#, c-format
+msgid "unrecognized subcommand: %s"
+msgstr "Nicht erkannter Unterbefehl: %s"
 
 #: builtin/commit-tree.c:18
 msgid ""
@@ -13626,70 +13888,65 @@ msgstr ""
 msgid "duplicate parent %s ignored"
 msgstr "doppelter Vorgänger %s ignoriert"
 
-#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:562
+#: builtin/commit-tree.c:56 builtin/commit-tree.c:134 builtin/log.c:562
 #, c-format
 msgid "not a valid object name %s"
 msgstr "Kein gültiger Objektname: %s"
 
-#: builtin/commit-tree.c:93
-#, c-format
-msgid "git commit-tree: failed to open '%s'"
-msgstr "git commit-tree: Fehler beim Öffnen von '%s'"
-
-#: builtin/commit-tree.c:96
+#: builtin/commit-tree.c:94
 #, c-format
 msgid "git commit-tree: failed to read '%s'"
 msgstr "git commit-tree: Fehler beim Lesen von '%s'"
 
-#: builtin/commit-tree.c:98
+#: builtin/commit-tree.c:96
 #, c-format
 msgid "git commit-tree: failed to close '%s'"
 msgstr "git commit-tree: Fehler beim Schließen von '%s'"
 
-#: builtin/commit-tree.c:111
+#: builtin/commit-tree.c:109
 msgid "parent"
 msgstr "Eltern-Commit"
 
-#: builtin/commit-tree.c:112
+#: builtin/commit-tree.c:110
 msgid "id of a parent commit object"
 msgstr "ID eines Eltern-Commit-Objektes."
 
-#: builtin/commit-tree.c:114 builtin/commit.c:1624 builtin/merge.c:282
-#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1601
-#: builtin/tag.c:456
+#: builtin/commit-tree.c:112 builtin/commit.c:1626 builtin/merge.c:283
+#: builtin/notes.c:407 builtin/notes.c:573 builtin/stash.c:1618
+#: builtin/tag.c:454
 msgid "message"
 msgstr "Beschreibung"
 
-#: builtin/commit-tree.c:115 builtin/commit.c:1624
+#: builtin/commit-tree.c:113 builtin/commit.c:1626
 msgid "commit message"
 msgstr "Commit-Beschreibung"
 
-#: builtin/commit-tree.c:118
+#: builtin/commit-tree.c:116
 msgid "read commit log message from file"
 msgstr "Commit-Beschreibung von Datei lesen"
 
-#: builtin/commit-tree.c:121 builtin/commit.c:1641 builtin/merge.c:299
+#: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
 #: builtin/pull.c:176 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "Commit mit GPG signieren"
 
-#: builtin/commit-tree.c:133
+#: builtin/commit-tree.c:131
 msgid "must give exactly one tree"
 msgstr "Brauche genau ein Tree-Objekt."
 
-#: builtin/commit-tree.c:140
+#: builtin/commit-tree.c:138
 msgid "git commit-tree: failed to read"
 msgstr "git commit-tree: Fehler beim Lesen"
 
-#: builtin/commit.c:41
+#: builtin/commit.c:42
 msgid "git commit [<options>] [--] <pathspec>..."
 msgstr "git commit [<Optionen>] [--] <Pfadspezifikation>..."
 
-#: builtin/commit.c:46
+#: builtin/commit.c:47
 msgid "git status [<options>] [--] <pathspec>..."
 msgstr "git status [<Optionen>] [--] <Pfadspezifikation>..."
 
-#: builtin/commit.c:51
+#: builtin/commit.c:52
 msgid ""
 "You asked to amend the most recent commit, but doing so would make\n"
 "it empty. You can repeat your command with --allow-empty, or you can\n"
@@ -13699,7 +13956,7 @@ msgstr ""
 "machen. Sie können Ihren Befehl mit --allow-empty wiederholen, oder diesen\n"
 "Commit mit \"git reset HEAD^\" vollständig entfernen.\n"
 
-#: builtin/commit.c:56
+#: builtin/commit.c:57
 msgid ""
 "The previous cherry-pick is now empty, possibly due to conflict resolution.\n"
 "If you wish to commit it anyway, use:\n"
@@ -13714,15 +13971,15 @@ msgstr ""
 "    git commit --allow-empty\n"
 "\n"
 
-#: builtin/commit.c:63
+#: builtin/commit.c:64
 msgid "Otherwise, please use 'git rebase --skip'\n"
 msgstr "Andernfalls benutzen Sie bitte 'git rebase --skip'\n"
 
-#: builtin/commit.c:66
+#: builtin/commit.c:67
 msgid "Otherwise, please use 'git cherry-pick --skip'\n"
 msgstr "Andernfalls benutzen Sie bitte 'git cherry-pick --skip'\n"
 
-#: builtin/commit.c:69
+#: builtin/commit.c:70
 msgid ""
 "and then use:\n"
 "\n"
@@ -13744,74 +14001,74 @@ msgstr ""
 "    git cherry-pick --skip\n"
 "\n"
 
-#: builtin/commit.c:324
+#: builtin/commit.c:325
 msgid "failed to unpack HEAD tree object"
 msgstr "Fehler beim Entpacken des Tree-Objektes von HEAD."
 
-#: builtin/commit.c:360
+#: builtin/commit.c:361
 msgid "--pathspec-from-file with -a does not make sense"
 msgstr "Option --pathspec-from-file mit -a ist nicht sinnvoll."
 
-#: builtin/commit.c:374
+#: builtin/commit.c:375
 msgid "No paths with --include/--only does not make sense."
 msgstr "Keine Pfade mit der Option --include/--only ist nicht sinnvoll."
 
-#: builtin/commit.c:386
+#: builtin/commit.c:387
 msgid "unable to create temporary index"
 msgstr "Konnte temporären Index nicht erstellen."
 
-#: builtin/commit.c:395
+#: builtin/commit.c:396
 msgid "interactive add failed"
 msgstr "interaktives Hinzufügen fehlgeschlagen"
 
-#: builtin/commit.c:410
+#: builtin/commit.c:411
 msgid "unable to update temporary index"
 msgstr "Konnte temporären Index nicht aktualisieren."
 
-#: builtin/commit.c:412
+#: builtin/commit.c:413
 msgid "Failed to update main cache tree"
 msgstr "Konnte Haupt-Cache-Verzeichnis nicht aktualisieren"
 
-#: builtin/commit.c:437 builtin/commit.c:460 builtin/commit.c:508
+#: builtin/commit.c:438 builtin/commit.c:461 builtin/commit.c:509
 msgid "unable to write new_index file"
 msgstr "Konnte new_index Datei nicht schreiben"
 
-#: builtin/commit.c:489
+#: builtin/commit.c:490
 msgid "cannot do a partial commit during a merge."
 msgstr "Kann keinen Teil-Commit durchführen, während ein Merge im Gange ist."
 
-#: builtin/commit.c:491
+#: builtin/commit.c:492
 msgid "cannot do a partial commit during a cherry-pick."
 msgstr ""
 "Kann keinen Teil-Commit durchführen, während \"cherry-pick\" im Gange ist."
 
-#: builtin/commit.c:493
+#: builtin/commit.c:494
 msgid "cannot do a partial commit during a rebase."
 msgstr "kann keinen Teil-Commit durchführen, während ein Rebase im Gange ist."
 
-#: builtin/commit.c:501
+#: builtin/commit.c:502
 msgid "cannot read the index"
 msgstr "Kann Index nicht lesen"
 
-#: builtin/commit.c:520
+#: builtin/commit.c:521
 msgid "unable to write temporary index file"
 msgstr "Konnte temporäre Index-Datei nicht schreiben."
 
-#: builtin/commit.c:618
+#: builtin/commit.c:619
 #, c-format
 msgid "commit '%s' lacks author header"
 msgstr "Commit '%s' fehlt Autor-Kopfbereich"
 
-#: builtin/commit.c:620
+#: builtin/commit.c:621
 #, c-format
 msgid "commit '%s' has malformed author line"
 msgstr "Commit '%s' hat fehlerhafte Autor-Zeile"
 
-#: builtin/commit.c:639
+#: builtin/commit.c:640
 msgid "malformed --author parameter"
 msgstr "Fehlerhafter --author Parameter"
 
-#: builtin/commit.c:692
+#: builtin/commit.c:693
 msgid ""
 "unable to select a comment character that is not used\n"
 "in the current commit message"
@@ -13819,43 +14076,43 @@ msgstr ""
 "Konnte kein Kommentar-Zeichen auswählen, das nicht in\n"
 "der aktuellen Commit-Beschreibung verwendet wird."
 
-#: builtin/commit.c:746 builtin/commit.c:780 builtin/commit.c:1165
+#: builtin/commit.c:747 builtin/commit.c:781 builtin/commit.c:1166
 #, c-format
 msgid "could not lookup commit %s"
 msgstr "Konnte Commit %s nicht nachschlagen"
 
-#: builtin/commit.c:758 builtin/shortlog.c:413
+#: builtin/commit.c:759 builtin/shortlog.c:416
 #, c-format
 msgid "(reading log message from standard input)\n"
 msgstr "(lese Log-Nachricht von Standard-Eingabe)\n"
 
-#: builtin/commit.c:760
+#: builtin/commit.c:761
 msgid "could not read log from standard input"
 msgstr "Konnte Log nicht von Standard-Eingabe lesen."
 
-#: builtin/commit.c:764
+#: builtin/commit.c:765
 #, c-format
 msgid "could not read log file '%s'"
 msgstr "Konnte Log-Datei '%s' nicht lesen"
 
-#: builtin/commit.c:801
+#: builtin/commit.c:802
 #, c-format
 msgid "cannot combine -m with --fixup:%s"
 msgstr "-m kann nicht mit --fixup:%s kombiniert werden"
 
-#: builtin/commit.c:813 builtin/commit.c:829
+#: builtin/commit.c:814 builtin/commit.c:830
 msgid "could not read SQUASH_MSG"
 msgstr "Konnte SQUASH_MSG nicht lesen"
 
-#: builtin/commit.c:820
+#: builtin/commit.c:821
 msgid "could not read MERGE_MSG"
 msgstr "Konnte MERGE_MSG nicht lesen"
 
-#: builtin/commit.c:880
+#: builtin/commit.c:881
 msgid "could not write commit template"
 msgstr "Konnte Commit-Vorlage nicht schreiben"
 
-#: builtin/commit.c:893
+#: builtin/commit.c:894
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13864,7 +14121,7 @@ msgstr ""
 "Bitte geben Sie eine Commit-Beschreibung für Ihre Änderungen ein. Zeilen,\n"
 "die mit '%c' beginnen, werden ignoriert.\n"
 
-#: builtin/commit.c:895
+#: builtin/commit.c:896
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13874,7 +14131,7 @@ msgstr ""
 "die mit '%c' beginnen, werden ignoriert, und eine leere Beschreibung\n"
 "bricht den Commit ab.\n"
 
-#: builtin/commit.c:899
+#: builtin/commit.c:900
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13884,7 +14141,7 @@ msgstr ""
 "die mit '%c' beginnen, werden beibehalten; wenn Sie möchten, können Sie\n"
 "diese entfernen.\n"
 
-#: builtin/commit.c:903
+#: builtin/commit.c:904
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13897,7 +14154,7 @@ msgstr ""
 "entfernen.\n"
 "Eine leere Beschreibung bricht den Commit ab.\n"
 
-#: builtin/commit.c:915
+#: builtin/commit.c:916
 msgid ""
 "\n"
 "It looks like you may be committing a merge.\n"
@@ -13911,7 +14168,7 @@ msgstr ""
 "\tgit update-ref -d MERGE_HEAD\n"
 "aus und versuchen Sie es erneut.\n"
 
-#: builtin/commit.c:920
+#: builtin/commit.c:921
 msgid ""
 "\n"
 "It looks like you may be committing a cherry-pick.\n"
@@ -13925,76 +14182,76 @@ msgstr ""
 "\tgit update-ref -d CHERRY_PICK_HEAD\n"
 "aus und versuchen Sie es erneut.\n"
 
-#: builtin/commit.c:947
+#: builtin/commit.c:948
 #, c-format
 msgid "%sAuthor:    %.*s <%.*s>"
 msgstr "%sAutor:           %.*s <%.*s>"
 
-#: builtin/commit.c:955
+#: builtin/commit.c:956
 #, c-format
 msgid "%sDate:      %s"
 msgstr "%sDatum:            %s"
 
-#: builtin/commit.c:962
+#: builtin/commit.c:963
 #, c-format
 msgid "%sCommitter: %.*s <%.*s>"
 msgstr "%sCommit-Ersteller: %.*s <%.*s>"
 
-#: builtin/commit.c:980
+#: builtin/commit.c:981
 msgid "Cannot read index"
 msgstr "Kann Index nicht lesen"
 
-#: builtin/commit.c:1025
+#: builtin/commit.c:1026
 msgid "unable to pass trailers to --trailers"
 msgstr "konnte Anhänge nicht an --trailers weitergeben"
 
-#: builtin/commit.c:1065
+#: builtin/commit.c:1066
 msgid "Error building trees"
 msgstr "Fehler beim Erzeugen der \"Tree\"-Objekte"
 
-#: builtin/commit.c:1079 builtin/tag.c:319
+#: builtin/commit.c:1080 builtin/tag.c:317
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr ""
 "Bitte liefern Sie eine Beschreibung entweder mit der Option -m oder -F.\n"
 
-#: builtin/commit.c:1123
+#: builtin/commit.c:1124
 #, c-format
 msgid "--author '%s' is not 'Name <email>' and matches no existing author"
 msgstr ""
 "--author '%s' ist nicht im Format 'Name <E-Mail>' und stimmt mit keinem "
 "vorhandenen Autor überein"
 
-#: builtin/commit.c:1137
+#: builtin/commit.c:1138
 #, c-format
 msgid "Invalid ignored mode '%s'"
 msgstr "Ungültiger ignored-Modus '%s'."
 
-#: builtin/commit.c:1155 builtin/commit.c:1448
+#: builtin/commit.c:1156 builtin/commit.c:1450
 #, c-format
 msgid "Invalid untracked files mode '%s'"
 msgstr "Ungültiger Modus '%s' für unversionierte Dateien"
 
-#: builtin/commit.c:1195
+#: builtin/commit.c:1196
 msgid "--long and -z are incompatible"
 msgstr "--long und -z sind inkompatibel"
 
-#: builtin/commit.c:1226
+#: builtin/commit.c:1227
 msgid "You are in the middle of a merge -- cannot reword."
 msgstr "Ein Merge ist im Gange -- kann Umformulierung nicht durchführen."
 
-#: builtin/commit.c:1228
+#: builtin/commit.c:1229
 msgid "You are in the middle of a cherry-pick -- cannot reword."
 msgstr "\"cherry-pick\" ist im Gange -- kann Umformulierung nicht durchführen."
 
-#: builtin/commit.c:1231
+#: builtin/commit.c:1232
 #, c-format
 msgid "cannot combine reword option of --fixup with path '%s'"
 msgstr ""
 "Option für Umformulierung bei --fixup kann nicht mit Pfad '%s' kombiniert "
 "werden"
 
-#: builtin/commit.c:1233
+#: builtin/commit.c:1234
 msgid ""
 "reword option of --fixup is mutually exclusive with --patch/--interactive/--"
 "all/--include/--only"
@@ -14002,105 +14259,105 @@ msgstr ""
 "Umformulierungsoption von --fixup und --patch/--interactive/--all/--"
 "include/--only schließen sich gegenseitig aus"
 
-#: builtin/commit.c:1252
+#: builtin/commit.c:1253
 msgid "Using both --reset-author and --author does not make sense"
 msgstr "--reset-author und --author können nicht gemeinsam verwendet werden"
 
-#: builtin/commit.c:1261
+#: builtin/commit.c:1260
 msgid "You have nothing to amend."
 msgstr "Sie haben nichts zum Nachbessern."
 
-#: builtin/commit.c:1264
+#: builtin/commit.c:1263
 msgid "You are in the middle of a merge -- cannot amend."
 msgstr "Ein Merge ist im Gange -- Nachbesserung nicht möglich."
 
-#: builtin/commit.c:1266
+#: builtin/commit.c:1265
 msgid "You are in the middle of a cherry-pick -- cannot amend."
 msgstr "\"cherry-pick\" ist im Gange -- Nachbesserung nicht möglich."
 
-#: builtin/commit.c:1268
+#: builtin/commit.c:1267
 msgid "You are in the middle of a rebase -- cannot amend."
 msgstr "Ein Rebase ist im Gange -- Nachbesserung nicht möglich."
 
-#: builtin/commit.c:1271
+#: builtin/commit.c:1270
 msgid "Options --squash and --fixup cannot be used together"
 msgstr ""
 "Die Optionen --squash und --fixup können nicht gemeinsam verwendet werden"
 
-#: builtin/commit.c:1281
+#: builtin/commit.c:1280
 msgid "Only one of -c/-C/-F/--fixup can be used."
 msgstr "Es kann nur eine Option von -c/-C/-F/--fixup verwendet werden."
 
-#: builtin/commit.c:1283
+#: builtin/commit.c:1282
 msgid "Option -m cannot be combined with -c/-C/-F."
 msgstr "Die Option -m kann nicht mit -c/-C/-F kombiniert werden."
 
-#: builtin/commit.c:1292
+#: builtin/commit.c:1291
 msgid "--reset-author can be used only with -C, -c or --amend."
 msgstr "--reset-author kann nur mit -C, -c oder --amend verwendet werden"
 
-#: builtin/commit.c:1310
+#: builtin/commit.c:1309
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
 msgstr ""
 "Es kann nur eine Option von --include/--only/--all/--interactive/--patch "
 "verwendet werden."
 
-#: builtin/commit.c:1338
+#: builtin/commit.c:1337
 #, c-format
 msgid "unknown option: --fixup=%s:%s"
 msgstr "unbekannte Option: --fixup=%s:%s"
 
-#: builtin/commit.c:1352
+#: builtin/commit.c:1354
 #, c-format
 msgid "paths '%s ...' with -a does not make sense"
 msgstr "Pfade '%s ...' mit -a sind nicht sinnvoll"
 
-#: builtin/commit.c:1483 builtin/commit.c:1652
+#: builtin/commit.c:1485 builtin/commit.c:1654
 msgid "show status concisely"
 msgstr "Status im Kurzformat anzeigen"
 
-#: builtin/commit.c:1485 builtin/commit.c:1654
+#: builtin/commit.c:1487 builtin/commit.c:1656
 msgid "show branch information"
 msgstr "Branchinformationen anzeigen"
 
-#: builtin/commit.c:1487
+#: builtin/commit.c:1489
 msgid "show stash information"
 msgstr "Stashinformationen anzeigen"
 
-#: builtin/commit.c:1489 builtin/commit.c:1656
+#: builtin/commit.c:1491 builtin/commit.c:1658
 msgid "compute full ahead/behind values"
 msgstr "voraus/hinterher-Werte berechnen"
 
-#: builtin/commit.c:1491
+#: builtin/commit.c:1493
 msgid "version"
 msgstr "Version"
 
-#: builtin/commit.c:1491 builtin/commit.c:1658 builtin/push.c:551
-#: builtin/worktree.c:690
+#: builtin/commit.c:1493 builtin/commit.c:1660 builtin/push.c:551
+#: builtin/worktree.c:691
 msgid "machine-readable output"
 msgstr "maschinenlesbare Ausgabe"
 
-#: builtin/commit.c:1494 builtin/commit.c:1660
+#: builtin/commit.c:1496 builtin/commit.c:1662
 msgid "show status in long format (default)"
 msgstr "Status im Langformat anzeigen (Standard)"
 
-#: builtin/commit.c:1497 builtin/commit.c:1663
+#: builtin/commit.c:1499 builtin/commit.c:1665
 msgid "terminate entries with NUL"
 msgstr "Einträge mit NUL-Zeichen abschließen"
 
-#: builtin/commit.c:1499 builtin/commit.c:1503 builtin/commit.c:1666
-#: builtin/fast-export.c:1198 builtin/fast-export.c:1201
-#: builtin/fast-export.c:1204 builtin/rebase.c:1407 parse-options.h:337
+#: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
+#: builtin/fast-export.c:1199 builtin/fast-export.c:1202
+#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:336
 msgid "mode"
 msgstr "Modus"
 
-#: builtin/commit.c:1500 builtin/commit.c:1666
+#: builtin/commit.c:1502 builtin/commit.c:1668
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
 "unversionierte Dateien anzeigen, optionale Modi: all, normal, no. (Standard: "
 "all)"
 
-#: builtin/commit.c:1504
+#: builtin/commit.c:1506
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
@@ -14108,11 +14365,11 @@ msgstr ""
 "ignorierte Dateien anzeigen, optionale Modi: traditional, matching, no. "
 "(Standard: traditional)"
 
-#: builtin/commit.c:1506 parse-options.h:193
+#: builtin/commit.c:1508 parse-options.h:192
 msgid "when"
 msgstr "wann"
 
-#: builtin/commit.c:1507
+#: builtin/commit.c:1509
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
@@ -14120,195 +14377,195 @@ msgstr ""
 "Änderungen in Submodulen ignorieren, optional wenn: all, dirty, untracked. "
 "(Standard: all)"
 
-#: builtin/commit.c:1509
+#: builtin/commit.c:1511
 msgid "list untracked files in columns"
 msgstr "unversionierte Dateien in Spalten auflisten"
 
-#: builtin/commit.c:1510
+#: builtin/commit.c:1512
 msgid "do not detect renames"
 msgstr "keine Umbenennungen ermitteln"
 
-#: builtin/commit.c:1512
+#: builtin/commit.c:1514
 msgid "detect renames, optionally set similarity index"
 msgstr "Umbenennungen erkennen, optional Index für Gleichheit setzen"
 
-#: builtin/commit.c:1535
+#: builtin/commit.c:1537
 msgid "Unsupported combination of ignored and untracked-files arguments"
 msgstr ""
 "Nicht unterstützte Kombination von ignored und untracked-files Argumenten."
 
-#: builtin/commit.c:1617
+#: builtin/commit.c:1619
 msgid "suppress summary after successful commit"
 msgstr "Zusammenfassung nach erfolgreichem Commit unterdrücken"
 
-#: builtin/commit.c:1618
+#: builtin/commit.c:1620
 msgid "show diff in commit message template"
 msgstr "Unterschiede in Commit-Beschreibungsvorlage anzeigen"
 
-#: builtin/commit.c:1620
+#: builtin/commit.c:1622
 msgid "Commit message options"
 msgstr "Optionen für Commit-Beschreibung"
 
-#: builtin/commit.c:1621 builtin/merge.c:286 builtin/tag.c:458
+#: builtin/commit.c:1623 builtin/merge.c:287 builtin/tag.c:456
 msgid "read message from file"
 msgstr "Beschreibung von Datei lesen"
 
-#: builtin/commit.c:1622
+#: builtin/commit.c:1624
 msgid "author"
 msgstr "Autor"
 
-#: builtin/commit.c:1622
+#: builtin/commit.c:1624
 msgid "override author for commit"
 msgstr "Autor eines Commits überschreiben"
 
-#: builtin/commit.c:1623 builtin/gc.c:550
+#: builtin/commit.c:1625 builtin/gc.c:550
 msgid "date"
 msgstr "Datum"
 
-#: builtin/commit.c:1623
+#: builtin/commit.c:1625
 msgid "override date for commit"
 msgstr "Datum eines Commits überschreiben"
 
-#: builtin/commit.c:1625 builtin/commit.c:1626 builtin/commit.c:1632
-#: parse-options.h:329 ref-filter.h:90
+#: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
+#: parse-options.h:328 ref-filter.h:92
 msgid "commit"
 msgstr "Commit"
 
-#: builtin/commit.c:1625
+#: builtin/commit.c:1627
 msgid "reuse and edit message from specified commit"
 msgstr "Beschreibung des angegebenen Commits wiederverwenden und editieren"
 
-#: builtin/commit.c:1626
+#: builtin/commit.c:1628
 msgid "reuse message from specified commit"
 msgstr "Beschreibung des angegebenen Commits wiederverwenden"
 
 #. TRANSLATORS: Leave "[(amend|reword):]" as-is,
 #. and only translate <commit>.
 #.
-#: builtin/commit.c:1631
+#: builtin/commit.c:1633
 msgid "[(amend|reword):]commit"
 msgstr "[(amend|reword):]Commit"
 
-#: builtin/commit.c:1631
+#: builtin/commit.c:1633
 msgid ""
 "use autosquash formatted message to fixup or amend/reword specified commit"
 msgstr ""
 "eine autosquash-formatierte Beschreibung zum Nachbessern/Umformulieren des "
 "angegebenen Commits verwenden"
 
-#: builtin/commit.c:1632
+#: builtin/commit.c:1634
 msgid "use autosquash formatted message to squash specified commit"
 msgstr ""
 "eine autosquash-formatierte Beschreibung beim \"squash\" des angegebenen "
 "Commits verwenden"
 
-#: builtin/commit.c:1633
+#: builtin/commit.c:1635
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr "Sie als Autor des Commits setzen (verwendet mit -C/-c/--amend)"
 
-#: builtin/commit.c:1634 builtin/interpret-trailers.c:111
+#: builtin/commit.c:1636 builtin/interpret-trailers.c:111
 msgid "trailer"
 msgstr "Anhang"
 
-#: builtin/commit.c:1634
+#: builtin/commit.c:1636
 msgid "add custom trailer(s)"
 msgstr "benutzerdefinierte Anhänge hinzufügen"
 
-#: builtin/commit.c:1635 builtin/log.c:1754 builtin/merge.c:302
+#: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
 #: builtin/pull.c:145 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "eine Signed-off-by Zeile hinzufügen"
 
-#: builtin/commit.c:1636
+#: builtin/commit.c:1638
 msgid "use specified template file"
 msgstr "angegebene Vorlagendatei verwenden"
 
-#: builtin/commit.c:1637
+#: builtin/commit.c:1639
 msgid "force edit of commit"
 msgstr "Bearbeitung des Commits erzwingen"
 
-#: builtin/commit.c:1639
+#: builtin/commit.c:1641
 msgid "include status in commit message template"
 msgstr "Status in die Commit-Beschreibungsvorlage einfügen"
 
-#: builtin/commit.c:1644
+#: builtin/commit.c:1646
 msgid "Commit contents options"
 msgstr "Optionen für Commit-Inhalt"
 
-#: builtin/commit.c:1645
+#: builtin/commit.c:1647
 msgid "commit all changed files"
 msgstr "alle geänderten Dateien committen"
 
-#: builtin/commit.c:1646
+#: builtin/commit.c:1648
 msgid "add specified files to index for commit"
 msgstr "die angegebenen Dateien zusätzlich zum Commit vormerken"
 
-#: builtin/commit.c:1647
+#: builtin/commit.c:1649
 msgid "interactively add files"
 msgstr "interaktives Hinzufügen von Dateien"
 
-#: builtin/commit.c:1648
+#: builtin/commit.c:1650
 msgid "interactively add changes"
 msgstr "interaktives Hinzufügen von Änderungen"
 
-#: builtin/commit.c:1649
+#: builtin/commit.c:1651
 msgid "commit only specified files"
 msgstr "nur die angegebenen Dateien committen"
 
-#: builtin/commit.c:1650
+#: builtin/commit.c:1652
 msgid "bypass pre-commit and commit-msg hooks"
 msgstr "Hooks pre-commit und commit-msg umgehen"
 
-#: builtin/commit.c:1651
+#: builtin/commit.c:1653
 msgid "show what would be committed"
 msgstr "anzeigen, was committet werden würde"
 
-#: builtin/commit.c:1664
+#: builtin/commit.c:1666
 msgid "amend previous commit"
 msgstr "vorherigen Commit ändern"
 
-#: builtin/commit.c:1665
+#: builtin/commit.c:1667
 msgid "bypass post-rewrite hook"
 msgstr "\"post-rewrite hook\" umgehen"
 
-#: builtin/commit.c:1672
+#: builtin/commit.c:1674
 msgid "ok to record an empty change"
 msgstr "Aufzeichnung einer leeren Änderung erlauben"
 
-#: builtin/commit.c:1674
+#: builtin/commit.c:1676
 msgid "ok to record a change with an empty message"
 msgstr "Aufzeichnung einer Änderung mit einer leeren Beschreibung erlauben"
 
-#: builtin/commit.c:1750
+#: builtin/commit.c:1752
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
 msgstr "Beschädigte MERGE_HEAD-Datei (%s)"
 
-#: builtin/commit.c:1757
+#: builtin/commit.c:1759
 msgid "could not read MERGE_MODE"
 msgstr "Konnte MERGE_MODE nicht lesen"
 
-#: builtin/commit.c:1778
+#: builtin/commit.c:1780
 #, c-format
 msgid "could not read commit message: %s"
 msgstr "Konnte Commit-Beschreibung nicht lesen: %s"
 
-#: builtin/commit.c:1785
+#: builtin/commit.c:1787
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
 msgstr "Commit aufgrund leerer Beschreibung abgebrochen.\n"
 
-#: builtin/commit.c:1790
+#: builtin/commit.c:1792
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
 msgstr "Commit abgebrochen; Sie haben die Beschreibung nicht editiert.\n"
 
-#: builtin/commit.c:1801
+#: builtin/commit.c:1803
 #, c-format
 msgid "Aborting commit due to empty commit message body.\n"
 msgstr "Commit aufgrund leerer Commit-Beschreibung abgebrochen.\n"
 
-#: builtin/commit.c:1837
+#: builtin/commit.c:1839
 msgid ""
 "repository has been updated, but unable to write\n"
 "new_index file. Check that disk is not full and quota is\n"
@@ -14682,7 +14939,7 @@ msgid "credential-cache--daemon unavailable; no unix socket support"
 msgstr ""
 "credential-cache--daemon nicht verfügbar; Unix-Socket wird nicht unterstützt"
 
-#: builtin/credential-cache.c:154
+#: builtin/credential-cache.c:180
 msgid "credential-cache unavailable; no unix socket support"
 msgstr "credential-cache nicht verfügbar; Unix-Socket wird nicht unterstützt"
 
@@ -14887,7 +15144,7 @@ msgstr "%s...%s: keine Merge-Basis"
 msgid "Not a git repository"
 msgstr "Kein Git-Repository"
 
-#: builtin/diff.c:532 builtin/grep.c:684
+#: builtin/diff.c:532 builtin/grep.c:698
 #, c-format
 msgid "invalid object '%s' given."
 msgstr "Objekt '%s' ist ungültig."
@@ -14911,115 +15168,117 @@ msgstr "%s...%s: mehrere Merge-Basen, nutze %s"
 msgid "git difftool [<options>] [<commit> [<commit>]] [--] [<path>...]"
 msgstr "git difftool [<Optionen>] [<Commit> [<Commit>]] [--] [<Pfad>...]"
 
-#: builtin/difftool.c:261
-#, c-format
-msgid "failed: %d"
-msgstr "fehlgeschlagen: %d"
-
-#: builtin/difftool.c:303
+#: builtin/difftool.c:293
 #, c-format
 msgid "could not read symlink %s"
 msgstr "konnte symbolische Verknüpfung %s nicht lesen"
 
-#: builtin/difftool.c:305
+#: builtin/difftool.c:295
 #, c-format
 msgid "could not read symlink file %s"
 msgstr "Konnte Datei von symbolischer Verknüpfung '%s' nicht lesen."
 
-#: builtin/difftool.c:313
+#: builtin/difftool.c:303
 #, c-format
 msgid "could not read object %s for symlink %s"
 msgstr "Konnte Objekt '%s' für symbolische Verknüpfung '%s' nicht lesen."
 
-#: builtin/difftool.c:413
+#: builtin/difftool.c:427
+#, fuzzy
 msgid ""
-"combined diff formats('-c' and '--cc') are not supported in\n"
-"directory diff mode('-d' and '--dir-diff')."
+"combined diff formats ('-c' and '--cc') are not supported in\n"
+"directory diff mode ('-d' and '--dir-diff')."
 msgstr ""
 "Kombinierte Diff-Formate('-c' und '--cc') werden im Verzeichnis-\n"
 "Diff-Modus('-d' und '--dir-diff') nicht unterstützt."
 
-#: builtin/difftool.c:637
+#: builtin/difftool.c:632
 #, c-format
 msgid "both files modified: '%s' and '%s'."
 msgstr "beide Dateien geändert: '%s' und '%s'."
 
-#: builtin/difftool.c:639
+#: builtin/difftool.c:634
 msgid "working tree file has been left."
 msgstr "Datei im Arbeitsverzeichnis belassen."
 
-#: builtin/difftool.c:650
+#: builtin/difftool.c:645
 #, c-format
 msgid "temporary files exist in '%s'."
 msgstr "Es existieren temporäre Dateien in '%s'."
 
-#: builtin/difftool.c:651
+#: builtin/difftool.c:646
 msgid "you may want to cleanup or recover these."
 msgstr "Sie könnten diese aufräumen oder wiederherstellen."
 
-#: builtin/difftool.c:699
+#: builtin/difftool.c:651
+#, c-format
+msgid "failed: %d"
+msgstr "fehlgeschlagen: %d"
+
+#: builtin/difftool.c:696
 msgid "use `diff.guitool` instead of `diff.tool`"
 msgstr "`diff.guitool` statt `diff.tool` benutzen"
 
-#: builtin/difftool.c:701
+#: builtin/difftool.c:698
 msgid "perform a full-directory diff"
 msgstr "Diff über ganzes Verzeichnis ausführen"
 
-#: builtin/difftool.c:703
+#: builtin/difftool.c:700
 msgid "do not prompt before launching a diff tool"
 msgstr "keine Eingabeaufforderung vor Ausführung eines Diff-Tools"
 
-#: builtin/difftool.c:708
+#: builtin/difftool.c:705
 msgid "use symlinks in dir-diff mode"
 msgstr "symbolische Verknüpfungen im dir-diff Modus verwenden"
 
-#: builtin/difftool.c:709
+#: builtin/difftool.c:706
 msgid "tool"
 msgstr "Tool"
 
-#: builtin/difftool.c:710
+#: builtin/difftool.c:707
 msgid "use the specified diff tool"
 msgstr "das angegebene Diff-Tool benutzen"
 
-#: builtin/difftool.c:712
+#: builtin/difftool.c:709
 msgid "print a list of diff tools that may be used with `--tool`"
 msgstr ""
 "eine Liste mit Diff-Tools darstellen, die mit `--tool` benutzt werden können"
 
-#: builtin/difftool.c:715
+#: builtin/difftool.c:712
+#, fuzzy
 msgid ""
-"make 'git-difftool' exit when an invoked diff tool returns a non - zero exit "
+"make 'git-difftool' exit when an invoked diff tool returns a non-zero exit "
 "code"
 msgstr ""
 "'git-difftool' beenden, wenn das aufgerufene Diff-Tool mit einem "
 "Rückkehrwert\n"
 "verschieden 0 ausgeführt wurde"
 
-#: builtin/difftool.c:718
+#: builtin/difftool.c:715
 msgid "specify a custom command for viewing diffs"
 msgstr "eigenen Befehl zur Anzeige von Unterschieden angeben"
 
-#: builtin/difftool.c:719
+#: builtin/difftool.c:716
 msgid "passed to `diff`"
 msgstr "an 'diff' übergeben"
 
-#: builtin/difftool.c:734
+#: builtin/difftool.c:732
 msgid "difftool requires worktree or --no-index"
 msgstr "difftool benötigt Arbeitsverzeichnis oder --no-index"
 
-#: builtin/difftool.c:741
+#: builtin/difftool.c:739
 msgid "--dir-diff is incompatible with --no-index"
 msgstr "--dir-diff kann nicht mit --no-index verwendet werden"
 
-#: builtin/difftool.c:744
+#: builtin/difftool.c:742
 msgid "--gui, --tool and --extcmd are mutually exclusive"
 msgstr "--gui, --tool und --extcmd schließen sich gegenseitig aus"
 
-#: builtin/difftool.c:752
+#: builtin/difftool.c:750
 msgid "no <tool> given for --tool=<tool>"
 msgstr "kein <Tool> für --tool=<Tool> angegeben"
 
-#: builtin/difftool.c:759
+#: builtin/difftool.c:757
 msgid "no <cmd> given for --extcmd=<cmd>"
 msgstr "kein <Programm> für --extcmd=<Programm> angegeben"
 
@@ -15027,7 +15286,7 @@ msgstr "kein <Programm> für --extcmd=<Programm> angegeben"
 msgid "git env--helper --type=[bool|ulong] <options> <env-var>"
 msgstr "git env--helper --type=[bool|ulong] <Optionen> <Umgebungsvariable>"
 
-#: builtin/env--helper.c:42 builtin/hash-object.c:98
+#: builtin/env--helper.c:42 builtin/hash-object.c:96
 msgid "type"
 msgstr "Art"
 
@@ -15059,100 +15318,100 @@ msgstr ""
 msgid "git fast-export [rev-list-opts]"
 msgstr "git fast-export [rev-list-opts]"
 
-#: builtin/fast-export.c:868
+#: builtin/fast-export.c:869
 msgid "Error: Cannot export nested tags unless --mark-tags is specified."
 msgstr ""
 "Fehler: Verschachtelte Tags können nicht exportiert werden, außer --mark-"
 "tags wurde angegeben."
 
-#: builtin/fast-export.c:1177
+#: builtin/fast-export.c:1178
 msgid "--anonymize-map token cannot be empty"
 msgstr "Token für --anonymize-map kann nicht leer sein"
 
-#: builtin/fast-export.c:1197
+#: builtin/fast-export.c:1198
 msgid "show progress after <n> objects"
 msgstr "Fortschritt nach <n> Objekten anzeigen"
 
-#: builtin/fast-export.c:1199
+#: builtin/fast-export.c:1200
 msgid "select handling of signed tags"
 msgstr "Behandlung von signierten Tags wählen"
 
-#: builtin/fast-export.c:1202
+#: builtin/fast-export.c:1203
 msgid "select handling of tags that tag filtered objects"
 msgstr "Behandlung von Tags wählen, die gefilterte Objekte markieren"
 
-#: builtin/fast-export.c:1205
+#: builtin/fast-export.c:1206
 msgid "select handling of commit messages in an alternate encoding"
 msgstr ""
 "Auswählen der Behandlung von Commit-Beschreibungen bei wechselndem Encoding"
 
-#: builtin/fast-export.c:1208
+#: builtin/fast-export.c:1209
 msgid "dump marks to this file"
 msgstr "Markierungen in diese Datei schreiben"
 
-#: builtin/fast-export.c:1210
+#: builtin/fast-export.c:1211
 msgid "import marks from this file"
 msgstr "Markierungen von dieser Datei importieren"
 
-#: builtin/fast-export.c:1214
+#: builtin/fast-export.c:1215
 msgid "import marks from this file if it exists"
 msgstr "Markierungen von dieser Datei importieren, wenn diese existiert"
 
-#: builtin/fast-export.c:1216
+#: builtin/fast-export.c:1217
 msgid "fake a tagger when tags lack one"
 msgstr "einen Tag-Ersteller vortäuschen, wenn das Tag keinen hat"
 
-#: builtin/fast-export.c:1218
+#: builtin/fast-export.c:1219
 msgid "output full tree for each commit"
 msgstr "für jeden Commit das gesamte Verzeichnis ausgeben"
 
-#: builtin/fast-export.c:1220
+#: builtin/fast-export.c:1221
 msgid "use the done feature to terminate the stream"
 msgstr "die \"done\"-Funktion benutzen, um den Datenstrom abzuschließen"
 
-#: builtin/fast-export.c:1221
+#: builtin/fast-export.c:1222
 msgid "skip output of blob data"
 msgstr "Ausgabe von Blob-Daten überspringen"
 
-#: builtin/fast-export.c:1222 builtin/log.c:1826
+#: builtin/fast-export.c:1223 builtin/log.c:1826
 msgid "refspec"
 msgstr "Refspec"
 
-#: builtin/fast-export.c:1223
+#: builtin/fast-export.c:1224
 msgid "apply refspec to exported refs"
 msgstr "Refspec auf exportierte Referenzen anwenden"
 
-#: builtin/fast-export.c:1224
+#: builtin/fast-export.c:1225
 msgid "anonymize output"
 msgstr "Ausgabe anonymisieren"
 
-#: builtin/fast-export.c:1225
+#: builtin/fast-export.c:1226
 msgid "from:to"
 msgstr "von:nach"
 
-#: builtin/fast-export.c:1226
+#: builtin/fast-export.c:1227
 msgid "convert <from> to <to> in anonymized output"
 msgstr "konvertiere <von> zu <nach> in anonymisierter Ausgabe"
 
-#: builtin/fast-export.c:1229
+#: builtin/fast-export.c:1230
 msgid "reference parents which are not in fast-export stream by object id"
 msgstr ""
 "Eltern, die nicht im Fast-Export-Stream sind, anhand ihrer Objekt-ID "
 "referenzieren"
 
-#: builtin/fast-export.c:1231
+#: builtin/fast-export.c:1232
 msgid "show original object ids of blobs/commits"
 msgstr "originale Objekt-IDs von Blobs/Commits anzeigen"
 
-#: builtin/fast-export.c:1233
+#: builtin/fast-export.c:1234
 msgid "label tags with mark ids"
 msgstr "Tags mit Markierungs-IDs beschriften"
 
-#: builtin/fast-export.c:1256
+#: builtin/fast-export.c:1257
 msgid "--anonymize-map without --anonymize does not make sense"
 msgstr "--anonymize-map ohne --anonymize ist nicht sinnvoll"
 
-#: builtin/fast-export.c:1271
+#: builtin/fast-export.c:1272
 msgid "Cannot pass both --import-marks and --import-marks-if-exists"
 msgstr ""
 "--import-marks und --import-marks-if-exists können nicht zusammen "
@@ -15363,62 +15622,62 @@ msgstr "akzeptiere Refspecs von der Standard-Eingabe"
 msgid "Couldn't find remote ref HEAD"
 msgstr "Konnte Remote-Referenz von HEAD nicht finden."
 
-#: builtin/fetch.c:757
+#: builtin/fetch.c:760
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "Konfiguration fetch.output enthält ungültigen Wert %s"
 
-#: builtin/fetch.c:856
+#: builtin/fetch.c:862
 #, c-format
 msgid "object %s not found"
 msgstr "Objekt %s nicht gefunden"
 
-#: builtin/fetch.c:860
+#: builtin/fetch.c:866
 msgid "[up to date]"
 msgstr "[aktuell]"
 
-#: builtin/fetch.c:873 builtin/fetch.c:889 builtin/fetch.c:961
+#: builtin/fetch.c:879 builtin/fetch.c:895 builtin/fetch.c:967
 msgid "[rejected]"
 msgstr "[zurückgewiesen]"
 
-#: builtin/fetch.c:874
+#: builtin/fetch.c:880
 msgid "can't fetch in current branch"
 msgstr "kann \"fetch\" im aktuellen Branch nicht ausführen"
 
-#: builtin/fetch.c:884
+#: builtin/fetch.c:890
 msgid "[tag update]"
 msgstr "[Tag Aktualisierung]"
 
-#: builtin/fetch.c:885 builtin/fetch.c:922 builtin/fetch.c:944
-#: builtin/fetch.c:956
+#: builtin/fetch.c:891 builtin/fetch.c:928 builtin/fetch.c:950
+#: builtin/fetch.c:962
 msgid "unable to update local ref"
 msgstr "kann lokale Referenz nicht aktualisieren"
 
-#: builtin/fetch.c:889
+#: builtin/fetch.c:895
 msgid "would clobber existing tag"
 msgstr "würde bestehende Tags verändern"
 
-#: builtin/fetch.c:911
+#: builtin/fetch.c:917
 msgid "[new tag]"
 msgstr "[neues Tag]"
 
-#: builtin/fetch.c:914
+#: builtin/fetch.c:920
 msgid "[new branch]"
 msgstr "[neuer Branch]"
 
-#: builtin/fetch.c:917
+#: builtin/fetch.c:923
 msgid "[new ref]"
 msgstr "[neue Referenz]"
 
-#: builtin/fetch.c:956
+#: builtin/fetch.c:962
 msgid "forced update"
 msgstr "Aktualisierung erzwungen"
 
-#: builtin/fetch.c:961
+#: builtin/fetch.c:967
 msgid "non-fast-forward"
 msgstr "kein Vorspulen"
 
-#: builtin/fetch.c:1065
+#: builtin/fetch.c:1070
 msgid ""
 "Fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled. To re-enable, use '--show-forced-updates'\n"
@@ -15429,7 +15688,7 @@ msgstr ""
 "aktivieren, nutzen Sie die Option '--show-forced-updates' oder führen\n"
 "Sie 'git config fetch.showForcedUpdates true' aus."
 
-#: builtin/fetch.c:1069
+#: builtin/fetch.c:1074
 #, c-format
 msgid ""
 "It took %.2f seconds to check forced updates. You can use\n"
@@ -15442,24 +15701,24 @@ msgstr ""
 "'git config fetch.showForcedUpdates false' ausführen, um diese Überprüfung\n"
 "zu umgehen.\n"
 
-#: builtin/fetch.c:1101
+#: builtin/fetch.c:1105
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s hat nicht alle erforderlichen Objekte gesendet\n"
 
-#: builtin/fetch.c:1129
+#: builtin/fetch.c:1134
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr ""
 "%s zurückgewiesen, da Root-Commits von Repositories mit unvollständiger\n"
 "Historie (shallow) nicht aktualisiert werden dürfen."
 
-#: builtin/fetch.c:1206 builtin/fetch.c:1357
+#: builtin/fetch.c:1223 builtin/fetch.c:1371
 #, c-format
 msgid "From %.*s\n"
 msgstr "Von %.*s\n"
 
-#: builtin/fetch.c:1228
+#: builtin/fetch.c:1244
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -15468,58 +15727,63 @@ msgstr ""
 "Einige lokale Referenzen konnten nicht aktualisiert werden; versuchen Sie\n"
 "'git remote prune %s', um jeden älteren, widersprüchlichen Branch zu löschen."
 
-#: builtin/fetch.c:1327
+#: builtin/fetch.c:1341
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s wird unreferenziert)"
 
-#: builtin/fetch.c:1328
+#: builtin/fetch.c:1342
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s wurde unreferenziert)"
 
-#: builtin/fetch.c:1360
+#: builtin/fetch.c:1374
 msgid "[deleted]"
 msgstr "[gelöscht]"
 
-#: builtin/fetch.c:1361 builtin/remote.c:1118
+#: builtin/fetch.c:1375 builtin/remote.c:1128
 msgid "(none)"
 msgstr "(nichts)"
 
-#: builtin/fetch.c:1384
+#: builtin/fetch.c:1398
 #, c-format
 msgid "Refusing to fetch into current branch %s of non-bare repository"
 msgstr ""
 "Der \"fetch\" in den aktuellen Branch %s von einem Nicht-Bare-Repository "
 "wurde verweigert."
 
-#: builtin/fetch.c:1403
+#: builtin/fetch.c:1417
 #, c-format
 msgid "Option \"%s\" value \"%s\" is not valid for %s"
 msgstr "Option \"%s\" Wert \"%s\" ist nicht gültig für %s"
 
-#: builtin/fetch.c:1406
+#: builtin/fetch.c:1420
 #, c-format
 msgid "Option \"%s\" is ignored for %s\n"
 msgstr "Option \"%s\" wird ignoriert für %s\n"
 
-#: builtin/fetch.c:1618
+#: builtin/fetch.c:1447
+#, fuzzy, c-format
+msgid "the object %s does not exist"
+msgstr "Pfad '%s' existiert nicht"
+
+#: builtin/fetch.c:1633
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "Mehrere Branches erkannt, inkompatibel mit --set-upstream"
 
-#: builtin/fetch.c:1633
+#: builtin/fetch.c:1648
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "Setze keinen Upstream für einen entfernten Remote-Tracking-Branch."
 
-#: builtin/fetch.c:1635
+#: builtin/fetch.c:1650
 msgid "not setting upstream for a remote tag"
 msgstr "Setze keinen Upstream für einen Tag eines Remote-Repositories."
 
-#: builtin/fetch.c:1637
+#: builtin/fetch.c:1652
 msgid "unknown branch type"
 msgstr "Unbekannter Branch-Typ"
 
-#: builtin/fetch.c:1639
+#: builtin/fetch.c:1654
 msgid ""
 "no source branch found.\n"
 "you need to specify exactly one branch with the --set-upstream option."
@@ -15527,22 +15791,22 @@ msgstr ""
 "Keinen Quell-Branch gefunden.\n"
 "Sie müssen bei der Option --set-upstream genau einen Branch angeben."
 
-#: builtin/fetch.c:1768 builtin/fetch.c:1831
+#: builtin/fetch.c:1783 builtin/fetch.c:1846
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Fordere an von %s\n"
 
-#: builtin/fetch.c:1778 builtin/fetch.c:1833 builtin/remote.c:101
+#: builtin/fetch.c:1793 builtin/fetch.c:1848 builtin/remote.c:101
 #, c-format
 msgid "Could not fetch %s"
 msgstr "Konnte nicht von %s anfordern"
 
-#: builtin/fetch.c:1790
+#: builtin/fetch.c:1805
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "Konnte '%s' nicht anfordern (Exit-Code: %d)\n"
 
-#: builtin/fetch.c:1894
+#: builtin/fetch.c:1909
 msgid ""
 "No remote repository specified.  Please, specify either a URL or a\n"
 "remote name from which new revisions should be fetched."
@@ -15551,60 +15815,60 @@ msgstr ""
 "oder den Namen des Remote-Repositories an, von welchem neue\n"
 "Commits angefordert werden sollen."
 
-#: builtin/fetch.c:1930
+#: builtin/fetch.c:1945
 msgid "You need to specify a tag name."
 msgstr "Sie müssen den Namen des Tags angeben."
 
-#: builtin/fetch.c:1994
+#: builtin/fetch.c:2009
 msgid "--negotiate-only needs one or more --negotiate-tip=*"
 msgstr "--negotiate-only benötigt einen oder mehrere --negotiate-tip=*"
 
-#: builtin/fetch.c:1998
+#: builtin/fetch.c:2013
 msgid "Negative depth in --deepen is not supported"
 msgstr "Negative Tiefe wird von --deepen nicht unterstützt."
 
-#: builtin/fetch.c:2000
+#: builtin/fetch.c:2015
 msgid "--deepen and --depth are mutually exclusive"
 msgstr "--deepen und --depth schließen sich gegenseitig aus"
 
-#: builtin/fetch.c:2005
+#: builtin/fetch.c:2020
 msgid "--depth and --unshallow cannot be used together"
 msgstr "--depth und --unshallow können nicht gemeinsam verwendet werden"
 
-#: builtin/fetch.c:2007
+#: builtin/fetch.c:2022
 msgid "--unshallow on a complete repository does not make sense"
 msgstr ""
 "--unshallow kann nicht in einem Repository mit vollständiger Historie "
 "verwendet werden"
 
-#: builtin/fetch.c:2024
+#: builtin/fetch.c:2039
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all akzeptiert kein Repository als Argument"
 
-#: builtin/fetch.c:2026
+#: builtin/fetch.c:2041
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all kann nicht mit Refspecs verwendet werden"
 
-#: builtin/fetch.c:2035
+#: builtin/fetch.c:2050
 #, c-format
 msgid "No such remote or remote group: %s"
 msgstr "Remote-Repository (einzeln oder Gruppe) nicht gefunden: %s"
 
-#: builtin/fetch.c:2042
+#: builtin/fetch.c:2057
 msgid "Fetching a group and specifying refspecs does not make sense"
 msgstr ""
 "Das Abholen einer Gruppe von Remote-Repositories kann nicht mit der Angabe\n"
 "von Refspecs verwendet werden."
 
-#: builtin/fetch.c:2058
+#: builtin/fetch.c:2073
 msgid "must supply remote when using --negotiate-only"
 msgstr "Remote wird benötigt, wenn --negotiate-only benutzt wird"
 
-#: builtin/fetch.c:2063
+#: builtin/fetch.c:2078
 msgid "Protocol does not support --negotiate-only, exiting."
 msgstr "Protokoll unterstützt --negotiate-only nicht, beende."
 
-#: builtin/fetch.c:2082
+#: builtin/fetch.c:2097
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -15612,13 +15876,13 @@ msgstr ""
 "--filter kann nur mit den Remote-Repositories verwendet werden,\n"
 "die in extensions.partialclone konfiguriert sind"
 
-#: builtin/fetch.c:2086
+#: builtin/fetch.c:2101
 msgid "--atomic can only be used when fetching from one remote"
 msgstr ""
 "--atomic kann nur verwendet werden, wenn nur von einem Remote-Repository "
 "abgefragt wird"
 
-#: builtin/fetch.c:2090
+#: builtin/fetch.c:2105
 msgid "--stdin can only be used when fetching from one remote"
 msgstr ""
 "--stdin kann nur verwendet werden, wenn nur von einem Remote-Repository "
@@ -15687,7 +15951,7 @@ msgstr "Platzhalter als Tcl-String formatieren"
 msgid "show only <n> matched refs"
 msgstr "nur <n> passende Referenzen anzeigen"
 
-#: builtin/for-each-ref.c:41 builtin/tag.c:483
+#: builtin/for-each-ref.c:41 builtin/tag.c:481
 msgid "respect format colors"
 msgstr "Formatfarben beachten"
 
@@ -15843,129 +16107,139 @@ msgstr "%s: kein Commit"
 msgid "notice: No default references"
 msgstr "Notiz: Keine Standardreferenzen"
 
-#: builtin/fsck.c:606
+#: builtin/fsck.c:621
+#, fuzzy, c-format
+msgid "%s: hash-path mismatch, found at: %s"
+msgstr "Hash stimmt nicht mit %s überein."
+
+#: builtin/fsck.c:624
 #, c-format
 msgid "%s: object corrupt or missing: %s"
 msgstr "%s: Objekt fehlerhaft oder nicht vorhanden: %s"
 
-#: builtin/fsck.c:619
+#: builtin/fsck.c:628
+#, fuzzy, c-format
+msgid "%s: object is of unknown type '%s': %s"
+msgstr "Objekt %s hat eine unbekannte Typ-Identifikation %d"
+
+#: builtin/fsck.c:644
 #, c-format
 msgid "%s: object could not be parsed: %s"
 msgstr "%s: Objekt konnte nicht geparst werden: %s"
 
-#: builtin/fsck.c:639
+#: builtin/fsck.c:664
 #, c-format
 msgid "bad sha1 file: %s"
 msgstr "Ungültige SHA1-Datei: %s"
 
-#: builtin/fsck.c:654
+#: builtin/fsck.c:685
 msgid "Checking object directory"
 msgstr "Prüfe Objekt-Verzeichnis"
 
-#: builtin/fsck.c:657
+#: builtin/fsck.c:688
 msgid "Checking object directories"
 msgstr "Prüfe Objekt-Verzeichnisse"
 
-#: builtin/fsck.c:672
+#: builtin/fsck.c:704
 #, c-format
 msgid "Checking %s link"
 msgstr "Prüfe %s Verknüpfung"
 
-#: builtin/fsck.c:677 builtin/index-pack.c:864
+#: builtin/fsck.c:709 builtin/index-pack.c:859
 #, c-format
 msgid "invalid %s"
 msgstr "Ungültiger Objekt-Typ %s"
 
-#: builtin/fsck.c:684
+#: builtin/fsck.c:716
 #, c-format
 msgid "%s points to something strange (%s)"
 msgstr "%s zeigt auf etwas seltsames (%s)"
 
-#: builtin/fsck.c:690
+#: builtin/fsck.c:722
 #, c-format
 msgid "%s: detached HEAD points at nothing"
 msgstr "%s: losgelöster HEAD zeigt auf nichts"
 
-#: builtin/fsck.c:694
+#: builtin/fsck.c:726
 #, c-format
 msgid "notice: %s points to an unborn branch (%s)"
 msgstr "Notiz: %s zeigt auf einen ungeborenen Branch (%s)"
 
-#: builtin/fsck.c:706
+#: builtin/fsck.c:738
 msgid "Checking cache tree"
 msgstr "Prüfe Cache-Verzeichnis"
 
-#: builtin/fsck.c:711
+#: builtin/fsck.c:743
 #, c-format
 msgid "%s: invalid sha1 pointer in cache-tree"
 msgstr "%s: Ungültiger SHA1-Zeiger in Cache-Verzeichnis"
 
-#: builtin/fsck.c:720
+#: builtin/fsck.c:752
 msgid "non-tree in cache-tree"
 msgstr "non-tree in Cache-Verzeichnis"
 
-#: builtin/fsck.c:751
+#: builtin/fsck.c:783
 msgid "git fsck [<options>] [<object>...]"
 msgstr "git fsck [<Optionen>] [<Objekt>...]"
 
-#: builtin/fsck.c:757
+#: builtin/fsck.c:789
 msgid "show unreachable objects"
 msgstr "unerreichbare Objekte anzeigen"
 
-#: builtin/fsck.c:758
+#: builtin/fsck.c:790
 msgid "show dangling objects"
 msgstr "unreferenzierte Objekte anzeigen"
 
-#: builtin/fsck.c:759
+#: builtin/fsck.c:791
 msgid "report tags"
 msgstr "Tags melden"
 
-#: builtin/fsck.c:760
+#: builtin/fsck.c:792
 msgid "report root nodes"
 msgstr "Hauptwurzeln melden"
 
-#: builtin/fsck.c:761
+#: builtin/fsck.c:793
 msgid "make index objects head nodes"
 msgstr "Index-Objekte in Erreichbarkeitsprüfung einbeziehen"
 
-#: builtin/fsck.c:762
+#: builtin/fsck.c:794
 msgid "make reflogs head nodes (default)"
 msgstr "Reflogs in Erreichbarkeitsprüfung einbeziehen (Standard)"
 
-#: builtin/fsck.c:763
+#: builtin/fsck.c:795
 msgid "also consider packs and alternate objects"
 msgstr "ebenso Pakete und alternative Objekte betrachten"
 
-#: builtin/fsck.c:764
+#: builtin/fsck.c:796
 msgid "check only connectivity"
 msgstr "nur Konnektivität prüfen"
 
-#: builtin/fsck.c:765 builtin/mktag.c:75
+#: builtin/fsck.c:797 builtin/mktag.c:76
 msgid "enable more strict checking"
 msgstr "genauere Prüfung aktivieren"
 
-#: builtin/fsck.c:767
+#: builtin/fsck.c:799
 msgid "write dangling objects in .git/lost-found"
 msgstr "unreferenzierte Objekte nach .git/lost-found schreiben"
 
-#: builtin/fsck.c:768 builtin/prune.c:134
+#: builtin/fsck.c:800 builtin/prune.c:134
 msgid "show progress"
 msgstr "Fortschrittsanzeige anzeigen"
 
-#: builtin/fsck.c:769
+#: builtin/fsck.c:801
 msgid "show verbose names for reachable objects"
 msgstr "ausführliche Namen für erreichbare Objekte anzeigen"
 
-#: builtin/fsck.c:828 builtin/index-pack.c:262
+#: builtin/fsck.c:861 builtin/index-pack.c:261
 msgid "Checking objects"
 msgstr "Prüfe Objekte"
 
-#: builtin/fsck.c:856
+#: builtin/fsck.c:889
 #, c-format
 msgid "%s: object missing"
 msgstr "%s: Objekt nicht vorhanden"
 
-#: builtin/fsck.c:867
+#: builtin/fsck.c:900
 #, c-format
 msgid "invalid parameter: expected sha1, got '%s'"
 msgstr "Ungültiger Parameter: SHA-1 erwartet, '%s' bekommen"
@@ -15989,16 +16263,16 @@ msgstr "Fehler beim Parsen von '%s' mit dem Wert '%s'"
 msgid "cannot stat '%s'"
 msgstr "Kann '%s' nicht lesen"
 
-#: builtin/gc.c:496 builtin/notes.c:240 builtin/tag.c:573
+#: builtin/gc.c:496 builtin/notes.c:238 builtin/tag.c:574
 #, c-format
 msgid "cannot read '%s'"
 msgstr "kann '%s' nicht lesen"
 
 #: builtin/gc.c:503
-#, c-format
+#, fuzzy, c-format
 msgid ""
 "The last gc run reported the following. Please correct the root cause\n"
-"and remove %s.\n"
+"and remove %s\n"
 "Automatic cleanup will not be performed until the file is removed.\n"
 "\n"
 "%s"
@@ -16091,154 +16365,196 @@ msgstr "--no-schedule ist nicht erlaubt"
 msgid "unrecognized --schedule argument '%s'"
 msgstr "nicht erkanntes --schedule Argument '%s'"
 
-#: builtin/gc.c:869
+#: builtin/gc.c:868
 msgid "failed to write commit-graph"
 msgstr "Fehler beim Schreiben des Commit-Graph"
 
-#: builtin/gc.c:905
+#: builtin/gc.c:904
 msgid "failed to prefetch remotes"
 msgstr "Vorabruf der Remote-Repositories fehlgeschlagen"
 
-#: builtin/gc.c:1022
+#: builtin/gc.c:1020
 msgid "failed to start 'git pack-objects' process"
 msgstr "konnte 'git pack-objects' Prozess nicht starten"
 
-#: builtin/gc.c:1039
+#: builtin/gc.c:1037
 msgid "failed to finish 'git pack-objects' process"
 msgstr "konnte 'git pack-objects' Prozess nicht beenden"
 
-#: builtin/gc.c:1091
+#: builtin/gc.c:1088
 msgid "failed to write multi-pack-index"
 msgstr "Fehler beim Schreiben des multi-pack-index"
 
-#: builtin/gc.c:1109
+#: builtin/gc.c:1104
 msgid "'git multi-pack-index expire' failed"
 msgstr "Fehler beim Ausführen von 'git multi-pack-index expire'"
 
-#: builtin/gc.c:1170
+#: builtin/gc.c:1163
 msgid "'git multi-pack-index repack' failed"
 msgstr "Fehler beim Ausführen von 'git multi-pack-index repack'"
 
-#: builtin/gc.c:1179
+#: builtin/gc.c:1172
 msgid ""
 "skipping incremental-repack task because core.multiPackIndex is disabled"
 msgstr ""
 "Überspringen der Aufgabe 'incremental-repack', weil core.multiPackIndex "
 "deaktiviert ist"
 
-#: builtin/gc.c:1283
+#: builtin/gc.c:1276
 #, c-format
 msgid "lock file '%s' exists, skipping maintenance"
 msgstr "Sperrdatei '%s' existiert, Wartung wird übersprungen"
 
-#: builtin/gc.c:1313
+#: builtin/gc.c:1306
 #, c-format
 msgid "task '%s' failed"
 msgstr "Aufgabe '%s' fehlgeschlagen"
 
-#: builtin/gc.c:1395
+#: builtin/gc.c:1388
 #, c-format
 msgid "'%s' is not a valid task"
 msgstr "'%s' ist keine gültige Aufgabe"
 
-#: builtin/gc.c:1400
+#: builtin/gc.c:1393
 #, c-format
 msgid "task '%s' cannot be selected multiple times"
 msgstr "Aufgabe '%s' kann nicht mehrfach ausgewählt werden"
 
-#: builtin/gc.c:1415
+#: builtin/gc.c:1408
 msgid "run tasks based on the state of the repository"
 msgstr "Aufgaben abhängig vom Zustand des Repositories ausführen"
 
-#: builtin/gc.c:1416
+#: builtin/gc.c:1409
 msgid "frequency"
 msgstr "Häufigkeit"
 
-#: builtin/gc.c:1417
+#: builtin/gc.c:1410
 msgid "run tasks based on frequency"
 msgstr "Aufgaben abhängig von der Häufigkeit ausführen"
 
-#: builtin/gc.c:1420
+#: builtin/gc.c:1413
 msgid "do not report progress or other information over stderr"
 msgstr "zeige keinen Fortschritt oder andere Informationen über stderr"
 
-#: builtin/gc.c:1421
+#: builtin/gc.c:1414
 msgid "task"
 msgstr "Aufgabe"
 
-#: builtin/gc.c:1422
+#: builtin/gc.c:1415
 msgid "run a specific task"
 msgstr "eine bestimmte Aufgabe ausführen"
 
-#: builtin/gc.c:1439
+#: builtin/gc.c:1432
 msgid "use at most one of --auto and --schedule=<frequency>"
 msgstr ""
 "nutzen Sie höchstens eine der Optionen --auto oder --schedule=<Häufigkeit>"
 
-#: builtin/gc.c:1482
+#: builtin/gc.c:1475
 msgid "failed to run 'git config'"
 msgstr "Fehler beim Ausführen von 'git config'"
 
-#: builtin/gc.c:1547
+#: builtin/gc.c:1627
 #, c-format
 msgid "failed to expand path '%s'"
 msgstr "Fehler beim Erweitern des Pfades '%s'"
 
-#: builtin/gc.c:1576
+#: builtin/gc.c:1654 builtin/gc.c:1692
 msgid "failed to start launchctl"
 msgstr "konnte launchctl nicht starten"
 
-#: builtin/gc.c:1613
+#: builtin/gc.c:1767 builtin/gc.c:2220
 #, c-format
 msgid "failed to create directories for '%s'"
 msgstr "Fehler beim Erstellen von Verzeichnissen für '%s'"
 
-#: builtin/gc.c:1674
+#: builtin/gc.c:1794
 #, c-format
 msgid "failed to bootstrap service %s"
 msgstr "Fehler beim Laden des Services %s"
 
-#: builtin/gc.c:1745
+#: builtin/gc.c:1887
 msgid "failed to create temp xml file"
 msgstr "Fehler beim Erstellen der temporären XML-Datei"
 
-#: builtin/gc.c:1835
+#: builtin/gc.c:1977
 msgid "failed to start schtasks"
 msgstr "Fehler beim Starten von schtasks"
 
-#: builtin/gc.c:1879
+#: builtin/gc.c:2046
 msgid "failed to run 'crontab -l'; your system might not support 'cron'"
 msgstr ""
 "Fehler beim Ausführen von 'crontab -l'; Ihr System unterstützt eventuell "
 "'cron' nicht"
 
-#: builtin/gc.c:1896
+#: builtin/gc.c:2063
 msgid "failed to run 'crontab'; your system might not support 'cron'"
 msgstr ""
 "Fehler beim Ausführen von 'crontab'; Ihr System unterstützt eventuell 'cron' "
 "nicht"
 
-#: builtin/gc.c:1900
+#: builtin/gc.c:2067
 msgid "failed to open stdin of 'crontab'"
 msgstr "Fehler beim Öffnen der Standard-Eingabe von 'crontab'"
 
-#: builtin/gc.c:1942
+#: builtin/gc.c:2109
 msgid "'crontab' died"
 msgstr "'crontab' abgebrochen"
 
-#: builtin/gc.c:1976
+#: builtin/gc.c:2174
+#, fuzzy
+msgid "failed to start systemctl"
+msgstr "Fehler beim Starten von schtasks"
+
+#: builtin/gc.c:2184
+#, fuzzy
+msgid "failed to run systemctl"
+msgstr "'%s' konnte nicht ausgeführt werden"
+
+#: builtin/gc.c:2193 builtin/gc.c:2198 builtin/worktree.c:62
+#: builtin/worktree.c:945
+#, c-format
+msgid "failed to delete '%s'"
+msgstr "Fehler beim Löschen von '%s'"
+
+#: builtin/gc.c:2378
+#, fuzzy, c-format
+msgid "unrecognized --scheduler argument '%s'"
+msgstr "nicht erkanntes --schedule Argument '%s'"
+
+#: builtin/gc.c:2403
+msgid "neither systemd timers nor crontab are available"
+msgstr ""
+
+#: builtin/gc.c:2418
+#, fuzzy, c-format
+msgid "%s scheduler is not available"
+msgstr "%s ist nicht verfügbar."
+
+#: builtin/gc.c:2432
 msgid "another process is scheduling background maintenance"
 msgstr "ein anderer Prozess plant die Hintergrundwartung"
 
-#: builtin/gc.c:2000
+#: builtin/gc.c:2454
+msgid "git maintenance start [--scheduler=<scheduler>]"
+msgstr ""
+
+#: builtin/gc.c:2463
+msgid "scheduler"
+msgstr ""
+
+#: builtin/gc.c:2464
+msgid "scheduler to trigger git maintenance run"
+msgstr ""
+
+#: builtin/gc.c:2478
 msgid "failed to add repo to global config"
 msgstr "Repository konnte nicht zur globalen Konfiguration hinzugefügt werden"
 
-#: builtin/gc.c:2010
+#: builtin/gc.c:2487
 msgid "git maintenance <subcommand> [<options>]"
 msgstr "git maintenance <Unterbefehl> [<Optionen>]"
 
-#: builtin/gc.c:2029
+#: builtin/gc.c:2506
 #, c-format
 msgid "invalid subcommand: %s"
 msgstr "ungültiger Unterbefehl: %s"
@@ -16247,12 +16563,12 @@ msgstr "ungültiger Unterbefehl: %s"
 msgid "git grep [<options>] [-e] <pattern> [<rev>...] [[--] <path>...]"
 msgstr "git grep [<Optionen>] [-e] <Muster> [<Commit>...] [[--] <Pfad>...]"
 
-#: builtin/grep.c:223
+#: builtin/grep.c:239
 #, c-format
 msgid "grep: failed to create thread: %s"
 msgstr "grep: Fehler beim Erzeugen eines Thread: %s"
 
-#: builtin/grep.c:277
+#: builtin/grep.c:293
 #, c-format
 msgid "invalid number of threads specified (%d) for %s"
 msgstr "ungültige Anzahl von Threads (%d) für %s angegeben"
@@ -16261,270 +16577,270 @@ msgstr "ungültige Anzahl von Threads (%d) für %s angegeben"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:285 builtin/index-pack.c:1588 builtin/index-pack.c:1791
-#: builtin/pack-objects.c:3129
+#: builtin/grep.c:301 builtin/index-pack.c:1582 builtin/index-pack.c:1785
+#: builtin/pack-objects.c:3142
 #, c-format
 msgid "no threads support, ignoring %s"
 msgstr "keine Unterstützung von Threads, '%s' wird ignoriert"
 
-#: builtin/grep.c:473 builtin/grep.c:603 builtin/grep.c:643
+#: builtin/grep.c:488 builtin/grep.c:617 builtin/grep.c:657
 #, c-format
 msgid "unable to read tree (%s)"
 msgstr "konnte \"Tree\"-Objekt (%s) nicht lesen"
 
-#: builtin/grep.c:658
+#: builtin/grep.c:672
 #, c-format
 msgid "unable to grep from object of type %s"
 msgstr "kann \"grep\" nicht mit Objekten des Typs %s durchführen"
 
-#: builtin/grep.c:738
+#: builtin/grep.c:752
 #, c-format
 msgid "switch `%c' expects a numerical value"
 msgstr "Schalter '%c' erwartet einen numerischen Wert"
 
-#: builtin/grep.c:837
+#: builtin/grep.c:851
 msgid "search in index instead of in the work tree"
 msgstr "im Index statt im Arbeitsverzeichnis suchen"
 
-#: builtin/grep.c:839
+#: builtin/grep.c:853
 msgid "find in contents not managed by git"
 msgstr "auch in Inhalten finden, die nicht von Git verwaltet werden"
 
-#: builtin/grep.c:841
+#: builtin/grep.c:855
 msgid "search in both tracked and untracked files"
 msgstr "in versionierten und unversionierten Dateien suchen"
 
-#: builtin/grep.c:843
+#: builtin/grep.c:857
 msgid "ignore files specified via '.gitignore'"
 msgstr "Dateien, die über '.gitignore' angegeben sind, ignorieren"
 
-#: builtin/grep.c:845
+#: builtin/grep.c:859
 msgid "recursively search in each submodule"
 msgstr "rekursive Suche in jedem Submodul"
 
-#: builtin/grep.c:848
+#: builtin/grep.c:862
 msgid "show non-matching lines"
 msgstr "Zeilen ohne Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:850
+#: builtin/grep.c:864
 msgid "case insensitive matching"
 msgstr "Übereinstimmungen unabhängig von Groß- und Kleinschreibung finden"
 
-#: builtin/grep.c:852
+#: builtin/grep.c:866
 msgid "match patterns only at word boundaries"
 msgstr "nur ganze Wörter suchen"
 
-#: builtin/grep.c:854
+#: builtin/grep.c:868
 msgid "process binary files as text"
 msgstr "binäre Dateien als Text verarbeiten"
 
-#: builtin/grep.c:856
+#: builtin/grep.c:870
 msgid "don't match patterns in binary files"
 msgstr "keine Muster in Binärdateien finden"
 
-#: builtin/grep.c:859
+#: builtin/grep.c:873
 msgid "process binary files with textconv filters"
 msgstr "binäre Dateien mit \"textconv\"-Filtern verarbeiten"
 
-#: builtin/grep.c:861
+#: builtin/grep.c:875
 msgid "search in subdirectories (default)"
 msgstr "in Unterverzeichnissen suchen (Standard)"
 
-#: builtin/grep.c:863
+#: builtin/grep.c:877
 msgid "descend at most <depth> levels"
 msgstr "höchstens <Tiefe> Ebenen durchlaufen"
 
-#: builtin/grep.c:867
+#: builtin/grep.c:881
 msgid "use extended POSIX regular expressions"
 msgstr "erweiterte reguläre Ausdrücke aus POSIX verwenden"
 
-#: builtin/grep.c:870
+#: builtin/grep.c:884
 msgid "use basic POSIX regular expressions (default)"
 msgstr "grundlegende reguläre Ausdrücke aus POSIX verwenden (Standard)"
 
-#: builtin/grep.c:873
+#: builtin/grep.c:887
 msgid "interpret patterns as fixed strings"
 msgstr "Muster als feste Zeichenketten interpretieren"
 
-#: builtin/grep.c:876
+#: builtin/grep.c:890
 msgid "use Perl-compatible regular expressions"
 msgstr "Perl-kompatible reguläre Ausdrücke verwenden"
 
-#: builtin/grep.c:879
+#: builtin/grep.c:893
 msgid "show line numbers"
 msgstr "Zeilennummern anzeigen"
 
-#: builtin/grep.c:880
+#: builtin/grep.c:894
 msgid "show column number of first match"
 msgstr "Nummer der Spalte des ersten Treffers anzeigen"
 
-#: builtin/grep.c:881
+#: builtin/grep.c:895
 msgid "don't show filenames"
 msgstr "keine Dateinamen anzeigen"
 
-#: builtin/grep.c:882
+#: builtin/grep.c:896
 msgid "show filenames"
 msgstr "Dateinamen anzeigen"
 
-#: builtin/grep.c:884
+#: builtin/grep.c:898
 msgid "show filenames relative to top directory"
 msgstr "Dateinamen relativ zum Projektverzeichnis anzeigen"
 
-#: builtin/grep.c:886
+#: builtin/grep.c:900
 msgid "show only filenames instead of matching lines"
 msgstr "nur Dateinamen anzeigen anstatt übereinstimmende Zeilen"
 
-#: builtin/grep.c:888
+#: builtin/grep.c:902
 msgid "synonym for --files-with-matches"
 msgstr "Synonym für --files-with-matches"
 
-#: builtin/grep.c:891
+#: builtin/grep.c:905
 msgid "show only the names of files without match"
 msgstr "nur die Dateinamen ohne Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:893
+#: builtin/grep.c:907
 msgid "print NUL after filenames"
 msgstr "NUL-Zeichen nach Dateinamen ausgeben"
 
-#: builtin/grep.c:896
+#: builtin/grep.c:910
 msgid "show only matching parts of a line"
 msgstr "nur übereinstimmende Teile der Zeile anzeigen"
 
-#: builtin/grep.c:898
+#: builtin/grep.c:912
 msgid "show the number of matches instead of matching lines"
 msgstr "anstatt der Zeilen, die Anzahl der übereinstimmenden Zeilen anzeigen"
 
-#: builtin/grep.c:899
+#: builtin/grep.c:913
 msgid "highlight matches"
 msgstr "Übereinstimmungen hervorheben"
 
-#: builtin/grep.c:901
+#: builtin/grep.c:915
 msgid "print empty line between matches from different files"
 msgstr ""
 "eine Leerzeile zwischen Übereinstimmungen in verschiedenen Dateien ausgeben"
 
-#: builtin/grep.c:903
+#: builtin/grep.c:917
 msgid "show filename only once above matches from same file"
 msgstr ""
 "den Dateinamen nur einmal oberhalb der Übereinstimmungen aus dieser Datei "
 "anzeigen"
 
-#: builtin/grep.c:906
+#: builtin/grep.c:920
 msgid "show <n> context lines before and after matches"
 msgstr "<n> Zeilen vor und nach den Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:909
+#: builtin/grep.c:923
 msgid "show <n> context lines before matches"
 msgstr "<n> Zeilen vor den Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:911
+#: builtin/grep.c:925
 msgid "show <n> context lines after matches"
 msgstr "<n> Zeilen nach den Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:913
+#: builtin/grep.c:927
 msgid "use <n> worker threads"
 msgstr "<n> Threads benutzen"
 
-#: builtin/grep.c:914
+#: builtin/grep.c:928
 msgid "shortcut for -C NUM"
 msgstr "Kurzform für -C NUM"
 
-#: builtin/grep.c:917
+#: builtin/grep.c:931
 msgid "show a line with the function name before matches"
 msgstr "eine Zeile mit dem Funktionsnamen vor Übereinstimmungen anzeigen"
 
-#: builtin/grep.c:919
+#: builtin/grep.c:933
 msgid "show the surrounding function"
 msgstr "die umgebende Funktion anzeigen"
 
-#: builtin/grep.c:922
+#: builtin/grep.c:936
 msgid "read patterns from file"
 msgstr "Muster von einer Datei lesen"
 
-#: builtin/grep.c:924
+#: builtin/grep.c:938
 msgid "match <pattern>"
 msgstr "<Muster> finden"
 
-#: builtin/grep.c:926
+#: builtin/grep.c:940
 msgid "combine patterns specified with -e"
 msgstr "Muster kombinieren, die mit -e angegeben wurden"
 
-#: builtin/grep.c:938
+#: builtin/grep.c:952
 msgid "indicate hit with exit status without output"
 msgstr "Übereinstimmungen nur durch Beendigungsstatus anzeigen"
 
-#: builtin/grep.c:940
+#: builtin/grep.c:954
 msgid "show only matches from files that match all patterns"
 msgstr ""
 "nur Übereinstimmungen von Dateien anzeigen, die allen Mustern entsprechen"
 
-#: builtin/grep.c:943
+#: builtin/grep.c:957
 msgid "pager"
 msgstr "Anzeigeprogramm"
 
-#: builtin/grep.c:943
+#: builtin/grep.c:957
 msgid "show matching files in the pager"
 msgstr "Dateien mit Übereinstimmungen im Anzeigeprogramm anzeigen"
 
-#: builtin/grep.c:947
+#: builtin/grep.c:961
 msgid "allow calling of grep(1) (ignored by this build)"
 msgstr "den Aufruf von grep(1) erlauben (von dieser Programmversion ignoriert)"
 
-#: builtin/grep.c:1013
+#: builtin/grep.c:1027
 msgid "no pattern given"
 msgstr "Kein Muster angegeben."
 
-#: builtin/grep.c:1049
+#: builtin/grep.c:1063
 msgid "--no-index or --untracked cannot be used with revs"
 msgstr "--no-index oder --untracked können nicht mit Commits verwendet werden"
 
-#: builtin/grep.c:1057
+#: builtin/grep.c:1071
 #, c-format
 msgid "unable to resolve revision: %s"
 msgstr "Konnte Commit nicht auflösen: %s"
 
-#: builtin/grep.c:1087
+#: builtin/grep.c:1101
 msgid "--untracked not supported with --recurse-submodules"
 msgstr "--untracked zusammen mit --recurse-submodules wird nicht unterstützt"
 
-#: builtin/grep.c:1091
+#: builtin/grep.c:1105
 msgid "invalid option combination, ignoring --threads"
 msgstr "Ungültige Kombination von Optionen, --threads wird ignoriert."
 
-#: builtin/grep.c:1094 builtin/pack-objects.c:4090
+#: builtin/grep.c:1108 builtin/pack-objects.c:4059
 msgid "no threads support, ignoring --threads"
 msgstr "Keine Unterstützung für Threads, --threads wird ignoriert."
 
-#: builtin/grep.c:1097 builtin/index-pack.c:1585 builtin/pack-objects.c:3126
+#: builtin/grep.c:1111 builtin/index-pack.c:1579 builtin/pack-objects.c:3139
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "ungültige Anzahl von Threads angegeben (%d)"
 
-#: builtin/grep.c:1131
+#: builtin/grep.c:1145
 msgid "--open-files-in-pager only works on the worktree"
 msgstr ""
 "--open-files-in-pager kann nur innerhalb des Arbeitsverzeichnisses verwendet "
 "werden"
 
-#: builtin/grep.c:1157
+#: builtin/grep.c:1171
 msgid "--cached or --untracked cannot be used with --no-index"
 msgstr "--cached und --untracked können nicht mit --no-index verwendet werden"
 
-#: builtin/grep.c:1160
+#: builtin/grep.c:1174
 msgid "--untracked cannot be used with --cached"
 msgstr "--untracked kann nicht mit --cached verwendet werden"
 
-#: builtin/grep.c:1166
+#: builtin/grep.c:1180
 msgid "--[no-]exclude-standard cannot be used for tracked contents"
 msgstr ""
 "--[no-]exclude-standard kann nicht mit versionierten Inhalten verwendet "
 "werden"
 
-#: builtin/grep.c:1174
+#: builtin/grep.c:1188
 msgid "both --cached and trees are given"
 msgstr "--cached und \"Tree\"-Objekte angegeben"
 
-#: builtin/hash-object.c:85
+#: builtin/hash-object.c:83
 msgid ""
 "git hash-object [-t <type>] [-w] [--path=<file> | --no-filters] [--stdin] "
 "[--] <file>..."
@@ -16532,97 +16848,108 @@ msgstr ""
 "git hash-object [-t <Art>] [-w] [--path=<Datei> | --no-filters] [--stdin] "
 "[--] <Datei>..."
 
-#: builtin/hash-object.c:86
+#: builtin/hash-object.c:84
 msgid "git hash-object  --stdin-paths"
 msgstr "git hash-object  --stdin-paths"
 
-#: builtin/hash-object.c:98
+#: builtin/hash-object.c:96
 msgid "object type"
 msgstr "Art des Objektes"
 
-#: builtin/hash-object.c:99
+#: builtin/hash-object.c:97
 msgid "write the object into the object database"
 msgstr "das Objekt in die Objektdatenbank schreiben"
 
-#: builtin/hash-object.c:101
+#: builtin/hash-object.c:99
 msgid "read the object from stdin"
 msgstr "das Objekt von der Standard-Eingabe lesen"
 
-#: builtin/hash-object.c:103
+#: builtin/hash-object.c:101
 msgid "store file as is without filters"
 msgstr "Datei wie sie ist speichern, ohne Filter"
 
-#: builtin/hash-object.c:104
+#: builtin/hash-object.c:102
 msgid ""
 "just hash any random garbage to create corrupt objects for debugging Git"
 msgstr ""
 "Hash über zufällige Daten, zur Erzeugung von beschädigten Objekten zur\n"
 "Fehlersuche in Git, erzeugen"
 
-#: builtin/hash-object.c:105
+#: builtin/hash-object.c:103
 msgid "process file as it were from this path"
 msgstr "Datei verarbeiten, als ob sie von diesem Pfad wäre"
 
-#: builtin/help.c:47
+#: builtin/help.c:55
 msgid "print all available commands"
 msgstr "alle vorhandenen Befehle anzeigen"
 
-#: builtin/help.c:48
+#: builtin/help.c:57
 msgid "exclude guides"
 msgstr "Anleitungen ausschließen"
 
-#: builtin/help.c:49
-msgid "print list of useful guides"
-msgstr "Liste von allgemein verwendeten Anleitungen anzeigen"
-
-#: builtin/help.c:50
-msgid "print all configuration variable names"
-msgstr "alle Namen der Konfigurationsvariablen ausgeben"
-
-#: builtin/help.c:52
+#: builtin/help.c:58
 msgid "show man page"
 msgstr "Handbuch anzeigen"
 
-#: builtin/help.c:53
+#: builtin/help.c:59
 msgid "show manual in web browser"
 msgstr "Handbuch in einem Webbrowser anzeigen"
 
-#: builtin/help.c:55
+#: builtin/help.c:61
 msgid "show info page"
 msgstr "Info-Seite anzeigen"
 
-#: builtin/help.c:57
+#: builtin/help.c:63
 msgid "print command description"
 msgstr "Beschreibung des Befehls ausgeben"
 
-#: builtin/help.c:62
-msgid "git help [--all] [--guides] [--man | --web | --info] [<command>]"
+#: builtin/help.c:65
+msgid "print list of useful guides"
+msgstr "Liste von allgemein verwendeten Anleitungen anzeigen"
+
+#: builtin/help.c:67
+msgid "print all configuration variable names"
+msgstr "alle Namen der Konfigurationsvariablen ausgeben"
+
+#: builtin/help.c:78
+#, fuzzy
+msgid ""
+"git help [-a|--all] [--[no-]verbose]]\n"
+"         [[-i|--info] [-m|--man] [-w|--web]] [<command>]"
 msgstr "git help [--all] [--guides] [--man | --web | --info] [<Befehl>]"
 
-#: builtin/help.c:163
+#: builtin/help.c:80
+msgid "git help [-g|--guides]"
+msgstr ""
+
+#: builtin/help.c:81
+msgid "git help [-c|--config]"
+msgstr ""
+
+#: builtin/help.c:196
 #, c-format
 msgid "unrecognized help format '%s'"
 msgstr "nicht erkanntes Hilfeformat: %s"
 
-#: builtin/help.c:190
+#: builtin/help.c:223
 msgid "Failed to start emacsclient."
 msgstr "Konnte emacsclient nicht starten."
 
-#: builtin/help.c:203
+#: builtin/help.c:236
 msgid "Failed to parse emacsclient version."
 msgstr "Konnte Version des emacsclient nicht parsen."
 
-#: builtin/help.c:211
+#: builtin/help.c:244
 #, c-format
 msgid "emacsclient version '%d' too old (< 22)."
 msgstr "Version des emacsclient '%d' ist zu alt (< 22)."
 
-#: builtin/help.c:229 builtin/help.c:251 builtin/help.c:261 builtin/help.c:269
+#: builtin/help.c:262 builtin/help.c:284 builtin/help.c:294 builtin/help.c:302
 #, c-format
 msgid "failed to exec '%s'"
 msgstr "Fehler beim Ausführen von '%s'"
 
-#: builtin/help.c:307
+#: builtin/help.c:340
 #, c-format
 msgid ""
 "'%s': path for unsupported man viewer.\n"
@@ -16631,7 +16958,7 @@ msgstr ""
 "'%s': Pfad für nicht unterstützten Handbuchbetrachter.\n"
 "Sie könnten stattdessen 'man.<Werkzeug>.cmd' benutzen."
 
-#: builtin/help.c:319
+#: builtin/help.c:352
 #, c-format
 msgid ""
 "'%s': cmd for supported man viewer.\n"
@@ -16640,332 +16967,324 @@ msgstr ""
 "'%s': Programm für unterstützten Handbuchbetrachter.\n"
 "Sie könnten stattdessen 'man.<Werkzeug>.path' benutzen."
 
-#: builtin/help.c:436
+#: builtin/help.c:467
 #, c-format
 msgid "'%s': unknown man viewer."
 msgstr "'%s': unbekannter Handbuch-Betrachter."
 
-#: builtin/help.c:452
+#: builtin/help.c:483
 msgid "no man viewer handled the request"
 msgstr "kein Handbuch-Betrachter konnte mit dieser Anfrage umgehen"
 
-#: builtin/help.c:459
+#: builtin/help.c:490
 msgid "no info viewer handled the request"
 msgstr "kein Informations-Betrachter konnte mit dieser Anfrage umgehen"
 
-#: builtin/help.c:517 builtin/help.c:528 git.c:348
+#: builtin/help.c:551 builtin/help.c:562 git.c:348
 #, c-format
 msgid "'%s' is aliased to '%s'"
 msgstr "Für '%s' wurde der Alias '%s' angelegt."
 
-#: builtin/help.c:531 git.c:380
+#: builtin/help.c:565 git.c:380
 #, c-format
 msgid "bad alias.%s string: %s"
 msgstr "Ungültiger alias.%s String: %s"
 
-#: builtin/help.c:561 builtin/help.c:591
+#: builtin/help.c:581
+#, fuzzy
+msgid "this option doesn't take any other arguments"
+msgstr "fetch --all akzeptiert kein Repository als Argument"
+
+#: builtin/help.c:602 builtin/help.c:629
 #, c-format
 msgid "usage: %s%s"
 msgstr "Verwendung: %s%s"
 
-#: builtin/help.c:575
+#: builtin/help.c:624
 msgid "'git help config' for more information"
 msgstr "'git help config' für weitere Informationen"
 
-#: builtin/index-pack.c:222
+#: builtin/index-pack.c:221
 #, c-format
 msgid "object type mismatch at %s"
 msgstr "Objekt-Typen passen bei %s nicht zusammen"
 
-#: builtin/index-pack.c:242
+#: builtin/index-pack.c:241
 #, c-format
 msgid "did not receive expected object %s"
 msgstr "konnte erwartetes Objekt %s nicht empfangen"
 
-#: builtin/index-pack.c:245
+#: builtin/index-pack.c:244
 #, c-format
 msgid "object %s: expected type %s, found %s"
 msgstr "Objekt %s: erwarteter Typ %s, %s gefunden"
 
-#: builtin/index-pack.c:295
+#: builtin/index-pack.c:294
 #, c-format
 msgid "cannot fill %d byte"
 msgid_plural "cannot fill %d bytes"
 msgstr[0] "kann %d Byte nicht lesen"
 msgstr[1] "kann %d Bytes nicht lesen"
 
-#: builtin/index-pack.c:305
+#: builtin/index-pack.c:304
 msgid "early EOF"
 msgstr "zu frühes Dateiende"
 
-#: builtin/index-pack.c:306
+#: builtin/index-pack.c:305
 msgid "read error on input"
 msgstr "Fehler beim Lesen der Eingabe"
 
-#: builtin/index-pack.c:318
+#: builtin/index-pack.c:317
 msgid "used more bytes than were available"
 msgstr "verwendete mehr Bytes als verfügbar waren"
 
-#: builtin/index-pack.c:325 builtin/pack-objects.c:756
+#: builtin/index-pack.c:324 builtin/pack-objects.c:756
 msgid "pack too large for current definition of off_t"
 msgstr "Paket ist zu groß für die aktuelle Definition von off_t"
 
-#: builtin/index-pack.c:328 builtin/unpack-objects.c:95
+#: builtin/index-pack.c:327 builtin/unpack-objects.c:95
 msgid "pack exceeds maximum allowed size"
 msgstr "Paket überschreitet die maximal erlaubte Größe"
 
-#: builtin/index-pack.c:343
-#, c-format
-msgid "unable to create '%s'"
-msgstr "konnte '%s' nicht erstellen"
-
-#: builtin/index-pack.c:349
-#, c-format
-msgid "cannot open packfile '%s'"
-msgstr "Kann Paketdatei '%s' nicht öffnen"
-
-#: builtin/index-pack.c:363
+#: builtin/index-pack.c:358
 msgid "pack signature mismatch"
 msgstr "Paketsignatur stimmt nicht überein"
 
-#: builtin/index-pack.c:365
+#: builtin/index-pack.c:360
 #, c-format
 msgid "pack version %<PRIu32> unsupported"
 msgstr "Paketversion %<PRIu32> nicht unterstützt"
 
-#: builtin/index-pack.c:381
+#: builtin/index-pack.c:376
 #, c-format
 msgid "pack has bad object at offset %<PRIuMAX>: %s"
 msgstr "Paket hat ein ungültiges Objekt bei Versatz %<PRIuMAX>: %s"
 
-#: builtin/index-pack.c:487
+#: builtin/index-pack.c:482
 #, c-format
 msgid "inflate returned %d"
 msgstr "Dekomprimierung gab %d zurück"
 
-#: builtin/index-pack.c:536
+#: builtin/index-pack.c:531
 msgid "offset value overflow for delta base object"
 msgstr "Wert für Versatz bei Differenzobjekt übergelaufen"
 
-#: builtin/index-pack.c:544
+#: builtin/index-pack.c:539
 msgid "delta base offset is out of bound"
 msgstr ""
 "Wert für Versatz bei Differenzobjekt liegt außerhalb des gültigen Bereichs"
 
-#: builtin/index-pack.c:552
+#: builtin/index-pack.c:547
 #, c-format
 msgid "unknown object type %d"
 msgstr "Unbekannter Objekt-Typ %d"
 
-#: builtin/index-pack.c:583
+#: builtin/index-pack.c:578
 msgid "cannot pread pack file"
 msgstr "Kann Paketdatei %s nicht lesen"
 
-#: builtin/index-pack.c:585
+#: builtin/index-pack.c:580
 #, c-format
 msgid "premature end of pack file, %<PRIuMAX> byte missing"
 msgid_plural "premature end of pack file, %<PRIuMAX> bytes missing"
 msgstr[0] "frühzeitiges Ende der Paketdatei, vermisse %<PRIuMAX> Byte"
 msgstr[1] "frühzeitiges Ende der Paketdatei, vermisse %<PRIuMAX> Bytes"
 
-#: builtin/index-pack.c:611
+#: builtin/index-pack.c:606
 msgid "serious inflate inconsistency"
 msgstr "ernsthafte Inkonsistenz nach Dekomprimierung"
 
-#: builtin/index-pack.c:756 builtin/index-pack.c:762 builtin/index-pack.c:786
-#: builtin/index-pack.c:825 builtin/index-pack.c:834
+#: builtin/index-pack.c:751 builtin/index-pack.c:757 builtin/index-pack.c:781
+#: builtin/index-pack.c:820 builtin/index-pack.c:829
 #, c-format
 msgid "SHA1 COLLISION FOUND WITH %s !"
 msgstr "SHA1 KOLLISION MIT %s GEFUNDEN !"
 
-#: builtin/index-pack.c:759 builtin/pack-objects.c:292
+#: builtin/index-pack.c:754 builtin/pack-objects.c:292
 #: builtin/pack-objects.c:352 builtin/pack-objects.c:458
 #, c-format
 msgid "unable to read %s"
 msgstr "kann %s nicht lesen"
 
-#: builtin/index-pack.c:823
+#: builtin/index-pack.c:818
 #, c-format
 msgid "cannot read existing object info %s"
 msgstr "Kann existierende Informationen zu Objekt %s nicht lesen."
 
-#: builtin/index-pack.c:831
+#: builtin/index-pack.c:826
 #, c-format
 msgid "cannot read existing object %s"
 msgstr "Kann existierendes Objekt %s nicht lesen."
 
-#: builtin/index-pack.c:845
+#: builtin/index-pack.c:840
 #, c-format
 msgid "invalid blob object %s"
 msgstr "ungültiges Blob-Objekt %s"
 
-#: builtin/index-pack.c:848 builtin/index-pack.c:867
+#: builtin/index-pack.c:843 builtin/index-pack.c:862
 msgid "fsck error in packed object"
 msgstr "fsck Fehler in gepacktem Objekt"
 
-#: builtin/index-pack.c:869
+#: builtin/index-pack.c:864
 #, c-format
 msgid "Not all child objects of %s are reachable"
 msgstr "Nicht alle Kind-Objekte von %s sind erreichbar"
 
-#: builtin/index-pack.c:930 builtin/index-pack.c:977
+#: builtin/index-pack.c:925 builtin/index-pack.c:972
 msgid "failed to apply delta"
 msgstr "Konnte Dateiunterschied nicht anwenden"
 
-#: builtin/index-pack.c:1160
+#: builtin/index-pack.c:1156
 msgid "Receiving objects"
 msgstr "Empfange Objekte"
 
-#: builtin/index-pack.c:1160
+#: builtin/index-pack.c:1156
 msgid "Indexing objects"
 msgstr "Indiziere Objekte"
 
-#: builtin/index-pack.c:1194
+#: builtin/index-pack.c:1190
 msgid "pack is corrupted (SHA1 mismatch)"
 msgstr "Paket ist beschädigt (SHA1 unterschiedlich)"
 
-#: builtin/index-pack.c:1199
+#: builtin/index-pack.c:1195
 msgid "cannot fstat packfile"
 msgstr "kann Paketdatei nicht lesen"
 
-#: builtin/index-pack.c:1202
+#: builtin/index-pack.c:1198
 msgid "pack has junk at the end"
 msgstr "Paketende enthält nicht verwendbaren Inhalt"
 
-#: builtin/index-pack.c:1214
+#: builtin/index-pack.c:1210
 msgid "confusion beyond insanity in parse_pack_objects()"
 msgstr "Fehler beim Ausführen von \"parse_pack_objects()\""
 
-#: builtin/index-pack.c:1237
+#: builtin/index-pack.c:1233
 msgid "Resolving deltas"
 msgstr "Löse Unterschiede auf"
 
-#: builtin/index-pack.c:1248 builtin/pack-objects.c:2892
+#: builtin/index-pack.c:1244 builtin/pack-objects.c:2905
 #, c-format
 msgid "unable to create thread: %s"
 msgstr "kann Thread nicht erzeugen: %s"
 
-#: builtin/index-pack.c:1281
+#: builtin/index-pack.c:1277
 msgid "confusion beyond insanity"
 msgstr "Fehler beim Auflösen der Unterschiede"
 
-#: builtin/index-pack.c:1287
+#: builtin/index-pack.c:1283
 #, c-format
 msgid "completed with %d local object"
 msgid_plural "completed with %d local objects"
 msgstr[0] "abgeschlossen mit %d lokalem Objekt"
 msgstr[1] "abgeschlossen mit %d lokalen Objekten"
 
-#: builtin/index-pack.c:1299
+#: builtin/index-pack.c:1295
 #, c-format
 msgid "Unexpected tail checksum for %s (disk corruption?)"
 msgstr "unerwartete Prüfsumme für %s (Festplattenfehler?)"
 
-#: builtin/index-pack.c:1303
+#: builtin/index-pack.c:1299
 #, c-format
 msgid "pack has %d unresolved delta"
 msgid_plural "pack has %d unresolved deltas"
 msgstr[0] "Paket hat %d unaufgelösten Unterschied"
 msgstr[1] "Paket hat %d unaufgelöste Unterschiede"
 
-#: builtin/index-pack.c:1327
+#: builtin/index-pack.c:1323
 #, c-format
 msgid "unable to deflate appended object (%d)"
 msgstr "Konnte angehängtes Objekt (%d) nicht komprimieren"
 
-#: builtin/index-pack.c:1423
+#: builtin/index-pack.c:1419
 #, c-format
 msgid "local object %s is corrupt"
 msgstr "lokales Objekt %s ist beschädigt"
 
-#: builtin/index-pack.c:1444
+#: builtin/index-pack.c:1440
 #, c-format
 msgid "packfile name '%s' does not end with '.%s'"
 msgstr "Name der Paketdatei '%s' endet nicht mit '.%s'"
 
-#: builtin/index-pack.c:1468
+#: builtin/index-pack.c:1464
 #, c-format
 msgid "cannot write %s file '%s'"
 msgstr "Kann %s Datei '%s' nicht schreiben."
 
-#: builtin/index-pack.c:1476
+#: builtin/index-pack.c:1472
 #, c-format
 msgid "cannot close written %s file '%s'"
 msgstr "Kann eben geschriebene %s Datei '%s' nicht schließen."
 
-#: builtin/index-pack.c:1502
+#: builtin/index-pack.c:1489
+#, fuzzy, c-format
+msgid "unable to rename temporary '*.%s' file to '%s'"
+msgstr "konnte temporäre Datei nicht zu %s umbenennen"
+
+#: builtin/index-pack.c:1514
 msgid "error while closing pack file"
 msgstr "Fehler beim Schließen der Paketdatei"
 
-#: builtin/index-pack.c:1516
-msgid "cannot store pack file"
-msgstr "Kann Paketdatei nicht speichern"
-
-#: builtin/index-pack.c:1524
-msgid "cannot store index file"
-msgstr "Kann Indexdatei nicht speichern"
-
-#: builtin/index-pack.c:1579 builtin/pack-objects.c:3137
+#: builtin/index-pack.c:1573 builtin/pack-objects.c:3150
 #, c-format
 msgid "bad pack.indexversion=%<PRIu32>"
 msgstr "\"pack.indexversion=%<PRIu32>\" ist ungültig"
 
-#: builtin/index-pack.c:1649
+#: builtin/index-pack.c:1643
 #, c-format
 msgid "Cannot open existing pack file '%s'"
 msgstr "Kann existierende Paketdatei '%s' nicht öffnen"
 
-#: builtin/index-pack.c:1651
+#: builtin/index-pack.c:1645
 #, c-format
 msgid "Cannot open existing pack idx file for '%s'"
 msgstr "Kann existierende Indexdatei für Paket '%s' nicht öffnen"
 
-#: builtin/index-pack.c:1699
+#: builtin/index-pack.c:1693
 #, c-format
 msgid "non delta: %d object"
 msgid_plural "non delta: %d objects"
 msgstr[0] "kein Unterschied: %d Objekt"
 msgstr[1] "kein Unterschied: %d Objekte"
 
-#: builtin/index-pack.c:1706
+#: builtin/index-pack.c:1700
 #, c-format
 msgid "chain length = %d: %lu object"
 msgid_plural "chain length = %d: %lu objects"
 msgstr[0] "Länge der Objekt-Liste = %d: %lu Objekt"
 msgstr[1] "Länge der Objekt-Liste = %d: %lu Objekte"
 
-#: builtin/index-pack.c:1748
+#: builtin/index-pack.c:1742
 msgid "Cannot come back to cwd"
 msgstr "Kann nicht zurück zum Arbeitsverzeichnis wechseln"
 
-#: builtin/index-pack.c:1802 builtin/index-pack.c:1805
-#: builtin/index-pack.c:1821 builtin/index-pack.c:1825
+#: builtin/index-pack.c:1796 builtin/index-pack.c:1799
+#: builtin/index-pack.c:1819 builtin/index-pack.c:1823
 #, c-format
 msgid "bad %s"
 msgstr "%s ist ungültig"
 
-#: builtin/index-pack.c:1831 builtin/init-db.c:379 builtin/init-db.c:614
+#: builtin/index-pack.c:1829 builtin/init-db.c:379 builtin/init-db.c:614
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "unbekannter Hash-Algorithmus '%s'"
 
-#: builtin/index-pack.c:1850
+#: builtin/index-pack.c:1848
 msgid "--fix-thin cannot be used without --stdin"
 msgstr "--fix-thin kann nicht ohne --stdin verwendet werden"
 
-#: builtin/index-pack.c:1852
+#: builtin/index-pack.c:1850
 msgid "--stdin requires a git repository"
 msgstr "--stdin erfordert ein Git-Repository"
 
-#: builtin/index-pack.c:1854
+#: builtin/index-pack.c:1852
 msgid "--object-format cannot be used with --stdin"
 msgstr "--object-format kann nicht mit --stdin verwendet werden"
 
-#: builtin/index-pack.c:1869
+#: builtin/index-pack.c:1867
 msgid "--verify with no packfile name given"
 msgstr "--verify wurde ohne Namen der Paketdatei angegeben"
 
-#: builtin/index-pack.c:1935 builtin/unpack-objects.c:584
+#: builtin/index-pack.c:1933 builtin/unpack-objects.c:584
 msgid "fsck error in pack objects"
 msgstr "fsck Fehler beim Packen von Objekten"
 
@@ -17609,124 +17928,131 @@ msgstr ""
 "Konnte gefolgten Remote-Branch nicht finden, bitte geben Sie <Upstream> "
 "manuell an.\n"
 
-#: builtin/ls-files.c:563
+#: builtin/ls-files.c:561
 msgid "git ls-files [<options>] [<file>...]"
 msgstr "git ls-files [<Optionen>] [<Datei>...]"
 
-#: builtin/ls-files.c:619
+#: builtin/ls-files.c:615
+#, fuzzy
+msgid "separate paths with the NUL character"
+msgstr "Pfade sind getrennt durch NUL Zeichen"
+
+#: builtin/ls-files.c:617
 msgid "identify the file status with tags"
 msgstr "den Dateistatus mit Tags anzeigen"
 
-#: builtin/ls-files.c:621
+#: builtin/ls-files.c:619
 msgid "use lowercase letters for 'assume unchanged' files"
 msgstr ""
 "Kleinbuchstaben für Dateien mit 'assume unchanged' Markierung verwenden"
 
-#: builtin/ls-files.c:623
+#: builtin/ls-files.c:621
 msgid "use lowercase letters for 'fsmonitor clean' files"
 msgstr "Kleinbuchstaben für 'fsmonitor clean' Dateien verwenden"
 
-#: builtin/ls-files.c:625
+#: builtin/ls-files.c:623
 msgid "show cached files in the output (default)"
 msgstr "zwischengespeicherte Dateien in der Ausgabe anzeigen (Standard)"
 
-#: builtin/ls-files.c:627
+#: builtin/ls-files.c:625
 msgid "show deleted files in the output"
 msgstr "entfernte Dateien in der Ausgabe anzeigen"
 
-#: builtin/ls-files.c:629
+#: builtin/ls-files.c:627
 msgid "show modified files in the output"
 msgstr "geänderte Dateien in der Ausgabe anzeigen"
 
-#: builtin/ls-files.c:631
+#: builtin/ls-files.c:629
 msgid "show other files in the output"
 msgstr "sonstige Dateien in der Ausgabe anzeigen"
 
-#: builtin/ls-files.c:633
+#: builtin/ls-files.c:631
 msgid "show ignored files in the output"
 msgstr "ignorierte Dateien in der Ausgabe anzeigen"
 
-#: builtin/ls-files.c:636
+#: builtin/ls-files.c:634
 msgid "show staged contents' object name in the output"
 msgstr ""
 "Objektnamen von Inhalten, die zum Commit vorgemerkt sind, in der Ausgabe "
 "anzeigen"
 
-#: builtin/ls-files.c:638
+#: builtin/ls-files.c:636
 msgid "show files on the filesystem that need to be removed"
 msgstr "Dateien im Dateisystem, die gelöscht werden müssen, anzeigen"
 
-#: builtin/ls-files.c:640
+#: builtin/ls-files.c:638
 msgid "show 'other' directories' names only"
 msgstr "nur Namen von 'sonstigen' Verzeichnissen anzeigen"
 
-#: builtin/ls-files.c:642
+#: builtin/ls-files.c:640
 msgid "show line endings of files"
 msgstr "Zeilenenden von Dateien anzeigen"
 
-#: builtin/ls-files.c:644
+#: builtin/ls-files.c:642
 msgid "don't show empty directories"
 msgstr "keine leeren Verzeichnisse anzeigen"
 
-#: builtin/ls-files.c:647
+#: builtin/ls-files.c:645
 msgid "show unmerged files in the output"
 msgstr "nicht zusammengeführte Dateien in der Ausgabe anzeigen"
 
-#: builtin/ls-files.c:649
+#: builtin/ls-files.c:647
 msgid "show resolve-undo information"
 msgstr "'resolve-undo' Informationen anzeigen"
 
-#: builtin/ls-files.c:651
+#: builtin/ls-files.c:649
 msgid "skip files matching pattern"
 msgstr "Dateien auslassen, die einem Muster entsprechen"
 
-#: builtin/ls-files.c:654
-msgid "exclude patterns are read from <file>"
-msgstr "Muster, gelesen von <Datei>, ausschließen"
+#: builtin/ls-files.c:652
+#, fuzzy
+msgid "read exclude patterns from <file>"
+msgstr "Muster von einer Datei lesen"
 
-#: builtin/ls-files.c:657
+#: builtin/ls-files.c:655
 msgid "read additional per-directory exclude patterns in <file>"
 msgstr "zusätzliche pro-Verzeichnis Auschlussmuster aus <Datei> auslesen"
 
-#: builtin/ls-files.c:659
+#: builtin/ls-files.c:657
 msgid "add the standard git exclusions"
 msgstr "die standardmäßigen Git-Ausschlüsse hinzufügen"
 
-#: builtin/ls-files.c:663
+#: builtin/ls-files.c:661
 msgid "make the output relative to the project top directory"
 msgstr "Ausgabe relativ zum Projektverzeichnis"
 
-#: builtin/ls-files.c:666
+#: builtin/ls-files.c:664
 msgid "recurse through submodules"
 msgstr "Rekursion in Submodulen durchführen"
 
-#: builtin/ls-files.c:668
+#: builtin/ls-files.c:666
 msgid "if any <file> is not in the index, treat this as an error"
 msgstr "als Fehler behandeln, wenn sich eine <Datei> nicht im Index befindet"
 
-#: builtin/ls-files.c:669
+#: builtin/ls-files.c:667
 msgid "tree-ish"
 msgstr "Commit-Referenz"
 
-#: builtin/ls-files.c:670
+#: builtin/ls-files.c:668
 msgid "pretend that paths removed since <tree-ish> are still present"
 msgstr ""
 "vorgeben, dass Pfade, die seit <Commit-Referenz> gelöscht wurden, immer noch "
 "vorhanden sind"
 
-#: builtin/ls-files.c:672
+#: builtin/ls-files.c:670
 msgid "show debugging data"
 msgstr "Ausgaben zur Fehlersuche anzeigen"
 
-#: builtin/ls-files.c:674
+#: builtin/ls-files.c:672
 msgid "suppress duplicate entries"
 msgstr "doppelte Einträge unterdrücken"
 
 #: builtin/ls-remote.c:9
+#, fuzzy
 msgid ""
 "git ls-remote [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
-"                     [-q | --quiet] [--exit-code] [--get-url]\n"
-"                     [--symref] [<repository> [<refs>...]]"
+"              [-q | --quiet] [--exit-code] [--get-url]\n"
+"              [--symref] [<repository> [<refs>...]]"
 msgstr ""
 "git ls-remote [--heads] [--tags] [--refs] [--upload-pack=<Programm>]\n"
 "                     [-q | --quiet] [--exit-code] [--get-url]\n"
@@ -17736,7 +18062,7 @@ msgstr ""
 msgid "do not print remote URL"
 msgstr "URL des Remote-Repositories nicht ausgeben"
 
-#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1399
+#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1103
 msgid "exec"
 msgstr "Programm"
 
@@ -17857,7 +18183,7 @@ msgstr "Aktion, wenn ein angeführtes CR gefunden wird"
 msgid "use headers in message's body"
 msgstr "nutze Header im Inhalt der Nachricht"
 
-#: builtin/mailsplit.c:241
+#: builtin/mailsplit.c:239
 #, c-format
 msgid "empty mbox: '%s'"
 msgstr "Leere mbox: '%s'"
@@ -17973,145 +18299,145 @@ msgstr "Konnte Referenz '%s' nicht auflösen"
 msgid "Merging %s with %s\n"
 msgstr "Führe %s mit %s zusammen\n"
 
-#: builtin/merge.c:58
+#: builtin/merge.c:59
 msgid "git merge [<options>] [<commit>...]"
 msgstr "git merge [<Optionen>] [<Commit>...]"
 
-#: builtin/merge.c:123
+#: builtin/merge.c:124
 msgid "switch `m' requires a value"
 msgstr "Schalter 'm' erfordert einen Wert."
 
-#: builtin/merge.c:146
+#: builtin/merge.c:147
 #, c-format
 msgid "option `%s' requires a value"
 msgstr "Option `%s' erfordert einen Wert."
 
-#: builtin/merge.c:199
+#: builtin/merge.c:200
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
 msgstr "Konnte Merge-Strategie '%s' nicht finden.\n"
 
-#: builtin/merge.c:200
+#: builtin/merge.c:201
 #, c-format
 msgid "Available strategies are:"
 msgstr "Verfügbare Strategien sind:"
 
-#: builtin/merge.c:205
+#: builtin/merge.c:206
 #, c-format
 msgid "Available custom strategies are:"
 msgstr "Verfügbare benutzerdefinierte Strategien sind:"
 
-#: builtin/merge.c:256 builtin/pull.c:133
+#: builtin/merge.c:257 builtin/pull.c:133
 msgid "do not show a diffstat at the end of the merge"
 msgstr "keine Zusammenfassung der Unterschiede am Schluss des Merges anzeigen"
 
-#: builtin/merge.c:259 builtin/pull.c:136
+#: builtin/merge.c:260 builtin/pull.c:136
 msgid "show a diffstat at the end of the merge"
 msgstr "eine Zusammenfassung der Unterschiede am Schluss des Merges anzeigen"
 
-#: builtin/merge.c:260 builtin/pull.c:139
+#: builtin/merge.c:261 builtin/pull.c:139
 msgid "(synonym to --stat)"
 msgstr "(Synonym für --stat)"
 
-#: builtin/merge.c:262 builtin/pull.c:142
+#: builtin/merge.c:263 builtin/pull.c:142
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "(höchstens <n>) Einträge von \"shortlog\" zur Beschreibung des Merge-Commits "
 "hinzufügen"
 
-#: builtin/merge.c:265 builtin/pull.c:148
+#: builtin/merge.c:266 builtin/pull.c:148
 msgid "create a single commit instead of doing a merge"
 msgstr "einen einzelnen Commit erzeugen statt einen Merge durchzuführen"
 
-#: builtin/merge.c:267 builtin/pull.c:151
+#: builtin/merge.c:268 builtin/pull.c:151
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "einen Commit durchführen, wenn der Merge erfolgreich war (Standard)"
 
-#: builtin/merge.c:269 builtin/pull.c:154
+#: builtin/merge.c:270 builtin/pull.c:154
 msgid "edit message before committing"
 msgstr "Bearbeitung der Beschreibung vor dem Commit"
 
-#: builtin/merge.c:271
+#: builtin/merge.c:272
 msgid "allow fast-forward (default)"
 msgstr "Vorspulen erlauben (Standard)"
 
-#: builtin/merge.c:273 builtin/pull.c:161
+#: builtin/merge.c:274 builtin/pull.c:161
 msgid "abort if fast-forward is not possible"
 msgstr "abbrechen, wenn kein Vorspulen möglich ist"
 
-#: builtin/merge.c:277 builtin/pull.c:164
+#: builtin/merge.c:278 builtin/pull.c:164
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "den genannten Commit auf eine gültige GPG-Signatur überprüfen"
 
-#: builtin/merge.c:278 builtin/notes.c:787 builtin/pull.c:168
-#: builtin/rebase.c:540 builtin/rebase.c:1413 builtin/revert.c:114
+#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:168
+#: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr "Strategie"
 
-#: builtin/merge.c:279 builtin/pull.c:169
+#: builtin/merge.c:280 builtin/pull.c:169
 msgid "merge strategy to use"
 msgstr "zu verwendende Merge-Strategie"
 
-#: builtin/merge.c:280 builtin/pull.c:172
+#: builtin/merge.c:281 builtin/pull.c:172
 msgid "option=value"
 msgstr "Option=Wert"
 
-#: builtin/merge.c:281 builtin/pull.c:173
+#: builtin/merge.c:282 builtin/pull.c:173
 msgid "option for selected merge strategy"
 msgstr "Option für ausgewählte Merge-Strategie"
 
-#: builtin/merge.c:283
+#: builtin/merge.c:284
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr ""
 "Commit-Beschreibung zusammenführen (für einen Merge, der kein Vorspulen war)"
 
-#: builtin/merge.c:290
+#: builtin/merge.c:291
 msgid "abort the current in-progress merge"
 msgstr "den sich im Gange befindlichen Merge abbrechen"
 
-#: builtin/merge.c:292
+#: builtin/merge.c:293
 msgid "--abort but leave index and working tree alone"
 msgstr "--abort, aber Index und Arbeitsverzeichnis unverändert lassen"
 
-#: builtin/merge.c:294
+#: builtin/merge.c:295
 msgid "continue the current in-progress merge"
 msgstr "den sich im Gange befindlichen Merge fortsetzen"
 
-#: builtin/merge.c:296 builtin/pull.c:180
+#: builtin/merge.c:297 builtin/pull.c:180
 msgid "allow merging unrelated histories"
 msgstr "erlaube das Zusammenführen von nicht zusammenhängenden Historien"
 
-#: builtin/merge.c:303
+#: builtin/merge.c:304
 msgid "bypass pre-merge-commit and commit-msg hooks"
 msgstr "Hooks pre-merge-commit und commit-msg umgehen"
 
-#: builtin/merge.c:320
+#: builtin/merge.c:321
 msgid "could not run stash."
 msgstr "Konnte \"stash\" nicht ausführen."
 
-#: builtin/merge.c:325
+#: builtin/merge.c:326
 msgid "stash failed"
 msgstr "\"stash\" fehlgeschlagen"
 
-#: builtin/merge.c:330
+#: builtin/merge.c:331
 #, c-format
 msgid "not a valid object: %s"
 msgstr "kein gültiges Objekt: %s"
 
-#: builtin/merge.c:352 builtin/merge.c:369
+#: builtin/merge.c:353 builtin/merge.c:370
 msgid "read-tree failed"
 msgstr "read-tree fehlgeschlagen"
 
-#: builtin/merge.c:400
+#: builtin/merge.c:401
 msgid "Already up to date. (nothing to squash)"
 msgstr "Bereits auf dem neuesten Stand. (nichts für Squash-Merge vorhanden)"
 
-#: builtin/merge.c:414
+#: builtin/merge.c:415
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
 msgstr "Squash Commit -- HEAD wird nicht aktualisiert\n"
 
-#: builtin/merge.c:464
+#: builtin/merge.c:465
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
 msgstr "Keine Merge-Commit-Beschreibung -- HEAD wird nicht aktualisiert\n"
@@ -18126,33 +18452,33 @@ msgstr "'%s' zeigt auf keinen Commit"
 msgid "Bad branch.%s.mergeoptions string: %s"
 msgstr "Ungültiger branch.%s.mergeoptions String: %s"
 
-#: builtin/merge.c:729
+#: builtin/merge.c:730
 msgid "Not handling anything other than two heads merge."
 msgstr "Es wird nur der Merge von zwei Branches behandelt."
 
-#: builtin/merge.c:742
-#, c-format
-msgid "Unknown option for merge-recursive: -X%s"
-msgstr "Unbekannte Option für merge-recursive: -X%s"
+#: builtin/merge.c:743
+#, fuzzy, c-format
+msgid "unknown strategy option: -X%s"
+msgstr "Unbekannte Option: %s\n"
 
-#: builtin/merge.c:761 t/helper/test-fast-rebase.c:223
+#: builtin/merge.c:762 t/helper/test-fast-rebase.c:223
 #, c-format
 msgid "unable to write %s"
 msgstr "konnte %s nicht schreiben"
 
-#: builtin/merge.c:813
+#: builtin/merge.c:814
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "konnte nicht von '%s' lesen"
 
-#: builtin/merge.c:822
+#: builtin/merge.c:823
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
 "Merge wurde nicht committet; benutzen Sie 'git commit', um den Merge "
 "abzuschließen.\n"
 
-#: builtin/merge.c:828
+#: builtin/merge.c:829
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
@@ -18163,11 +18489,11 @@ msgstr ""
 "Upstream-Branch mit einem Thema-Branch zusammenführt.\n"
 "\n"
 
-#: builtin/merge.c:833
+#: builtin/merge.c:834
 msgid "An empty message aborts the commit.\n"
 msgstr "Eine leere Commit-Beschreibung bricht den Commit ab.\n"
 
-#: builtin/merge.c:836
+#: builtin/merge.c:837
 #, c-format
 msgid ""
 "Lines starting with '%c' will be ignored, and an empty message aborts\n"
@@ -18176,75 +18502,75 @@ msgstr ""
 "Zeilen, die mit '%c' beginnen, werden ignoriert,\n"
 "und eine leere Beschreibung bricht den Commit ab.\n"
 
-#: builtin/merge.c:889
+#: builtin/merge.c:892
 msgid "Empty commit message."
 msgstr "Leere Commit-Beschreibung"
 
-#: builtin/merge.c:904
+#: builtin/merge.c:907
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Wunderbar.\n"
 
-#: builtin/merge.c:965
+#: builtin/merge.c:968
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
 "Automatischer Merge fehlgeschlagen; beheben Sie die Konflikte und committen "
 "Sie dann das Ergebnis.\n"
 
-#: builtin/merge.c:1004
+#: builtin/merge.c:1007
 msgid "No current branch."
 msgstr "Sie befinden sich auf keinem Branch."
 
-#: builtin/merge.c:1006
+#: builtin/merge.c:1009
 msgid "No remote for the current branch."
 msgstr "Kein Remote-Repository für den aktuellen Branch."
 
-#: builtin/merge.c:1008
+#: builtin/merge.c:1011
 msgid "No default upstream defined for the current branch."
 msgstr ""
 "Es ist kein Standard-Upstream-Branch für den aktuellen Branch definiert."
 
-#: builtin/merge.c:1013
+#: builtin/merge.c:1016
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "Kein Remote-Tracking-Branch für %s von %s"
 
-#: builtin/merge.c:1070
+#: builtin/merge.c:1073
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Fehlerhafter Wert '%s' in Umgebungsvariable '%s'"
 
-#: builtin/merge.c:1173
+#: builtin/merge.c:1174
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "nichts was wir in %s zusammenführen können: %s"
 
-#: builtin/merge.c:1207
+#: builtin/merge.c:1208
 msgid "not something we can merge"
 msgstr "nichts was wir zusammenführen können"
 
-#: builtin/merge.c:1317
+#: builtin/merge.c:1321
 msgid "--abort expects no arguments"
 msgstr "--abort akzeptiert keine Argumente"
 
-#: builtin/merge.c:1321
+#: builtin/merge.c:1325
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr "Es gibt keinen Merge abzubrechen (MERGE_HEAD fehlt)"
 
-#: builtin/merge.c:1339
+#: builtin/merge.c:1343
 msgid "--quit expects no arguments"
 msgstr "--quit erwartet keine Argumente"
 
-#: builtin/merge.c:1352
+#: builtin/merge.c:1356
 msgid "--continue expects no arguments"
 msgstr "--continue erwartet keine Argumente"
 
-#: builtin/merge.c:1356
+#: builtin/merge.c:1360
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "Es ist kein Merge im Gange (MERGE_HEAD fehlt)."
 
-#: builtin/merge.c:1372
+#: builtin/merge.c:1376
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -18252,7 +18578,7 @@ msgstr ""
 "Sie haben Ihren Merge nicht abgeschlossen (MERGE_HEAD existiert).\n"
 "Bitte committen Sie Ihre Änderungen, bevor Sie den Merge ausführen."
 
-#: builtin/merge.c:1379
+#: builtin/merge.c:1383
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -18260,91 +18586,87 @@ msgstr ""
 "Sie haben \"cherry-pick\" nicht abgeschlossen (CHERRY_PICK_HEAD existiert).\n"
 "Bitte committen Sie Ihre Änderungen, bevor Sie den Merge ausführen."
 
-#: builtin/merge.c:1382
+#: builtin/merge.c:1386
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr ""
 "Sie haben \"cherry-pick\" nicht abgeschlossen (CHERRY_PICK_HEAD existiert)."
 
-#: builtin/merge.c:1396
+#: builtin/merge.c:1400
 msgid "You cannot combine --squash with --no-ff."
 msgstr "Sie können --squash nicht mit --no-ff kombinieren."
 
-#: builtin/merge.c:1398
+#: builtin/merge.c:1402
 msgid "You cannot combine --squash with --commit."
 msgstr "Sie können --squash nicht mit --commit kombinieren."
 
-#: builtin/merge.c:1414
+#: builtin/merge.c:1418
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr "Kein Commit angegeben und merge.defaultToUpstream ist nicht gesetzt."
 
-#: builtin/merge.c:1431
+#: builtin/merge.c:1435
 msgid "Squash commit into empty head not supported yet"
 msgstr "Squash-Merge auf einen leeren Branch wird noch nicht unterstützt"
 
-#: builtin/merge.c:1433
+#: builtin/merge.c:1437
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr ""
 "Nicht vorzuspulender Commit kann nicht in einem leeren Branch verwendet "
 "werden."
 
-#: builtin/merge.c:1438
+#: builtin/merge.c:1442
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "%s - nichts was wir zusammenführen können"
 
-#: builtin/merge.c:1440
+#: builtin/merge.c:1444
 msgid "Can merge only exactly one commit into empty head"
 msgstr "Kann nur exakt einen Commit in einem leeren Branch zusammenführen"
 
-#: builtin/merge.c:1521
+#: builtin/merge.c:1531
 msgid "refusing to merge unrelated histories"
 msgstr "verweigere den Merge von nicht zusammenhängenden Historien"
 
-#: builtin/merge.c:1540
+#: builtin/merge.c:1550
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "Aktualisiere %s..%s\n"
 
-#: builtin/merge.c:1587
+#: builtin/merge.c:1598
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "Probiere wirklich trivialen \"in-index\"-Merge ...\n"
 
-#: builtin/merge.c:1594
+#: builtin/merge.c:1605
 #, c-format
 msgid "Nope.\n"
 msgstr "Nein.\n"
 
-#: builtin/merge.c:1625
-msgid "Not possible to fast-forward, aborting."
-msgstr "Vorspulen nicht möglich, breche ab."
-
-#: builtin/merge.c:1653 builtin/merge.c:1719
+#: builtin/merge.c:1664 builtin/merge.c:1730
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "Rücklauf des Verzeichnisses bis zum Ursprung ...\n"
 
-#: builtin/merge.c:1657
+#: builtin/merge.c:1668
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Probiere Merge-Strategie %s ...\n"
 
-#: builtin/merge.c:1709
+#: builtin/merge.c:1720
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Keine Merge-Strategie behandelt diesen Merge.\n"
 
-#: builtin/merge.c:1711
+#: builtin/merge.c:1722
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "Merge mit Strategie %s fehlgeschlagen.\n"
 
-#: builtin/merge.c:1721
+#: builtin/merge.c:1732
 #, c-format
 msgid "Using the %s strategy to prepare resolving by hand.\n"
 msgstr "Benutze die Strategie %s, um die Auflösung per Hand vorzubereiten.\n"
 
-#: builtin/merge.c:1735
+#: builtin/merge.c:1746
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
@@ -18379,16 +18701,16 @@ msgstr "konnte getaggtes Objekt '%s' nicht lesen"
 msgid "object '%s' tagged as '%s', but is a '%s' type"
 msgstr "Objekt '%s' als '%s' getaggt, aber ist ein '%s' Typ"
 
-#: builtin/mktag.c:97
+#: builtin/mktag.c:98
 msgid "tag on stdin did not pass our strict fsck check"
 msgstr ""
 "Tag von der Standardeingabe für unsere strenge Überprüfung bei fsck ungültig"
 
-#: builtin/mktag.c:100
+#: builtin/mktag.c:101
 msgid "tag on stdin did not refer to a valid object"
 msgstr "Tag von der Standard-Eingabe verweiste nicht auf gültiges Objekt"
 
-#: builtin/mktag.c:103 builtin/tag.c:243
+#: builtin/mktag.c:104 builtin/tag.c:243
 msgid "unable to write tag file"
 msgstr "konnte Tag-Datei nicht schreiben"
 
@@ -18409,47 +18731,59 @@ msgid "allow creation of more than one tree"
 msgstr "die Erstellung von mehr als einem \"Tree\"-Objekt erlauben"
 
 #: builtin/multi-pack-index.c:10
-msgid "git multi-pack-index [<options>] write [--preferred-pack=<pack>]"
+#, fuzzy
+msgid ""
+"git multi-pack-index [<options>] write [--preferred-pack=<pack>][--refs-"
+"snapshot=<path>]"
 msgstr "git multi-pack-index [<Optionen>] write [--preferred-pack=<Paket>]"
 
-#: builtin/multi-pack-index.c:13
+#: builtin/multi-pack-index.c:14
 msgid "git multi-pack-index [<options>] verify"
 msgstr "git multi-pack-index [<Optionen>] verify"
 
-#: builtin/multi-pack-index.c:16
+#: builtin/multi-pack-index.c:17
 msgid "git multi-pack-index [<options>] expire"
 msgstr "git multi-pack-index [<Optionen>] expire"
 
-#: builtin/multi-pack-index.c:19
+#: builtin/multi-pack-index.c:20
 msgid "git multi-pack-index [<options>] repack [--batch-size=<size>]"
 msgstr "git multi-pack-index [<Optionen>] repack [--batch-size=<Größe>]"
 
-#: builtin/multi-pack-index.c:54
+#: builtin/multi-pack-index.c:57
 msgid "object directory containing set of packfile and pack-index pairs"
 msgstr ""
 "Objekt-Verzeichnis, welches Paare von Packdateien und pack-index enthält"
 
-#: builtin/multi-pack-index.c:69
+#: builtin/multi-pack-index.c:98
 msgid "preferred-pack"
 msgstr "bevorzugtes Paket"
 
-#: builtin/multi-pack-index.c:70
+#: builtin/multi-pack-index.c:99
 msgid "pack for reuse when computing a multi-pack bitmap"
 msgstr ""
 "Paket für die Wiederbenutzung, wenn eine Multi-Pack Bitmap berechnet wird"
 
-#: builtin/multi-pack-index.c:128
+#: builtin/multi-pack-index.c:100
+#, fuzzy
+msgid "write multi-pack bitmap"
+msgstr "Fehler beim Schreiben des multi-pack-index"
+
+#: builtin/multi-pack-index.c:105
+#, fuzzy
+msgid "write multi-pack index containing only given indexes"
+msgstr "git multi-pack-index [<Optionen>] verify"
+
+#: builtin/multi-pack-index.c:107
+msgid "refs snapshot for selecting bitmap commits"
+msgstr ""
+
+#: builtin/multi-pack-index.c:202
 msgid ""
 "during repack, collect pack-files of smaller size into a batch that is "
 "larger than this size"
 msgstr ""
 "Während des Umpackens, sammle Paket-Dateien von geringerer Größe in "
 "einenStapel, welcher größer ist als diese Größe"
-
-#: builtin/multi-pack-index.c:179
-#, c-format
-msgid "unrecognized subcommand: %s"
-msgstr "Nicht erkannter Unterbefehl: %s"
 
 #: builtin/mv.c:18
 msgid "git mv [<options>] <source>... <destination>"
@@ -18480,72 +18814,72 @@ msgstr "Verschieben/Umbenennen erzwingen, auch wenn das Ziel existiert"
 msgid "skip move/rename errors"
 msgstr "Fehler beim Verschieben oder Umbenennen überspringen"
 
-#: builtin/mv.c:170
+#: builtin/mv.c:172
 #, c-format
 msgid "destination '%s' is not a directory"
 msgstr "Ziel '%s' ist kein Verzeichnis"
 
-#: builtin/mv.c:181
+#: builtin/mv.c:184
 #, c-format
 msgid "Checking rename of '%s' to '%s'\n"
 msgstr "Prüfe Umbenennung von '%s' nach '%s'\n"
 
-#: builtin/mv.c:185
+#: builtin/mv.c:190
 msgid "bad source"
 msgstr "ungültige Quelle"
 
-#: builtin/mv.c:188
+#: builtin/mv.c:193
 msgid "can not move directory into itself"
 msgstr "kann Verzeichnis nicht in sich selbst verschieben"
 
-#: builtin/mv.c:191
+#: builtin/mv.c:196
 msgid "cannot move directory over file"
 msgstr "kann Verzeichnis nicht über Datei verschieben"
 
-#: builtin/mv.c:200
+#: builtin/mv.c:205
 msgid "source directory is empty"
 msgstr "Quellverzeichnis ist leer"
 
-#: builtin/mv.c:225
+#: builtin/mv.c:231
 msgid "not under version control"
 msgstr "nicht unter Versionskontrolle"
 
-#: builtin/mv.c:227
+#: builtin/mv.c:233
 msgid "conflicted"
 msgstr "in Konflikt"
 
-#: builtin/mv.c:230
+#: builtin/mv.c:236
 msgid "destination exists"
 msgstr "Ziel existiert bereits"
 
-#: builtin/mv.c:238
+#: builtin/mv.c:244
 #, c-format
 msgid "overwriting '%s'"
 msgstr "überschreibe '%s'"
 
-#: builtin/mv.c:241
+#: builtin/mv.c:247
 msgid "Cannot overwrite"
 msgstr "Kann nicht überschreiben"
 
-#: builtin/mv.c:244
+#: builtin/mv.c:250
 msgid "multiple sources for the same target"
 msgstr "mehrere Quellen für dasselbe Ziel"
 
-#: builtin/mv.c:246
+#: builtin/mv.c:252
 msgid "destination directory does not exist"
 msgstr "Zielverzeichnis existiert nicht"
 
-#: builtin/mv.c:253
+#: builtin/mv.c:280
 #, c-format
 msgid "%s, source=%s, destination=%s"
 msgstr "%s, Quelle=%s, Ziel=%s"
 
-#: builtin/mv.c:274
+#: builtin/mv.c:308
 #, c-format
 msgid "Renaming %s to %s\n"
 msgstr "Benenne %s nach %s um\n"
 
-#: builtin/mv.c:280 builtin/remote.c:785 builtin/repack.c:667
+#: builtin/mv.c:314 builtin/remote.c:790 builtin/repack.c:853
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "Umbenennung von '%s' fehlgeschlagen"
@@ -18724,48 +19058,48 @@ msgstr "Konnte Ausgabe von 'show' nicht lesen."
 msgid "failed to finish 'show' for object '%s'"
 msgstr "konnte 'show' für Objekt '%s' nicht abschließen"
 
-#: builtin/notes.c:197
+#: builtin/notes.c:195
 msgid "please supply the note contents using either -m or -F option"
 msgstr ""
 "Bitte liefern Sie die Notiz-Inhalte unter Verwendung der Option -m oder -F."
 
-#: builtin/notes.c:206
+#: builtin/notes.c:204
 msgid "unable to write note object"
 msgstr "Konnte Notiz-Objekt nicht schreiben"
 
-#: builtin/notes.c:208
+#: builtin/notes.c:206
 #, c-format
 msgid "the note contents have been left in %s"
 msgstr "Die Notiz-Inhalte wurden in %s belassen."
 
-#: builtin/notes.c:242 builtin/tag.c:576
+#: builtin/notes.c:240 builtin/tag.c:577
 #, c-format
 msgid "could not open or read '%s'"
 msgstr "konnte '%s' nicht öffnen oder lesen"
 
-#: builtin/notes.c:263 builtin/notes.c:313 builtin/notes.c:315
-#: builtin/notes.c:383 builtin/notes.c:438 builtin/notes.c:526
-#: builtin/notes.c:531 builtin/notes.c:610 builtin/notes.c:672
+#: builtin/notes.c:261 builtin/notes.c:311 builtin/notes.c:313
+#: builtin/notes.c:381 builtin/notes.c:436 builtin/notes.c:524
+#: builtin/notes.c:529 builtin/notes.c:608 builtin/notes.c:670
 #, c-format
 msgid "failed to resolve '%s' as a valid ref."
 msgstr "Konnte '%s' nicht als gültige Referenz auflösen."
 
-#: builtin/notes.c:265
+#: builtin/notes.c:263
 #, c-format
 msgid "failed to read object '%s'."
 msgstr "Fehler beim Lesen des Objektes '%s'."
 
-#: builtin/notes.c:268
+#: builtin/notes.c:266
 #, c-format
 msgid "cannot read note data from non-blob object '%s'."
 msgstr "Kann Notiz-Daten nicht von Nicht-Blob Objekt '%s' lesen."
 
-#: builtin/notes.c:309
+#: builtin/notes.c:307
 #, c-format
 msgid "malformed input line: '%s'."
 msgstr "Fehlerhafte Eingabezeile: '%s'."
 
-#: builtin/notes.c:324
+#: builtin/notes.c:322
 #, c-format
 msgid "failed to copy notes from '%s' to '%s'"
 msgstr "Fehler beim Kopieren der Notizen von '%s' nach '%s'"
@@ -18773,50 +19107,50 @@ msgstr "Fehler beim Kopieren der Notizen von '%s' nach '%s'"
 #. TRANSLATORS: the first %s will be replaced by a git
 #. notes command: 'add', 'merge', 'remove', etc.
 #.
-#: builtin/notes.c:356
+#: builtin/notes.c:354
 #, c-format
 msgid "refusing to %s notes in %s (outside of refs/notes/)"
 msgstr ""
 "Ausführung von %s auf Notizen in %s (außerhalb von refs/notes/) "
 "zurückgewiesen"
 
-#: builtin/notes.c:376 builtin/notes.c:431 builtin/notes.c:509
-#: builtin/notes.c:521 builtin/notes.c:598 builtin/notes.c:665
-#: builtin/notes.c:815 builtin/notes.c:963 builtin/notes.c:985
-#: builtin/prune-packed.c:25 builtin/tag.c:586
+#: builtin/notes.c:374 builtin/notes.c:429 builtin/notes.c:507
+#: builtin/notes.c:519 builtin/notes.c:596 builtin/notes.c:663
+#: builtin/notes.c:813 builtin/notes.c:961 builtin/notes.c:983
+#: builtin/prune-packed.c:25 builtin/tag.c:587
 msgid "too many arguments"
 msgstr "Zu viele Argumente."
 
-#: builtin/notes.c:389 builtin/notes.c:678
+#: builtin/notes.c:387 builtin/notes.c:676
 #, c-format
 msgid "no note found for object %s."
 msgstr "Keine Notiz für Objekt %s gefunden."
 
-#: builtin/notes.c:410 builtin/notes.c:576
+#: builtin/notes.c:408 builtin/notes.c:574
 msgid "note contents as a string"
 msgstr "Notizinhalte als Zeichenkette"
 
-#: builtin/notes.c:413 builtin/notes.c:579
+#: builtin/notes.c:411 builtin/notes.c:577
 msgid "note contents in a file"
 msgstr "Notizinhalte in einer Datei"
 
-#: builtin/notes.c:416 builtin/notes.c:582
+#: builtin/notes.c:414 builtin/notes.c:580
 msgid "reuse and edit specified note object"
 msgstr "Wiederverwendung und Bearbeitung des angegebenen Notiz-Objektes"
 
-#: builtin/notes.c:419 builtin/notes.c:585
+#: builtin/notes.c:417 builtin/notes.c:583
 msgid "reuse specified note object"
 msgstr "Wiederverwendung des angegebenen Notiz-Objektes"
 
-#: builtin/notes.c:422 builtin/notes.c:588
+#: builtin/notes.c:420 builtin/notes.c:586
 msgid "allow storing empty note"
 msgstr "Speichern leerer Notiz erlauben"
 
-#: builtin/notes.c:423 builtin/notes.c:496
+#: builtin/notes.c:421 builtin/notes.c:494
 msgid "replace existing notes"
 msgstr "existierende Notizen ersetzen"
 
-#: builtin/notes.c:448
+#: builtin/notes.c:446
 #, c-format
 msgid ""
 "Cannot add notes. Found existing notes for object %s. Use '-f' to overwrite "
@@ -18825,31 +19159,31 @@ msgstr ""
 "Konnte Notizen nicht hinzufügen. Existierende Notizen für Objekt %s "
 "gefunden. Verwenden Sie '-f', um die existierenden Notizen zu überschreiben."
 
-#: builtin/notes.c:463 builtin/notes.c:544
+#: builtin/notes.c:461 builtin/notes.c:542
 #, c-format
 msgid "Overwriting existing notes for object %s\n"
 msgstr "Überschreibe existierende Notizen für Objekt %s\n"
 
-#: builtin/notes.c:475 builtin/notes.c:637 builtin/notes.c:902
+#: builtin/notes.c:473 builtin/notes.c:635 builtin/notes.c:900
 #, c-format
 msgid "Removing note for object %s\n"
 msgstr "Entferne Notiz für Objekt %s\n"
 
-#: builtin/notes.c:497
+#: builtin/notes.c:495
 msgid "read objects from stdin"
 msgstr "Objekte von der Standard-Eingabe lesen"
 
-#: builtin/notes.c:499
+#: builtin/notes.c:497
 msgid "load rewriting config for <command> (implies --stdin)"
 msgstr ""
 "Konfiguration für <Befehl> zum Umschreiben von Commits laden (impliziert --"
 "stdin)"
 
-#: builtin/notes.c:517
+#: builtin/notes.c:515
 msgid "too few arguments"
 msgstr "zu wenige Argumente"
 
-#: builtin/notes.c:538
+#: builtin/notes.c:536
 #, c-format
 msgid ""
 "Cannot copy notes. Found existing notes for object %s. Use '-f' to overwrite "
@@ -18858,12 +19192,12 @@ msgstr ""
 "Kann Notizen nicht kopieren. Existierende Notizen für Objekt %s gefunden. "
 "Verwenden Sie '-f', um die existierenden Notizen zu überschreiben."
 
-#: builtin/notes.c:550
+#: builtin/notes.c:548
 #, c-format
 msgid "missing notes on source object %s. Cannot copy."
 msgstr "Keine Notizen für Quell-Objekt %s. Kopie nicht möglich."
 
-#: builtin/notes.c:603
+#: builtin/notes.c:601
 #, c-format
 msgid ""
 "The -m/-F/-c/-C options have been deprecated for the 'edit' subcommand.\n"
@@ -18872,52 +19206,52 @@ msgstr ""
 "Die Optionen -m/-F/-c/-C sind für den Unterbefehl 'edit' veraltet.\n"
 "Bitte benutzen Sie stattdessen 'git notes add -f -m/-F/-c/-C'.\n"
 
-#: builtin/notes.c:698
+#: builtin/notes.c:696
 msgid "failed to delete ref NOTES_MERGE_PARTIAL"
 msgstr "Fehler beim Löschen der Referenz NOTES_MERGE_PARTIAL"
 
-#: builtin/notes.c:700
+#: builtin/notes.c:698
 msgid "failed to delete ref NOTES_MERGE_REF"
 msgstr "Fehler beim Löschen der Referenz NOTES_MERGE_REF"
 
-#: builtin/notes.c:702
+#: builtin/notes.c:700
 msgid "failed to remove 'git notes merge' worktree"
 msgstr "Fehler beim Löschen des Arbeitsverzeichnisses von 'git notes merge'."
 
-#: builtin/notes.c:722
+#: builtin/notes.c:720
 msgid "failed to read ref NOTES_MERGE_PARTIAL"
 msgstr "Fehler beim Lesen der Referenz NOTES_MERGE_PARTIAL"
 
-#: builtin/notes.c:724
+#: builtin/notes.c:722
 msgid "could not find commit from NOTES_MERGE_PARTIAL."
 msgstr "Konnte Commit von NOTES_MERGE_PARTIAL nicht finden."
 
-#: builtin/notes.c:726
+#: builtin/notes.c:724
 msgid "could not parse commit from NOTES_MERGE_PARTIAL."
 msgstr "Konnte Commit von NOTES_MERGE_PARTIAL nicht parsen."
 
-#: builtin/notes.c:739
+#: builtin/notes.c:737
 msgid "failed to resolve NOTES_MERGE_REF"
 msgstr "Fehler beim Auflösen von NOTES_MERGE_REF"
 
-#: builtin/notes.c:742
+#: builtin/notes.c:740
 msgid "failed to finalize notes merge"
 msgstr "Fehler beim Abschließen der Zusammenführung der Notizen."
 
-#: builtin/notes.c:768
+#: builtin/notes.c:766
 #, c-format
 msgid "unknown notes merge strategy %s"
 msgstr "unbekannte Merge-Strategie '%s' für Notizen"
 
-#: builtin/notes.c:784
+#: builtin/notes.c:782
 msgid "General options"
 msgstr "Allgemeine Optionen"
 
-#: builtin/notes.c:786
+#: builtin/notes.c:784
 msgid "Merge options"
 msgstr "Merge-Optionen"
 
-#: builtin/notes.c:788
+#: builtin/notes.c:786
 msgid ""
 "resolve notes conflicts using the given strategy (manual/ours/theirs/union/"
 "cat_sort_uniq)"
@@ -18925,49 +19259,49 @@ msgstr ""
 "löst Konflikte bei Notizen mit der angegebenen Strategie auf (manual/ours/"
 "theirs/union/cat_sort_uniq)"
 
-#: builtin/notes.c:790
+#: builtin/notes.c:788
 msgid "Committing unmerged notes"
 msgstr "nicht zusammengeführte Notizen eintragen"
 
-#: builtin/notes.c:792
+#: builtin/notes.c:790
 msgid "finalize notes merge by committing unmerged notes"
 msgstr ""
 "Merge von Notizen abschließen, in dem nicht zusammengeführte Notizen "
 "committet werden"
 
-#: builtin/notes.c:794
+#: builtin/notes.c:792
 msgid "Aborting notes merge resolution"
 msgstr "Konfliktauflösung beim Merge von Notizen abbrechen"
 
-#: builtin/notes.c:796
+#: builtin/notes.c:794
 msgid "abort notes merge"
 msgstr "Merge von Notizen abbrechen"
 
-#: builtin/notes.c:807
+#: builtin/notes.c:805
 msgid "cannot mix --commit, --abort or -s/--strategy"
 msgstr "Kann --commit, --abort oder -s/--strategy nicht kombinieren."
 
-#: builtin/notes.c:812
+#: builtin/notes.c:810
 msgid "must specify a notes ref to merge"
 msgstr "Sie müssen eine Notiz-Referenz zum Mergen angeben."
 
-#: builtin/notes.c:836
+#: builtin/notes.c:834
 #, c-format
 msgid "unknown -s/--strategy: %s"
 msgstr "Unbekannter Wert für -s/--strategy: %s"
 
-#: builtin/notes.c:873
+#: builtin/notes.c:871
 #, c-format
 msgid "a notes merge into %s is already in-progress at %s"
 msgstr "Ein Merge von Notizen nach %s ist bereits im Gange bei %s"
 
-#: builtin/notes.c:876
+#: builtin/notes.c:874
 #, c-format
 msgid "failed to store link to current notes ref (%s)"
 msgstr ""
 "Fehler beim Speichern der Verknüpfung zur aktuellen Notes-Referenz (%s)"
 
-#: builtin/notes.c:878
+#: builtin/notes.c:876
 #, c-format
 msgid ""
 "Automatic notes merge failed. Fix conflicts in %s and commit the result with "
@@ -18979,41 +19313,41 @@ msgstr ""
 "commit',\n"
 "oder brechen Sie den Merge mit 'git notes merge --abort' ab.\n"
 
-#: builtin/notes.c:897 builtin/tag.c:589
+#: builtin/notes.c:895 builtin/tag.c:590
 #, c-format
 msgid "Failed to resolve '%s' as a valid ref."
 msgstr "Konnte '%s' nicht als gültige Referenz auflösen."
 
-#: builtin/notes.c:900
+#: builtin/notes.c:898
 #, c-format
 msgid "Object %s has no note\n"
 msgstr "Objekt %s hat keine Notiz\n"
 
-#: builtin/notes.c:912
+#: builtin/notes.c:910
 msgid "attempt to remove non-existent note is not an error"
 msgstr "der Versuch, eine nicht existierende Notiz zu löschen, ist kein Fehler"
 
-#: builtin/notes.c:915
+#: builtin/notes.c:913
 msgid "read object names from the standard input"
 msgstr "Objektnamen von der Standard-Eingabe lesen"
 
-#: builtin/notes.c:954 builtin/prune.c:132 builtin/worktree.c:146
+#: builtin/notes.c:952 builtin/prune.c:132 builtin/worktree.c:147
 msgid "do not remove, show only"
 msgstr "nicht löschen, nur anzeigen"
 
-#: builtin/notes.c:955
+#: builtin/notes.c:953
 msgid "report pruned notes"
 msgstr "gelöschte Notizen melden"
 
-#: builtin/notes.c:998
+#: builtin/notes.c:996
 msgid "notes-ref"
 msgstr "Notiz-Referenz"
 
-#: builtin/notes.c:999
+#: builtin/notes.c:997
 msgid "use notes from <notes-ref>"
 msgstr "Notizen von <Notiz-Referenz> verwenden"
 
-#: builtin/notes.c:1034 builtin/stash.c:1735
+#: builtin/notes.c:1032 builtin/stash.c:1752
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr "Unbekannter Unterbefehl: %s"
@@ -19066,86 +19400,91 @@ msgstr "%u Objekte geordnet, %<PRIu32> erwartet."
 msgid "expected object at offset %<PRIuMAX> in pack %s"
 msgstr "Objekt beim Offset %<PRIuMAX> in Paket %s erwartet"
 
-#: builtin/pack-objects.c:1155
+#: builtin/pack-objects.c:1160
 msgid "disabling bitmap writing, packs are split due to pack.packSizeLimit"
 msgstr ""
 "Deaktiviere Schreiben der Bitmap, Pakete wurden durch pack.packSizeLimit\n"
 "aufgetrennt."
 
-#: builtin/pack-objects.c:1168
+#: builtin/pack-objects.c:1173
 msgid "Writing objects"
 msgstr "Schreibe Objekte"
 
-#: builtin/pack-objects.c:1229 builtin/update-index.c:90
+#: builtin/pack-objects.c:1235 builtin/update-index.c:90
 #, c-format
 msgid "failed to stat %s"
 msgstr "Konnte '%s' nicht lesen"
 
-#: builtin/pack-objects.c:1281
+#: builtin/pack-objects.c:1268
+#, fuzzy
+msgid "failed to write bitmap index"
+msgstr "Bitmap-Index schreiben"
+
+#: builtin/pack-objects.c:1294
 #, c-format
 msgid "wrote %<PRIu32> objects while expecting %<PRIu32>"
 msgstr "Schrieb %<PRIu32> Objekte während %<PRIu32> erwartet waren."
 
-#: builtin/pack-objects.c:1523
+#: builtin/pack-objects.c:1536
 msgid "disabling bitmap writing, as some objects are not being packed"
 msgstr ""
 "Deaktiviere Schreiben der Bitmap, da einige Objekte nicht in eine Pack-"
 "Datei\n"
 "geschrieben wurden."
 
-#: builtin/pack-objects.c:1971
+#: builtin/pack-objects.c:1984
 #, c-format
 msgid "delta base offset overflow in pack for %s"
 msgstr "\"delta base offset\" Überlauf in Paket für %s"
 
-#: builtin/pack-objects.c:1980
+#: builtin/pack-objects.c:1993
 #, c-format
 msgid "delta base offset out of bound for %s"
 msgstr "\"delta base offset\" liegt außerhalb des gültigen Bereichs für %s"
 
-#: builtin/pack-objects.c:2261
+#: builtin/pack-objects.c:2274
 msgid "Counting objects"
 msgstr "Zähle Objekte"
 
-#: builtin/pack-objects.c:2426
+#: builtin/pack-objects.c:2439
 #, c-format
 msgid "unable to parse object header of %s"
 msgstr "Konnte Kopfbereich von Objekt '%s' nicht parsen."
 
-#: builtin/pack-objects.c:2496 builtin/pack-objects.c:2512
-#: builtin/pack-objects.c:2522
+#: builtin/pack-objects.c:2509 builtin/pack-objects.c:2525
+#: builtin/pack-objects.c:2535
 #, c-format
 msgid "object %s cannot be read"
 msgstr "Objekt %s kann nicht gelesen werden."
 
-#: builtin/pack-objects.c:2499 builtin/pack-objects.c:2526
+#: builtin/pack-objects.c:2512 builtin/pack-objects.c:2539
 #, c-format
 msgid "object %s inconsistent object length (%<PRIuMAX> vs %<PRIuMAX>)"
 msgstr "Inkonsistente Objektlänge bei Objekt %s (%<PRIuMAX> vs %<PRIuMAX>)"
 
-#: builtin/pack-objects.c:2536
+#: builtin/pack-objects.c:2549
 msgid "suboptimal pack - out of memory"
 msgstr "ungünstiges Packet - Speicher voll"
 
-#: builtin/pack-objects.c:2851
+#: builtin/pack-objects.c:2864
 #, c-format
 msgid "Delta compression using up to %d threads"
 msgstr "Delta-Kompression verwendet bis zu %d Threads."
 
-#: builtin/pack-objects.c:2990
+#: builtin/pack-objects.c:3003
 #, c-format
 msgid "unable to pack objects reachable from tag %s"
 msgstr "Konnte keine Objekte packen, die von Tag %s erreichbar sind."
 
-#: builtin/pack-objects.c:3076
+#: builtin/pack-objects.c:3089
 msgid "Compressing objects"
 msgstr "Komprimiere Objekte"
 
-#: builtin/pack-objects.c:3082
+#: builtin/pack-objects.c:3095
 msgid "inconsistency with delta count"
 msgstr "Inkonsistenz mit der Anzahl von Deltas"
 
-#: builtin/pack-objects.c:3161
+#: builtin/pack-objects.c:3174
 #, c-format
 msgid ""
 "value of uploadpack.blobpackfileuri must be of the form '<object-hash> <pack-"
@@ -19154,7 +19493,7 @@ msgstr ""
 "Wert für uploadpack.blobpackfileuri muss in der Form '<Objekt-Hash> <Pack-"
 "Hash> <URI>' vorliegen ('%s' erhalten)"
 
-#: builtin/pack-objects.c:3164
+#: builtin/pack-objects.c:3177
 #, c-format
 msgid ""
 "object already configured in another uploadpack.blobpackfileuri (got '%s')"
@@ -19162,17 +19501,18 @@ msgstr ""
 "Objekt bereits in einem anderen uploadpack.blobpackfileuri konfiguriert "
 "('%s' erhalten)"
 
-#: builtin/pack-objects.c:3199
+#: builtin/pack-objects.c:3212
 #, c-format
 msgid "could not get type of object %s in pack %s"
 msgstr "konnte Typ von Objekt %s in Paket %s nicht bestimmen"
 
-#: builtin/pack-objects.c:3321 builtin/pack-objects.c:3335
+#: builtin/pack-objects.c:3340 builtin/pack-objects.c:3351
+#: builtin/pack-objects.c:3365
 #, c-format
 msgid "could not find pack '%s'"
 msgstr "Konnte Paket '%s' nicht finden"
 
-#: builtin/pack-objects.c:3378
+#: builtin/pack-objects.c:3408
 #, c-format
 msgid ""
 "expected edge object ID, got garbage:\n"
@@ -19181,7 +19521,7 @@ msgstr ""
 "erwartete Randobjekt-ID, erhielt nutzlose Daten:\n"
 " %s"
 
-#: builtin/pack-objects.c:3384
+#: builtin/pack-objects.c:3414
 #, c-format
 msgid ""
 "expected object ID, got garbage:\n"
@@ -19190,263 +19530,263 @@ msgstr ""
 "erwartete Objekt-ID, erhielt nutzlose Daten:\n"
 " %s"
 
-#: builtin/pack-objects.c:3482
+#: builtin/pack-objects.c:3507
 msgid "invalid value for --missing"
 msgstr "ungültiger Wert für --missing"
 
-#: builtin/pack-objects.c:3541 builtin/pack-objects.c:3650
+#: builtin/pack-objects.c:3532 builtin/pack-objects.c:3619
 msgid "cannot open pack index"
 msgstr "kann Paketindex nicht öffnen"
 
-#: builtin/pack-objects.c:3572
+#: builtin/pack-objects.c:3541
 #, c-format
 msgid "loose object at %s could not be examined"
 msgstr "loses Objekt bei %s konnte nicht untersucht werden"
 
-#: builtin/pack-objects.c:3658
+#: builtin/pack-objects.c:3627
 msgid "unable to force loose object"
 msgstr "konnte loses Objekt nicht erzwingen"
 
-#: builtin/pack-objects.c:3788
+#: builtin/pack-objects.c:3757
 #, c-format
 msgid "not a rev '%s'"
 msgstr "'%s' ist kein Commit"
 
-#: builtin/pack-objects.c:3791 builtin/rev-parse.c:1061
+#: builtin/pack-objects.c:3760 builtin/rev-parse.c:1061
 #, c-format
 msgid "bad revision '%s'"
 msgstr "ungültiger Commit '%s'"
 
-#: builtin/pack-objects.c:3819
+#: builtin/pack-objects.c:3788
 msgid "unable to add recent objects"
 msgstr "konnte neuere Objekte nicht hinzufügen"
 
-#: builtin/pack-objects.c:3872
+#: builtin/pack-objects.c:3841
 #, c-format
 msgid "unsupported index version %s"
 msgstr "nicht unterstützte Index-Version %s"
 
-#: builtin/pack-objects.c:3876
+#: builtin/pack-objects.c:3845
 #, c-format
 msgid "bad index version '%s'"
 msgstr "ungültige Index-Version '%s'"
 
-#: builtin/pack-objects.c:3915
+#: builtin/pack-objects.c:3884
 msgid "<version>[,<offset>]"
 msgstr "<Version>[,<Offset>]"
 
-#: builtin/pack-objects.c:3916
+#: builtin/pack-objects.c:3885
 msgid "write the pack index file in the specified idx format version"
 msgstr ""
 "die Index-Datei des Paketes in der angegebenen Indexformat-Version schreiben"
 
-#: builtin/pack-objects.c:3919
+#: builtin/pack-objects.c:3888
 msgid "maximum size of each output pack file"
 msgstr "maximale Größe für jede ausgegebene Paketdatei"
 
-#: builtin/pack-objects.c:3921
+#: builtin/pack-objects.c:3890
 msgid "ignore borrowed objects from alternate object store"
 msgstr "geliehene Objekte von alternativem Objektspeicher ignorieren"
 
-#: builtin/pack-objects.c:3923
+#: builtin/pack-objects.c:3892
 msgid "ignore packed objects"
 msgstr "gepackte Objekte ignorieren"
 
-#: builtin/pack-objects.c:3925
+#: builtin/pack-objects.c:3894
 msgid "limit pack window by objects"
 msgstr "Paketfenster durch Objekte begrenzen"
 
-#: builtin/pack-objects.c:3927
+#: builtin/pack-objects.c:3896
 msgid "limit pack window by memory in addition to object limit"
 msgstr ""
 "Paketfenster, zusätzlich zur Objektbegrenzung, durch Speicher begrenzen"
 
-#: builtin/pack-objects.c:3929
+#: builtin/pack-objects.c:3898
 msgid "maximum length of delta chain allowed in the resulting pack"
 msgstr ""
 "maximale Länge der erlaubten Differenzverkettung im resultierenden Paket"
 
-#: builtin/pack-objects.c:3931
+#: builtin/pack-objects.c:3900
 msgid "reuse existing deltas"
 msgstr "existierende Unterschiede wiederverwenden"
 
-#: builtin/pack-objects.c:3933
+#: builtin/pack-objects.c:3902
 msgid "reuse existing objects"
 msgstr "existierende Objekte wiederverwenden"
 
-#: builtin/pack-objects.c:3935
+#: builtin/pack-objects.c:3904
 msgid "use OFS_DELTA objects"
 msgstr "OFS_DELTA Objekte verwenden"
 
-#: builtin/pack-objects.c:3937
+#: builtin/pack-objects.c:3906
 msgid "use threads when searching for best delta matches"
 msgstr ""
 "Threads bei der Suche nach den besten Übereinstimmungen bei Unterschieden "
 "verwenden"
 
-#: builtin/pack-objects.c:3939
+#: builtin/pack-objects.c:3908
 msgid "do not create an empty pack output"
 msgstr "keine leeren Pakete erzeugen"
 
-#: builtin/pack-objects.c:3941
+#: builtin/pack-objects.c:3910
 msgid "read revision arguments from standard input"
 msgstr "Argumente bezüglich Commits von der Standard-Eingabe lesen"
 
-#: builtin/pack-objects.c:3943
+#: builtin/pack-objects.c:3912
 msgid "limit the objects to those that are not yet packed"
 msgstr "die Objekte zu solchen, die noch nicht gepackt wurden, begrenzen"
 
-#: builtin/pack-objects.c:3946
+#: builtin/pack-objects.c:3915
 msgid "include objects reachable from any reference"
 msgstr "Objekte einschließen, die von jeder Referenz erreichbar sind"
 
-#: builtin/pack-objects.c:3949
+#: builtin/pack-objects.c:3918
 msgid "include objects referred by reflog entries"
 msgstr ""
 "Objekte einschließen, die von Einträgen des Reflogs referenziert werden"
 
-#: builtin/pack-objects.c:3952
+#: builtin/pack-objects.c:3921
 msgid "include objects referred to by the index"
 msgstr "Objekte einschließen, die vom Index referenziert werden"
 
-#: builtin/pack-objects.c:3955
+#: builtin/pack-objects.c:3924
 msgid "read packs from stdin"
 msgstr "Pakete von der Standard-Eingabe lesen"
 
-#: builtin/pack-objects.c:3957
+#: builtin/pack-objects.c:3926
 msgid "output pack to stdout"
 msgstr "Paket in die Standard-Ausgabe schreiben"
 
-#: builtin/pack-objects.c:3959
+#: builtin/pack-objects.c:3928
 msgid "include tag objects that refer to objects to be packed"
 msgstr "Tag-Objekte einschließen, die auf gepackte Objekte referenzieren"
 
-#: builtin/pack-objects.c:3961
+#: builtin/pack-objects.c:3930
 msgid "keep unreachable objects"
 msgstr "nicht erreichbare Objekte behalten"
 
-#: builtin/pack-objects.c:3963
+#: builtin/pack-objects.c:3932
 msgid "pack loose unreachable objects"
 msgstr "nicht erreichbare lose Objekte packen"
 
-#: builtin/pack-objects.c:3965
+#: builtin/pack-objects.c:3934
 msgid "unpack unreachable objects newer than <time>"
 msgstr "nicht erreichbare Objekte entpacken, die neuer als <Zeit> sind"
 
-#: builtin/pack-objects.c:3968
+#: builtin/pack-objects.c:3937
 msgid "use the sparse reachability algorithm"
 msgstr "den \"sparse\" Algorithmus zur Bestimmung der Erreichbarkeit benutzen"
 
-#: builtin/pack-objects.c:3970
+#: builtin/pack-objects.c:3939
 msgid "create thin packs"
 msgstr "dünnere Pakete erzeugen"
 
-#: builtin/pack-objects.c:3972
+#: builtin/pack-objects.c:3941
 msgid "create packs suitable for shallow fetches"
 msgstr ""
 "Pakete geeignet für Abholung mit unvollständiger Historie (shallow) erzeugen"
 
-#: builtin/pack-objects.c:3974
+#: builtin/pack-objects.c:3943
 msgid "ignore packs that have companion .keep file"
 msgstr "Pakete ignorieren, die .keep Dateien haben"
 
-#: builtin/pack-objects.c:3976
+#: builtin/pack-objects.c:3945
 msgid "ignore this pack"
 msgstr "dieses Paket ignorieren"
 
-#: builtin/pack-objects.c:3978
+#: builtin/pack-objects.c:3947
 msgid "pack compression level"
 msgstr "Komprimierungsgrad für Paketierung"
 
-#: builtin/pack-objects.c:3980
+#: builtin/pack-objects.c:3949
 msgid "do not hide commits by grafts"
 msgstr "keine künstlichen Vorgänger-Commits (\"grafts\") verbergen"
 
-#: builtin/pack-objects.c:3982
+#: builtin/pack-objects.c:3951
 msgid "use a bitmap index if available to speed up counting objects"
 msgstr ""
 "Bitmap-Index (falls verfügbar) zur Optimierung der Objektzählung benutzen"
 
-#: builtin/pack-objects.c:3984
+#: builtin/pack-objects.c:3953
 msgid "write a bitmap index together with the pack index"
 msgstr "Bitmap-Index zusammen mit Pack-Index schreiben"
 
-#: builtin/pack-objects.c:3988
+#: builtin/pack-objects.c:3957
 msgid "write a bitmap index if possible"
 msgstr "Bitmap-Index schreiben, wenn möglich"
 
-#: builtin/pack-objects.c:3992
+#: builtin/pack-objects.c:3961
 msgid "handling for missing objects"
 msgstr "Behandlung für fehlende Objekte"
 
-#: builtin/pack-objects.c:3995
+#: builtin/pack-objects.c:3964
 msgid "do not pack objects in promisor packfiles"
 msgstr ""
 "keine Objekte aus Packdateien von partiell geklonten Remote-Repositories "
 "packen"
 
-#: builtin/pack-objects.c:3997
+#: builtin/pack-objects.c:3966
 msgid "respect islands during delta compression"
 msgstr "Delta-Islands bei Delta-Kompression beachten"
 
-#: builtin/pack-objects.c:3999
+#: builtin/pack-objects.c:3968
 msgid "protocol"
 msgstr "Protokoll"
 
-#: builtin/pack-objects.c:4000
+#: builtin/pack-objects.c:3969
 msgid "exclude any configured uploadpack.blobpackfileuri with this protocol"
 msgstr ""
 "jegliche konfigurierte uploadpack.blobpackfileuri für dieses Protkoll "
 "ausschließen"
 
-#: builtin/pack-objects.c:4033
+#: builtin/pack-objects.c:4002
 #, c-format
 msgid "delta chain depth %d is too deep, forcing %d"
 msgstr "Tiefe für Verkettung von Unterschieden %d ist zu tief, erzwinge %d"
 
-#: builtin/pack-objects.c:4038
+#: builtin/pack-objects.c:4007
 #, c-format
 msgid "pack.deltaCacheLimit is too high, forcing %d"
 msgstr "pack.deltaCacheLimit ist zu hoch, erzwinge %d"
 
-#: builtin/pack-objects.c:4094
+#: builtin/pack-objects.c:4063
 msgid "--max-pack-size cannot be used to build a pack for transfer"
 msgstr ""
 "--max-pack-size kann nicht für die Erstellung eines Pakets für eine "
 "Übertragung\n"
 "benutzt werden."
 
-#: builtin/pack-objects.c:4096
+#: builtin/pack-objects.c:4065
 msgid "minimum pack size limit is 1 MiB"
 msgstr "Minimales Limit für die Paketgröße ist 1 MiB."
 
-#: builtin/pack-objects.c:4101
+#: builtin/pack-objects.c:4070
 msgid "--thin cannot be used to build an indexable pack"
 msgstr ""
 "--thin kann nicht benutzt werden, um ein indizierbares Paket zu erstellen."
 
-#: builtin/pack-objects.c:4104
+#: builtin/pack-objects.c:4073
 msgid "--keep-unreachable and --unpack-unreachable are incompatible"
 msgstr "--keep-unreachable und --unpack-unreachable sind inkompatibel"
 
-#: builtin/pack-objects.c:4110
+#: builtin/pack-objects.c:4079
 msgid "cannot use --filter without --stdout"
 msgstr "Kann --filter nicht ohne --stdout benutzen."
 
-#: builtin/pack-objects.c:4112
+#: builtin/pack-objects.c:4081
 msgid "cannot use --filter with --stdin-packs"
 msgstr "kann --filter nicht mit --stdin-packs benutzen"
 
-#: builtin/pack-objects.c:4116
+#: builtin/pack-objects.c:4085
 msgid "cannot use internal rev list with --stdin-packs"
 msgstr ""
 "interne Commit-Liste kann nicht gemeinsam mit --stdin-packs verwendet werden"
 
-#: builtin/pack-objects.c:4175
+#: builtin/pack-objects.c:4144
 msgid "Enumerating objects"
 msgstr "Objekte aufzählen"
 
-#: builtin/pack-objects.c:4212
+#: builtin/pack-objects.c:4181
 #, c-format
 msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
@@ -19504,7 +19844,7 @@ msgstr ""
 "Traversierung auf Objekte außerhalb von Packdateien aus partiell geklonten "
 "Remote-Repositories einschränken"
 
-#: builtin/prune.c:152
+#: builtin/prune.c:151
 msgid "cannot prune in a precious-objects repo"
 msgstr "kann \"prune\" in precious-objects Repository nicht ausführen"
 
@@ -19529,11 +19869,11 @@ msgstr "Optionen bezogen auf Merge"
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "Integration von Änderungen durch Rebase statt Merge"
 
-#: builtin/pull.c:158 builtin/rebase.c:491 builtin/revert.c:126
+#: builtin/pull.c:158 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "Vorspulen erlauben"
 
-#: builtin/pull.c:167 parse-options.h:340
+#: builtin/pull.c:167 parse-options.h:339
 msgid "automatically stash/stash pop before and after"
 msgstr "automatischer Stash/Stash-Pop davor und danach"
 
@@ -19589,7 +19929,7 @@ msgstr ""
 "Repository für den aktuellen Branch ist, müssen Sie einen Branch auf\n"
 "der Befehlszeile angeben."
 
-#: builtin/pull.c:456 builtin/rebase.c:1248
+#: builtin/pull.c:456 builtin/rebase.c:951
 msgid "You are not currently on a branch."
 msgstr "Im Moment auf keinem Branch."
 
@@ -19608,7 +19948,7 @@ msgid "See git-pull(1) for details."
 msgstr "Siehe git-pull(1) für weitere Details."
 
 #: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
-#: builtin/rebase.c:1254
+#: builtin/rebase.c:957
 msgid "<remote>"
 msgstr "<Remote-Repository>"
 
@@ -19616,7 +19956,7 @@ msgstr "<Remote-Repository>"
 msgid "<branch>"
 msgstr "<Branch>"
 
-#: builtin/pull.c:471 builtin/rebase.c:1246
+#: builtin/pull.c:471 builtin/rebase.c:949
 msgid "There is no tracking information for the current branch."
 msgstr "Es gibt keine Tracking-Informationen für den aktuellen Branch."
 
@@ -19647,11 +19987,12 @@ msgstr "Konnte nicht auf Commit '%s' zugreifen."
 msgid "ignoring --verify-signatures for rebase"
 msgstr "Ignoriere --verify-signatures für Rebase"
 
-#: builtin/pull.c:930
+#: builtin/pull.c:936
+#, fuzzy
 msgid ""
-"Pulling without specifying how to reconcile divergent branches is\n"
-"discouraged. You can squelch this message by running one of the following\n"
-"commands sometime before your next pull:\n"
+"You have divergent branches and need to specify how to reconcile them.\n"
+"You can do so by running one of the following commands sometime before\n"
+"your next pull:\n"
 "\n"
 "  git config pull.rebase false  # merge (the default strategy)\n"
 "  git config pull.rebase true   # rebase\n"
@@ -19677,21 +20018,21 @@ msgstr ""
 "Option --rebase, --no-rebase oder --ff-only auf der Kommandozeile nutzen,\n"
 "um das konfigurierte Standardverhalten pro Aufruf zu überschreiben.\n"
 
-#: builtin/pull.c:990
+#: builtin/pull.c:1010
 msgid "Updating an unborn branch with changes added to the index."
 msgstr ""
 "Aktualisiere einen ungeborenen Branch mit Änderungen, die zum Commit "
 "vorgemerkt sind."
 
-#: builtin/pull.c:994
+#: builtin/pull.c:1014
 msgid "pull with rebase"
 msgstr "Pull mit Rebase"
 
-#: builtin/pull.c:995
+#: builtin/pull.c:1015
 msgid "please commit or stash them."
 msgstr "Bitte committen Sie die Änderungen oder benutzen Sie \"stash\"."
 
-#: builtin/pull.c:1020
+#: builtin/pull.c:1040
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -19701,7 +20042,7 @@ msgstr ""
 "\"fetch\" aktualisierte die Spitze des aktuellen Branches.\n"
 "Spule Ihr Arbeitsverzeichnis von Commit %s vor."
 
-#: builtin/pull.c:1026
+#: builtin/pull.c:1046
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -19718,15 +20059,24 @@ msgstr ""
 "$ git reset --hard\n"
 "zur Wiederherstellung aus."
 
-#: builtin/pull.c:1041
+#: builtin/pull.c:1061
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Kann nicht mehrere Branches in einen leeren Branch zusammenführen."
 
-#: builtin/pull.c:1045
+#: builtin/pull.c:1066
 msgid "Cannot rebase onto multiple branches."
 msgstr "Kann Rebase nicht auf mehrere Branches ausführen."
 
-#: builtin/pull.c:1065
+#: builtin/pull.c:1068
+#, fuzzy
+msgid "Cannot fast-forward to multiple branches."
+msgstr "Kann Rebase nicht auf mehrere Branches ausführen."
+
+#: builtin/pull.c:1082
+msgid "Need to specify how to reconcile divergent branches."
+msgstr ""
+
+#: builtin/pull.c:1096
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "Kann Rebase nicht mit lokal aufgezeichneten Änderungen in Submodulen "
@@ -19917,15 +20267,15 @@ msgstr "Push nach %s\n"
 msgid "failed to push some refs to '%s'"
 msgstr "Fehler beim Versenden einiger Referenzen nach '%s'"
 
-#: builtin/push.c:544
+#: builtin/push.c:544 builtin/submodule--helper.c:3258
 msgid "repository"
 msgstr "Repository"
 
-#: builtin/push.c:545 builtin/send-pack.c:189
+#: builtin/push.c:545 builtin/send-pack.c:193
 msgid "push all refs"
 msgstr "alle Referenzen versenden"
 
-#: builtin/push.c:546 builtin/send-pack.c:191
+#: builtin/push.c:546 builtin/send-pack.c:195
 msgid "mirror all refs"
 msgstr "alle Referenzen spiegeln"
 
@@ -19937,19 +20287,19 @@ msgstr "Referenzen löschen"
 msgid "push tags (can't be used with --all or --mirror)"
 msgstr "Tags versenden (kann nicht mit --all oder --mirror verwendet werden)"
 
-#: builtin/push.c:552 builtin/send-pack.c:192
+#: builtin/push.c:552 builtin/send-pack.c:196
 msgid "force updates"
 msgstr "Aktualisierung erzwingen"
 
-#: builtin/push.c:553 builtin/send-pack.c:204
+#: builtin/push.c:553 builtin/send-pack.c:208
 msgid "<refname>:<expect>"
 msgstr "<Referenzname>:<Erwartungswert>"
 
-#: builtin/push.c:554 builtin/send-pack.c:205
+#: builtin/push.c:554 builtin/send-pack.c:209
 msgid "require old value of ref to be at this value"
 msgstr "Referenz muss sich auf dem angegebenen Wert befinden"
 
-#: builtin/push.c:557 builtin/send-pack.c:208
+#: builtin/push.c:557 builtin/send-pack.c:212
 msgid "require remote updates to be integrated locally"
 msgstr "Aktualisierungen des Remote müssen lokal integriert werden"
 
@@ -19957,12 +20307,12 @@ msgstr "Aktualisierungen des Remote müssen lokal integriert werden"
 msgid "control recursive pushing of submodules"
 msgstr "rekursiven \"push\" von Submodulen steuern"
 
-#: builtin/push.c:561 builtin/send-pack.c:199
+#: builtin/push.c:561 builtin/send-pack.c:203
 msgid "use thin pack"
 msgstr "kleinere Pakete verwenden"
 
-#: builtin/push.c:562 builtin/push.c:563 builtin/send-pack.c:186
-#: builtin/send-pack.c:187
+#: builtin/push.c:562 builtin/push.c:563 builtin/send-pack.c:190
+#: builtin/send-pack.c:191
 msgid "receive pack program"
 msgstr "'receive pack' Programm"
 
@@ -19982,11 +20332,11 @@ msgstr "\"pre-push hook\" umgehen"
 msgid "push missing but relevant tags"
 msgstr "fehlende, aber relevante Tags versenden"
 
-#: builtin/push.c:572 builtin/send-pack.c:193
+#: builtin/push.c:572 builtin/send-pack.c:197
 msgid "GPG sign the push"
 msgstr "signiert \"push\" mit GPG"
 
-#: builtin/push.c:574 builtin/send-pack.c:200
+#: builtin/push.c:574 builtin/send-pack.c:204
 msgid "request atomic transaction on remote side"
 msgstr "Referenzen atomar versenden"
 
@@ -20097,85 +20447,86 @@ msgid "need two commit ranges"
 msgstr "Benötige zwei Commit-Bereiche."
 
 #: builtin/read-tree.c:41
+#, fuzzy
 msgid ""
 "git read-tree [(-m [--trivial] [--aggressive] | --reset | --prefix=<prefix>) "
-"[-u [--exclude-per-directory=<gitignore>] | -i]] [--no-sparse-checkout] [--"
-"index-output=<file>] (--empty | <tree-ish1> [<tree-ish2> [<tree-ish3>]])"
+"[-u | -i]] [--no-sparse-checkout] [--index-output=<file>] (--empty | <tree-"
+"ish1> [<tree-ish2> [<tree-ish3>]])"
 msgstr ""
 "git read-tree [(-m [--trivial] [--aggressive] | --reset | --prefix=<Präfix>) "
 "[-u [--exclude-per-directory=<gitignore>] | -i]] [--no-sparse-checkout] [--"
 "index-output=<Datei>] (--empty | <Commit-Referenz1> [<Commit-Referenz2> "
 "[<Commit-Referenz3>]])"
 
-#: builtin/read-tree.c:124
+#: builtin/read-tree.c:116
 msgid "write resulting index to <file>"
 msgstr "resultierenden Index nach <Datei> schreiben"
 
-#: builtin/read-tree.c:127
+#: builtin/read-tree.c:119
 msgid "only empty the index"
 msgstr "nur den Index leeren"
 
-#: builtin/read-tree.c:129
+#: builtin/read-tree.c:121
 msgid "Merging"
 msgstr "Merge"
 
-#: builtin/read-tree.c:131
+#: builtin/read-tree.c:123
 msgid "perform a merge in addition to a read"
 msgstr "einen Merge, zusätzlich zum Lesen, ausführen"
 
-#: builtin/read-tree.c:133
+#: builtin/read-tree.c:125
 msgid "3-way merge if no file level merging required"
 msgstr "3-Wege-Merge, wenn kein Merge auf Dateiebene erforderlich ist"
 
-#: builtin/read-tree.c:135
+#: builtin/read-tree.c:127
 msgid "3-way merge in presence of adds and removes"
 msgstr "3-Wege-Merge bei Vorhandensein von hinzugefügten/entfernten Zeilen"
 
-#: builtin/read-tree.c:137
+#: builtin/read-tree.c:129
 msgid "same as -m, but discard unmerged entries"
 msgstr "genau wie -m, aber nicht zusammengeführte Einträge verwerfen"
 
-#: builtin/read-tree.c:138
+#: builtin/read-tree.c:130
 msgid "<subdirectory>/"
 msgstr "<Unterverzeichnis>/"
 
-#: builtin/read-tree.c:139
+#: builtin/read-tree.c:131
 msgid "read the tree into the index under <subdirectory>/"
 msgstr "das Verzeichnis in den Index unter <Unterverzeichnis>/ lesen"
 
-#: builtin/read-tree.c:142
+#: builtin/read-tree.c:134
 msgid "update working tree with merge result"
 msgstr "Arbeitsverzeichnis mit dem Ergebnis des Merges aktualisieren"
 
-#: builtin/read-tree.c:144
+#: builtin/read-tree.c:136
 msgid "gitignore"
 msgstr "gitignore"
 
-#: builtin/read-tree.c:145
+#: builtin/read-tree.c:137
 msgid "allow explicitly ignored files to be overwritten"
 msgstr "explizit ignorierte Dateien zu überschreiben erlauben"
 
-#: builtin/read-tree.c:148
+#: builtin/read-tree.c:140
 msgid "don't check the working tree after merging"
 msgstr "das Arbeitsverzeichnis nach dem Merge nicht prüfen"
 
-#: builtin/read-tree.c:149
+#: builtin/read-tree.c:141
 msgid "don't update the index or the work tree"
 msgstr "weder den Index, noch das Arbeitsverzeichnis aktualisieren"
 
-#: builtin/read-tree.c:151
+#: builtin/read-tree.c:143
 msgid "skip applying sparse checkout filter"
 msgstr "Anwendung des Filters für partielles Auschecken überspringen"
 
-#: builtin/read-tree.c:153
+#: builtin/read-tree.c:145
 msgid "debug unpack-trees"
 msgstr "unpack-trees protokollieren"
 
-#: builtin/read-tree.c:157
+#: builtin/read-tree.c:149
 msgid "suppress feedback messages"
 msgstr "Rückmeldungen unterdrücken"
 
-#: builtin/read-tree.c:188
+#: builtin/read-tree.c:183
 msgid "You need to resolve your current index first"
 msgstr "Sie müssen zuerst die Konflikte in Ihrem aktuellen Index auflösen."
 
@@ -20198,194 +20549,44 @@ msgstr ""
 msgid "git rebase --continue | --abort | --skip | --edit-todo"
 msgstr "git rebase --continue | --abort | --skip | --edit-todo"
 
-#: builtin/rebase.c:194 builtin/rebase.c:218 builtin/rebase.c:245
-#, c-format
-msgid "unusable todo list: '%s'"
-msgstr "Unbenutzbare TODO-Liste: '%s'"
-
-#: builtin/rebase.c:311
+#: builtin/rebase.c:230
 #, c-format
 msgid "could not create temporary %s"
 msgstr "Konnte temporäres Verzeichnis '%s' nicht erstellen."
 
-#: builtin/rebase.c:317
+#: builtin/rebase.c:236
 msgid "could not mark as interactive"
 msgstr "Markierung auf interaktiven Rebase fehlgeschlagen."
 
-#: builtin/rebase.c:370
+#: builtin/rebase.c:289
 msgid "could not generate todo list"
 msgstr "Konnte TODO-Liste nicht erzeugen."
 
-#: builtin/rebase.c:412
+#: builtin/rebase.c:331
 msgid "a base commit must be provided with --upstream or --onto"
 msgstr "Ein Basis-Commit muss mit --upstream oder --onto angegeben werden."
 
-#: builtin/rebase.c:481
-msgid "git rebase--interactive [<options>]"
-msgstr "git rebase--interactive [<Optionen>]"
-
-#: builtin/rebase.c:494 builtin/rebase.c:1389
-msgid "keep commits which start empty"
-msgstr "behalte Commits, die leer beginnen"
-
-#: builtin/rebase.c:498 builtin/revert.c:128
-msgid "allow commits with empty messages"
-msgstr "Commits mit leerer Beschreibung erlauben"
-
-#: builtin/rebase.c:500
-msgid "rebase merge commits"
-msgstr "Rebase auf Merge-Commits ausführen"
-
-#: builtin/rebase.c:502
-msgid "keep original branch points of cousins"
-msgstr "originale Branch-Punkte der Cousins behalten"
-
-#: builtin/rebase.c:504
-msgid "move commits that begin with squash!/fixup!"
-msgstr "Commits verschieben, die mit squash!/fixup! beginnen"
-
-#: builtin/rebase.c:505
-msgid "sign commits"
-msgstr "Commits signieren"
-
-#: builtin/rebase.c:507 builtin/rebase.c:1328
-msgid "display a diffstat of what changed upstream"
-msgstr ""
-"Zusammenfassung der Unterschiede gegenüber dem Upstream-Branch anzeigen"
-
-#: builtin/rebase.c:509
-msgid "continue rebase"
-msgstr "Rebase fortsetzen"
-
-#: builtin/rebase.c:511
-msgid "skip commit"
-msgstr "Commit auslassen"
-
-#: builtin/rebase.c:512
-msgid "edit the todo list"
-msgstr "die TODO-Liste bearbeiten"
-
-#: builtin/rebase.c:514
-msgid "show the current patch"
-msgstr "den aktuellen Patch anzeigen"
-
-#: builtin/rebase.c:517
-msgid "shorten commit ids in the todo list"
-msgstr "Commit-IDs in der TODO-Liste verkürzen"
-
-#: builtin/rebase.c:519
-msgid "expand commit ids in the todo list"
-msgstr "Commit-IDs in der TODO-Liste erweitern"
-
-#: builtin/rebase.c:521
-msgid "check the todo list"
-msgstr "die TODO-Liste prüfen"
-
-#: builtin/rebase.c:523
-msgid "rearrange fixup/squash lines"
-msgstr "fixup/squash-Zeilen umordnen"
-
-#: builtin/rebase.c:525
-msgid "insert exec commands in todo list"
-msgstr "\"exec\"-Befehle in TODO-Liste einfügen"
-
-#: builtin/rebase.c:526
-msgid "onto"
-msgstr "auf"
-
-#: builtin/rebase.c:529
-msgid "restrict-revision"
-msgstr "Begrenzungscommit"
-
-#: builtin/rebase.c:529
-msgid "restrict revision"
-msgstr "Begrenzungscommit"
-
-#: builtin/rebase.c:531
-msgid "squash-onto"
-msgstr "squash-onto"
-
-#: builtin/rebase.c:532
-msgid "squash onto"
-msgstr "squash onto"
-
-#: builtin/rebase.c:534
-msgid "the upstream commit"
-msgstr "der Upstream-Commit"
-
-#: builtin/rebase.c:536
-msgid "head-name"
-msgstr "head-Name"
-
-#: builtin/rebase.c:536
-msgid "head name"
-msgstr "head-Name"
-
-#: builtin/rebase.c:541
-msgid "rebase strategy"
-msgstr "Rebase-Strategie"
-
-#: builtin/rebase.c:542
-msgid "strategy-opts"
-msgstr "Strategie-Optionen"
-
-#: builtin/rebase.c:543
-msgid "strategy options"
-msgstr "Strategie-Optionen"
-
-#: builtin/rebase.c:544
-msgid "switch-to"
-msgstr "wechseln zu"
-
-#: builtin/rebase.c:545
-msgid "the branch or commit to checkout"
-msgstr "der Branch oder Commit zum Auschecken"
-
-#: builtin/rebase.c:546
-msgid "onto-name"
-msgstr "onto-Name"
-
-#: builtin/rebase.c:546
-msgid "onto name"
-msgstr "onto-Name"
-
-#: builtin/rebase.c:547
-msgid "cmd"
-msgstr "Befehl"
-
-#: builtin/rebase.c:547
-msgid "the command to run"
-msgstr "auszuführender Befehl"
-
-#: builtin/rebase.c:550 builtin/rebase.c:1422
-msgid "automatically re-schedule any `exec` that fails"
-msgstr "jeden fehlgeschlagenen `exec`-Befehl neu ansetzen"
-
-#: builtin/rebase.c:566
-msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
-msgstr "--[no-]rebase-cousins hat ohne --rebase-merges keine Auswirkung"
-
-#: builtin/rebase.c:582
+#: builtin/rebase.c:390
 #, c-format
 msgid "%s requires the merge backend"
 msgstr "%s erfordert das Merge-Backend"
 
-#: builtin/rebase.c:625
+#: builtin/rebase.c:432
 #, c-format
 msgid "could not get 'onto': '%s'"
 msgstr "Konnte 'onto' nicht bestimmen: '%s'"
 
-#: builtin/rebase.c:642
+#: builtin/rebase.c:449
 #, c-format
 msgid "invalid orig-head: '%s'"
 msgstr "Ungültiges orig-head: '%s'"
 
-#: builtin/rebase.c:667
+#: builtin/rebase.c:474
 #, c-format
 msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
 msgstr "Ignoriere ungültiges allow_rerere_autoupdate: '%s'"
 
-#: builtin/rebase.c:813 git-rebase--preserve-merges.sh:81
+#: builtin/rebase.c:597
 msgid ""
 "Resolve all conflicts manually, mark them as resolved with\n"
 "\"git add/rm <conflicted_files>\", then run \"git rebase --continue\".\n"
@@ -20401,7 +20602,7 @@ msgstr ""
 "Um abzubrechen und zurück zum Zustand vor \"git rebase\" zu gelangen,\n"
 "führen Sie \"git rebase --abort\" aus."
 
-#: builtin/rebase.c:896
+#: builtin/rebase.c:680
 #, c-format
 msgid ""
 "\n"
@@ -20421,7 +20622,7 @@ msgstr ""
 "Infolge dessen kann Git auf diesen Revisionen Rebase nicht\n"
 "ausführen."
 
-#: builtin/rebase.c:1222
+#: builtin/rebase.c:925
 #, c-format
 msgid ""
 "unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and \"ask"
@@ -20430,7 +20631,7 @@ msgstr ""
 "nicht erkannter leerer Typ '%s'; Gültige Werte sind \"drop\", \"keep\", und "
 "\"ask\"."
 
-#: builtin/rebase.c:1240
+#: builtin/rebase.c:943
 #, c-format
 msgid ""
 "%s\n"
@@ -20448,7 +20649,7 @@ msgstr ""
 "    git rebase '<Branch>'\n"
 "\n"
 
-#: builtin/rebase.c:1256
+#: builtin/rebase.c:959
 #, c-format
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:\n"
@@ -20462,188 +20663,201 @@ msgstr ""
 "    git branch --set-upstream-to=%s/<Branch> %s\n"
 "\n"
 
-#: builtin/rebase.c:1286
+#: builtin/rebase.c:989
 msgid "exec commands cannot contain newlines"
 msgstr "\"exec\"-Befehle können keine neuen Zeilen enthalten"
 
-#: builtin/rebase.c:1290
+#: builtin/rebase.c:993
 msgid "empty exec command"
 msgstr "Leerer \"exec\"-Befehl."
 
-#: builtin/rebase.c:1319
+#: builtin/rebase.c:1023
 msgid "rebase onto given branch instead of upstream"
 msgstr "Rebase auf angegebenen Branch anstelle des Upstream-Branches ausführen"
 
-#: builtin/rebase.c:1321
+#: builtin/rebase.c:1025
 msgid "use the merge-base of upstream and branch as the current base"
 msgstr "Nutze die Merge-Basis von Upstream und Branch als die aktuelle Basis"
 
-#: builtin/rebase.c:1323
+#: builtin/rebase.c:1027
 msgid "allow pre-rebase hook to run"
 msgstr "Ausführung des pre-rebase-Hooks erlauben"
 
-#: builtin/rebase.c:1325
+#: builtin/rebase.c:1029
 msgid "be quiet. implies --no-stat"
 msgstr "weniger Ausgaben (impliziert --no-stat)"
 
-#: builtin/rebase.c:1331
+#: builtin/rebase.c:1032
+msgid "display a diffstat of what changed upstream"
+msgstr ""
+"Zusammenfassung der Unterschiede gegenüber dem Upstream-Branch anzeigen"
+
+#: builtin/rebase.c:1035
 msgid "do not show diffstat of what changed upstream"
 msgstr ""
 "Zusammenfassung der Unterschiede gegenüber dem Upstream-Branch verbergen"
 
-#: builtin/rebase.c:1334
+#: builtin/rebase.c:1038
 msgid "add a Signed-off-by trailer to each commit"
 msgstr "eine Signed-off-by Zeile zu jedem Commit hinzufügen"
 
-#: builtin/rebase.c:1337
+#: builtin/rebase.c:1041
 msgid "make committer date match author date"
 msgstr "Datum des Commit-Erstellers soll mit Datum des Autors übereinstimmen"
 
-#: builtin/rebase.c:1339
+#: builtin/rebase.c:1043
 msgid "ignore author date and use current date"
 msgstr "ignoriere Autor-Datum und nutze aktuelles Datum"
 
-#: builtin/rebase.c:1341
+#: builtin/rebase.c:1045
 msgid "synonym of --reset-author-date"
 msgstr "Synonym für --reset-author-date"
 
-#: builtin/rebase.c:1343 builtin/rebase.c:1347
+#: builtin/rebase.c:1047 builtin/rebase.c:1051
 msgid "passed to 'git apply'"
 msgstr "an 'git apply' übergeben"
 
-#: builtin/rebase.c:1345
+#: builtin/rebase.c:1049
 msgid "ignore changes in whitespace"
 msgstr "Whitespace-Änderungen ignorieren"
 
-#: builtin/rebase.c:1349 builtin/rebase.c:1352
+#: builtin/rebase.c:1053 builtin/rebase.c:1056
 msgid "cherry-pick all commits, even if unchanged"
 msgstr ""
 "Cherry-Pick auf alle Commits ausführen, auch wenn diese unverändert sind"
 
-#: builtin/rebase.c:1354
+#: builtin/rebase.c:1058
 msgid "continue"
 msgstr "fortsetzen"
 
-#: builtin/rebase.c:1357
+#: builtin/rebase.c:1061
 msgid "skip current patch and continue"
 msgstr "den aktuellen Patch auslassen und fortfahren"
 
-#: builtin/rebase.c:1359
+#: builtin/rebase.c:1063
 msgid "abort and check out the original branch"
 msgstr "abbrechen und den ursprünglichen Branch auschecken"
 
-#: builtin/rebase.c:1362
+#: builtin/rebase.c:1066
 msgid "abort but keep HEAD where it is"
 msgstr "abbrechen, aber HEAD an aktueller Stelle belassen"
 
-#: builtin/rebase.c:1363
+#: builtin/rebase.c:1067
 msgid "edit the todo list during an interactive rebase"
 msgstr "TODO-Liste während eines interaktiven Rebase bearbeiten"
 
-#: builtin/rebase.c:1366
+#: builtin/rebase.c:1070
 msgid "show the patch file being applied or merged"
 msgstr "den Patch, der gerade angewendet oder zusammengeführt wird, anzeigen"
 
-#: builtin/rebase.c:1369
+#: builtin/rebase.c:1073
 msgid "use apply strategies to rebase"
 msgstr "Strategien von 'git am' bei Rebase verwenden"
 
-#: builtin/rebase.c:1373
+#: builtin/rebase.c:1077
 msgid "use merging strategies to rebase"
 msgstr "Merge-Strategien beim Rebase verwenden"
 
-#: builtin/rebase.c:1377
+#: builtin/rebase.c:1081
 msgid "let the user edit the list of commits to rebase"
 msgstr "den Benutzer die Liste der Commits für den Rebase bearbeiten lassen"
 
-#: builtin/rebase.c:1381
+#: builtin/rebase.c:1085
 msgid "(DEPRECATED) try to recreate merges instead of ignoring them"
 msgstr "(VERALTET) Versuche, Merges wiederherzustellen statt sie zu ignorieren"
 
-#: builtin/rebase.c:1386
+#: builtin/rebase.c:1090
 msgid "how to handle commits that become empty"
 msgstr "wie sollen Commits behandelt werden, die leer werden"
 
-#: builtin/rebase.c:1393
+#: builtin/rebase.c:1093
+msgid "keep commits which start empty"
+msgstr "behalte Commits, die leer beginnen"
+
+#: builtin/rebase.c:1097
 msgid "move commits that begin with squash!/fixup! under -i"
 msgstr "bei -i Commits verschieben, die mit squash!/fixup! beginnen"
 
-#: builtin/rebase.c:1400
+#: builtin/rebase.c:1104
 msgid "add exec lines after each commit of the editable list"
 msgstr "exec-Zeilen nach jedem Commit der editierbaren Liste hinzufügen"
 
-#: builtin/rebase.c:1404
+#: builtin/rebase.c:1108
 msgid "allow rebasing commits with empty messages"
 msgstr "Rebase von Commits mit leerer Beschreibung erlauben"
 
-#: builtin/rebase.c:1408
+#: builtin/rebase.c:1112
 msgid "try to rebase merges instead of skipping them"
 msgstr "versuchen, Rebase mit Merges auszuführen, statt diese zu überspringen"
 
-#: builtin/rebase.c:1411
+#: builtin/rebase.c:1115
 msgid "use 'merge-base --fork-point' to refine upstream"
 msgstr "'merge-base --fork-point' benutzen, um Upstream-Branch zu bestimmen"
 
-#: builtin/rebase.c:1413
+#: builtin/rebase.c:1117
 msgid "use the given merge strategy"
 msgstr "angegebene Merge-Strategie verwenden"
 
-#: builtin/rebase.c:1415 builtin/revert.c:115
+#: builtin/rebase.c:1119 builtin/revert.c:115
 msgid "option"
 msgstr "Option"
 
-#: builtin/rebase.c:1416
+#: builtin/rebase.c:1120
 msgid "pass the argument through to the merge strategy"
 msgstr "Argument zur Merge-Strategie durchreichen"
 
-#: builtin/rebase.c:1419
+#: builtin/rebase.c:1123
 msgid "rebase all reachable commits up to the root(s)"
 msgstr "Rebase auf alle erreichbaren Commits bis zum Root-Commit ausführen"
 
-#: builtin/rebase.c:1424
+#: builtin/rebase.c:1126
+msgid "automatically re-schedule any `exec` that fails"
+msgstr "jeden fehlgeschlagenen `exec`-Befehl neu ansetzen"
+
+#: builtin/rebase.c:1128
 msgid "apply all changes, even those already present upstream"
 msgstr ""
 "alle Änderungen anwenden, auch jene, die bereits im Upstream-Branch "
 "vorhanden sind"
 
-#: builtin/rebase.c:1442
+#: builtin/rebase.c:1149
 msgid "It looks like 'git am' is in progress. Cannot rebase."
 msgstr "'git am' scheint im Gange zu sein. Kann Rebase nicht durchführen."
 
-#: builtin/rebase.c:1483
-msgid ""
-"git rebase --preserve-merges is deprecated. Use --rebase-merges instead."
+#: builtin/rebase.c:1180
+#, fuzzy
+msgid "--preserve-merges was replaced by --rebase-merges"
 msgstr ""
 "'git rebase --preserve-merges' ist veraltet. Benutzen Sie stattdessen '--"
 "rebase-merges'."
 
-#: builtin/rebase.c:1488
+#: builtin/rebase.c:1193
 msgid "cannot combine '--keep-base' with '--onto'"
 msgstr "'--keep-base' kann nicht mit '--onto' kombiniert werden"
 
-#: builtin/rebase.c:1490
+#: builtin/rebase.c:1195
 msgid "cannot combine '--keep-base' with '--root'"
 msgstr "'--keep-base' kann nicht mit '--root' kombiniert werden"
 
-#: builtin/rebase.c:1494
+#: builtin/rebase.c:1199
 msgid "cannot combine '--root' with '--fork-point'"
 msgstr "'--root' kann nicht mit '--fork-point' kombiniert werden"
 
-#: builtin/rebase.c:1497
+#: builtin/rebase.c:1202
 msgid "No rebase in progress?"
 msgstr "Kein Rebase im Gange?"
 
-#: builtin/rebase.c:1501
+#: builtin/rebase.c:1206
 msgid "The --edit-todo action can only be used during interactive rebase."
 msgstr ""
 "Die --edit-todo Aktion kann nur während eines interaktiven Rebase verwendet "
 "werden."
 
-#: builtin/rebase.c:1524 t/helper/test-fast-rebase.c:122
+#: builtin/rebase.c:1229 t/helper/test-fast-rebase.c:122
 msgid "Cannot read HEAD"
 msgstr "Kann HEAD nicht lesen"
 
-#: builtin/rebase.c:1536
+#: builtin/rebase.c:1241
 msgid ""
 "You must edit all merge conflicts and then\n"
 "mark them as resolved using git add"
@@ -20651,16 +20865,16 @@ msgstr ""
 "Sie müssen alle Merge-Konflikte editieren und diese dann\n"
 "mittels \"git add\" als aufgelöst markieren"
 
-#: builtin/rebase.c:1555
+#: builtin/rebase.c:1260
 msgid "could not discard worktree changes"
 msgstr "Konnte Änderungen im Arbeitsverzeichnis nicht verwerfen."
 
-#: builtin/rebase.c:1574
+#: builtin/rebase.c:1279
 #, c-format
 msgid "could not move back to %s"
 msgstr "Konnte nicht zu %s zurückgehen."
 
-#: builtin/rebase.c:1620
+#: builtin/rebase.c:1325
 #, c-format
 msgid ""
 "It seems that there is already a %s directory, and\n"
@@ -20681,147 +20895,135 @@ msgstr ""
 "und führen Sie diesen Befehl nochmal aus. Es wird angehalten, falls noch\n"
 "etwas Schützenswertes vorhanden ist.\n"
 
-#: builtin/rebase.c:1648
+#: builtin/rebase.c:1353
 msgid "switch `C' expects a numerical value"
 msgstr "Schalter `C' erwartet einen numerischen Wert."
 
-#: builtin/rebase.c:1690
+#: builtin/rebase.c:1395
 #, c-format
 msgid "Unknown mode: %s"
 msgstr "Unbekannter Modus: %s"
 
-#: builtin/rebase.c:1729
+#: builtin/rebase.c:1434
 msgid "--strategy requires --merge or --interactive"
 msgstr "--strategy erfordert --merge oder --interactive"
 
-#: builtin/rebase.c:1759
+#: builtin/rebase.c:1463
 msgid "cannot combine apply options with merge options"
 msgstr ""
 "Optionen für \"am\" können nicht mit Optionen für \"merge\" kombiniert "
 "werden."
 
-#: builtin/rebase.c:1772
+#: builtin/rebase.c:1476
 #, c-format
 msgid "Unknown rebase backend: %s"
 msgstr "Unbekanntes Rebase-Backend: %s"
 
-#: builtin/rebase.c:1802
+#: builtin/rebase.c:1505
 msgid "--reschedule-failed-exec requires --exec or --interactive"
 msgstr "--reschedule-failed-exec erfordert --exec oder --interactive"
 
-#: builtin/rebase.c:1822
-msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
-msgstr ""
-"'--preserve-merges' kann nicht mit '--rebase-merges' kombiniert werden."
-
-#: builtin/rebase.c:1826
-msgid ""
-"error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
-msgstr ""
-"Fehler: '--preserve-merges' kann nicht mit '--reschedule-failed-exec' "
-"kombiniert werden."
-
-#: builtin/rebase.c:1850
+#: builtin/rebase.c:1536
 #, c-format
 msgid "invalid upstream '%s'"
 msgstr "Ungültiger Upstream '%s'"
 
-#: builtin/rebase.c:1856
+#: builtin/rebase.c:1542
 msgid "Could not create new root commit"
 msgstr "Konnte neuen Root-Commit nicht erstellen."
 
-#: builtin/rebase.c:1882
+#: builtin/rebase.c:1568
 #, c-format
 msgid "'%s': need exactly one merge base with branch"
 msgstr "'%s': benötige genau eine Merge-Basis mit dem Branch"
 
-#: builtin/rebase.c:1885
+#: builtin/rebase.c:1571
 #, c-format
 msgid "'%s': need exactly one merge base"
 msgstr "'%s': benötige genau eine Merge-Basis"
 
-#: builtin/rebase.c:1893
+#: builtin/rebase.c:1580
 #, c-format
 msgid "Does not point to a valid commit '%s'"
 msgstr "'%s' zeigt auf keinen gültigen Commit."
 
-#: builtin/rebase.c:1921
-#, c-format
-msgid "fatal: no such branch/commit '%s'"
+#: builtin/rebase.c:1607
+#, fuzzy, c-format
+msgid "no such branch/commit '%s'"
 msgstr "fatal: Branch/Commit '%s' nicht gefunden"
 
-#: builtin/rebase.c:1929 builtin/submodule--helper.c:39
-#: builtin/submodule--helper.c:2431
+#: builtin/rebase.c:1618 builtin/submodule--helper.c:39
+#: builtin/submodule--helper.c:2658
 #, c-format
 msgid "No such ref: %s"
 msgstr "Referenz nicht gefunden: %s"
 
-#: builtin/rebase.c:1940
+#: builtin/rebase.c:1629
 msgid "Could not resolve HEAD to a revision"
 msgstr "Konnte HEAD zu keinem Commit auflösen."
 
-#: builtin/rebase.c:1961
+#: builtin/rebase.c:1650
 msgid "Please commit or stash them."
 msgstr "Bitte committen Sie die Änderungen oder benutzen Sie \"stash\"."
 
-#: builtin/rebase.c:1997
+#: builtin/rebase.c:1686
 #, c-format
 msgid "could not switch to %s"
 msgstr "Konnte nicht zu %s wechseln."
 
-#: builtin/rebase.c:2008
+#: builtin/rebase.c:1697
 msgid "HEAD is up to date."
 msgstr "HEAD ist aktuell."
 
-#: builtin/rebase.c:2010
+#: builtin/rebase.c:1699
 #, c-format
 msgid "Current branch %s is up to date.\n"
 msgstr "Aktueller Branch %s ist auf dem neuesten Stand.\n"
 
-#: builtin/rebase.c:2018
+#: builtin/rebase.c:1707
 msgid "HEAD is up to date, rebase forced."
 msgstr "HEAD ist aktuell, Rebase erzwungen."
 
-#: builtin/rebase.c:2020
+#: builtin/rebase.c:1709
 #, c-format
 msgid "Current branch %s is up to date, rebase forced.\n"
 msgstr "Aktueller Branch %s ist auf dem neuesten Stand, Rebase erzwungen.\n"
 
-#: builtin/rebase.c:2028
+#: builtin/rebase.c:1717
 msgid "The pre-rebase hook refused to rebase."
 msgstr "Der \"pre-rebase hook\" hat den Rebase zurückgewiesen."
 
-#: builtin/rebase.c:2035
+#: builtin/rebase.c:1724
 #, c-format
 msgid "Changes to %s:\n"
 msgstr "Änderungen zu %s:\n"
 
-#: builtin/rebase.c:2038
+#: builtin/rebase.c:1727
 #, c-format
 msgid "Changes from %s to %s:\n"
 msgstr "Änderungen von %s zu %s:\n"
 
-#: builtin/rebase.c:2063
+#: builtin/rebase.c:1752
 #, c-format
 msgid "First, rewinding head to replay your work on top of it...\n"
 msgstr ""
 "Zunächst wird der Branch zurückgespult, um Ihre Änderungen darauf neu "
 "anzuwenden...\n"
 
-#: builtin/rebase.c:2072
+#: builtin/rebase.c:1761
 msgid "Could not detach HEAD"
 msgstr "Konnte HEAD nicht loslösen."
 
-#: builtin/rebase.c:2081
+#: builtin/rebase.c:1770
 #, c-format
 msgid "Fast-forwarded %s to %s.\n"
 msgstr "Spule %s vor zu %s.\n"
 
-#: builtin/receive-pack.c:34
+#: builtin/receive-pack.c:35
 msgid "git receive-pack <git-dir>"
 msgstr "git receive-pack <Git-Verzeichnis>"
 
-#: builtin/receive-pack.c:1275
+#: builtin/receive-pack.c:1280
 msgid ""
 "By default, updating the current branch in a non-bare repository\n"
 "is denied, because it will make the index and work tree inconsistent\n"
@@ -20853,7 +21055,7 @@ msgstr ""
 "setzen Sie die Konfigurationsvariable 'receive.denyCurrentBranch' auf\n"
 "'refuse'."
 
-#: builtin/receive-pack.c:1295
+#: builtin/receive-pack.c:1300
 msgid ""
 "By default, deleting the current branch is denied, because the next\n"
 "'git clone' won't result in any file checked out, causing confusion.\n"
@@ -20874,11 +21076,11 @@ msgstr ""
 "\n"
 "Um diese Meldung zu unterdrücken, setzen Sie die Variable auf 'refuse'."
 
-#: builtin/receive-pack.c:2478
+#: builtin/receive-pack.c:2480
 msgid "quiet"
 msgstr "weniger Ausgaben"
 
-#: builtin/receive-pack.c:2492
+#: builtin/receive-pack.c:2495
 msgid "You must specify a directory."
 msgstr "Sie müssen ein Repository angeben."
 
@@ -20919,7 +21121,7 @@ msgstr "Markiere nicht erreichbare Objekte..."
 msgid "%s points nowhere!"
 msgstr "%s zeigt auf nichts!"
 
-#: builtin/reflog.c:699
+#: builtin/reflog.c:700
 msgid "no reflog specified to delete"
 msgstr "Kein Reflog zum Löschen angegeben."
 
@@ -21079,7 +21281,7 @@ msgstr ""
 "die Angabe von zu folgenden Branches kann nur mit dem Anfordern von "
 "Spiegelarchiven verwendet werden"
 
-#: builtin/remote.c:195 builtin/remote.c:700
+#: builtin/remote.c:195 builtin/remote.c:705
 #, c-format
 msgid "remote %s already exists."
 msgstr "externes Repository %s existiert bereits."
@@ -21089,25 +21291,30 @@ msgstr "externes Repository %s existiert bereits."
 msgid "Could not setup master '%s'"
 msgstr "Konnte symbolische Referenz für Hauptbranch von '%s' nicht einrichten"
 
-#: builtin/remote.c:355
+#: builtin/remote.c:322
+#, c-format
+msgid "unhandled branch.%s.rebase=%s; assuming 'true'"
+msgstr ""
+
+#: builtin/remote.c:366
 #, c-format
 msgid "Could not get fetch map for refspec %s"
 msgstr "Konnte Fetch-Map für Refspec %s nicht bekommen"
 
-#: builtin/remote.c:454 builtin/remote.c:462
+#: builtin/remote.c:460 builtin/remote.c:468
 msgid "(matching)"
 msgstr "(übereinstimmend)"
 
-#: builtin/remote.c:466
+#: builtin/remote.c:472
 msgid "(delete)"
 msgstr "(lösche)"
 
-#: builtin/remote.c:655
+#: builtin/remote.c:660
 #, c-format
 msgid "could not set '%s'"
 msgstr "konnte '%s' nicht setzen"
 
-#: builtin/remote.c:660
+#: builtin/remote.c:665
 #, c-format
 msgid ""
 "The %s configuration remote.pushDefault in:\n"
@@ -21118,17 +21325,17 @@ msgstr ""
 "\t%s:%d\n"
 "benennt jetzt das nicht existierende Remote-Repository '%s'"
 
-#: builtin/remote.c:691 builtin/remote.c:836 builtin/remote.c:943
+#: builtin/remote.c:696 builtin/remote.c:841 builtin/remote.c:948
 #, c-format
 msgid "No such remote: '%s'"
 msgstr "Remote-Repository nicht gefunden: '%s'"
 
-#: builtin/remote.c:710
+#: builtin/remote.c:715
 #, c-format
 msgid "Could not rename config section '%s' to '%s'"
 msgstr "Konnte Sektion '%s' in Konfiguration nicht nach '%s' umbenennen"
 
-#: builtin/remote.c:730
+#: builtin/remote.c:735
 #, c-format
 msgid ""
 "Not updating non-default fetch refspec\n"
@@ -21139,17 +21346,17 @@ msgstr ""
 "\t%s\n"
 "\tBitte aktualisieren Sie, falls notwendig, die Konfiguration manuell."
 
-#: builtin/remote.c:770
+#: builtin/remote.c:775
 #, c-format
 msgid "deleting '%s' failed"
 msgstr "Konnte '%s' nicht löschen"
 
-#: builtin/remote.c:804
+#: builtin/remote.c:809
 #, c-format
 msgid "creating '%s' failed"
 msgstr "Konnte '%s' nicht erstellen"
 
-#: builtin/remote.c:882
+#: builtin/remote.c:887
 msgid ""
 "Note: A branch outside the refs/remotes/ hierarchy was not removed;\n"
 "to delete it, use:"
@@ -21165,118 +21372,118 @@ msgstr[1] ""
 "entfernt;\n"
 "um diese zu entfernen, benutzen Sie:"
 
-#: builtin/remote.c:896
+#: builtin/remote.c:901
 #, c-format
 msgid "Could not remove config section '%s'"
 msgstr "Konnte Sektion '%s' nicht aus Konfiguration entfernen"
 
-#: builtin/remote.c:999
+#: builtin/remote.c:1009
 #, c-format
 msgid " new (next fetch will store in remotes/%s)"
 msgstr " neu (wird bei nächstem \"fetch\" in remotes/%s gespeichert)"
 
-#: builtin/remote.c:1002
+#: builtin/remote.c:1012
 msgid " tracked"
 msgstr " gefolgt"
 
-#: builtin/remote.c:1004
+#: builtin/remote.c:1014
 msgid " stale (use 'git remote prune' to remove)"
 msgstr " veraltet (benutzen Sie 'git remote prune' zum Löschen)"
 
-#: builtin/remote.c:1006
+#: builtin/remote.c:1016
 msgid " ???"
 msgstr " ???"
 
-#: builtin/remote.c:1047
+#: builtin/remote.c:1057
 #, c-format
 msgid "invalid branch.%s.merge; cannot rebase onto > 1 branch"
 msgstr "ungültiges branch.%s.merge; kann Rebase nicht auf > 1 Branch ausführen"
 
-#: builtin/remote.c:1056
+#: builtin/remote.c:1066
 #, c-format
 msgid "rebases interactively onto remote %s"
 msgstr "interaktiver Rebase auf Remote-Branch %s"
 
-#: builtin/remote.c:1058
+#: builtin/remote.c:1068
 #, c-format
 msgid "rebases interactively (with merges) onto remote %s"
 msgstr "interaktiver Rebase (mit Merges) auf Remote-Branch %s"
 
-#: builtin/remote.c:1061
+#: builtin/remote.c:1071
 #, c-format
 msgid "rebases onto remote %s"
 msgstr "Rebase auf Remote-Branch %s"
 
-#: builtin/remote.c:1065
+#: builtin/remote.c:1075
 #, c-format
 msgid " merges with remote %s"
 msgstr " führt mit Remote-Branch %s zusammen"
 
-#: builtin/remote.c:1068
+#: builtin/remote.c:1078
 #, c-format
 msgid "merges with remote %s"
 msgstr "führt mit Remote-Branch %s zusammen"
 
-#: builtin/remote.c:1071
+#: builtin/remote.c:1081
 #, c-format
 msgid "%-*s    and with remote %s\n"
 msgstr "%-*s    und mit Remote-Branch %s\n"
 
-#: builtin/remote.c:1114
+#: builtin/remote.c:1124
 msgid "create"
 msgstr "erstellt"
 
-#: builtin/remote.c:1117
+#: builtin/remote.c:1127
 msgid "delete"
 msgstr "gelöscht"
 
-#: builtin/remote.c:1121
+#: builtin/remote.c:1131
 msgid "up to date"
 msgstr "aktuell"
 
-#: builtin/remote.c:1124
+#: builtin/remote.c:1134
 msgid "fast-forwardable"
 msgstr "vorspulbar"
 
-#: builtin/remote.c:1127
+#: builtin/remote.c:1137
 msgid "local out of date"
 msgstr "lokal nicht aktuell"
 
-#: builtin/remote.c:1134
+#: builtin/remote.c:1144
 #, c-format
 msgid "    %-*s forces to %-*s (%s)"
 msgstr "    %-*s erzwingt Versandt nach %-*s (%s)"
 
-#: builtin/remote.c:1137
+#: builtin/remote.c:1147
 #, c-format
 msgid "    %-*s pushes to %-*s (%s)"
 msgstr "    %-*s versendet nach %-*s (%s)"
 
-#: builtin/remote.c:1141
+#: builtin/remote.c:1151
 #, c-format
 msgid "    %-*s forces to %s"
 msgstr "    %-*s erzwingt Versand nach %s"
 
-#: builtin/remote.c:1144
+#: builtin/remote.c:1154
 #, c-format
 msgid "    %-*s pushes to %s"
 msgstr "    %-*s versendet nach %s"
 
-#: builtin/remote.c:1212
+#: builtin/remote.c:1222
 msgid "do not query remotes"
 msgstr "keine Abfrage von Remote-Repositories"
 
-#: builtin/remote.c:1239
+#: builtin/remote.c:1243
 #, c-format
 msgid "* remote %s"
 msgstr "* Remote-Repository %s"
 
-#: builtin/remote.c:1240
+#: builtin/remote.c:1244
 #, c-format
 msgid "  Fetch URL: %s"
 msgstr "  URL zum Abholen: %s"
 
-#: builtin/remote.c:1241 builtin/remote.c:1257 builtin/remote.c:1396
+#: builtin/remote.c:1245 builtin/remote.c:1261 builtin/remote.c:1398
 msgid "(no URL)"
 msgstr "(keine URL)"
 
@@ -21284,25 +21491,25 @@ msgstr "(keine URL)"
 #. with the one in " Fetch URL: %s"
 #. translation.
 #.
-#: builtin/remote.c:1255 builtin/remote.c:1257
+#: builtin/remote.c:1259 builtin/remote.c:1261
 #, c-format
 msgid "  Push  URL: %s"
 msgstr "  URL zum Versenden: %s"
 
-#: builtin/remote.c:1259 builtin/remote.c:1261 builtin/remote.c:1263
+#: builtin/remote.c:1263 builtin/remote.c:1265 builtin/remote.c:1267
 #, c-format
 msgid "  HEAD branch: %s"
 msgstr "  Hauptbranch: %s"
 
-#: builtin/remote.c:1259
+#: builtin/remote.c:1263
 msgid "(not queried)"
 msgstr "(nicht abgefragt)"
 
-#: builtin/remote.c:1261
+#: builtin/remote.c:1265
 msgid "(unknown)"
 msgstr "(unbekannt)"
 
-#: builtin/remote.c:1265
+#: builtin/remote.c:1269
 #, c-format
 msgid ""
 "  HEAD branch (remote HEAD is ambiguous, may be one of the following):\n"
@@ -21310,162 +21517,166 @@ msgstr ""
 "  Hauptbranch (externer HEAD ist mehrdeutig, könnte einer der folgenden "
 "sein):\n"
 
-#: builtin/remote.c:1277
+#: builtin/remote.c:1281
 #, c-format
 msgid "  Remote branch:%s"
 msgid_plural "  Remote branches:%s"
 msgstr[0] "  Remote-Branch:%s"
 msgstr[1] "  Remote-Branches:%s"
 
-#: builtin/remote.c:1280 builtin/remote.c:1306
+#: builtin/remote.c:1284 builtin/remote.c:1310
 msgid " (status not queried)"
 msgstr " (Zustand nicht abgefragt)"
 
-#: builtin/remote.c:1289
+#: builtin/remote.c:1293
 msgid "  Local branch configured for 'git pull':"
 msgid_plural "  Local branches configured for 'git pull':"
 msgstr[0] "  Lokaler Branch konfiguriert für 'git pull':"
 msgstr[1] "  Lokale Branches konfiguriert für 'git pull':"
 
-#: builtin/remote.c:1297
+#: builtin/remote.c:1301
 msgid "  Local refs will be mirrored by 'git push'"
 msgstr "  Lokale Referenzen werden von 'git push' gespiegelt"
 
-#: builtin/remote.c:1303
+#: builtin/remote.c:1307
 #, c-format
 msgid "  Local ref configured for 'git push'%s:"
 msgid_plural "  Local refs configured for 'git push'%s:"
 msgstr[0] "  Lokale Referenz konfiguriert für 'git push'%s:"
 msgstr[1] "  Lokale Referenzen konfiguriert für 'git push'%s:"
 
-#: builtin/remote.c:1324
+#: builtin/remote.c:1328
 msgid "set refs/remotes/<name>/HEAD according to remote"
 msgstr "setzt refs/remotes/<Name>/HEAD gemäß dem Remote-Repository"
 
-#: builtin/remote.c:1326
+#: builtin/remote.c:1330
 msgid "delete refs/remotes/<name>/HEAD"
 msgstr "entfernt refs/remotes/<Name>/HEAD"
 
-#: builtin/remote.c:1341
+#: builtin/remote.c:1344
 msgid "Cannot determine remote HEAD"
 msgstr "Kann HEAD des Remote-Repositories nicht bestimmen"
 
-#: builtin/remote.c:1343
+#: builtin/remote.c:1346
 msgid "Multiple remote HEAD branches. Please choose one explicitly with:"
 msgstr ""
 "Mehrere Hauptbranches im Remote-Repository. Bitte wählen Sie explizit einen "
 "aus mit:"
 
-#: builtin/remote.c:1353
+#: builtin/remote.c:1356
 #, c-format
 msgid "Could not delete %s"
 msgstr "Konnte %s nicht entfernen"
 
-#: builtin/remote.c:1361
+#: builtin/remote.c:1364
 #, c-format
 msgid "Not a valid ref: %s"
 msgstr "keine gültige Referenz: %s"
 
-#: builtin/remote.c:1363
+#: builtin/remote.c:1366
 #, c-format
 msgid "Could not setup %s"
 msgstr "Konnte %s nicht einrichten"
 
-#: builtin/remote.c:1381
+#: builtin/remote.c:1384
 #, c-format
 msgid " %s will become dangling!"
 msgstr " %s wird unreferenziert!"
 
-#: builtin/remote.c:1382
+#: builtin/remote.c:1385
 #, c-format
 msgid " %s has become dangling!"
 msgstr " %s wurde unreferenziert!"
 
-#: builtin/remote.c:1392
+#: builtin/remote.c:1394
 #, c-format
 msgid "Pruning %s"
 msgstr "entferne veraltete Branches von %s"
 
-#: builtin/remote.c:1393
+#: builtin/remote.c:1395
 #, c-format
 msgid "URL: %s"
 msgstr "URL: %s"
 
-#: builtin/remote.c:1409
+#: builtin/remote.c:1411
 #, c-format
 msgid " * [would prune] %s"
 msgstr " * [würde veralteten Branch entfernen] %s"
 
-#: builtin/remote.c:1412
+#: builtin/remote.c:1414
 #, c-format
 msgid " * [pruned] %s"
 msgstr "* [veralteten Branch entfernt] %s"
 
-#: builtin/remote.c:1457
+#: builtin/remote.c:1459
 msgid "prune remotes after fetching"
 msgstr "entferne veraltete Branches im Remote-Repository nach \"fetch\""
 
-#: builtin/remote.c:1521 builtin/remote.c:1577 builtin/remote.c:1647
+#: builtin/remote.c:1523 builtin/remote.c:1579 builtin/remote.c:1649
 #, c-format
 msgid "No such remote '%s'"
 msgstr "Remote-Repository '%s' nicht gefunden"
 
-#: builtin/remote.c:1539
+#: builtin/remote.c:1541
 msgid "add branch"
 msgstr "Branch hinzufügen"
 
-#: builtin/remote.c:1546
+#: builtin/remote.c:1548
 msgid "no remote specified"
 msgstr "kein Remote-Repository angegeben"
 
-#: builtin/remote.c:1563
+#: builtin/remote.c:1565
 msgid "query push URLs rather than fetch URLs"
 msgstr "nur URLs für Push ausgeben"
 
-#: builtin/remote.c:1565
+#: builtin/remote.c:1567
 msgid "return all URLs"
 msgstr "alle URLs ausgeben"
 
-#: builtin/remote.c:1595
+#: builtin/remote.c:1597
 #, c-format
 msgid "no URLs configured for remote '%s'"
 msgstr "Keine URLs für Remote-Repository '%s' konfiguriert."
 
-#: builtin/remote.c:1621
+#: builtin/remote.c:1623
 msgid "manipulate push URLs"
 msgstr "URLs für \"push\" manipulieren"
 
-#: builtin/remote.c:1623
+#: builtin/remote.c:1625
 msgid "add URL"
 msgstr "URL hinzufügen"
 
-#: builtin/remote.c:1625
+#: builtin/remote.c:1627
 msgid "delete URLs"
 msgstr "URLs löschen"
 
-#: builtin/remote.c:1632
+#: builtin/remote.c:1634
 msgid "--add --delete doesn't make sense"
 msgstr "--add und --delete können nicht gemeinsam verwendet werden"
 
-#: builtin/remote.c:1673
+#: builtin/remote.c:1675
 #, c-format
 msgid "Invalid old URL pattern: %s"
 msgstr "ungültiges altes URL Format: %s"
 
-#: builtin/remote.c:1681
+#: builtin/remote.c:1683
 #, c-format
 msgid "No such URL found: %s"
 msgstr "URL nicht gefunden: %s"
 
-#: builtin/remote.c:1683
+#: builtin/remote.c:1685
 msgid "Will not delete all non-push URLs"
 msgstr "Werde keine URLs entfernen, die nicht für \"push\" bestimmt sind"
 
-#: builtin/repack.c:26
+#: builtin/remote.c:1702
+msgid "be verbose; must be placed before a subcommand"
+msgstr "erweiterte Ausgaben; muss vor einem Unterbefehl angegeben werden"
+
+#: builtin/repack.c:28
 msgid "git repack [<options>]"
 msgstr "git repack [<Optionen>]"
 
-#: builtin/repack.c:31
+#: builtin/repack.c:33
 msgid ""
 "Incremental repacks are incompatible with bitmap indexes.  Use\n"
 "--no-write-bitmap-index or disable the pack.writebitmaps configuration."
@@ -21474,148 +21685,163 @@ msgstr ""
 "--no-write-bitmap-index oder deaktivieren Sie die pack.writebitmaps\n"
 "Konfiguration."
 
-#: builtin/repack.c:198
+#: builtin/repack.c:201
 msgid "could not start pack-objects to repack promisor objects"
 msgstr ""
 "Konnte 'pack-objects' für das Neupacken von Objekten aus partiell geklonten\n"
 "Remote-Repositories nicht starten."
 
-#: builtin/repack.c:270 builtin/repack.c:630
+#: builtin/repack.c:273 builtin/repack.c:816
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
 msgstr ""
 "repack: Erwarte Zeilen mit vollständiger Hex-Objekt-ID nur von pack-objects."
 
-#: builtin/repack.c:294
+#: builtin/repack.c:297
 msgid "could not finish pack-objects to repack promisor objects"
 msgstr ""
 "Konnte 'pack-objects' für das Neupacken von Objekten aus partiell geklonten\n"
 "Remote-Repositories nicht abschließen."
 
-#: builtin/repack.c:309
+#: builtin/repack.c:312
 #, c-format
 msgid "cannot open index for %s"
 msgstr "konnte Index für %s nicht öffnen"
 
-#: builtin/repack.c:368
+#: builtin/repack.c:371
 #, c-format
 msgid "pack %s too large to consider in geometric progression"
 msgstr ""
 "Paket %s zu groß, um es bei der geometrischen Progression zu berücksichtigen"
 
-#: builtin/repack.c:401 builtin/repack.c:408 builtin/repack.c:413
+#: builtin/repack.c:404 builtin/repack.c:411 builtin/repack.c:416
 #, c-format
 msgid "pack %s too large to roll up"
 msgstr "Paket %s zu groß zum Aufrollen"
 
-#: builtin/repack.c:460
+#: builtin/repack.c:496
+#, fuzzy, c-format
+msgid "could not open tempfile %s for writing"
+msgstr "Konnte '%s' nicht zum Schreiben öffnen."
+
+#: builtin/repack.c:514
+#, fuzzy
+msgid "could not close refs snapshot tempfile"
+msgstr "konnte temporäre Datei nicht erstellen"
+
+#: builtin/repack.c:628
 msgid "pack everything in a single pack"
 msgstr "alles in eine einzige Pack-Datei packen"
 
-#: builtin/repack.c:462
+#: builtin/repack.c:630
 msgid "same as -a, and turn unreachable objects loose"
 msgstr "genau wie -a, unerreichbare Objekte werden aber nicht gelöscht"
 
-#: builtin/repack.c:465
+#: builtin/repack.c:633
 msgid "remove redundant packs, and run git-prune-packed"
 msgstr "redundante Pakete entfernen und \"git-prune-packed\" ausführen"
 
-#: builtin/repack.c:467
+#: builtin/repack.c:635
 msgid "pass --no-reuse-delta to git-pack-objects"
 msgstr "--no-reuse-delta an git-pack-objects übergeben"
 
-#: builtin/repack.c:469
+#: builtin/repack.c:637
 msgid "pass --no-reuse-object to git-pack-objects"
 msgstr "--no-reuse-object an git-pack-objects übergeben"
 
-#: builtin/repack.c:471
+#: builtin/repack.c:639
 msgid "do not run git-update-server-info"
 msgstr "git-update-server-info nicht ausführen"
 
-#: builtin/repack.c:474
+#: builtin/repack.c:642
 msgid "pass --local to git-pack-objects"
 msgstr "--local an git-pack-objects übergeben"
 
-#: builtin/repack.c:476
+#: builtin/repack.c:644
 msgid "write bitmap index"
 msgstr "Bitmap-Index schreiben"
 
-#: builtin/repack.c:478
+#: builtin/repack.c:646
 msgid "pass --delta-islands to git-pack-objects"
 msgstr "--delta-islands an git-pack-objects übergeben"
 
-#: builtin/repack.c:479
+#: builtin/repack.c:647
 msgid "approxidate"
 msgstr "Datumsangabe"
 
-#: builtin/repack.c:480
+#: builtin/repack.c:648
 msgid "with -A, do not loosen objects older than this"
 msgstr "mit -A, keine Objekte älter als dieses Datum löschen"
 
-#: builtin/repack.c:482
+#: builtin/repack.c:650
 msgid "with -a, repack unreachable objects"
 msgstr "mit -a, nicht erreichbare Objekte neu packen"
 
-#: builtin/repack.c:484
+#: builtin/repack.c:652
 msgid "size of the window used for delta compression"
 msgstr "Größe des Fensters für die Delta-Kompression"
 
-#: builtin/repack.c:485 builtin/repack.c:491
+#: builtin/repack.c:653 builtin/repack.c:659
 msgid "bytes"
 msgstr "Bytes"
 
-#: builtin/repack.c:486
+#: builtin/repack.c:654
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr ""
 "gleiches wie oben, aber die Speichergröße statt der Anzahl der Einträge "
 "limitieren"
 
-#: builtin/repack.c:488
+#: builtin/repack.c:656
 msgid "limits the maximum delta depth"
 msgstr "die maximale Delta-Tiefe limitieren"
 
-#: builtin/repack.c:490
+#: builtin/repack.c:658
 msgid "limits the maximum number of threads"
 msgstr "maximale Anzahl von Threads limitieren"
 
-#: builtin/repack.c:492
+#: builtin/repack.c:660
 msgid "maximum size of each packfile"
 msgstr "maximale Größe für jede Paketdatei"
 
-#: builtin/repack.c:494
+#: builtin/repack.c:662
 msgid "repack objects in packs marked with .keep"
 msgstr ""
 "Objekte umpacken, die sich in mit .keep markierten Pack-Dateien befinden"
 
-#: builtin/repack.c:496
+#: builtin/repack.c:664
 msgid "do not repack this pack"
 msgstr "dieses Paket nicht neu packen"
 
-#: builtin/repack.c:498
+#: builtin/repack.c:666
 msgid "find a geometric progression with factor <N>"
 msgstr "eine geometrische Progression mit Faktor <N> finden"
 
-#: builtin/repack.c:508
+#: builtin/repack.c:668
+#, fuzzy
+msgid "write a multi-pack index of the resulting packs"
+msgstr "Fehler beim Ausführen von 'git multi-pack-index repack'"
+
+#: builtin/repack.c:678
 msgid "cannot delete packs in a precious-objects repo"
 msgstr "kann Pack-Dateien in precious-objects Repository nicht löschen"
 
-#: builtin/repack.c:512
+#: builtin/repack.c:682
 msgid "--keep-unreachable and -A are incompatible"
 msgstr "--keep-unreachable und -A sind inkompatibel"
 
-#: builtin/repack.c:527
+#: builtin/repack.c:713
 msgid "--geometric is incompatible with -A, -a"
 msgstr "--geometric ist inkompatibel mit -A, -a"
 
-#: builtin/repack.c:639
+#: builtin/repack.c:825
 msgid "Nothing new to pack."
 msgstr "Nichts Neues zum Packen."
 
-#: builtin/repack.c:669
+#: builtin/repack.c:855
 #, c-format
 msgid "missing required file: %s"
 msgstr "benötigte Datei fehlt: %s"
 
-#: builtin/repack.c:671
+#: builtin/repack.c:857
 #, c-format
 msgid "could not unlink: %s"
 msgstr "konnte nicht löschen: %s"
@@ -21927,93 +22153,93 @@ msgstr "zusammenführen"
 msgid "keep"
 msgstr "keep"
 
-#: builtin/reset.c:83
+#: builtin/reset.c:89
 msgid "You do not have a valid HEAD."
 msgstr "Sie haben keinen gültigen HEAD."
 
-#: builtin/reset.c:85
+#: builtin/reset.c:91
 msgid "Failed to find tree of HEAD."
 msgstr "Fehler beim Finden des \"Tree\"-Objektes von HEAD."
 
-#: builtin/reset.c:91
+#: builtin/reset.c:97
 #, c-format
 msgid "Failed to find tree of %s."
 msgstr "Fehler beim Finden des \"Tree\"-Objektes von %s."
 
-#: builtin/reset.c:116
+#: builtin/reset.c:122
 #, c-format
 msgid "HEAD is now at %s"
 msgstr "HEAD ist jetzt bei %s"
 
-#: builtin/reset.c:195
+#: builtin/reset.c:201
 #, c-format
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "Kann keinen '%s'-Reset durchführen, während ein Merge im Gange ist."
 
-#: builtin/reset.c:295 builtin/stash.c:589 builtin/stash.c:663
-#: builtin/stash.c:687
+#: builtin/reset.c:301 builtin/stash.c:605 builtin/stash.c:679
+#: builtin/stash.c:703
 msgid "be quiet, only report errors"
 msgstr "weniger Ausgaben, nur Fehler melden"
 
-#: builtin/reset.c:297
+#: builtin/reset.c:303
 msgid "reset HEAD and index"
 msgstr "HEAD und Index umsetzen"
 
-#: builtin/reset.c:298
+#: builtin/reset.c:304
 msgid "reset only HEAD"
 msgstr "nur HEAD umsetzen"
 
-#: builtin/reset.c:300 builtin/reset.c:302
+#: builtin/reset.c:306 builtin/reset.c:308
 msgid "reset HEAD, index and working tree"
 msgstr "HEAD, Index und Arbeitsverzeichnis umsetzen"
 
-#: builtin/reset.c:304
+#: builtin/reset.c:310
 msgid "reset HEAD but keep local changes"
 msgstr "HEAD umsetzen, aber lokale Änderungen behalten"
 
-#: builtin/reset.c:310
+#: builtin/reset.c:316
 msgid "record only the fact that removed paths will be added later"
 msgstr "nur speichern, dass gelöschte Pfade später hinzugefügt werden sollen"
 
-#: builtin/reset.c:344
+#: builtin/reset.c:350
 #, c-format
 msgid "Failed to resolve '%s' as a valid revision."
 msgstr "Konnte '%s' nicht als gültigen Commit auflösen."
 
-#: builtin/reset.c:352
+#: builtin/reset.c:358
 #, c-format
 msgid "Failed to resolve '%s' as a valid tree."
 msgstr "Konnte '%s' nicht als gültiges \"Tree\"-Objekt auflösen."
 
-#: builtin/reset.c:361
+#: builtin/reset.c:367
 msgid "--patch is incompatible with --{hard,mixed,soft}"
 msgstr "--patch ist inkompatibel mit --{hard,mixed,soft}"
 
-#: builtin/reset.c:371
+#: builtin/reset.c:377
 msgid "--mixed with paths is deprecated; use 'git reset -- <paths>' instead."
 msgstr ""
 "--mixed mit Pfaden ist veraltet; benutzen Sie stattdessen 'git reset -- "
 "<Pfade>'."
 
-#: builtin/reset.c:373
+#: builtin/reset.c:379
 #, c-format
 msgid "Cannot do %s reset with paths."
 msgstr "Ein '%s'-Reset mit Pfaden ist nicht möglich."
 
-#: builtin/reset.c:388
+#: builtin/reset.c:394
 #, c-format
 msgid "%s reset is not allowed in a bare repository"
 msgstr "'%s'-Reset ist in einem Bare-Repository nicht erlaubt"
 
-#: builtin/reset.c:392
+#: builtin/reset.c:398
 msgid "-N can only be used with --mixed"
 msgstr "-N kann nur mit --mixed benutzt werden"
 
-#: builtin/reset.c:413
+#: builtin/reset.c:419
 msgid "Unstaged changes after reset:"
 msgstr "Nicht zum Commit vorgemerkte Änderungen nach Zurücksetzung:"
 
-#: builtin/reset.c:416
+#: builtin/reset.c:422
 #, c-format
 msgid ""
 "\n"
@@ -22027,12 +22253,12 @@ msgstr ""
 "das zu verhindern. Setzen Sie die Konfigurationseinstellung reset.quiet\n"
 "auf \"true\", um das zum Standard zu machen.\n"
 
-#: builtin/reset.c:434
+#: builtin/reset.c:440
 #, c-format
 msgid "Could not reset index file to revision '%s'."
 msgstr "Konnte Index-Datei nicht zu Commit '%s' setzen."
 
-#: builtin/reset.c:439
+#: builtin/reset.c:445
 msgid "Could not write new index file."
 msgstr "Konnte neue Index-Datei nicht schreiben."
 
@@ -22215,15 +22441,19 @@ msgstr "Commit-Namen anhängen"
 msgid "preserve initially empty commits"
 msgstr "ursprüngliche, leere Commits erhalten"
 
+#: builtin/revert.c:128
+msgid "allow commits with empty messages"
+msgstr "Commits mit leerer Beschreibung erlauben"
+
 #: builtin/revert.c:129
 msgid "keep redundant, empty commits"
 msgstr "redundante, leere Commits behalten"
 
-#: builtin/revert.c:237
+#: builtin/revert.c:241
 msgid "revert failed"
 msgstr "\"revert\" fehlgeschlagen"
 
-#: builtin/revert.c:250
+#: builtin/revert.c:254
 msgid "cherry-pick failed"
 msgstr "\"cherry-pick\" fehlgeschlagen"
 
@@ -22275,54 +22505,55 @@ msgid_plural "the following files have local modifications:"
 msgstr[0] "die folgende Datei hat lokale Änderungen:"
 msgstr[1] "die folgenden Dateien haben lokale Änderungen:"
 
-#: builtin/rm.c:244
+#: builtin/rm.c:245
 msgid "do not list removed files"
 msgstr "keine gelöschten Dateien auflisten"
 
-#: builtin/rm.c:245
+#: builtin/rm.c:246
 msgid "only remove from the index"
 msgstr "nur aus dem Index entfernen"
 
-#: builtin/rm.c:246
+#: builtin/rm.c:247
 msgid "override the up-to-date check"
 msgstr "die \"up-to-date\" Prüfung überschreiben"
 
-#: builtin/rm.c:247
+#: builtin/rm.c:248
 msgid "allow recursive removal"
 msgstr "rekursives Entfernen erlauben"
 
-#: builtin/rm.c:249
+#: builtin/rm.c:250
 msgid "exit with a zero status even if nothing matched"
 msgstr "mit Rückgabewert 0 beenden, wenn keine Übereinstimmung gefunden wurde"
 
-#: builtin/rm.c:283
+#: builtin/rm.c:285
 msgid "No pathspec was given. Which files should I remove?"
 msgstr ""
 "Es wurde keine Pfadspezifikation angegeben. Welche Dateien sollen entfernt "
 "werden?"
 
-#: builtin/rm.c:310
+#: builtin/rm.c:315
 msgid "please stage your changes to .gitmodules or stash them to proceed"
 msgstr ""
 "Bitte merken Sie Ihre Änderungen in .gitmodules zum Commit vor oder\n"
 "benutzen Sie \"stash\", um fortzufahren."
 
-#: builtin/rm.c:331
+#: builtin/rm.c:337
 #, c-format
 msgid "not removing '%s' recursively without -r"
 msgstr "'%s' wird nicht ohne -r rekursiv entfernt"
 
-#: builtin/rm.c:379
+#: builtin/rm.c:385
 #, c-format
 msgid "git rm: unable to remove %s"
 msgstr "git rm: konnte %s nicht löschen"
 
 #: builtin/send-pack.c:20
+#, fuzzy
 msgid ""
-"git send-pack [--all | --mirror] [--dry-run] [--force] [--receive-pack=<git-"
-"receive-pack>] [--verbose] [--thin] [--atomic] [<host>:]<directory> "
-"[<ref>...]\n"
-"  --all and explicit <ref> specification are mutually exclusive."
+"git send-pack [--mirror] [--dry-run] [--force]\n"
+"              [--receive-pack=<git-receive-pack>]\n"
+"              [--verbose] [--thin] [--atomic]\n"
+"              [<host>:]<directory> (--all | <ref>...)"
 msgstr ""
 "git send-pack [--all | --mirror] [--dry-run] [--force] [--receive-pack=<git-"
 "receive-pack>] [--verbose] [--thin] [--atomic] [<Host>:]<Verzeichnis> "
@@ -22330,19 +22561,19 @@ msgstr ""
 "  --all und die explizite Angabe einer <Referenz> schließen sich gegenseitig "
 "aus."
 
-#: builtin/send-pack.c:188
+#: builtin/send-pack.c:192
 msgid "remote name"
 msgstr "Name des Remote-Repositories"
 
-#: builtin/send-pack.c:201
+#: builtin/send-pack.c:205
 msgid "use stateless RPC protocol"
 msgstr "zustandsloses RPC-Protokoll verwenden"
 
-#: builtin/send-pack.c:202
+#: builtin/send-pack.c:206
 msgid "read refs from stdin"
 msgstr "Referenzen von der Standard-Eingabe lesen"
 
-#: builtin/send-pack.c:203
+#: builtin/send-pack.c:207
 msgid "print status from remote helper"
 msgstr "Status des Remote-Helpers ausgeben"
 
@@ -22400,16 +22631,17 @@ msgstr "Feld"
 msgid "group by field"
 msgstr "Gruppieren nach Feld"
 
-#: builtin/shortlog.c:391
+#: builtin/shortlog.c:394
 msgid "too many arguments given outside repository"
 msgstr "zu viele Argumente außerhalb des Repositories angegeben"
 
 #: builtin/show-branch.c:13
+#, fuzzy
 msgid ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
-"\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
-"\t\t[--more=<n> | --list | --independent | --merge-base]\n"
-"\t\t[--no-name | --sha1-name] [--topics] [(<rev> | <glob>)...]"
+"                [--current] [--color[=<when>] | --no-color] [--sparse]\n"
+"                [--more=<n> | --list | --independent | --merge-base]\n"
+"                [--no-name | --sha1-name] [--topics] [(<rev> | <glob>)...]"
 msgstr ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
 "\t\t[--current] [--color[=<Wann>] | --no-color] [--sparse]\n"
@@ -22427,116 +22659,116 @@ msgid_plural "ignoring %s; cannot handle more than %d refs"
 msgstr[0] "ignoriere %s; kann nicht mehr als %d Referenz behandeln"
 msgstr[1] "ignoriere %s; kann nicht mehr als %d Referenzen behandeln"
 
-#: builtin/show-branch.c:548
+#: builtin/show-branch.c:547
 #, c-format
 msgid "no matching refs with %s"
 msgstr "keine übereinstimmenden Referenzen mit %s"
 
-#: builtin/show-branch.c:645
+#: builtin/show-branch.c:644
 msgid "show remote-tracking and local branches"
 msgstr "Remote-Tracking und lokale Branches anzeigen"
 
-#: builtin/show-branch.c:647
+#: builtin/show-branch.c:646
 msgid "show remote-tracking branches"
 msgstr "Remote-Tracking-Branches anzeigen"
 
-#: builtin/show-branch.c:649
+#: builtin/show-branch.c:648
 msgid "color '*!+-' corresponding to the branch"
 msgstr "'*!+-' entsprechend des Branches einfärben"
 
-#: builtin/show-branch.c:651
+#: builtin/show-branch.c:650
 msgid "show <n> more commits after the common ancestor"
 msgstr "<n> weitere Commits nach dem gemeinsamen Vorgänger-Commit anzeigen"
 
-#: builtin/show-branch.c:653
+#: builtin/show-branch.c:652
 msgid "synonym to more=-1"
 msgstr "Synonym für more=-1"
 
-#: builtin/show-branch.c:654
+#: builtin/show-branch.c:653
 msgid "suppress naming strings"
 msgstr "Namen unterdrücken"
 
-#: builtin/show-branch.c:656
+#: builtin/show-branch.c:655
 msgid "include the current branch"
 msgstr "den aktuellen Branch einbeziehen"
 
-#: builtin/show-branch.c:658
+#: builtin/show-branch.c:657
 msgid "name commits with their object names"
 msgstr "Commits nach ihren Objektnamen benennen"
 
-#: builtin/show-branch.c:660
+#: builtin/show-branch.c:659
 msgid "show possible merge bases"
 msgstr "mögliche Merge-Basen anzeigen"
 
-#: builtin/show-branch.c:662
+#: builtin/show-branch.c:661
 msgid "show refs unreachable from any other ref"
 msgstr ""
 "Referenzen, die unerreichbar von allen anderen Referenzen sind, anzeigen"
 
-#: builtin/show-branch.c:664
+#: builtin/show-branch.c:663
 msgid "show commits in topological order"
 msgstr "Commits in topologischer Ordnung anzeigen"
 
-#: builtin/show-branch.c:667
+#: builtin/show-branch.c:666
 msgid "show only commits not on the first branch"
 msgstr "nur Commits anzeigen, die sich nicht im ersten Branch befinden"
 
-#: builtin/show-branch.c:669
+#: builtin/show-branch.c:668
 msgid "show merges reachable from only one tip"
 msgstr "Merges anzeigen, die nur von einem Branch aus erreichbar sind"
 
-#: builtin/show-branch.c:671
+#: builtin/show-branch.c:670
 msgid "topologically sort, maintaining date order where possible"
 msgstr "topologische Sortierung, Beibehaltung Datumsordnung wo möglich"
 
-#: builtin/show-branch.c:674
+#: builtin/show-branch.c:673
 msgid "<n>[,<base>]"
 msgstr "<n>[,<Basis>]"
 
-#: builtin/show-branch.c:675
+#: builtin/show-branch.c:674
 msgid "show <n> most recent ref-log entries starting at base"
 msgstr "die <n> jüngsten Einträge im Reflog, beginnend an der Basis, anzeigen"
 
-#: builtin/show-branch.c:711
+#: builtin/show-branch.c:710
 msgid ""
 "--reflog is incompatible with --all, --remotes, --independent or --merge-base"
 msgstr ""
 "--reflog ist inkompatibel mit --all, --remotes, --independent oder --merge-"
 "base"
 
-#: builtin/show-branch.c:735
+#: builtin/show-branch.c:734
 msgid "no branches given, and HEAD is not valid"
 msgstr "keine Branches angegeben, und HEAD ist ungültig"
 
-#: builtin/show-branch.c:738
+#: builtin/show-branch.c:737
 msgid "--reflog option needs one branch name"
 msgstr "die Option --reflog benötigt einen Branchnamen"
 
-#: builtin/show-branch.c:741
+#: builtin/show-branch.c:740
 #, c-format
 msgid "only %d entry can be shown at one time."
 msgid_plural "only %d entries can be shown at one time."
 msgstr[0] "nur %d Eintrag kann zur selben Zeit angezeigt werden."
 msgstr[1] "nur %d Einträge können zur selben Zeit angezeigt werden."
 
-#: builtin/show-branch.c:745
+#: builtin/show-branch.c:744
 #, c-format
 msgid "no such ref %s"
 msgstr "Referenz nicht gefunden: %s"
 
-#: builtin/show-branch.c:831
+#: builtin/show-branch.c:828
 #, c-format
 msgid "cannot handle more than %d rev."
 msgid_plural "cannot handle more than %d revs."
 msgstr[0] "Kann nicht mehr als %d Commit behandeln."
 msgstr[1] "Kann nicht mehr als %d Commits behandeln."
 
-#: builtin/show-branch.c:835
+#: builtin/show-branch.c:832
 #, c-format
 msgid "'%s' is not a valid ref."
 msgstr "'%s' ist keine gültige Referenz."
 
-#: builtin/show-branch.c:838
+#: builtin/show-branch.c:835
 #, c-format
 msgid "cannot find commit %s (%s)"
 msgstr "kann Commit %s (%s) nicht finden"
@@ -22611,74 +22843,86 @@ msgstr ""
 "dieses Arbeitsverzeichnis ist nicht partiell (Datei für partieller Checkout "
 "existiert eventuell nicht)"
 
-#: builtin/sparse-checkout.c:227
+#: builtin/sparse-checkout.c:173
+#, c-format
+msgid ""
+"directory '%s' contains untracked files, but is not in the sparse-checkout "
+"cone"
+msgstr ""
+
+#: builtin/sparse-checkout.c:181
+#, fuzzy, c-format
+msgid "failed to remove directory '%s'"
+msgstr "Fehler beim Erstellen von Verzeichnis '%s'"
+
+#: builtin/sparse-checkout.c:321
 msgid "failed to create directory for sparse-checkout file"
 msgstr ""
 "Fehler beim Erstellen eines Verzeichnisses für Datei eines partiellen "
 "Checkouts"
 
-#: builtin/sparse-checkout.c:268
+#: builtin/sparse-checkout.c:362
 msgid "unable to upgrade repository format to enable worktreeConfig"
 msgstr ""
 "Repository-Format konnte nicht erweitert werden, um worktreeConfig zu "
 "aktivieren"
 
-#: builtin/sparse-checkout.c:270
+#: builtin/sparse-checkout.c:364
 msgid "failed to set extensions.worktreeConfig setting"
 msgstr "Einstellung für extensions.worktreeConfig konnte nicht gesetzt werden"
 
-#: builtin/sparse-checkout.c:290
+#: builtin/sparse-checkout.c:384
 msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
 msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
 
-#: builtin/sparse-checkout.c:310
+#: builtin/sparse-checkout.c:404
 msgid "initialize the sparse-checkout in cone mode"
 msgstr "initialisiere den partiellen Checkout im Cone-Modus"
 
-#: builtin/sparse-checkout.c:312
+#: builtin/sparse-checkout.c:406
 msgid "toggle the use of a sparse index"
 msgstr "die Nutzung des Sparse-Index umschalten"
 
-#: builtin/sparse-checkout.c:340
+#: builtin/sparse-checkout.c:434
 msgid "failed to modify sparse-index config"
 msgstr "Verändern der Konfiguration für Sparse-Index fehlgeschlagen"
 
-#: builtin/sparse-checkout.c:361
+#: builtin/sparse-checkout.c:455
 #, c-format
 msgid "failed to open '%s'"
 msgstr "Fehler beim Öffnen von '%s'"
 
-#: builtin/sparse-checkout.c:413
+#: builtin/sparse-checkout.c:507
 #, c-format
 msgid "could not normalize path %s"
 msgstr "konnte Pfad '%s' nicht normalisieren"
 
-#: builtin/sparse-checkout.c:425
+#: builtin/sparse-checkout.c:519
 msgid "git sparse-checkout (set|add) (--stdin | <patterns>)"
 msgstr "git sparse-checkout (set|add) (--stdin | <Muster>)"
 
-#: builtin/sparse-checkout.c:450
+#: builtin/sparse-checkout.c:544
 #, c-format
 msgid "unable to unquote C-style string '%s'"
 msgstr "konnte Anführungszeichen von C-Style Zeichenkette '%s' nicht entfernen"
 
-#: builtin/sparse-checkout.c:504 builtin/sparse-checkout.c:528
+#: builtin/sparse-checkout.c:598 builtin/sparse-checkout.c:622
 msgid "unable to load existing sparse-checkout patterns"
 msgstr "konnte die existierenden Muster des partiellen Checkouts nicht laden"
 
-#: builtin/sparse-checkout.c:573
+#: builtin/sparse-checkout.c:667
 msgid "read patterns from standard in"
 msgstr "Muster von der Standard-Eingabe lesen"
 
-#: builtin/sparse-checkout.c:588
+#: builtin/sparse-checkout.c:682
 msgid "git sparse-checkout reapply"
 msgstr "git sparse-checkout reapply"
 
-#: builtin/sparse-checkout.c:607
+#: builtin/sparse-checkout.c:701
 msgid "git sparse-checkout disable"
 msgstr "git sparse-checkout disable"
 
-#: builtin/sparse-checkout.c:638
+#: builtin/sparse-checkout.c:732
 msgid "error while refreshing working directory"
 msgstr "Fehler während der Aktualisierung des Arbeitsverzeichnisses."
 
@@ -22714,7 +22958,7 @@ msgstr ""
 "          [--pathspec-from-file=<Datei> [--pathspec-file-nul]]\n"
 "          [--] [<Pfadspezifikation>...]]"
 
-#: builtin/stash.c:34 builtin/stash.c:87
+#: builtin/stash.c:34
 msgid ""
 "git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [<message>]"
@@ -22744,6 +22988,15 @@ msgstr ""
 "          [-u|--include-untracked] [-a|--all] [-m|--message <Nachricht>]\n"
 "          [--] [<Pfadspezifikation>...]]"
 
+#: builtin/stash.c:87
+#, fuzzy
+msgid ""
+"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"               [-u|--include-untracked] [-a|--all] [<message>]"
+msgstr ""
+"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"          [-u|--include-untracked] [-a|--all] [<Nachricht>]"
+
 #: builtin/stash.c:130
 #, c-format
 msgid "'%s' is not a stash-like commit"
@@ -22767,7 +23020,7 @@ msgstr "'%s' ist kein gültiger Referenzname."
 msgid "git stash clear with arguments is unimplemented"
 msgstr "git stash clear mit Parametern ist nicht implementiert"
 
-#: builtin/stash.c:431
+#: builtin/stash.c:447
 #, c-format
 msgid ""
 "WARNING: Untracked file in way of tracked file!  Renaming\n"
@@ -22779,169 +23032,169 @@ msgstr ""
 "            %s -> %s\n"
 "         um Platz zu schaffen.\n"
 
-#: builtin/stash.c:492
+#: builtin/stash.c:508
 msgid "cannot apply a stash in the middle of a merge"
 msgstr "Kann Stash nicht anwenden, solange ein Merge im Gange ist"
 
-#: builtin/stash.c:503
+#: builtin/stash.c:519
 #, c-format
 msgid "could not generate diff %s^!."
 msgstr "Konnte keinen Diff erzeugen %s^!."
 
-#: builtin/stash.c:510
+#: builtin/stash.c:526
 msgid "conflicts in index. Try without --index."
 msgstr "Konflikte im Index. Versuchen Sie es ohne --index."
 
-#: builtin/stash.c:516
+#: builtin/stash.c:532
 msgid "could not save index tree"
 msgstr "Konnte Index-Verzeichnis nicht speichern"
 
-#: builtin/stash.c:525
-msgid "could not restore untracked files from stash"
-msgstr "Konnte unversionierte Dateien vom Stash nicht wiederherstellen."
-
-#: builtin/stash.c:539
+#: builtin/stash.c:552
 #, c-format
 msgid "Merging %s with %s"
 msgstr "Führe %s mit %s zusammen"
 
-#: builtin/stash.c:549
+#: builtin/stash.c:562
 msgid "Index was not unstashed."
 msgstr "Index wurde nicht aus dem Stash zurückgeladen."
 
-#: builtin/stash.c:591 builtin/stash.c:689
+#: builtin/stash.c:575
+msgid "could not restore untracked files from stash"
+msgstr "Konnte unversionierte Dateien vom Stash nicht wiederherstellen."
+
+#: builtin/stash.c:607 builtin/stash.c:705
 msgid "attempt to recreate the index"
 msgstr "Versuche Index wiederherzustellen."
 
-#: builtin/stash.c:635
+#: builtin/stash.c:651
 #, c-format
 msgid "Dropped %s (%s)"
 msgstr "%s (%s) gelöscht"
 
-#: builtin/stash.c:638
+#: builtin/stash.c:654
 #, c-format
 msgid "%s: Could not drop stash entry"
 msgstr "%s: Konnte Stash-Eintrag nicht löschen"
 
-#: builtin/stash.c:651
+#: builtin/stash.c:667
 #, c-format
 msgid "'%s' is not a stash reference"
 msgstr "'%s' ist keine Stash-Referenz"
 
-#: builtin/stash.c:701
+#: builtin/stash.c:717
 msgid "The stash entry is kept in case you need it again."
 msgstr ""
 "Der Stash-Eintrag wird für den Fall behalten, dass Sie diesen nochmal "
 "benötigen."
 
-#: builtin/stash.c:724
+#: builtin/stash.c:740
 msgid "No branch name specified"
 msgstr "Kein Branchname spezifiziert"
 
-#: builtin/stash.c:808
+#: builtin/stash.c:824
 msgid "failed to parse tree"
 msgstr "Parsen der Tree-Objekte fehlgeschlagen"
 
-#: builtin/stash.c:819
+#: builtin/stash.c:835
 msgid "failed to unpack trees"
 msgstr "Entpacken der Tree-Objekte fehlgeschlagen"
 
-#: builtin/stash.c:839
+#: builtin/stash.c:855
 msgid "include untracked files in the stash"
 msgstr "unversionierte Dateien in Stash einbeziehen"
 
-#: builtin/stash.c:842
+#: builtin/stash.c:858
 msgid "only show untracked files in the stash"
 msgstr "nur unversionierte Dateien im Stash anzeigen"
 
-#: builtin/stash.c:929 builtin/stash.c:966
+#: builtin/stash.c:945 builtin/stash.c:982
 #, c-format
 msgid "Cannot update %s with %s"
 msgstr "Kann nicht %s mit %s aktualisieren."
 
-#: builtin/stash.c:947 builtin/stash.c:1602 builtin/stash.c:1667
+#: builtin/stash.c:963 builtin/stash.c:1619 builtin/stash.c:1684
 msgid "stash message"
 msgstr "Stash-Beschreibung"
 
-#: builtin/stash.c:957
+#: builtin/stash.c:973
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "\"git stash store\" erwartet ein Argument <Commit>"
 
-#: builtin/stash.c:1171
+#: builtin/stash.c:1187
 msgid "No changes selected"
 msgstr "Keine Änderungen ausgewählt"
 
-#: builtin/stash.c:1271
+#: builtin/stash.c:1287
 msgid "You do not have the initial commit yet"
 msgstr "Sie haben bisher noch keinen initialen Commit"
 
-#: builtin/stash.c:1298
+#: builtin/stash.c:1314
 msgid "Cannot save the current index state"
 msgstr "Kann den aktuellen Zustand des Index nicht speichern"
 
-#: builtin/stash.c:1307
+#: builtin/stash.c:1323
 msgid "Cannot save the untracked files"
 msgstr "Kann die unversionierten Dateien nicht speichern"
 
-#: builtin/stash.c:1318 builtin/stash.c:1327
+#: builtin/stash.c:1334 builtin/stash.c:1343
 msgid "Cannot save the current worktree state"
 msgstr "Kann den aktuellen Zustand des Arbeitsverzeichnisses nicht speichern"
 
-#: builtin/stash.c:1355
+#: builtin/stash.c:1371
 msgid "Cannot record working tree state"
 msgstr "Kann Zustand des Arbeitsverzeichnisses nicht aufzeichnen"
 
-#: builtin/stash.c:1404
+#: builtin/stash.c:1420
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr ""
 "Kann nicht gleichzeitig --patch und --include-untracked oder --all verwenden"
 
-#: builtin/stash.c:1422
+#: builtin/stash.c:1438
 msgid "Did you forget to 'git add'?"
 msgstr "Haben Sie vielleicht 'git add' vergessen?"
 
-#: builtin/stash.c:1437
+#: builtin/stash.c:1453
 msgid "No local changes to save"
 msgstr "Keine lokalen Änderungen zum Speichern"
 
-#: builtin/stash.c:1444
+#: builtin/stash.c:1460
 msgid "Cannot initialize stash"
 msgstr "Kann \"stash\" nicht initialisieren"
 
-#: builtin/stash.c:1459
+#: builtin/stash.c:1475
 msgid "Cannot save the current status"
 msgstr "Kann den aktuellen Status nicht speichern"
 
-#: builtin/stash.c:1464
+#: builtin/stash.c:1480
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "Arbeitsverzeichnis und Index-Status %s gespeichert."
 
-#: builtin/stash.c:1554
+#: builtin/stash.c:1571
 msgid "Cannot remove worktree changes"
 msgstr "Kann Änderungen im Arbeitsverzeichnis nicht löschen"
 
-#: builtin/stash.c:1593 builtin/stash.c:1658
+#: builtin/stash.c:1610 builtin/stash.c:1675
 msgid "keep index"
 msgstr "behalte Index"
 
-#: builtin/stash.c:1595 builtin/stash.c:1660
+#: builtin/stash.c:1612 builtin/stash.c:1677
 msgid "stash in patch mode"
 msgstr "Stash in Patch-Modus"
 
-#: builtin/stash.c:1596 builtin/stash.c:1661
+#: builtin/stash.c:1613 builtin/stash.c:1678
 msgid "quiet mode"
 msgstr "weniger Ausgaben"
 
-#: builtin/stash.c:1598 builtin/stash.c:1663
+#: builtin/stash.c:1615 builtin/stash.c:1680
 msgid "include untracked files in stash"
 msgstr "unversionierte Dateien in Stash einbeziehen"
 
-#: builtin/stash.c:1600 builtin/stash.c:1665
+#: builtin/stash.c:1617 builtin/stash.c:1682
 msgid "include ignore files"
 msgstr "ignorierte Dateien einbeziehen"
 
-#: builtin/stash.c:1700
+#: builtin/stash.c:1717
 msgid ""
 "the stash.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -22967,7 +23220,7 @@ msgstr ""
 msgid "prepend comment character and space to each line"
 msgstr "Kommentarzeichen mit Leerzeichen an jede Zeile voranstellen"
 
-#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2440
+#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2667
 #, c-format
 msgid "Expecting a full ref name, got %s"
 msgstr "Vollständiger Referenzname erwartet, %s erhalten"
@@ -22981,27 +23234,35 @@ msgstr "'submodule--helper print-default-remote' erwartet keine Argumente."
 msgid "cannot strip one component off url '%s'"
 msgstr "Kann eine Komponente von URL '%s' nicht extrahieren"
 
-#: builtin/submodule--helper.c:411 builtin/submodule--helper.c:1887
-#: builtin/submodule--helper.c:2891
+#: builtin/submodule--helper.c:211
+#, c-format
+msgid ""
+"could not look up configuration '%s'. Assuming this repository is its own "
+"authoritative upstream."
+msgstr ""
+"Konnte Konfiguration '%s' nicht nachschlagen. Nehme an, dass dieses\n"
+"Repository sein eigenes verbindliches Upstream-Repository ist."
+
+#: builtin/submodule--helper.c:405 builtin/submodule--helper.c:1858
 msgid "alternative anchor for relative paths"
 msgstr "Alternativer Anker für relative Pfade"
 
-#: builtin/submodule--helper.c:416
+#: builtin/submodule--helper.c:410
 msgid "git submodule--helper list [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper list [--prefix=<Pfad>] [<Pfad>...]"
 
-#: builtin/submodule--helper.c:474 builtin/submodule--helper.c:631
-#: builtin/submodule--helper.c:654
+#: builtin/submodule--helper.c:468 builtin/submodule--helper.c:605
+#: builtin/submodule--helper.c:628
 #, c-format
 msgid "No url found for submodule path '%s' in .gitmodules"
 msgstr "Keine URL für Submodul-Pfad '%s' in .gitmodules gefunden"
 
-#: builtin/submodule--helper.c:526
+#: builtin/submodule--helper.c:520
 #, c-format
 msgid "Entering '%s'\n"
 msgstr "Betrete '%s'\n"
 
-#: builtin/submodule--helper.c:529
+#: builtin/submodule--helper.c:523
 #, c-format
 msgid ""
 "run_command returned non-zero status for %s\n"
@@ -23010,7 +23271,7 @@ msgstr ""
 "run_command gab nicht-Null Status für '%s' zurück.\n"
 "."
 
-#: builtin/submodule--helper.c:551
+#: builtin/submodule--helper.c:545
 #, c-format
 msgid ""
 "run_command returned non-zero status while recursing in the nested "
@@ -23022,177 +23283,168 @@ msgstr ""
 "nicht-Null Status zurück.\n"
 "."
 
-#: builtin/submodule--helper.c:567
+#: builtin/submodule--helper.c:561
 msgid "suppress output of entering each submodule command"
 msgstr "Ausgaben beim Betreten eines Submodul-Befehls unterdrücken"
 
-#: builtin/submodule--helper.c:569 builtin/submodule--helper.c:890
-#: builtin/submodule--helper.c:1489
+#: builtin/submodule--helper.c:563 builtin/submodule--helper.c:864
+#: builtin/submodule--helper.c:1453
 msgid "recurse into nested submodules"
 msgstr "Rekursion in verschachtelte Submodule durchführen"
 
-#: builtin/submodule--helper.c:574
+#: builtin/submodule--helper.c:568
 msgid "git submodule--helper foreach [--quiet] [--recursive] [--] <command>"
 msgstr "git submodule--helper foreach [--quiet] [--recursive] [--] <Befehl>"
 
-#: builtin/submodule--helper.c:601
-#, c-format
-msgid ""
-"could not look up configuration '%s'. Assuming this repository is its own "
-"authoritative upstream."
-msgstr ""
-"Konnte Konfiguration '%s' nicht nachschlagen. Nehme an, dass dieses\n"
-"Repository sein eigenes verbindliches Upstream-Repository ist."
-
-#: builtin/submodule--helper.c:668
+#: builtin/submodule--helper.c:642
 #, c-format
 msgid "Failed to register url for submodule path '%s'"
 msgstr ""
 "Fehler beim Eintragen der URL für Submodul-Pfad '%s' in die Konfiguration."
 
-#: builtin/submodule--helper.c:672
+#: builtin/submodule--helper.c:646
 #, c-format
 msgid "Submodule '%s' (%s) registered for path '%s'\n"
 msgstr "Submodul '%s' (%s) für Pfad '%s' in die Konfiguration eingetragen.\n"
 
-#: builtin/submodule--helper.c:682
+#: builtin/submodule--helper.c:656
 #, c-format
 msgid "warning: command update mode suggested for submodule '%s'\n"
 msgstr "Warnung: 'update'-Modus für Submodul '%s' vorgeschlagen\n"
 
-#: builtin/submodule--helper.c:689
+#: builtin/submodule--helper.c:663
 #, c-format
 msgid "Failed to register update mode for submodule path '%s'"
 msgstr ""
 "Fehler bei Änderung des Aktualisierungsmodus für Submodul-Pfad '%s' in der\n"
 "Konfiguration."
 
-#: builtin/submodule--helper.c:711
+#: builtin/submodule--helper.c:685
 msgid "suppress output for initializing a submodule"
 msgstr "Ausgaben bei Initialisierung eines Submoduls unterdrücken"
 
-#: builtin/submodule--helper.c:716
+#: builtin/submodule--helper.c:690
 msgid "git submodule--helper init [<options>] [<path>]"
 msgstr "git submodule--helper init [<Optionen>] [<Pfad>]"
 
-#: builtin/submodule--helper.c:789 builtin/submodule--helper.c:924
+#: builtin/submodule--helper.c:763 builtin/submodule--helper.c:898
 #, c-format
 msgid "no submodule mapping found in .gitmodules for path '%s'"
 msgstr "Keine Submodul-Zuordnung in .gitmodules für Pfad '%s' gefunden"
 
-#: builtin/submodule--helper.c:837
+#: builtin/submodule--helper.c:811
 #, c-format
 msgid "could not resolve HEAD ref inside the submodule '%s'"
 msgstr "Konnte HEAD-Referenz nicht innerhalb des Submodul-Pfads '%s' auflösen."
 
-#: builtin/submodule--helper.c:864 builtin/submodule--helper.c:1459
+#: builtin/submodule--helper.c:838 builtin/submodule--helper.c:1423
 #, c-format
 msgid "failed to recurse into submodule '%s'"
 msgstr "Fehler bei Rekursion in Submodul '%s'."
 
-#: builtin/submodule--helper.c:888 builtin/submodule--helper.c:1625
+#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1589
 msgid "suppress submodule status output"
 msgstr "Ausgabe des Submodul-Status unterdrücken"
 
-#: builtin/submodule--helper.c:889
+#: builtin/submodule--helper.c:863
 msgid ""
 "use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
 msgstr ""
 "den Commit benutzen, der im Index gespeichert ist, statt den im Submodul HEAD"
 
-#: builtin/submodule--helper.c:895
+#: builtin/submodule--helper.c:869
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
 msgstr "git submodule status [--quiet] [--cached] [--recursive] [<Pfad>...]"
 
-#: builtin/submodule--helper.c:919
+#: builtin/submodule--helper.c:893
 msgid "git submodule--helper name <path>"
 msgstr "git submodule--helper name <Pfad>"
 
-#: builtin/submodule--helper.c:991
+#: builtin/submodule--helper.c:965
 #, c-format
 msgid "* %s %s(blob)->%s(submodule)"
 msgstr "* %s %s(blob)->%s(submodule)"
 
-#: builtin/submodule--helper.c:994
+#: builtin/submodule--helper.c:968
 #, c-format
 msgid "* %s %s(submodule)->%s(blob)"
 msgstr "* %s %s(submodule)->%s(blob)"
 
-#: builtin/submodule--helper.c:1007
+#: builtin/submodule--helper.c:981
 #, c-format
 msgid "%s"
 msgstr "%s"
 
-#: builtin/submodule--helper.c:1057
+#: builtin/submodule--helper.c:1031
 #, c-format
 msgid "couldn't hash object from '%s'"
 msgstr "Hash eines Objektes von '%s' konnte nicht erzeugt werden"
 
-#: builtin/submodule--helper.c:1061
+#: builtin/submodule--helper.c:1035
 #, c-format
 msgid "unexpected mode %o\n"
 msgstr "unerwarteter Modus %o\n"
 
-#: builtin/submodule--helper.c:1302
+#: builtin/submodule--helper.c:1276
 msgid "use the commit stored in the index instead of the submodule HEAD"
 msgstr ""
 "benutze den Commit, der im Index gespeichert ist, statt vom Submodul HEAD"
 
-#: builtin/submodule--helper.c:1304
+#: builtin/submodule--helper.c:1278
 msgid "compare the commit in the index with that in the submodule HEAD"
 msgstr "den Commit aus dem Index mit dem im Submodul HEAD vergleichen"
 
-#: builtin/submodule--helper.c:1306
+#: builtin/submodule--helper.c:1280
 msgid "skip submodules with 'ignore_config' value set to 'all'"
 msgstr ""
 "überspringe Submodule, wo der 'ignore_config' Wert auf 'all' gesetzt ist"
 
-#: builtin/submodule--helper.c:1308
+#: builtin/submodule--helper.c:1282
 msgid "limit the summary size"
 msgstr "Größe der Zusammenfassung begrenzen"
 
-#: builtin/submodule--helper.c:1313
+#: builtin/submodule--helper.c:1287
 msgid "git submodule--helper summary [<options>] [<commit>] [--] [<path>]"
 msgstr "git submodule--helper summary [<Optionen>] [<Commit>] [--] [<Pfad>]"
 
-#: builtin/submodule--helper.c:1337
+#: builtin/submodule--helper.c:1311
 msgid "could not fetch a revision for HEAD"
 msgstr "konnte keinen Commit für HEAD holen"
 
-#: builtin/submodule--helper.c:1342
+#: builtin/submodule--helper.c:1316
 msgid "--cached and --files are mutually exclusive"
 msgstr "--cached und --files schließen sich gegenseitig aus"
 
-#: builtin/submodule--helper.c:1409
+#: builtin/submodule--helper.c:1373
 #, c-format
 msgid "Synchronizing submodule url for '%s'\n"
 msgstr "Synchronisiere Submodul-URL für '%s'\n"
 
-#: builtin/submodule--helper.c:1415
+#: builtin/submodule--helper.c:1379
 #, c-format
 msgid "failed to register url for submodule path '%s'"
 msgstr "Fehler beim Registrieren der URL für Submodul-Pfad '%s'"
 
-#: builtin/submodule--helper.c:1429
+#: builtin/submodule--helper.c:1393
 #, c-format
 msgid "failed to get the default remote for submodule '%s'"
 msgstr "Fehler beim Lesen des Standard-Remote-Repositories für Submodul '%s'"
 
-#: builtin/submodule--helper.c:1440
+#: builtin/submodule--helper.c:1404
 #, c-format
 msgid "failed to update remote for submodule '%s'"
 msgstr "Fehler beim Aktualisieren des Remote-Repositories für Submodul '%s'"
 
-#: builtin/submodule--helper.c:1487
+#: builtin/submodule--helper.c:1451
 msgid "suppress output of synchronizing submodule url"
 msgstr "Ausgaben bei der Synchronisierung der Submodul-URLs unterdrücken"
 
-#: builtin/submodule--helper.c:1494
+#: builtin/submodule--helper.c:1458
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
 msgstr "git submodule--helper sync [--quiet] [--recursive] [<Pfad>]"
 
-#: builtin/submodule--helper.c:1548
+#: builtin/submodule--helper.c:1512
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains a .git directory (use 'rm -rf' if you "
@@ -23202,7 +23454,7 @@ msgstr ""
 "(benutzen Sie 'rm -rf', wenn Sie dieses wirklich mitsamt seiner Historie\n"
 "löschen möchten)"
 
-#: builtin/submodule--helper.c:1560
+#: builtin/submodule--helper.c:1524
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
@@ -23211,49 +23463,49 @@ msgstr ""
 "Arbeitsverzeichnis von Submodul in '%s' enthält lokale Änderungen;\n"
 "verwenden Sie '-f', um diese zu verwerfen."
 
-#: builtin/submodule--helper.c:1568
+#: builtin/submodule--helper.c:1532
 #, c-format
 msgid "Cleared directory '%s'\n"
 msgstr "Verzeichnis '%s' bereinigt.\n"
 
-#: builtin/submodule--helper.c:1570
+#: builtin/submodule--helper.c:1534
 #, c-format
 msgid "Could not remove submodule work tree '%s'\n"
 msgstr "Konnte Arbeitsverzeichnis des Submoduls in '%s' nicht löschen.\n"
 
-#: builtin/submodule--helper.c:1581
+#: builtin/submodule--helper.c:1545
 #, c-format
 msgid "could not create empty submodule directory %s"
 msgstr "Konnte kein leeres Verzeichnis für Submodul in '%s' erstellen."
 
-#: builtin/submodule--helper.c:1597
+#: builtin/submodule--helper.c:1561
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "Submodul '%s' (%s) für Pfad '%s' ausgetragen.\n"
 
-#: builtin/submodule--helper.c:1626
+#: builtin/submodule--helper.c:1590
 msgid "remove submodule working trees even if they contain local changes"
 msgstr ""
 "Arbeitsverzeichnisse von Submodulen löschen, auch wenn lokale Änderungen "
 "vorliegen"
 
-#: builtin/submodule--helper.c:1627
+#: builtin/submodule--helper.c:1591
 msgid "unregister all submodules"
 msgstr "alle Submodule austragen"
 
-#: builtin/submodule--helper.c:1632
+#: builtin/submodule--helper.c:1596
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<Pfad>...]]"
 
-#: builtin/submodule--helper.c:1646
+#: builtin/submodule--helper.c:1610
 msgid "Use '--all' if you really want to deinitialize all submodules"
 msgstr ""
 "Verwenden Sie '--all', wenn Sie wirklich alle Submodule deinitialisieren\n"
 "möchten."
 
-#: builtin/submodule--helper.c:1690
+#: builtin/submodule--helper.c:1655
 msgid ""
 "An alternate computed from a superproject's alternate is invalid.\n"
 "To allow Git to clone without an alternate in such a case, set\n"
@@ -23266,69 +23518,69 @@ msgstr ""
 "submodule.alternateErrorStrategy auf 'info' oder klone mit der Option\n"
 "'--reference-if-able' statt '--reference'."
 
-#: builtin/submodule--helper.c:1729 builtin/submodule--helper.c:1732
+#: builtin/submodule--helper.c:1700 builtin/submodule--helper.c:1703
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
 msgstr "Submodul '%s' kann Alternative nicht hinzufügen: %s"
 
-#: builtin/submodule--helper.c:1768
+#: builtin/submodule--helper.c:1739
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
 msgstr "Wert '%s' für submodule.alternateErrorStrategy wird nicht erkannt"
 
-#: builtin/submodule--helper.c:1775
+#: builtin/submodule--helper.c:1746
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
 msgstr "Wert '%s' für submodule.alternateLocation wird nicht erkannt."
 
-#: builtin/submodule--helper.c:1800
+#: builtin/submodule--helper.c:1771
 #, c-format
 msgid "refusing to create/use '%s' in another submodule's git dir"
 msgstr ""
 "Erstellung/Benutzung von '%s' in einem anderen Submodul-Git-Verzeichnis\n"
 "verweigert."
 
-#: builtin/submodule--helper.c:1841
+#: builtin/submodule--helper.c:1812
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
 msgstr "Klonen von '%s' in Submodul-Pfad '%s' fehlgeschlagen."
 
-#: builtin/submodule--helper.c:1846
+#: builtin/submodule--helper.c:1817
 #, c-format
 msgid "directory not empty: '%s'"
 msgstr "Verzeichnis ist nicht leer: '%s'"
 
-#: builtin/submodule--helper.c:1858
+#: builtin/submodule--helper.c:1829
 #, c-format
 msgid "could not get submodule directory for '%s'"
 msgstr "Konnte Submodul-Verzeichnis '%s' nicht finden."
 
-#: builtin/submodule--helper.c:1890 builtin/submodule--helper.c:2894
+#: builtin/submodule--helper.c:1861
 msgid "where the new submodule will be cloned to"
 msgstr "Pfad für neues Submodul"
 
-#: builtin/submodule--helper.c:1893 builtin/submodule--helper.c:2897
+#: builtin/submodule--helper.c:1864
 msgid "name of the new submodule"
 msgstr "Name des neuen Submoduls"
 
-#: builtin/submodule--helper.c:1896 builtin/submodule--helper.c:2900
+#: builtin/submodule--helper.c:1867
 msgid "url where to clone the submodule from"
 msgstr "URL von der das Submodul geklont wird"
 
-#: builtin/submodule--helper.c:1904 builtin/submodule--helper.c:2907
+#: builtin/submodule--helper.c:1875 builtin/submodule--helper.c:3264
 msgid "depth for shallow clones"
 msgstr "Tiefe des Klons mit unvollständiger Historie (shallow)"
 
-#: builtin/submodule--helper.c:1907 builtin/submodule--helper.c:2365
-#: builtin/submodule--helper.c:2909
+#: builtin/submodule--helper.c:1878 builtin/submodule--helper.c:2525
+#: builtin/submodule--helper.c:3257
 msgid "force cloning progress"
 msgstr "Fortschrittsanzeige beim Klonen erzwingen"
 
-#: builtin/submodule--helper.c:1909 builtin/submodule--helper.c:2367
+#: builtin/submodule--helper.c:1880 builtin/submodule--helper.c:2527
 msgid "disallow cloning into non-empty directory"
 msgstr "Klonen in ein nicht leeres Verzeichnis verbieten"
 
-#: builtin/submodule--helper.c:1916
+#: builtin/submodule--helper.c:1887
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
 "<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
@@ -23338,88 +23590,192 @@ msgstr ""
 "<Repository>] [--name <Name>] [--depth <Tiefe>] [--single-branch] --url "
 "<URL> --path <Pfad>"
 
-#: builtin/submodule--helper.c:1953
+#: builtin/submodule--helper.c:1924
 #, c-format
 msgid "Invalid update mode '%s' for submodule path '%s'"
 msgstr "Ungültiger Aktualisierungsmodus '%s' für Submodul-Pfad '%s'."
 
-#: builtin/submodule--helper.c:1957
+#: builtin/submodule--helper.c:1928
 #, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
 msgstr ""
 "Ungültiger Aktualisierungsmodus '%s' für Submodul-Pfad '%s' konfiguriert."
 
-#: builtin/submodule--helper.c:2058
+#: builtin/submodule--helper.c:2043
 #, c-format
 msgid "Submodule path '%s' not initialized"
 msgstr "Submodul-Pfad '%s' nicht initialisiert"
 
-#: builtin/submodule--helper.c:2062
+#: builtin/submodule--helper.c:2047
 msgid "Maybe you want to use 'update --init'?"
 msgstr "Meinten Sie vielleicht 'update --init'?"
 
-#: builtin/submodule--helper.c:2092
+#: builtin/submodule--helper.c:2077
 #, c-format
 msgid "Skipping unmerged submodule %s"
 msgstr "Überspringe nicht zusammengeführtes Submodul %s"
 
-#: builtin/submodule--helper.c:2121
+#: builtin/submodule--helper.c:2106
 #, c-format
 msgid "Skipping submodule '%s'"
 msgstr "Überspringe Submodul '%s'"
 
-#: builtin/submodule--helper.c:2271
+#: builtin/submodule--helper.c:2256
 #, c-format
 msgid "Failed to clone '%s'. Retry scheduled"
 msgstr "Fehler beim Klonen von '%s'. Weiterer Versuch geplant"
 
-#: builtin/submodule--helper.c:2282
+#: builtin/submodule--helper.c:2267
 #, c-format
 msgid "Failed to clone '%s' a second time, aborting"
 msgstr "Zweiter Versuch '%s' zu klonen fehlgeschlagen, breche ab."
 
-#: builtin/submodule--helper.c:2344 builtin/submodule--helper.c:2590
+#: builtin/submodule--helper.c:2372
+#, fuzzy, c-format
+msgid "Unable to checkout '%s' in submodule path '%s'"
+msgstr "Konnte '$sha1' in Submodul-Pfad '$displaypath' nicht auschecken."
+
+#: builtin/submodule--helper.c:2376
+#, fuzzy, c-format
+msgid "Unable to rebase '%s' in submodule path '%s'"
+msgstr "Rebase auf '$sha1' in Submodul-Pfad '$displaypath' nicht möglich"
+
+#: builtin/submodule--helper.c:2380
+#, fuzzy, c-format
+msgid "Unable to merge '%s' in submodule path '%s'"
+msgstr "Merge von '$sha1' in Submodul-Pfad '$displaypath' fehlgeschlagen"
+
+#: builtin/submodule--helper.c:2384
+#, fuzzy, c-format
+msgid "Execution of '%s %s' failed in submodule path '%s'"
+msgstr ""
+"Ausführung von '$command $sha1' in Submodul-Pfad '$displaypath' "
+"fehlgeschlagen"
+
+#: builtin/submodule--helper.c:2408
+#, fuzzy, c-format
+msgid "Submodule path '%s': checked out '%s'\n"
+msgstr "Submodul-Pfad: '$displaypath': '$sha1' ausgecheckt"
+
+#: builtin/submodule--helper.c:2412
+#, fuzzy, c-format
+msgid "Submodule path '%s': rebased into '%s'\n"
+msgstr "Submodul-Pfad '$displaypath': Rebase auf '$sha1'"
+
+#: builtin/submodule--helper.c:2416
+#, fuzzy, c-format
+msgid "Submodule path '%s': merged in '%s'\n"
+msgstr "Submodul-Pfad '$displaypath': zusammengeführt in '$sha1'"
+
+#: builtin/submodule--helper.c:2420
+#, fuzzy, c-format
+msgid "Submodule path '%s': '%s %s'\n"
+msgstr "Submodul-Pfad '%s' nicht initialisiert"
+
+#: builtin/submodule--helper.c:2444
+#, fuzzy, c-format
+msgid "Unable to fetch in submodule path '%s'; trying to directly fetch %s:"
+msgstr ""
+"Konnte \"fetch\" in Submodul-Pfad '$displaypath' nicht ausführen. Versuche "
+"$sha1 direkt anzufordern:"
+
+#: builtin/submodule--helper.c:2453
+#, fuzzy, c-format
+msgid ""
+"Fetched in submodule path '%s', but it did not contain %s. Direct fetching "
+"of that commit failed."
+msgstr ""
+"\"fetch\" in Submodul-Pfad '$displaypath' ausgeführt, aber $sha1 nicht\n"
+"enthalten. Direktes Anfordern dieses Commits ist fehlgeschlagen."
+
+#: builtin/submodule--helper.c:2504 builtin/submodule--helper.c:2574
+#: builtin/submodule--helper.c:2812
 msgid "path into the working tree"
 msgstr "Pfad zum Arbeitsverzeichnis"
 
-#: builtin/submodule--helper.c:2347
+#: builtin/submodule--helper.c:2507 builtin/submodule--helper.c:2579
 msgid "path into the working tree, across nested submodule boundaries"
 msgstr ""
 "Pfad zum Arbeitsverzeichnis, über verschachtelte Submodul-Grenzen hinweg"
 
-#: builtin/submodule--helper.c:2351
+#: builtin/submodule--helper.c:2511 builtin/submodule--helper.c:2577
 msgid "rebase, merge, checkout or none"
 msgstr "rebase, merge, checkout oder none"
 
-#: builtin/submodule--helper.c:2357
+#: builtin/submodule--helper.c:2517
 msgid "create a shallow clone truncated to the specified number of revisions"
 msgstr ""
 "einen Klon mit unvollständiger Historie (shallow) erstellen, abgeschnitten "
 "bei der angegebenen Anzahl von Commits"
 
-#: builtin/submodule--helper.c:2360
+#: builtin/submodule--helper.c:2520
 msgid "parallel jobs"
 msgstr "Parallele Ausführungen"
 
-#: builtin/submodule--helper.c:2362
+#: builtin/submodule--helper.c:2522
 msgid "whether the initial clone should follow the shallow recommendation"
 msgstr ""
 "ob das initiale Klonen den Empfehlungen für eine unvollständige\n"
 "Historie (shallow) folgen soll"
 
-#: builtin/submodule--helper.c:2363
+#: builtin/submodule--helper.c:2523
 msgid "don't print cloning progress"
 msgstr "keine Fortschrittsanzeige beim Klonen"
 
-#: builtin/submodule--helper.c:2374
+#: builtin/submodule--helper.c:2534
 msgid "git submodule--helper update-clone [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper update-clone [--prefix=<Pfad>] [<Pfad>...]"
 
-#: builtin/submodule--helper.c:2387
+#: builtin/submodule--helper.c:2547
 msgid "bad value for update parameter"
 msgstr "Fehlerhafter Wert für update Parameter"
 
-#: builtin/submodule--helper.c:2435
+#: builtin/submodule--helper.c:2565
+#, fuzzy
+msgid "suppress output for update by rebase or merge"
+msgstr "Ausgaben beim Setzen der URL eines Submoduls unterdrücken"
+
+#: builtin/submodule--helper.c:2566
+#, fuzzy
+msgid "force checkout updates"
+msgstr "Aktualisierung erzwingen"
+
+#: builtin/submodule--helper.c:2568
+#, fuzzy
+msgid "don't fetch new objects from the remote site"
+msgstr "Tree-Objekt vom aktuellen Index erstellen"
+
+#: builtin/submodule--helper.c:2570
+msgid "overrides update mode in case the repository is a fresh clone"
+msgstr ""
+
+#: builtin/submodule--helper.c:2571
+#, fuzzy
+msgid "depth for shallow fetch"
+msgstr "Tiefe des Klons mit unvollständiger Historie (shallow)"
+
+#: builtin/submodule--helper.c:2581
+msgid "sha1"
+msgstr ""
+
+#: builtin/submodule--helper.c:2582
+msgid "SHA1 expected by superproject"
+msgstr ""
+
+#: builtin/submodule--helper.c:2584
+msgid "subsha1"
+msgstr ""
+
+#: builtin/submodule--helper.c:2585
+msgid "SHA1 of submodule's HEAD"
+msgstr ""
+
+#: builtin/submodule--helper.c:2591
+#, fuzzy
+msgid "git submodule--helper run-update-procedure [<options>] <path>"
+msgstr "git submodule--helper init [<Optionen>] [<Pfad>]"
+
+#: builtin/submodule--helper.c:2662
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
@@ -23428,106 +23784,106 @@ msgstr ""
 "Branch von Submodul (%s) ist konfiguriert, den Branch des Hauptprojektes\n"
 "zu erben, aber das Hauptprojekt befindet sich auf keinem Branch."
 
-#: builtin/submodule--helper.c:2558
+#: builtin/submodule--helper.c:2780
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
 msgstr "Konnte kein Repository-Handle für Submodul '%s' erhalten."
 
-#: builtin/submodule--helper.c:2591
+#: builtin/submodule--helper.c:2813
 msgid "recurse into submodules"
 msgstr "Rekursion in Submodule durchführen"
 
-#: builtin/submodule--helper.c:2597
+#: builtin/submodule--helper.c:2819
 msgid "git submodule--helper absorb-git-dirs [<options>] [<path>...]"
 msgstr "git submodule--helper absorb-git-dirs [<Optionen>] [<Pfad>...]"
 
-#: builtin/submodule--helper.c:2653
+#: builtin/submodule--helper.c:2875
 msgid "check if it is safe to write to the .gitmodules file"
 msgstr "prüfen, ob es sicher ist, in die Datei .gitmodules zu schreiben"
 
-#: builtin/submodule--helper.c:2656
+#: builtin/submodule--helper.c:2878
 msgid "unset the config in the .gitmodules file"
 msgstr "Konfiguration in der .gitmodules-Datei entfernen"
 
-#: builtin/submodule--helper.c:2661
+#: builtin/submodule--helper.c:2883
 msgid "git submodule--helper config <name> [<value>]"
 msgstr "git submodule--helper config <name> [<Wert>]"
 
-#: builtin/submodule--helper.c:2662
+#: builtin/submodule--helper.c:2884
 msgid "git submodule--helper config --unset <name>"
 msgstr "git submodule--helper config --unset <Name>"
 
-#: builtin/submodule--helper.c:2663
+#: builtin/submodule--helper.c:2885
 msgid "git submodule--helper config --check-writeable"
 msgstr "git submodule--helper config --check-writeable"
 
-#: builtin/submodule--helper.c:2682 git-submodule.sh:150
-#, sh-format
+#: builtin/submodule--helper.c:2904 builtin/submodule--helper.c:3120
+#: builtin/submodule--helper.c:3276
 msgid "please make sure that the .gitmodules file is in the working tree"
 msgstr ""
 "Bitte stellen Sie sicher, dass sich die Datei .gitmodules im "
 "Arbeitsverzeichnis befindet."
 
-#: builtin/submodule--helper.c:2698
+#: builtin/submodule--helper.c:2920
 msgid "suppress output for setting url of a submodule"
 msgstr "Ausgaben beim Setzen der URL eines Submoduls unterdrücken"
 
-#: builtin/submodule--helper.c:2702
+#: builtin/submodule--helper.c:2924
 msgid "git submodule--helper set-url [--quiet] <path> <newurl>"
 msgstr "git submodule--helper set-url [--quiet] <Pfad> <neue URL>"
 
-#: builtin/submodule--helper.c:2735
+#: builtin/submodule--helper.c:2957
 msgid "set the default tracking branch to master"
 msgstr "Standard-Tracking-Branch auf master setzen"
 
-#: builtin/submodule--helper.c:2737
+#: builtin/submodule--helper.c:2959
 msgid "set the default tracking branch"
 msgstr "Standard-Tracking-Branch setzen"
 
-#: builtin/submodule--helper.c:2741
+#: builtin/submodule--helper.c:2963
 msgid "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
 msgstr "git submodule--helper set-branch [-q|--quiet] (-d|--default) [<Pfad>]"
 
-#: builtin/submodule--helper.c:2742
+#: builtin/submodule--helper.c:2964
 msgid ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
 msgstr ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <Branch> <Pfad>"
 
-#: builtin/submodule--helper.c:2749
+#: builtin/submodule--helper.c:2971
 msgid "--branch or --default required"
 msgstr "Option --branch oder --default erforderlich"
 
-#: builtin/submodule--helper.c:2752
+#: builtin/submodule--helper.c:2974
 msgid "--branch and --default are mutually exclusive"
 msgstr "--branch und --default schließen sich gegenseitig aus"
 
-#: builtin/submodule--helper.c:2815
+#: builtin/submodule--helper.c:3037
 #, c-format
 msgid "Adding existing repo at '%s' to the index\n"
 msgstr "Füge existierendes Repository in '%s' dem Index hinzu\n"
 
-#: builtin/submodule--helper.c:2818
+#: builtin/submodule--helper.c:3040
 #, c-format
 msgid "'%s' already exists and is not a valid git repo"
 msgstr "'%s' existiert bereits und ist kein gültiges Git-Repository"
 
-#: builtin/submodule--helper.c:2828
-#, c-format
-msgid "A git directory for '%s' is found locally with remote(s):"
+#: builtin/submodule--helper.c:3053
+#, fuzzy, c-format
+msgid "A git directory for '%s' is found locally with remote(s):\n"
 msgstr ""
 "Ein Git-Verzeichnis für '%s' wurde lokal gefunden mit den Remote-"
 "Repositories:"
 
-#: builtin/submodule--helper.c:2833
-#, c-format
+#: builtin/submodule--helper.c:3060
+#, fuzzy, c-format
 msgid ""
 "If you want to reuse this local git directory instead of cloning again from\n"
 "  %s\n"
 "use the '--force' option. If the local git directory is not the correct "
 "repo\n"
-"or if you are unsure what this means, choose another name with the '--name' "
-"option.\n"
+"or you are unsure what this means choose another name with the '--name' "
+"option."
 msgstr ""
 "Wenn Sie das lokale Git-Verzeichnis wiederverwenden wollen, anstatt erneut "
 "von\n"
@@ -23537,38 +23893,89 @@ msgstr ""
 "nicht das korrekte Repository ist oder Sie unsicher sind, was das bedeutet,\n"
 "wählen Sie einen anderen Namen mit der Option '--name'.\n"
 
-#: builtin/submodule--helper.c:2842
+#: builtin/submodule--helper.c:3072
 #, c-format
 msgid "Reactivating local git directory for submodule '%s'\n"
 msgstr "Reaktiviere lokales Git-Verzeichnis für Submodul '%s'\n"
 
-#: builtin/submodule--helper.c:2875
+#: builtin/submodule--helper.c:3109
 #, c-format
 msgid "unable to checkout submodule '%s'"
 msgstr "Kann Submodul '%s' nicht auschecken"
 
-#: builtin/submodule--helper.c:2888
-msgid "branch of repository to checkout on cloning"
+#: builtin/submodule--helper.c:3148
+#, fuzzy, c-format
+msgid "Failed to add submodule '%s'"
+msgstr "Hinzufügen von Submodul '$sm_path' fehlgeschlagen"
+
+#: builtin/submodule--helper.c:3152 builtin/submodule--helper.c:3157
+#: builtin/submodule--helper.c:3165
+#, fuzzy, c-format
+msgid "Failed to register submodule '%s'"
+msgstr "Fehler beim Eintragen von Submodul '$sm_path' in die Konfiguration."
+
+#: builtin/submodule--helper.c:3221
+#, fuzzy, c-format
+msgid "'%s' already exists in the index"
+msgstr "'$sm_path' ist bereits zum Commit vorgemerkt"
+
+#: builtin/submodule--helper.c:3224
+#, fuzzy, c-format
+msgid "'%s' already exists in the index and is not a submodule"
+msgstr "'$sm_path' ist bereits zum Commit vorgemerkt und ist kein Submodul"
+
+#: builtin/submodule--helper.c:3253
+#, fuzzy
+msgid "branch of repository to add as submodule"
 msgstr "Branch des Repositories zum Auschecken beim Klonen"
 
-#: builtin/submodule--helper.c:2910
+#: builtin/submodule--helper.c:3254
 msgid "allow adding an otherwise ignored submodule path"
 msgstr "das Hinzufügen eines andernfalls ignorierten Submodul-Pfads erlauben"
 
-#: builtin/submodule--helper.c:2917
-msgid ""
-"git submodule--helper add-clone [<options>...] --url <url> --path <path> --"
-"name <name>"
-msgstr ""
-"git submodule--helper add-clone [<Optionen>...] --url <URL> --path <Pfad> --"
-"name <Name>"
+#: builtin/submodule--helper.c:3256
+#, fuzzy
+msgid "print only error messages"
+msgstr "nur zusammengeführte Referenzen ausgeben"
 
-#: builtin/submodule--helper.c:2985 git.c:449 git.c:724
+#: builtin/submodule--helper.c:3260
+#, fuzzy
+msgid "borrow the objects from reference repositories"
+msgstr "geliehene Objekte von alternativem Objektspeicher ignorieren"
+
+#: builtin/submodule--helper.c:3262
+msgid ""
+"sets the submodule’s name to the given string instead of defaulting to its "
+"path"
+msgstr ""
+
+#: builtin/submodule--helper.c:3269
+#, fuzzy
+msgid "git submodule--helper add [<options>] [--] <repository> [<path>]"
+msgstr "git submodule--helper summary [<Optionen>] [<Commit>] [--] [<Pfad>]"
+
+#: builtin/submodule--helper.c:3297
+msgid "Relative path can only be used from the toplevel of the working tree"
+msgstr ""
+"Relative Pfade können nur von der obersten Ebene des Arbeitsverzeichnisses "
+"benutzt werden."
+
+#: builtin/submodule--helper.c:3305
+#, fuzzy, c-format
+msgid "repo URL: '%s' must be absolute or begin with ./|../"
+msgstr "repo URL: '$repo' muss absolut sein oder mit ./|../ beginnen"
+
+#: builtin/submodule--helper.c:3340
+#, fuzzy, c-format
+msgid "'%s' is not a valid submodule name"
+msgstr "'%s' ist kein gültiger Name für ein Remote-Repository"
+
+#: builtin/submodule--helper.c:3404 git.c:449 git.c:723
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s unterstützt kein --super-prefix"
 
-#: builtin/submodule--helper.c:2991
+#: builtin/submodule--helper.c:3410
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
 msgstr "'%s' ist kein gültiger Unterbefehl von submodule--helper"
@@ -23594,18 +24001,19 @@ msgstr "symbolische Referenzen löschen"
 msgid "shorten ref output"
 msgstr "verkürzte Ausgabe der Referenzen"
 
-#: builtin/symbolic-ref.c:45 builtin/update-ref.c:499
+#: builtin/symbolic-ref.c:45 builtin/update-ref.c:505
 msgid "reason"
 msgstr "Grund"
 
-#: builtin/symbolic-ref.c:45 builtin/update-ref.c:499
+#: builtin/symbolic-ref.c:45 builtin/update-ref.c:505
 msgid "reason of the update"
 msgstr "Grund für die Aktualisierung"
 
 #: builtin/tag.c:25
+#, fuzzy
 msgid ""
 "git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <file>]\n"
-"\t\t<tagname> [<head>]"
+"        <tagname> [<head>]"
 msgstr ""
 "git tag [-a | -s | -u <Schlüssel-id>] [-f] [-m <Beschreibung> | -F <Datei>]\n"
 "\t\t<Tagname> [<Commit>]"
@@ -23615,10 +24023,11 @@ msgid "git tag -d <tagname>..."
 msgstr "git tag -d <Tagname>..."
 
 #: builtin/tag.c:28
+#, fuzzy
 msgid ""
 "git tag -l [-n[<num>]] [--contains <commit>] [--no-contains <commit>] [--"
 "points-at <object>]\n"
-"\t\t[--format=<format>] [--merged <commit>] [--no-merged <commit>] "
+"        [--format=<format>] [--merged <commit>] [--no-merged <commit>] "
 "[<pattern>...]"
 msgstr ""
 "git tag -l [-n[<Nummer>]] [--contains <Commit>] [--no-contains <Commit>] [--"
@@ -23690,130 +24099,130 @@ msgstr ""
 msgid "bad object type."
 msgstr "ungültiger Objekt-Typ"
 
-#: builtin/tag.c:328
+#: builtin/tag.c:326
 msgid "no tag message?"
 msgstr "keine Tag-Beschreibung?"
 
-#: builtin/tag.c:335
+#: builtin/tag.c:333
 #, c-format
 msgid "The tag message has been left in %s\n"
 msgstr "Die Tag-Beschreibung wurde in %s gelassen\n"
 
-#: builtin/tag.c:446
+#: builtin/tag.c:444
 msgid "list tag names"
 msgstr "Tagnamen auflisten"
 
-#: builtin/tag.c:448
+#: builtin/tag.c:446
 msgid "print <n> lines of each tag message"
 msgstr "<n> Zeilen jeder Tag-Beschreibung anzeigen"
 
-#: builtin/tag.c:450
+#: builtin/tag.c:448
 msgid "delete tags"
 msgstr "Tags löschen"
 
-#: builtin/tag.c:451
+#: builtin/tag.c:449
 msgid "verify tags"
 msgstr "Tags überprüfen"
 
-#: builtin/tag.c:453
+#: builtin/tag.c:451
 msgid "Tag creation options"
 msgstr "Optionen für Erstellung von Tags"
 
-#: builtin/tag.c:455
+#: builtin/tag.c:453
 msgid "annotated tag, needs a message"
 msgstr "annotiertes Tag, benötigt eine Beschreibung"
 
-#: builtin/tag.c:457
+#: builtin/tag.c:455
 msgid "tag message"
 msgstr "Tag-Beschreibung"
 
-#: builtin/tag.c:459
+#: builtin/tag.c:457
 msgid "force edit of tag message"
 msgstr "Bearbeitung der Tag-Beschreibung erzwingen"
 
-#: builtin/tag.c:460
+#: builtin/tag.c:458
 msgid "annotated and GPG-signed tag"
 msgstr "annotiertes und GPG-signiertes Tag"
 
-#: builtin/tag.c:463
+#: builtin/tag.c:461
 msgid "use another key to sign the tag"
 msgstr "einen anderen Schlüssel verwenden, um das Tag zu signieren"
 
-#: builtin/tag.c:464
+#: builtin/tag.c:462
 msgid "replace the tag if exists"
 msgstr "das Tag ersetzen, wenn es existiert"
 
-#: builtin/tag.c:465 builtin/update-ref.c:505
+#: builtin/tag.c:463 builtin/update-ref.c:511
 msgid "create a reflog"
 msgstr "Reflog erstellen"
 
-#: builtin/tag.c:467
+#: builtin/tag.c:465
 msgid "Tag listing options"
 msgstr "Optionen für Auflistung der Tags"
 
-#: builtin/tag.c:468
+#: builtin/tag.c:466
 msgid "show tag list in columns"
 msgstr "Liste der Tags in Spalten anzeigen"
 
-#: builtin/tag.c:469 builtin/tag.c:471
+#: builtin/tag.c:467 builtin/tag.c:469
 msgid "print only tags that contain the commit"
 msgstr "nur Tags ausgeben, die diesen Commit beinhalten"
 
-#: builtin/tag.c:470 builtin/tag.c:472
+#: builtin/tag.c:468 builtin/tag.c:470
 msgid "print only tags that don't contain the commit"
 msgstr "nur Tags ausgeben, die diesen Commit nicht enthalten"
 
-#: builtin/tag.c:473
+#: builtin/tag.c:471
 msgid "print only tags that are merged"
 msgstr "nur Tags ausgeben, die gemerged wurden"
 
-#: builtin/tag.c:474
+#: builtin/tag.c:472
 msgid "print only tags that are not merged"
 msgstr "nur Tags ausgeben, die nicht gemerged wurden"
 
-#: builtin/tag.c:478
+#: builtin/tag.c:476
 msgid "print only tags of the object"
 msgstr "nur Tags von dem Objekt ausgeben"
 
-#: builtin/tag.c:526
+#: builtin/tag.c:525
 msgid "--column and -n are incompatible"
 msgstr "--column und -n sind inkompatibel"
 
-#: builtin/tag.c:548
+#: builtin/tag.c:546
 msgid "-n option is only allowed in list mode"
 msgstr "die Option -n ist nur im Listenmodus erlaubt"
 
-#: builtin/tag.c:550
+#: builtin/tag.c:548
 msgid "--contains option is only allowed in list mode"
 msgstr "--contains ist nur im Listenmodus erlaubt"
 
-#: builtin/tag.c:552
+#: builtin/tag.c:550
 msgid "--no-contains option is only allowed in list mode"
 msgstr "--no-contains ist nur im Listenmodus erlaubt"
 
-#: builtin/tag.c:554
+#: builtin/tag.c:552
 msgid "--points-at option is only allowed in list mode"
 msgstr "--points-at ist nur im Listenmodus erlaubt"
 
-#: builtin/tag.c:556
+#: builtin/tag.c:554
 msgid "--merged and --no-merged options are only allowed in list mode"
 msgstr "--merged und --no-merged sind nur im Listenmodus erlaubt"
 
-#: builtin/tag.c:567
+#: builtin/tag.c:568
 msgid "only one -F or -m option is allowed."
 msgstr "nur eine -F oder -m Option ist erlaubt."
 
-#: builtin/tag.c:592
+#: builtin/tag.c:593
 #, c-format
 msgid "'%s' is not a valid tag name."
 msgstr "'%s' ist kein gültiger Tagname."
 
-#: builtin/tag.c:597
+#: builtin/tag.c:598
 #, c-format
 msgid "tag '%s' already exists"
 msgstr "Tag '%s' existiert bereits"
 
-#: builtin/tag.c:628
+#: builtin/tag.c:629
 #, c-format
 msgid "Updated tag '%s' (was %s)\n"
 msgstr "Tag '%s' aktualisiert (war %s)\n"
@@ -23827,214 +24236,209 @@ msgstr "Entpacke Objekte"
 msgid "failed to create directory %s"
 msgstr "Fehler beim Erstellen von Verzeichnis '%s'"
 
-#: builtin/update-index.c:100
-#, c-format
-msgid "failed to create file %s"
-msgstr "Konnte Datei '%s' nicht erstellen"
-
-#: builtin/update-index.c:108
+#: builtin/update-index.c:106
 #, c-format
 msgid "failed to delete file %s"
 msgstr "Konnte Datei '%s' nicht löschen"
 
-#: builtin/update-index.c:115 builtin/update-index.c:221
+#: builtin/update-index.c:113 builtin/update-index.c:219
 #, c-format
 msgid "failed to delete directory %s"
 msgstr "Konnte Verzeichnis '%s' nicht löschen"
 
-#: builtin/update-index.c:140
+#: builtin/update-index.c:138
 #, c-format
 msgid "Testing mtime in '%s' "
 msgstr "Prüfe mtime in '%s' "
 
-#: builtin/update-index.c:154
+#: builtin/update-index.c:152
 msgid "directory stat info does not change after adding a new file"
 msgstr ""
 "Verzeichnisinformationen haben sich nach Hinzufügen einer neuen Datei nicht "
 "geändert"
 
-#: builtin/update-index.c:167
+#: builtin/update-index.c:165
 msgid "directory stat info does not change after adding a new directory"
 msgstr ""
 "Verzeichnisinformationen haben sich nach Hinzufügen eines neuen "
 "Verzeichnisses nicht geändert"
 
-#: builtin/update-index.c:180
+#: builtin/update-index.c:178
 msgid "directory stat info changes after updating a file"
 msgstr ""
 "Verzeichnisinformationen haben sich nach Aktualisierung einer Datei geändert"
 
-#: builtin/update-index.c:191
+#: builtin/update-index.c:189
 msgid "directory stat info changes after adding a file inside subdirectory"
 msgstr ""
 "Verzeichnisinformationen haben sich nach Hinzufügen einer Datei in ein "
 "Unterverzeichnis geändert"
 
-#: builtin/update-index.c:202
+#: builtin/update-index.c:200
 msgid "directory stat info does not change after deleting a file"
 msgstr ""
 "Verzeichnisinformationen haben sich nach dem Löschen einer Datei nicht "
 "geändert"
 
-#: builtin/update-index.c:215
+#: builtin/update-index.c:213
 msgid "directory stat info does not change after deleting a directory"
 msgstr ""
 "Verzeichnisinformationen haben sich nach dem Löschen eines Verzeichnisses "
 "nicht geändert"
 
-#: builtin/update-index.c:222
+#: builtin/update-index.c:220
 msgid " OK"
 msgstr " OK"
 
-#: builtin/update-index.c:591
+#: builtin/update-index.c:589
 msgid "git update-index [<options>] [--] [<file>...]"
 msgstr "git update-index [<Optionen>] [--] [<Datei>...]"
 
-#: builtin/update-index.c:976
+#: builtin/update-index.c:974
 msgid "continue refresh even when index needs update"
 msgstr ""
 "Aktualisierung fortsetzen, auch wenn der Index aktualisiert werden muss"
 
-#: builtin/update-index.c:979
+#: builtin/update-index.c:977
 msgid "refresh: ignore submodules"
 msgstr "Aktualisierung: ignoriert Submodule"
 
-#: builtin/update-index.c:982
+#: builtin/update-index.c:980
 msgid "do not ignore new files"
 msgstr "keine neuen Dateien ignorieren"
 
-#: builtin/update-index.c:984
+#: builtin/update-index.c:982
 msgid "let files replace directories and vice-versa"
 msgstr "Dateien Verzeichnisse ersetzen lassen, und umgedreht"
 
-#: builtin/update-index.c:986
+#: builtin/update-index.c:984
 msgid "notice files missing from worktree"
 msgstr "fehlende Dateien im Arbeitsverzeichnis beachten"
 
-#: builtin/update-index.c:988
+#: builtin/update-index.c:986
 msgid "refresh even if index contains unmerged entries"
 msgstr ""
 "aktualisieren, auch wenn der Index nicht zusammengeführte Einträge beinhaltet"
 
-#: builtin/update-index.c:991
+#: builtin/update-index.c:989
 msgid "refresh stat information"
 msgstr "Dateiinformationen aktualisieren"
 
-#: builtin/update-index.c:995
+#: builtin/update-index.c:993
 msgid "like --refresh, but ignore assume-unchanged setting"
 msgstr "wie --refresh, ignoriert aber \"assume-unchanged\" Einstellung"
 
-#: builtin/update-index.c:999
+#: builtin/update-index.c:997
 msgid "<mode>,<object>,<path>"
 msgstr "<Modus>,<Objekt>,<Pfad>"
 
-#: builtin/update-index.c:1000
+#: builtin/update-index.c:998
 msgid "add the specified entry to the index"
 msgstr "den angegebenen Eintrag zum Commit vormerken"
 
-#: builtin/update-index.c:1010
+#: builtin/update-index.c:1008
 msgid "mark files as \"not changing\""
 msgstr "diese Datei immer als unverändert betrachten"
 
-#: builtin/update-index.c:1013
+#: builtin/update-index.c:1011
 msgid "clear assumed-unchanged bit"
 msgstr "\"assumed-unchanged\"-Bit löschen"
 
-#: builtin/update-index.c:1016
+#: builtin/update-index.c:1014
 msgid "mark files as \"index-only\""
 msgstr "Dateien als \"index-only\" markieren"
 
-#: builtin/update-index.c:1019
+#: builtin/update-index.c:1017
 msgid "clear skip-worktree bit"
 msgstr "\"skip-worktree\"-Bit löschen"
 
-#: builtin/update-index.c:1022
+#: builtin/update-index.c:1020
 msgid "do not touch index-only entries"
 msgstr "\"index-only\" Einträge überspringen"
 
-#: builtin/update-index.c:1024
+#: builtin/update-index.c:1022
 msgid "add to index only; do not add content to object database"
 msgstr ""
 "die Änderungen nur zum Commit vormerken; Inhalt wird nicht der Objekt-"
 "Datenbank hinzugefügt"
 
-#: builtin/update-index.c:1026
+#: builtin/update-index.c:1024
 msgid "remove named paths even if present in worktree"
 msgstr ""
 "benannte Pfade löschen, auch wenn sie sich im Arbeitsverzeichnis befinden"
 
-#: builtin/update-index.c:1028
+#: builtin/update-index.c:1026
 msgid "with --stdin: input lines are terminated by null bytes"
 msgstr "mit --stdin: eingegebene Zeilen sind durch NUL-Bytes abgeschlossen"
 
-#: builtin/update-index.c:1030
+#: builtin/update-index.c:1028
 msgid "read list of paths to be updated from standard input"
 msgstr "Liste der zu aktualisierenden Pfade von der Standard-Eingabe lesen"
 
-#: builtin/update-index.c:1034
+#: builtin/update-index.c:1032
 msgid "add entries from standard input to the index"
 msgstr "Einträge von der Standard-Eingabe zum Commit vormerken"
 
-#: builtin/update-index.c:1038
+#: builtin/update-index.c:1036
 msgid "repopulate stages #2 and #3 for the listed paths"
 msgstr ""
 "wiederholtes Einpflegen der Zustände #2 und #3 für die aufgelisteten Pfade"
 
-#: builtin/update-index.c:1042
+#: builtin/update-index.c:1040
 msgid "only update entries that differ from HEAD"
 msgstr "nur Einträge aktualisieren, die unterschiedlich zu HEAD sind"
 
-#: builtin/update-index.c:1046
+#: builtin/update-index.c:1044
 msgid "ignore files missing from worktree"
 msgstr "fehlende Dateien im Arbeitsverzeichnis ignorieren"
 
-#: builtin/update-index.c:1049
+#: builtin/update-index.c:1047
 msgid "report actions to standard output"
 msgstr "die Aktionen in der Standard-Ausgabe ausgeben"
 
-#: builtin/update-index.c:1051
+#: builtin/update-index.c:1049
 msgid "(for porcelains) forget saved unresolved conflicts"
 msgstr "(für Fremdprogramme) keine gespeicherten, nicht aufgelöste Konflikte"
 
-#: builtin/update-index.c:1055
+#: builtin/update-index.c:1053
 msgid "write index in this format"
 msgstr "Index-Datei in diesem Format schreiben"
 
-#: builtin/update-index.c:1057
+#: builtin/update-index.c:1055
 msgid "enable or disable split index"
 msgstr "Splitting des Index aktivieren oder deaktivieren"
 
-#: builtin/update-index.c:1059
+#: builtin/update-index.c:1057
 msgid "enable/disable untracked cache"
 msgstr "Cache für unversionierte Dateien aktivieren oder deaktivieren"
 
-#: builtin/update-index.c:1061
+#: builtin/update-index.c:1059
 msgid "test if the filesystem supports untracked cache"
 msgstr ""
 "prüfen, ob das Dateisystem einen Cache für unversionierte Dateien unterstützt"
 
-#: builtin/update-index.c:1063
+#: builtin/update-index.c:1061
 msgid "enable untracked cache without testing the filesystem"
 msgstr ""
 "Cache für unversionierte Dateien ohne Prüfung des Dateisystems aktivieren"
 
-#: builtin/update-index.c:1065
+#: builtin/update-index.c:1063
 msgid "write out the index even if is not flagged as changed"
 msgstr "Index rausschreiben, auch wenn dieser nicht als geändert markiert ist"
 
-#: builtin/update-index.c:1067
+#: builtin/update-index.c:1065
 msgid "enable or disable file system monitor"
 msgstr "Dateisystem-Monitor aktivieren oder deaktivieren"
 
-#: builtin/update-index.c:1069
+#: builtin/update-index.c:1067
 msgid "mark files as fsmonitor valid"
 msgstr "Dateien als \"fsmonitor valid\" markieren"
 
-#: builtin/update-index.c:1072
+#: builtin/update-index.c:1070
 msgid "clear fsmonitor valid bit"
 msgstr "\"fsmonitor valid\"-Bit löschen"
 
-#: builtin/update-index.c:1175
+#: builtin/update-index.c:1173
 msgid ""
 "core.splitIndex is set to false; remove or change it, if you really want to "
 "enable split index"
@@ -24042,7 +24446,7 @@ msgstr ""
 "core.splitIndex ist auf 'false' gesetzt; entfernen oder ändern Sie dies,\n"
 "wenn sie wirklich das Splitting des Index aktivieren möchten"
 
-#: builtin/update-index.c:1184
+#: builtin/update-index.c:1182
 msgid ""
 "core.splitIndex is set to true; remove or change it, if you really want to "
 "disable split index"
@@ -24050,7 +24454,7 @@ msgstr ""
 "core.splitIndex ist auf 'true' gesetzt; entfernen oder ändern Sie dies,\n"
 "wenn Sie wirklich das Splitting des Index deaktivieren möchten"
 
-#: builtin/update-index.c:1196
+#: builtin/update-index.c:1194
 msgid ""
 "core.untrackedCache is set to true; remove or change it, if you really want "
 "to disable the untracked cache"
@@ -24058,11 +24462,11 @@ msgstr ""
 "core.untrackedCache ist auf 'true' gesetzt; entfernen oder ändern Sie dies,\n"
 "wenn Sie wirklich den Cache für unversionierte Dateien deaktivieren möchten"
 
-#: builtin/update-index.c:1200
+#: builtin/update-index.c:1198
 msgid "Untracked cache disabled"
 msgstr "Cache für unversionierte Dateien deaktiviert"
 
-#: builtin/update-index.c:1208
+#: builtin/update-index.c:1206
 msgid ""
 "core.untrackedCache is set to false; remove or change it, if you really want "
 "to enable the untracked cache"
@@ -24071,23 +24475,23 @@ msgstr ""
 "dies,\n"
 "wenn sie wirklich den Cache für unversionierte Dateien aktivieren möchten"
 
-#: builtin/update-index.c:1212
+#: builtin/update-index.c:1210
 #, c-format
 msgid "Untracked cache enabled for '%s'"
 msgstr "Cache für unversionierte Dateien für '%s' aktiviert"
 
-#: builtin/update-index.c:1220
+#: builtin/update-index.c:1218
 msgid "core.fsmonitor is unset; set it if you really want to enable fsmonitor"
 msgstr ""
 "core.fsmonitor nicht gesetzt; setzen Sie es, wenn Sie den Dateisystem-"
 "Monitor\n"
 "wirklich aktivieren möchten"
 
-#: builtin/update-index.c:1224
+#: builtin/update-index.c:1222
 msgid "fsmonitor enabled"
 msgstr "Dateisystem-Monitor aktiviert"
 
-#: builtin/update-index.c:1227
+#: builtin/update-index.c:1225
 msgid ""
 "core.fsmonitor is set; remove it if you really want to disable fsmonitor"
 msgstr ""
@@ -24095,7 +24499,7 @@ msgstr ""
 "Monitor\n"
 "wirklich deaktivieren möchten."
 
-#: builtin/update-index.c:1231
+#: builtin/update-index.c:1229
 msgid "fsmonitor disabled"
 msgstr "Dateisystem-Monitor deaktiviert"
 
@@ -24112,19 +24516,19 @@ msgstr ""
 msgid "git update-ref [<options>] --stdin [-z]"
 msgstr "git update-ref [<Optionen>] --stdin [-z]"
 
-#: builtin/update-ref.c:500
+#: builtin/update-ref.c:506
 msgid "delete the reference"
 msgstr "diese Referenz löschen"
 
-#: builtin/update-ref.c:502
+#: builtin/update-ref.c:508
 msgid "update <refname> not the one it points to"
 msgstr "<Referenzname> aktualisieren, nicht den Verweis"
 
-#: builtin/update-ref.c:503
+#: builtin/update-ref.c:509
 msgid "stdin has NUL-terminated arguments"
 msgstr "Standard-Eingabe hat durch NUL-Zeichen abgeschlossene Argumente"
 
-#: builtin/update-ref.c:504
+#: builtin/update-ref.c:510
 msgid "read updates from stdin"
 msgstr "Aktualisierungen von der Standard-Eingabe lesen"
 
@@ -24140,21 +24544,21 @@ msgstr "die Informationsdateien von Grund auf aktualisieren"
 msgid "git upload-pack [<options>] <dir>"
 msgstr "git upload-pack [<Optionen>] <Verzeichnis>"
 
-#: builtin/upload-pack.c:23 t/helper/test-serve-v2.c:17
+#: builtin/upload-pack.c:24 t/helper/test-serve-v2.c:17
 msgid "quit after a single request/response exchange"
 msgstr "nach einem einzigen Request/Response-Austausch beenden"
 
-#: builtin/upload-pack.c:25
-msgid "exit immediately after initial ref advertisement"
-msgstr "direkt nach der initialen Angabe der Commits beenden"
+#: builtin/upload-pack.c:26
+msgid "serve up the info/refs for git-http-backend"
+msgstr ""
 
-#: builtin/upload-pack.c:27
+#: builtin/upload-pack.c:29
 msgid "do not try <directory>/.git/ if <directory> is no Git directory"
 msgstr ""
 "kein Versuch in <Verzeichnis>/.git/ wenn <Verzeichnis> kein Git-Verzeichnis "
 "ist"
 
-#: builtin/upload-pack.c:29
+#: builtin/upload-pack.c:31
 msgid "interrupt transfer after <n> seconds of inactivity"
 msgstr "Übertragung nach <n> Sekunden Inaktivität unterbrechen"
 
@@ -24190,63 +24594,58 @@ msgstr "git verify-tag [-v | --verbose] [--format=<Format>] <Tag>..."
 msgid "print tag contents"
 msgstr "Tag-Inhalte ausgeben"
 
-#: builtin/worktree.c:18
+#: builtin/worktree.c:19
 msgid "git worktree add [<options>] <path> [<commit-ish>]"
 msgstr "git worktree add [<Optionen>] <Pfad> [<Commit-Angabe>]"
 
-#: builtin/worktree.c:19
+#: builtin/worktree.c:20
 msgid "git worktree list [<options>]"
 msgstr "git worktree list [<Optionen>]"
 
-#: builtin/worktree.c:20
+#: builtin/worktree.c:21
 msgid "git worktree lock [<options>] <path>"
 msgstr "git worktree lock [<Optionen>] <Pfad>"
 
-#: builtin/worktree.c:21
+#: builtin/worktree.c:22
 msgid "git worktree move <worktree> <new-path>"
 msgstr "git worktree move <Arbeitsverzeichnis> <neuer-Pfad>"
 
-#: builtin/worktree.c:22
+#: builtin/worktree.c:23
 msgid "git worktree prune [<options>]"
 msgstr "git worktree prune [<Optionen>]"
 
-#: builtin/worktree.c:23
+#: builtin/worktree.c:24
 msgid "git worktree remove [<options>] <worktree>"
 msgstr "git worktree remove [<Optionen>] <Arbeitsverzeichnis>"
 
-#: builtin/worktree.c:24
+#: builtin/worktree.c:25
 msgid "git worktree unlock <path>"
 msgstr "git worktree unlock <Pfad>"
 
-#: builtin/worktree.c:61 builtin/worktree.c:944
-#, c-format
-msgid "failed to delete '%s'"
-msgstr "Fehler beim Löschen von '%s'"
-
-#: builtin/worktree.c:74
+#: builtin/worktree.c:75
 #, c-format
 msgid "Removing %s/%s: %s"
 msgstr "Entferne %s/%s: %s"
 
-#: builtin/worktree.c:147
+#: builtin/worktree.c:148
 msgid "report pruned working trees"
 msgstr "entfernte Arbeitsverzeichnisse ausgeben"
 
-#: builtin/worktree.c:149
+#: builtin/worktree.c:150
 msgid "expire working trees older than <time>"
 msgstr "Arbeitsverzeichnisse älter als <Zeit> verfallen lassen"
 
-#: builtin/worktree.c:219
+#: builtin/worktree.c:220
 #, c-format
 msgid "'%s' already exists"
 msgstr "'%s' existiert bereits"
 
-#: builtin/worktree.c:228
+#: builtin/worktree.c:229
 #, c-format
 msgid "unusable worktree destination '%s'"
 msgstr "nicht nutzbares Ziel des Arbeitsverzeichnisses '%s'"
 
-#: builtin/worktree.c:233
+#: builtin/worktree.c:234
 #, c-format
 msgid ""
 "'%s' is a missing but locked worktree;\n"
@@ -24256,7 +24655,7 @@ msgstr ""
 "Benutzen Sie '%s -f -f' zum Überschreiben, oder 'unlock' und 'prune'\n"
 "oder 'remove' zum Löschen."
 
-#: builtin/worktree.c:235
+#: builtin/worktree.c:236
 #, c-format
 msgid ""
 "'%s' is a missing but already registered worktree;\n"
@@ -24266,149 +24665,149 @@ msgstr ""
 "Benutzen Sie '%s -f' zum Überschreiben, oder 'prune' oder 'remove' zum\n"
 "Löschen."
 
-#: builtin/worktree.c:286
+#: builtin/worktree.c:287
 #, c-format
 msgid "could not create directory of '%s'"
 msgstr "Konnte Verzeichnis '%s' nicht erstellen."
 
-#: builtin/worktree.c:308
+#: builtin/worktree.c:309
 msgid "initializing"
 msgstr "initialisiere"
 
-#: builtin/worktree.c:420 builtin/worktree.c:426
+#: builtin/worktree.c:421 builtin/worktree.c:427
 #, c-format
 msgid "Preparing worktree (new branch '%s')"
 msgstr "Bereite Arbeitsverzeichnis vor (neuer Branch '%s')"
 
-#: builtin/worktree.c:422
+#: builtin/worktree.c:423
 #, c-format
 msgid "Preparing worktree (resetting branch '%s'; was at %s)"
 msgstr "Bereite Arbeitsverzeichnis vor (setze Branch '%s' um; war bei %s)"
 
-#: builtin/worktree.c:431
+#: builtin/worktree.c:432
 #, c-format
 msgid "Preparing worktree (checking out '%s')"
 msgstr "Bereite Arbeitsverzeichnis vor (checke '%s' aus)"
 
-#: builtin/worktree.c:437
+#: builtin/worktree.c:438
 #, c-format
 msgid "Preparing worktree (detached HEAD %s)"
 msgstr "Bereite Arbeitsverzeichnis vor (losgelöster HEAD %s)"
 
-#: builtin/worktree.c:482
+#: builtin/worktree.c:483
 msgid "checkout <branch> even if already checked out in other worktree"
 msgstr ""
 "<Branch> auschecken, auch wenn dieser bereits in einem anderen "
 "Arbeitsverzeichnis ausgecheckt ist"
 
-#: builtin/worktree.c:485
+#: builtin/worktree.c:486
 msgid "create a new branch"
 msgstr "neuen Branch erstellen"
 
-#: builtin/worktree.c:487
+#: builtin/worktree.c:488
 msgid "create or reset a branch"
 msgstr "Branch erstellen oder umsetzen"
 
-#: builtin/worktree.c:489
+#: builtin/worktree.c:490
 msgid "populate the new working tree"
 msgstr "das neue Arbeitsverzeichnis auschecken"
 
-#: builtin/worktree.c:490
+#: builtin/worktree.c:491
 msgid "keep the new working tree locked"
 msgstr "das neue Arbeitsverzeichnis gesperrt lassen"
 
-#: builtin/worktree.c:492 builtin/worktree.c:729
+#: builtin/worktree.c:493 builtin/worktree.c:730
 msgid "reason for locking"
 msgstr "Sperrgrund"
 
-#: builtin/worktree.c:495
+#: builtin/worktree.c:496
 msgid "set up tracking mode (see git-branch(1))"
 msgstr "Modus zum Folgen von Branches einstellen (siehe git-branch(1))"
 
-#: builtin/worktree.c:498
+#: builtin/worktree.c:499
 msgid "try to match the new branch name with a remote-tracking branch"
 msgstr ""
 "versuchen, eine Übereinstimmung des Branch-Namens mit einem\n"
 "Remote-Tracking-Branch herzustellen"
 
-#: builtin/worktree.c:506
+#: builtin/worktree.c:507
 msgid "-b, -B, and --detach are mutually exclusive"
 msgstr "-b, -B und --detach schließen sich gegenseitig aus"
 
-#: builtin/worktree.c:508
+#: builtin/worktree.c:509
 msgid "--reason requires --lock"
 msgstr "--reason benötigt --lock"
 
-#: builtin/worktree.c:512
+#: builtin/worktree.c:513
 msgid "added with --lock"
 msgstr "mit --lock hinzugefügt"
 
-#: builtin/worktree.c:574
+#: builtin/worktree.c:575
 msgid "--[no-]track can only be used if a new branch is created"
 msgstr ""
 "--[no]-track kann nur verwendet werden, wenn ein neuer Branch erstellt wird."
 
-#: builtin/worktree.c:691
+#: builtin/worktree.c:692
 msgid "show extended annotations and reasons, if available"
 msgstr "erweiterte Anmerkungen und Gründe anzeigen, falls vorhanden"
 
-#: builtin/worktree.c:693
+#: builtin/worktree.c:694
 msgid "add 'prunable' annotation to worktrees older than <time>"
 msgstr ""
 "'prunable'-Anmerkung zu Arbeitsverzeichnissen älter als <Zeit> hinzufügen"
 
-#: builtin/worktree.c:702
+#: builtin/worktree.c:703
 msgid "--verbose and --porcelain are mutually exclusive"
 msgstr "--verbose und --porcelain schließen sich gegenseitig aus"
 
-#: builtin/worktree.c:741 builtin/worktree.c:774 builtin/worktree.c:848
-#: builtin/worktree.c:972
+#: builtin/worktree.c:742 builtin/worktree.c:775 builtin/worktree.c:849
+#: builtin/worktree.c:973
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr "'%s' ist kein Arbeitsverzeichnis"
 
-#: builtin/worktree.c:743 builtin/worktree.c:776
+#: builtin/worktree.c:744 builtin/worktree.c:777
 msgid "The main working tree cannot be locked or unlocked"
 msgstr "Das Hauptarbeitsverzeichnis kann nicht gesperrt oder entsperrt werden."
 
-#: builtin/worktree.c:748
+#: builtin/worktree.c:749
 #, c-format
 msgid "'%s' is already locked, reason: %s"
 msgstr "'%s' ist bereits gesperrt, Grund: %s"
 
-#: builtin/worktree.c:750
+#: builtin/worktree.c:751
 #, c-format
 msgid "'%s' is already locked"
 msgstr "'%s' ist bereits gesperrt"
 
-#: builtin/worktree.c:778
+#: builtin/worktree.c:779
 #, c-format
 msgid "'%s' is not locked"
 msgstr "'%s' ist nicht gesperrt"
 
-#: builtin/worktree.c:819
+#: builtin/worktree.c:820
 msgid "working trees containing submodules cannot be moved or removed"
 msgstr ""
 "Arbeitsverzeichnisse, die Submodule enthalten, können nicht verschoben oder\n"
 "entfernt werden."
 
-#: builtin/worktree.c:827
+#: builtin/worktree.c:828
 msgid "force move even if worktree is dirty or locked"
 msgstr ""
 "Verschieben erzwingen, auch wenn das Arbeitsverzeichnis geändert oder "
 "gesperrt ist"
 
-#: builtin/worktree.c:850 builtin/worktree.c:974
+#: builtin/worktree.c:851 builtin/worktree.c:975
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr "'%s' ist ein Hauptarbeitsverzeichnis"
 
-#: builtin/worktree.c:855
+#: builtin/worktree.c:856
 #, c-format
 msgid "could not figure out destination name from '%s'"
 msgstr "Konnte Zielname aus '%s' nicht bestimmen."
 
-#: builtin/worktree.c:868
+#: builtin/worktree.c:869
 #, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
@@ -24418,7 +24817,7 @@ msgstr ""
 "Benutzen Sie 'move -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:870
+#: builtin/worktree.c:871
 msgid ""
 "cannot move a locked working tree;\n"
 "use 'move -f -f' to override or unlock first"
@@ -24427,40 +24826,40 @@ msgstr ""
 "Benutzen Sie 'move -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:873
+#: builtin/worktree.c:874
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
 msgstr "Validierung fehlgeschlagen, kann Arbeitszeichnis nicht verschieben: %s"
 
-#: builtin/worktree.c:878
+#: builtin/worktree.c:879
 #, c-format
 msgid "failed to move '%s' to '%s'"
 msgstr "Fehler beim Verschieben von '%s' nach '%s'"
 
-#: builtin/worktree.c:924
+#: builtin/worktree.c:925
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr "Fehler beim Ausführen von 'git status' auf '%s'"
 
-#: builtin/worktree.c:928
+#: builtin/worktree.c:929
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
 "'%s' enthält geänderte oder nicht versionierte Dateien, benutzen Sie --force "
 "zum Löschen"
 
-#: builtin/worktree.c:933
+#: builtin/worktree.c:934
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr "Fehler beim Ausführen von 'git status' auf '%s'. Code: %d"
 
-#: builtin/worktree.c:956
+#: builtin/worktree.c:957
 msgid "force removal even if worktree is dirty or locked"
 msgstr ""
 "Löschen erzwingen, auch wenn das Arbeitsverzeichnis geändert oder gesperrt "
 "ist"
 
-#: builtin/worktree.c:979
+#: builtin/worktree.c:980
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
@@ -24470,7 +24869,7 @@ msgstr ""
 "Benutzen Sie 'remove -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:981
+#: builtin/worktree.c:982
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
@@ -24479,17 +24878,17 @@ msgstr ""
 "Benutzen Sie 'remove -f -f' zum Überschreiben oder entsperren Sie zuerst\n"
 "das Arbeitsverzeichnis."
 
-#: builtin/worktree.c:984
+#: builtin/worktree.c:985
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr "Validierung fehlgeschlagen, kann Arbeitsverzeichnis nicht löschen: %s"
 
-#: builtin/worktree.c:1008
+#: builtin/worktree.c:1009
 #, c-format
 msgid "repair: %s: %s"
 msgstr "repariere: %s: %s"
 
-#: builtin/worktree.c:1011
+#: builtin/worktree.c:1012
 #, c-format
 msgid "error: %s: %s"
 msgstr "Fehler: %s: %s"
@@ -24617,17 +25016,17 @@ msgstr "Unbekannter Fehler beim Schreiben in die Standard-Ausgabe."
 msgid "close failed on standard output"
 msgstr "Fehler beim Schließen der Standard-Ausgabe."
 
-#: git.c:833
+#: git.c:832
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr "Alias-Schleife erkannt: Erweiterung von '%s' schließt nicht ab:%s"
 
-#: git.c:883
+#: git.c:882
 #, c-format
 msgid "cannot handle %s as a builtin"
 msgstr "Kann %s nicht als eingebauten Befehl behandeln."
 
-#: git.c:896
+#: git.c:895
 #, c-format
 msgid ""
 "usage: %s\n"
@@ -24636,12 +25035,12 @@ msgstr ""
 "Verwendung: %s\n"
 "\n"
 
-#: git.c:916
+#: git.c:915
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr "Erweiterung von Alias '%s' fehlgeschlagen; '%s' ist kein Git-Befehl\n"
 
-#: git.c:928
+#: git.c:927
 #, c-format
 msgid "failed to run command '%s': %s\n"
 msgstr "Fehler beim Ausführen von Befehl '%s': %s\n"
@@ -24688,65 +25087,31 @@ msgstr "test-tool serve-v2 [<Optionen>]"
 msgid "exit immediately after advertising capabilities"
 msgstr "direkt nach Anzeige der angebotenen Fähigkeiten beenden"
 
-#: t/helper/test-simple-ipc.c:262
-#, c-format
-msgid "socket/pipe already in use: '%s'"
-msgstr "Socket/Pipe bereits in Benutzung: '%s'"
-
-#: t/helper/test-simple-ipc.c:264
-#, c-format
-msgid "could not start server on: '%s'"
-msgstr "konnte Server nicht starten auf: '%s'"
-
-#: t/helper/test-simple-ipc.c:295 t/helper/test-simple-ipc.c:331
-msgid "could not spawn daemon in the background"
-msgstr "Daemon konnte nicht im Hintergrund erzeugt werden"
-
-#: t/helper/test-simple-ipc.c:356
-msgid "waitpid failed"
-msgstr "waitpid fehlgeschlagen"
-
-#: t/helper/test-simple-ipc.c:376
-msgid "daemon not online yet"
-msgstr "Daemon ist noch nicht online"
-
-#: t/helper/test-simple-ipc.c:406
-msgid "daemon failed to start"
-msgstr "Fehler beim Starten des Daemons"
-
-#: t/helper/test-simple-ipc.c:410
-msgid "waitpid is confused"
-msgstr "waitpid ist verwirrt"
-
-#: t/helper/test-simple-ipc.c:541
-msgid "daemon has not shutdown yet"
-msgstr "Daemon ist noch nicht heruntergefahren"
-
-#: t/helper/test-simple-ipc.c:682
+#: t/helper/test-simple-ipc.c:581
 msgid "test-helper simple-ipc is-active    [<name>] [<options>]"
 msgstr "test-helper simple-ipc is-active    [<Name>] [<Optionen>]"
 
-#: t/helper/test-simple-ipc.c:683
+#: t/helper/test-simple-ipc.c:582
 msgid "test-helper simple-ipc run-daemon   [<name>] [<threads>]"
 msgstr "test-helper simple-ipc run-daemon   [<Name>] [<Threads>]"
 
-#: t/helper/test-simple-ipc.c:684
+#: t/helper/test-simple-ipc.c:583
 msgid "test-helper simple-ipc start-daemon [<name>] [<threads>] [<max-wait>]"
 msgstr "test-helper simple-ipc start-daemon [<Name>] [<Threads>] [<max-wait>]"
 
-#: t/helper/test-simple-ipc.c:685
+#: t/helper/test-simple-ipc.c:584
 msgid "test-helper simple-ipc stop-daemon  [<name>] [<max-wait>]"
 msgstr "test-helper simple-ipc stop-daemon  [<Name>] [<max-wait>]"
 
-#: t/helper/test-simple-ipc.c:686
+#: t/helper/test-simple-ipc.c:585
 msgid "test-helper simple-ipc send         [<name>] [<token>]"
 msgstr "test-helper simple-ipc send         [<Name>] [<Token>]"
 
-#: t/helper/test-simple-ipc.c:687
+#: t/helper/test-simple-ipc.c:586
 msgid "test-helper simple-ipc sendbytes    [<name>] [<bytecount>] [<byte>]"
 msgstr "test-helper simple-ipc sendbytes    [<Name>] [<bytecount>] [<Byte>]"
 
-#: t/helper/test-simple-ipc.c:688
+#: t/helper/test-simple-ipc.c:587
 msgid ""
 "test-helper simple-ipc multiple     [<name>] [<threads>] [<bytecount>] "
 "[<batchsize>]"
@@ -24754,86 +25119,83 @@ msgstr ""
 "test-helper simple-ipc multiple     [<Name>] [<Threads>] [<bytecount>] "
 "[<batchsize>]"
 
-#: t/helper/test-simple-ipc.c:696
+#: t/helper/test-simple-ipc.c:595
 msgid "name or pathname of unix domain socket"
 msgstr "Name oder Pfadname des UNIX-Domain-Sockets"
 
-#: t/helper/test-simple-ipc.c:698
+#: t/helper/test-simple-ipc.c:597
 msgid "named-pipe name"
 msgstr "Name der benannten Pipe"
 
-#: t/helper/test-simple-ipc.c:700
+#: t/helper/test-simple-ipc.c:599
 msgid "number of threads in server thread pool"
 msgstr "Anzahl der Threads im Thread-Pool des Servers"
 
-#: t/helper/test-simple-ipc.c:701
+#: t/helper/test-simple-ipc.c:600
 msgid "seconds to wait for daemon to start or stop"
 msgstr "Sekunden, um auf Starten oder Stoppen des Daemons zu warten"
 
-#: t/helper/test-simple-ipc.c:703
+#: t/helper/test-simple-ipc.c:602
 msgid "number of bytes"
 msgstr "Anzahl von Bytes"
 
-#: t/helper/test-simple-ipc.c:704
+#: t/helper/test-simple-ipc.c:603
 msgid "number of requests per thread"
 msgstr "Anzahl der Anfragen pro Thread"
 
-#: t/helper/test-simple-ipc.c:706
+#: t/helper/test-simple-ipc.c:605
 msgid "byte"
 msgstr "Byte"
 
-#: t/helper/test-simple-ipc.c:706
+#: t/helper/test-simple-ipc.c:605
 msgid "ballast character"
 msgstr "Ballast-Zeichen"
 
-#: t/helper/test-simple-ipc.c:707
+#: t/helper/test-simple-ipc.c:606
 msgid "token"
 msgstr "Token"
 
-#: t/helper/test-simple-ipc.c:707
+#: t/helper/test-simple-ipc.c:606
 msgid "command token to send to the server"
 msgstr "Befehlstoken, der an den Server gesendet werden soll"
 
-#: http.c:399
+#: http.c:350
 #, c-format
 msgid "negative value for http.postbuffer; defaulting to %d"
 msgstr "negativer Wert für http.postbuffer; benutze Standardwert %d"
 
-#: http.c:420
+#: http.c:371
 msgid "Delegation control is not supported with cURL < 7.22.0"
 msgstr "Kontrolle über Delegation wird mit cURL < 7.22.0 nicht unterstützt"
 
-#: http.c:429
-msgid "Public key pinning not supported with cURL < 7.44.0"
+#: http.c:380
+#, fuzzy
+msgid "Public key pinning not supported with cURL < 7.39.0"
 msgstr ""
 "Das Anheften des öffentlichen Schlüssels wird mit cURL < 7.44.0\n"
 "nicht unterstützt."
 
-#: http.c:910
+#: http.c:812
 msgid "CURLSSLOPT_NO_REVOKE not supported with cURL < 7.44.0"
 msgstr "CURLSSLOPT_NO_REVOKE wird mit cURL < 7.44.0 nicht unterstützt."
 
-#: http.c:989
-msgid "Protocol restrictions not supported with cURL < 7.19.4"
-msgstr "Protokollbeschränkungen werden mit cURL < 7.19.4 nicht unterstützt."
-
-#: http.c:1132
+#: http.c:1016
 #, c-format
 msgid "Unsupported SSL backend '%s'. Supported SSL backends:"
 msgstr "Nicht unterstütztes SSL-Backend '%s'. Unterstützte SSL-Backends:"
 
-#: http.c:1139
+#: http.c:1023
 #, c-format
 msgid "Could not set SSL backend to '%s': cURL was built without SSL backends"
 msgstr ""
 "Konnte SSL-Backend nicht zu '%s' setzen: cURL wurde ohne SSL-Backends gebaut."
 
-#: http.c:1143
+#: http.c:1027
 #, c-format
 msgid "Could not set SSL backend to '%s': already set"
 msgstr "Konnte SSL-Backend nicht zu '%s' setzen: bereits gesetzt"
 
-#: http.c:2034
+#: http.c:1876
 #, c-format
 msgid ""
 "unable to update url base from redirection:\n"
@@ -24849,45 +25211,50 @@ msgstr ""
 msgid "invalid quoting in push-option value: '%s'"
 msgstr "Ungültiges Quoting beim \"push-option\"-Wert: '%s'"
 
-#: remote-curl.c:307
+#: remote-curl.c:304
 #, c-format
 msgid "%sinfo/refs not valid: is this a git repository?"
 msgstr "%sinfo/refs nicht gültig: Ist das ein Git-Repository?"
 
-#: remote-curl.c:408
+#: remote-curl.c:405
 msgid "invalid server response; expected service, got flush packet"
 msgstr "ungültige Antwort des Servers; Service erwartet, Flush-Paket bekommen"
 
-#: remote-curl.c:439
+#: remote-curl.c:436
 #, c-format
 msgid "invalid server response; got '%s'"
 msgstr "ungültige Serverantwort; '%s' bekommen"
 
-#: remote-curl.c:499
+#: remote-curl.c:496
 #, c-format
 msgid "repository '%s' not found"
 msgstr "Repository '%s' nicht gefunden"
 
-#: remote-curl.c:503
+#: remote-curl.c:500
 #, c-format
 msgid "Authentication failed for '%s'"
 msgstr "Authentifizierung fehlgeschlagen für '%s'"
 
-#: remote-curl.c:507
+#: remote-curl.c:504
+#, c-format
+msgid "unable to access '%s' with http.pinnedPubkey configuration: %s"
+msgstr ""
+
+#: remote-curl.c:508
 #, c-format
 msgid "unable to access '%s': %s"
 msgstr "konnte nicht auf '%s' zugreifen: %s"
 
-#: remote-curl.c:513
+#: remote-curl.c:514
 #, c-format
 msgid "redirecting to %s"
 msgstr "Umleitung nach %s"
 
-#: remote-curl.c:644
+#: remote-curl.c:645
 msgid "shouldn't have EOF when not gentle on EOF"
 msgstr "sollte kein EOF haben, wenn nicht behutsam mit EOF"
 
-#: remote-curl.c:656
+#: remote-curl.c:657
 msgid "remote server sent unexpected response end packet"
 msgstr "Remote Server sendete unerwartetes Antwort-Endpaket"
 
@@ -24897,83 +25264,83 @@ msgstr ""
 "konnte nicht RPC-POST-Daten zurückspulen - Versuchen Sie http.postBuffer zu "
 "erhöhen"
 
-#: remote-curl.c:756
+#: remote-curl.c:755
 #, c-format
 msgid "remote-curl: bad line length character: %.4s"
 msgstr "remote-curl: ungültiges Zeichen für Zeilenlänge: %.4s"
 
-#: remote-curl.c:758
+#: remote-curl.c:757
 msgid "remote-curl: unexpected response end packet"
 msgstr "remote-curl: unerwartetes Antwort-Endpaket"
 
-#: remote-curl.c:834
+#: remote-curl.c:833
 #, c-format
 msgid "RPC failed; %s"
 msgstr "RPC fehlgeschlagen; %s"
 
-#: remote-curl.c:874
+#: remote-curl.c:873
 msgid "cannot handle pushes this big"
 msgstr "Kann solche großen Übertragungen nicht verarbeiten."
 
-#: remote-curl.c:989
+#: remote-curl.c:986
 #, c-format
 msgid "cannot deflate request; zlib deflate error %d"
 msgstr "Kann Request nicht komprimieren; \"zlib deflate\"-Fehler %d"
 
-#: remote-curl.c:993
+#: remote-curl.c:990
 #, c-format
 msgid "cannot deflate request; zlib end error %d"
 msgstr "Kann Request nicht komprimieren; \"zlib end\"-Fehler %d"
 
-#: remote-curl.c:1043
+#: remote-curl.c:1040
 #, c-format
 msgid "%d bytes of length header were received"
 msgstr "%d Bytes des Längen-Headers wurden empfangen"
 
-#: remote-curl.c:1045
+#: remote-curl.c:1042
 #, c-format
 msgid "%d bytes of body are still expected"
 msgstr "%d Bytes des Bodys werden noch erwartet"
 
-#: remote-curl.c:1134
+#: remote-curl.c:1131
 msgid "dumb http transport does not support shallow capabilities"
 msgstr "Dumb HTTP-Transport unterstützt keine shallow-Funktionen"
 
-#: remote-curl.c:1149
+#: remote-curl.c:1146
 msgid "fetch failed."
 msgstr "\"fetch\" fehlgeschlagen."
 
-#: remote-curl.c:1195
+#: remote-curl.c:1192
 msgid "cannot fetch by sha1 over smart http"
 msgstr "Kann SHA-1 nicht über Smart-HTTP anfordern"
 
-#: remote-curl.c:1239 remote-curl.c:1245
+#: remote-curl.c:1236 remote-curl.c:1242
 #, c-format
 msgid "protocol error: expected sha/ref, got '%s'"
 msgstr "Protokollfehler: SHA-1/Referenz erwartet, '%s' bekommen"
 
-#: remote-curl.c:1257 remote-curl.c:1375
+#: remote-curl.c:1254 remote-curl.c:1372
 #, c-format
 msgid "http transport does not support %s"
 msgstr "HTTP-Transport unterstützt nicht %s"
 
-#: remote-curl.c:1293
+#: remote-curl.c:1290
 msgid "git-http-push failed"
 msgstr "\"git-http-push\" fehlgeschlagen"
 
-#: remote-curl.c:1481
+#: remote-curl.c:1478
 msgid "remote-curl: usage: git remote-curl <remote> [<url>]"
 msgstr "remote-curl: Verwendung: git remote-curl <Remote-Repository> [<URL>]"
 
-#: remote-curl.c:1513
+#: remote-curl.c:1510
 msgid "remote-curl: error reading command stream from git"
 msgstr "remote-curl: Fehler beim Lesen des Kommando-Streams von Git"
 
-#: remote-curl.c:1520
+#: remote-curl.c:1517
 msgid "remote-curl: fetch attempted without a local repo"
 msgstr "remote-curl: \"fetch\" ohne lokales Repository versucht"
 
-#: remote-curl.c:1561
+#: remote-curl.c:1558
 #, c-format
 msgid "remote-curl: unknown command '%s' from git"
 msgstr "remote-curl: Unbekannter Befehl '%s' von Git"
@@ -24994,46 +25361,46 @@ msgstr "Argumente"
 msgid "object filtering"
 msgstr "Filtern nach Objekten"
 
-#: parse-options.h:184
+#: parse-options.h:183
 msgid "expiry-date"
 msgstr "Verfallsdatum"
 
-#: parse-options.h:198
+#: parse-options.h:197
 msgid "no-op (backward compatibility)"
 msgstr "Kein Effekt (Rückwärtskompatibilität)"
 
-#: parse-options.h:310
+#: parse-options.h:309
 msgid "be more verbose"
 msgstr "erweiterte Ausgaben"
 
-#: parse-options.h:312
+#: parse-options.h:311
 msgid "be more quiet"
 msgstr "weniger Ausgaben"
 
-#: parse-options.h:318
+#: parse-options.h:317
 msgid "use <n> digits to display object names"
 msgstr "benutze <Anzahl> Ziffern zur Anzeige von Objektnamen"
 
-#: parse-options.h:337
+#: parse-options.h:336
 msgid "how to strip spaces and #comments from message"
 msgstr ""
 "wie Leerzeichen und #Kommentare von der Beschreibung getrennt werden sollen"
 
-#: parse-options.h:338
+#: parse-options.h:337
 msgid "read pathspec from file"
 msgstr "Pfadspezifikation aus einer Datei lesen"
 
-#: parse-options.h:339
+#: parse-options.h:338
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""
 "Mit der Option --pathspec-from-file sind Pfade durch NUL-Zeichen getrennt"
 
-#: ref-filter.h:99
+#: ref-filter.h:101
 msgid "key"
 msgstr "Schüssel"
 
-#: ref-filter.h:99
+#: ref-filter.h:101
 msgid "field name to sort on"
 msgstr "sortiere nach diesem Feld"
 
@@ -25751,41 +26118,6 @@ msgstr "eine einführende Anleitung zu Git"
 msgid "An overview of recommended workflows with Git"
 msgstr "Eine Übersicht über empfohlene Arbeitsabläufe mit Git"
 
-#: git-bisect.sh:68
-msgid "bisect run failed: no command provided."
-msgstr "'bisect run' fehlgeschlagen: kein Befehl angegeben."
-
-#: git-bisect.sh:73
-#, sh-format
-msgid "running $command"
-msgstr "führe $command aus"
-
-#: git-bisect.sh:80
-#, sh-format
-msgid ""
-"bisect run failed:\n"
-"exit code $res from '$command' is < 0 or >= 128"
-msgstr ""
-"'bisect run' fehlgeschlagen:\n"
-"Exit-Code $res von '$command' ist < 0 oder >= 128"
-
-#: git-bisect.sh:105
-msgid "bisect run cannot continue any more"
-msgstr "'bisect run' kann nicht mehr fortgesetzt werden"
-
-#: git-bisect.sh:111
-#, sh-format
-msgid ""
-"bisect run failed:\n"
-"'bisect-state $state' exited with error code $res"
-msgstr ""
-"'bisect run' fehlgeschlagen:\n"
-"'bisect-state $state' wurde mit Fehlerwert $res beendet"
-
-#: git-bisect.sh:118
-msgid "bisect run success"
-msgstr "'bisect run' erfolgreich ausgeführt"
-
 #: git-merge-octopus.sh:46
 msgid ""
 "Error: Your local changes to the following files would be overwritten by "
@@ -25827,53 +26159,17 @@ msgstr "Versuche einfachen Merge mit $pretty_name"
 msgid "Simple merge did not work, trying automatic merge."
 msgstr "Einfacher Merge hat nicht funktioniert, versuche automatischen Merge."
 
-#: git-submodule.sh:179
-msgid "Relative path can only be used from the toplevel of the working tree"
-msgstr ""
-"Relative Pfade können nur von der obersten Ebene des Arbeitsverzeichnisses "
-"benutzt werden."
-
-#: git-submodule.sh:189
-#, sh-format
-msgid "repo URL: '$repo' must be absolute or begin with ./|../"
-msgstr "repo URL: '$repo' muss absolut sein oder mit ./|../ beginnen"
-
-#: git-submodule.sh:208
-#, sh-format
-msgid "'$sm_path' already exists in the index"
-msgstr "'$sm_path' ist bereits zum Commit vorgemerkt"
-
-#: git-submodule.sh:211
-#, sh-format
-msgid "'$sm_path' already exists in the index and is not a submodule"
-msgstr "'$sm_path' ist bereits zum Commit vorgemerkt und ist kein Submodul"
-
-#: git-submodule.sh:218
-#, sh-format
-msgid "'$sm_path' does not have a commit checked out"
-msgstr "'$sm_path' hat keinen Commit ausgecheckt"
-
-#: git-submodule.sh:248
-#, sh-format
-msgid "Failed to add submodule '$sm_path'"
-msgstr "Hinzufügen von Submodul '$sm_path' fehlgeschlagen"
-
-#: git-submodule.sh:257
-#, sh-format
-msgid "Failed to register submodule '$sm_path'"
-msgstr "Fehler beim Eintragen von Submodul '$sm_path' in die Konfiguration."
-
-#: git-submodule.sh:532
+#: git-submodule.sh:401
 #, sh-format
 msgid "Unable to find current revision in submodule path '$displaypath'"
 msgstr "Konnte aktuellen Commit in Submodul-Pfad '$displaypath' nicht finden."
 
-#: git-submodule.sh:542
+#: git-submodule.sh:411
 #, sh-format
 msgid "Unable to fetch in submodule path '$sm_path'"
 msgstr "Konnte \"fetch\" in Submodul-Pfad '$sm_path' nicht ausführen"
 
-#: git-submodule.sh:547
+#: git-submodule.sh:416
 #, sh-format
 msgid ""
 "Unable to find current ${remote_name}/${branch} revision in submodule path "
@@ -25882,408 +26178,10 @@ msgstr ""
 "Konnte aktuellen Commit von ${remote_name}/${branch} in Submodul-Pfad\n"
 "'$sm_path' nicht finden."
 
-#: git-submodule.sh:565
-#, sh-format
-msgid ""
-"Unable to fetch in submodule path '$displaypath'; trying to directly fetch "
-"$sha1:"
-msgstr ""
-"Konnte \"fetch\" in Submodul-Pfad '$displaypath' nicht ausführen. Versuche "
-"$sha1 direkt anzufordern:"
-
-#: git-submodule.sh:571
-#, sh-format
-msgid ""
-"Fetched in submodule path '$displaypath', but it did not contain $sha1. "
-"Direct fetching of that commit failed."
-msgstr ""
-"\"fetch\" in Submodul-Pfad '$displaypath' ausgeführt, aber $sha1 nicht\n"
-"enthalten. Direktes Anfordern dieses Commits ist fehlgeschlagen."
-
-#: git-submodule.sh:578
-#, sh-format
-msgid "Unable to checkout '$sha1' in submodule path '$displaypath'"
-msgstr "Konnte '$sha1' in Submodul-Pfad '$displaypath' nicht auschecken."
-
-#: git-submodule.sh:579
-#, sh-format
-msgid "Submodule path '$displaypath': checked out '$sha1'"
-msgstr "Submodul-Pfad: '$displaypath': '$sha1' ausgecheckt"
-
-#: git-submodule.sh:583
-#, sh-format
-msgid "Unable to rebase '$sha1' in submodule path '$displaypath'"
-msgstr "Rebase auf '$sha1' in Submodul-Pfad '$displaypath' nicht möglich"
-
-#: git-submodule.sh:584
-#, sh-format
-msgid "Submodule path '$displaypath': rebased into '$sha1'"
-msgstr "Submodul-Pfad '$displaypath': Rebase auf '$sha1'"
-
-#: git-submodule.sh:589
-#, sh-format
-msgid "Unable to merge '$sha1' in submodule path '$displaypath'"
-msgstr "Merge von '$sha1' in Submodul-Pfad '$displaypath' fehlgeschlagen"
-
-#: git-submodule.sh:590
-#, sh-format
-msgid "Submodule path '$displaypath': merged in '$sha1'"
-msgstr "Submodul-Pfad '$displaypath': zusammengeführt in '$sha1'"
-
-#: git-submodule.sh:595
-#, sh-format
-msgid "Execution of '$command $sha1' failed in submodule path '$displaypath'"
-msgstr ""
-"Ausführung von '$command $sha1' in Submodul-Pfad '$displaypath' "
-"fehlgeschlagen"
-
-#: git-submodule.sh:596
-#, sh-format
-msgid "Submodule path '$displaypath': '$command $sha1'"
-msgstr "Submodul-Pfad '$displaypath': '$command $sha1'"
-
-#: git-submodule.sh:627
+#: git-submodule.sh:464
 #, sh-format
 msgid "Failed to recurse into submodule path '$displaypath'"
 msgstr "Fehler bei Rekursion in Submodul-Pfad '$displaypath'"
-
-#: git-rebase--preserve-merges.sh:109
-msgid "Applied autostash."
-msgstr "Automatischen Stash angewendet."
-
-#: git-rebase--preserve-merges.sh:112
-#, sh-format
-msgid "Cannot store $stash_sha1"
-msgstr "Kann $stash_sha1 nicht speichern."
-
-#: git-rebase--preserve-merges.sh:113
-msgid ""
-"Applying autostash resulted in conflicts.\n"
-"Your changes are safe in the stash.\n"
-"You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
-msgstr ""
-"Anwendung des automatischen Stash resultierte in Konflikten.\n"
-"Ihre Änderungen sind im Stash sicher.\n"
-"Sie können jederzeit \"git stash pop\" oder \"git stash drop\" ausführen.\n"
-
-#: git-rebase--preserve-merges.sh:191
-#, sh-format
-msgid "Rebasing ($new_count/$total)"
-msgstr "Führe Rebase aus ($new_count/$total)"
-
-#: git-rebase--preserve-merges.sh:197
-msgid ""
-"\n"
-"Commands:\n"
-"p, pick <commit> = use commit\n"
-"r, reword <commit> = use commit, but edit the commit message\n"
-"e, edit <commit> = use commit, but stop for amending\n"
-"s, squash <commit> = use commit, but meld into previous commit\n"
-"f, fixup <commit> = like \"squash\", but discard this commit's log message\n"
-"x, exec <commit> = run command (the rest of the line) using shell\n"
-"d, drop <commit> = remove commit\n"
-"l, label <label> = label current HEAD with a name\n"
-"t, reset <label> = reset HEAD to a label\n"
-"m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
-".       create a merge commit using the original merge commit's\n"
-".       message (or the oneline, if no original merge commit was\n"
-".       specified). Use -c <commit> to reword the commit message.\n"
-"\n"
-"These lines can be re-ordered; they are executed from top to bottom.\n"
-msgstr ""
-"\n"
-"Befehle:\n"
-"p, pick <Commit> = Commit verwenden\n"
-"r, reword <Commit> = Commit verwenden, aber Commit-Beschreibung bearbeiten\n"
-"e, edit <Commit> = Commit verwenden, aber zum Nachbessern anhalten\n"
-"s, squash <Commit> = Commit verwenden, aber mit vorherigem Commit vereinen\n"
-"f, fixup <Commit> = wie \"squash\", aber diese Commit-Beschreibung "
-"verwerfen\n"
-"x, exec <Commit> = Befehl (Rest der Zeile) mittels Shell ausführen\n"
-"d, drop <Commit> = Commit entfernen\n"
-"l, label <Label> = aktuellen HEAD mit Label versehen\n"
-"t, reset <Label> = HEAD zu einem Label umsetzen\n"
-"m, merge [-C <Commit> | -c <Commit>] <Label> [# <eineZeile>]\n"
-".       Merge-Commit mit der originalen Merge-Commit-Beschreibung erstellen\n"
-".       (oder die eine Zeile, wenn keine originale Merge-Commit-"
-"Beschreibung\n"
-".       spezifiziert ist). Benutzen Sie -c <Commit> zum Bearbeiten der\n"
-".       Commit-Beschreibung.\n"
-"\n"
-"Diese Zeilen können umsortiert werden; Sie werden von oben nach unten\n"
-"ausgeführt.\n"
-
-#: git-rebase--preserve-merges.sh:260
-#, sh-format
-msgid ""
-"You can amend the commit now, with\n"
-"\n"
-"\tgit commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"Once you are satisfied with your changes, run\n"
-"\n"
-"\tgit rebase --continue"
-msgstr ""
-"Sie können den Commit nun nachbessern mit:\n"
-"\n"
-"\tgit commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"Sobald Sie mit Ihren Änderungen zufrieden sind, führen Sie aus:\n"
-"\n"
-"\tgit rebase --continue"
-
-#: git-rebase--preserve-merges.sh:285
-#, sh-format
-msgid "$sha1: not a commit that can be picked"
-msgstr "$sha1: kein Commit der gepickt werden kann"
-
-#: git-rebase--preserve-merges.sh:324
-#, sh-format
-msgid "Invalid commit name: $sha1"
-msgstr "Ungültiger Commit-Name: $sha1"
-
-#: git-rebase--preserve-merges.sh:354
-msgid "Cannot write current commit's replacement sha1"
-msgstr "Kann ersetzenden SHA-1 des aktuellen Commits nicht schreiben"
-
-#: git-rebase--preserve-merges.sh:405
-#, sh-format
-msgid "Fast-forward to $sha1"
-msgstr "Spule vor zu $sha1"
-
-#: git-rebase--preserve-merges.sh:407
-#, sh-format
-msgid "Cannot fast-forward to $sha1"
-msgstr "Kann nicht zu $sha1 vorspulen"
-
-#: git-rebase--preserve-merges.sh:416
-#, sh-format
-msgid "Cannot move HEAD to $first_parent"
-msgstr "Kann HEAD nicht auf $first_parent setzen"
-
-#: git-rebase--preserve-merges.sh:421
-#, sh-format
-msgid "Refusing to squash a merge: $sha1"
-msgstr "\"squash\" eines Merges ($sha1) zurückgewiesen."
-
-#: git-rebase--preserve-merges.sh:439
-#, sh-format
-msgid "Error redoing merge $sha1"
-msgstr "Fehler beim Wiederholen des Merges von $sha1"
-
-#: git-rebase--preserve-merges.sh:448
-#, sh-format
-msgid "Could not pick $sha1"
-msgstr "Konnte $sha1 nicht picken"
-
-#: git-rebase--preserve-merges.sh:457
-#, sh-format
-msgid "This is the commit message #${n}:"
-msgstr "Das ist Commit-Beschreibung #${n}:"
-
-#: git-rebase--preserve-merges.sh:462
-#, sh-format
-msgid "The commit message #${n} will be skipped:"
-msgstr "Commit-Beschreibung #${n} wird ausgelassen:"
-
-#: git-rebase--preserve-merges.sh:473
-#, sh-format
-msgid "This is a combination of $count commit."
-msgid_plural "This is a combination of $count commits."
-msgstr[0] "Das ist eine Kombination aus $count Commit."
-msgstr[1] "Das ist eine Kombination aus $count Commits."
-
-#: git-rebase--preserve-merges.sh:482
-#, sh-format
-msgid "Cannot write $fixup_msg"
-msgstr "Kann $fixup_msg nicht schreiben"
-
-#: git-rebase--preserve-merges.sh:485
-msgid "This is a combination of 2 commits."
-msgstr "Das ist eine Kombination aus 2 Commits."
-
-#: git-rebase--preserve-merges.sh:526 git-rebase--preserve-merges.sh:569
-#: git-rebase--preserve-merges.sh:572
-#, sh-format
-msgid "Could not apply $sha1... $rest"
-msgstr "Konnte $sha1... ($rest) nicht anwenden"
-
-#: git-rebase--preserve-merges.sh:601
-#, sh-format
-msgid ""
-"Could not amend commit after successfully picking $sha1... $rest\n"
-"This is most likely due to an empty commit message, or the pre-commit hook\n"
-"failed. If the pre-commit hook failed, you may need to resolve the issue "
-"before\n"
-"you are able to reword the commit."
-msgstr ""
-"Konnte Commit nicht nachbessern, nachdem dieser verwendet wurde: $sha1... "
-"$rest\n"
-"Das passierte sehr wahrscheinlich wegen einer leeren Commit-Beschreibung, "
-"oder\n"
-"weil der pre-commit Hook fehlschlug. Falls der pre-commit Hook fehlschlug,\n"
-"sollten Sie das Problem beheben, bevor Sie die Commit-Beschreibung ändern "
-"können."
-
-#: git-rebase--preserve-merges.sh:616
-#, sh-format
-msgid "Stopped at $sha1_abbrev... $rest"
-msgstr "Angehalten bei $sha1_abbrev... $rest"
-
-#: git-rebase--preserve-merges.sh:631
-#, sh-format
-msgid "Cannot '$squash_style' without a previous commit"
-msgstr "Kann nicht '$squash_style' ohne vorherigen Commit"
-
-#: git-rebase--preserve-merges.sh:673
-#, sh-format
-msgid "Executing: $rest"
-msgstr "Führe aus: $rest"
-
-#: git-rebase--preserve-merges.sh:681
-#, sh-format
-msgid "Execution failed: $rest"
-msgstr "Ausführung fehlgeschlagen: $rest"
-
-#: git-rebase--preserve-merges.sh:683
-msgid "and made changes to the index and/or the working tree"
-msgstr "Der Index und/oder das Arbeitsverzeichnis wurde geändert."
-
-#: git-rebase--preserve-merges.sh:685
-msgid ""
-"You can fix the problem, and then run\n"
-"\n"
-"\tgit rebase --continue"
-msgstr ""
-"Sie können das Problem beheben, und dann\n"
-"\n"
-"\tgit rebase --continue\n"
-"\n"
-"ausführen."
-
-#. TRANSLATORS: after these lines is a command to be issued by the user
-#: git-rebase--preserve-merges.sh:698
-#, sh-format
-msgid ""
-"Execution succeeded: $rest\n"
-"but left changes to the index and/or the working tree\n"
-"Commit or stash your changes, and then run\n"
-"\n"
-"\tgit rebase --continue"
-msgstr ""
-"Ausführung erfolgreich: $rest\n"
-"Aber Änderungen in Index oder Arbeitsverzeichnis verblieben.\n"
-"Committen Sie Ihre Änderungen oder benutzen Sie \"stash\".\n"
-"Führen Sie dann aus:\n"
-"\n"
-"\tgit rebase --continue"
-
-#: git-rebase--preserve-merges.sh:709
-#, sh-format
-msgid "Unknown command: $command $sha1 $rest"
-msgstr "Unbekannter Befehl: $command $sha1 $rest"
-
-#: git-rebase--preserve-merges.sh:710
-msgid "Please fix this using 'git rebase --edit-todo'."
-msgstr "Bitte beheben Sie das, indem Sie 'git rebase --edit-todo' ausführen."
-
-#: git-rebase--preserve-merges.sh:745
-#, sh-format
-msgid "Successfully rebased and updated $head_name."
-msgstr "Erfolgreich Rebase ausgeführt und $head_name aktualisiert."
-
-#: git-rebase--preserve-merges.sh:802
-msgid "Could not remove CHERRY_PICK_HEAD"
-msgstr "Konnte CHERRY_PICK_HEAD nicht löschen"
-
-#: git-rebase--preserve-merges.sh:807
-#, sh-format
-msgid ""
-"You have staged changes in your working tree.\n"
-"If these changes are meant to be\n"
-"squashed into the previous commit, run:\n"
-"\n"
-"  git commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"If they are meant to go into a new commit, run:\n"
-"\n"
-"  git commit $gpg_sign_opt_quoted\n"
-"\n"
-"In both cases, once you're done, continue with:\n"
-"\n"
-"  git rebase --continue\n"
-msgstr ""
-"Es befinden sich zum Commit vorgemerkte Änderungen in Ihrem "
-"Arbeitsverzeichnis.\n"
-"Wenn diese Änderungen in den vorherigen Commit aufgenommen werden sollen,\n"
-"führen Sie aus:\n"
-"\n"
-"  git commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"Wenn daraus ein neuer Commit erzeugt werden soll, führen Sie aus:\n"
-"\n"
-"  git commit $gpg_sign_opt_quoted\n"
-"\n"
-"Im Anschluss führen Sie zum Fortfahren aus:\n"
-"\n"
-"  git rebase --continue\n"
-
-#: git-rebase--preserve-merges.sh:824
-msgid "Error trying to find the author identity to amend commit"
-msgstr ""
-"Fehler beim Versuch die Identität des Authors zum Verbessern des Commits zu\n"
-"finden"
-
-#: git-rebase--preserve-merges.sh:829
-msgid ""
-"You have uncommitted changes in your working tree. Please commit them\n"
-"first and then run 'git rebase --continue' again."
-msgstr ""
-"Sie haben nicht committete Änderungen in Ihrem Arbeitsverzeichnis. Bitte\n"
-"committen Sie diese zuerst und führen Sie dann 'git rebase --continue' "
-"erneut\n"
-"aus."
-
-#: git-rebase--preserve-merges.sh:834 git-rebase--preserve-merges.sh:838
-msgid "Could not commit staged changes."
-msgstr "Konnte Änderungen aus der Staging-Area nicht committen."
-
-#: git-rebase--preserve-merges.sh:869 git-rebase--preserve-merges.sh:955
-msgid "Could not execute editor"
-msgstr "Konnte Editor nicht ausführen."
-
-#: git-rebase--preserve-merges.sh:890
-#, sh-format
-msgid "Could not checkout $switch_to"
-msgstr "Konnte $switch_to nicht auschecken."
-
-#: git-rebase--preserve-merges.sh:897
-msgid "No HEAD?"
-msgstr "Kein HEAD?"
-
-#: git-rebase--preserve-merges.sh:898
-#, sh-format
-msgid "Could not create temporary $state_dir"
-msgstr "Konnte temporäres Verzeichnis $state_dir nicht erstellen."
-
-#: git-rebase--preserve-merges.sh:901
-msgid "Could not mark as interactive"
-msgstr "Konnte nicht als interaktiven Rebase markieren."
-
-#: git-rebase--preserve-merges.sh:933
-#, sh-format
-msgid "Rebase $shortrevisions onto $shortonto ($todocount command)"
-msgid_plural "Rebase $shortrevisions onto $shortonto ($todocount commands)"
-msgstr[0] "Rebase von $shortrevisions auf $shortonto ($todocount Kommando)"
-msgstr[1] "Rebase von $shortrevisions auf $shortonto ($todocount Kommandos)"
-
-#: git-rebase--preserve-merges.sh:945
-msgid "Note that empty commits are commented out"
-msgstr "Leere Commits sind auskommentiert."
-
-#: git-rebase--preserve-merges.sh:987 git-rebase--preserve-merges.sh:992
-msgid "Could not init rewritten commits"
-msgstr "Konnte neu geschriebene Commits nicht initialisieren."
 
 #: git-sh-setup.sh:89 git-sh-setup.sh:94
 #, sh-format
@@ -26304,61 +26202,37 @@ msgstr ""
 "fatal: $program_name kann ohne ein Arbeitsverzeichnis nicht verwendet werden."
 
 #: git-sh-setup.sh:221
-msgid "Cannot rebase: You have unstaged changes."
-msgstr ""
-"Rebase nicht möglich: Sie haben Änderungen, die nicht zum Commit vorgemerkt "
-"sind."
-
-#: git-sh-setup.sh:224
 msgid "Cannot rewrite branches: You have unstaged changes."
 msgstr ""
 "Kann Branches nicht neu schreiben: Sie haben Änderungen, die nicht zum "
 "Commit\n"
 "vorgemerkt sind."
 
-#: git-sh-setup.sh:227
-msgid "Cannot pull with rebase: You have unstaged changes."
-msgstr ""
-"Kann \"pull\" mit \"rebase\" nicht ausführen: Sie haben Änderungen, die "
-"nicht zum Commit vorgemerkt sind."
-
-#: git-sh-setup.sh:230
+#: git-sh-setup.sh:224
 #, sh-format
 msgid "Cannot $action: You have unstaged changes."
 msgstr ""
 "Kann $action nicht ausführen: Sie haben Änderungen, die nicht zum Commit\n"
 "vorgemerkt sind."
 
-#: git-sh-setup.sh:243
-msgid "Cannot rebase: Your index contains uncommitted changes."
-msgstr ""
-"Rebase nicht möglich: Die Staging-Area beinhaltet nicht committete "
-"Änderungen."
-
-#: git-sh-setup.sh:246
-msgid "Cannot pull with rebase: Your index contains uncommitted changes."
-msgstr ""
-"Kann \"pull\" mit \"rebase\" nicht ausführen: Die Staging-Area beinhaltet "
-"nicht committete Änderungen."
-
-#: git-sh-setup.sh:249
+#: git-sh-setup.sh:235
 #, sh-format
 msgid "Cannot $action: Your index contains uncommitted changes."
 msgstr ""
 "Kann $action nicht ausführen: Die Staging-Area beinhaltet nicht committete\n"
 "Änderungen."
 
-#: git-sh-setup.sh:253
+#: git-sh-setup.sh:237
 msgid "Additionally, your index contains uncommitted changes."
 msgstr "Zusätzlich beinhaltet die Staging-Area nicht committete Änderungen."
 
-#: git-sh-setup.sh:373
+#: git-sh-setup.sh:357
 msgid "You need to run this command from the toplevel of the working tree."
 msgstr ""
 "Sie müssen den Befehl von der obersten Ebene des Arbeitsverzeichnisses "
 "ausführen."
 
-#: git-sh-setup.sh:378
+#: git-sh-setup.sh:362
 msgid "Unable to determine absolute path of git directory"
 msgstr "Konnte absoluten Pfad des Git-Verzeichnisses nicht bestimmen."
 
@@ -27026,7 +26900,7 @@ msgstr "Ergebnis: "
 msgid "Result: OK\n"
 msgstr "Ergebnis: OK\n"
 
-#: git-send-email.perl:1709
+#: git-send-email.perl:1708
 #, perl-format
 msgid "can't open file %s"
 msgstr "Kann Datei %s nicht öffnen"
@@ -27051,30 +26925,30 @@ msgstr "(non-mbox) Füge cc: hinzu: %s von Zeile '%s'\n"
 msgid "(body) Adding cc: %s from line '%s'\n"
 msgstr "(body) Füge cc: hinzu: %s von Zeile '%s'\n"
 
-#: git-send-email.perl:1965
+#: git-send-email.perl:1973
 #, perl-format
 msgid "(%s) Could not execute '%s'"
 msgstr "(%s) Konnte '%s' nicht ausführen"
 
-#: git-send-email.perl:1972
+#: git-send-email.perl:1980
 #, perl-format
 msgid "(%s) Adding %s: %s from: '%s'\n"
 msgstr "(%s) Füge %s: %s hinzu von: '%s'\n"
 
-#: git-send-email.perl:1976
+#: git-send-email.perl:1984
 #, perl-format
 msgid "(%s) failed to close pipe to '%s'"
 msgstr "(%s) Fehler beim Schließen der Pipe nach '%s'"
 
-#: git-send-email.perl:2006
+#: git-send-email.perl:2014
 msgid "cannot send message as 7bit"
 msgstr "Kann Nachricht nicht als 7bit versenden."
 
-#: git-send-email.perl:2014
+#: git-send-email.perl:2022
 msgid "invalid transfer encoding"
 msgstr "Ungültiges Transfer-Encoding"
 
-#: git-send-email.perl:2051
+#: git-send-email.perl:2059
 #, perl-format
 msgid ""
 "fatal: %s: rejected by sendemail-validate hook\n"
@@ -27085,12 +26959,12 @@ msgstr ""
 "%s\n"
 "Warnung: Es wurden keine Patches gesendet\n"
 
-#: git-send-email.perl:2061 git-send-email.perl:2114 git-send-email.perl:2124
+#: git-send-email.perl:2069 git-send-email.perl:2122 git-send-email.perl:2132
 #, perl-format
 msgid "unable to open %s: %s\n"
 msgstr "konnte %s nicht öffnen: %s\n"
 
-#: git-send-email.perl:2064
+#: git-send-email.perl:2072
 #, perl-format
 msgid ""
 "fatal: %s:%d is longer than 998 characters\n"
@@ -27099,13 +26973,547 @@ msgstr ""
 "fatal: %s:%d ist länger als 998 Zeichen\n"
 "Warnung: Es wurden keine Patches gesendet\n"
 
-#: git-send-email.perl:2082
+#: git-send-email.perl:2090
 #, perl-format
 msgid "Skipping %s with backup suffix '%s'.\n"
 msgstr "Lasse %s mit Backup-Suffix '%s' aus.\n"
 
 #. TRANSLATORS: please keep "[y|N]" as is.
-#: git-send-email.perl:2086
+#: git-send-email.perl:2094
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Wollen Sie %s wirklich versenden? [y|N]: "
+
+#~ msgid ""
+#~ "The following pathspecs didn't match any eligible path, but they do match "
+#~ "index\n"
+#~ "entries outside the current sparse checkout:\n"
+#~ msgstr ""
+#~ "Die folgenden Pfadspezifikationen entsprachen keinem geeigneten Pfad, "
+#~ "aber\n"
+#~ "entsprechen Index-Einträgen außerhalb des aktuellen partiellen "
+#~ "Checkouts:\n"
+
+#~ msgid ""
+#~ "Disable or modify the sparsity rules if you intend to update such entries."
+#~ msgstr ""
+#~ "Deaktivieren oder verändern Sie die Regeln für partielle Checkouts, wenn "
+#~ "Sie solche Einträge aktualisieren möchten."
+
+#~ msgid "could not set GIT_DIR to '%s'"
+#~ msgstr "konnte GIT_DIR nicht zu '%s' setzen"
+
+#~ msgid "unable to unpack %s header with --allow-unknown-type"
+#~ msgstr "Konnte %s Kopfbereich nicht mit --allow-unknown-type entpacken."
+
+#~ msgid "unable to parse %s header with --allow-unknown-type"
+#~ msgstr "Konnte %s Kopfbereich mit --allow-unknown-type nicht parsen."
+
+#~ msgid "open /dev/null failed"
+#~ msgstr "Öffnen von /dev/null fehlgeschlagen"
+
+#~ msgid ""
+#~ "after resolving the conflicts, mark the corrected paths\n"
+#~ "with 'git add <paths>' or 'git rm <paths>'\n"
+#~ "and commit the result with 'git commit'"
+#~ msgstr ""
+#~ "nach Auflösung der Konflikte markieren Sie die korrigierten Pfade\n"
+#~ "mit 'git add <Pfade>' oder 'git rm <Pfade>' und tragen Sie das Ergebnis "
+#~ "mit\n"
+#~ "'git commit' ein"
+
+#~ msgid "open /dev/null or dup failed"
+#~ msgstr "Öffnen von /dev/null oder dup fehlgeschlagen."
+
+#~ msgid "attempting to use sparse-index without cone mode"
+#~ msgstr "versuche partiellen Index ohne Cone-Modus zu benutzen"
+
+#~ msgid "unable to update cache-tree, staying full"
+#~ msgstr "konnte Cache-Verzeichnis nicht aktualisieren, bleibt voll"
+
+#~ msgid "Could not open '%s' for writing."
+#~ msgstr "Konnte '%s' nicht zum Schreiben öffnen."
+
+#~ msgid "could not create archive file '%s'"
+#~ msgstr "Konnte Archiv-Datei '%s' nicht erstellen."
+
+#~ msgid ""
+#~ "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
+#~ msgstr ""
+#~ "git bisect--helper --bisect-next-check <Begriff_gut> <Begriff_schlecht> "
+#~ "[<Begriff>]"
+
+#~ msgid "--bisect-next-check requires 2 or 3 arguments"
+#~ msgstr "--bisect-next-check benötigt 2 oder 3 Argumente"
+
+#~ msgid "couldn't create a new file at '%s'"
+#~ msgstr "konnte keine neue Datei unter '%s' erstellen"
+
+#~ msgid "git commit-tree: failed to open '%s'"
+#~ msgstr "git commit-tree: Fehler beim Öffnen von '%s'"
+
+#~ msgid "cannot open packfile '%s'"
+#~ msgstr "Kann Paketdatei '%s' nicht öffnen"
+
+#~ msgid "cannot store pack file"
+#~ msgstr "Kann Paketdatei nicht speichern"
+
+#~ msgid "cannot store index file"
+#~ msgstr "Kann Indexdatei nicht speichern"
+
+#~ msgid "exclude patterns are read from <file>"
+#~ msgstr "Muster, gelesen von <Datei>, ausschließen"
+
+#~ msgid "Unknown option for merge-recursive: -X%s"
+#~ msgstr "Unbekannte Option für merge-recursive: -X%s"
+
+#~ msgid "unusable todo list: '%s'"
+#~ msgstr "Unbenutzbare TODO-Liste: '%s'"
+
+#~ msgid "git rebase--interactive [<options>]"
+#~ msgstr "git rebase--interactive [<Optionen>]"
+
+#~ msgid "rebase merge commits"
+#~ msgstr "Rebase auf Merge-Commits ausführen"
+
+#~ msgid "keep original branch points of cousins"
+#~ msgstr "originale Branch-Punkte der Cousins behalten"
+
+#~ msgid "move commits that begin with squash!/fixup!"
+#~ msgstr "Commits verschieben, die mit squash!/fixup! beginnen"
+
+#~ msgid "sign commits"
+#~ msgstr "Commits signieren"
+
+#~ msgid "continue rebase"
+#~ msgstr "Rebase fortsetzen"
+
+#~ msgid "skip commit"
+#~ msgstr "Commit auslassen"
+
+#~ msgid "edit the todo list"
+#~ msgstr "die TODO-Liste bearbeiten"
+
+#~ msgid "show the current patch"
+#~ msgstr "den aktuellen Patch anzeigen"
+
+#~ msgid "shorten commit ids in the todo list"
+#~ msgstr "Commit-IDs in der TODO-Liste verkürzen"
+
+#~ msgid "expand commit ids in the todo list"
+#~ msgstr "Commit-IDs in der TODO-Liste erweitern"
+
+#~ msgid "check the todo list"
+#~ msgstr "die TODO-Liste prüfen"
+
+#~ msgid "rearrange fixup/squash lines"
+#~ msgstr "fixup/squash-Zeilen umordnen"
+
+#~ msgid "insert exec commands in todo list"
+#~ msgstr "\"exec\"-Befehle in TODO-Liste einfügen"
+
+#~ msgid "onto"
+#~ msgstr "auf"
+
+#~ msgid "restrict-revision"
+#~ msgstr "Begrenzungscommit"
+
+#~ msgid "restrict revision"
+#~ msgstr "Begrenzungscommit"
+
+#~ msgid "squash-onto"
+#~ msgstr "squash-onto"
+
+#~ msgid "squash onto"
+#~ msgstr "squash onto"
+
+#~ msgid "the upstream commit"
+#~ msgstr "der Upstream-Commit"
+
+#~ msgid "head-name"
+#~ msgstr "head-Name"
+
+#~ msgid "head name"
+#~ msgstr "head-Name"
+
+#~ msgid "rebase strategy"
+#~ msgstr "Rebase-Strategie"
+
+#~ msgid "strategy-opts"
+#~ msgstr "Strategie-Optionen"
+
+#~ msgid "strategy options"
+#~ msgstr "Strategie-Optionen"
+
+#~ msgid "switch-to"
+#~ msgstr "wechseln zu"
+
+#~ msgid "the branch or commit to checkout"
+#~ msgstr "der Branch oder Commit zum Auschecken"
+
+#~ msgid "onto-name"
+#~ msgstr "onto-Name"
+
+#~ msgid "onto name"
+#~ msgstr "onto-Name"
+
+#~ msgid "cmd"
+#~ msgstr "Befehl"
+
+#~ msgid "the command to run"
+#~ msgstr "auszuführender Befehl"
+
+#~ msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
+#~ msgstr "--[no-]rebase-cousins hat ohne --rebase-merges keine Auswirkung"
+
+#~ msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
+#~ msgstr ""
+#~ "'--preserve-merges' kann nicht mit '--rebase-merges' kombiniert werden."
+
+#~ msgid ""
+#~ "error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
+#~ msgstr ""
+#~ "Fehler: '--preserve-merges' kann nicht mit '--reschedule-failed-exec' "
+#~ "kombiniert werden."
+
+#~ msgid ""
+#~ "git submodule--helper add-clone [<options>...] --url <url> --path <path> "
+#~ "--name <name>"
+#~ msgstr ""
+#~ "git submodule--helper add-clone [<Optionen>...] --url <URL> --path <Pfad> "
+#~ "--name <Name>"
+
+#~ msgid "failed to create file %s"
+#~ msgstr "Konnte Datei '%s' nicht erstellen"
+
+#~ msgid "exit immediately after initial ref advertisement"
+#~ msgstr "direkt nach der initialen Angabe der Commits beenden"
+
+#~ msgid "socket/pipe already in use: '%s'"
+#~ msgstr "Socket/Pipe bereits in Benutzung: '%s'"
+
+#~ msgid "could not start server on: '%s'"
+#~ msgstr "konnte Server nicht starten auf: '%s'"
+
+#~ msgid "could not spawn daemon in the background"
+#~ msgstr "Daemon konnte nicht im Hintergrund erzeugt werden"
+
+#~ msgid "waitpid failed"
+#~ msgstr "waitpid fehlgeschlagen"
+
+#~ msgid "daemon not online yet"
+#~ msgstr "Daemon ist noch nicht online"
+
+#~ msgid "daemon failed to start"
+#~ msgstr "Fehler beim Starten des Daemons"
+
+#~ msgid "waitpid is confused"
+#~ msgstr "waitpid ist verwirrt"
+
+#~ msgid "daemon has not shutdown yet"
+#~ msgstr "Daemon ist noch nicht heruntergefahren"
+
+#~ msgid "Protocol restrictions not supported with cURL < 7.19.4"
+#~ msgstr "Protokollbeschränkungen werden mit cURL < 7.19.4 nicht unterstützt."
+
+#~ msgid "running $command"
+#~ msgstr "führe $command aus"
+
+#~ msgid "'$sm_path' does not have a commit checked out"
+#~ msgstr "'$sm_path' hat keinen Commit ausgecheckt"
+
+#~ msgid "Submodule path '$displaypath': '$command $sha1'"
+#~ msgstr "Submodul-Pfad '$displaypath': '$command $sha1'"
+
+#~ msgid "Applied autostash."
+#~ msgstr "Automatischen Stash angewendet."
+
+#~ msgid "Cannot store $stash_sha1"
+#~ msgstr "Kann $stash_sha1 nicht speichern."
+
+#~ msgid ""
+#~ "Applying autostash resulted in conflicts.\n"
+#~ "Your changes are safe in the stash.\n"
+#~ "You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
+#~ msgstr ""
+#~ "Anwendung des automatischen Stash resultierte in Konflikten.\n"
+#~ "Ihre Änderungen sind im Stash sicher.\n"
+#~ "Sie können jederzeit \"git stash pop\" oder \"git stash drop\" "
+#~ "ausführen.\n"
+
+#~ msgid "Rebasing ($new_count/$total)"
+#~ msgstr "Führe Rebase aus ($new_count/$total)"
+
+#~ msgid ""
+#~ "\n"
+#~ "Commands:\n"
+#~ "p, pick <commit> = use commit\n"
+#~ "r, reword <commit> = use commit, but edit the commit message\n"
+#~ "e, edit <commit> = use commit, but stop for amending\n"
+#~ "s, squash <commit> = use commit, but meld into previous commit\n"
+#~ "f, fixup <commit> = like \"squash\", but discard this commit's log "
+#~ "message\n"
+#~ "x, exec <commit> = run command (the rest of the line) using shell\n"
+#~ "d, drop <commit> = remove commit\n"
+#~ "l, label <label> = label current HEAD with a name\n"
+#~ "t, reset <label> = reset HEAD to a label\n"
+#~ "m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
+#~ ".       create a merge commit using the original merge commit's\n"
+#~ ".       message (or the oneline, if no original merge commit was\n"
+#~ ".       specified). Use -c <commit> to reword the commit message.\n"
+#~ "\n"
+#~ "These lines can be re-ordered; they are executed from top to bottom.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Befehle:\n"
+#~ "p, pick <Commit> = Commit verwenden\n"
+#~ "r, reword <Commit> = Commit verwenden, aber Commit-Beschreibung "
+#~ "bearbeiten\n"
+#~ "e, edit <Commit> = Commit verwenden, aber zum Nachbessern anhalten\n"
+#~ "s, squash <Commit> = Commit verwenden, aber mit vorherigem Commit "
+#~ "vereinen\n"
+#~ "f, fixup <Commit> = wie \"squash\", aber diese Commit-Beschreibung "
+#~ "verwerfen\n"
+#~ "x, exec <Commit> = Befehl (Rest der Zeile) mittels Shell ausführen\n"
+#~ "d, drop <Commit> = Commit entfernen\n"
+#~ "l, label <Label> = aktuellen HEAD mit Label versehen\n"
+#~ "t, reset <Label> = HEAD zu einem Label umsetzen\n"
+#~ "m, merge [-C <Commit> | -c <Commit>] <Label> [# <eineZeile>]\n"
+#~ ".       Merge-Commit mit der originalen Merge-Commit-Beschreibung "
+#~ "erstellen\n"
+#~ ".       (oder die eine Zeile, wenn keine originale Merge-Commit-"
+#~ "Beschreibung\n"
+#~ ".       spezifiziert ist). Benutzen Sie -c <Commit> zum Bearbeiten der\n"
+#~ ".       Commit-Beschreibung.\n"
+#~ "\n"
+#~ "Diese Zeilen können umsortiert werden; Sie werden von oben nach unten\n"
+#~ "ausgeführt.\n"
+
+#~ msgid ""
+#~ "You can amend the commit now, with\n"
+#~ "\n"
+#~ "\tgit commit --amend $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "Once you are satisfied with your changes, run\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+#~ msgstr ""
+#~ "Sie können den Commit nun nachbessern mit:\n"
+#~ "\n"
+#~ "\tgit commit --amend $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "Sobald Sie mit Ihren Änderungen zufrieden sind, führen Sie aus:\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+
+#~ msgid "$sha1: not a commit that can be picked"
+#~ msgstr "$sha1: kein Commit der gepickt werden kann"
+
+#~ msgid "Invalid commit name: $sha1"
+#~ msgstr "Ungültiger Commit-Name: $sha1"
+
+#~ msgid "Cannot write current commit's replacement sha1"
+#~ msgstr "Kann ersetzenden SHA-1 des aktuellen Commits nicht schreiben"
+
+#~ msgid "Fast-forward to $sha1"
+#~ msgstr "Spule vor zu $sha1"
+
+#~ msgid "Cannot fast-forward to $sha1"
+#~ msgstr "Kann nicht zu $sha1 vorspulen"
+
+#~ msgid "Cannot move HEAD to $first_parent"
+#~ msgstr "Kann HEAD nicht auf $first_parent setzen"
+
+#~ msgid "Refusing to squash a merge: $sha1"
+#~ msgstr "\"squash\" eines Merges ($sha1) zurückgewiesen."
+
+#~ msgid "Error redoing merge $sha1"
+#~ msgstr "Fehler beim Wiederholen des Merges von $sha1"
+
+#~ msgid "Could not pick $sha1"
+#~ msgstr "Konnte $sha1 nicht picken"
+
+#~ msgid "This is the commit message #${n}:"
+#~ msgstr "Das ist Commit-Beschreibung #${n}:"
+
+#~ msgid "The commit message #${n} will be skipped:"
+#~ msgstr "Commit-Beschreibung #${n} wird ausgelassen:"
+
+#~ msgid "This is a combination of $count commit."
+#~ msgid_plural "This is a combination of $count commits."
+#~ msgstr[0] "Das ist eine Kombination aus $count Commit."
+#~ msgstr[1] "Das ist eine Kombination aus $count Commits."
+
+#~ msgid "Cannot write $fixup_msg"
+#~ msgstr "Kann $fixup_msg nicht schreiben"
+
+#~ msgid "This is a combination of 2 commits."
+#~ msgstr "Das ist eine Kombination aus 2 Commits."
+
+#~ msgid "Could not apply $sha1... $rest"
+#~ msgstr "Konnte $sha1... ($rest) nicht anwenden"
+
+#~ msgid ""
+#~ "Could not amend commit after successfully picking $sha1... $rest\n"
+#~ "This is most likely due to an empty commit message, or the pre-commit "
+#~ "hook\n"
+#~ "failed. If the pre-commit hook failed, you may need to resolve the issue "
+#~ "before\n"
+#~ "you are able to reword the commit."
+#~ msgstr ""
+#~ "Konnte Commit nicht nachbessern, nachdem dieser verwendet wurde: $sha1... "
+#~ "$rest\n"
+#~ "Das passierte sehr wahrscheinlich wegen einer leeren Commit-Beschreibung, "
+#~ "oder\n"
+#~ "weil der pre-commit Hook fehlschlug. Falls der pre-commit Hook "
+#~ "fehlschlug,\n"
+#~ "sollten Sie das Problem beheben, bevor Sie die Commit-Beschreibung ändern "
+#~ "können."
+
+#~ msgid "Stopped at $sha1_abbrev... $rest"
+#~ msgstr "Angehalten bei $sha1_abbrev... $rest"
+
+#~ msgid "Cannot '$squash_style' without a previous commit"
+#~ msgstr "Kann nicht '$squash_style' ohne vorherigen Commit"
+
+#~ msgid "Executing: $rest"
+#~ msgstr "Führe aus: $rest"
+
+#~ msgid "Execution failed: $rest"
+#~ msgstr "Ausführung fehlgeschlagen: $rest"
+
+#~ msgid "and made changes to the index and/or the working tree"
+#~ msgstr "Der Index und/oder das Arbeitsverzeichnis wurde geändert."
+
+#~ msgid ""
+#~ "You can fix the problem, and then run\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+#~ msgstr ""
+#~ "Sie können das Problem beheben, und dann\n"
+#~ "\n"
+#~ "\tgit rebase --continue\n"
+#~ "\n"
+#~ "ausführen."
+
+#~ msgid ""
+#~ "Execution succeeded: $rest\n"
+#~ "but left changes to the index and/or the working tree\n"
+#~ "Commit or stash your changes, and then run\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+#~ msgstr ""
+#~ "Ausführung erfolgreich: $rest\n"
+#~ "Aber Änderungen in Index oder Arbeitsverzeichnis verblieben.\n"
+#~ "Committen Sie Ihre Änderungen oder benutzen Sie \"stash\".\n"
+#~ "Führen Sie dann aus:\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+
+#~ msgid "Unknown command: $command $sha1 $rest"
+#~ msgstr "Unbekannter Befehl: $command $sha1 $rest"
+
+#~ msgid "Please fix this using 'git rebase --edit-todo'."
+#~ msgstr ""
+#~ "Bitte beheben Sie das, indem Sie 'git rebase --edit-todo' ausführen."
+
+#~ msgid "Successfully rebased and updated $head_name."
+#~ msgstr "Erfolgreich Rebase ausgeführt und $head_name aktualisiert."
+
+#~ msgid "Could not remove CHERRY_PICK_HEAD"
+#~ msgstr "Konnte CHERRY_PICK_HEAD nicht löschen"
+
+#~ msgid ""
+#~ "You have staged changes in your working tree.\n"
+#~ "If these changes are meant to be\n"
+#~ "squashed into the previous commit, run:\n"
+#~ "\n"
+#~ "  git commit --amend $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "If they are meant to go into a new commit, run:\n"
+#~ "\n"
+#~ "  git commit $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "In both cases, once you're done, continue with:\n"
+#~ "\n"
+#~ "  git rebase --continue\n"
+#~ msgstr ""
+#~ "Es befinden sich zum Commit vorgemerkte Änderungen in Ihrem "
+#~ "Arbeitsverzeichnis.\n"
+#~ "Wenn diese Änderungen in den vorherigen Commit aufgenommen werden "
+#~ "sollen,\n"
+#~ "führen Sie aus:\n"
+#~ "\n"
+#~ "  git commit --amend $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "Wenn daraus ein neuer Commit erzeugt werden soll, führen Sie aus:\n"
+#~ "\n"
+#~ "  git commit $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "Im Anschluss führen Sie zum Fortfahren aus:\n"
+#~ "\n"
+#~ "  git rebase --continue\n"
+
+#~ msgid "Error trying to find the author identity to amend commit"
+#~ msgstr ""
+#~ "Fehler beim Versuch die Identität des Authors zum Verbessern des Commits "
+#~ "zu\n"
+#~ "finden"
+
+#~ msgid ""
+#~ "You have uncommitted changes in your working tree. Please commit them\n"
+#~ "first and then run 'git rebase --continue' again."
+#~ msgstr ""
+#~ "Sie haben nicht committete Änderungen in Ihrem Arbeitsverzeichnis. Bitte\n"
+#~ "committen Sie diese zuerst und führen Sie dann 'git rebase --continue' "
+#~ "erneut\n"
+#~ "aus."
+
+#~ msgid "Could not commit staged changes."
+#~ msgstr "Konnte Änderungen aus der Staging-Area nicht committen."
+
+#~ msgid "Could not execute editor"
+#~ msgstr "Konnte Editor nicht ausführen."
+
+#~ msgid "Could not checkout $switch_to"
+#~ msgstr "Konnte $switch_to nicht auschecken."
+
+#~ msgid "No HEAD?"
+#~ msgstr "Kein HEAD?"
+
+#~ msgid "Could not create temporary $state_dir"
+#~ msgstr "Konnte temporäres Verzeichnis $state_dir nicht erstellen."
+
+#~ msgid "Could not mark as interactive"
+#~ msgstr "Konnte nicht als interaktiven Rebase markieren."
+
+#~ msgid "Rebase $shortrevisions onto $shortonto ($todocount command)"
+#~ msgid_plural "Rebase $shortrevisions onto $shortonto ($todocount commands)"
+#~ msgstr[0] "Rebase von $shortrevisions auf $shortonto ($todocount Kommando)"
+#~ msgstr[1] "Rebase von $shortrevisions auf $shortonto ($todocount Kommandos)"
+
+#~ msgid "Note that empty commits are commented out"
+#~ msgstr "Leere Commits sind auskommentiert."
+
+#~ msgid "Could not init rewritten commits"
+#~ msgstr "Konnte neu geschriebene Commits nicht initialisieren."
+
+#~ msgid "Cannot rebase: You have unstaged changes."
+#~ msgstr ""
+#~ "Rebase nicht möglich: Sie haben Änderungen, die nicht zum Commit "
+#~ "vorgemerkt sind."
+
+#~ msgid "Cannot pull with rebase: You have unstaged changes."
+#~ msgstr ""
+#~ "Kann \"pull\" mit \"rebase\" nicht ausführen: Sie haben Änderungen, die "
+#~ "nicht zum Commit vorgemerkt sind."
+
+#~ msgid "Cannot rebase: Your index contains uncommitted changes."
+#~ msgstr ""
+#~ "Rebase nicht möglich: Die Staging-Area beinhaltet nicht committete "
+#~ "Änderungen."
+
+#~ msgid "Cannot pull with rebase: Your index contains uncommitted changes."
+#~ msgstr ""
+#~ "Kann \"pull\" mit \"rebase\" nicht ausführen: Die Staging-Area beinhaltet "
+#~ "nicht committete Änderungen."

--- a/po/de.po
+++ b/po/de.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-11-04 08:34+0800\n"
+"POT-Creation-Date: 2021-11-10 08:55+0800\n"
 "PO-Revision-Date: 2021-11-07 19:48+0100\n"
 "Last-Translator: Matthias Rüster <matthias.ruester@gmail.com>\n"
 "Language-Team: Matthias Rüster <matthias.ruester@gmail.com>\n"
@@ -212,7 +212,7 @@ msgstr "aus Staging-Area entfernt"
 
 #: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
 #: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:190
+#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:194
 #: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
 #: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
 #: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
@@ -10663,7 +10663,7 @@ msgstr ""
 "ignoriert:\n"
 
 #: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
-#: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:550
+#: builtin/prune-packed.c:14 builtin/pull.c:208 builtin/push.c:550
 #: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr "Probelauf"
@@ -11145,11 +11145,11 @@ msgstr "an git-apply übergeben"
 
 #: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
 #: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
-#: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
+#: builtin/pull.c:142 builtin/pull.c:204 builtin/pull.c:221
 #: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
 #: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
 #: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
-#: parse-options.h:316
+#: parse-options.h:315
 msgid "n"
 msgstr "Anzahl"
 
@@ -11201,7 +11201,7 @@ msgid "use current timestamp for author date"
 msgstr "aktuellen Zeitstempel als Autor-Datum verwenden"
 
 #: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
-#: builtin/merge.c:299 builtin/pull.c:175 builtin/rebase.c:1099
+#: builtin/merge.c:299 builtin/pull.c:179 builtin/rebase.c:1099
 #: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
 msgstr "GPG-Schlüsselkennung"
@@ -11708,7 +11708,7 @@ msgstr "Statistiken zum Arbeitsaufwand anzeigen"
 #: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
 #: builtin/merge.c:298 builtin/multi-pack-index.c:103
 #: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
-#: builtin/multi-pack-index.c:204 builtin/pull.c:119 builtin/push.c:566
+#: builtin/multi-pack-index.c:204 builtin/pull.c:120 builtin/push.c:566
 #: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "Fortschrittsanzeige erzwingen"
@@ -13014,7 +13014,7 @@ msgstr "Branch- oder Commit-Argument fehlt"
 msgid "perform a 3-way merge with the new branch"
 msgstr "einen 3-Wege-Merge mit dem neuen Branch ausführen"
 
-#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:322
+#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:321
 msgid "style"
 msgstr "Stil"
 
@@ -13442,7 +13442,7 @@ msgid "path to git-upload-pack on the remote"
 msgstr "Pfad zu \"git-upload-pack\" auf der Gegenseite"
 
 #: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
-#: builtin/pull.c:208
+#: builtin/pull.c:212
 msgid "depth"
 msgstr "Tiefe"
 
@@ -13452,7 +13452,7 @@ msgstr ""
 "einen Klon mit unvollständiger Historie (shallow) in dieser Tiefe erstellen"
 
 #: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
-#: builtin/pull.c:211
+#: builtin/pull.c:215
 msgid "time"
 msgstr "Zeit"
 
@@ -13464,11 +13464,11 @@ msgstr ""
 "erstellen"
 
 #: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1022
+#: builtin/pull.c:218 builtin/pull.c:243 builtin/rebase.c:1022
 msgid "revision"
 msgstr "Commit"
 
-#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:215
+#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:219
 msgid "deepen history of shallow clone, excluding rev"
 msgstr ""
 "die Historie eines Klons mit unvollständiger Historie (shallow) mittels\n"
@@ -13504,21 +13504,21 @@ msgid "set config inside the new repository"
 msgstr "Konfiguration innerhalb des neuen Repositories setzen"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:200
+#: builtin/pull.c:234 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "serverspezifisch"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:201
+#: builtin/pull.c:235 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr "Option übertragen"
 
-#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:234
+#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:238
 #: builtin/push.c:576
 msgid "use IPv4 addresses only"
 msgstr "nur IPv4-Adressen benutzen"
 
-#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:237
+#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:241
 #: builtin/push.c:578
 msgid "use IPv6 addresses only"
 msgstr "nur IPv6-Adressen benutzen"
@@ -13930,7 +13930,7 @@ msgid "read commit log message from file"
 msgstr "Commit-Beschreibung von Datei lesen"
 
 #: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
-#: builtin/pull.c:176 builtin/revert.c:118
+#: builtin/pull.c:180 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "Commit mit GPG signieren"
 
@@ -14351,7 +14351,7 @@ msgstr "Einträge mit NUL-Zeichen abschließen"
 
 #: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
 #: builtin/fast-export.c:1199 builtin/fast-export.c:1202
-#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:336
+#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:335
 msgid "mode"
 msgstr "Modus"
 
@@ -14431,7 +14431,7 @@ msgid "override date for commit"
 msgstr "Datum eines Commits überschreiben"
 
 #: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
-#: parse-options.h:328 ref-filter.h:92
+#: parse-options.h:327 ref-filter.h:92
 msgid "commit"
 msgstr "Commit"
 
@@ -14476,7 +14476,7 @@ msgid "add custom trailer(s)"
 msgstr "benutzerdefinierte Anhänge hinzufügen"
 
 #: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
-#: builtin/pull.c:145 builtin/revert.c:110
+#: builtin/pull.c:146 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "eine Signed-off-by Zeile hinzufügen"
 
@@ -15472,15 +15472,15 @@ msgstr "git fetch --all [<Optionen>]"
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel kann nicht negativ sein"
 
-#: builtin/fetch.c:145 builtin/pull.c:185
+#: builtin/fetch.c:145 builtin/pull.c:189
 msgid "fetch from all remotes"
 msgstr "fordert von allen Remote-Repositories an"
 
-#: builtin/fetch.c:147 builtin/pull.c:245
+#: builtin/fetch.c:147 builtin/pull.c:249
 msgid "set upstream for git pull/fetch"
 msgstr "Upstream für \"git pull/fetch\" setzen"
 
-#: builtin/fetch.c:149 builtin/pull.c:188
+#: builtin/fetch.c:149 builtin/pull.c:192
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "an .git/FETCH_HEAD anhängen statt zu überschreiben"
 
@@ -15488,7 +15488,7 @@ msgstr "an .git/FETCH_HEAD anhängen statt zu überschreiben"
 msgid "use atomic transaction to update references"
 msgstr "atomare Transaktionen nutzen, um Referenzen zu aktualisieren"
 
-#: builtin/fetch.c:153 builtin/pull.c:191
+#: builtin/fetch.c:153 builtin/pull.c:195
 msgid "path to upload pack on remote end"
 msgstr "Pfad des Programms zum Hochladen von Paketen auf der Gegenseite"
 
@@ -15500,7 +15500,7 @@ msgstr "das Überschreiben einer lokalen Referenz erzwingen"
 msgid "fetch from multiple remotes"
 msgstr "von mehreren Remote-Repositories anfordern"
 
-#: builtin/fetch.c:158 builtin/pull.c:195
+#: builtin/fetch.c:158 builtin/pull.c:199
 msgid "fetch all tags and associated objects"
 msgstr "alle Tags und verbundene Objekte anfordern"
 
@@ -15518,7 +15518,7 @@ msgstr ""
 "Refspec verändern, damit alle Referenzen unter refs/prefetch/ platziert "
 "werden"
 
-#: builtin/fetch.c:166 builtin/pull.c:198
+#: builtin/fetch.c:166 builtin/pull.c:202
 msgid "prune remote-tracking branches no longer on remote"
 msgstr ""
 "Remote-Tracking-Branches entfernen, die sich nicht mehr im Remote-Repository "
@@ -15530,7 +15530,7 @@ msgstr ""
 "lokale Tags entfernen, die sich nicht mehr im Remote-Repository befinden, "
 "und geänderte Tags aktualisieren"
 
-#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:122
+#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:123
 msgid "on-demand"
 msgstr "bei-Bedarf"
 
@@ -15542,7 +15542,7 @@ msgstr "rekursive Anforderungen von Submodulen kontrollieren"
 msgid "write fetched references to the FETCH_HEAD file"
 msgstr "schreibe angeforderte Referenzen in die FETCH_HEAD-Datei"
 
-#: builtin/fetch.c:176 builtin/pull.c:206
+#: builtin/fetch.c:176 builtin/pull.c:210
 msgid "keep downloaded pack"
 msgstr "heruntergeladenes Paket behalten"
 
@@ -15550,20 +15550,20 @@ msgstr "heruntergeladenes Paket behalten"
 msgid "allow updating of HEAD ref"
 msgstr "Aktualisierung der \"HEAD\"-Referenz erlauben"
 
-#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:209
-#: builtin/pull.c:218
+#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:213
+#: builtin/pull.c:222
 msgid "deepen history of shallow clone"
 msgstr ""
 "die Historie eines Klons mit unvollständiger Historie (shallow) vertiefen"
 
-#: builtin/fetch.c:183 builtin/pull.c:212
+#: builtin/fetch.c:183 builtin/pull.c:216
 msgid "deepen history of shallow repository based on time"
 msgstr ""
 "die Historie eines Klons mit unvollständiger Historie (shallow) auf "
 "Zeitbasis\n"
 "vertiefen"
 
-#: builtin/fetch.c:189 builtin/pull.c:221
+#: builtin/fetch.c:189 builtin/pull.c:225
 msgid "convert to a complete repository"
 msgstr "zu einem vollständigen Repository konvertieren"
 
@@ -15579,19 +15579,19 @@ msgstr ""
 "Standard für die rekursive Anforderung von Submodulen (geringere Priorität\n"
 "als Konfigurationsdateien)"
 
-#: builtin/fetch.c:199 builtin/pull.c:224
+#: builtin/fetch.c:199 builtin/pull.c:228
 msgid "accept refs that update .git/shallow"
 msgstr "Referenzen, die .git/shallow aktualisieren, akzeptieren"
 
-#: builtin/fetch.c:200 builtin/pull.c:226
+#: builtin/fetch.c:200 builtin/pull.c:230
 msgid "refmap"
 msgstr "Refmap"
 
-#: builtin/fetch.c:201 builtin/pull.c:227
+#: builtin/fetch.c:201 builtin/pull.c:231
 msgid "specify fetch refmap"
 msgstr "Refmap für 'fetch' angeben"
 
-#: builtin/fetch.c:208 builtin/pull.c:240
+#: builtin/fetch.c:208 builtin/pull.c:244
 msgid "report that we have only objects reachable from this object"
 msgstr ""
 "ausgeben, dass wir nur Objekte haben, die von diesem Objekt aus erreichbar "
@@ -15607,7 +15607,7 @@ msgstr ""
 msgid "run 'maintenance --auto' after fetching"
 msgstr "führe 'maintenance --auto' nach \"fetch\" aus"
 
-#: builtin/fetch.c:217 builtin/pull.c:243
+#: builtin/fetch.c:217 builtin/pull.c:247
 msgid "check for forced-updates on all updated branches"
 msgstr "Prüfe auf erzwungene Aktualisierungen in allen aktualisierten Branches"
 
@@ -18323,33 +18323,33 @@ msgstr "Verfügbare Strategien sind:"
 msgid "Available custom strategies are:"
 msgstr "Verfügbare benutzerdefinierte Strategien sind:"
 
-#: builtin/merge.c:257 builtin/pull.c:133
+#: builtin/merge.c:257 builtin/pull.c:134
 msgid "do not show a diffstat at the end of the merge"
 msgstr "keine Zusammenfassung der Unterschiede am Schluss des Merges anzeigen"
 
-#: builtin/merge.c:260 builtin/pull.c:136
+#: builtin/merge.c:260 builtin/pull.c:137
 msgid "show a diffstat at the end of the merge"
 msgstr "eine Zusammenfassung der Unterschiede am Schluss des Merges anzeigen"
 
-#: builtin/merge.c:261 builtin/pull.c:139
+#: builtin/merge.c:261 builtin/pull.c:140
 msgid "(synonym to --stat)"
 msgstr "(Synonym für --stat)"
 
-#: builtin/merge.c:263 builtin/pull.c:142
+#: builtin/merge.c:263 builtin/pull.c:143
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "(höchstens <n>) Einträge von \"shortlog\" zur Beschreibung des Merge-Commits "
 "hinzufügen"
 
-#: builtin/merge.c:266 builtin/pull.c:148
+#: builtin/merge.c:266 builtin/pull.c:149
 msgid "create a single commit instead of doing a merge"
 msgstr "einen einzelnen Commit erzeugen statt einen Merge durchzuführen"
 
-#: builtin/merge.c:268 builtin/pull.c:151
+#: builtin/merge.c:268 builtin/pull.c:152
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "einen Commit durchführen, wenn der Merge erfolgreich war (Standard)"
 
-#: builtin/merge.c:270 builtin/pull.c:154
+#: builtin/merge.c:270 builtin/pull.c:155
 msgid "edit message before committing"
 msgstr "Bearbeitung der Beschreibung vor dem Commit"
 
@@ -18357,28 +18357,28 @@ msgstr "Bearbeitung der Beschreibung vor dem Commit"
 msgid "allow fast-forward (default)"
 msgstr "Vorspulen erlauben (Standard)"
 
-#: builtin/merge.c:274 builtin/pull.c:161
+#: builtin/merge.c:274 builtin/pull.c:162
 msgid "abort if fast-forward is not possible"
 msgstr "abbrechen, wenn kein Vorspulen möglich ist"
 
-#: builtin/merge.c:278 builtin/pull.c:164
+#: builtin/merge.c:278 builtin/pull.c:168
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "den genannten Commit auf eine gültige GPG-Signatur überprüfen"
 
-#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:168
+#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:172
 #: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr "Strategie"
 
-#: builtin/merge.c:280 builtin/pull.c:169
+#: builtin/merge.c:280 builtin/pull.c:173
 msgid "merge strategy to use"
 msgstr "zu verwendende Merge-Strategie"
 
-#: builtin/merge.c:281 builtin/pull.c:172
+#: builtin/merge.c:281 builtin/pull.c:176
 msgid "option=value"
 msgstr "Option=Wert"
 
-#: builtin/merge.c:282 builtin/pull.c:173
+#: builtin/merge.c:282 builtin/pull.c:177
 msgid "option for selected merge strategy"
 msgstr "Option für ausgewählte Merge-Strategie"
 
@@ -18399,7 +18399,7 @@ msgstr "--abort, aber Index und Arbeitsverzeichnis unverändert lassen"
 msgid "continue the current in-progress merge"
 msgstr "den sich im Gange befindlichen Merge fortsetzen"
 
-#: builtin/merge.c:297 builtin/pull.c:180
+#: builtin/merge.c:297 builtin/pull.c:184
 msgid "allow merging unrelated histories"
 msgstr "erlaube das Zusammenführen von nicht zusammenhängenden Historien"
 
@@ -19851,44 +19851,49 @@ msgstr "Ungültiger Wert für %s: %s"
 msgid "git pull [<options>] [<repository> [<refspec>...]]"
 msgstr "git pull [<Optionen>] [<Repository> [<Refspec>...]]"
 
-#: builtin/pull.c:123
+#: builtin/pull.c:124
 msgid "control for recursive fetching of submodules"
 msgstr "rekursive Anforderungen von Submodulen kontrollieren"
 
-#: builtin/pull.c:127
+#: builtin/pull.c:128
 msgid "Options related to merging"
 msgstr "Optionen bezogen auf Merge"
 
-#: builtin/pull.c:130
+#: builtin/pull.c:131
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "Integration von Änderungen durch Rebase statt Merge"
 
-#: builtin/pull.c:158 builtin/revert.c:126
+#: builtin/pull.c:159 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "Vorspulen erlauben"
 
-#: builtin/pull.c:167 parse-options.h:339
+#: builtin/pull.c:165
+#, fuzzy
+msgid "control use of pre-merge-commit and commit-msg hooks"
+msgstr "Hooks pre-merge-commit und commit-msg umgehen"
+
+#: builtin/pull.c:171 parse-options.h:338
 msgid "automatically stash/stash pop before and after"
 msgstr "automatischer Stash/Stash-Pop davor und danach"
 
-#: builtin/pull.c:183
+#: builtin/pull.c:187
 msgid "Options related to fetching"
 msgstr "Optionen bezogen auf Fetch"
 
-#: builtin/pull.c:193
+#: builtin/pull.c:197
 msgid "force overwrite of local branch"
 msgstr "das Überschreiben von lokalen Branches erzwingen"
 
-#: builtin/pull.c:201
+#: builtin/pull.c:205
 msgid "number of submodules pulled in parallel"
 msgstr "Anzahl der parallel mit 'pull' zu verarbeitenden Submodule"
 
-#: builtin/pull.c:317
+#: builtin/pull.c:321
 #, c-format
 msgid "Invalid value for pull.ff: %s"
 msgstr "Ungültiger Wert für pull.ff: %s"
 
-#: builtin/pull.c:445
+#: builtin/pull.c:449
 msgid ""
 "There is no candidate for rebasing against among the refs that you just "
 "fetched."
@@ -19896,14 +19901,14 @@ msgstr ""
 "Es gibt keinen Kandidaten für Rebase innerhalb der Referenzen, die eben "
 "angefordert wurden."
 
-#: builtin/pull.c:447
+#: builtin/pull.c:451
 msgid ""
 "There are no candidates for merging among the refs that you just fetched."
 msgstr ""
 "Es gibt keine Kandidaten für Merge innerhalb der Referenzen, die eben "
 "angefordert wurden."
 
-#: builtin/pull.c:448
+#: builtin/pull.c:452
 msgid ""
 "Generally this means that you provided a wildcard refspec which had no\n"
 "matches on the remote end."
@@ -19911,7 +19916,7 @@ msgstr ""
 "Im Allgemeinen bedeutet das, dass Sie einen Refspec mit Wildcards angegeben\n"
 "haben, der auf der Gegenseite mit keinen Referenzen übereinstimmt."
 
-#: builtin/pull.c:451
+#: builtin/pull.c:455
 #, c-format
 msgid ""
 "You asked to pull from the remote '%s', but did not specify\n"
@@ -19923,38 +19928,38 @@ msgstr ""
 "Repository für den aktuellen Branch ist, müssen Sie einen Branch auf\n"
 "der Befehlszeile angeben."
 
-#: builtin/pull.c:456 builtin/rebase.c:951
+#: builtin/pull.c:460 builtin/rebase.c:951
 msgid "You are not currently on a branch."
 msgstr "Im Moment auf keinem Branch."
 
-#: builtin/pull.c:458 builtin/pull.c:473
+#: builtin/pull.c:462 builtin/pull.c:477
 msgid "Please specify which branch you want to rebase against."
 msgstr ""
 "Bitte geben Sie den Branch an, gegen welchen Sie \"rebase\" ausführen "
 "möchten."
 
-#: builtin/pull.c:460 builtin/pull.c:475
+#: builtin/pull.c:464 builtin/pull.c:479
 msgid "Please specify which branch you want to merge with."
 msgstr "Bitte geben Sie den Branch an, welchen Sie zusammenführen möchten."
 
-#: builtin/pull.c:461 builtin/pull.c:476
+#: builtin/pull.c:465 builtin/pull.c:480
 msgid "See git-pull(1) for details."
 msgstr "Siehe git-pull(1) für weitere Details."
 
-#: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
+#: builtin/pull.c:467 builtin/pull.c:473 builtin/pull.c:482
 #: builtin/rebase.c:957
 msgid "<remote>"
 msgstr "<Remote-Repository>"
 
-#: builtin/pull.c:463 builtin/pull.c:478 builtin/pull.c:483
+#: builtin/pull.c:467 builtin/pull.c:482 builtin/pull.c:487
 msgid "<branch>"
 msgstr "<Branch>"
 
-#: builtin/pull.c:471 builtin/rebase.c:949
+#: builtin/pull.c:475 builtin/rebase.c:949
 msgid "There is no tracking information for the current branch."
 msgstr "Es gibt keine Tracking-Informationen für den aktuellen Branch."
 
-#: builtin/pull.c:480
+#: builtin/pull.c:484
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:"
 msgstr ""
@@ -19962,7 +19967,7 @@ msgstr ""
 "Sie\n"
 "dies tun mit:"
 
-#: builtin/pull.c:485
+#: builtin/pull.c:489
 #, c-format
 msgid ""
 "Your configuration specifies to merge with the ref '%s'\n"
@@ -19972,16 +19977,16 @@ msgstr ""
 "des Remote-Repositories durchzuführen, aber diese Referenz\n"
 "wurde nicht angefordert."
 
-#: builtin/pull.c:596
+#: builtin/pull.c:600
 #, c-format
 msgid "unable to access commit %s"
 msgstr "Konnte nicht auf Commit '%s' zugreifen."
 
-#: builtin/pull.c:902
+#: builtin/pull.c:908
 msgid "ignoring --verify-signatures for rebase"
 msgstr "Ignoriere --verify-signatures für Rebase"
 
-#: builtin/pull.c:936
+#: builtin/pull.c:942
 msgid ""
 "You have divergent branches and need to specify how to reconcile them.\n"
 "You can do so by running one of the following commands sometime before\n"
@@ -20011,21 +20016,21 @@ msgstr ""
 "Option --rebase, --no-rebase oder --ff-only auf der Kommandozeile nutzen,\n"
 "um das konfigurierte Standardverhalten pro Aufruf zu überschreiben.\n"
 
-#: builtin/pull.c:1010
+#: builtin/pull.c:1016
 msgid "Updating an unborn branch with changes added to the index."
 msgstr ""
 "Aktualisiere einen ungeborenen Branch mit Änderungen, die zum Commit "
 "vorgemerkt sind."
 
-#: builtin/pull.c:1014
+#: builtin/pull.c:1020
 msgid "pull with rebase"
 msgstr "Pull mit Rebase"
 
-#: builtin/pull.c:1015
+#: builtin/pull.c:1021
 msgid "please commit or stash them."
 msgstr "Bitte committen Sie die Änderungen oder benutzen Sie \"stash\"."
 
-#: builtin/pull.c:1040
+#: builtin/pull.c:1046
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -20035,7 +20040,7 @@ msgstr ""
 "\"fetch\" aktualisierte die Spitze des aktuellen Branches.\n"
 "Spule Ihr Arbeitsverzeichnis von Commit %s vor."
 
-#: builtin/pull.c:1046
+#: builtin/pull.c:1052
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -20052,25 +20057,25 @@ msgstr ""
 "$ git reset --hard\n"
 "zur Wiederherstellung aus."
 
-#: builtin/pull.c:1061
+#: builtin/pull.c:1067
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Kann nicht mehrere Branches in einen leeren Branch zusammenführen."
 
-#: builtin/pull.c:1066
+#: builtin/pull.c:1072
 msgid "Cannot rebase onto multiple branches."
 msgstr "Kann Rebase nicht auf mehrere Branches ausführen."
 
-#: builtin/pull.c:1068
+#: builtin/pull.c:1074
 msgid "Cannot fast-forward to multiple branches."
 msgstr "Kann nicht zu mehreren Branches vorspulen."
 
-#: builtin/pull.c:1082
+#: builtin/pull.c:1088
 msgid "Need to specify how to reconcile divergent branches."
 msgstr ""
 "Es muss angegeben werden, wie mit abweichenden Branches umgegangen werden "
 "sollen."
 
-#: builtin/pull.c:1096
+#: builtin/pull.c:1102
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "Kann Rebase nicht mit lokal aufgezeichneten Änderungen in Submodulen "
@@ -23668,8 +23673,8 @@ msgid ""
 "Fetched in submodule path '%s', but it did not contain %s. Direct fetching "
 "of that commit failed."
 msgstr ""
-"\"fetch\" in Submodul-Pfad '%s' ausgeführt, aber enthielt nicht %s. "
-"Direktes Anfordern dieses Commits ist fehlgeschlagen."
+"\"fetch\" in Submodul-Pfad '%s' ausgeführt, aber enthielt nicht %s. Direktes "
+"Anfordern dieses Commits ist fehlgeschlagen."
 
 #: builtin/submodule--helper.c:2504 builtin/submodule--helper.c:2574
 #: builtin/submodule--helper.c:2812
@@ -25346,28 +25351,28 @@ msgstr "Verfallsdatum"
 msgid "no-op (backward compatibility)"
 msgstr "Kein Effekt (Rückwärtskompatibilität)"
 
-#: parse-options.h:309
+#: parse-options.h:308
 msgid "be more verbose"
 msgstr "erweiterte Ausgaben"
 
-#: parse-options.h:311
+#: parse-options.h:310
 msgid "be more quiet"
 msgstr "weniger Ausgaben"
 
-#: parse-options.h:317
+#: parse-options.h:316
 msgid "use <n> digits to display object names"
 msgstr "benutze <Anzahl> Ziffern zur Anzeige von Objektnamen"
 
-#: parse-options.h:336
+#: parse-options.h:335
 msgid "how to strip spaces and #comments from message"
 msgstr ""
 "wie Leerzeichen und #Kommentare von der Beschreibung getrennt werden sollen"
 
-#: parse-options.h:337
+#: parse-options.h:336
 msgid "read pathspec from file"
 msgstr "Pfadspezifikation aus einer Datei lesen"
 
-#: parse-options.h:338
+#: parse-options.h:337
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -1268,7 +1268,7 @@ msgstr "%s: Patch konnte nicht angewendet werden"
 #: apply.c:4042
 #, c-format
 msgid "Checking patch %s..."
-msgstr "Prüfe Patch %s ..."
+msgstr "Prüfe Patch %s..."
 
 #: apply.c:4134
 #, c-format
@@ -10950,7 +10950,7 @@ msgstr ""
 msgid "Using index info to reconstruct a base tree..."
 msgstr ""
 "Verwende Informationen aus der Staging-Area, um ein Basisverzeichnis "
-"nachzustellen ..."
+"nachzustellen..."
 
 #: builtin/am.c:1560
 msgid ""
@@ -10962,7 +10962,7 @@ msgstr ""
 
 #: builtin/am.c:1566
 msgid "Falling back to patching base and 3-way merge..."
-msgstr "Falle zurück zum Patchen der Basis und zum 3-Wege-Merge ..."
+msgstr "Falle zurück zum Patchen der Basis und zum 3-Wege-Merge..."
 
 #: builtin/am.c:1592
 msgid "Failed to merge in the changes."
@@ -11325,7 +11325,7 @@ msgstr "git bisect--helper --bisect-visualize"
 
 #: builtin/bisect--helper.c:34
 msgid "git bisect--helper --bisect-run <cmd>..."
-msgstr "git bisect--helper --bisect-run <Programm>"
+msgstr "git bisect--helper --bisect-run <Programm>..."
 
 #: builtin/bisect--helper.c:109
 #, c-format
@@ -13676,7 +13676,7 @@ msgstr "Klone in Bare-Repository '%s' ...\n"
 #: builtin/clone.c:996
 #, c-format
 msgid "Cloning into '%s'...\n"
-msgstr "Klone nach '%s' ...\n"
+msgstr "Klone nach '%s'...\n"
 
 #: builtin/clone.c:1025
 msgid ""
@@ -18640,12 +18640,12 @@ msgstr "Nein.\n"
 #: builtin/merge.c:1664 builtin/merge.c:1730
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
-msgstr "Rücklauf des Verzeichnisses bis zum Ursprung ...\n"
+msgstr "Rücklauf des Verzeichnisses bis zum Ursprung...\n"
 
 #: builtin/merge.c:1668
 #, c-format
 msgid "Trying merge strategy %s...\n"
-msgstr "Probiere Merge-Strategie %s ...\n"
+msgstr "Probiere Merge-Strategie %s...\n"
 
 #: builtin/merge.c:1720
 #, c-format
@@ -26660,7 +26660,7 @@ msgid ""
 msgstr ""
 "Datei '%s' existiert, aber es könnte auch der Bereich von Commits sein,\n"
 "für den Patches erzeugt werden sollen. Bitte machen Sie dies eindeutig\n"
-"indem Sie ...\n"
+"indem Sie...\n"
 "\n"
 "    * \"./%s\" angeben, wenn Sie eine Datei meinen, oder\n"
 "    * die Option --format-patch angeben, wenn Sie einen Commit-Bereich "

--- a/po/de.po
+++ b/po/de.po
@@ -7099,7 +7099,7 @@ msgstr "Format: %%(else) Atom ohne ein %%(then) Atom verwendet"
 #: ref-filter.c:950
 #, c-format
 msgid "format: %%(else) atom used more than once"
-msgstr "Format: %%(end) Atom mehr als einmal verwendet"
+msgstr "Format: %%(else) Atom mehr als einmal verwendet"
 
 #: ref-filter.c:965
 #, c-format

--- a/po/de.po
+++ b/po/de.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
 "POT-Creation-Date: 2021-11-04 08:34+0800\n"
-"PO-Revision-Date: 2021-05-23 18:32+0200\n"
+"PO-Revision-Date: 2021-11-07 19:48+0100\n"
 "Last-Translator: Matthias Rüster <matthias.ruester@gmail.com>\n"
 "Language-Team: Matthias Rüster <matthias.ruester@gmail.com>\n"
 "Language: de\n"
@@ -843,6 +843,9 @@ msgid ""
 "outside of your sparse-checkout definition, so will not be\n"
 "updated in the index:\n"
 msgstr ""
+"Die folgenden Pfade und/oder Pfadspezifikationen entsprachen keinem Pfad,\n"
+"der außerhalb Ihrer partiellen Checkout-Definition existierte, weshalb\n"
+"diese nicht im Index aktualisiert werden:\n"
 
 #: advice.c:234
 msgid ""
@@ -850,6 +853,10 @@ msgid ""
 "* Use the --sparse option.\n"
 "* Disable or modify the sparsity rules."
 msgstr ""
+"Wenn Sie beabsichtigen, solche Einträge zu aktualisieren, versuchen Sie es\n"
+"mit einem der folgenden Schritte:\n"
+"* Verwenden Sie die Option --sparse.\n"
+"* Deaktivieren oder ändern Sie die Regeln für partielle Checkouts."
 
 #: advice.c:242
 #, c-format
@@ -4389,42 +4396,50 @@ msgid ""
 "gpg.ssh.allowedSignersFile needs to be configured and exist for ssh "
 "signature verification"
 msgstr ""
+"gpg.ssh.allowedSignersFile muss konfiguriert sein und für die Überprüfung "
+"der SSH-Signatur vorhanden sein"
 
 #: gpg-interface.c:469
 msgid ""
 "ssh-keygen -Y find-principals/verify is needed for ssh signature "
 "verification (available in openssh version 8.2p1+)"
 msgstr ""
+"ssh-keygen -Y find-principals/verify wird für die Verifizierung der SSH-"
+"Signatur benötigt (verfügbar in openssh Version 8.2p1+)"
 
 #: gpg-interface.c:523
 #, c-format
 msgid "ssh signing revocation file configured but not found: %s"
-msgstr ""
+msgstr "SSH-Signatursperrdatei konfiguriert, aber nicht gefunden: %s"
 
 #: gpg-interface.c:576
-#, fuzzy, c-format
+#, c-format
 msgid "bad/incompatible signature '%s'"
-msgstr "%s ist inkompatibel mit %s."
+msgstr "fehlerhafte/inkompatible Signatur '%s'"
 
 #: gpg-interface.c:735 gpg-interface.c:740
-#, fuzzy, c-format
+#, c-format
 msgid "failed to get the ssh fingerprint for key '%s'"
-msgstr "Fehler beim Lesen des Standard-Remote-Repositories für Submodul '%s'"
+msgstr "konnte SSH-Fingerabdruck für Schlüssel '%s' nicht bekommen"
 
 #: gpg-interface.c:762
 msgid ""
 "either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured"
 msgstr ""
+"entweder user.signingkey oder gpg.ssh.defaultKeyCommand muss konfiguriert "
+"sein"
 
 #: gpg-interface.c:780
 #, c-format
 msgid "gpg.ssh.defaultKeyCommand succeeded but returned no keys: %s %s"
 msgstr ""
+"gpg.ssh.defaultKeyCommand war erfolgreich, gab aber keine Schlüssel zurück: "
+"%s %s"
 
 #: gpg-interface.c:786
 #, c-format
 msgid "gpg.ssh.defaultKeyCommand failed: %s %s"
-msgstr ""
+msgstr "gpg.ssh.defaultKeyCommand fehlgeschlagen: %s %s"
 
 #: gpg-interface.c:874
 msgid "gpg failed to sign the data"
@@ -4432,28 +4447,30 @@ msgstr "gpg beim Signieren der Daten fehlgeschlagen"
 
 #: gpg-interface.c:895
 msgid "user.signingkey needs to be set for ssh signing"
-msgstr ""
+msgstr "user.signingkey muss für die SSH-Signatur festgelegt werden"
 
 #: gpg-interface.c:906
-#, fuzzy, c-format
+#, c-format
 msgid "failed writing ssh signing key to '%s'"
-msgstr "Fehler beim Schreiben der losgelösten Signatur nach '%s'"
+msgstr "Fehler beim Schreiben des SSH-Signaturschlüssels nach '%s'"
 
 #: gpg-interface.c:924
-#, fuzzy, c-format
+#, c-format
 msgid "failed writing ssh signing key buffer to '%s'"
-msgstr "Fehler beim Schreiben der losgelösten Signatur nach '%s'"
+msgstr "Fehler beim Schreiben des SSH-Signaturschlüsselpuffers nach '%s'"
 
 #: gpg-interface.c:942
 msgid ""
 "ssh-keygen -Y sign is needed for ssh signing (available in openssh version "
 "8.2p1+)"
 msgstr ""
+"\"ssh-keygen -Y sign\" wird für die SSH-Signatur benötigt (verfügbar in "
+"openssh Version 8.2p1+)"
 
 #: gpg-interface.c:954
-#, fuzzy, c-format
+#, c-format
 msgid "failed reading ssh signing data buffer from '%s'"
-msgstr "Fehler beim Schreiben der losgelösten Signatur nach '%s'"
+msgstr "Fehler beim Lesen des SSH-Signaturdatenpuffers von '%s'"
 
 #: graph.c:98
 #, c-format
@@ -4604,7 +4621,7 @@ msgstr "Setze fort unter der Annahme, dass Sie '%s' meinten."
 #: help.c:646
 #, c-format
 msgid "Run '%s' instead? (y/N)"
-msgstr ""
+msgstr "Führen Sie stattdessen '%s' aus? (y/N)"
 
 #: help.c:654
 #, c-format
@@ -4819,9 +4836,9 @@ msgid "invalid value '%s' for lsrefs.unborn"
 msgstr "ungültiger Wert '%s' für lsrefs.unborn"
 
 #: ls-refs.c:174
-#, fuzzy, c-format
+#, c-format
 msgid "unexpected line: '%s'"
-msgstr "unerwartetes wanted-ref: '%s'"
+msgstr "unerwartete Zeile: '%s'"
 
 #: ls-refs.c:178
 msgid "expected flush after ls-refs arguments"
@@ -5490,14 +5507,14 @@ msgid "cannot store reverse index file"
 msgstr "kann Reverse-Index-Datei nicht speichern"
 
 #: midx.c:990
-#, fuzzy, c-format
+#, c-format
 msgid "could not parse line: %s"
-msgstr "konnte %s nicht parsen"
+msgstr "Zeile konnte nicht analysiert werden: %s"
 
 #: midx.c:992
-#, fuzzy, c-format
+#, c-format
 msgid "malformed line: %s"
-msgstr "Fehlerhafte Eingabezeile: '%s'."
+msgstr "fehlerhafte Zeile: %s"
 
 #: midx.c:1159
 msgid "ignoring existing multi-pack-index; checksum mismatch"
@@ -5505,12 +5522,11 @@ msgstr ""
 "ignoriere existierenden multi-pack-index; Prüfsumme stimmt nicht überein"
 
 #: midx.c:1184
-#, fuzzy
 msgid "could not load pack"
-msgstr "Konnte Paket '%s' nicht finden"
+msgstr "Paket konnte nicht geladen werden"
 
 #: midx.c:1190
-#, fuzzy, c-format
+#, c-format
 msgid "could not open index for %s"
 msgstr "konnte Index für %s nicht öffnen"
 
@@ -5524,9 +5540,9 @@ msgid "unknown preferred pack: '%s'"
 msgstr "unbekanntes bevorzugtes Paket: '%s'"
 
 #: midx.c:1289
-#, fuzzy, c-format
+#, c-format
 msgid "cannot select preferred pack %s with no objects"
-msgstr "kann Pack-Dateien in precious-objects Repository nicht löschen"
+msgstr "bevorzugtes Paket %s ohne Objekte kann nicht ausgewählt werden"
 
 #: midx.c:1321
 #, c-format
@@ -5543,14 +5559,12 @@ msgid "no pack files to index."
 msgstr "keine Packdateien zum Indizieren."
 
 #: midx.c:1417
-#, fuzzy
 msgid "could not write multi-pack bitmap"
-msgstr "Konnte Commit-Vorlage nicht schreiben"
+msgstr "Multipack-Bitmap konnte nicht geschrieben werden"
 
 #: midx.c:1427
-#, fuzzy
 msgid "could not write multi-pack-index"
-msgstr "Fehler beim Schreiben des multi-pack-index"
+msgstr "Multi-Pack-Index konnte nicht geschrieben werden"
 
 #: midx.c:1486 builtin/clean.c:37
 #, c-format
@@ -5809,7 +5823,7 @@ msgstr "Konnte %s Kopfbereich nicht entpacken."
 #: object-file.c:1434
 #, c-format
 msgid "header for %s too long, exceeds %d bytes"
-msgstr ""
+msgstr "Header für %s zu lang, überschreitet %d Bytes"
 
 #: object-file.c:1664
 #, c-format
@@ -6085,13 +6099,12 @@ msgid "hash mismatch %s"
 msgstr "Hash stimmt nicht mit %s überein."
 
 #: pack-bitmap.c:348
-#, fuzzy
 msgid "multi-pack bitmap is missing required reverse index"
-msgstr "multi-pack-index fehlt erforderlicher Objekt offset Chunk"
+msgstr "Multipack-Bitmap fehlt erforderlicher Reverse-Index"
 
 #: pack-bitmap.c:424
 msgid "load_reverse_index: could not open pack"
-msgstr ""
+msgstr "load_reverse_index: Paket konnte nicht geöffnet werden"
 
 #: pack-bitmap.c:1064 pack-bitmap.c:1070 builtin/pack-objects.c:2424
 #, c-format
@@ -6099,9 +6112,9 @@ msgid "unable to get size of %s"
 msgstr "Konnte Größe von %s nicht bestimmen."
 
 #: pack-bitmap.c:1916
-#, fuzzy, c-format
+#, c-format
 msgid "could not find %s in pack %s at offset %<PRIuMAX>"
-msgstr "Konnte Paket '%s' nicht finden"
+msgstr "konnte %s nicht in Paket %s bei Offset %<PRIuMAX> finden"
 
 #: pack-bitmap.c:1952 builtin/rev-list.c:92
 #, c-format
@@ -6293,7 +6306,7 @@ msgstr "      oder: %s"
 #: parse-options.c:969
 #, c-format
 msgid "%*s%s"
-msgstr ""
+msgstr "%*s%s"
 
 #: parse-options.c:992
 #, c-format
@@ -6890,7 +6903,7 @@ msgstr ""
 #: rebase.c:29
 #, c-format
 msgid "%s: 'preserve' superseded by 'merges'"
-msgstr ""
+msgstr "%s: 'preserve' wurde durch 'merges' ersetzt"
 
 #: ref-filter.c:42 wt-status.c:2036
 msgid "gone"
@@ -6982,9 +6995,9 @@ msgid "unrecognized %%(contents) argument: %s"
 msgstr "nicht erkanntes %%(contents) Argument: %s"
 
 #: ref-filter.c:443
-#, fuzzy, c-format
+#, c-format
 msgid "unrecognized %%(raw) argument: %s"
-msgstr "nicht erkanntes %%(%s) Argument: %s"
+msgstr "nicht erkanntes %%(raw) Argument: %s"
 
 #: ref-filter.c:458
 #, c-format
@@ -7032,9 +7045,9 @@ msgid "unrecognized %%(if) argument: %s"
 msgstr "nicht erkanntes %%(if) Argument: %s"
 
 #: ref-filter.c:568
-#, fuzzy, c-format
+#, c-format
 msgid "%%(rest) does not take arguments"
-msgstr "%%(body) akzeptiert keine Argumente"
+msgstr "%%(rest) akzeptiert keine Argumente"
 
 #: ref-filter.c:680
 #, c-format
@@ -7101,12 +7114,12 @@ msgstr "Fehlerhafter Formatierungsstring %s"
 #: ref-filter.c:1033
 #, c-format
 msgid "this command reject atom %%(%.*s)"
-msgstr ""
+msgstr "dieser Befehl lehnt Atom ab %%(%.*s)"
 
 #: ref-filter.c:1040
-#, fuzzy, c-format
+#, c-format
 msgid "--format=%.*s cannot be used with --python, --shell, --tcl"
-msgstr "--object-format kann nicht mit --stdin verwendet werden"
+msgstr "--format=%.*s kann nicht mit --python, --shell, --tcl verwendet werden"
 
 #: ref-filter.c:1706
 #, c-format
@@ -7689,18 +7702,16 @@ msgid "failed to find tree of %s"
 msgstr "Fehler beim Finden des \"Tree\"-Objektes von %s."
 
 #: revision.c:2259
-#, fuzzy
 msgid "--unsorted-input is incompatible with --no-walk"
-msgstr "--dir-diff kann nicht mit --no-index verwendet werden"
+msgstr "--unsorted-input ist nicht kompatibel mit --no-walk"
 
 #: revision.c:2346
 msgid "--unpacked=<packfile> no longer supported"
 msgstr "--unpacked=<Pack-Datei> wird nicht länger unterstützt"
 
 #: revision.c:2655 revision.c:2659
-#, fuzzy
 msgid "--no-walk is incompatible with --unsorted-input"
-msgstr "--dir-diff kann nicht mit --no-index verwendet werden"
+msgstr "--no-walk ist nicht kompatibel mit --unsorted-input"
 
 #: revision.c:2690
 msgid "your current branch appears to be broken"
@@ -7814,7 +7825,6 @@ msgstr ""
 "mit 'git add <Pfade>' oder 'git rm <Pfade>'"
 
 #: sequencer.c:423
-#, fuzzy
 msgid ""
 "After resolving the conflicts, mark them with\n"
 "\"git add/rm <pathspec>\", then run\n"
@@ -7824,15 +7834,14 @@ msgid ""
 "run \"git cherry-pick --abort\"."
 msgstr ""
 "Lösen Sie alle Konflikte manuell auf, markieren Sie diese mit\n"
-"\"git add/rm <konfliktbehaftete_Dateien>\" und führen Sie dann\n"
-"\"git rebase --continue\" aus.\n"
-"Sie können auch stattdessen diesen Commit auslassen, indem\n"
-"Sie \"git rebase --skip\" ausführen.\n"
-"Um abzubrechen und zurück zum Zustand vor \"git rebase\" zu gelangen,\n"
-"führen Sie \"git rebase --abort\" aus."
+"\"git add/rm <Pfadspezifikation>\" und führen Sie dann\n"
+"\"git cherry-pick --continue\" aus.\n"
+"Sie können stattdessen auch diesen Commit auslassen, indem\n"
+"Sie \"git cherry-pick --skip\" ausführen.\n"
+"Um abzubrechen und zurück zum Zustand vor \"git cherry-pick\" zu\n"
+"gelangen, führen Sie \"git cherry-pick --abort\" aus."
 
 #: sequencer.c:430
-#, fuzzy
 msgid ""
 "After resolving the conflicts, mark them with\n"
 "\"git add/rm <pathspec>\", then run\n"
@@ -7842,12 +7851,12 @@ msgid ""
 "run \"git revert --abort\"."
 msgstr ""
 "Lösen Sie alle Konflikte manuell auf, markieren Sie diese mit\n"
-"\"git add/rm <konfliktbehaftete_Dateien>\" und führen Sie dann\n"
-"\"git rebase --continue\" aus.\n"
-"Sie können auch stattdessen diesen Commit auslassen, indem\n"
-"Sie \"git rebase --skip\" ausführen.\n"
-"Um abzubrechen und zurück zum Zustand vor \"git rebase\" zu gelangen,\n"
-"führen Sie \"git rebase --abort\" aus."
+"\"git add/rm <Pfadspezifikation>\" und führen Sie dann\n"
+"\"git revert --continue\" aus.\n"
+"Sie können stattdessen auch diesen Commit auslassen, indem\n"
+"Sie \"git revert --skip\" ausführen.\n"
+"Um abzubrechen und zurück zum Zustand vor \"git revert\" zu gelangen,\n"
+"führen Sie \"git revert --abort\" aus."
 
 #: sequencer.c:448 sequencer.c:3290
 #, c-format
@@ -8710,13 +8719,14 @@ msgid "can't revert as initial commit"
 msgstr "Kann nicht als allerersten Commit einen Revert ausführen."
 
 #: sequencer.c:5192 sequencer.c:5421
-#, fuzzy, c-format
+#, c-format
 msgid "skipped previously applied commit %s"
-msgstr "vorherigen Commit ändern"
+msgstr "zuvor angewendeten Commit %s übersprungen"
 
 #: sequencer.c:5262 sequencer.c:5437
 msgid "use --reapply-cherry-picks to include skipped commits"
 msgstr ""
+"verwenden Sie --reapply-cherry-picks, um übersprungene Commits einzubeziehen"
 
 #: sequencer.c:5408
 msgid "make_script: unhandled options"
@@ -9967,7 +9977,7 @@ msgid "gitdir file points to non-existent location"
 msgstr "gitdir-Datei verweist auf nicht existierenden Ort"
 
 #: wrapper.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "could not setenv '%s'"
 msgstr "konnte '%s' nicht setzen"
 
@@ -10712,9 +10722,10 @@ msgid "check if - even missing - files are ignored in dry run"
 msgstr "prüfen ob - auch fehlende - Dateien im Probelauf ignoriert werden"
 
 #: builtin/add.c:389 builtin/mv.c:128 builtin/rm.c:251
-#, fuzzy
 msgid "allow updating entries outside of the sparse-checkout cone"
-msgstr "initialisiere den partiellen Checkout im Cone-Modus"
+msgstr ""
+"erlaube das Aktualisieren von Einträgen außerhalb des partiellen Checkouts "
+"im Cone-Modus"
 
 #: builtin/add.c:391 builtin/update-index.c:1004
 msgid "override the executable bit of the listed files"
@@ -11309,14 +11320,12 @@ msgid "git bisect--helper --bisect-skip [(<rev>|<range>)...]"
 msgstr "git bisect--helper --bisect-skip [(<Commit>|<Bereich>)...]"
 
 #: builtin/bisect--helper.c:33
-#, fuzzy
 msgid "git bisect--helper --bisect-visualize"
-msgstr "git bisect--helper --bisect-next"
+msgstr "git bisect--helper --bisect-visualize"
 
 #: builtin/bisect--helper.c:34
-#, fuzzy
 msgid "git bisect--helper --bisect-run <cmd>..."
-msgstr "git bisect--helper --bisect-reset [<Commit>]"
+msgstr "git bisect--helper --bisect-run <Programm>"
 
 #: builtin/bisect--helper.c:109
 #, c-format
@@ -11329,9 +11338,9 @@ msgid "could not write to file '%s'"
 msgstr "konnte nicht in Datei '%s' schreiben"
 
 #: builtin/bisect--helper.c:154
-#, fuzzy, c-format
+#, c-format
 msgid "cannot open file '%s' for reading"
-msgstr "kann Datei '%s' nicht für die Wiederholung lesen"
+msgstr "Datei '%s' kann nicht zum Lesen geöffnet werden"
 
 #: builtin/bisect--helper.c:170
 #, c-format
@@ -11543,21 +11552,19 @@ msgid "bisect run failed: no command provided."
 msgstr "'bisect run' fehlgeschlagen: kein Befehl angegeben."
 
 #: builtin/bisect--helper.c:1116
-#, fuzzy, c-format
+#, c-format
 msgid "running %s\n"
-msgstr "entferne veraltete Branches von %s"
+msgstr "Ausführen von %s\n"
 
 #: builtin/bisect--helper.c:1120
-#, fuzzy, c-format
+#, c-format
 msgid "bisect run failed: exit code %d from '%s' is < 0 or >= 128"
-msgstr ""
-"'bisect run' fehlgeschlagen:\n"
-"Exit-Code $res von '$command' ist < 0 oder >= 128"
+msgstr "'bisect run' fehlgeschlagen: Exit-Code %d von '%s' ist < 0 oder >= 128"
 
 #: builtin/bisect--helper.c:1136
-#, fuzzy, c-format
+#, c-format
 msgid "cannot open file '%s' for writing"
-msgstr "Konnte '%s' nicht zum Schreiben öffnen."
+msgstr "Datei '%s' kann nicht zum Schreiben geöffnet werden"
 
 #: builtin/bisect--helper.c:1152
 msgid "bisect run cannot continue any more"
@@ -11569,18 +11576,18 @@ msgid "bisect run success"
 msgstr "'bisect run' erfolgreich ausgeführt"
 
 #: builtin/bisect--helper.c:1157
-#, fuzzy, c-format
+#, c-format
 msgid "bisect found first bad commit"
-msgstr "binäre Suche nur mit einem %s Commit"
+msgstr "binäre Suche fand ersten schlechten Commit"
 
 #: builtin/bisect--helper.c:1160
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "bisect run failed: 'git bisect--helper --bisect-state %s' exited with error "
 "code %d"
 msgstr ""
-"'bisect run' fehlgeschlagen:\n"
-"'bisect-state $state' wurde mit Fehlerwert $res beendet"
+"'bisect run' fehlgeschlagen: 'git bisect--helper --bisect-state %s' mit "
+"Fehlercode %d beendet"
 
 #: builtin/bisect--helper.c:1192
 msgid "reset the bisection state"
@@ -11619,14 +11626,12 @@ msgid "skip some commits for checkout"
 msgstr "einige Commits für das Auschecken überspringen"
 
 #: builtin/bisect--helper.c:1210
-#, fuzzy
 msgid "visualize the bisection"
-msgstr "Sitzung für binäre Suche starten"
+msgstr "binäre Suche visualisieren"
 
 #: builtin/bisect--helper.c:1212
-#, fuzzy
 msgid "use <cmd>... to automatically bisect."
-msgstr "nicht automatisch committen"
+msgstr "verwende <Programm>... für die automatische binäre Suche."
 
 #: builtin/bisect--helper.c:1214
 msgid "no log for BISECT_WRITE"
@@ -12395,9 +12400,8 @@ msgid "Need a repository to unbundle."
 msgstr "Zum Entpacken wird ein Repository benötigt."
 
 #: builtin/bundle.c:185
-#, fuzzy
 msgid "Unbundling objects"
-msgstr "Indiziere Objekte"
+msgstr "Entpacken von Objekten"
 
 #: builtin/bundle.c:219 builtin/remote.c:1733
 #, c-format
@@ -15184,13 +15188,12 @@ msgid "could not read object %s for symlink %s"
 msgstr "Konnte Objekt '%s' für symbolische Verknüpfung '%s' nicht lesen."
 
 #: builtin/difftool.c:427
-#, fuzzy
 msgid ""
 "combined diff formats ('-c' and '--cc') are not supported in\n"
 "directory diff mode ('-d' and '--dir-diff')."
 msgstr ""
-"Kombinierte Diff-Formate('-c' und '--cc') werden im Verzeichnis-\n"
-"Diff-Modus('-d' und '--dir-diff') nicht unterstützt."
+"kombinierte Diff-Formate ('-c' und '--cc') werden im Verzeichnis-\n"
+"Diff-Modus ('-d' und '--dir-diff') nicht unterstützt."
 
 #: builtin/difftool.c:632
 #, c-format
@@ -15245,14 +15248,12 @@ msgstr ""
 "eine Liste mit Diff-Tools darstellen, die mit `--tool` benutzt werden können"
 
 #: builtin/difftool.c:712
-#, fuzzy
 msgid ""
 "make 'git-difftool' exit when an invoked diff tool returns a non-zero exit "
 "code"
 msgstr ""
-"'git-difftool' beenden, wenn das aufgerufene Diff-Tool mit einem "
-"Rückkehrwert\n"
-"verschieden 0 ausgeführt wurde"
+"'git-difftool' beenden, wenn das aufgerufene Diff-Tool mit einem Exit-Code "
+"ungleich 0 ausgeführt wurde"
 
 #: builtin/difftool.c:715
 msgid "specify a custom command for viewing diffs"
@@ -15763,9 +15764,9 @@ msgid "Option \"%s\" is ignored for %s\n"
 msgstr "Option \"%s\" wird ignoriert für %s\n"
 
 #: builtin/fetch.c:1447
-#, fuzzy, c-format
+#, c-format
 msgid "the object %s does not exist"
-msgstr "Pfad '%s' existiert nicht"
+msgstr "das Objekt %s ist nicht vorhanden"
 
 #: builtin/fetch.c:1633
 msgid "multiple branches detected, incompatible with --set-upstream"
@@ -16108,9 +16109,9 @@ msgid "notice: No default references"
 msgstr "Notiz: Keine Standardreferenzen"
 
 #: builtin/fsck.c:621
-#, fuzzy, c-format
+#, c-format
 msgid "%s: hash-path mismatch, found at: %s"
-msgstr "Hash stimmt nicht mit %s überein."
+msgstr "%s: Hash-Pfad stimmt nicht überein, gefunden bei: %s"
 
 #: builtin/fsck.c:624
 #, c-format
@@ -16118,9 +16119,9 @@ msgid "%s: object corrupt or missing: %s"
 msgstr "%s: Objekt fehlerhaft oder nicht vorhanden: %s"
 
 #: builtin/fsck.c:628
-#, fuzzy, c-format
+#, c-format
 msgid "%s: object is of unknown type '%s': %s"
-msgstr "Objekt %s hat eine unbekannte Typ-Identifikation %d"
+msgstr "%s: Objekt hat einen unbekannten Typ '%s': %s"
 
 #: builtin/fsck.c:644
 #, c-format
@@ -16269,7 +16270,7 @@ msgid "cannot read '%s'"
 msgstr "kann '%s' nicht lesen"
 
 #: builtin/gc.c:503
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "The last gc run reported the following. Please correct the root cause\n"
 "and remove %s\n"
@@ -16501,14 +16502,12 @@ msgid "'crontab' died"
 msgstr "'crontab' abgebrochen"
 
 #: builtin/gc.c:2174
-#, fuzzy
 msgid "failed to start systemctl"
-msgstr "Fehler beim Starten von schtasks"
+msgstr "Fehler beim Starten von systemctl"
 
 #: builtin/gc.c:2184
-#, fuzzy
 msgid "failed to run systemctl"
-msgstr "'%s' konnte nicht ausgeführt werden"
+msgstr "Fehler beim Ausführen von systemctl"
 
 #: builtin/gc.c:2193 builtin/gc.c:2198 builtin/worktree.c:62
 #: builtin/worktree.c:945
@@ -16517,18 +16516,18 @@ msgid "failed to delete '%s'"
 msgstr "Fehler beim Löschen von '%s'"
 
 #: builtin/gc.c:2378
-#, fuzzy, c-format
+#, c-format
 msgid "unrecognized --scheduler argument '%s'"
-msgstr "nicht erkanntes --schedule Argument '%s'"
+msgstr "nicht erkanntes --scheduler Argument '%s'"
 
 #: builtin/gc.c:2403
 msgid "neither systemd timers nor crontab are available"
-msgstr ""
+msgstr "weder Timer von systemd, noch crontab ist verfügbar"
 
 #: builtin/gc.c:2418
-#, fuzzy, c-format
+#, c-format
 msgid "%s scheduler is not available"
-msgstr "%s ist nicht verfügbar."
+msgstr "%s Scheduler ist nicht verfügbar"
 
 #: builtin/gc.c:2432
 msgid "another process is scheduling background maintenance"
@@ -16536,15 +16535,15 @@ msgstr "ein anderer Prozess plant die Hintergrundwartung"
 
 #: builtin/gc.c:2454
 msgid "git maintenance start [--scheduler=<scheduler>]"
-msgstr ""
+msgstr "git maintenance start [--scheduler=<Scheduler>]"
 
 #: builtin/gc.c:2463
 msgid "scheduler"
-msgstr ""
+msgstr "Scheduler"
 
 #: builtin/gc.c:2464
 msgid "scheduler to trigger git maintenance run"
-msgstr ""
+msgstr "Scheduler, um \"git maintenance run\" auzuführen"
 
 #: builtin/gc.c:2478
 msgid "failed to add repo to global config"
@@ -16912,19 +16911,20 @@ msgid "print all configuration variable names"
 msgstr "alle Namen der Konfigurationsvariablen ausgeben"
 
 #: builtin/help.c:78
-#, fuzzy
 msgid ""
 "git help [-a|--all] [--[no-]verbose]]\n"
 "         [[-i|--info] [-m|--man] [-w|--web]] [<command>]"
-msgstr "git help [--all] [--guides] [--man | --web | --info] [<Befehl>]"
+msgstr ""
+"git help [-a|--all] [--[no-]verbose]]\n"
+"         [[-i|--info] [-m|--man] [-w|--web]] [<Befehl>]"
 
 #: builtin/help.c:80
 msgid "git help [-g|--guides]"
-msgstr ""
+msgstr "git help [-g|--guides]"
 
 #: builtin/help.c:81
 msgid "git help [-c|--config]"
-msgstr ""
+msgstr "git help [-c|--config]"
 
 #: builtin/help.c:196
 #, c-format
@@ -16991,9 +16991,8 @@ msgid "bad alias.%s string: %s"
 msgstr "Ungültiger alias.%s String: %s"
 
 #: builtin/help.c:581
-#, fuzzy
 msgid "this option doesn't take any other arguments"
-msgstr "fetch --all akzeptiert kein Repository als Argument"
+msgstr "diese Option akzeptiert keine anderen Argumente"
 
 #: builtin/help.c:602 builtin/help.c:629
 #, c-format
@@ -17216,9 +17215,9 @@ msgid "cannot close written %s file '%s'"
 msgstr "Kann eben geschriebene %s Datei '%s' nicht schließen."
 
 #: builtin/index-pack.c:1489
-#, fuzzy, c-format
+#, c-format
 msgid "unable to rename temporary '*.%s' file to '%s'"
-msgstr "konnte temporäre Datei nicht zu %s umbenennen"
+msgstr "konnte temporäre Datei '*.%s' nicht zu '%s' umbenennen"
 
 #: builtin/index-pack.c:1514
 msgid "error while closing pack file"
@@ -17933,9 +17932,8 @@ msgid "git ls-files [<options>] [<file>...]"
 msgstr "git ls-files [<Optionen>] [<Datei>...]"
 
 #: builtin/ls-files.c:615
-#, fuzzy
 msgid "separate paths with the NUL character"
-msgstr "Pfade sind getrennt durch NUL Zeichen"
+msgstr "Pfade durch NUL-Zeichen trennen"
 
 #: builtin/ls-files.c:617
 msgid "identify the file status with tags"
@@ -18005,9 +18003,8 @@ msgid "skip files matching pattern"
 msgstr "Dateien auslassen, die einem Muster entsprechen"
 
 #: builtin/ls-files.c:652
-#, fuzzy
 msgid "read exclude patterns from <file>"
-msgstr "Muster von einer Datei lesen"
+msgstr "Ausschlussmuster aus <Datei> lesen"
 
 #: builtin/ls-files.c:655
 msgid "read additional per-directory exclude patterns in <file>"
@@ -18048,15 +18045,14 @@ msgid "suppress duplicate entries"
 msgstr "doppelte Einträge unterdrücken"
 
 #: builtin/ls-remote.c:9
-#, fuzzy
 msgid ""
 "git ls-remote [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
 "              [-q | --quiet] [--exit-code] [--get-url]\n"
 "              [--symref] [<repository> [<refs>...]]"
 msgstr ""
 "git ls-remote [--heads] [--tags] [--refs] [--upload-pack=<Programm>]\n"
-"                     [-q | --quiet] [--exit-code] [--get-url]\n"
-"                     [--symref] [<Repository> [<Referenzen>...]]"
+"              [-q | --quiet] [--exit-code] [--get-url]\n"
+"              [--symref] [<Repository> [<Referenzen>...]]"
 
 #: builtin/ls-remote.c:60
 msgid "do not print remote URL"
@@ -18457,9 +18453,9 @@ msgid "Not handling anything other than two heads merge."
 msgstr "Es wird nur der Merge von zwei Branches behandelt."
 
 #: builtin/merge.c:743
-#, fuzzy, c-format
+#, c-format
 msgid "unknown strategy option: -X%s"
-msgstr "Unbekannte Option: %s\n"
+msgstr "unbekannte Strategie-Option: -X%s"
 
 #: builtin/merge.c:762 t/helper/test-fast-rebase.c:223
 #, c-format
@@ -18731,11 +18727,12 @@ msgid "allow creation of more than one tree"
 msgstr "die Erstellung von mehr als einem \"Tree\"-Objekt erlauben"
 
 #: builtin/multi-pack-index.c:10
-#, fuzzy
 msgid ""
 "git multi-pack-index [<options>] write [--preferred-pack=<pack>][--refs-"
 "snapshot=<path>]"
-msgstr "git multi-pack-index [<Optionen>] write [--preferred-pack=<Paket>]"
+msgstr ""
+"git multi-pack-index [<Optionen>] write [--preferred-pack=<Paket>][--refs-"
+"snapshot=<Pfad>]"
 
 #: builtin/multi-pack-index.c:14
 msgid "git multi-pack-index [<options>] verify"
@@ -18764,18 +18761,16 @@ msgstr ""
 "Paket für die Wiederbenutzung, wenn eine Multi-Pack Bitmap berechnet wird"
 
 #: builtin/multi-pack-index.c:100
-#, fuzzy
 msgid "write multi-pack bitmap"
-msgstr "Fehler beim Schreiben des multi-pack-index"
+msgstr "schreibe Multipack-Bitmap"
 
 #: builtin/multi-pack-index.c:105
-#, fuzzy
 msgid "write multi-pack index containing only given indexes"
-msgstr "git multi-pack-index [<Optionen>] verify"
+msgstr "schreibe nur Multipack-Bitmap-Index, die vorgegebene Indexe enthalten"
 
 #: builtin/multi-pack-index.c:107
 msgid "refs snapshot for selecting bitmap commits"
-msgstr ""
+msgstr "Referenzen-Snapshot, um Bitmap-Commits auszuwählen"
 
 #: builtin/multi-pack-index.c:202
 msgid ""
@@ -19416,9 +19411,8 @@ msgid "failed to stat %s"
 msgstr "Konnte '%s' nicht lesen"
 
 #: builtin/pack-objects.c:1268
-#, fuzzy
 msgid "failed to write bitmap index"
-msgstr "Bitmap-Index schreiben"
+msgstr "Fehler beim Schreiben des Bitmap-Index"
 
 #: builtin/pack-objects.c:1294
 #, c-format
@@ -19988,7 +19982,6 @@ msgid "ignoring --verify-signatures for rebase"
 msgstr "Ignoriere --verify-signatures für Rebase"
 
 #: builtin/pull.c:936
-#, fuzzy
 msgid ""
 "You have divergent branches and need to specify how to reconcile them.\n"
 "You can do so by running one of the following commands sometime before\n"
@@ -20004,10 +19997,10 @@ msgid ""
 "or --ff-only on the command line to override the configured default per\n"
 "invocation.\n"
 msgstr ""
-"Es wird davon abgeraten zu Pullen, ohne anzugeben, wie mit abweichenden\n"
-"Branches umgegangen werden soll. Sie können diese Nachricht unterdrücken,\n"
-"indem Sie einen der folgenden Befehle ausführen, bevor der nächste Pull\n"
-"ausgeführt wird:\n"
+"Sie haben abweichende Branches und müssen angeben, wie mit diesen\n"
+"umgegangen werden soll.\n"
+"Sie können dies tun, indem Sie einen der folgenden Befehle vor dem\n"
+"nächsten Pull ausführen:\n"
 "\n"
 "  git config pull.rebase false  # Merge (Standard-Strategie)\n"
 "  git config pull.rebase true   # Rebase\n"
@@ -20068,13 +20061,14 @@ msgid "Cannot rebase onto multiple branches."
 msgstr "Kann Rebase nicht auf mehrere Branches ausführen."
 
 #: builtin/pull.c:1068
-#, fuzzy
 msgid "Cannot fast-forward to multiple branches."
-msgstr "Kann Rebase nicht auf mehrere Branches ausführen."
+msgstr "Kann nicht zu mehreren Branches vorspulen."
 
 #: builtin/pull.c:1082
 msgid "Need to specify how to reconcile divergent branches."
 msgstr ""
+"Es muss angegeben werden, wie mit abweichenden Branches umgegangen werden "
+"sollen."
 
 #: builtin/pull.c:1096
 msgid "cannot rebase with locally recorded submodule modifications"
@@ -20447,16 +20441,14 @@ msgid "need two commit ranges"
 msgstr "Benötige zwei Commit-Bereiche."
 
 #: builtin/read-tree.c:41
-#, fuzzy
 msgid ""
 "git read-tree [(-m [--trivial] [--aggressive] | --reset | --prefix=<prefix>) "
 "[-u | -i]] [--no-sparse-checkout] [--index-output=<file>] (--empty | <tree-"
 "ish1> [<tree-ish2> [<tree-ish3>]])"
 msgstr ""
 "git read-tree [(-m [--trivial] [--aggressive] | --reset | --prefix=<Präfix>) "
-"[-u [--exclude-per-directory=<gitignore>] | -i]] [--no-sparse-checkout] [--"
-"index-output=<Datei>] (--empty | <Commit-Referenz1> [<Commit-Referenz2> "
-"[<Commit-Referenz3>]])"
+"[-u | -i]] [--no-sparse-checkout] [--index-output=<Datei>] (--empty | "
+"<Commit-Referenz1> [<Commit-Referenz2> [<Commit-Referenz3>]])"
 
 #: builtin/read-tree.c:116
 msgid "write resulting index to <file>"
@@ -20825,11 +20817,8 @@ msgid "It looks like 'git am' is in progress. Cannot rebase."
 msgstr "'git am' scheint im Gange zu sein. Kann Rebase nicht durchführen."
 
 #: builtin/rebase.c:1180
-#, fuzzy
 msgid "--preserve-merges was replaced by --rebase-merges"
-msgstr ""
-"'git rebase --preserve-merges' ist veraltet. Benutzen Sie stattdessen '--"
-"rebase-merges'."
+msgstr "--preserve-merges wurde durch --rebase-merges ersetzt"
 
 #: builtin/rebase.c:1193
 msgid "cannot combine '--keep-base' with '--onto'"
@@ -20948,9 +20937,9 @@ msgid "Does not point to a valid commit '%s'"
 msgstr "'%s' zeigt auf keinen gültigen Commit."
 
 #: builtin/rebase.c:1607
-#, fuzzy, c-format
+#, c-format
 msgid "no such branch/commit '%s'"
-msgstr "fatal: Branch/Commit '%s' nicht gefunden"
+msgstr "Branch/Commit '%s' nicht gefunden"
 
 #: builtin/rebase.c:1618 builtin/submodule--helper.c:39
 #: builtin/submodule--helper.c:2658
@@ -21294,7 +21283,7 @@ msgstr "Konnte symbolische Referenz für Hauptbranch von '%s' nicht einrichten"
 #: builtin/remote.c:322
 #, c-format
 msgid "unhandled branch.%s.rebase=%s; assuming 'true'"
-msgstr ""
+msgstr "unbehandeltes branch.%s.rebase=%s; 'true' wird angenommen"
 
 #: builtin/remote.c:366
 #, c-format
@@ -21719,14 +21708,13 @@ msgid "pack %s too large to roll up"
 msgstr "Paket %s zu groß zum Aufrollen"
 
 #: builtin/repack.c:496
-#, fuzzy, c-format
+#, c-format
 msgid "could not open tempfile %s for writing"
-msgstr "Konnte '%s' nicht zum Schreiben öffnen."
+msgstr "konnte temporäre Datei '%s' nicht zum Schreiben öffnen"
 
 #: builtin/repack.c:514
-#, fuzzy
 msgid "could not close refs snapshot tempfile"
-msgstr "konnte temporäre Datei nicht erstellen"
+msgstr "konnte temporäre Referenzen-Snapshot-Datei nicht schließen"
 
 #: builtin/repack.c:628
 msgid "pack everything in a single pack"
@@ -21816,9 +21804,8 @@ msgid "find a geometric progression with factor <N>"
 msgstr "eine geometrische Progression mit Faktor <N> finden"
 
 #: builtin/repack.c:668
-#, fuzzy
 msgid "write a multi-pack index of the resulting packs"
-msgstr "Fehler beim Ausführen von 'git multi-pack-index repack'"
+msgstr "ein Multipack-Index des resultierenden Pakets schreiben"
 
 #: builtin/repack.c:678
 msgid "cannot delete packs in a precious-objects repo"
@@ -22548,18 +22535,16 @@ msgid "git rm: unable to remove %s"
 msgstr "git rm: konnte %s nicht löschen"
 
 #: builtin/send-pack.c:20
-#, fuzzy
 msgid ""
 "git send-pack [--mirror] [--dry-run] [--force]\n"
 "              [--receive-pack=<git-receive-pack>]\n"
 "              [--verbose] [--thin] [--atomic]\n"
 "              [<host>:]<directory> (--all | <ref>...)"
 msgstr ""
-"git send-pack [--all | --mirror] [--dry-run] [--force] [--receive-pack=<git-"
-"receive-pack>] [--verbose] [--thin] [--atomic] [<Host>:]<Verzeichnis> "
-"[<Referenz>...]\n"
-"  --all und die explizite Angabe einer <Referenz> schließen sich gegenseitig "
-"aus."
+"git send-pack [--mirror] [--dry-run] [--force]\n"
+"              [--receive-pack=<git-receive-pack>]\n"
+"              [--verbose] [--thin] [--atomic]\n"
+"              [<Host>:]<Verzeichnis> (--all | <Referenz>...)"
 
 #: builtin/send-pack.c:192
 msgid "remote name"
@@ -22636,7 +22621,6 @@ msgid "too many arguments given outside repository"
 msgstr "zu viele Argumente außerhalb des Repositories angegeben"
 
 #: builtin/show-branch.c:13
-#, fuzzy
 msgid ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
 "                [--current] [--color[=<when>] | --no-color] [--sparse]\n"
@@ -22644,9 +22628,9 @@ msgid ""
 "                [--no-name | --sha1-name] [--topics] [(<rev> | <glob>)...]"
 msgstr ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
-"\t\t[--current] [--color[=<Wann>] | --no-color] [--sparse]\n"
-"\t\t[--more=<n> | --list | --independent | --merge-base]\n"
-"\t\t[--no-name | --sha1-name] [--topics] [(<Commit> | <glob>)...]"
+"                [--current] [--color[=<Wann>] | --no-color] [--sparse]\n"
+"                [--more=<n> | --list | --independent | --merge-base]\n"
+"                [--no-name | --sha1-name] [--topics] [(<Commit> | <glob>)...]"
 
 #: builtin/show-branch.c:17
 msgid "git show-branch (-g | --reflog)[=<n>[,<base>]] [--list] [<ref>]"
@@ -22849,11 +22833,13 @@ msgid ""
 "directory '%s' contains untracked files, but is not in the sparse-checkout "
 "cone"
 msgstr ""
+"Verzeichnis '%s' enthält unversionierte Dateien, aber ist nicht innerhalb "
+"des partiellen Checkouts im Cone-Modus"
 
 #: builtin/sparse-checkout.c:181
-#, fuzzy, c-format
+#, c-format
 msgid "failed to remove directory '%s'"
-msgstr "Fehler beim Erstellen von Verzeichnis '%s'"
+msgstr "Fehler beim Löschen des Verzeichnisses '%s'"
 
 #: builtin/sparse-checkout.c:321
 msgid "failed to create directory for sparse-checkout file"
@@ -22989,13 +22975,12 @@ msgstr ""
 "          [--] [<Pfadspezifikation>...]]"
 
 #: builtin/stash.c:87
-#, fuzzy
 msgid ""
 "git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "               [-u|--include-untracked] [-a|--all] [<message>]"
 msgstr ""
 "git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
-"          [-u|--include-untracked] [-a|--all] [<Nachricht>]"
+"               [-u|--include-untracked] [-a|--all] [<Nachricht>]"
 
 #: builtin/stash.c:130
 #, c-format
@@ -23631,62 +23616,60 @@ msgid "Failed to clone '%s' a second time, aborting"
 msgstr "Zweiter Versuch '%s' zu klonen fehlgeschlagen, breche ab."
 
 #: builtin/submodule--helper.c:2372
-#, fuzzy, c-format
+#, c-format
 msgid "Unable to checkout '%s' in submodule path '%s'"
-msgstr "Konnte '$sha1' in Submodul-Pfad '$displaypath' nicht auschecken."
+msgstr "Konnte '%s' nicht im Submodul-Pfad '%s' auschecken"
 
 #: builtin/submodule--helper.c:2376
-#, fuzzy, c-format
+#, c-format
 msgid "Unable to rebase '%s' in submodule path '%s'"
-msgstr "Rebase auf '$sha1' in Submodul-Pfad '$displaypath' nicht möglich"
+msgstr "Rebase von '%s' in Submodul-Pfad '%s' nicht möglich"
 
 #: builtin/submodule--helper.c:2380
-#, fuzzy, c-format
+#, c-format
 msgid "Unable to merge '%s' in submodule path '%s'"
-msgstr "Merge von '$sha1' in Submodul-Pfad '$displaypath' fehlgeschlagen"
+msgstr "Merge von '%s' in Submodul-Pfad '%s' fehlgeschlagen"
 
 #: builtin/submodule--helper.c:2384
-#, fuzzy, c-format
+#, c-format
 msgid "Execution of '%s %s' failed in submodule path '%s'"
-msgstr ""
-"Ausführung von '$command $sha1' in Submodul-Pfad '$displaypath' "
-"fehlgeschlagen"
+msgstr "Ausführung von '%s %s' in Submodul-Pfad '%s' fehlgeschlagen"
 
 #: builtin/submodule--helper.c:2408
-#, fuzzy, c-format
+#, c-format
 msgid "Submodule path '%s': checked out '%s'\n"
-msgstr "Submodul-Pfad: '$displaypath': '$sha1' ausgecheckt"
+msgstr "Submodul-Pfad '%s': '%s' ausgecheckt\n"
 
 #: builtin/submodule--helper.c:2412
-#, fuzzy, c-format
+#, c-format
 msgid "Submodule path '%s': rebased into '%s'\n"
-msgstr "Submodul-Pfad '$displaypath': Rebase auf '$sha1'"
+msgstr "Submodul-Pfad '%s': Rebase in '%s'\n"
 
 #: builtin/submodule--helper.c:2416
-#, fuzzy, c-format
+#, c-format
 msgid "Submodule path '%s': merged in '%s'\n"
-msgstr "Submodul-Pfad '$displaypath': zusammengeführt in '$sha1'"
+msgstr "Submodul-Pfad '%s': zusammengeführt in '%s'\n"
 
 #: builtin/submodule--helper.c:2420
-#, fuzzy, c-format
+#, c-format
 msgid "Submodule path '%s': '%s %s'\n"
-msgstr "Submodul-Pfad '%s' nicht initialisiert"
+msgstr "Submodul-Pfad '%s': '%s %s'\n"
 
 #: builtin/submodule--helper.c:2444
-#, fuzzy, c-format
+#, c-format
 msgid "Unable to fetch in submodule path '%s'; trying to directly fetch %s:"
 msgstr ""
-"Konnte \"fetch\" in Submodul-Pfad '$displaypath' nicht ausführen. Versuche "
-"$sha1 direkt anzufordern:"
+"Konnte \"fetch\" in Submodul-Pfad '%s' nicht ausführen. Versuche %s direkt "
+"anzufordern:"
 
 #: builtin/submodule--helper.c:2453
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Fetched in submodule path '%s', but it did not contain %s. Direct fetching "
 "of that commit failed."
 msgstr ""
-"\"fetch\" in Submodul-Pfad '$displaypath' ausgeführt, aber $sha1 nicht\n"
-"enthalten. Direktes Anfordern dieses Commits ist fehlgeschlagen."
+"\"fetch\" in Submodul-Pfad '%s' ausgeführt, aber enthielt nicht %s. "
+"Direktes Anfordern dieses Commits ist fehlgeschlagen."
 
 #: builtin/submodule--helper.c:2504 builtin/submodule--helper.c:2574
 #: builtin/submodule--helper.c:2812
@@ -23731,49 +23714,46 @@ msgid "bad value for update parameter"
 msgstr "Fehlerhafter Wert für update Parameter"
 
 #: builtin/submodule--helper.c:2565
-#, fuzzy
 msgid "suppress output for update by rebase or merge"
-msgstr "Ausgaben beim Setzen der URL eines Submoduls unterdrücken"
+msgstr "Ausgaben bei Aktualisierung durch Rebase oder Merge unterdrücken"
 
 #: builtin/submodule--helper.c:2566
-#, fuzzy
 msgid "force checkout updates"
-msgstr "Aktualisierung erzwingen"
+msgstr "Checkout-Aktualisierungen erzwingen"
 
 #: builtin/submodule--helper.c:2568
-#, fuzzy
 msgid "don't fetch new objects from the remote site"
-msgstr "Tree-Objekt vom aktuellen Index erstellen"
+msgstr "keine neuen Objekte von Remote abrufen"
 
 #: builtin/submodule--helper.c:2570
 msgid "overrides update mode in case the repository is a fresh clone"
 msgstr ""
+"überschreibt den Aktualisierungsmodus, falls es sich bei dem Repository um "
+"einen neuen Klon handelt"
 
 #: builtin/submodule--helper.c:2571
-#, fuzzy
 msgid "depth for shallow fetch"
-msgstr "Tiefe des Klons mit unvollständiger Historie (shallow)"
+msgstr "Tiefe des Abrufens mit unvollständiger Historie (shallow)"
 
 #: builtin/submodule--helper.c:2581
 msgid "sha1"
-msgstr ""
+msgstr "sha1"
 
 #: builtin/submodule--helper.c:2582
 msgid "SHA1 expected by superproject"
-msgstr ""
+msgstr "SHA1 vom übergeordneten Projekt erwartet"
 
 #: builtin/submodule--helper.c:2584
 msgid "subsha1"
-msgstr ""
+msgstr "subsha1"
 
 #: builtin/submodule--helper.c:2585
 msgid "SHA1 of submodule's HEAD"
-msgstr ""
+msgstr "SHA1 vom HEAD des Submoduls"
 
 #: builtin/submodule--helper.c:2591
-#, fuzzy
 msgid "git submodule--helper run-update-procedure [<options>] <path>"
-msgstr "git submodule--helper init [<Optionen>] [<Pfad>]"
+msgstr "git submodule--helper run-update-procedure [<Optionen>] <Pfad>"
 
 #: builtin/submodule--helper.c:2662
 #, c-format
@@ -23869,14 +23849,14 @@ msgid "'%s' already exists and is not a valid git repo"
 msgstr "'%s' existiert bereits und ist kein gültiges Git-Repository"
 
 #: builtin/submodule--helper.c:3053
-#, fuzzy, c-format
+#, c-format
 msgid "A git directory for '%s' is found locally with remote(s):\n"
 msgstr ""
 "Ein Git-Verzeichnis für '%s' wurde lokal gefunden mit den Remote-"
-"Repositories:"
+"Repositories:\n"
 
 #: builtin/submodule--helper.c:3060
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "If you want to reuse this local git directory instead of cloning again from\n"
 "  %s\n"
@@ -23891,7 +23871,7 @@ msgstr ""
 "zu klonen, benutzen Sie die Option '--force'. Wenn das lokale Git-"
 "Verzeichnis\n"
 "nicht das korrekte Repository ist oder Sie unsicher sind, was das bedeutet,\n"
-"wählen Sie einen anderen Namen mit der Option '--name'.\n"
+"wählen Sie einen anderen Namen mit der Option '--name'."
 
 #: builtin/submodule--helper.c:3072
 #, c-format
@@ -23904,55 +23884,53 @@ msgid "unable to checkout submodule '%s'"
 msgstr "Kann Submodul '%s' nicht auschecken"
 
 #: builtin/submodule--helper.c:3148
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to add submodule '%s'"
-msgstr "Hinzufügen von Submodul '$sm_path' fehlgeschlagen"
+msgstr "Hinzufügen von Submodul '%s' fehlgeschlagen"
 
 #: builtin/submodule--helper.c:3152 builtin/submodule--helper.c:3157
 #: builtin/submodule--helper.c:3165
-#, fuzzy, c-format
+#, c-format
 msgid "Failed to register submodule '%s'"
-msgstr "Fehler beim Eintragen von Submodul '$sm_path' in die Konfiguration."
+msgstr "Fehler beim Registrieren von Submodul '%s'"
 
 #: builtin/submodule--helper.c:3221
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' already exists in the index"
-msgstr "'$sm_path' ist bereits zum Commit vorgemerkt"
+msgstr "'%s' ist bereits zum Commit vorgemerkt"
 
 #: builtin/submodule--helper.c:3224
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' already exists in the index and is not a submodule"
-msgstr "'$sm_path' ist bereits zum Commit vorgemerkt und ist kein Submodul"
+msgstr "'%s' ist bereits zum Commit vorgemerkt und ist kein Submodul"
 
 #: builtin/submodule--helper.c:3253
-#, fuzzy
 msgid "branch of repository to add as submodule"
-msgstr "Branch des Repositories zum Auschecken beim Klonen"
+msgstr "Branch des Repositories zum Hinzufügen als Submodul"
 
 #: builtin/submodule--helper.c:3254
 msgid "allow adding an otherwise ignored submodule path"
 msgstr "das Hinzufügen eines andernfalls ignorierten Submodul-Pfads erlauben"
 
 #: builtin/submodule--helper.c:3256
-#, fuzzy
 msgid "print only error messages"
-msgstr "nur zusammengeführte Referenzen ausgeben"
+msgstr "nur Fehlermeldungen ausgeben"
 
 #: builtin/submodule--helper.c:3260
-#, fuzzy
 msgid "borrow the objects from reference repositories"
-msgstr "geliehene Objekte von alternativem Objektspeicher ignorieren"
+msgstr "die Objekte von Referenz-Repositories ausleihen"
 
 #: builtin/submodule--helper.c:3262
 msgid ""
 "sets the submodule’s name to the given string instead of defaulting to its "
 "path"
 msgstr ""
+"legt den Namen des Submoduls auf die angegebene Zeichenkette fest, statt "
+"standardmäßig dessen Pfad zu nehmen"
 
 #: builtin/submodule--helper.c:3269
-#, fuzzy
 msgid "git submodule--helper add [<options>] [--] <repository> [<path>]"
-msgstr "git submodule--helper summary [<Optionen>] [<Commit>] [--] [<Pfad>]"
+msgstr "git submodule--helper add [<Optionen>] [--] <Repository> [<Pfad>]"
 
 #: builtin/submodule--helper.c:3297
 msgid "Relative path can only be used from the toplevel of the working tree"
@@ -23961,14 +23939,14 @@ msgstr ""
 "benutzt werden."
 
 #: builtin/submodule--helper.c:3305
-#, fuzzy, c-format
+#, c-format
 msgid "repo URL: '%s' must be absolute or begin with ./|../"
-msgstr "repo URL: '$repo' muss absolut sein oder mit ./|../ beginnen"
+msgstr "repo URL: '%s' muss absolut sein oder mit ./|../ beginnen"
 
 #: builtin/submodule--helper.c:3340
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not a valid submodule name"
-msgstr "'%s' ist kein gültiger Name für ein Remote-Repository"
+msgstr "'%s' ist kein gültiger Submodul-Name"
 
 #: builtin/submodule--helper.c:3404 git.c:449 git.c:723
 #, c-format
@@ -24010,20 +23988,18 @@ msgid "reason of the update"
 msgstr "Grund für die Aktualisierung"
 
 #: builtin/tag.c:25
-#, fuzzy
 msgid ""
 "git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <file>]\n"
 "        <tagname> [<head>]"
 msgstr ""
-"git tag [-a | -s | -u <Schlüssel-id>] [-f] [-m <Beschreibung> | -F <Datei>]\n"
-"\t\t<Tagname> [<Commit>]"
+"git tag [-a | -s | -u <Schlüssel-ID>] [-f] [-m <Beschreibung> | -F <Datei>]\n"
+"        <Tagname> [<Commit>]"
 
 #: builtin/tag.c:27
 msgid "git tag -d <tagname>..."
 msgstr "git tag -d <Tagname>..."
 
 #: builtin/tag.c:28
-#, fuzzy
 msgid ""
 "git tag -l [-n[<num>]] [--contains <commit>] [--no-contains <commit>] [--"
 "points-at <object>]\n"
@@ -24032,7 +24008,7 @@ msgid ""
 msgstr ""
 "git tag -l [-n[<Nummer>]] [--contains <Commit>] [--no-contains <Commit>] [--"
 "points-at <Objekt>]\n"
-"\t\t[--format=<format>] [--merged <Commit>] [--no-merged <Commit>] "
+"        [--format=<format>] [--merged <Commit>] [--no-merged <Commit>] "
 "[<Muster>...]"
 
 #: builtin/tag.c:30
@@ -24550,7 +24526,7 @@ msgstr "nach einem einzigen Request/Response-Austausch beenden"
 
 #: builtin/upload-pack.c:26
 msgid "serve up the info/refs for git-http-backend"
-msgstr ""
+msgstr "info/refs für git-http-backend übergeben"
 
 #: builtin/upload-pack.c:29
 msgid "do not try <directory>/.git/ if <directory> is no Git directory"
@@ -25169,11 +25145,10 @@ msgid "Delegation control is not supported with cURL < 7.22.0"
 msgstr "Kontrolle über Delegation wird mit cURL < 7.22.0 nicht unterstützt"
 
 #: http.c:380
-#, fuzzy
 msgid "Public key pinning not supported with cURL < 7.39.0"
 msgstr ""
-"Das Anheften des öffentlichen Schlüssels wird mit cURL < 7.44.0\n"
-"nicht unterstützt."
+"Das Anheften des öffentlichen Schlüssels wird mit cURL < 7.39.0 nicht "
+"unterstützt"
 
 #: http.c:812
 msgid "CURLSSLOPT_NO_REVOKE not supported with cURL < 7.44.0"
@@ -25239,6 +25214,8 @@ msgstr "Authentifizierung fehlgeschlagen für '%s'"
 #, c-format
 msgid "unable to access '%s' with http.pinnedPubkey configuration: %s"
 msgstr ""
+"auf '%s' kann nicht mit Konfiguration http.pinnedPubkey zugegriffen werden: "
+"%s"
 
 #: remote-curl.c:508
 #, c-format
@@ -26983,537 +26960,3 @@ msgstr "Lasse %s mit Backup-Suffix '%s' aus.\n"
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Wollen Sie %s wirklich versenden? [y|N]: "
-
-#~ msgid ""
-#~ "The following pathspecs didn't match any eligible path, but they do match "
-#~ "index\n"
-#~ "entries outside the current sparse checkout:\n"
-#~ msgstr ""
-#~ "Die folgenden Pfadspezifikationen entsprachen keinem geeigneten Pfad, "
-#~ "aber\n"
-#~ "entsprechen Index-Einträgen außerhalb des aktuellen partiellen "
-#~ "Checkouts:\n"
-
-#~ msgid ""
-#~ "Disable or modify the sparsity rules if you intend to update such entries."
-#~ msgstr ""
-#~ "Deaktivieren oder verändern Sie die Regeln für partielle Checkouts, wenn "
-#~ "Sie solche Einträge aktualisieren möchten."
-
-#~ msgid "could not set GIT_DIR to '%s'"
-#~ msgstr "konnte GIT_DIR nicht zu '%s' setzen"
-
-#~ msgid "unable to unpack %s header with --allow-unknown-type"
-#~ msgstr "Konnte %s Kopfbereich nicht mit --allow-unknown-type entpacken."
-
-#~ msgid "unable to parse %s header with --allow-unknown-type"
-#~ msgstr "Konnte %s Kopfbereich mit --allow-unknown-type nicht parsen."
-
-#~ msgid "open /dev/null failed"
-#~ msgstr "Öffnen von /dev/null fehlgeschlagen"
-
-#~ msgid ""
-#~ "after resolving the conflicts, mark the corrected paths\n"
-#~ "with 'git add <paths>' or 'git rm <paths>'\n"
-#~ "and commit the result with 'git commit'"
-#~ msgstr ""
-#~ "nach Auflösung der Konflikte markieren Sie die korrigierten Pfade\n"
-#~ "mit 'git add <Pfade>' oder 'git rm <Pfade>' und tragen Sie das Ergebnis "
-#~ "mit\n"
-#~ "'git commit' ein"
-
-#~ msgid "open /dev/null or dup failed"
-#~ msgstr "Öffnen von /dev/null oder dup fehlgeschlagen."
-
-#~ msgid "attempting to use sparse-index without cone mode"
-#~ msgstr "versuche partiellen Index ohne Cone-Modus zu benutzen"
-
-#~ msgid "unable to update cache-tree, staying full"
-#~ msgstr "konnte Cache-Verzeichnis nicht aktualisieren, bleibt voll"
-
-#~ msgid "Could not open '%s' for writing."
-#~ msgstr "Konnte '%s' nicht zum Schreiben öffnen."
-
-#~ msgid "could not create archive file '%s'"
-#~ msgstr "Konnte Archiv-Datei '%s' nicht erstellen."
-
-#~ msgid ""
-#~ "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
-#~ msgstr ""
-#~ "git bisect--helper --bisect-next-check <Begriff_gut> <Begriff_schlecht> "
-#~ "[<Begriff>]"
-
-#~ msgid "--bisect-next-check requires 2 or 3 arguments"
-#~ msgstr "--bisect-next-check benötigt 2 oder 3 Argumente"
-
-#~ msgid "couldn't create a new file at '%s'"
-#~ msgstr "konnte keine neue Datei unter '%s' erstellen"
-
-#~ msgid "git commit-tree: failed to open '%s'"
-#~ msgstr "git commit-tree: Fehler beim Öffnen von '%s'"
-
-#~ msgid "cannot open packfile '%s'"
-#~ msgstr "Kann Paketdatei '%s' nicht öffnen"
-
-#~ msgid "cannot store pack file"
-#~ msgstr "Kann Paketdatei nicht speichern"
-
-#~ msgid "cannot store index file"
-#~ msgstr "Kann Indexdatei nicht speichern"
-
-#~ msgid "exclude patterns are read from <file>"
-#~ msgstr "Muster, gelesen von <Datei>, ausschließen"
-
-#~ msgid "Unknown option for merge-recursive: -X%s"
-#~ msgstr "Unbekannte Option für merge-recursive: -X%s"
-
-#~ msgid "unusable todo list: '%s'"
-#~ msgstr "Unbenutzbare TODO-Liste: '%s'"
-
-#~ msgid "git rebase--interactive [<options>]"
-#~ msgstr "git rebase--interactive [<Optionen>]"
-
-#~ msgid "rebase merge commits"
-#~ msgstr "Rebase auf Merge-Commits ausführen"
-
-#~ msgid "keep original branch points of cousins"
-#~ msgstr "originale Branch-Punkte der Cousins behalten"
-
-#~ msgid "move commits that begin with squash!/fixup!"
-#~ msgstr "Commits verschieben, die mit squash!/fixup! beginnen"
-
-#~ msgid "sign commits"
-#~ msgstr "Commits signieren"
-
-#~ msgid "continue rebase"
-#~ msgstr "Rebase fortsetzen"
-
-#~ msgid "skip commit"
-#~ msgstr "Commit auslassen"
-
-#~ msgid "edit the todo list"
-#~ msgstr "die TODO-Liste bearbeiten"
-
-#~ msgid "show the current patch"
-#~ msgstr "den aktuellen Patch anzeigen"
-
-#~ msgid "shorten commit ids in the todo list"
-#~ msgstr "Commit-IDs in der TODO-Liste verkürzen"
-
-#~ msgid "expand commit ids in the todo list"
-#~ msgstr "Commit-IDs in der TODO-Liste erweitern"
-
-#~ msgid "check the todo list"
-#~ msgstr "die TODO-Liste prüfen"
-
-#~ msgid "rearrange fixup/squash lines"
-#~ msgstr "fixup/squash-Zeilen umordnen"
-
-#~ msgid "insert exec commands in todo list"
-#~ msgstr "\"exec\"-Befehle in TODO-Liste einfügen"
-
-#~ msgid "onto"
-#~ msgstr "auf"
-
-#~ msgid "restrict-revision"
-#~ msgstr "Begrenzungscommit"
-
-#~ msgid "restrict revision"
-#~ msgstr "Begrenzungscommit"
-
-#~ msgid "squash-onto"
-#~ msgstr "squash-onto"
-
-#~ msgid "squash onto"
-#~ msgstr "squash onto"
-
-#~ msgid "the upstream commit"
-#~ msgstr "der Upstream-Commit"
-
-#~ msgid "head-name"
-#~ msgstr "head-Name"
-
-#~ msgid "head name"
-#~ msgstr "head-Name"
-
-#~ msgid "rebase strategy"
-#~ msgstr "Rebase-Strategie"
-
-#~ msgid "strategy-opts"
-#~ msgstr "Strategie-Optionen"
-
-#~ msgid "strategy options"
-#~ msgstr "Strategie-Optionen"
-
-#~ msgid "switch-to"
-#~ msgstr "wechseln zu"
-
-#~ msgid "the branch or commit to checkout"
-#~ msgstr "der Branch oder Commit zum Auschecken"
-
-#~ msgid "onto-name"
-#~ msgstr "onto-Name"
-
-#~ msgid "onto name"
-#~ msgstr "onto-Name"
-
-#~ msgid "cmd"
-#~ msgstr "Befehl"
-
-#~ msgid "the command to run"
-#~ msgstr "auszuführender Befehl"
-
-#~ msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
-#~ msgstr "--[no-]rebase-cousins hat ohne --rebase-merges keine Auswirkung"
-
-#~ msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
-#~ msgstr ""
-#~ "'--preserve-merges' kann nicht mit '--rebase-merges' kombiniert werden."
-
-#~ msgid ""
-#~ "error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
-#~ msgstr ""
-#~ "Fehler: '--preserve-merges' kann nicht mit '--reschedule-failed-exec' "
-#~ "kombiniert werden."
-
-#~ msgid ""
-#~ "git submodule--helper add-clone [<options>...] --url <url> --path <path> "
-#~ "--name <name>"
-#~ msgstr ""
-#~ "git submodule--helper add-clone [<Optionen>...] --url <URL> --path <Pfad> "
-#~ "--name <Name>"
-
-#~ msgid "failed to create file %s"
-#~ msgstr "Konnte Datei '%s' nicht erstellen"
-
-#~ msgid "exit immediately after initial ref advertisement"
-#~ msgstr "direkt nach der initialen Angabe der Commits beenden"
-
-#~ msgid "socket/pipe already in use: '%s'"
-#~ msgstr "Socket/Pipe bereits in Benutzung: '%s'"
-
-#~ msgid "could not start server on: '%s'"
-#~ msgstr "konnte Server nicht starten auf: '%s'"
-
-#~ msgid "could not spawn daemon in the background"
-#~ msgstr "Daemon konnte nicht im Hintergrund erzeugt werden"
-
-#~ msgid "waitpid failed"
-#~ msgstr "waitpid fehlgeschlagen"
-
-#~ msgid "daemon not online yet"
-#~ msgstr "Daemon ist noch nicht online"
-
-#~ msgid "daemon failed to start"
-#~ msgstr "Fehler beim Starten des Daemons"
-
-#~ msgid "waitpid is confused"
-#~ msgstr "waitpid ist verwirrt"
-
-#~ msgid "daemon has not shutdown yet"
-#~ msgstr "Daemon ist noch nicht heruntergefahren"
-
-#~ msgid "Protocol restrictions not supported with cURL < 7.19.4"
-#~ msgstr "Protokollbeschränkungen werden mit cURL < 7.19.4 nicht unterstützt."
-
-#~ msgid "running $command"
-#~ msgstr "führe $command aus"
-
-#~ msgid "'$sm_path' does not have a commit checked out"
-#~ msgstr "'$sm_path' hat keinen Commit ausgecheckt"
-
-#~ msgid "Submodule path '$displaypath': '$command $sha1'"
-#~ msgstr "Submodul-Pfad '$displaypath': '$command $sha1'"
-
-#~ msgid "Applied autostash."
-#~ msgstr "Automatischen Stash angewendet."
-
-#~ msgid "Cannot store $stash_sha1"
-#~ msgstr "Kann $stash_sha1 nicht speichern."
-
-#~ msgid ""
-#~ "Applying autostash resulted in conflicts.\n"
-#~ "Your changes are safe in the stash.\n"
-#~ "You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
-#~ msgstr ""
-#~ "Anwendung des automatischen Stash resultierte in Konflikten.\n"
-#~ "Ihre Änderungen sind im Stash sicher.\n"
-#~ "Sie können jederzeit \"git stash pop\" oder \"git stash drop\" "
-#~ "ausführen.\n"
-
-#~ msgid "Rebasing ($new_count/$total)"
-#~ msgstr "Führe Rebase aus ($new_count/$total)"
-
-#~ msgid ""
-#~ "\n"
-#~ "Commands:\n"
-#~ "p, pick <commit> = use commit\n"
-#~ "r, reword <commit> = use commit, but edit the commit message\n"
-#~ "e, edit <commit> = use commit, but stop for amending\n"
-#~ "s, squash <commit> = use commit, but meld into previous commit\n"
-#~ "f, fixup <commit> = like \"squash\", but discard this commit's log "
-#~ "message\n"
-#~ "x, exec <commit> = run command (the rest of the line) using shell\n"
-#~ "d, drop <commit> = remove commit\n"
-#~ "l, label <label> = label current HEAD with a name\n"
-#~ "t, reset <label> = reset HEAD to a label\n"
-#~ "m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
-#~ ".       create a merge commit using the original merge commit's\n"
-#~ ".       message (or the oneline, if no original merge commit was\n"
-#~ ".       specified). Use -c <commit> to reword the commit message.\n"
-#~ "\n"
-#~ "These lines can be re-ordered; they are executed from top to bottom.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Befehle:\n"
-#~ "p, pick <Commit> = Commit verwenden\n"
-#~ "r, reword <Commit> = Commit verwenden, aber Commit-Beschreibung "
-#~ "bearbeiten\n"
-#~ "e, edit <Commit> = Commit verwenden, aber zum Nachbessern anhalten\n"
-#~ "s, squash <Commit> = Commit verwenden, aber mit vorherigem Commit "
-#~ "vereinen\n"
-#~ "f, fixup <Commit> = wie \"squash\", aber diese Commit-Beschreibung "
-#~ "verwerfen\n"
-#~ "x, exec <Commit> = Befehl (Rest der Zeile) mittels Shell ausführen\n"
-#~ "d, drop <Commit> = Commit entfernen\n"
-#~ "l, label <Label> = aktuellen HEAD mit Label versehen\n"
-#~ "t, reset <Label> = HEAD zu einem Label umsetzen\n"
-#~ "m, merge [-C <Commit> | -c <Commit>] <Label> [# <eineZeile>]\n"
-#~ ".       Merge-Commit mit der originalen Merge-Commit-Beschreibung "
-#~ "erstellen\n"
-#~ ".       (oder die eine Zeile, wenn keine originale Merge-Commit-"
-#~ "Beschreibung\n"
-#~ ".       spezifiziert ist). Benutzen Sie -c <Commit> zum Bearbeiten der\n"
-#~ ".       Commit-Beschreibung.\n"
-#~ "\n"
-#~ "Diese Zeilen können umsortiert werden; Sie werden von oben nach unten\n"
-#~ "ausgeführt.\n"
-
-#~ msgid ""
-#~ "You can amend the commit now, with\n"
-#~ "\n"
-#~ "\tgit commit --amend $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "Once you are satisfied with your changes, run\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-#~ msgstr ""
-#~ "Sie können den Commit nun nachbessern mit:\n"
-#~ "\n"
-#~ "\tgit commit --amend $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "Sobald Sie mit Ihren Änderungen zufrieden sind, führen Sie aus:\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-
-#~ msgid "$sha1: not a commit that can be picked"
-#~ msgstr "$sha1: kein Commit der gepickt werden kann"
-
-#~ msgid "Invalid commit name: $sha1"
-#~ msgstr "Ungültiger Commit-Name: $sha1"
-
-#~ msgid "Cannot write current commit's replacement sha1"
-#~ msgstr "Kann ersetzenden SHA-1 des aktuellen Commits nicht schreiben"
-
-#~ msgid "Fast-forward to $sha1"
-#~ msgstr "Spule vor zu $sha1"
-
-#~ msgid "Cannot fast-forward to $sha1"
-#~ msgstr "Kann nicht zu $sha1 vorspulen"
-
-#~ msgid "Cannot move HEAD to $first_parent"
-#~ msgstr "Kann HEAD nicht auf $first_parent setzen"
-
-#~ msgid "Refusing to squash a merge: $sha1"
-#~ msgstr "\"squash\" eines Merges ($sha1) zurückgewiesen."
-
-#~ msgid "Error redoing merge $sha1"
-#~ msgstr "Fehler beim Wiederholen des Merges von $sha1"
-
-#~ msgid "Could not pick $sha1"
-#~ msgstr "Konnte $sha1 nicht picken"
-
-#~ msgid "This is the commit message #${n}:"
-#~ msgstr "Das ist Commit-Beschreibung #${n}:"
-
-#~ msgid "The commit message #${n} will be skipped:"
-#~ msgstr "Commit-Beschreibung #${n} wird ausgelassen:"
-
-#~ msgid "This is a combination of $count commit."
-#~ msgid_plural "This is a combination of $count commits."
-#~ msgstr[0] "Das ist eine Kombination aus $count Commit."
-#~ msgstr[1] "Das ist eine Kombination aus $count Commits."
-
-#~ msgid "Cannot write $fixup_msg"
-#~ msgstr "Kann $fixup_msg nicht schreiben"
-
-#~ msgid "This is a combination of 2 commits."
-#~ msgstr "Das ist eine Kombination aus 2 Commits."
-
-#~ msgid "Could not apply $sha1... $rest"
-#~ msgstr "Konnte $sha1... ($rest) nicht anwenden"
-
-#~ msgid ""
-#~ "Could not amend commit after successfully picking $sha1... $rest\n"
-#~ "This is most likely due to an empty commit message, or the pre-commit "
-#~ "hook\n"
-#~ "failed. If the pre-commit hook failed, you may need to resolve the issue "
-#~ "before\n"
-#~ "you are able to reword the commit."
-#~ msgstr ""
-#~ "Konnte Commit nicht nachbessern, nachdem dieser verwendet wurde: $sha1... "
-#~ "$rest\n"
-#~ "Das passierte sehr wahrscheinlich wegen einer leeren Commit-Beschreibung, "
-#~ "oder\n"
-#~ "weil der pre-commit Hook fehlschlug. Falls der pre-commit Hook "
-#~ "fehlschlug,\n"
-#~ "sollten Sie das Problem beheben, bevor Sie die Commit-Beschreibung ändern "
-#~ "können."
-
-#~ msgid "Stopped at $sha1_abbrev... $rest"
-#~ msgstr "Angehalten bei $sha1_abbrev... $rest"
-
-#~ msgid "Cannot '$squash_style' without a previous commit"
-#~ msgstr "Kann nicht '$squash_style' ohne vorherigen Commit"
-
-#~ msgid "Executing: $rest"
-#~ msgstr "Führe aus: $rest"
-
-#~ msgid "Execution failed: $rest"
-#~ msgstr "Ausführung fehlgeschlagen: $rest"
-
-#~ msgid "and made changes to the index and/or the working tree"
-#~ msgstr "Der Index und/oder das Arbeitsverzeichnis wurde geändert."
-
-#~ msgid ""
-#~ "You can fix the problem, and then run\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-#~ msgstr ""
-#~ "Sie können das Problem beheben, und dann\n"
-#~ "\n"
-#~ "\tgit rebase --continue\n"
-#~ "\n"
-#~ "ausführen."
-
-#~ msgid ""
-#~ "Execution succeeded: $rest\n"
-#~ "but left changes to the index and/or the working tree\n"
-#~ "Commit or stash your changes, and then run\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-#~ msgstr ""
-#~ "Ausführung erfolgreich: $rest\n"
-#~ "Aber Änderungen in Index oder Arbeitsverzeichnis verblieben.\n"
-#~ "Committen Sie Ihre Änderungen oder benutzen Sie \"stash\".\n"
-#~ "Führen Sie dann aus:\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-
-#~ msgid "Unknown command: $command $sha1 $rest"
-#~ msgstr "Unbekannter Befehl: $command $sha1 $rest"
-
-#~ msgid "Please fix this using 'git rebase --edit-todo'."
-#~ msgstr ""
-#~ "Bitte beheben Sie das, indem Sie 'git rebase --edit-todo' ausführen."
-
-#~ msgid "Successfully rebased and updated $head_name."
-#~ msgstr "Erfolgreich Rebase ausgeführt und $head_name aktualisiert."
-
-#~ msgid "Could not remove CHERRY_PICK_HEAD"
-#~ msgstr "Konnte CHERRY_PICK_HEAD nicht löschen"
-
-#~ msgid ""
-#~ "You have staged changes in your working tree.\n"
-#~ "If these changes are meant to be\n"
-#~ "squashed into the previous commit, run:\n"
-#~ "\n"
-#~ "  git commit --amend $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "If they are meant to go into a new commit, run:\n"
-#~ "\n"
-#~ "  git commit $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "In both cases, once you're done, continue with:\n"
-#~ "\n"
-#~ "  git rebase --continue\n"
-#~ msgstr ""
-#~ "Es befinden sich zum Commit vorgemerkte Änderungen in Ihrem "
-#~ "Arbeitsverzeichnis.\n"
-#~ "Wenn diese Änderungen in den vorherigen Commit aufgenommen werden "
-#~ "sollen,\n"
-#~ "führen Sie aus:\n"
-#~ "\n"
-#~ "  git commit --amend $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "Wenn daraus ein neuer Commit erzeugt werden soll, führen Sie aus:\n"
-#~ "\n"
-#~ "  git commit $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "Im Anschluss führen Sie zum Fortfahren aus:\n"
-#~ "\n"
-#~ "  git rebase --continue\n"
-
-#~ msgid "Error trying to find the author identity to amend commit"
-#~ msgstr ""
-#~ "Fehler beim Versuch die Identität des Authors zum Verbessern des Commits "
-#~ "zu\n"
-#~ "finden"
-
-#~ msgid ""
-#~ "You have uncommitted changes in your working tree. Please commit them\n"
-#~ "first and then run 'git rebase --continue' again."
-#~ msgstr ""
-#~ "Sie haben nicht committete Änderungen in Ihrem Arbeitsverzeichnis. Bitte\n"
-#~ "committen Sie diese zuerst und führen Sie dann 'git rebase --continue' "
-#~ "erneut\n"
-#~ "aus."
-
-#~ msgid "Could not commit staged changes."
-#~ msgstr "Konnte Änderungen aus der Staging-Area nicht committen."
-
-#~ msgid "Could not execute editor"
-#~ msgstr "Konnte Editor nicht ausführen."
-
-#~ msgid "Could not checkout $switch_to"
-#~ msgstr "Konnte $switch_to nicht auschecken."
-
-#~ msgid "No HEAD?"
-#~ msgstr "Kein HEAD?"
-
-#~ msgid "Could not create temporary $state_dir"
-#~ msgstr "Konnte temporäres Verzeichnis $state_dir nicht erstellen."
-
-#~ msgid "Could not mark as interactive"
-#~ msgstr "Konnte nicht als interaktiven Rebase markieren."
-
-#~ msgid "Rebase $shortrevisions onto $shortonto ($todocount command)"
-#~ msgid_plural "Rebase $shortrevisions onto $shortonto ($todocount commands)"
-#~ msgstr[0] "Rebase von $shortrevisions auf $shortonto ($todocount Kommando)"
-#~ msgstr[1] "Rebase von $shortrevisions auf $shortonto ($todocount Kommandos)"
-
-#~ msgid "Note that empty commits are commented out"
-#~ msgstr "Leere Commits sind auskommentiert."
-
-#~ msgid "Could not init rewritten commits"
-#~ msgstr "Konnte neu geschriebene Commits nicht initialisieren."
-
-#~ msgid "Cannot rebase: You have unstaged changes."
-#~ msgstr ""
-#~ "Rebase nicht möglich: Sie haben Änderungen, die nicht zum Commit "
-#~ "vorgemerkt sind."
-
-#~ msgid "Cannot pull with rebase: You have unstaged changes."
-#~ msgstr ""
-#~ "Kann \"pull\" mit \"rebase\" nicht ausführen: Sie haben Änderungen, die "
-#~ "nicht zum Commit vorgemerkt sind."
-
-#~ msgid "Cannot rebase: Your index contains uncommitted changes."
-#~ msgstr ""
-#~ "Rebase nicht möglich: Die Staging-Area beinhaltet nicht committete "
-#~ "Änderungen."
-
-#~ msgid "Cannot pull with rebase: Your index contains uncommitted changes."
-#~ msgstr ""
-#~ "Kann \"pull\" mit \"rebase\" nicht ausführen: Die Staging-Area beinhaltet "
-#~ "nicht committete Änderungen."

--- a/po/de.po
+++ b/po/de.po
@@ -4447,7 +4447,7 @@ msgstr "gpg beim Signieren der Daten fehlgeschlagen"
 
 #: gpg-interface.c:895
 msgid "user.signingkey needs to be set for ssh signing"
-msgstr "user.signingkey muss für die SSH-Signatur festgelegt werden"
+msgstr "user.signingkey muss für die SSH-Signatur gesetzt sein"
 
 #: gpg-interface.c:906
 #, c-format
@@ -4621,7 +4621,7 @@ msgstr "Setze fort unter der Annahme, dass Sie '%s' meinten."
 #: help.c:646
 #, c-format
 msgid "Run '%s' instead? (y/N)"
-msgstr "Führen Sie stattdessen '%s' aus? (y/N)"
+msgstr "Stattdessen '%s' ausführen? (y/N)"
 
 #: help.c:654
 #, c-format
@@ -5509,7 +5509,7 @@ msgstr "kann Reverse-Index-Datei nicht speichern"
 #: midx.c:990
 #, c-format
 msgid "could not parse line: %s"
-msgstr "Zeile konnte nicht analysiert werden: %s"
+msgstr "Zeile konnte nicht geparst werden: %s"
 
 #: midx.c:992
 #, c-format
@@ -18766,7 +18766,7 @@ msgstr "schreibe Multipack-Bitmap"
 
 #: builtin/multi-pack-index.c:105
 msgid "write multi-pack index containing only given indexes"
-msgstr "schreibe nur Multipack-Bitmap-Index, die vorgegebene Indexe enthalten"
+msgstr "Multipack-Index schreiben, der nur die gegebenen Indexe enthält"
 
 #: builtin/multi-pack-index.c:107
 msgid "refs snapshot for selecting bitmap commits"
@@ -23628,7 +23628,7 @@ msgstr "Rebase von '%s' in Submodul-Pfad '%s' nicht möglich"
 #: builtin/submodule--helper.c:2380
 #, c-format
 msgid "Unable to merge '%s' in submodule path '%s'"
-msgstr "Merge von '%s' in Submodul-Pfad '%s' fehlgeschlagen"
+msgstr "Merge von '%s' in Submodul-Pfad '%s' nicht möglich"
 
 #: builtin/submodule--helper.c:2384
 #, c-format
@@ -23881,7 +23881,7 @@ msgstr "Reaktiviere lokales Git-Verzeichnis für Submodul '%s'\n"
 #: builtin/submodule--helper.c:3109
 #, c-format
 msgid "unable to checkout submodule '%s'"
-msgstr "Kann Submodul '%s' nicht auschecken"
+msgstr "kann Submodul '%s' nicht auschecken"
 
 #: builtin/submodule--helper.c:3148
 #, c-format
@@ -23897,12 +23897,12 @@ msgstr "Fehler beim Registrieren von Submodul '%s'"
 #: builtin/submodule--helper.c:3221
 #, c-format
 msgid "'%s' already exists in the index"
-msgstr "'%s' ist bereits zum Commit vorgemerkt"
+msgstr "'%s' existiert bereits im Index"
 
 #: builtin/submodule--helper.c:3224
 #, c-format
 msgid "'%s' already exists in the index and is not a submodule"
-msgstr "'%s' ist bereits zum Commit vorgemerkt und ist kein Submodul"
+msgstr "'%s' existiert bereits im Index und ist kein Submodul"
 
 #: builtin/submodule--helper.c:3253
 msgid "branch of repository to add as submodule"

--- a/po/de.po
+++ b/po/de.po
@@ -19868,9 +19868,8 @@ msgid "allow fast-forward"
 msgstr "Vorspulen erlauben"
 
 #: builtin/pull.c:165
-#, fuzzy
 msgid "control use of pre-merge-commit and commit-msg hooks"
-msgstr "Hooks pre-merge-commit und commit-msg umgehen"
+msgstr "Benutzung der pre-merge-commit und commit-msg Hooks kontrollieren"
 
 #: builtin/pull.c:171 parse-options.h:338
 msgid "automatically stash/stash pop before and after"

--- a/po/es.po
+++ b/po/es.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-08-14 07:56+0800\n"
-"PO-Revision-Date: 2021-08-14 11:37-0500\n"
+"POT-Creation-Date: 2021-11-04 08:34+0800\n"
+"PO-Revision-Date: 2021-11-07 18:53-0500\n"
 "Last-Translator: Alex Henrie <alexhenrie24@gmail.com>\n"
 "Language-Team: CodeLabora <codelabora@gmail.com>\n"
 "Language: es\n"
@@ -18,214 +18,214 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.0\n"
 
-#: add-interactive.c:376
+#: add-interactive.c:380
 #, c-format
 msgid "Huh (%s)?"
 msgstr "¿Ahh (%s)?"
 
-#: add-interactive.c:529 add-interactive.c:830 reset.c:64 sequencer.c:3493
-#: sequencer.c:3964 sequencer.c:4119 builtin/rebase.c:1528
-#: builtin/rebase.c:1953
+#: add-interactive.c:533 add-interactive.c:834 reset.c:65 sequencer.c:3512
+#: sequencer.c:3979 sequencer.c:4141 builtin/rebase.c:1233
+#: builtin/rebase.c:1642
 msgid "could not read index"
 msgstr "no se pudo leer índice"
 
-#: add-interactive.c:584 git-add--interactive.perl:269
+#: add-interactive.c:588 git-add--interactive.perl:269
 #: git-add--interactive.perl:294
 msgid "binary"
 msgstr "binario"
 
-#: add-interactive.c:642 git-add--interactive.perl:278
+#: add-interactive.c:646 git-add--interactive.perl:278
 #: git-add--interactive.perl:332
 msgid "nothing"
 msgstr "nada"
 
-#: add-interactive.c:643 git-add--interactive.perl:314
+#: add-interactive.c:647 git-add--interactive.perl:314
 #: git-add--interactive.perl:329
 msgid "unchanged"
 msgstr "sin cambios"
 
-#: add-interactive.c:680 git-add--interactive.perl:641
+#: add-interactive.c:684 git-add--interactive.perl:641
 msgid "Update"
 msgstr "Actualizar"
 
-#: add-interactive.c:697 add-interactive.c:885
+#: add-interactive.c:701 add-interactive.c:889
 #, c-format
 msgid "could not stage '%s'"
 msgstr "no se pudo poner en stage '%s'"
 
-#: add-interactive.c:703 add-interactive.c:892 reset.c:88 sequencer.c:3707
+#: add-interactive.c:707 add-interactive.c:896 reset.c:89 sequencer.c:3718
 msgid "could not write index"
 msgstr "no se pudo escribir índice"
 
-#: add-interactive.c:706 git-add--interactive.perl:626
+#: add-interactive.c:710 git-add--interactive.perl:626
 #, c-format, perl-format
 msgid "updated %d path\n"
 msgid_plural "updated %d paths\n"
 msgstr[0] "actualizada %d ruta\n"
 msgstr[1] "actualizadas %d rutas\n"
 
-#: add-interactive.c:724 git-add--interactive.perl:676
+#: add-interactive.c:728 git-add--interactive.perl:676
 #, c-format, perl-format
 msgid "note: %s is untracked now.\n"
 msgstr "nota: %s no es rastreado ahora.\n"
 
-#: add-interactive.c:729 apply.c:4127 builtin/checkout.c:298
-#: builtin/reset.c:145
+#: add-interactive.c:733 apply.c:4149 builtin/checkout.c:298
+#: builtin/reset.c:151
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
 msgstr "make_cache_entry falló para la ruta '%s'"
 
-#: add-interactive.c:759 git-add--interactive.perl:653
+#: add-interactive.c:763 git-add--interactive.perl:653
 msgid "Revert"
 msgstr "Revertir"
 
-#: add-interactive.c:775
+#: add-interactive.c:779
 msgid "Could not parse HEAD^{tree}"
 msgstr "No se pudo analizar HEAD^{tree}"
 
-#: add-interactive.c:813 git-add--interactive.perl:629
+#: add-interactive.c:817 git-add--interactive.perl:629
 #, c-format, perl-format
 msgid "reverted %d path\n"
 msgid_plural "reverted %d paths\n"
 msgstr[0] "revertida %d ruta\n"
 msgstr[1] "revertidas %d rutas\n"
 
-#: add-interactive.c:864 git-add--interactive.perl:693
+#: add-interactive.c:868 git-add--interactive.perl:693
 #, c-format
 msgid "No untracked files.\n"
 msgstr "No hay archivos sin rastrear.\n"
 
-#: add-interactive.c:868 git-add--interactive.perl:687
+#: add-interactive.c:872 git-add--interactive.perl:687
 msgid "Add untracked"
 msgstr "Agregar no rastreados"
 
-#: add-interactive.c:895 git-add--interactive.perl:623
+#: add-interactive.c:899 git-add--interactive.perl:623
 #, c-format, perl-format
 msgid "added %d path\n"
 msgid_plural "added %d paths\n"
 msgstr[0] "agregada %d ruta\n"
 msgstr[1] "agregadas %d rutas\n"
 
-#: add-interactive.c:925
+#: add-interactive.c:929
 #, c-format
 msgid "ignoring unmerged: %s"
 msgstr "ignorando lo no fusionado: %s"
 
-#: add-interactive.c:937 add-patch.c:1752 git-add--interactive.perl:1369
+#: add-interactive.c:941 add-patch.c:1752 git-add--interactive.perl:1369
 #, c-format
 msgid "Only binary files changed.\n"
 msgstr "Solo cambiaron archivos binarios.\n"
 
-#: add-interactive.c:939 add-patch.c:1750 git-add--interactive.perl:1371
+#: add-interactive.c:943 add-patch.c:1750 git-add--interactive.perl:1371
 #, c-format
 msgid "No changes.\n"
 msgstr "Sin cambios.\n"
 
-#: add-interactive.c:943 git-add--interactive.perl:1379
+#: add-interactive.c:947 git-add--interactive.perl:1379
 msgid "Patch update"
 msgstr "Actualización del parche"
 
-#: add-interactive.c:982 git-add--interactive.perl:1792
+#: add-interactive.c:986 git-add--interactive.perl:1792
 msgid "Review diff"
 msgstr "Revisión de diff"
 
-#: add-interactive.c:1010
+#: add-interactive.c:1014
 msgid "show paths with changes"
 msgstr "mostrar rutas con cambios"
 
-#: add-interactive.c:1012
+#: add-interactive.c:1016
 msgid "add working tree state to the staged set of changes"
 msgstr "agregar estado del árbol de trabajo al conjunto de cambios en stage"
 
-#: add-interactive.c:1014
+#: add-interactive.c:1018
 msgid "revert staged set of changes back to the HEAD version"
 msgstr "revertir conjunto de cambios en stage a la versión de HEAD"
 
-#: add-interactive.c:1016
+#: add-interactive.c:1020
 msgid "pick hunks and update selectively"
 msgstr "elegir fragmentos y actualizar de forma selectiva"
 
-#: add-interactive.c:1018
+#: add-interactive.c:1022
 msgid "view diff between HEAD and index"
 msgstr "ver diff entre HEAD e index"
 
-#: add-interactive.c:1020
+#: add-interactive.c:1024
 msgid "add contents of untracked files to the staged set of changes"
 msgstr ""
 "agregar contenidos de archivos sin rastrear al conjunto de cambios de stage"
 
-#: add-interactive.c:1028 add-interactive.c:1077
+#: add-interactive.c:1032 add-interactive.c:1081
 msgid "Prompt help:"
 msgstr "Mostrar ayuda:"
 
-#: add-interactive.c:1030
-msgid "select a single item"
-msgstr "selecciona un único objeto"
-
-#: add-interactive.c:1032
-msgid "select a range of items"
-msgstr "selecciona un rango de objetos"
-
 #: add-interactive.c:1034
-msgid "select multiple ranges"
-msgstr "selecciona múltiples rangos"
+msgid "select a single item"
+msgstr "seleccionar un único objeto"
 
-#: add-interactive.c:1036 add-interactive.c:1081
+#: add-interactive.c:1036
+msgid "select a range of items"
+msgstr "seleccionar un rango de objetos"
+
+#: add-interactive.c:1038
+msgid "select multiple ranges"
+msgstr "seleccionar múltiples rangos"
+
+#: add-interactive.c:1040 add-interactive.c:1085
 msgid "select item based on unique prefix"
 msgstr "seleccionar objeto basado en prefijo único"
 
-#: add-interactive.c:1038
+#: add-interactive.c:1042
 msgid "unselect specified items"
 msgstr "quitar objetos especificados"
 
-#: add-interactive.c:1040
+#: add-interactive.c:1044
 msgid "choose all items"
 msgstr "escoger todos los objetos"
 
-#: add-interactive.c:1042
+#: add-interactive.c:1046
 msgid "(empty) finish selecting"
 msgstr "(vacío) finalizar selección"
 
-#: add-interactive.c:1079
-msgid "select a numbered item"
-msgstr "selecciona un objeto numerado"
-
 #: add-interactive.c:1083
-msgid "(empty) select nothing"
-msgstr "(vacío) selecciona nada"
+msgid "select a numbered item"
+msgstr "seleccionar un objeto numerado"
 
-#: add-interactive.c:1091 builtin/clean.c:813 git-add--interactive.perl:1896
+#: add-interactive.c:1087
+msgid "(empty) select nothing"
+msgstr "(vacío) no seleccionar nada"
+
+#: add-interactive.c:1095 builtin/clean.c:813 git-add--interactive.perl:1896
 msgid "*** Commands ***"
 msgstr "*** Comandos ***"
 
-#: add-interactive.c:1092 builtin/clean.c:814 git-add--interactive.perl:1893
+#: add-interactive.c:1096 builtin/clean.c:814 git-add--interactive.perl:1893
 msgid "What now"
 msgstr "Ahora qué"
 
-#: add-interactive.c:1144 git-add--interactive.perl:213
+#: add-interactive.c:1148 git-add--interactive.perl:213
 msgid "staged"
 msgstr "rastreado"
 
-#: add-interactive.c:1144 git-add--interactive.perl:213
+#: add-interactive.c:1148 git-add--interactive.perl:213
 msgid "unstaged"
 msgstr "no rastreado"
 
-#: add-interactive.c:1144 apply.c:4994 apply.c:4997 builtin/am.c:2309
-#: builtin/am.c:2312 builtin/bugreport.c:135 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:285 builtin/pull.c:190
-#: builtin/submodule--helper.c:410 builtin/submodule--helper.c:1886
-#: builtin/submodule--helper.c:1889 builtin/submodule--helper.c:2343
-#: builtin/submodule--helper.c:2346 builtin/submodule--helper.c:2589
-#: builtin/submodule--helper.c:2890 builtin/submodule--helper.c:2893
+#: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
+#: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
+#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:190
+#: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
+#: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
+#: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
+#: builtin/submodule--helper.c:2578 builtin/submodule--helper.c:2811
 #: git-add--interactive.perl:213
 msgid "path"
 msgstr "ruta"
 
-#: add-interactive.c:1151
+#: add-interactive.c:1155
 msgid "could not refresh index"
 msgstr "no se pudo refrescar el índice"
 
-#: add-interactive.c:1165 builtin/clean.c:778 git-add--interactive.perl:1803
+#: add-interactive.c:1169 builtin/clean.c:778 git-add--interactive.perl:1803
 #, c-format
 msgid "Bye.\n"
 msgstr "Adiós.\n"
@@ -255,8 +255,8 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "staging."
 msgstr ""
-"Si el parche aplica limpiamente, el fragmento editado será marcado inmediatamente "
-"para el área de stage."
+"Si el parche aplica limpiamente, el fragmento editado será marcado "
+"inmediatamente para el área de stage."
 
 #: add-patch.c:42
 msgid ""
@@ -298,8 +298,8 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "stashing."
 msgstr ""
-"Si el parche aplica limpiamente, el fragmento editado será marcado inmediatamente "
-"para hacer stash."
+"Si el parche aplica limpiamente, el fragmento editado será marcado "
+"inmediatamente para hacer stash."
 
 #: add-patch.c:64
 msgid ""
@@ -313,7 +313,8 @@ msgstr ""
 "n - no hacer stash a este fragmento\n"
 "q - quit; no hacer stash a este fragmento o a ninguno de los restantes\n"
 "a - hacer stash a este fragmento y a todos los posteriores en el archivo\n"
-"d - no hacer stash a este fragmento ni ninguno de los posteriores en el archivo\n"
+"d - no hacer stash a este fragmento ni ninguno de los posteriores en el "
+"archivo\n"
 
 #: add-patch.c:80 git-add--interactive.perl:1443
 #, c-format, perl-format
@@ -340,8 +341,8 @@ msgid ""
 "If the patch applies cleanly, the edited hunk will immediately be marked for "
 "unstaging."
 msgstr ""
-"Si el parche aplica limpiamente, el fragmento editado será marcado inmediatamente "
-"para sacar del área de stage."
+"Si el parche aplica limpiamente, el fragmento editado será marcado "
+"inmediatamente para sacar del área de stage."
 
 #: add-patch.c:88
 msgid ""
@@ -353,10 +354,12 @@ msgid ""
 msgstr ""
 "y - sacar desde hunk del área de stage\n"
 "n - no sacar este fragmento del area de stage\n"
-"q - quit; no sacar del area de stage este fragmento ni ninguno de los restantes\n"
-"a - sacar del area de stage este fragmento y todos los posteriores en el archivo\n"
-"d - no sacar del area de stage este fragmento ni ninguno de los posteriores en el "
+"q - quit; no sacar del area de stage este fragmento ni ninguno de los "
+"restantes\n"
+"a - sacar del area de stage este fragmento y todos los posteriores en el "
 "archivo\n"
+"d - no sacar del area de stage este fragmento ni ninguno de los posteriores "
+"en el archivo\n"
 
 #: add-patch.c:103 git-add--interactive.perl:1449
 #, c-format, perl-format
@@ -376,7 +379,7 @@ msgstr "¿Aplicar adición al índice [y,n,q,a,d%s,?]? "
 #: add-patch.c:106 git-add--interactive.perl:1452
 #, c-format, perl-format
 msgid "Apply this hunk to index [y,n,q,a,d%s,?]? "
-msgstr "¿Aplicar este fragmetno al índice [y,n,q,a,d%s,?]? "
+msgstr "¿Aplicar este fragmento al índice [y,n,q,a,d%s,?]? "
 
 #: add-patch.c:108 add-patch.c:176 add-patch.c:221
 msgid ""
@@ -502,7 +505,8 @@ msgstr "¿Aplicar adición al índice y al árbol de trabajo [y,n,q,a,d%s,?]? "
 #: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1470
 #, c-format, perl-format
 msgid "Apply this hunk to index and worktree [y,n,q,a,d%s,?]? "
-msgstr "¿Aplicar este fragmento al índice y árbol de trabajo [y,n,q,a,d,/%s,?]? "
+msgstr ""
+"¿Aplicar este fragmento al índice y árbol de trabajo [y,n,q,a,d,/%s,?]? "
 
 #: add-patch.c:179
 msgid ""
@@ -591,7 +595,7 @@ msgstr ""
 
 #: add-patch.c:1082 git-add--interactive.perl:1115
 msgid "Manual hunk edit mode -- see bottom for a quick guide.\n"
-msgstr "Modo de edición manual de hunk -- vea abajo para una guía rápida.\n"
+msgstr "Modo de edición manual de hunk -- mira abajo para una guía rápida.\n"
 
 #: add-patch.c:1086
 #, c-format
@@ -614,7 +618,8 @@ msgid ""
 "aborted and the hunk is left unchanged.\n"
 msgstr ""
 "Si esto no aplica de manera limpia, se te da la oportunidad de\n"
-"editar nuevamente. Si todas las líneas del fragmento son eliminadas, entonces\n"
+"editar nuevamente. Si todas las líneas del fragmento son eliminadas, "
+"entonces\n"
 "la edición es abortada y el fragmento queda sin cambios.\n"
 
 #: add-patch.c:1133
@@ -668,11 +673,12 @@ msgid ""
 "e - manually edit the current hunk\n"
 "? - print help\n"
 msgstr ""
-"j - deja este fragmento sin decidir, ver el siguiente fragmento sin decisión\n"
-"J - deja este fragmento sin decidir, ver siguiente fragmento \n"
-"k - deja este fragmento sin decidir, ver fragmento previo sin decidir\n"
-"K - deja este fragmento sin decidir, ver fragmento anterior\n"
-"g - selecciona un fragmento a dónde ir\n"
+"j - dejar este fragmento sin decidir, ver el siguiente fragmento sin "
+"decisión\n"
+"J - dejar este fragmento sin decidir, ver siguiente fragmento \n"
+"k - dejar este fragmento sin decidir, ver fragmento previo sin decidir\n"
+"K - dejar este fragmento sin decidir, ver fragmento anterior\n"
+"g - seleccionar un fragmento a dónde ir\n"
 "/ - buscar un fragmento que cumpla con el regex dado\n"
 "s - separar el fragmento actual en más pequeños\n"
 "e - editar manualmente el fragmento actual\n"
@@ -744,7 +750,7 @@ msgstr "Perdón, no se puede editar este pedazo"
 msgid "'git apply' failed"
 msgstr "falló 'git apply'"
 
-#: advice.c:145
+#: advice.c:78
 #, c-format
 msgid ""
 "\n"
@@ -753,38 +759,38 @@ msgstr ""
 "\n"
 "Desactivar este mensaje con \"git config advice.%s false\""
 
-#: advice.c:161
+#: advice.c:94
 #, c-format
 msgid "%shint: %.*s%s\n"
 msgstr "%sayuda: %.*s%s\n"
 
-#: advice.c:252
+#: advice.c:178
 msgid "Cherry-picking is not possible because you have unmerged files."
 msgstr ""
 "No es posible ejecutar cherry-picking porque tienes archivos sin fusionar."
 
-#: advice.c:254
+#: advice.c:180
 msgid "Committing is not possible because you have unmerged files."
 msgstr "No es posible realizar un commit porque tienes archivos sin fusionar."
 
-#: advice.c:256
+#: advice.c:182
 msgid "Merging is not possible because you have unmerged files."
 msgstr "No es posible hacer merge porque tienes archivos sin fusionar."
 
-#: advice.c:258
+#: advice.c:184
 msgid "Pulling is not possible because you have unmerged files."
 msgstr "No es posible hacer pull porque tienes archivos sin fusionar."
 
-#: advice.c:260
+#: advice.c:186
 msgid "Reverting is not possible because you have unmerged files."
 msgstr "No es posible revertir porque tienes archivos sin fusionar."
 
-#: advice.c:262
+#: advice.c:188
 #, c-format
 msgid "It is not possible to %s because you have unmerged files."
 msgstr "No es posible %s porque tienes archivos sin fusionar."
 
-#: advice.c:270
+#: advice.c:196
 msgid ""
 "Fix them up in the work tree, and then use 'git add/rm <file>'\n"
 "as appropriate to mark resolution and make a commit."
@@ -792,41 +798,48 @@ msgstr ""
 "Corrígelos en el árbol de trabajo y entonces usa 'git add/rm <archivo>',\n"
 "como sea apropiado, para marcar la resolución y realizar un commit."
 
-#: advice.c:278
+#: advice.c:204
 msgid "Exiting because of an unresolved conflict."
 msgstr "Saliendo porque existe un conflicto sin resolver."
 
-#: advice.c:283 builtin/merge.c:1375
+#: advice.c:209 builtin/merge.c:1379
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "No has concluido tu fusión (MERGE_HEAD existe)."
 
-#: advice.c:285
+#: advice.c:211
 msgid "Please, commit your changes before merging."
 msgstr "Por favor, realiza un commit antes de fusionar."
 
-#: advice.c:286
+#: advice.c:212
 msgid "Exiting because of unfinished merge."
 msgstr "Saliendo por una fusión inconclusa."
 
-#: advice.c:296
+#: advice.c:217
+msgid "Not possible to fast-forward, aborting."
+msgstr "No es posible hacer fast-forward, abortando."
+
+#: advice.c:227
 #, c-format
 msgid ""
-"The following pathspecs didn't match any eligible path, but they do match "
-"index\n"
-"entries outside the current sparse checkout:\n"
+"The following paths and/or pathspecs matched paths that exist\n"
+"outside of your sparse-checkout definition, so will not be\n"
+"updated in the index:\n"
 msgstr ""
-"El siguiente pathspecs no concuerda con ninguna ruta elegible, pero "
-"concuerda con\n"
-"entradas del índice fuera del checkout sparse actual:\n"
+"La siguiente ruta y/o pathspecs coinciden con rutas existentes\n"
+"fuera de su definición para sparse-checkout, por lo que no\n"
+"se actualizarán en el índice:\n"
 
-#: advice.c:303
+#: advice.c:234
 msgid ""
-"Disable or modify the sparsity rules if you intend to update such entries."
+"If you intend to update such entries, try one of the following:\n"
+"* Use the --sparse option.\n"
+"* Disable or modify the sparsity rules."
 msgstr ""
-"Deshabilitar  o modificar las reglas de escasez si intenta actualizar dichas "
-"entradas."
+"Si desea actualizar esa entrada, intente lo siguiente:\n"
+"* Use la opción --sparse.\n"
+"* Deshabilite o modifique las reglas de escasez."
 
-#: advice.c:310
+#: advice.c:242
 #, c-format
 msgid ""
 "Note: switching to '%s'.\n"
@@ -1015,49 +1028,49 @@ msgstr "el archivo borrado %s todavía tiene contenido"
 msgid "** warning: file %s becomes empty but is not deleted"
 msgstr "** peligro: el archivo %s está vacío pero no es borrado"
 
-#: apply.c:1977
+#: apply.c:1978
 #, c-format
 msgid "corrupt binary patch at line %d: %.*s"
 msgstr "parche binario corrupto en la línea %d: %.*s"
 
-#: apply.c:2014
+#: apply.c:2015
 #, c-format
 msgid "unrecognized binary patch at line %d"
 msgstr "parche binario no reconocido en la línea %d"
 
-#: apply.c:2176
+#: apply.c:2177
 #, c-format
 msgid "patch with only garbage at line %d"
 msgstr "parche que solo contiene basura en la línea %d"
 
-#: apply.c:2262
+#: apply.c:2263
 #, c-format
 msgid "unable to read symlink %s"
 msgstr "no es posible leer el enlace simbólico %s"
 
-#: apply.c:2266
+#: apply.c:2267
 #, c-format
 msgid "unable to open or read %s"
 msgstr "no es posible abrir o leer %s"
 
-#: apply.c:2935
+#: apply.c:2936
 #, c-format
 msgid "invalid start of line: '%c'"
 msgstr "comienzo inválido de línea: '%c'"
 
-#: apply.c:3056
+#: apply.c:3057
 #, c-format
 msgid "Hunk #%d succeeded at %d (offset %d line)."
 msgid_plural "Hunk #%d succeeded at %d (offset %d lines)."
 msgstr[0] "Hunk #%d tuvo éxito en %d (%d línea compensada)."
 msgstr[1] "Hunk #%d tuvo éxito en %d (%d líneas compensadas)."
 
-#: apply.c:3068
+#: apply.c:3069
 #, c-format
 msgid "Context reduced to (%ld/%ld) to apply fragment at %d"
 msgstr "Contexto reducido a (%ld/%ld) para aplicar el fragmento en %d"
 
-#: apply.c:3074
+#: apply.c:3075
 #, c-format
 msgid ""
 "while searching for:\n"
@@ -1066,23 +1079,24 @@ msgstr ""
 "mientras se buscaba:\n"
 "%.*s"
 
-#: apply.c:3096
+#: apply.c:3097
 #, c-format
 msgid "missing binary patch data for '%s'"
 msgstr "data perdida en parche binario para '%s'"
 
-#: apply.c:3104
+#: apply.c:3105
 #, c-format
 msgid "cannot reverse-apply a binary patch without the reverse hunk to '%s'"
 msgstr ""
-"no se puede revertir-aplicar un parche binario sin el fragmento revertido a '%s'"
+"no se puede revertir-aplicar un parche binario sin el fragmento revertido a "
+"'%s'"
 
-#: apply.c:3151
+#: apply.c:3152
 #, c-format
 msgid "cannot apply binary patch to '%s' without full index line"
 msgstr "no se puede aplicar el parche binario a '%s' sin un índice completo"
 
-#: apply.c:3162
+#: apply.c:3163
 #, c-format
 msgid ""
 "the patch applies to '%s' (%s), which does not match the current contents."
@@ -1090,289 +1104,290 @@ msgstr ""
 "el parche aplica a '%s' (%s), lo cual no concuerda con los contenidos "
 "actuales."
 
-#: apply.c:3170
+#: apply.c:3171
 #, c-format
 msgid "the patch applies to an empty '%s' but it is not empty"
 msgstr "el parche aplica a un '%s' vacío, pero este no lo esta"
 
-#: apply.c:3188
+#: apply.c:3189
 #, c-format
 msgid "the necessary postimage %s for '%s' cannot be read"
 msgstr "la postimagen necesaria %s para '%s' no se puede leer"
 
-#: apply.c:3201
+#: apply.c:3202
 #, c-format
 msgid "binary patch does not apply to '%s'"
 msgstr "el parche binario no aplica para '%s'"
 
-#: apply.c:3208
+#: apply.c:3209
 #, c-format
 msgid "binary patch to '%s' creates incorrect result (expecting %s, got %s)"
 msgstr ""
 "el parche binario para '%s' crea un resultado incorrecto (esperando %s, se "
 "obtuvo %s)"
 
-#: apply.c:3229
+#: apply.c:3230
 #, c-format
 msgid "patch failed: %s:%ld"
 msgstr "el parche falló: %s:%ld"
 
-#: apply.c:3352
+#: apply.c:3353
 #, c-format
 msgid "cannot checkout %s"
 msgstr "no se puede hacer checkout a %s"
 
-#: apply.c:3404 apply.c:3415 apply.c:3461 midx.c:98 pack-revindex.c:214
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:102 pack-revindex.c:214
 #: setup.c:308
 #, c-format
 msgid "failed to read %s"
 msgstr "no se pudo leer %s"
 
-#: apply.c:3412
+#: apply.c:3413
 #, c-format
 msgid "reading from '%s' beyond a symbolic link"
 msgstr "leyendo de '%s' tras un enlace simbólico"
 
-#: apply.c:3441 apply.c:3687
+#: apply.c:3442 apply.c:3709
 #, c-format
 msgid "path %s has been renamed/deleted"
 msgstr "la ruta %s ha sido renombrada/suprimida"
 
-#: apply.c:3527 apply.c:3702
+#: apply.c:3549 apply.c:3724
 #, c-format
 msgid "%s: does not exist in index"
 msgstr "%s: no existe en el índice"
 
-#: apply.c:3536 apply.c:3710 apply.c:3954
+#: apply.c:3558 apply.c:3732 apply.c:3976
 #, c-format
 msgid "%s: does not match index"
 msgstr "%s: no concuerda con el índice"
 
-#: apply.c:3571
+#: apply.c:3593
 msgid "repository lacks the necessary blob to perform 3-way merge."
 msgstr ""
 "el repositorio carece del blob necesario para realizar un merge de tres vías."
 
-#: apply.c:3574
+#: apply.c:3596
 #, c-format
 msgid "Performing three-way merge...\n"
 msgstr "Realizando un merge de tres vías...\n"
 
-#: apply.c:3590 apply.c:3594
+#: apply.c:3612 apply.c:3616
 #, c-format
 msgid "cannot read the current contents of '%s'"
 msgstr "no se pueden leer los contenidos actuales de '%s'"
 
-#: apply.c:3606
+#: apply.c:3628
 #, c-format
 msgid "Failed to perform three-way merge...\n"
 msgstr "Falló en realizar fusión de tres vías...\n"
 
-#: apply.c:3620
+#: apply.c:3642
 #, c-format
 msgid "Applied patch to '%s' with conflicts.\n"
 msgstr "Parche aplicado a '%s' con conflictos.\n"
 
-#: apply.c:3625
+#: apply.c:3647
 #, c-format
 msgid "Applied patch to '%s' cleanly.\n"
 msgstr "Parche aplicado a '%s' limpiamente\n"
 
-#: apply.c:3642
+#: apply.c:3664
 #, c-format
 msgid "Falling back to direct application...\n"
 msgstr "Retrocediendo a la aplicación...\n"
 
-#: apply.c:3654
+#: apply.c:3676
 msgid "removal patch leaves file contents"
 msgstr "parche de eliminación deja contenidos en el archivo"
 
-#: apply.c:3727
+#: apply.c:3749
 #, c-format
 msgid "%s: wrong type"
 msgstr "%s: tipo incorrecto"
 
-#: apply.c:3729
+#: apply.c:3751
 #, c-format
 msgid "%s has type %o, expected %o"
 msgstr "%s tiene tipo %o, se esperaba %o"
 
-#: apply.c:3894 apply.c:3896 read-cache.c:863 read-cache.c:892
-#: read-cache.c:1353
+#: apply.c:3916 apply.c:3918 read-cache.c:876 read-cache.c:905
+#: read-cache.c:1368
 #, c-format
 msgid "invalid path '%s'"
 msgstr "ruta inválida '%s'"
 
-#: apply.c:3952
+#: apply.c:3974
 #, c-format
 msgid "%s: already exists in index"
 msgstr "%s: ya existe en el índice"
 
-#: apply.c:3956
+#: apply.c:3978
 #, c-format
 msgid "%s: already exists in working directory"
 msgstr "%s: ya existe en el directorio de trabajo"
 
-#: apply.c:3976
+#: apply.c:3998
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
 msgstr "nuevo modo (%o) de %s no concuerda con el viejo modo (%o)"
 
-#: apply.c:3981
+#: apply.c:4003
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
 msgstr "nuevo modo (%o) de %s no concuerda con el viejo modo (%o) de %s"
 
-#: apply.c:4001
+#: apply.c:4023
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
 msgstr "archivo afectado '%s' está tras un enlace simbólico"
 
-#: apply.c:4005
+#: apply.c:4027
 #, c-format
 msgid "%s: patch does not apply"
 msgstr "%s: el parche no aplica"
 
-#: apply.c:4020
+#: apply.c:4042
 #, c-format
 msgid "Checking patch %s..."
 msgstr "Revisando el parche %s..."
 
-#: apply.c:4112
+#: apply.c:4134
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
 msgstr "falta información del sha1 o es inútil para el submódulo %s"
 
-#: apply.c:4119
+#: apply.c:4141
 #, c-format
 msgid "mode change for %s, which is not in current HEAD"
 msgstr "modo cambiado para %s, el cual no se encuentra en el HEAD actual"
 
-#: apply.c:4122
+#: apply.c:4144
 #, c-format
 msgid "sha1 information is lacking or useless (%s)."
 msgstr "falta información sha1 o es inútil (%s)."
 
-#: apply.c:4131
+#: apply.c:4153
 #, c-format
 msgid "could not add %s to temporary index"
 msgstr "no se pudo añadir %s al índice temporal"
 
-#: apply.c:4141
+#: apply.c:4163
 #, c-format
 msgid "could not write temporary index to %s"
 msgstr "no se pudo escribir un índice temporal para %s"
 
-#: apply.c:4279
+#: apply.c:4301
 #, c-format
 msgid "unable to remove %s from index"
 msgstr "no se puede eliminar %s del índice"
 
-#: apply.c:4313
+#: apply.c:4335
 #, c-format
 msgid "corrupt patch for submodule %s"
 msgstr "parche corrupto para el submódulo %s"
 
-#: apply.c:4319
+#: apply.c:4341
 #, c-format
 msgid "unable to stat newly created file '%s'"
 msgstr "no es posible hacer stat en el archivo recién creado '%s'"
 
-#: apply.c:4327
+#: apply.c:4349
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr ""
 "no es posible crear una copia de seguridad para el archivo recién creado %s"
 
-#: apply.c:4333 apply.c:4478
+#: apply.c:4355 apply.c:4500
 #, c-format
 msgid "unable to add cache entry for %s"
 msgstr "no es posible agregar una entrada en el cache para %s"
 
-#: apply.c:4376 builtin/bisect--helper.c:525
+#: apply.c:4398 builtin/bisect--helper.c:540 builtin/gc.c:2241
+#: builtin/gc.c:2276
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "falló escribir a '%s'"
 
-#: apply.c:4380
+#: apply.c:4402
 #, c-format
 msgid "closing file '%s'"
 msgstr "cerrando archivo '%s'"
 
-#: apply.c:4450
+#: apply.c:4472
 #, c-format
 msgid "unable to write file '%s' mode %o"
 msgstr "no es posible escribir el archivo '%s' modo %o"
 
-#: apply.c:4548
+#: apply.c:4570
 #, c-format
 msgid "Applied patch %s cleanly."
 msgstr "Parche %s aplicado limpiamente."
 
-#: apply.c:4556
+#: apply.c:4578
 msgid "internal error"
 msgstr "error interno"
 
-#: apply.c:4559
+#: apply.c:4581
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
 msgstr[0] "Aplicando parche %%s con %d rechazo..."
 msgstr[1] "Aplicando parche %%s con %d rechazos..."
 
-#: apply.c:4570
+#: apply.c:4592
 #, c-format
 msgid "truncating .rej filename to %.*s.rej"
 msgstr "truncando el nombre de archivo .rej a %.*s.rej"
 
-#: apply.c:4578 builtin/fetch.c:993 builtin/fetch.c:1394
+#: apply.c:4600 builtin/fetch.c:998 builtin/fetch.c:1408
 #, c-format
 msgid "cannot open %s"
 msgstr "no se puede abrir %s"
 
-#: apply.c:4592
+#: apply.c:4614
 #, c-format
 msgid "Hunk #%d applied cleanly."
 msgstr "Hunk #%d aplicado limpiamente."
 
-#: apply.c:4596
+#: apply.c:4618
 #, c-format
 msgid "Rejected hunk #%d."
 msgstr "Hunk #%d rechazado."
 
-#: apply.c:4725
+#: apply.c:4747
 #, c-format
 msgid "Skipped patch '%s'."
 msgstr "Parche '%s' saltado."
 
-#: apply.c:4733
+#: apply.c:4755
 msgid "unrecognized input"
 msgstr "input no reconocido"
 
-#: apply.c:4753
+#: apply.c:4775
 msgid "unable to read index file"
 msgstr "no es posible leer el archivo índice"
 
-#: apply.c:4910
+#: apply.c:4932
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr "no se puede abrir el parche '%s': %s"
 
-#: apply.c:4937
+#: apply.c:4959
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "%d error de espacios en blanco silenciado"
 msgstr[1] "%d errores de espacios en blanco silenciados"
 
-#: apply.c:4943 apply.c:4958
+#: apply.c:4965 apply.c:4980
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] "%d línea agrega errores de espacios en blanco."
 msgstr[1] "%d líneas agregan errores de espacios en blanco."
 
-#: apply.c:4951
+#: apply.c:4973
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
@@ -1381,139 +1396,139 @@ msgstr[0] ""
 msgstr[1] ""
 "%d líneas aplicadas después de arreglar los errores de espacios en blanco."
 
-#: apply.c:4967 builtin/add.c:678 builtin/mv.c:304 builtin/rm.c:423
+#: apply.c:4989 builtin/add.c:707 builtin/mv.c:338 builtin/rm.c:429
 msgid "Unable to write new index file"
 msgstr "No es posible escribir el archivo índice"
 
-#: apply.c:4995
+#: apply.c:5017
 msgid "don't apply changes matching the given path"
 msgstr "no aplicar cambios que concuerden con la ruta suministrada"
 
-#: apply.c:4998
+#: apply.c:5020
 msgid "apply changes matching the given path"
 msgstr "aplicar cambios que concuerden con la ruta suministrada"
 
-#: apply.c:5000 builtin/am.c:2318
+#: apply.c:5022 builtin/am.c:2320
 msgid "num"
 msgstr "num"
 
-#: apply.c:5001
+#: apply.c:5023
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr "eliminar <num> slashes iniciales de las rutas diff tradicionales"
 
-#: apply.c:5004
+#: apply.c:5026
 msgid "ignore additions made by the patch"
 msgstr "ignorar adiciones hechas por el parche"
 
-#: apply.c:5006
+#: apply.c:5028
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr "en lugar de aplicar el parche, mostrar diffstat para la entrada"
 
-#: apply.c:5010
+#: apply.c:5032
 msgid "show number of added and deleted lines in decimal notation"
 msgstr "mostrar el número de líneas agregadas y eliminadas en notación decimal"
 
-#: apply.c:5012
+#: apply.c:5034
 msgid "instead of applying the patch, output a summary for the input"
 msgstr "en lugar de aplicar el parche, mostrar un resumen para la entrada"
 
-#: apply.c:5014
+#: apply.c:5036
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr "en lugar de aplicar el parche, ver si el parche es aplicable"
 
-#: apply.c:5016
+#: apply.c:5038
 msgid "make sure the patch is applicable to the current index"
 msgstr "asegurar que el parche sea aplicable al índice actual"
 
-#: apply.c:5018
+#: apply.c:5040
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "marca los nuevos archivos con `git add --intent-to-add`"
 
-#: apply.c:5020
+#: apply.c:5042
 msgid "apply a patch without touching the working tree"
 msgstr "aplicar un parche sin tocar el árbol de trabajo"
 
-#: apply.c:5022
+#: apply.c:5044
 msgid "accept a patch that touches outside the working area"
 msgstr "aceptar un parche que toque fuera del área de trabajo"
 
-#: apply.c:5025
+#: apply.c:5047
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr "también aplicar el parche (usar con --stat/--summary/--check)"
 
-#: apply.c:5027
+#: apply.c:5049
 msgid "attempt three-way merge, fall back on normal patch if that fails"
 msgstr ""
 "intentar merge de tres vías, regresar al parche normal si el parche no aplica"
 
-#: apply.c:5029
+#: apply.c:5051
 msgid "build a temporary index based on embedded index information"
 msgstr ""
 "construir un índice temporal basado en la información de índice incrustada"
 
-#: apply.c:5032 builtin/checkout-index.c:196 builtin/ls-files.c:617
+#: apply.c:5054 builtin/checkout-index.c:196
 msgid "paths are separated with NUL character"
 msgstr "rutas están separadas con un carácter NULL"
 
-#: apply.c:5034
+#: apply.c:5056
 msgid "ensure at least <n> lines of context match"
 msgstr "asegurar que al menos <n> líneas del contexto concuerden"
 
-#: apply.c:5035 builtin/am.c:2294 builtin/am.c:2297
+#: apply.c:5057 builtin/am.c:2296 builtin/am.c:2299
 #: builtin/interpret-trailers.c:98 builtin/interpret-trailers.c:100
-#: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3991
-#: builtin/rebase.c:1347
+#: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3960
+#: builtin/rebase.c:1051
 msgid "action"
 msgstr "acción"
 
-#: apply.c:5036
+#: apply.c:5058
 msgid "detect new or modified lines that have whitespace errors"
 msgstr ""
 "detectar líneas nuevas o modificadas que contienen errores de espacios en "
 "blanco"
 
-#: apply.c:5039 apply.c:5042
+#: apply.c:5061 apply.c:5064
 msgid "ignore changes in whitespace when finding context"
 msgstr ""
 "ignorar cambios en los espacios en blanco cuando se encuentra el contexto"
 
-#: apply.c:5045
+#: apply.c:5067
 msgid "apply the patch in reverse"
 msgstr "aplicar el parche en reversa"
 
-#: apply.c:5047
+#: apply.c:5069
 msgid "don't expect at least one line of context"
 msgstr "no espera al menos una línea del contexto"
 
-#: apply.c:5049
+#: apply.c:5071
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr "dejar los hunks rechazados en los archivos *.rej correspontientes"
 
-#: apply.c:5051
+#: apply.c:5073
 msgid "allow overlapping hunks"
 msgstr "permitir solapamiento de hunks"
 
-#: apply.c:5052 builtin/add.c:364 builtin/check-ignore.c:22
-#: builtin/commit.c:1481 builtin/count-objects.c:98 builtin/fsck.c:756
-#: builtin/log.c:2297 builtin/mv.c:123 builtin/read-tree.c:128
+#: apply.c:5074 builtin/add.c:372 builtin/check-ignore.c:22
+#: builtin/commit.c:1483 builtin/count-objects.c:98 builtin/fsck.c:788
+#: builtin/log.c:2297 builtin/mv.c:123 builtin/read-tree.c:120
 msgid "be verbose"
 msgstr "ser verboso"
 
-#: apply.c:5054
+#: apply.c:5076
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr ""
 "tolerar nuevas líneas faltantes detectadas incorrectamente al final del "
 "archivo"
 
-#: apply.c:5057
+#: apply.c:5079
 msgid "do not trust the line counts in the hunk headers"
 msgstr "no confiar en el conteo de líneas en los headers del fragmento"
 
-#: apply.c:5059 builtin/am.c:2306
+#: apply.c:5081 builtin/am.c:2308
 msgid "root"
 msgstr "raíz"
 
-#: apply.c:5060
+#: apply.c:5082
 msgid "prepend <root> to all filenames"
 msgstr "anteponer <root> a todos los nombres de archivos"
 
@@ -1585,152 +1600,151 @@ msgstr "git archive --remote <repo> [--exec <comando>] --list"
 msgid "cannot read %s"
 msgstr "no se puede leer %s"
 
-#: archive.c:342 sequencer.c:460 sequencer.c:1915 sequencer.c:3095
-#: sequencer.c:3537 sequencer.c:3665 builtin/am.c:262 builtin/commit.c:833
-#: builtin/merge.c:1144
+#: archive.c:341 sequencer.c:473 sequencer.c:1932 sequencer.c:3114
+#: sequencer.c:3556 sequencer.c:3684 builtin/am.c:263 builtin/commit.c:834
+#: builtin/merge.c:1145
 #, c-format
 msgid "could not read '%s'"
 msgstr "no se pudo leer '%s'"
 
-#: archive.c:427 builtin/add.c:205 builtin/add.c:645 builtin/rm.c:328
+#: archive.c:426 builtin/add.c:215 builtin/add.c:674 builtin/rm.c:334
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "ruta especificada '%s' no concordó con ningún archivo"
 
-#: archive.c:451
+#: archive.c:450
 #, c-format
 msgid "no such ref: %.*s"
 msgstr "no existe el ref: %.*s"
 
-#: archive.c:457
+#: archive.c:456
 #, c-format
 msgid "not a valid object name: %s"
 msgstr "nombre de objeto no válido: %s"
 
-#: archive.c:470
+#: archive.c:469
 #, c-format
 msgid "not a tree object: %s"
 msgstr "no es un objeto tree: %s"
 
-#: archive.c:482
+#: archive.c:481
 msgid "current working directory is untracked"
 msgstr "directorio de trabajo actual no rastreado"
 
-#: archive.c:523
+#: archive.c:522
 #, c-format
 msgid "File not found: %s"
 msgstr "Archivo no encontrado: %s"
 
-#: archive.c:525
+#: archive.c:524
 #, c-format
 msgid "Not a regular file: %s"
 msgstr "No es un archivo regular: %s"
 
-#: archive.c:552
+#: archive.c:551
 msgid "fmt"
 msgstr "fmt"
 
-#: archive.c:552
+#: archive.c:551
 msgid "archive format"
 msgstr "formato de crónica"
 
-#: archive.c:553 builtin/log.c:1775
+#: archive.c:552 builtin/log.c:1775
 msgid "prefix"
 msgstr "prefijo"
 
-#: archive.c:554
+#: archive.c:553
 msgid "prepend prefix to each pathname in the archive"
 msgstr "anteponer prefijo a cada ruta en la crónica"
 
-#: archive.c:555 archive.c:558 builtin/blame.c:884 builtin/blame.c:888
-#: builtin/blame.c:889 builtin/commit-tree.c:117 builtin/config.c:135
-#: builtin/fast-export.c:1207 builtin/fast-export.c:1209
-#: builtin/fast-export.c:1213 builtin/grep.c:921 builtin/hash-object.c:105
-#: builtin/ls-files.c:653 builtin/ls-files.c:656 builtin/notes.c:412
-#: builtin/notes.c:578 builtin/read-tree.c:123 parse-options.h:191
+#: archive.c:554 archive.c:557 builtin/blame.c:880 builtin/blame.c:884
+#: builtin/blame.c:885 builtin/commit-tree.c:115 builtin/config.c:135
+#: builtin/fast-export.c:1208 builtin/fast-export.c:1210
+#: builtin/fast-export.c:1214 builtin/grep.c:935 builtin/hash-object.c:103
+#: builtin/ls-files.c:651 builtin/ls-files.c:654 builtin/notes.c:410
+#: builtin/notes.c:576 builtin/read-tree.c:115 parse-options.h:190
 msgid "file"
 msgstr "archivo"
 
-#: archive.c:556
+#: archive.c:555
 msgid "add untracked file to archive"
 msgstr "incluir archivos sin seguimiento a la crónica"
 
-#: archive.c:559 builtin/archive.c:90
+#: archive.c:558 builtin/archive.c:88
 msgid "write the archive to this file"
 msgstr "escribe la crónica en este archivo"
 
-#: archive.c:561
+#: archive.c:560
 msgid "read .gitattributes in working directory"
 msgstr "leer .gitattributes en el directorio de trabajo"
 
-#: archive.c:562
+#: archive.c:561
 msgid "report archived files on stderr"
 msgstr "reportar archivos en la crónica por stderr"
 
-#: archive.c:564
+#: archive.c:563
 msgid "set compression level"
 msgstr "configurar nivel de compresión"
 
-#: archive.c:567
+#: archive.c:566
 msgid "list supported archive formats"
 msgstr "listar los formatos de crónica soportados"
 
-#: archive.c:569 builtin/archive.c:91 builtin/clone.c:118 builtin/clone.c:121
-#: builtin/submodule--helper.c:1898 builtin/submodule--helper.c:2352
-#: builtin/submodule--helper.c:2902
+#: archive.c:568 builtin/archive.c:89 builtin/clone.c:118 builtin/clone.c:121
+#: builtin/submodule--helper.c:1869 builtin/submodule--helper.c:2512
 msgid "repo"
 msgstr "repo"
 
-#: archive.c:570 builtin/archive.c:92
+#: archive.c:569 builtin/archive.c:90
 msgid "retrieve the archive from remote repository <repo>"
 msgstr "obtener la crónica del repositorio remoto <repo>"
 
-#: archive.c:571 builtin/archive.c:93 builtin/difftool.c:717
-#: builtin/notes.c:498
+#: archive.c:570 builtin/archive.c:91 builtin/difftool.c:714
+#: builtin/notes.c:496
 msgid "command"
 msgstr "comando"
 
-#: archive.c:572 builtin/archive.c:94
+#: archive.c:571 builtin/archive.c:92
 msgid "path to the remote git-upload-archive command"
 msgstr "ruta para el comando git-upload-archive remoto"
 
-#: archive.c:579
+#: archive.c:578
 msgid "Unexpected option --remote"
 msgstr "Opción inesperada --remote"
 
-#: archive.c:581
+#: archive.c:580
 msgid "Option --exec can only be used together with --remote"
 msgstr "Opción --exec solo puede ser utilizada con --remote"
 
-#: archive.c:583
+#: archive.c:582
 msgid "Unexpected option --output"
 msgstr "Opción inesperada --output"
 
-#: archive.c:585
+#: archive.c:584
 msgid "Options --add-file and --remote cannot be used together"
 msgstr "Opciones --add-file y --remote no pueden ser usadas juntas"
 
-#: archive.c:607
+#: archive.c:606
 #, c-format
 msgid "Unknown archive format '%s'"
 msgstr "Formato de crónica desconocido '%s'"
 
-#: archive.c:616
+#: archive.c:615
 #, c-format
 msgid "Argument not supported for format '%s': -%d"
 msgstr "Argumento no soportado para formato '%s': -%d"
 
-#: attr.c:202
+#: attr.c:203
 #, c-format
 msgid "%.*s is not a valid attribute name"
 msgstr "%.*s no es un nombre de atributo válido"
 
-#: attr.c:363
+#: attr.c:364
 #, c-format
 msgid "%s not allowed: %s:%d"
 msgstr "%s no permitido: %s:%d"
 
-#: attr.c:403
+#: attr.c:404
 msgid ""
 "Negative patterns are ignored in git attributes\n"
 "Use '\\!' for literal leading exclamation."
@@ -1738,22 +1752,22 @@ msgstr ""
 "Los patrones negativos son ignorados en los atributos de git\n"
 "Usa '\\!' para comenzar literalmente con exclamación."
 
-#: bisect.c:489
+#: bisect.c:488
 #, c-format
 msgid "Badly quoted content in file '%s': %s"
 msgstr "Revisa las comillas en el archivo '%s': %s"
 
-#: bisect.c:699
+#: bisect.c:698
 #, c-format
 msgid "We cannot bisect more!\n"
 msgstr "¡No podemos biseccionar más!\n"
 
-#: bisect.c:766
+#: bisect.c:764
 #, c-format
 msgid "Not a valid commit name %s"
 msgstr "No es un nombre de commit válido %s"
 
-#: bisect.c:791
+#: bisect.c:789
 #, c-format
 msgid ""
 "The merge base %s is bad.\n"
@@ -1762,7 +1776,7 @@ msgstr ""
 "La base de fusión %s está mal.\n"
 "Esto quiere decir que el bug ha sido corregido entre %s y [%s].\n"
 
-#: bisect.c:796
+#: bisect.c:794
 #, c-format
 msgid ""
 "The merge base %s is new.\n"
@@ -1771,7 +1785,7 @@ msgstr ""
 "La base de fusión %s es nueva.\n"
 "Esta propiedad ha cambiado entre %s y [%s].\n"
 
-#: bisect.c:801
+#: bisect.c:799
 #, c-format
 msgid ""
 "The merge base %s is %s.\n"
@@ -1780,7 +1794,7 @@ msgstr ""
 "La base de fusión %s es %s.\n"
 "Esto quiere decir que el primer '%s' commit está entre %s y [%s].\n"
 
-#: bisect.c:809
+#: bisect.c:807
 #, c-format
 msgid ""
 "Some %s revs are not ancestors of the %s rev.\n"
@@ -1791,7 +1805,7 @@ msgstr ""
 "git bisect no puede trabajar bien en este caso.\n"
 "¿Tal vez confundiste las revisiones %s y %s?\n"
 
-#: bisect.c:822
+#: bisect.c:820
 #, c-format
 msgid ""
 "the merge base between %s and [%s] must be skipped.\n"
@@ -1803,36 +1817,36 @@ msgstr ""
 "%s.\n"
 "Vamos a continuar de todas maneras."
 
-#: bisect.c:861
+#: bisect.c:859
 #, c-format
 msgid "Bisecting: a merge base must be tested\n"
 msgstr "Biseccionando: una base de fusión debe ser probada\n"
 
-#: bisect.c:911
+#: bisect.c:909
 #, c-format
 msgid "a %s revision is needed"
 msgstr "una revisión %s es necesaria"
 
-#: bisect.c:941 builtin/notes.c:177 builtin/tag.c:298
+#: bisect.c:939
 #, c-format
 msgid "could not create file '%s'"
 msgstr "no se pudo crear el archivo '%s'"
 
-#: bisect.c:987 builtin/merge.c:153
+#: bisect.c:985 builtin/merge.c:154
 #, c-format
 msgid "could not read file '%s'"
 msgstr "no se pudo leer el archivo '%s'"
 
-#: bisect.c:1027
+#: bisect.c:1025
 msgid "reading bisect refs failed"
 msgstr "falló leer las refs de bisect"
 
-#: bisect.c:1057
+#: bisect.c:1055
 #, c-format
 msgid "%s was both %s and %s\n"
 msgstr "%s fue tanto %s como %s\n"
 
-#: bisect.c:1066
+#: bisect.c:1064
 #, c-format
 msgid ""
 "No testable commit found.\n"
@@ -1841,7 +1855,7 @@ msgstr ""
 "No se encontró commit que se pueda probar.\n"
 "¿Quizás iniciaste con parámetros de rutas incorrectos?\n"
 
-#: bisect.c:1095
+#: bisect.c:1093
 #, c-format
 msgid "(roughly %d step)"
 msgid_plural "(roughly %d steps)"
@@ -1851,7 +1865,7 @@ msgstr[1] "(aproximadamente %d pasos)"
 #. TRANSLATORS: the last %s will be replaced with "(roughly %d
 #. steps)" translation.
 #.
-#: bisect.c:1101
+#: bisect.c:1099
 #, c-format
 msgid "Bisecting: %d revision left to test after this %s\n"
 msgid_plural "Bisecting: %d revisions left to test after this %s\n"
@@ -1871,11 +1885,12 @@ msgid "--reverse and --first-parent together require specified latest commit"
 msgstr ""
 "--reverse y --first-parent juntos requieren especificar el último commit"
 
-#: blame.c:2820 bundle.c:224 ref-filter.c:2278 remote.c:2041 sequencer.c:2333
-#: sequencer.c:4865 submodule.c:844 builtin/commit.c:1113 builtin/log.c:414
-#: builtin/log.c:1021 builtin/log.c:1629 builtin/log.c:2056 builtin/log.c:2346
-#: builtin/merge.c:428 builtin/pack-objects.c:3343 builtin/pack-objects.c:3806
-#: builtin/pack-objects.c:3821 builtin/shortlog.c:255
+#: blame.c:2820 bundle.c:224 midx.c:1039 ref-filter.c:2370 remote.c:2041
+#: sequencer.c:2350 sequencer.c:4902 submodule.c:883 builtin/commit.c:1114
+#: builtin/log.c:414 builtin/log.c:1021 builtin/log.c:1629 builtin/log.c:2056
+#: builtin/log.c:2346 builtin/merge.c:429 builtin/pack-objects.c:3373
+#: builtin/pack-objects.c:3775 builtin/pack-objects.c:3790
+#: builtin/shortlog.c:255
 msgid "revision walk setup failed"
 msgstr "falló la configuración del recorrido de revisiones"
 
@@ -2065,8 +2080,8 @@ msgstr "'%s' no se ve como un archivo bundle v2 o v3"
 msgid "unrecognized header: %s%s (%d)"
 msgstr "header no reconocido %s%s (%d)"
 
-#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2593 sequencer.c:3385
-#: builtin/commit.c:861
+#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2618 sequencer.c:3404
+#: builtin/commit.c:862
 #, c-format
 msgid "could not open '%s'"
 msgstr "no se pudo abrir '%s'"
@@ -2124,7 +2139,7 @@ msgstr "versión de bundle no soportada %d"
 msgid "cannot write bundle version %d with algorithm %s"
 msgstr "no se puede escribir la versión de paquete %d con el algoritmo %s"
 
-#: bundle.c:524 builtin/log.c:210 builtin/log.c:1938 builtin/shortlog.c:396
+#: bundle.c:524 builtin/log.c:210 builtin/log.c:1938 builtin/shortlog.c:399
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr "argumento no reconocido: %s"
@@ -2166,7 +2181,7 @@ msgstr "chunk final tiene un id distinto de cero %<PRIx32>"
 msgid "invalid color value: %.*s"
 msgstr "color inválido: %.*s"
 
-#: commit-graph.c:204 midx.c:47
+#: commit-graph.c:204 midx.c:51
 msgid "invalid hash version"
 msgstr "versión de hash inválida"
 
@@ -2211,192 +2226,192 @@ msgstr "cadena de commit-graph inválida: línea '%s' no es un hash"
 msgid "unable to find all commit-graph files"
 msgstr "no es posible encontrar los archivos commit-graph"
 
-#: commit-graph.c:745 commit-graph.c:782
+#: commit-graph.c:746 commit-graph.c:783
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr "posición de commit inválida. commit-graph está probablemente corrupto"
 
-#: commit-graph.c:766
+#: commit-graph.c:767
 #, c-format
 msgid "could not find commit %s"
 msgstr "no se pudo encontrar commit %s"
 
-#: commit-graph.c:799
+#: commit-graph.c:800
 msgid "commit-graph requires overflow generation data but has none"
 msgstr ""
 "commit-graph requiere datos de generación de desbordamiento pero no tiene "
 "ninguno"
 
-#: commit-graph.c:1075 builtin/am.c:1341
+#: commit-graph.c:1105 builtin/am.c:1342
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "no es posible analizar el commit %s"
 
-#: commit-graph.c:1337 builtin/pack-objects.c:3057
+#: commit-graph.c:1367 builtin/pack-objects.c:3070
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "incapaz de obtener el tipo de objeto: %s"
 
-#: commit-graph.c:1368
+#: commit-graph.c:1398
 msgid "Loading known commits in commit graph"
 msgstr "Cargando commits conocidos en commit graph"
 
-#: commit-graph.c:1385
+#: commit-graph.c:1415
 msgid "Expanding reachable commits in commit graph"
 msgstr "Expandiendo commits alcanzables en commit graph"
 
-#: commit-graph.c:1405
+#: commit-graph.c:1435
 msgid "Clearing commit marks in commit graph"
 msgstr "Limpiando marcas de commits en commit graph"
 
-#: commit-graph.c:1424
+#: commit-graph.c:1454
 msgid "Computing commit graph topological levels"
 msgstr "Calculando niveles topológicos de commit graph"
 
-#: commit-graph.c:1477
+#: commit-graph.c:1507
 msgid "Computing commit graph generation numbers"
 msgstr "Calculando números de generación de commit graph"
 
-#: commit-graph.c:1558
+#: commit-graph.c:1588
 msgid "Computing commit changed paths Bloom filters"
 msgstr "Calculando números de generación de commit graph"
 
-#: commit-graph.c:1635
+#: commit-graph.c:1665
 msgid "Collecting referenced commits"
 msgstr "Recolectando commits referenciados"
 
-#: commit-graph.c:1660
+#: commit-graph.c:1690
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] "Encontrando commits para commit graph en %d pack"
 msgstr[1] "Encontrando commits para commit graph en %d packs"
 
-#: commit-graph.c:1673
+#: commit-graph.c:1703
 #, c-format
 msgid "error adding pack %s"
 msgstr "error al agregar pack %s"
 
-#: commit-graph.c:1677
+#: commit-graph.c:1707
 #, c-format
 msgid "error opening index for %s"
 msgstr "error al abrir index para %s"
 
-#: commit-graph.c:1714
+#: commit-graph.c:1744
 msgid "Finding commits for commit graph among packed objects"
 msgstr "Encontrando commits para commit graph entre los objetos empaquetados"
 
-#: commit-graph.c:1732
+#: commit-graph.c:1762
 msgid "Finding extra edges in commit graph"
 msgstr "Encontrando esquinas extra en commit graph"
 
-#: commit-graph.c:1781
+#: commit-graph.c:1811
 msgid "failed to write correct number of base graph ids"
 msgstr "falló al escribir el número correcto de ids de base graph"
 
-#: commit-graph.c:1812 midx.c:911
+#: commit-graph.c:1842 midx.c:1146
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "no se pudo crear directorios principales para %s"
 
-#: commit-graph.c:1825
+#: commit-graph.c:1855
 msgid "unable to create temporary graph layer"
 msgstr "no es posible crear una capa de gráfico temporal"
 
-#: commit-graph.c:1830
+#: commit-graph.c:1860
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "no se pudo poner permisos compartidos a '%s'"
 
-#: commit-graph.c:1887
+#: commit-graph.c:1917
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "Escribiendo commit graph en %d paso"
 msgstr[1] "Escribiendo commit graph en %d pasos"
 
-#: commit-graph.c:1923
+#: commit-graph.c:1953
 msgid "unable to open commit-graph chain file"
 msgstr "no se pudo abrir la cadena de archivos commit-graph"
 
-#: commit-graph.c:1939
+#: commit-graph.c:1969
 msgid "failed to rename base commit-graph file"
 msgstr "no se pudo renombrar el archivo base commit-graph"
 
-#: commit-graph.c:1959
+#: commit-graph.c:1989
 msgid "failed to rename temporary commit-graph file"
 msgstr "falló al renombrar el archivo temporal commit-graph"
 
-#: commit-graph.c:2092
+#: commit-graph.c:2122
 msgid "Scanning merged commits"
 msgstr "Escaneando commits fusionados"
 
-#: commit-graph.c:2136
+#: commit-graph.c:2166
 msgid "Merging commit-graph"
 msgstr "Fusionando commit-graph"
 
-#: commit-graph.c:2244
+#: commit-graph.c:2274
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 "intentando escribir un commit-graph, pero 'core.commitGraph' está "
 "deshabilitado"
 
-#: commit-graph.c:2351
+#: commit-graph.c:2381
 msgid "too many commits to write graph"
 msgstr "demasiados commits para escribir el gráfico"
 
-#: commit-graph.c:2449
+#: commit-graph.c:2479
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "el archivo de commit-graph tiene checksums incorrectos y probablemente está "
 "corrupto"
 
-#: commit-graph.c:2459
+#: commit-graph.c:2489
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "commit-graph tiene un orden de OID incorrecto: %s luego %s"
 
-#: commit-graph.c:2469 commit-graph.c:2484
+#: commit-graph.c:2499 commit-graph.c:2514
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr "commit-graph tiene un valor fanout incorrecto: fanout[%d] = %u != %u"
 
-#: commit-graph.c:2476
+#: commit-graph.c:2506
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "falló al analizar commit %s para commit-graph"
 
-#: commit-graph.c:2494
+#: commit-graph.c:2524
 msgid "Verifying commits in commit graph"
 msgstr "Verificando commits en commit graph"
 
-#: commit-graph.c:2509
+#: commit-graph.c:2539
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "falló al analizar el commit %s de la base de datos de objetos para commit-"
 "graph"
 
-#: commit-graph.c:2516
+#: commit-graph.c:2546
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr "OID del árbol raíz para commit %s en commit-graph es %s != %s"
 
-#: commit-graph.c:2526
+#: commit-graph.c:2556
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr "lista padre de commit-graph para commit %s es demasiada larga"
 
-#: commit-graph.c:2535
+#: commit-graph.c:2565
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "padre de commit-graph para %s es %s != %s"
 
-#: commit-graph.c:2549
+#: commit-graph.c:2579
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr "lista de padres de commit-graph para commit %s termina prematuramente"
 
-#: commit-graph.c:2554
+#: commit-graph.c:2584
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2404,7 +2419,7 @@ msgstr ""
 "commit-graph tiene número de generación cero para %s, pero no cero en otro "
 "lugar"
 
-#: commit-graph.c:2558
+#: commit-graph.c:2588
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2412,29 +2427,29 @@ msgstr ""
 "commit-graph tiene número de generación no cero para %s, pero cero en otro "
 "lugar"
 
-#: commit-graph.c:2575
+#: commit-graph.c:2605
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr "generación commit-graph para commit %s es %<PRIuMAX> < %<PRIuMAX>"
 
-#: commit-graph.c:2581
+#: commit-graph.c:2611
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 "fecha de commit para commit %s en commit-graph es %<PRIuMAX> != %<PRIuMAX>"
 
-#: commit.c:52 sequencer.c:3088 builtin/am.c:372 builtin/am.c:417
-#: builtin/am.c:422 builtin/am.c:1420 builtin/am.c:2067 builtin/replace.c:457
+#: commit.c:53 sequencer.c:3107 builtin/am.c:373 builtin/am.c:418
+#: builtin/am.c:423 builtin/am.c:1421 builtin/am.c:2068 builtin/replace.c:457
 #, c-format
 msgid "could not parse %s"
 msgstr "no se puede analizar %s"
 
-#: commit.c:54
+#: commit.c:55
 #, c-format
 msgid "%s %s is not a commit!"
 msgstr "¡%s %s no es un commit!"
 
-#: commit.c:194
+#: commit.c:196
 msgid ""
 "Support for <GIT_DIR>/info/grafts is deprecated\n"
 "and will be removed in a future Git version.\n"
@@ -2448,33 +2463,33 @@ msgstr ""
 "El soporte para <GIT_DIR>/info/grafts ha sido deprecado\n"
 "y será eliminado en una versión futura de Git.\n"
 "\n"
-"Por favor use \"git replace --convert-graft-file\"\n"
+"Por favor usa \"git replace --convert-graft-file\"\n"
 "para convertir los grafts en refs.\n"
 "\n"
-"Apapa este mensaje ejecutando\n"
+"Apaga este mensaje ejecutando\n"
 "\"git config advice.graftFileDeprecated false\""
 
-#: commit.c:1237
+#: commit.c:1239
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
 msgstr "Commit %s tiene una firma GPG no confiable, pretendidamente por %s."
 
-#: commit.c:1241
+#: commit.c:1243
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
 msgstr "Commit %s tiene una mala firma GPG pretendidamente por %s."
 
-#: commit.c:1244
+#: commit.c:1246
 #, c-format
 msgid "Commit %s does not have a GPG signature."
 msgstr "Commit %s no tiene una firma GPG."
 
-#: commit.c:1247
+#: commit.c:1249
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
 msgstr "El commit %s tiene una buena firma GPG por %s\n"
 
-#: commit.c:1501
+#: commit.c:1503
 msgid ""
 "Warning: commit message did not conform to UTF-8.\n"
 "You may want to amend it after fixing the message, or set the config\n"
@@ -2489,7 +2504,7 @@ msgstr ""
 msgid "memory exhausted"
 msgstr "memoria agotada"
 
-#: config.c:126
+#: config.c:125
 #, c-format
 msgid ""
 "exceeded maximum include depth (%d) while including\n"
@@ -2504,36 +2519,36 @@ msgstr ""
 "\t%s\n"
 "Esto puede ser causado por inclusiones circulares."
 
-#: config.c:142
+#: config.c:141
 #, c-format
 msgid "could not expand include path '%s'"
 msgstr "no se pudo expandir rutas de inclusión '%s'"
 
-#: config.c:153
+#: config.c:152
 msgid "relative config includes must come from files"
 msgstr "inclusiones de configuración relativas tienen que venir de archivos"
 
-#: config.c:199
+#: config.c:201
 msgid "relative config include conditionals must come from files"
 msgstr ""
 "la configuración relativa incluye condicionales que deben venir de archivos"
 
-#: config.c:396
+#: config.c:398
 #, c-format
 msgid "invalid config format: %s"
 msgstr "formato config inválido: %s"
 
-#: config.c:400
+#: config.c:402
 #, c-format
 msgid "missing environment variable name for configuration '%.*s'"
 msgstr "falta el nombre de la variable de entorno para la configuración '%.*s'"
 
-#: config.c:405
+#: config.c:407
 #, c-format
 msgid "missing environment variable '%s' for configuration '%.*s'"
 msgstr "falta la variable de entorno '%s' para la configuración '%.*s'"
 
-#: config.c:442
+#: config.c:443
 #, c-format
 msgid "key does not contain a section: %s"
 msgstr "llave no contiene una sección: %s"
@@ -2543,298 +2558,298 @@ msgstr "llave no contiene una sección: %s"
 msgid "key does not contain variable name: %s"
 msgstr "llave no contiene el nombre de variable: %s"
 
-#: config.c:472 sequencer.c:2785
+#: config.c:470 sequencer.c:2804
 #, c-format
 msgid "invalid key: %s"
 msgstr "llave inválida: %s"
 
-#: config.c:478
+#: config.c:475
 #, c-format
 msgid "invalid key (newline): %s"
 msgstr "llave inválida (nueva línea): %s"
 
-#: config.c:511
+#: config.c:495
 msgid "empty config key"
 msgstr "clave de config vacía"
 
-#: config.c:529 config.c:541
+#: config.c:513 config.c:525
 #, c-format
 msgid "bogus config parameter: %s"
 msgstr "parámetro de configuración malogrado: %s"
 
-#: config.c:555 config.c:572 config.c:579 config.c:588
+#: config.c:539 config.c:556 config.c:563 config.c:572
 #, c-format
 msgid "bogus format in %s"
 msgstr "formato malogrado en %s"
 
-#: config.c:622
+#: config.c:606
 #, c-format
 msgid "bogus count in %s"
 msgstr "conteo malogrado en %s"
 
-#: config.c:626
+#: config.c:610
 #, c-format
 msgid "too many entries in %s"
 msgstr "demasiadas entradas en %s"
 
-#: config.c:636
+#: config.c:620
 #, c-format
 msgid "missing config key %s"
 msgstr "llave de configuración faltante %s"
 
-#: config.c:644
+#: config.c:628
 #, c-format
 msgid "missing config value %s"
 msgstr "valor de config faltante para %s"
 
-#: config.c:995
+#: config.c:979
 #, c-format
 msgid "bad config line %d in blob %s"
 msgstr "mala línea de config %d en el blob %s"
 
-#: config.c:999
+#: config.c:983
 #, c-format
 msgid "bad config line %d in file %s"
 msgstr "mala línea de config %d en el archivo %s"
 
-#: config.c:1003
+#: config.c:987
 #, c-format
 msgid "bad config line %d in standard input"
 msgstr "mala línea de config %d en la entrada standard"
 
-#: config.c:1007
+#: config.c:991
 #, c-format
 msgid "bad config line %d in submodule-blob %s"
 msgstr "mala línea de config %d en el submódulo-blob %s"
 
-#: config.c:1011
+#: config.c:995
 #, c-format
 msgid "bad config line %d in command line %s"
 msgstr "mala línea de config %d en la línea de comando %s"
 
-#: config.c:1015
+#: config.c:999
 #, c-format
 msgid "bad config line %d in %s"
 msgstr "mala línea de config %d en %s"
 
-#: config.c:1152
+#: config.c:1136
 msgid "out of range"
 msgstr "fuera de rango"
 
-#: config.c:1152
+#: config.c:1136
 msgid "invalid unit"
 msgstr "unidad inválida"
 
-#: config.c:1153
+#: config.c:1137
 #, c-format
 msgid "bad numeric config value '%s' for '%s': %s"
 msgstr "mal valor de config numérico '%s' para '%s': %s"
 
-#: config.c:1163
+#: config.c:1147
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in blob %s: %s"
 msgstr "mal valor de config numérico '%s' para '%s' en el blob %s: %s"
 
-#: config.c:1166
+#: config.c:1150
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in file %s: %s"
 msgstr "mal valor de config numérico '%s' para '%s' en el archivo %s: %s"
 
-#: config.c:1169
+#: config.c:1153
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in standard input: %s"
 msgstr "mal valor de config numérico '%s' para '%s' en la entrada standard: %s"
 
-#: config.c:1172
+#: config.c:1156
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in submodule-blob %s: %s"
 msgstr ""
 "mal valor de config numérico '%s' para '%s' en el submódulo-blob %s: %s"
 
-#: config.c:1175
+#: config.c:1159
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in command line %s: %s"
 msgstr ""
 "mal valor de config numérico '%s' para '%s' en la línea de comando %s: %s"
 
-#: config.c:1178
+#: config.c:1162
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in %s: %s"
 msgstr "mal valor de config numérico '%s' para '%s' en %s: %s"
 
-#: config.c:1257
+#: config.c:1241
 #, c-format
 msgid "bad boolean config value '%s' for '%s'"
 msgstr "mal valor de config booleano '%s' para '%s'"
 
-#: config.c:1275
+#: config.c:1259
 #, c-format
 msgid "failed to expand user dir in: '%s'"
 msgstr "falló al expandir el directorio de usuario en: '%s'"
 
-#: config.c:1284
+#: config.c:1268
 #, c-format
 msgid "'%s' for '%s' is not a valid timestamp"
 msgstr "'%s' para '%s' no es una marca de tiempo válida"
 
-#: config.c:1377
+#: config.c:1361
 #, c-format
 msgid "abbrev length out of range: %d"
 msgstr "largo de abreviatura fuera de rango: %d"
 
-#: config.c:1391 config.c:1402
+#: config.c:1375 config.c:1386
 #, c-format
 msgid "bad zlib compression level %d"
 msgstr "nivel de compresión de zlib erróneo %d"
 
-#: config.c:1494
+#: config.c:1476
 msgid "core.commentChar should only be one character"
-msgstr "core.commentChar debería tener solo un caracter"
+msgstr "core.commentChar debería tener solo un carácter"
 
-#: config.c:1527
+#: config.c:1509
 #, c-format
 msgid "invalid mode for object creation: %s"
 msgstr "modo inválido de creación de objetos: %s"
 
-#: config.c:1599
+#: config.c:1581
 #, c-format
 msgid "malformed value for %s"
 msgstr "valor malformado para %s"
 
-#: config.c:1625
+#: config.c:1607
 #, c-format
 msgid "malformed value for %s: %s"
 msgstr "valor malformado para %s: %s"
 
-#: config.c:1626
+#: config.c:1608
 msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr "debe ser uno de nothing, matching, simple, upstream o current"
 
-#: config.c:1687 builtin/pack-objects.c:4084
+#: config.c:1669 builtin/pack-objects.c:4053
 #, c-format
 msgid "bad pack compression level %d"
 msgstr "nivel de compresión de pack erróneo %d"
 
-#: config.c:1809
+#: config.c:1792
 #, c-format
 msgid "unable to load config blob object '%s'"
 msgstr "incapaz de cargar configuración de objeto blob '%s'"
 
-#: config.c:1812
+#: config.c:1795
 #, c-format
 msgid "reference '%s' does not point to a blob"
 msgstr "referencia '%s' no apunta a un blob"
 
-#: config.c:1829
+#: config.c:1813
 #, c-format
 msgid "unable to resolve config blob '%s'"
 msgstr "no es posible resolver configuración de blob '%s'"
 
-#: config.c:1874
+#: config.c:1858
 #, c-format
 msgid "failed to parse %s"
 msgstr "no se pudo analizar %s"
 
-#: config.c:1930
+#: config.c:1914
 msgid "unable to parse command-line config"
 msgstr "no es posible analizar la configuración de la línea de comando"
 
-#: config.c:2294
+#: config.c:2282
 msgid "unknown error occurred while reading the configuration files"
 msgstr ""
 "error desconocido ocurrió mientras se leían los archivos de configuración"
 
-#: config.c:2468
+#: config.c:2456
 #, c-format
 msgid "Invalid %s: '%s'"
 msgstr "%s inválido: '%s'"
 
-#: config.c:2513
+#: config.c:2501
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
 msgstr "valor splitIndex.maxPercentChange '%d' debe estar entre 0 y 100"
 
-#: config.c:2559
+#: config.c:2547
 #, c-format
 msgid "unable to parse '%s' from command-line config"
 msgstr "no es posible analizar '%s' de la configuración de la línea de comando"
 
-#: config.c:2561
+#: config.c:2549
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
 msgstr "mala variable de config '%s' en el archivo '%s' en la línea %d"
 
-#: config.c:2645
+#: config.c:2633
 #, c-format
 msgid "invalid section name '%s'"
 msgstr "nombre de sección inválido '%s'"
 
-#: config.c:2677
+#: config.c:2665
 #, c-format
 msgid "%s has multiple values"
 msgstr "%s tiene múltiples valores"
 
-#: config.c:2706
+#: config.c:2694
 #, c-format
 msgid "failed to write new configuration file %s"
 msgstr "falló al escribir nuevo archivo de configuración %s"
 
-#: config.c:2958 config.c:3285
+#: config.c:2946 config.c:3273
 #, c-format
 msgid "could not lock config file %s"
 msgstr "no se pudo bloquear archivo de configuración %s"
 
-#: config.c:2969
+#: config.c:2957
 #, c-format
 msgid "opening %s"
 msgstr "abriendo %s"
 
-#: config.c:3006 builtin/config.c:361
+#: config.c:2994 builtin/config.c:361
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "patrón inválido: %s"
 
-#: config.c:3031
+#: config.c:3019
 #, c-format
 msgid "invalid config file %s"
 msgstr "archivo de configuración inválido: %s"
 
-#: config.c:3044 config.c:3298
+#: config.c:3032 config.c:3286
 #, c-format
 msgid "fstat on %s failed"
 msgstr "fstat en %s falló"
 
-#: config.c:3055
+#: config.c:3043
 #, c-format
 msgid "unable to mmap '%s'%s"
 msgstr "no es posible hacer mmap '%s'%s"
 
-#: config.c:3065 config.c:3303
+#: config.c:3053 config.c:3291
 #, c-format
 msgid "chmod on %s failed"
 msgstr "chmod en %s falló"
 
-#: config.c:3150 config.c:3400
+#: config.c:3138 config.c:3388
 #, c-format
 msgid "could not write config file %s"
 msgstr "no se pudo escribir el archivo de configuración %s"
 
-#: config.c:3184
+#: config.c:3172
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "no se pudo configurar '%s' a '%s'"
 
-#: config.c:3186 builtin/remote.c:657 builtin/remote.c:855 builtin/remote.c:863
+#: config.c:3174 builtin/remote.c:662 builtin/remote.c:860 builtin/remote.c:868
 #, c-format
 msgid "could not unset '%s'"
 msgstr "no se pudo desactivar '%s'"
 
-#: config.c:3276
+#: config.c:3264
 #, c-format
 msgid "invalid section name: %s"
 msgstr "nombre de sección inválido: %s"
 
-#: config.c:3443
+#: config.c:3431
 #, c-format
 msgid "missing value for '%s'"
 msgstr "valor faltante para '%s'"
@@ -2869,72 +2884,72 @@ msgstr "servidor no soporta feature '%s'"
 msgid "expected flush after capabilities"
 msgstr "se espera flush tras capacidades"
 
-#: connect.c:263
+#: connect.c:265
 #, c-format
 msgid "ignoring capabilities after first line '%s'"
 msgstr "ignorando capacidades tras primera línea '%s'"
 
-#: connect.c:284
+#: connect.c:286
 msgid "protocol error: unexpected capabilities^{}"
 msgstr "error de protocolo: capacidades imprevistas^{}"
 
-#: connect.c:306
+#: connect.c:308
 #, c-format
 msgid "protocol error: expected shallow sha-1, got '%s'"
 msgstr "error de protocolo: sha-1 superficial esperado, se obtuvo '%s'"
 
-#: connect.c:308
+#: connect.c:310
 msgid "repository on the other end cannot be shallow"
 msgstr "el repositorio en el otro lado no puede ser superficial"
 
-#: connect.c:347
+#: connect.c:349
 msgid "invalid packet"
 msgstr "paquete inválido"
 
-#: connect.c:367
+#: connect.c:369
 #, c-format
 msgid "protocol error: unexpected '%s'"
 msgstr "error de protocolo: '%s' inesperado"
 
-#: connect.c:497
+#: connect.c:499
 #, c-format
 msgid "unknown object format '%s' specified by server"
 msgstr "formato de objeto desconocido '%s' ha sido provisto por el servidor"
 
-#: connect.c:526
+#: connect.c:528
 #, c-format
 msgid "invalid ls-refs response: %s"
 msgstr "respuesta de ls-refs inválida: %s"
 
-#: connect.c:530
+#: connect.c:532
 msgid "expected flush after ref listing"
 msgstr "flush esperado tras listado de refs"
 
-#: connect.c:533
+#: connect.c:535
 msgid "expected response end packet after ref listing"
 msgstr "se esperaba un paquete final luego del ref listing"
 
-#: connect.c:666
+#: connect.c:670
 #, c-format
 msgid "protocol '%s' is not supported"
 msgstr "protocolo '%s' no es soportado"
 
-#: connect.c:717
+#: connect.c:721
 msgid "unable to set SO_KEEPALIVE on socket"
 msgstr "no es posible configurar SO_KEEPALIVE en el socket"
 
-#: connect.c:757 connect.c:820
+#: connect.c:761 connect.c:824
 #, c-format
 msgid "Looking up %s ... "
 msgstr "Revisando %s... "
 
-#: connect.c:761
+#: connect.c:765
 #, c-format
 msgid "unable to look up %s (port %s) (%s)"
 msgstr "no se puede revisar %s (puerto %s) (%s)"
 
 #. TRANSLATORS: this is the end of "Looking up %s ... "
-#: connect.c:765 connect.c:836
+#: connect.c:769 connect.c:840
 #, c-format
 msgid ""
 "done.\n"
@@ -2943,7 +2958,7 @@ msgstr ""
 "hecho.\n"
 "Conectando a %s (puerto %s) ... "
 
-#: connect.c:787 connect.c:864
+#: connect.c:791 connect.c:868
 #, c-format
 msgid ""
 "unable to connect to %s:\n"
@@ -2953,78 +2968,78 @@ msgstr ""
 "%s"
 
 #. TRANSLATORS: this is the end of "Connecting to %s (port %s) ... "
-#: connect.c:793 connect.c:870
+#: connect.c:797 connect.c:874
 msgid "done."
 msgstr "hecho."
 
-#: connect.c:824
+#: connect.c:828
 #, c-format
 msgid "unable to look up %s (%s)"
 msgstr "no es posible revisar %s (%s)"
 
-#: connect.c:830
+#: connect.c:834
 #, c-format
 msgid "unknown port %s"
 msgstr "puerto desconocido %s"
 
-#: connect.c:967 connect.c:1299
+#: connect.c:971 connect.c:1303
 #, c-format
 msgid "strange hostname '%s' blocked"
 msgstr "hostname extraño '%s' bloqueado"
 
-#: connect.c:969
+#: connect.c:973
 #, c-format
 msgid "strange port '%s' blocked"
 msgstr "puerto extraño '%s' bloqueado"
 
-#: connect.c:979
+#: connect.c:983
 #, c-format
 msgid "cannot start proxy %s"
 msgstr "no se puede comenzar proxy %s"
 
-#: connect.c:1050
+#: connect.c:1054
 msgid "no path specified; see 'git help pull' for valid url syntax"
 msgstr ""
-"no hay ruta especificada; vea 'git help pull' para sintaxis válida de url"
+"no hay ruta especificada; mira 'git help pull' para sintaxis válida de url"
 
-#: connect.c:1190
+#: connect.c:1194
 msgid "newline is forbidden in git:// hosts and repo paths"
 msgstr "la nueva línea está prohibida en git://hosts y rutas de repositorio"
 
-#: connect.c:1247
+#: connect.c:1251
 msgid "ssh variant 'simple' does not support -4"
 msgstr "variante 'simple' de ssh no soporta -4"
 
-#: connect.c:1259
+#: connect.c:1263
 msgid "ssh variant 'simple' does not support -6"
 msgstr "variante 'simple' de ssh no soporta -6"
 
-#: connect.c:1276
+#: connect.c:1280
 msgid "ssh variant 'simple' does not support setting port"
 msgstr "variante ssh 'simple' no soporta configurar puerto"
 
-#: connect.c:1388
+#: connect.c:1392
 #, c-format
 msgid "strange pathname '%s' blocked"
 msgstr "ruta extraña '%s' bloqueada"
 
-#: connect.c:1436
+#: connect.c:1440
 msgid "unable to fork"
 msgstr "no es posible hacer fork"
 
-#: connected.c:108 builtin/fsck.c:189 builtin/prune.c:45
+#: connected.c:109 builtin/fsck.c:189 builtin/prune.c:45
 msgid "Checking connectivity"
 msgstr "Verificando conectividad"
 
-#: connected.c:120
+#: connected.c:122
 msgid "Could not run 'git rev-list'"
 msgstr "No se pudo ejecutar 'git rev-list'"
 
-#: connected.c:144
+#: connected.c:146
 msgid "failed write to rev-list"
 msgstr "falló escribir a rev-list"
 
-#: connected.c:149
+#: connected.c:151
 msgid "failed to close rev-list's stdin"
 msgstr "falló al cerrar la entrada standard de rev-list"
 
@@ -3169,17 +3184,17 @@ msgstr "rehusando trabajar con campo host faltante en la credencial"
 msgid "refusing to work with credential missing protocol field"
 msgstr "rehusando trabajar con campo protocolo faltante en la credencial"
 
-#: credential.c:394
+#: credential.c:395
 #, c-format
 msgid "url contains a newline in its %s component: %s"
 msgstr "url contiene una nueva línea en su componente %s: %s"
 
-#: credential.c:438
+#: credential.c:439
 #, c-format
 msgid "url has no scheme: %s"
 msgstr "url no tiene scheme: %s"
 
-#: credential.c:511
+#: credential.c:512
 #, c-format
 msgid "credential url cannot be parsed: %s"
 msgstr "url de credencial no puede ser analizada: %s"
@@ -3281,23 +3296,23 @@ msgstr "%d islas marcadas, listo.\n"
 msgid "unknown value for --diff-merges: %s"
 msgstr "valor desconocido para --diff-merges: %s"
 
-#: diff-lib.c:557
+#: diff-lib.c:561
 msgid "--merge-base does not work with ranges"
 msgstr "--merge-base no funciona con rangos"
 
-#: diff-lib.c:559
+#: diff-lib.c:563
 msgid "--merge-base only works with commits"
 msgstr "--merge-base solo funciona con confirmaciones"
 
-#: diff-lib.c:576
+#: diff-lib.c:580
 msgid "unable to get HEAD"
 msgstr "no es posible obtener HEAD"
 
-#: diff-lib.c:583
+#: diff-lib.c:587
 msgid "no merge base found"
 msgstr "no se encontró base de fusión"
 
-#: diff-lib.c:585
+#: diff-lib.c:589
 msgid "multiple merge bases found"
 msgstr "múltiples bases de fusión encontradas"
 
@@ -3310,20 +3325,20 @@ msgid ""
 "Not a git repository. Use --no-index to compare two paths outside a working "
 "tree"
 msgstr ""
-"No es un repositorio git. Use --no-index para comparar dos paths fuera del "
+"No es un repositorio git. Usa --no-index para comparar dos paths fuera del "
 "árbol de trabajo"
 
-#: diff.c:156
+#: diff.c:157
 #, c-format
 msgid "  Failed to parse dirstat cut-off percentage '%s'\n"
 msgstr "  Falló al analizar porcentaje de corte de dirstat '%s'\n"
 
-#: diff.c:161
+#: diff.c:162
 #, c-format
 msgid "  Unknown dirstat parameter '%s'\n"
 msgstr "  Parámetro '%s' de dirstat desconocido\n"
 
-#: diff.c:297
+#: diff.c:298
 msgid ""
 "color moved setting must be one of 'no', 'default', 'blocks', 'zebra', "
 "'dimmed-zebra', 'plain'"
@@ -3331,7 +3346,7 @@ msgstr ""
 "opción de color tiene que ser una de 'no', 'default', 'blocks', 'zebra', "
 "'dimmed-zebra', 'plain'"
 
-#: diff.c:325
+#: diff.c:326
 #, c-format
 msgid ""
 "unknown color-moved-ws mode '%s', possible values are 'ignore-space-change', "
@@ -3341,7 +3356,7 @@ msgstr ""
 "change', 'ignore-space-at-eol', 'ignore-all-space', 'allow-indentation-"
 "change'"
 
-#: diff.c:333
+#: diff.c:334
 msgid ""
 "color-moved-ws: allow-indentation-change cannot be combined with other "
 "whitespace modes"
@@ -3349,13 +3364,13 @@ msgstr ""
 "color-moved-ws: allow-indentation-change no puede ser combinado con otros "
 "modos de espacios en blanco"
 
-#: diff.c:410
+#: diff.c:411
 #, c-format
 msgid "Unknown value for 'diff.submodule' config variable: '%s'"
 msgstr ""
 "Valor para la variable de configuración 'diff.submodule' desconocido: '%s'"
 
-#: diff.c:470
+#: diff.c:471
 #, c-format
 msgid ""
 "Found errors in 'diff.dirstat' config variable:\n"
@@ -3364,49 +3379,49 @@ msgstr ""
 "Errores en la variable de config 'diff.dirstat' encontrados:\n"
 "%s"
 
-#: diff.c:4282
+#: diff.c:4290
 #, c-format
 msgid "external diff died, stopping at %s"
 msgstr "diff externo murió, deteniendo en %s"
 
-#: diff.c:4634
+#: diff.c:4642
 msgid "--name-only, --name-status, --check and -s are mutually exclusive"
 msgstr "--name-only, --name-status, --check y -s son mutuamente exclusivas"
 
-#: diff.c:4637
+#: diff.c:4645
 msgid "-G, -S and --find-object are mutually exclusive"
 msgstr "-G, -S y --find-object son mutuamente exclusivas"
 
-#: diff.c:4640
+#: diff.c:4648
 msgid ""
 "-G and --pickaxe-regex are mutually exclusive, use --pickaxe-regex with -S"
 msgstr ""
-"-G y --pickaxe-regex son mutuamente exclusivos, use --pickaxe-regex con -S"
+"-G y --pickaxe-regex son mutuamente exclusivos, usa --pickaxe-regex con -S"
 
-#: diff.c:4643
+#: diff.c:4651
 msgid ""
 "--pickaxe-all and --find-object are mutually exclusive, use --pickaxe-all "
 "with -G and -S"
 msgstr ""
-"--pickaxe-all y --find-object son mutuamente exclusivas, use --pickaxe-all "
+"--pickaxe-all y --find-object son mutuamente exclusivas, usa --pickaxe-all "
 "con -G y -S"
 
-#: diff.c:4722
+#: diff.c:4730
 msgid "--follow requires exactly one pathspec"
 msgstr "--follow requiere exactamente un pathspec"
 
-#: diff.c:4770
+#: diff.c:4778
 #, c-format
 msgid "invalid --stat value: %s"
 msgstr "valor --stat inválido: %s"
 
-#: diff.c:4775 diff.c:4780 diff.c:4785 diff.c:4790 diff.c:5318
-#: parse-options.c:197 parse-options.c:201 builtin/commit-graph.c:180
+#: diff.c:4783 diff.c:4788 diff.c:4793 diff.c:4798 diff.c:5326
+#: parse-options.c:217 parse-options.c:221
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "%s espera un valor numérico"
 
-#: diff.c:4807
+#: diff.c:4815
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -3415,42 +3430,42 @@ msgstr ""
 "Falló al analizar parámetro de opción --dirstat/-X:\n"
 "%s"
 
-#: diff.c:4892
+#: diff.c:4900
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
 msgstr "cambio de clase desconocido '%c' en --diff-filter=%s"
 
-#: diff.c:4916
+#: diff.c:4924
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
 msgstr "valor desconocido luego de ws-error-highlight=%.*s"
 
-#: diff.c:4930
+#: diff.c:4938
 #, c-format
 msgid "unable to resolve '%s'"
 msgstr "no se puede resolver '%s'"
 
-#: diff.c:4980 diff.c:4986
+#: diff.c:4988 diff.c:4994
 #, c-format
 msgid "%s expects <n>/<m> form"
 msgstr "%s espera forma <n>/<m>"
 
-#: diff.c:4998
+#: diff.c:5006
 #, c-format
 msgid "%s expects a character, got '%s'"
 msgstr "%s esperaba un char, se obtuvo '%s'"
 
-#: diff.c:5019
+#: diff.c:5027
 #, c-format
 msgid "bad --color-moved argument: %s"
 msgstr "mal argumento --color-moved: %s"
 
-#: diff.c:5038
+#: diff.c:5046
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
 msgstr "modo inválido '%s' en --color-moved-ws"
 
-#: diff.c:5078
+#: diff.c:5086
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
@@ -3458,159 +3473,159 @@ msgstr ""
 "opción diff-algorithm acepta \"myers\", \"minimal\", \"patience\" e "
 "\"histogram\""
 
-#: diff.c:5114 diff.c:5134
+#: diff.c:5122 diff.c:5142
 #, c-format
 msgid "invalid argument to %s"
 msgstr "argumento inválido para %s"
 
-#: diff.c:5238
+#: diff.c:5246
 #, c-format
 msgid "invalid regex given to -I: '%s'"
 msgstr "regex inválido para -I: '%s'"
 
-#: diff.c:5287
+#: diff.c:5295
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
 msgstr "falló al analizar parámetro de opción --submodule: '%s'"
 
-#: diff.c:5343
+#: diff.c:5351
 #, c-format
 msgid "bad --word-diff argument: %s"
 msgstr "mal argumento --word-diff: %s"
 
-#: diff.c:5379
+#: diff.c:5387
 msgid "Diff output format options"
 msgstr "Opciones de formato de salida para diff"
 
-#: diff.c:5381 diff.c:5387
+#: diff.c:5389 diff.c:5395
 msgid "generate patch"
 msgstr "generar parche"
 
-#: diff.c:5384 builtin/log.c:179
+#: diff.c:5392 builtin/log.c:179
 msgid "suppress diff output"
 msgstr "suprimir salida de diff"
 
-#: diff.c:5389 diff.c:5503 diff.c:5510
+#: diff.c:5397 diff.c:5511 diff.c:5518
 msgid "<n>"
 msgstr "<n>"
 
-#: diff.c:5390 diff.c:5393
+#: diff.c:5398 diff.c:5401
 msgid "generate diffs with <n> lines context"
-msgstr "genera diffs con <n> líneas de contexto"
+msgstr "generar diffs con <n> líneas de contexto"
 
-#: diff.c:5395
+#: diff.c:5403
 msgid "generate the diff in raw format"
-msgstr "genera el diff en formato raw"
+msgstr "generar el diff en formato raw"
 
-#: diff.c:5398
+#: diff.c:5406
 msgid "synonym for '-p --raw'"
 msgstr "sinónimo para '-p --raw'"
 
-#: diff.c:5402
+#: diff.c:5410
 msgid "synonym for '-p --stat'"
 msgstr "sinónimo para '-p --stat'"
 
-#: diff.c:5406
+#: diff.c:5414
 msgid "machine friendly --stat"
 msgstr "--stat amigable para máquina"
 
-#: diff.c:5409
+#: diff.c:5417
 msgid "output only the last line of --stat"
 msgstr "mostrar solo la última línea para --stat"
 
-#: diff.c:5411 diff.c:5419
+#: diff.c:5419 diff.c:5427
 msgid "<param1,param2>..."
 msgstr "<param1,param2>..."
 
-#: diff.c:5412
+#: diff.c:5420
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr ""
-"muestra la distribución de cantidades de cambios relativas para cada "
+"mostrar la distribución de cantidades de cambios relativas para cada "
 "subdirectorio"
 
-#: diff.c:5416
+#: diff.c:5424
 msgid "synonym for --dirstat=cumulative"
 msgstr "sinónimo para --dirstat=cumulative"
 
-#: diff.c:5420
+#: diff.c:5428
 msgid "synonym for --dirstat=files,param1,param2..."
-msgstr "sinonimo para --dirstat=archivos,param1,param2..."
+msgstr "sinónimo para --dirstat=archivos,param1,param2..."
 
-#: diff.c:5424
+#: diff.c:5432
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
-"advierte si cambios introducen conflictos de markers o errores de espacios "
+"advertir si cambios introducen conflictos de markers o errores de espacios "
 "en blanco"
 
-#: diff.c:5427
+#: diff.c:5435
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr ""
 "resumen condensado de creaciones, cambios de nombres y cambios de modos"
 
-#: diff.c:5430
+#: diff.c:5438
 msgid "show only names of changed files"
 msgstr "mostrar solo nombres de archivos cambiados"
 
-#: diff.c:5433
+#: diff.c:5441
 msgid "show only names and status of changed files"
 msgstr "mostrar solo nombres y estados de archivos cambiados"
 
-#: diff.c:5435
+#: diff.c:5443
 msgid "<width>[,<name-width>[,<count>]]"
 msgstr "<ancho>[,<ancho-de-nombre>[,<cantidad>]]"
 
-#: diff.c:5436
+#: diff.c:5444
 msgid "generate diffstat"
 msgstr "generar diffstat"
 
-#: diff.c:5438 diff.c:5441 diff.c:5444
+#: diff.c:5446 diff.c:5449 diff.c:5452
 msgid "<width>"
 msgstr "<ancho>"
 
-#: diff.c:5439
-msgid "generate diffstat with a given width"
-msgstr "genera diffstat con un ancho dado"
-
-#: diff.c:5442
-msgid "generate diffstat with a given name width"
-msgstr "genera diffstat con un ancho de nombre dado"
-
-#: diff.c:5445
-msgid "generate diffstat with a given graph width"
-msgstr "genera diffstat con un ancho de graph dado"
-
 #: diff.c:5447
+msgid "generate diffstat with a given width"
+msgstr "generar diffstat con un ancho dado"
+
+#: diff.c:5450
+msgid "generate diffstat with a given name width"
+msgstr "generar diffstat con un ancho de nombre dado"
+
+#: diff.c:5453
+msgid "generate diffstat with a given graph width"
+msgstr "generar diffstat con un ancho de graph dado"
+
+#: diff.c:5455
 msgid "<count>"
 msgstr "<cantidad>"
 
-#: diff.c:5448
+#: diff.c:5456
 msgid "generate diffstat with limited lines"
-msgstr "genera diffstat con líneas limitadas"
+msgstr "generar diffstat con líneas limitadas"
 
-#: diff.c:5451
+#: diff.c:5459
 msgid "generate compact summary in diffstat"
-msgstr "genera un resumen compacto de diffstat"
+msgstr "generar un resumen compacto de diffstat"
 
-#: diff.c:5454
+#: diff.c:5462
 msgid "output a binary diff that can be applied"
-msgstr "muestra un diff binario que puede ser aplicado"
+msgstr "mostrar un diff binario que puede ser aplicado"
 
-#: diff.c:5457
+#: diff.c:5465
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr ""
 "mostrar todo un pre- y post-image de nombres de objetos en las líneas \"index"
 "\""
 
-#: diff.c:5459
+#: diff.c:5467
 msgid "show colored diff"
 msgstr "mostrar diff colorido"
 
-#: diff.c:5460
+#: diff.c:5468
 msgid "<kind>"
 msgstr "<tipo>"
 
-#: diff.c:5461
+#: diff.c:5469
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
@@ -3618,7 +3633,7 @@ msgstr ""
 "resaltar errores de espacios en blanco en las líneas 'context', 'old' o "
 "'new' del diff"
 
-#: diff.c:5464
+#: diff.c:5472
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
@@ -3626,330 +3641,330 @@ msgstr ""
 "no consolidar los pathnames y usar NULs como terminadores de campos en --raw "
 "o --numstat"
 
-#: diff.c:5467 diff.c:5470 diff.c:5473 diff.c:5582
+#: diff.c:5475 diff.c:5478 diff.c:5481 diff.c:5590
 msgid "<prefix>"
 msgstr "<prefijo>"
 
-#: diff.c:5468
+#: diff.c:5476
 msgid "show the given source prefix instead of \"a/\""
 msgstr "mostrar el prefijo de fuente dado en lugar de \"a/\""
 
-#: diff.c:5471
+#: diff.c:5479
 msgid "show the given destination prefix instead of \"b/\""
 msgstr "mostrar el prefijo de destino dado en lugar de \"b/\""
 
-#: diff.c:5474
+#: diff.c:5482
 msgid "prepend an additional prefix to every line of output"
 msgstr "anteponer un prefijo adicional a cada línea mostrada"
 
-#: diff.c:5477
+#: diff.c:5485
 msgid "do not show any source or destination prefix"
 msgstr "no mostrar ningún prefijo de fuente o destino"
 
-#: diff.c:5480
+#: diff.c:5488
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
-"muestra el contexto entre hunks de diff hasta el número especificado de "
+"mostrar el contexto entre hunks de diff hasta el número especificado de "
 "líneas"
 
-#: diff.c:5484 diff.c:5489 diff.c:5494
+#: diff.c:5492 diff.c:5497 diff.c:5502
 msgid "<char>"
 msgstr "<char>"
 
-#: diff.c:5485
+#: diff.c:5493
 msgid "specify the character to indicate a new line instead of '+'"
-msgstr "especifica el char para indicar una nueva línea en lugar de '+'"
-
-#: diff.c:5490
-msgid "specify the character to indicate an old line instead of '-'"
-msgstr "especifica el char para indicar una línea vieja en lugar de '-'"
-
-#: diff.c:5495
-msgid "specify the character to indicate a context instead of ' '"
-msgstr "especifica el char para indicar un contexto en lugar de ' '"
+msgstr "especificar el char para indicar una nueva línea en lugar de '+'"
 
 #: diff.c:5498
+msgid "specify the character to indicate an old line instead of '-'"
+msgstr "especificar el char para indicar una línea vieja en lugar de '-'"
+
+#: diff.c:5503
+msgid "specify the character to indicate a context instead of ' '"
+msgstr "especificar el char para indicar un contexto en lugar de ' '"
+
+#: diff.c:5506
 msgid "Diff rename options"
 msgstr "Opciones de diff rename"
 
-#: diff.c:5499
+#: diff.c:5507
 msgid "<n>[/<m>]"
 msgstr "<n>[/<m>]"
 
-#: diff.c:5500
+#: diff.c:5508
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr "descomponer los cambios de reescritura en pares de borrar y crear"
 
-#: diff.c:5504
+#: diff.c:5512
 msgid "detect renames"
 msgstr "detectar renombrados"
 
-#: diff.c:5508
+#: diff.c:5516
 msgid "omit the preimage for deletes"
-msgstr "omite la preimage para borrados"
+msgstr "omitir la preimage para borrados"
 
-#: diff.c:5511
+#: diff.c:5519
 msgid "detect copies"
 msgstr "detectar copias"
 
-#: diff.c:5515
+#: diff.c:5523
 msgid "use unmodified files as source to find copies"
-msgstr "usa archivos no modificados como fuente para encontrar copias"
-
-#: diff.c:5517
-msgid "disable rename detection"
-msgstr "deshabilita detección de renombrados"
-
-#: diff.c:5520
-msgid "use empty blobs as rename source"
-msgstr "usa blobs vacíos como fuente de renombramiento"
-
-#: diff.c:5522
-msgid "continue listing the history of a file beyond renames"
-msgstr ""
-"continua listando el historial de un archivo más allá de renombramientos"
+msgstr "usar archivos no modificados como fuente para encontrar copias"
 
 #: diff.c:5525
+msgid "disable rename detection"
+msgstr "deshabilitar detección de renombrados"
+
+#: diff.c:5528
+msgid "use empty blobs as rename source"
+msgstr "usar blobs vacíos como fuente de renombramiento"
+
+#: diff.c:5530
+msgid "continue listing the history of a file beyond renames"
+msgstr ""
+"continuar listando el historial de un archivo más allá de renombramientos"
+
+#: diff.c:5533
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
 msgstr ""
-"previene detección de renombramientos/copias si el número de destinos para "
+"prevenir detección de renombramientos/copias si el número de destinos para "
 "renombramientos/copias excede el límite dado"
 
-#: diff.c:5527
+#: diff.c:5535
 msgid "Diff algorithm options"
 msgstr "Opciones de algoritmos de diff"
 
-#: diff.c:5529
+#: diff.c:5537
 msgid "produce the smallest possible diff"
-msgstr "produce el diff más pequeño posible"
+msgstr "producir el diff más pequeño posible"
 
-#: diff.c:5532
+#: diff.c:5540
 msgid "ignore whitespace when comparing lines"
 msgstr "ignorar espacios en blanco cuando comparando líneas"
 
-#: diff.c:5535
+#: diff.c:5543
 msgid "ignore changes in amount of whitespace"
 msgstr "ignorar cambios en la cantidad de líneas en blanco"
 
-#: diff.c:5538
+#: diff.c:5546
 msgid "ignore changes in whitespace at EOL"
 msgstr "ignorar cambios en espacios en blanco en EOL"
 
-#: diff.c:5541
+#: diff.c:5549
 msgid "ignore carrier-return at the end of line"
-msgstr "ignora carrier-return al final de la línea"
+msgstr "ignorar carrier-return al final de la línea"
 
-#: diff.c:5544
+#: diff.c:5552
 msgid "ignore changes whose lines are all blank"
-msgstr "ignora cambios cuyas líneas son todas en blanco"
+msgstr "ignorar cambios cuyas líneas son todas en blanco"
 
-#: diff.c:5546 diff.c:5568 diff.c:5571 diff.c:5616
+#: diff.c:5554 diff.c:5576 diff.c:5579 diff.c:5624
 msgid "<regex>"
 msgstr "<regex>"
 
-#: diff.c:5547
+#: diff.c:5555
 msgid "ignore changes whose all lines match <regex>"
-msgstr "ignora cambios cuyas líneas concuerdan con <regex>"
+msgstr "ignorar cambios cuyas líneas concuerdan con <regex>"
 
-#: diff.c:5550
+#: diff.c:5558
 msgid "heuristic to shift diff hunk boundaries for easy reading"
 msgstr "heurística para cambiar los límites de hunk para una fácil lectura"
 
-#: diff.c:5553
+#: diff.c:5561
 msgid "generate diff using the \"patience diff\" algorithm"
 msgstr "genera un diff usando algoritmo \"patience diff\""
 
-#: diff.c:5557
+#: diff.c:5565
 msgid "generate diff using the \"histogram diff\" algorithm"
 msgstr "genera un diff usando algoritmo \"histogram diff\""
 
-#: diff.c:5559
+#: diff.c:5567
 msgid "<algorithm>"
 msgstr "<algoritmo>"
 
-#: diff.c:5560
+#: diff.c:5568
 msgid "choose a diff algorithm"
-msgstr "escoge un algoritmo para diff"
+msgstr "escoger un algoritmo para diff"
 
-#: diff.c:5562
+#: diff.c:5570
 msgid "<text>"
 msgstr "<texto>"
 
-#: diff.c:5563
+#: diff.c:5571
 msgid "generate diff using the \"anchored diff\" algorithm"
-msgstr "genera un diff usando algoritmo \"anchored diff\""
+msgstr "generar un diff usando algoritmo \"anchored diff\""
 
-#: diff.c:5565 diff.c:5574 diff.c:5577
+#: diff.c:5573 diff.c:5582 diff.c:5585
 msgid "<mode>"
 msgstr "<modo>"
 
-#: diff.c:5566
+#: diff.c:5574
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr ""
-"muestra diff por palabras usando <modo> para delimitar las palabras cambiadas"
+"mostrar diff por palabras usando <modo> para delimitar las palabras cambiadas"
 
-#: diff.c:5569
+#: diff.c:5577
 msgid "use <regex> to decide what a word is"
-msgstr "usa <regex> para decidir qué es una palabra"
+msgstr "usar <regex> para decidir qué es una palabra"
 
-#: diff.c:5572
+#: diff.c:5580
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
 msgstr "equivalente a --word-diff=color --word-diff-regex=<regex>"
 
-#: diff.c:5575
+#: diff.c:5583
 msgid "moved lines of code are colored differently"
 msgstr "líneas movidas de código están coloreadas diferente"
 
-#: diff.c:5578
+#: diff.c:5586
 msgid "how white spaces are ignored in --color-moved"
 msgstr "como espacios en blanco son ignorados en --color-moved"
 
-#: diff.c:5581
+#: diff.c:5589
 msgid "Other diff options"
 msgstr "Otras opciones de diff"
 
-#: diff.c:5583
+#: diff.c:5591
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
-"cuando ejecutado desde un subdir, excluye cambios del exterior y muestra "
+"cuando ejecutado desde un subdir, excluir cambios del exterior y muestra "
 "paths relativos"
 
-#: diff.c:5587
+#: diff.c:5595
 msgid "treat all files as text"
 msgstr "tratar todos los archivos como texto"
 
-#: diff.c:5589
-msgid "swap two inputs, reverse the diff"
-msgstr "cambia dos inputs, invierte el diff"
-
-#: diff.c:5591
-msgid "exit with 1 if there were differences, 0 otherwise"
-msgstr "termina con 1 si hubieron diferencias, de lo contrario con 0"
-
-#: diff.c:5593
-msgid "disable all output of the program"
-msgstr "deshabilita todo el salida del programa"
-
-#: diff.c:5595
-msgid "allow an external diff helper to be executed"
-msgstr "permite la ejecución de un diff helper externo"
-
 #: diff.c:5597
-msgid "run external text conversion filters when comparing binary files"
-msgstr ""
-"ejecuta filtros de conversión de texto externos cuando comparando binarios"
+msgid "swap two inputs, reverse the diff"
+msgstr "cambiar dos inputs, invierte el diff"
 
 #: diff.c:5599
+msgid "exit with 1 if there were differences, 0 otherwise"
+msgstr "terminar con 1 si hubieron diferencias, de lo contrario con 0"
+
+#: diff.c:5601
+msgid "disable all output of the program"
+msgstr "deshabilitar toda la salida del programa"
+
+#: diff.c:5603
+msgid "allow an external diff helper to be executed"
+msgstr "permitir la ejecución de un diff helper externo"
+
+#: diff.c:5605
+msgid "run external text conversion filters when comparing binary files"
+msgstr ""
+"ejecutar filtros de conversión de texto externos cuando comparando binarios"
+
+#: diff.c:5607
 msgid "<when>"
 msgstr "<cuando>"
 
-#: diff.c:5600
+#: diff.c:5608
 msgid "ignore changes to submodules in the diff generation"
 msgstr "ignorar cambios a submódulos en la generación de diff"
 
-#: diff.c:5603
+#: diff.c:5611
 msgid "<format>"
 msgstr "<formato>"
 
-#: diff.c:5604
+#: diff.c:5612
 msgid "specify how differences in submodules are shown"
-msgstr "especifica como son mostradas las diferencias en submódulos"
+msgstr "especificar como son mostradas las diferencias en submódulos"
 
-#: diff.c:5608
+#: diff.c:5616
 msgid "hide 'git add -N' entries from the index"
 msgstr "ocultar entradas 'git add -N' del índice"
 
-#: diff.c:5611
+#: diff.c:5619
 msgid "treat 'git add -N' entries as real in the index"
-msgstr "trata entradas 'git add -N' como reales en el índice"
+msgstr "tratar entradas 'git add -N' como reales en el índice"
 
-#: diff.c:5613
+#: diff.c:5621
 msgid "<string>"
 msgstr "<string>"
 
-#: diff.c:5614
+#: diff.c:5622
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
 msgstr ""
-"busca diferencias que cambien el número de ocurrencias del string "
+"buscar diferencias que cambien el número de ocurrencias del string "
 "especificado"
 
-#: diff.c:5617
+#: diff.c:5625
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
 msgstr ""
-"busca por diferencias que cambien el número de ocurrencias del regex "
+"buscar diferencias que cambien el número de ocurrencias del regex "
 "especificado"
 
-#: diff.c:5620
+#: diff.c:5628
 msgid "show all changes in the changeset with -S or -G"
 msgstr "mostrar todos los cambios en el changeset con -S o -G"
 
-#: diff.c:5623
+#: diff.c:5631
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr "tratar <string> en -S como una expresión regular extendida de POSIX"
 
-#: diff.c:5626
+#: diff.c:5634
 msgid "control the order in which files appear in the output"
 msgstr "controlar el orden en el que los archivos aparecen en la salida"
 
-#: diff.c:5627 diff.c:5630
+#: diff.c:5635 diff.c:5638
 msgid "<path>"
 msgstr "<ruta>"
 
-#: diff.c:5628
+#: diff.c:5636
 msgid "show the change in the specified path first"
 msgstr "mostrar el cambio en la ruta especificada primero"
 
-#: diff.c:5631
+#: diff.c:5639
 msgid "skip the output to the specified path"
-msgstr "saltar el salida de la ruta especificada"
+msgstr "saltar la salida de la ruta especificada"
 
-#: diff.c:5633
+#: diff.c:5641
 msgid "<object-id>"
 msgstr "<id-de-objeto>"
 
-#: diff.c:5634
+#: diff.c:5642
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
 msgstr ""
-"busca diferencias que cambien el número de ocurrencias para el objeto "
+"buscar diferencias que cambien el número de ocurrencias para el objeto "
 "especificado"
 
-#: diff.c:5636
+#: diff.c:5644
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "[(A|C|D|M|R|T|U|X|B)...[*]]"
 
-#: diff.c:5637
+#: diff.c:5645
 msgid "select files by diff type"
-msgstr "selecciona archivos por tipo de diff"
+msgstr "seleccionar archivos por tipo de diff"
 
-#: diff.c:5639
+#: diff.c:5647
 msgid "<file>"
 msgstr "<archivo>"
 
-#: diff.c:5640
+#: diff.c:5648
 msgid "Output to a specific file"
 msgstr "Output a un archivo específico"
 
-#: diff.c:6298
+#: diff.c:6306
 msgid "exhaustive rename detection was skipped due to too many files."
 msgstr ""
 "detección exhaustiva de cambio de nombre fue saltada por haber demasiados "
 "archivos."
 
-#: diff.c:6301
+#: diff.c:6309
 msgid "only found copies from modified paths due to too many files."
 msgstr ""
 "solo se encontraron copias de rutas modificadas por haber demasiados "
 "archivos."
 
-#: diff.c:6304
+#: diff.c:6312
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
@@ -3962,7 +3977,7 @@ msgstr ""
 msgid "failed to read orderfile '%s'"
 msgstr "falló al leer archivo de orden '%s'"
 
-#: diffcore-rename.c:1514
+#: diffcore-rename.c:1564
 msgid "Performing inexact rename detection"
 msgstr "Realizando una detección de cambios de nombre inexacta"
 
@@ -4001,339 +4016,416 @@ msgstr "deshabilitar coincidencia de patrónes cónica"
 msgid "cannot use %s as an exclude file"
 msgstr "no se puede usar %s como archivo de exclusión"
 
-#: dir.c:2351
+#: dir.c:2464
 #, c-format
 msgid "could not open directory '%s'"
 msgstr "no se pudo abrir el directorio '%s'"
 
-#: dir.c:2653
+#: dir.c:2766
 msgid "failed to get kernel name and information"
 msgstr "falló al conseguir el nombre y la información del kernel"
 
-#: dir.c:2777
+#: dir.c:2890
 msgid "untracked cache is disabled on this system or location"
 msgstr "untracked cache está desactivado en este sistema o ubicación"
 
-#: dir.c:3610
+#: dir.c:3158
+msgid ""
+"No directory name could be guessed.\n"
+"Please specify a directory on the command line"
+msgstr ""
+"No se pudo adivinar ningún nombre de directorio.\n"
+"Por favor especifica un directorio en la línea de comando"
+
+#: dir.c:3837
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "archivo índice corrompido en repositorio %s"
 
-#: dir.c:3657 dir.c:3662
+#: dir.c:3884 dir.c:3889
 #, c-format
 msgid "could not create directories for %s"
 msgstr "no se pudo crear directorios para %s"
 
-#: dir.c:3691
+#: dir.c:3918
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "no se pudo migrar el directorio git de '%s' a '%s'"
 
-#: editor.c:74
+#: editor.c:77
 #, c-format
 msgid "hint: Waiting for your editor to close the file...%c"
 msgstr "ayuda: Esperando que tu editor cierre el archivo ...%c"
 
-#: entry.c:176
+#: entry.c:177
 msgid "Filtering content"
 msgstr "Filtrando contenido"
 
-#: entry.c:497
+#: entry.c:498
 #, c-format
 msgid "could not stat file '%s'"
 msgstr "no se pudo hacer stat en el archivo '%s'"
 
-#: environment.c:152
+#: environment.c:143
 #, c-format
 msgid "bad git namespace path \"%s\""
 msgstr "ruta de namespace de git mala \"%s\""
-
-#: environment.c:334
-#, c-format
-msgid "could not set GIT_DIR to '%s'"
-msgstr "no se pudo configurar GIT_DIR a '%s'"
 
 #: exec-cmd.c:363
 #, c-format
 msgid "too many args to run %s"
 msgstr "demasiados argumentos para ejecutar %s"
 
-#: fetch-pack.c:182
+#: fetch-pack.c:193
 msgid "git fetch-pack: expected shallow list"
 msgstr "git fetch-pack: lista de superficiales esperada"
 
-#: fetch-pack.c:185
+#: fetch-pack.c:196
 msgid "git fetch-pack: expected a flush packet after shallow list"
 msgstr ""
 "git fetch-pack: se esperaba un flush packet luego de la lista de "
 "superficiales"
 
-#: fetch-pack.c:196
+#: fetch-pack.c:207
 msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
 msgstr "git fetch-pack: se esperaba ACK/NAK, se obtuvo un flush packet"
 
-#: fetch-pack.c:216
+#: fetch-pack.c:227
 #, c-format
 msgid "git fetch-pack: expected ACK/NAK, got '%s'"
 msgstr "git fetch-pack: se esperaba ACK/NAK, se obtuvo '%s'"
 
-#: fetch-pack.c:227
+#: fetch-pack.c:238
 msgid "unable to write to remote"
 msgstr "no se puede escribir al remoto"
 
-#: fetch-pack.c:288
+#: fetch-pack.c:299
 msgid "--stateless-rpc requires multi_ack_detailed"
 msgstr "--stateless-rpc requiere multi_ack_detailed"
 
-#: fetch-pack.c:383 fetch-pack.c:1423
+#: fetch-pack.c:394 fetch-pack.c:1434
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "línea shallow inválida: %s"
 
-#: fetch-pack.c:389 fetch-pack.c:1429
+#: fetch-pack.c:400 fetch-pack.c:1440
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "línea unshallow inválida: %s"
 
-#: fetch-pack.c:391 fetch-pack.c:1431
+#: fetch-pack.c:402 fetch-pack.c:1442
 #, c-format
 msgid "object not found: %s"
 msgstr "objeto no encontrado: %s"
 
-#: fetch-pack.c:394 fetch-pack.c:1434
+#: fetch-pack.c:405 fetch-pack.c:1445
 #, c-format
 msgid "error in object: %s"
 msgstr "error en objeto: %s"
 
-#: fetch-pack.c:396 fetch-pack.c:1436
+#: fetch-pack.c:407 fetch-pack.c:1447
 #, c-format
 msgid "no shallow found: %s"
 msgstr "shallow no encontrado: %s"
 
-#: fetch-pack.c:399 fetch-pack.c:1440
+#: fetch-pack.c:410 fetch-pack.c:1451
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "se esperaba shallow/unshallow, se obtuvo %s"
 
-#: fetch-pack.c:439
+#: fetch-pack.c:450
 #, c-format
 msgid "got %s %d %s"
 msgstr "se obtuvo %s %d %s"
 
-#: fetch-pack.c:456
+#: fetch-pack.c:467
 #, c-format
 msgid "invalid commit %s"
 msgstr "commit inválido %s"
 
-#: fetch-pack.c:487
+#: fetch-pack.c:498
 msgid "giving up"
 msgstr "rindiéndose"
 
-#: fetch-pack.c:500 progress.c:339
+#: fetch-pack.c:511 progress.c:339
 msgid "done"
 msgstr "listo"
 
-#: fetch-pack.c:512
+#: fetch-pack.c:523
 #, c-format
 msgid "got %s (%d) %s"
 msgstr "se obtuvo %s (%d) %s"
 
-#: fetch-pack.c:548
+#: fetch-pack.c:559
 #, c-format
 msgid "Marking %s as complete"
 msgstr "Marcando %s como completa"
 
-#: fetch-pack.c:763
+#: fetch-pack.c:774
 #, c-format
 msgid "already have %s (%s)"
 msgstr "ya se tiene %s (%s)"
 
-#: fetch-pack.c:849
+#: fetch-pack.c:860
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-pack: no se puede ejecutar un demultiplexor de banda lateral"
 
-#: fetch-pack.c:857
+#: fetch-pack.c:868
 msgid "protocol error: bad pack header"
 msgstr "error de protocolo: header de paquete erróneo"
 
-#: fetch-pack.c:951
+#: fetch-pack.c:962
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-pack: no se puede ejecutar %s"
 
-#: fetch-pack.c:957
+#: fetch-pack.c:968
 msgid "fetch-pack: invalid index-pack output"
 msgstr "fetch-pack: salida de index-pack no válida"
 
-#: fetch-pack.c:974
+#: fetch-pack.c:985
 #, c-format
 msgid "%s failed"
 msgstr "%s falló"
 
-#: fetch-pack.c:976
+#: fetch-pack.c:987
 msgid "error in sideband demultiplexer"
 msgstr "error en demultiplexor de banda lateral"
 
-#: fetch-pack.c:1019
+#: fetch-pack.c:1030
 #, c-format
 msgid "Server version is %.*s"
 msgstr "Versión de servidor es %.*s"
 
-#: fetch-pack.c:1027 fetch-pack.c:1033 fetch-pack.c:1036 fetch-pack.c:1042
-#: fetch-pack.c:1046 fetch-pack.c:1050 fetch-pack.c:1054 fetch-pack.c:1058
-#: fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070 fetch-pack.c:1074
-#: fetch-pack.c:1080 fetch-pack.c:1086 fetch-pack.c:1091 fetch-pack.c:1096
+#: fetch-pack.c:1038 fetch-pack.c:1044 fetch-pack.c:1047 fetch-pack.c:1053
+#: fetch-pack.c:1057 fetch-pack.c:1061 fetch-pack.c:1065 fetch-pack.c:1069
+#: fetch-pack.c:1073 fetch-pack.c:1077 fetch-pack.c:1081 fetch-pack.c:1085
+#: fetch-pack.c:1091 fetch-pack.c:1097 fetch-pack.c:1102 fetch-pack.c:1107
 #, c-format
 msgid "Server supports %s"
 msgstr "El servidor soporta %s"
 
-#: fetch-pack.c:1029
+#: fetch-pack.c:1040
 msgid "Server does not support shallow clients"
 msgstr "El servidor no soporta clientes superficiales"
 
-#: fetch-pack.c:1089
+#: fetch-pack.c:1100
 msgid "Server does not support --shallow-since"
 msgstr "El servidor no soporta --shallow-since"
 
-#: fetch-pack.c:1094
+#: fetch-pack.c:1105
 msgid "Server does not support --shallow-exclude"
 msgstr "El servidor no soporta --shallow-exclude"
 
-#: fetch-pack.c:1098
+#: fetch-pack.c:1109
 msgid "Server does not support --deepen"
 msgstr "El servidor no soporta --deepen"
 
-#: fetch-pack.c:1100
+#: fetch-pack.c:1111
 msgid "Server does not support this repository's object format"
 msgstr "El servidor no soporta el formato de objetos de este repositorio"
 
-#: fetch-pack.c:1113
+#: fetch-pack.c:1124
 msgid "no common commits"
 msgstr "no hay commits comunes"
 
-#: fetch-pack.c:1122 fetch-pack.c:1469 builtin/clone.c:1238
+#: fetch-pack.c:1133 fetch-pack.c:1480 builtin/clone.c:1130
 msgid "source repository is shallow, reject to clone."
 msgstr "el repositorio fuente es superficial, rechazando clonado."
 
-#: fetch-pack.c:1128 fetch-pack.c:1660
+#: fetch-pack.c:1139 fetch-pack.c:1671
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack: fetch falló."
 
-#: fetch-pack.c:1242
+#: fetch-pack.c:1253
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "algoritmos no compatibles: cliente %s; servidor %s"
 
-#: fetch-pack.c:1246
+#: fetch-pack.c:1257
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "el servidor no soporta el algoritmo '%s'"
 
-#: fetch-pack.c:1279
+#: fetch-pack.c:1290
 msgid "Server does not support shallow requests"
 msgstr "El servidor no soporta peticiones superficiales"
 
-#: fetch-pack.c:1286
+#: fetch-pack.c:1297
 msgid "Server supports filter"
 msgstr "El servidor soporta filtración"
 
-#: fetch-pack.c:1329 fetch-pack.c:2043
+#: fetch-pack.c:1340 fetch-pack.c:2053
 msgid "unable to write request to remote"
 msgstr "no se puede escribir request al remoto"
 
-#: fetch-pack.c:1347
+#: fetch-pack.c:1358
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "error al leer header de sección '%s'"
 
-#: fetch-pack.c:1353
+#: fetch-pack.c:1364
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "se esperaba '%s', se recibió '%s'"
 
-#: fetch-pack.c:1387
+#: fetch-pack.c:1398
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "línea de confirmación inesperada: '%s'"
 
-#: fetch-pack.c:1392
+#: fetch-pack.c:1403
 #, c-format
 msgid "error processing acks: %d"
 msgstr "error al procesar acks: %d"
 
-#: fetch-pack.c:1402
+#: fetch-pack.c:1413
 msgid "expected packfile to be sent after 'ready'"
 msgstr "se esperaba que el packfile fuera enviado luego del 'listo'"
 
-#: fetch-pack.c:1404
+#: fetch-pack.c:1415
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr "se esperaba que ninguna otra sección fuera enviada luego del 'listo'"
 
-#: fetch-pack.c:1445
+#: fetch-pack.c:1456
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "error al procesar información de superficiales: %d"
 
-#: fetch-pack.c:1494
+#: fetch-pack.c:1505
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "se esperaba wanted-ref, se obtuvo '%s'"
 
-#: fetch-pack.c:1499
+#: fetch-pack.c:1510
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "wanted-ref inesperado: '%s'"
 
-#: fetch-pack.c:1504
+#: fetch-pack.c:1515
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "error al procesar refs deseadas: %d"
 
-#: fetch-pack.c:1534
+#: fetch-pack.c:1545
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: se esperaba un paquete final de respuesta"
 
-#: fetch-pack.c:1939
+#: fetch-pack.c:1949
 msgid "no matching remote head"
 msgstr "no concuerda el head remoto"
 
-#: fetch-pack.c:1962 builtin/clone.c:697
+#: fetch-pack.c:1972 builtin/clone.c:581
 msgid "remote did not send all necessary objects"
 msgstr "remoto no mandó todos los objetos necesarios"
 
-#: fetch-pack.c:2065
+#: fetch-pack.c:2075
 msgid "unexpected 'ready' from remote"
 msgstr "'listo' inesperado del remoto"
 
-#: fetch-pack.c:2088
+#: fetch-pack.c:2098
 #, c-format
 msgid "no such remote ref %s"
 msgstr "no existe ref remota %s"
 
-#: fetch-pack.c:2091
+#: fetch-pack.c:2101
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "El servidor no permite solicitudes de objetos inadvertidos %s"
 
-#: gpg-interface.c:273
+#: gpg-interface.c:329 gpg-interface.c:451 gpg-interface.c:902
+#: gpg-interface.c:918
 msgid "could not create temporary file"
 msgstr "no se pudo crear archivo temporal"
 
-#: gpg-interface.c:276
+#: gpg-interface.c:332 gpg-interface.c:454
 #, c-format
 msgid "failed writing detached signature to '%s'"
 msgstr "falló al escribir la firma separada para '%s'"
 
-#: gpg-interface.c:470
+#: gpg-interface.c:445
+msgid ""
+"gpg.ssh.allowedSignersFile needs to be configured and exist for ssh "
+"signature verification"
+msgstr ""
+"gpg.ssh.allowedSignersFile necesita ser configurado y existe para "
+"verificación de firmas ssh"
+
+#: gpg-interface.c:469
+msgid ""
+"ssh-keygen -Y find-principals/verify is needed for ssh signature "
+"verification (available in openssh version 8.2p1+)"
+msgstr ""
+"ssh-keygen -Y find-principals/verify se necesita para la verficación de ssh "
+"(disponible en openssh versión 8.2p1+)"
+
+#: gpg-interface.c:523
+#, c-format
+msgid "ssh signing revocation file configured but not found: %s"
+msgstr "archivo de revocación de firmas ssh configurado pero no encontrado: %s"
+
+#: gpg-interface.c:576
+#, c-format
+msgid "bad/incompatible signature '%s'"
+msgstr "firma mala/incompatible '%s'"
+
+#: gpg-interface.c:735 gpg-interface.c:740
+#, c-format
+msgid "failed to get the ssh fingerprint for key '%s'"
+msgstr "error al conseguir la huella de ssh para la llave '%s'"
+
+#: gpg-interface.c:762
+msgid ""
+"either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured"
+msgstr "user.signingkey o gpg.ssh.defaultKeyCommand necesitan ser configurados"
+
+#: gpg-interface.c:780
+#, c-format
+msgid "gpg.ssh.defaultKeyCommand succeeded but returned no keys: %s %s"
+msgstr "gpg.ssh.defaultKeyCommand exitoso pero no retornó ninguna llave: %s %s"
+
+#: gpg-interface.c:786
+#, c-format
+msgid "gpg.ssh.defaultKeyCommand failed: %s %s"
+msgstr "gpg.ssh.defaultKeyCommand falló: %s %s"
+
+#: gpg-interface.c:874
 msgid "gpg failed to sign the data"
 msgstr "gpg falló al firmar los datos"
+
+#: gpg-interface.c:895
+msgid "user.signingkey needs to be set for ssh signing"
+msgstr "user.signingkey necesita ser configurado para firmar con ssh"
+
+#: gpg-interface.c:906
+#, c-format
+msgid "failed writing ssh signing key to '%s'"
+msgstr "falló al escribir la llave de firma para '%s'"
+
+#: gpg-interface.c:924
+#, c-format
+msgid "failed writing ssh signing key buffer to '%s'"
+msgstr "falló al escribir el buffer para lla llave de firma para '%s'"
+
+#: gpg-interface.c:942
+msgid ""
+"ssh-keygen -Y sign is needed for ssh signing (available in openssh version "
+"8.2p1+)"
+msgstr ""
+"ssh-keygen -Y signs se necesita para el firmado con ssh (disponible en "
+"openssh versión 8.2p1+)"
+
+#: gpg-interface.c:954
+#, c-format
+msgid "failed reading ssh signing data buffer from '%s'"
+msgstr "falló al leer la firma ssh desde '%s'"
 
 #: graph.c:98
 #, c-format
 msgid "ignored invalid color '%.*s' in log.graphColors"
 msgstr "ignorado color inválido '%.*s' en log.graphColors"
 
-#: grep.c:531
+#: grep.c:533
 msgid ""
 "given pattern contains NULL byte (via -f <file>). This is only supported "
 "with -P under PCRE v2"
@@ -4341,109 +4433,109 @@ msgstr ""
 "el patrón provisto contiene bytes NULL (vía -f <archivo>). Esto solo es "
 "soportado con -P bajo PCRE v2"
 
-#: grep.c:1895
+#: grep.c:1928
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr "'%s': no es posible leer %s"
 
-#: grep.c:1912 setup.c:176 builtin/clone.c:416 builtin/diff.c:90
+#: grep.c:1945 setup.c:176 builtin/clone.c:302 builtin/diff.c:90
 #: builtin/rm.c:136
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "falló al hacer stat en '%s'"
 
-#: grep.c:1923
+#: grep.c:1956
 #, c-format
 msgid "'%s': short read"
 msgstr "'%s': lectura corta"
 
-#: help.c:23
-msgid "start a working area (see also: git help tutorial)"
-msgstr "comienza un área de trabajo (ver también: git help tutorial)"
-
 #: help.c:24
-msgid "work on the current change (see also: git help everyday)"
-msgstr "trabaja en los cambios actuales (ver también: git help everyday)"
+msgid "start a working area (see also: git help tutorial)"
+msgstr "comenzar un área de trabajo (mira también: git help tutorial)"
 
 #: help.c:25
-msgid "examine the history and state (see also: git help revisions)"
-msgstr "examina el historial y el estado (ver también: git help revisions)"
+msgid "work on the current change (see also: git help everyday)"
+msgstr "trabajar en los cambios actuales (mira también: git help everyday)"
 
 #: help.c:26
-msgid "grow, mark and tweak your common history"
-msgstr "crece, marca y ajusta tu historial común"
+msgid "examine the history and state (see also: git help revisions)"
+msgstr "examinar el historial y el estado (mira también: git help revisions)"
 
 #: help.c:27
-msgid "collaborate (see also: git help workflows)"
-msgstr "colabora (mira también: git help workflows)"
+msgid "grow, mark and tweak your common history"
+msgstr "crecer, marcar y ajustar tu historial común"
 
-#: help.c:31
+#: help.c:28
+msgid "collaborate (see also: git help workflows)"
+msgstr "colaborar (mira también: git help workflows)"
+
+#: help.c:32
 msgid "Main Porcelain Commands"
 msgstr "Comandos de Porcelana principales"
 
-#: help.c:32
+#: help.c:33
 msgid "Ancillary Commands / Manipulators"
 msgstr "Comandos auxiliares / Manipuladores"
 
-#: help.c:33
+#: help.c:34
 msgid "Ancillary Commands / Interrogators"
 msgstr "Comandos auxiliares / Interrogadores"
 
-#: help.c:34
-msgid "Interacting with Others"
-msgstr "Interactuando con Otros"
-
 #: help.c:35
+msgid "Interacting with Others"
+msgstr "Interactuar con Otros"
+
+#: help.c:36
 msgid "Low-level Commands / Manipulators"
 msgstr "Comandos de bajo nivel / Manipuladores"
 
-#: help.c:36
+#: help.c:37
 msgid "Low-level Commands / Interrogators"
 msgstr "Comandos de bajo nivel / Interrogadores"
 
-#: help.c:37
+#: help.c:38
 msgid "Low-level Commands / Syncing Repositories"
 msgstr "Comandos de bajo nivel / Sincronización de repositorios"
 
-#: help.c:38
+#: help.c:39
 msgid "Low-level Commands / Internal Helpers"
 msgstr "Comandos de bajo nivel / Auxiliares internos"
 
-#: help.c:300
+#: help.c:313
 #, c-format
 msgid "available git commands in '%s'"
 msgstr "comandos disponibles de git en '%s'"
 
-#: help.c:307
+#: help.c:320
 msgid "git commands available from elsewhere on your $PATH"
 msgstr "comandos disponibles de git desde otro lugar en tu $PATH"
 
-#: help.c:316
+#: help.c:329
 msgid "These are common Git commands used in various situations:"
 msgstr "Estos son comandos comunes de Git usados en varias situaciones:"
 
-#: help.c:365 git.c:100
+#: help.c:378 git.c:100
 #, c-format
 msgid "unsupported command listing type '%s'"
 msgstr "tipo de listado de comandos no soportado '%s'"
 
-#: help.c:405
+#: help.c:418
 msgid "The Git concept guides are:"
 msgstr "Las guías de conceptos de Git son:"
 
-#: help.c:429
+#: help.c:442
 msgid "See 'git help <command>' to read about a specific subcommand"
-msgstr "Vea 'git help <comando>' para leer sobre los subcomandos específicos"
+msgstr "Mira 'git help <comando>' para leer sobre los subcomandos específicos"
 
-#: help.c:434
+#: help.c:447
 msgid "External commands"
 msgstr "Comandos externos"
 
-#: help.c:449
+#: help.c:462
 msgid "Command aliases"
 msgstr "Aliases de comando"
 
-#: help.c:527
+#: help.c:543
 #, c-format
 msgid ""
 "'%s' appears to be a git command, but we were not\n"
@@ -4452,31 +4544,36 @@ msgstr ""
 "'%s' parece ser un comando de git, pero no hemos\n"
 "podido ejecutarlo. ¿Tal vez git-%s se ha roto?"
 
-#: help.c:543 help.c:631
+#: help.c:565 help.c:662
 #, c-format
 msgid "git: '%s' is not a git command. See 'git --help'."
 msgstr "git: '%s' no es un comando de git. Mira 'git --help'."
 
-#: help.c:591
+#: help.c:613
 msgid "Uh oh. Your system reports no Git commands at all."
 msgstr "Oh oh. Tu sistema no reporta ningún comando de Git."
 
-#: help.c:613
+#: help.c:635
 #, c-format
 msgid "WARNING: You called a Git command named '%s', which does not exist."
 msgstr "PELIGRO: Has llamado a un comando de Git '%s', el cual no existe."
 
-#: help.c:618
+#: help.c:640
 #, c-format
 msgid "Continuing under the assumption that you meant '%s'."
 msgstr "Continuando asumiendo que quisiste decir '%s'."
 
-#: help.c:623
+#: help.c:646
+#, c-format
+msgid "Run '%s' instead? (y/N)"
+msgstr "Ejecutar '%s' en su lugar? (y/N)"
+
+#: help.c:654
 #, c-format
 msgid "Continuing in %0.1f seconds, assuming that you meant '%s'."
 msgstr "Continuando en %0.1f segundos, asumiendo que quisiste decir '%s'."
 
-#: help.c:635
+#: help.c:666
 msgid ""
 "\n"
 "The most similar command is"
@@ -4490,16 +4587,16 @@ msgstr[1] ""
 "\n"
 "Los comandos más similares son"
 
-#: help.c:675
+#: help.c:706
 msgid "git version [<options>]"
 msgstr "git version [<opciones>]"
 
-#: help.c:730
+#: help.c:761
 #, c-format
 msgid "%s: %s - %s"
 msgstr "%s: %s - %s"
 
-#: help.c:734
+#: help.c:765
 msgid ""
 "\n"
 "Did you mean this?"
@@ -4512,6 +4609,15 @@ msgstr[0] ""
 msgstr[1] ""
 "\n"
 "¿Quisiste decir alguno de estos?"
+
+#: hook.c:27
+#, c-format
+msgid ""
+"The '%s' hook was ignored because it's not set as executable.\n"
+"You can disable this warning with `git config advice.ignoredHook false`."
+msgstr ""
+"El hook '%s' fue ignorado porque no ha sido configurado como ejecutable.\n"
+"Puedes desactivar esta advertencia con `git config advice.ignoredHook false`."
 
 #: ident.c:353
 msgid "Author identity unknown\n"
@@ -4575,7 +4681,7 @@ msgstr "no se puede tener un nombre de identidad vacío (para <%s>)"
 msgid "name consists only of disallowed characters: %s"
 msgstr "el nombre consiste solo de caracteres no permitidos: %s"
 
-#: ident.c:454 builtin/commit.c:647
+#: ident.c:454 builtin/commit.c:648
 #, c-format
 msgid "invalid date format: %s"
 msgstr "formato de fecha inválido: %s"
@@ -4656,7 +4762,7 @@ msgstr ""
 "No se puede crear '%s.lock': %s.\n"
 "\n"
 "Otro proceso git parece estar ejecutando en el repositorio, es decir\n"
-"un editor abierto con 'git commit'. Por favor asegúrese de que todos los "
+"un editor abierto con 'git commit'. Por favor asegúrate de que todos los "
 "procesos\n"
 "estén terminados y vuelve a intentar. Si el fallo permanece, un proceso git\n"
 "puede haber roto el repositorio antes:\n"
@@ -4672,7 +4778,12 @@ msgstr "No se pudo crear '%s.lock': %s"
 msgid "invalid value '%s' for lsrefs.unborn"
 msgstr "valor inválido '%s' para lsrefs.unborn"
 
-#: ls-refs.c:167
+#: ls-refs.c:174
+#, c-format
+msgid "unexpected line: '%s'"
+msgstr "línea inesperada: '%s'"
+
+#: ls-refs.c:178
 msgid "expected flush after ls-refs arguments"
 msgstr "se esperaba un flush luego de argumentos ls-refs"
 
@@ -4680,37 +4791,37 @@ msgstr "se esperaba un flush luego de argumentos ls-refs"
 msgid "quoted CRLF detected"
 msgstr "CRLF con comillas detectado"
 
-#: mailinfo.c:1254 builtin/am.c:176 builtin/mailinfo.c:46
+#: mailinfo.c:1254 builtin/am.c:177 builtin/mailinfo.c:46
 #, c-format
 msgid "bad action '%s' for '%s'"
 msgstr "mala acción '%s' para '%s'"
 
-#: merge-ort.c:1569 merge-recursive.c:1201
+#: merge-ort.c:1584 merge-recursive.c:1211
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
 msgstr "Falló al fusionar el submódulo %s (no revisado)"
 
-#: merge-ort.c:1578 merge-recursive.c:1208
+#: merge-ort.c:1593 merge-recursive.c:1218
 #, c-format
 msgid "Failed to merge submodule %s (commits not present)"
 msgstr "Falló al fusionar el submódulo %s (commits no presentes)"
 
-#: merge-ort.c:1587 merge-recursive.c:1215
+#: merge-ort.c:1602 merge-recursive.c:1225
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
 msgstr "Falló el fusionar submódulo %s (commits no siguen la base de fusión)"
 
-#: merge-ort.c:1597 merge-ort.c:1604
+#: merge-ort.c:1612 merge-ort.c:1620
 #, c-format
 msgid "Note: Fast-forwarding submodule %s to %s"
 msgstr "Nota: Fast-forward de submódulo %s a %s"
 
-#: merge-ort.c:1625
+#: merge-ort.c:1642
 #, c-format
 msgid "Failed to merge submodule %s"
 msgstr "Falló al fusionar el submódulo %s"
 
-#: merge-ort.c:1632
+#: merge-ort.c:1649
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but a possible merge resolution exists:\n"
@@ -4720,7 +4831,7 @@ msgstr ""
 "fusión:\n"
 "%s\n"
 
-#: merge-ort.c:1636 merge-recursive.c:1269
+#: merge-ort.c:1653 merge-recursive.c:1281
 #, c-format
 msgid ""
 "If this is correct simply add it to the index for example\n"
@@ -4737,30 +4848,31 @@ msgstr ""
 "\n"
 "el cual aceptará esta sugerencia.\n"
 
-#: merge-ort.c:1649
+#: merge-ort.c:1666
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but multiple possible merges exist:\n"
 "%s"
 msgstr ""
-"Falló al fusionar el submódulo %s, pero existen múltipes fusiones posibles:\n"
+"Falló al fusionar el submódulo %s, pero existen múltiples fusiones "
+"posibles:\n"
 "%s"
 
-#: merge-ort.c:1868 merge-recursive.c:1358
+#: merge-ort.c:1887 merge-recursive.c:1372
 msgid "Failed to execute internal merge"
 msgstr "Falló al ejecutar la fusión interna"
 
-#: merge-ort.c:1873 merge-recursive.c:1363
+#: merge-ort.c:1892 merge-recursive.c:1377
 #, c-format
 msgid "Unable to add %s to database"
 msgstr "No es posible agregar %s a la base de datos"
 
-#: merge-ort.c:1880 merge-recursive.c:1396
+#: merge-ort.c:1899 merge-recursive.c:1410
 #, c-format
 msgid "Auto-merging %s"
 msgstr "Auto-fusionando %s"
 
-#: merge-ort.c:2019 merge-recursive.c:2118
+#: merge-ort.c:2038 merge-recursive.c:2132
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
@@ -4770,7 +4882,7 @@ msgstr ""
 "existente en %s se interpone con el cambio de nombres implícito, poniendo "
 "la(s) siguiente(s) ruta(s) aquí: %s."
 
-#: merge-ort.c:2029 merge-recursive.c:2128
+#: merge-ort.c:2048 merge-recursive.c:2142
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
@@ -4779,7 +4891,7 @@ msgstr ""
 "CONFLICTO (cambio de nombre de directorio implícito): No se puede mapear más "
 "de una ruta para %s; cambio de nombre implícito intentó poner estas rutas: %s"
 
-#: merge-ort.c:2087
+#: merge-ort.c:2106
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to rename %s to; it was "
@@ -4790,7 +4902,7 @@ msgstr ""
 "cambiar el nombre de %s; se le cambió el nombre a varios otros directorios, "
 "sin que ningún destino obtuviera la mayoría de los archivos."
 
-#: merge-ort.c:2241 merge-recursive.c:2464
+#: merge-ort.c:2260 merge-recursive.c:2478
 #, c-format
 msgid ""
 "WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
@@ -4799,7 +4911,7 @@ msgstr ""
 "PELIGRO: Evitando aplicar %s -> %s renombrado a %s, porque %s mismo fue "
 "renombrado."
 
-#: merge-ort.c:2385 merge-recursive.c:3247
+#: merge-ort.c:2400 merge-recursive.c:3261
 #, c-format
 msgid ""
 "Path updated: %s added in %s inside a directory that was renamed in %s; "
@@ -4808,7 +4920,7 @@ msgstr ""
 "Path actualizado: %s agregado en %s dentro de un directorio que fue "
 "renombrado en %s; moviéndolo a %s."
 
-#: merge-ort.c:2392 merge-recursive.c:3254
+#: merge-ort.c:2407 merge-recursive.c:3268
 #, c-format
 msgid ""
 "Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
@@ -4817,7 +4929,7 @@ msgstr ""
 "Path actualizado: %s renombrado a %s en %s, dentro de un directorio que fue "
 "renombrado en %s; moviéndolo a %s."
 
-#: merge-ort.c:2405 merge-recursive.c:3250
+#: merge-ort.c:2420 merge-recursive.c:3264
 #, c-format
 msgid ""
 "CONFLICT (file location): %s added in %s inside a directory that was renamed "
@@ -4826,7 +4938,7 @@ msgstr ""
 "CONFLICTO (ubicación de archivo): %s agregado en %s dentro de un directorio "
 "que fue renombrado en %s, sugerimos que debería ser movido a %s."
 
-#: merge-ort.c:2413 merge-recursive.c:3257
+#: merge-ort.c:2428 merge-recursive.c:3271
 #, c-format
 msgid ""
 "CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
@@ -4836,13 +4948,13 @@ msgstr ""
 "directorio que fue renombrado en %s, sugiriendo que tal vez debería ser "
 "movido a %s."
 
-#: merge-ort.c:2569
+#: merge-ort.c:2584
 #, c-format
 msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
 msgstr ""
 "CONFLICTO (renombrar / renombrar): %s renombrado a %s en %s y %s en %s."
 
-#: merge-ort.c:2664
+#: merge-ort.c:2679
 #, c-format
 msgid ""
 "CONFLICT (rename involved in collision): rename of %s -> %s has content "
@@ -4853,24 +4965,24 @@ msgstr ""
 "->%s tiene conflictos de contenido Y colisiona con otra ruta; esto puede "
 "resultar en marcadores de conflicto anidados."
 
-#: merge-ort.c:2683 merge-ort.c:2707
+#: merge-ort.c:2698 merge-ort.c:2722
 #, c-format
 msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
 msgstr ""
 "CONFLICTO (renombrar / eliminar): %s renombrado a %s en %s, pero eliminado "
 "en %s."
 
-#: merge-ort.c:3182 merge-recursive.c:3008
+#: merge-ort.c:3212 merge-recursive.c:3022
 #, c-format
 msgid "cannot read object %s"
 msgstr "no se pudo leer el objeto %s"
 
-#: merge-ort.c:3185 merge-recursive.c:3011
+#: merge-ort.c:3215 merge-recursive.c:3025
 #, c-format
 msgid "object %s is not a blob"
 msgstr "objeto %s no es un blob"
 
-#: merge-ort.c:3613
+#: merge-ort.c:3644
 #, c-format
 msgid ""
 "CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
@@ -4879,7 +4991,7 @@ msgstr ""
 "CONFLICTO (archivo / directorio): directorio en el camino de %s de %s; "
 "moviéndolo a %s en su lugar."
 
-#: merge-ort.c:3689
+#: merge-ort.c:3721
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed both "
@@ -4889,7 +5001,7 @@ msgstr ""
 "fueron renombrados para que cada uno pueda ser grabado en algún lugar "
 "diferente."
 
-#: merge-ort.c:3696
+#: merge-ort.c:3728
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed one "
@@ -4899,24 +5011,24 @@ msgstr ""
 "ellos fue renombrado para que cada uno pueda ser grabado en algún lugar "
 "diferente."
 
-#: merge-ort.c:3796 merge-recursive.c:3087
+#: merge-ort.c:3819 merge-recursive.c:3101
 msgid "content"
 msgstr "contenido"
 
-#: merge-ort.c:3798 merge-recursive.c:3091
+#: merge-ort.c:3821 merge-recursive.c:3105
 msgid "add/add"
 msgstr "agregar/agregar"
 
-#: merge-ort.c:3800 merge-recursive.c:3136
+#: merge-ort.c:3823 merge-recursive.c:3150
 msgid "submodule"
 msgstr "submódulo"
 
-#: merge-ort.c:3802 merge-recursive.c:3137
+#: merge-ort.c:3825 merge-recursive.c:3151
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "CONFLICTO (%s): Conflicto de fusión en %s"
 
-#: merge-ort.c:3833
+#: merge-ort.c:3856
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
@@ -4925,7 +5037,7 @@ msgstr ""
 "CONFLICTO (modificar / eliminar): %s eliminado en %s y modificado en %s. "
 "Versión %s de %s restante en el árbol."
 
-#: merge-ort.c:4120
+#: merge-ort.c:4152
 #, c-format
 msgid ""
 "Note: %s not up to date and in way of checking out conflicted version; old "
@@ -4937,13 +5049,13 @@ msgstr ""
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
-#: merge-ort.c:4487
+#: merge-ort.c:4521
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
 msgstr ""
 "la recopilación de información de fusión falló para los árboles %s, %s, %s"
 
-#: merge-ort-wrappers.c:13 merge-recursive.c:3702
+#: merge-ort-wrappers.c:13 merge-recursive.c:3716
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -4953,106 +5065,106 @@ msgstr ""
 "merge:\n"
 "  %s"
 
-#: merge-ort-wrappers.c:33 merge-recursive.c:3468 builtin/merge.c:402
+#: merge-ort-wrappers.c:33 merge-recursive.c:3482 builtin/merge.c:403
 msgid "Already up to date."
 msgstr "Ya está actualizado."
 
-#: merge-recursive.c:352
+#: merge-recursive.c:353
 msgid "(bad commit)\n"
 msgstr "(commit erróneo)\n"
 
-#: merge-recursive.c:375
+#: merge-recursive.c:381
 #, c-format
 msgid "add_cacheinfo failed for path '%s'; merge aborting."
 msgstr "add_cacheinfo falló para la ruta '%s'; abortando fusión."
 
-#: merge-recursive.c:384
+#: merge-recursive.c:390
 #, c-format
 msgid "add_cacheinfo failed to refresh for path '%s'; merge aborting."
 msgstr "add_cacheinfo falló al refrescar la ruta '%s'; abortando fusión."
 
-#: merge-recursive.c:872
+#: merge-recursive.c:881
 #, c-format
 msgid "failed to create path '%s'%s"
 msgstr "falló al crear la ruta '%s'%s"
 
-#: merge-recursive.c:883
+#: merge-recursive.c:892
 #, c-format
 msgid "Removing %s to make room for subdirectory\n"
 msgstr "Quitando %s para hacer espacio para un subdirectorio\n"
 
-#: merge-recursive.c:897 merge-recursive.c:916
+#: merge-recursive.c:906 merge-recursive.c:925
 msgid ": perhaps a D/F conflict?"
 msgstr ": ¿tal vez un conflicto D/F?"
 
-#: merge-recursive.c:906
+#: merge-recursive.c:915
 #, c-format
 msgid "refusing to lose untracked file at '%s'"
 msgstr "rehusando perder el archivo no rastreado en '%s'"
 
-#: merge-recursive.c:947 builtin/cat-file.c:41
+#: merge-recursive.c:956 builtin/cat-file.c:41
 #, c-format
 msgid "cannot read object %s '%s'"
 msgstr "no se puede leer el objeto %s '%s'"
 
-#: merge-recursive.c:952
+#: merge-recursive.c:961
 #, c-format
 msgid "blob expected for %s '%s'"
 msgstr "se esperaba blob para %s '%s'"
 
-#: merge-recursive.c:977
+#: merge-recursive.c:986
 #, c-format
 msgid "failed to open '%s': %s"
 msgstr "falló al abrir '%s': %s"
 
-#: merge-recursive.c:988
+#: merge-recursive.c:997
 #, c-format
 msgid "failed to symlink '%s': %s"
 msgstr "falló al crear el enlace simbólico '%s': %s"
 
-#: merge-recursive.c:993
+#: merge-recursive.c:1002
 #, c-format
 msgid "do not know what to do with %06o %s '%s'"
 msgstr "no sé qué hacer con %06o %s '%s'"
 
-#: merge-recursive.c:1223 merge-recursive.c:1235
+#: merge-recursive.c:1233 merge-recursive.c:1246
 #, c-format
 msgid "Fast-forwarding submodule %s to the following commit:"
 msgstr "Haciendo fast-forward a submódulo %s hasta el siguiente commit:"
 
-#: merge-recursive.c:1226 merge-recursive.c:1238
+#: merge-recursive.c:1236 merge-recursive.c:1249
 #, c-format
 msgid "Fast-forwarding submodule %s"
 msgstr "Avance rápido en submódulo %s"
 
-#: merge-recursive.c:1261
+#: merge-recursive.c:1273
 #, c-format
 msgid "Failed to merge submodule %s (merge following commits not found)"
 msgstr ""
 "Falló al fusionar submódulo %s (los siguentes commits no fueron encontrados)"
 
-#: merge-recursive.c:1265
+#: merge-recursive.c:1277
 #, c-format
 msgid "Failed to merge submodule %s (not fast-forward)"
 msgstr "Falló al fusionar el submódulo %s (avance rápido no es posible)"
 
-#: merge-recursive.c:1266
+#: merge-recursive.c:1278
 msgid "Found a possible merge resolution for the submodule:\n"
 msgstr "Se encontró una posible solución de fusión para el submódulo:\n"
 
-#: merge-recursive.c:1278
+#: merge-recursive.c:1290
 #, c-format
 msgid "Failed to merge submodule %s (multiple merges found)"
 msgstr "Falló al fusionar el submódulo %s (múltiples fusiones encontradas)"
 
-#: merge-recursive.c:1420
+#: merge-recursive.c:1434
 #, c-format
 msgid "Error: Refusing to lose untracked file at %s; writing to %s instead."
 msgstr ""
 "Error: Rehusando perder el archivo no rastreado en %s; escribiéndolo a %s en "
 "cambio."
 
-#: merge-recursive.c:1492
+#: merge-recursive.c:1506
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
@@ -5061,7 +5173,7 @@ msgstr ""
 "CONFLICTO (%s/borrar): %s borrado en %s y %s en %s. Se dejó la versión %s de "
 "%s en el árbol."
 
-#: merge-recursive.c:1497
+#: merge-recursive.c:1511
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
@@ -5070,7 +5182,7 @@ msgstr ""
 "CONFLICTO (%s/borrar): %s borrado en %s y %s para %s en %s. Versión %s de %s "
 "permanece en el árbol."
 
-#: merge-recursive.c:1504
+#: merge-recursive.c:1518
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
@@ -5079,7 +5191,7 @@ msgstr ""
 "CONFLICTO (%s/eliminar): %s eliminado en %s y %s en %s. Versión %s de %s "
 "dejada en el árbol, en %s."
 
-#: merge-recursive.c:1509
+#: merge-recursive.c:1523
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
@@ -5088,44 +5200,44 @@ msgstr ""
 "CONFLICTO (%s/borrar): %s borrado en %s y %s para %s en %s. Versión %s de %s "
 "permanece en el árbol en %s."
 
-#: merge-recursive.c:1544
+#: merge-recursive.c:1558
 msgid "rename"
 msgstr "renombrar"
 
-#: merge-recursive.c:1544
+#: merge-recursive.c:1558
 msgid "renamed"
 msgstr "renombrado"
 
-#: merge-recursive.c:1595 merge-recursive.c:2501 merge-recursive.c:3164
+#: merge-recursive.c:1609 merge-recursive.c:2515 merge-recursive.c:3178
 #, c-format
 msgid "Refusing to lose dirty file at %s"
 msgstr "Rehusando perder el archivo sucio en %s"
 
-#: merge-recursive.c:1605
+#: merge-recursive.c:1619
 #, c-format
 msgid "Refusing to lose untracked file at %s, even though it's in the way."
 msgstr ""
 "Rehusando perder el archivo no rastreado en %s, incluso aunque se está "
 "interponiendo."
 
-#: merge-recursive.c:1663
+#: merge-recursive.c:1677
 #, c-format
 msgid "CONFLICT (rename/add): Rename %s->%s in %s.  Added %s in %s"
 msgstr ""
 "CONFLICTO (renombrar/agregar): Renombrar %s->%s en %s.  %s agregado en %s"
 
-#: merge-recursive.c:1694
+#: merge-recursive.c:1708
 #, c-format
 msgid "%s is a directory in %s adding as %s instead"
 msgstr "%s es un directorio en %s agregando como %s más bien"
 
-#: merge-recursive.c:1699
+#: merge-recursive.c:1713
 #, c-format
 msgid "Refusing to lose untracked file at %s; adding as %s instead"
 msgstr ""
 "Rehusando perder el archivo no rastreado en %s; agregándolo como %s en cambio"
 
-#: merge-recursive.c:1726
+#: merge-recursive.c:1740
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename \"%s\"->\"%s\" in branch \"%s\" rename \"%s"
@@ -5134,18 +5246,18 @@ msgstr ""
 "CONFLICTO (renombrar/renombrar): Renombrar \"%s\"->\"%s\" en la rama \"%s\" "
 "renombrar \"%s\"->\"%s\" en \"%s\"%s"
 
-#: merge-recursive.c:1731
+#: merge-recursive.c:1745
 msgid " (left unresolved)"
 msgstr " (dejado sin resolver)"
 
-#: merge-recursive.c:1823
+#: merge-recursive.c:1837
 #, c-format
 msgid "CONFLICT (rename/rename): Rename %s->%s in %s. Rename %s->%s in %s"
 msgstr ""
 "CONFLICTO (renombrar/renombrar): Renombrar %s->%s en %s. Renombrar %s->%s en "
 "%s"
 
-#: merge-recursive.c:2086
+#: merge-recursive.c:2100
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to place %s because "
@@ -5156,7 +5268,7 @@ msgstr ""
 "colocar %s porque el directorio %s fue renombrado a múltiples otros "
 "directorios, sin ningún que contenga la mayoría de archivos."
 
-#: merge-recursive.c:2220
+#: merge-recursive.c:2234
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename directory %s->%s in %s. Rename directory %s-"
@@ -5165,81 +5277,81 @@ msgstr ""
 "CONFLICTO (renombrar/renombrar): Renombrar directorio %s->%s en %s. "
 "Renombrar directorio %s->%s en %s"
 
-#: merge-recursive.c:3075
+#: merge-recursive.c:3089
 msgid "modify"
 msgstr "modificar"
 
-#: merge-recursive.c:3075
+#: merge-recursive.c:3089
 msgid "modified"
 msgstr "modificado"
 
-#: merge-recursive.c:3114
+#: merge-recursive.c:3128
 #, c-format
 msgid "Skipped %s (merged same as existing)"
 msgstr "Saltado %s (fusionado como existente)"
 
-#: merge-recursive.c:3167
+#: merge-recursive.c:3181
 #, c-format
 msgid "Adding as %s instead"
 msgstr "Agregando más bien como %s"
 
-#: merge-recursive.c:3371
+#: merge-recursive.c:3385
 #, c-format
 msgid "Removing %s"
 msgstr "Eliminando %s"
 
-#: merge-recursive.c:3394
+#: merge-recursive.c:3408
 msgid "file/directory"
 msgstr "archivo/directorio"
 
-#: merge-recursive.c:3399
+#: merge-recursive.c:3413
 msgid "directory/file"
 msgstr "directorio/archivo"
 
-#: merge-recursive.c:3406
+#: merge-recursive.c:3420
 #, c-format
 msgid "CONFLICT (%s): There is a directory with name %s in %s. Adding %s as %s"
 msgstr ""
 "CONFLICTO (%s): Hay un directorio con el nombre %s en %s. Agregando %s como "
 "%s"
 
-#: merge-recursive.c:3415
+#: merge-recursive.c:3429
 #, c-format
 msgid "Adding %s"
 msgstr "Agregando %s"
 
-#: merge-recursive.c:3424
+#: merge-recursive.c:3438
 #, c-format
 msgid "CONFLICT (add/add): Merge conflict in %s"
 msgstr "CONFLICTO (add/add): Conflicto de merge en %s"
 
-#: merge-recursive.c:3477
+#: merge-recursive.c:3491
 #, c-format
 msgid "merging of trees %s and %s failed"
 msgstr "falló la fusión de los árboles %s y %s"
 
-#: merge-recursive.c:3571
+#: merge-recursive.c:3585
 msgid "Merging:"
 msgstr "Fusionando:"
 
-#: merge-recursive.c:3584
+#: merge-recursive.c:3598
 #, c-format
 msgid "found %u common ancestor:"
 msgid_plural "found %u common ancestors:"
 msgstr[0] "se encontró %u ancestro común:"
 msgstr[1] "se encontraron %u ancestros comunes:"
 
-#: merge-recursive.c:3634
+#: merge-recursive.c:3648
 msgid "merge returned no commit"
 msgstr "la fusión no devolvió ningún commit"
 
-#: merge-recursive.c:3799
+#: merge-recursive.c:3816
 #, c-format
 msgid "Could not parse object '%s'"
 msgstr "No se pudo analizar el objeto '%s'"
 
-#: merge-recursive.c:3817 builtin/merge.c:717 builtin/merge.c:901
-#: builtin/stash.c:473
+#: merge-recursive.c:3834 builtin/merge.c:718 builtin/merge.c:904
+#: builtin/stash.c:489
 msgid "Unable to write index."
 msgstr "Incapaz de escribir el índice."
 
@@ -5247,196 +5359,228 @@ msgstr "Incapaz de escribir el índice."
 msgid "failed to read the cache"
 msgstr "falló al leer la cache"
 
-#: merge.c:108 rerere.c:704 builtin/am.c:1932 builtin/am.c:1966
-#: builtin/checkout.c:590 builtin/checkout.c:844 builtin/clone.c:821
-#: builtin/stash.c:267
+#: merge.c:102 rerere.c:704 builtin/am.c:1933 builtin/am.c:1967
+#: builtin/checkout.c:590 builtin/checkout.c:842 builtin/clone.c:706
+#: builtin/stash.c:269
 msgid "unable to write new index file"
 msgstr "no es posible escribir el archivo índice"
 
-#: midx.c:74
+#: midx.c:78
 msgid "multi-pack-index OID fanout is of the wrong size"
 msgstr ""
 "el abanico de OID de índice de paquetes múltiples es del tamaño incorrecto"
 
-#: midx.c:105
+#: midx.c:109
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "el archivo multi-pack-index %s es demasiado pequeño"
 
-#: midx.c:121
+#: midx.c:125
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr "firma de multi-pack-index 0x%08x no concuerda con firma 0x%08x"
 
-#: midx.c:126
+#: midx.c:130
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "versión %d de multi-pack-index no reconocida"
 
-#: midx.c:131
+#: midx.c:135
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr ""
 "la versión de hash de índice de paquetes múltiples %u no coincide con la "
 "versión %u"
 
-#: midx.c:148
+#: midx.c:152
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "a multi-pack-index le falta el conjunto pack-name requerido"
 
-#: midx.c:150
+#: midx.c:154
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "a multi-pack-index le falta el conjunto OID fanout requerido"
 
-#: midx.c:152
+#: midx.c:156
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr "a multi-pack-index le falta el conjunto OID fanout requerido"
 
-#: midx.c:154
+#: midx.c:158
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr "a multi-pack-index le falta el conjunto de offset del objeto requerido"
 
-#: midx.c:170
+#: midx.c:174
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr ""
 "nombres de paquete de multi-pack-index fuera de orden: '%s' antes de '%s'"
 
-#: midx.c:214
+#: midx.c:221
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr "mal pack-int-id: %u (%u paquetes totales)"
 
-#: midx.c:264
+#: midx.c:271
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr ""
 "multi-pack-index guarda un offset de 64-bit, pero off_t es demasiado pequeño"
 
-#: midx.c:490
+#: midx.c:502
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "falló al agregar packfile '%s'"
 
-#: midx.c:496
+#: midx.c:508
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "falló al abrir pack-index '%s'"
 
-#: midx.c:564
+#: midx.c:576
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "falló al ubicar objeto %d en packfile"
 
-#: midx.c:880 builtin/index-pack.c:1533
+#: midx.c:892
 msgid "cannot store reverse index file"
 msgstr "no se puede almacenar el archivo de índice inverso"
 
-#: midx.c:920
+#: midx.c:990
+#, c-format
+msgid "could not parse line: %s"
+msgstr "no se puede analizar línea: %s"
+
+#: midx.c:992
+#, c-format
+msgid "malformed line: %s"
+msgstr "línea mal formada: %s"
+
+#: midx.c:1159
 msgid "ignoring existing multi-pack-index; checksum mismatch"
 msgstr "ignorando el actual multi-pack-index; checksum no concuerda"
 
-#: midx.c:943
+#: midx.c:1184
+msgid "could not load pack"
+msgstr "no se pudo cargar pack"
+
+#: midx.c:1190
+#, c-format
+msgid "could not open index for %s"
+msgstr "no se puede abrir index para %s"
+
+#: midx.c:1201
 msgid "Adding packfiles to multi-pack-index"
 msgstr "Agregando packfiles a multi-pack-index"
 
-#: midx.c:989
-#, c-format
-msgid "did not see pack-file %s to drop"
-msgstr "no se vió el pack-file que abandonar %s"
-
-#: midx.c:1034
+#: midx.c:1244
 #, c-format
 msgid "unknown preferred pack: '%s'"
 msgstr "pack preferido desconocido: '%s'"
 
-#: midx.c:1039
+#: midx.c:1289
+#, c-format
+msgid "cannot select preferred pack %s with no objects"
+msgstr "no se pueden seleccionar el paquete preferido %s sin objetos"
+
+#: midx.c:1321
+#, c-format
+msgid "did not see pack-file %s to drop"
+msgstr "no se vió el pack-file que abandonar %s"
+
+#: midx.c:1367
 #, c-format
 msgid "preferred pack '%s' is expired"
 msgstr "pack de referencia '% s' ha expirado"
 
-#: midx.c:1055
+#: midx.c:1380
 msgid "no pack files to index."
 msgstr "no hay archivos pack para indexar."
 
-#: midx.c:1135 builtin/clean.c:37
+#: midx.c:1417
+msgid "could not write multi-pack bitmap"
+msgstr "no se pudo escribir bitmap multi-paquete"
+
+#: midx.c:1427
+msgid "could not write multi-pack-index"
+msgstr "no se pudo escribir multi-pack-index"
+
+#: midx.c:1486 builtin/clean.c:37
 #, c-format
 msgid "failed to remove %s"
 msgstr "falló al borrar %s"
 
-#: midx.c:1166
+#: midx.c:1517
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "falló al limpiar multi-pack-index en %s"
 
-#: midx.c:1225
+#: midx.c:1577
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr ""
 "el archivo de índice de paquetes múltiples existe, pero no se pudo analizar"
 
-#: midx.c:1233
+#: midx.c:1585
 msgid "incorrect checksum"
 msgstr "checksum incorrecto"
 
-#: midx.c:1236
+#: midx.c:1588
 msgid "Looking for referenced packfiles"
 msgstr "Buscando packfiles referidos"
 
-#: midx.c:1251
+#: midx.c:1603
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 msgstr ""
 "oid fanout fuera de orden: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 
-#: midx.c:1256
+#: midx.c:1608
 msgid "the midx contains no oid"
 msgstr "el midx no contiene oid"
 
-#: midx.c:1265
+#: midx.c:1617
 msgid "Verifying OID order in multi-pack-index"
 msgstr "Verificando orden de OID en multi-pack-index"
 
-#: midx.c:1274
+#: midx.c:1626
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr "oid lookup fuera de orden: oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1294
+#: midx.c:1646
 msgid "Sorting objects by packfile"
 msgstr "Ordenando objetos por packfile"
 
-#: midx.c:1301
+#: midx.c:1653
 msgid "Verifying object offsets"
 msgstr "Verificando offsets de objetos"
 
-#: midx.c:1317
+#: midx.c:1669
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "fallo al cargar entrada pack para oid[%d] = %s"
 
-#: midx.c:1323
+#: midx.c:1675
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "falló al cargar el pack-index para packfile %s"
 
-#: midx.c:1332
+#: midx.c:1684
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr "offset para objeto incorrecto oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#: midx.c:1357
+#: midx.c:1709
 msgid "Counting referenced objects"
 msgstr "Contando objetos no referenciados"
 
-#: midx.c:1367
+#: midx.c:1719
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "Encontrando y borrando packfiles sin referencias"
 
-#: midx.c:1558
+#: midx.c:1911
 msgid "could not start pack-objects"
 msgstr "no se pudo iniciar pack-objects"
 
-#: midx.c:1578
+#: midx.c:1931
 msgid "could not finish pack-objects"
 msgstr "no se pudo finalizar pack-objects"
 
@@ -5462,7 +5606,7 @@ msgid ""
 "Please, use 'git notes merge --commit' or 'git notes merge --abort' to "
 "commit/abort the previous merge before you start a new notes merge."
 msgstr ""
-"No has concluido tu fusión preia de notas (%s existe).\n"
+"No has concluido tu fusión previa de notas (%s existe).\n"
 "Por favor, usa 'git notes merge --commit' o 'git notes merge --abort' para "
 "confirmar/abortar la fusión previa antes de comenzar una nueva fusión de "
 "notas."
@@ -5496,262 +5640,262 @@ msgstr "Rehusando reescribir notas en %s (fuera de refs/notes/)"
 msgid "Bad %s value: '%s'"
 msgstr "Valor erróneo para %s: '%s'"
 
-#: object-file.c:526
+#: object-file.c:459
 #, c-format
 msgid "object directory %s does not exist; check .git/objects/info/alternates"
 msgstr ""
 "directorio de objetos %s no existe; revisa .git/objects/info/alternates"
 
-#: object-file.c:584
+#: object-file.c:517
 #, c-format
 msgid "unable to normalize alternate object path: %s"
 msgstr "incapaz de normalizar la ruta de objeto alterno: %s"
 
-#: object-file.c:658
+#: object-file.c:591
 #, c-format
 msgid "%s: ignoring alternate object stores, nesting too deep"
 msgstr "%s: ignorando espacios de objetos alternos, anidado demasiado profundo"
 
-#: object-file.c:665
+#: object-file.c:598
 #, c-format
 msgid "unable to normalize object directory: %s"
 msgstr "incapaz de normalizar directorio de objetos: %s"
 
-#: object-file.c:708
+#: object-file.c:641
 msgid "unable to fdopen alternates lockfile"
 msgstr "no es posible hacer fdopen en lockfile alternos"
 
-#: object-file.c:726
+#: object-file.c:659
 msgid "unable to read alternates file"
 msgstr "no es posible leer el archivo de alternativos"
 
-#: object-file.c:733
+#: object-file.c:666
 msgid "unable to move new alternates file into place"
 msgstr "no es posible mover el nuevo archivo de alternativos al lugar"
 
-#: object-file.c:768
+#: object-file.c:701
 #, c-format
 msgid "path '%s' does not exist"
 msgstr "ruta '%s' no existe"
 
-#: object-file.c:789
+#: object-file.c:722
 #, c-format
 msgid "reference repository '%s' as a linked checkout is not supported yet."
 msgstr ""
 "repositorio de referencia '%s' como un checkout vinculado no es soportado "
 "todavía."
 
-#: object-file.c:795
+#: object-file.c:728
 #, c-format
 msgid "reference repository '%s' is not a local repository."
 msgstr "repositorio de referencia '%s' no es un repositorio local."
 
-#: object-file.c:801
+#: object-file.c:734
 #, c-format
 msgid "reference repository '%s' is shallow"
 msgstr "repositorio de referencia '%s' es superficial (shallow)"
 
-#: object-file.c:809
+#: object-file.c:742
 #, c-format
 msgid "reference repository '%s' is grafted"
 msgstr "repositorio de referencia '% s' está injertado"
 
-#: object-file.c:869
+#: object-file.c:773
+#, c-format
+msgid "could not find object directory matching %s"
+msgstr "no se pudo encontrar el directorio de objetos concordante con %s"
+
+#: object-file.c:823
 #, c-format
 msgid "invalid line while parsing alternate refs: %s"
 msgstr "línea inválida mientras se analizaban refs alternas: %s"
 
-#: object-file.c:1019
+#: object-file.c:973
 #, c-format
 msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
 msgstr "intentando usar mmap %<PRIuMAX> sobre límite %<PRIuMAX>"
 
-#: object-file.c:1054
+#: object-file.c:1008
 #, c-format
 msgid "mmap failed%s"
 msgstr "mmap falló %s"
 
-#: object-file.c:1218
+#: object-file.c:1174
 #, c-format
 msgid "object file %s is empty"
 msgstr "archivo de objeto %s está vacío"
 
-#: object-file.c:1353 object-file.c:2548
+#: object-file.c:1293 object-file.c:2499
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr "objeto suelto corrupto '%s'"
 
-#: object-file.c:1355 object-file.c:2552
+#: object-file.c:1295 object-file.c:2503
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr "basura al final del objeto suelto '%s'"
 
-#: object-file.c:1397
-msgid "invalid object type"
-msgstr "tipo de objeto inválido"
-
-#: object-file.c:1481
-#, c-format
-msgid "unable to unpack %s header with --allow-unknown-type"
-msgstr "no es posible desempacar header %s con --allow-unknown-type"
-
-#: object-file.c:1484
-#, c-format
-msgid "unable to unpack %s header"
-msgstr "incapaz de desempaquetar header %s"
-
-#: object-file.c:1490
-#, c-format
-msgid "unable to parse %s header with --allow-unknown-type"
-msgstr "no es posible analizar header %s con --allow-unknown-type"
-
-#: object-file.c:1493
+#: object-file.c:1417
 #, c-format
 msgid "unable to parse %s header"
 msgstr "incapaz de analizar header %s"
 
-#: object-file.c:1717
+#: object-file.c:1419
+msgid "invalid object type"
+msgstr "tipo de objeto inválido"
+
+#: object-file.c:1430
+#, c-format
+msgid "unable to unpack %s header"
+msgstr "incapaz de desempaquetar header %s"
+
+#: object-file.c:1434
+#, c-format
+msgid "header for %s too long, exceeds %d bytes"
+msgstr "cabecera para %s es muy larga, excede %d bytes"
+
+#: object-file.c:1664
 #, c-format
 msgid "failed to read object %s"
 msgstr "falló al leer objeto %s"
 
-#: object-file.c:1721
+#: object-file.c:1668
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr "reemplazo %s no encontrado para %s"
 
-#: object-file.c:1725
+#: object-file.c:1672
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr "objeto suelto %s (guardado en %s) está corrompido"
 
-#: object-file.c:1729
+#: object-file.c:1676
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr "objeto empaquetado %s (guardado en %s) está corrompido"
 
-#: object-file.c:1834
+#: object-file.c:1781
 #, c-format
 msgid "unable to write file %s"
 msgstr "no es posible escribir archivo %s"
 
-#: object-file.c:1841
+#: object-file.c:1788
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr "no se pudo poner permisos a '%s'"
 
-#: object-file.c:1848
+#: object-file.c:1795
 msgid "file write error"
 msgstr "falló de escritura"
 
-#: object-file.c:1868
+#: object-file.c:1815
 msgid "error when closing loose object file"
 msgstr "error al cerrar el archivo de objeto suelto"
 
-#: object-file.c:1933
+#: object-file.c:1882
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 "permisos insuficientes para agregar un objeto a la base de datos del "
 "repositorio %s"
 
-#: object-file.c:1935
+#: object-file.c:1884
 msgid "unable to create temporary file"
 msgstr "no es posible crear un archivo temporal"
 
-#: object-file.c:1959
+#: object-file.c:1908
 msgid "unable to write loose object file"
 msgstr "no es posible escribir el archivo de objeto suelto"
 
-#: object-file.c:1965
+#: object-file.c:1914
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr "no es posible desinflar el objeto nuevo %s (%d)"
 
-#: object-file.c:1969
+#: object-file.c:1918
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr "deflateEnd en objeto %s falló (%d)"
 
-#: object-file.c:1973
+#: object-file.c:1922
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr "confundido por fuente de data de objetos inestable para %s"
 
-#: object-file.c:1983 builtin/pack-objects.c:1237
+#: object-file.c:1933 builtin/pack-objects.c:1243
 #, c-format
 msgid "failed utime() on %s"
 msgstr "falló utime() en %s"
 
-#: object-file.c:2060
+#: object-file.c:2011
 #, c-format
 msgid "cannot read object for %s"
 msgstr "no se pudo leer el objeto para %s"
 
-#: object-file.c:2111
+#: object-file.c:2062
 msgid "corrupt commit"
 msgstr "commit corrupto"
 
-#: object-file.c:2119
+#: object-file.c:2070
 msgid "corrupt tag"
 msgstr "tag corrupto"
 
-#: object-file.c:2219
+#: object-file.c:2170
 #, c-format
 msgid "read error while indexing %s"
 msgstr "error de lectura al indexar %s"
 
-#: object-file.c:2222
+#: object-file.c:2173
 #, c-format
 msgid "short read while indexing %s"
 msgstr "lectura corta al indexar %s"
 
-#: object-file.c:2295 object-file.c:2305
+#: object-file.c:2246 object-file.c:2256
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr "%s: falló al insertar en la base de datos"
 
-#: object-file.c:2311
+#: object-file.c:2262
 #, c-format
 msgid "%s: unsupported file type"
 msgstr "%s: tipo de archivo no soportado"
 
-#: object-file.c:2335
+#: object-file.c:2286 builtin/fetch.c:1445
 #, c-format
 msgid "%s is not a valid object"
 msgstr "%s no es objeto válido"
 
-#: object-file.c:2337
+#: object-file.c:2288
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr "%s no es un objeto '%s' válido"
 
-#: object-file.c:2364 builtin/index-pack.c:192
+#: object-file.c:2315
 #, c-format
 msgid "unable to open %s"
 msgstr "no es posible abrir %s"
 
-#: object-file.c:2559 object-file.c:2612
+#: object-file.c:2510
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
 msgstr "hash no concuerda para %s (se esperaba %s)"
 
-#: object-file.c:2583
+#: object-file.c:2533
 #, c-format
 msgid "unable to mmap %s"
 msgstr "no es posible hacer mmap a %s"
 
-#: object-file.c:2588
+#: object-file.c:2539
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr "incapaz de desempaquetar header de %s"
 
-#: object-file.c:2594
+#: object-file.c:2544
 #, c-format
 msgid "unable to parse header of %s"
 msgstr "incapaz de analizar header de %s"
 
-#: object-file.c:2605
+#: object-file.c:2555
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr "no es posible desempaquetar contenidos de %s"
@@ -5880,12 +6024,25 @@ msgstr "incapaz de analizar objeto: %s"
 msgid "hash mismatch %s"
 msgstr "hash no concuerda %s"
 
-#: pack-bitmap.c:868 pack-bitmap.c:874 builtin/pack-objects.c:2411
+#: pack-bitmap.c:348
+msgid "multi-pack bitmap is missing required reverse index"
+msgstr "a multi-pack-index le falta un índice reveretido"
+
+#: pack-bitmap.c:424
+msgid "load_reverse_index: could not open pack"
+msgstr "load_reverse_index: no se pudo abrir el paquete"
+
+#: pack-bitmap.c:1064 pack-bitmap.c:1070 builtin/pack-objects.c:2424
 #, c-format
 msgid "unable to get size of %s"
 msgstr "no se pudo obtener el tamaño de %s"
 
-#: pack-bitmap.c:1571 builtin/rev-list.c:92
+#: pack-bitmap.c:1916
+#, c-format
+msgid "could not find %s in pack %s at offset %<PRIuMAX>"
+msgstr "no se pudo encontrar %s en paquete %s en el offset %<PRIuMAX>"
+
+#: pack-bitmap.c:1952 builtin/rev-list.c:92
 #, c-format
 msgid "unable to get disk usage of %s"
 msgstr "no se puede obtener el uso de disco de %s"
@@ -5915,47 +6072,47 @@ msgstr "archivo reverse-index %s tiene una versión no soportada %<PRIu32>"
 msgid "reverse-index file %s has unsupported hash id %<PRIu32>"
 msgstr "archivo reverse-index %s tiene un id de hash no soportado %<PRIu32>"
 
-#: pack-write.c:250
+#: pack-write.c:251
 msgid "cannot both write and verify reverse index"
 msgstr "no puede escribir y verificar el índice inverso"
 
-#: pack-write.c:271
+#: pack-write.c:270
 #, c-format
 msgid "could not stat: %s"
 msgstr "no se pudo hacer stat: %s"
 
-#: pack-write.c:283
+#: pack-write.c:282
 #, c-format
 msgid "failed to make %s readable"
 msgstr "no pudo hacer %s legible"
 
-#: pack-write.c:522
+#: pack-write.c:520
 #, c-format
 msgid "could not write '%s' promisor file"
 msgstr "no se pudo escribir el archivo promisor '%s'"
 
-#: packfile.c:625
+#: packfile.c:626
 msgid "offset before end of packfile (broken .idx?)"
 msgstr "offset antes del final del paquete (¿.idx roto?)"
 
-#: packfile.c:655
+#: packfile.c:656
 #, c-format
 msgid "packfile %s cannot be mapped%s"
 msgstr "objeto %s no puede ser mapeado %s"
 
-#: packfile.c:1934
+#: packfile.c:1923
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr ""
 "offset antes del comienzo del índice del paquete para %s (¿índice corrupto?)"
 
-#: packfile.c:1938
+#: packfile.c:1927
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr ""
 "offset más allá del índice de fin de paquete para %s (¿índice truncado?)"
 
-#: parse-options-cb.c:20 parse-options-cb.c:24
+#: parse-options-cb.c:20 parse-options-cb.c:24 builtin/commit-graph.c:175
 #, c-format
 msgid "option `%s' expects a numerical value"
 msgstr "opción `%s' espera un valor numérico"
@@ -5975,71 +6132,71 @@ msgstr "opción `%s' puede usar \"always\", \"auto\", o \"never\""
 msgid "malformed object name '%s'"
 msgstr "nombre de objeto mal formado '%s'"
 
-#: parse-options.c:38
+#: parse-options.c:58
 #, c-format
 msgid "%s requires a value"
 msgstr "%s requiere un valor"
 
-#: parse-options.c:73
+#: parse-options.c:93
 #, c-format
 msgid "%s is incompatible with %s"
 msgstr "%s es incompatible con %s"
 
-#: parse-options.c:78
+#: parse-options.c:98
 #, c-format
 msgid "%s : incompatible with something else"
 msgstr "%s : incompatible con otra cosa"
 
-#: parse-options.c:92 parse-options.c:96 parse-options.c:317
+#: parse-options.c:112 parse-options.c:116
 #, c-format
 msgid "%s takes no value"
 msgstr "%s no toma valores"
 
-#: parse-options.c:94
+#: parse-options.c:114
 #, c-format
 msgid "%s isn't available"
 msgstr "%s no está disponible"
 
-#: parse-options.c:217
+#: parse-options.c:237
 #, c-format
 msgid "%s expects a non-negative integer value with an optional k/m/g suffix"
 msgstr "%s espera un valor entero no negativo con un sufijo opcional k/m/g"
 
-#: parse-options.c:386
+#: parse-options.c:393
 #, c-format
 msgid "ambiguous option: %s (could be --%s%s or --%s%s)"
 msgstr "opción ambigua: %s (puede ser --%s%s o --%s%s)"
 
-#: parse-options.c:420 parse-options.c:428
+#: parse-options.c:427 parse-options.c:435
 #, c-format
 msgid "did you mean `--%s` (with two dashes)?"
 msgstr "¿quisiste decir `--%s` (con dos guiones)?"
 
-#: parse-options.c:668 parse-options.c:988
+#: parse-options.c:677 parse-options.c:1053
 #, c-format
 msgid "alias of --%s"
 msgstr "alias de --%s"
 
-#: parse-options.c:879
+#: parse-options.c:891
 #, c-format
 msgid "unknown option `%s'"
 msgstr "opción `%s' desconocida"
 
-#: parse-options.c:881
+#: parse-options.c:893
 #, c-format
 msgid "unknown switch `%c'"
 msgstr "switch desconocido `%c'"
 
-#: parse-options.c:883
+#: parse-options.c:895
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
 msgstr "opción desconocida en string no ascii: `%s'"
 
-#: parse-options.c:907
+#: parse-options.c:919
 msgid "..."
 msgstr "..."
 
-#: parse-options.c:926
+#: parse-options.c:933
 #, c-format
 msgid "usage: %s"
 msgstr "uso: %s"
@@ -6047,49 +6204,73 @@ msgstr "uso: %s"
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
 #.
-#: parse-options.c:932
+#: parse-options.c:948
 #, c-format
 msgid "   or: %s"
 msgstr "   o: %s"
 
-#: parse-options.c:935
+#. TRANSLATORS: You should only need to translate this format
+#. string if your language is a RTL language (e.g. Arabic,
+#. Hebrew etc.), not if it's a LTR language (e.g. German,
+#. Russian, Chinese etc.).
+#. *
+#. When a translated usage string has an embedded "\n" it's
+#. because options have wrapped to the next line. The line
+#. after the "\n" will then be padded to align with the
+#. command name, such as N_("git cmd [opt]\n<8
+#. spaces>[opt2]"), where the 8 spaces are the same length as
+#. "git cmd ".
+#. *
+#. This format string prints out that already-translated
+#. line. The "%*s" is whitespace padding to account for the
+#. padding at the start of the line that we add in this
+#. function. The "%s" is a line in the (hopefully already
+#. translated) N_() usage string, which contained embedded
+#. newlines before we split it up.
+#.
+#: parse-options.c:969
+#, c-format
+msgid "%*s%s"
+msgstr "%*s%s"
+
+#: parse-options.c:992
 #, c-format
 msgid "    %s"
 msgstr "    %s"
 
-#: parse-options.c:974
+#: parse-options.c:1039
 msgid "-NUM"
 msgstr "-NUM"
 
-#: path.c:915
+#: path.c:922
 #, c-format
 msgid "Could not make %s writable by group"
 msgstr "No se pudo hacer que %s fuera escribible por el grupo"
 
-#: pathspec.c:151
+#: pathspec.c:150
 msgid "Escape character '\\' not allowed as last character in attr value"
 msgstr ""
 "Carácter de escape '\\' no permitido como último carácter en el valor attr"
 
-#: pathspec.c:169
+#: pathspec.c:168
 msgid "Only one 'attr:' specification is allowed."
 msgstr "Solo se permite una única especificación 'attr'."
 
-#: pathspec.c:172
+#: pathspec.c:171
 msgid "attr spec must not be empty"
 msgstr "la especificación attr no puede estar vacía"
 
-#: pathspec.c:215
+#: pathspec.c:214
 #, c-format
 msgid "invalid attribute name %s"
 msgstr "nombre de atributo %s inválido"
 
-#: pathspec.c:280
+#: pathspec.c:279
 msgid "global 'glob' and 'noglob' pathspec settings are incompatible"
 msgstr ""
 "configuraciones globales de pathspec 'glob' y 'noglob' son incompatibles"
 
-#: pathspec.c:287
+#: pathspec.c:286
 msgid ""
 "global 'literal' pathspec setting is incompatible with all other global "
 "pathspec settings"
@@ -6097,54 +6278,54 @@ msgstr ""
 "la configuración global de 'literal' para patrones de ruta es incompatible "
 "con las demás configuraciones globales de patrones de ruta"
 
-#: pathspec.c:327
+#: pathspec.c:326
 msgid "invalid parameter for pathspec magic 'prefix'"
 msgstr "parámetro no válido para la magia de pathspec 'prefix'"
 
-#: pathspec.c:348
+#: pathspec.c:347
 #, c-format
 msgid "Invalid pathspec magic '%.*s' in '%s'"
 msgstr "Magia de pathspec inválida '%.*s' en '%s'"
 
-#: pathspec.c:353
+#: pathspec.c:352
 #, c-format
 msgid "Missing ')' at the end of pathspec magic in '%s'"
 msgstr "Falta ')' al final de la magia de pathspec en '%s'"
 
-#: pathspec.c:391
+#: pathspec.c:390
 #, c-format
 msgid "Unimplemented pathspec magic '%c' in '%s'"
 msgstr "Magia de pathspec '%c' no implementada en '%s'"
 
-#: pathspec.c:450
+#: pathspec.c:449
 #, c-format
 msgid "%s: 'literal' and 'glob' are incompatible"
 msgstr "%s: 'literal' y 'glob' son incompatibles"
 
-#: pathspec.c:466
+#: pathspec.c:465
 #, c-format
 msgid "%s: '%s' is outside repository at '%s'"
 msgstr "%s: '%s' está fuera del repositorio en '%s'"
 
-#: pathspec.c:542
+#: pathspec.c:541
 #, c-format
 msgid "'%s' (mnemonic: '%c')"
 msgstr "'%s' (nemotécnico: '%c')"
 
-#: pathspec.c:552
+#: pathspec.c:551
 #, c-format
 msgid "%s: pathspec magic not supported by this command: %s"
 msgstr "%s: magia de pathspec no soportada por este comando: %s"
 
-#: pathspec.c:619
+#: pathspec.c:618
 #, c-format
 msgid "pathspec '%s' is beyond a symbolic link"
 msgstr "el patrón de ruta '%s' está detrás de un enlace simbólico"
 
-#: pathspec.c:664
+#: pathspec.c:663
 #, c-format
 msgid "line is badly quoted: %s"
-msgstr "la línea está mál entrecomillada: %s"
+msgstr "la línea está mal entrecomillada: %s"
 
 #: pkt-line.c:92
 msgid "unable to write flush packet"
@@ -6162,7 +6343,7 @@ msgstr "no es posible escribir paquete de respuesta final"
 msgid "flush packet write failed"
 msgstr "limpieza de escritura de paquetes falló"
 
-#: pkt-line.c:153 pkt-line.c:265
+#: pkt-line.c:153
 msgid "protocol error: impossibly long line"
 msgstr "error de protocolo: línea imposiblemente larga"
 
@@ -6170,7 +6351,7 @@ msgstr "error de protocolo: línea imposiblemente larga"
 msgid "packet write with format failed"
 msgstr "escritura de paquetes con formato falló"
 
-#: pkt-line.c:204
+#: pkt-line.c:204 pkt-line.c:252
 msgid "packet write failed - data exceeds max packet size"
 msgstr "fallo al escribir paquete - la data excede al tamaño máximo de paquete"
 
@@ -6179,25 +6360,25 @@ msgstr "fallo al escribir paquete - la data excede al tamaño máximo de paquete
 msgid "packet write failed: %s"
 msgstr "escritura de paquetes falló: %s"
 
-#: pkt-line.c:328 pkt-line.c:329
+#: pkt-line.c:349 pkt-line.c:350
 msgid "read error"
 msgstr "error de lectura"
 
-#: pkt-line.c:339 pkt-line.c:340
+#: pkt-line.c:360 pkt-line.c:361
 msgid "the remote end hung up unexpectedly"
 msgstr "el remoto se colgó de manera inesperada"
 
-#: pkt-line.c:369 pkt-line.c:371
+#: pkt-line.c:390 pkt-line.c:392
 #, c-format
 msgid "protocol error: bad line length character: %.4s"
-msgstr "error de protocolo: mal caracter de largo de línea: %.4s"
+msgstr "error de protocolo: mal carácter de largo de línea: %.4s"
 
-#: pkt-line.c:386 pkt-line.c:388 pkt-line.c:394 pkt-line.c:396
+#: pkt-line.c:407 pkt-line.c:409 pkt-line.c:415 pkt-line.c:417
 #, c-format
 msgid "protocol error: bad line length %d"
 msgstr "error de protocolo: mal largo de línea %d"
 
-#: pkt-line.c:413 sideband.c:165
+#: pkt-line.c:434 sideband.c:165
 #, c-format
 msgid "remote error: %s"
 msgstr "error remoto: %s"
@@ -6211,21 +6392,21 @@ msgstr "Refrescando index"
 msgid "unable to create threaded lstat: %s"
 msgstr "no es posible crear lstat hilado: %s"
 
-#: pretty.c:988
+#: pretty.c:1051
 msgid "unable to parse --pretty format"
 msgstr "incapaz de analizar el formato de --pretty"
 
 #: promisor-remote.c:31
 msgid "promisor-remote: unable to fork off fetch subprocess"
-msgstr "promisor-remote: no se puede bifurcar el subproceso de recuperación"
+msgstr "promisor-remote: no se puede bifurcar el subproceso de fetch"
 
 #: promisor-remote.c:38 promisor-remote.c:40
 msgid "promisor-remote: could not write to fetch subprocess"
-msgstr "proiso-remote: no se pudo escribir para recuperar el subproceso"
+msgstr "promisor-remote: no se pudo escribir al subproceso de fetch"
 
 #: promisor-remote.c:44
 msgid "promisor-remote: could not close stdin to fetch subprocess"
-msgstr "promisor-remote: no se pudo cerrar stdin para recuperar el subproceso"
+msgstr "promisor-remote: no se pudo cerrar stdin al subproceso de fetch"
 
 #: promisor-remote.c:54
 #, c-format
@@ -6240,20 +6421,20 @@ msgstr "info de objeto: se espera flush tras argumentos"
 msgid "Removing duplicate objects"
 msgstr "Quitando objetos duplicados"
 
-#: range-diff.c:78
+#: range-diff.c:67
 msgid "could not start `log`"
 msgstr "no se pudo comenzar `log`"
 
-#: range-diff.c:80
+#: range-diff.c:69
 msgid "could not read `log` output"
 msgstr "no se pudo leer salida de `log`"
 
-#: range-diff.c:101 sequencer.c:5550
+#: range-diff.c:97 sequencer.c:5605
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr "no se pudo analizar commit '%s'"
 
-#: range-diff.c:115
+#: range-diff.c:111
 #, c-format
 msgid ""
 "could not parse first line of `log` output: did not start with 'commit ': "
@@ -6262,12 +6443,12 @@ msgstr ""
 "no se pudo leer la primera línea de salida de `log`: no comienza con 'commit "
 "': '%s'"
 
-#: range-diff.c:140
+#: range-diff.c:137
 #, c-format
 msgid "could not parse git header '%.*s'"
 msgstr "no se puede analizar git header '%.*s'"
 
-#: range-diff.c:307
+#: range-diff.c:304
 msgid "failed to generate diff"
 msgstr "falló al generar diff"
 
@@ -6296,7 +6477,7 @@ msgstr ""
 "%s: solo se pueden agregar archivos regulares, symbolic links o git-"
 "directories"
 
-#: read-cache.c:753
+#: read-cache.c:753 builtin/submodule--helper.c:3241
 #, c-format
 msgid "'%s' does not have a commit checked out"
 msgstr "'%s' no tiene un commit checked out"
@@ -6316,16 +6497,16 @@ msgstr "no es posible agregar '%s' al index"
 msgid "unable to stat '%s'"
 msgstr "incapaz de hacer stat en '%s'"
 
-#: read-cache.c:1358
+#: read-cache.c:1373
 #, c-format
 msgid "'%s' appears as both a file and as a directory"
 msgstr "'%s' parece ser un directorio y un archivo a la vez"
 
-#: read-cache.c:1573
+#: read-cache.c:1588
 msgid "Refresh index"
 msgstr "Refrescar index"
 
-#: read-cache.c:1705
+#: read-cache.c:1720
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -6334,7 +6515,7 @@ msgstr ""
 "index.version configurado, pero el valor no es válido.\n"
 "Usando versión %i"
 
-#: read-cache.c:1715
+#: read-cache.c:1730
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -6343,143 +6524,143 @@ msgstr ""
 "GIT_INDEX_VERSION configurado, pero el valor no es válido.\n"
 "Usando versión %i"
 
-#: read-cache.c:1771
+#: read-cache.c:1786
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr "mala firma 0x%08x"
 
-#: read-cache.c:1774
+#: read-cache.c:1789
 #, c-format
 msgid "bad index version %d"
 msgstr "mala versión de índice %d"
 
-#: read-cache.c:1783
+#: read-cache.c:1798
 msgid "bad index file sha1 signature"
 msgstr "mala firma sha1 del archivo index"
 
-#: read-cache.c:1817
+#: read-cache.c:1832
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr "index usa la extensión %.4s, cosa que no entendemos"
 
-#: read-cache.c:1819
+#: read-cache.c:1834
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr "ignorando extensión %.4s"
 
-#: read-cache.c:1856
+#: read-cache.c:1871
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr "formato de índice desconocido 0x%08x"
 
-#: read-cache.c:1872
+#: read-cache.c:1887
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "campo nombre malformado en el índice, cerca de ruta '%s'"
 
-#: read-cache.c:1929
+#: read-cache.c:1944
 msgid "unordered stage entries in index"
 msgstr "entradas en stage desordenadas en index"
 
-#: read-cache.c:1932
+#: read-cache.c:1947
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr "múltiples entradas de stage para archivo fusionado '%s'"
 
-#: read-cache.c:1935
+#: read-cache.c:1950
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr "entradas de stage desordenadas para '%s'"
 
-#: read-cache.c:2041 read-cache.c:2339 rerere.c:549 rerere.c:583 rerere.c:1095
-#: submodule.c:1622 builtin/add.c:575 builtin/check-ignore.c:183
-#: builtin/checkout.c:519 builtin/checkout.c:706 builtin/clean.c:987
-#: builtin/commit.c:377 builtin/diff-tree.c:122 builtin/grep.c:505
-#: builtin/mv.c:146 builtin/reset.c:247 builtin/rm.c:291
-#: builtin/submodule--helper.c:333
+#: read-cache.c:2065 read-cache.c:2363 rerere.c:549 rerere.c:583 rerere.c:1095
+#: submodule.c:1662 builtin/add.c:603 builtin/check-ignore.c:183
+#: builtin/checkout.c:519 builtin/checkout.c:708 builtin/clean.c:987
+#: builtin/commit.c:378 builtin/diff-tree.c:122 builtin/grep.c:519
+#: builtin/mv.c:148 builtin/reset.c:253 builtin/rm.c:293
+#: builtin/submodule--helper.c:327 builtin/submodule--helper.c:3201
 msgid "index file corrupt"
 msgstr "archivo índice corrompido"
 
-#: read-cache.c:2185
+#: read-cache.c:2209
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr "no es posible crear hilo load_cache_entries: %s"
 
-#: read-cache.c:2198
+#: read-cache.c:2222
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr "no es posible unir hilo load_cache_entries: %s"
 
-#: read-cache.c:2231
+#: read-cache.c:2255
 #, c-format
 msgid "%s: index file open failed"
 msgstr "%s: falló al abrir el archivo index"
 
-#: read-cache.c:2235
+#: read-cache.c:2259
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr "%s: no se puede hacer stat en el índice abierto"
 
-#: read-cache.c:2239
+#: read-cache.c:2263
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr "%s: archivo index más pequeño de lo esperado"
 
-#: read-cache.c:2243
+#: read-cache.c:2267
 #, c-format
 msgid "%s: unable to map index file%s"
 msgstr "%s: no se pudo mapear el archivo index %s"
 
-#: read-cache.c:2286
+#: read-cache.c:2310
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr "no es posible crear hilo load_index_extensions: %s"
 
-#: read-cache.c:2313
+#: read-cache.c:2337
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr "no es posible unir hilo load_index_extensions: %s"
 
-#: read-cache.c:2351
+#: read-cache.c:2375
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr "no se pudo refrescar el índice compartido '%s'"
 
-#: read-cache.c:2398
+#: read-cache.c:2434
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr "index roto, se esperaba %s en %s, se obtuvo %s"
 
-#: read-cache.c:3032 strbuf.c:1173 wrapper.c:633 builtin/merge.c:1146
+#: read-cache.c:3065 strbuf.c:1179 wrapper.c:641 builtin/merge.c:1147
 #, c-format
 msgid "could not close '%s'"
 msgstr "no se pudo cerrar '%s'"
 
-#: read-cache.c:3075
+#: read-cache.c:3108
 msgid "failed to convert to a sparse-index"
 msgstr "falló al convertir a un índice sparse"
 
-#: read-cache.c:3146 sequencer.c:2684 sequencer.c:4440
+#: read-cache.c:3179
 #, c-format
 msgid "could not stat '%s'"
 msgstr "no se pudo hacer stat en '%s'"
 
-#: read-cache.c:3159
+#: read-cache.c:3192
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "no es posible abrir el directorio de git: %s"
 
-#: read-cache.c:3171
+#: read-cache.c:3204
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "no es posible eliminar el vinculo: %s"
 
-#: read-cache.c:3200
+#: read-cache.c:3233
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr "no se pudo arreglar bits de permisos en '%s'"
 
-#: read-cache.c:3349
+#: read-cache.c:3390
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr "%s: no se puede eliminar hasta stage #0"
@@ -6536,13 +6717,13 @@ msgstr ""
 "\t, a menos que se use -C, en cuyo caso\n"
 "\tmantiene solo el mensaje del commit; -c es lo mismo que -C\n"
 "\tpero abre el editor\n"
-"x, exec <commit> = ejecuta comando (el resto de la línea) usando un shell\n"
+"x, exec <commit> = ejecutar comando (el resto de la línea) usando un shell\n"
 "b, break = parar aquí (continuar rebase luego con 'git rebase --continue')\n"
 "d, drop <commit> = eliminar commit\n"
 "l, label <label> = poner label al HEAD actual con un nombre\n"
 "t, reset <label> = reiniciar HEAD al label\n"
 "m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
-".       crea un commit de fusión usando el mensaje original de\n"
+".       crear un commit de fusión usando el mensaje original de\n"
 ".       fusión (o la línea de oneline, si no se especifica un mensaje\n"
 ".       de commit). Use -c <commit> para reescribir el mensaje del commit.\n"
 "\n"
@@ -6556,7 +6737,7 @@ msgid_plural "Rebase %s onto %s (%d commands)"
 msgstr[0] "Rebase %s en %s (%d comando)"
 msgstr[1] "Rebase %s en %s (%d comandos)"
 
-#: rebase-interactive.c:75 git-rebase--preserve-merges.sh:218
+#: rebase-interactive.c:75
 msgid ""
 "\n"
 "Do not remove any line. Use 'drop' explicitly to remove a commit.\n"
@@ -6564,7 +6745,7 @@ msgstr ""
 "\n"
 "No elimines ninguna línea. Usa 'drop' explícitamente para borrar un commit.\n"
 
-#: rebase-interactive.c:78 git-rebase--preserve-merges.sh:222
+#: rebase-interactive.c:78
 msgid ""
 "\n"
 "If you remove a line here THAT COMMIT WILL BE LOST.\n"
@@ -6572,7 +6753,7 @@ msgstr ""
 "\n"
 "Si eliminas una línea aquí EL COMMIT SE PERDERÁ.\n"
 
-#: rebase-interactive.c:84 git-rebase--preserve-merges.sh:861
+#: rebase-interactive.c:84
 msgid ""
 "\n"
 "You are editing the todo file of an ongoing interactive rebase.\n"
@@ -6586,7 +6767,7 @@ msgstr ""
 "    git rebase --continue\n"
 "\n"
 
-#: rebase-interactive.c:89 git-rebase--preserve-merges.sh:938
+#: rebase-interactive.c:89
 msgid ""
 "\n"
 "However, if you remove everything, the rebase will be aborted.\n"
@@ -6596,14 +6777,14 @@ msgstr ""
 "Como sea, si quieres borrar todo, el rebase será abortado.\n"
 "\n"
 
-#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3836
-#: sequencer.c:3862 sequencer.c:5656 builtin/fsck.c:328 builtin/rebase.c:271
+#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3888
+#: sequencer.c:3914 sequencer.c:5711 builtin/fsck.c:328 builtin/gc.c:1789
+#: builtin/rebase.c:190
 #, c-format
 msgid "could not write '%s'"
 msgstr "no se pudo escribir '%s'"
 
-#: rebase-interactive.c:119 builtin/rebase.c:203 builtin/rebase.c:229
-#: builtin/rebase.c:253
+#: rebase-interactive.c:119
 #, c-format
 msgid "could not write '%s'."
 msgstr "no se pudo escribir '%s'."
@@ -6627,20 +6808,18 @@ msgid ""
 "The possible behaviours are: ignore, warn, error.\n"
 "\n"
 msgstr ""
-"Para evitar este mensaje, use \"drop\" para eliminar de forma explícita un "
+"Para evitar este mensaje, usa \"drop\" para eliminar de forma explícita un "
 "commit.\n"
 "\n"
-"Use 'git config rebase.missingCommitsCheck' para cambiar el nivel de "
+"Usa 'git config rebase.missingCommitsCheck' para cambiar el nivel de "
 "advertencias.\n"
 "Los posibles comportamientos son: ignore, warn, error.\n"
 "\n"
 
-#: rebase-interactive.c:236 rebase-interactive.c:241 sequencer.c:2597
-#: builtin/rebase.c:189 builtin/rebase.c:214 builtin/rebase.c:240
-#: builtin/rebase.c:265
+#: rebase.c:29
 #, c-format
-msgid "could not read '%s'."
-msgstr "no se puede leer '%s'."
+msgid "%s: 'preserve' superseded by 'merges'"
+msgstr "%s: 'preserve' es supercedido por 'merges'"
 
 #: ref-filter.c:42 wt-status.c:2036
 msgid "gone"
@@ -6661,132 +6840,142 @@ msgstr "detrás %d"
 msgid "ahead %d, behind %d"
 msgstr "delante %d, detrás %d"
 
-#: ref-filter.c:230
+#: ref-filter.c:235
 #, c-format
 msgid "expected format: %%(color:<color>)"
 msgstr "formato esperado: %%(color:<color>)"
 
-#: ref-filter.c:232
+#: ref-filter.c:237
 #, c-format
 msgid "unrecognized color: %%(color:%s)"
 msgstr "color no reconocido: %%(color:%s)"
 
-#: ref-filter.c:254
+#: ref-filter.c:259
 #, c-format
 msgid "Integer value expected refname:lstrip=%s"
 msgstr "Valor entero esperado refname:lstrip=%s"
 
-#: ref-filter.c:258
+#: ref-filter.c:263
 #, c-format
 msgid "Integer value expected refname:rstrip=%s"
 msgstr "Valor entero esperado refname:rstrip=%s"
 
-#: ref-filter.c:260
+#: ref-filter.c:265
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
 msgstr "argumento %%(%s) no reconocido: %s"
 
-#: ref-filter.c:315
+#: ref-filter.c:320
 #, c-format
 msgid "%%(objecttype) does not take arguments"
 msgstr "%%(objecttype) no toma ningún argumento"
 
-#: ref-filter.c:339
+#: ref-filter.c:344
 #, c-format
 msgid "unrecognized %%(objectsize) argument: %s"
 msgstr "argumento %%(objectsize) no reconocido: %s"
 
-#: ref-filter.c:347
+#: ref-filter.c:352
 #, c-format
 msgid "%%(deltabase) does not take arguments"
 msgstr "%%(deltabase) no toma argumentos"
 
-#: ref-filter.c:359
+#: ref-filter.c:364
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr "%%(body) no toma ningún argumento"
 
-#: ref-filter.c:372
+#: ref-filter.c:377
 #, c-format
 msgid "unrecognized %%(subject) argument: %s"
 msgstr "argumento %%(subject) no reconocido: %s"
 
-#: ref-filter.c:391
+#: ref-filter.c:396
 #, c-format
 msgid "expected %%(trailers:key=<value>)"
 msgstr "se esperaba %%(trailers:key=<value>)"
 
-#: ref-filter.c:393
+#: ref-filter.c:398
 #, c-format
 msgid "unknown %%(trailers) argument: %s"
 msgstr "argumento %%(trailers) desconocido: %s"
 
-#: ref-filter.c:424
+#: ref-filter.c:429
 #, c-format
 msgid "positive value expected contents:lines=%s"
 msgstr "valor positivo esperado contents:lines=%s"
 
-#: ref-filter.c:426
+#: ref-filter.c:431
 #, c-format
 msgid "unrecognized %%(contents) argument: %s"
 msgstr "argumento %%(contents) no reconocido: %s"
 
-#: ref-filter.c:441
+#: ref-filter.c:443
+#, c-format
+msgid "unrecognized %%(raw) argument: %s"
+msgstr "argumento %%(raw) no reconocido: %s"
+
+#: ref-filter.c:458
 #, c-format
 msgid "positive value expected '%s' in %%(%s)"
 msgstr "valor positivo esperado '%s' en %%(%s)"
 
-#: ref-filter.c:445
+#: ref-filter.c:462
 #, c-format
 msgid "unrecognized argument '%s' in %%(%s)"
 msgstr "argumento '%s' no reconocido en %%(%s)"
 
-#: ref-filter.c:459
+#: ref-filter.c:476
 #, c-format
 msgid "unrecognized email option: %s"
 msgstr "opción de email desconocida: %s"
 
-#: ref-filter.c:489
+#: ref-filter.c:506
 #, c-format
 msgid "expected format: %%(align:<width>,<position>)"
 msgstr "formato esperado: %%(align:<ancho>,<posición>)"
 
-#: ref-filter.c:501
+#: ref-filter.c:518
 #, c-format
 msgid "unrecognized position:%s"
 msgstr "posición desconocida: %s"
 
-#: ref-filter.c:508
+#: ref-filter.c:525
 #, c-format
 msgid "unrecognized width:%s"
 msgstr "ancho desconocido: %s"
 
-#: ref-filter.c:517
+#: ref-filter.c:534
 #, c-format
 msgid "unrecognized %%(align) argument: %s"
 msgstr "argumento no reconocido para %%(align): %s"
 
-#: ref-filter.c:525
+#: ref-filter.c:542
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr "se esperaba un ancho positivo con el átomo %%(align)"
 
-#: ref-filter.c:543
+#: ref-filter.c:560
 #, c-format
 msgid "unrecognized %%(if) argument: %s"
 msgstr "argumento %%(if) no reconocido: %s"
 
-#: ref-filter.c:645
+#: ref-filter.c:568
+#, c-format
+msgid "%%(rest) does not take arguments"
+msgstr "%%(rest) no toma ningún argumento"
+
+#: ref-filter.c:680
 #, c-format
 msgid "malformed field name: %.*s"
 msgstr "nombre mal formado de campo: %.*s"
 
-#: ref-filter.c:672
+#: ref-filter.c:707
 #, c-format
 msgid "unknown field name: %.*s"
 msgstr "nombre de campo desconocido: %.*s"
 
-#: ref-filter.c:676
+#: ref-filter.c:711
 #, c-format
 msgid ""
 "not a git repository, but the field '%.*s' requires access to object data"
@@ -6794,126 +6983,136 @@ msgstr ""
 "no es un repositorio git, pero el campo '%.*s' requiere acceso a los datos "
 "de objeto"
 
-#: ref-filter.c:801
+#: ref-filter.c:844
 #, c-format
 msgid "format: %%(if) atom used without a %%(then) atom"
 msgstr "formato: átomo %%(if) usado sin un átomo %%(then)"
 
-#: ref-filter.c:865
+#: ref-filter.c:910
 #, c-format
 msgid "format: %%(then) atom used without an %%(if) atom"
 msgstr "formato: átomo %%(then) usado sin átomo %%(if)"
 
-#: ref-filter.c:867
+#: ref-filter.c:912
 #, c-format
 msgid "format: %%(then) atom used more than once"
 msgstr "formato: átomo %%(then) usado más de una vez"
 
-#: ref-filter.c:869
+#: ref-filter.c:914
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr "formato: átomo %%(then) usado después de %%(else)"
 
-#: ref-filter.c:897
+#: ref-filter.c:946
 #, c-format
 msgid "format: %%(else) atom used without an %%(if) atom"
 msgstr "formato: átomo %%(else) usado sin un átomo %%(if)"
 
-#: ref-filter.c:899
+#: ref-filter.c:948
 #, c-format
 msgid "format: %%(else) atom used without a %%(then) atom"
 msgstr "formato: átomo %%(else) usado sin un átomo %%(then)"
 
-#: ref-filter.c:901
+#: ref-filter.c:950
 #, c-format
 msgid "format: %%(else) atom used more than once"
 msgstr "formato: átomo %%(else) usado más de una vez"
 
-#: ref-filter.c:916
+#: ref-filter.c:965
 #, c-format
 msgid "format: %%(end) atom used without corresponding atom"
 msgstr "formato: átomo %%(end) usado sin átomo correspondiente"
 
-#: ref-filter.c:973
+#: ref-filter.c:1027
 #, c-format
 msgid "malformed format string %s"
 msgstr "formato de cadena mal formado %s"
 
-#: ref-filter.c:1621
+#: ref-filter.c:1033
+#, c-format
+msgid "this command reject atom %%(%.*s)"
+msgstr "este comando rechaza el átomo %%(%.*s)"
+
+#: ref-filter.c:1040
+#, c-format
+msgid "--format=%.*s cannot be used with --python, --shell, --tcl"
+msgstr "--format=%.*s no se puede usar con --python, --shell, --tcl"
+
+#: ref-filter.c:1706
 #, c-format
 msgid "(no branch, rebasing %s)"
 msgstr "(no hay rama, rebasando %s)"
 
-#: ref-filter.c:1624
+#: ref-filter.c:1709
 #, c-format
 msgid "(no branch, rebasing detached HEAD %s)"
 msgstr "(no hay rama, rebasando con HEAD desacoplado %s)"
 
-#: ref-filter.c:1627
+#: ref-filter.c:1712
 #, c-format
 msgid "(no branch, bisect started on %s)"
 msgstr "(no hay rama, comenzando biseccón en %s)"
 
-#: ref-filter.c:1631
+#: ref-filter.c:1716
 #, c-format
 msgid "(HEAD detached at %s)"
 msgstr "(HEAD desacoplado en %s)"
 
-#: ref-filter.c:1634
+#: ref-filter.c:1719
 #, c-format
 msgid "(HEAD detached from %s)"
 msgstr "(HEAD desacoplado de %s)"
 
-#: ref-filter.c:1637
+#: ref-filter.c:1722
 msgid "(no branch)"
 msgstr "(sin rama)"
 
-#: ref-filter.c:1669 ref-filter.c:1880
+#: ref-filter.c:1754 ref-filter.c:1972
 #, c-format
 msgid "missing object %s for %s"
 msgstr "falta objeto %s para %s"
 
-#: ref-filter.c:1679
+#: ref-filter.c:1764
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr "parse_object_buffer falló en %s para %s"
 
-#: ref-filter.c:2064
+#: ref-filter.c:2155
 #, c-format
 msgid "malformed object at '%s'"
 msgstr "objeto mal formado en '%s'"
 
-#: ref-filter.c:2153
+#: ref-filter.c:2245
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr "ignorando referencia con nombre roto %s"
 
-#: ref-filter.c:2158 refs.c:676
+#: ref-filter.c:2250 refs.c:673
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "ignorando referencia rota %s"
 
-#: ref-filter.c:2502
+#: ref-filter.c:2623
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "formato: falta átomo %%(end)"
 
-#: ref-filter.c:2596
+#: ref-filter.c:2726
 #, c-format
 msgid "malformed object name %s"
 msgstr "nombre de objeto mal formado %s"
 
-#: ref-filter.c:2601
+#: ref-filter.c:2731
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "opción '%s' debe apuntar a un commit"
 
-#: refs.c:264
+#: refs.c:261
 #, c-format
 msgid "%s does not point to a valid object!"
 msgstr "¡%s no apunta a ningún objeto válido!"
 
-#: refs.c:566
+#: refs.c:563
 #, c-format
 msgid ""
 "Using '%s' as the name for the initial branch. This default branch name\n"
@@ -6931,7 +7130,7 @@ msgstr ""
 "predeterminado\n"
 "está sujeto a cambios. Para configurar el nombre de la rama inicial para "
 "usar en todos\n"
-"de sus nuevos repositorios, reprimiendo esta advertencia, llame a:\n"
+"de sus nuevos repositorios, reprimiendo esta advertencia, llama a:\n"
 "\n"
 "\tgit config --global init.defaultBranch <nombre>\n"
 "\n"
@@ -6941,81 +7140,81 @@ msgstr ""
 "\n"
 "\tgit branch -m <nombre>\n"
 
-#: refs.c:588
+#: refs.c:585
 #, c-format
 msgid "could not retrieve `%s`"
 msgstr "no se pudo recibir `%s`"
 
-#: refs.c:598
+#: refs.c:595
 #, c-format
 msgid "invalid branch name: %s = %s"
 msgstr "nombre de rama inválido: %s = %s"
 
-#: refs.c:674
+#: refs.c:671
 #, c-format
 msgid "ignoring dangling symref %s"
 msgstr "ignorando referencia symbólica rota %s"
 
-#: refs.c:922
+#: refs.c:920
 #, c-format
 msgid "log for ref %s has gap after %s"
 msgstr "log de ref %s tiene un vacío tras %s"
 
-#: refs.c:929
+#: refs.c:927
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
 msgstr "log de ref %s finalizado inesperadamente en %s"
 
-#: refs.c:994
+#: refs.c:992
 #, c-format
 msgid "log for %s is empty"
 msgstr "log de %s está vacío"
 
-#: refs.c:1086
+#: refs.c:1084
 #, c-format
 msgid "refusing to update ref with bad name '%s'"
 msgstr "rehusando actualizar ref con mal nombre '%s'"
 
-#: refs.c:1157
+#: refs.c:1155
 #, c-format
 msgid "update_ref failed for ref '%s': %s"
 msgstr "update_ref falló para ref '%s': %s"
 
-#: refs.c:2051
+#: refs.c:2062
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "no se permiten múltiples actualizaciones para ref '%s'"
 
-#: refs.c:2131
+#: refs.c:2142
 msgid "ref updates forbidden inside quarantine environment"
 msgstr "actualizaciones de ref prohibidas dentro de ambiente de cuarentena"
 
-#: refs.c:2142
+#: refs.c:2153
 msgid "ref updates aborted by hook"
 msgstr "ref updates abortados por el hook"
 
-#: refs.c:2242 refs.c:2272
+#: refs.c:2253 refs.c:2283
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "'%s' existe; no se puede crear '%s'"
 
-#: refs.c:2248 refs.c:2283
+#: refs.c:2259 refs.c:2294
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "no se puede procesar '%s' y '%s' al mismo tiempo"
 
-#: refs/files-backend.c:1228
+#: refs/files-backend.c:1271
 #, c-format
 msgid "could not remove reference %s"
 msgstr "no se pudo eliminar la referencia %s"
 
-#: refs/files-backend.c:1242 refs/packed-backend.c:1542
-#: refs/packed-backend.c:1552
+#: refs/files-backend.c:1285 refs/packed-backend.c:1549
+#: refs/packed-backend.c:1559
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr "no se pudo eliminar la referencia %s: %s"
 
-#: refs/files-backend.c:1245 refs/packed-backend.c:1555
+#: refs/files-backend.c:1288 refs/packed-backend.c:1562
 #, c-format
 msgid "could not delete references: %s"
 msgstr "no se pudo eliminar las referencias: %s"
@@ -7304,7 +7503,7 @@ msgstr "duplicar ref de reemplazo: %s"
 #: replace-object.c:82
 #, c-format
 msgid "replace depth too high for object %s"
-msgstr "profundiad de reemplazo demasiada para objeto %s"
+msgstr "profundidad de reemplazo demasiada para objeto %s"
 
 #: rerere.c:201 rerere.c:210 rerere.c:213
 msgid "corrupt MERGE_RR"
@@ -7319,7 +7518,7 @@ msgstr "incapaz de escribir entrada rerere"
 msgid "there were errors while writing '%s' (%s)"
 msgstr "hubieron errores mientras se escribía '%s' (%s)"
 
-#: rerere.c:482
+#: rerere.c:482 builtin/gc.c:2246 builtin/gc.c:2281
 #, c-format
 msgid "failed to flush '%s'"
 msgstr "falló al hacer flush '%s'"
@@ -7364,8 +7563,8 @@ msgstr "no se puede desvincular stray '%s'"
 msgid "Recorded preimage for '%s'"
 msgstr "Preimagen grabada para '%s'"
 
-#: rerere.c:865 submodule.c:2076 builtin/log.c:2002
-#: builtin/submodule--helper.c:1805 builtin/submodule--helper.c:1848
+#: rerere.c:865 submodule.c:2121 builtin/log.c:2002
+#: builtin/submodule--helper.c:1776 builtin/submodule--helper.c:1819
 #, c-format
 msgid "could not create directory '%s'"
 msgstr "no se pudo crear el directorio '%s'"
@@ -7403,45 +7602,40 @@ msgstr "no es posible abrir directorio rr-cache"
 msgid "could not determine HEAD revision"
 msgstr "no se pudo determinar revisión HEAD"
 
-#: reset.c:69 reset.c:75 sequencer.c:3689
+#: reset.c:70 reset.c:76 sequencer.c:3705
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "falló al encontrar árbol de %s"
 
-#: revision.c:2344
+#: revision.c:2259
+msgid "--unsorted-input is incompatible with --no-walk"
+msgstr "--unsorted-input es incompatible con --no-walk"
+
+#: revision.c:2346
 msgid "--unpacked=<packfile> no longer supported"
 msgstr "--unpacked=<packfile> ya no es soportado"
 
-#: revision.c:2684
+#: revision.c:2655 revision.c:2659
+msgid "--no-walk is incompatible with --unsorted-input"
+msgstr "--no-walk es incompatible con --unsorted-input"
+
+#: revision.c:2690
 msgid "your current branch appears to be broken"
 msgstr "tu rama actual parece estar rota"
 
-#: revision.c:2687
+#: revision.c:2693
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
 msgstr "tu rama actual '%s' no tiene ningún commit todavía"
 
-#: revision.c:2893
+#: revision.c:2895
 msgid "-L does not yet support diff formats besides -p and -s"
 msgstr "-L no soporta todavía formatos de diff fuera de -p y -s"
 
-#: run-command.c:766
-msgid "open /dev/null failed"
-msgstr "falló al abrir /dev/null"
-
-#: run-command.c:1274
+#: run-command.c:1278
 #, c-format
 msgid "cannot create async thread: %s"
 msgstr "no es posible crear hilo async: %s"
-
-#: run-command.c:1344
-#, c-format
-msgid ""
-"The '%s' hook was ignored because it's not set as executable.\n"
-"You can disable this warning with `git config advice.ignoredHook false`."
-msgstr ""
-"El hook '%s' fue ignorado porque no ha sido configurado como ejecutable.\n"
-"Puedes desactivar esta advertencia con `git config advice.ignoredHook false`."
 
 #: send-pack.c:150
 msgid "unexpected flush packet while reading remote unpack status"
@@ -7462,24 +7656,24 @@ msgstr "desempaquetado remoto falló: %s"
 msgid "failed to sign the push certificate"
 msgstr "falló al firmar el certificado de push"
 
-#: send-pack.c:433
+#: send-pack.c:435
 msgid "send-pack: unable to fork off fetch subprocess"
 msgstr ""
 "send-pack: no es posible bifurcar el proceso de búsqueda en un subproceso"
 
-#: send-pack.c:455
+#: send-pack.c:457
 msgid "push negotiation failed; proceeding anyway with push"
 msgstr "negociación push falló; procediendo con el push de todas formas"
 
-#: send-pack.c:526
+#: send-pack.c:528
 msgid "the receiving end does not support this repository's hash algorithm"
 msgstr "el destino no soporta el algoritmo de hash de este repositorio"
 
-#: send-pack.c:535
+#: send-pack.c:537
 msgid "the receiving end does not support --signed push"
 msgstr "el final receptor no soporta push --signed"
 
-#: send-pack.c:537
+#: send-pack.c:539
 msgid ""
 "not sending a push certificate since the receiving end does not support --"
 "signed push"
@@ -7487,47 +7681,48 @@ msgstr ""
 "no se manda un certificado de push ya que el destino no soporta push firmado "
 "(--signed)"
 
-#: send-pack.c:544
+#: send-pack.c:546
 msgid "the receiving end does not support --atomic push"
 msgstr "el destino no soporta push atómico (--atomic)"
 
-#: send-pack.c:549
+#: send-pack.c:551
 msgid "the receiving end does not support push options"
 msgstr "el destino no soporta opciones de push"
 
-#: sequencer.c:196
+#: sequencer.c:197
 #, c-format
 msgid "invalid commit message cleanup mode '%s'"
 msgstr "mensaje de commit inválido, modo cleanup '%s'"
 
-#: sequencer.c:324
+#: sequencer.c:325
 #, c-format
 msgid "could not delete '%s'"
 msgstr "no se pudo borrar '%s'"
 
-#: sequencer.c:344 builtin/rebase.c:757 builtin/rebase.c:1592 builtin/rm.c:402
+#: sequencer.c:345 sequencer.c:4754 builtin/rebase.c:563 builtin/rebase.c:1297
+#: builtin/rm.c:408
 #, c-format
 msgid "could not remove '%s'"
 msgstr "no se pudo eliminar '%s'"
 
-#: sequencer.c:354
+#: sequencer.c:355
 msgid "revert"
 msgstr "revertir"
 
-#: sequencer.c:356
+#: sequencer.c:357
 msgid "cherry-pick"
 msgstr "cherry-pick"
 
-#: sequencer.c:358
+#: sequencer.c:359
 msgid "rebase"
 msgstr "rebase"
 
-#: sequencer.c:360
+#: sequencer.c:361
 #, c-format
 msgid "unknown action: %d"
 msgstr "acción desconocida: %d"
 
-#: sequencer.c:419
+#: sequencer.c:420
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'"
@@ -7535,53 +7730,75 @@ msgstr ""
 "después de resolver los conflictos, marca las rutas corregidas\n"
 "con 'git add <rutas>' o 'git rm <rutas>'"
 
-#: sequencer.c:422
+#: sequencer.c:423
 msgid ""
-"after resolving the conflicts, mark the corrected paths\n"
-"with 'git add <paths>' or 'git rm <paths>'\n"
-"and commit the result with 'git commit'"
+"After resolving the conflicts, mark them with\n"
+"\"git add/rm <pathspec>\", then run\n"
+"\"git cherry-pick --continue\".\n"
+"You can instead skip this commit with \"git cherry-pick --skip\".\n"
+"To abort and get back to the state before \"git cherry-pick\",\n"
+"run \"git cherry-pick --abort\"."
 msgstr ""
-"tras resolver los conflictos, marca las rutas corregidas\n"
-"con 'git add <rutas>' o 'git rm <rutas>'\n"
-"y haz un commit del resultado con 'git commit'"
+"Luego de resolver los conflictos, márquelos con\n"
+"\"git add/rm <pathspec>\", luego ejecute\n"
+"\"git cherry-pick --continue\".\n"
+"O puede saltar este commit con \"git cherry-pick --skip\".\n"
+"Para abortar y regresar al estado anterior a \"git cherry-pick\",\n"
+"ejecute \"git cherry-pick --abort\"."
 
-#: sequencer.c:435 sequencer.c:3271
+#: sequencer.c:430
+msgid ""
+"After resolving the conflicts, mark them with\n"
+"\"git add/rm <pathspec>\", then run\n"
+"\"git revert --continue\".\n"
+"You can instead skip this commit with \"git revert --skip\".\n"
+"To abort and get back to the state before \"git revert\",\n"
+"run \"git revert --abort\"."
+msgstr ""
+"Tras resolver los conflictos, márquelos con\n"
+"\"git add/rm <pathspec>\", luego ejecute\n"
+"\"git revert --continue\".\n"
+"O puede saltar este commit con \"git revert --skip\".\n"
+"Para abortar y regresar al estado anterior a \"git revert\",\n"
+"ejecute \"git revert --abort\"."
+
+#: sequencer.c:448 sequencer.c:3290
 #, c-format
 msgid "could not lock '%s'"
 msgstr "no se pudo bloquear '%s'"
 
-#: sequencer.c:437 sequencer.c:3070 sequencer.c:3275 sequencer.c:3289
-#: sequencer.c:3547 sequencer.c:5566 strbuf.c:1170 wrapper.c:631
+#: sequencer.c:450 sequencer.c:3089 sequencer.c:3294 sequencer.c:3308
+#: sequencer.c:3566 sequencer.c:5621 strbuf.c:1176 wrapper.c:639
 #, c-format
 msgid "could not write to '%s'"
 msgstr "no se pudo escribir en '%s'"
 
-#: sequencer.c:442
+#: sequencer.c:455
 #, c-format
 msgid "could not write eol to '%s'"
 msgstr "no se pudo escribir EOL en '%s'"
 
-#: sequencer.c:447 sequencer.c:3075 sequencer.c:3277 sequencer.c:3291
-#: sequencer.c:3555
+#: sequencer.c:460 sequencer.c:3094 sequencer.c:3296 sequencer.c:3310
+#: sequencer.c:3574
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "falló al finalizar '%s'"
 
-#: sequencer.c:486
+#: sequencer.c:499
 #, c-format
 msgid "your local changes would be overwritten by %s."
 msgstr "tus cambios locales serán sobreescritos por %s."
 
-#: sequencer.c:490
+#: sequencer.c:503
 msgid "commit your changes or stash them to proceed."
 msgstr "realiza un commit con tus cambios o haz un stash para proceder."
 
-#: sequencer.c:522
+#: sequencer.c:535
 #, c-format
 msgid "%s: fast-forward"
 msgstr "%s: avance rápido"
 
-#: sequencer.c:561 builtin/tag.c:609
+#: sequencer.c:574 builtin/tag.c:610
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Modo cleanup inválido %s"
@@ -7589,65 +7806,65 @@ msgstr "Modo cleanup inválido %s"
 #. TRANSLATORS: %s will be "revert", "cherry-pick" or
 #. "rebase".
 #.
-#: sequencer.c:671
+#: sequencer.c:685
 #, c-format
 msgid "%s: Unable to write new index file"
 msgstr "%s: Incapaz de escribir el nuevo archivo índice"
 
-#: sequencer.c:685
+#: sequencer.c:699
 msgid "unable to update cache tree"
 msgstr "no es posible actualizar el árbol de caché"
 
-#: sequencer.c:699
+#: sequencer.c:713
 msgid "could not resolve HEAD commit"
 msgstr "no se pudo resolver el commit de HEAD"
 
-#: sequencer.c:779
+#: sequencer.c:793
 #, c-format
 msgid "no key present in '%.*s'"
 msgstr "no hay llave presente en '%.*s'"
 
-#: sequencer.c:790
+#: sequencer.c:804
 #, c-format
 msgid "unable to dequote value of '%s'"
 msgstr "no es posible dequote valor de '%s'"
 
-#: sequencer.c:827 wrapper.c:201 wrapper.c:371 builtin/am.c:729
-#: builtin/am.c:821 builtin/merge.c:1141 builtin/rebase.c:910
+#: sequencer.c:841 wrapper.c:209 wrapper.c:379 builtin/am.c:730
+#: builtin/am.c:822 builtin/rebase.c:694
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "no se pudo abrir '%s' para lectura"
 
-#: sequencer.c:837
+#: sequencer.c:851
 msgid "'GIT_AUTHOR_NAME' already given"
 msgstr "'GIT_AUTHOR_NAME' ya proporcionado"
 
-#: sequencer.c:842
+#: sequencer.c:856
 msgid "'GIT_AUTHOR_EMAIL' already given"
 msgstr "'GIT_AUTHOR_EMAIL' ya proporcionado"
 
-#: sequencer.c:847
+#: sequencer.c:861
 msgid "'GIT_AUTHOR_DATE' already given"
 msgstr "'GIT_AUTHOR_DATE' ya proporcionado"
 
-#: sequencer.c:851
+#: sequencer.c:865
 #, c-format
 msgid "unknown variable '%s'"
 msgstr "variable desconocida '%s'"
 
-#: sequencer.c:856
+#: sequencer.c:870
 msgid "missing 'GIT_AUTHOR_NAME'"
 msgstr "falta 'GIT_AUTHOR_NAME'"
 
-#: sequencer.c:858
+#: sequencer.c:872
 msgid "missing 'GIT_AUTHOR_EMAIL'"
 msgstr "falta 'GIT_AUTHOR_EMAIL'"
 
-#: sequencer.c:860
+#: sequencer.c:874
 msgid "missing 'GIT_AUTHOR_DATE'"
 msgstr "falta 'GIT_AUTHOR_DATE'"
 
-#: sequencer.c:925
+#: sequencer.c:939
 #, c-format
 msgid ""
 "you have staged changes in your working tree\n"
@@ -7673,15 +7890,15 @@ msgstr ""
 "\n"
 "  git commit %s\n"
 "\n"
-"en cambos casos, cuando acabes, continua con:\n"
+"en ambos casos, cuando acabes, continúa con:\n"
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:1212
+#: sequencer.c:1229
 msgid "'prepare-commit-msg' hook failed"
 msgstr "hook 'prepare-commit-msg' falló"
 
-#: sequencer.c:1218
+#: sequencer.c:1235
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7708,7 +7925,7 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1231
+#: sequencer.c:1248
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7732,343 +7949,348 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1273
+#: sequencer.c:1290
 msgid "couldn't look up newly created commit"
 msgstr "no se pudo revisar el commit recién creado"
 
-#: sequencer.c:1275
+#: sequencer.c:1292
 msgid "could not parse newly created commit"
 msgstr "no se pudo analizar el commit recién creado"
 
-#: sequencer.c:1321
+#: sequencer.c:1338
 msgid "unable to resolve HEAD after creating commit"
 msgstr "no se pudo resolver HEAD tras crear el commit"
 
-#: sequencer.c:1323
+#: sequencer.c:1340
 msgid "detached HEAD"
 msgstr "HEAD desacoplado"
 
-#: sequencer.c:1327
+#: sequencer.c:1344
 msgid " (root-commit)"
 msgstr " (commit-raíz)"
 
-#: sequencer.c:1348
+#: sequencer.c:1365
 msgid "could not parse HEAD"
 msgstr "no se pudo analizar HEAD"
 
-#: sequencer.c:1350
+#: sequencer.c:1367
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "¡HEAD %s no es un commit!"
 
-#: sequencer.c:1354 sequencer.c:1432 builtin/commit.c:1705
+#: sequencer.c:1371 sequencer.c:1449 builtin/commit.c:1707
 msgid "could not parse HEAD commit"
 msgstr "no se pudo analizar el commit de HEAD"
 
-#: sequencer.c:1410 sequencer.c:2295
+#: sequencer.c:1427 sequencer.c:2312
 msgid "unable to parse commit author"
 msgstr "no es posible analizar el autor del commit"
 
-#: sequencer.c:1421 builtin/am.c:1615 builtin/merge.c:707
+#: sequencer.c:1438 builtin/am.c:1616 builtin/merge.c:708
 msgid "git write-tree failed to write a tree"
 msgstr "git write-tree falló al escribir el árbol"
 
-#: sequencer.c:1454 sequencer.c:1574
+#: sequencer.c:1471 sequencer.c:1591
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "no se puede leer el mensaje del commit de '%s'"
 
-#: sequencer.c:1485 sequencer.c:1517
+#: sequencer.c:1502 sequencer.c:1534
 #, c-format
 msgid "invalid author identity '%s'"
 msgstr "identidad de autor inválida '%s'"
 
-#: sequencer.c:1491
+#: sequencer.c:1508
 msgid "corrupt author: missing date information"
 msgstr "autor corrupto: falta información de fecha"
 
-#: sequencer.c:1530 builtin/am.c:1642 builtin/commit.c:1819 builtin/merge.c:910
-#: builtin/merge.c:935 t/helper/test-fast-rebase.c:78
+#: sequencer.c:1547 builtin/am.c:1643 builtin/commit.c:1821 builtin/merge.c:913
+#: builtin/merge.c:938 t/helper/test-fast-rebase.c:78
 msgid "failed to write commit object"
 msgstr "falló al escribir el objeto commit"
 
-#: sequencer.c:1557 sequencer.c:4492 t/helper/test-fast-rebase.c:199
+#: sequencer.c:1574 sequencer.c:4526 t/helper/test-fast-rebase.c:199
 #: t/helper/test-fast-rebase.c:217
 #, c-format
 msgid "could not update %s"
 msgstr "no se puede actualizar %s"
 
-#: sequencer.c:1606
+#: sequencer.c:1623
 #, c-format
 msgid "could not parse commit %s"
 msgstr "no se pudo analizar commit %s"
 
-#: sequencer.c:1611
+#: sequencer.c:1628
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "no se pudo analizar el commit padre %s"
 
-#: sequencer.c:1694 sequencer.c:1975
+#: sequencer.c:1711 sequencer.c:1992
 #, c-format
 msgid "unknown command: %d"
 msgstr "comando desconocido: %d"
 
-#: sequencer.c:1736 git-rebase--preserve-merges.sh:486
+#: sequencer.c:1753
 msgid "This is the 1st commit message:"
 msgstr "Este es el mensaje del 1er commit:"
 
-#: sequencer.c:1737
+#: sequencer.c:1754
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "Este es el mensaje del commit #%d:"
 
-#: sequencer.c:1738
+#: sequencer.c:1755
 msgid "The 1st commit message will be skipped:"
 msgstr "El mensaje del 1er commit será saltado:"
 
-#: sequencer.c:1739
+#: sequencer.c:1756
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "El mensaje del commit #%d será saltado:"
 
-#: sequencer.c:1740
+#: sequencer.c:1757
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr "Esta es una combinación de %d commits."
 
-#: sequencer.c:1887 sequencer.c:1944
+#: sequencer.c:1904 sequencer.c:1961
 #, c-format
 msgid "cannot write '%s'"
 msgstr "no se puede escribir '%s'"
 
-#: sequencer.c:1934
+#: sequencer.c:1951
 msgid "need a HEAD to fixup"
 msgstr "se necesita un HEAD para arreglar"
 
-#: sequencer.c:1936 sequencer.c:3582
+#: sequencer.c:1953 sequencer.c:3601
 msgid "could not read HEAD"
 msgstr "no se pudo leer HEAD"
 
-#: sequencer.c:1938
+#: sequencer.c:1955
 msgid "could not read HEAD's commit message"
 msgstr "no se pudo leer el mensaje de commit de HEAD"
 
-#: sequencer.c:1962
+#: sequencer.c:1979
 #, c-format
 msgid "could not read commit message of %s"
 msgstr "no se puede leer el mensaje del commit de %s"
 
-#: sequencer.c:2072
+#: sequencer.c:2089
 msgid "your index file is unmerged."
 msgstr "tu archivo índice no está fusionado."
 
-#: sequencer.c:2079
+#: sequencer.c:2096
 msgid "cannot fixup root commit"
 msgstr "no se puede arreglar el commit raíz"
 
-#: sequencer.c:2098
+#: sequencer.c:2115
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "el commit %s es una fusión pero no se proporcionó la opción -m."
 
-#: sequencer.c:2106 sequencer.c:2114
+#: sequencer.c:2123 sequencer.c:2131
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "el commit %s no tiene un padre %d"
 
-#: sequencer.c:2120
+#: sequencer.c:2137
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "no se puede obtener el mensaje de commit para %s"
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:2139
+#: sequencer.c:2156
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: no se puede analizar el commit padre %s"
 
-#: sequencer.c:2205
+#: sequencer.c:2222
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "no se puede renombrar '%s' a '%s'"
 
-#: sequencer.c:2265
+#: sequencer.c:2282
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "no se pudo revertir %s... %s"
 
-#: sequencer.c:2266
+#: sequencer.c:2283
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "no se pudo aplicar %s... %s"
 
-#: sequencer.c:2287
+#: sequencer.c:2304
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr "descartando $%s %s -- contenidos del parche ya están en upstream\n"
 
-#: sequencer.c:2345
+#: sequencer.c:2362
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: falló al leer el índice"
 
-#: sequencer.c:2352
+#: sequencer.c:2370
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: falló al refrescar el índice"
 
-#: sequencer.c:2425
+#: sequencer.c:2450
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "%s no acepta argumentos: '%s'"
 
-#: sequencer.c:2434
+#: sequencer.c:2459
 #, c-format
 msgid "missing arguments for %s"
 msgstr "faltan argumentos para %s"
 
-#: sequencer.c:2477
+#: sequencer.c:2502
 #, c-format
 msgid "could not parse '%s'"
 msgstr "no se puede analizar '%s'"
 
-#: sequencer.c:2538
+#: sequencer.c:2563
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "línea inválida %d: %.*s"
 
-#: sequencer.c:2549
+#: sequencer.c:2574
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "no se puede '%s' sin un commit previo"
 
-#: sequencer.c:2635
+#: sequencer.c:2622 builtin/rebase.c:184
+#, c-format
+msgid "could not read '%s'."
+msgstr "no se puede leer '%s'."
+
+#: sequencer.c:2660
 msgid "cancelling a cherry picking in progress"
 msgstr "cancelando cherry-pick en progreso"
 
-#: sequencer.c:2644
+#: sequencer.c:2669
 msgid "cancelling a revert in progress"
 msgstr "cancelando revert en progreso"
 
-#: sequencer.c:2690
+#: sequencer.c:2709
 msgid "please fix this using 'git rebase --edit-todo'."
-msgstr "por favor arregle esto usando 'git rebase --edit-todo'."
+msgstr "por favor arregla esto usando 'git rebase --edit-todo'."
 
-#: sequencer.c:2692
+#: sequencer.c:2711
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "hoja de instrucciones inutilizable: '%s'"
 
-#: sequencer.c:2697
+#: sequencer.c:2716
 msgid "no commits parsed."
 msgstr "ningún commit analizado."
 
-#: sequencer.c:2708
+#: sequencer.c:2727
 msgid "cannot cherry-pick during a revert."
 msgstr "no se puede realizar cherry-pick durante un revert."
 
-#: sequencer.c:2710
+#: sequencer.c:2729
 msgid "cannot revert during a cherry-pick."
 msgstr "no se puede realizar un revert durante un cherry-pick."
 
-#: sequencer.c:2788
+#: sequencer.c:2807
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr "valor inválido para %s: %s"
 
-#: sequencer.c:2897
+#: sequencer.c:2916
 msgid "unusable squash-onto"
 msgstr "squash-onto inservible"
 
-#: sequencer.c:2917
+#: sequencer.c:2936
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "hoja de opciones mal formada: '%s'"
 
-#: sequencer.c:3012 sequencer.c:4868
+#: sequencer.c:3031 sequencer.c:4905
 msgid "empty commit set passed"
 msgstr "conjunto de commits vacío entregado"
 
-#: sequencer.c:3029
+#: sequencer.c:3048
 msgid "revert is already in progress"
 msgstr "revert ya está en progreso"
 
-#: sequencer.c:3031
+#: sequencer.c:3050
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr "intenta \"git revert (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:3034
+#: sequencer.c:3053
 msgid "cherry-pick is already in progress"
 msgstr "cherry-pick ya está en progreso"
 
-#: sequencer.c:3036
+#: sequencer.c:3055
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr "intenta \"git cherry-pick (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:3050
+#: sequencer.c:3069
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr "no se pudo crear un directorio secuenciador '%s'"
 
-#: sequencer.c:3065
+#: sequencer.c:3084
 msgid "could not lock HEAD"
 msgstr "no se pudo bloquear HEAD"
 
-#: sequencer.c:3125 sequencer.c:4581
+#: sequencer.c:3144 sequencer.c:4615
 msgid "no cherry-pick or revert in progress"
 msgstr "ningún cherry-pick o revert en progreso"
 
-#: sequencer.c:3127 sequencer.c:3138
+#: sequencer.c:3146 sequencer.c:3157
 msgid "cannot resolve HEAD"
 msgstr "no se puede resolver HEAD"
 
-#: sequencer.c:3129 sequencer.c:3173
+#: sequencer.c:3148 sequencer.c:3192
 msgid "cannot abort from a branch yet to be born"
 msgstr "no se puede abortar de una rama por nacer"
 
-#: sequencer.c:3159 builtin/grep.c:758
+#: sequencer.c:3178 builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr "no se puede abrir '%s'"
 
-#: sequencer.c:3161
+#: sequencer.c:3180
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "no se puede leer '%s': %s"
 
-#: sequencer.c:3162
+#: sequencer.c:3181
 msgid "unexpected end of file"
 msgstr "final de archivo inesperado"
 
-#: sequencer.c:3168
+#: sequencer.c:3187
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr "archivo HEAD '%s' guardado antes de cherry-pick está corrupto"
 
-#: sequencer.c:3179
+#: sequencer.c:3198
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr "Parece que se ha movido HEAD. No se hace rebobinado, ¡revisa tu HEAD!"
 
-#: sequencer.c:3220
+#: sequencer.c:3239
 msgid "no revert in progress"
 msgstr "no hay revert en progreso"
 
-#: sequencer.c:3229
+#: sequencer.c:3248
 msgid "no cherry-pick in progress"
 msgstr "ningún cherry-pick en progreso"
 
-#: sequencer.c:3239
+#: sequencer.c:3258
 msgid "failed to skip the commit"
 msgstr "falló al escribir el commit"
 
-#: sequencer.c:3246
+#: sequencer.c:3265
 msgid "there is nothing to skip"
 msgstr "no hay nada que saltar"
 
-#: sequencer.c:3249
+#: sequencer.c:3268
 #, c-format
 msgid ""
 "have you committed already?\n"
@@ -8077,16 +8299,16 @@ msgstr ""
 "¿ya has hecho el commit?\n"
 "intenta \"git %s --continue\""
 
-#: sequencer.c:3411 sequencer.c:4472
+#: sequencer.c:3430 sequencer.c:4506
 msgid "cannot read HEAD"
 msgstr "no se puede leer HEAD"
 
-#: sequencer.c:3428
+#: sequencer.c:3447
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "no se pudo copiar '%s' a '%s'"
 
-#: sequencer.c:3436
+#: sequencer.c:3455
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -8105,27 +8327,27 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:3446
+#: sequencer.c:3465
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "No se pudo aplicar %s... %.*s"
 
-#: sequencer.c:3453
+#: sequencer.c:3472
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "No se pudo fusionar %.*s"
 
-#: sequencer.c:3467 sequencer.c:3471 builtin/difftool.c:644
+#: sequencer.c:3486 sequencer.c:3490 builtin/difftool.c:639
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "no se pudo copiar '%s' a '%s'"
 
-#: sequencer.c:3483
+#: sequencer.c:3502
 #, c-format
 msgid "Executing: %s\n"
 msgstr "Ejecutando: %s\n"
 
-#: sequencer.c:3498
+#: sequencer.c:3517
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -8140,11 +8362,11 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3504
+#: sequencer.c:3523
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "y se hicieron cambios al índice y/o árbol de trabajo\n"
 
-#: sequencer.c:3510
+#: sequencer.c:3529
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -8161,90 +8383,90 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3572
+#: sequencer.c:3591
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "nombre de label ilegal: '%.*s'"
 
-#: sequencer.c:3645
+#: sequencer.c:3664
 msgid "writing fake root commit"
 msgstr "escribiendo commit raíz falso"
 
-#: sequencer.c:3650
+#: sequencer.c:3669
 msgid "writing squash-onto"
 msgstr "escribiendo squash-onto"
 
-#: sequencer.c:3734
+#: sequencer.c:3748
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "no se pudo resolver '%s'"
 
-#: sequencer.c:3767
+#: sequencer.c:3780
 msgid "cannot merge without a current revision"
 msgstr "no se puede fusionar sin una versión actual"
 
-#: sequencer.c:3789
+#: sequencer.c:3802
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "no se puede analizar '%.*s'"
 
-#: sequencer.c:3798
+#: sequencer.c:3811
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "nada para fusionar: '%.*s'"
 
-#: sequencer.c:3810
+#: sequencer.c:3823
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr "fusión octopus no puede ser ejecutada en la punta de un [nuevo root]"
 
-#: sequencer.c:3826
+#: sequencer.c:3878
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "no se puede leer el mensaje del commit '%s'"
 
-#: sequencer.c:4009
+#: sequencer.c:4024
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "ni se pudo intentar fusionar '%.*s'"
 
-#: sequencer.c:4025
+#: sequencer.c:4040
 msgid "merge: Unable to write new index file"
 msgstr "fusión: No se puede escribir el nuevo archivo índice"
 
-#: sequencer.c:4099
+#: sequencer.c:4121
 msgid "Cannot autostash"
 msgstr "No se puede ejecutar autostash"
 
-#: sequencer.c:4102
+#: sequencer.c:4124
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Respuesta de stash inesperada: '%s'"
 
-#: sequencer.c:4108
+#: sequencer.c:4130
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "No se pudo crear el directorio para '%s'"
 
-#: sequencer.c:4111
+#: sequencer.c:4133
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "Autostash creado: %s\n"
 
-#: sequencer.c:4115
+#: sequencer.c:4137
 msgid "could not reset --hard"
 msgstr "no se pudo reset --hard"
 
-#: sequencer.c:4140
+#: sequencer.c:4162
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "Autostash aplicado.\n"
 
-#: sequencer.c:4152
+#: sequencer.c:4174
 #, c-format
 msgid "cannot store %s"
 msgstr "no se puede guardar %s"
 
-#: sequencer.c:4155
+#: sequencer.c:4177
 #, c-format
 msgid ""
 "%s\n"
@@ -8256,29 +8478,29 @@ msgstr ""
 "Puedes ejecutar \"git stash pop\" o \"git stash drop\" en cualquier "
 "momento.\n"
 
-#: sequencer.c:4160
+#: sequencer.c:4182
 msgid "Applying autostash resulted in conflicts."
 msgstr "Aplicar autostash resultó en conflictos."
 
-#: sequencer.c:4161
+#: sequencer.c:4183
 msgid "Autostash exists; creating a new stash entry."
 msgstr "Autostash existe; creando una nueva entrada stash."
 
-#: sequencer.c:4233 git-rebase--preserve-merges.sh:769
+#: sequencer.c:4255
 msgid "could not detach HEAD"
 msgstr "no se pudo desacoplar HEAD"
 
-#: sequencer.c:4248
+#: sequencer.c:4270
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Detenido en HEAD\n"
 
-#: sequencer.c:4250
+#: sequencer.c:4272
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Detenido en %s\n"
 
-#: sequencer.c:4258
+#: sequencer.c:4304
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -8294,63 +8516,63 @@ msgstr ""
 "\n"
 "    %.*s\n"
 "Ha sido reprogramado; Para editar el comando antes de continuar, por favor\n"
-"edite la lista de \"todo\" primero:\n"
+"edita la lista de \"todo\" primero:\n"
 "\n"
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:4304
+#: sequencer.c:4350
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr "Aplicando rebase (%d/%d)%s"
 
-#: sequencer.c:4350
+#: sequencer.c:4396
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Detenido en %s...  %.*s\n"
 
-#: sequencer.c:4421
+#: sequencer.c:4466
 #, c-format
 msgid "unknown command %d"
 msgstr "comando desconocido %d"
 
-#: sequencer.c:4480
+#: sequencer.c:4514
 msgid "could not read orig-head"
 msgstr "no se pudo leer orig-head"
 
-#: sequencer.c:4485
+#: sequencer.c:4519
 msgid "could not read 'onto'"
 msgstr "no se pudo leer 'onto'"
 
-#: sequencer.c:4499
+#: sequencer.c:4533
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "no se pudo actualizar HEAD a %s"
 
-#: sequencer.c:4559
+#: sequencer.c:4593
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr "Rebase aplicado satisfactoriamente y actualizado %s.\n"
 
-#: sequencer.c:4611
+#: sequencer.c:4645
 msgid "cannot rebase: You have unstaged changes."
 msgstr "no se puede realizar rebase: Tienes cambios fuera del área de stage."
 
-#: sequencer.c:4620
+#: sequencer.c:4654
 msgid "cannot amend non-existing commit"
 msgstr "no se puede arreglar un commit no existente"
 
-#: sequencer.c:4622
+#: sequencer.c:4656
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "archivo inválido: '%s'"
 
-#: sequencer.c:4624
+#: sequencer.c:4658
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "contenido inválido: '%s'"
 
-#: sequencer.c:4627
+#: sequencer.c:4661
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -8361,50 +8583,59 @@ msgstr ""
 "un commit con estos\n"
 "primero y luego ejecuta 'git rebase --continue' de nuevo."
 
-#: sequencer.c:4663 sequencer.c:4702
+#: sequencer.c:4697 sequencer.c:4736
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "no se pudo escribir el archivo: '%s'"
 
-#: sequencer.c:4718
+#: sequencer.c:4752
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "no se pudo eliminar CHERRY_PICK_HEAD"
 
-#: sequencer.c:4725
+#: sequencer.c:4762
 msgid "could not commit staged changes."
 msgstr "no se pudo realizar el commit con los cambios en el área de stage."
 
-#: sequencer.c:4845
+#: sequencer.c:4882
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: no se puede aplicar cherry-pick a un %s"
 
-#: sequencer.c:4849
+#: sequencer.c:4886
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: revisión errónea"
 
-#: sequencer.c:4884
+#: sequencer.c:4921
 msgid "can't revert as initial commit"
 msgstr "no se puede revertir como commit inicial"
 
-#: sequencer.c:5361
+#: sequencer.c:5192 sequencer.c:5421
+#, c-format
+msgid "skipped previously applied commit %s"
+msgstr "se ha saltado el commit %s aplicado previamente"
+
+#: sequencer.c:5262 sequencer.c:5437
+msgid "use --reapply-cherry-picks to include skipped commits"
+msgstr "use --reapply-cherry-picks para incluir los commits saltados"
+
+#: sequencer.c:5408
 msgid "make_script: unhandled options"
 msgstr "make_script: opciones desconocidas"
 
-#: sequencer.c:5364
+#: sequencer.c:5411
 msgid "make_script: error preparing revisions"
 msgstr "make_script: error al preparar revisiones"
 
-#: sequencer.c:5614 sequencer.c:5631
+#: sequencer.c:5669 sequencer.c:5686
 msgid "nothing to do"
 msgstr "nada que hacer"
 
-#: sequencer.c:5650
+#: sequencer.c:5705
 msgid "could not skip unnecessary pick commands"
 msgstr "no se pudo saltar los comandos pick innecesarios"
 
-#: sequencer.c:5750
+#: sequencer.c:5805
 msgid "the script was already rearranged."
 msgstr "este script ya fue reorganizado."
 
@@ -8420,7 +8651,7 @@ msgid ""
 "Use 'git <command> -- <path>...' to specify paths that do not exist locally."
 msgstr ""
 "%s: no existe la ruta en el árbol de trabajo.\n"
-"Use 'git <comando> -- <ruta>...' para especificar rutas que no existen "
+"Usa 'git <comando> -- <ruta>...' para especificar rutas que no existen "
 "localmente."
 
 #: setup.c:198
@@ -8432,7 +8663,7 @@ msgid ""
 msgstr ""
 "argumento ambiguo '%s': revisión desconocida o ruta fuera del árbol de "
 "trabajo.\n"
-"Use '--' para separar las rutas de las revisiones, de esta manera:\n"
+"Usa '--' para separar las rutas de las revisiones, de esta manera:\n"
 "'git <comando> [<revisión>...] -- [<archivo>...]'"
 
 #: setup.c:264
@@ -8448,7 +8679,7 @@ msgid ""
 "'git <command> [<revision>...] -- [<file>...]'"
 msgstr ""
 "argumento ambiguo '%s': ambos revisión y nombre de archivo\n"
-"Use '--' para separar rutas de revisiones, de esta manera:\n"
+"Usa '--' para separar rutas de revisiones, de esta manera:\n"
 "'git <comando> [<revisión>...] -- [<archivo>...]'"
 
 #: setup.c:419
@@ -8566,27 +8797,15 @@ msgstr ""
 "problema con el valor del modo de archivo core.sharedRepository (0%.3o).\n"
 "El dueño de los archivos tiene que tener permisos de lectura y escritura."
 
-#: setup.c:1430
-msgid "open /dev/null or dup failed"
-msgstr "falló al abrir /dev/null o hacer dup"
-
-#: setup.c:1445
+#: setup.c:1443
 msgid "fork failed"
 msgstr "falló fork"
 
-#: setup.c:1450 t/helper/test-simple-ipc.c:285
+#: setup.c:1448
 msgid "setsid failed"
 msgstr "falló setsid"
 
-#: sparse-index.c:162
-msgid "attempting to use sparse-index without cone mode"
-msgstr "intentando usar sparse-index sin modo cono"
-
-#: sparse-index.c:176
-msgid "unable to update cache-tree, staying full"
-msgstr "no es posible actualizar el cache del árbol, manteniendo full"
-
-#: sparse-index.c:263
+#: sparse-index.c:273
 #, c-format
 msgid "index entry is a directory, but not sparse (%08x)"
 msgstr "la entrada de índice es un directorio, pero no escazo (%08x)"
@@ -8643,13 +8862,13 @@ msgid_plural "%u bytes/s"
 msgstr[0] "%u bytes/s"
 msgstr[1] "%u bytes/s"
 
-#: strbuf.c:1168 wrapper.c:199 wrapper.c:369 builtin/am.c:738
-#: builtin/rebase.c:866
+#: strbuf.c:1174 wrapper.c:207 wrapper.c:377 builtin/am.c:739
+#: builtin/rebase.c:650
 #, c-format
 msgid "could not open '%s' for writing"
 msgstr "no se pudo abrir '%s' para escritura"
 
-#: strbuf.c:1177
+#: strbuf.c:1183
 #, c-format
 msgid "could not edit '%s'"
 msgstr "no se pudo editar '%s'"
@@ -8675,7 +8894,7 @@ msgstr ""
 msgid "invalid value for %s"
 msgstr "valor inválido para %s"
 
-#: submodule-config.c:766
+#: submodule-config.c:767
 #, c-format
 msgid "Could not update .gitmodules entry %s"
 msgstr "No se pudo actualizar la entrada %s de .gitmodules"
@@ -8683,7 +8902,7 @@ msgstr "No se pudo actualizar la entrada %s de .gitmodules"
 #: submodule.c:114 submodule.c:143
 msgid "Cannot change unmerged .gitmodules, resolve merge conflicts first"
 msgstr ""
-"No se puede cambiar .gitmodules no fusionados, primero resuelva los "
+"No se puede cambiar .gitmodules no fusionados, primero resuelve los "
 "conflictos de fusión"
 
 #: submodule.c:118 submodule.c:147
@@ -8700,22 +8919,22 @@ msgstr "No se pudo eliminar la entrada %s de .gitmodules"
 msgid "staging updated .gitmodules failed"
 msgstr "falló realizar stage a los .gitmodules actualizados"
 
-#: submodule.c:328
+#: submodule.c:358
 #, c-format
 msgid "in unpopulated submodule '%s'"
 msgstr "en el submódulo no poblado '%s'"
 
-#: submodule.c:359
+#: submodule.c:389
 #, c-format
 msgid "Pathspec '%s' is in submodule '%.*s'"
 msgstr "El patrón de ruta '%s' está en el submódulo '%.*s'"
 
-#: submodule.c:436
+#: submodule.c:466
 #, c-format
 msgid "bad --ignore-submodules argument: %s"
 msgstr "mal argumento --ignore-submodules: %s"
 
-#: submodule.c:805
+#: submodule.c:844
 #, c-format
 msgid ""
 "Submodule in commit %s at path: '%s' collides with a submodule named the "
@@ -8724,12 +8943,12 @@ msgstr ""
 "Submódulo en el commit %s en la ruta: '%s' colisiona con un submódulo "
 "llamado igual. Saltándolo."
 
-#: submodule.c:908
+#: submodule.c:954
 #, c-format
 msgid "submodule entry '%s' (%s) is a %s, not a commit"
 msgstr "entrada de submódulo '%s' (%s) es un %s, no un commit"
 
-#: submodule.c:993
+#: submodule.c:1042
 #, c-format
 msgid ""
 "Could not run 'git rev-list <commits> --not --remotes -n 1' command in "
@@ -8738,36 +8957,36 @@ msgstr ""
 "No se pudo ejecutar comando 'git rev-list <commits> --not --remotes -n 1' en "
 "el submódulo %s"
 
-#: submodule.c:1116
+#: submodule.c:1165
 #, c-format
 msgid "process for submodule '%s' failed"
 msgstr "proceso para submódulo '%s' falló"
 
-#: submodule.c:1145 builtin/branch.c:691 builtin/submodule--helper.c:2486
+#: submodule.c:1194 builtin/branch.c:692 builtin/submodule--helper.c:2713
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "Falló al resolver HEAD como un ref válido."
 
-#: submodule.c:1156
+#: submodule.c:1205
 #, c-format
 msgid "Pushing submodule '%s'\n"
 msgstr "Empujando submódulo '%s'\n"
 
-#: submodule.c:1159
+#: submodule.c:1208
 #, c-format
 msgid "Unable to push submodule '%s'\n"
 msgstr "No es posible hacer push al submódulo '%s'\n"
 
-#: submodule.c:1451
+#: submodule.c:1491
 #, c-format
 msgid "Fetching submodule %s%s\n"
 msgstr "Haciendo fetch al submódulo %s%s\n"
 
-#: submodule.c:1485
+#: submodule.c:1525
 #, c-format
 msgid "Could not access submodule '%s'\n"
 msgstr "No se pudo acceder al submódulo '%s'\n"
 
-#: submodule.c:1640
+#: submodule.c:1680
 #, c-format
 msgid ""
 "Errors during submodule fetch:\n"
@@ -8776,62 +8995,62 @@ msgstr ""
 "Errores durante el fetch del submódulo:\n"
 "%s"
 
-#: submodule.c:1665
+#: submodule.c:1705
 #, c-format
 msgid "'%s' not recognized as a git repository"
 msgstr "'%s' no reconocido como un repositorio git"
 
-#: submodule.c:1682
+#: submodule.c:1722
 #, c-format
 msgid "Could not run 'git status --porcelain=2' in submodule %s"
 msgstr "No se pudo ejecutar 'git status --porcelain=2' en el submódulo %s"
 
-#: submodule.c:1723
+#: submodule.c:1763
 #, c-format
 msgid "'git status --porcelain=2' failed in submodule %s"
 msgstr "'git status --porcelain=2' falló en el submódulo %s"
 
-#: submodule.c:1798
+#: submodule.c:1838
 #, c-format
 msgid "could not start 'git status' in submodule '%s'"
 msgstr "no se pudo comenzar 'git status' en el submódulo '%s'"
 
-#: submodule.c:1811
+#: submodule.c:1851
 #, c-format
 msgid "could not run 'git status' in submodule '%s'"
 msgstr "no se pudo ejecutar 'git status' en el submódulo '%s'"
 
-#: submodule.c:1826
+#: submodule.c:1868
 #, c-format
 msgid "Could not unset core.worktree setting in submodule '%s'"
 msgstr "No se pudo quitar configuración core.worktree en submódulo '%s'"
 
-#: submodule.c:1853 submodule.c:2163
+#: submodule.c:1895 submodule.c:2210
 #, c-format
 msgid "could not recurse into submodule '%s'"
 msgstr "no se pudo recursar en el submódulo '%s'"
 
-#: submodule.c:1874
+#: submodule.c:1917
 msgid "could not reset submodule index"
 msgstr "no se pudo reiniciar el índice del submódulo"
 
-#: submodule.c:1916
+#: submodule.c:1959
 #, c-format
 msgid "submodule '%s' has dirty index"
 msgstr "submódulo '%s' tiene un índice corrupto"
 
-#: submodule.c:1968
+#: submodule.c:2013
 #, c-format
 msgid "Submodule '%s' could not be updated."
 msgstr "Submódulo '%s' no pudo ser actualizado."
 
-#: submodule.c:2036
+#: submodule.c:2081
 #, c-format
 msgid "submodule git dir '%s' is inside git dir '%.*s'"
 msgstr ""
 "directorio de git del submódulo '%s' está dentro del directorio de git '%.*s'"
 
-#: submodule.c:2057
+#: submodule.c:2102
 #, c-format
 msgid ""
 "relocate_gitdir for submodule '%s' with more than one worktree not supported"
@@ -8839,17 +9058,17 @@ msgstr ""
 "relocate_gitdir para el submódulo '%s' con más de un árbol de trabajo no "
 "soportado"
 
-#: submodule.c:2069 submodule.c:2128
+#: submodule.c:2114 submodule.c:2174
 #, c-format
 msgid "could not lookup name for submodule '%s'"
 msgstr "no se pudo resolver el nombre para el submódulo '%s'"
 
-#: submodule.c:2073
+#: submodule.c:2118
 #, c-format
 msgid "refusing to move '%s' into an existing git dir"
 msgstr "rechazando mover '%s' dentro de un directorio git existente"
 
-#: submodule.c:2080
+#: submodule.c:2124
 #, c-format
 msgid ""
 "Migrating git directory of '%s%s' from\n"
@@ -8860,11 +9079,11 @@ msgstr ""
 "'%s' hacia\n"
 "'%s'\n"
 
-#: submodule.c:2208
+#: submodule.c:2255
 msgid "could not start ls-files in .."
 msgstr "no se pudo comenzar ls-files en .."
 
-#: submodule.c:2248
+#: submodule.c:2295
 #, c-format
 msgid "ls-tree returned unexpected return code %d"
 msgstr "ls-tree devolvió un código %d inesperado"
@@ -8886,7 +9105,7 @@ msgid "unknown value '%s' for key '%s'"
 msgstr "valor '%s' desconocido para la clave '%s'"
 
 #: trailer.c:547 trailer.c:552 trailer.c:557 builtin/remote.c:299
-#: builtin/remote.c:324
+#: builtin/remote.c:327
 #, c-format
 msgid "more than one %s"
 msgstr "más de un %s"
@@ -8901,11 +9120,11 @@ msgstr "token de remolque vacío en el trailer '%.*s'"
 msgid "could not read input file '%s'"
 msgstr "no se pudo leer el archivo de entrada '%s'"
 
-#: trailer.c:766 builtin/mktag.c:88 imap-send.c:1577
+#: trailer.c:766 builtin/mktag.c:89 imap-send.c:1573
 msgid "could not read from stdin"
 msgstr "no se pudo leer desde stdin"
 
-#: trailer.c:1024 wrapper.c:676
+#: trailer.c:1024 wrapper.c:684
 #, c-format
 msgid "could not stat %s"
 msgstr "no se pudo hacer stat en %s"
@@ -8973,7 +9192,7 @@ msgstr "no se pudo ejecutar fast-import"
 msgid "error while running fast-import"
 msgstr "error al ejecutar fast-import"
 
-#: transport-helper.c:549 transport-helper.c:1247
+#: transport-helper.c:549 transport-helper.c:1251
 #, c-format
 msgid "could not read ref %s"
 msgstr "no se pudo leer la referencia %s"
@@ -8991,7 +9210,7 @@ msgstr "configurar servicio de ruta remota no soportado por el protocolo"
 msgid "invalid remote service path"
 msgstr "ruta de servicio remoto inválida"
 
-#: transport-helper.c:661 transport.c:1477
+#: transport-helper.c:661 transport.c:1475
 msgid "operation not supported by protocol"
 msgstr "operación no soportada por protocolo"
 
@@ -9000,7 +9219,7 @@ msgstr "operación no soportada por protocolo"
 msgid "can't connect to subservice %s"
 msgstr "no se puede conectar al subservicio %s"
 
-#: transport-helper.c:693 transport.c:400
+#: transport-helper.c:693 transport.c:404
 msgid "--negotiate-only requires protocol v2"
 msgstr "--negotiate-only requiere protocolo v2"
 
@@ -9013,59 +9232,59 @@ msgstr "'opción' sin una directiva correspondiente 'ok/error'"
 msgid "expected ok/error, helper said '%s'"
 msgstr "se esperaba ok/error, helper dijo '%s'"
 
-#: transport-helper.c:855
+#: transport-helper.c:859
 #, c-format
 msgid "helper reported unexpected status of %s"
 msgstr "helper reportó estado inesperado de %s"
 
-#: transport-helper.c:938
+#: transport-helper.c:942
 #, c-format
 msgid "helper %s does not support dry-run"
 msgstr "helper %s no soporta dry-run"
 
-#: transport-helper.c:941
+#: transport-helper.c:945
 #, c-format
 msgid "helper %s does not support --signed"
 msgstr "helper %s no soporta --signed"
 
-#: transport-helper.c:944
+#: transport-helper.c:948
 #, c-format
 msgid "helper %s does not support --signed=if-asked"
 msgstr "helper %s no soporta --signed=if-asked"
 
-#: transport-helper.c:949
+#: transport-helper.c:953
 #, c-format
 msgid "helper %s does not support --atomic"
 msgstr "helper %s no soporta --atomic"
 
-#: transport-helper.c:953
+#: transport-helper.c:957
 #, c-format
 msgid "helper %s does not support --%s"
 msgstr "helper %s no soporta --%s"
 
-#: transport-helper.c:960
+#: transport-helper.c:964
 #, c-format
 msgid "helper %s does not support 'push-option'"
 msgstr "helper %s no soporta 'push-option'"
 
-#: transport-helper.c:1060
+#: transport-helper.c:1064
 msgid "remote-helper doesn't support push; refspec needed"
 msgstr "remote-helper no soporta push; se necesita refspec"
 
-#: transport-helper.c:1065
+#: transport-helper.c:1069
 #, c-format
 msgid "helper %s does not support 'force'"
 msgstr "helper %s no soporta 'force'"
 
-#: transport-helper.c:1112
+#: transport-helper.c:1116
 msgid "couldn't run fast-export"
 msgstr "no se pudo ejecutar fast-export"
 
-#: transport-helper.c:1117
+#: transport-helper.c:1121
 msgid "error while running fast-export"
 msgstr "error al ejecutar fast-export"
 
-#: transport-helper.c:1142
+#: transport-helper.c:1146
 #, c-format
 msgid ""
 "No refs in common and none specified; doing nothing.\n"
@@ -9074,52 +9293,52 @@ msgstr ""
 "No hay refs comunes y ninguno especificado; no se hace nada.\n"
 "Tal vez deberías especificar un branch.\n"
 
-#: transport-helper.c:1224
+#: transport-helper.c:1228
 #, c-format
 msgid "unsupported object format '%s'"
 msgstr "formato de objeto no soportado '%s'"
 
-#: transport-helper.c:1233
+#: transport-helper.c:1237
 #, c-format
 msgid "malformed response in ref list: %s"
 msgstr "respuesta malformada en lista de refs: %s"
 
-#: transport-helper.c:1385
+#: transport-helper.c:1389
 #, c-format
 msgid "read(%s) failed"
 msgstr "read(%s) falló"
 
-#: transport-helper.c:1412
+#: transport-helper.c:1416
 #, c-format
 msgid "write(%s) failed"
 msgstr "write(%s) falló"
 
-#: transport-helper.c:1461
+#: transport-helper.c:1465
 #, c-format
 msgid "%s thread failed"
 msgstr "hilo %s falló"
 
-#: transport-helper.c:1465
+#: transport-helper.c:1469
 #, c-format
 msgid "%s thread failed to join: %s"
 msgstr "hilo %s falló al unirse: %s"
 
-#: transport-helper.c:1484 transport-helper.c:1488
+#: transport-helper.c:1488 transport-helper.c:1492
 #, c-format
 msgid "can't start thread for copying data: %s"
 msgstr "no se puede iniciar el hilo para copiar data: %s"
 
-#: transport-helper.c:1525
+#: transport-helper.c:1529
 #, c-format
 msgid "%s process failed to wait"
 msgstr "proceso %s falló al esperar"
 
-#: transport-helper.c:1529
+#: transport-helper.c:1533
 #, c-format
 msgid "%s process failed"
 msgstr "proceso %s falló"
 
-#: transport-helper.c:1547 transport-helper.c:1556
+#: transport-helper.c:1551 transport-helper.c:1560
 msgid "can't start thread for copying data"
 msgstr "no se puede iniciar hilo para copiar data"
 
@@ -9133,46 +9352,46 @@ msgstr "Configurará upstream de '%s' a '%s' de '%s'\n"
 msgid "could not read bundle '%s'"
 msgstr "no se pudo leer el conjunto '%s'"
 
-#: transport.c:223
+#: transport.c:227
 #, c-format
 msgid "transport: invalid depth option '%s'"
 msgstr "transport: opción de profundidad inválida '%s'"
 
-#: transport.c:275
+#: transport.c:279
 msgid "see protocol.version in 'git help config' for more details"
-msgstr "ver protocol.version en 'git help config' para más información"
+msgstr "mira protocol.version en 'git help config' para más información"
 
-#: transport.c:276
+#: transport.c:280
 msgid "server options require protocol version 2 or later"
 msgstr "opciones del servidor requieren protocolo versión 2 o posterior"
 
-#: transport.c:403
+#: transport.c:407
 msgid "server does not support wait-for-done"
 msgstr "el servidor no soporta wait-for-done"
 
-#: transport.c:755
+#: transport.c:759
 msgid "could not parse transport.color.* config"
 msgstr "no se pudo analizar valor de configuración transport.color.*"
 
-#: transport.c:830
+#: transport.c:834
 msgid "support for protocol v2 not implemented yet"
 msgstr "soporte para protocolo v2 no implementado todavía"
 
-#: transport.c:965
+#: transport.c:967
 #, c-format
 msgid "unknown value for config '%s': %s"
 msgstr "valor desconocido para configuración '%s': %s"
 
-#: transport.c:1031
+#: transport.c:1033
 #, c-format
 msgid "transport '%s' not allowed"
 msgstr "transporte '%s' no permitido"
 
-#: transport.c:1084
+#: transport.c:1082
 msgid "git-over-rsync is no longer supported"
 msgstr "git-over-rsync ya no es soportado"
 
-#: transport.c:1187
+#: transport.c:1185
 #, c-format
 msgid ""
 "The following submodule paths contain changes that can\n"
@@ -9181,7 +9400,7 @@ msgstr ""
 "La siguiente ruta de submódulo contiene cambios que no\n"
 "pueden ser encontrados en ningún remoto:\n"
 
-#: transport.c:1191
+#: transport.c:1189
 #, c-format
 msgid ""
 "\n"
@@ -9208,11 +9427,11 @@ msgstr ""
 "para hacer un push al remoto.\n"
 "\n"
 
-#: transport.c:1199
+#: transport.c:1197
 msgid "Aborting."
 msgstr "Abortando."
 
-#: transport.c:1346
+#: transport.c:1344
 msgid "failed to push all needed submodules"
 msgstr "falló al hacer push a todos los submódulos necesarios"
 
@@ -9497,17 +9716,17 @@ msgstr ""
 "en un filesystem case-insensitive) y solo una del grupo\n"
 "colisionando está en el árbol de trabajo:\n"
 
-#: unpack-trees.c:1618
+#: unpack-trees.c:1620
 msgid "Updating index flags"
 msgstr "Actualizando flags del índice"
 
-#: unpack-trees.c:2718
+#: unpack-trees.c:2772
 #, c-format
 msgid "worktree and untracked commit have duplicate entries: %s"
 msgstr ""
 "el árbol de trabajo y commits no monitoreados tienen entradas duplicadas: %s"
 
-#: upload-pack.c:1548
+#: upload-pack.c:1561
 msgid "expected flush after fetch arguments"
 msgstr "se espera flush tras argumentos fetch"
 
@@ -9544,7 +9763,7 @@ msgstr "segmento de ruta '..' inválido"
 msgid "Fetching objects"
 msgstr "Haciendo fetch a objetos"
 
-#: worktree.c:236 builtin/am.c:2152
+#: worktree.c:236 builtin/am.c:2154 builtin/bisect--helper.c:156
 #, c-format
 msgid "failed to read '%s'"
 msgstr "falló al leer '%s'"
@@ -9645,17 +9864,27 @@ msgstr "archivo gitdir inválido"
 msgid "gitdir file points to non-existent location"
 msgstr "archivo gitdir apunta a una ubicación inexistente"
 
-#: wrapper.c:197 wrapper.c:367
+#: wrapper.c:151
+#, c-format
+msgid "could not setenv '%s'"
+msgstr "no se pudo establecer setenv '%s'"
+
+#: wrapper.c:203
+#, c-format
+msgid "unable to create '%s'"
+msgstr "no se puede crear '%s'"
+
+#: wrapper.c:205 wrapper.c:375
 #, c-format
 msgid "could not open '%s' for reading and writing"
 msgstr "no se pudo abrir '%s' para lectura y escritura"
 
-#: wrapper.c:398 wrapper.c:599
+#: wrapper.c:406 wrapper.c:607
 #, c-format
 msgid "unable to access '%s'"
 msgstr "no es posible acceder '%s'"
 
-#: wrapper.c:607
+#: wrapper.c:615
 msgid "unable to get current working directory"
 msgstr "no es posible obtener el directorio de trabajo actual"
 
@@ -9722,8 +9951,8 @@ msgstr ""
 #: wt-status.c:243
 msgid "  (commit or discard the untracked or modified content in submodules)"
 msgstr ""
-"  (confirmar o descartar el contenido sin seguimiento o modificado en los "
-"sub-módulos)"
+"  (confirma o descarta el contenido sin seguimiento o modificado en los sub-"
+"módulos)"
 
 #: wt-status.c:254
 #, c-format
@@ -9823,7 +10052,7 @@ msgid ""
 "Do not modify or remove the line above.\n"
 "Everything below it will be ignored."
 msgstr ""
-"No modifique ni borre la línea de encima.\n"
+"No modifiques ni borres la línea de encima.\n"
 "Todo lo que esté por abajo será ignorado."
 
 #: wt-status.c:1165
@@ -10006,7 +10235,7 @@ msgstr "  (usa \"git cherry-pick --skip\" para saltar este parche)"
 #: wt-status.c:1490
 msgid "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)"
 msgstr ""
-"  (use \"git cherry-pick --abort\" para cancelar la operación cherry-pick)"
+"  (usa \"git cherry-pick --abort\" para cancelar la operación cherry-pick)"
 
 #: wt-status.c:1500
 msgid "Revert currently in progress."
@@ -10057,7 +10286,7 @@ msgstr "Estás en un sparse checkout."
 #: wt-status.c:1550
 #, c-format
 msgid "You are in a sparse checkout with %d%% of tracked files present."
-msgstr "Estas en un checkout de sparse con %d%% archivos rastreados presentes."
+msgstr "Estás en un checkout de sparse con %d%% archivos rastreados presentes."
 
 #: wt-status.c:1794
 msgid "On branch "
@@ -10108,7 +10337,7 @@ msgid ""
 msgstr ""
 "Tomó %.2f segundos enumerar los archivos no rastreados. 'status -uno'\n"
 "puede acelerarlo, pero tienes que ser cuidadoso de no olvidar agregar\n"
-"nuevos archivos tú mismo (vea 'git help status')."
+"nuevos archivos tú mismo (mira 'git help status')."
 
 #: wt-status.c:1857
 #, c-format
@@ -10208,25 +10437,25 @@ msgstr "adicionalmente, tu índice contiene cambios que no están en un commit."
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr "no se puede %s: Tu índice contiene cambios que no están en un commit."
 
-#: compat/simple-ipc/ipc-unix-socket.c:182
+#: compat/simple-ipc/ipc-unix-socket.c:183
 msgid "could not send IPC command"
 msgstr "no se pudo enviar el comando IPC"
 
-#: compat/simple-ipc/ipc-unix-socket.c:189
+#: compat/simple-ipc/ipc-unix-socket.c:190
 msgid "could not read IPC response"
 msgstr "no se pudo leer la respuesta IPC"
 
-#: compat/simple-ipc/ipc-unix-socket.c:866
+#: compat/simple-ipc/ipc-unix-socket.c:870
 #, c-format
 msgid "could not start accept_thread '%s'"
 msgstr "no se pudo iniciar el accept_thread '%s'"
 
-#: compat/simple-ipc/ipc-unix-socket.c:878
+#: compat/simple-ipc/ipc-unix-socket.c:882
 #, c-format
 msgid "could not start worker[0] for '%s'"
 msgstr "no se pudo iniciar el worker[0] para '%s'"
 
-#: compat/precompose_utf8.c:58 builtin/clone.c:461
+#: compat/precompose_utf8.c:58 builtin/clone.c:347
 #, c-format
 msgid "failed to unlink '%s'"
 msgstr "falló al desvincular '%s'"
@@ -10235,134 +10464,133 @@ msgstr "falló al desvincular '%s'"
 msgid "git add [<options>] [--] <pathspec>..."
 msgstr "git add [<opciones>] [--] <especificación-de-ruta>..."
 
-#: builtin/add.c:61
+#: builtin/add.c:64
 #, c-format
 msgid "cannot chmod %cx '%s'"
 msgstr "no se puede aplicar chmod %cx '%s'"
 
-#: builtin/add.c:99
+#: builtin/add.c:106
 #, c-format
 msgid "unexpected diff status %c"
 msgstr "diff status inesperado %c"
 
-#: builtin/add.c:104 builtin/commit.c:297
+#: builtin/add.c:111 builtin/commit.c:298
 msgid "updating files failed"
 msgstr "falló la actualización de archivos"
 
-#: builtin/add.c:114
+#: builtin/add.c:121
 #, c-format
 msgid "remove '%s'\n"
 msgstr "eliminar '%s'\n"
 
-#: builtin/add.c:198
+#: builtin/add.c:205
 msgid "Unstaged changes after refreshing the index:"
 msgstr "Cambios fuera del área de stage tras refrescar el índice:"
 
-#: builtin/add.c:307 builtin/rev-parse.c:993
+#: builtin/add.c:317 builtin/rev-parse.c:993
 msgid "Could not read the index"
 msgstr "No se pudo leer el índice"
 
-#: builtin/add.c:318
-#, c-format
-msgid "Could not open '%s' for writing."
-msgstr "No se pudo abrir '%s' para escritura."
-
-#: builtin/add.c:322
+#: builtin/add.c:330
 msgid "Could not write patch"
 msgstr "No se puede escribir el parche"
 
-#: builtin/add.c:325
+#: builtin/add.c:333
 msgid "editing patch failed"
 msgstr "falló la edición del parche"
 
-#: builtin/add.c:328
+#: builtin/add.c:336
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "No se pudo hacer stat en '%s'"
 
-#: builtin/add.c:330
+#: builtin/add.c:338
 msgid "Empty patch. Aborted."
 msgstr "Parche vacío. Abortado."
 
-#: builtin/add.c:335
+#: builtin/add.c:343
 #, c-format
 msgid "Could not apply '%s'"
 msgstr "No se pudo aplicar '%s'"
 
-#: builtin/add.c:343
+#: builtin/add.c:351
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr ""
 "Las siguientes rutas son ignoradas por uno de tus archivos .gitignore:\n"
 
-#: builtin/add.c:363 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
+#: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
 #: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:550
-#: builtin/remote.c:1427 builtin/rm.c:243 builtin/send-pack.c:190
+#: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr "dry run (ejecución en seco)"
 
-#: builtin/add.c:366
+#: builtin/add.c:374
 msgid "interactive picking"
 msgstr "selección interactiva"
 
-#: builtin/add.c:367 builtin/checkout.c:1562 builtin/reset.c:308
+#: builtin/add.c:375 builtin/checkout.c:1560 builtin/reset.c:314
 msgid "select hunks interactively"
 msgstr "elegir fragmentos de forma interactiva"
 
-#: builtin/add.c:368
+#: builtin/add.c:376
 msgid "edit current diff and apply"
 msgstr "editar diff actual y aplicar"
 
-#: builtin/add.c:369
+#: builtin/add.c:377
 msgid "allow adding otherwise ignored files"
 msgstr "permitir agregar archivos que de otro modo se ignoren"
 
-#: builtin/add.c:370
+#: builtin/add.c:378
 msgid "update tracked files"
 msgstr "actualizar los archivos rastreados"
 
-#: builtin/add.c:371
+#: builtin/add.c:379
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr "renormalizar EOL de los archivos rastreados (implica -u)"
 
-#: builtin/add.c:372
+#: builtin/add.c:380
 msgid "record only the fact that the path will be added later"
 msgstr "grabar solo el hecho de que la ruta será agregada luego"
 
-#: builtin/add.c:373
+#: builtin/add.c:381
 msgid "add changes from all tracked and untracked files"
 msgstr "agregar los cambios de todos los archivos con y sin seguimiento"
 
-#: builtin/add.c:376
+#: builtin/add.c:384
 msgid "ignore paths removed in the working tree (same as --no-all)"
 msgstr ""
 "ignorar rutas eliminadas en el árbol de trabajo (lo mismo que --no-all)"
 
-#: builtin/add.c:378
+#: builtin/add.c:386
 msgid "don't add, only refresh the index"
 msgstr "no agregar, solo actualizar el índice"
 
-#: builtin/add.c:379
+#: builtin/add.c:387
 msgid "just skip files which cannot be added because of errors"
 msgstr "saltar los archivos que no pueden ser agregados a causa de errores"
 
-#: builtin/add.c:380
+#: builtin/add.c:388
 msgid "check if - even missing - files are ignored in dry run"
 msgstr ""
 "comprobar si los archivos - incluso los que faltan - se ignoran en dry run"
 
-#: builtin/add.c:382 builtin/update-index.c:1006
+#: builtin/add.c:389 builtin/mv.c:128 builtin/rm.c:251
+msgid "allow updating entries outside of the sparse-checkout cone"
+msgstr "permite actualizar entradas fuera del cono de sparse-checkout"
+
+#: builtin/add.c:391 builtin/update-index.c:1004
 msgid "override the executable bit of the listed files"
 msgstr "sobrescribir el bit ejecutable de los archivos listados"
 
-#: builtin/add.c:384
+#: builtin/add.c:393
 msgid "warn when adding an embedded repository"
 msgstr "avisar cuando se agrega un repositorio incrustado"
 
-#: builtin/add.c:386
+#: builtin/add.c:395
 msgid "backend for `git stash -p`"
 msgstr "backend para `git stash -p`"
 
-#: builtin/add.c:404
+#: builtin/add.c:413
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -10391,14 +10619,14 @@ msgstr ""
 "\n"
 "\tgit rm --cached %s\n"
 "\n"
-"Vea \"git help submodule\" para más información."
+"Mira \"git help submodule\" para más información."
 
-#: builtin/add.c:432
+#: builtin/add.c:442
 #, c-format
 msgid "adding embedded git repository: %s"
 msgstr "agregando repositorio de git embebido: %s"
 
-#: builtin/add.c:451
+#: builtin/add.c:462
 msgid ""
 "Use -f if you really want to add them.\n"
 "Turn this message off by running\n"
@@ -10408,51 +10636,51 @@ msgstr ""
 "Desactiva este mensaje ejecutando\n"
 "\"git config advice.addIgnoredFile false\""
 
-#: builtin/add.c:460
+#: builtin/add.c:477
 msgid "adding files failed"
 msgstr "falló al agregar archivos"
 
-#: builtin/add.c:488
+#: builtin/add.c:513
 msgid "--dry-run is incompatible with --interactive/--patch"
 msgstr "--dry-run es incompatible con --interactive/--patch"
 
-#: builtin/add.c:490 builtin/commit.c:357
+#: builtin/add.c:515 builtin/commit.c:358
 msgid "--pathspec-from-file is incompatible with --interactive/--patch"
 msgstr "--pathspec-from-file es incompatible con --interactive/--patch"
 
-#: builtin/add.c:507
+#: builtin/add.c:532
 msgid "--pathspec-from-file is incompatible with --edit"
 msgstr "--pathspec-from-file es incompatible con --edit"
 
-#: builtin/add.c:519
+#: builtin/add.c:544
 msgid "-A and -u are mutually incompatible"
 msgstr "-A y -u son mutuamente incompatibles"
 
-#: builtin/add.c:522
+#: builtin/add.c:547
 msgid "Option --ignore-missing can only be used together with --dry-run"
 msgstr "Opción --ignore-missing solo puede ser usada junto a --dry-run"
 
-#: builtin/add.c:526
+#: builtin/add.c:551
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "El parámetro '%s' para --chmod debe ser -x o +x"
 
-#: builtin/add.c:544 builtin/checkout.c:1733 builtin/commit.c:363
-#: builtin/reset.c:328 builtin/rm.c:273 builtin/stash.c:1633
+#: builtin/add.c:572 builtin/checkout.c:1731 builtin/commit.c:364
+#: builtin/reset.c:334 builtin/rm.c:275 builtin/stash.c:1650
 msgid "--pathspec-from-file is incompatible with pathspec arguments"
 msgstr "--pathspec-from-file es incompatible con argumentos de pathspec"
 
-#: builtin/add.c:551 builtin/checkout.c:1745 builtin/commit.c:369
-#: builtin/reset.c:334 builtin/rm.c:279 builtin/stash.c:1639
+#: builtin/add.c:579 builtin/checkout.c:1743 builtin/commit.c:370
+#: builtin/reset.c:340 builtin/rm.c:281 builtin/stash.c:1656
 msgid "--pathspec-file-nul requires --pathspec-from-file"
 msgstr "--pathspec-file-nul requiere --pathspec-from-file"
 
-#: builtin/add.c:555
+#: builtin/add.c:583
 #, c-format
 msgid "Nothing specified, nothing added.\n"
 msgstr "Nada especificado, nada agregado.\n"
 
-#: builtin/add.c:557
+#: builtin/add.c:585
 msgid ""
 "Maybe you wanted to say 'git add .'?\n"
 "Turn this message off by running\n"
@@ -10462,111 +10690,110 @@ msgstr ""
 "Desactiva este mensage ejecutando\n"
 "\"git config advice.addEmptyPathspec false\""
 
-#: builtin/am.c:365
+#: builtin/am.c:366
 msgid "could not parse author script"
 msgstr "no se pudo analizar el script del autor"
 
-#: builtin/am.c:455
+#: builtin/am.c:456
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
 msgstr "'%s' fue borrado por el hook de applypatch-msg"
 
-#: builtin/am.c:497
+#: builtin/am.c:498
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr "Línea de entrada mal formada: '%s'."
 
-#: builtin/am.c:535
+#: builtin/am.c:536
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
 msgstr "Falló al copiar notas de '%s' a '%s'"
 
-#: builtin/am.c:561
+#: builtin/am.c:562
 msgid "fseek failed"
 msgstr "fallo de fseek"
 
-#: builtin/am.c:749
+#: builtin/am.c:750
 #, c-format
 msgid "could not parse patch '%s'"
 msgstr "no se pudo analizar el parche '%s'"
 
-#: builtin/am.c:814
+#: builtin/am.c:815
 msgid "Only one StGIT patch series can be applied at once"
 msgstr "Solo un parche StGIT puede ser aplicado a la vez"
 
-#: builtin/am.c:862
+#: builtin/am.c:863
 msgid "invalid timestamp"
 msgstr "timestamp inválido"
 
-#: builtin/am.c:867 builtin/am.c:879
+#: builtin/am.c:868 builtin/am.c:880
 msgid "invalid Date line"
 msgstr "línea Date inválida"
 
-#: builtin/am.c:874
+#: builtin/am.c:875
 msgid "invalid timezone offset"
 msgstr "offset de zona horaria inválido"
 
-#: builtin/am.c:967
+#: builtin/am.c:968
 msgid "Patch format detection failed."
 msgstr "Falló al detectar el formato del parche."
 
-#: builtin/am.c:972 builtin/clone.c:414
+#: builtin/am.c:973 builtin/clone.c:300
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "falló al crear el directorio '%s'"
 
-#: builtin/am.c:977
+#: builtin/am.c:978
 msgid "Failed to split patches."
 msgstr "Falló al dividir parches."
 
-#: builtin/am.c:1126
+#: builtin/am.c:1127
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\"."
 msgstr "Cuando hayas resuelto este problema, ejecuta \"%s --continue\"."
 
-#: builtin/am.c:1127
+#: builtin/am.c:1128
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
 msgstr "Si prefieres saltar este parche, ejecuta \"%s --skip\"."
 
-#: builtin/am.c:1128
+#: builtin/am.c:1129
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr ""
-"Para restaurar la rama original y detener el parcheo, ejecutar \"%s --abort"
-"\"."
+"Para restaurar la rama original y detener el parcheo, ejecuta \"%s --abort\"."
 
-#: builtin/am.c:1223
+#: builtin/am.c:1224
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
 "Parche enviado con format=flowed; espacios al final de las líneas tal vez "
 "desaparezcan."
 
-#: builtin/am.c:1251
+#: builtin/am.c:1252
 msgid "Patch is empty."
 msgstr "El parche está vacío."
 
-#: builtin/am.c:1316
+#: builtin/am.c:1317
 #, c-format
 msgid "missing author line in commit %s"
 msgstr "falta línea de autor en commit %s"
 
-#: builtin/am.c:1319
+#: builtin/am.c:1320
 #, c-format
 msgid "invalid ident line: %.*s"
 msgstr "línea de identificación no válida: %.*s"
 
-#: builtin/am.c:1538
+#: builtin/am.c:1539
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
 "Repositorio carece de los blobs necesarios para retroceder en una fusión de "
 "3 vías."
 
-#: builtin/am.c:1540
+#: builtin/am.c:1541
 msgid "Using index info to reconstruct a base tree..."
 msgstr "Usando la información del índice para reconstruir un árbol base..."
 
-#: builtin/am.c:1559
+#: builtin/am.c:1560
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
@@ -10574,24 +10801,24 @@ msgstr ""
 "¿Editaste el parche a mano?\n"
 "No aplica a los blobs registrados en su índice."
 
-#: builtin/am.c:1565
+#: builtin/am.c:1566
 msgid "Falling back to patching base and 3-way merge..."
 msgstr "Retrocediendo para parchar base y fusionar de 3 vías..."
 
-#: builtin/am.c:1591
+#: builtin/am.c:1592
 msgid "Failed to merge in the changes."
 msgstr "Falló al fusionar los cambios."
 
-#: builtin/am.c:1623
+#: builtin/am.c:1624
 msgid "applying to an empty history"
 msgstr "aplicando a un historial vacío"
 
-#: builtin/am.c:1675 builtin/am.c:1679
+#: builtin/am.c:1676 builtin/am.c:1680
 #, c-format
 msgid "cannot resume: %s does not exist."
 msgstr "no se puede continuar: %s no existe."
 
-#: builtin/am.c:1697
+#: builtin/am.c:1698
 msgid "Commit Body is:"
 msgstr "Cuerpo de commit es:"
 
@@ -10599,37 +10826,37 @@ msgstr "Cuerpo de commit es:"
 #. in your translation. The program will only accept English
 #. input at this point.
 #.
-#: builtin/am.c:1707
+#: builtin/am.c:1708
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr "¿Aplicar? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 
-#: builtin/am.c:1753 builtin/commit.c:408
+#: builtin/am.c:1754 builtin/commit.c:409
 msgid "unable to write index file"
 msgstr "no es posible escribir el archivo índice"
 
-#: builtin/am.c:1757
+#: builtin/am.c:1758
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
 msgstr "Índice sucio: no se puede aplicar parches (sucio: %s)"
 
-#: builtin/am.c:1797 builtin/am.c:1865
+#: builtin/am.c:1798 builtin/am.c:1865
 #, c-format
 msgid "Applying: %.*s"
 msgstr "Aplicando: %.*s"
 
-#: builtin/am.c:1814
+#: builtin/am.c:1815
 msgid "No changes -- Patch already applied."
 msgstr "Sin cambios -- Parche ya aplicado."
 
-#: builtin/am.c:1820
+#: builtin/am.c:1821
 #, c-format
 msgid "Patch failed at %s %.*s"
 msgstr "El parche falló en %s %.*s"
 
-#: builtin/am.c:1824
+#: builtin/am.c:1825
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
-msgstr "Use 'git am --show-current-patch=diff' para ver el parche fallido"
+msgstr "Usa 'git am --show-current-patch=diff' para ver el parche fallido"
 
 #: builtin/am.c:1868
 msgid ""
@@ -10654,17 +10881,17 @@ msgstr ""
 "Se puede ejecutar `git rm` en el archivo para aceptar \"borrado por ellos\" "
 "en él."
 
-#: builtin/am.c:1982 builtin/am.c:1986 builtin/am.c:1998 builtin/reset.c:347
-#: builtin/reset.c:355
+#: builtin/am.c:1983 builtin/am.c:1987 builtin/am.c:1999 builtin/reset.c:353
+#: builtin/reset.c:361
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "No se pudo analizar el objeto '%s'."
 
-#: builtin/am.c:2034
+#: builtin/am.c:2035 builtin/am.c:2111
 msgid "failed to clean index"
 msgstr "falló al limpiar el índice"
 
-#: builtin/am.c:2078
+#: builtin/am.c:2079
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
@@ -10672,190 +10899,190 @@ msgstr ""
 "Parece haber movido HEAD desde el último falló 'am'.\n"
 "No rebobinando a ORIG_HEAD"
 
-#: builtin/am.c:2185
+#: builtin/am.c:2187
 #, c-format
 msgid "Invalid value for --patch-format: %s"
 msgstr "Valor inválido para --patch-format: %s"
 
-#: builtin/am.c:2227
+#: builtin/am.c:2229
 #, c-format
 msgid "Invalid value for --show-current-patch: %s"
 msgstr "Valor inválido para --show-current-patch: %s"
 
-#: builtin/am.c:2231
+#: builtin/am.c:2233
 #, c-format
 msgid "--show-current-patch=%s is incompatible with --show-current-patch=%s"
 msgstr "--show-current-patch=%s es incompatible con --show-current-patch=%s"
 
-#: builtin/am.c:2262
+#: builtin/am.c:2264
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
 msgstr "git am [<opciones>] [(<mbox> | <Directorio-de-correo>)...]"
 
-#: builtin/am.c:2263
+#: builtin/am.c:2265
 msgid "git am [<options>] (--continue | --skip | --abort)"
 msgstr "git am [<opciones>] (--continue | --skip | --abort)"
 
-#: builtin/am.c:2269
+#: builtin/am.c:2271
 msgid "run interactively"
 msgstr "ejecutar de manera interactiva"
 
-#: builtin/am.c:2271
+#: builtin/am.c:2273
 msgid "historical option -- no-op"
 msgstr "opción histórica -- no-op"
 
-#: builtin/am.c:2273
+#: builtin/am.c:2275
 msgid "allow fall back on 3way merging if needed"
 msgstr "permitir retroceso en fusión de 3 vías si es necesario"
 
-#: builtin/am.c:2274 builtin/init-db.c:547 builtin/prune-packed.c:16
-#: builtin/repack.c:472 builtin/stash.c:945
+#: builtin/am.c:2276 builtin/init-db.c:547 builtin/prune-packed.c:16
+#: builtin/repack.c:640 builtin/stash.c:961
 msgid "be quiet"
 msgstr "ser silencioso"
 
-#: builtin/am.c:2276
+#: builtin/am.c:2278
 msgid "add a Signed-off-by trailer to the commit message"
 msgstr "agregar una línea \"Signed-off-by\" al mensaje del commit"
 
-#: builtin/am.c:2279
+#: builtin/am.c:2281
 msgid "recode into utf8 (default)"
 msgstr "recodificar en utf8 (default)"
 
-#: builtin/am.c:2281
+#: builtin/am.c:2283
 msgid "pass -k flag to git-mailinfo"
 msgstr "pasar flag -k a git-mailinfo"
 
-#: builtin/am.c:2283
+#: builtin/am.c:2285
 msgid "pass -b flag to git-mailinfo"
 msgstr "pasar flag -b a git-mailinfo"
 
-#: builtin/am.c:2285
+#: builtin/am.c:2287
 msgid "pass -m flag to git-mailinfo"
 msgstr "pasar flag -m a git-mailinfo"
 
-#: builtin/am.c:2287
+#: builtin/am.c:2289
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
 msgstr "pasar flag --keep-cr a git-mailsplit para formato mbox"
 
-#: builtin/am.c:2290
+#: builtin/am.c:2292
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr ""
 "no pasar flag --keep-cr a git-mailsplit independientemente de am.keepcr"
 
-#: builtin/am.c:2293
+#: builtin/am.c:2295
 msgid "strip everything before a scissors line"
 msgstr "descubrir todo antes de una línea de tijeras"
 
-#: builtin/am.c:2295
+#: builtin/am.c:2297
 msgid "pass it through git-mailinfo"
 msgstr "pasarlo a través de git-mailinfo"
 
-#: builtin/am.c:2298 builtin/am.c:2301 builtin/am.c:2304 builtin/am.c:2307
-#: builtin/am.c:2310 builtin/am.c:2313 builtin/am.c:2316 builtin/am.c:2319
-#: builtin/am.c:2325
+#: builtin/am.c:2300 builtin/am.c:2303 builtin/am.c:2306 builtin/am.c:2309
+#: builtin/am.c:2312 builtin/am.c:2315 builtin/am.c:2318 builtin/am.c:2321
+#: builtin/am.c:2327
 msgid "pass it through git-apply"
 msgstr "pasarlo a través de git-apply"
 
-#: builtin/am.c:2315 builtin/commit.c:1512 builtin/fmt-merge-msg.c:17
-#: builtin/fmt-merge-msg.c:20 builtin/grep.c:905 builtin/merge.c:261
+#: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
+#: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
 #: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
-#: builtin/rebase.c:1342 builtin/repack.c:483 builtin/repack.c:487
-#: builtin/repack.c:489 builtin/show-branch.c:650 builtin/show-ref.c:172
-#: builtin/tag.c:447 parse-options.h:155 parse-options.h:176
-#: parse-options.h:317
+#: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
+#: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
+#: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
+#: parse-options.h:316
 msgid "n"
 msgstr "n"
 
-#: builtin/am.c:2321 builtin/branch.c:672 builtin/bugreport.c:137
-#: builtin/for-each-ref.c:40 builtin/replace.c:556 builtin/tag.c:481
+#: builtin/am.c:2323 builtin/branch.c:673 builtin/bugreport.c:109
+#: builtin/for-each-ref.c:40 builtin/replace.c:556 builtin/tag.c:479
 #: builtin/verify-tag.c:38
 msgid "format"
 msgstr "formato"
 
-#: builtin/am.c:2322
+#: builtin/am.c:2324
 msgid "format the patch(es) are in"
 msgstr "formato de los parches"
 
-#: builtin/am.c:2328
+#: builtin/am.c:2330
 msgid "override error message when patch failure occurs"
 msgstr "sobrescribir mensaje de error cuando fallos de parcheo ocurran"
 
-#: builtin/am.c:2330
+#: builtin/am.c:2332
 msgid "continue applying patches after resolving a conflict"
 msgstr "continuar aplicando los parches tras resolver conflictos"
 
-#: builtin/am.c:2333
+#: builtin/am.c:2335
 msgid "synonyms for --continue"
 msgstr "sinónimos para --continue"
 
-#: builtin/am.c:2336
+#: builtin/am.c:2338
 msgid "skip the current patch"
 msgstr "saltar el parche actual"
 
-#: builtin/am.c:2339
+#: builtin/am.c:2341
 msgid "restore the original branch and abort the patching operation"
 msgstr "restaurar la rama original y abortar la operación de parcheo"
 
-#: builtin/am.c:2342
+#: builtin/am.c:2344
 msgid "abort the patching operation but keep HEAD where it is"
 msgstr "abortar la operación de parcheo pero mantener HEAD donde está"
 
-#: builtin/am.c:2346
+#: builtin/am.c:2348
 msgid "show the patch being applied"
-msgstr "muestra el parche siendo aplicado"
+msgstr "mostrar el parche siendo aplicado"
 
-#: builtin/am.c:2351
+#: builtin/am.c:2353
 msgid "lie about committer date"
 msgstr "mentir sobre la fecha del committer"
 
-#: builtin/am.c:2353
+#: builtin/am.c:2355
 msgid "use current timestamp for author date"
 msgstr "usar el timestamp actual para la fecha del autor"
 
-#: builtin/am.c:2355 builtin/commit-tree.c:120 builtin/commit.c:1640
-#: builtin/merge.c:298 builtin/pull.c:175 builtin/rebase.c:537
-#: builtin/rebase.c:1395 builtin/revert.c:117 builtin/tag.c:462
+#: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
+#: builtin/merge.c:299 builtin/pull.c:175 builtin/rebase.c:1099
+#: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
 msgstr "key-id"
 
-#: builtin/am.c:2356 builtin/rebase.c:538 builtin/rebase.c:1396
+#: builtin/am.c:2358 builtin/rebase.c:1100
 msgid "GPG-sign commits"
 msgstr "firmar los commits con GPG"
 
-#: builtin/am.c:2359
+#: builtin/am.c:2361
 msgid "(internal use for git-rebase)"
 msgstr "(uso interno para git-rebase)"
 
-#: builtin/am.c:2377
+#: builtin/am.c:2379
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
 msgstr ""
 "La opción -b/--binary ha estado deshabilitada por mucho tiempo, y\n"
-"será eliminada. Por favor no la use más."
+"será eliminada. Por favor no la uses más."
 
-#: builtin/am.c:2384
+#: builtin/am.c:2386
 msgid "failed to read the index"
 msgstr "falló al leer el índice"
 
-#: builtin/am.c:2399
+#: builtin/am.c:2401
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr "directorio de rebase previo %s todavía existe pero un mbox fue dado."
 
-#: builtin/am.c:2423
+#: builtin/am.c:2425
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
 "Use \"git am --abort\" to remove it."
 msgstr ""
 "Directorio extraviado %s encontrado.\n"
-"Use \"git am --abort\" para borrarlo."
+"Usa \"git am --abort\" para borrarlo."
 
-#: builtin/am.c:2429
+#: builtin/am.c:2431
 msgid "Resolve operation not in progress, we are not resuming."
 msgstr "Operación de resolución no está en progreso, no vamos a continuar."
 
-#: builtin/am.c:2439
+#: builtin/am.c:2441
 msgid "interactive mode requires patches on the command line"
 msgstr "modo interactivo requiere parches en la línea de comando"
 
@@ -10863,43 +11090,34 @@ msgstr "modo interactivo requiere parches en la línea de comando"
 msgid "git apply [<options>] [<patch>...]"
 msgstr "git apply [<opciones>] [<parche>...]"
 
-#: builtin/archive.c:17
-#, c-format
-msgid "could not create archive file '%s'"
-msgstr "no se pudo crear el archivo de crónica '%s'"
-
-#: builtin/archive.c:20
+#: builtin/archive.c:18
 msgid "could not redirect output"
 msgstr "no se pudo redirigir la salida"
 
-#: builtin/archive.c:37
+#: builtin/archive.c:35
 msgid "git archive: Remote with no URL"
 msgstr "git archive: Remote sin URL"
 
-#: builtin/archive.c:61
+#: builtin/archive.c:59
 msgid "git archive: expected ACK/NAK, got a flush packet"
 msgstr "git archive: se esperaba ACK/NAK, se obtuvo flush packet"
 
-#: builtin/archive.c:64
+#: builtin/archive.c:62
 #, c-format
 msgid "git archive: NACK %s"
 msgstr "git archive: NACK %s"
 
-#: builtin/archive.c:65
+#: builtin/archive.c:63
 msgid "git archive: protocol error"
 msgstr "git archive: error de protocolo"
 
-#: builtin/archive.c:69
+#: builtin/archive.c:67
 msgid "git archive: expected a flush"
 msgstr "git archive: se esperaba un flush"
 
-#: builtin/bisect--helper.c:23
+#: builtin/bisect--helper.c:24
 msgid "git bisect--helper --bisect-reset [<commit>]"
 msgstr "git bisect--helper --bisect-reset [<commit>]"
-
-#: builtin/bisect--helper.c:24
-msgid "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
-msgstr "git bisect--helper --bisect-next-check <buen_term> <mal_term> [<term>]"
 
 #: builtin/bisect--helper.c:25
 msgid ""
@@ -10939,46 +11157,59 @@ msgstr "git bisect--helper --bisect-replay <archivo>"
 msgid "git bisect--helper --bisect-skip [(<rev>|<range>)...]"
 msgstr "git bisect--helper --bisect-skip [(<rev>|<rango>)...]"
 
-#: builtin/bisect--helper.c:107
+#: builtin/bisect--helper.c:33
+msgid "git bisect--helper --bisect-visualize"
+msgstr "git bisect--helper --bisect-visualize"
+
+#: builtin/bisect--helper.c:34
+msgid "git bisect--helper --bisect-run <cmd>..."
+msgstr "git bisect--helper --bisect-run <cmd>..."
+
+#: builtin/bisect--helper.c:109
 #, c-format
 msgid "cannot open file '%s' in mode '%s'"
 msgstr "no se puede abrir archivo '%s' en modo '%s'"
 
-#: builtin/bisect--helper.c:114
+#: builtin/bisect--helper.c:116
 #, c-format
 msgid "could not write to file '%s'"
 msgstr "no se pudo escribir al archivo '%s'"
 
-#: builtin/bisect--helper.c:155
+#: builtin/bisect--helper.c:154
+#, c-format
+msgid "cannot open file '%s' for reading"
+msgstr "no se puede abrir archivo '%s' para lectura"
+
+#: builtin/bisect--helper.c:170
 #, c-format
 msgid "'%s' is not a valid term"
 msgstr "'%s' no es un término válido"
 
-#: builtin/bisect--helper.c:159
+#: builtin/bisect--helper.c:174
 #, c-format
 msgid "can't use the builtin command '%s' as a term"
 msgstr "no se puede usar el comando nativo '%s' como un término"
 
-#: builtin/bisect--helper.c:169
+#: builtin/bisect--helper.c:184
 #, c-format
 msgid "can't change the meaning of the term '%s'"
 msgstr "no se puede cambiar el significado del término '%s'"
 
-#: builtin/bisect--helper.c:179
+#: builtin/bisect--helper.c:194
 msgid "please use two different terms"
-msgstr "por favor use dos términos diferentes"
+msgstr "por favor usa dos términos diferentes"
 
-#: builtin/bisect--helper.c:195
+#: builtin/bisect--helper.c:210
 #, c-format
 msgid "We are not bisecting.\n"
 msgstr "No estamos bisecando.\n"
 
-#: builtin/bisect--helper.c:203
+#: builtin/bisect--helper.c:218
 #, c-format
 msgid "'%s' is not a valid commit"
 msgstr "'%s' no es un commit válido"
 
-#: builtin/bisect--helper.c:212
+#: builtin/bisect--helper.c:227
 #, c-format
 msgid ""
 "could not check out original HEAD '%s'. Try 'git bisect reset <commit>'."
@@ -10986,27 +11217,27 @@ msgstr ""
 "no se pudo hacer check out al HEAD original '%s'. Intenta 'git bisect reset "
 "<commit>'."
 
-#: builtin/bisect--helper.c:256
+#: builtin/bisect--helper.c:271
 #, c-format
 msgid "Bad bisect_write argument: %s"
 msgstr "Mal argumento bisect_write: %s"
 
-#: builtin/bisect--helper.c:261
+#: builtin/bisect--helper.c:276
 #, c-format
 msgid "couldn't get the oid of the rev '%s'"
 msgstr "no se pudo obtener el oid de la rev '%s'"
 
-#: builtin/bisect--helper.c:273
+#: builtin/bisect--helper.c:288
 #, c-format
 msgid "couldn't open the file '%s'"
 msgstr "no se pudo abrir el archivo '%s'"
 
-#: builtin/bisect--helper.c:299
+#: builtin/bisect--helper.c:314
 #, c-format
 msgid "Invalid command: you're currently in a %s/%s bisect"
 msgstr "Comando inválido: actualmente se encuentra en un bisect %s/%s"
 
-#: builtin/bisect--helper.c:326
+#: builtin/bisect--helper.c:341
 #, c-format
 msgid ""
 "You need to give me at least one %s and %s revision.\n"
@@ -11015,7 +11246,7 @@ msgstr ""
 "Tienes que dar al menos una revisión %s y una %s.\n"
 "Se puede ver \"git bisect %s\" y \"git bisect %s\" para eso."
 
-#: builtin/bisect--helper.c:330
+#: builtin/bisect--helper.c:345
 #, c-format
 msgid ""
 "You need to start by \"git bisect start\".\n"
@@ -11026,7 +11257,7 @@ msgstr ""
 "Después tienes que entregar al menos una revisión %s y una %s.\n"
 "Puedes usar \"git bisect %s\" y \"git bisect %s\" para eso."
 
-#: builtin/bisect--helper.c:350
+#: builtin/bisect--helper.c:365
 #, c-format
 msgid "bisecting only with a %s commit"
 msgstr "haciendo bisect solo con un commit %s"
@@ -11035,15 +11266,15 @@ msgstr "haciendo bisect solo con un commit %s"
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:358
+#: builtin/bisect--helper.c:373
 msgid "Are you sure [Y/n]? "
 msgstr "¿Estás seguro [Y/n]? "
 
-#: builtin/bisect--helper.c:419
+#: builtin/bisect--helper.c:434
 msgid "no terms defined"
 msgstr "no hay términos definidos"
 
-#: builtin/bisect--helper.c:422
+#: builtin/bisect--helper.c:437
 #, c-format
 msgid ""
 "Your current terms are %s for the old state\n"
@@ -11052,7 +11283,7 @@ msgstr ""
 "Tus términos actuales son %s para el estado viejo\n"
 "y %s para el estado nuevo.\n"
 
-#: builtin/bisect--helper.c:432
+#: builtin/bisect--helper.c:447
 #, c-format
 msgid ""
 "invalid argument %s for 'git bisect terms'.\n"
@@ -11061,53 +11292,53 @@ msgstr ""
 "argumento inválido %s para 'git bisect terms'.\n"
 "Las opciones soportadas son: --term-good|--term-old y --term-bad|--term-new."
 
-#: builtin/bisect--helper.c:499 builtin/bisect--helper.c:1023
+#: builtin/bisect--helper.c:514 builtin/bisect--helper.c:1038
 msgid "revision walk setup failed\n"
 msgstr "la configuración del recorrido de revisiones falló\n"
 
-#: builtin/bisect--helper.c:521
+#: builtin/bisect--helper.c:536
 #, c-format
 msgid "could not open '%s' for appending"
 msgstr "no se pudo abrir '%s' en modo append"
 
-#: builtin/bisect--helper.c:640 builtin/bisect--helper.c:653
+#: builtin/bisect--helper.c:655 builtin/bisect--helper.c:668
 msgid "'' is not a valid term"
 msgstr "'' no es un término válido"
 
-#: builtin/bisect--helper.c:663
+#: builtin/bisect--helper.c:678
 #, c-format
 msgid "unrecognized option: '%s'"
 msgstr "opción desconocida: '%s'"
 
-#: builtin/bisect--helper.c:667
+#: builtin/bisect--helper.c:682
 #, c-format
 msgid "'%s' does not appear to be a valid revision"
 msgstr "'%s' no parece ser una revisión válida"
 
-#: builtin/bisect--helper.c:698
+#: builtin/bisect--helper.c:713
 msgid "bad HEAD - I need a HEAD"
 msgstr "mal HEAD - Necesito un HEAD"
 
-#: builtin/bisect--helper.c:713
+#: builtin/bisect--helper.c:728
 #, c-format
 msgid "checking out '%s' failed. Try 'git bisect start <valid-branch>'."
 msgstr ""
-"error al hacer checkout '%s'. Intente 'git bisect start <rama-válida>'."
+"error al hacer checkout '%s'. Intenta 'git bisect start <rama-válida>'."
 
-#: builtin/bisect--helper.c:734
+#: builtin/bisect--helper.c:749
 msgid "won't bisect on cg-seek'ed tree"
 msgstr "no se bisecará en un árbol con cg-seek"
 
-#: builtin/bisect--helper.c:737
+#: builtin/bisect--helper.c:752
 msgid "bad HEAD - strange symbolic ref"
 msgstr "mal HEAD - ref simbólico extraño"
 
-#: builtin/bisect--helper.c:757
+#: builtin/bisect--helper.c:772
 #, c-format
 msgid "invalid ref: '%s'"
 msgstr "ref inválido: '%s'"
 
-#: builtin/bisect--helper.c:815
+#: builtin/bisect--helper.c:830
 msgid "You need to start by \"git bisect start\"\n"
 msgstr "Debes iniciar con \"git bisect start\"\n"
 
@@ -11115,104 +11346,150 @@ msgstr "Debes iniciar con \"git bisect start\"\n"
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:826
+#: builtin/bisect--helper.c:841
 msgid "Do you want me to do it for you [Y/n]? "
 msgstr "¿Quieres que lo haga por ti [Y/n]? "
 
-#: builtin/bisect--helper.c:844
+#: builtin/bisect--helper.c:859
 msgid "Please call `--bisect-state` with at least one argument"
-msgstr "Llame a `--bisect-state` con al menos un argumento"
+msgstr "Por favor llama a `--bisect-state` con al menos un argumento"
 
-#: builtin/bisect--helper.c:857
+#: builtin/bisect--helper.c:872
 #, c-format
 msgid "'git bisect %s' can take only one argument."
 msgstr "'git bisect %s' solo puede tomar un argumento."
 
-#: builtin/bisect--helper.c:869 builtin/bisect--helper.c:882
+#: builtin/bisect--helper.c:884 builtin/bisect--helper.c:897
 #, c-format
 msgid "Bad rev input: %s"
 msgstr "Mala entrada rev: %s"
 
-#: builtin/bisect--helper.c:889
+#: builtin/bisect--helper.c:904
 #, c-format
 msgid "Bad rev input (not a commit): %s"
 msgstr "Mala entrada rev (no es un commit): %s"
 
-#: builtin/bisect--helper.c:921
+#: builtin/bisect--helper.c:936
 msgid "We are not bisecting."
 msgstr "No estamos bisecando."
 
-#: builtin/bisect--helper.c:971
+#: builtin/bisect--helper.c:986
 #, c-format
 msgid "'%s'?? what are you talking about?"
 msgstr "¿¿'%s'?? ¿De qué estás hablando?"
 
-#: builtin/bisect--helper.c:983
+#: builtin/bisect--helper.c:998
 #, c-format
 msgid "cannot read file '%s' for replaying"
 msgstr "no se puede leer '%s' para reproducir"
 
-#: builtin/bisect--helper.c:1056
+#: builtin/bisect--helper.c:1107 builtin/bisect--helper.c:1274
+msgid "bisect run failed: no command provided."
+msgstr "bisect falló: no se proveyó comando."
+
+#: builtin/bisect--helper.c:1116
+#, c-format
+msgid "running %s\n"
+msgstr "ejecutando %s\n"
+
+#: builtin/bisect--helper.c:1120
+#, c-format
+msgid "bisect run failed: exit code %d from '%s' is < 0 or >= 128"
+msgstr "bisect falló: código de salida %d de '%s' es <0 o >=128"
+
+#: builtin/bisect--helper.c:1136
+#, c-format
+msgid "cannot open file '%s' for writing"
+msgstr "no se pudo abrir archivo '%s' para escritura"
+
+#: builtin/bisect--helper.c:1152
+msgid "bisect run cannot continue any more"
+msgstr "bisect no puede seguir continuando"
+
+#: builtin/bisect--helper.c:1154
+#, c-format
+msgid "bisect run success"
+msgstr "bisect exitoso"
+
+#: builtin/bisect--helper.c:1157
+#, c-format
+msgid "bisect found first bad commit"
+msgstr "bisect encontró el primer mal commit"
+
+#: builtin/bisect--helper.c:1160
+#, c-format
+msgid ""
+"bisect run failed: 'git bisect--helper --bisect-state %s' exited with error "
+"code %d"
+msgstr ""
+"ejecución de bisect falló:  'git bisect--helper --bisect-state %s' terminó "
+"con código de error %d"
+
+#: builtin/bisect--helper.c:1192
 msgid "reset the bisection state"
 msgstr "reiniciar el estado de bisect"
 
-#: builtin/bisect--helper.c:1058
+#: builtin/bisect--helper.c:1194
 msgid "check whether bad or good terms exist"
 msgstr "revisar si existen términos malos o buenos"
 
-#: builtin/bisect--helper.c:1060
+#: builtin/bisect--helper.c:1196
 msgid "print out the bisect terms"
 msgstr "imprimir los terms del bisect"
 
-#: builtin/bisect--helper.c:1062
+#: builtin/bisect--helper.c:1198
 msgid "start the bisect session"
 msgstr "comenzar la sesión de bisect"
 
-#: builtin/bisect--helper.c:1064
+#: builtin/bisect--helper.c:1200
 msgid "find the next bisection commit"
 msgstr "encontrar el siguiente commit de bisección"
 
-#: builtin/bisect--helper.c:1066
+#: builtin/bisect--helper.c:1202
 msgid "mark the state of ref (or refs)"
 msgstr "marcar el estado de ref (o refs)"
 
-#: builtin/bisect--helper.c:1068
+#: builtin/bisect--helper.c:1204
 msgid "list the bisection steps so far"
 msgstr "listar los pasos de bisección hasta ahora"
 
-#: builtin/bisect--helper.c:1070
+#: builtin/bisect--helper.c:1206
 msgid "replay the bisection process from the given file"
 msgstr "reproducir el proceso de bisección del archivo dado"
 
-#: builtin/bisect--helper.c:1072
+#: builtin/bisect--helper.c:1208
 msgid "skip some commits for checkout"
 msgstr "saltar algunos commits para checkout"
 
-#: builtin/bisect--helper.c:1074
+#: builtin/bisect--helper.c:1210
+msgid "visualize the bisection"
+msgstr "visualizar bisección"
+
+#: builtin/bisect--helper.c:1212
+msgid "use <cmd>... to automatically bisect."
+msgstr "use <cmd>... para aplicar bisección automática."
+
+#: builtin/bisect--helper.c:1214
 msgid "no log for BISECT_WRITE"
 msgstr "no hay log para BISECT_WRITE"
 
-#: builtin/bisect--helper.c:1089
+#: builtin/bisect--helper.c:1229
 msgid "--bisect-reset requires either no argument or a commit"
 msgstr "--bisect-reset requiere o un commit o ningún argumento"
 
-#: builtin/bisect--helper.c:1094
-msgid "--bisect-next-check requires 2 or 3 arguments"
-msgstr "--bisect-next-check requiere 2 o 3 argumentos"
-
-#: builtin/bisect--helper.c:1100
+#: builtin/bisect--helper.c:1234
 msgid "--bisect-terms requires 0 or 1 argument"
 msgstr "--bisect-terms requiere 0 o 1 argumentos"
 
-#: builtin/bisect--helper.c:1109
+#: builtin/bisect--helper.c:1243
 msgid "--bisect-next requires 0 arguments"
 msgstr "--bisect-next requiere 0 argumentos"
 
-#: builtin/bisect--helper.c:1120
+#: builtin/bisect--helper.c:1254
 msgid "--bisect-log requires 0 arguments"
 msgstr "--bisect-log requiere 0 argumentos"
 
-#: builtin/bisect--helper.c:1125
+#: builtin/bisect--helper.c:1259
 msgid "no logfile given"
 msgstr "ningún logfile proporcionado"
 
@@ -11224,151 +11501,153 @@ msgstr "git blame [<opciones>] [<opciones-de-rev>] [<revisión>] [--] <archivo>"
 msgid "<rev-opts> are documented in git-rev-list(1)"
 msgstr "<opciones-de-rev> están documentadas en git-rev-list(1)"
 
-#: builtin/blame.c:410
+#: builtin/blame.c:406
 #, c-format
 msgid "expecting a color: %s"
 msgstr "esperando un color: %s"
 
-#: builtin/blame.c:417
+#: builtin/blame.c:413
 msgid "must end with a color"
 msgstr "tiene que terminar con un color"
 
-#: builtin/blame.c:728
+#: builtin/blame.c:724
 #, c-format
 msgid "invalid color '%s' in color.blame.repeatedLines"
 msgstr "color inválido '%s' en color.blame.repeatedLines"
 
-#: builtin/blame.c:746
+#: builtin/blame.c:742
 msgid "invalid value for blame.coloring"
 msgstr "valor inválido para blame.coloring"
 
-#: builtin/blame.c:845
+#: builtin/blame.c:841
 #, c-format
 msgid "cannot find revision %s to ignore"
 msgstr "no se pudo encontrar revisión %s para ignorar"
 
-#: builtin/blame.c:867
+#: builtin/blame.c:863
 msgid "show blame entries as we find them, incrementally"
 msgstr "mostrar las entradas blame como las encontramos, incrementalmente"
 
-#: builtin/blame.c:868
+#: builtin/blame.c:864
 msgid "do not show object names of boundary commits (Default: off)"
 msgstr "no mostrar nombres de objetos de commits extremos (Default: off)"
 
-#: builtin/blame.c:869
+#: builtin/blame.c:865
 msgid "do not treat root commits as boundaries (Default: off)"
 msgstr "no tratar commits raíces como extremos (Default: off)"
 
-#: builtin/blame.c:870
+#: builtin/blame.c:866
 msgid "show work cost statistics"
 msgstr "mostrar estadísticas de costo de trabajo"
 
-#: builtin/blame.c:871 builtin/checkout.c:1519 builtin/clone.c:94
-#: builtin/commit-graph.c:84 builtin/commit-graph.c:222 builtin/fetch.c:179
-#: builtin/merge.c:297 builtin/multi-pack-index.c:55 builtin/pull.c:119
-#: builtin/push.c:566 builtin/send-pack.c:198
+#: builtin/blame.c:867 builtin/checkout.c:1517 builtin/clone.c:94
+#: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
+#: builtin/merge.c:298 builtin/multi-pack-index.c:103
+#: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
+#: builtin/multi-pack-index.c:204 builtin/pull.c:119 builtin/push.c:566
+#: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "forzar el reporte de progreso"
 
-#: builtin/blame.c:872
+#: builtin/blame.c:868
 msgid "show output score for blame entries"
 msgstr "mostrar la puntuación de salida de las entradas de blame"
 
-#: builtin/blame.c:873
+#: builtin/blame.c:869
 msgid "show original filename (Default: auto)"
 msgstr "mostrar nombre original del archivo (Default: auto)"
 
-#: builtin/blame.c:874
+#: builtin/blame.c:870
 msgid "show original linenumber (Default: off)"
 msgstr "mostrar número de línea original (Default: off)"
 
-#: builtin/blame.c:875
+#: builtin/blame.c:871
 msgid "show in a format designed for machine consumption"
 msgstr "mostrar en un formato diseñado para consumo de máquina"
 
-#: builtin/blame.c:876
+#: builtin/blame.c:872
 msgid "show porcelain format with per-line commit information"
 msgstr "mostrar en formato porcelana con información de commit por línea"
 
-#: builtin/blame.c:877
+#: builtin/blame.c:873
 msgid "use the same output mode as git-annotate (Default: off)"
 msgstr "usar el mismo modo de salida como git-annotate (Default: off)"
 
-#: builtin/blame.c:878
+#: builtin/blame.c:874
 msgid "show raw timestamp (Default: off)"
 msgstr "mostrar timestamp en formato raw (Default: off)"
 
-#: builtin/blame.c:879
+#: builtin/blame.c:875
 msgid "show long commit SHA1 (Default: off)"
 msgstr "mostrar SHA1 del commit en formato largo (Default: off)"
 
-#: builtin/blame.c:880
+#: builtin/blame.c:876
 msgid "suppress author name and timestamp (Default: off)"
 msgstr "suprimir nombre del autor y timestamp (Default: off)"
 
-#: builtin/blame.c:881
+#: builtin/blame.c:877
 msgid "show author email instead of name (Default: off)"
 msgstr "mostrar el email del autor en cambio de su nombre (Default: off)"
 
-#: builtin/blame.c:882
+#: builtin/blame.c:878
 msgid "ignore whitespace differences"
 msgstr "ignorar diferencias de espacios en blanco"
 
-#: builtin/blame.c:883 builtin/log.c:1823
+#: builtin/blame.c:879 builtin/log.c:1823
 msgid "rev"
 msgstr "rev"
 
-#: builtin/blame.c:883
+#: builtin/blame.c:879
 msgid "ignore <rev> when blaming"
 msgstr "ignorar <rev> durante el blame"
 
-#: builtin/blame.c:884
+#: builtin/blame.c:880
 msgid "ignore revisions from <file>"
 msgstr "ignorar revisiones de <archivo>"
 
-#: builtin/blame.c:885
+#: builtin/blame.c:881
 msgid "color redundant metadata from previous line differently"
 msgstr "colorear metadata redundante de líneas previas de manera diferente"
 
-#: builtin/blame.c:886
+#: builtin/blame.c:882
 msgid "color lines by age"
 msgstr "colorear líneas por edad"
 
-#: builtin/blame.c:887
+#: builtin/blame.c:883
 msgid "spend extra cycles to find better match"
 msgstr "ocupar más ciclos para encontrar mejores resultados"
 
-#: builtin/blame.c:888
+#: builtin/blame.c:884
 msgid "use revisions from <file> instead of calling git-rev-list"
-msgstr "use revisiones en <archivo> en lugar de llamar git-rev-list"
+msgstr "usar revisiones en <archivo> en lugar de llamar git-rev-list"
 
-#: builtin/blame.c:889
+#: builtin/blame.c:885
 msgid "use <file>'s contents as the final image"
 msgstr "usar contenido de <archivo> como imagen final"
 
-#: builtin/blame.c:890 builtin/blame.c:891
+#: builtin/blame.c:886 builtin/blame.c:887
 msgid "score"
 msgstr "puntaje"
 
-#: builtin/blame.c:890
+#: builtin/blame.c:886
 msgid "find line copies within and across files"
 msgstr "encontrar copias de líneas entre y a través de archivos"
 
-#: builtin/blame.c:891
+#: builtin/blame.c:887
 msgid "find line movements within and across files"
 msgstr "encontrar movimientos de líneas entre y a través de archivos"
 
-#: builtin/blame.c:892
+#: builtin/blame.c:888
 msgid "range"
 msgstr "rango"
 
-#: builtin/blame.c:893
+#: builtin/blame.c:889
 msgid "process only line range <start>,<end> or function :<funcname>"
 msgstr ""
 "procesar solo el rango de líneas <inicio>,<fin> o función :<nombre-de-"
 "función>"
 
-#: builtin/blame.c:945
+#: builtin/blame.c:944
 msgid "--progress can't be used with --incremental or porcelain formats"
 msgstr ""
 "--progress no puede ser usado con --incremental o formatos de porcelana"
@@ -11381,18 +11660,18 @@ msgstr ""
 #. your language may need more or fewer display
 #. columns.
 #.
-#: builtin/blame.c:996
+#: builtin/blame.c:995
 msgid "4 years, 11 months ago"
 msgstr "hace 4 años, 11 meses"
 
-#: builtin/blame.c:1112
+#: builtin/blame.c:1111
 #, c-format
 msgid "file %s has only %lu line"
 msgid_plural "file %s has only %lu lines"
 msgstr[0] "archivo %s tiene solo %lu línea"
 msgstr[1] "archivo %s tiene solo %lu líneas"
 
-#: builtin/blame.c:1157
+#: builtin/blame.c:1156
 msgid "Blaming lines"
 msgstr "Blaming a líneas"
 
@@ -11493,78 +11772,78 @@ msgstr "Eliminada la rama de rastreo remota %s (era %s).\n"
 msgid "Deleted branch %s (was %s).\n"
 msgstr "Eliminada la rama %s (era %s).\n"
 
-#: builtin/branch.c:440 builtin/tag.c:63
+#: builtin/branch.c:441 builtin/tag.c:63
 msgid "unable to parse format string"
 msgstr "no es posible analizar el string de formato"
 
-#: builtin/branch.c:471
+#: builtin/branch.c:472
 msgid "could not resolve HEAD"
 msgstr "no se pudo resolver HEAD"
 
-#: builtin/branch.c:477
+#: builtin/branch.c:478
 #, c-format
 msgid "HEAD (%s) points outside of refs/heads/"
 msgstr "HEAD (%s) apunta fuera de refs/heads/"
 
-#: builtin/branch.c:492
+#: builtin/branch.c:493
 #, c-format
 msgid "Branch %s is being rebased at %s"
 msgstr "Rama %s está siendo rebasada en %s"
 
-#: builtin/branch.c:496
+#: builtin/branch.c:497
 #, c-format
 msgid "Branch %s is being bisected at %s"
 msgstr "Rama %s está siendo bisecada en %s"
 
-#: builtin/branch.c:513
+#: builtin/branch.c:514
 msgid "cannot copy the current branch while not on any."
 msgstr "no se puede copiar la rama actual mientras no se está en ninguna."
 
-#: builtin/branch.c:515
+#: builtin/branch.c:516
 msgid "cannot rename the current branch while not on any."
 msgstr "no se puede renombrar la rama actual mientras no se está en ninguna."
 
-#: builtin/branch.c:526
+#: builtin/branch.c:527
 #, c-format
 msgid "Invalid branch name: '%s'"
 msgstr "Nombre de rama inválido: '%s'"
 
-#: builtin/branch.c:555
+#: builtin/branch.c:556
 msgid "Branch rename failed"
 msgstr "Cambio de nombre de rama fallido"
 
-#: builtin/branch.c:557
+#: builtin/branch.c:558
 msgid "Branch copy failed"
 msgstr "Duplicación de rama fallida"
 
-#: builtin/branch.c:561
+#: builtin/branch.c:562
 #, c-format
 msgid "Created a copy of a misnamed branch '%s'"
 msgstr "Copia creada de la rama malnombrada '%s'"
 
-#: builtin/branch.c:564
+#: builtin/branch.c:565
 #, c-format
 msgid "Renamed a misnamed branch '%s' away"
 msgstr "Rama mal llamada '%s' renombrada"
 
-#: builtin/branch.c:570
+#: builtin/branch.c:571
 #, c-format
 msgid "Branch renamed to %s, but HEAD is not updated!"
 msgstr "¡Rama renombrada a %s, pero HEAD no está actualizado!"
 
-#: builtin/branch.c:579
+#: builtin/branch.c:580
 msgid "Branch is renamed, but update of config-file failed"
 msgstr ""
 "La rama está renombrada, pero falló la actualización del archivo de "
 "configuración"
 
-#: builtin/branch.c:581
+#: builtin/branch.c:582
 msgid "Branch is copied, but update of config-file failed"
 msgstr ""
 "La rama está copiada, pero falló la actualización del archivo de "
 "configuración"
 
-#: builtin/branch.c:597
+#: builtin/branch.c:598
 #, c-format
 msgid ""
 "Please edit the description for the branch\n"
@@ -11575,180 +11854,180 @@ msgstr ""
 "%s\n"
 "Las líneas que comiencen con '%c' serán eliminadas.\n"
 
-#: builtin/branch.c:631
+#: builtin/branch.c:632
 msgid "Generic options"
 msgstr "Opciones genéricas"
 
-#: builtin/branch.c:633
+#: builtin/branch.c:634
 msgid "show hash and subject, give twice for upstream branch"
 msgstr "mostrar hash y tema, dar dos veces para rama upstream"
 
-#: builtin/branch.c:634
+#: builtin/branch.c:635
 msgid "suppress informational messages"
 msgstr "suprimir mensajes informativos"
 
-#: builtin/branch.c:635
+#: builtin/branch.c:636
 msgid "set up tracking mode (see git-pull(1))"
 msgstr "configurando modo tracking (mirar git-pull(1))"
 
-#: builtin/branch.c:637
+#: builtin/branch.c:638
 msgid "do not use"
 msgstr "no usar"
 
-#: builtin/branch.c:639 builtin/rebase.c:533
+#: builtin/branch.c:640
 msgid "upstream"
 msgstr "upstream"
 
-#: builtin/branch.c:639
+#: builtin/branch.c:640
 msgid "change the upstream info"
 msgstr "cambiar info de upstream"
 
-#: builtin/branch.c:640
-msgid "unset the upstream info"
-msgstr "desconfigurando la info de upstream"
-
 #: builtin/branch.c:641
+msgid "unset the upstream info"
+msgstr "desconfigurar la info de upstream"
+
+#: builtin/branch.c:642
 msgid "use colored output"
 msgstr "usar salida con colores"
 
-#: builtin/branch.c:642
+#: builtin/branch.c:643
 msgid "act on remote-tracking branches"
 msgstr "actuar en ramas de rastreo remoto"
 
-#: builtin/branch.c:644 builtin/branch.c:646
+#: builtin/branch.c:645 builtin/branch.c:647
 msgid "print only branches that contain the commit"
 msgstr "mostrar solo ramas que contengan el commit"
 
-#: builtin/branch.c:645 builtin/branch.c:647
+#: builtin/branch.c:646 builtin/branch.c:648
 msgid "print only branches that don't contain the commit"
 msgstr "mostrar solo ramas que no contengan el commit"
 
-#: builtin/branch.c:650
+#: builtin/branch.c:651
 msgid "Specific git-branch actions:"
 msgstr "Acciones específicas de git-branch:"
 
-#: builtin/branch.c:651
+#: builtin/branch.c:652
 msgid "list both remote-tracking and local branches"
-msgstr "listar ramas de remote-tracking y locales"
+msgstr "listar ramas de remote-tracking y locales"
 
-#: builtin/branch.c:653
+#: builtin/branch.c:654
 msgid "delete fully merged branch"
 msgstr "borrar ramas totalmente fusionadas"
 
-#: builtin/branch.c:654
+#: builtin/branch.c:655
 msgid "delete branch (even if not merged)"
 msgstr "borrar rama (incluso si no está fusionada)"
 
-#: builtin/branch.c:655
+#: builtin/branch.c:656
 msgid "move/rename a branch and its reflog"
 msgstr "mover/renombrar una rama y su reflog"
 
-#: builtin/branch.c:656
+#: builtin/branch.c:657
 msgid "move/rename a branch, even if target exists"
 msgstr "mover/renombrar una rama, incluso si el destino existe"
 
-#: builtin/branch.c:657
+#: builtin/branch.c:658
 msgid "copy a branch and its reflog"
 msgstr "copiar una rama y su reflog"
 
-#: builtin/branch.c:658
+#: builtin/branch.c:659
 msgid "copy a branch, even if target exists"
 msgstr "copiar una rama, incluso si el destino existe"
 
-#: builtin/branch.c:659
+#: builtin/branch.c:660
 msgid "list branch names"
 msgstr "listar nombres de ramas"
 
-#: builtin/branch.c:660
-msgid "show current branch name"
-msgstr "muestra el nombre de branch actual"
-
 #: builtin/branch.c:661
-msgid "create the branch's reflog"
-msgstr "crea el reflog de la rama"
+msgid "show current branch name"
+msgstr "mostrar el nombre de branch actual"
 
-#: builtin/branch.c:663
-msgid "edit the description for the branch"
-msgstr "edita la descripción de la rama"
+#: builtin/branch.c:662
+msgid "create the branch's reflog"
+msgstr "crear el reflog de la rama"
 
 #: builtin/branch.c:664
-msgid "force creation, move/rename, deletion"
-msgstr "fuerza la creación, movimiento/renombramiento, eliminación"
+msgid "edit the description for the branch"
+msgstr "editar la descripción de la rama"
 
 #: builtin/branch.c:665
-msgid "print only branches that are merged"
-msgstr "muestra solo ramas que hayan sido fusionadas"
+msgid "force creation, move/rename, deletion"
+msgstr "forzar la creación, movimiento/renombramiento, eliminación"
 
 #: builtin/branch.c:666
-msgid "print only branches that are not merged"
-msgstr "muestra solo ramas que no han sido fusionadas"
+msgid "print only branches that are merged"
+msgstr "mostrar solo ramas que hayan sido fusionadas"
 
 #: builtin/branch.c:667
-msgid "list branches in columns"
-msgstr "muestra las ramas en columnas"
+msgid "print only branches that are not merged"
+msgstr "mostrar solo ramas que no han sido fusionadas"
 
-#: builtin/branch.c:669 builtin/for-each-ref.c:44 builtin/notes.c:415
-#: builtin/notes.c:418 builtin/notes.c:581 builtin/notes.c:584
-#: builtin/tag.c:477
+#: builtin/branch.c:668
+msgid "list branches in columns"
+msgstr "mostrar las ramas en columnas"
+
+#: builtin/branch.c:670 builtin/for-each-ref.c:44 builtin/notes.c:413
+#: builtin/notes.c:416 builtin/notes.c:579 builtin/notes.c:582
+#: builtin/tag.c:475
 msgid "object"
 msgstr "objeto"
 
-#: builtin/branch.c:670
+#: builtin/branch.c:671
 msgid "print only branches of the object"
 msgstr "imprimir solo las ramas del objeto"
 
-#: builtin/branch.c:671 builtin/for-each-ref.c:50 builtin/tag.c:484
+#: builtin/branch.c:672 builtin/for-each-ref.c:50 builtin/tag.c:482
 msgid "sorting and filtering are case insensitive"
 msgstr "ordenamiento y filtración son case-insensitive"
 
-#: builtin/branch.c:672 builtin/for-each-ref.c:40 builtin/tag.c:482
+#: builtin/branch.c:673 builtin/for-each-ref.c:40 builtin/tag.c:480
 #: builtin/verify-tag.c:38
 msgid "format to use for the output"
 msgstr "formato para usar para el output"
 
-#: builtin/branch.c:695 builtin/clone.c:794
+#: builtin/branch.c:696 builtin/clone.c:678
 msgid "HEAD not found below refs/heads!"
 msgstr "¡HEAD no encontrado dentro de refs/heads!"
 
-#: builtin/branch.c:719
+#: builtin/branch.c:720
 msgid "--column and --verbose are incompatible"
 msgstr "--column y --verbose son incompatibles"
 
-#: builtin/branch.c:734 builtin/branch.c:790 builtin/branch.c:799
+#: builtin/branch.c:735 builtin/branch.c:792 builtin/branch.c:801
 msgid "branch name required"
 msgstr "se necesita el nombre de la rama"
 
-#: builtin/branch.c:766
+#: builtin/branch.c:768
 msgid "Cannot give description to detached HEAD"
 msgstr "No se puede dar descripción al HEAD desacoplado"
 
-#: builtin/branch.c:771
+#: builtin/branch.c:773
 msgid "cannot edit description of more than one branch"
 msgstr "no se puede editar la descripción de más de una rama"
 
-#: builtin/branch.c:778
+#: builtin/branch.c:780
 #, c-format
 msgid "No commit on branch '%s' yet."
 msgstr "Aún no hay commits en la rama '%s'."
 
-#: builtin/branch.c:781
+#: builtin/branch.c:783
 #, c-format
 msgid "No branch named '%s'."
 msgstr "No hay ninguna rama llamada '%s'."
 
-#: builtin/branch.c:796
+#: builtin/branch.c:798
 msgid "too many branches for a copy operation"
 msgstr "demasiadas ramas para una operación de duplicación"
 
-#: builtin/branch.c:805
+#: builtin/branch.c:807
 msgid "too many arguments for a rename operation"
 msgstr "demasiados argumentos para una operación de renombramiento"
 
-#: builtin/branch.c:810
+#: builtin/branch.c:812
 msgid "too many arguments to set new upstream"
 msgstr "demasiados argumentos para configurar un nuevo upstream"
 
-#: builtin/branch.c:814
+#: builtin/branch.c:816
 #, c-format
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch."
@@ -11756,32 +12035,32 @@ msgstr ""
 "no se pudo configurar upstream de HEAD a %s cuando este no apunta a ninguna "
 "rama."
 
-#: builtin/branch.c:817 builtin/branch.c:840
+#: builtin/branch.c:819 builtin/branch.c:842
 #, c-format
 msgid "no such branch '%s'"
 msgstr "no hay tal rama '%s'"
 
-#: builtin/branch.c:821
+#: builtin/branch.c:823
 #, c-format
 msgid "branch '%s' does not exist"
 msgstr "la rama '%s' no existe"
 
-#: builtin/branch.c:834
+#: builtin/branch.c:836
 msgid "too many arguments to unset upstream"
 msgstr "demasiados argumentos para desconfigurar upstream"
 
-#: builtin/branch.c:838
+#: builtin/branch.c:840
 msgid "could not unset upstream of HEAD when it does not point to any branch."
 msgstr ""
 "no se puede desconfigurar upstream de HEAD cuando este no apunta a ninguna "
 "rama."
 
-#: builtin/branch.c:844
+#: builtin/branch.c:846
 #, c-format
 msgid "Branch '%s' has no upstream information"
 msgstr "Rama '%s' no tiene información de upstream"
 
-#: builtin/branch.c:854
+#: builtin/branch.c:856
 msgid ""
 "The -a, and -r, options to 'git branch' do not take a branch name.\n"
 "Did you mean to use: -a|-r --list <pattern>?"
@@ -11789,41 +12068,41 @@ msgstr ""
 "Las opciones -a, y -r, de 'git branch' no toman un nombre de rama.\n"
 "¿Quisiste usar: -a|-r --list <patrón>?"
 
-#: builtin/branch.c:858
+#: builtin/branch.c:860
 msgid ""
 "the '--set-upstream' option is no longer supported. Please use '--track' or "
 "'--set-upstream-to' instead."
 msgstr ""
-"la opción '--set-upstream' ya no es soportada. Considere usar '--track' o '--"
+"la opción '--set-upstream' ya no es soportada. Considera usar '--track' o '--"
 "set-upstream-to' en cambio."
 
-#: builtin/bugreport.c:15
+#: builtin/bugreport.c:16
 msgid "git version:\n"
 msgstr "versión de git:\n"
 
-#: builtin/bugreport.c:21
+#: builtin/bugreport.c:22
 #, c-format
 msgid "uname() failed with error '%s' (%d)\n"
 msgstr "uname() falló con error '%s' (%d)\n"
 
-#: builtin/bugreport.c:31
+#: builtin/bugreport.c:32
 msgid "compiler info: "
 msgstr "información del compilador: "
 
-#: builtin/bugreport.c:34
+#: builtin/bugreport.c:35
 msgid "libc info: "
 msgstr "información de libc: "
 
-#: builtin/bugreport.c:80
+#: builtin/bugreport.c:49
 msgid "not run from a git repository - no hooks to show\n"
 msgstr "no ejecutado desde un repositorio git - no hay hooks para mostrar\n"
 
-#: builtin/bugreport.c:90
+#: builtin/bugreport.c:62
 msgid "git bugreport [-o|--output-directory <file>] [-s|--suffix <format>]"
 msgstr ""
 "git bugreport [-o|--output-directory <archivo>] [-s|--suffix <formato>]"
 
-#: builtin/bugreport.c:97
+#: builtin/bugreport.c:69
 msgid ""
 "Thank you for filling out a Git bug report!\n"
 "Please answer the following questions to help us understand your issue.\n"
@@ -11842,7 +12121,7 @@ msgid ""
 "You can delete any lines you don't wish to share.\n"
 msgstr ""
 "¡Gracias por prepara un reporte de bug de Git!\n"
-"Por favor conteste las siguientes preguntas para ayudarnos a entender el "
+"Por favor contesta las siguientes preguntas para ayudarnos a entender el "
 "problema.\n"
 "\n"
 "¿Qué hiciste antes de que sucediera el bug? (Pasos para reproducir el "
@@ -11850,7 +12129,7 @@ msgstr ""
 "\n"
 "¿Qué esperabas que sucediera? (Comportamiento esperado)\n"
 "\n"
-"¿Qué sucedio en lugar de eso? (Comportamiento real)\n"
+"¿Qué sucedió en lugar de eso? (Comportamiento real)\n"
 "\n"
 "¿Qué es diferente entre lo que esperabas y lo que pasó de verdad?\n"
 "\n"
@@ -11859,39 +12138,34 @@ msgstr ""
 "Por favor revisa el resto del reporte abajo.\n"
 "Puedes borrar cualquier línea que no desees compartir.\n"
 
-#: builtin/bugreport.c:136
+#: builtin/bugreport.c:108
 msgid "specify a destination for the bugreport file"
 msgstr "especificar el destino para el archivo de reporte de bug"
 
-#: builtin/bugreport.c:138
+#: builtin/bugreport.c:110
 msgid "specify a strftime format suffix for the filename"
 msgstr ""
 "especificar el sufijo de formato de strftime para el nombre del archivo"
 
-#: builtin/bugreport.c:160
+#: builtin/bugreport.c:132
 #, c-format
 msgid "could not create leading directories for '%s'"
 msgstr "no se pudo crear directorios principales para '%s'"
 
-#: builtin/bugreport.c:167
+#: builtin/bugreport.c:139
 msgid "System Info"
 msgstr "Información del sistema"
 
-#: builtin/bugreport.c:170
+#: builtin/bugreport.c:142
 msgid "Enabled Hooks"
 msgstr "Hooks habilitados"
 
-#: builtin/bugreport.c:177
-#, c-format
-msgid "couldn't create a new file at '%s'"
-msgstr "no se pudo crear un archivo nuevo en '%s'"
-
-#: builtin/bugreport.c:180
+#: builtin/bugreport.c:149
 #, c-format
 msgid "unable to write to %s"
 msgstr "no es posible escribir en %s"
 
-#: builtin/bugreport.c:190
+#: builtin/bugreport.c:159
 #, c-format
 msgid "Created new report at '%s'.\n"
 msgstr "Crear un nuevo reporte en '%s'.\n"
@@ -11912,53 +12186,53 @@ msgstr "git bundle list-heads <archivo> [<nombre-de-ref>...]"
 msgid "git bundle unbundle <file> [<refname>...]"
 msgstr "git bundle unbundle <archivo> [<nombre-de-ref>...]"
 
-#: builtin/bundle.c:67 builtin/pack-objects.c:3907
+#: builtin/bundle.c:65 builtin/pack-objects.c:3876
 msgid "do not show progress meter"
 msgstr "no mostrar medidor de progreso"
 
-#: builtin/bundle.c:69 builtin/pack-objects.c:3909
+#: builtin/bundle.c:67 builtin/bundle.c:167 builtin/pack-objects.c:3878
 msgid "show progress meter"
 msgstr "mostrar medidor de progreso"
 
-#: builtin/bundle.c:71 builtin/pack-objects.c:3911
+#: builtin/bundle.c:69 builtin/pack-objects.c:3880
 msgid "show progress meter during object writing phase"
 msgstr "mostrar medidor de progreso durante la fase de escritura de objeto"
 
-#: builtin/bundle.c:74 builtin/pack-objects.c:3914
+#: builtin/bundle.c:72 builtin/pack-objects.c:3883
 msgid "similar to --all-progress when progress meter is shown"
 msgstr "similar a --all-progress cuando medidor de progreso es mostrado"
 
-#: builtin/bundle.c:76
+#: builtin/bundle.c:74
 msgid "specify bundle format version"
 msgstr "especificar la versión del formato del paquete"
 
-#: builtin/bundle.c:96
+#: builtin/bundle.c:94
 msgid "Need a repository to create a bundle."
 msgstr "Se necesita un repositorio para agrupar."
 
-#: builtin/bundle.c:109
+#: builtin/bundle.c:107
 msgid "do not show bundle details"
 msgstr "no mostrar detalles del bundle"
 
-#: builtin/bundle.c:128
+#: builtin/bundle.c:126
 #, c-format
 msgid "%s is okay\n"
 msgstr "%s está bien\n"
 
-#: builtin/bundle.c:179
+#: builtin/bundle.c:182
 msgid "Need a repository to unbundle."
 msgstr "Se necesita un repositorio para desagrupar."
 
-#: builtin/bundle.c:191 builtin/remote.c:1700
-msgid "be verbose; must be placed before a subcommand"
-msgstr "ser verboso; tiene que ser agregado antes de un subcomando"
+#: builtin/bundle.c:185
+msgid "Unbundling objects"
+msgstr "Desagrupando objetos"
 
-#: builtin/bundle.c:213 builtin/remote.c:1731
+#: builtin/bundle.c:219 builtin/remote.c:1733
 #, c-format
 msgid "Unknown subcommand: %s"
 msgstr "Sub-comando desconocido: %s"
 
-#: builtin/cat-file.c:596
+#: builtin/cat-file.c:622
 msgid ""
 "git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e | -"
 "p | <type> | --textconv | --filters) [--path=<path>] <object>"
@@ -11966,7 +12240,7 @@ msgstr ""
 "git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e | -"
 "p | <tipo> | --textconv | --filters) [--path=<ruta>] <objeto>"
 
-#: builtin/cat-file.c:597
+#: builtin/cat-file.c:623
 msgid ""
 "git cat-file (--batch[=<format>] | --batch-check[=<format>]) [--follow-"
 "symlinks] [--textconv | --filters]"
@@ -11974,74 +12248,74 @@ msgstr ""
 "git cat-file (--batch[=<formato>] | --batch-check[=<formato>]) [--follow-"
 "symlinks] [--textconv | --filters]"
 
-#: builtin/cat-file.c:618
+#: builtin/cat-file.c:644
 msgid "only one batch option may be specified"
 msgstr "solo se puede especificar una opción batch"
 
-#: builtin/cat-file.c:636
+#: builtin/cat-file.c:662
 msgid "<type> can be one of: blob, tree, commit, tag"
 msgstr "<tipo> puede ser: blob, tree, commit, tag"
 
-#: builtin/cat-file.c:637
+#: builtin/cat-file.c:663
 msgid "show object type"
 msgstr "mostrar el tipo del objeto"
 
-#: builtin/cat-file.c:638
+#: builtin/cat-file.c:664
 msgid "show object size"
 msgstr "mostrar el tamaño del objeto"
 
-#: builtin/cat-file.c:640
+#: builtin/cat-file.c:666
 msgid "exit with zero when there's no error"
 msgstr "salir con cero cuando no haya error"
 
-#: builtin/cat-file.c:641
+#: builtin/cat-file.c:667
 msgid "pretty-print object's content"
 msgstr "realizar pretty-print del contenido del objeto"
 
-#: builtin/cat-file.c:643
+#: builtin/cat-file.c:669
 msgid "for blob objects, run textconv on object's content"
 msgstr "para objetos blob, ejecuta textconv en el contenido del objeto"
 
-#: builtin/cat-file.c:645
+#: builtin/cat-file.c:671
 msgid "for blob objects, run filters on object's content"
 msgstr "para objetos blob, ejecuta filters en el contenido del objeto"
 
-#: builtin/cat-file.c:646
+#: builtin/cat-file.c:672
 msgid "blob"
 msgstr "blob"
 
-#: builtin/cat-file.c:647
+#: builtin/cat-file.c:673
 msgid "use a specific path for --textconv/--filters"
-msgstr "use una ruta específica para --textconv/--filters"
+msgstr "usar una ruta específica para --textconv/--filters"
 
-#: builtin/cat-file.c:649
+#: builtin/cat-file.c:675
 msgid "allow -s and -t to work with broken/corrupt objects"
 msgstr "permita que -s y -t funcionen con objetos rotos o corruptos"
 
-#: builtin/cat-file.c:650
+#: builtin/cat-file.c:676
 msgid "buffer --batch output"
 msgstr "salida buffer --batch"
 
-#: builtin/cat-file.c:652
+#: builtin/cat-file.c:678
 msgid "show info and content of objects fed from the standard input"
 msgstr "mostrar info y content de los objetos alimentados por standard input"
 
-#: builtin/cat-file.c:656
+#: builtin/cat-file.c:682
 msgid "show info about objects fed from the standard input"
 msgstr "mostrar info de los objetos alimentados por standard input"
 
-#: builtin/cat-file.c:660
+#: builtin/cat-file.c:686
 msgid "follow in-tree symlinks (used with --batch or --batch-check)"
 msgstr ""
 "seguir los enlaces simbólicos en el árbol (usado con --batch o --batch-check)"
 
-#: builtin/cat-file.c:662
+#: builtin/cat-file.c:688
 msgid "show all objects with --batch or --batch-check"
 msgstr "mostrar todos los objetos con --batch o --batch-check"
 
-#: builtin/cat-file.c:664
+#: builtin/cat-file.c:690
 msgid "do not order --batch-all-objects output"
-msgstr "no ordenar el salida de --batch-all-objects"
+msgstr "no ordenar la salida de --batch-all-objects"
 
 #: builtin/check-attr.c:13
 msgid "git check-attr [-a | --all | <attr>...] [--] <pathname>..."
@@ -12057,9 +12331,9 @@ msgstr "reportar todos los atributos configurados en el archivo"
 
 #: builtin/check-attr.c:22
 msgid "use .gitattributes only from the index"
-msgstr "use .gitattributes solo desde el índice"
+msgstr "usar .gitattributes solo desde el índice"
 
-#: builtin/check-attr.c:23 builtin/check-ignore.c:25 builtin/hash-object.c:102
+#: builtin/check-attr.c:23 builtin/check-ignore.c:25 builtin/hash-object.c:100
 msgid "read file names from stdin"
 msgstr "leer nombres de archivos de stdin"
 
@@ -12067,8 +12341,8 @@ msgstr "leer nombres de archivos de stdin"
 msgid "terminate input and output records by a NUL character"
 msgstr "terminar registros de entrada y salida con un carácter NUL"
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1515 builtin/gc.c:549
-#: builtin/worktree.c:493
+#: builtin/check-ignore.c:21 builtin/checkout.c:1513 builtin/gc.c:549
+#: builtin/worktree.c:494
 msgid "suppress progress reporting"
 msgstr "suprimir el reporte de progreso"
 
@@ -12126,11 +12400,10 @@ msgid "git checkout--worker [<options>]"
 msgstr "git checkout--worker [<opciones>]"
 
 #: builtin/checkout--worker.c:118 builtin/checkout-index.c:201
-#: builtin/column.c:31 builtin/submodule--helper.c:1892
-#: builtin/submodule--helper.c:1895 builtin/submodule--helper.c:1903
-#: builtin/submodule--helper.c:2350 builtin/submodule--helper.c:2896
-#: builtin/submodule--helper.c:2899 builtin/worktree.c:491
-#: builtin/worktree.c:728
+#: builtin/column.c:31 builtin/column.c:32 builtin/submodule--helper.c:1863
+#: builtin/submodule--helper.c:1866 builtin/submodule--helper.c:1874
+#: builtin/submodule--helper.c:2510 builtin/submodule--helper.c:2576
+#: builtin/worktree.c:492 builtin/worktree.c:729
 msgid "string"
 msgstr "string"
 
@@ -12283,11 +12556,11 @@ msgstr "'%s' o '%s' no puede ser usado con %s"
 msgid "path '%s' is unmerged"
 msgstr "ruta '%s' no está fusionada"
 
-#: builtin/checkout.c:734
+#: builtin/checkout.c:736
 msgid "you need to resolve your current index first"
 msgstr "necesitas resolver tu índice actual primero"
 
-#: builtin/checkout.c:788
+#: builtin/checkout.c:786
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -12296,50 +12569,50 @@ msgstr ""
 "no se puede continuar con los cambios en stage en los siguientes archivos:\n"
 "%s"
 
-#: builtin/checkout.c:881
+#: builtin/checkout.c:879
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "No se puede hacer reflog para '%s': %s\n"
 
-#: builtin/checkout.c:923
+#: builtin/checkout.c:921
 msgid "HEAD is now at"
 msgstr "HEAD está ahora en"
 
-#: builtin/checkout.c:927 builtin/clone.c:725 t/helper/test-fast-rebase.c:203
+#: builtin/checkout.c:925 builtin/clone.c:609 t/helper/test-fast-rebase.c:203
 msgid "unable to update HEAD"
 msgstr "no es posible actualizar HEAD"
 
-#: builtin/checkout.c:931
+#: builtin/checkout.c:929
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Reiniciar rama '%s'\n"
 
-#: builtin/checkout.c:934
+#: builtin/checkout.c:932
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Ya en '%s'\n"
 
-#: builtin/checkout.c:938
+#: builtin/checkout.c:936
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Rama reiniciada y cambiada a '%s'\n"
 
-#: builtin/checkout.c:940 builtin/checkout.c:1371
+#: builtin/checkout.c:938 builtin/checkout.c:1369
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Cambiado a nueva rama '%s'\n"
 
-#: builtin/checkout.c:942
+#: builtin/checkout.c:940
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Cambiado a rama '%s'\n"
 
-#: builtin/checkout.c:993
+#: builtin/checkout.c:991
 #, c-format
 msgid " ... and %d more.\n"
 msgstr " ... y %d más.\n"
 
-#: builtin/checkout.c:999
+#: builtin/checkout.c:997
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -12362,7 +12635,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:1018
+#: builtin/checkout.c:1016
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -12389,28 +12662,28 @@ msgstr[1] ""
 " git branch <nombre-de-rama> %s\n"
 "\n"
 
-#: builtin/checkout.c:1053
+#: builtin/checkout.c:1051
 msgid "internal error in revision walk"
 msgstr "error interno en recorrido de revisiones"
 
-#: builtin/checkout.c:1057
+#: builtin/checkout.c:1055
 msgid "Previous HEAD position was"
 msgstr "La posición previa de HEAD era"
 
-#: builtin/checkout.c:1097 builtin/checkout.c:1366
+#: builtin/checkout.c:1095 builtin/checkout.c:1364
 msgid "You are on a branch yet to be born"
 msgstr "Estás en una rama por nacer"
 
-#: builtin/checkout.c:1179
+#: builtin/checkout.c:1177
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
 "Please use -- (and optionally --no-guess) to disambiguate"
 msgstr ""
 "'%s' puede ser tanto un archivo local como una rama de rastreo.\n"
-"Por favor use -- (y opcionalmente --no-guess) para desambiguar"
+"Por favor usa -- (y opcionalmente --no-guess) para desambiguar"
 
-#: builtin/checkout.c:1186
+#: builtin/checkout.c:1184
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -12430,51 +12703,51 @@ msgstr ""
 "un remoto particular, como 'origin', considera configurar\n"
 "checkout.defaultRemote=origin en tu configuración."
 
-#: builtin/checkout.c:1196
+#: builtin/checkout.c:1194
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "'%s' concordó con múltiples (%d) ramas de rastreo remoto"
 
-#: builtin/checkout.c:1262
+#: builtin/checkout.c:1260
 msgid "only one reference expected"
 msgstr "solo una referencia esperada"
 
-#: builtin/checkout.c:1279
+#: builtin/checkout.c:1277
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "solo una referencia esperada, %d entregadas."
 
-#: builtin/checkout.c:1325 builtin/worktree.c:268 builtin/worktree.c:436
+#: builtin/checkout.c:1323 builtin/worktree.c:269 builtin/worktree.c:437
 #, c-format
 msgid "invalid reference: %s"
 msgstr "referencia inválida: %s"
 
-#: builtin/checkout.c:1338 builtin/checkout.c:1707
+#: builtin/checkout.c:1336 builtin/checkout.c:1705
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "la referencia no es un árbol: %s"
 
-#: builtin/checkout.c:1385
+#: builtin/checkout.c:1383
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "se esperaba un branch, se obtuvo tag '%s'"
 
-#: builtin/checkout.c:1387
+#: builtin/checkout.c:1385
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "se espera una rama, se obtuvo una rama remota '%s'"
 
-#: builtin/checkout.c:1388 builtin/checkout.c:1396
+#: builtin/checkout.c:1386 builtin/checkout.c:1394
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "se esperaba branch, se obtuvo '%s'"
 
-#: builtin/checkout.c:1391
+#: builtin/checkout.c:1389
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "se espera una rama, se obtuvo commit '%s'"
 
-#: builtin/checkout.c:1407
+#: builtin/checkout.c:1405
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -12482,7 +12755,7 @@ msgstr ""
 "no se puede cambiar de branch durante un merge\n"
 "Considera \"git merge --quit\" o \"git worktree add\"."
 
-#: builtin/checkout.c:1411
+#: builtin/checkout.c:1409
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
@@ -12490,7 +12763,7 @@ msgstr ""
 "no se puede cambiar de branch en medio de una sesión de am\n"
 "Considera \"git am --quit\" o \"git worktree add\"."
 
-#: builtin/checkout.c:1415
+#: builtin/checkout.c:1413
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
@@ -12498,7 +12771,7 @@ msgstr ""
 "no se puede cambiar de branch durante un rebase\n"
 "Considera \"git rebase --quit\" o \"git worktree add\"."
 
-#: builtin/checkout.c:1419
+#: builtin/checkout.c:1417
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
@@ -12506,7 +12779,7 @@ msgstr ""
 "no se puede cambiar de branch durante un cherry-pick\n"
 "Considera \"git cherry-pick --quit\" o \"git worktree add\"."
 
-#: builtin/checkout.c:1423
+#: builtin/checkout.c:1421
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -12514,137 +12787,137 @@ msgstr ""
 "no se puede cambiar de branch durante un revert\n"
 "Considera \"git revert --quit\" o \"git worktree add\"."
 
-#: builtin/checkout.c:1427
+#: builtin/checkout.c:1425
 msgid "you are switching branch while bisecting"
 msgstr "estás cambiando de rama durante un bisect"
 
-#: builtin/checkout.c:1434
+#: builtin/checkout.c:1432
 msgid "paths cannot be used with switching branches"
 msgstr "rutas no pueden ser usadas con cambios de rama"
 
-#: builtin/checkout.c:1437 builtin/checkout.c:1441 builtin/checkout.c:1445
+#: builtin/checkout.c:1435 builtin/checkout.c:1439 builtin/checkout.c:1443
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "'%s' no puede ser usado con cambios de ramas"
 
-#: builtin/checkout.c:1449 builtin/checkout.c:1452 builtin/checkout.c:1455
-#: builtin/checkout.c:1460 builtin/checkout.c:1465
+#: builtin/checkout.c:1447 builtin/checkout.c:1450 builtin/checkout.c:1453
+#: builtin/checkout.c:1458 builtin/checkout.c:1463
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "'%s' no puede ser usado con '%s'"
 
-#: builtin/checkout.c:1462
+#: builtin/checkout.c:1460
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "'%s' no puede tomar <punto de partida>"
 
-#: builtin/checkout.c:1470
+#: builtin/checkout.c:1468
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "No se puede cambiar rama a un '%s' sin commits"
 
-#: builtin/checkout.c:1477
+#: builtin/checkout.c:1475
 msgid "missing branch or commit argument"
 msgstr "falta branch o commit como argumento"
 
-#: builtin/checkout.c:1520
+#: builtin/checkout.c:1518
 msgid "perform a 3-way merge with the new branch"
 msgstr "realizar una fusión de tres vías con la rama nueva"
 
-#: builtin/checkout.c:1521 builtin/log.c:1810 parse-options.h:323
+#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:322
 msgid "style"
 msgstr "estilo"
 
-#: builtin/checkout.c:1522
+#: builtin/checkout.c:1520
 msgid "conflict style (merge or diff3)"
 msgstr "estilo de conflictos (merge o diff3)"
 
-#: builtin/checkout.c:1534 builtin/worktree.c:488
+#: builtin/checkout.c:1532 builtin/worktree.c:489
 msgid "detach HEAD at named commit"
 msgstr "desacoplar HEAD en el commit nombrado"
 
-#: builtin/checkout.c:1535
+#: builtin/checkout.c:1533
 msgid "set upstream info for new branch"
 msgstr "configurar info de upstream para una rama nueva"
 
-#: builtin/checkout.c:1537
+#: builtin/checkout.c:1535
 msgid "force checkout (throw away local modifications)"
 msgstr "forzar el checkout (descartar modificaciones locales)"
 
-#: builtin/checkout.c:1539
+#: builtin/checkout.c:1537
 msgid "new-branch"
 msgstr "nueva-rama"
 
-#: builtin/checkout.c:1539
+#: builtin/checkout.c:1537
 msgid "new unparented branch"
 msgstr "nueva rama no emparentada"
 
-#: builtin/checkout.c:1541 builtin/merge.c:301
+#: builtin/checkout.c:1539 builtin/merge.c:302
 msgid "update ignored files (default)"
 msgstr "actualizar archivos ignorados (default)"
 
-#: builtin/checkout.c:1544
+#: builtin/checkout.c:1542
 msgid "do not check if another worktree is holding the given ref"
 msgstr "no averiguar si otro árbol de trabajo contiene la ref entregada"
 
-#: builtin/checkout.c:1557
+#: builtin/checkout.c:1555
 msgid "checkout our version for unmerged files"
 msgstr "hacer checkout a nuestra versión para archivos sin fusionar"
 
-#: builtin/checkout.c:1560
+#: builtin/checkout.c:1558
 msgid "checkout their version for unmerged files"
 msgstr "hacer checkout a su versión para los archivos sin fusionar"
 
-#: builtin/checkout.c:1564
+#: builtin/checkout.c:1562
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "no limitar pathspecs a entradas escasas solamente"
 
-#: builtin/checkout.c:1622
+#: builtin/checkout.c:1620
 #, c-format
 msgid "-%c, -%c and --orphan are mutually exclusive"
 msgstr "-%c, -%c y --orphan son mutuamente exclusivas"
 
-#: builtin/checkout.c:1626
+#: builtin/checkout.c:1624
 msgid "-p and --overlay are mutually exclusive"
 msgstr "-p y --overlay son mutuamente exclusivas"
 
-#: builtin/checkout.c:1663
+#: builtin/checkout.c:1661
 msgid "--track needs a branch name"
 msgstr "--track necesita el nombre de una rama"
 
-#: builtin/checkout.c:1668
+#: builtin/checkout.c:1666
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "falta nombre de rama; prueba -%c"
 
-#: builtin/checkout.c:1700
+#: builtin/checkout.c:1698
 #, c-format
 msgid "could not resolve %s"
 msgstr "no se pudo resolver %s"
 
-#: builtin/checkout.c:1716
+#: builtin/checkout.c:1714
 msgid "invalid path specification"
 msgstr "especificación de ruta inválida"
 
-#: builtin/checkout.c:1723
+#: builtin/checkout.c:1721
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr "'%s' no es un commit y una rama '%s' no puede ser creada desde este"
 
-#: builtin/checkout.c:1727
+#: builtin/checkout.c:1725
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach no toma un argumento de ruta '%s'"
 
-#: builtin/checkout.c:1736
+#: builtin/checkout.c:1734
 msgid "--pathspec-from-file is incompatible with --detach"
 msgstr "--pathspec-from-file es incompatible con --detach"
 
-#: builtin/checkout.c:1739 builtin/reset.c:325 builtin/stash.c:1630
+#: builtin/checkout.c:1737 builtin/reset.c:331 builtin/stash.c:1647
 msgid "--pathspec-from-file is incompatible with --patch"
 msgstr "--pathspec-from-file es incompatible con --patch"
 
-#: builtin/checkout.c:1752
+#: builtin/checkout.c:1750
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -12652,71 +12925,71 @@ msgstr ""
 "git checkout: --ours/--theirs, --force y --merge son incompatibles cuando\n"
 "se revisa fuera del índice."
 
-#: builtin/checkout.c:1757
+#: builtin/checkout.c:1755
 msgid "you must specify path(s) to restore"
 msgstr "debes especificar path(s) para restaurar"
 
-#: builtin/checkout.c:1783 builtin/checkout.c:1785 builtin/checkout.c:1834
-#: builtin/checkout.c:1836 builtin/clone.c:126 builtin/remote.c:170
-#: builtin/remote.c:172 builtin/submodule--helper.c:2736
-#: builtin/submodule--helper.c:2887 builtin/worktree.c:484
-#: builtin/worktree.c:486
+#: builtin/checkout.c:1781 builtin/checkout.c:1783 builtin/checkout.c:1832
+#: builtin/checkout.c:1834 builtin/clone.c:126 builtin/remote.c:170
+#: builtin/remote.c:172 builtin/submodule--helper.c:2958
+#: builtin/submodule--helper.c:3252 builtin/worktree.c:485
+#: builtin/worktree.c:487
 msgid "branch"
 msgstr "rama"
 
-#: builtin/checkout.c:1784
+#: builtin/checkout.c:1782
 msgid "create and checkout a new branch"
 msgstr "crear y hacer checkout a una nueva rama"
 
-#: builtin/checkout.c:1786
+#: builtin/checkout.c:1784
 msgid "create/reset and checkout a branch"
 msgstr "crear/reiniciar y hacer checkout a una rama"
 
-#: builtin/checkout.c:1787
+#: builtin/checkout.c:1785
 msgid "create reflog for new branch"
 msgstr "crear un reflog para una nueva rama"
 
-#: builtin/checkout.c:1789
+#: builtin/checkout.c:1787
 msgid "second guess 'git checkout <no-such-branch>' (default)"
-msgstr "adivinar segunda opción 'git checkout <no-hay-tal-rama>' (default)"
+msgstr "cuestionar opción 'git checkout <no-hay-tal-rama>' (default)"
 
-#: builtin/checkout.c:1790
+#: builtin/checkout.c:1788
 msgid "use overlay mode (default)"
 msgstr "usar modo overlay (default)"
 
-#: builtin/checkout.c:1835
+#: builtin/checkout.c:1833
 msgid "create and switch to a new branch"
 msgstr "crear y hacer switch a una nueva rama"
 
-#: builtin/checkout.c:1837
+#: builtin/checkout.c:1835
 msgid "create/reset and switch to a branch"
 msgstr "crear/reiniciar y hacer switch a una rama"
 
-#: builtin/checkout.c:1839
+#: builtin/checkout.c:1837
 msgid "second guess 'git switch <no-such-branch>'"
-msgstr "adivinar segunda opción 'git checkout <no-hay-tal-rama>'"
+msgstr "cuestionar opción 'git checkout <no-hay-tal-rama>'"
 
-#: builtin/checkout.c:1841
+#: builtin/checkout.c:1839
 msgid "throw away local modifications"
 msgstr "descartar modificaciones locales"
 
-#: builtin/checkout.c:1875
+#: builtin/checkout.c:1873
 msgid "which tree-ish to checkout from"
 msgstr "de qué árbol hacer el checkout"
 
-#: builtin/checkout.c:1877
+#: builtin/checkout.c:1875
 msgid "restore the index"
 msgstr "restaurar el índice"
 
-#: builtin/checkout.c:1879
+#: builtin/checkout.c:1877
 msgid "restore the working tree (default)"
 msgstr "restaurar el árbol de trabajo (default)"
 
-#: builtin/checkout.c:1881
+#: builtin/checkout.c:1879
 msgid "ignore unmerged entries"
 msgstr "ignorar entradas no fusionadas"
 
-#: builtin/checkout.c:1882
+#: builtin/checkout.c:1880
 msgid "use overlay mode"
 msgstr "usar modo overlay"
 
@@ -12760,8 +13033,8 @@ msgid ""
 "           - (empty) select nothing\n"
 msgstr ""
 "Ayuda de comandos:\n"
-"1          - selecciona un objeto por número\n"
-"foo        - selecciona un objeto basado en un prefijo único\n"
+"1          - seleccionar un objeto por número\n"
+"foo        - seleccionar un objeto basado en un prefijo único\n"
 "           - (vacío) no elegir nada\n"
 
 #: builtin/clean.c:304 git-add--interactive.perl:602
@@ -12777,10 +13050,10 @@ msgid ""
 "           - (empty) finish selecting\n"
 msgstr ""
 "Ayuda de comandos:\n"
-"1          - selecciona un objeto único\n"
-"3-5        - selecciona un rango de objetos\n"
-"2-3,6-9    - selecciona múltiples rangos\n"
-"foo        - selecciona un objeto basado en un prefijo único\n"
+"1          - seleccionar un objeto único\n"
+"3-5        - seleccionar un rango de objetos\n"
+"2-3,6-9    - seleccionar múltiples rangos\n"
+"foo        - seleccionar un objeto basado en un prefijo único\n"
 "-...       - de-seleccionar objetos especificados\n"
 "*          - escoger todos los objetos\n"
 "           - (vacío) terminar selección\n"
@@ -12822,8 +13095,8 @@ msgid ""
 "?                   - help for prompt selection"
 msgstr ""
 "clean               - comenzar la limpieza\n"
-"filter by pattern   - excluye objetos de la eliminación\n"
-"select by numbers   - selecciona objetos a ser borrados por número\n"
+"filter by pattern   - excluir objetos de la eliminación\n"
+"select by numbers   - seleccionar objetos a ser borrados por número\n"
 "ask each            - confirmar cada eliminación (como \"rm -i\")\n"
 "quit                - parar limpieza\n"
 "help                - esta pantalla\n"
@@ -12856,8 +13129,8 @@ msgid "remove whole directories"
 msgstr "borrar directorios completos"
 
 #: builtin/clean.c:906 builtin/describe.c:565 builtin/describe.c:567
-#: builtin/grep.c:923 builtin/log.c:184 builtin/log.c:186
-#: builtin/ls-files.c:650 builtin/name-rev.c:526 builtin/name-rev.c:528
+#: builtin/grep.c:937 builtin/log.c:184 builtin/log.c:186
+#: builtin/ls-files.c:648 builtin/name-rev.c:526 builtin/name-rev.c:528
 #: builtin/show-ref.c:179
 msgid "pattern"
 msgstr "patrón"
@@ -12946,25 +13219,26 @@ msgstr "directorio-template"
 msgid "directory from which templates will be used"
 msgstr "directorio del cual los templates serán usados"
 
-#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1899
-#: builtin/submodule--helper.c:2353 builtin/submodule--helper.c:2903
+#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1870
+#: builtin/submodule--helper.c:2513 builtin/submodule--helper.c:3259
 msgid "reference repository"
 msgstr "repositorio de referencia"
 
-#: builtin/clone.c:123 builtin/submodule--helper.c:1901
-#: builtin/submodule--helper.c:2355 builtin/submodule--helper.c:2905
+#: builtin/clone.c:123 builtin/submodule--helper.c:1872
+#: builtin/submodule--helper.c:2515
 msgid "use --reference only while cloning"
-msgstr "usa --reference solamente si estás clonando"
+msgstr "usar --reference solamente si estás clonando"
 
 #: builtin/clone.c:124 builtin/column.c:27 builtin/init-db.c:550
-#: builtin/merge-file.c:46 builtin/pack-objects.c:3975 builtin/repack.c:495
-#: t/helper/test-simple-ipc.c:696 t/helper/test-simple-ipc.c:698
+#: builtin/merge-file.c:46 builtin/pack-objects.c:3944 builtin/repack.c:663
+#: builtin/submodule--helper.c:3261 t/helper/test-simple-ipc.c:595
+#: t/helper/test-simple-ipc.c:597
 msgid "name"
 msgstr "nombre"
 
 #: builtin/clone.c:125
 msgid "use <name> instead of 'origin' to track upstream"
-msgstr "use <nombre> en lugar de 'origin' para rastrear upstream"
+msgstr "usar <nombre> en lugar de 'origin' para rastrear upstream"
 
 #: builtin/clone.c:127
 msgid "checkout <branch> instead of the remote's HEAD"
@@ -12974,7 +13248,7 @@ msgstr "checkout <rama> en lugar de HEAD remota"
 msgid "path to git-upload-pack on the remote"
 msgstr "ruta para git-upload-pack en el remoto"
 
-#: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:862
+#: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
 #: builtin/pull.c:208
 msgid "depth"
 msgstr "profundidad"
@@ -12983,7 +13257,7 @@ msgstr "profundidad"
 msgid "create a shallow clone of that depth"
 msgstr "crear un clon superficial de esa profundidad"
 
-#: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3964
+#: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
 #: builtin/pull.c:211
 msgid "time"
 msgstr "tiempo"
@@ -12993,7 +13267,7 @@ msgid "create a shallow clone since a specific time"
 msgstr "crear un clon superficial desde el tiempo específico"
 
 #: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1318
+#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1022
 msgid "revision"
 msgstr "revisión"
 
@@ -13001,8 +13275,8 @@ msgstr "revisión"
 msgid "deepen history of shallow clone, excluding rev"
 msgstr "ahondar historia de clon superficial, excluyendo rev"
 
-#: builtin/clone.c:137 builtin/submodule--helper.c:1911
-#: builtin/submodule--helper.c:2369
+#: builtin/clone.c:137 builtin/submodule--helper.c:1882
+#: builtin/submodule--helper.c:2529
 msgid "clone only one branch, HEAD or --branch"
 msgstr "clonar solo una rama, HEAD o --branch"
 
@@ -13020,7 +13294,7 @@ msgstr "gitdir"
 
 #: builtin/clone.c:143 builtin/init-db.c:549
 msgid "separate git dir from working tree"
-msgstr "separa git dir del árbol de trabajo"
+msgstr "separar git dir del árbol de trabajo"
 
 #: builtin/clone.c:144
 msgid "key=value"
@@ -13031,12 +13305,12 @@ msgid "set config inside the new repository"
 msgstr "configurar config dentro del nuevo repositorio"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:196
+#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "específico-al-servidor"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:197
+#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr "opción para trasmitir"
 
@@ -13059,50 +13333,42 @@ msgid "initialize sparse-checkout file to include only files at root"
 msgstr ""
 "inicializar archivo sparse-checkout para incluir solo archivos en la raíz"
 
-#: builtin/clone.c:292
-msgid ""
-"No directory name could be guessed.\n"
-"Please specify a directory on the command line"
-msgstr ""
-"No se pudo adivinar ningún nombre de directorio.\n"
-"Por favor especifique un directorio en la línea de comando"
-
-#: builtin/clone.c:345
+#: builtin/clone.c:231
 #, c-format
 msgid "info: Could not add alternate for '%s': %s\n"
 msgstr "info: No se pudo agregar un alterno para '%s': %s\n"
 
-#: builtin/clone.c:418
+#: builtin/clone.c:304
 #, c-format
 msgid "%s exists and is not a directory"
 msgstr "%s existe pero no es un directorio"
 
-#: builtin/clone.c:436
+#: builtin/clone.c:322
 #, c-format
 msgid "failed to start iterator over '%s'"
 msgstr "falló al iniciar el iterador sobre '%s'"
 
-#: builtin/clone.c:467
+#: builtin/clone.c:353
 #, c-format
 msgid "failed to create link '%s'"
 msgstr "falló al crear link '%s'"
 
-#: builtin/clone.c:471
+#: builtin/clone.c:357
 #, c-format
 msgid "failed to copy file to '%s'"
 msgstr "falló al copiar archivo a '%s'"
 
-#: builtin/clone.c:476
+#: builtin/clone.c:362
 #, c-format
 msgid "failed to iterate over '%s'"
 msgstr "falló al iterar sobre '%s'"
 
-#: builtin/clone.c:503
+#: builtin/clone.c:389
 #, c-format
 msgid "done.\n"
 msgstr "hecho.\n"
 
-#: builtin/clone.c:517
+#: builtin/clone.c:403
 msgid ""
 "Clone succeeded, but checkout failed.\n"
 "You can inspect what was checked out with 'git status'\n"
@@ -13112,105 +13378,105 @@ msgstr ""
 "Puedes inspeccionar a qué se hizo checkout con 'git status'\n"
 "y volver a intentarlo con 'git restore --source=HEAD :/'\n"
 
-#: builtin/clone.c:594
+#: builtin/clone.c:480
 #, c-format
 msgid "Could not find remote branch %s to clone."
 msgstr "No se pudo encontrar la rama remota %s para clonar."
 
-#: builtin/clone.c:713
+#: builtin/clone.c:597
 #, c-format
 msgid "unable to update %s"
 msgstr "incapaz de actualizar %s"
 
-#: builtin/clone.c:761
+#: builtin/clone.c:645
 msgid "failed to initialize sparse-checkout"
 msgstr "falló al inicializar sparse-checkout"
 
-#: builtin/clone.c:784
+#: builtin/clone.c:668
 msgid "remote HEAD refers to nonexistent ref, unable to checkout.\n"
 msgstr ""
 "remoto HEAD refiere a un ref inexistente, no se puede hacer checkout.\n"
 
-#: builtin/clone.c:816
+#: builtin/clone.c:701
 msgid "unable to checkout working tree"
 msgstr "no es posible realizar checkout en el árbol de trabajo"
 
-#: builtin/clone.c:894
+#: builtin/clone.c:779
 msgid "unable to write parameters to config file"
 msgstr "no es posible escribir parámetros al archivo config"
 
-#: builtin/clone.c:957
+#: builtin/clone.c:842
 msgid "cannot repack to clean up"
 msgstr "no se puede reempaquetar para limpiar"
 
-#: builtin/clone.c:959
+#: builtin/clone.c:844
 msgid "cannot unlink temporary alternates file"
 msgstr "no se puede desvincular archivo de alternos temporal"
 
-#: builtin/clone.c:1001 builtin/receive-pack.c:2490
+#: builtin/clone.c:886 builtin/receive-pack.c:2493
 msgid "Too many arguments."
 msgstr "Demasiados argumentos."
 
-#: builtin/clone.c:1005
+#: builtin/clone.c:890
 msgid "You must specify a repository to clone."
 msgstr "Tienes que especificar un repositorio para clonar."
 
-#: builtin/clone.c:1018
+#: builtin/clone.c:903
 #, c-format
 msgid "--bare and --origin %s options are incompatible."
 msgstr "Las opciones --bare y --origin %s son incompatibles."
 
-#: builtin/clone.c:1021
+#: builtin/clone.c:906
 msgid "--bare and --separate-git-dir are incompatible."
 msgstr "--bare y --separate-git-dir son incompatibles."
 
-#: builtin/clone.c:1035
+#: builtin/clone.c:920
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "repositorio '%s' no existe"
 
-#: builtin/clone.c:1039 builtin/fetch.c:2014
+#: builtin/clone.c:924 builtin/fetch.c:2029
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "profundidad %s no es un número positivo"
 
-#: builtin/clone.c:1049
+#: builtin/clone.c:934
 #, c-format
 msgid "destination path '%s' already exists and is not an empty directory."
 msgstr "la ruta de destino '%s' ya existe y no es un directorio vacío."
 
-#: builtin/clone.c:1055
+#: builtin/clone.c:940
 #, c-format
 msgid "repository path '%s' already exists and is not an empty directory."
 msgstr "la ruta del repositorio '%s' ya existe y no es un directorio vacío."
 
-#: builtin/clone.c:1069
+#: builtin/clone.c:954
 #, c-format
 msgid "working tree '%s' already exists."
 msgstr "directorio de trabajo '%s' ya existe."
 
-#: builtin/clone.c:1084 builtin/clone.c:1105 builtin/difftool.c:272
-#: builtin/log.c:1997 builtin/worktree.c:280 builtin/worktree.c:312
+#: builtin/clone.c:969 builtin/clone.c:990 builtin/difftool.c:262
+#: builtin/log.c:1997 builtin/worktree.c:281 builtin/worktree.c:313
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "no se pudo crear directorios principales de '%s'"
 
-#: builtin/clone.c:1089
+#: builtin/clone.c:974
 #, c-format
 msgid "could not create work tree dir '%s'"
 msgstr "no se pudo crear un árbol de trabajo '%s'"
 
-#: builtin/clone.c:1109
+#: builtin/clone.c:994
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
 msgstr "Clonando en un repositorio vacío '%s'...\n"
 
-#: builtin/clone.c:1111
+#: builtin/clone.c:996
 #, c-format
 msgid "Cloning into '%s'...\n"
 msgstr "Clonando en '%s'...\n"
 
-#: builtin/clone.c:1135
+#: builtin/clone.c:1025
 msgid ""
 "clone --recursive is not compatible with both --reference and --reference-if-"
 "able"
@@ -13218,48 +13484,48 @@ msgstr ""
 "clone --recursive no es compatible con --reference y --reference-if-able al "
 "mismo tiempo"
 
-#: builtin/clone.c:1188 builtin/remote.c:200 builtin/remote.c:705
+#: builtin/clone.c:1080 builtin/remote.c:200 builtin/remote.c:710
 #, c-format
 msgid "'%s' is not a valid remote name"
 msgstr "'%s' no es un nombre remoto válido"
 
-#: builtin/clone.c:1229
+#: builtin/clone.c:1121
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr "--depth es ignorada en clonaciones locales; usa file:// más bien."
 
-#: builtin/clone.c:1231
+#: builtin/clone.c:1123
 msgid "--shallow-since is ignored in local clones; use file:// instead."
 msgstr ""
-"--shallow-since es ignorado en clonaciones locales; use file:// en su lugar."
+"--shallow-since es ignorado en clonaciones locales; usa file:// en su lugar."
 
-#: builtin/clone.c:1233
+#: builtin/clone.c:1125
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
 msgstr ""
-"--shallow-exclude es ignorado en clonaciones locales; use file:// en su "
+"--shallow-exclude es ignorado en clonaciones locales; usa file:// en su "
 "lugar."
 
-#: builtin/clone.c:1235
+#: builtin/clone.c:1127
 msgid "--filter is ignored in local clones; use file:// instead."
 msgstr "--filter es ignorado en clonaciones locales; usa file:// en su lugar."
 
-#: builtin/clone.c:1240
+#: builtin/clone.c:1132
 msgid "source repository is shallow, ignoring --local"
 msgstr "repositorio fuente es superficial, ignorando --local"
 
-#: builtin/clone.c:1245
+#: builtin/clone.c:1137
 msgid "--local is ignored"
 msgstr "--local es ignorado"
 
-#: builtin/clone.c:1324 builtin/clone.c:1383
+#: builtin/clone.c:1216 builtin/clone.c:1276
 msgid "remote transport reported error"
 msgstr "transporte remoto reportó error"
 
-#: builtin/clone.c:1336 builtin/clone.c:1344
+#: builtin/clone.c:1228 builtin/clone.c:1239
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "Rama remota %s no encontrada en upstream %s"
 
-#: builtin/clone.c:1347
+#: builtin/clone.c:1242
 msgid "You appear to have cloned an empty repository."
 msgstr "Pareces haber clonado un repositorio sin contenido."
 
@@ -13295,13 +13561,13 @@ msgstr "espacio padding entre columnas"
 msgid "--command must be the first argument"
 msgstr "--command debe ser el primer argumento"
 
-#: builtin/commit-graph.c:13 builtin/commit-graph.c:22
+#: builtin/commit-graph.c:13
 msgid ""
 "git commit-graph verify [--object-dir <objdir>] [--shallow] [--[no-]progress]"
 msgstr ""
 "git commit-graph verify [--object-dir <objdir>] [--shallow] [--[no-]progress]"
 
-#: builtin/commit-graph.c:14 builtin/commit-graph.c:27
+#: builtin/commit-graph.c:16
 msgid ""
 "git commit-graph write [--object-dir <objdir>] [--append] [--"
 "split[=<strategy>]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
@@ -13311,92 +13577,90 @@ msgstr ""
 "split[=<estrategia>]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
 "paths] [--[no-]max-new-filters <n>] [--[no-]progress] <opciones de split>"
 
-#: builtin/commit-graph.c:64
-#, c-format
-msgid "could not find object directory matching %s"
-msgstr "no se pudo encontrar el directorio de objetos concordante con %s"
-
-#: builtin/commit-graph.c:80 builtin/commit-graph.c:210
-#: builtin/commit-graph.c:316 builtin/fetch.c:191 builtin/log.c:1779
+#: builtin/commit-graph.c:51 builtin/fetch.c:191 builtin/log.c:1779
 msgid "dir"
 msgstr "dir"
 
-#: builtin/commit-graph.c:81 builtin/commit-graph.c:211
-#: builtin/commit-graph.c:317
+#: builtin/commit-graph.c:52
 msgid "the object directory to store the graph"
 msgstr "el directorio de objetos en que guardar el gráfico"
 
-#: builtin/commit-graph.c:83
+#: builtin/commit-graph.c:73
 msgid "if the commit-graph is split, only verify the tip file"
 msgstr "si el commit-graph está cortado, solo verifica el archivo tope"
 
-#: builtin/commit-graph.c:106
+#: builtin/commit-graph.c:100
 #, c-format
 msgid "Could not open commit-graph '%s'"
 msgstr "No se pudo abrir commit-graph '%s'"
 
-#: builtin/commit-graph.c:142
+#: builtin/commit-graph.c:137
 #, c-format
 msgid "unrecognized --split argument, %s"
 msgstr "argumento --split no reconocido, %s"
 
-#: builtin/commit-graph.c:155
+#: builtin/commit-graph.c:150
 #, c-format
 msgid "unexpected non-hex object ID: %s"
 msgstr "ID de objeto no hex inesperado: %s"
 
-#: builtin/commit-graph.c:160
+#: builtin/commit-graph.c:155
 #, c-format
 msgid "invalid object: %s"
 msgstr "no es un objeto válido: %s"
 
-#: builtin/commit-graph.c:213
+#: builtin/commit-graph.c:205
 msgid "start walk at all refs"
 msgstr "comenzar recorrido en todas las refs"
 
-#: builtin/commit-graph.c:215
+#: builtin/commit-graph.c:207
 msgid "scan pack-indexes listed by stdin for commits"
 msgstr "escanear paquete de índices por stdin por commits"
 
-#: builtin/commit-graph.c:217
+#: builtin/commit-graph.c:209
 msgid "start walk at commits listed by stdin"
 msgstr "comenzar recorrido a los commits listados por stdin"
 
-#: builtin/commit-graph.c:219
+#: builtin/commit-graph.c:211
 msgid "include all commits already in the commit-graph file"
-msgstr "incluye todos los commits que ya están en el archivo commit-graph"
+msgstr "incluir todos los commits que ya están en el archivo commit-graph"
 
-#: builtin/commit-graph.c:221
+#: builtin/commit-graph.c:213
 msgid "enable computation for changed paths"
 msgstr "habilitar computación para rutas cambiadas"
 
-#: builtin/commit-graph.c:224
+#: builtin/commit-graph.c:215
 msgid "allow writing an incremental commit-graph file"
 msgstr "permitir escribir un archivo commit-graph incremental"
 
-#: builtin/commit-graph.c:228
+#: builtin/commit-graph.c:219
 msgid "maximum number of commits in a non-base split commit-graph"
 msgstr "número máximo de commits en un commit-graph sin base cortada"
 
-#: builtin/commit-graph.c:230
+#: builtin/commit-graph.c:221
 msgid "maximum ratio between two levels of a split commit-graph"
 msgstr "razón máxima entre dos niveles de corte de commit-graph"
 
-#: builtin/commit-graph.c:232
+#: builtin/commit-graph.c:223
 msgid "only expire files older than a given date-time"
 msgstr "solo caducar objetos más viejos a una fecha dada"
 
-#: builtin/commit-graph.c:234
+#: builtin/commit-graph.c:225
 msgid "maximum number of changed-path Bloom filters to compute"
 msgstr "número máximo de cambios de ruta de filtro Bloom para computar"
 
-#: builtin/commit-graph.c:255
+#: builtin/commit-graph.c:251
 msgid "use at most one of --reachable, --stdin-commits, or --stdin-packs"
-msgstr "use como máximo uno de --reachable, --stdin-commits, o --stdin-packs"
+msgstr "usa como máximo uno de --reachable, --stdin-commits, o --stdin-packs"
 
-#: builtin/commit-graph.c:287
+#: builtin/commit-graph.c:282
 msgid "Collecting commits from input"
 msgstr "Recolectando commits del input"
+
+#: builtin/commit-graph.c:328 builtin/multi-pack-index.c:255
+#, c-format
+msgid "unrecognized subcommand: %s"
+msgstr "subcomando desconocido: %s"
 
 #: builtin/commit-tree.c:18
 msgid ""
@@ -13411,70 +13675,65 @@ msgstr ""
 msgid "duplicate parent %s ignored"
 msgstr "padre duplicado %s ignorado"
 
-#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:562
+#: builtin/commit-tree.c:56 builtin/commit-tree.c:134 builtin/log.c:562
 #, c-format
 msgid "not a valid object name %s"
 msgstr "no es un nombre de objeto válido %s"
 
-#: builtin/commit-tree.c:93
-#, c-format
-msgid "git commit-tree: failed to open '%s'"
-msgstr "git commit-tree: falló al abrir '%s'"
-
-#: builtin/commit-tree.c:96
+#: builtin/commit-tree.c:94
 #, c-format
 msgid "git commit-tree: failed to read '%s'"
 msgstr "git commit-tree: falló al leer '%s'"
 
-#: builtin/commit-tree.c:98
+#: builtin/commit-tree.c:96
 #, c-format
 msgid "git commit-tree: failed to close '%s'"
 msgstr "git commit-tree: falló al cerrar '%s'"
 
-#: builtin/commit-tree.c:111
+#: builtin/commit-tree.c:109
 msgid "parent"
 msgstr "padre"
 
-#: builtin/commit-tree.c:112
+#: builtin/commit-tree.c:110
 msgid "id of a parent commit object"
 msgstr "id del objeto commit padre"
 
-#: builtin/commit-tree.c:114 builtin/commit.c:1624 builtin/merge.c:282
-#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1601
-#: builtin/tag.c:456
+#: builtin/commit-tree.c:112 builtin/commit.c:1626 builtin/merge.c:283
+#: builtin/notes.c:407 builtin/notes.c:573 builtin/stash.c:1618
+#: builtin/tag.c:454
 msgid "message"
 msgstr "mensaje"
 
-#: builtin/commit-tree.c:115 builtin/commit.c:1624
+#: builtin/commit-tree.c:113 builtin/commit.c:1626
 msgid "commit message"
 msgstr "mensaje del commit"
 
-#: builtin/commit-tree.c:118
+#: builtin/commit-tree.c:116
 msgid "read commit log message from file"
 msgstr "leer mensaje de commit desde un archivo"
 
-#: builtin/commit-tree.c:121 builtin/commit.c:1641 builtin/merge.c:299
+#: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
 #: builtin/pull.c:176 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "Firmar commit con GPG"
 
-#: builtin/commit-tree.c:133
+#: builtin/commit-tree.c:131
 msgid "must give exactly one tree"
-msgstr "tiene que dar exactamente un árbol"
+msgstr "hay que dar exactamente un árbol"
 
-#: builtin/commit-tree.c:140
+#: builtin/commit-tree.c:138
 msgid "git commit-tree: failed to read"
 msgstr "git commit-tree: falló al leer"
 
-#: builtin/commit.c:41
+#: builtin/commit.c:42
 msgid "git commit [<options>] [--] <pathspec>..."
 msgstr "git commit [<opciones>] [--] <especificación-de-ruta>..."
 
-#: builtin/commit.c:46
+#: builtin/commit.c:47
 msgid "git status [<options>] [--] <pathspec>..."
 msgstr "git status [<opciones>] [--] <especificación-de-ruta>..."
 
-#: builtin/commit.c:51
+#: builtin/commit.c:52
 msgid ""
 "You asked to amend the most recent commit, but doing so would make\n"
 "it empty. You can repeat your command with --allow-empty, or you can\n"
@@ -13484,7 +13743,7 @@ msgstr ""
 "vaciaría. Puedes repetir el comando con --allow-empty, o puedes eliminar\n"
 "el commit completamente con \"git reset HEAD^\".\n"
 
-#: builtin/commit.c:56
+#: builtin/commit.c:57
 msgid ""
 "The previous cherry-pick is now empty, possibly due to conflict resolution.\n"
 "If you wish to commit it anyway, use:\n"
@@ -13499,15 +13758,15 @@ msgstr ""
 "    git commit --allow-empty\n"
 "\n"
 
-#: builtin/commit.c:63
+#: builtin/commit.c:64
 msgid "Otherwise, please use 'git rebase --skip'\n"
 msgstr "Caso contrario, por favor usa 'git rebase --skip'\n"
 
-#: builtin/commit.c:66
+#: builtin/commit.c:67
 msgid "Otherwise, please use 'git cherry-pick --skip'\n"
 msgstr "Caso contrario, por favor usa 'git cherry-pick --skip'\n"
 
-#: builtin/commit.c:69
+#: builtin/commit.c:70
 msgid ""
 "and then use:\n"
 "\n"
@@ -13529,73 +13788,73 @@ msgstr ""
 "     git cherry-pick --skip\n"
 "\n"
 
-#: builtin/commit.c:324
+#: builtin/commit.c:325
 msgid "failed to unpack HEAD tree object"
 msgstr "falló al desempaquetar objeto del árbol HEAD"
 
-#: builtin/commit.c:360
+#: builtin/commit.c:361
 msgid "--pathspec-from-file with -a does not make sense"
 msgstr "--pathspec-from-file con -a no tiene sentido"
 
-#: builtin/commit.c:374
+#: builtin/commit.c:375
 msgid "No paths with --include/--only does not make sense."
 msgstr "--include/--only sin ruta no tiene sentido."
 
-#: builtin/commit.c:386
+#: builtin/commit.c:387
 msgid "unable to create temporary index"
 msgstr "no es posible crear un índice temporal"
 
-#: builtin/commit.c:395
+#: builtin/commit.c:396
 msgid "interactive add failed"
 msgstr "adición interactiva fallida"
 
-#: builtin/commit.c:410
+#: builtin/commit.c:411
 msgid "unable to update temporary index"
 msgstr "no es posible actualizar el índice temporal"
 
-#: builtin/commit.c:412
+#: builtin/commit.c:413
 msgid "Failed to update main cache tree"
 msgstr "Falló al actualizar el árbol de caché principal"
 
-#: builtin/commit.c:437 builtin/commit.c:460 builtin/commit.c:508
+#: builtin/commit.c:438 builtin/commit.c:461 builtin/commit.c:509
 msgid "unable to write new_index file"
 msgstr "no es posible escribir archivo new_index"
 
-#: builtin/commit.c:489
+#: builtin/commit.c:490
 msgid "cannot do a partial commit during a merge."
 msgstr "no se puede realizar un commit parcial durante una fusión."
 
-#: builtin/commit.c:491
+#: builtin/commit.c:492
 msgid "cannot do a partial commit during a cherry-pick."
 msgstr "no se puede realizar un commit parcial durante un cherry-pick."
 
-#: builtin/commit.c:493
+#: builtin/commit.c:494
 msgid "cannot do a partial commit during a rebase."
 msgstr "no se puede realizar un commit parcial durante un rebase."
 
-#: builtin/commit.c:501
+#: builtin/commit.c:502
 msgid "cannot read the index"
 msgstr "no se puede leer el índice"
 
-#: builtin/commit.c:520
+#: builtin/commit.c:521
 msgid "unable to write temporary index file"
 msgstr "no es posible escribir el índice temporal"
 
-#: builtin/commit.c:618
+#: builtin/commit.c:619
 #, c-format
 msgid "commit '%s' lacks author header"
 msgstr "commit '%s' requiere cabecera de autor"
 
-#: builtin/commit.c:620
+#: builtin/commit.c:621
 #, c-format
 msgid "commit '%s' has malformed author line"
 msgstr "el commit '%s' tiene una línea de autor mal formada"
 
-#: builtin/commit.c:639
+#: builtin/commit.c:640
 msgid "malformed --author parameter"
 msgstr "parámetro --author mal formado"
 
-#: builtin/commit.c:692
+#: builtin/commit.c:693
 msgid ""
 "unable to select a comment character that is not used\n"
 "in the current commit message"
@@ -13603,43 +13862,43 @@ msgstr ""
 "no es posible seleccionar un carácter de comentario que no sea usado\n"
 "en el mensaje de commit actual"
 
-#: builtin/commit.c:746 builtin/commit.c:780 builtin/commit.c:1165
+#: builtin/commit.c:747 builtin/commit.c:781 builtin/commit.c:1166
 #, c-format
 msgid "could not lookup commit %s"
 msgstr "no se pudo revisar el commit %s"
 
-#: builtin/commit.c:758 builtin/shortlog.c:413
+#: builtin/commit.c:759 builtin/shortlog.c:416
 #, c-format
 msgid "(reading log message from standard input)\n"
 msgstr "(leyendo mensajes de logs desde standard input)\n"
 
-#: builtin/commit.c:760
+#: builtin/commit.c:761
 msgid "could not read log from standard input"
 msgstr "no se pudo leer log desde standard input"
 
-#: builtin/commit.c:764
+#: builtin/commit.c:765
 #, c-format
 msgid "could not read log file '%s'"
 msgstr "no se pudo leer el log '%s'"
 
-#: builtin/commit.c:801
+#: builtin/commit.c:802
 #, c-format
 msgid "cannot combine -m with --fixup:%s"
 msgstr "no se puede combinar -m con --fixup:%s"
 
-#: builtin/commit.c:813 builtin/commit.c:829
+#: builtin/commit.c:814 builtin/commit.c:830
 msgid "could not read SQUASH_MSG"
 msgstr "no se pudo leer SQUASH_MSG"
 
-#: builtin/commit.c:820
+#: builtin/commit.c:821
 msgid "could not read MERGE_MSG"
 msgstr "no se pudo leer MERGE_MSG"
 
-#: builtin/commit.c:880
+#: builtin/commit.c:881
 msgid "could not write commit template"
 msgstr "no se pudo escribir el template del commit"
 
-#: builtin/commit.c:893
+#: builtin/commit.c:894
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13648,7 +13907,7 @@ msgstr ""
 "Por favor ingresa el mensaje del commit para tus cambios. Las\n"
 " líneas que comiencen con '%c' serán ignoradas.\n"
 
-#: builtin/commit.c:895
+#: builtin/commit.c:896
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13658,17 +13917,17 @@ msgstr ""
 " líneas que comiencen con '%c' serán ignoradas, y un mensaje\n"
 " vacío aborta el commit.\n"
 
-#: builtin/commit.c:899
+#: builtin/commit.c:900
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
 "with '%c' will be kept; you may remove them yourself if you want to.\n"
 msgstr ""
 "Por favor ingresa el mensaje del commit para tus cambios. Las\n"
-" líneas que comiencen con '%c' serán guardadas; puede eliminarlas\n"
-" usted mismo si lo desea.\n"
+" líneas que comiencen con '%c' serán guardadas; puedes eliminarlas\n"
+" tú mismo si lo deseas.\n"
 
-#: builtin/commit.c:903
+#: builtin/commit.c:904
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13676,11 +13935,11 @@ msgid ""
 "An empty message aborts the commit.\n"
 msgstr ""
 "Por favor ingresa el mensaje del commit para tus cambios. Las\n"
-" líneas que comiencen con '%c' serán guardadas; puede eliminarlas\n"
-" usted mismo si lo desea.\n"
+" líneas que comiencen con '%c' serán guardadas; puedes eliminarlas\n"
+" tú mismo si lo deseas.\n"
 "Un mensaje vacío aborta el commit.\n"
 
-#: builtin/commit.c:915
+#: builtin/commit.c:916
 msgid ""
 "\n"
 "It looks like you may be committing a merge.\n"
@@ -13689,12 +13948,12 @@ msgid ""
 "and try again.\n"
 msgstr ""
 "\n"
-"Parece que está realizando una fusión.\n"
-"Si esto no es correcto, ejecute\n"
+"Parece que estás realizando una fusión.\n"
+"Si esto no es correcto, ejecuta\n"
 "\tgit update-ref -d MERGE_HEAD\n"
 "e intenta de nuevo.\n"
 
-#: builtin/commit.c:920
+#: builtin/commit.c:921
 msgid ""
 "\n"
 "It looks like you may be committing a cherry-pick.\n"
@@ -13703,78 +13962,78 @@ msgid ""
 "and try again.\n"
 msgstr ""
 "\n"
-"Parece que puede estar cometiendo una selección de cerezas.\n"
-"Si esto no es correcto, ejecute\n"
+"Parece que puedes estar cometiendo una selección de cerezas.\n"
+"Si esto no es correcto, ejecuta\n"
 "\tgit update-ref -d CHERRY_PICK_HEAD\n"
 "e intenta de nuevo.\n"
 
-#: builtin/commit.c:947
+#: builtin/commit.c:948
 #, c-format
 msgid "%sAuthor:    %.*s <%.*s>"
 msgstr "%sAutor:     %.*s <%.*s>"
 
-#: builtin/commit.c:955
+#: builtin/commit.c:956
 #, c-format
 msgid "%sDate:      %s"
 msgstr "%sFecha:     %s"
 
-#: builtin/commit.c:962
+#: builtin/commit.c:963
 #, c-format
 msgid "%sCommitter: %.*s <%.*s>"
 msgstr "%sCommitter: %.*s <%.*s>"
 
-#: builtin/commit.c:980
+#: builtin/commit.c:981
 msgid "Cannot read index"
 msgstr "No se puede leer el índice"
 
-#: builtin/commit.c:1025
+#: builtin/commit.c:1026
 msgid "unable to pass trailers to --trailers"
 msgstr "no se puede pasar trailers a --trailers"
 
-#: builtin/commit.c:1065
+#: builtin/commit.c:1066
 msgid "Error building trees"
 msgstr "Error al construir los árboles"
 
-#: builtin/commit.c:1079 builtin/tag.c:319
+#: builtin/commit.c:1080 builtin/tag.c:317
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr "Por favor suministra el mensaje usando las opciones -m o -F.\n"
 
-#: builtin/commit.c:1123
+#: builtin/commit.c:1124
 #, c-format
 msgid "--author '%s' is not 'Name <email>' and matches no existing author"
 msgstr ""
 "--author '%s' no está en el formato 'Name <email>' y no concuerda con ningún "
 "autor existente"
 
-#: builtin/commit.c:1137
+#: builtin/commit.c:1138
 #, c-format
 msgid "Invalid ignored mode '%s'"
 msgstr "Modo de ignorancia inválido '%s'"
 
-#: builtin/commit.c:1155 builtin/commit.c:1448
+#: builtin/commit.c:1156 builtin/commit.c:1450
 #, c-format
 msgid "Invalid untracked files mode '%s'"
 msgstr "Modo inválido de archivos no rastreados '%s'"
 
-#: builtin/commit.c:1195
+#: builtin/commit.c:1196
 msgid "--long and -z are incompatible"
 msgstr "--long y -z son incompatibles"
 
-#: builtin/commit.c:1226
+#: builtin/commit.c:1227
 msgid "You are in the middle of a merge -- cannot reword."
 msgstr "Estás en medio de una fusión -- no puedes renombrar."
 
-#: builtin/commit.c:1228
+#: builtin/commit.c:1229
 msgid "You are in the middle of a cherry-pick -- cannot reword."
-msgstr "Está en medio de un cherry-pick -- no se puede renombrar."
+msgstr "Estás en medio de un cherry-pick -- no se puede renombrar."
 
-#: builtin/commit.c:1231
+#: builtin/commit.c:1232
 #, c-format
 msgid "cannot combine reword option of --fixup with path '%s'"
 msgstr "no se puede combinar opción de renombrar de --fixup con ruta '%s'"
 
-#: builtin/commit.c:1233
+#: builtin/commit.c:1234
 msgid ""
 "reword option of --fixup is mutually exclusive with --patch/--interactive/--"
 "all/--include/--only"
@@ -13782,103 +14041,103 @@ msgstr ""
 "opción de refraseado de --fixup es mutuamente exclusiva con --patch/--"
 "interactive/--all/--include/--only"
 
-#: builtin/commit.c:1252
+#: builtin/commit.c:1253
 msgid "Using both --reset-author and --author does not make sense"
 msgstr "Usar ambos --reset-author y --author no tiene sentido"
 
-#: builtin/commit.c:1261
+#: builtin/commit.c:1260
 msgid "You have nothing to amend."
 msgstr "No tienes nada que enmendar."
 
-#: builtin/commit.c:1264
+#: builtin/commit.c:1263
 msgid "You are in the middle of a merge -- cannot amend."
 msgstr "Estás en medio de una fusión -- no puedes enmendar."
 
-#: builtin/commit.c:1266
+#: builtin/commit.c:1265
 msgid "You are in the middle of a cherry-pick -- cannot amend."
-msgstr "Está en medio de un cherry-pick -- no se puede enmendar."
+msgstr "Estás en medio de un cherry-pick -- no se puede enmendar."
 
-#: builtin/commit.c:1268
+#: builtin/commit.c:1267
 msgid "You are in the middle of a rebase -- cannot amend."
 msgstr "Estás en medio de una fusión -- no puedes enmendar."
 
-#: builtin/commit.c:1271
+#: builtin/commit.c:1270
 msgid "Options --squash and --fixup cannot be used together"
 msgstr "Opciones --squash y --fixup no pueden ser usadas juntas"
 
-#: builtin/commit.c:1281
+#: builtin/commit.c:1280
 msgid "Only one of -c/-C/-F/--fixup can be used."
 msgstr "Solo uno de -c/-C/-F/--fixup puede ser usado."
 
-#: builtin/commit.c:1283
+#: builtin/commit.c:1282
 msgid "Option -m cannot be combined with -c/-C/-F."
 msgstr "La opción -m no puede ser combinada con -c/-C/-F."
 
-#: builtin/commit.c:1292
+#: builtin/commit.c:1291
 msgid "--reset-author can be used only with -C, -c or --amend."
 msgstr "--reset-author solo puede ser usada con -C, -c o --amend."
 
-#: builtin/commit.c:1310
+#: builtin/commit.c:1309
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
 msgstr ""
 "Solo uno de --include/--only/--all/--interactive/--patch puede ser usado."
 
-#: builtin/commit.c:1338
+#: builtin/commit.c:1337
 #, c-format
 msgid "unknown option: --fixup=%s:%s"
 msgstr "opción desconocida: --fixup=%s:%s"
 
-#: builtin/commit.c:1352
+#: builtin/commit.c:1354
 #, c-format
 msgid "paths '%s ...' with -a does not make sense"
 msgstr "paths '%s ...' con -a no tiene sentido"
 
-#: builtin/commit.c:1483 builtin/commit.c:1652
+#: builtin/commit.c:1485 builtin/commit.c:1654
 msgid "show status concisely"
 msgstr "mostrar status de manera concisa"
 
-#: builtin/commit.c:1485 builtin/commit.c:1654
+#: builtin/commit.c:1487 builtin/commit.c:1656
 msgid "show branch information"
 msgstr "mostrar información de la rama"
 
-#: builtin/commit.c:1487
+#: builtin/commit.c:1489
 msgid "show stash information"
 msgstr "mostrar información del stash"
 
-#: builtin/commit.c:1489 builtin/commit.c:1656
+#: builtin/commit.c:1491 builtin/commit.c:1658
 msgid "compute full ahead/behind values"
 msgstr "calcular todos los valores delante/atrás"
 
-#: builtin/commit.c:1491
+#: builtin/commit.c:1493
 msgid "version"
-msgstr "version"
+msgstr "versión"
 
-#: builtin/commit.c:1491 builtin/commit.c:1658 builtin/push.c:551
-#: builtin/worktree.c:690
+#: builtin/commit.c:1493 builtin/commit.c:1660 builtin/push.c:551
+#: builtin/worktree.c:691
 msgid "machine-readable output"
 msgstr "output en formato de máquina"
 
-#: builtin/commit.c:1494 builtin/commit.c:1660
+#: builtin/commit.c:1496 builtin/commit.c:1662
 msgid "show status in long format (default)"
 msgstr "mostrar status en formato largo (default)"
 
-#: builtin/commit.c:1497 builtin/commit.c:1663
+#: builtin/commit.c:1499 builtin/commit.c:1665
 msgid "terminate entries with NUL"
 msgstr "terminar entradas con NUL"
 
-#: builtin/commit.c:1499 builtin/commit.c:1503 builtin/commit.c:1666
-#: builtin/fast-export.c:1198 builtin/fast-export.c:1201
-#: builtin/fast-export.c:1204 builtin/rebase.c:1407 parse-options.h:337
+#: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
+#: builtin/fast-export.c:1199 builtin/fast-export.c:1202
+#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:336
 msgid "mode"
 msgstr "modo"
 
-#: builtin/commit.c:1500 builtin/commit.c:1666
+#: builtin/commit.c:1502 builtin/commit.c:1668
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
 "mostrar archivos sin seguimiento, modos opcionales: all, normal, no. "
 "(Predeterminado: all)"
 
-#: builtin/commit.c:1504
+#: builtin/commit.c:1506
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
@@ -13886,11 +14145,11 @@ msgstr ""
 "mostrar archivos ignorados, modos opcionales: traditional, matching, no. "
 "(Predeterminado: traditional)"
 
-#: builtin/commit.c:1506 parse-options.h:193
+#: builtin/commit.c:1508 parse-options.h:192
 msgid "when"
 msgstr "cuando"
 
-#: builtin/commit.c:1507
+#: builtin/commit.c:1509
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
@@ -13898,202 +14157,202 @@ msgstr ""
 "ignorar cambios en submódulos, opcional cuando: all, dirty, untracked. "
 "(Default: all)"
 
-#: builtin/commit.c:1509
+#: builtin/commit.c:1511
 msgid "list untracked files in columns"
 msgstr "listar en columnas los archivos sin seguimiento"
 
-#: builtin/commit.c:1510
+#: builtin/commit.c:1512
 msgid "do not detect renames"
 msgstr "no detectar renombrados"
 
-#: builtin/commit.c:1512
+#: builtin/commit.c:1514
 msgid "detect renames, optionally set similarity index"
 msgstr "detectar renombrados, opcionalmente configurar similaridad de índice"
 
-#: builtin/commit.c:1535
+#: builtin/commit.c:1537
 msgid "Unsupported combination of ignored and untracked-files arguments"
 msgstr ""
 "Combinación de argumentos de archivos ignorados y no rastreados no soportada"
 
-#: builtin/commit.c:1617
+#: builtin/commit.c:1619
 msgid "suppress summary after successful commit"
-msgstr "suprime summary tras un commit exitoso"
+msgstr "suprimir summary tras un commit exitoso"
 
-#: builtin/commit.c:1618
+#: builtin/commit.c:1620
 msgid "show diff in commit message template"
 msgstr "mostrar diff en el template del mensaje de commit"
 
-#: builtin/commit.c:1620
+#: builtin/commit.c:1622
 msgid "Commit message options"
 msgstr "Opciones para el mensaje del commit"
 
-#: builtin/commit.c:1621 builtin/merge.c:286 builtin/tag.c:458
+#: builtin/commit.c:1623 builtin/merge.c:287 builtin/tag.c:456
 msgid "read message from file"
 msgstr "leer mensaje desde un archivo"
 
-#: builtin/commit.c:1622
+#: builtin/commit.c:1624
 msgid "author"
 msgstr "autor"
 
-#: builtin/commit.c:1622
+#: builtin/commit.c:1624
 msgid "override author for commit"
-msgstr "sobrescribe el autor del commit"
+msgstr "sobrescribir el autor del commit"
 
-#: builtin/commit.c:1623 builtin/gc.c:550
+#: builtin/commit.c:1625 builtin/gc.c:550
 msgid "date"
 msgstr "fecha"
 
-#: builtin/commit.c:1623
+#: builtin/commit.c:1625
 msgid "override date for commit"
-msgstr "sobrescribe la fecha del commit"
+msgstr "sobrescribir la fecha del commit"
 
-#: builtin/commit.c:1625 builtin/commit.c:1626 builtin/commit.c:1632
-#: parse-options.h:329 ref-filter.h:90
+#: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
+#: parse-options.h:328 ref-filter.h:92
 msgid "commit"
 msgstr "confirmar"
 
-#: builtin/commit.c:1625
+#: builtin/commit.c:1627
 msgid "reuse and edit message from specified commit"
 msgstr "reusar y editar el mensaje de un commit específico"
 
-#: builtin/commit.c:1626
+#: builtin/commit.c:1628
 msgid "reuse message from specified commit"
 msgstr "reusar el mensaje de un commit específico"
 
 #. TRANSLATORS: Leave "[(amend|reword):]" as-is,
 #. and only translate <commit>.
 #.
-#: builtin/commit.c:1631
+#: builtin/commit.c:1633
 msgid "[(amend|reword):]commit"
 msgstr "[(amend|reword):]commit"
 
-#: builtin/commit.c:1631
+#: builtin/commit.c:1633
 msgid ""
 "use autosquash formatted message to fixup or amend/reword specified commit"
 msgstr ""
-"usar mensaje de formato autosquash para arreglar el amend/renombrado del "
+"usar mensaje de formato autosquash para arreglar el amend/renombrado del "
 "commit especificado"
 
-#: builtin/commit.c:1632
+#: builtin/commit.c:1634
 msgid "use autosquash formatted message to squash specified commit"
 msgstr ""
 "usar el mensaje de formato autosquash para realizar squash al commit "
 "especificado"
 
-#: builtin/commit.c:1633
+#: builtin/commit.c:1635
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr "el autor del commit soy yo ahora (usado con -C/-c/--amend)"
 
-#: builtin/commit.c:1634 builtin/interpret-trailers.c:111
+#: builtin/commit.c:1636 builtin/interpret-trailers.c:111
 msgid "trailer"
 msgstr "trailer"
 
-#: builtin/commit.c:1634
+#: builtin/commit.c:1636
 msgid "add custom trailer(s)"
 msgstr "agregando trailer(s) personalizados"
 
-#: builtin/commit.c:1635 builtin/log.c:1754 builtin/merge.c:302
+#: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
 #: builtin/pull.c:145 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "agregar una línea Signed-off-by al final"
 
-#: builtin/commit.c:1636
+#: builtin/commit.c:1638
 msgid "use specified template file"
 msgstr "usar archivo de template especificado"
 
-#: builtin/commit.c:1637
+#: builtin/commit.c:1639
 msgid "force edit of commit"
 msgstr "forzar la edición del commit"
 
-#: builtin/commit.c:1639
+#: builtin/commit.c:1641
 msgid "include status in commit message template"
 msgstr "incluir status en el template del mensaje de commit"
 
-#: builtin/commit.c:1644
+#: builtin/commit.c:1646
 msgid "Commit contents options"
 msgstr "Opciones para el contenido del commit"
 
-#: builtin/commit.c:1645
+#: builtin/commit.c:1647
 msgid "commit all changed files"
 msgstr "confirmar todos los archivos cambiados"
 
-#: builtin/commit.c:1646
+#: builtin/commit.c:1648
 msgid "add specified files to index for commit"
 msgstr "agregar archivos específicos al índice para confirmar"
 
-#: builtin/commit.c:1647
+#: builtin/commit.c:1649
 msgid "interactively add files"
 msgstr "agregar archivos interactivamente"
 
-#: builtin/commit.c:1648
+#: builtin/commit.c:1650
 msgid "interactively add changes"
 msgstr "agregar cambios interactivamente"
 
-#: builtin/commit.c:1649
+#: builtin/commit.c:1651
 msgid "commit only specified files"
 msgstr "solo confirmar archivos específicos"
 
-#: builtin/commit.c:1650
+#: builtin/commit.c:1652
 msgid "bypass pre-commit and commit-msg hooks"
 msgstr "evitar los capturadores (hooks) de pre-commit y commit-msg"
 
-#: builtin/commit.c:1651
+#: builtin/commit.c:1653
 msgid "show what would be committed"
 msgstr "mostrar lo que sería incluido en el commit"
 
-#: builtin/commit.c:1664
+#: builtin/commit.c:1666
 msgid "amend previous commit"
 msgstr "enmendar commit previo"
 
-#: builtin/commit.c:1665
+#: builtin/commit.c:1667
 msgid "bypass post-rewrite hook"
-msgstr "salta el gancho de postreescritura"
+msgstr "saltar el gancho de postreescritura"
 
-#: builtin/commit.c:1672
+#: builtin/commit.c:1674
 msgid "ok to record an empty change"
 msgstr "vale grabar un cambio vacío"
 
-#: builtin/commit.c:1674
+#: builtin/commit.c:1676
 msgid "ok to record a change with an empty message"
 msgstr "vale grabar un cambio con un mensaje vacío"
 
-#: builtin/commit.c:1750
+#: builtin/commit.c:1752
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
 msgstr "Archivo MERGE_HEAD (%s) corrupto"
 
-#: builtin/commit.c:1757
+#: builtin/commit.c:1759
 msgid "could not read MERGE_MODE"
 msgstr "no se pudo leer MERGE_MODE"
 
-#: builtin/commit.c:1778
+#: builtin/commit.c:1780
 #, c-format
 msgid "could not read commit message: %s"
 msgstr "no se pudo leer el mensaje de commit: %s"
 
-#: builtin/commit.c:1785
+#: builtin/commit.c:1787
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
 msgstr "Abortando commit debido que el mensaje está en blanco.\n"
 
-#: builtin/commit.c:1790
+#: builtin/commit.c:1792
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
 msgstr "Abortando commit; no se ha editado el mensaje.\n"
 
-#: builtin/commit.c:1801
+#: builtin/commit.c:1803
 #, c-format
 msgid "Aborting commit due to empty commit message body.\n"
 msgstr "Abortando commit debido que el cuerpo del mensaje está en blanco.\n"
 
-#: builtin/commit.c:1837
+#: builtin/commit.c:1839
 msgid ""
 "repository has been updated, but unable to write\n"
 "new_index file. Check that disk is not full and quota is\n"
 "not exceeded, and then \"git restore --staged :/\" to recover."
 msgstr ""
 "el repositorio ha sido actualizado, pero no se pudo escribir el archivo\n"
-"new_index. Verifique que el disco no esté lleno y la cuota no haya\n"
+"new_index. Verifica que el disco no esté lleno y la cuota no haya\n"
 "sido superada, y luego \"git restore --staged :/\" para recuperar."
 
 #: builtin/config.c:11
@@ -14192,7 +14451,7 @@ msgstr "listar todo"
 
 #: builtin/config.c:149
 msgid "use string equality when comparing values to 'value-pattern'"
-msgstr "use la igualdad de cadenas al comparar valores con 'patrón de valor'"
+msgstr "usar la igualdad de cadenas al comparar valores con 'patrón de valor'"
 
 #: builtin/config.c:150
 msgid "open an editor"
@@ -14271,7 +14530,7 @@ msgstr "valor"
 
 #: builtin/config.c:167
 msgid "with --get, use default value when missing entry"
-msgstr "con --get, usa el valor por defecto cuando falta una entrada"
+msgstr "con --get, usar el valor por defecto cuando falta una entrada"
 
 #: builtin/config.c:181
 #, c-format
@@ -14357,7 +14616,7 @@ msgid ""
 msgstr ""
 "--worktree no puede ser usado con múltiples árboles de trabajo a menos que "
 "la\n"
-"extensión worktreeConfig esté habilitada. Por favor lea \"CONFIGURATION FILE"
+"extensión worktreeConfig esté habilitada. Por favor lee \"CONFIGURATION FILE"
 "\"\n"
 "en \"git help worktree\" para más detalles"
 
@@ -14417,7 +14676,7 @@ msgid ""
 "       Use a regexp, --add or --replace-all to change %s."
 msgstr ""
 "no se puede sobrescribir múltiples valores con un único valor\n"
-"       Use una regexp, --add o --replace-all para cambiar %s."
+"       Usa una regexp, --add o --replace-all para cambiar %s."
 
 #: builtin/config.c:943 builtin/config.c:954
 #, c-format
@@ -14454,7 +14713,7 @@ msgstr "mostrar mensajes de debug en stderr"
 msgid "credential-cache--daemon unavailable; no unix socket support"
 msgstr "credential-cache--daemon no disponible; sin soporte de socket Unix"
 
-#: builtin/credential-cache.c:154
+#: builtin/credential-cache.c:180
 msgid "credential-cache unavailable; no unix socket support"
 msgstr "credential-cache no disponible; sin soporte de socket Unix"
 
@@ -14516,7 +14775,7 @@ msgid ""
 "However, there were unannotated tags: try --tags."
 msgstr ""
 "No hay tags anotados que puedan describir '%s'.\n"
-"Sin embargo, hubieron tags no anotados: intente --tags."
+"Sin embargo, hubieron tags no anotados: intenta --tags."
 
 #: builtin/describe.c:428
 #, c-format
@@ -14525,7 +14784,7 @@ msgid ""
 "Try --always, or create some tags."
 msgstr ""
 "Ningún tag puede describir '%s'.\n"
-"Intente --always, o cree algunos tags."
+"Intenta --always, o crea algunos tags."
 
 #: builtin/describe.c:458
 #, c-format
@@ -14566,11 +14825,11 @@ msgstr "hacer debug a la estrategia de búsqueda en stderr"
 
 #: builtin/describe.c:556
 msgid "use any ref"
-msgstr "use cualquier ref"
+msgstr "usar cualquier ref"
 
 #: builtin/describe.c:557
 msgid "use any tag, even unannotated"
-msgstr "use cualquier tag, incluso los no anotados"
+msgstr "usar cualquier tag, incluso los no anotados"
 
 #: builtin/describe.c:558
 msgid "always use long format"
@@ -14649,13 +14908,13 @@ msgstr "opción inválida: %s"
 #: builtin/diff.c:376
 #, c-format
 msgid "%s...%s: no merge base"
-msgstr "%s...%s: se neceista una base de fusión"
+msgstr "%s...%s: se necesita una base de fusión"
 
 #: builtin/diff.c:486
 msgid "Not a git repository"
 msgstr "No es un repositorio git"
 
-#: builtin/diff.c:532 builtin/grep.c:684
+#: builtin/diff.c:532 builtin/grep.c:698
 #, c-format
 msgid "invalid object '%s' given."
 msgstr "objeto '%s' entregado no es válido."
@@ -14679,114 +14938,114 @@ msgstr "%s...%s: múltiples bases de fusión, usando %s"
 msgid "git difftool [<options>] [<commit> [<commit>]] [--] [<path>...]"
 msgstr "git difftool [<opciones>] [<commit> [<commit>]] [--] [<ruta>...]"
 
-#: builtin/difftool.c:261
-#, c-format
-msgid "failed: %d"
-msgstr "falló: %d"
-
-#: builtin/difftool.c:303
+#: builtin/difftool.c:293
 #, c-format
 msgid "could not read symlink %s"
 msgstr "no se pudo leer el symlink %s"
 
-#: builtin/difftool.c:305
+#: builtin/difftool.c:295
 #, c-format
 msgid "could not read symlink file %s"
 msgstr "no se pudo leer el archivo symlink %s"
 
-#: builtin/difftool.c:313
+#: builtin/difftool.c:303
 #, c-format
 msgid "could not read object %s for symlink %s"
 msgstr "no se pudo leer el objeto %s para el symlink %s"
 
-#: builtin/difftool.c:413
+#: builtin/difftool.c:427
 msgid ""
-"combined diff formats('-c' and '--cc') are not supported in\n"
-"directory diff mode('-d' and '--dir-diff')."
+"combined diff formats ('-c' and '--cc') are not supported in\n"
+"directory diff mode ('-d' and '--dir-diff')."
 msgstr ""
 "formatos combinados de diff ('-c' y '--cc') no soportados en\n"
 "modo diff para directorio('-d' y '--dir-diff')."
 
-#: builtin/difftool.c:637
+#: builtin/difftool.c:632
 #, c-format
 msgid "both files modified: '%s' and '%s'."
 msgstr "ambos archivos modificados: '%s' y '%s'."
 
-#: builtin/difftool.c:639
+#: builtin/difftool.c:634
 msgid "working tree file has been left."
 msgstr "archivo del árbol de trabajo ha sido dejado."
 
-#: builtin/difftool.c:650
+#: builtin/difftool.c:645
 #, c-format
 msgid "temporary files exist in '%s'."
 msgstr "archivo temporal existe en '%s'."
 
-#: builtin/difftool.c:651
+#: builtin/difftool.c:646
 msgid "you may want to cleanup or recover these."
 msgstr "tal vez desees limpiar o recuperar estos."
 
-#: builtin/difftool.c:699
-msgid "use `diff.guitool` instead of `diff.tool`"
-msgstr "use `diff.guitool` en lugar de `diff.tool`"
+#: builtin/difftool.c:651
+#, c-format
+msgid "failed: %d"
+msgstr "falló: %d"
 
-#: builtin/difftool.c:701
+#: builtin/difftool.c:696
+msgid "use `diff.guitool` instead of `diff.tool`"
+msgstr "usar `diff.guitool` en lugar de `diff.tool`"
+
+#: builtin/difftool.c:698
 msgid "perform a full-directory diff"
 msgstr "realizar un diff de todo el directorio"
 
-#: builtin/difftool.c:703
+#: builtin/difftool.c:700
 msgid "do not prompt before launching a diff tool"
 msgstr "no mostrar antes de lanzar una herramienta de diff"
 
-#: builtin/difftool.c:708
+#: builtin/difftool.c:705
 msgid "use symlinks in dir-diff mode"
 msgstr "usar enlaces simbólicos en modo dir-diff"
 
-#: builtin/difftool.c:709
+#: builtin/difftool.c:706
 msgid "tool"
 msgstr "herramienta"
 
-#: builtin/difftool.c:710
+#: builtin/difftool.c:707
 msgid "use the specified diff tool"
 msgstr "usar la herramienta de diff especificada"
 
-#: builtin/difftool.c:712
+#: builtin/difftool.c:709
 msgid "print a list of diff tools that may be used with `--tool`"
 msgstr ""
 "mostrar una lista de herramientas de diff que pueden ser usadas con `--tool`"
 
-#: builtin/difftool.c:715
+#: builtin/difftool.c:712
 msgid ""
-"make 'git-difftool' exit when an invoked diff tool returns a non - zero exit "
+"make 'git-difftool' exit when an invoked diff tool returns a non-zero exit "
 "code"
 msgstr ""
 "hacer que 'git-difftool' salga cuando una herramienta de diff retorne un "
 "código de salida distinto de cero"
 
-#: builtin/difftool.c:718
+#: builtin/difftool.c:715
 msgid "specify a custom command for viewing diffs"
 msgstr "especificar un comando personalizado para ver diffs"
 
-#: builtin/difftool.c:719
+#: builtin/difftool.c:716
 msgid "passed to `diff`"
 msgstr "pasado a `diff`"
 
-#: builtin/difftool.c:734
+#: builtin/difftool.c:732
 msgid "difftool requires worktree or --no-index"
 msgstr "difftool requiere un árbol de trabajo o --no-index"
 
-#: builtin/difftool.c:741
+#: builtin/difftool.c:739
 msgid "--dir-diff is incompatible with --no-index"
 msgstr "--dir-diff es incompatible con --no-index"
 
-#: builtin/difftool.c:744
+#: builtin/difftool.c:742
 msgid "--gui, --tool and --extcmd are mutually exclusive"
 msgstr "--gui, --tool y --extcmd son mutuamente exclusivas"
 
-#: builtin/difftool.c:752
+#: builtin/difftool.c:750
 msgid "no <tool> given for --tool=<tool>"
 msgstr "no se ha proporcionado <herramienta> para --tool=<herramienta>"
 
-#: builtin/difftool.c:759
+#: builtin/difftool.c:757
 msgid "no <cmd> given for --extcmd=<cmd>"
 msgstr "no se ha entregado <comando> para --extcmd=<comando>"
 
@@ -14794,7 +15053,7 @@ msgstr "no se ha entregado <comando> para --extcmd=<comando>"
 msgid "git env--helper --type=[bool|ulong] <options> <env-var>"
 msgstr "git env--helper --type=[bool|ulong] <opciones> <env-var>"
 
-#: builtin/env--helper.c:42 builtin/hash-object.c:98
+#: builtin/env--helper.c:42 builtin/hash-object.c:96
 msgid "type"
 msgstr "tipo"
 
@@ -14823,98 +15082,98 @@ msgstr ""
 msgid "git fast-export [rev-list-opts]"
 msgstr "git fast-export [rev-list-opts]"
 
-#: builtin/fast-export.c:868
+#: builtin/fast-export.c:869
 msgid "Error: Cannot export nested tags unless --mark-tags is specified."
 msgstr ""
 "Error: No se puede exportar los tags anidados a menos que --mark-tags sea "
 "especificado."
 
-#: builtin/fast-export.c:1177
+#: builtin/fast-export.c:1178
 msgid "--anonymize-map token cannot be empty"
 msgstr "token --anonymize-map no puede estar vacío"
 
-#: builtin/fast-export.c:1197
+#: builtin/fast-export.c:1198
 msgid "show progress after <n> objects"
 msgstr "mostrar progreso después de <n> objetos"
 
-#: builtin/fast-export.c:1199
+#: builtin/fast-export.c:1200
 msgid "select handling of signed tags"
 msgstr "seleccionar el manejo de tags firmados"
 
-#: builtin/fast-export.c:1202
+#: builtin/fast-export.c:1203
 msgid "select handling of tags that tag filtered objects"
 msgstr "seleccionar el manejo de tags que son tags de objetos filtrados"
 
-#: builtin/fast-export.c:1205
+#: builtin/fast-export.c:1206
 msgid "select handling of commit messages in an alternate encoding"
 msgstr "seleccionar el manejo de mensajes de commit en un encoding diferente"
 
-#: builtin/fast-export.c:1208
+#: builtin/fast-export.c:1209
 msgid "dump marks to this file"
 msgstr "volcar marcas a este archivo"
 
-#: builtin/fast-export.c:1210
+#: builtin/fast-export.c:1211
 msgid "import marks from this file"
 msgstr "importar marcas de este archivo"
 
-#: builtin/fast-export.c:1214
+#: builtin/fast-export.c:1215
 msgid "import marks from this file if it exists"
 msgstr "importar marcas de este archivo si existe"
 
-#: builtin/fast-export.c:1216
+#: builtin/fast-export.c:1217
 msgid "fake a tagger when tags lack one"
 msgstr "falsificar un tagger cuando les falta uno"
 
-#: builtin/fast-export.c:1218
+#: builtin/fast-export.c:1219
 msgid "output full tree for each commit"
 msgstr "mostrar todo el árbol para cada commit"
 
-#: builtin/fast-export.c:1220
-msgid "use the done feature to terminate the stream"
-msgstr "use el feature done para terminar el stream"
-
 #: builtin/fast-export.c:1221
-msgid "skip output of blob data"
-msgstr "saltar el salida de data blob"
+msgid "use the done feature to terminate the stream"
+msgstr "usar el feature done para terminar el stream"
 
-#: builtin/fast-export.c:1222 builtin/log.c:1826
+#: builtin/fast-export.c:1222
+msgid "skip output of blob data"
+msgstr "saltar la salida de data blob"
+
+#: builtin/fast-export.c:1223 builtin/log.c:1826
 msgid "refspec"
 msgstr "refspec"
 
-#: builtin/fast-export.c:1223
+#: builtin/fast-export.c:1224
 msgid "apply refspec to exported refs"
 msgstr "aplicar refspec para los refs exportados"
 
-#: builtin/fast-export.c:1224
+#: builtin/fast-export.c:1225
 msgid "anonymize output"
 msgstr "anonimizar la salida"
 
-#: builtin/fast-export.c:1225
+#: builtin/fast-export.c:1226
 msgid "from:to"
 msgstr "de:para"
 
-#: builtin/fast-export.c:1226
+#: builtin/fast-export.c:1227
 msgid "convert <from> to <to> in anonymized output"
 msgstr "convertir <de> a <para> en output anonimizado"
 
-#: builtin/fast-export.c:1229
+#: builtin/fast-export.c:1230
 msgid "reference parents which are not in fast-export stream by object id"
 msgstr ""
 "referir a los padres que no estén en fast-export stream por id de objeto"
 
-#: builtin/fast-export.c:1231
+#: builtin/fast-export.c:1232
 msgid "show original object ids of blobs/commits"
 msgstr "mostrar ids de objetos originales para blobs/commits"
 
-#: builtin/fast-export.c:1233
+#: builtin/fast-export.c:1234
 msgid "label tags with mark ids"
 msgstr "marcar tags con ids de mark"
 
-#: builtin/fast-export.c:1256
+#: builtin/fast-export.c:1257
 msgid "--anonymize-map without --anonymize does not make sense"
 msgstr "--anonymize-map sin --anonymize no tiene sentido"
 
-#: builtin/fast-export.c:1271
+#: builtin/fast-export.c:1272
 msgid "Cannot pass both --import-marks and --import-marks-if-exists"
 msgstr "No se puede pasar ambos --import-marks y --import-marks-if-exists"
 
@@ -15088,17 +15347,17 @@ msgstr "especificar extracción de refmap"
 
 #: builtin/fetch.c:208 builtin/pull.c:240
 msgid "report that we have only objects reachable from this object"
-msgstr "reporta que solo tenemos objetos alcanzables de este objeto"
+msgstr "reportar que solo tenemos objetos alcanzables de este objeto"
 
 #: builtin/fetch.c:210
 msgid "do not fetch a packfile; instead, print ancestors of negotiation tips"
 msgstr ""
-"no realizar fecth al packfile; en lugar de eso, mostrar los ancestros de las "
+"no realizar fetch al packfile; en lugar de eso, mostrar los ancestros de las "
 "puntas de negociación"
 
 #: builtin/fetch.c:213 builtin/fetch.c:215
 msgid "run 'maintenance --auto' after fetching"
-msgstr "ejecute 'maintenance --auto' después de buscar"
+msgstr "ejecutar 'maintenance --auto' después de buscar"
 
 #: builtin/fetch.c:217 builtin/pull.c:243
 msgid "check for forced-updates on all updated branches"
@@ -15116,73 +15375,73 @@ msgstr "aceptar refspecs de stdin"
 msgid "Couldn't find remote ref HEAD"
 msgstr "No se pudo encontrar ref remota HEAD"
 
-#: builtin/fetch.c:757
+#: builtin/fetch.c:760
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "la configuración fetch.output contiene el valor inválido %s"
 
-#: builtin/fetch.c:856
+#: builtin/fetch.c:862
 #, c-format
 msgid "object %s not found"
 msgstr "objeto %s no encontrado"
 
-#: builtin/fetch.c:860
+#: builtin/fetch.c:866
 msgid "[up to date]"
 msgstr "[actualizado]"
 
-#: builtin/fetch.c:873 builtin/fetch.c:889 builtin/fetch.c:961
+#: builtin/fetch.c:879 builtin/fetch.c:895 builtin/fetch.c:967
 msgid "[rejected]"
 msgstr "[rechazado]"
 
-#: builtin/fetch.c:874
+#: builtin/fetch.c:880
 msgid "can't fetch in current branch"
 msgstr "no se puede traer en la rama actual"
 
-#: builtin/fetch.c:884
+#: builtin/fetch.c:890
 msgid "[tag update]"
 msgstr "[actualización de tag]"
 
-#: builtin/fetch.c:885 builtin/fetch.c:922 builtin/fetch.c:944
-#: builtin/fetch.c:956
+#: builtin/fetch.c:891 builtin/fetch.c:928 builtin/fetch.c:950
+#: builtin/fetch.c:962
 msgid "unable to update local ref"
 msgstr "no es posible actualizar el ref local"
 
-#: builtin/fetch.c:889
+#: builtin/fetch.c:895
 msgid "would clobber existing tag"
 msgstr "sobrescribiría tag existente"
 
-#: builtin/fetch.c:911
+#: builtin/fetch.c:917
 msgid "[new tag]"
 msgstr "[nuevo tag]"
 
-#: builtin/fetch.c:914
+#: builtin/fetch.c:920
 msgid "[new branch]"
 msgstr "[nueva rama]"
 
-#: builtin/fetch.c:917
+#: builtin/fetch.c:923
 msgid "[new ref]"
 msgstr "[nueva referencia]"
 
-#: builtin/fetch.c:956
+#: builtin/fetch.c:962
 msgid "forced update"
 msgstr "actualización forzada"
 
-#: builtin/fetch.c:961
+#: builtin/fetch.c:967
 msgid "non-fast-forward"
 msgstr "avance no rápido"
 
-#: builtin/fetch.c:1065
+#: builtin/fetch.c:1070
 msgid ""
 "Fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled. To re-enable, use '--show-forced-updates'\n"
 "flag or run 'git config fetch.showForcedUpdates true'."
 msgstr ""
 "Fetch normalmente incida qué branches han tenido un update forzado,\n"
-"pero esa validación ha sido deshabilitada. Para activarla de nuevo use '--"
+"pero esa validación ha sido deshabilitada. Para activarla de nuevo usa '--"
 "show-forced-updates'\n"
-"o ejecute 'git config fetch.showForcedUpdates true'."
+"o ejecuta 'git config fetch.showForcedUpdates true'."
 
-#: builtin/fetch.c:1069
+#: builtin/fetch.c:1074
 #, c-format
 msgid ""
 "It took %.2f seconds to check forced updates. You can use\n"
@@ -15195,80 +15454,85 @@ msgstr ""
 "false'\n"
 "para evitar esta validación.\n"
 
-#: builtin/fetch.c:1101
+#: builtin/fetch.c:1105
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s no envió todos los objetos necesarios\n"
 
-#: builtin/fetch.c:1129
+#: builtin/fetch.c:1134
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr "rechazado %s porque raíces superficiales no pueden ser actualizada"
 
-#: builtin/fetch.c:1206 builtin/fetch.c:1357
+#: builtin/fetch.c:1223 builtin/fetch.c:1371
 #, c-format
 msgid "From %.*s\n"
 msgstr "Desde %.*s\n"
 
-#: builtin/fetch.c:1228
+#: builtin/fetch.c:1244
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
 " 'git remote prune %s' to remove any old, conflicting branches"
 msgstr ""
-"algunos refs locales no pudieron ser actualizados; intente ejecutar\n"
+"algunos refs locales no pudieron ser actualizados; intenta ejecutar\n"
 " 'git remote prune %s' para eliminar cualquier rama vieja o conflictiva"
 
-#: builtin/fetch.c:1327
+#: builtin/fetch.c:1341
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s se volverá colgante)"
 
-#: builtin/fetch.c:1328
+#: builtin/fetch.c:1342
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s se ha vuelto colgante)"
 
-#: builtin/fetch.c:1360
+#: builtin/fetch.c:1374
 msgid "[deleted]"
 msgstr "[eliminado]"
 
-#: builtin/fetch.c:1361 builtin/remote.c:1118
+#: builtin/fetch.c:1375 builtin/remote.c:1128
 msgid "(none)"
 msgstr "(nada)"
 
-#: builtin/fetch.c:1384
+#: builtin/fetch.c:1398
 #, c-format
 msgid "Refusing to fetch into current branch %s of non-bare repository"
 msgstr "Rehusando extraer en la rama actual %s de un repositorio no vacío"
 
-#: builtin/fetch.c:1403
+#: builtin/fetch.c:1417
 #, c-format
 msgid "Option \"%s\" value \"%s\" is not valid for %s"
 msgstr "Valor \"%2$s\" de opción \"%1$s\" no es válido para %3$s"
 
-#: builtin/fetch.c:1406
+#: builtin/fetch.c:1420
 #, c-format
 msgid "Option \"%s\" is ignored for %s\n"
 msgstr "Opción \"%s\" es ignorada por %s\n"
 
-#: builtin/fetch.c:1618
+#: builtin/fetch.c:1447
+#, c-format
+msgid "the object %s does not exist"
+msgstr "el objeto %s no existe"
+
+#: builtin/fetch.c:1633
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "múltiples ramas detectadas, incompatible con --set-upstream"
 
-#: builtin/fetch.c:1633
+#: builtin/fetch.c:1648
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "no configurar upstream para una rama de rastreo remoto"
 
-#: builtin/fetch.c:1635
+#: builtin/fetch.c:1650
 msgid "not setting upstream for a remote tag"
 msgstr "no configurar upstream para un tag remoto"
 
-#: builtin/fetch.c:1637
+#: builtin/fetch.c:1652
 msgid "unknown branch type"
 msgstr "tipo de branch desconocido"
 
-#: builtin/fetch.c:1639
+#: builtin/fetch.c:1654
 msgid ""
 "no source branch found.\n"
 "you need to specify exactly one branch with the --set-upstream option."
@@ -15276,79 +15540,79 @@ msgstr ""
 "no se encontró rama fuente.\n"
 "tienes que especificar exactamente una rama con la opción --set-upstream."
 
-#: builtin/fetch.c:1768 builtin/fetch.c:1831
+#: builtin/fetch.c:1783 builtin/fetch.c:1846
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Extrayendo %s\n"
 
-#: builtin/fetch.c:1778 builtin/fetch.c:1833 builtin/remote.c:101
+#: builtin/fetch.c:1793 builtin/fetch.c:1848 builtin/remote.c:101
 #, c-format
 msgid "Could not fetch %s"
 msgstr "No se pudo extraer %s"
 
-#: builtin/fetch.c:1790
+#: builtin/fetch.c:1805
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "no se pudo hacer fetch a '%s' (código de salida: %d)\n"
 
-#: builtin/fetch.c:1894
+#: builtin/fetch.c:1909
 msgid ""
 "No remote repository specified.  Please, specify either a URL or a\n"
 "remote name from which new revisions should be fetched."
 msgstr ""
-"No hay repositorio remoto especificado. Por favor, especifique un URL o un\n"
+"No hay repositorio remoto especificado. Por favor, especifica un URL o un\n"
 "nombre remoto del cual las nuevas revisiones deben ser extraídas."
 
-#: builtin/fetch.c:1930
+#: builtin/fetch.c:1945
 msgid "You need to specify a tag name."
 msgstr "Tienes que especificar un nombre de tag."
 
-#: builtin/fetch.c:1994
+#: builtin/fetch.c:2009
 msgid "--negotiate-only needs one or more --negotiate-tip=*"
 msgstr "--negotiate-only necesita uno o más --negotiate-tip=*"
 
-#: builtin/fetch.c:1998
+#: builtin/fetch.c:2013
 msgid "Negative depth in --deepen is not supported"
 msgstr "Profundidad negativa en --deepen no soportada"
 
-#: builtin/fetch.c:2000
+#: builtin/fetch.c:2015
 msgid "--deepen and --depth are mutually exclusive"
 msgstr "--deepen y --depth son mutuamente exclusivas"
 
-#: builtin/fetch.c:2005
+#: builtin/fetch.c:2020
 msgid "--depth and --unshallow cannot be used together"
 msgstr "--depth y --unshallow no pueden ser usadas juntas"
 
-#: builtin/fetch.c:2007
+#: builtin/fetch.c:2022
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "--unshallow no tiene sentido en un repositorio completo"
 
-#: builtin/fetch.c:2024
+#: builtin/fetch.c:2039
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all no toma un argumento de repositorio"
 
-#: builtin/fetch.c:2026
+#: builtin/fetch.c:2041
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all no tiene sentido con refspecs"
 
-#: builtin/fetch.c:2035
+#: builtin/fetch.c:2050
 #, c-format
 msgid "No such remote or remote group: %s"
 msgstr "No existe el remoto o grupo remoto: %s"
 
-#: builtin/fetch.c:2042
+#: builtin/fetch.c:2057
 msgid "Fetching a group and specifying refspecs does not make sense"
 msgstr "Extraer un grupo y especificar refspecs no tiene sentido"
 
-#: builtin/fetch.c:2058
+#: builtin/fetch.c:2073
 msgid "must supply remote when using --negotiate-only"
 msgstr "tiene que proveer un remoto cuando usa --negotiate-only"
 
-#: builtin/fetch.c:2063
+#: builtin/fetch.c:2078
 msgid "Protocol does not support --negotiate-only, exiting."
 msgstr "Protocolo no soporta --negotiate-only, saliendo."
 
-#: builtin/fetch.c:2082
+#: builtin/fetch.c:2097
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -15356,11 +15620,11 @@ msgstr ""
 "--filter solo puede ser usado con el remoto configurado en extensions."
 "partialclone"
 
-#: builtin/fetch.c:2086
+#: builtin/fetch.c:2101
 msgid "--atomic can only be used when fetching from one remote"
 msgstr "--atomic solo se puede usar cuando se busca desde un control remoto"
 
-#: builtin/fetch.c:2090
+#: builtin/fetch.c:2105
 msgid "--stdin can only be used when fetching from one remote"
 msgstr "--stdin solo se puede usar cuando se busca desde un control remoto"
 
@@ -15384,7 +15648,7 @@ msgstr "texto"
 
 #: builtin/fmt-merge-msg.c:25
 msgid "use <text> as start of message"
-msgstr "use <text> como comienzo de mensaje"
+msgstr "usar <text> como comienzo de mensaje"
 
 #: builtin/fmt-merge-msg.c:26
 msgid "file to read from"
@@ -15408,25 +15672,25 @@ msgstr "git for-each-ref [--contains [<commit>]] [--no-contains [<commit>]]"
 
 #: builtin/for-each-ref.c:30
 msgid "quote placeholders suitably for shells"
-msgstr "cite los marcadores de posición adecuadamente para los shells"
+msgstr "entrecomillar los marcadores de posición adecuadamente para los shells"
 
 #: builtin/for-each-ref.c:32
 msgid "quote placeholders suitably for perl"
-msgstr "cite los marcadores de posición adecuadamente para perl"
+msgstr "entrecomillar los marcadores de posición adecuadamente para perl"
 
 #: builtin/for-each-ref.c:34
 msgid "quote placeholders suitably for python"
-msgstr "cite los marcadores de posición adecuadamente para python"
+msgstr "entrecomillar los marcadores de posición adecuadamente para python"
 
 #: builtin/for-each-ref.c:36
 msgid "quote placeholders suitably for Tcl"
-msgstr "cite los marcadores de posición adecuadamente para Tcl"
+msgstr "entrecomillar los marcadores de posición adecuadamente para Tcl"
 
 #: builtin/for-each-ref.c:39
 msgid "show only <n> matched refs"
 msgstr "mostrar solo <n> refs encontradas"
 
-#: builtin/for-each-ref.c:41 builtin/tag.c:483
+#: builtin/for-each-ref.c:41 builtin/tag.c:481
 msgid "respect format colors"
 msgstr "respetar los colores de formato"
 
@@ -15582,129 +15846,139 @@ msgstr "%s: no es un commit"
 msgid "notice: No default references"
 msgstr "aviso: No hay referencias por defecto"
 
-#: builtin/fsck.c:606
+#: builtin/fsck.c:621
+#, c-format
+msgid "%s: hash-path mismatch, found at: %s"
+msgstr "%s: hash-path no concuerda, encontrado en: %s"
+
+#: builtin/fsck.c:624
 #, c-format
 msgid "%s: object corrupt or missing: %s"
 msgstr "%s: objeto corrupto o no encontrado: %s"
 
-#: builtin/fsck.c:619
+#: builtin/fsck.c:628
+#, c-format
+msgid "%s: object is of unknown type '%s': %s"
+msgstr "%s: objeto de tipo desconocido '%s':%s"
+
+#: builtin/fsck.c:644
 #, c-format
 msgid "%s: object could not be parsed: %s"
 msgstr "%s: no se pudo analizar objeto: %s"
 
-#: builtin/fsck.c:639
+#: builtin/fsck.c:664
 #, c-format
 msgid "bad sha1 file: %s"
 msgstr "mal sha1 de archivo: %s"
 
-#: builtin/fsck.c:654
+#: builtin/fsck.c:685
 msgid "Checking object directory"
 msgstr "Revisando directorio de objetos"
 
-#: builtin/fsck.c:657
+#: builtin/fsck.c:688
 msgid "Checking object directories"
 msgstr "Revisando objetos directorios"
 
-#: builtin/fsck.c:672
+#: builtin/fsck.c:704
 #, c-format
 msgid "Checking %s link"
 msgstr "Revisando link %s"
 
-#: builtin/fsck.c:677 builtin/index-pack.c:864
+#: builtin/fsck.c:709 builtin/index-pack.c:859
 #, c-format
 msgid "invalid %s"
 msgstr "%s inválido"
 
-#: builtin/fsck.c:684
+#: builtin/fsck.c:716
 #, c-format
 msgid "%s points to something strange (%s)"
 msgstr "%s apunta a algo extraño (%s)"
 
-#: builtin/fsck.c:690
+#: builtin/fsck.c:722
 #, c-format
 msgid "%s: detached HEAD points at nothing"
 msgstr "%s: HEAD desacoplado no apunta a nada"
 
-#: builtin/fsck.c:694
+#: builtin/fsck.c:726
 #, c-format
 msgid "notice: %s points to an unborn branch (%s)"
 msgstr "aviso: %s apunta a un branch no nacido (%s)"
 
-#: builtin/fsck.c:706
+#: builtin/fsck.c:738
 msgid "Checking cache tree"
 msgstr "Revisando el tree caché"
 
-#: builtin/fsck.c:711
+#: builtin/fsck.c:743
 #, c-format
 msgid "%s: invalid sha1 pointer in cache-tree"
 msgstr "%s: puntero inválido sha1 en cache-tree"
 
-#: builtin/fsck.c:720
+#: builtin/fsck.c:752
 msgid "non-tree in cache-tree"
 msgstr "non-tree en cache-tree"
 
-#: builtin/fsck.c:751
+#: builtin/fsck.c:783
 msgid "git fsck [<options>] [<object>...]"
 msgstr "git fsck [<opciones>] [<objeto>...]"
 
-#: builtin/fsck.c:757
+#: builtin/fsck.c:789
 msgid "show unreachable objects"
 msgstr "mostrar objetos inalcanzables"
 
-#: builtin/fsck.c:758
+#: builtin/fsck.c:790
 msgid "show dangling objects"
 msgstr "mostrar objetos colgantes"
 
-#: builtin/fsck.c:759
+#: builtin/fsck.c:791
 msgid "report tags"
 msgstr "reportar tags"
 
-#: builtin/fsck.c:760
+#: builtin/fsck.c:792
 msgid "report root nodes"
 msgstr "reportar nodos raíz"
 
-#: builtin/fsck.c:761
+#: builtin/fsck.c:793
 msgid "make index objects head nodes"
 msgstr "hacer objetos índices cabezas de nodos"
 
-#: builtin/fsck.c:762
+#: builtin/fsck.c:794
 msgid "make reflogs head nodes (default)"
 msgstr "hacer reflogs cabeza de nodos (default)"
 
-#: builtin/fsck.c:763
+#: builtin/fsck.c:795
 msgid "also consider packs and alternate objects"
 msgstr "también considerar paquetes y objetos alternos"
 
-#: builtin/fsck.c:764
+#: builtin/fsck.c:796
 msgid "check only connectivity"
 msgstr "revisar solo conectividad"
 
-#: builtin/fsck.c:765 builtin/mktag.c:75
+#: builtin/fsck.c:797 builtin/mktag.c:76
 msgid "enable more strict checking"
 msgstr "habilitar revisión más estricta"
 
-#: builtin/fsck.c:767
+#: builtin/fsck.c:799
 msgid "write dangling objects in .git/lost-found"
 msgstr "escribir objetos colgantes en .git/lost-found"
 
-#: builtin/fsck.c:768 builtin/prune.c:134
+#: builtin/fsck.c:800 builtin/prune.c:134
 msgid "show progress"
 msgstr "mostrar progreso"
 
-#: builtin/fsck.c:769
+#: builtin/fsck.c:801
 msgid "show verbose names for reachable objects"
 msgstr "mostrar nombres verbosos de objetos alcanzables"
 
-#: builtin/fsck.c:828 builtin/index-pack.c:262
+#: builtin/fsck.c:861 builtin/index-pack.c:261
 msgid "Checking objects"
 msgstr "Revisando objetos"
 
-#: builtin/fsck.c:856
+#: builtin/fsck.c:889
 #, c-format
 msgid "%s: object missing"
 msgstr "%s: objeto faltante"
 
-#: builtin/fsck.c:867
+#: builtin/fsck.c:900
 #, c-format
 msgid "invalid parameter: expected sha1, got '%s'"
 msgstr "parámetro inválido: sha1 esperado, se obtuvo '%s'"
@@ -15728,7 +16002,7 @@ msgstr "falló al analizar '%s' valor '%s'"
 msgid "cannot stat '%s'"
 msgstr "no se puede hacer stat en '%s'"
 
-#: builtin/gc.c:496 builtin/notes.c:240 builtin/tag.c:573
+#: builtin/gc.c:496 builtin/notes.c:238 builtin/tag.c:574
 #, c-format
 msgid "cannot read '%s'"
 msgstr "no se puede leer '%s'"
@@ -15737,13 +16011,13 @@ msgstr "no se puede leer '%s'"
 #, c-format
 msgid ""
 "The last gc run reported the following. Please correct the root cause\n"
-"and remove %s.\n"
+"and remove %s\n"
 "Automatic cleanup will not be performed until the file is removed.\n"
 "\n"
 "%s"
 msgstr ""
 "El último gc reportó lo siguiente. Por favor corrige la causa\n"
-"y elimine %s.\n"
+"y elimina %s\n"
 "Limpieza automática no se realizará hasta que el archivo sea eliminado.\n"
 "\n"
 "%s"
@@ -15782,25 +16056,25 @@ msgstr "falló al analizar valor %s de prune expiry"
 #, c-format
 msgid "Auto packing the repository in background for optimum performance.\n"
 msgstr ""
-"Auto empaquetado del repositorio en segundo plano para un performance "
+"Auto empaquetado del repositorio en segundo plano para un rendimiento "
 "óptimo.\n"
 
 #: builtin/gc.c:609
 #, c-format
 msgid "Auto packing the repository for optimum performance.\n"
-msgstr "Auto empaquetado del repositorio para performance óptimo.\n"
+msgstr "Auto empaquetado del repositorio para rendimiento óptimo.\n"
 
 #: builtin/gc.c:610
 #, c-format
 msgid "See \"git help gc\" for manual housekeeping.\n"
-msgstr "Vea \"git help gc\" para limpieza manual.\n"
+msgstr "Mira \"git help gc\" para limpieza manual.\n"
 
 #: builtin/gc.c:650
 #, c-format
 msgid ""
 "gc is already running on machine '%s' pid %<PRIuMAX> (use --force if not)"
 msgstr ""
-"gc ya está ejecutándose en la máquina '%s' pid %<PRIuMAX> (use --force si no "
+"gc ya está ejecutándose en la máquina '%s' pid %<PRIuMAX> (usa --force si no "
 "es así)"
 
 #: builtin/gc.c:705
@@ -15825,151 +16099,191 @@ msgstr "--no-schedule no está permitido"
 msgid "unrecognized --schedule argument '%s'"
 msgstr "argumento --schedule no reconocido, '%s'"
 
-#: builtin/gc.c:869
+#: builtin/gc.c:868
 msgid "failed to write commit-graph"
 msgstr "no se pudo escribir el commit-graph"
 
-#: builtin/gc.c:905
+#: builtin/gc.c:904
 msgid "failed to prefetch remotes"
 msgstr "falló al hacer prefetch a los remotos"
 
-#: builtin/gc.c:1022
+#: builtin/gc.c:1020
 msgid "failed to start 'git pack-objects' process"
 msgstr "no se pudo iniciar el proceso 'git pack-objects'"
 
-#: builtin/gc.c:1039
+#: builtin/gc.c:1037
 msgid "failed to finish 'git pack-objects' process"
 msgstr "no se pudo finalizar el proceso 'git pack-objects'"
 
-#: builtin/gc.c:1091
+#: builtin/gc.c:1088
 msgid "failed to write multi-pack-index"
 msgstr "no se pudo escribir el índice de paquetes múltiples"
 
-#: builtin/gc.c:1109
+#: builtin/gc.c:1104
 msgid "'git multi-pack-index expire' failed"
 msgstr "'git multi-pack-index expire' falló"
 
-#: builtin/gc.c:1170
+#: builtin/gc.c:1163
 msgid "'git multi-pack-index repack' failed"
 msgstr "'git multi-pack-index repack' falló"
 
-#: builtin/gc.c:1179
+#: builtin/gc.c:1172
 msgid ""
 "skipping incremental-repack task because core.multiPackIndex is disabled"
 msgstr ""
 "omitiendo la tarea de reempaquetado incremental porque core.multiPackIndex "
 "está deshabilitado"
 
-#: builtin/gc.c:1283
+#: builtin/gc.c:1276
 #, c-format
 msgid "lock file '%s' exists, skipping maintenance"
 msgstr "el archivo de bloqueo '%s' existe, omitiendo el mantenimiento"
 
-#: builtin/gc.c:1313
+#: builtin/gc.c:1306
 #, c-format
 msgid "task '%s' failed"
 msgstr "tarea '%s' falló"
 
-#: builtin/gc.c:1395
+#: builtin/gc.c:1388
 #, c-format
 msgid "'%s' is not a valid task"
 msgstr "'%s' no es una tarea válida"
 
-#: builtin/gc.c:1400
+#: builtin/gc.c:1393
 #, c-format
 msgid "task '%s' cannot be selected multiple times"
-msgstr "tarea '%s' no puede ser seleccionada múltipes veces"
+msgstr "tarea '%s' no puede ser seleccionada múltiples veces"
 
-#: builtin/gc.c:1415
+#: builtin/gc.c:1408
 msgid "run tasks based on the state of the repository"
 msgstr "ejecutar tareas basadas en el estado del repositorio"
 
-#: builtin/gc.c:1416
+#: builtin/gc.c:1409
 msgid "frequency"
 msgstr "frecuencia"
 
-#: builtin/gc.c:1417
+#: builtin/gc.c:1410
 msgid "run tasks based on frequency"
 msgstr "ejecutar tareas basado en frecuencia"
 
-#: builtin/gc.c:1420
+#: builtin/gc.c:1413
 msgid "do not report progress or other information over stderr"
 msgstr "no reportar progreso u otra información por medio de stderr"
 
-#: builtin/gc.c:1421
+#: builtin/gc.c:1414
 msgid "task"
 msgstr "tarea"
 
-#: builtin/gc.c:1422
+#: builtin/gc.c:1415
 msgid "run a specific task"
 msgstr "ejecutar una tarea específica"
 
-#: builtin/gc.c:1439
+#: builtin/gc.c:1432
 msgid "use at most one of --auto and --schedule=<frequency>"
 msgstr "usar como máximo una de --auto y --schedule=<frecuencia>"
 
-#: builtin/gc.c:1482
+#: builtin/gc.c:1475
 msgid "failed to run 'git config'"
 msgstr "no pudo ejecutar 'git config'"
 
-#: builtin/gc.c:1547
+#: builtin/gc.c:1627
 #, c-format
 msgid "failed to expand path '%s'"
 msgstr "falló al expandir la ruta '%s'"
 
-#: builtin/gc.c:1576
+#: builtin/gc.c:1654 builtin/gc.c:1692
 msgid "failed to start launchctl"
 msgstr "falló al iniciar launchctl"
 
-#: builtin/gc.c:1613
+#: builtin/gc.c:1767 builtin/gc.c:2220
 #, c-format
 msgid "failed to create directories for '%s'"
 msgstr "falló al crear directorios para '%s'"
 
-#: builtin/gc.c:1674
+#: builtin/gc.c:1794
 #, c-format
 msgid "failed to bootstrap service %s"
 msgstr "falló al generar el servicio %s"
 
-#: builtin/gc.c:1745
+#: builtin/gc.c:1887
 msgid "failed to create temp xml file"
 msgstr "no se pudo crear el archivo temp xml"
 
-#: builtin/gc.c:1835
+#: builtin/gc.c:1977
 msgid "failed to start schtasks"
 msgstr "no se pudo iniciar schtasks"
 
-#: builtin/gc.c:1879
+#: builtin/gc.c:2046
 msgid "failed to run 'crontab -l'; your system might not support 'cron'"
 msgstr ""
 "no se pudo ejecutar 'crontab -l'; es posible que su sistema no soporte 'cron'"
 
-#: builtin/gc.c:1896
+#: builtin/gc.c:2063
 msgid "failed to run 'crontab'; your system might not support 'cron'"
 msgstr ""
 "no se pudo ejecutar 'crontab'; es posible que su sistema no soporte 'cron'"
 
-#: builtin/gc.c:1900
+#: builtin/gc.c:2067
 msgid "failed to open stdin of 'crontab'"
 msgstr "no se pudo abrir stdin de 'crontab'"
 
-#: builtin/gc.c:1942
+#: builtin/gc.c:2109
 msgid "'crontab' died"
 msgstr "'crontab' murió"
 
-#: builtin/gc.c:1976
+#: builtin/gc.c:2174
+msgid "failed to start systemctl"
+msgstr "falló al iniciar systemctl"
+
+#: builtin/gc.c:2184
+msgid "failed to run systemctl"
+msgstr "falló el ejecutar systemctl"
+
+#: builtin/gc.c:2193 builtin/gc.c:2198 builtin/worktree.c:62
+#: builtin/worktree.c:945
+#, c-format
+msgid "failed to delete '%s'"
+msgstr "falló al borrar '%s'"
+
+#: builtin/gc.c:2378
+#, c-format
+msgid "unrecognized --scheduler argument '%s'"
+msgstr "argumento --scheduler no reconocido '%s'"
+
+#: builtin/gc.c:2403
+msgid "neither systemd timers nor crontab are available"
+msgstr "ni systemd ni crontab disponibles"
+
+#: builtin/gc.c:2418
+#, c-format
+msgid "%s scheduler is not available"
+msgstr "%s planificador no disponible"
+
+#: builtin/gc.c:2432
 msgid "another process is scheduling background maintenance"
 msgstr "otro proceso está programando el mantenimiento en segundo plano"
 
-#: builtin/gc.c:2000
+#: builtin/gc.c:2454
+msgid "git maintenance start [--scheduler=<scheduler>]"
+msgstr "git maintenance start [--scheduler=<planificador>]"
+
+#: builtin/gc.c:2463
+msgid "scheduler"
+msgstr "planificador"
+
+#: builtin/gc.c:2464
+msgid "scheduler to trigger git maintenance run"
+msgstr "planificador para iniciar git maintenance run"
+
+#: builtin/gc.c:2478
 msgid "failed to add repo to global config"
 msgstr "no se pudo agregar el repositorio a la configuración global"
 
-#: builtin/gc.c:2010
+#: builtin/gc.c:2487
 msgid "git maintenance <subcommand> [<options>]"
 msgstr "git maintenance <subcomando> [<opciones>]"
 
-#: builtin/gc.c:2029
+#: builtin/gc.c:2506
 #, c-format
 msgid "invalid subcommand: %s"
 msgstr "subcomando no válido: %s"
@@ -15978,12 +16292,12 @@ msgstr "subcomando no válido: %s"
 msgid "git grep [<options>] [-e] <pattern> [<rev>...] [[--] <path>...]"
 msgstr "git grep [<opciones>] [-e] <patrón> [<rev>...] [[--] <ruta>...]"
 
-#: builtin/grep.c:223
+#: builtin/grep.c:239
 #, c-format
 msgid "grep: failed to create thread: %s"
 msgstr "grep: falló al crear el hilo: %s"
 
-#: builtin/grep.c:277
+#: builtin/grep.c:293
 #, c-format
 msgid "invalid number of threads specified (%d) for %s"
 msgstr "número inválido de hilos especificado (%d) para %s"
@@ -15992,266 +16306,266 @@ msgstr "número inválido de hilos especificado (%d) para %s"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:285 builtin/index-pack.c:1588 builtin/index-pack.c:1791
-#: builtin/pack-objects.c:3129
+#: builtin/grep.c:301 builtin/index-pack.c:1582 builtin/index-pack.c:1785
+#: builtin/pack-objects.c:3142
 #, c-format
 msgid "no threads support, ignoring %s"
 msgstr "no hay soporte para hilos, ignorando %s"
 
-#: builtin/grep.c:473 builtin/grep.c:603 builtin/grep.c:643
+#: builtin/grep.c:488 builtin/grep.c:617 builtin/grep.c:657
 #, c-format
 msgid "unable to read tree (%s)"
 msgstr "no es posible leer el árbol (%s)"
 
-#: builtin/grep.c:658
+#: builtin/grep.c:672
 #, c-format
 msgid "unable to grep from object of type %s"
 msgstr "no es posible realizar grep del objeto de tipo %s"
 
-#: builtin/grep.c:738
+#: builtin/grep.c:752
 #, c-format
 msgid "switch `%c' expects a numerical value"
 msgstr "switch `%c' espera un valor numérico"
 
-#: builtin/grep.c:837
+#: builtin/grep.c:851
 msgid "search in index instead of in the work tree"
 msgstr "buscar en el índice en lugar del árbol de trabajo"
 
-#: builtin/grep.c:839
+#: builtin/grep.c:853
 msgid "find in contents not managed by git"
 msgstr "buscar en contenidos no manejados por git"
 
-#: builtin/grep.c:841
+#: builtin/grep.c:855
 msgid "search in both tracked and untracked files"
 msgstr "buscar en archivos rastreados y no rastreados"
 
-#: builtin/grep.c:843
+#: builtin/grep.c:857
 msgid "ignore files specified via '.gitignore'"
 msgstr "ignorar archivos especificados vía '.gitignore'"
 
-#: builtin/grep.c:845
+#: builtin/grep.c:859
 msgid "recursively search in each submodule"
 msgstr "búsqueda recursiva en cada submódulo"
 
-#: builtin/grep.c:848
+#: builtin/grep.c:862
 msgid "show non-matching lines"
 msgstr "mostrar líneas que no concuerden"
 
-#: builtin/grep.c:850
+#: builtin/grep.c:864
 msgid "case insensitive matching"
 msgstr "búsqueda insensible a mayúsculas"
 
-#: builtin/grep.c:852
+#: builtin/grep.c:866
 msgid "match patterns only at word boundaries"
 msgstr "concordar patrón solo a los límites de las palabras"
 
-#: builtin/grep.c:854
+#: builtin/grep.c:868
 msgid "process binary files as text"
 msgstr "procesar archivos binarios como texto"
 
-#: builtin/grep.c:856
+#: builtin/grep.c:870
 msgid "don't match patterns in binary files"
 msgstr "no concordar patrones en archivos binarios"
 
-#: builtin/grep.c:859
+#: builtin/grep.c:873
 msgid "process binary files with textconv filters"
 msgstr "procesar archivos binarios con filtros textconv"
 
-#: builtin/grep.c:861
+#: builtin/grep.c:875
 msgid "search in subdirectories (default)"
 msgstr "buscar en subdirectorios (default)"
 
-#: builtin/grep.c:863
+#: builtin/grep.c:877
 msgid "descend at most <depth> levels"
 msgstr "descender como máximo <valor-de-profundiad> niveles"
 
-#: builtin/grep.c:867
+#: builtin/grep.c:881
 msgid "use extended POSIX regular expressions"
 msgstr "usar expresiones regulares POSIX extendidas"
 
-#: builtin/grep.c:870
+#: builtin/grep.c:884
 msgid "use basic POSIX regular expressions (default)"
 msgstr "usar expresiones regulares POSIX (default)"
 
-#: builtin/grep.c:873
+#: builtin/grep.c:887
 msgid "interpret patterns as fixed strings"
 msgstr "interpretar patrones como strings fijos"
 
-#: builtin/grep.c:876
+#: builtin/grep.c:890
 msgid "use Perl-compatible regular expressions"
 msgstr "usar expresiones regulares compatibles con Perl"
 
-#: builtin/grep.c:879
+#: builtin/grep.c:893
 msgid "show line numbers"
 msgstr "mostrar números de línea"
 
-#: builtin/grep.c:880
+#: builtin/grep.c:894
 msgid "show column number of first match"
 msgstr "mostrar el número de columna de la primera coincidencia"
 
-#: builtin/grep.c:881
+#: builtin/grep.c:895
 msgid "don't show filenames"
 msgstr "no mostrar nombres de archivo"
 
-#: builtin/grep.c:882
+#: builtin/grep.c:896
 msgid "show filenames"
 msgstr "mostrar nombres de archivo"
 
-#: builtin/grep.c:884
+#: builtin/grep.c:898
 msgid "show filenames relative to top directory"
 msgstr "mostrar nombres de archivo relativos al directorio superior"
 
-#: builtin/grep.c:886
+#: builtin/grep.c:900
 msgid "show only filenames instead of matching lines"
 msgstr "mostrar solo nombres de archivos en lugar de líneas encontradas"
 
-#: builtin/grep.c:888
+#: builtin/grep.c:902
 msgid "synonym for --files-with-matches"
 msgstr "sinónimo para --files-with-matches"
 
-#: builtin/grep.c:891
+#: builtin/grep.c:905
 msgid "show only the names of files without match"
 msgstr "mostrar solo los nombres de archivos sin coincidencias"
 
-#: builtin/grep.c:893
+#: builtin/grep.c:907
 msgid "print NUL after filenames"
 msgstr "imprimir NUL después del nombre de archivo"
 
-#: builtin/grep.c:896
+#: builtin/grep.c:910
 msgid "show only matching parts of a line"
 msgstr "mostrar solo las partes que concuerden de una línea"
 
-#: builtin/grep.c:898
+#: builtin/grep.c:912
 msgid "show the number of matches instead of matching lines"
 msgstr "mostrar el número de concordancias en lugar de las líneas concordantes"
 
-#: builtin/grep.c:899
+#: builtin/grep.c:913
 msgid "highlight matches"
 msgstr "resaltar concordancias"
 
-#: builtin/grep.c:901
+#: builtin/grep.c:915
 msgid "print empty line between matches from different files"
 msgstr "imprimir una línea vacía entre coincidencias de diferentes archivos"
 
-#: builtin/grep.c:903
+#: builtin/grep.c:917
 msgid "show filename only once above matches from same file"
 msgstr ""
 "mostrar el nombre de archivo solo una vez para concordancias en el mismo "
 "archivo"
 
-#: builtin/grep.c:906
+#: builtin/grep.c:920
 msgid "show <n> context lines before and after matches"
 msgstr "mostrar <n> líneas de contexto antes y después de la concordancia"
 
-#: builtin/grep.c:909
+#: builtin/grep.c:923
 msgid "show <n> context lines before matches"
 msgstr "mostrar <n> líneas de contexto antes de las concordancias"
 
-#: builtin/grep.c:911
+#: builtin/grep.c:925
 msgid "show <n> context lines after matches"
 msgstr "mostrar <n> líneas de context después de las concordancias"
 
-#: builtin/grep.c:913
+#: builtin/grep.c:927
 msgid "use <n> worker threads"
 msgstr "usar <n> hilos de trabajo"
 
-#: builtin/grep.c:914
+#: builtin/grep.c:928
 msgid "shortcut for -C NUM"
 msgstr "atajo para -C NUM"
 
-#: builtin/grep.c:917
+#: builtin/grep.c:931
 msgid "show a line with the function name before matches"
 msgstr ""
 "mostrar una línea con el nombre de la función antes de las concordancias"
 
-#: builtin/grep.c:919
+#: builtin/grep.c:933
 msgid "show the surrounding function"
 msgstr "mostrar la función circundante"
 
-#: builtin/grep.c:922
+#: builtin/grep.c:936
 msgid "read patterns from file"
 msgstr "leer patrones del archivo"
 
-#: builtin/grep.c:924
+#: builtin/grep.c:938
 msgid "match <pattern>"
 msgstr "concordar <patrón>"
 
-#: builtin/grep.c:926
+#: builtin/grep.c:940
 msgid "combine patterns specified with -e"
 msgstr "combinar patrones especificados con -e"
 
-#: builtin/grep.c:938
+#: builtin/grep.c:952
 msgid "indicate hit with exit status without output"
 msgstr "indicar concordancia con exit status sin output"
 
-#: builtin/grep.c:940
+#: builtin/grep.c:954
 msgid "show only matches from files that match all patterns"
 msgstr ""
 "mostrar solo concordancias con archivos que concuerdan con todos los patrones"
 
-#: builtin/grep.c:943
+#: builtin/grep.c:957
 msgid "pager"
 msgstr "paginador"
 
-#: builtin/grep.c:943
+#: builtin/grep.c:957
 msgid "show matching files in the pager"
 msgstr "mostrar archivos concordantes en el paginador"
 
-#: builtin/grep.c:947
+#: builtin/grep.c:961
 msgid "allow calling of grep(1) (ignored by this build)"
 msgstr "permitir el llamado de grep(1) (ignorado por esta build)"
 
-#: builtin/grep.c:1013
+#: builtin/grep.c:1027
 msgid "no pattern given"
 msgstr "no se ha entregado ningún patrón"
 
-#: builtin/grep.c:1049
+#: builtin/grep.c:1063
 msgid "--no-index or --untracked cannot be used with revs"
 msgstr "--no-index o --untracked no se puede usar con revs"
 
-#: builtin/grep.c:1057
+#: builtin/grep.c:1071
 #, c-format
 msgid "unable to resolve revision: %s"
 msgstr "no es posible resolver revisión: %s"
 
-#: builtin/grep.c:1087
+#: builtin/grep.c:1101
 msgid "--untracked not supported with --recurse-submodules"
 msgstr "--untracked no es soportada con --recurse-submodules"
 
-#: builtin/grep.c:1091
+#: builtin/grep.c:1105
 msgid "invalid option combination, ignoring --threads"
 msgstr "combinación de opciones inválida, ignorando --threads"
 
-#: builtin/grep.c:1094 builtin/pack-objects.c:4090
+#: builtin/grep.c:1108 builtin/pack-objects.c:4059
 msgid "no threads support, ignoring --threads"
 msgstr "no se soportan hilos, ignorando --threads"
 
-#: builtin/grep.c:1097 builtin/index-pack.c:1585 builtin/pack-objects.c:3126
+#: builtin/grep.c:1111 builtin/index-pack.c:1579 builtin/pack-objects.c:3139
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "número inválido de hilos especificado (%d)"
 
-#: builtin/grep.c:1131
+#: builtin/grep.c:1145
 msgid "--open-files-in-pager only works on the worktree"
 msgstr "--open-files-in-pager solo funciona en el árbol de trabajo"
 
-#: builtin/grep.c:1157
+#: builtin/grep.c:1171
 msgid "--cached or --untracked cannot be used with --no-index"
 msgstr "--cached o --untracked no pueden ser usadas con --no-index"
 
-#: builtin/grep.c:1160
+#: builtin/grep.c:1174
 msgid "--untracked cannot be used with --cached"
 msgstr "--untracked no se puede usar con --cached"
 
-#: builtin/grep.c:1166
+#: builtin/grep.c:1180
 msgid "--[no-]exclude-standard cannot be used for tracked contents"
 msgstr "--[no-]exclude-standard no puede ser usada para contenido rastreado"
 
-#: builtin/grep.c:1174
+#: builtin/grep.c:1188
 msgid "both --cached and trees are given"
 msgstr "ambos --cached y árboles han sido entregados"
 
-#: builtin/hash-object.c:85
+#: builtin/hash-object.c:83
 msgid ""
 "git hash-object [-t <type>] [-w] [--path=<file> | --no-filters] [--stdin] "
 "[--] <file>..."
@@ -16259,439 +16573,442 @@ msgstr ""
 "git hash-object [-t <tipo>] [-w] [--path=<archivo> | --no-filters] [--stdin] "
 "[--] <archivo>..."
 
-#: builtin/hash-object.c:86
+#: builtin/hash-object.c:84
 msgid "git hash-object  --stdin-paths"
 msgstr "git hash-object  --stdin-paths"
 
-#: builtin/hash-object.c:98
+#: builtin/hash-object.c:96
 msgid "object type"
 msgstr "tipo de objeto"
 
-#: builtin/hash-object.c:99
+#: builtin/hash-object.c:97
 msgid "write the object into the object database"
 msgstr "escribir el objeto en la base de datos de objetos"
 
-#: builtin/hash-object.c:101
+#: builtin/hash-object.c:99
 msgid "read the object from stdin"
 msgstr "leer el objeto de stdin"
 
-#: builtin/hash-object.c:103
+#: builtin/hash-object.c:101
 msgid "store file as is without filters"
 msgstr "guardar el archivo tal cual sin filtros"
 
-#: builtin/hash-object.c:104
+#: builtin/hash-object.c:102
 msgid ""
 "just hash any random garbage to create corrupt objects for debugging Git"
 msgstr ""
 "solo realizar un hash a cualquier basura random para crear un objeto "
 "corrupto para hacer debugging de Git"
 
-#: builtin/hash-object.c:105
+#: builtin/hash-object.c:103
 msgid "process file as it were from this path"
 msgstr "procesar el archivo como si fuera de esta ruta"
 
-#: builtin/help.c:47
+#: builtin/help.c:55
 msgid "print all available commands"
 msgstr "mostrar todos los comandos disponibles"
 
-#: builtin/help.c:48
+#: builtin/help.c:57
 msgid "exclude guides"
 msgstr "excluir las guias"
 
-#: builtin/help.c:49
-msgid "print list of useful guides"
-msgstr "mostrar una lista de guías útiles"
-
-#: builtin/help.c:50
-msgid "print all configuration variable names"
-msgstr "imprimir todos los nombres de variables de configuración"
-
-#: builtin/help.c:52
+#: builtin/help.c:58
 msgid "show man page"
 msgstr "mostrar la página del manual"
 
-#: builtin/help.c:53
+#: builtin/help.c:59
 msgid "show manual in web browser"
 msgstr "mostrar la página del manual en un navegador web"
 
-#: builtin/help.c:55
+#: builtin/help.c:61
 msgid "show info page"
 msgstr "mostrar la página de info"
 
-#: builtin/help.c:57
+#: builtin/help.c:63
 msgid "print command description"
 msgstr "imprimir descripción del comando"
 
-#: builtin/help.c:62
-msgid "git help [--all] [--guides] [--man | --web | --info] [<command>]"
-msgstr "git help [--all] [--guides] [--man | --web | --info] [<comando>]"
+#: builtin/help.c:65
+msgid "print list of useful guides"
+msgstr "mostrar una lista de guías útiles"
 
-#: builtin/help.c:163
+#: builtin/help.c:67
+msgid "print all configuration variable names"
+msgstr "imprimir todos los nombres de variables de configuración"
+
+#: builtin/help.c:78
+msgid ""
+"git help [-a|--all] [--[no-]verbose]]\n"
+"         [[-i|--info] [-m|--man] [-w|--web]] [<command>]"
+msgstr ""
+"git help [-a|--all] [--[no-]verbose]]\n"
+"         [[-i|--info] [-m|--man] [-w|--web]] [<command>]"
+
+#: builtin/help.c:80
+msgid "git help [-g|--guides]"
+msgstr "git help [-g|--guides]"
+
+#: builtin/help.c:81
+msgid "git help [-c|--config]"
+msgstr "git help [-c|--config]"
+
+#: builtin/help.c:196
 #, c-format
 msgid "unrecognized help format '%s'"
 msgstr "formato help no reconocido '%s'"
 
-#: builtin/help.c:190
+#: builtin/help.c:223
 msgid "Failed to start emacsclient."
 msgstr "Falló al iniciar emacsclient."
 
-#: builtin/help.c:203
+#: builtin/help.c:236
 msgid "Failed to parse emacsclient version."
 msgstr "Falló al analizar la versión de emacsclient."
 
-#: builtin/help.c:211
+#: builtin/help.c:244
 #, c-format
 msgid "emacsclient version '%d' too old (< 22)."
 msgstr "la versión '%d' de emacsclient es demasiada antigua (<22)."
 
-#: builtin/help.c:229 builtin/help.c:251 builtin/help.c:261 builtin/help.c:269
+#: builtin/help.c:262 builtin/help.c:284 builtin/help.c:294 builtin/help.c:302
 #, c-format
 msgid "failed to exec '%s'"
 msgstr "falló al ejecutar '%s'"
 
-#: builtin/help.c:307
+#: builtin/help.c:340
 #, c-format
 msgid ""
 "'%s': path for unsupported man viewer.\n"
 "Please consider using 'man.<tool>.cmd' instead."
 msgstr ""
 "'%s': ruta para un visualizador del manual no soportado.\n"
-"Por favor considere usar 'man.<herramienta>.cmd'."
+"Por favor considera usar 'man.<herramienta>.cmd'."
 
-#: builtin/help.c:319
+#: builtin/help.c:352
 #, c-format
 msgid ""
 "'%s': cmd for supported man viewer.\n"
 "Please consider using 'man.<tool>.path' instead."
 msgstr ""
 "'%s': comando para man viewer soportado.\n"
-"Por favor considere usar 'man.<herramienta>.path."
+"Por favor considera usar 'man.<herramienta>.path."
 
-#: builtin/help.c:436
+#: builtin/help.c:467
 #, c-format
 msgid "'%s': unknown man viewer."
 msgstr "'%s': visualizador de man desconocido."
 
-#: builtin/help.c:452
+#: builtin/help.c:483
 msgid "no man viewer handled the request"
 msgstr "ningún visualizador de manual procesó la petición"
 
-#: builtin/help.c:459
+#: builtin/help.c:490
 msgid "no info viewer handled the request"
 msgstr "ningún visor de info manejó la petición"
 
-#: builtin/help.c:517 builtin/help.c:528 git.c:348
+#: builtin/help.c:551 builtin/help.c:562 git.c:348
 #, c-format
 msgid "'%s' is aliased to '%s'"
 msgstr "'%s' tiene el alias '%s'"
 
-#: builtin/help.c:531 git.c:380
+#: builtin/help.c:565 git.c:380
 #, c-format
 msgid "bad alias.%s string: %s"
 msgstr "mal alias.%s string: %s"
 
-#: builtin/help.c:561 builtin/help.c:591
+#: builtin/help.c:581
+msgid "this option doesn't take any other arguments"
+msgstr "esta opción no requiere argumentos"
+
+#: builtin/help.c:602 builtin/help.c:629
 #, c-format
 msgid "usage: %s%s"
 msgstr "uso: %s%s"
 
-#: builtin/help.c:575
+#: builtin/help.c:624
 msgid "'git help config' for more information"
 msgstr "'git help config' para más información"
 
-#: builtin/index-pack.c:222
+#: builtin/index-pack.c:221
 #, c-format
 msgid "object type mismatch at %s"
 msgstr "el tipo del objeto no concuerda en %s"
 
-#: builtin/index-pack.c:242
+#: builtin/index-pack.c:241
 #, c-format
 msgid "did not receive expected object %s"
 msgstr "no se recibió el objeto esperado %s"
 
-#: builtin/index-pack.c:245
+#: builtin/index-pack.c:244
 #, c-format
 msgid "object %s: expected type %s, found %s"
 msgstr "objeto %s: tipo esperado %s, encontrado %s"
 
-#: builtin/index-pack.c:295
+#: builtin/index-pack.c:294
 #, c-format
 msgid "cannot fill %d byte"
 msgid_plural "cannot fill %d bytes"
 msgstr[0] "no se puede llenar %d byte"
 msgstr[1] "no se pueden llenar %d bytes"
 
-#: builtin/index-pack.c:305
+#: builtin/index-pack.c:304
 msgid "early EOF"
 msgstr "EOF temprano"
 
-#: builtin/index-pack.c:306
+#: builtin/index-pack.c:305
 msgid "read error on input"
 msgstr "error al leer en input"
 
-#: builtin/index-pack.c:318
+#: builtin/index-pack.c:317
 msgid "used more bytes than were available"
 msgstr "se usaron más bytes de los disponibles"
 
-#: builtin/index-pack.c:325 builtin/pack-objects.c:756
+#: builtin/index-pack.c:324 builtin/pack-objects.c:756
 msgid "pack too large for current definition of off_t"
 msgstr "paquete demasiado grande para la definición actual de off_t"
 
-#: builtin/index-pack.c:328 builtin/unpack-objects.c:95
+#: builtin/index-pack.c:327 builtin/unpack-objects.c:95
 msgid "pack exceeds maximum allowed size"
 msgstr "paquete excede el máximo tamaño permitido"
 
-#: builtin/index-pack.c:343
-#, c-format
-msgid "unable to create '%s'"
-msgstr "no se puede crear '%s'"
-
-#: builtin/index-pack.c:349
-#, c-format
-msgid "cannot open packfile '%s'"
-msgstr "no se puede abrir el archivo de paquete '%s'"
-
-#: builtin/index-pack.c:363
+#: builtin/index-pack.c:358
 msgid "pack signature mismatch"
 msgstr "firma del paquete no concuerda"
 
-#: builtin/index-pack.c:365
+#: builtin/index-pack.c:360
 #, c-format
 msgid "pack version %<PRIu32> unsupported"
 msgstr "versión de paquete %<PRIu32> no soportada"
 
-#: builtin/index-pack.c:381
+#: builtin/index-pack.c:376
 #, c-format
 msgid "pack has bad object at offset %<PRIuMAX>: %s"
 msgstr "paquete tiene un mal objeto en el offset %<PRIuMAX>: %s"
 
-#: builtin/index-pack.c:487
+#: builtin/index-pack.c:482
 #, c-format
 msgid "inflate returned %d"
 msgstr "inflate devolvió %d"
 
-#: builtin/index-pack.c:536
+#: builtin/index-pack.c:531
 msgid "offset value overflow for delta base object"
 msgstr "valor de offset desbordado para el objeto base delta"
 
-#: builtin/index-pack.c:544
+#: builtin/index-pack.c:539
 msgid "delta base offset is out of bound"
 msgstr "offset de base delta está fuera de límites"
 
-#: builtin/index-pack.c:552
+#: builtin/index-pack.c:547
 #, c-format
 msgid "unknown object type %d"
 msgstr "tipo de objeto %d desconocido"
 
-#: builtin/index-pack.c:583
+#: builtin/index-pack.c:578
 msgid "cannot pread pack file"
 msgstr "no se puede hacer pread en el paquete"
 
-#: builtin/index-pack.c:585
+#: builtin/index-pack.c:580
 #, c-format
 msgid "premature end of pack file, %<PRIuMAX> byte missing"
 msgid_plural "premature end of pack file, %<PRIuMAX> bytes missing"
 msgstr[0] "final prematuro de archivo de paquete, %<PRIuMAX> byte faltante"
 msgstr[1] "final prematuro de archivo de paquete, %<PRIuMAX> bytes faltantes"
 
-#: builtin/index-pack.c:611
+#: builtin/index-pack.c:606
 msgid "serious inflate inconsistency"
 msgstr "inconsistencia seria en inflate"
 
-#: builtin/index-pack.c:756 builtin/index-pack.c:762 builtin/index-pack.c:786
-#: builtin/index-pack.c:825 builtin/index-pack.c:834
+#: builtin/index-pack.c:751 builtin/index-pack.c:757 builtin/index-pack.c:781
+#: builtin/index-pack.c:820 builtin/index-pack.c:829
 #, c-format
 msgid "SHA1 COLLISION FOUND WITH %s !"
 msgstr "¡ COLISIÓN DE SHA1 ENCONTRADA CON %s !"
 
-#: builtin/index-pack.c:759 builtin/pack-objects.c:292
+#: builtin/index-pack.c:754 builtin/pack-objects.c:292
 #: builtin/pack-objects.c:352 builtin/pack-objects.c:458
 #, c-format
 msgid "unable to read %s"
 msgstr "no es posible leer %s"
 
-#: builtin/index-pack.c:823
+#: builtin/index-pack.c:818
 #, c-format
 msgid "cannot read existing object info %s"
 msgstr "no se puede leer la información existente del objeto %s"
 
-#: builtin/index-pack.c:831
+#: builtin/index-pack.c:826
 #, c-format
 msgid "cannot read existing object %s"
 msgstr "no se puede leer el objeto existente %s"
 
-#: builtin/index-pack.c:845
+#: builtin/index-pack.c:840
 #, c-format
 msgid "invalid blob object %s"
 msgstr "objeto blob %s inválido"
 
-#: builtin/index-pack.c:848 builtin/index-pack.c:867
+#: builtin/index-pack.c:843 builtin/index-pack.c:862
 msgid "fsck error in packed object"
 msgstr "error de fsck en el objeto empaquetado"
 
-#: builtin/index-pack.c:869
+#: builtin/index-pack.c:864
 #, c-format
 msgid "Not all child objects of %s are reachable"
 msgstr "No todos los objetos hijos de %s son alcanzables"
 
-#: builtin/index-pack.c:930 builtin/index-pack.c:977
+#: builtin/index-pack.c:925 builtin/index-pack.c:972
 msgid "failed to apply delta"
 msgstr "falló al aplicar delta"
 
-#: builtin/index-pack.c:1160
+#: builtin/index-pack.c:1156
 msgid "Receiving objects"
 msgstr "Recibiendo objetos"
 
-#: builtin/index-pack.c:1160
+#: builtin/index-pack.c:1156
 msgid "Indexing objects"
 msgstr "Indexando objetos"
 
-#: builtin/index-pack.c:1194
+#: builtin/index-pack.c:1190
 msgid "pack is corrupted (SHA1 mismatch)"
 msgstr "paquete está corrompido (SHA1 no concuerda)"
 
-#: builtin/index-pack.c:1199
+#: builtin/index-pack.c:1195
 msgid "cannot fstat packfile"
 msgstr "no se puede fstat al archivo de paquete"
 
-#: builtin/index-pack.c:1202
+#: builtin/index-pack.c:1198
 msgid "pack has junk at the end"
 msgstr "el paquete tiene basura al final"
 
-#: builtin/index-pack.c:1214
+#: builtin/index-pack.c:1210
 msgid "confusion beyond insanity in parse_pack_objects()"
 msgstr "confusión más allá de la locura en parse_pack_objects()"
 
-#: builtin/index-pack.c:1237
+#: builtin/index-pack.c:1233
 msgid "Resolving deltas"
 msgstr "Resolviendo deltas"
 
-#: builtin/index-pack.c:1248 builtin/pack-objects.c:2892
+#: builtin/index-pack.c:1244 builtin/pack-objects.c:2905
 #, c-format
 msgid "unable to create thread: %s"
 msgstr "no es posible crear hilo: %s"
 
-#: builtin/index-pack.c:1281
+#: builtin/index-pack.c:1277
 msgid "confusion beyond insanity"
 msgstr "confusión más allá de la locura"
 
-#: builtin/index-pack.c:1287
+#: builtin/index-pack.c:1283
 #, c-format
 msgid "completed with %d local object"
 msgid_plural "completed with %d local objects"
 msgstr[0] "completado con %d objeto local"
 msgstr[1] "completado con %d objetos locales"
 
-#: builtin/index-pack.c:1299
+#: builtin/index-pack.c:1295
 #, c-format
 msgid "Unexpected tail checksum for %s (disk corruption?)"
 msgstr "Tail checksum para %s inesperada (¿corrupción de disco?)"
 
-#: builtin/index-pack.c:1303
+#: builtin/index-pack.c:1299
 #, c-format
 msgid "pack has %d unresolved delta"
 msgid_plural "pack has %d unresolved deltas"
 msgstr[0] "paquete tiene %d delta sin resolver"
 msgstr[1] "paquete tiene %d deltas sin resolver"
 
-#: builtin/index-pack.c:1327
+#: builtin/index-pack.c:1323
 #, c-format
 msgid "unable to deflate appended object (%d)"
 msgstr "no es posible desinflar el objeto adjunto (%d)"
 
-#: builtin/index-pack.c:1423
+#: builtin/index-pack.c:1419
 #, c-format
 msgid "local object %s is corrupt"
 msgstr "objeto local %s está corrompido"
 
-#: builtin/index-pack.c:1444
+#: builtin/index-pack.c:1440
 #, c-format
 msgid "packfile name '%s' does not end with '.%s'"
 msgstr "el nombre del archivo de paquete '%s' no termina con '.%s'"
 
-#: builtin/index-pack.c:1468
+#: builtin/index-pack.c:1464
 #, c-format
 msgid "cannot write %s file '%s'"
 msgstr "no se puede escribir archivo '%2$s' de %1$s"
 
-#: builtin/index-pack.c:1476
+#: builtin/index-pack.c:1472
 #, c-format
 msgid "cannot close written %s file '%s'"
 msgstr "no se puede cerrar el archivo escrito '%2$s' de %1$s"
 
-#: builtin/index-pack.c:1502
+#: builtin/index-pack.c:1489
+#, c-format
+msgid "unable to rename temporary '*.%s' file to '%s'"
+msgstr "no se pudo renombrar el archivo temporal '*.%s' a '%s'"
+
+#: builtin/index-pack.c:1514
 msgid "error while closing pack file"
 msgstr "error mientras se cerraba el archivo paquete"
 
-#: builtin/index-pack.c:1516
-msgid "cannot store pack file"
-msgstr "no se puede guardar el archivo paquete"
-
-#: builtin/index-pack.c:1524
-msgid "cannot store index file"
-msgstr "no se puede guardar el archivo índice"
-
-#: builtin/index-pack.c:1579 builtin/pack-objects.c:3137
+#: builtin/index-pack.c:1573 builtin/pack-objects.c:3150
 #, c-format
 msgid "bad pack.indexversion=%<PRIu32>"
 msgstr "mal pack.indexversion=%<PRIu32>"
 
-#: builtin/index-pack.c:1649
+#: builtin/index-pack.c:1643
 #, c-format
 msgid "Cannot open existing pack file '%s'"
 msgstr "No se puede abrir el archivo paquete existente '%s'"
 
-#: builtin/index-pack.c:1651
+#: builtin/index-pack.c:1645
 #, c-format
 msgid "Cannot open existing pack idx file for '%s'"
 msgstr "No se puede abrir el archivo índice del paquete para '%s'"
 
-#: builtin/index-pack.c:1699
+#: builtin/index-pack.c:1693
 #, c-format
 msgid "non delta: %d object"
 msgid_plural "non delta: %d objects"
 msgstr[0] "no delta: %d objeto"
 msgstr[1] "no delta: %d objetos"
 
-#: builtin/index-pack.c:1706
+#: builtin/index-pack.c:1700
 #, c-format
 msgid "chain length = %d: %lu object"
 msgid_plural "chain length = %d: %lu objects"
 msgstr[0] "largo de cadena = %d: %lu objeto"
 msgstr[1] "largo de cadena = %d: %lu objetos"
 
-#: builtin/index-pack.c:1748
+#: builtin/index-pack.c:1742
 msgid "Cannot come back to cwd"
 msgstr "No se puede regresar a cwd"
 
-#: builtin/index-pack.c:1802 builtin/index-pack.c:1805
-#: builtin/index-pack.c:1821 builtin/index-pack.c:1825
+#: builtin/index-pack.c:1796 builtin/index-pack.c:1799
+#: builtin/index-pack.c:1819 builtin/index-pack.c:1823
 #, c-format
 msgid "bad %s"
 msgstr "mal %s"
 
-#: builtin/index-pack.c:1831 builtin/init-db.c:379 builtin/init-db.c:614
+#: builtin/index-pack.c:1829 builtin/init-db.c:379 builtin/init-db.c:614
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "algoritmo hash desconocido '%s'"
 
-#: builtin/index-pack.c:1850
+#: builtin/index-pack.c:1848
 msgid "--fix-thin cannot be used without --stdin"
 msgstr "--fix-thin no puede ser usada sin --stdin"
 
-#: builtin/index-pack.c:1852
+#: builtin/index-pack.c:1850
 msgid "--stdin requires a git repository"
 msgstr "--stdin requiere un repositorio git"
 
-#: builtin/index-pack.c:1854
+#: builtin/index-pack.c:1852
 msgid "--object-format cannot be used with --stdin"
 msgstr "--object-format no se puede usar con --stdin"
 
-#: builtin/index-pack.c:1869
+#: builtin/index-pack.c:1867
 msgid "--verify with no packfile name given"
 msgstr "--verify no recibió ningún nombre de archivo de paquete"
 
-#: builtin/index-pack.c:1935 builtin/unpack-objects.c:584
+#: builtin/index-pack.c:1933 builtin/unpack-objects.c:584
 msgid "fsck error in pack objects"
 msgstr "error de fsck en objetos paquete"
 
@@ -16799,7 +17116,7 @@ msgstr "permisos"
 #: builtin/init-db.c:545
 msgid "specify that the git repository is to be shared amongst several users"
 msgstr ""
-"especifica que el repositorio de git será compartido entre varios usuarios"
+"especificar que el repositorio de git será compartido entre varios usuarios"
 
 #: builtin/init-db.c:551
 msgid "override the name of the initial branch"
@@ -17067,11 +17384,11 @@ msgstr "usando '%s' como origen de diferencia de rango de la serie actual"
 
 #: builtin/log.c:1749
 msgid "use [PATCH n/m] even with a single patch"
-msgstr "use [PATCH n/m] incluso con un único parche"
+msgstr "usar [PATCH n/m] incluso con un único parche"
 
 #: builtin/log.c:1752
 msgid "use [PATCH] even with multiple patches"
-msgstr "use [PATCH] incluso con múltiples parches"
+msgstr "usar [PATCH] incluso con múltiples parches"
 
 #: builtin/log.c:1756
 msgid "print patches to standard out"
@@ -17092,7 +17409,7 @@ msgstr "sfx"
 
 #: builtin/log.c:1762
 msgid "use <sfx> instead of '.patch'"
-msgstr "use <sfx> en lugar de '.patch'"
+msgstr "usar <sfx> en lugar de '.patch'"
 
 #: builtin/log.c:1764
 msgid "start numbering patches at <n> instead of 1"
@@ -17112,7 +17429,7 @@ msgstr "tamaño máximo de nombre de archivo resultante"
 
 #: builtin/log.c:1770
 msgid "use [RFC PATCH] instead of [PATCH]"
-msgstr "use [RFC PATCH] en lugar de [PATCH]"
+msgstr "usar [RFC PATCH] en lugar de [PATCH]"
 
 #: builtin/log.c:1773
 msgid "cover-from-description-mode"
@@ -17121,12 +17438,12 @@ msgstr "modo-cover-from-description"
 #: builtin/log.c:1774
 msgid "generate parts of a cover letter based on a branch's description"
 msgstr ""
-"genera partes de una carta de presentación basado en la descripción de la "
+"generar partes de una carta de presentación basadas en la descripción de la "
 "rama"
 
 #: builtin/log.c:1776
 msgid "use [<prefix>] instead of [PATCH]"
-msgstr "use [<prefijo>] en lugar de [PATCH]"
+msgstr "usar [<prefijo>] en lugar de [PATCH]"
 
 #: builtin/log.c:1779
 msgid "store resulting files in <dir>"
@@ -17146,7 +17463,7 @@ msgstr "poner hash de todos ceros en la cabecera From"
 
 #: builtin/log.c:1789
 msgid "don't include a patch matching a commit upstream"
-msgstr "no incluya un parche que coincida con un commit en upstream"
+msgstr "no incluir un parche que coincida con un commit en upstream"
 
 #: builtin/log.c:1791
 msgid "show patch format instead of default (patch + stat)"
@@ -17241,11 +17558,11 @@ msgstr "mostrar medidor de progreso mientras se generan los parches"
 
 #: builtin/log.c:1824
 msgid "show changes against <rev> in cover letter or single patch"
-msgstr "muestra cambios contra <rev> en cover letter o en un solo parche"
+msgstr "mostrar cambios contra <rev> en cover letter o en un solo parche"
 
 #: builtin/log.c:1827
 msgid "show changes against <refspec> in cover letter or single patch"
-msgstr "muestra cambios contra <refspec> en cover letter o en un solo parche"
+msgstr "mostrar cambios contra <refspec> en cover letter o en un solo parche"
 
 #: builtin/log.c:1829 builtin/range-diff.c:28
 msgid "percentage by which creation is weighted"
@@ -17332,134 +17649,138 @@ msgstr "git cherry [-v] [<upstream> [<head> [<límite>]]]"
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> manually.\n"
 msgstr ""
-"No se pudo encontrar una rama remota rastreada, por favor especifique "
+"No se pudo encontrar una rama remota rastreada, por favor especifica "
 "<upstream> manualmente.\n"
 
-#: builtin/ls-files.c:563
+#: builtin/ls-files.c:561
 msgid "git ls-files [<options>] [<file>...]"
 msgstr "git ls-files [<opciones>] [<archivo>...]"
 
-#: builtin/ls-files.c:619
-msgid "identify the file status with tags"
-msgstr "identifique el estado del archivo con tags"
+#: builtin/ls-files.c:615
+msgid "separate paths with the NUL character"
+msgstr "rutas están separadas con un carácter NULL"
 
-#: builtin/ls-files.c:621
+#: builtin/ls-files.c:617
+msgid "identify the file status with tags"
+msgstr "identificar el estado del archivo con tags"
+
+#: builtin/ls-files.c:619
 msgid "use lowercase letters for 'assume unchanged' files"
 msgstr "usar letras minúsculas para archivos 'asumidos sin cambios'"
 
-#: builtin/ls-files.c:623
+#: builtin/ls-files.c:621
 msgid "use lowercase letters for 'fsmonitor clean' files"
 msgstr "usar letras minúsculas para archivos de 'fsmonitor clean'"
 
-#: builtin/ls-files.c:625
+#: builtin/ls-files.c:623
 msgid "show cached files in the output (default)"
 msgstr "mostrar archivos en caché en la salida (default)"
 
-#: builtin/ls-files.c:627
+#: builtin/ls-files.c:625
 msgid "show deleted files in the output"
 msgstr "mostrar archivos borrados en la salida"
 
-#: builtin/ls-files.c:629
+#: builtin/ls-files.c:627
 msgid "show modified files in the output"
 msgstr "mostrar archivos modificados en la salida"
 
-#: builtin/ls-files.c:631
+#: builtin/ls-files.c:629
 msgid "show other files in the output"
 msgstr "mostrar otros archivos en la salida"
 
-#: builtin/ls-files.c:633
+#: builtin/ls-files.c:631
 msgid "show ignored files in the output"
 msgstr "mostrar archivos ignorados en la salida"
 
-#: builtin/ls-files.c:636
+#: builtin/ls-files.c:634
 msgid "show staged contents' object name in the output"
 msgstr "mostrar nombre de objeto del contenido del área de stage en la salida"
 
-#: builtin/ls-files.c:638
+#: builtin/ls-files.c:636
 msgid "show files on the filesystem that need to be removed"
 msgstr "mostrar archivos en el filesystem que necesiten ser borrados"
 
-#: builtin/ls-files.c:640
+#: builtin/ls-files.c:638
 msgid "show 'other' directories' names only"
 msgstr "mostrar solo nombres de 'otros' directorios"
 
-#: builtin/ls-files.c:642
+#: builtin/ls-files.c:640
 msgid "show line endings of files"
 msgstr "mostrar finales de línea de archivos"
 
-#: builtin/ls-files.c:644
+#: builtin/ls-files.c:642
 msgid "don't show empty directories"
 msgstr "no mostrar directorios vacíos"
 
-#: builtin/ls-files.c:647
+#: builtin/ls-files.c:645
 msgid "show unmerged files in the output"
 msgstr "mostrar archivos no fusionados en la salida"
 
-#: builtin/ls-files.c:649
+#: builtin/ls-files.c:647
 msgid "show resolve-undo information"
 msgstr "mostrar información resolver-deshacer"
 
-#: builtin/ls-files.c:651
+#: builtin/ls-files.c:649
 msgid "skip files matching pattern"
 msgstr "saltar archivos que concuerden con el patrón"
 
-#: builtin/ls-files.c:654
-msgid "exclude patterns are read from <file>"
-msgstr "excluir patrones leídos de <archivo>"
+#: builtin/ls-files.c:652
+msgid "read exclude patterns from <file>"
+msgstr "leer patrones exclude del archivo <archivo>"
 
-#: builtin/ls-files.c:657
+#: builtin/ls-files.c:655
 msgid "read additional per-directory exclude patterns in <file>"
 msgstr "leer patrones adicionales de exclusión por directorio en <archivo>"
 
-#: builtin/ls-files.c:659
+#: builtin/ls-files.c:657
 msgid "add the standard git exclusions"
 msgstr "agregar las exclusiones standard de git"
 
-#: builtin/ls-files.c:663
+#: builtin/ls-files.c:661
 msgid "make the output relative to the project top directory"
 msgstr "hacer la salida relativa al directorio principal del proyecto"
 
-#: builtin/ls-files.c:666
+#: builtin/ls-files.c:664
 msgid "recurse through submodules"
 msgstr "recurrir a través de submódulos"
 
-#: builtin/ls-files.c:668
+#: builtin/ls-files.c:666
 msgid "if any <file> is not in the index, treat this as an error"
 msgstr "si cualquier <archivo> no está en el índice, tratarlo como un error"
 
-#: builtin/ls-files.c:669
+#: builtin/ls-files.c:667
 msgid "tree-ish"
 msgstr "árbol-ismo"
 
-#: builtin/ls-files.c:670
+#: builtin/ls-files.c:668
 msgid "pretend that paths removed since <tree-ish> are still present"
 msgstr ""
 "fingir que las rutas hayan sido borradas ya que todavía hay <árbol-ismos> "
 "presentes"
 
-#: builtin/ls-files.c:672
+#: builtin/ls-files.c:670
 msgid "show debugging data"
 msgstr "mostrar data de debug"
 
-#: builtin/ls-files.c:674
+#: builtin/ls-files.c:672
 msgid "suppress duplicate entries"
 msgstr "suprimir entradas duplicadas"
 
 #: builtin/ls-remote.c:9
 msgid ""
 "git ls-remote [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
-"                     [-q | --quiet] [--exit-code] [--get-url]\n"
-"                     [--symref] [<repository> [<refs>...]]"
+"              [-q | --quiet] [--exit-code] [--get-url]\n"
+"              [--symref] [<repository> [<refs>...]]"
 msgstr ""
 "git ls-remote [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
-"                     [-q | --quiet] [--exit-code] [--get-url]\n"
-"                     [--symref] [<repositorio> [<refs>...]]"
+"              [-q | --quiet] [--exit-code] [--get-url]\n"
+"              [--symref] [<repositorio> [<refs>...]]"
 
 #: builtin/ls-remote.c:60
 msgid "do not print remote URL"
 msgstr "no mostrar el URL remoto"
 
-#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1399
+#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1103
 msgid "exec"
 msgstr "ejecutar"
 
@@ -17577,7 +17898,7 @@ msgstr "actión cuando se encuentra un CR citado"
 msgid "use headers in message's body"
 msgstr "usar cabeceras en el cuerpo del mensaje"
 
-#: builtin/mailsplit.c:241
+#: builtin/mailsplit.c:239
 #, c-format
 msgid "empty mbox: '%s'"
 msgstr "mbox vacío: '%s'"
@@ -17616,7 +17937,7 @@ msgstr "listar revs no alcanzables desde otros"
 
 #: builtin/merge-base.c:149
 msgid "is the first one ancestor of the other?"
-msgstr "¿es el primer ancestro del otro?"
+msgstr "¿es el primero ancestro del otro?"
 
 #: builtin/merge-base.c:151
 msgid "find where <commit> forked from reflog of <ref>"
@@ -17693,144 +18014,144 @@ msgstr "no se pudo resolver ref '%s'"
 msgid "Merging %s with %s\n"
 msgstr "Fusionando %s con %s\n"
 
-#: builtin/merge.c:58
+#: builtin/merge.c:59
 msgid "git merge [<options>] [<commit>...]"
 msgstr "git merge [<opciones>] [<commit>...]"
 
-#: builtin/merge.c:123
+#: builtin/merge.c:124
 msgid "switch `m' requires a value"
 msgstr "opción `m' requiere un valor"
 
-#: builtin/merge.c:146
+#: builtin/merge.c:147
 #, c-format
 msgid "option `%s' requires a value"
 msgstr "opción `%s' requiere un valor"
 
-#: builtin/merge.c:199
+#: builtin/merge.c:200
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
 msgstr "No se pudo encontrar estrategia de fusión '%s'.\n"
 
-#: builtin/merge.c:200
+#: builtin/merge.c:201
 #, c-format
 msgid "Available strategies are:"
 msgstr "Estrategias disponibles son:"
 
-#: builtin/merge.c:205
+#: builtin/merge.c:206
 #, c-format
 msgid "Available custom strategies are:"
 msgstr "Estrategias personalizadas disponibles son:"
 
-#: builtin/merge.c:256 builtin/pull.c:133
+#: builtin/merge.c:257 builtin/pull.c:133
 msgid "do not show a diffstat at the end of the merge"
 msgstr "no mostrar un diffstat al final de la fusión"
 
-#: builtin/merge.c:259 builtin/pull.c:136
+#: builtin/merge.c:260 builtin/pull.c:136
 msgid "show a diffstat at the end of the merge"
 msgstr "mostrar un diffstat al final de la fusión"
 
-#: builtin/merge.c:260 builtin/pull.c:139
+#: builtin/merge.c:261 builtin/pull.c:139
 msgid "(synonym to --stat)"
 msgstr "(sinónimo para --stat)"
 
-#: builtin/merge.c:262 builtin/pull.c:142
+#: builtin/merge.c:263 builtin/pull.c:142
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "agregar (como máximo <n>) entradas del shortlog al mensaje del commit de "
 "fusión"
 
-#: builtin/merge.c:265 builtin/pull.c:148
+#: builtin/merge.c:266 builtin/pull.c:148
 msgid "create a single commit instead of doing a merge"
 msgstr "crear un commit único en lugar de hacer una fusión"
 
-#: builtin/merge.c:267 builtin/pull.c:151
+#: builtin/merge.c:268 builtin/pull.c:151
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "realizar un commit si la fusión es exitosa (default)"
 
-#: builtin/merge.c:269 builtin/pull.c:154
+#: builtin/merge.c:270 builtin/pull.c:154
 msgid "edit message before committing"
 msgstr "editar mensaje antes de realizar commit"
 
-#: builtin/merge.c:271
+#: builtin/merge.c:272
 msgid "allow fast-forward (default)"
 msgstr "permitir fast-forward (default)"
 
-#: builtin/merge.c:273 builtin/pull.c:161
+#: builtin/merge.c:274 builtin/pull.c:161
 msgid "abort if fast-forward is not possible"
 msgstr "abortar si fast-forward no es posible"
 
-#: builtin/merge.c:277 builtin/pull.c:164
+#: builtin/merge.c:278 builtin/pull.c:164
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "verificar que el commit nombrado tenga una firma GPG válida"
 
-#: builtin/merge.c:278 builtin/notes.c:787 builtin/pull.c:168
-#: builtin/rebase.c:540 builtin/rebase.c:1413 builtin/revert.c:114
+#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:168
+#: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr "estrategia"
 
-#: builtin/merge.c:279 builtin/pull.c:169
+#: builtin/merge.c:280 builtin/pull.c:169
 msgid "merge strategy to use"
 msgstr "estrategia de fusión para usar"
 
-#: builtin/merge.c:280 builtin/pull.c:172
+#: builtin/merge.c:281 builtin/pull.c:172
 msgid "option=value"
 msgstr "opción=valor"
 
-#: builtin/merge.c:281 builtin/pull.c:173
+#: builtin/merge.c:282 builtin/pull.c:173
 msgid "option for selected merge strategy"
 msgstr "opción para la estrategia de fusión seleccionada"
 
-#: builtin/merge.c:283
+#: builtin/merge.c:284
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr "fusionar mensaje de commit (para una fusión no fast-forward)"
 
-#: builtin/merge.c:290
+#: builtin/merge.c:291
 msgid "abort the current in-progress merge"
 msgstr "abortar la fusión en progreso actual"
 
-#: builtin/merge.c:292
+#: builtin/merge.c:293
 msgid "--abort but leave index and working tree alone"
 msgstr "--abort pero no tocar el índice ni el árbol de trabajo"
 
-#: builtin/merge.c:294
+#: builtin/merge.c:295
 msgid "continue the current in-progress merge"
 msgstr "continuar la fusión en progreso actual"
 
-#: builtin/merge.c:296 builtin/pull.c:180
+#: builtin/merge.c:297 builtin/pull.c:180
 msgid "allow merging unrelated histories"
 msgstr "permitir fusionar historias no relacionadas"
 
-#: builtin/merge.c:303
+#: builtin/merge.c:304
 msgid "bypass pre-merge-commit and commit-msg hooks"
 msgstr "hacer un bypass a hooks pre-merge-commit y commit-msg"
 
-#: builtin/merge.c:320
+#: builtin/merge.c:321
 msgid "could not run stash."
 msgstr "no se pudo ejecutar stash."
 
-#: builtin/merge.c:325
+#: builtin/merge.c:326
 msgid "stash failed"
 msgstr "stash falló"
 
-#: builtin/merge.c:330
+#: builtin/merge.c:331
 #, c-format
 msgid "not a valid object: %s"
 msgstr "no es un objeto válido: %s"
 
-#: builtin/merge.c:352 builtin/merge.c:369
+#: builtin/merge.c:353 builtin/merge.c:370
 msgid "read-tree failed"
 msgstr "lectura de árbol falló"
 
-#: builtin/merge.c:400
+#: builtin/merge.c:401
 msgid "Already up to date. (nothing to squash)"
 msgstr "Ya está actualizado. (nada para hacer squash)"
 
-#: builtin/merge.c:414
+#: builtin/merge.c:415
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
 msgstr "Commit de squash -- no actualizando HEAD\n"
 
-#: builtin/merge.c:464
+#: builtin/merge.c:465
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
 msgstr "No hay mensaje de fusión -- no actualizando HEAD\n"
@@ -17845,48 +18166,48 @@ msgstr "'%s' no apunta a ningún commit"
 msgid "Bad branch.%s.mergeoptions string: %s"
 msgstr "Mal string branch.%s.mergeoptions: %s"
 
-#: builtin/merge.c:729
+#: builtin/merge.c:730
 msgid "Not handling anything other than two heads merge."
 msgstr "No manejando nada más que fusión de dos heads."
 
-#: builtin/merge.c:742
+#: builtin/merge.c:743
 #, c-format
-msgid "Unknown option for merge-recursive: -X%s"
-msgstr "Opción desconocida para merge-recursive: -X%s"
+msgid "unknown strategy option: -X%s"
+msgstr "opción de estrategia desconocida: -X%s"
 
-#: builtin/merge.c:761 t/helper/test-fast-rebase.c:223
+#: builtin/merge.c:762 t/helper/test-fast-rebase.c:223
 #, c-format
 msgid "unable to write %s"
 msgstr "no es posible escribir %s"
 
-#: builtin/merge.c:813
+#: builtin/merge.c:814
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "No se pudo leer de '%s'"
 
-#: builtin/merge.c:822
+#: builtin/merge.c:823
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
-"No se realiza commit de fusión; use 'git commit' para completar la fusión.\n"
+"No se realiza commit de fusión; usa 'git commit' para completar la fusión.\n"
 
-#: builtin/merge.c:828
+#: builtin/merge.c:829
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
 "\n"
 msgstr ""
-"Por favor ingrese un mensaje de commit que explique por qué es necesaria "
+"Por favor ingresa un mensaje de commit que explique por qué es necesaria "
 "esta fusión,\n"
 "especialmente si esto fusiona un upstream actualizado en una rama de "
 "tópico.\n"
 "\n"
 
-#: builtin/merge.c:833
+#: builtin/merge.c:834
 msgid "An empty message aborts the commit.\n"
 msgstr "Un mensaje vacío aborta el commit.\n"
 
-#: builtin/merge.c:836
+#: builtin/merge.c:837
 #, c-format
 msgid ""
 "Lines starting with '%c' will be ignored, and an empty message aborts\n"
@@ -17895,74 +18216,74 @@ msgstr ""
 "Líneas comenzando con '%c' serán ignoradas, y un mensaje vacío aborta\n"
 "el commit.\n"
 
-#: builtin/merge.c:889
+#: builtin/merge.c:892
 msgid "Empty commit message."
 msgstr "Mensaje de commit vacío."
 
-#: builtin/merge.c:904
+#: builtin/merge.c:907
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Maravilloso.\n"
 
-#: builtin/merge.c:965
+#: builtin/merge.c:968
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
 "Fusión automática falló; arregle los conflictos y luego realice un commit "
 "con el resultado.\n"
 
-#: builtin/merge.c:1004
+#: builtin/merge.c:1007
 msgid "No current branch."
 msgstr "No rama actual."
 
-#: builtin/merge.c:1006
+#: builtin/merge.c:1009
 msgid "No remote for the current branch."
 msgstr "No hay remoto para la rama actual."
 
-#: builtin/merge.c:1008
+#: builtin/merge.c:1011
 msgid "No default upstream defined for the current branch."
 msgstr "Por defecto, no hay un upstream definido para la rama actual."
 
-#: builtin/merge.c:1013
+#: builtin/merge.c:1016
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "No hay rama de rastreo remota para %s de %s"
 
-#: builtin/merge.c:1070
+#: builtin/merge.c:1073
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Valor erróneo '%s' en el entorno '%s'"
 
-#: builtin/merge.c:1173
+#: builtin/merge.c:1174
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "nada que podamos fusionar en %s: %s"
 
-#: builtin/merge.c:1207
+#: builtin/merge.c:1208
 msgid "not something we can merge"
 msgstr "nada que podamos fusionar"
 
-#: builtin/merge.c:1317
+#: builtin/merge.c:1321
 msgid "--abort expects no arguments"
 msgstr "--abort no espera argumentos"
 
-#: builtin/merge.c:1321
+#: builtin/merge.c:1325
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr "No hay una fusión para abortar (falta MERGE_HEAD)"
 
-#: builtin/merge.c:1339
+#: builtin/merge.c:1343
 msgid "--quit expects no arguments"
 msgstr "--quit no espera argumentos"
 
-#: builtin/merge.c:1352
+#: builtin/merge.c:1356
 msgid "--continue expects no arguments"
 msgstr "--continue no espera argumentos"
 
-#: builtin/merge.c:1356
+#: builtin/merge.c:1360
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "No hay fusión en progreso (falta MERGE_HEAD)."
 
-#: builtin/merge.c:1372
+#: builtin/merge.c:1376
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17970,7 +18291,7 @@ msgstr ""
 "No has concluido la fusión (existe MERGE_HEAD).\n"
 "Por favor, realiza un commit con los cambios antes de fusionar."
 
-#: builtin/merge.c:1379
+#: builtin/merge.c:1383
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17978,89 +18299,85 @@ msgstr ""
 "No has concluido el cherry-pick (existe CHERRY_PICK_HEAD).\n"
 "Por favor, realiza un commit con los cambios antes de fusionar."
 
-#: builtin/merge.c:1382
+#: builtin/merge.c:1386
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr "No has concluido el cherry-pick (existe CHERRY_PICK_HEAD)."
 
-#: builtin/merge.c:1396
+#: builtin/merge.c:1400
 msgid "You cannot combine --squash with --no-ff."
 msgstr "No se puede combinar --squash con --no-ff."
 
-#: builtin/merge.c:1398
+#: builtin/merge.c:1402
 msgid "You cannot combine --squash with --commit."
 msgstr "No se puede combinar --squash con --commit."
 
-#: builtin/merge.c:1414
+#: builtin/merge.c:1418
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr ""
 "No hay commit especificado y merge.defaultToUpstream no está configurado."
 
-#: builtin/merge.c:1431
+#: builtin/merge.c:1435
 msgid "Squash commit into empty head not supported yet"
 msgstr "Aplastar un commit a un head vacío no es soportado todavía"
 
-#: builtin/merge.c:1433
+#: builtin/merge.c:1437
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr "Commit no fast-forward no tiene sentido dentro de un head vacío"
 
-#: builtin/merge.c:1438
+#: builtin/merge.c:1442
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "%s - nada que podamos fusionar"
 
-#: builtin/merge.c:1440
+#: builtin/merge.c:1444
 msgid "Can merge only exactly one commit into empty head"
 msgstr "Solo se puede fusionar exactamente un commit en un head vacío"
 
-#: builtin/merge.c:1521
+#: builtin/merge.c:1531
 msgid "refusing to merge unrelated histories"
 msgstr "rehusando fusionar historias no relacionadas"
 
-#: builtin/merge.c:1540
+#: builtin/merge.c:1550
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "Actualizando %s..%s\n"
 
-#: builtin/merge.c:1587
+#: builtin/merge.c:1598
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "Intentando fusión en índice realmente trivial...\n"
 
-#: builtin/merge.c:1594
+#: builtin/merge.c:1605
 #, c-format
 msgid "Nope.\n"
 msgstr "No.\n"
 
-#: builtin/merge.c:1625
-msgid "Not possible to fast-forward, aborting."
-msgstr "No es posible hacer fast-forward, abortando."
-
-#: builtin/merge.c:1653 builtin/merge.c:1719
+#: builtin/merge.c:1664 builtin/merge.c:1730
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "Rebobinando el árbol a original...\n"
 
-#: builtin/merge.c:1657
+#: builtin/merge.c:1668
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Intentando estrategia de fusión %s...\n"
 
-#: builtin/merge.c:1709
+#: builtin/merge.c:1720
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Ninguna estrategia de fusión manejó la fusión.\n"
 
-#: builtin/merge.c:1711
+#: builtin/merge.c:1722
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "Fusionar con estrategia %s falló.\n"
 
-#: builtin/merge.c:1721
+#: builtin/merge.c:1732
 #, c-format
 msgid "Using the %s strategy to prepare resolving by hand.\n"
 msgstr "Usando estrategia %s para preparar resolución a mano.\n"
 
-#: builtin/merge.c:1735
+#: builtin/merge.c:1746
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
@@ -18095,15 +18412,15 @@ msgstr "no se pudo leer objeto etiquetado '%s'"
 msgid "object '%s' tagged as '%s', but is a '%s' type"
 msgstr "objeto '%s' es etiquetado como '%s', pero es de tipo '%s'"
 
-#: builtin/mktag.c:97
+#: builtin/mktag.c:98
 msgid "tag on stdin did not pass our strict fsck check"
 msgstr "etiqueta en stdin no pasó nuestro estricto control fsck"
 
-#: builtin/mktag.c:100
+#: builtin/mktag.c:101
 msgid "tag on stdin did not refer to a valid object"
 msgstr "tag en stdin no se refería a un objeto válido"
 
-#: builtin/mktag.c:103 builtin/tag.c:243
+#: builtin/mktag.c:104 builtin/tag.c:243
 msgid "unable to write tag file"
 msgstr "incapaz de escribir el archivo de tag"
 
@@ -18124,46 +18441,57 @@ msgid "allow creation of more than one tree"
 msgstr "permitir la creación de más de un árbol"
 
 #: builtin/multi-pack-index.c:10
-msgid "git multi-pack-index [<options>] write [--preferred-pack=<pack>]"
-msgstr "git multi-pack-index [<opciones>] write [--preferred-pack=<pack>]"
+msgid ""
+"git multi-pack-index [<options>] write [--preferred-pack=<pack>][--refs-"
+"snapshot=<path>]"
+msgstr ""
+"git multi-pack-index [<options>] write [--preferred-pack=<pack>][--refs-"
+"snapshot=<path>]"
 
-#: builtin/multi-pack-index.c:13
+#: builtin/multi-pack-index.c:14
 msgid "git multi-pack-index [<options>] verify"
 msgstr "git multi-pack-index [<opciones>] verify"
 
-#: builtin/multi-pack-index.c:16
+#: builtin/multi-pack-index.c:17
 msgid "git multi-pack-index [<options>] expire"
 msgstr "git multi-pack-index [<opciones>] expire"
 
-#: builtin/multi-pack-index.c:19
+#: builtin/multi-pack-index.c:20
 msgid "git multi-pack-index [<options>] repack [--batch-size=<size>]"
 msgstr "git multi-pack-index [<opciones>] repack [--batch-size=<tamaño>]"
 
-#: builtin/multi-pack-index.c:54
+#: builtin/multi-pack-index.c:57
 msgid "object directory containing set of packfile and pack-index pairs"
 msgstr ""
 "directorio de objetos conteniendo conjunto de pares de packfile y pack-index"
 
-#: builtin/multi-pack-index.c:69
+#: builtin/multi-pack-index.c:98
 msgid "preferred-pack"
 msgstr "pack preferido"
 
-#: builtin/multi-pack-index.c:70
+#: builtin/multi-pack-index.c:99
 msgid "pack for reuse when computing a multi-pack bitmap"
 msgstr "pack para reuso cuando se calcula un bitmap de múltiples packs"
 
-#: builtin/multi-pack-index.c:128
+#: builtin/multi-pack-index.c:100
+msgid "write multi-pack bitmap"
+msgstr "escribir bitmap multi-pack"
+
+#: builtin/multi-pack-index.c:105
+msgid "write multi-pack index containing only given indexes"
+msgstr "escribir el índice multi-pack que contenga los siguientes índices"
+
+#: builtin/multi-pack-index.c:107
+msgid "refs snapshot for selecting bitmap commits"
+msgstr "referencia los snapshots para seleccionar los commits de bitmap"
+
+#: builtin/multi-pack-index.c:202
 msgid ""
 "during repack, collect pack-files of smaller size into a batch that is "
 "larger than this size"
 msgstr ""
 "durante el repack, recolectar los pack-files de tamaño menor en un batch que "
 "sea más grande que este tamaño"
-
-#: builtin/multi-pack-index.c:179
-#, c-format
-msgid "unrecognized subcommand: %s"
-msgstr "subcomando desconocido: %s"
 
 #: builtin/mv.c:18
 msgid "git mv [<options>] <source>... <destination>"
@@ -18193,72 +18521,72 @@ msgstr "forzar mover/renombrar incluso si el destino existe"
 msgid "skip move/rename errors"
 msgstr "saltar errores de mover/renombrar"
 
-#: builtin/mv.c:170
+#: builtin/mv.c:172
 #, c-format
 msgid "destination '%s' is not a directory"
 msgstr "destino '%s' no es un directorio"
 
-#: builtin/mv.c:181
+#: builtin/mv.c:184
 #, c-format
 msgid "Checking rename of '%s' to '%s'\n"
 msgstr "Revisando cambio de nombre de '%s' a '%s'\n"
 
-#: builtin/mv.c:185
+#: builtin/mv.c:190
 msgid "bad source"
 msgstr "mala fuente"
 
-#: builtin/mv.c:188
+#: builtin/mv.c:193
 msgid "can not move directory into itself"
 msgstr "no se puede mover un directorio en sí mismo"
 
-#: builtin/mv.c:191
+#: builtin/mv.c:196
 msgid "cannot move directory over file"
 msgstr "no se puede mover un directorio dentro de un archivo"
 
-#: builtin/mv.c:200
+#: builtin/mv.c:205
 msgid "source directory is empty"
 msgstr "directorio de fuente está vacío"
 
-#: builtin/mv.c:225
+#: builtin/mv.c:231
 msgid "not under version control"
 msgstr "no se encuentra bajo control de versiones"
 
-#: builtin/mv.c:227
+#: builtin/mv.c:233
 msgid "conflicted"
 msgstr "en conflicto"
 
-#: builtin/mv.c:230
+#: builtin/mv.c:236
 msgid "destination exists"
 msgstr "destino existe"
 
-#: builtin/mv.c:238
+#: builtin/mv.c:244
 #, c-format
 msgid "overwriting '%s'"
 msgstr "sobrescribiendo '%s'"
 
-#: builtin/mv.c:241
+#: builtin/mv.c:247
 msgid "Cannot overwrite"
 msgstr "No se puede sobrescribir"
 
-#: builtin/mv.c:244
+#: builtin/mv.c:250
 msgid "multiple sources for the same target"
 msgstr "múltiples fuentes para el mismo destino"
 
-#: builtin/mv.c:246
+#: builtin/mv.c:252
 msgid "destination directory does not exist"
 msgstr "el directorio de destino no existe"
 
-#: builtin/mv.c:253
+#: builtin/mv.c:280
 #, c-format
 msgid "%s, source=%s, destination=%s"
 msgstr "%s, fuente=%s, destino=%s"
 
-#: builtin/mv.c:274
+#: builtin/mv.c:308
 #, c-format
 msgid "Renaming %s to %s\n"
 msgstr "Renombrando %s a %s\n"
 
-#: builtin/mv.c:280 builtin/remote.c:785 builtin/repack.c:667
+#: builtin/mv.c:314 builtin/remote.c:790 builtin/repack.c:853
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "renombrar '%s' falló"
@@ -18439,47 +18767,47 @@ msgstr "no se pudo leer salida de 'show'"
 msgid "failed to finish 'show' for object '%s'"
 msgstr "falló la finalización de 'show' para el objeto '%s'"
 
-#: builtin/notes.c:197
+#: builtin/notes.c:195
 msgid "please supply the note contents using either -m or -F option"
-msgstr "por favor suministrar los contenidos de nota usando la opción -m o -F"
+msgstr "por favor suministra los contenidos de nota usando la opción -m o -F"
 
-#: builtin/notes.c:206
+#: builtin/notes.c:204
 msgid "unable to write note object"
 msgstr "incapaz de escribir el objeto de nota"
 
-#: builtin/notes.c:208
+#: builtin/notes.c:206
 #, c-format
 msgid "the note contents have been left in %s"
 msgstr "los contenidos de nota han sido dejados en %s"
 
-#: builtin/notes.c:242 builtin/tag.c:576
+#: builtin/notes.c:240 builtin/tag.c:577
 #, c-format
 msgid "could not open or read '%s'"
 msgstr "no se pudo abrir o leer '%s'"
 
-#: builtin/notes.c:263 builtin/notes.c:313 builtin/notes.c:315
-#: builtin/notes.c:383 builtin/notes.c:438 builtin/notes.c:526
-#: builtin/notes.c:531 builtin/notes.c:610 builtin/notes.c:672
+#: builtin/notes.c:261 builtin/notes.c:311 builtin/notes.c:313
+#: builtin/notes.c:381 builtin/notes.c:436 builtin/notes.c:524
+#: builtin/notes.c:529 builtin/notes.c:608 builtin/notes.c:670
 #, c-format
 msgid "failed to resolve '%s' as a valid ref."
 msgstr "falló al resolver '%s' como ref válida."
 
-#: builtin/notes.c:265
+#: builtin/notes.c:263
 #, c-format
 msgid "failed to read object '%s'."
 msgstr "falló al leer objeto '%s'."
 
-#: builtin/notes.c:268
+#: builtin/notes.c:266
 #, c-format
 msgid "cannot read note data from non-blob object '%s'."
 msgstr "no se puede leer los datos de la nota de un objeto no blob '%s'."
 
-#: builtin/notes.c:309
+#: builtin/notes.c:307
 #, c-format
 msgid "malformed input line: '%s'."
 msgstr "línea de entrada mal formada: '%s'."
 
-#: builtin/notes.c:324
+#: builtin/notes.c:322
 #, c-format
 msgid "failed to copy notes from '%s' to '%s'"
 msgstr "falló al copiar notas de '%s' a '%s'"
@@ -18487,147 +18815,147 @@ msgstr "falló al copiar notas de '%s' a '%s'"
 #. TRANSLATORS: the first %s will be replaced by a git
 #. notes command: 'add', 'merge', 'remove', etc.
 #.
-#: builtin/notes.c:356
+#: builtin/notes.c:354
 #, c-format
 msgid "refusing to %s notes in %s (outside of refs/notes/)"
 msgstr "rechazando %s notas en %s (fuera de refs/notes/)"
 
-#: builtin/notes.c:376 builtin/notes.c:431 builtin/notes.c:509
-#: builtin/notes.c:521 builtin/notes.c:598 builtin/notes.c:665
-#: builtin/notes.c:815 builtin/notes.c:963 builtin/notes.c:985
-#: builtin/prune-packed.c:25 builtin/tag.c:586
+#: builtin/notes.c:374 builtin/notes.c:429 builtin/notes.c:507
+#: builtin/notes.c:519 builtin/notes.c:596 builtin/notes.c:663
+#: builtin/notes.c:813 builtin/notes.c:961 builtin/notes.c:983
+#: builtin/prune-packed.c:25 builtin/tag.c:587
 msgid "too many arguments"
-msgstr "muchos argumentos"
+msgstr "demasiados argumentos"
 
-#: builtin/notes.c:389 builtin/notes.c:678
+#: builtin/notes.c:387 builtin/notes.c:676
 #, c-format
 msgid "no note found for object %s."
 msgstr "no se encontraron notas para objeto %s."
 
-#: builtin/notes.c:410 builtin/notes.c:576
+#: builtin/notes.c:408 builtin/notes.c:574
 msgid "note contents as a string"
 msgstr "contenidos de la nota como cadena"
 
-#: builtin/notes.c:413 builtin/notes.c:579
+#: builtin/notes.c:411 builtin/notes.c:577
 msgid "note contents in a file"
 msgstr "contenidos de la nota en un archivo"
 
-#: builtin/notes.c:416 builtin/notes.c:582
+#: builtin/notes.c:414 builtin/notes.c:580
 msgid "reuse and edit specified note object"
 msgstr "reutilizar y editar el objeto de nota especificado"
 
-#: builtin/notes.c:419 builtin/notes.c:585
+#: builtin/notes.c:417 builtin/notes.c:583
 msgid "reuse specified note object"
 msgstr "reutilizar el objeto de nota especificado"
 
-#: builtin/notes.c:422 builtin/notes.c:588
+#: builtin/notes.c:420 builtin/notes.c:586
 msgid "allow storing empty note"
 msgstr "permitir almacenar nota vacía"
 
-#: builtin/notes.c:423 builtin/notes.c:496
+#: builtin/notes.c:421 builtin/notes.c:494
 msgid "replace existing notes"
 msgstr "reemplazar notas existentes"
 
-#: builtin/notes.c:448
+#: builtin/notes.c:446
 #, c-format
 msgid ""
 "Cannot add notes. Found existing notes for object %s. Use '-f' to overwrite "
 "existing notes"
 msgstr ""
-"No se puede agregar notas. Se encontró notas existentes para objeto %s. Use "
+"No se puede agregar notas. Se encontró notas existentes para objeto %s. Usa "
 "'-f' para sobrescribir las notas existentes"
 
-#: builtin/notes.c:463 builtin/notes.c:544
+#: builtin/notes.c:461 builtin/notes.c:542
 #, c-format
 msgid "Overwriting existing notes for object %s\n"
 msgstr "Sobrescribiendo notas existentes para objeto %s\n"
 
-#: builtin/notes.c:475 builtin/notes.c:637 builtin/notes.c:902
+#: builtin/notes.c:473 builtin/notes.c:635 builtin/notes.c:900
 #, c-format
 msgid "Removing note for object %s\n"
 msgstr "Quitando nota del objeto %s\n"
 
-#: builtin/notes.c:497
+#: builtin/notes.c:495
 msgid "read objects from stdin"
 msgstr "leer objetos desde stdin"
 
-#: builtin/notes.c:499
+#: builtin/notes.c:497
 msgid "load rewriting config for <command> (implies --stdin)"
 msgstr "cargar configuración de reescritura para <comando> (implica --stdin)"
 
-#: builtin/notes.c:517
+#: builtin/notes.c:515
 msgid "too few arguments"
 msgstr "demasiados pocos argumentos"
 
-#: builtin/notes.c:538
+#: builtin/notes.c:536
 #, c-format
 msgid ""
 "Cannot copy notes. Found existing notes for object %s. Use '-f' to overwrite "
 "existing notes"
 msgstr ""
 "No se puede copiar notas. Se encontró notas existentes para el objeto %s. "
-"Use '-f' para sobrescribir las notas existentes"
+"Usa '-f' para sobrescribir las notas existentes"
 
-#: builtin/notes.c:550
+#: builtin/notes.c:548
 #, c-format
 msgid "missing notes on source object %s. Cannot copy."
 msgstr "faltan notas en el objeto de fuente %s. No se puede copiar."
 
-#: builtin/notes.c:603
+#: builtin/notes.c:601
 #, c-format
 msgid ""
 "The -m/-F/-c/-C options have been deprecated for the 'edit' subcommand.\n"
 "Please use 'git notes add -f -m/-F/-c/-C' instead.\n"
 msgstr ""
 "Las opciones -m/-F/-c/-C han sido deprecadas por el subcomando 'edit'.\n"
-"Por favor use 'git notes add -f -m/-F/-c/-C' en cambio.\n"
+"Por favor usa 'git notes add -f -m/-F/-c/-C' en cambio.\n"
 
-#: builtin/notes.c:698
+#: builtin/notes.c:696
 msgid "failed to delete ref NOTES_MERGE_PARTIAL"
 msgstr "falló al borrar ref NOTES_MERGE_PARTIAL"
 
-#: builtin/notes.c:700
+#: builtin/notes.c:698
 msgid "failed to delete ref NOTES_MERGE_REF"
 msgstr "falló al borrar ref NOTES_MERGE_REF"
 
-#: builtin/notes.c:702
+#: builtin/notes.c:700
 msgid "failed to remove 'git notes merge' worktree"
 msgstr "no se pudo eliminar el árbol de trabajo 'git notes merge'"
 
-#: builtin/notes.c:722
+#: builtin/notes.c:720
 msgid "failed to read ref NOTES_MERGE_PARTIAL"
 msgstr "falló al leer ref NOTES_MERGE_PARTIAL"
 
-#: builtin/notes.c:724
+#: builtin/notes.c:722
 msgid "could not find commit from NOTES_MERGE_PARTIAL."
 msgstr "no se pudo encontrar commit de NOTES_MERGE_PARTIAL."
 
-#: builtin/notes.c:726
+#: builtin/notes.c:724
 msgid "could not parse commit from NOTES_MERGE_PARTIAL."
 msgstr "no se pudo analizar commit de NOTES_MERGE_PARTIAL."
 
-#: builtin/notes.c:739
+#: builtin/notes.c:737
 msgid "failed to resolve NOTES_MERGE_REF"
 msgstr "falló al resolver NOTES_MERGE_REF"
 
-#: builtin/notes.c:742
+#: builtin/notes.c:740
 msgid "failed to finalize notes merge"
 msgstr "falló al finalizar la fusión de notas"
 
-#: builtin/notes.c:768
+#: builtin/notes.c:766
 #, c-format
 msgid "unknown notes merge strategy %s"
 msgstr "estrategia de fusión de notas %s desconocida"
 
-#: builtin/notes.c:784
+#: builtin/notes.c:782
 msgid "General options"
 msgstr "Opciones generales"
 
-#: builtin/notes.c:786
+#: builtin/notes.c:784
 msgid "Merge options"
 msgstr "Opciones de fusión"
 
-#: builtin/notes.c:788
+#: builtin/notes.c:786
 msgid ""
 "resolve notes conflicts using the given strategy (manual/ours/theirs/union/"
 "cat_sort_uniq)"
@@ -18635,92 +18963,92 @@ msgstr ""
 "resolver conflictos de notas usando la estrategia entregada (manual/ours/"
 "theirs/union/cat_sort_uniq)"
 
-#: builtin/notes.c:790
+#: builtin/notes.c:788
 msgid "Committing unmerged notes"
 msgstr "Realizando commit a las notas no fusionadas"
 
-#: builtin/notes.c:792
+#: builtin/notes.c:790
 msgid "finalize notes merge by committing unmerged notes"
 msgstr ""
 "finalizar fusión de notas realizando un commit de las notas no fusionadas"
 
-#: builtin/notes.c:794
+#: builtin/notes.c:792
 msgid "Aborting notes merge resolution"
 msgstr "Abortando resolución de fusión de notas"
 
-#: builtin/notes.c:796
+#: builtin/notes.c:794
 msgid "abort notes merge"
 msgstr "abortar fusión de notas"
 
-#: builtin/notes.c:807
+#: builtin/notes.c:805
 msgid "cannot mix --commit, --abort or -s/--strategy"
 msgstr "no se pueden mezclar --commit, --abort o -s/--strategy"
 
-#: builtin/notes.c:812
+#: builtin/notes.c:810
 msgid "must specify a notes ref to merge"
 msgstr "se debe especificar una ref de notas a fusionar"
 
-#: builtin/notes.c:836
+#: builtin/notes.c:834
 #, c-format
 msgid "unknown -s/--strategy: %s"
 msgstr "--strategy/-s desconocida: %s"
 
-#: builtin/notes.c:873
+#: builtin/notes.c:871
 #, c-format
 msgid "a notes merge into %s is already in-progress at %s"
 msgstr "una fusión de notas en %s ya está en progreso en %s"
 
-#: builtin/notes.c:876
+#: builtin/notes.c:874
 #, c-format
 msgid "failed to store link to current notes ref (%s)"
 msgstr "falló al guardar un link para el ref de notas actual (%s)"
 
-#: builtin/notes.c:878
+#: builtin/notes.c:876
 #, c-format
 msgid ""
 "Automatic notes merge failed. Fix conflicts in %s and commit the result with "
 "'git notes merge --commit', or abort the merge with 'git notes merge --"
 "abort'.\n"
 msgstr ""
-"Fusión automática de notas falló. Arregle conflictos en %s y realice un "
-"commit con el resultado 'git notes merge --commit', o aborte la fusión con "
+"Fusión automática de notas falló. Arregla conflictos en %s y realiza un "
+"commit con el resultado 'git notes merge --commit', o aborta la fusión con "
 "'git notes merge --abort'.\n"
 
-#: builtin/notes.c:897 builtin/tag.c:589
+#: builtin/notes.c:895 builtin/tag.c:590
 #, c-format
 msgid "Failed to resolve '%s' as a valid ref."
 msgstr "Falló al resolver '%s' como una ref válida."
 
-#: builtin/notes.c:900
+#: builtin/notes.c:898
 #, c-format
 msgid "Object %s has no note\n"
 msgstr "El objeto %s no tiene notas\n"
 
-#: builtin/notes.c:912
+#: builtin/notes.c:910
 msgid "attempt to remove non-existent note is not an error"
 msgstr "intentar eliminar una nota no existente no es un error"
 
-#: builtin/notes.c:915
+#: builtin/notes.c:913
 msgid "read object names from the standard input"
 msgstr "leer nombres de objetos de standard input"
 
-#: builtin/notes.c:954 builtin/prune.c:132 builtin/worktree.c:146
+#: builtin/notes.c:952 builtin/prune.c:132 builtin/worktree.c:147
 msgid "do not remove, show only"
 msgstr "no eliminar, solo mostrar"
 
-#: builtin/notes.c:955
+#: builtin/notes.c:953
 msgid "report pruned notes"
 msgstr "reportar notas recortadas"
 
-#: builtin/notes.c:998
+#: builtin/notes.c:996
 msgid "notes-ref"
 msgstr "referencia-de-notas"
 
-#: builtin/notes.c:999
+#: builtin/notes.c:997
 msgid "use notes from <notes-ref>"
 msgstr "usar notas desde <referencia-de-notas>"
 
-#: builtin/notes.c:1034 builtin/stash.c:1735
+#: builtin/notes.c:1032 builtin/stash.c:1752
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr "subcomando desconocido: %s"
@@ -18773,86 +19101,90 @@ msgstr "%u objetos ordenados, esperados %<PRIu32>"
 msgid "expected object at offset %<PRIuMAX> in pack %s"
 msgstr "objeto esperado en el desplazamiento %<PRIuMAX> en el paquete %s"
 
-#: builtin/pack-objects.c:1155
+#: builtin/pack-objects.c:1160
 msgid "disabling bitmap writing, packs are split due to pack.packSizeLimit"
 msgstr ""
 "deshabilitando escritura bitmap, paquetes son divididos debido a pack."
 "packSizeLimit"
 
-#: builtin/pack-objects.c:1168
+#: builtin/pack-objects.c:1173
 msgid "Writing objects"
 msgstr "Escribiendo objetos"
 
-#: builtin/pack-objects.c:1229 builtin/update-index.c:90
+#: builtin/pack-objects.c:1235 builtin/update-index.c:90
 #, c-format
 msgid "failed to stat %s"
 msgstr "falló al iniciar %s"
 
-#: builtin/pack-objects.c:1281
+#: builtin/pack-objects.c:1268
+msgid "failed to write bitmap index"
+msgstr "escribir un índice de bitmap"
+
+#: builtin/pack-objects.c:1294
 #, c-format
 msgid "wrote %<PRIu32> objects while expecting %<PRIu32>"
 msgstr "%<PRIu32> objetos escritos mientras se esperaban %<PRIu32>"
 
-#: builtin/pack-objects.c:1523
+#: builtin/pack-objects.c:1536
 msgid "disabling bitmap writing, as some objects are not being packed"
 msgstr ""
 "deshabilitando escritura bitmap, ya que algunos objetos no están siendo "
 "empaquetados"
 
-#: builtin/pack-objects.c:1971
+#: builtin/pack-objects.c:1984
 #, c-format
 msgid "delta base offset overflow in pack for %s"
 msgstr "overflow de offset de base de delta en paquete para %s"
 
-#: builtin/pack-objects.c:1980
+#: builtin/pack-objects.c:1993
 #, c-format
 msgid "delta base offset out of bound for %s"
 msgstr "offset de base de delta está fuera de límites para %s"
 
-#: builtin/pack-objects.c:2261
+#: builtin/pack-objects.c:2274
 msgid "Counting objects"
 msgstr "Contando objetos"
 
-#: builtin/pack-objects.c:2426
+#: builtin/pack-objects.c:2439
 #, c-format
 msgid "unable to parse object header of %s"
 msgstr "incapaz de analizar header del objeto %s"
 
-#: builtin/pack-objects.c:2496 builtin/pack-objects.c:2512
-#: builtin/pack-objects.c:2522
+#: builtin/pack-objects.c:2509 builtin/pack-objects.c:2525
+#: builtin/pack-objects.c:2535
 #, c-format
 msgid "object %s cannot be read"
 msgstr "objeto %s no puede ser leído"
 
-#: builtin/pack-objects.c:2499 builtin/pack-objects.c:2526
+#: builtin/pack-objects.c:2512 builtin/pack-objects.c:2539
 #, c-format
 msgid "object %s inconsistent object length (%<PRIuMAX> vs %<PRIuMAX>)"
 msgstr ""
 "objeto %s inconsistente con el largo del objeto (%<PRIuMAX> vs %<PRIuMAX>)"
 
-#: builtin/pack-objects.c:2536
+#: builtin/pack-objects.c:2549
 msgid "suboptimal pack - out of memory"
 msgstr "suboptimal pack - fuera de memoria"
 
-#: builtin/pack-objects.c:2851
+#: builtin/pack-objects.c:2864
 #, c-format
 msgid "Delta compression using up to %d threads"
 msgstr "Compresión delta usando hasta %d hilos"
 
-#: builtin/pack-objects.c:2990
+#: builtin/pack-objects.c:3003
 #, c-format
 msgid "unable to pack objects reachable from tag %s"
 msgstr "no es posible empaquetar objetos alcanzables desde tag %s"
 
-#: builtin/pack-objects.c:3076
+#: builtin/pack-objects.c:3089
 msgid "Compressing objects"
 msgstr "Comprimiendo objetos"
 
-#: builtin/pack-objects.c:3082
+#: builtin/pack-objects.c:3095
 msgid "inconsistency with delta count"
 msgstr "inconsistencia con la cuenta de delta"
 
-#: builtin/pack-objects.c:3161
+#: builtin/pack-objects.c:3174
 #, c-format
 msgid ""
 "value of uploadpack.blobpackfileuri must be of the form '<object-hash> <pack-"
@@ -18861,7 +19193,7 @@ msgstr ""
 "valor para uploadpack.blobpackfileuri tiene que ser de la forma '<hash-de-"
 "objeto> <hash-de-pack> <uri>' (se tuvo '%s')"
 
-#: builtin/pack-objects.c:3164
+#: builtin/pack-objects.c:3177
 #, c-format
 msgid ""
 "object already configured in another uploadpack.blobpackfileuri (got '%s')"
@@ -18869,17 +19201,18 @@ msgstr ""
 "objeto ya está configurado en otro uploadpack.blobpackfileuri (se obtuvo "
 "'%s')"
 
-#: builtin/pack-objects.c:3199
+#: builtin/pack-objects.c:3212
 #, c-format
 msgid "could not get type of object %s in pack %s"
 msgstr "no se puede obtener el tipo de objeto %s en pack %s"
 
-#: builtin/pack-objects.c:3321 builtin/pack-objects.c:3335
+#: builtin/pack-objects.c:3340 builtin/pack-objects.c:3351
+#: builtin/pack-objects.c:3365
 #, c-format
 msgid "could not find pack '%s'"
 msgstr "no se pudo encontrar pack '%s'"
 
-#: builtin/pack-objects.c:3378
+#: builtin/pack-objects.c:3408
 #, c-format
 msgid ""
 "expected edge object ID, got garbage:\n"
@@ -18888,261 +19221,260 @@ msgstr ""
 "se esperaba ID de objeto al borde, se obtuvo basura:\n"
 "%s"
 
-#: builtin/pack-objects.c:3384
+#: builtin/pack-objects.c:3414
 #, c-format
 msgid ""
 "expected object ID, got garbage:\n"
 " %s"
 msgstr ""
-"se esperaba ID de objeto, se obtuvo basuta:\n"
+"se esperaba ID de objeto, se obtuvo basura:\n"
 "%s"
 
-#: builtin/pack-objects.c:3482
+#: builtin/pack-objects.c:3507
 msgid "invalid value for --missing"
 msgstr "valor inválido para --missing"
 
-#: builtin/pack-objects.c:3541 builtin/pack-objects.c:3650
+#: builtin/pack-objects.c:3532 builtin/pack-objects.c:3619
 msgid "cannot open pack index"
 msgstr "no se puede abrir índice de paquetes"
 
-#: builtin/pack-objects.c:3572
+#: builtin/pack-objects.c:3541
 #, c-format
 msgid "loose object at %s could not be examined"
 msgstr "objeto suelto en %s no pudo ser examinado"
 
-#: builtin/pack-objects.c:3658
+#: builtin/pack-objects.c:3627
 msgid "unable to force loose object"
 msgstr "incapaz de forzar que el objecto se suelte"
 
-#: builtin/pack-objects.c:3788
+#: builtin/pack-objects.c:3757
 #, c-format
 msgid "not a rev '%s'"
 msgstr "no es una rev '%s'"
 
-#: builtin/pack-objects.c:3791 builtin/rev-parse.c:1061
+#: builtin/pack-objects.c:3760 builtin/rev-parse.c:1061
 #, c-format
 msgid "bad revision '%s'"
 msgstr "mala revisión '%s'"
 
-#: builtin/pack-objects.c:3819
+#: builtin/pack-objects.c:3788
 msgid "unable to add recent objects"
 msgstr "incapaz de añadir objetos recientes"
 
-#: builtin/pack-objects.c:3872
+#: builtin/pack-objects.c:3841
 #, c-format
 msgid "unsupported index version %s"
 msgstr "versión de índice no soportada %s"
 
-#: builtin/pack-objects.c:3876
+#: builtin/pack-objects.c:3845
 #, c-format
 msgid "bad index version '%s'"
 msgstr "mala versión del índice '%s'"
 
-#: builtin/pack-objects.c:3915
+#: builtin/pack-objects.c:3884
 msgid "<version>[,<offset>]"
 msgstr "<versión>[,<offset>]"
 
-#: builtin/pack-objects.c:3916
+#: builtin/pack-objects.c:3885
 msgid "write the pack index file in the specified idx format version"
 msgstr ""
 "escribir el índice de paquete en la versión de formato idx especificado"
 
-#: builtin/pack-objects.c:3919
+#: builtin/pack-objects.c:3888
 msgid "maximum size of each output pack file"
 msgstr "tamaño máximo de cada paquete resultante"
 
-#: builtin/pack-objects.c:3921
+#: builtin/pack-objects.c:3890
 msgid "ignore borrowed objects from alternate object store"
 msgstr "ignorar objetos prestados de otros almacenes de objetos"
 
-#: builtin/pack-objects.c:3923
+#: builtin/pack-objects.c:3892
 msgid "ignore packed objects"
 msgstr "ignorar objetos empaquetados"
 
-#: builtin/pack-objects.c:3925
+#: builtin/pack-objects.c:3894
 msgid "limit pack window by objects"
 msgstr "limitar ventana de paquete por objetos"
 
-#: builtin/pack-objects.c:3927
+#: builtin/pack-objects.c:3896
 msgid "limit pack window by memory in addition to object limit"
 msgstr "limitar ventana de paquete por memoria en adición a límite de objetos"
 
-#: builtin/pack-objects.c:3929
+#: builtin/pack-objects.c:3898
 msgid "maximum length of delta chain allowed in the resulting pack"
 msgstr "longitud máxima de cadena delta permitida en el paquete resultante"
 
-#: builtin/pack-objects.c:3931
+#: builtin/pack-objects.c:3900
 msgid "reuse existing deltas"
 msgstr "reusar deltas existentes"
 
-#: builtin/pack-objects.c:3933
+#: builtin/pack-objects.c:3902
 msgid "reuse existing objects"
 msgstr "reutilizar objetos existentes"
 
-#: builtin/pack-objects.c:3935
+#: builtin/pack-objects.c:3904
 msgid "use OFS_DELTA objects"
 msgstr "usar objetos OFS_DELTA"
 
-#: builtin/pack-objects.c:3937
+#: builtin/pack-objects.c:3906
 msgid "use threads when searching for best delta matches"
 msgstr "usar hilos cuando se busque para mejores concordancias de delta"
 
-#: builtin/pack-objects.c:3939
+#: builtin/pack-objects.c:3908
 msgid "do not create an empty pack output"
 msgstr "no crear un paquete resultante vacío"
 
-#: builtin/pack-objects.c:3941
+#: builtin/pack-objects.c:3910
 msgid "read revision arguments from standard input"
 msgstr "leer argumentos de revisión de standard input"
 
-#: builtin/pack-objects.c:3943
+#: builtin/pack-objects.c:3912
 msgid "limit the objects to those that are not yet packed"
 msgstr "limitar los objetos a aquellos que no hayan sido empaquetados todavía"
 
-#: builtin/pack-objects.c:3946
+#: builtin/pack-objects.c:3915
 msgid "include objects reachable from any reference"
 msgstr "incluir objetos alcanzables por cualquier referencia"
 
-#: builtin/pack-objects.c:3949
+#: builtin/pack-objects.c:3918
 msgid "include objects referred by reflog entries"
 msgstr "incluir objetos referidos por entradas de reflog"
 
-#: builtin/pack-objects.c:3952
+#: builtin/pack-objects.c:3921
 msgid "include objects referred to by the index"
 msgstr "incluir objetos referidos por el índice"
 
-#: builtin/pack-objects.c:3955
+#: builtin/pack-objects.c:3924
 msgid "read packs from stdin"
 msgstr "leer packs de stdin"
 
-#: builtin/pack-objects.c:3957
+#: builtin/pack-objects.c:3926
 msgid "output pack to stdout"
 msgstr "mostrar paquete en stdout"
 
-#: builtin/pack-objects.c:3959
+#: builtin/pack-objects.c:3928
 msgid "include tag objects that refer to objects to be packed"
 msgstr "incluir objetos tag que refieran a objetos a ser empaquetados"
 
-#: builtin/pack-objects.c:3961
+#: builtin/pack-objects.c:3930
 msgid "keep unreachable objects"
 msgstr "mantener objetos inalcanzables"
 
-#: builtin/pack-objects.c:3963
+#: builtin/pack-objects.c:3932
 msgid "pack loose unreachable objects"
 msgstr "empaquetar objetos sueltos inalcanzables"
 
-#: builtin/pack-objects.c:3965
+#: builtin/pack-objects.c:3934
 msgid "unpack unreachable objects newer than <time>"
 msgstr "desempaquetar objetos inalcanzables más nuevos que <tiempo>"
 
-#: builtin/pack-objects.c:3968
+#: builtin/pack-objects.c:3937
 msgid "use the sparse reachability algorithm"
 msgstr "usar el algoritmo sparse reachability"
 
-#: builtin/pack-objects.c:3970
+#: builtin/pack-objects.c:3939
 msgid "create thin packs"
 msgstr "crear paquetes delgados"
 
-#: builtin/pack-objects.c:3972
+#: builtin/pack-objects.c:3941
 msgid "create packs suitable for shallow fetches"
 msgstr "crear paquetes adecuados para fetches superficiales"
 
-#: builtin/pack-objects.c:3974
+#: builtin/pack-objects.c:3943
 msgid "ignore packs that have companion .keep file"
 msgstr "ignorar paquetes que tengan un archivo .keep acompañante"
 
-#: builtin/pack-objects.c:3976
+#: builtin/pack-objects.c:3945
 msgid "ignore this pack"
 msgstr "ignorar este paquete"
 
-#: builtin/pack-objects.c:3978
+#: builtin/pack-objects.c:3947
 msgid "pack compression level"
 msgstr "nivel de compresión del paquete"
 
-#: builtin/pack-objects.c:3980
+#: builtin/pack-objects.c:3949
 msgid "do not hide commits by grafts"
 msgstr "no ocultar commits por injertos"
 
-#: builtin/pack-objects.c:3982
+#: builtin/pack-objects.c:3951
 msgid "use a bitmap index if available to speed up counting objects"
 msgstr ""
 "usar un índice bitmap si está disponible para acelerar la cuenta de objetos"
 
-#: builtin/pack-objects.c:3984
+#: builtin/pack-objects.c:3953
 msgid "write a bitmap index together with the pack index"
 msgstr "escribir un índice de bitmap junto al índice de paquete"
 
-#: builtin/pack-objects.c:3988
+#: builtin/pack-objects.c:3957
 msgid "write a bitmap index if possible"
 msgstr "escribir un índice de bitmap si es posible"
 
-#: builtin/pack-objects.c:3992
+#: builtin/pack-objects.c:3961
 msgid "handling for missing objects"
 msgstr "manejo de objetos perdidos"
 
-#: builtin/pack-objects.c:3995
+#: builtin/pack-objects.c:3964
 msgid "do not pack objects in promisor packfiles"
 msgstr "no se puede empaquetar objetos en packfiles promisores"
 
-#: builtin/pack-objects.c:3997
+#: builtin/pack-objects.c:3966
 msgid "respect islands during delta compression"
 msgstr "respetar islas durante la compresión delta"
 
-#: builtin/pack-objects.c:3999
+#: builtin/pack-objects.c:3968
 msgid "protocol"
 msgstr "protocolo"
 
-#: builtin/pack-objects.c:4000
+#: builtin/pack-objects.c:3969
 msgid "exclude any configured uploadpack.blobpackfileuri with this protocol"
 msgstr ""
-"excluyendo cualquier uploadpack.blobpackfileuri configurado con este "
-"protocolo"
+"excluir cualquier uploadpack.blobpackfileuri configurado con este protocolo"
 
-#: builtin/pack-objects.c:4033
+#: builtin/pack-objects.c:4002
 #, c-format
 msgid "delta chain depth %d is too deep, forcing %d"
 msgstr "profundidad de cadena de delta %d es demasiada profunda, forzando %d"
 
-#: builtin/pack-objects.c:4038
+#: builtin/pack-objects.c:4007
 #, c-format
 msgid "pack.deltaCacheLimit is too high, forcing %d"
 msgstr "pack.deltaCacheLimit es demasiado grande, forzando %d"
 
-#: builtin/pack-objects.c:4094
+#: builtin/pack-objects.c:4063
 msgid "--max-pack-size cannot be used to build a pack for transfer"
 msgstr ""
 "--max-pack-size no puede ser usado para construir un paquete para "
 "transferencia"
 
-#: builtin/pack-objects.c:4096
+#: builtin/pack-objects.c:4065
 msgid "minimum pack size limit is 1 MiB"
 msgstr "tamaño mínimo del paquete es 1 MiB"
 
-#: builtin/pack-objects.c:4101
+#: builtin/pack-objects.c:4070
 msgid "--thin cannot be used to build an indexable pack"
 msgstr "--thin no puede ser usado para construir un paquete indexable"
 
-#: builtin/pack-objects.c:4104
+#: builtin/pack-objects.c:4073
 msgid "--keep-unreachable and --unpack-unreachable are incompatible"
 msgstr "--keep-unreachable y --unpack-unreachable son incompatibles"
 
-#: builtin/pack-objects.c:4110
+#: builtin/pack-objects.c:4079
 msgid "cannot use --filter without --stdout"
 msgstr "no se puede usar --filter sin --stdout"
 
-#: builtin/pack-objects.c:4112
+#: builtin/pack-objects.c:4081
 msgid "cannot use --filter with --stdin-packs"
 msgstr "no se puede usar --filter con --stdin-packs"
 
-#: builtin/pack-objects.c:4116
+#: builtin/pack-objects.c:4085
 msgid "cannot use internal rev list with --stdin-packs"
 msgstr "no se puede usar un lista interna de rev con --stdin-packs"
 
-#: builtin/pack-objects.c:4175
+#: builtin/pack-objects.c:4144
 msgid "Enumerating objects"
 msgstr "Enumerando objetos"
 
-#: builtin/pack-objects.c:4212
+#: builtin/pack-objects.c:4181
 #, c-format
 msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
@@ -19160,9 +19492,9 @@ msgid ""
 "to <git@vger.kernel.org>.  Thanks.\n"
 msgstr ""
 "'git pack-redundant' está nominado para su eliminación.\n"
-"Si todavía usa este comando, agregue una extra\n"
+"Si todavía usas este comando, agrega una extra\n"
 "opción, '--i-still-use-this', en la línea de comando\n"
-"y háganos saber que todavía lo usa enviando un correo electrónico\n"
+"y háganos saber que todavía lo usas enviando un correo electrónico\n"
 "a <git@vger.kernel.org>. Gracias.\n"
 
 #: builtin/pack-refs.c:8
@@ -19197,7 +19529,7 @@ msgstr "caducar objetos más viejos a <tiempo>"
 msgid "limit traversal to objects outside promisor packfiles"
 msgstr "limitar el recorrido a objetos fuera de los paquetes del promisor"
 
-#: builtin/prune.c:152
+#: builtin/prune.c:151
 msgid "cannot prune in a precious-objects repo"
 msgstr "no se puede recortar en un repositorio de objetos preciosos"
 
@@ -19223,11 +19555,11 @@ msgstr "Opciones relacionadas a fusión"
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "incorporar cambios por rebase en lugar de fusión"
 
-#: builtin/pull.c:158 builtin/rebase.c:491 builtin/revert.c:126
+#: builtin/pull.c:158 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "permitir fast-forward"
 
-#: builtin/pull.c:167 parse-options.h:340
+#: builtin/pull.c:167 parse-options.h:339
 msgid "automatically stash/stash pop before and after"
 msgstr "ejecutar automáticamente stash/stash pop antes y después"
 
@@ -19280,7 +19612,7 @@ msgstr ""
 "una rama. Porque este no es el remoto configurado por default\n"
 "para tu rama actual, tienes que especificar una rama en la línea de comando."
 
-#: builtin/pull.c:456 builtin/rebase.c:1248
+#: builtin/pull.c:456 builtin/rebase.c:951
 msgid "You are not currently on a branch."
 msgstr "No te encuentras actualmente en una rama."
 
@@ -19297,7 +19629,7 @@ msgid "See git-pull(1) for details."
 msgstr "Ver git-pull(1) para detalles."
 
 #: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
-#: builtin/rebase.c:1254
+#: builtin/rebase.c:957
 msgid "<remote>"
 msgstr "<remoto>"
 
@@ -19305,7 +19637,7 @@ msgstr "<remoto>"
 msgid "<branch>"
 msgstr "<rama>"
 
-#: builtin/pull.c:471 builtin/rebase.c:1246
+#: builtin/pull.c:471 builtin/rebase.c:949
 msgid "There is no tracking information for the current branch."
 msgstr "No hay información de rastreo para la rama actual."
 
@@ -19334,11 +19666,11 @@ msgstr "no es posible acceder al commit %s"
 msgid "ignoring --verify-signatures for rebase"
 msgstr "ignorando --verify-signatures para rebase"
 
-#: builtin/pull.c:930
+#: builtin/pull.c:936
 msgid ""
-"Pulling without specifying how to reconcile divergent branches is\n"
-"discouraged. You can squelch this message by running one of the following\n"
-"commands sometime before your next pull:\n"
+"You have divergent branches and need to specify how to reconcile them.\n"
+"You can do so by running one of the following commands sometime before\n"
+"your next pull:\n"
 "\n"
 "  git config pull.rebase false  # merge (the default strategy)\n"
 "  git config pull.rebase true   # rebase\n"
@@ -19362,21 +19694,20 @@ msgstr ""
 "la preferencia en todos los repositorios. Puedes también pasar --rebase,\n"
 "--no-rebase, o --ff-only en el comando para sobrescribir la configuración\n"
 "por defecto en cada invocación.\n"
-"\n"
 
-#: builtin/pull.c:990
+#: builtin/pull.c:1010
 msgid "Updating an unborn branch with changes added to the index."
 msgstr "Actualizando una rama no nacida con cambios agregados al índice."
 
-#: builtin/pull.c:994
+#: builtin/pull.c:1014
 msgid "pull with rebase"
 msgstr "pull con rebase"
 
-#: builtin/pull.c:995
+#: builtin/pull.c:1015
 msgid "please commit or stash them."
 msgstr "por favor realiza un commit o un stash con ellos."
 
-#: builtin/pull.c:1020
+#: builtin/pull.c:1040
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -19387,7 +19718,7 @@ msgstr ""
 "realizando fast-forward al árbol de trabajo\n"
 "desde commit %s."
 
-#: builtin/pull.c:1026
+#: builtin/pull.c:1046
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -19398,21 +19729,29 @@ msgid ""
 "to recover."
 msgstr ""
 "No se puede realizar fast-forward en tu árbol de trabajo.\n"
-"Tras asegurarse que haya guardado todo lo preciado de la salida de\n"
+"Tras asegurarte que hayas guardado todo lo preciado de la salida de\n"
 "$ git diff %s\n"
-",ejecute\n"
+",ejecuta\n"
 "$ git reset --hard\n"
 "para recuperar."
 
-#: builtin/pull.c:1041
+#: builtin/pull.c:1061
 msgid "Cannot merge multiple branches into empty head."
 msgstr "No se puede fusionar múltiples ramas en un head vacío."
 
-#: builtin/pull.c:1045
+#: builtin/pull.c:1066
 msgid "Cannot rebase onto multiple branches."
 msgstr "No se puede rebasar en múltiples ramas."
 
-#: builtin/pull.c:1065
+#: builtin/pull.c:1068
+msgid "Cannot fast-forward to multiple branches."
+msgstr "No se puede hacer fast-forward en múltiples ramas."
+
+#: builtin/pull.c:1082
+msgid "Need to specify how to reconcile divergent branches."
+msgstr "Necesita especificar cómo reconciliar las ramas divergentes."
+
+#: builtin/pull.c:1096
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "no se puede rebasar con modificaciones de submódulos grabadas localmente"
@@ -19475,7 +19814,7 @@ msgid ""
 msgstr ""
 "Actualmente no estás en una rama.\n"
 "Para hacer un push a la historia que lleva al estado actual\n"
-"(HEAD desacoplado), use\n"
+"(HEAD desacoplado), usa\n"
 "\n"
 "\tgit push %s HEAD:<nombre-de-rama-remota>\n"
 
@@ -19489,7 +19828,7 @@ msgid ""
 msgstr ""
 "La rama actual %s no tiene una rama upstream.\n"
 "Para realizar un push de la rama actual y configurar el remoto como "
-"upstream, use\n"
+"upstream, usa\n"
 "\n"
 "\tgit push --set-upstream %s %s\n"
 
@@ -19536,10 +19875,10 @@ msgid ""
 "See the 'Note about fast-forwards' in 'git push --help' for details."
 msgstr ""
 "Actualizaciones fueron rechazadas porque una punta de rama en el push está\n"
-"detrás de su contraparte remota. Verifique esta rama e integre los cambios "
+"detrás de su contraparte remota. Cambia a esta rama e integra los cambios "
 "remotos\n"
 "(ejem. 'git pull ...') antes de volver a hacer push.\n"
-"Vea las 'Notes about fast-forwards' en 'git push --help' para más detalles."
+"Mira las 'Notes about fast-forwards' en 'git push --help' para más detalles."
 
 #: builtin/push.c:270
 msgid ""
@@ -19551,9 +19890,9 @@ msgid ""
 msgstr ""
 "Actualizaciones fueron rechazadas porque el remoto contiene trabajo que\n"
 "no existe localmente. Esto es causado usualmente por otro repositorio\n"
-"realizando push a la misma ref. Quizás quiera integrar primero los cambios\n"
+"realizando push a la misma ref. Quizás quieras integrar primero los cambios\n"
 "remotos (ej. 'git pull ...') antes de volver a hacer push.\n"
-"Vea 'Notes about fast-forwards' en 'git push --help' para detalles."
+"Mira 'Notes about fast-forwards' en 'git push --help' para detalles."
 
 #: builtin/push.c:277
 msgid "Updates were rejected because the tag already exists in the remote."
@@ -19579,7 +19918,7 @@ msgid ""
 msgstr ""
 "Las actualizaciones se rechazaron porque la punta de la rama de seguimiento\n"
 "remoto se ha actualizado desde la última vez que se realizó checkout. Es "
-"posible que desee\n"
+"posible que desees\n"
 "integrar esos cambios localmente (por ejemplo, 'git pull ...')\n"
 "antes de forzar una actualización.\n"
 
@@ -19593,15 +19932,15 @@ msgstr "Haciendo push a %s\n"
 msgid "failed to push some refs to '%s'"
 msgstr "falló el push de algunas referencias a '%s'"
 
-#: builtin/push.c:544
+#: builtin/push.c:544 builtin/submodule--helper.c:3258
 msgid "repository"
 msgstr "repositorio"
 
-#: builtin/push.c:545 builtin/send-pack.c:189
+#: builtin/push.c:545 builtin/send-pack.c:193
 msgid "push all refs"
 msgstr "realizar push a todas las refs"
 
-#: builtin/push.c:546 builtin/send-pack.c:191
+#: builtin/push.c:546 builtin/send-pack.c:195
 msgid "mirror all refs"
 msgstr "realizar mirror a todas las refs"
 
@@ -19613,32 +19952,32 @@ msgstr "borrar refs"
 msgid "push tags (can't be used with --all or --mirror)"
 msgstr "realizar push a tags (no puede ser usado con --all o --mirror)"
 
-#: builtin/push.c:552 builtin/send-pack.c:192
+#: builtin/push.c:552 builtin/send-pack.c:196
 msgid "force updates"
 msgstr "forzar actualizaciones"
 
-#: builtin/push.c:553 builtin/send-pack.c:204
+#: builtin/push.c:553 builtin/send-pack.c:208
 msgid "<refname>:<expect>"
 msgstr "<refname>:<expect>"
 
-#: builtin/push.c:554 builtin/send-pack.c:205
+#: builtin/push.c:554 builtin/send-pack.c:209
 msgid "require old value of ref to be at this value"
-msgstr "requiere que el valor viejo de ref sea este valor"
+msgstr "requerir que el valor viejo de ref sea este valor"
 
-#: builtin/push.c:557 builtin/send-pack.c:208
+#: builtin/push.c:557 builtin/send-pack.c:212
 msgid "require remote updates to be integrated locally"
-msgstr "requieren que las actualizaciones remotas se integren localmente"
+msgstr "requerir que las actualizaciones remotas se integren localmente"
 
 #: builtin/push.c:560
 msgid "control recursive pushing of submodules"
 msgstr "controlar push recursivo de submódulos"
 
-#: builtin/push.c:561 builtin/send-pack.c:199
+#: builtin/push.c:561 builtin/send-pack.c:203
 msgid "use thin pack"
 msgstr "usar empaquetado delgado"
 
-#: builtin/push.c:562 builtin/push.c:563 builtin/send-pack.c:186
-#: builtin/send-pack.c:187
+#: builtin/push.c:562 builtin/push.c:563 builtin/send-pack.c:190
+#: builtin/send-pack.c:191
 msgid "receive pack program"
 msgstr "programa de recepción de paquetes"
 
@@ -19658,11 +19997,11 @@ msgstr "hacer un bypass al hook pre-push"
 msgid "push missing but relevant tags"
 msgstr "realizar push de tags faltantes pero relevantes"
 
-#: builtin/push.c:572 builtin/send-pack.c:193
+#: builtin/push.c:572 builtin/send-pack.c:197
 msgid "GPG sign the push"
 msgstr "Firmar con GPG el push"
 
-#: builtin/push.c:574 builtin/send-pack.c:200
+#: builtin/push.c:574 builtin/send-pack.c:204
 msgid "request atomic transaction on remote side"
 msgstr "solicitar transacción atómica en el lado remoto"
 
@@ -19775,83 +20114,82 @@ msgstr "se necesitan dos rangos de commits"
 #: builtin/read-tree.c:41
 msgid ""
 "git read-tree [(-m [--trivial] [--aggressive] | --reset | --prefix=<prefix>) "
-"[-u [--exclude-per-directory=<gitignore>] | -i]] [--no-sparse-checkout] [--"
-"index-output=<file>] (--empty | <tree-ish1> [<tree-ish2> [<tree-ish3>]])"
+"[-u | -i]] [--no-sparse-checkout] [--index-output=<file>] (--empty | <tree-"
+"ish1> [<tree-ish2> [<tree-ish3>]])"
 msgstr ""
-"git read-tree [(-m [--trivial] [--aggressive] | --reset | --"
-"prefix=<prefijo>) [-u [--exclude-per-directory=<gitignore>] | -i]] [--no-"
-"sparse-checkout] [--index-output=<archivo>] (--empty | <árbol-ismo1> [<árbol-"
-"ismo2> [<árbol-ismo3>]])"
+"git read-tree [(-m [--trivial] [--aggressive] | --reset | --prefix=<prefix>) "
+"[-u | -i]] [--no-sparse-checkout] [--index-output=<file>] (--empty | <tree-"
+"ish1> [<tree-ish2> [<tree-ish3>]])"
 
-#: builtin/read-tree.c:124
+#: builtin/read-tree.c:116
 msgid "write resulting index to <file>"
 msgstr "escribir índice resultante en <archivo>"
 
-#: builtin/read-tree.c:127
+#: builtin/read-tree.c:119
 msgid "only empty the index"
 msgstr "solo vaciar el índice"
 
-#: builtin/read-tree.c:129
+#: builtin/read-tree.c:121
 msgid "Merging"
 msgstr "Fusionando"
 
-#: builtin/read-tree.c:131
+#: builtin/read-tree.c:123
 msgid "perform a merge in addition to a read"
 msgstr "realizar un merge en adición a una lectura"
 
-#: builtin/read-tree.c:133
+#: builtin/read-tree.c:125
 msgid "3-way merge if no file level merging required"
 msgstr "fusión de 3 vías si no se requiere ninguna fusión a nivel de archivo"
 
-#: builtin/read-tree.c:135
+#: builtin/read-tree.c:127
 msgid "3-way merge in presence of adds and removes"
 msgstr "fusión de 3 vías en presencia de adiciones y eliminaciones"
 
-#: builtin/read-tree.c:137
+#: builtin/read-tree.c:129
 msgid "same as -m, but discard unmerged entries"
 msgstr "igual que -m, pero descarta entradas sin fusionar"
 
-#: builtin/read-tree.c:138
+#: builtin/read-tree.c:130
 msgid "<subdirectory>/"
 msgstr "<subdirectorio>/"
 
-#: builtin/read-tree.c:139
+#: builtin/read-tree.c:131
 msgid "read the tree into the index under <subdirectory>/"
-msgstr "lea el árbol en el índice bajo <subdirectorio>/"
+msgstr "leer el árbol en el índice bajo <subdirectorio>/"
 
-#: builtin/read-tree.c:142
+#: builtin/read-tree.c:134
 msgid "update working tree with merge result"
 msgstr "actualiza el árbol de trabajo con el resultado de la fusión"
 
-#: builtin/read-tree.c:144
+#: builtin/read-tree.c:136
 msgid "gitignore"
 msgstr "gitignore"
 
-#: builtin/read-tree.c:145
+#: builtin/read-tree.c:137
 msgid "allow explicitly ignored files to be overwritten"
 msgstr "permitir sobrescritura de archivos explícitamente ignorados"
 
-#: builtin/read-tree.c:148
+#: builtin/read-tree.c:140
 msgid "don't check the working tree after merging"
 msgstr "no revisar el árbol de trabajo tras fusionar"
 
-#: builtin/read-tree.c:149
+#: builtin/read-tree.c:141
 msgid "don't update the index or the work tree"
 msgstr "no actualizar el índice o el árbol de trabajo"
 
-#: builtin/read-tree.c:151
+#: builtin/read-tree.c:143
 msgid "skip applying sparse checkout filter"
 msgstr "saltar aplicación de filtro de sparse checkout"
 
-#: builtin/read-tree.c:153
+#: builtin/read-tree.c:145
 msgid "debug unpack-trees"
 msgstr "debug unpack-trees"
 
-#: builtin/read-tree.c:157
+#: builtin/read-tree.c:149
 msgid "suppress feedback messages"
 msgstr "suprimir mensajes de feedback"
 
-#: builtin/read-tree.c:188
+#: builtin/read-tree.c:183
 msgid "You need to resolve your current index first"
 msgstr "Necesitas resolver tu índice actual primero"
 
@@ -19873,193 +20211,44 @@ msgstr ""
 msgid "git rebase --continue | --abort | --skip | --edit-todo"
 msgstr "git rebase --continue | --abort | --skip | --edit-todo"
 
-#: builtin/rebase.c:194 builtin/rebase.c:218 builtin/rebase.c:245
-#, c-format
-msgid "unusable todo list: '%s'"
-msgstr "lista de pendientes inutilizable: '%s'"
-
-#: builtin/rebase.c:311
+#: builtin/rebase.c:230
 #, c-format
 msgid "could not create temporary %s"
 msgstr "no se pudo crear archivo temporal %s"
 
-#: builtin/rebase.c:317
+#: builtin/rebase.c:236
 msgid "could not mark as interactive"
 msgstr "no se pudo marcar como interactivo"
 
-#: builtin/rebase.c:370
+#: builtin/rebase.c:289
 msgid "could not generate todo list"
 msgstr "no se pudo generar lista de pendientes"
 
-#: builtin/rebase.c:412
+#: builtin/rebase.c:331
 msgid "a base commit must be provided with --upstream or --onto"
 msgstr "un commit base tiene que ser provisto con --upstream o --onto"
 
-#: builtin/rebase.c:481
-msgid "git rebase--interactive [<options>]"
-msgstr "git rebase--interactive [<opciones>]"
-
-#: builtin/rebase.c:494 builtin/rebase.c:1389
-msgid "keep commits which start empty"
-msgstr "mantener commits que comiencen con vacío"
-
-#: builtin/rebase.c:498 builtin/revert.c:128
-msgid "allow commits with empty messages"
-msgstr "permitir commits con mensajes vacíos"
-
-#: builtin/rebase.c:500
-msgid "rebase merge commits"
-msgstr "rebasar commits de fusión"
-
-#: builtin/rebase.c:502
-msgid "keep original branch points of cousins"
-msgstr "mantener puntas de bifurcación originales de los primos"
-
-#: builtin/rebase.c:504
-msgid "move commits that begin with squash!/fixup!"
-msgstr "mover commits que comiencen con squash!/fixup!"
-
-#: builtin/rebase.c:505
-msgid "sign commits"
-msgstr "firmar commits"
-
-#: builtin/rebase.c:507 builtin/rebase.c:1328
-msgid "display a diffstat of what changed upstream"
-msgstr "mostrar un diffstat de lo que cambió en upstream"
-
-#: builtin/rebase.c:509
-msgid "continue rebase"
-msgstr "continuar rebase"
-
-#: builtin/rebase.c:511
-msgid "skip commit"
-msgstr "saltar commit"
-
-#: builtin/rebase.c:512
-msgid "edit the todo list"
-msgstr "editar la lista de pendientes"
-
-#: builtin/rebase.c:514
-msgid "show the current patch"
-msgstr "mostrar el parche actual"
-
-#: builtin/rebase.c:517
-msgid "shorten commit ids in the todo list"
-msgstr "ids de commits cortos en la lista de pendientes"
-
-#: builtin/rebase.c:519
-msgid "expand commit ids in the todo list"
-msgstr "expandir ids de commits en la lista de pendientes"
-
-#: builtin/rebase.c:521
-msgid "check the todo list"
-msgstr "revisar la lista de pendientes"
-
-#: builtin/rebase.c:523
-msgid "rearrange fixup/squash lines"
-msgstr "reordenar líneas fixup/squash"
-
-#: builtin/rebase.c:525
-msgid "insert exec commands in todo list"
-msgstr "insertar comando exec en la lista de pendientes"
-
-#: builtin/rebase.c:526
-msgid "onto"
-msgstr "sobre"
-
-#: builtin/rebase.c:529
-msgid "restrict-revision"
-msgstr "restrict-revision"
-
-#: builtin/rebase.c:529
-msgid "restrict revision"
-msgstr "restringir revision"
-
-#: builtin/rebase.c:531
-msgid "squash-onto"
-msgstr "squash-onto"
-
-#: builtin/rebase.c:532
-msgid "squash onto"
-msgstr "squash a"
-
-#: builtin/rebase.c:534
-msgid "the upstream commit"
-msgstr "el commit de upstream"
-
-#: builtin/rebase.c:536
-msgid "head-name"
-msgstr "head-name"
-
-#: builtin/rebase.c:536
-msgid "head name"
-msgstr "nombre de head"
-
-#: builtin/rebase.c:541
-msgid "rebase strategy"
-msgstr "estrategia de rebase"
-
-#: builtin/rebase.c:542
-msgid "strategy-opts"
-msgstr "strategy-opts"
-
-#: builtin/rebase.c:543
-msgid "strategy options"
-msgstr "opciones de estrategia"
-
-#: builtin/rebase.c:544
-msgid "switch-to"
-msgstr "cambiar a"
-
-#: builtin/rebase.c:545
-msgid "the branch or commit to checkout"
-msgstr "la rama o commit para hacer checkout"
-
-#: builtin/rebase.c:546
-msgid "onto-name"
-msgstr "sobre-nombre"
-
-#: builtin/rebase.c:546
-msgid "onto name"
-msgstr "sobre nombre"
-
-#: builtin/rebase.c:547
-msgid "cmd"
-msgstr "cmd"
-
-#: builtin/rebase.c:547
-msgid "the command to run"
-msgstr "el comando para ejecutar"
-
-#: builtin/rebase.c:550 builtin/rebase.c:1422
-msgid "automatically re-schedule any `exec` that fails"
-msgstr "reprogramar automaticamente cualquier `exec` que falle"
-
-#: builtin/rebase.c:566
-msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
-msgstr "--[no-]rebase-cousins no tiene efecto sin --rebase-merges"
-
-#: builtin/rebase.c:582
+#: builtin/rebase.c:390
 #, c-format
 msgid "%s requires the merge backend"
 msgstr "%s requiere un backend de fusión"
 
-#: builtin/rebase.c:625
+#: builtin/rebase.c:432
 #, c-format
 msgid "could not get 'onto': '%s'"
 msgstr "no se pudo conseguir 'onto': '%s'"
 
-#: builtin/rebase.c:642
+#: builtin/rebase.c:449
 #, c-format
 msgid "invalid orig-head: '%s'"
 msgstr "orig-head inválido: '%s'"
 
-#: builtin/rebase.c:667
+#: builtin/rebase.c:474
 #, c-format
 msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
 msgstr "ignorando inválido allow_rerere_autoupdate: '%s'"
 
-#: builtin/rebase.c:813 git-rebase--preserve-merges.sh:81
+#: builtin/rebase.c:597
 msgid ""
 "Resolve all conflicts manually, mark them as resolved with\n"
 "\"git add/rm <conflicted_files>\", then run \"git rebase --continue\".\n"
@@ -20067,14 +20256,14 @@ msgid ""
 "To abort and get back to the state before \"git rebase\", run \"git rebase --"
 "abort\"."
 msgstr ""
-"Resuelva todos los conflictos manualmente ya sea con\n"
-"\"git add/rm <archivo_conflictivo>\", luego ejecute \"git rebase --continue"
+"Resuelve todos los conflictos manualmente ya sea con\n"
+"\"git add/rm <archivo_conflictivo>\", luego ejecuta \"git rebase --continue"
 "\".\n"
 "Si prefieres saltar este parche, ejecuta \"git rebase --skip\" .\n"
 "Para abortar y regresar al estado previo al \"git rebase\", ejecuta \"git "
 "rebase --abort\"."
 
-#: builtin/rebase.c:896
+#: builtin/rebase.c:680
 #, c-format
 msgid ""
 "\n"
@@ -20093,7 +20282,7 @@ msgstr ""
 "\n"
 "Como resultado, git no puede hacer rebase con ellos."
 
-#: builtin/rebase.c:1222
+#: builtin/rebase.c:925
 #, c-format
 msgid ""
 "unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and \"ask"
@@ -20102,7 +20291,7 @@ msgstr ""
 "tipo '%s' vacío y desconocido; valores válidos son \"drop\", \"keep\", y "
 "\"ask\"."
 
-#: builtin/rebase.c:1240
+#: builtin/rebase.c:943
 #, c-format
 msgid ""
 "%s\n"
@@ -20119,7 +20308,7 @@ msgstr ""
 "    git rebase '<rama>'\n"
 "\n"
 
-#: builtin/rebase.c:1256
+#: builtin/rebase.c:959
 #, c-format
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:\n"
@@ -20132,184 +20321,194 @@ msgstr ""
 "    git branch --set-upstream-to=%s/<rama> %s\n"
 "\n"
 
-#: builtin/rebase.c:1286
+#: builtin/rebase.c:989
 msgid "exec commands cannot contain newlines"
 msgstr "comandos exec no pueden contener newlines"
 
-#: builtin/rebase.c:1290
+#: builtin/rebase.c:993
 msgid "empty exec command"
 msgstr "comando exec vacío"
 
-#: builtin/rebase.c:1319
+#: builtin/rebase.c:1023
 msgid "rebase onto given branch instead of upstream"
 msgstr "haciendo rebase sobre rama dada en lugar de upstream"
 
-#: builtin/rebase.c:1321
+#: builtin/rebase.c:1025
 msgid "use the merge-base of upstream and branch as the current base"
 msgstr "usar la base de fusión de upstream y la rama como base actual"
 
-#: builtin/rebase.c:1323
+#: builtin/rebase.c:1027
 msgid "allow pre-rebase hook to run"
 msgstr "permitir ejecutar hook pre-rebase"
 
-#: builtin/rebase.c:1325
+#: builtin/rebase.c:1029
 msgid "be quiet. implies --no-stat"
 msgstr "ser silencioso. implica --no-stat"
 
-#: builtin/rebase.c:1331
+#: builtin/rebase.c:1032
+msgid "display a diffstat of what changed upstream"
+msgstr "mostrar un diffstat de lo que cambió en upstream"
+
+#: builtin/rebase.c:1035
 msgid "do not show diffstat of what changed upstream"
 msgstr "no mostrar un diffstat de lo que cambió en upstream"
 
-#: builtin/rebase.c:1334
+#: builtin/rebase.c:1038
 msgid "add a Signed-off-by trailer to each commit"
 msgstr "agregar una línea \"Signed-off-by\" al mensaje de cada commit"
 
-#: builtin/rebase.c:1337
+#: builtin/rebase.c:1041
 msgid "make committer date match author date"
 msgstr "hacer que la fecha del commit concuerde con la fecha de autoría"
 
-#: builtin/rebase.c:1339
+#: builtin/rebase.c:1043
 msgid "ignore author date and use current date"
 msgstr "ignorar la fecha del autor y usar la fecha actual"
 
-#: builtin/rebase.c:1341
+#: builtin/rebase.c:1045
 msgid "synonym of --reset-author-date"
 msgstr "sinónimo para --reset-author-date"
 
-#: builtin/rebase.c:1343 builtin/rebase.c:1347
+#: builtin/rebase.c:1047 builtin/rebase.c:1051
 msgid "passed to 'git apply'"
 msgstr "pasado a 'git apply'"
 
-#: builtin/rebase.c:1345
+#: builtin/rebase.c:1049
 msgid "ignore changes in whitespace"
 msgstr "ignorar cambios en espacios en blanco"
 
-#: builtin/rebase.c:1349 builtin/rebase.c:1352
+#: builtin/rebase.c:1053 builtin/rebase.c:1056
 msgid "cherry-pick all commits, even if unchanged"
 msgstr "cherry-pick todos los commits, incluso si no han cambiado"
 
-#: builtin/rebase.c:1354
+#: builtin/rebase.c:1058
 msgid "continue"
 msgstr "continuar"
 
-#: builtin/rebase.c:1357
+#: builtin/rebase.c:1061
 msgid "skip current patch and continue"
 msgstr "saltar el parche y continuar"
 
-#: builtin/rebase.c:1359
+#: builtin/rebase.c:1063
 msgid "abort and check out the original branch"
-msgstr "aborta y revisa la rama original"
+msgstr "abortar y cambiar a la rama original"
 
-#: builtin/rebase.c:1362
+#: builtin/rebase.c:1066
 msgid "abort but keep HEAD where it is"
-msgstr "aborta pero mantiene HEAD donde está"
+msgstr "abortar pero mantiene HEAD donde está"
 
-#: builtin/rebase.c:1363
+#: builtin/rebase.c:1067
 msgid "edit the todo list during an interactive rebase"
 msgstr "editar la lista de pendientes durante el rebase interactivo"
 
-#: builtin/rebase.c:1366
+#: builtin/rebase.c:1070
 msgid "show the patch file being applied or merged"
-msgstr "muestra el archivo parche siendo aplicado o fusionado"
+msgstr "mostrar el archivo parche siendo aplicado o fusionado"
 
-#: builtin/rebase.c:1369
+#: builtin/rebase.c:1073
 msgid "use apply strategies to rebase"
 msgstr "usar estrategias de apply para el rebase"
 
-#: builtin/rebase.c:1373
+#: builtin/rebase.c:1077
 msgid "use merging strategies to rebase"
 msgstr "usar estrategias de fusión para el rebase"
 
-#: builtin/rebase.c:1377
+#: builtin/rebase.c:1081
 msgid "let the user edit the list of commits to rebase"
 msgstr "permitir al usuario editar la lista de commits para rebasar"
 
-#: builtin/rebase.c:1381
+#: builtin/rebase.c:1085
 msgid "(DEPRECATED) try to recreate merges instead of ignoring them"
 msgstr "(DEPRECADO) intentar recrear merges en lugar de ignorarlos"
 
-#: builtin/rebase.c:1386
+#: builtin/rebase.c:1090
 msgid "how to handle commits that become empty"
 msgstr "como manejar commits que se vuelven vacíos"
 
-#: builtin/rebase.c:1393
+#: builtin/rebase.c:1093
+msgid "keep commits which start empty"
+msgstr "mantener commits que comiencen con vacío"
+
+#: builtin/rebase.c:1097
 msgid "move commits that begin with squash!/fixup! under -i"
 msgstr "mover commits que comiencen con squash!/fixup! bajo -i"
 
-#: builtin/rebase.c:1400
+#: builtin/rebase.c:1104
 msgid "add exec lines after each commit of the editable list"
 msgstr "agregar líneas exec tras cada commit de la lista editable"
 
-#: builtin/rebase.c:1404
+#: builtin/rebase.c:1108
 msgid "allow rebasing commits with empty messages"
 msgstr "permitir rebase de commits con mensajes vacíos"
 
-#: builtin/rebase.c:1408
+#: builtin/rebase.c:1112
 msgid "try to rebase merges instead of skipping them"
 msgstr "intentar rebase de fusiones en lugar de saltarlas"
 
-#: builtin/rebase.c:1411
+#: builtin/rebase.c:1115
 msgid "use 'merge-base --fork-point' to refine upstream"
-msgstr "use 'merge-base --fork-point' para refinar upstream"
+msgstr "usar 'merge-base --fork-point' para refinar upstream"
 
-#: builtin/rebase.c:1413
+#: builtin/rebase.c:1117
 msgid "use the given merge strategy"
 msgstr "usar la estrategia de merge dada"
 
-#: builtin/rebase.c:1415 builtin/revert.c:115
+#: builtin/rebase.c:1119 builtin/revert.c:115
 msgid "option"
 msgstr "opción"
 
-#: builtin/rebase.c:1416
+#: builtin/rebase.c:1120
 msgid "pass the argument through to the merge strategy"
 msgstr "pasar el argumento para la estrategia de fusión"
 
-#: builtin/rebase.c:1419
+#: builtin/rebase.c:1123
 msgid "rebase all reachable commits up to the root(s)"
 msgstr "hacer rebase a todos los commits alcanzables hasta la raíz(raíces)"
 
-#: builtin/rebase.c:1424
+#: builtin/rebase.c:1126
+msgid "automatically re-schedule any `exec` that fails"
+msgstr "reprogramar automaticamente cualquier `exec` que falle"
+
+#: builtin/rebase.c:1128
 msgid "apply all changes, even those already present upstream"
 msgstr ""
 "aplicar todos los cambios, incluso aquellos que ya están presentes en "
 "upstream"
 
-#: builtin/rebase.c:1442
+#: builtin/rebase.c:1149
 msgid "It looks like 'git am' is in progress. Cannot rebase."
 msgstr "Parece que 'git am' está en progreso. No se puede rebasar."
 
-#: builtin/rebase.c:1483
-msgid ""
-"git rebase --preserve-merges is deprecated. Use --rebase-merges instead."
-msgstr ""
-"git rebase --preserve-merges está deprecado. Use --rebase-merges en su lugar."
+#: builtin/rebase.c:1180
+msgid "--preserve-merges was replaced by --rebase-merges"
+msgstr "--preserve-merges fue reemplazado por --rebase-merges"
 
-#: builtin/rebase.c:1488
+#: builtin/rebase.c:1193
 msgid "cannot combine '--keep-base' with '--onto'"
 msgstr "no se puede combinar '--keep-base' con '--onto'"
 
-#: builtin/rebase.c:1490
+#: builtin/rebase.c:1195
 msgid "cannot combine '--keep-base' with '--root'"
 msgstr "no se puede combinar '--keep-base' con '--root'"
 
-#: builtin/rebase.c:1494
+#: builtin/rebase.c:1199
 msgid "cannot combine '--root' with '--fork-point'"
 msgstr "no se puede combinar '--root' con '--fork-point'"
 
-#: builtin/rebase.c:1497
+#: builtin/rebase.c:1202
 msgid "No rebase in progress?"
 msgstr "¿No hay rebase en progreso?"
 
-#: builtin/rebase.c:1501
+#: builtin/rebase.c:1206
 msgid "The --edit-todo action can only be used during interactive rebase."
 msgstr ""
 "La acción --edit-todo solo puede ser usada al rebasar interactivamente."
 
-#: builtin/rebase.c:1524 t/helper/test-fast-rebase.c:122
+#: builtin/rebase.c:1229 t/helper/test-fast-rebase.c:122
 msgid "Cannot read HEAD"
 msgstr "No se puede leer el HEAD"
 
-#: builtin/rebase.c:1536
+#: builtin/rebase.c:1241
 msgid ""
 "You must edit all merge conflicts and then\n"
 "mark them as resolved using git add"
@@ -20317,16 +20516,16 @@ msgstr ""
 "Tienes que editar todos los conflictos de fusión y luego\n"
 "marcarlos como resueltos usando git add"
 
-#: builtin/rebase.c:1555
+#: builtin/rebase.c:1260
 msgid "could not discard worktree changes"
 msgstr "no se pudo descartar los cambios del árbol de trabajo"
 
-#: builtin/rebase.c:1574
+#: builtin/rebase.c:1279
 #, c-format
 msgid "could not move back to %s"
 msgstr "no se puede regresar a %s"
 
-#: builtin/rebase.c:1620
+#: builtin/rebase.c:1325
 #, c-format
 msgid ""
 "It seems that there is already a %s directory, and\n"
@@ -20347,144 +20546,133 @@ msgstr ""
 "y ejecútame nuevamente. Me estoy deteniendo en caso de que tengas\n"
 "algo de valor ahí.\n"
 
-#: builtin/rebase.c:1648
+#: builtin/rebase.c:1353
 msgid "switch `C' expects a numerical value"
 msgstr "switch `C' espera un valor numérico"
 
-#: builtin/rebase.c:1690
+#: builtin/rebase.c:1395
 #, c-format
 msgid "Unknown mode: %s"
 msgstr "Modo desconocido: %s"
 
-#: builtin/rebase.c:1729
+#: builtin/rebase.c:1434
 msgid "--strategy requires --merge or --interactive"
 msgstr "--strategy requiere --merge o --interactive"
 
-#: builtin/rebase.c:1759
+#: builtin/rebase.c:1463
 msgid "cannot combine apply options with merge options"
 msgstr "no se pueden combinar opciones de apply con opciones de merge"
 
-#: builtin/rebase.c:1772
+#: builtin/rebase.c:1476
 #, c-format
 msgid "Unknown rebase backend: %s"
 msgstr "Backend de rebase desconocido: %s"
 
-#: builtin/rebase.c:1802
+#: builtin/rebase.c:1505
 msgid "--reschedule-failed-exec requires --exec or --interactive"
 msgstr "--reschedule-failed-exec requiere --exec o --interactive"
 
-#: builtin/rebase.c:1822
-msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
-msgstr "no se puede combinar '--preserve-merges' con '--rebase-merges'"
-
-#: builtin/rebase.c:1826
-msgid ""
-"error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
-msgstr ""
-"error: no se puede combinar '--preserve-merges' con '--reschedule-failed-"
-"exec'"
-
-#: builtin/rebase.c:1850
+#: builtin/rebase.c:1536
 #, c-format
 msgid "invalid upstream '%s'"
 msgstr "upstream inválido '%s'"
 
-#: builtin/rebase.c:1856
+#: builtin/rebase.c:1542
 msgid "Could not create new root commit"
 msgstr "No se pudo crear commit raíz nuevo"
 
-#: builtin/rebase.c:1882
+#: builtin/rebase.c:1568
 #, c-format
 msgid "'%s': need exactly one merge base with branch"
 msgstr "'%s': necesita exactamente una base de fusión con rama"
 
-#: builtin/rebase.c:1885
+#: builtin/rebase.c:1571
 #, c-format
 msgid "'%s': need exactly one merge base"
 msgstr "'%s': necesita exactamente una base de fusión"
 
-#: builtin/rebase.c:1893
+#: builtin/rebase.c:1580
 #, c-format
 msgid "Does not point to a valid commit '%s'"
 msgstr "No apunta a un commit válido '%s'"
 
-#: builtin/rebase.c:1921
+#: builtin/rebase.c:1607
 #, c-format
-msgid "fatal: no such branch/commit '%s'"
-msgstr "fatal: no existe la rama/commit: '%s'"
+msgid "no such branch/commit '%s'"
+msgstr "no existe la rama/commit: '%s'"
 
-#: builtin/rebase.c:1929 builtin/submodule--helper.c:39
-#: builtin/submodule--helper.c:2431
+#: builtin/rebase.c:1618 builtin/submodule--helper.c:39
+#: builtin/submodule--helper.c:2658
 #, c-format
 msgid "No such ref: %s"
 msgstr "No existe ref: %s"
 
-#: builtin/rebase.c:1940
+#: builtin/rebase.c:1629
 msgid "Could not resolve HEAD to a revision"
 msgstr "No se pudo resolver HEAD a una revisión"
 
-#: builtin/rebase.c:1961
+#: builtin/rebase.c:1650
 msgid "Please commit or stash them."
 msgstr "Por favor, confírmalos o guárdalos."
 
-#: builtin/rebase.c:1997
+#: builtin/rebase.c:1686
 #, c-format
 msgid "could not switch to %s"
 msgstr "no se pudo cambiar a %s"
 
-#: builtin/rebase.c:2008
+#: builtin/rebase.c:1697
 msgid "HEAD is up to date."
 msgstr "HEAD está actualizado."
 
-#: builtin/rebase.c:2010
+#: builtin/rebase.c:1699
 #, c-format
 msgid "Current branch %s is up to date.\n"
 msgstr "La rama actual %s está actualizada.\n"
 
-#: builtin/rebase.c:2018
+#: builtin/rebase.c:1707
 msgid "HEAD is up to date, rebase forced."
 msgstr "HEAD está actualizado, rebase forzado."
 
-#: builtin/rebase.c:2020
+#: builtin/rebase.c:1709
 #, c-format
 msgid "Current branch %s is up to date, rebase forced.\n"
 msgstr "Rama actual %s está actualizada, rebase forzado.\n"
 
-#: builtin/rebase.c:2028
+#: builtin/rebase.c:1717
 msgid "The pre-rebase hook refused to rebase."
 msgstr "El hook pre-rebase rechazó el rebase."
 
-#: builtin/rebase.c:2035
+#: builtin/rebase.c:1724
 #, c-format
 msgid "Changes to %s:\n"
 msgstr "Cambios a %s:\n"
 
-#: builtin/rebase.c:2038
+#: builtin/rebase.c:1727
 #, c-format
 msgid "Changes from %s to %s:\n"
 msgstr "Cambios desde %s a %s:\n"
 
-#: builtin/rebase.c:2063
+#: builtin/rebase.c:1752
 #, c-format
 msgid "First, rewinding head to replay your work on top of it...\n"
 msgstr ""
 "En primer lugar, rebobinando HEAD para después reproducir tus cambios encima "
 "de esta...\n"
 
-#: builtin/rebase.c:2072
+#: builtin/rebase.c:1761
 msgid "Could not detach HEAD"
 msgstr "No se puede desacoplar HEAD"
 
-#: builtin/rebase.c:2081
+#: builtin/rebase.c:1770
 #, c-format
 msgid "Fast-forwarded %s to %s.\n"
 msgstr "Avance rápido de %s a %s.\n"
 
-#: builtin/receive-pack.c:34
+#: builtin/receive-pack.c:35
 msgid "git receive-pack <git-dir>"
 msgstr "git receive-pack <git-dir>"
 
-#: builtin/receive-pack.c:1275
+#: builtin/receive-pack.c:1280
 msgid ""
 "By default, updating the current branch in a non-bare repository\n"
 "is denied, because it will make the index and work tree inconsistent\n"
@@ -20517,7 +20705,7 @@ msgstr ""
 "Para suprimir este mensaje y mantener el comportamiento predeterminado,\n"
 "configura 'receive.denyCurrentBranch' a 'refuse'."
 
-#: builtin/receive-pack.c:1295
+#: builtin/receive-pack.c:1300
 msgid ""
 "By default, deleting the current branch is denied, because the next\n"
 "'git clone' won't result in any file checked out, causing confusion.\n"
@@ -20538,11 +20726,11 @@ msgstr ""
 "\n"
 "Para suprimir este mensaje, puedes configurarlo en 'refuse'."
 
-#: builtin/receive-pack.c:2478
+#: builtin/receive-pack.c:2480
 msgid "quiet"
 msgstr "silencioso"
 
-#: builtin/receive-pack.c:2492
+#: builtin/receive-pack.c:2495
 msgid "You must specify a directory."
 msgstr "Se tiene que especificar un directorio."
 
@@ -20583,7 +20771,7 @@ msgstr "Marcando objectos alcanzables..."
 msgid "%s points nowhere!"
 msgstr "¡%s no apunta a ningún lado!"
 
-#: builtin/reflog.c:699
+#: builtin/reflog.c:700
 msgid "no reflog specified to delete"
 msgstr "no reflog especificado para borrar"
 
@@ -20740,7 +20928,7 @@ msgstr "especificar una rama master no tiene sentido con --mirror"
 msgid "specifying branches to track makes sense only with fetch mirrors"
 msgstr "especificar ramas para rastrear solo tiene sentido con fetch mirrors"
 
-#: builtin/remote.c:195 builtin/remote.c:700
+#: builtin/remote.c:195 builtin/remote.c:705
 #, c-format
 msgid "remote %s already exists."
 msgstr "remoto %s ya existe."
@@ -20750,25 +20938,30 @@ msgstr "remoto %s ya existe."
 msgid "Could not setup master '%s'"
 msgstr "No se pudo configurar master '%s'"
 
-#: builtin/remote.c:355
+#: builtin/remote.c:322
+#, c-format
+msgid "unhandled branch.%s.rebase=%s; assuming 'true'"
+msgstr "branch.%s.rebase=%s no manejado; se asume 'true'"
+
+#: builtin/remote.c:366
 #, c-format
 msgid "Could not get fetch map for refspec %s"
 msgstr "No se pudo obtener el mapa de fetch para refspec %s"
 
-#: builtin/remote.c:454 builtin/remote.c:462
+#: builtin/remote.c:460 builtin/remote.c:468
 msgid "(matching)"
 msgstr "(concordando)"
 
-#: builtin/remote.c:466
+#: builtin/remote.c:472
 msgid "(delete)"
 msgstr "(eliminar)"
 
-#: builtin/remote.c:655
+#: builtin/remote.c:660
 #, c-format
 msgid "could not set '%s'"
 msgstr "no se pudo configurar '%s'"
 
-#: builtin/remote.c:660
+#: builtin/remote.c:665
 #, c-format
 msgid ""
 "The %s configuration remote.pushDefault in:\n"
@@ -20779,17 +20972,17 @@ msgstr ""
 "\t%s:%d\n"
 "ahora nombra al remoto inexistente '%s'"
 
-#: builtin/remote.c:691 builtin/remote.c:836 builtin/remote.c:943
+#: builtin/remote.c:696 builtin/remote.c:841 builtin/remote.c:948
 #, c-format
 msgid "No such remote: '%s'"
 msgstr "No existe el remoto '%s'"
 
-#: builtin/remote.c:710
+#: builtin/remote.c:715
 #, c-format
 msgid "Could not rename config section '%s' to '%s'"
 msgstr "No se pudo renombrar la sección de configuración '%s' a '%s'"
 
-#: builtin/remote.c:730
+#: builtin/remote.c:735
 #, c-format
 msgid ""
 "Not updating non-default fetch refspec\n"
@@ -20798,19 +20991,19 @@ msgid ""
 msgstr ""
 "No se actualiza refspec de fetch no predeterminada\n"
 "\t%s\n"
-"\tPor favor actualice la configuración manualmente si es necesario."
+"\tPor favor actualiza la configuración manualmente si es necesario."
 
-#: builtin/remote.c:770
+#: builtin/remote.c:775
 #, c-format
 msgid "deleting '%s' failed"
 msgstr "borrar '%s' falló"
 
-#: builtin/remote.c:804
+#: builtin/remote.c:809
 #, c-format
 msgid "creating '%s' failed"
 msgstr "crear '%s' falló"
 
-#: builtin/remote.c:882
+#: builtin/remote.c:887
 msgid ""
 "Note: A branch outside the refs/remotes/ hierarchy was not removed;\n"
 "to delete it, use:"
@@ -20819,124 +21012,124 @@ msgid_plural ""
 "to delete them, use:"
 msgstr[0] ""
 "Nota: Una rama fuera de la jerarquía refs/remotes/ no fue eliminada;\n"
-"para borrarla, use:"
+"para borrarla, usa:"
 msgstr[1] ""
 "Nota: Algunas ramas fuera de la jerarquía refs/remotes/ no fueron "
 "eliminadas;\n"
-"para borrarlas, use:"
+"para borrarlas, usa:"
 
-#: builtin/remote.c:896
+#: builtin/remote.c:901
 #, c-format
 msgid "Could not remove config section '%s'"
 msgstr "No se pudo borrar la sección de configuración '%s'"
 
-#: builtin/remote.c:999
+#: builtin/remote.c:1009
 #, c-format
 msgid " new (next fetch will store in remotes/%s)"
 msgstr " nuevo (siguiente fetch se guardará en remotes/%s)"
 
-#: builtin/remote.c:1002
+#: builtin/remote.c:1012
 msgid " tracked"
 msgstr " rastreada"
 
-#: builtin/remote.c:1004
+#: builtin/remote.c:1014
 msgid " stale (use 'git remote prune' to remove)"
-msgstr " viejo (use 'git remote prune' para eliminar)"
+msgstr " viejo (usa 'git remote prune' para eliminar)"
 
-#: builtin/remote.c:1006
+#: builtin/remote.c:1016
 msgid " ???"
 msgstr " ???"
 
-#: builtin/remote.c:1047
+#: builtin/remote.c:1057
 #, c-format
 msgid "invalid branch.%s.merge; cannot rebase onto > 1 branch"
 msgstr "inválido branch.%s.merge; no se puede rebasar en > 1 rama"
 
-#: builtin/remote.c:1056
+#: builtin/remote.c:1066
 #, c-format
 msgid "rebases interactively onto remote %s"
 msgstr "rebasa interactivamente en remoto %s"
 
-#: builtin/remote.c:1058
+#: builtin/remote.c:1068
 #, c-format
 msgid "rebases interactively (with merges) onto remote %s"
 msgstr "rebasa interactivamente (con fusiones) en remoto %s"
 
-#: builtin/remote.c:1061
+#: builtin/remote.c:1071
 #, c-format
 msgid "rebases onto remote %s"
 msgstr "rebasa sobre el remoto %s"
 
-#: builtin/remote.c:1065
+#: builtin/remote.c:1075
 #, c-format
 msgid " merges with remote %s"
 msgstr " se fusiona con remoto %s"
 
-#: builtin/remote.c:1068
+#: builtin/remote.c:1078
 #, c-format
 msgid "merges with remote %s"
 msgstr "fusiona con remoto %s"
 
-#: builtin/remote.c:1071
+#: builtin/remote.c:1081
 #, c-format
 msgid "%-*s    and with remote %s\n"
 msgstr "%-*s y con el remoto %s\n"
 
-#: builtin/remote.c:1114
+#: builtin/remote.c:1124
 msgid "create"
 msgstr "crear"
 
-#: builtin/remote.c:1117
+#: builtin/remote.c:1127
 msgid "delete"
 msgstr "borrar"
 
-#: builtin/remote.c:1121
+#: builtin/remote.c:1131
 msgid "up to date"
 msgstr "actualizado"
 
-#: builtin/remote.c:1124
+#: builtin/remote.c:1134
 msgid "fast-forwardable"
 msgstr "se puede realizar fast-forward"
 
-#: builtin/remote.c:1127
+#: builtin/remote.c:1137
 msgid "local out of date"
 msgstr "desactualizado local"
 
-#: builtin/remote.c:1134
+#: builtin/remote.c:1144
 #, c-format
 msgid "    %-*s forces to %-*s (%s)"
 msgstr "    %-*s fuerza a %-*s (%s)"
 
-#: builtin/remote.c:1137
+#: builtin/remote.c:1147
 #, c-format
 msgid "    %-*s pushes to %-*s (%s)"
 msgstr "    %-*s publica a %-*s (%s)"
 
-#: builtin/remote.c:1141
+#: builtin/remote.c:1151
 #, c-format
 msgid "    %-*s forces to %s"
 msgstr "    %-*s fuerza a %s"
 
-#: builtin/remote.c:1144
+#: builtin/remote.c:1154
 #, c-format
 msgid "    %-*s pushes to %s"
 msgstr "    %-*s publica a %s"
 
-#: builtin/remote.c:1212
+#: builtin/remote.c:1222
 msgid "do not query remotes"
 msgstr "no consultar remotos"
 
-#: builtin/remote.c:1239
+#: builtin/remote.c:1243
 #, c-format
 msgid "* remote %s"
 msgstr "* remoto %s"
 
-#: builtin/remote.c:1240
+#: builtin/remote.c:1244
 #, c-format
 msgid "  Fetch URL: %s"
 msgstr "  URL  para obtener: %s"
 
-#: builtin/remote.c:1241 builtin/remote.c:1257 builtin/remote.c:1396
+#: builtin/remote.c:1245 builtin/remote.c:1261 builtin/remote.c:1398
 msgid "(no URL)"
 msgstr "(sin URL)"
 
@@ -20944,330 +21137,348 @@ msgstr "(sin URL)"
 #. with the one in " Fetch URL: %s"
 #. translation.
 #.
-#: builtin/remote.c:1255 builtin/remote.c:1257
+#: builtin/remote.c:1259 builtin/remote.c:1261
 #, c-format
 msgid "  Push  URL: %s"
 msgstr "  URL para publicar: %s"
 
-#: builtin/remote.c:1259 builtin/remote.c:1261 builtin/remote.c:1263
+#: builtin/remote.c:1263 builtin/remote.c:1265 builtin/remote.c:1267
 #, c-format
 msgid "  HEAD branch: %s"
 msgstr "  Rama HEAD: %s"
 
-#: builtin/remote.c:1259
+#: builtin/remote.c:1263
 msgid "(not queried)"
 msgstr "(no consultado)"
 
-#: builtin/remote.c:1261
+#: builtin/remote.c:1265
 msgid "(unknown)"
 msgstr "(desconocido)"
 
-#: builtin/remote.c:1265
+#: builtin/remote.c:1269
 #, c-format
 msgid ""
 "  HEAD branch (remote HEAD is ambiguous, may be one of the following):\n"
 msgstr ""
 "  Rama HEAD (HEAD remoto es ambiguo, puede ser uno de los siguientes):\n"
 
-#: builtin/remote.c:1277
+#: builtin/remote.c:1281
 #, c-format
 msgid "  Remote branch:%s"
 msgid_plural "  Remote branches:%s"
 msgstr[0] "  Rama remota:%s"
 msgstr[1] "  Ramas remotas:%s"
 
-#: builtin/remote.c:1280 builtin/remote.c:1306
+#: builtin/remote.c:1284 builtin/remote.c:1310
 msgid " (status not queried)"
 msgstr " (estado no consultado)"
 
-#: builtin/remote.c:1289
+#: builtin/remote.c:1293
 msgid "  Local branch configured for 'git pull':"
 msgid_plural "  Local branches configured for 'git pull':"
 msgstr[0] "  Rama local configurada para 'git pull':"
 msgstr[1] "  Ramas locales configuradas para 'git pull':"
 
-#: builtin/remote.c:1297
+#: builtin/remote.c:1301
 msgid "  Local refs will be mirrored by 'git push'"
 msgstr "  Las referencias locales serán reflejadas por 'git push'"
 
-#: builtin/remote.c:1303
+#: builtin/remote.c:1307
 #, c-format
 msgid "  Local ref configured for 'git push'%s:"
 msgid_plural "  Local refs configured for 'git push'%s:"
 msgstr[0] "  Referencia local configurada para 'git push'%s:"
 msgstr[1] "  Referencias locales configuradas para 'git push'%s:"
 
-#: builtin/remote.c:1324
+#: builtin/remote.c:1328
 msgid "set refs/remotes/<name>/HEAD according to remote"
 msgstr "configurar refs/remotes/<nombre>/HEAD de acuerdo al remoto"
 
-#: builtin/remote.c:1326
+#: builtin/remote.c:1330
 msgid "delete refs/remotes/<name>/HEAD"
 msgstr "borrar refs/remotos/<nombre>/HEAD"
 
-#: builtin/remote.c:1341
+#: builtin/remote.c:1344
 msgid "Cannot determine remote HEAD"
 msgstr "No se puede determinar el HEAD remoto"
 
-#: builtin/remote.c:1343
+#: builtin/remote.c:1346
 msgid "Multiple remote HEAD branches. Please choose one explicitly with:"
 msgstr "Múltiples ramas HEAD remotas. Por favor escoja una explícitamente con:"
 
-#: builtin/remote.c:1353
+#: builtin/remote.c:1356
 #, c-format
 msgid "Could not delete %s"
 msgstr "No se pudo borrar %s"
 
-#: builtin/remote.c:1361
+#: builtin/remote.c:1364
 #, c-format
 msgid "Not a valid ref: %s"
 msgstr "No es un ref válido: %s"
 
-#: builtin/remote.c:1363
+#: builtin/remote.c:1366
 #, c-format
 msgid "Could not setup %s"
 msgstr "No se pudo configurar %s"
 
-#: builtin/remote.c:1381
+#: builtin/remote.c:1384
 #, c-format
 msgid " %s will become dangling!"
 msgstr " ¡%s se volverá colgante!"
 
-#: builtin/remote.c:1382
+#: builtin/remote.c:1385
 #, c-format
 msgid " %s has become dangling!"
 msgstr " ¡%s se ha vuelto colgante!"
 
-#: builtin/remote.c:1392
+#: builtin/remote.c:1394
 #, c-format
 msgid "Pruning %s"
 msgstr "Recortando %s"
 
-#: builtin/remote.c:1393
+#: builtin/remote.c:1395
 #, c-format
 msgid "URL: %s"
 msgstr "URL: %s"
 
-#: builtin/remote.c:1409
+#: builtin/remote.c:1411
 #, c-format
 msgid " * [would prune] %s"
 msgstr " * [se acortará] %s"
 
-#: builtin/remote.c:1412
+#: builtin/remote.c:1414
 #, c-format
 msgid " * [pruned] %s"
 msgstr " * [prune realizado] %s"
 
-#: builtin/remote.c:1457
+#: builtin/remote.c:1459
 msgid "prune remotes after fetching"
 msgstr "recortar remotos tras realizar fetch"
 
-#: builtin/remote.c:1521 builtin/remote.c:1577 builtin/remote.c:1647
+#: builtin/remote.c:1523 builtin/remote.c:1579 builtin/remote.c:1649
 #, c-format
 msgid "No such remote '%s'"
 msgstr "No existe el remoto '%s'"
 
-#: builtin/remote.c:1539
+#: builtin/remote.c:1541
 msgid "add branch"
 msgstr "agregar rama"
 
-#: builtin/remote.c:1546
+#: builtin/remote.c:1548
 msgid "no remote specified"
 msgstr "no hay remotos especificados"
 
-#: builtin/remote.c:1563
+#: builtin/remote.c:1565
 msgid "query push URLs rather than fetch URLs"
 msgstr "consultar URLs de push en lugar de URLs de fetch"
 
-#: builtin/remote.c:1565
+#: builtin/remote.c:1567
 msgid "return all URLs"
 msgstr "retornar todos los URLs"
 
-#: builtin/remote.c:1595
+#: builtin/remote.c:1597
 #, c-format
 msgid "no URLs configured for remote '%s'"
 msgstr "no hay URLs configurados para remoto '%s'"
 
-#: builtin/remote.c:1621
+#: builtin/remote.c:1623
 msgid "manipulate push URLs"
 msgstr "manipular URLs de push"
 
-#: builtin/remote.c:1623
+#: builtin/remote.c:1625
 msgid "add URL"
 msgstr "agregar URL"
 
-#: builtin/remote.c:1625
+#: builtin/remote.c:1627
 msgid "delete URLs"
 msgstr "borrar URLs"
 
-#: builtin/remote.c:1632
+#: builtin/remote.c:1634
 msgid "--add --delete doesn't make sense"
 msgstr "--add --delete no tiene sentido"
 
-#: builtin/remote.c:1673
+#: builtin/remote.c:1675
 #, c-format
 msgid "Invalid old URL pattern: %s"
 msgstr "Patrón de URL viejo inválido: %s"
 
-#: builtin/remote.c:1681
+#: builtin/remote.c:1683
 #, c-format
 msgid "No such URL found: %s"
 msgstr "No se encontró URL: %s"
 
-#: builtin/remote.c:1683
+#: builtin/remote.c:1685
 msgid "Will not delete all non-push URLs"
 msgstr "No borrará todos los URLs no de push"
 
-#: builtin/repack.c:26
+#: builtin/remote.c:1702
+msgid "be verbose; must be placed before a subcommand"
+msgstr "ser verboso; tiene que ser agregado antes de un subcomando"
+
+#: builtin/repack.c:28
 msgid "git repack [<options>]"
 msgstr "git repack [<opciones>]"
 
-#: builtin/repack.c:31
+#: builtin/repack.c:33
 msgid ""
 "Incremental repacks are incompatible with bitmap indexes.  Use\n"
 "--no-write-bitmap-index or disable the pack.writebitmaps configuration."
 msgstr ""
-"Reempaquetados incrementales son incompatibles con índices bitmap. Use\n"
-"--no-write-bitmap-index o deshabilite la configuración pack.writebitmaps."
+"Reempaquetados incrementales son incompatibles con índices bitmap. Usa\n"
+"--no-write-bitmap-index o deshabilita la configuración pack.writebitmaps."
 
-#: builtin/repack.c:198
+#: builtin/repack.c:201
 msgid "could not start pack-objects to repack promisor objects"
 msgstr "no se puede iniciar pack-objects para reempaquetar objetos promisores"
 
-#: builtin/repack.c:270 builtin/repack.c:630
+#: builtin/repack.c:273 builtin/repack.c:816
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
 msgstr ""
 "repack: Esperando líneas de ID de objeto completas en hex solo desde pack-"
 "objects."
 
-#: builtin/repack.c:294
+#: builtin/repack.c:297
 msgid "could not finish pack-objects to repack promisor objects"
 msgstr ""
 "no se puede finalizar pack-objects para reempaquetar objetos promisores"
 
-#: builtin/repack.c:309
+#: builtin/repack.c:312
 #, c-format
 msgid "cannot open index for %s"
 msgstr "no se puede abrir index para %s"
 
-#: builtin/repack.c:368
+#: builtin/repack.c:371
 #, c-format
 msgid "pack %s too large to consider in geometric progression"
-msgstr "pack %s es muy grande para considerar en la progresión geométrica"
+msgstr ""
+"pack %s es demasiado grande para considerar en la progresión geométrica"
 
-#: builtin/repack.c:401 builtin/repack.c:408 builtin/repack.c:413
+#: builtin/repack.c:404 builtin/repack.c:411 builtin/repack.c:416
 #, c-format
 msgid "pack %s too large to roll up"
-msgstr "pack %s es muy grande para hacer un roll up"
+msgstr "pack %s es demasiado grande para hacer un roll up"
 
-#: builtin/repack.c:460
+#: builtin/repack.c:496
+#, c-format
+msgid "could not open tempfile %s for writing"
+msgstr "no se pudo abrir %s para escritura"
+
+#: builtin/repack.c:514
+msgid "could not close refs snapshot tempfile"
+msgstr "no se pudo cerrar snapshot de refs temporal"
+
+#: builtin/repack.c:628
 msgid "pack everything in a single pack"
 msgstr "empaquetar todo en un único paquete"
 
-#: builtin/repack.c:462
+#: builtin/repack.c:630
 msgid "same as -a, and turn unreachable objects loose"
 msgstr "lo mismo que -a, y soltar objetos inalcanzables"
 
-#: builtin/repack.c:465
+#: builtin/repack.c:633
 msgid "remove redundant packs, and run git-prune-packed"
 msgstr "eliminar paquetes redundantes, y ejecutar git-prune-packed"
 
-#: builtin/repack.c:467
+#: builtin/repack.c:635
 msgid "pass --no-reuse-delta to git-pack-objects"
 msgstr "pasar --no-reuse-delta a git-pack-objects"
 
-#: builtin/repack.c:469
+#: builtin/repack.c:637
 msgid "pass --no-reuse-object to git-pack-objects"
 msgstr "pasar --no-reuse-object a git-pack-objects"
 
-#: builtin/repack.c:471
+#: builtin/repack.c:639
 msgid "do not run git-update-server-info"
 msgstr "no ejecutar git-update-server-info"
 
-#: builtin/repack.c:474
+#: builtin/repack.c:642
 msgid "pass --local to git-pack-objects"
 msgstr "pasar --local a git-pack-objects"
 
-#: builtin/repack.c:476
+#: builtin/repack.c:644
 msgid "write bitmap index"
 msgstr "escribir un índice de bitmap"
 
-#: builtin/repack.c:478
+#: builtin/repack.c:646
 msgid "pass --delta-islands to git-pack-objects"
 msgstr "pasar --delta-islands a git-pack-objects"
 
-#: builtin/repack.c:479
+#: builtin/repack.c:647
 msgid "approxidate"
 msgstr "approxidate"
 
-#: builtin/repack.c:480
+#: builtin/repack.c:648
 msgid "with -A, do not loosen objects older than this"
 msgstr "con -A, no perder objetos más antiguos que este"
 
-#: builtin/repack.c:482
+#: builtin/repack.c:650
 msgid "with -a, repack unreachable objects"
 msgstr "con -a, reempaquetar objetos inalcanzables"
 
-#: builtin/repack.c:484
+#: builtin/repack.c:652
 msgid "size of the window used for delta compression"
 msgstr "tamaño de la ventana usada para la compresión delta"
 
-#: builtin/repack.c:485 builtin/repack.c:491
+#: builtin/repack.c:653 builtin/repack.c:659
 msgid "bytes"
 msgstr "bytes"
 
-#: builtin/repack.c:486
+#: builtin/repack.c:654
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr ""
 "lo mismo que arriba, pero limita el tamaño de memoria en lugar del número de "
 "entradas"
 
-#: builtin/repack.c:488
+#: builtin/repack.c:656
 msgid "limits the maximum delta depth"
 msgstr "limita la profundidad máxima del delta"
 
-#: builtin/repack.c:490
+#: builtin/repack.c:658
 msgid "limits the maximum number of threads"
 msgstr "limita el número máximo de hilos"
 
-#: builtin/repack.c:492
+#: builtin/repack.c:660
 msgid "maximum size of each packfile"
 msgstr "tamaño máximo de cada paquete"
 
-#: builtin/repack.c:494
+#: builtin/repack.c:662
 msgid "repack objects in packs marked with .keep"
 msgstr "reempaquetar objetos en paquetes marcados con .keep"
 
-#: builtin/repack.c:496
+#: builtin/repack.c:664
 msgid "do not repack this pack"
 msgstr "no reempaquetar este paquete"
 
-#: builtin/repack.c:498
+#: builtin/repack.c:666
 msgid "find a geometric progression with factor <N>"
 msgstr "encontrar una progresión geométrica con factor <N>"
 
-#: builtin/repack.c:508
+#: builtin/repack.c:668
+msgid "write a multi-pack index of the resulting packs"
+msgstr "escribir un índice multi-pack de los paquetes resultantes"
+
+#: builtin/repack.c:678
 msgid "cannot delete packs in a precious-objects repo"
 msgstr "no se pueden borrar paquetes en un repositorio de objetos preciosos"
 
-#: builtin/repack.c:512
+#: builtin/repack.c:682
 msgid "--keep-unreachable and -A are incompatible"
 msgstr "--keep-unreachable y -A son incompatibles"
 
-#: builtin/repack.c:527
+#: builtin/repack.c:713
 msgid "--geometric is incompatible with -A, -a"
 msgstr "--geometric es incompatible con -A, -a"
 
-#: builtin/repack.c:639
+#: builtin/repack.c:825
 msgid "Nothing new to pack."
 msgstr "Nada nuevo para empaquetar."
 
-#: builtin/repack.c:669
+#: builtin/repack.c:855
 #, c-format
 msgid "missing required file: %s"
 msgstr "falta archivo requerido: %s"
 
-#: builtin/repack.c:671
+#: builtin/repack.c:857
 #, c-format
 msgid "could not unlink: %s"
 msgstr "no se pudo desvincular: %s"
@@ -21416,7 +21627,7 @@ msgid ""
 "original commit '%s' contains mergetag '%s' that is discarded; use --edit "
 "instead of --graft"
 msgstr ""
-"commit original '%s' contiene un mergetag '%s' que es descartado; use --edit "
+"commit original '%s' contiene un mergetag '%s' que es descartado; usa --edit "
 "en lugar de --graft"
 
 #: builtin/replace.c:469
@@ -21577,92 +21788,92 @@ msgstr "fusionar"
 msgid "keep"
 msgstr "mantener"
 
-#: builtin/reset.c:83
+#: builtin/reset.c:89
 msgid "You do not have a valid HEAD."
 msgstr "No hay un HEAD válido."
 
-#: builtin/reset.c:85
+#: builtin/reset.c:91
 msgid "Failed to find tree of HEAD."
 msgstr "Falló al encontrar el árbol de HEAD."
 
-#: builtin/reset.c:91
+#: builtin/reset.c:97
 #, c-format
 msgid "Failed to find tree of %s."
 msgstr "Falló al encontrar árbol de %s."
 
-#: builtin/reset.c:116
+#: builtin/reset.c:122
 #, c-format
 msgid "HEAD is now at %s"
 msgstr "HEAD está ahora en %s"
 
-#: builtin/reset.c:195
+#: builtin/reset.c:201
 #, c-format
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "No se puede realizar un reset %s en medio de una fusión."
 
-#: builtin/reset.c:295 builtin/stash.c:589 builtin/stash.c:663
-#: builtin/stash.c:687
+#: builtin/reset.c:301 builtin/stash.c:605 builtin/stash.c:679
+#: builtin/stash.c:703
 msgid "be quiet, only report errors"
 msgstr "ser silencioso, solo reportar errores"
 
-#: builtin/reset.c:297
+#: builtin/reset.c:303
 msgid "reset HEAD and index"
 msgstr "reiniciar HEAD e índice"
 
-#: builtin/reset.c:298
+#: builtin/reset.c:304
 msgid "reset only HEAD"
 msgstr "reiniciar solo HEAD"
 
-#: builtin/reset.c:300 builtin/reset.c:302
+#: builtin/reset.c:306 builtin/reset.c:308
 msgid "reset HEAD, index and working tree"
 msgstr "reiniciar HEAD, índice y árbol de trabajo"
 
-#: builtin/reset.c:304
+#: builtin/reset.c:310
 msgid "reset HEAD but keep local changes"
 msgstr "reiniciar HEAD pero mantener cambios locales"
 
-#: builtin/reset.c:310
+#: builtin/reset.c:316
 msgid "record only the fact that removed paths will be added later"
 msgstr "grabar solo el hecho de que las rutas eliminadas serán agregadas luego"
 
-#: builtin/reset.c:344
+#: builtin/reset.c:350
 #, c-format
 msgid "Failed to resolve '%s' as a valid revision."
 msgstr "Falló al resolver '%s' como una revisión válida."
 
-#: builtin/reset.c:352
+#: builtin/reset.c:358
 #, c-format
 msgid "Failed to resolve '%s' as a valid tree."
 msgstr "Falló al resolver '%s' como un árbol válido."
 
-#: builtin/reset.c:361
+#: builtin/reset.c:367
 msgid "--patch is incompatible with --{hard,mixed,soft}"
 msgstr "--patch es incompatible con --{hard,mixed,soft}"
 
-#: builtin/reset.c:371
+#: builtin/reset.c:377
 msgid "--mixed with paths is deprecated; use 'git reset -- <paths>' instead."
 msgstr ""
-"--mixed con rutas ha sido deprecado; use 'git reset -- <rutas>' en cambio."
+"--mixed con rutas ha sido deprecado; usa 'git reset -- <rutas>' en cambio."
 
-#: builtin/reset.c:373
+#: builtin/reset.c:379
 #, c-format
 msgid "Cannot do %s reset with paths."
 msgstr "No se puede hacer un reset %s con rutas."
 
-#: builtin/reset.c:388
+#: builtin/reset.c:394
 #, c-format
 msgid "%s reset is not allowed in a bare repository"
 msgstr "%s reset no está permitido en un repositorio vacío"
 
-#: builtin/reset.c:392
+#: builtin/reset.c:398
 msgid "-N can only be used with --mixed"
 msgstr "-N solo puede ser usada con --mixed"
 
-#: builtin/reset.c:413
+#: builtin/reset.c:419
 msgid "Unstaged changes after reset:"
 msgstr "Cambios fuera del área de stage tras el reset:"
 
-#: builtin/reset.c:416
+#: builtin/reset.c:422
 #, c-format
 msgid ""
 "\n"
@@ -21676,12 +21887,12 @@ msgstr ""
 "usar '--quiet' para evitar esto.  Configura la opción reset.quiet a true\n"
 "para volverlo en el default.\n"
 
-#: builtin/reset.c:434
+#: builtin/reset.c:440
 #, c-format
 msgid "Could not reset index file to revision '%s'."
 msgstr "No se puede reiniciar el índice a la revisión '%s'."
 
-#: builtin/reset.c:439
+#: builtin/reset.c:445
 msgid "Could not write new index file."
 msgstr "No se puede escribir un nuevo archivo índice."
 
@@ -21741,7 +21952,7 @@ msgstr ""
 "   or: git rev-parse --sq-quote [<arg>...]\n"
 "   or: git rev-parse [<opciones>] [<arg>...]\n"
 "\n"
-"Ejecute \"git rev-parse --parseopt -h\" para más información sobre el primer "
+"Ejecuta \"git rev-parse --parseopt -h\" para más información sobre el primer "
 "uso."
 
 #: builtin/rev-parse.c:712
@@ -21786,7 +21997,7 @@ msgstr "modo desconocido para --abbrev-ref: %s"
 #: builtin/rev-parse.c:1023
 #, c-format
 msgid "unknown mode for --show-object-format: %s"
-msgstr "modo desconocidopara --show-object-format: %s"
+msgstr "modo desconocido para --show-object-format: %s"
 
 #: builtin/revert.c:24
 msgid "git revert [<options>] <commit-ish>..."
@@ -21862,15 +22073,19 @@ msgstr "adjuntar el nombre del commit"
 msgid "preserve initially empty commits"
 msgstr "preservar commits iniciales vacíos"
 
+#: builtin/revert.c:128
+msgid "allow commits with empty messages"
+msgstr "permitir commits con mensajes vacíos"
+
 #: builtin/revert.c:129
 msgid "keep redundant, empty commits"
 msgstr "mantener commits redundantes, vacíos"
 
-#: builtin/revert.c:237
+#: builtin/revert.c:241
 msgid "revert failed"
 msgstr "falló al revertir"
 
-#: builtin/revert.c:250
+#: builtin/revert.c:254
 msgid "cherry-pick failed"
 msgstr "cherry-pick falló"
 
@@ -21920,71 +22135,71 @@ msgid_plural "the following files have local modifications:"
 msgstr[0] "el siguiente archivo tiene modificaciones locales:"
 msgstr[1] "los siguientes archivos tienen modificaciones locales:"
 
-#: builtin/rm.c:244
+#: builtin/rm.c:245
 msgid "do not list removed files"
 msgstr "no listar archivos eliminados"
 
-#: builtin/rm.c:245
+#: builtin/rm.c:246
 msgid "only remove from the index"
 msgstr "solo eliminar del índice"
 
-#: builtin/rm.c:246
-msgid "override the up-to-date check"
-msgstr "salta el check de actualización"
-
 #: builtin/rm.c:247
+msgid "override the up-to-date check"
+msgstr "saltar el check de actualización"
+
+#: builtin/rm.c:248
 msgid "allow recursive removal"
 msgstr "permitir eliminar de forma recursiva"
 
-#: builtin/rm.c:249
+#: builtin/rm.c:250
 msgid "exit with a zero status even if nothing matched"
 msgstr "salir con estado cero incluso si nada coincide"
 
-#: builtin/rm.c:283
+#: builtin/rm.c:285
 msgid "No pathspec was given. Which files should I remove?"
 msgstr "No se entregó un pathspec. ¿Qué archivos se deberían eliminar?"
 
-#: builtin/rm.c:310
+#: builtin/rm.c:315
 msgid "please stage your changes to .gitmodules or stash them to proceed"
 msgstr ""
 "por favor agrega tus cambios a .gitmodules al stage o realiza un stash para "
 "proceder"
 
-#: builtin/rm.c:331
+#: builtin/rm.c:337
 #, c-format
 msgid "not removing '%s' recursively without -r"
 msgstr "no eliminando '%s' de manera recursiva sin -r"
 
-#: builtin/rm.c:379
+#: builtin/rm.c:385
 #, c-format
 msgid "git rm: unable to remove %s"
 msgstr "git rm: no es posible eliminar %s"
 
 #: builtin/send-pack.c:20
 msgid ""
-"git send-pack [--all | --mirror] [--dry-run] [--force] [--receive-pack=<git-"
-"receive-pack>] [--verbose] [--thin] [--atomic] [<host>:]<directory> "
-"[<ref>...]\n"
-"  --all and explicit <ref> specification are mutually exclusive."
+"git send-pack [--mirror] [--dry-run] [--force]\n"
+"              [--receive-pack=<git-receive-pack>]\n"
+"              [--verbose] [--thin] [--atomic]\n"
+"              [<host>:]<directory> (--all | <ref>...)"
 msgstr ""
-"git send-pack [--all | --mirror] [--dry-run] [--force] [--receive-pack=<git-"
-"receive-pack>] [--verbose] [--thin] [--atomic] [<host>:]<directory> "
-"[<ref>...]\n"
-"  --all y especificaciones <ref> explícitas son mutuamente exclusivas."
+"git send-pack [--mirror] [--dry-run] [--force]\n"
+"              [--receive-pack=<git-receive-pack>]\n"
+"              [--verbose] [--thin] [--atomic]\n"
+"              [<host>:]<directorio> (--all | <ref>...)"
 
-#: builtin/send-pack.c:188
+#: builtin/send-pack.c:192
 msgid "remote name"
 msgstr "nombre remoto"
 
-#: builtin/send-pack.c:201
+#: builtin/send-pack.c:205
 msgid "use stateless RPC protocol"
 msgstr "usar protocolo RPC sin estado"
 
-#: builtin/send-pack.c:202
+#: builtin/send-pack.c:206
 msgid "read refs from stdin"
 msgstr "leer refs de stdin"
 
-#: builtin/send-pack.c:203
+#: builtin/send-pack.c:207
 msgid "print status from remote helper"
 msgstr "mostrar status del remote helper"
 
@@ -22041,21 +22256,21 @@ msgstr "campo"
 msgid "group by field"
 msgstr "agrupar por campo"
 
-#: builtin/shortlog.c:391
+#: builtin/shortlog.c:394
 msgid "too many arguments given outside repository"
 msgstr "demasiados argumentos dados fuera del repositorio"
 
 #: builtin/show-branch.c:13
 msgid ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
-"\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
-"\t\t[--more=<n> | --list | --independent | --merge-base]\n"
-"\t\t[--no-name | --sha1-name] [--topics] [(<rev> | <glob>)...]"
+"                [--current] [--color[=<when>] | --no-color] [--sparse]\n"
+"                [--more=<n> | --list | --independent | --merge-base]\n"
+"                [--no-name | --sha1-name] [--topics] [(<rev> | <glob>)...]"
 msgstr ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
-"\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
-"\t\t[--more=<n> | --list | --independent | --merge-base]\n"
-"\t\t[--no-name | --sha1-name] [--topics] [(<rev> | <glob>)...]"
+"                [--current] [--color[=<when>] | --no-color] [--sparse]\n"
+"                [--more=<n> | --list | --independent | --merge-base]\n"
+"                [--no-name | --sha1-name] [--topics] [(<rev> | <glob>)...]"
 
 #: builtin/show-branch.c:17
 msgid "git show-branch (-g | --reflog)[=<n>[,<base>]] [--list] [<ref>]"
@@ -22068,114 +22283,114 @@ msgid_plural "ignoring %s; cannot handle more than %d refs"
 msgstr[0] "ignorando %s; no se puede manejar más de %d ref"
 msgstr[1] "ignorando %s; no se puede manejar más de %d refs"
 
-#: builtin/show-branch.c:548
+#: builtin/show-branch.c:547
 #, c-format
 msgid "no matching refs with %s"
 msgstr "no hay refs que concuerden con %s"
 
-#: builtin/show-branch.c:645
+#: builtin/show-branch.c:644
 msgid "show remote-tracking and local branches"
 msgstr "mostrar ramas locales y de rastreo remoto"
 
-#: builtin/show-branch.c:647
+#: builtin/show-branch.c:646
 msgid "show remote-tracking branches"
 msgstr "mostrar ramas de rastreo remoto"
 
-#: builtin/show-branch.c:649
+#: builtin/show-branch.c:648
 msgid "color '*!+-' corresponding to the branch"
 msgstr "colorear '*!+-' correspondiendo a la rama"
 
-#: builtin/show-branch.c:651
+#: builtin/show-branch.c:650
 msgid "show <n> more commits after the common ancestor"
 msgstr "mostrar <n> commits más tras encontrar el ancestro común"
 
-#: builtin/show-branch.c:653
+#: builtin/show-branch.c:652
 msgid "synonym to more=-1"
 msgstr "sinónimo de más=-1"
 
-#: builtin/show-branch.c:654
+#: builtin/show-branch.c:653
 msgid "suppress naming strings"
 msgstr "suprimir strings de nombre"
 
-#: builtin/show-branch.c:656
+#: builtin/show-branch.c:655
 msgid "include the current branch"
 msgstr "incluir la rama actual"
 
-#: builtin/show-branch.c:658
+#: builtin/show-branch.c:657
 msgid "name commits with their object names"
 msgstr "nombrar commits con sus nombres de objeto"
 
-#: builtin/show-branch.c:660
+#: builtin/show-branch.c:659
 msgid "show possible merge bases"
 msgstr "mostrar bases de fusión posibles"
 
-#: builtin/show-branch.c:662
+#: builtin/show-branch.c:661
 msgid "show refs unreachable from any other ref"
 msgstr "mostrar refs inalcanzables por ningún otro ref"
 
-#: builtin/show-branch.c:664
+#: builtin/show-branch.c:663
 msgid "show commits in topological order"
 msgstr "mostrar commits en orden topológico"
 
-#: builtin/show-branch.c:667
+#: builtin/show-branch.c:666
 msgid "show only commits not on the first branch"
 msgstr "mostrar solo commits que no estén en la primera rama"
 
-#: builtin/show-branch.c:669
+#: builtin/show-branch.c:668
 msgid "show merges reachable from only one tip"
 msgstr "mostrar fusiones alcanzables por solo una punta"
 
-#: builtin/show-branch.c:671
+#: builtin/show-branch.c:670
 msgid "topologically sort, maintaining date order where possible"
 msgstr "orden topológico, manteniendo el orden de fechas donde sea posible"
 
-#: builtin/show-branch.c:674
+#: builtin/show-branch.c:673
 msgid "<n>[,<base>]"
 msgstr "<n>[,<base>]"
 
-#: builtin/show-branch.c:675
+#: builtin/show-branch.c:674
 msgid "show <n> most recent ref-log entries starting at base"
 msgstr "mostrar <n> entradas más recientes de ref-log comenzando desde la base"
 
-#: builtin/show-branch.c:711
+#: builtin/show-branch.c:710
 msgid ""
 "--reflog is incompatible with --all, --remotes, --independent or --merge-base"
 msgstr ""
 "--reflog no es compatible con --all, --remotes, --independent o --merge-base"
 
-#: builtin/show-branch.c:735
+#: builtin/show-branch.c:734
 msgid "no branches given, and HEAD is not valid"
 msgstr "no se dieron ramas, y el HEAD no es válido"
 
-#: builtin/show-branch.c:738
+#: builtin/show-branch.c:737
 msgid "--reflog option needs one branch name"
 msgstr "opción --reflog necesita un nombre de rama"
 
-#: builtin/show-branch.c:741
+#: builtin/show-branch.c:740
 #, c-format
 msgid "only %d entry can be shown at one time."
 msgid_plural "only %d entries can be shown at one time."
 msgstr[0] "solo %d entrada puede ser mostrada a la vez."
 msgstr[1] "solo %d entradas pueden ser mostradas a la vez."
 
-#: builtin/show-branch.c:745
+#: builtin/show-branch.c:744
 #, c-format
 msgid "no such ref %s"
 msgstr "no existe el ref %s"
 
-#: builtin/show-branch.c:831
+#: builtin/show-branch.c:828
 #, c-format
 msgid "cannot handle more than %d rev."
 msgid_plural "cannot handle more than %d revs."
 msgstr[0] "no se puede manejar más de %d rev."
 msgstr[1] "no se puede manejar más de %d revs."
 
-#: builtin/show-branch.c:835
+#: builtin/show-branch.c:832
 #, c-format
 msgid "'%s' is not a valid ref."
 msgstr "'%s' no es una ref válida."
 
-#: builtin/show-branch.c:838
+#: builtin/show-branch.c:835
 #, c-format
 msgid "cannot find commit %s (%s)"
 msgstr "no se puede encontrar el commit %s (%s)"
@@ -22246,72 +22461,86 @@ msgstr ""
 "este árbol de trabajo no es sparse (archivo sparse-checkout tal vez no "
 "existe)"
 
-#: builtin/sparse-checkout.c:227
+#: builtin/sparse-checkout.c:173
+#, c-format
+msgid ""
+"directory '%s' contains untracked files, but is not in the sparse-checkout "
+"cone"
+msgstr ""
+"directorio '%s' contiene archivos no rastreados, pero no está en el cono de "
+"sparse-checkout"
+
+#: builtin/sparse-checkout.c:181
+#, c-format
+msgid "failed to remove directory '%s'"
+msgstr "falló al borrar directorio '%s'"
+
+#: builtin/sparse-checkout.c:321
 msgid "failed to create directory for sparse-checkout file"
 msgstr "falló al crear directorio para el archivo sparse-checkout"
 
-#: builtin/sparse-checkout.c:268
+#: builtin/sparse-checkout.c:362
 msgid "unable to upgrade repository format to enable worktreeConfig"
 msgstr ""
 "no es posible actualizar el formato de repositorio para habilitar "
 "worktreeConfig"
 
-#: builtin/sparse-checkout.c:270
+#: builtin/sparse-checkout.c:364
 msgid "failed to set extensions.worktreeConfig setting"
 msgstr "falló al configurar opción extensions.worktreeConfig"
 
-#: builtin/sparse-checkout.c:290
+#: builtin/sparse-checkout.c:384
 msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
 msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
 
-#: builtin/sparse-checkout.c:310
+#: builtin/sparse-checkout.c:404
 msgid "initialize the sparse-checkout in cone mode"
 msgstr "inicializa el sparse-checkout en modo cono"
 
-#: builtin/sparse-checkout.c:312
+#: builtin/sparse-checkout.c:406
 msgid "toggle the use of a sparse index"
 msgstr "activar el uso de un índice sparse"
 
-#: builtin/sparse-checkout.c:340
+#: builtin/sparse-checkout.c:434
 msgid "failed to modify sparse-index config"
 msgstr "falló al modificar la configuración del índice sparse"
 
-#: builtin/sparse-checkout.c:361
+#: builtin/sparse-checkout.c:455
 #, c-format
 msgid "failed to open '%s'"
 msgstr "falló al abrir '%s'"
 
-#: builtin/sparse-checkout.c:413
+#: builtin/sparse-checkout.c:507
 #, c-format
 msgid "could not normalize path %s"
 msgstr "no se pudo normalizar la ruta %s"
 
-#: builtin/sparse-checkout.c:425
+#: builtin/sparse-checkout.c:519
 msgid "git sparse-checkout (set|add) (--stdin | <patterns>)"
 msgstr "git sparse-checkout (set|add) (--stdin | <patrones>)"
 
-#: builtin/sparse-checkout.c:450
+#: builtin/sparse-checkout.c:544
 #, c-format
 msgid "unable to unquote C-style string '%s'"
 msgstr "no es posible dequote la cadena de estilo C '%s'"
 
-#: builtin/sparse-checkout.c:504 builtin/sparse-checkout.c:528
+#: builtin/sparse-checkout.c:598 builtin/sparse-checkout.c:622
 msgid "unable to load existing sparse-checkout patterns"
 msgstr "no se pudo cargar patrones de sparse-checkout existentes"
 
-#: builtin/sparse-checkout.c:573
+#: builtin/sparse-checkout.c:667
 msgid "read patterns from standard in"
 msgstr "leer patrones de standard in"
 
-#: builtin/sparse-checkout.c:588
+#: builtin/sparse-checkout.c:682
 msgid "git sparse-checkout reapply"
 msgstr "git sparse-checkout reapply"
 
-#: builtin/sparse-checkout.c:607
+#: builtin/sparse-checkout.c:701
 msgid "git sparse-checkout disable"
 msgstr "git sparse-checkout disable"
 
-#: builtin/sparse-checkout.c:638
+#: builtin/sparse-checkout.c:732
 msgid "error while refreshing working directory"
 msgstr "error al refrescar directorio de trabajo"
 
@@ -22347,7 +22576,7 @@ msgstr ""
 "          [--pathspec-from-file=<archivo> [--pathspec-file-nul]]\n"
 "          [--] [<pathspec>...]]"
 
-#: builtin/stash.c:34 builtin/stash.c:87
+#: builtin/stash.c:34
 msgid ""
 "git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [<message>]"
@@ -22377,6 +22606,14 @@ msgstr ""
 "          [-u|--include-untracked] [-a|--all] [-m|--message <mensaje>]\n"
 "          [--] [<pathspec>...]]"
 
+#: builtin/stash.c:87
+msgid ""
+"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"               [-u|--include-untracked] [-a|--all] [<message>]"
+msgstr ""
+"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"               [-u|--include-untracked] [-a|--all] [<mensaje>]"
+
 #: builtin/stash.c:130
 #, c-format
 msgid "'%s' is not a stash-like commit"
@@ -22400,7 +22637,7 @@ msgstr "%s no es una referencia válida"
 msgid "git stash clear with arguments is unimplemented"
 msgstr "git stash clear con argumentos no está implementado"
 
-#: builtin/stash.c:431
+#: builtin/stash.c:447
 #, c-format
 msgid ""
 "WARNING: Untracked file in way of tracked file!  Renaming\n"
@@ -22412,172 +22649,172 @@ msgstr ""
 "             %s ->%s\n"
 "          Para hacer espacio.\n"
 
-#: builtin/stash.c:492
+#: builtin/stash.c:508
 msgid "cannot apply a stash in the middle of a merge"
 msgstr "no se puede aplicar un stash en medio de un merge"
 
-#: builtin/stash.c:503
+#: builtin/stash.c:519
 #, c-format
 msgid "could not generate diff %s^!."
 msgstr "¡no se pudo generar diff %s^!."
 
-#: builtin/stash.c:510
+#: builtin/stash.c:526
 msgid "conflicts in index. Try without --index."
-msgstr "conflictos en índice. Intente sin --index."
+msgstr "conflictos en índice. Intenta sin --index."
 
-#: builtin/stash.c:516
+#: builtin/stash.c:532
 msgid "could not save index tree"
 msgstr "no se pudo guardar el árbol de índice"
 
-#: builtin/stash.c:525
-msgid "could not restore untracked files from stash"
-msgstr "no se pudo restaurar archivos no rastreados de la entrada stash"
-
-#: builtin/stash.c:539
+#: builtin/stash.c:552
 #, c-format
 msgid "Merging %s with %s"
 msgstr "Fusionando %s con %s"
 
-#: builtin/stash.c:549
+#: builtin/stash.c:562
 msgid "Index was not unstashed."
 msgstr "El índice no fue sacado de stash."
 
-#: builtin/stash.c:591 builtin/stash.c:689
+#: builtin/stash.c:575
+msgid "could not restore untracked files from stash"
+msgstr "no se pudo restaurar archivos no rastreados de la entrada stash"
+
+#: builtin/stash.c:607 builtin/stash.c:705
 msgid "attempt to recreate the index"
 msgstr "intento de recrear el índice"
 
-#: builtin/stash.c:635
+#: builtin/stash.c:651
 #, c-format
 msgid "Dropped %s (%s)"
 msgstr "Descartado %s (%s)"
 
-#: builtin/stash.c:638
+#: builtin/stash.c:654
 #, c-format
 msgid "%s: Could not drop stash entry"
 msgstr "%s: No se pudo borrar entrada stash"
 
-#: builtin/stash.c:651
+#: builtin/stash.c:667
 #, c-format
 msgid "'%s' is not a stash reference"
 msgstr "'%s' no es una referencia stash"
 
-#: builtin/stash.c:701
+#: builtin/stash.c:717
 msgid "The stash entry is kept in case you need it again."
 msgstr "La entrada de stash se guardó en caso de ser necesario nuevamente."
 
-#: builtin/stash.c:724
+#: builtin/stash.c:740
 msgid "No branch name specified"
 msgstr "No se especificó el nombre de la rama"
 
-#: builtin/stash.c:808
+#: builtin/stash.c:824
 msgid "failed to parse tree"
 msgstr "falló al analizar el árbol"
 
-#: builtin/stash.c:819
+#: builtin/stash.c:835
 msgid "failed to unpack trees"
 msgstr "falló al desempaquetar árboles"
 
-#: builtin/stash.c:839
+#: builtin/stash.c:855
 msgid "include untracked files in the stash"
 msgstr "incluir archivos no rastreados en el stash"
 
-#: builtin/stash.c:842
+#: builtin/stash.c:858
 msgid "only show untracked files in the stash"
 msgstr "solo mostrar archivos no rastreados en el stash"
 
-#: builtin/stash.c:929 builtin/stash.c:966
+#: builtin/stash.c:945 builtin/stash.c:982
 #, c-format
 msgid "Cannot update %s with %s"
 msgstr "No se puede actualizar %s con %s"
 
-#: builtin/stash.c:947 builtin/stash.c:1602 builtin/stash.c:1667
+#: builtin/stash.c:963 builtin/stash.c:1619 builtin/stash.c:1684
 msgid "stash message"
 msgstr "mensaje de stash"
 
-#: builtin/stash.c:957
+#: builtin/stash.c:973
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "\"git stash store\" requiere un argumento <commit>"
 
-#: builtin/stash.c:1171
+#: builtin/stash.c:1187
 msgid "No changes selected"
 msgstr "Sin cambios seleccionados"
 
-#: builtin/stash.c:1271
+#: builtin/stash.c:1287
 msgid "You do not have the initial commit yet"
 msgstr "Aún no tienes un commit inicial"
 
-#: builtin/stash.c:1298
+#: builtin/stash.c:1314
 msgid "Cannot save the current index state"
 msgstr "No se puede guardar el estado actual del índice"
 
-#: builtin/stash.c:1307
+#: builtin/stash.c:1323
 msgid "Cannot save the untracked files"
 msgstr "No se pueden guardar los archivos no rastreados"
 
-#: builtin/stash.c:1318 builtin/stash.c:1327
+#: builtin/stash.c:1334 builtin/stash.c:1343
 msgid "Cannot save the current worktree state"
 msgstr "No se puede guardar el estado actual del árbol de trabajo"
 
-#: builtin/stash.c:1355
+#: builtin/stash.c:1371
 msgid "Cannot record working tree state"
 msgstr "No se puede grabar el estado del árbol de trabajo"
 
-#: builtin/stash.c:1404
+#: builtin/stash.c:1420
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr "No se puede usar --patch y --include-untracked o --all al mismo tiempo"
 
-#: builtin/stash.c:1422
+#: builtin/stash.c:1438
 msgid "Did you forget to 'git add'?"
 msgstr "¿Olvidaste 'git add'?"
 
-#: builtin/stash.c:1437
+#: builtin/stash.c:1453
 msgid "No local changes to save"
 msgstr "No hay cambios locales para guardar"
 
-#: builtin/stash.c:1444
+#: builtin/stash.c:1460
 msgid "Cannot initialize stash"
 msgstr "No se puede inicializar stash"
 
-#: builtin/stash.c:1459
+#: builtin/stash.c:1475
 msgid "Cannot save the current status"
 msgstr "No se puede guardar el estado actual"
 
-#: builtin/stash.c:1464
+#: builtin/stash.c:1480
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "Directorio de trabajo y estado de índice %s guardados"
 
-#: builtin/stash.c:1554
+#: builtin/stash.c:1571
 msgid "Cannot remove worktree changes"
 msgstr "No se pueden eliminar cambios del árbol de trabajo"
 
-#: builtin/stash.c:1593 builtin/stash.c:1658
+#: builtin/stash.c:1610 builtin/stash.c:1675
 msgid "keep index"
 msgstr "mantener index"
 
-#: builtin/stash.c:1595 builtin/stash.c:1660
+#: builtin/stash.c:1612 builtin/stash.c:1677
 msgid "stash in patch mode"
 msgstr "stash en modo patch"
 
-#: builtin/stash.c:1596 builtin/stash.c:1661
+#: builtin/stash.c:1613 builtin/stash.c:1678
 msgid "quiet mode"
 msgstr "modo tranquilo"
 
-#: builtin/stash.c:1598 builtin/stash.c:1663
+#: builtin/stash.c:1615 builtin/stash.c:1680
 msgid "include untracked files in stash"
 msgstr "incluir archivos sin seguimiento en stash"
 
-#: builtin/stash.c:1600 builtin/stash.c:1665
+#: builtin/stash.c:1617 builtin/stash.c:1682
 msgid "include ignore files"
 msgstr "incluir archivos ignorados"
 
-#: builtin/stash.c:1700
+#: builtin/stash.c:1717
 msgid ""
 "the stash.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
 msgstr ""
 "¡el soporte para stash.useBuiltin ha sido eliminado!\n"
-"Vea su entrada en 'git help config' para detalles."
+"Mira su entrada en 'git help config' para detalles."
 
 #: builtin/stripspace.c:18
 msgid "git stripspace [-s | --strip-comments]"
@@ -22596,7 +22833,7 @@ msgstr ""
 msgid "prepend comment character and space to each line"
 msgstr "anteponer carácter de comentario y espacio a cada línea"
 
-#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2440
+#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2667
 #, c-format
 msgid "Expecting a full ref name, got %s"
 msgstr "Se esperaba un nombre de ref completo, se obtuvo %s"
@@ -22610,27 +22847,35 @@ msgstr "submodule--helper print-default-remote no toma argumentos"
 msgid "cannot strip one component off url '%s'"
 msgstr "no se puede quitar un componente del url '%s'"
 
-#: builtin/submodule--helper.c:411 builtin/submodule--helper.c:1887
-#: builtin/submodule--helper.c:2891
+#: builtin/submodule--helper.c:211
+#, c-format
+msgid ""
+"could not look up configuration '%s'. Assuming this repository is its own "
+"authoritative upstream."
+msgstr ""
+"no se pudo encontrar configuración '%s'. Asumiendo que este repositorio es "
+"su propio upstream autoritario."
+
+#: builtin/submodule--helper.c:405 builtin/submodule--helper.c:1858
 msgid "alternative anchor for relative paths"
 msgstr "ancho alternativo para rutas relativas"
 
-#: builtin/submodule--helper.c:416
+#: builtin/submodule--helper.c:410
 msgid "git submodule--helper list [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper list [--prefix=<ruta>] [<ruta>...]"
 
-#: builtin/submodule--helper.c:474 builtin/submodule--helper.c:631
-#: builtin/submodule--helper.c:654
+#: builtin/submodule--helper.c:468 builtin/submodule--helper.c:605
+#: builtin/submodule--helper.c:628
 #, c-format
 msgid "No url found for submodule path '%s' in .gitmodules"
 msgstr "No se encontró url para la ruta del submódulo '%s' en .gitmodules"
 
-#: builtin/submodule--helper.c:526
+#: builtin/submodule--helper.c:520
 #, c-format
 msgid "Entering '%s'\n"
 msgstr "Entrando '%s'\n"
 
-#: builtin/submodule--helper.c:529
+#: builtin/submodule--helper.c:523
 #, c-format
 msgid ""
 "run_command returned non-zero status for %s\n"
@@ -22639,7 +22884,7 @@ msgstr ""
 "run_command devolvió estado no cero para %s\n"
 "."
 
-#: builtin/submodule--helper.c:551
+#: builtin/submodule--helper.c:545
 #, c-format
 msgid ""
 "run_command returned non-zero status while recursing in the nested "
@@ -22650,79 +22895,70 @@ msgstr ""
 "anidados de %s\n"
 "."
 
-#: builtin/submodule--helper.c:567
+#: builtin/submodule--helper.c:561
 msgid "suppress output of entering each submodule command"
 msgstr "suprime la salida de inicializar cada comando de submódulo"
 
-#: builtin/submodule--helper.c:569 builtin/submodule--helper.c:890
-#: builtin/submodule--helper.c:1489
+#: builtin/submodule--helper.c:563 builtin/submodule--helper.c:864
+#: builtin/submodule--helper.c:1453
 msgid "recurse into nested submodules"
 msgstr "recursar en submódulos anidados"
 
-#: builtin/submodule--helper.c:574
+#: builtin/submodule--helper.c:568
 msgid "git submodule--helper foreach [--quiet] [--recursive] [--] <command>"
 msgstr "git submodule--helper foreach [--quiet] [--recursive] [--] <comando>"
 
-#: builtin/submodule--helper.c:601
-#, c-format
-msgid ""
-"could not look up configuration '%s'. Assuming this repository is its own "
-"authoritative upstream."
-msgstr ""
-"no se pudo encontrar configuración '%s'. Asumiendo que este repositorio es "
-"su propio upstream autoritativo."
-
-#: builtin/submodule--helper.c:668
+#: builtin/submodule--helper.c:642
 #, c-format
 msgid "Failed to register url for submodule path '%s'"
 msgstr "Falló al registrar el url para la ruta del submódulo '%s'"
 
-#: builtin/submodule--helper.c:672
+#: builtin/submodule--helper.c:646
 #, c-format
 msgid "Submodule '%s' (%s) registered for path '%s'\n"
 msgstr "Submódulo '%s' (%s) registrado para ruta '%s'\n"
 
-#: builtin/submodule--helper.c:682
+#: builtin/submodule--helper.c:656
 #, c-format
 msgid "warning: command update mode suggested for submodule '%s'\n"
 msgstr ""
 "peligro: modo de actualización de comandos sugerido para el submódulo '%s'\n"
 
-#: builtin/submodule--helper.c:689
+#: builtin/submodule--helper.c:663
 #, c-format
 msgid "Failed to register update mode for submodule path '%s'"
 msgstr ""
 "Error al registrar el modo de actualización para la ruta del submódulo '%s'"
 
-#: builtin/submodule--helper.c:711
+#: builtin/submodule--helper.c:685
 msgid "suppress output for initializing a submodule"
 msgstr "suprime la salida de inicializar un submódulo"
 
-#: builtin/submodule--helper.c:716
+#: builtin/submodule--helper.c:690
 msgid "git submodule--helper init [<options>] [<path>]"
 msgstr "git submodule--helper init [<opciones>] [<path>]"
 
-#: builtin/submodule--helper.c:789 builtin/submodule--helper.c:924
+#: builtin/submodule--helper.c:763 builtin/submodule--helper.c:898
 #, c-format
 msgid "no submodule mapping found in .gitmodules for path '%s'"
 msgstr ""
 "no se ha encontrado mapeo de submódulos en .gitmodules para la ruta '%s'"
 
-#: builtin/submodule--helper.c:837
+#: builtin/submodule--helper.c:811
 #, c-format
 msgid "could not resolve HEAD ref inside the submodule '%s'"
 msgstr "no se pudo resolver ref de HEAD dentro del submódulo '%s'"
 
-#: builtin/submodule--helper.c:864 builtin/submodule--helper.c:1459
+#: builtin/submodule--helper.c:838 builtin/submodule--helper.c:1423
 #, c-format
 msgid "failed to recurse into submodule '%s'"
 msgstr "falló al recursar en el submódulo '%s'"
 
-#: builtin/submodule--helper.c:888 builtin/submodule--helper.c:1625
+#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1589
 msgid "suppress submodule status output"
 msgstr "suprimir salida del estado del submódulo"
 
-#: builtin/submodule--helper.c:889
+#: builtin/submodule--helper.c:863
 msgid ""
 "use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
@@ -22730,109 +22966,109 @@ msgstr ""
 "usar el commit guardado en el índice en lugar del guardado en el submódulo "
 "HEAD"
 
-#: builtin/submodule--helper.c:895
+#: builtin/submodule--helper.c:869
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
 msgstr "git submodule status [--quiet] [--cached] [--recursive] [<ruta>...]"
 
-#: builtin/submodule--helper.c:919
+#: builtin/submodule--helper.c:893
 msgid "git submodule--helper name <path>"
 msgstr "git submodule--helper name <ruta>"
 
-#: builtin/submodule--helper.c:991
+#: builtin/submodule--helper.c:965
 #, c-format
 msgid "* %s %s(blob)->%s(submodule)"
 msgstr "* %s %s(blob)->%s(submodule)"
 
-#: builtin/submodule--helper.c:994
+#: builtin/submodule--helper.c:968
 #, c-format
 msgid "* %s %s(submodule)->%s(blob)"
 msgstr "* %s %s(submodule)->%s(blob)"
 
-#: builtin/submodule--helper.c:1007
+#: builtin/submodule--helper.c:981
 #, c-format
 msgid "%s"
 msgstr "%s"
 
-#: builtin/submodule--helper.c:1057
+#: builtin/submodule--helper.c:1031
 #, c-format
 msgid "couldn't hash object from '%s'"
 msgstr "no se pudo realizar hash del objeto '%s'"
 
-#: builtin/submodule--helper.c:1061
+#: builtin/submodule--helper.c:1035
 #, c-format
 msgid "unexpected mode %o\n"
 msgstr "modo %o inesperado\n"
 
-#: builtin/submodule--helper.c:1302
+#: builtin/submodule--helper.c:1276
 msgid "use the commit stored in the index instead of the submodule HEAD"
 msgstr ""
 "usar el commit guardado en el índice en lugar del guardado en el submódulo "
 "HEAD"
 
-#: builtin/submodule--helper.c:1304
+#: builtin/submodule--helper.c:1278
 msgid "compare the commit in the index with that in the submodule HEAD"
 msgstr ""
 "usar el commit guardado en el índice para comparar con el guardado en el "
 "submódulo HEAD"
 
-#: builtin/submodule--helper.c:1306
+#: builtin/submodule--helper.c:1280
 msgid "skip submodules with 'ignore_config' value set to 'all'"
 msgstr "omitir submódulos con el valor 'ignore_config' establecido en 'all'"
 
-#: builtin/submodule--helper.c:1308
+#: builtin/submodule--helper.c:1282
 msgid "limit the summary size"
 msgstr "limitar el tamaño de resumen"
 
-#: builtin/submodule--helper.c:1313
+#: builtin/submodule--helper.c:1287
 msgid "git submodule--helper summary [<options>] [<commit>] [--] [<path>]"
 msgstr "git submodule--helper summary [<options>] [<commit>] [--] [<path>]"
 
-#: builtin/submodule--helper.c:1337
+#: builtin/submodule--helper.c:1311
 msgid "could not fetch a revision for HEAD"
 msgstr "no se puede obtener la revisión para HEAD"
 
-#: builtin/submodule--helper.c:1342
+#: builtin/submodule--helper.c:1316
 msgid "--cached and --files are mutually exclusive"
 msgstr "--cached y --files son mutuamente exclusivos"
 
-#: builtin/submodule--helper.c:1409
+#: builtin/submodule--helper.c:1373
 #, c-format
 msgid "Synchronizing submodule url for '%s'\n"
 msgstr "Sincronizando url del submódulo para '%s'\n"
 
-#: builtin/submodule--helper.c:1415
+#: builtin/submodule--helper.c:1379
 #, c-format
 msgid "failed to register url for submodule path '%s'"
 msgstr "falló al registrar el url para la ruta del submódulo '%s'"
 
-#: builtin/submodule--helper.c:1429
+#: builtin/submodule--helper.c:1393
 #, c-format
 msgid "failed to get the default remote for submodule '%s'"
 msgstr "error al conseguir el remoto por defecto para el submódulo '%s'"
 
-#: builtin/submodule--helper.c:1440
+#: builtin/submodule--helper.c:1404
 #, c-format
 msgid "failed to update remote for submodule '%s'"
 msgstr "error al actualizar el remoto para el submódulo '%s'"
 
-#: builtin/submodule--helper.c:1487
+#: builtin/submodule--helper.c:1451
 msgid "suppress output of synchronizing submodule url"
 msgstr "suprime la salida de sincronizar el url del submódulo"
 
-#: builtin/submodule--helper.c:1494
+#: builtin/submodule--helper.c:1458
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
 msgstr "git submodule--helper sync [--quiet] [--recursive] [<ruta>]"
 
-#: builtin/submodule--helper.c:1548
+#: builtin/submodule--helper.c:1512
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains a .git directory (use 'rm -rf' if you "
 "really want to remove it including all of its history)"
 msgstr ""
-"El árbol de trabajo de submódulo '%s' contiene un directorio .git (use 'rm -"
+"El árbol de trabajo de submódulo '%s' contiene un directorio .git (usa 'rm -"
 "rf' si realmente quieres eliminarlo incluyendo todo en su historia)"
 
-#: builtin/submodule--helper.c:1560
+#: builtin/submodule--helper.c:1524
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
@@ -22841,46 +23077,46 @@ msgstr ""
 "El árbol de trabajo de submódulo '%s' contiene modificaciones locales; usa '-"
 "f' para descartarlas"
 
-#: builtin/submodule--helper.c:1568
+#: builtin/submodule--helper.c:1532
 #, c-format
 msgid "Cleared directory '%s'\n"
 msgstr "Directorio '%s' limpiado\n"
 
-#: builtin/submodule--helper.c:1570
+#: builtin/submodule--helper.c:1534
 #, c-format
 msgid "Could not remove submodule work tree '%s'\n"
 msgstr "No se pudo eliminar el árbol de trabajo de submódulo '%s'\n"
 
-#: builtin/submodule--helper.c:1581
+#: builtin/submodule--helper.c:1545
 #, c-format
 msgid "could not create empty submodule directory %s"
 msgstr "no se pudo crear directorio vacío de submódulo %s"
 
-#: builtin/submodule--helper.c:1597
+#: builtin/submodule--helper.c:1561
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "Submódulo '%s' (%s) no registrado para ruta '%s'\n"
 
-#: builtin/submodule--helper.c:1626
+#: builtin/submodule--helper.c:1590
 msgid "remove submodule working trees even if they contain local changes"
 msgstr ""
 "quitar árboles de trabajo de submódulos incluso si contienen cambios locales"
 
-#: builtin/submodule--helper.c:1627
+#: builtin/submodule--helper.c:1591
 msgid "unregister all submodules"
 msgstr "quitar todos los submódulos"
 
-#: builtin/submodule--helper.c:1632
+#: builtin/submodule--helper.c:1596
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<ruta>...]]"
 
-#: builtin/submodule--helper.c:1646
+#: builtin/submodule--helper.c:1610
 msgid "Use '--all' if you really want to deinitialize all submodules"
 msgstr "Usa '--all' si realmente quieres desinicializar todos los submódulos"
 
-#: builtin/submodule--helper.c:1690
+#: builtin/submodule--helper.c:1655
 msgid ""
 "An alternate computed from a superproject's alternate is invalid.\n"
 "To allow Git to clone without an alternate in such a case, set\n"
@@ -22889,72 +23125,72 @@ msgid ""
 msgstr ""
 "Una alternativa calculada a partir de la alternativa de un superproyecto no "
 "es válida.\n"
-"Para permitir que Git clone sin una alternativa en ese caso, establezca\n"
-"submodule.alternateErrorStrategy a 'info' o, de manera equivalente, clonar "
+"Para permitir que Git clone sin una alternativa en ese caso, establece\n"
+"submodule.alternateErrorStrategy a 'info' o, de manera equivalente, clona "
 "con\n"
 "'--reference-if-able' en lugar de '--reference'."
 
-#: builtin/submodule--helper.c:1729 builtin/submodule--helper.c:1732
+#: builtin/submodule--helper.c:1700 builtin/submodule--helper.c:1703
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
 msgstr "submódulo '%s' no puede agregar alterno: %s"
 
-#: builtin/submodule--helper.c:1768
+#: builtin/submodule--helper.c:1739
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
 msgstr "Valor '%s' para submodule.alternateErrorStrategy no es reconocido"
 
-#: builtin/submodule--helper.c:1775
+#: builtin/submodule--helper.c:1746
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
 msgstr "Valor '%s' para submodule.alternateLocation no es reconocido"
 
-#: builtin/submodule--helper.c:1800
+#: builtin/submodule--helper.c:1771
 #, c-format
 msgid "refusing to create/use '%s' in another submodule's git dir"
 msgstr "rechazando crear/usar '%s' en el directorio de git de otro submódulo"
 
-#: builtin/submodule--helper.c:1841
+#: builtin/submodule--helper.c:1812
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
 msgstr "clonación de '%s' en la ruta de submódulo '%s' falló"
 
-#: builtin/submodule--helper.c:1846
+#: builtin/submodule--helper.c:1817
 #, c-format
 msgid "directory not empty: '%s'"
 msgstr "directorio no está vacío: '%s'"
 
-#: builtin/submodule--helper.c:1858
+#: builtin/submodule--helper.c:1829
 #, c-format
 msgid "could not get submodule directory for '%s'"
 msgstr "no se pudo obtener el directorio de submódulo para '%s'"
 
-#: builtin/submodule--helper.c:1890 builtin/submodule--helper.c:2894
+#: builtin/submodule--helper.c:1861
 msgid "where the new submodule will be cloned to"
 msgstr "a donde el nuevo submódulo será clonado"
 
-#: builtin/submodule--helper.c:1893 builtin/submodule--helper.c:2897
+#: builtin/submodule--helper.c:1864
 msgid "name of the new submodule"
 msgstr "nombre del nuevo submódulo"
 
-#: builtin/submodule--helper.c:1896 builtin/submodule--helper.c:2900
+#: builtin/submodule--helper.c:1867
 msgid "url where to clone the submodule from"
 msgstr "url de dónde clonar el submódulo"
 
-#: builtin/submodule--helper.c:1904 builtin/submodule--helper.c:2907
+#: builtin/submodule--helper.c:1875 builtin/submodule--helper.c:3264
 msgid "depth for shallow clones"
 msgstr "profundidad para clones superficiales"
 
-#: builtin/submodule--helper.c:1907 builtin/submodule--helper.c:2365
-#: builtin/submodule--helper.c:2909
+#: builtin/submodule--helper.c:1878 builtin/submodule--helper.c:2525
+#: builtin/submodule--helper.c:3257
 msgid "force cloning progress"
 msgstr "forzar el proceso de clonación"
 
-#: builtin/submodule--helper.c:1909 builtin/submodule--helper.c:2367
+#: builtin/submodule--helper.c:1880 builtin/submodule--helper.c:2527
 msgid "disallow cloning into non-empty directory"
 msgstr "no permitir clonar en directorios no vacíos"
 
-#: builtin/submodule--helper.c:1916
+#: builtin/submodule--helper.c:1887
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
 "<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
@@ -22964,83 +23200,182 @@ msgstr ""
 "<repositorio>] [--name <nombre>] [--depth <profundidad>] [--single-branch] --"
 "url <url> --path <ruta>"
 
-#: builtin/submodule--helper.c:1953
+#: builtin/submodule--helper.c:1924
 #, c-format
 msgid "Invalid update mode '%s' for submodule path '%s'"
 msgstr "Modo de actualización inválido '%s' para ruta de submódulo '%s'"
 
-#: builtin/submodule--helper.c:1957
+#: builtin/submodule--helper.c:1928
 #, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
 msgstr ""
 "Modo de actualización inválido '%s' configurado para ruta de submódulo '%s'"
 
-#: builtin/submodule--helper.c:2058
+#: builtin/submodule--helper.c:2043
 #, c-format
 msgid "Submodule path '%s' not initialized"
 msgstr "Ruta de submódulo '%s' no inicializada"
 
-#: builtin/submodule--helper.c:2062
+#: builtin/submodule--helper.c:2047
 msgid "Maybe you want to use 'update --init'?"
 msgstr "¿Tal vez quieres usar 'update --init'?"
 
-#: builtin/submodule--helper.c:2092
+#: builtin/submodule--helper.c:2077
 #, c-format
 msgid "Skipping unmerged submodule %s"
 msgstr "Saltando submódulo %s no fusionado"
 
-#: builtin/submodule--helper.c:2121
+#: builtin/submodule--helper.c:2106
 #, c-format
 msgid "Skipping submodule '%s'"
 msgstr "Saltando submódulo '%s'"
 
-#: builtin/submodule--helper.c:2271
+#: builtin/submodule--helper.c:2256
 #, c-format
 msgid "Failed to clone '%s'. Retry scheduled"
 msgstr "Falló al clonar '%s'. Reintento programado"
 
-#: builtin/submodule--helper.c:2282
+#: builtin/submodule--helper.c:2267
 #, c-format
 msgid "Failed to clone '%s' a second time, aborting"
 msgstr "Falló al clonar '%s' una segunda vez, abortando"
 
-#: builtin/submodule--helper.c:2344 builtin/submodule--helper.c:2590
+#: builtin/submodule--helper.c:2372
+#, c-format
+msgid "Unable to checkout '%s' in submodule path '%s'"
+msgstr "No es posible revisar '%s' en la ruta de submódulo '%s'"
+
+#: builtin/submodule--helper.c:2376
+#, c-format
+msgid "Unable to rebase '%s' in submodule path '%s'"
+msgstr "No es posible ejecutar rebase a '%s' en la ruta de submódulo '%s'"
+
+#: builtin/submodule--helper.c:2380
+#, c-format
+msgid "Unable to merge '%s' in submodule path '%s'"
+msgstr "Incapaz de fusionar '%s' en la ruta del submódulo '%s'"
+
+#: builtin/submodule--helper.c:2384
+#, c-format
+msgid "Execution of '%s %s' failed in submodule path '%s'"
+msgstr "Falló la ejecución de '%s %s' en la ruta de submódulo '%s'"
+
+#: builtin/submodule--helper.c:2408
+#, c-format
+msgid "Submodule path '%s': checked out '%s'\n"
+msgstr "Ruta de submódulo '%s': check out realizado a '%s'\n"
+
+#: builtin/submodule--helper.c:2412
+#, c-format
+msgid "Submodule path '%s': rebased into '%s'\n"
+msgstr "Ruta de submódulo '%s': rebasado a '%s'\n"
+
+#: builtin/submodule--helper.c:2416
+#, c-format
+msgid "Submodule path '%s': merged in '%s'\n"
+msgstr "Ruta de submódulo '%s': fusionado en '%s'\n"
+
+#: builtin/submodule--helper.c:2420
+#, c-format
+msgid "Submodule path '%s': '%s %s'\n"
+msgstr "Ruta de submódulo '%s': '%s %s'\n"
+
+#: builtin/submodule--helper.c:2444
+#, c-format
+msgid "Unable to fetch in submodule path '%s'; trying to directly fetch %s:"
+msgstr ""
+"No es posible realizar fetch en la ruta de submódulo '%s'; intentando hacer "
+"un fetch directo de %s:"
+
+#: builtin/submodule--helper.c:2453
+#, c-format
+msgid ""
+"Fetched in submodule path '%s', but it did not contain %s. Direct fetching "
+"of that commit failed."
+msgstr ""
+"Fetch realizado en la ruta de submódulo '%s', pero no contenía %s. Fetch "
+"directo del commit falló."
+
+#: builtin/submodule--helper.c:2504 builtin/submodule--helper.c:2574
+#: builtin/submodule--helper.c:2812
 msgid "path into the working tree"
 msgstr "ruta al árbol de trabajo"
 
-#: builtin/submodule--helper.c:2347
+#: builtin/submodule--helper.c:2507 builtin/submodule--helper.c:2579
 msgid "path into the working tree, across nested submodule boundaries"
 msgstr "ruta al árbol de trabajo, a través de fronteras de submódulos anidados"
 
-#: builtin/submodule--helper.c:2351
+#: builtin/submodule--helper.c:2511 builtin/submodule--helper.c:2577
 msgid "rebase, merge, checkout or none"
 msgstr "rebase, merge, checkout o none"
 
-#: builtin/submodule--helper.c:2357
+#: builtin/submodule--helper.c:2517
 msgid "create a shallow clone truncated to the specified number of revisions"
 msgstr "crea un clon superficial truncado al número especificado de revisiones"
 
-#: builtin/submodule--helper.c:2360
+#: builtin/submodule--helper.c:2520
 msgid "parallel jobs"
 msgstr "tareas paralelas"
 
-#: builtin/submodule--helper.c:2362
+#: builtin/submodule--helper.c:2522
 msgid "whether the initial clone should follow the shallow recommendation"
 msgstr "si el clon inicial debe seguir la recomendación de superficialidad"
 
-#: builtin/submodule--helper.c:2363
+#: builtin/submodule--helper.c:2523
 msgid "don't print cloning progress"
 msgstr "no mostrar el progreso de clonación"
 
-#: builtin/submodule--helper.c:2374
+#: builtin/submodule--helper.c:2534
 msgid "git submodule--helper update-clone [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper update-clone [--prefix=<ruta>] [<ruta>...]"
 
-#: builtin/submodule--helper.c:2387
+#: builtin/submodule--helper.c:2547
 msgid "bad value for update parameter"
 msgstr "mal valor para parámetro update"
 
-#: builtin/submodule--helper.c:2435
+#: builtin/submodule--helper.c:2565
+msgid "suppress output for update by rebase or merge"
+msgstr "suprime la salida para actualización por rebase o fusión"
+
+#: builtin/submodule--helper.c:2566
+msgid "force checkout updates"
+msgstr "forzar actualizaciones de checkout"
+
+#: builtin/submodule--helper.c:2568
+msgid "don't fetch new objects from the remote site"
+msgstr "no recuperar objetos nuevos del sitio remoto"
+
+#: builtin/submodule--helper.c:2570
+msgid "overrides update mode in case the repository is a fresh clone"
+msgstr ""
+"sobreescribe el modo de actualización en caso de que el respositorio sea un "
+"clon fresco"
+
+#: builtin/submodule--helper.c:2571
+msgid "depth for shallow fetch"
+msgstr "profundidad para recuperación superficial"
+
+#: builtin/submodule--helper.c:2581
+msgid "sha1"
+msgstr "sha1"
+
+#: builtin/submodule--helper.c:2582
+msgid "SHA1 expected by superproject"
+msgstr "SHA1 esperado para superproyecto"
+
+#: builtin/submodule--helper.c:2584
+msgid "subsha1"
+msgstr "subsha1"
+
+#: builtin/submodule--helper.c:2585
+msgid "SHA1 of submodule's HEAD"
+msgstr "SHA1 del submódulo de HEAD"
+
+#: builtin/submodule--helper.c:2591
+msgid "git submodule--helper run-update-procedure [<options>] <path>"
+msgstr "git submodule--helper run-update-procedure [<options>] <path>"
+
+#: builtin/submodule--helper.c:2662
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
@@ -23049,144 +23384,194 @@ msgstr ""
 "Rama de submódulo (%s) configurada para heredar rama del superproyecto, pero "
 "el superproyecto no está en ninguna rama"
 
-#: builtin/submodule--helper.c:2558
+#: builtin/submodule--helper.c:2780
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
 msgstr "no se pudo conseguir un handle de repositorio para el submódulo '%s'"
 
-#: builtin/submodule--helper.c:2591
+#: builtin/submodule--helper.c:2813
 msgid "recurse into submodules"
 msgstr "recurrir a submódulos"
 
-#: builtin/submodule--helper.c:2597
+#: builtin/submodule--helper.c:2819
 msgid "git submodule--helper absorb-git-dirs [<options>] [<path>...]"
 msgstr "git submodule--helper absorb-git-dirs [<opciones>] [<path>...]"
 
-#: builtin/submodule--helper.c:2653
+#: builtin/submodule--helper.c:2875
 msgid "check if it is safe to write to the .gitmodules file"
 msgstr "revisar si es seguro escribir al archivo .gitmodules"
 
-#: builtin/submodule--helper.c:2656
+#: builtin/submodule--helper.c:2878
 msgid "unset the config in the .gitmodules file"
-msgstr "desconfigura la opción en el archivo .gitmodules"
+msgstr "desconfigurar la opción en el archivo .gitmodules"
 
-#: builtin/submodule--helper.c:2661
+#: builtin/submodule--helper.c:2883
 msgid "git submodule--helper config <name> [<value>]"
 msgstr "git submodule--helper config <nombre> [<valor>]"
 
-#: builtin/submodule--helper.c:2662
+#: builtin/submodule--helper.c:2884
 msgid "git submodule--helper config --unset <name>"
 msgstr "git submodule--helper config --unset <nombre>"
 
-#: builtin/submodule--helper.c:2663
+#: builtin/submodule--helper.c:2885
 msgid "git submodule--helper config --check-writeable"
 msgstr "git submodule--helper config --check-writeable"
 
-#: builtin/submodule--helper.c:2682 git-submodule.sh:150
-#, sh-format
+#: builtin/submodule--helper.c:2904 builtin/submodule--helper.c:3120
+#: builtin/submodule--helper.c:3276
 msgid "please make sure that the .gitmodules file is in the working tree"
 msgstr ""
 "por favor asegúrate que el archivo .gitmodules esté en el árbol de trabajo"
 
-#: builtin/submodule--helper.c:2698
+#: builtin/submodule--helper.c:2920
 msgid "suppress output for setting url of a submodule"
 msgstr "suprime la salida de inicializar la url de un submódulo"
 
-#: builtin/submodule--helper.c:2702
+#: builtin/submodule--helper.c:2924
 msgid "git submodule--helper set-url [--quiet] <path> <newurl>"
 msgstr "git submodule--helper set-url [--quiet] <ruta> <nueva url>"
 
-#: builtin/submodule--helper.c:2735
+#: builtin/submodule--helper.c:2957
 msgid "set the default tracking branch to master"
 msgstr "configurar la rama de rastreo por defecto a master"
 
-#: builtin/submodule--helper.c:2737
+#: builtin/submodule--helper.c:2959
 msgid "set the default tracking branch"
 msgstr "configurar la rama de rastreo por defecto"
 
-#: builtin/submodule--helper.c:2741
+#: builtin/submodule--helper.c:2963
 msgid "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
 msgstr "git submodule--helper set-branch [-q|--quiet] (-d|--default) <ruta>"
 
-#: builtin/submodule--helper.c:2742
+#: builtin/submodule--helper.c:2964
 msgid ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
 msgstr ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <rama> <ruta>"
 
-#: builtin/submodule--helper.c:2749
+#: builtin/submodule--helper.c:2971
 msgid "--branch or --default required"
 msgstr "--branch o --default requerido"
 
-#: builtin/submodule--helper.c:2752
+#: builtin/submodule--helper.c:2974
 msgid "--branch and --default are mutually exclusive"
 msgstr "--branch y --default son mutuamente exclusivos"
 
-#: builtin/submodule--helper.c:2815
+#: builtin/submodule--helper.c:3037
 #, c-format
 msgid "Adding existing repo at '%s' to the index\n"
 msgstr "Agregando el repositorio existente en '%s' al índice\n"
 
-#: builtin/submodule--helper.c:2818
+#: builtin/submodule--helper.c:3040
 #, c-format
 msgid "'%s' already exists and is not a valid git repo"
 msgstr "'%s' ya existe y no es un repositorio git válido"
 
-#: builtin/submodule--helper.c:2828
+#: builtin/submodule--helper.c:3053
 #, c-format
-msgid "A git directory for '%s' is found locally with remote(s):"
+msgid "A git directory for '%s' is found locally with remote(s):\n"
 msgstr ""
-"Se encontró localmente un directorio git para '%s' con el(los) remoto(s):"
+"Se encontró localmente un directorio git para '%s' con el(los) remoto(s):\n"
 
-#: builtin/submodule--helper.c:2833
+#: builtin/submodule--helper.c:3060
 #, c-format
 msgid ""
 "If you want to reuse this local git directory instead of cloning again from\n"
 "  %s\n"
 "use the '--force' option. If the local git directory is not the correct "
 "repo\n"
-"or if you are unsure what this means, choose another name with the '--name' "
-"option.\n"
+"or you are unsure what this means choose another name with the '--name' "
+"option."
 msgstr ""
-"Si quiere reusar este directorio git local en lugar de clonar nuevamente de\n"
+"Si quieres reusar este directorio git local en lugar de clonar nuevamente "
+"de\n"
 "  %s\n"
 "usa la opción '--force'. Si el directorio git local no es el repositorio "
 "correcto\n"
 "o no estás seguro de lo que esto significa, escoge otro nombre con la opción "
-"'--name'.\n"
+"'--name'."
 
-#: builtin/submodule--helper.c:2842
+#: builtin/submodule--helper.c:3072
 #, c-format
 msgid "Reactivating local git directory for submodule '%s'\n"
 msgstr "Reactivando directorio git local para el submódulo '%s'.\n"
 
-#: builtin/submodule--helper.c:2875
+#: builtin/submodule--helper.c:3109
 #, c-format
 msgid "unable to checkout submodule '%s'"
 msgstr "no es posible hacer checkout al submódulo '%s'"
 
-#: builtin/submodule--helper.c:2888
-msgid "branch of repository to checkout on cloning"
-msgstr "la rama del repositorio para hacer checkout durante clonado"
+#: builtin/submodule--helper.c:3148
+#, c-format
+msgid "Failed to add submodule '%s'"
+msgstr "Falló al agregar el submódulo '%s'"
 
-#: builtin/submodule--helper.c:2910
+#: builtin/submodule--helper.c:3152 builtin/submodule--helper.c:3157
+#: builtin/submodule--helper.c:3165
+#, c-format
+msgid "Failed to register submodule '%s'"
+msgstr "Falló al registrar el submódulo '%s'"
+
+#: builtin/submodule--helper.c:3221
+#, c-format
+msgid "'%s' already exists in the index"
+msgstr "'%s' ya existe en el índice"
+
+#: builtin/submodule--helper.c:3224
+#, c-format
+msgid "'%s' already exists in the index and is not a submodule"
+msgstr "'%s' ya existe en el índice y no es un submódulo"
+
+#: builtin/submodule--helper.c:3253
+msgid "branch of repository to add as submodule"
+msgstr "rama del repositorio para agregar como submódulo"
+
+#: builtin/submodule--helper.c:3254
 msgid "allow adding an otherwise ignored submodule path"
-msgstr "permitir agregar una ruta de submódulo sino ignorada"
+msgstr "permitir agregar una ruta de submódulo que de otro modo se ignora"
 
-#: builtin/submodule--helper.c:2917
+#: builtin/submodule--helper.c:3256
+msgid "print only error messages"
+msgstr "mostrar solo mensajes de error"
+
+#: builtin/submodule--helper.c:3260
+msgid "borrow the objects from reference repositories"
+msgstr "prestar los objetos de los repositorios de referencia"
+
+#: builtin/submodule--helper.c:3262
 msgid ""
-"git submodule--helper add-clone [<options>...] --url <url> --path <path> --"
-"name <name>"
+"sets the submodule’s name to the given string instead of defaulting to its "
+"path"
 msgstr ""
-"git submodule--helper add-clone [<options>...] --url <url> --path <ruta> --"
-"name <nombre>"
+"configura el nombre del submódulo para el string dado en lugar de ir a la "
+"ruta por defecto"
 
-#: builtin/submodule--helper.c:2985 git.c:449 git.c:724
+#: builtin/submodule--helper.c:3269
+msgid "git submodule--helper add [<options>] [--] <repository> [<path>]"
+msgstr "git submodule--helper add [<options>] [--] <repository> [<path>]"
+
+#: builtin/submodule--helper.c:3297
+msgid "Relative path can only be used from the toplevel of the working tree"
+msgstr ""
+"La ruta relativa solo se puede usar desde el nivel superior del árbol de "
+"trabajo"
+
+#: builtin/submodule--helper.c:3305
+#, c-format
+msgid "repo URL: '%s' must be absolute or begin with ./|../"
+msgstr "repo URL: '%s' debe ser absoluta o iniciar con ./|../"
+
+#: builtin/submodule--helper.c:3340
+#, c-format
+msgid "'%s' is not a valid submodule name"
+msgstr "'%s' no es un nombre de submódulo válido"
+
+#: builtin/submodule--helper.c:3404 git.c:449 git.c:723
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s no soporta --super-prefix"
 
-#: builtin/submodule--helper.c:2991
+#: builtin/submodule--helper.c:3410
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
 msgstr "'%s' no es un comando submodule--helper válido"
@@ -23211,21 +23596,21 @@ msgstr "eliminar referencia simbólica"
 msgid "shorten ref output"
 msgstr "salida de referencia más corta"
 
-#: builtin/symbolic-ref.c:45 builtin/update-ref.c:499
+#: builtin/symbolic-ref.c:45 builtin/update-ref.c:505
 msgid "reason"
 msgstr "razón"
 
-#: builtin/symbolic-ref.c:45 builtin/update-ref.c:499
+#: builtin/symbolic-ref.c:45 builtin/update-ref.c:505
 msgid "reason of the update"
 msgstr "razón de la actualización"
 
 #: builtin/tag.c:25
 msgid ""
 "git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <file>]\n"
-"\t\t<tagname> [<head>]"
+"        <tagname> [<head>]"
 msgstr ""
-"git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <archivo>]\n"
-"\t\t<nombre-tag> [<head>]"
+"git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <file>]\n"
+"        <tagname> [<head>]"
 
 #: builtin/tag.c:27
 msgid "git tag -d <tagname>..."
@@ -23235,13 +23620,13 @@ msgstr "git tag -d <nombre-de-tag>..."
 msgid ""
 "git tag -l [-n[<num>]] [--contains <commit>] [--no-contains <commit>] [--"
 "points-at <object>]\n"
-"\t\t[--format=<format>] [--merged <commit>] [--no-merged <commit>] "
+"        [--format=<format>] [--merged <commit>] [--no-merged <commit>] "
 "[<pattern>...]"
 msgstr ""
 "git tag -l [-n[<num>]] [--contains <commit>] [--no-contains <commit>] [--"
-"points-at <objeto>]\n"
-"\t\t[--format=<formato>] [--merged <commit>] [--no-merged <commit>] "
-"[<patrón>...]"
+"points-at <object>]\n"
+"        [--format=<format>] [--merged <commit>] [--no-merged <commit>] "
+"[<pattern>...]"
 
 #: builtin/tag.c:30
 msgid "git tag -v [--format=<format>] <tagname>..."
@@ -23306,130 +23691,130 @@ msgstr ""
 msgid "bad object type."
 msgstr "tipo de objeto erróneo."
 
-#: builtin/tag.c:328
+#: builtin/tag.c:326
 msgid "no tag message?"
 msgstr "¿sin mensaje de tag?"
 
-#: builtin/tag.c:335
+#: builtin/tag.c:333
 #, c-format
 msgid "The tag message has been left in %s\n"
 msgstr "El mensaje del tag ha sido dejado en %s\n"
 
-#: builtin/tag.c:446
+#: builtin/tag.c:444
 msgid "list tag names"
 msgstr "listar nombres de tags"
 
-#: builtin/tag.c:448
+#: builtin/tag.c:446
 msgid "print <n> lines of each tag message"
 msgstr "imprimir <n> líneas de cada mensaje de tag"
 
-#: builtin/tag.c:450
+#: builtin/tag.c:448
 msgid "delete tags"
 msgstr "eliminar tags"
 
-#: builtin/tag.c:451
+#: builtin/tag.c:449
 msgid "verify tags"
 msgstr "verificar tags"
 
-#: builtin/tag.c:453
+#: builtin/tag.c:451
 msgid "Tag creation options"
 msgstr "Opciones de creación de tags"
 
-#: builtin/tag.c:455
+#: builtin/tag.c:453
 msgid "annotated tag, needs a message"
 msgstr "tags anotadas necesitan un mensaje"
 
-#: builtin/tag.c:457
+#: builtin/tag.c:455
 msgid "tag message"
 msgstr "mensaje de tag"
 
-#: builtin/tag.c:459
+#: builtin/tag.c:457
 msgid "force edit of tag message"
 msgstr "forzar la edición del mensaje de tag"
 
-#: builtin/tag.c:460
+#: builtin/tag.c:458
 msgid "annotated and GPG-signed tag"
 msgstr "tag anotado y firmado con GPG"
 
-#: builtin/tag.c:463
+#: builtin/tag.c:461
 msgid "use another key to sign the tag"
 msgstr "usar otra clave para firmar el tag"
 
-#: builtin/tag.c:464
+#: builtin/tag.c:462
 msgid "replace the tag if exists"
 msgstr "remplazar tag si existe"
 
-#: builtin/tag.c:465 builtin/update-ref.c:505
+#: builtin/tag.c:463 builtin/update-ref.c:511
 msgid "create a reflog"
 msgstr "crear un reflog"
 
-#: builtin/tag.c:467
+#: builtin/tag.c:465
 msgid "Tag listing options"
 msgstr "Opciones de listado de tag"
 
-#: builtin/tag.c:468
+#: builtin/tag.c:466
 msgid "show tag list in columns"
 msgstr "mostrar lista de tags en columnas"
 
-#: builtin/tag.c:469 builtin/tag.c:471
+#: builtin/tag.c:467 builtin/tag.c:469
 msgid "print only tags that contain the commit"
 msgstr "mostrar solo tags que contengan el commit"
 
-#: builtin/tag.c:470 builtin/tag.c:472
+#: builtin/tag.c:468 builtin/tag.c:470
 msgid "print only tags that don't contain the commit"
 msgstr "mostrar solo tags que no contengan el commit"
 
-#: builtin/tag.c:473
+#: builtin/tag.c:471
 msgid "print only tags that are merged"
 msgstr "solo imprimir las tags que estén fusionadas"
 
-#: builtin/tag.c:474
+#: builtin/tag.c:472
 msgid "print only tags that are not merged"
 msgstr "solo imprimir las tags que no estén fusionadas"
 
-#: builtin/tag.c:478
+#: builtin/tag.c:476
 msgid "print only tags of the object"
 msgstr "solo imprimir tags del objeto"
 
-#: builtin/tag.c:526
+#: builtin/tag.c:525
 msgid "--column and -n are incompatible"
 msgstr "--column y -n son incompatibles"
 
-#: builtin/tag.c:548
+#: builtin/tag.c:546
 msgid "-n option is only allowed in list mode"
 msgstr "opción -n solo es permitida en modo lista"
 
-#: builtin/tag.c:550
+#: builtin/tag.c:548
 msgid "--contains option is only allowed in list mode"
 msgstr "opción --contains solo es permitido en modo lista"
 
-#: builtin/tag.c:552
+#: builtin/tag.c:550
 msgid "--no-contains option is only allowed in list mode"
 msgstr "opción --no-contains solo es permitida en modo lista"
 
-#: builtin/tag.c:554
+#: builtin/tag.c:552
 msgid "--points-at option is only allowed in list mode"
 msgstr "opción --points-at solo es permitida en modo lista"
 
-#: builtin/tag.c:556
+#: builtin/tag.c:554
 msgid "--merged and --no-merged options are only allowed in list mode"
 msgstr "opciones --merged y --no-merged solo están permitidas en modo lista"
 
-#: builtin/tag.c:567
+#: builtin/tag.c:568
 msgid "only one -F or -m option is allowed."
 msgstr "solo se permite una de las opciones, -m o -F."
 
-#: builtin/tag.c:592
+#: builtin/tag.c:593
 #, c-format
 msgid "'%s' is not a valid tag name."
 msgstr "'%s' no es un nombre de tag válido."
 
-#: builtin/tag.c:597
+#: builtin/tag.c:598
 #, c-format
 msgid "tag '%s' already exists"
 msgstr "el tag '%s' ya existe"
 
-#: builtin/tag.c:628
+#: builtin/tag.c:629
 #, c-format
 msgid "Updated tag '%s' (was %s)\n"
 msgstr "Etiqueta '%s' actualizada (era %s)\n"
@@ -23443,202 +23828,197 @@ msgstr "Desempaquetando objetos"
 msgid "failed to create directory %s"
 msgstr "falló al crear directorio %s"
 
-#: builtin/update-index.c:100
-#, c-format
-msgid "failed to create file %s"
-msgstr "falló al crear el archivo %s"
-
-#: builtin/update-index.c:108
+#: builtin/update-index.c:106
 #, c-format
 msgid "failed to delete file %s"
 msgstr "falló al eliminar el archivo %s"
 
-#: builtin/update-index.c:115 builtin/update-index.c:221
+#: builtin/update-index.c:113 builtin/update-index.c:219
 #, c-format
 msgid "failed to delete directory %s"
 msgstr "falló al eliminar directorio %s"
 
-#: builtin/update-index.c:140
+#: builtin/update-index.c:138
 #, c-format
 msgid "Testing mtime in '%s' "
 msgstr "Probando mtime en '%s' "
 
-#: builtin/update-index.c:154
+#: builtin/update-index.c:152
 msgid "directory stat info does not change after adding a new file"
 msgstr "info de estado del directorio no cambia tras agregar un nuevo archivo"
 
-#: builtin/update-index.c:167
+#: builtin/update-index.c:165
 msgid "directory stat info does not change after adding a new directory"
 msgstr ""
 "info de estado del directorio no cambia tras agregar un nuevo directorio"
 
-#: builtin/update-index.c:180
+#: builtin/update-index.c:178
 msgid "directory stat info changes after updating a file"
 msgstr "info de estado del directorio cambia tras actualizar un archivo"
 
-#: builtin/update-index.c:191
+#: builtin/update-index.c:189
 msgid "directory stat info changes after adding a file inside subdirectory"
 msgstr ""
 "info de estado del directorio cambia tras agregar un archivo dentro del "
 "subdirectorio"
 
-#: builtin/update-index.c:202
+#: builtin/update-index.c:200
 msgid "directory stat info does not change after deleting a file"
 msgstr "info de estado del directorio no cambia tras borrar un archivo"
 
-#: builtin/update-index.c:215
+#: builtin/update-index.c:213
 msgid "directory stat info does not change after deleting a directory"
 msgstr "info de estado del directorio no cambia tras borrar un directorio"
 
-#: builtin/update-index.c:222
+#: builtin/update-index.c:220
 msgid " OK"
 msgstr " OK"
 
-#: builtin/update-index.c:591
+#: builtin/update-index.c:589
 msgid "git update-index [<options>] [--] [<file>...]"
 msgstr "git update-index [<opciones>] [--] [<archivo>...]"
 
-#: builtin/update-index.c:976
+#: builtin/update-index.c:974
 msgid "continue refresh even when index needs update"
 msgstr ""
 "continuar refresh (refrescamiento) incluso cuando el índice necesita "
 "actualización"
 
-#: builtin/update-index.c:979
+#: builtin/update-index.c:977
 msgid "refresh: ignore submodules"
 msgstr "refresh: ignora submódulos"
 
-#: builtin/update-index.c:982
+#: builtin/update-index.c:980
 msgid "do not ignore new files"
 msgstr "no ignorar archivos nuevos"
 
-#: builtin/update-index.c:984
+#: builtin/update-index.c:982
 msgid "let files replace directories and vice-versa"
 msgstr "permitir que archivos remplacen directorios y viceversa"
 
-#: builtin/update-index.c:986
+#: builtin/update-index.c:984
 msgid "notice files missing from worktree"
 msgstr "avisar de archivos faltando del árbol de trabajo"
 
-#: builtin/update-index.c:988
+#: builtin/update-index.c:986
 msgid "refresh even if index contains unmerged entries"
 msgstr "ejecutar refresh incluso si el índice contiene entradas sin cambios"
 
-#: builtin/update-index.c:991
+#: builtin/update-index.c:989
 msgid "refresh stat information"
 msgstr "refrescar información de estado"
 
-#: builtin/update-index.c:995
+#: builtin/update-index.c:993
 msgid "like --refresh, but ignore assume-unchanged setting"
 msgstr "como --refresh, pero ignora configuración assume-unchanged"
 
-#: builtin/update-index.c:999
+#: builtin/update-index.c:997
 msgid "<mode>,<object>,<path>"
 msgstr "<modo>,<objeto>,<ruta>"
 
-#: builtin/update-index.c:1000
+#: builtin/update-index.c:998
 msgid "add the specified entry to the index"
 msgstr "agregar la entrada especificada al índice"
 
-#: builtin/update-index.c:1010
+#: builtin/update-index.c:1008
 msgid "mark files as \"not changing\""
 msgstr "marcar archivos como \"not changing\""
 
-#: builtin/update-index.c:1013
+#: builtin/update-index.c:1011
 msgid "clear assumed-unchanged bit"
 msgstr "limpiar bit assumed-unchanged"
 
-#: builtin/update-index.c:1016
+#: builtin/update-index.c:1014
 msgid "mark files as \"index-only\""
 msgstr "marcar archivos como \"index-only\""
 
-#: builtin/update-index.c:1019
+#: builtin/update-index.c:1017
 msgid "clear skip-worktree bit"
 msgstr "limpiar bit skip-worktree"
 
-#: builtin/update-index.c:1022
+#: builtin/update-index.c:1020
 msgid "do not touch index-only entries"
 msgstr "no tocar entradas index-only"
 
-#: builtin/update-index.c:1024
+#: builtin/update-index.c:1022
 msgid "add to index only; do not add content to object database"
 msgstr ""
 "agregar solo al índice; no agregar contenido a la base de datos de objetos"
 
-#: builtin/update-index.c:1026
+#: builtin/update-index.c:1024
 msgid "remove named paths even if present in worktree"
 msgstr ""
 "eliminar rutas nombradas incluso si están presentes en el árbol de trabajo"
 
-#: builtin/update-index.c:1028
+#: builtin/update-index.c:1026
 msgid "with --stdin: input lines are terminated by null bytes"
 msgstr "con --stdin: las líneas de entrada son terminadas con bytes nulos"
 
-#: builtin/update-index.c:1030
+#: builtin/update-index.c:1028
 msgid "read list of paths to be updated from standard input"
 msgstr "leer la lista de rutas que actualizar desde standard input"
 
-#: builtin/update-index.c:1034
+#: builtin/update-index.c:1032
 msgid "add entries from standard input to the index"
 msgstr "agregar entradas de standard input al índice"
 
-#: builtin/update-index.c:1038
+#: builtin/update-index.c:1036
 msgid "repopulate stages #2 and #3 for the listed paths"
 msgstr "repoblar stages #2 y #3 para las rutas listadas"
 
-#: builtin/update-index.c:1042
+#: builtin/update-index.c:1040
 msgid "only update entries that differ from HEAD"
 msgstr "solo actualizar entradas que difieran de HEAD"
 
-#: builtin/update-index.c:1046
+#: builtin/update-index.c:1044
 msgid "ignore files missing from worktree"
 msgstr "ignorar archivos faltantes en el árbol de trabajo"
 
-#: builtin/update-index.c:1049
+#: builtin/update-index.c:1047
 msgid "report actions to standard output"
 msgstr "reportar acciones por standard output"
 
-#: builtin/update-index.c:1051
+#: builtin/update-index.c:1049
 msgid "(for porcelains) forget saved unresolved conflicts"
 msgstr "(para porcelanas) olvidar conflictos guardados sin resolución"
 
-#: builtin/update-index.c:1055
+#: builtin/update-index.c:1053
 msgid "write index in this format"
 msgstr "escribir índice en este formato"
 
-#: builtin/update-index.c:1057
+#: builtin/update-index.c:1055
 msgid "enable or disable split index"
 msgstr "activar o desactivar índice dividido"
 
-#: builtin/update-index.c:1059
+#: builtin/update-index.c:1057
 msgid "enable/disable untracked cache"
 msgstr "habilitar o deshabilitar caché no rastreado"
 
-#: builtin/update-index.c:1061
+#: builtin/update-index.c:1059
 msgid "test if the filesystem supports untracked cache"
 msgstr "probar si el filesystem soporta caché no rastreado"
 
-#: builtin/update-index.c:1063
+#: builtin/update-index.c:1061
 msgid "enable untracked cache without testing the filesystem"
 msgstr "habilitar caché no rastreado sin probar el filesystem"
 
-#: builtin/update-index.c:1065
+#: builtin/update-index.c:1063
 msgid "write out the index even if is not flagged as changed"
 msgstr "escribir el índice incluso si no está marcado como cambiado"
 
-#: builtin/update-index.c:1067
+#: builtin/update-index.c:1065
 msgid "enable or disable file system monitor"
 msgstr "activar o desactivar monitor de sistema de archivos"
 
-#: builtin/update-index.c:1069
+#: builtin/update-index.c:1067
 msgid "mark files as fsmonitor valid"
 msgstr "marcar archivos como válidos para fsmonitor"
 
-#: builtin/update-index.c:1072
+#: builtin/update-index.c:1070
 msgid "clear fsmonitor valid bit"
-msgstr "limpia el bit de validación fsmonitor"
+msgstr "limpiar el bit de validación fsmonitor"
 
-#: builtin/update-index.c:1175
+#: builtin/update-index.c:1173
 msgid ""
 "core.splitIndex is set to false; remove or change it, if you really want to "
 "enable split index"
@@ -23646,7 +24026,7 @@ msgstr ""
 "core.splitIndex está configurado en false; quítalo o cámbialo, si realmente "
 "quieres habilitar el índice partido"
 
-#: builtin/update-index.c:1184
+#: builtin/update-index.c:1182
 msgid ""
 "core.splitIndex is set to true; remove or change it, if you really want to "
 "disable split index"
@@ -23654,7 +24034,7 @@ msgstr ""
 "core.splitIndex está configurado en true; quítalo o cámbialo, si realmente "
 "quieres deshabilitar el índice partido"
 
-#: builtin/update-index.c:1196
+#: builtin/update-index.c:1194
 msgid ""
 "core.untrackedCache is set to true; remove or change it, if you really want "
 "to disable the untracked cache"
@@ -23662,11 +24042,11 @@ msgstr ""
 "core.untrackedCache está configurado en true; quítalo o cámbialo, si "
 "realmente quieres deshabilitar el chaché no rastreado"
 
-#: builtin/update-index.c:1200
+#: builtin/update-index.c:1198
 msgid "Untracked cache disabled"
 msgstr "Caché no rastreado deshabilitado"
 
-#: builtin/update-index.c:1208
+#: builtin/update-index.c:1206
 msgid ""
 "core.untrackedCache is set to false; remove or change it, if you really want "
 "to enable the untracked cache"
@@ -23674,29 +24054,29 @@ msgstr ""
 "core.untrackedCache está configurado en false; quítalo o cámbialo, si "
 "realmente quieres habilitar el caché no rastreado"
 
-#: builtin/update-index.c:1212
+#: builtin/update-index.c:1210
 #, c-format
 msgid "Untracked cache enabled for '%s'"
 msgstr "Caché no rastreado habilitado para '%s'"
 
-#: builtin/update-index.c:1220
+#: builtin/update-index.c:1218
 msgid "core.fsmonitor is unset; set it if you really want to enable fsmonitor"
 msgstr ""
 "core.fsmonitor no está configurado; actívalo si realmente quieres habilitar "
 "fsmonitor"
 
-#: builtin/update-index.c:1224
+#: builtin/update-index.c:1222
 msgid "fsmonitor enabled"
 msgstr "fsmonitor activado"
 
-#: builtin/update-index.c:1227
+#: builtin/update-index.c:1225
 msgid ""
 "core.fsmonitor is set; remove it if you really want to disable fsmonitor"
 msgstr ""
 "core.fsmonitor está configurado; quítalo si realmente quieres deshabilitar "
 "el fsmonitor"
 
-#: builtin/update-index.c:1231
+#: builtin/update-index.c:1229
 msgid "fsmonitor disabled"
 msgstr "fsmonitor desactivado"
 
@@ -23714,21 +24094,21 @@ msgstr ""
 msgid "git update-ref [<options>] --stdin [-z]"
 msgstr "git update-ref [<opciones>] --stdin [-z]"
 
-#: builtin/update-ref.c:500
+#: builtin/update-ref.c:506
 msgid "delete the reference"
 msgstr "eliminar la referencia"
 
-#: builtin/update-ref.c:502
+#: builtin/update-ref.c:508
 msgid "update <refname> not the one it points to"
-msgstr "actualiza <refname> no la a que apunta"
+msgstr "actualizar <refname> no la a que apunta"
 
-#: builtin/update-ref.c:503
+#: builtin/update-ref.c:509
 msgid "stdin has NUL-terminated arguments"
 msgstr "stdin tiene argumentos terminados en NUL"
 
-#: builtin/update-ref.c:504
+#: builtin/update-ref.c:510
 msgid "read updates from stdin"
-msgstr "lee actualizaciones de stdin"
+msgstr "leer actualizaciones de stdin"
 
 #: builtin/update-server-info.c:7
 msgid "git update-server-info [--force]"
@@ -23736,25 +24116,25 @@ msgstr "git update-server-info [--force]"
 
 #: builtin/update-server-info.c:15
 msgid "update the info files from scratch"
-msgstr "actualiza los archivos info desde cero"
+msgstr "actualizar los archivos info desde cero"
 
 #: builtin/upload-pack.c:11
 msgid "git upload-pack [<options>] <dir>"
 msgstr "git upload-pack [<opciones>] <directorio>"
 
-#: builtin/upload-pack.c:23 t/helper/test-serve-v2.c:17
+#: builtin/upload-pack.c:24 t/helper/test-serve-v2.c:17
 msgid "quit after a single request/response exchange"
-msgstr "sale después de un solo intercambio petición/respuesta"
+msgstr "salir después de un solo intercambio petición/respuesta"
 
-#: builtin/upload-pack.c:25
-msgid "exit immediately after initial ref advertisement"
-msgstr "salir inmediatamente tras el anuncio inicial de ref"
-
-#: builtin/upload-pack.c:27
-msgid "do not try <directory>/.git/ if <directory> is no Git directory"
-msgstr "no intente <directorio>/.git/ si <directorio> no es un directorio Git"
+#: builtin/upload-pack.c:26
+msgid "serve up the info/refs for git-http-backend"
+msgstr "servir los info/refs para git-http-backend"
 
 #: builtin/upload-pack.c:29
+msgid "do not try <directory>/.git/ if <directory> is no Git directory"
+msgstr "no probar <directorio>/.git/ si <directorio> no es un directorio Git"
+
+#: builtin/upload-pack.c:31
 msgid "interrupt transfer after <n> seconds of inactivity"
 msgstr "interrumpir transferencia tras <n> segundos de inactividad"
 
@@ -23768,7 +24148,7 @@ msgstr "imprimir contenido del commit"
 
 #: builtin/verify-commit.c:69 builtin/verify-tag.c:37
 msgid "print raw gpg status output"
-msgstr "muestra la salida de status gpg en formato raw"
+msgstr "mostrar la salida de status gpg en formato raw"
 
 #: builtin/verify-pack.c:59
 msgid "git verify-pack [-v | --verbose] [-s | --stat-only] <pack>..."
@@ -23790,63 +24170,58 @@ msgstr "git verify-tag [-v | --verbose] [--format=<formato>] <tag>..."
 msgid "print tag contents"
 msgstr "imprimir contenido del tag"
 
-#: builtin/worktree.c:18
+#: builtin/worktree.c:19
 msgid "git worktree add [<options>] <path> [<commit-ish>]"
 msgstr "git worktree add [<opciones>] <ruta> [<commit-ish>]"
 
-#: builtin/worktree.c:19
+#: builtin/worktree.c:20
 msgid "git worktree list [<options>]"
 msgstr "git worktree list [<opciones>]"
 
-#: builtin/worktree.c:20
+#: builtin/worktree.c:21
 msgid "git worktree lock [<options>] <path>"
 msgstr "git worktree lock [<opciones>] <ruta>"
 
-#: builtin/worktree.c:21
+#: builtin/worktree.c:22
 msgid "git worktree move <worktree> <new-path>"
 msgstr "git worktree move <worktree> <nueva-ruta>"
 
-#: builtin/worktree.c:22
+#: builtin/worktree.c:23
 msgid "git worktree prune [<options>]"
 msgstr "git worktree prune [<opciones>]"
 
-#: builtin/worktree.c:23
+#: builtin/worktree.c:24
 msgid "git worktree remove [<options>] <worktree>"
 msgstr "git worktree remove [<opciones>] <worktree>"
 
-#: builtin/worktree.c:24
+#: builtin/worktree.c:25
 msgid "git worktree unlock <path>"
 msgstr "git worktree unlock <ruta>"
 
-#: builtin/worktree.c:61 builtin/worktree.c:944
-#, c-format
-msgid "failed to delete '%s'"
-msgstr "falló al borrar '%s'"
-
-#: builtin/worktree.c:74
+#: builtin/worktree.c:75
 #, c-format
 msgid "Removing %s/%s: %s"
 msgstr "Eliminando %s/%s: %s"
 
-#: builtin/worktree.c:147
+#: builtin/worktree.c:148
 msgid "report pruned working trees"
-msgstr "reporta árboles de trabajo recortados"
+msgstr "reportar árboles de trabajo recortados"
 
-#: builtin/worktree.c:149
+#: builtin/worktree.c:150
 msgid "expire working trees older than <time>"
 msgstr "caducar árboles de trabajo más viejos a <tiempo>"
 
-#: builtin/worktree.c:219
+#: builtin/worktree.c:220
 #, c-format
 msgid "'%s' already exists"
 msgstr "'%s' ya existe"
 
-#: builtin/worktree.c:228
+#: builtin/worktree.c:229
 #, c-format
 msgid "unusable worktree destination '%s'"
 msgstr "destino de worktree inutilizable '%s'"
 
-#: builtin/worktree.c:233
+#: builtin/worktree.c:234
 #, c-format
 msgid ""
 "'%s' is a missing but locked worktree;\n"
@@ -23856,7 +24231,7 @@ msgstr ""
 "usa '%s -f -f' para sobreescribir, o 'unlock' y 'prune' o 'remove' para "
 "limpiar"
 
-#: builtin/worktree.c:235
+#: builtin/worktree.c:236
 #, c-format
 msgid ""
 "'%s' is a missing but already registered worktree;\n"
@@ -23865,219 +24240,219 @@ msgstr ""
 "'%s' es un árbol de trabajo faltante pero ya registrado;\n"
 "usa '%s -f' para sobreescribir, o 'prune' o 'remove' para limpiar"
 
-#: builtin/worktree.c:286
+#: builtin/worktree.c:287
 #, c-format
 msgid "could not create directory of '%s'"
 msgstr "no se pudo crear directorio de '%s'"
 
-#: builtin/worktree.c:308
+#: builtin/worktree.c:309
 msgid "initializing"
 msgstr "inicializando"
 
-#: builtin/worktree.c:420 builtin/worktree.c:426
+#: builtin/worktree.c:421 builtin/worktree.c:427
 #, c-format
 msgid "Preparing worktree (new branch '%s')"
 msgstr "Preparando árbol de trabajo (nueva rama '%s')"
 
-#: builtin/worktree.c:422
+#: builtin/worktree.c:423
 #, c-format
 msgid "Preparing worktree (resetting branch '%s'; was at %s)"
 msgstr "Preparando árbol de trabajo (reiniciando rama '%s'; estaba en %s)"
 
-#: builtin/worktree.c:431
+#: builtin/worktree.c:432
 #, c-format
 msgid "Preparing worktree (checking out '%s')"
 msgstr "Preparando árbol de trabajo (haciendo checkout a '%s')"
 
-#: builtin/worktree.c:437
+#: builtin/worktree.c:438
 #, c-format
 msgid "Preparing worktree (detached HEAD %s)"
 msgstr "Preparando árbol de trabajo (HEAD desacoplado %s)"
 
-#: builtin/worktree.c:482
+#: builtin/worktree.c:483
 msgid "checkout <branch> even if already checked out in other worktree"
 msgstr ""
 "hacer checkout a <rama> incluso si ya hay checkout de ella en otro árbol de "
 "trabajo"
 
-#: builtin/worktree.c:485
+#: builtin/worktree.c:486
 msgid "create a new branch"
 msgstr "crear una nueva rama"
 
-#: builtin/worktree.c:487
+#: builtin/worktree.c:488
 msgid "create or reset a branch"
 msgstr "crear o restablecer una rama"
 
-#: builtin/worktree.c:489
+#: builtin/worktree.c:490
 msgid "populate the new working tree"
 msgstr "popular el nuevo árbol de trabajo"
 
-#: builtin/worktree.c:490
+#: builtin/worktree.c:491
 msgid "keep the new working tree locked"
 msgstr "mantener el nuevo árbol de trabajo bloqueado"
 
-#: builtin/worktree.c:492 builtin/worktree.c:729
+#: builtin/worktree.c:493 builtin/worktree.c:730
 msgid "reason for locking"
 msgstr "razón para bloquear"
 
-#: builtin/worktree.c:495
+#: builtin/worktree.c:496
 msgid "set up tracking mode (see git-branch(1))"
 msgstr "configurando modo tracking (mirar git-branch(1))"
 
-#: builtin/worktree.c:498
+#: builtin/worktree.c:499
 msgid "try to match the new branch name with a remote-tracking branch"
 msgstr ""
 "intentar emparejar el nuevo nombre de rama con una rama de rastreo remoto"
 
-#: builtin/worktree.c:506
+#: builtin/worktree.c:507
 msgid "-b, -B, and --detach are mutually exclusive"
 msgstr "-b, -B, y --detach son mutuamente exclusivas"
 
-#: builtin/worktree.c:508
+#: builtin/worktree.c:509
 msgid "--reason requires --lock"
 msgstr "--reason requiere --lock"
 
-#: builtin/worktree.c:512
+#: builtin/worktree.c:513
 msgid "added with --lock"
 msgstr "agregado con --lock"
 
-#: builtin/worktree.c:574
+#: builtin/worktree.c:575
 msgid "--[no-]track can only be used if a new branch is created"
 msgstr "--[no-]track solo puede ser usado si una nueva rama es creada"
 
-#: builtin/worktree.c:691
+#: builtin/worktree.c:692
 msgid "show extended annotations and reasons, if available"
 msgstr "mostrar anotaciones ampliadas y motivos, si están disponibles"
 
-#: builtin/worktree.c:693
+#: builtin/worktree.c:694
 msgid "add 'prunable' annotation to worktrees older than <time>"
 msgstr ""
-"agregue la anotación 'podable' a los árboles de trabajo anteriores a <tiempo>"
+"agregar la anotación 'podable' a los árboles de trabajo anteriores a <tiempo>"
 
-#: builtin/worktree.c:702
+#: builtin/worktree.c:703
 msgid "--verbose and --porcelain are mutually exclusive"
 msgstr "--verbose and --porcelain son mutuamente exclusivas"
 
-#: builtin/worktree.c:741 builtin/worktree.c:774 builtin/worktree.c:848
-#: builtin/worktree.c:972
+#: builtin/worktree.c:742 builtin/worktree.c:775 builtin/worktree.c:849
+#: builtin/worktree.c:973
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr "'%s' no es un árbol de trabajo"
 
-#: builtin/worktree.c:743 builtin/worktree.c:776
+#: builtin/worktree.c:744 builtin/worktree.c:777
 msgid "The main working tree cannot be locked or unlocked"
 msgstr "El árbol de trabajo principal no puede ser bloqueado ni desbloqueado"
 
-#: builtin/worktree.c:748
+#: builtin/worktree.c:749
 #, c-format
 msgid "'%s' is already locked, reason: %s"
 msgstr "'%s' ya está bloqueado; razón: %s"
 
-#: builtin/worktree.c:750
+#: builtin/worktree.c:751
 #, c-format
 msgid "'%s' is already locked"
 msgstr "'%s' ya está bloqueado"
 
-#: builtin/worktree.c:778
+#: builtin/worktree.c:779
 #, c-format
 msgid "'%s' is not locked"
 msgstr "'%s' no está bloqueado"
 
-#: builtin/worktree.c:819
+#: builtin/worktree.c:820
 msgid "working trees containing submodules cannot be moved or removed"
 msgstr ""
 "árboles de trabajo conteniendo submódulos no pueden ser movidos o eliminados"
 
-#: builtin/worktree.c:827
+#: builtin/worktree.c:828
 msgid "force move even if worktree is dirty or locked"
 msgstr "forzar move incluso si el árbol de trabajo está sucio o bloqueado"
 
-#: builtin/worktree.c:850 builtin/worktree.c:974
+#: builtin/worktree.c:851 builtin/worktree.c:975
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr "'%s' es un árbol de trabajo principal"
 
-#: builtin/worktree.c:855
+#: builtin/worktree.c:856
 #, c-format
 msgid "could not figure out destination name from '%s'"
 msgstr "no se pudo descubrir el nombre de destino de '%s'"
 
-#: builtin/worktree.c:868
+#: builtin/worktree.c:869
 #, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
 "use 'move -f -f' to override or unlock first"
 msgstr ""
 "no se puede mover un árbol de trabajo bloqueado, motivo del bloqueo: %s\n"
-"use 'move -f -f' para forzar o desbloquear primero"
+"usa 'move -f -f' para forzar o desbloquear primero"
 
-#: builtin/worktree.c:870
+#: builtin/worktree.c:871
 msgid ""
 "cannot move a locked working tree;\n"
 "use 'move -f -f' to override or unlock first"
 msgstr ""
 "no se puede mover un árbol de trabajo bloqueado;\n"
-"use 'move -f -f' para forzar o desbloquear primero"
+"usa 'move -f -f' para forzar o desbloquear primero"
 
-#: builtin/worktree.c:873
+#: builtin/worktree.c:874
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
 msgstr "falló validación, no se puede mover el árbol de trabajo: %s"
 
-#: builtin/worktree.c:878
+#: builtin/worktree.c:879
 #, c-format
 msgid "failed to move '%s' to '%s'"
 msgstr "falló al mover '%s' a '%s'"
 
-#: builtin/worktree.c:924
+#: builtin/worktree.c:925
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr "falló al ejecutar 'git status' en '%s'"
 
-#: builtin/worktree.c:928
+#: builtin/worktree.c:929
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
-"'%s' contiene archivos modificados o no rastreados, use --force para borrarlo"
+"'%s' contiene archivos modificados o no rastreados, usa --force para borrarlo"
 
-#: builtin/worktree.c:933
+#: builtin/worktree.c:934
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr "no se pudo ejecutar 'git status' en '%s', código %d"
 
-#: builtin/worktree.c:956
+#: builtin/worktree.c:957
 msgid "force removal even if worktree is dirty or locked"
 msgstr ""
 "forzar eliminación incluso si el árbol de trabajo está sucio o bloqueado"
 
-#: builtin/worktree.c:979
+#: builtin/worktree.c:980
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
 "use 'remove -f -f' to override or unlock first"
 msgstr ""
 "no se puede eliminar árbol de trabajo bloqueado, razón del bloqueo: %s\n"
-"use 'remove -f -f' para forzar o desbloquear primero"
+"usa 'remove -f -f' para forzar o desbloquear primero"
 
-#: builtin/worktree.c:981
+#: builtin/worktree.c:982
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
 msgstr ""
 "no se pueden eliminar árbol de trabajo bloqueado;\n"
-"use 'remove -f -f' para forzar o desbloquear primero"
+"usa 'remove -f -f' para forzar o desbloquear primero"
 
-#: builtin/worktree.c:984
+#: builtin/worktree.c:985
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr "falló validación, no se puede eliminar árbol de trabajo: %s"
 
-#: builtin/worktree.c:1008
+#: builtin/worktree.c:1009
 #, c-format
 msgid "repair: %s: %s"
 msgstr "reparar: %s: %s"
 
-#: builtin/worktree.c:1011
+#: builtin/worktree.c:1012
 #, c-format
 msgid "error: %s: %s"
 msgstr "error: %s: %s"
@@ -24125,7 +24500,7 @@ msgid ""
 "See 'git help git' for an overview of the system."
 msgstr ""
 "'git help -a' y 'git help -g' listan los subcomandos disponibles y algunas\n"
-"guías de concepto. Consulte 'git help <command>' o 'git help <concepto>'\n"
+"guías de concepto. Consulta 'git help <command>' o 'git help <concepto>'\n"
 "para leer sobre un subcomando o concepto específico.\n"
 "Mira 'git help git' para una vista general del sistema."
 
@@ -24205,17 +24580,17 @@ msgstr "error desconocido de escritura en standard output"
 msgid "close failed on standard output"
 msgstr "cierre falló en standard output"
 
-#: git.c:833
+#: git.c:832
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr "bucle de alias detectado: expansión de '%s' no termina: %s"
 
-#: git.c:883
+#: git.c:882
 #, c-format
 msgid "cannot handle %s as a builtin"
 msgstr "no se puede manejar %s como un builtin"
 
-#: git.c:896
+#: git.c:895
 #, c-format
 msgid ""
 "usage: %s\n"
@@ -24226,12 +24601,12 @@ msgstr ""
 "\n"
 "\n"
 
-#: git.c:916
+#: git.c:915
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr "expansión del alias '%s' falló; '%s' no es un comando de git\n"
 
-#: git.c:928
+#: git.c:927
 #, c-format
 msgid "failed to run command '%s': %s\n"
 msgstr "falló al ejecutar comando '%s': %s\n"
@@ -24278,67 +24653,33 @@ msgstr "test-tool serve-v2 [<opciones>]"
 msgid "exit immediately after advertising capabilities"
 msgstr "salir inmediatamente tras anunciar capacidades"
 
-#: t/helper/test-simple-ipc.c:262
-#, c-format
-msgid "socket/pipe already in use: '%s'"
-msgstr "socket/pipe ya está en uso: '%s'"
-
-#: t/helper/test-simple-ipc.c:264
-#, c-format
-msgid "could not start server on: '%s'"
-msgstr "no se pudo iniciar el servidor en: '%s'"
-
-#: t/helper/test-simple-ipc.c:295 t/helper/test-simple-ipc.c:331
-msgid "could not spawn daemon in the background"
-msgstr "no se puede generar demonio en el background"
-
-#: t/helper/test-simple-ipc.c:356
-msgid "waitpid failed"
-msgstr "falló waitpid"
-
-#: t/helper/test-simple-ipc.c:376
-msgid "daemon not online yet"
-msgstr "demonio no está en línea todavía"
-
-#: t/helper/test-simple-ipc.c:406
-msgid "daemon failed to start"
-msgstr "falló al iniciar demonio"
-
-#: t/helper/test-simple-ipc.c:410
-msgid "waitpid is confused"
-msgstr "waitpid está confundido"
-
-#: t/helper/test-simple-ipc.c:541
-msgid "daemon has not shutdown yet"
-msgstr "demonio no se ha apagado todavía"
-
-#: t/helper/test-simple-ipc.c:682
+#: t/helper/test-simple-ipc.c:581
 msgid "test-helper simple-ipc is-active    [<name>] [<options>]"
 msgstr "test-helper simple-ipc is-active  [<nombre>] [<opciones>]"
 
-#: t/helper/test-simple-ipc.c:683
+#: t/helper/test-simple-ipc.c:582
 msgid "test-helper simple-ipc run-daemon   [<name>] [<threads>]"
 msgstr "test-helper simple-ipc run-daemon   [<nombre>] [<hilos>]"
 
-#: t/helper/test-simple-ipc.c:684
+#: t/helper/test-simple-ipc.c:583
 msgid "test-helper simple-ipc start-daemon [<name>] [<threads>] [<max-wait>]"
 msgstr ""
 "test-helper simple-ipc start-daemon [<nombre>] [<hilos>] [<espera-maxima>]"
 
-#: t/helper/test-simple-ipc.c:685
+#: t/helper/test-simple-ipc.c:584
 msgid "test-helper simple-ipc stop-daemon  [<name>] [<max-wait>]"
 msgstr "test-helper simple-ipc stop-daemon  [<nombre>] [<espera-maxima>]"
 
-#: t/helper/test-simple-ipc.c:686
+#: t/helper/test-simple-ipc.c:585
 msgid "test-helper simple-ipc send         [<name>] [<token>]"
 msgstr "test-helper simple-ipc send         [<nombre>] [<token>]"
 
-#: t/helper/test-simple-ipc.c:687
+#: t/helper/test-simple-ipc.c:586
 msgid "test-helper simple-ipc sendbytes    [<name>] [<bytecount>] [<byte>]"
 msgstr ""
 "test-helper simple-ipc sendbytes    [<nombre>] [<cuenta de bytes>] [<byte>]"
 
-#: t/helper/test-simple-ipc.c:688
+#: t/helper/test-simple-ipc.c:587
 msgid ""
 "test-helper simple-ipc multiple     [<name>] [<threads>] [<bytecount>] "
 "[<batchsize>]"
@@ -24346,85 +24687,81 @@ msgstr ""
 "test-helper simple-ipc multiple     [<nombre>] [<hilos>] [<cuenta de bytes>] "
 "[<tamaño de batch>]"
 
-#: t/helper/test-simple-ipc.c:696
+#: t/helper/test-simple-ipc.c:595
 msgid "name or pathname of unix domain socket"
 msgstr "nombre o ruta de nombre de socket de dominio unix"
 
-#: t/helper/test-simple-ipc.c:698
+#: t/helper/test-simple-ipc.c:597
 msgid "named-pipe name"
 msgstr "nombre de named-pipe"
 
-#: t/helper/test-simple-ipc.c:700
+#: t/helper/test-simple-ipc.c:599
 msgid "number of threads in server thread pool"
 msgstr "número de hilos en el pool de hilos del servidor"
 
-#: t/helper/test-simple-ipc.c:701
+#: t/helper/test-simple-ipc.c:600
 msgid "seconds to wait for daemon to start or stop"
 msgstr "segundos a esperar para que el dominio empiece o se detenga"
 
-#: t/helper/test-simple-ipc.c:703
+#: t/helper/test-simple-ipc.c:602
 msgid "number of bytes"
 msgstr "número de bytes"
 
-#: t/helper/test-simple-ipc.c:704
+#: t/helper/test-simple-ipc.c:603
 msgid "number of requests per thread"
-msgstr "númeor de peticiones por hilo"
+msgstr "número de peticiones por hilo"
 
-#: t/helper/test-simple-ipc.c:706
+#: t/helper/test-simple-ipc.c:605
 msgid "byte"
 msgstr "byte"
 
-#: t/helper/test-simple-ipc.c:706
+#: t/helper/test-simple-ipc.c:605
 msgid "ballast character"
-msgstr "caracter lastre"
+msgstr "carácter lastre"
 
-#: t/helper/test-simple-ipc.c:707
+#: t/helper/test-simple-ipc.c:606
 msgid "token"
 msgstr "token"
 
-#: t/helper/test-simple-ipc.c:707
+#: t/helper/test-simple-ipc.c:606
 msgid "command token to send to the server"
-msgstr "comando token para enviar al servidor"
+msgstr "token de comando para enviar al servidor"
 
-#: http.c:399
+#: http.c:350
 #, c-format
 msgid "negative value for http.postbuffer; defaulting to %d"
 msgstr "valor negativo para http.postbuffer; poniendo el default %d"
 
-#: http.c:420
+#: http.c:371
 msgid "Delegation control is not supported with cURL < 7.22.0"
 msgstr "Delegación de control no es soportada con cURL < 7.22.0"
 
-#: http.c:429
-msgid "Public key pinning not supported with cURL < 7.44.0"
-msgstr "Fijación de llave pública no es soportada con cURL < 7.44.0"
+#: http.c:380
+msgid "Public key pinning not supported with cURL < 7.39.0"
+msgstr "Fijación de llave pública no es soportada con cURL < 7.39.0"
 
-#: http.c:910
+#: http.c:812
 msgid "CURLSSLOPT_NO_REVOKE not supported with cURL < 7.44.0"
 msgstr "CURLSSLOPT_NO_REVOKE no soportado con cURL < 7.44.0"
 
-#: http.c:989
-msgid "Protocol restrictions not supported with cURL < 7.19.4"
-msgstr "Restricción de protocolo no soportada con cURL < 7.19.4"
-
-#: http.c:1132
+#: http.c:1016
 #, c-format
 msgid "Unsupported SSL backend '%s'. Supported SSL backends:"
 msgstr "Backend SSL no soportado '%s'. Backends SSL soportados:"
 
-#: http.c:1139
+#: http.c:1023
 #, c-format
 msgid "Could not set SSL backend to '%s': cURL was built without SSL backends"
 msgstr ""
 "No se pudo configurar backend SSL a '%s': cURL fue construido sin backends "
 "SSL"
 
-#: http.c:1143
+#: http.c:1027
 #, c-format
 msgid "Could not set SSL backend to '%s': already set"
 msgstr "No se pudo configurar backend SSL para '%s': ya configurado"
 
-#: http.c:2034
+#: http.c:1876
 #, c-format
 msgid ""
 "unable to update url base from redirection:\n"
@@ -24440,47 +24777,53 @@ msgstr ""
 msgid "invalid quoting in push-option value: '%s'"
 msgstr "quoting inválido en valor de push-option: '%s'"
 
-#: remote-curl.c:307
+#: remote-curl.c:304
 #, c-format
 msgid "%sinfo/refs not valid: is this a git repository?"
 msgstr "%sinfo/refs no es válido: ¿es este un repositorio git?"
 
-#: remote-curl.c:408
+#: remote-curl.c:405
 msgid "invalid server response; expected service, got flush packet"
 msgstr ""
 "respuesta de servidor inválida; se esperaba servicio, se obtuvo un flush "
 "packet"
 
-#: remote-curl.c:439
+#: remote-curl.c:436
 #, c-format
 msgid "invalid server response; got '%s'"
 msgstr "respuesta de servidor inválida; se obtuvo '%s'"
 
-#: remote-curl.c:499
+#: remote-curl.c:496
 #, c-format
 msgid "repository '%s' not found"
 msgstr "repositorio '%s' no encontrado"
 
-#: remote-curl.c:503
+#: remote-curl.c:500
 #, c-format
 msgid "Authentication failed for '%s'"
 msgstr "Autenticación falló para '%s'"
 
-#: remote-curl.c:507
+#: remote-curl.c:504
+#, c-format
+msgid "unable to access '%s' with http.pinnedPubkey configuration: %s"
+msgstr ""
+"no es posible acceder a '%s' con la configuración http.pinnedPubkey: %s"
+
+#: remote-curl.c:508
 #, c-format
 msgid "unable to access '%s': %s"
 msgstr "no es posible acceder a '%s': %s"
 
-#: remote-curl.c:513
+#: remote-curl.c:514
 #, c-format
 msgid "redirecting to %s"
 msgstr "redirigiendo a %s"
 
-#: remote-curl.c:644
+#: remote-curl.c:645
 msgid "shouldn't have EOF when not gentle on EOF"
 msgstr "no se debería tener EOF cuando no es laxo con EOF"
 
-#: remote-curl.c:656
+#: remote-curl.c:657
 msgid "remote server sent unexpected response end packet"
 msgstr "el servidor remoto envió una respuesta de fin de paquete inesperada"
 
@@ -24489,83 +24832,83 @@ msgid "unable to rewind rpc post data - try increasing http.postBuffer"
 msgstr ""
 "no es posible rebobinar rpc post data - intenta incrementar http.postBuffer"
 
-#: remote-curl.c:756
+#: remote-curl.c:755
 #, c-format
 msgid "remote-curl: bad line length character: %.4s"
 msgstr "remote-curl: mal carácter de largo de línea: %.4s"
 
-#: remote-curl.c:758
+#: remote-curl.c:757
 msgid "remote-curl: unexpected response end packet"
 msgstr "remote-curl: packet de respuesta final inesperado"
 
-#: remote-curl.c:834
+#: remote-curl.c:833
 #, c-format
 msgid "RPC failed; %s"
 msgstr "RPC falló; %s"
 
-#: remote-curl.c:874
+#: remote-curl.c:873
 msgid "cannot handle pushes this big"
 msgstr "no se puede manejar pushes tan grandes"
 
-#: remote-curl.c:989
+#: remote-curl.c:986
 #, c-format
 msgid "cannot deflate request; zlib deflate error %d"
 msgstr "no se puede desinflar el request; zlib deflate error %d"
 
-#: remote-curl.c:993
+#: remote-curl.c:990
 #, c-format
 msgid "cannot deflate request; zlib end error %d"
 msgstr "no se puede desinflar el request; zlib end error %d"
 
-#: remote-curl.c:1043
+#: remote-curl.c:1040
 #, c-format
 msgid "%d bytes of length header were received"
 msgstr "%d bytes de header de longitud fueron recibidos"
 
-#: remote-curl.c:1045
+#: remote-curl.c:1042
 #, c-format
 msgid "%d bytes of body are still expected"
 msgstr "%d bytes de cuerpo se siguen esperando"
 
-#: remote-curl.c:1134
+#: remote-curl.c:1131
 msgid "dumb http transport does not support shallow capabilities"
 msgstr "dump http transport no soporta capacidades superficiales"
 
-#: remote-curl.c:1149
+#: remote-curl.c:1146
 msgid "fetch failed."
 msgstr "fetch falló."
 
-#: remote-curl.c:1195
+#: remote-curl.c:1192
 msgid "cannot fetch by sha1 over smart http"
 msgstr "no se puede hacer fetch por sha1 sobre smart http"
 
-#: remote-curl.c:1239 remote-curl.c:1245
+#: remote-curl.c:1236 remote-curl.c:1242
 #, c-format
 msgid "protocol error: expected sha/ref, got '%s'"
 msgstr "error de protocolo: se esperaba sha/ref, se obtuvo '%s'"
 
-#: remote-curl.c:1257 remote-curl.c:1375
+#: remote-curl.c:1254 remote-curl.c:1372
 #, c-format
 msgid "http transport does not support %s"
 msgstr "http transport no soporta %s"
 
-#: remote-curl.c:1293
+#: remote-curl.c:1290
 msgid "git-http-push failed"
 msgstr "git-http-push falló"
 
-#: remote-curl.c:1481
+#: remote-curl.c:1478
 msgid "remote-curl: usage: git remote-curl <remote> [<url>]"
 msgstr "remote-curl: uso: git remote-curl <remote> [<url>]"
 
-#: remote-curl.c:1513
+#: remote-curl.c:1510
 msgid "remote-curl: error reading command stream from git"
 msgstr "remote-curl: error al leer command stream de git"
 
-#: remote-curl.c:1520
+#: remote-curl.c:1517
 msgid "remote-curl: fetch attempted without a local repo"
 msgstr "remote-curl: fetch intentado sin un repositorio local"
 
-#: remote-curl.c:1561
+#: remote-curl.c:1558
 #, c-format
 msgid "remote-curl: unknown command '%s' from git"
 msgstr "remote-curl: comando '%s' desconocido de git"
@@ -24586,46 +24929,46 @@ msgstr "args"
 msgid "object filtering"
 msgstr "filtrado de objeto"
 
-#: parse-options.h:184
+#: parse-options.h:183
 msgid "expiry-date"
 msgstr "fecha de caducidad"
 
-#: parse-options.h:198
+#: parse-options.h:197
 msgid "no-op (backward compatibility)"
 msgstr "no-op (compatibilidad con versiones anteriores)"
 
-#: parse-options.h:310
+#: parse-options.h:309
 msgid "be more verbose"
 msgstr "ser más verboso"
 
-#: parse-options.h:312
+#: parse-options.h:311
 msgid "be more quiet"
 msgstr "ser más callado"
 
-#: parse-options.h:318
+#: parse-options.h:317
 msgid "use <n> digits to display object names"
-msgstr "use <n> cifras para mostrar los nombres de los objetos"
+msgstr "usar <n> cifras para mostrar los nombres de los objetos"
 
-#: parse-options.h:337
+#: parse-options.h:336
 msgid "how to strip spaces and #comments from message"
 msgstr "cómo quitar espacios y #comentarios de mensajes"
 
-#: parse-options.h:338
+#: parse-options.h:337
 msgid "read pathspec from file"
 msgstr "leer pathspec de archivo"
 
-#: parse-options.h:339
+#: parse-options.h:338
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""
-"con --pathspec-from-file, elementos de pathspec son separados con caracter "
+"con --pathspec-from-file, elementos de pathspec son separados con carácter "
 "NUL"
 
-#: ref-filter.h:99
+#: ref-filter.h:101
 msgid "key"
 msgstr "clave"
 
-#: ref-filter.h:99
+#: ref-filter.h:101
 msgid "field name to sort on"
 msgstr "nombre del campo por el cuál ordenar"
 
@@ -24637,7 +24980,7 @@ msgstr ""
 
 #: command-list.h:50
 msgid "Add file contents to the index"
-msgstr "Agrega contenido de archivos al índice"
+msgstr "Agregar contenido de archivos al índice"
 
 #: command-list.h:51
 msgid "Apply a series of patches from a mailbox"
@@ -24661,7 +25004,7 @@ msgstr "Crear una crónica de archivos de un árbol nombrado"
 
 #: command-list.h:56
 msgid "Use binary search to find the commit that introduced a bug"
-msgstr "Use la búsqueda binaria para encontrar el commit que introdujo el bug"
+msgstr "Usar la búsqueda binaria para encontrar el commit que introdujo el bug"
 
 #: command-list.h:57
 msgid "Show what revision and author last modified each line of a file"
@@ -24670,7 +25013,7 @@ msgstr ""
 
 #: command-list.h:58
 msgid "List, create, or delete branches"
-msgstr "Lista, crea, o borra ramas"
+msgstr "Listar, crear, o borrar ramas"
 
 #: command-list.h:59
 msgid "Collect information for user to file a bug report"
@@ -24701,7 +25044,7 @@ msgstr ""
 
 #: command-list.h:65
 msgid "Switch branches or restore working tree files"
-msgstr "Cambia de rama o restaura archivos del árbol de trabajo"
+msgstr "Cambiar de rama o restaura archivos del árbol de trabajo"
 
 #: command-list.h:66
 msgid "Copy files from the index to the working tree"
@@ -24709,15 +25052,15 @@ msgstr "Copiar archivos del índice al árbol de trabajo"
 
 #: command-list.h:67
 msgid "Ensures that a reference name is well formed"
-msgstr "Asegura que un nombre de referencia esté bien formado"
+msgstr "Asegurar que un nombre de referencia esté bien formado"
 
 #: command-list.h:68
 msgid "Find commits yet to be applied to upstream"
-msgstr "Encuentra commits que falten aplicar en upstream"
+msgstr "Encontrar commits que falten aplicar en upstream"
 
 #: command-list.h:69
 msgid "Apply the changes introduced by some existing commits"
-msgstr "Aplica los cambios introducidos por algunos commits existentes"
+msgstr "Aplicar los cambios introducidos por algunos commits existentes"
 
 #: command-list.h:70
 msgid "Graphical alternative to git-commit"
@@ -24729,7 +25072,7 @@ msgstr "Quitar archivos no rastreados del árbol de trabajo"
 
 #: command-list.h:72
 msgid "Clone a repository into a new directory"
-msgstr "Clona un repositorio dentro de un nuevo directorio"
+msgstr "Clonar un repositorio dentro de un nuevo directorio"
 
 #: command-list.h:73
 msgid "Display data in columns"
@@ -24737,15 +25080,15 @@ msgstr "Mostrar data en columnas"
 
 #: command-list.h:74
 msgid "Record changes to the repository"
-msgstr "Graba los cambios al repositorio"
+msgstr "Grabar los cambios al repositorio"
 
 #: command-list.h:75
 msgid "Write and verify Git commit-graph files"
-msgstr "Escribe y verifica los archivos commit-graph de Git"
+msgstr "Escribir y verificar los archivos commit-graph de Git"
 
 #: command-list.h:76
 msgid "Create a new commit object"
-msgstr "Crea un nuevo objeto commit"
+msgstr "Crear un nuevo objeto commit"
 
 #: command-list.h:77
 msgid "Get and set repository or global options"
@@ -24769,11 +25112,11 @@ msgstr "Auxiliar para guardar credenciales en disco"
 
 #: command-list.h:82
 msgid "Export a single commit to a CVS checkout"
-msgstr "Exporta un commit único a CVS checkout"
+msgstr "Exportar un commit único a CVS checkout"
 
 #: command-list.h:83
 msgid "Salvage your data out of another SCM people love to hate"
-msgstr "Salva tus datos de otro SCM que la gente adora odiar"
+msgstr "Salvar tus datos de otro SCM que la gente adora odiar"
 
 #: command-list.h:84
 msgid "A CVS server emulator for Git"
@@ -24791,20 +25134,20 @@ msgstr ""
 
 #: command-list.h:87
 msgid "Show changes between commits, commit and working tree, etc"
-msgstr "Muestra los cambios entre commits, commit y árbol de trabajo, etc"
+msgstr "Mostrar los cambios entre commits, commit y árbol de trabajo, etc"
 
 #: command-list.h:88
 msgid "Compares files in the working tree and the index"
-msgstr "Compara archivos del árbol de trabajo y del índice"
+msgstr "Comparar archivos del árbol de trabajo y del índice"
 
 #: command-list.h:89
 msgid "Compare a tree to the working tree or index"
-msgstr "Compara un árbol con el árbol de trabajo o índice"
+msgstr "Comparar un árbol con el árbol de trabajo o índice"
 
 #: command-list.h:90
 msgid "Compares the content and mode of blobs found via two tree objects"
 msgstr ""
-"Compara el contenido y el modo de blobs encontrados a través de dos objetos "
+"Comparar el contenido y el modo de blobs encontrados a través de dos objetos "
 "de árbol"
 
 #: command-list.h:91
@@ -24821,11 +25164,11 @@ msgstr "Backend para importadores de data de Git rápidos"
 
 #: command-list.h:94
 msgid "Download objects and refs from another repository"
-msgstr "Descarga objetos y referencias de otro repositorio"
+msgstr "Descargar objetos y referencias de otro repositorio"
 
 #: command-list.h:95
 msgid "Receive missing objects from another repository"
-msgstr "Descarga objetos faltantes de otro repositorio"
+msgstr "Descargar objetos faltantes de otro repositorio"
 
 #: command-list.h:96
 msgid "Rewrite branches"
@@ -24833,7 +25176,7 @@ msgstr "Reescribir ramas"
 
 #: command-list.h:97
 msgid "Produce a merge commit message"
-msgstr "Produce un mensaje de commit de fusión"
+msgstr "Producir un mensaje de commit de fusión"
 
 #: command-list.h:98
 msgid "Output information on each ref"
@@ -24841,28 +25184,28 @@ msgstr "Información de output en cada ref"
 
 #: command-list.h:99
 msgid "Run a Git command on a list of repositories"
-msgstr "Ejecute un comando de Git en una lista de repositorios"
+msgstr "Ejecutar un comando de Git en una lista de repositorios"
 
 #: command-list.h:100
 msgid "Prepare patches for e-mail submission"
-msgstr "Prepara parches para ser enviados por e-mail"
+msgstr "Preparar parches para ser enviados por e-mail"
 
 #: command-list.h:101
 msgid "Verifies the connectivity and validity of the objects in the database"
 msgstr ""
-"Verifica la conectividad y disponibilidad de los objetos en la base de datos"
+"Verificar la conectividad y disponibilidad de los objetos en la base de datos"
 
 #: command-list.h:102
 msgid "Cleanup unnecessary files and optimize the local repository"
-msgstr "Limpia archivos innecesarios y optimiza el repositorio local"
+msgstr "Limpiar archivos innecesarios y optimiza el repositorio local"
 
 #: command-list.h:103
 msgid "Extract commit ID from an archive created using git-archive"
-msgstr "Extrae el ID de commit de una crónica creada usando git-archive"
+msgstr "Extraer el ID de commit de una crónica creada usando git-archive"
 
 #: command-list.h:104
 msgid "Print lines matching a pattern"
-msgstr "Imprime las líneas que concuerden con el patrón"
+msgstr "Imprimir las líneas que concuerden con el patrón"
 
 #: command-list.h:105
 msgid "A portable graphical interface to Git"
@@ -24870,7 +25213,7 @@ msgstr "Una interfaz gráfica portátil para Git"
 
 #: command-list.h:106
 msgid "Compute object ID and optionally creates a blob from a file"
-msgstr "Computa ID de objeto y, opcionalmente, crea un blob de un archivo"
+msgstr "Computar ID de objeto y, opcionalmente, crear un blob de un archivo"
 
 #: command-list.h:107
 msgid "Display help information about Git"
@@ -24882,11 +25225,11 @@ msgstr "Implementación de lado de servidor de Git por HTTP"
 
 #: command-list.h:109
 msgid "Download from a remote Git repository via HTTP"
-msgstr "Descarga de un repositorio Git remoto vía HTTP"
+msgstr "Descargar de un repositorio Git remoto vía HTTP"
 
 #: command-list.h:110
 msgid "Push objects over HTTP/DAV to another repository"
-msgstr "Empuja objetos por HTTP/DAV a otro repositorio"
+msgstr "Empujar objetos por HTTP/DAV a otro repositorio"
 
 #: command-list.h:111
 msgid "Send a collection of patches from stdin to an IMAP folder"
@@ -24894,11 +25237,11 @@ msgstr "Enviar una colección de parches de stdin a una carpeta IMAP"
 
 #: command-list.h:112
 msgid "Build pack index file for an existing packed archive"
-msgstr "Construye un archivo de índice para una crónica empaquetada existente"
+msgstr "Construir un archivo de índice para una crónica empaquetada existente"
 
 #: command-list.h:113
 msgid "Create an empty Git repository or reinitialize an existing one"
-msgstr "Crea un repositorio de Git vacío o reinicia el que ya existe"
+msgstr "Crear un repositorio de Git vacío o reinicia el que ya existe"
 
 #: command-list.h:114
 msgid "Instantly browse your working repository in gitweb"
@@ -24914,19 +25257,19 @@ msgstr "El navegador de repositorio Git"
 
 #: command-list.h:117
 msgid "Show commit logs"
-msgstr "Muestra los logs de los commits"
+msgstr "Mostrar los logs de los commits"
 
 #: command-list.h:118
 msgid "Show information about files in the index and the working tree"
-msgstr "Muestra información sobre archivos en el índice y el árbol de trabajo"
+msgstr "Mostrar información sobre archivos en el índice y el árbol de trabajo"
 
 #: command-list.h:119
 msgid "List references in a remote repository"
-msgstr "Lista referencias en un repositorio remoto"
+msgstr "Listar referencias en un repositorio remoto"
 
 #: command-list.h:120
 msgid "List the contents of a tree object"
-msgstr "Lista los contenidos de un objeto árbol"
+msgstr "Listar los contenidos de un objeto árbol"
 
 #: command-list.h:121
 msgid "Extracts patch and authorship from a single e-mail message"
@@ -24938,23 +25281,23 @@ msgstr "Programa divisor de mbox simple de UNIX"
 
 #: command-list.h:123
 msgid "Run tasks to optimize Git repository data"
-msgstr "Ejecute tareas para optimizar los datos del repositorio de Git"
+msgstr "Ejecutar tareas para optimizar los datos del repositorio de Git"
 
 #: command-list.h:124
 msgid "Join two or more development histories together"
-msgstr "Junta dos o más historiales de desarrollo juntos"
+msgstr "Juntar dos o más historiales de desarrollo juntos"
 
 #: command-list.h:125
 msgid "Find as good common ancestors as possible for a merge"
-msgstr "Encuentra ancestros tan buenos como posible para una fusión"
+msgstr "Encontrar ancestros tan buenos como posible para una fusión"
 
 #: command-list.h:126
 msgid "Run a three-way file merge"
-msgstr "Ejecuta una fusión de tres vías en un archivo"
+msgstr "Ejecutar una fusión de tres vías en un archivo"
 
 #: command-list.h:127
 msgid "Run a merge for files needing merging"
-msgstr "Ejecuta una fusión para archivos que la necesiten"
+msgstr "Ejecutar una fusión para archivos que la necesiten"
 
 #: command-list.h:128
 msgid "The standard helper program to use with git-merge-index"
@@ -24963,8 +25306,8 @@ msgstr "El programa de ayuda estándar para usar con git-merge-index"
 #: command-list.h:129
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
 msgstr ""
-"Ejecuta las herramientas de fusión de resolución de conflictos para resolver "
-"conflictos de fusión"
+"Ejecutar las herramientas de fusión de resolución de conflictos para "
+"resolver conflictos de fusión"
 
 #: command-list.h:130
 msgid "Show three-way merge without touching index"
@@ -24972,11 +25315,11 @@ msgstr "Mostrar fusión de tres vías sin tocar el índice"
 
 #: command-list.h:131
 msgid "Write and verify multi-pack-indexes"
-msgstr "Escribe y verifica archivos multi-pack-index"
+msgstr "Escribir y verificar archivos multi-pack-index"
 
 #: command-list.h:132
 msgid "Creates a tag object with extra validation"
-msgstr "Crea un objeto de etiqueta con validación adicional"
+msgstr "Crear un objeto de etiqueta con validación adicional"
 
 #: command-list.h:133
 msgid "Build a tree-object from ls-tree formatted text"
@@ -24984,7 +25327,7 @@ msgstr "Construir un objeto árbol de un texto en formato ls-tree"
 
 #: command-list.h:134
 msgid "Move or rename a file, a directory, or a symlink"
-msgstr "Mueve o cambia el nombre a archivos, directorios o enlaces simbólicos"
+msgstr "Mover o cambiar el nombre a archivos, directorios o enlaces simbólicos"
 
 #: command-list.h:135
 msgid "Find symbolic names for given revs"
@@ -24992,7 +25335,7 @@ msgstr "Encontrar nombres simbólicos para revs dados"
 
 #: command-list.h:136
 msgid "Add or inspect object notes"
-msgstr "Agrega o inspecciona notas de objeto"
+msgstr "Agregar o inspeccionar notas de objeto"
 
 #: command-list.h:137
 msgid "Import from and submit to Perforce repositories"
@@ -25000,15 +25343,15 @@ msgstr "Importar desde y enviar a repositorios Perforce"
 
 #: command-list.h:138
 msgid "Create a packed archive of objects"
-msgstr "Crea una crónica de objetos empaquetada"
+msgstr "Crear una crónica de objetos empaquetada"
 
 #: command-list.h:139
 msgid "Find redundant pack files"
-msgstr "Encuentra archivos de paquete redundantes"
+msgstr "Encontrar archivos de paquete redundantes"
 
 #: command-list.h:140
 msgid "Pack heads and tags for efficient repository access"
-msgstr "Empaqueta heads y tags para un acceso eficiente al repositorio"
+msgstr "Empaquetar heads y tags para un acceso eficiente al repositorio"
 
 #: command-list.h:141
 msgid "Compute unique ID for a patch"
@@ -25016,7 +25359,8 @@ msgstr "Calcular ID único para un parche"
 
 #: command-list.h:142
 msgid "Prune all unreachable objects from the object database"
-msgstr "Limpia todos los objetos no alcanzables de la base de datos de objetos"
+msgstr ""
+"Limpiar todos los objetos no alcanzables de la base de datos de objetos"
 
 #: command-list.h:143
 msgid "Remove extra objects that are already in pack files"
@@ -25024,27 +25368,27 @@ msgstr "Quitar objetos extras que ya estén en archivos empaquetados"
 
 #: command-list.h:144
 msgid "Fetch from and integrate with another repository or a local branch"
-msgstr "Realiza un fetch e integra con otro repositorio o rama local"
+msgstr "Realizar un fetch e integra con otro repositorio o rama local"
 
 #: command-list.h:145
 msgid "Update remote refs along with associated objects"
-msgstr "Actualiza referencias remotas junto con sus objetos asociados"
+msgstr "Actualizar referencias remotas junto con sus objetos asociados"
 
 #: command-list.h:146
 msgid "Applies a quilt patchset onto the current branch"
-msgstr "Aplica un parche quilt en la rama actual"
+msgstr "Aplicar un parche quilt en la rama actual"
 
 #: command-list.h:147
 msgid "Compare two commit ranges (e.g. two versions of a branch)"
-msgstr "Compara dos rangos de commits (por ejemplo dos versions de un branch)"
+msgstr "Comparar dos rangos de commits (por ejemplo dos versions de un branch)"
 
 #: command-list.h:148
 msgid "Reads tree information into the index"
-msgstr "Lee información del árbol al índice"
+msgstr "Leer información del árbol al índice"
 
 #: command-list.h:149
 msgid "Reapply commits on top of another base tip"
-msgstr "Vuelve a aplicar commits en la punta de otra rama"
+msgstr "Volver a aplicar commits en la punta de otra rama"
 
 #: command-list.h:150
 msgid "Receive what is pushed into the repository"
@@ -25056,7 +25400,7 @@ msgstr "Gestionar información de reflog"
 
 #: command-list.h:152
 msgid "Manage set of tracked repositories"
-msgstr "Gestiona un conjunto de repositorios rastreados"
+msgstr "Gestionar un conjunto de repositorios rastreados"
 
 #: command-list.h:153
 msgid "Pack unpacked objects in a repository"
@@ -25064,11 +25408,11 @@ msgstr "Empaquetar objetos no empaquetados en un repositorio"
 
 #: command-list.h:154
 msgid "Create, list, delete refs to replace objects"
-msgstr "Crea, lista, borra referencias para reemplazar objetos"
+msgstr "Crear, listar, borrar referencias para reemplazar objetos"
 
 #: command-list.h:155
 msgid "Generates a summary of pending changes"
-msgstr "Genera un resumen de cambios pendientes"
+msgstr "Generar un resumen de cambios pendientes"
 
 #: command-list.h:156
 msgid "Reuse recorded resolution of conflicted merges"
@@ -25076,7 +25420,7 @@ msgstr "Reutilizar la resolución registrada de fusiones conflictivas"
 
 #: command-list.h:157
 msgid "Reset current HEAD to the specified state"
-msgstr "Reinicia el HEAD actual a un estado específico"
+msgstr "Reiniciar el HEAD actual a un estado específico"
 
 #: command-list.h:158
 msgid "Restore working tree files"
@@ -25084,11 +25428,11 @@ msgstr "Restaurar archivos del árbol de trabajo"
 
 #: command-list.h:159
 msgid "Revert some existing commits"
-msgstr "Revierte algunos commits existentes"
+msgstr "Reviertir algunos commits existentes"
 
 #: command-list.h:160
 msgid "Lists commit objects in reverse chronological order"
-msgstr "Lista objetos commit en orden cronológico inverso"
+msgstr "Listar objetos commit en orden cronológico inverso"
 
 #: command-list.h:161
 msgid "Pick out and massage parameters"
@@ -25096,11 +25440,11 @@ msgstr "Seleccionar y masajear los parámetros"
 
 #: command-list.h:162
 msgid "Remove files from the working tree and from the index"
-msgstr "Borra archivos del árbol de trabajo y del índice"
+msgstr "Borrar archivos del árbol de trabajo y del índice"
 
 #: command-list.h:163
 msgid "Send a collection of patches as emails"
-msgstr "Envía una colección de parches como e-mails"
+msgstr "Enviar una colección de parches como e-mails"
 
 #: command-list.h:164
 msgid "Push objects over Git protocol to another repository"
@@ -25116,7 +25460,7 @@ msgstr "Resumir la salida de 'git log'"
 
 #: command-list.h:167
 msgid "Show various types of objects"
-msgstr "Muestra varios tipos de objetos"
+msgstr "Mostrar varios tipos de objetos"
 
 #: command-list.h:168
 msgid "Show branches and their commits"
@@ -25140,7 +25484,7 @@ msgstr "Código común de configuración de script de shell de Git"
 
 #: command-list.h:173
 msgid "Initialize and modify the sparse-checkout"
-msgstr "Inicializa y modifica el sparse-checkout"
+msgstr "Inicializar y modificar el sparse-checkout"
 
 #: command-list.h:174
 msgid "Stash the changes in a dirty working directory away"
@@ -25148,11 +25492,11 @@ msgstr "Poner en un stash los cambios en un directorio de trabajo sucio"
 
 #: command-list.h:175
 msgid "Add file contents to the staging area"
-msgstr "Agrega contenidos de un archivo al área de staging"
+msgstr "Agregar contenidos de un archivo al área de staging"
 
 #: command-list.h:176
 msgid "Show the working tree status"
-msgstr "Muestra el estado del árbol de trabajo"
+msgstr "Mostrar el estado del árbol de trabajo"
 
 #: command-list.h:177
 msgid "Remove unnecessary whitespace"
@@ -25160,7 +25504,7 @@ msgstr "Eliminar el espacio en blanco innecesario"
 
 #: command-list.h:178
 msgid "Initialize, update or inspect submodules"
-msgstr "Inicializa, actualiza o inspecciona submódulos"
+msgstr "Inicializar, actualizar o inspeccionar submódulos"
 
 #: command-list.h:179
 msgid "Bidirectional operation between a Subversion repository and Git"
@@ -25172,33 +25516,33 @@ msgstr "Cambiar de branch"
 
 #: command-list.h:181
 msgid "Read, modify and delete symbolic refs"
-msgstr "Lee, modifica y borra referencias simbólicas"
+msgstr "Leer, modificar y borrar referencias simbólicas"
 
 #: command-list.h:182
 msgid "Create, list, delete or verify a tag object signed with GPG"
-msgstr "Crea, lista, borra o verifica un objeto de tag firmado con GPG"
+msgstr "Crear, listar, borrar o verificar un objeto de tag firmado con GPG"
 
 #: command-list.h:183
 msgid "Creates a temporary file with a blob's contents"
-msgstr "Crea un archivo temporal con contenidos de un blob"
+msgstr "Crear un archivo temporal con contenidos de un blob"
 
 #: command-list.h:184
 msgid "Unpack objects from a packed archive"
-msgstr "Desempaqueta objetos de una crónica empaquetada"
+msgstr "Desempaquetar objetos de una crónica empaquetada"
 
 #: command-list.h:185
 msgid "Register file contents in the working tree to the index"
-msgstr "Registra contenidos de archivos en el árbol de trabajo al índice"
+msgstr "Registrar contenidos de archivos en el árbol de trabajo al índice"
 
 #: command-list.h:186
 msgid "Update the object name stored in a ref safely"
 msgstr ""
-"Actualiza el nombre del objeto almacenado en una referencia de forma segura"
+"Actualizar el nombre del objeto almacenado en una referencia de forma segura"
 
 #: command-list.h:187
 msgid "Update auxiliary info file to help dumb servers"
 msgstr ""
-"Actualiza el archivo de información auxiliar para ayudar a los servidores "
+"Actualizar el archivo de información auxiliar para ayudar a los servidores "
 "dumb"
 
 #: command-list.h:188
@@ -25219,11 +25563,11 @@ msgstr "Verificar firma GPG de commits"
 
 #: command-list.h:192
 msgid "Validate packed Git archive files"
-msgstr "Valida crónicas Git empaquetadas"
+msgstr "Validar crónicas Git empaquetadas"
 
 #: command-list.h:193
 msgid "Check the GPG signature of tags"
-msgstr "Verifica la firma GPG de etiquetas"
+msgstr "Verificar la firma GPG de etiquetas"
 
 #: command-list.h:194
 msgid "Git web interface (web frontend to Git repositories)"
@@ -25231,15 +25575,15 @@ msgstr "Interfaz web Git (interfaz web para repositorios Git)"
 
 #: command-list.h:195
 msgid "Show logs with difference each commit introduces"
-msgstr "Muestra logs con las diferencias que cada commit introduce"
+msgstr "Mostrar logs con las diferencias que cada commit introduce"
 
 #: command-list.h:196
 msgid "Manage multiple working trees"
-msgstr "Gestiona múltiples árboles de trabajo"
+msgstr "Gestionar múltiples árboles de trabajo"
 
 #: command-list.h:197
 msgid "Create a tree object from the current index"
-msgstr "Crea un objeto árbol del índice actual"
+msgstr "Crear un objeto árbol del índice actual"
 
 #: command-list.h:198
 msgid "Defining attributes per path"
@@ -25283,7 +25627,7 @@ msgstr "Hooks utilizados por Git"
 
 #: command-list.h:208
 msgid "Specifies intentionally untracked files to ignore"
-msgstr "Especifica de forma intencional archivos sin seguimiento a ignorar"
+msgstr "Especificar de forma intencional archivos sin seguimiento a ignorar"
 
 #: command-list.h:209
 msgid "Map author/committer names and/or E-Mail addresses"
@@ -25327,41 +25671,6 @@ msgstr "Un tutorial de introducción a Git"
 msgid "An overview of recommended workflows with Git"
 msgstr "Una visión general de flujos de trabajo recomendados con Git"
 
-#: git-bisect.sh:68
-msgid "bisect run failed: no command provided."
-msgstr "bisect falló: no se proveyó comando."
-
-#: git-bisect.sh:73
-#, sh-format
-msgid "running $command"
-msgstr "ejecutando $command"
-
-#: git-bisect.sh:80
-#, sh-format
-msgid ""
-"bisect run failed:\n"
-"exit code $res from '$command' is < 0 or >= 128"
-msgstr ""
-"bisect falló:\n"
-"código de salida $res de '$command' es <0 o >=128"
-
-#: git-bisect.sh:105
-msgid "bisect run cannot continue any more"
-msgstr "bisect no puede seguir continuando"
-
-#: git-bisect.sh:111
-#, sh-format
-msgid ""
-"bisect run failed:\n"
-"'bisect-state $state' exited with error code $res"
-msgstr ""
-"bisect run falló:\n"
-"'bisect-state $state' salió con el código de error $res"
-
-#: git-bisect.sh:118
-msgid "bisect run success"
-msgstr "bisect exitoso"
-
 #: git-merge-octopus.sh:46
 msgid ""
 "Error: Your local changes to the following files would be overwritten by "
@@ -25402,55 +25711,19 @@ msgstr "Intentando fusión simple con $pretty_name"
 msgid "Simple merge did not work, trying automatic merge."
 msgstr "Fusión simple no funcionó, intentando fusión automática."
 
-#: git-submodule.sh:179
-msgid "Relative path can only be used from the toplevel of the working tree"
-msgstr ""
-"La ruta relativa solo se puede usar desde el nivel superior del árbol de "
-"trabajo"
-
-#: git-submodule.sh:189
-#, sh-format
-msgid "repo URL: '$repo' must be absolute or begin with ./|../"
-msgstr "repo URL: '$repo' debe ser absoluta o iniciar con ./|../"
-
-#: git-submodule.sh:208
-#, sh-format
-msgid "'$sm_path' already exists in the index"
-msgstr "'$sm_path' ya existe en el índice"
-
-#: git-submodule.sh:211
-#, sh-format
-msgid "'$sm_path' already exists in the index and is not a submodule"
-msgstr "'$sm_path' ya existe en el índice y no es un submódulo"
-
-#: git-submodule.sh:218
-#, sh-format
-msgid "'$sm_path' does not have a commit checked out"
-msgstr "'$sm_path' no tiene un commit checked out"
-
-#: git-submodule.sh:248
-#, sh-format
-msgid "Failed to add submodule '$sm_path'"
-msgstr "Falló al agregar el submódulo '$sm_path'"
-
-#: git-submodule.sh:257
-#, sh-format
-msgid "Failed to register submodule '$sm_path'"
-msgstr "Falló al registrar el submódulo '$sm_path'"
-
-#: git-submodule.sh:532
+#: git-submodule.sh:401
 #, sh-format
 msgid "Unable to find current revision in submodule path '$displaypath'"
 msgstr ""
 "No se pudo encontrar la revisión actual en la ruta de submódulo "
 "'$displaypath'"
 
-#: git-submodule.sh:542
+#: git-submodule.sh:411
 #, sh-format
 msgid "Unable to fetch in submodule path '$sm_path'"
 msgstr "No es posible realizar fetch en la ruta de submódulo '$sm_path'"
 
-#: git-submodule.sh:547
+#: git-submodule.sh:416
 #, sh-format
 msgid ""
 "Unable to find current ${remote_name}/${branch} revision in submodule path "
@@ -25459,401 +25732,10 @@ msgstr ""
 "No es posible encontrar revisión actual ${remote_name}/${branch} en la ruta "
 "de submódulo '$sm_path'"
 
-#: git-submodule.sh:565
-#, sh-format
-msgid ""
-"Unable to fetch in submodule path '$displaypath'; trying to directly fetch "
-"$sha1:"
-msgstr ""
-"No es posible realizar fetch en la ruta de submódulo '$displaypath'; "
-"intentando hacer un fetch directo de $sha1:"
-
-#: git-submodule.sh:571
-#, sh-format
-msgid ""
-"Fetched in submodule path '$displaypath', but it did not contain $sha1. "
-"Direct fetching of that commit failed."
-msgstr ""
-"Fetch realizado en la ruta de submódulo '$displaypath', pero no contenía "
-"$sha1. Fetch directo del commit falló."
-
-#: git-submodule.sh:578
-#, sh-format
-msgid "Unable to checkout '$sha1' in submodule path '$displaypath'"
-msgstr "No es posible revisar '$sha1' en la ruta de submódulo '$displaypath'"
-
-#: git-submodule.sh:579
-#, sh-format
-msgid "Submodule path '$displaypath': checked out '$sha1'"
-msgstr "Ruta de submódulo '$displaypath': check out realizado a '$sha1'"
-
-#: git-submodule.sh:583
-#, sh-format
-msgid "Unable to rebase '$sha1' in submodule path '$displaypath'"
-msgstr ""
-"No es posible ejecutar rebase a '$sha1' en la ruta de submódulo "
-"'$displaypath'"
-
-#: git-submodule.sh:584
-#, sh-format
-msgid "Submodule path '$displaypath': rebased into '$sha1'"
-msgstr "Ruta de submódulo '$displaypath': rebasado a '$sha1'"
-
-#: git-submodule.sh:589
-#, sh-format
-msgid "Unable to merge '$sha1' in submodule path '$displaypath'"
-msgstr "Incapaz de fusionar '$sha1' en la ruta del submódulo '$displaypath'"
-
-#: git-submodule.sh:590
-#, sh-format
-msgid "Submodule path '$displaypath': merged in '$sha1'"
-msgstr "Ruta de submódulo '$displaypath': fusionado en '$sha1'"
-
-#: git-submodule.sh:595
-#, sh-format
-msgid "Execution of '$command $sha1' failed in submodule path '$displaypath'"
-msgstr ""
-"Falló la ejecución de '$command $sha1' en la ruta de submódulo '$displaypath'"
-
-#: git-submodule.sh:596
-#, sh-format
-msgid "Submodule path '$displaypath': '$command $sha1'"
-msgstr "Ruta de submódulo '$displaypath': '$command $sha1'"
-
-#: git-submodule.sh:627
+#: git-submodule.sh:464
 #, sh-format
 msgid "Failed to recurse into submodule path '$displaypath'"
 msgstr "Falló al recurrir en la ruta de submódulo '$displaypath'"
-
-#: git-rebase--preserve-merges.sh:109
-msgid "Applied autostash."
-msgstr "Autostash aplicado."
-
-#: git-rebase--preserve-merges.sh:112
-#, sh-format
-msgid "Cannot store $stash_sha1"
-msgstr "No se puede almacenar $stash_sha1"
-
-#: git-rebase--preserve-merges.sh:113
-msgid ""
-"Applying autostash resulted in conflicts.\n"
-"Your changes are safe in the stash.\n"
-"You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
-msgstr ""
-"Aplicar autostash resultó en conflictos.\n"
-"Tus cambios están seguros en el stash.\n"
-"Puedes ejecutar \"git stash pop\" o \"git stash drop\" en cualquier "
-"momento.\n"
-
-#: git-rebase--preserve-merges.sh:191
-#, sh-format
-msgid "Rebasing ($new_count/$total)"
-msgstr "Rebasando ($new_count/$total)"
-
-#: git-rebase--preserve-merges.sh:197
-msgid ""
-"\n"
-"Commands:\n"
-"p, pick <commit> = use commit\n"
-"r, reword <commit> = use commit, but edit the commit message\n"
-"e, edit <commit> = use commit, but stop for amending\n"
-"s, squash <commit> = use commit, but meld into previous commit\n"
-"f, fixup <commit> = like \"squash\", but discard this commit's log message\n"
-"x, exec <commit> = run command (the rest of the line) using shell\n"
-"d, drop <commit> = remove commit\n"
-"l, label <label> = label current HEAD with a name\n"
-"t, reset <label> = reset HEAD to a label\n"
-"m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
-".       create a merge commit using the original merge commit's\n"
-".       message (or the oneline, if no original merge commit was\n"
-".       specified). Use -c <commit> to reword the commit message.\n"
-"\n"
-"These lines can be re-ordered; they are executed from top to bottom.\n"
-msgstr ""
-"\n"
-"Comandos:\n"
-"p, pick <commit> = usar commit\n"
-"r, reword <commit> = usar commit, pero editar el mensaje de commit\n"
-"e, edit <commit> = usar commit, pero parar para un amend\n"
-"s, squash <commit> = usar commit, pero fusionarlo en el commit previo\n"
-"f, fixup <commit> = como \"squash\", pero descarta el mensaje del log de "
-"este commit\n"
-"x, exec <commit> = ejecuta comando (el resto de la línea) usando un shell\n"
-"d, drop <commit> = eliminar commit\n"
-"l, label <label> = poner label al HEAD actual con un nombre\n"
-"t, reset <label> = reiniciar HEAD al label\n"
-"m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
-".       crea un commit de fusión usando el mensaje original de\n"
-".       fusión (o la línea de oneline, si no se especifica un mensaje\n"
-".       de commit). Use -c <commit> para reescribir el mensaje del commit.\n"
-"\n"
-"Estas líneas pueden ser reordenadas; son ejecutadas desde arriba hacia "
-"abajo.\n"
-
-#: git-rebase--preserve-merges.sh:260
-#, sh-format
-msgid ""
-"You can amend the commit now, with\n"
-"\n"
-"\tgit commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"Once you are satisfied with your changes, run\n"
-"\n"
-"\tgit rebase --continue"
-msgstr ""
-"Puedes enmendar el commit ahora, con\n"
-"\n"
-"\tgit commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"Una vez que estés satisfecho con los cambios, ejecuta\n"
-"\n"
-"\tgit rebase --continue"
-
-#: git-rebase--preserve-merges.sh:285
-#, sh-format
-msgid "$sha1: not a commit that can be picked"
-msgstr "$sha1: no es un commit que pueda ser cogido"
-
-#: git-rebase--preserve-merges.sh:324
-#, sh-format
-msgid "Invalid commit name: $sha1"
-msgstr "Nombre de commit inválido: $sha1"
-
-#: git-rebase--preserve-merges.sh:354
-msgid "Cannot write current commit's replacement sha1"
-msgstr "No se puede escribir el remplazo sha1 del commit actual"
-
-#: git-rebase--preserve-merges.sh:405
-#, sh-format
-msgid "Fast-forward to $sha1"
-msgstr "Avance rápido a $sha1"
-
-#: git-rebase--preserve-merges.sh:407
-#, sh-format
-msgid "Cannot fast-forward to $sha1"
-msgstr "No se puede realizar avance rápido a $sha1"
-
-#: git-rebase--preserve-merges.sh:416
-#, sh-format
-msgid "Cannot move HEAD to $first_parent"
-msgstr "No se puede mover HEAD a $first_parent"
-
-#: git-rebase--preserve-merges.sh:421
-#, sh-format
-msgid "Refusing to squash a merge: $sha1"
-msgstr "Rehusando ejecutar squash en fusión: $sha1"
-
-#: git-rebase--preserve-merges.sh:439
-#, sh-format
-msgid "Error redoing merge $sha1"
-msgstr "Error al rehacer fusión $sha1"
-
-#: git-rebase--preserve-merges.sh:448
-#, sh-format
-msgid "Could not pick $sha1"
-msgstr "No se pudo coger $sha1"
-
-#: git-rebase--preserve-merges.sh:457
-#, sh-format
-msgid "This is the commit message #${n}:"
-msgstr "Este es el mensaje del commit #${n}:"
-
-#: git-rebase--preserve-merges.sh:462
-#, sh-format
-msgid "The commit message #${n} will be skipped:"
-msgstr "El mensaje del commit  #${n} será ignorado:"
-
-#: git-rebase--preserve-merges.sh:473
-#, sh-format
-msgid "This is a combination of $count commit."
-msgid_plural "This is a combination of $count commits."
-msgstr[0] "Esta es una combinación de $count commit."
-msgstr[1] "Esta es la combinación de $count commits."
-
-#: git-rebase--preserve-merges.sh:482
-#, sh-format
-msgid "Cannot write $fixup_msg"
-msgstr "No se puede escribir $fixup_msg"
-
-#: git-rebase--preserve-merges.sh:485
-msgid "This is a combination of 2 commits."
-msgstr "Esto es una combinación de 2 commits."
-
-#: git-rebase--preserve-merges.sh:526 git-rebase--preserve-merges.sh:569
-#: git-rebase--preserve-merges.sh:572
-#, sh-format
-msgid "Could not apply $sha1... $rest"
-msgstr "No se pudo aplicar $sha1... $rest"
-
-#: git-rebase--preserve-merges.sh:601
-#, sh-format
-msgid ""
-"Could not amend commit after successfully picking $sha1... $rest\n"
-"This is most likely due to an empty commit message, or the pre-commit hook\n"
-"failed. If the pre-commit hook failed, you may need to resolve the issue "
-"before\n"
-"you are able to reword the commit."
-msgstr ""
-"No se pudo corregir commit después de seleccionar exitosamente $sha1 ... "
-"$rest\n"
-"Esto es probablemente debido a un mensaje de commit vacío, o el hook pre-"
-"commit\n"
-"ha fallado. Si el hook pre-commit falló, es posible que debas resolver el "
-"problema antes\n"
-"de que sea capaz de reformular el commit."
-
-#: git-rebase--preserve-merges.sh:616
-#, sh-format
-msgid "Stopped at $sha1_abbrev... $rest"
-msgstr "Detenido en $sha1_abbrev... $rest"
-
-#: git-rebase--preserve-merges.sh:631
-#, sh-format
-msgid "Cannot '$squash_style' without a previous commit"
-msgstr "No se puede '$squash_style' sin un commit previo"
-
-#: git-rebase--preserve-merges.sh:673
-#, sh-format
-msgid "Executing: $rest"
-msgstr "Ejecutando: $rest"
-
-#: git-rebase--preserve-merges.sh:681
-#, sh-format
-msgid "Execution failed: $rest"
-msgstr "Ejecución fallida: $rest"
-
-#: git-rebase--preserve-merges.sh:683
-msgid "and made changes to the index and/or the working tree"
-msgstr "y hizo cambios al índice y/o al árbol de trabajo"
-
-#: git-rebase--preserve-merges.sh:685
-msgid ""
-"You can fix the problem, and then run\n"
-"\n"
-"\tgit rebase --continue"
-msgstr ""
-"Puedes corregir el problema y entonces ejecutar\n"
-"\n"
-"\tgit rebase --continue"
-
-#. TRANSLATORS: after these lines is a command to be issued by the user
-#: git-rebase--preserve-merges.sh:698
-#, sh-format
-msgid ""
-"Execution succeeded: $rest\n"
-"but left changes to the index and/or the working tree\n"
-"Commit or stash your changes, and then run\n"
-"\n"
-"\tgit rebase --continue"
-msgstr ""
-"La ejecución tuvo éxito: $rest\n"
-"Pero dejó cambios en el índice y/o en el árbol de trabajo\n"
-"Realiza un commit o stash con los cambios y, a continuación, ejecuta\n"
-"\n"
-"\tgit rebase --continue"
-
-#: git-rebase--preserve-merges.sh:709
-#, sh-format
-msgid "Unknown command: $command $sha1 $rest"
-msgstr "Comando desconocido: $command $sha1 $rest"
-
-#: git-rebase--preserve-merges.sh:710
-msgid "Please fix this using 'git rebase --edit-todo'."
-msgstr "Por favor, corrige esto usando 'git rebase --edit-todo'."
-
-#: git-rebase--preserve-merges.sh:745
-#, sh-format
-msgid "Successfully rebased and updated $head_name."
-msgstr "$head_name rebasado y actualizado satisfactoriamente."
-
-#: git-rebase--preserve-merges.sh:802
-msgid "Could not remove CHERRY_PICK_HEAD"
-msgstr "No se pudo eliminar CHERRY_PICK_HEAD"
-
-#: git-rebase--preserve-merges.sh:807
-#, sh-format
-msgid ""
-"You have staged changes in your working tree.\n"
-"If these changes are meant to be\n"
-"squashed into the previous commit, run:\n"
-"\n"
-"  git commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"If they are meant to go into a new commit, run:\n"
-"\n"
-"  git commit $gpg_sign_opt_quoted\n"
-"\n"
-"In both cases, once you're done, continue with:\n"
-"\n"
-"  git rebase --continue\n"
-msgstr ""
-"Tienes cambios en el área de stage de tu árbol de trabajo.\n"
-"Si estos cambios están destinados a\n"
-"ser aplastados en el commit previo, ejecuta:\n"
-"\n"
-"  git commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"Si estos están destinados a ir en un nuevo commit, ejecuta:\n"
-"\n"
-"  git commit $gpg_sign_opt_quoted\n"
-"\n"
-"En ambos casos, cuando termines, continue con:\n"
-"\n"
-"  git rebase --continue\n"
-
-#: git-rebase--preserve-merges.sh:824
-msgid "Error trying to find the author identity to amend commit"
-msgstr ""
-"Error al tratar de encontrar la identidad del autor para remediar el commit"
-
-#: git-rebase--preserve-merges.sh:829
-msgid ""
-"You have uncommitted changes in your working tree. Please commit them\n"
-"first and then run 'git rebase --continue' again."
-msgstr ""
-"Tienes cambios sin confirmar en tu árbol de trabajo. Por favor, confírmalos\n"
-"primero y entonces ejecuta 'git rebase --continue' de nuevo."
-
-#: git-rebase--preserve-merges.sh:834 git-rebase--preserve-merges.sh:838
-msgid "Could not commit staged changes."
-msgstr "No se pudo realizar el commit con los cambios en el área de stage."
-
-#: git-rebase--preserve-merges.sh:869 git-rebase--preserve-merges.sh:955
-msgid "Could not execute editor"
-msgstr "No se pudo ejecutar el editor"
-
-#: git-rebase--preserve-merges.sh:890
-#, sh-format
-msgid "Could not checkout $switch_to"
-msgstr "No se pudo actualizar el árbol de trabajo a $switch_to"
-
-#: git-rebase--preserve-merges.sh:897
-msgid "No HEAD?"
-msgstr "¿Sin HEAD?"
-
-#: git-rebase--preserve-merges.sh:898
-#, sh-format
-msgid "Could not create temporary $state_dir"
-msgstr "No se pudo crear $state_dir temporalmente"
-
-#: git-rebase--preserve-merges.sh:901
-msgid "Could not mark as interactive"
-msgstr "No se pudo marcar como interactivo"
-
-#: git-rebase--preserve-merges.sh:933
-#, sh-format
-msgid "Rebase $shortrevisions onto $shortonto ($todocount command)"
-msgid_plural "Rebase $shortrevisions onto $shortonto ($todocount commands)"
-msgstr[0] "Rebase $shortrevisions en $shortonto ($todocount comando)"
-msgstr[1] "Rebase $shortrevisions en $shortonto ($todocount comandos)"
-
-#: git-rebase--preserve-merges.sh:945
-msgid "Note that empty commits are commented out"
-msgstr "Tenga en cuenta que los commits vacíos están comentados"
-
-#: git-rebase--preserve-merges.sh:987 git-rebase--preserve-merges.sh:992
-msgid "Could not init rewritten commits"
-msgstr "No se pudo inicializar los commits reescritos"
 
 #: git-sh-setup.sh:89 git-sh-setup.sh:94
 #, sh-format
@@ -25872,55 +25754,32 @@ msgid "fatal: $program_name cannot be used without a working tree."
 msgstr "fatal: $program_name no puede ser usado sin un árbol de trabajo."
 
 #: git-sh-setup.sh:221
-msgid "Cannot rebase: You have unstaged changes."
-msgstr ""
-"No se puede aplicar rebase: Tienes cambios que no están en el área de stage."
-
-#: git-sh-setup.sh:224
 msgid "Cannot rewrite branches: You have unstaged changes."
 msgstr ""
 "No se puede reescribir las ramas: Tienes cambios que no están en el área de "
 "stage."
 
-#: git-sh-setup.sh:227
-msgid "Cannot pull with rebase: You have unstaged changes."
-msgstr ""
-"No se puede aplicar pull con rebase: Tienes cambios que no están en el área "
-"de stage."
-
-#: git-sh-setup.sh:230
+#: git-sh-setup.sh:224
 #, sh-format
 msgid "Cannot $action: You have unstaged changes."
 msgstr "No se puede $action: Tienes cambios que no están en el área de stage."
 
-#: git-sh-setup.sh:243
-msgid "Cannot rebase: Your index contains uncommitted changes."
-msgstr ""
-"No se puede hacer rebase: Tu índice contiene cambios que no están en un "
-"commit."
-
-#: git-sh-setup.sh:246
-msgid "Cannot pull with rebase: Your index contains uncommitted changes."
-msgstr ""
-"No se puede hacer pull con rebase: Tu índice contiene cambios que no están "
-"en un commit."
-
-#: git-sh-setup.sh:249
+#: git-sh-setup.sh:235
 #, sh-format
 msgid "Cannot $action: Your index contains uncommitted changes."
 msgstr "No se puede $action: El índice contiene cambios sin confirmar."
 
-#: git-sh-setup.sh:253
+#: git-sh-setup.sh:237
 msgid "Additionally, your index contains uncommitted changes."
 msgstr "Adicionalmente, tu índice contiene cambios que no están en un commit."
 
-#: git-sh-setup.sh:373
+#: git-sh-setup.sh:357
 msgid "You need to run this command from the toplevel of the working tree."
 msgstr ""
 "Necesitas ejecutar este comando desde el nivel superior de tu árbol de "
 "trabajo."
 
-#: git-sh-setup.sh:378
+#: git-sh-setup.sh:362
 msgid "Unable to determine absolute path of git directory"
 msgstr "Incapaz de determinar la ruta absoluta del directorio git"
 
@@ -25993,8 +25852,8 @@ msgid ""
 "Lines starting with %s will be removed.\n"
 msgstr ""
 "---\n"
-"Para eliminar '%s' líneas, haga de ellas líneas ' ' (contexto).\n"
-"Para eliminar '%s' líneas, bórrelas.\n"
+"Para eliminar '%s' líneas, haz de ellas líneas ' ' (contexto).\n"
+"Para eliminar '%s' líneas, bórralas.\n"
 "Líneas comenzando con %s serán eliminadas.\n"
 
 #: git-add--interactive.perl:1143
@@ -26014,8 +25873,8 @@ msgstr ""
 "n - no aplicar stage a este fragmento\n"
 "q - quit; no aplicar stage a este fragmento ni ninguno de los restantes\n"
 "a - aplicar stage a este fragmento y a todos los posteriores en el archivo\n"
-"d - no aplicar stage a este fragmento ni a ninguno de los posteriores en este "
-"archivo"
+"d - no aplicar stage a este fragmento ni a ninguno de los posteriores en "
+"este archivo"
 
 #: git-add--interactive.perl:1257
 msgid ""
@@ -26029,7 +25888,8 @@ msgstr ""
 "n - no hacer stash a este fragmento\n"
 "q - quit; no hacer stash a este fragmento ni a ninguno de los restantes\n"
 "a - hacer stash a este fragmento y a todos los posteriores en el archivo\n"
-"d - no hacer stash a este fragmento ni ninguno de los posteriores en el archivo"
+"d - no hacer stash a este fragmento ni ninguno de los posteriores en el "
+"archivo"
 
 #: git-add--interactive.perl:1263
 msgid ""
@@ -26041,10 +25901,12 @@ msgid ""
 msgstr ""
 "y - sacar este fragmento del área de stage\n"
 "n - no sacar este fragmento del area de stage\n"
-"q - quit; no sacar del area de stage este fragmento ni ninguno de los restantes\n"
-"a - sacar del area de stage este fragmento y todos los posteriores en el archivo\n"
-"d - no sacar del area de stage este fragmento ni ninguno de los posteriores en el "
-"archivo"
+"q - quit; no sacar del area de stage este fragmento ni ninguno de los "
+"restantes\n"
+"a - sacar del area de stage este fragmento y todos los posteriores en el "
+"archivo\n"
+"d - no sacar del area de stage este fragmento ni ninguno de los posteriores "
+"en el archivo"
 
 #: git-add--interactive.perl:1269
 msgid ""
@@ -26231,14 +26093,14 @@ msgid ""
 "add untracked - add contents of untracked files to the staged set of "
 "changes\n"
 msgstr ""
-"status        - muestra las rutas con cambios\n"
-"update        - agrega el estado del árbol de trabajo al set de cambios en "
+"status        - mostrar las rutas con cambios\n"
+"update        - agregar el estado del árbol de trabajo al set de cambios en "
 "el área de stage\n"
-"revert        - revierte los cambios en el área de stage de regreso a la "
+"revert        - revertir los cambios en el área de stage de regreso a la "
 "versión HEAD\n"
-"patch         - selecciona los hunks y actualiza de forma selectiva\n"
+"patch         - seleccionar los hunks y actualiza de forma selectiva\n"
 "diff          - mirar la diff entre HEAD y el índice\n"
-"add untracked - agrega contenidos de archivos no rastreados al grupo de "
+"add untracked - agregar contenidos de archivos no rastreados al grupo de "
 "cambios del area de stage\n"
 
 #: git-add--interactive.perl:1828 git-add--interactive.perl:1840
@@ -26298,9 +26160,9 @@ msgid ""
 "Set sendemail.forbidSendmailVariables to false to disable this check.\n"
 msgstr ""
 "fatal: opciones de configuración encontradas para 'sendmail'\n"
-"git-send-email está configurado con las opciones sendemail.* - tenga en "
-"cuenta la 'e'.\n"
-"Establezca sendemail.forbidSendmailVariables en false para deshabilitar esta "
+"git-send-email está configurado con las opciones sendemail.* - ten en cuenta "
+"la 'e'.\n"
+"Establece sendemail.forbidSendmailVariables en false para deshabilitar esta "
 "verificación.\n"
 
 #: git-send-email.perl:530 git-send-email.perl:746
@@ -26394,10 +26256,10 @@ msgid ""
 "Clear the body content if you don't wish to send a summary.\n"
 msgstr ""
 "Líneas que comienzan en \"GIT:\" serán eliminadas.\n"
-"Considere incluir un diffstat global o una tabla de contenidos\n"
+"Considera incluir un diffstat global o una tabla de contenidos\n"
 "para el parche que estás escribiendo.\n"
 "\n"
-"Limpiar el contenido de body si no deseas mandar un resumen.\n"
+"Limpia el contenido de body si no deseas mandar un resumen.\n"
 
 #: git-send-email.perl:826
 #, perl-format
@@ -26562,7 +26424,7 @@ msgstr "Resultado: "
 msgid "Result: OK\n"
 msgstr "Resultado: OK\n"
 
-#: git-send-email.perl:1709
+#: git-send-email.perl:1708
 #, perl-format
 msgid "can't open file %s"
 msgstr "no se puede abrir el archivo %s"
@@ -26587,30 +26449,30 @@ msgstr "(non-mbox) Agregando cc: %s de la línea '%s'\n"
 msgid "(body) Adding cc: %s from line '%s'\n"
 msgstr "(body) Agregando cc: %s de la línea '%s'\n"
 
-#: git-send-email.perl:1965
+#: git-send-email.perl:1973
 #, perl-format
 msgid "(%s) Could not execute '%s'"
 msgstr "(%s) no se pudo ejecutar '%s'"
 
-#: git-send-email.perl:1972
+#: git-send-email.perl:1980
 #, perl-format
 msgid "(%s) Adding %s: %s from: '%s'\n"
 msgstr "(%s) Agregando %s: %s de: '%s'\n"
 
-#: git-send-email.perl:1976
+#: git-send-email.perl:1984
 #, perl-format
 msgid "(%s) failed to close pipe to '%s'"
 msgstr "(%s) falló al cerrar el pipe a '%s'"
 
-#: git-send-email.perl:2006
+#: git-send-email.perl:2014
 msgid "cannot send message as 7bit"
 msgstr "no se puede mandar mensaje como 7bit"
 
-#: git-send-email.perl:2014
+#: git-send-email.perl:2022
 msgid "invalid transfer encoding"
 msgstr "codificación de transferencia inválida"
 
-#: git-send-email.perl:2051
+#: git-send-email.perl:2059
 #, perl-format
 msgid ""
 "fatal: %s: rejected by sendemail-validate hook\n"
@@ -26621,12 +26483,12 @@ msgstr ""
 "%s\n"
 "peligro: no se mandaron parches\n"
 
-#: git-send-email.perl:2061 git-send-email.perl:2114 git-send-email.perl:2124
+#: git-send-email.perl:2069 git-send-email.perl:2122 git-send-email.perl:2132
 #, perl-format
 msgid "unable to open %s: %s\n"
 msgstr "no es posible abrir %s: %s\n"
 
-#: git-send-email.perl:2064
+#: git-send-email.perl:2072
 #, perl-format
 msgid ""
 "fatal: %s:%d is longer than 998 characters\n"
@@ -26635,16 +26497,579 @@ msgstr ""
 "fatal: %s: %d es más grande que 998 caracteres\n"
 "peligro: no se mandaron parches\n"
 
-#: git-send-email.perl:2082
+#: git-send-email.perl:2090
 #, perl-format
 msgid "Skipping %s with backup suffix '%s'.\n"
 msgstr "Saltando %s con el sufijo de backup '%s'.\n"
 
 #. TRANSLATORS: please keep "[y|N]" as is.
-#: git-send-email.perl:2086
+#: git-send-email.perl:2094
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "¿Realmente deseas mandar %s? [y|N]: "
+
+#, c-format
+#~ msgid ""
+#~ "The following pathspecs didn't match any eligible path, but they do match "
+#~ "index\n"
+#~ "entries outside the current sparse checkout:\n"
+#~ msgstr ""
+#~ "Los siguientes pathspecs no concuerdan con ninguna ruta elegible, pero "
+#~ "concuerdan\n"
+#~ "con entradas del índice fuera del checkout sparse actual:\n"
+
+#~ msgid ""
+#~ "Disable or modify the sparsity rules if you intend to update such entries."
+#~ msgstr ""
+#~ "Deshabilitar o modificar las reglas de escasez si tienes intención de "
+#~ "actualizar dichas entradas."
+
+#, c-format
+#~ msgid "could not set GIT_DIR to '%s'"
+#~ msgstr "no se pudo configurar GIT_DIR a '%s'"
+
+#, c-format
+#~ msgid "unable to unpack %s header with --allow-unknown-type"
+#~ msgstr "no es posible desempacar header %s con --allow-unknown-type"
+
+#, c-format
+#~ msgid "unable to parse %s header with --allow-unknown-type"
+#~ msgstr "no es posible analizar header %s con --allow-unknown-type"
+
+#~ msgid "open /dev/null failed"
+#~ msgstr "falló al abrir /dev/null"
+
+#~ msgid ""
+#~ "after resolving the conflicts, mark the corrected paths\n"
+#~ "with 'git add <paths>' or 'git rm <paths>'\n"
+#~ "and commit the result with 'git commit'"
+#~ msgstr ""
+#~ "tras resolver los conflictos, marca las rutas corregidas\n"
+#~ "con 'git add <rutas>' o 'git rm <rutas>'\n"
+#~ "y haz un commit del resultado con 'git commit'"
+
+#~ msgid "open /dev/null or dup failed"
+#~ msgstr "falló al abrir /dev/null o hacer dup"
+
+#~ msgid "attempting to use sparse-index without cone mode"
+#~ msgstr "intentando usar sparse-index sin modo cono"
+
+#~ msgid "unable to update cache-tree, staying full"
+#~ msgstr "no es posible actualizar el cache del árbol, manteniendo full"
+
+#, c-format
+#~ msgid "Could not open '%s' for writing."
+#~ msgstr "No se pudo abrir '%s' para escritura."
+
+#, c-format
+#~ msgid "could not create archive file '%s'"
+#~ msgstr "no se pudo crear el archivo de crónica '%s'"
+
+#~ msgid ""
+#~ "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
+#~ msgstr ""
+#~ "git bisect--helper --bisect-next-check <buen_term> <mal_term> [<term>]"
+
+#~ msgid "--bisect-next-check requires 2 or 3 arguments"
+#~ msgstr "--bisect-next-check requiere 2 o 3 argumentos"
+
+#, c-format
+#~ msgid "couldn't create a new file at '%s'"
+#~ msgstr "no se pudo crear un archivo nuevo en '%s'"
+
+#, c-format
+#~ msgid "git commit-tree: failed to open '%s'"
+#~ msgstr "git commit-tree: falló al abrir '%s'"
+
+#, c-format
+#~ msgid "cannot open packfile '%s'"
+#~ msgstr "no se puede abrir el archivo de paquete '%s'"
+
+#~ msgid "cannot store pack file"
+#~ msgstr "no se puede guardar el archivo paquete"
+
+#~ msgid "cannot store index file"
+#~ msgstr "no se puede guardar el archivo índice"
+
+#~ msgid "exclude patterns are read from <file>"
+#~ msgstr "excluir patrones leídos de <archivo>"
+
+#, c-format
+#~ msgid "Unknown option for merge-recursive: -X%s"
+#~ msgstr "Opción desconocida para merge-recursive: -X%s"
+
+#, c-format
+#~ msgid "unusable todo list: '%s'"
+#~ msgstr "lista de pendientes inutilizable: '%s'"
+
+#~ msgid "git rebase--interactive [<options>]"
+#~ msgstr "git rebase--interactive [<opciones>]"
+
+#~ msgid "rebase merge commits"
+#~ msgstr "rebasar commits de fusión"
+
+#~ msgid "keep original branch points of cousins"
+#~ msgstr "mantener puntas de bifurcación originales de los primos"
+
+#~ msgid "move commits that begin with squash!/fixup!"
+#~ msgstr "mover commits que comiencen con squash!/fixup!"
+
+#~ msgid "sign commits"
+#~ msgstr "firmar commits"
+
+#~ msgid "continue rebase"
+#~ msgstr "continuar rebase"
+
+#~ msgid "skip commit"
+#~ msgstr "saltar commit"
+
+#~ msgid "edit the todo list"
+#~ msgstr "editar la lista de pendientes"
+
+#~ msgid "show the current patch"
+#~ msgstr "mostrar el parche actual"
+
+#~ msgid "shorten commit ids in the todo list"
+#~ msgstr "ids de commits cortos en la lista de pendientes"
+
+#~ msgid "expand commit ids in the todo list"
+#~ msgstr "expandir ids de commits en la lista de pendientes"
+
+#~ msgid "check the todo list"
+#~ msgstr "revisar la lista de pendientes"
+
+#~ msgid "rearrange fixup/squash lines"
+#~ msgstr "reordenar líneas fixup/squash"
+
+#~ msgid "insert exec commands in todo list"
+#~ msgstr "insertar comando exec en la lista de pendientes"
+
+#~ msgid "onto"
+#~ msgstr "sobre"
+
+#~ msgid "restrict-revision"
+#~ msgstr "restrict-revision"
+
+#~ msgid "restrict revision"
+#~ msgstr "restringir revisión"
+
+#~ msgid "squash-onto"
+#~ msgstr "squash-onto"
+
+#~ msgid "squash onto"
+#~ msgstr "squash a"
+
+#~ msgid "the upstream commit"
+#~ msgstr "el commit de upstream"
+
+#~ msgid "head-name"
+#~ msgstr "head-name"
+
+#~ msgid "head name"
+#~ msgstr "nombre de head"
+
+#~ msgid "rebase strategy"
+#~ msgstr "estrategia de rebase"
+
+#~ msgid "strategy-opts"
+#~ msgstr "strategy-opts"
+
+#~ msgid "strategy options"
+#~ msgstr "opciones de estrategia"
+
+#~ msgid "switch-to"
+#~ msgstr "cambiar a"
+
+#~ msgid "the branch or commit to checkout"
+#~ msgstr "la rama o commit para hacer checkout"
+
+#~ msgid "onto-name"
+#~ msgstr "sobre-nombre"
+
+#~ msgid "onto name"
+#~ msgstr "sobre nombre"
+
+#~ msgid "cmd"
+#~ msgstr "cmd"
+
+#~ msgid "the command to run"
+#~ msgstr "el comando para ejecutar"
+
+#~ msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
+#~ msgstr "--[no-]rebase-cousins no tiene efecto sin --rebase-merges"
+
+#~ msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
+#~ msgstr "no se puede combinar '--preserve-merges' con '--rebase-merges'"
+
+#~ msgid ""
+#~ "error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
+#~ msgstr ""
+#~ "error: no se puede combinar '--preserve-merges' con '--reschedule-failed-"
+#~ "exec'"
+
+#~ msgid ""
+#~ "git submodule--helper add-clone [<options>...] --url <url> --path <path> "
+#~ "--name <name>"
+#~ msgstr ""
+#~ "git submodule--helper add-clone [<options>...] --url <url> --path <ruta> "
+#~ "--name <nombre>"
+
+#, c-format
+#~ msgid "failed to create file %s"
+#~ msgstr "falló al crear el archivo %s"
+
+#~ msgid "exit immediately after initial ref advertisement"
+#~ msgstr "salir inmediatamente tras el anuncio inicial de ref"
+
+#, c-format
+#~ msgid "socket/pipe already in use: '%s'"
+#~ msgstr "socket/pipe ya está en uso: '%s'"
+
+#, c-format
+#~ msgid "could not start server on: '%s'"
+#~ msgstr "no se pudo iniciar el servidor en: '%s'"
+
+#~ msgid "could not spawn daemon in the background"
+#~ msgstr "no se puede generar demonio en el background"
+
+#~ msgid "waitpid failed"
+#~ msgstr "falló waitpid"
+
+#~ msgid "daemon not online yet"
+#~ msgstr "demonio no está en línea todavía"
+
+#~ msgid "daemon failed to start"
+#~ msgstr "falló al iniciar demonio"
+
+#~ msgid "waitpid is confused"
+#~ msgstr "waitpid está confundido"
+
+#~ msgid "daemon has not shutdown yet"
+#~ msgstr "demonio no se ha apagado todavía"
+
+#~ msgid "Protocol restrictions not supported with cURL < 7.19.4"
+#~ msgstr "Restricción de protocolo no soportada con cURL < 7.19.4"
+
+#, sh-format
+#~ msgid "running $command"
+#~ msgstr "ejecutando $command"
+
+#, sh-format
+#~ msgid "'$sm_path' does not have a commit checked out"
+#~ msgstr "'$sm_path' no tiene un commit checked out"
+
+#, sh-format
+#~ msgid "Submodule path '$displaypath': '$command $sha1'"
+#~ msgstr "Ruta de submódulo '$displaypath': '$command $sha1'"
+
+#~ msgid "Applied autostash."
+#~ msgstr "Autostash aplicado."
+
+#, sh-format
+#~ msgid "Cannot store $stash_sha1"
+#~ msgstr "No se puede almacenar $stash_sha1"
+
+#~ msgid ""
+#~ "Applying autostash resulted in conflicts.\n"
+#~ "Your changes are safe in the stash.\n"
+#~ "You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
+#~ msgstr ""
+#~ "Aplicar autostash resultó en conflictos.\n"
+#~ "Tus cambios están seguros en el stash.\n"
+#~ "Puedes ejecutar \"git stash pop\" o \"git stash drop\" en cualquier "
+#~ "momento.\n"
+
+#, sh-format
+#~ msgid "Rebasing ($new_count/$total)"
+#~ msgstr "Rebasando ($new_count/$total)"
+
+#~ msgid ""
+#~ "\n"
+#~ "Commands:\n"
+#~ "p, pick <commit> = use commit\n"
+#~ "r, reword <commit> = use commit, but edit the commit message\n"
+#~ "e, edit <commit> = use commit, but stop for amending\n"
+#~ "s, squash <commit> = use commit, but meld into previous commit\n"
+#~ "f, fixup <commit> = like \"squash\", but discard this commit's log "
+#~ "message\n"
+#~ "x, exec <commit> = run command (the rest of the line) using shell\n"
+#~ "d, drop <commit> = remove commit\n"
+#~ "l, label <label> = label current HEAD with a name\n"
+#~ "t, reset <label> = reset HEAD to a label\n"
+#~ "m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
+#~ ".       create a merge commit using the original merge commit's\n"
+#~ ".       message (or the oneline, if no original merge commit was\n"
+#~ ".       specified). Use -c <commit> to reword the commit message.\n"
+#~ "\n"
+#~ "These lines can be re-ordered; they are executed from top to bottom.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Comandos:\n"
+#~ "p, pick <commit> = usar commit\n"
+#~ "r, reword <commit> = usar commit, pero editar el mensaje de commit\n"
+#~ "e, edit <commit> = usar commit, pero parar para un amend\n"
+#~ "s, squash <commit> = usar commit, pero fusionarlo en el commit previo\n"
+#~ "f, fixup <commit> = como \"squash\", pero descarta el mensaje del log de "
+#~ "este commit\n"
+#~ "x, exec <commit> = ejecutar comando (el resto de la línea) usando un "
+#~ "shell\n"
+#~ "d, drop <commit> = eliminar commit\n"
+#~ "l, label <label> = poner label al HEAD actual con un nombre\n"
+#~ "t, reset <label> = reiniciar HEAD al label\n"
+#~ "m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
+#~ ".       crear un commit de fusión usando el mensaje original de\n"
+#~ ".       fusión (o la línea de oneline, si no se especifica un mensaje\n"
+#~ ".       de commit). Usa -c <commit> para reescribir el mensaje del "
+#~ "commit.\n"
+#~ "\n"
+#~ "Estas líneas pueden ser reordenadas; son ejecutadas desde arriba hacia "
+#~ "abajo.\n"
+
+#, sh-format
+#~ msgid ""
+#~ "You can amend the commit now, with\n"
+#~ "\n"
+#~ "\tgit commit --amend $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "Once you are satisfied with your changes, run\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+#~ msgstr ""
+#~ "Puedes enmendar el commit ahora, con\n"
+#~ "\n"
+#~ "\tgit commit --amend $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "Una vez que estés satisfecho con los cambios, ejecuta\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+
+#, sh-format
+#~ msgid "$sha1: not a commit that can be picked"
+#~ msgstr "$sha1: no es un commit que pueda ser cogido"
+
+#, sh-format
+#~ msgid "Invalid commit name: $sha1"
+#~ msgstr "Nombre de commit inválido: $sha1"
+
+#~ msgid "Cannot write current commit's replacement sha1"
+#~ msgstr "No se puede escribir el remplazo sha1 del commit actual"
+
+#, sh-format
+#~ msgid "Fast-forward to $sha1"
+#~ msgstr "Avance rápido a $sha1"
+
+#, sh-format
+#~ msgid "Cannot fast-forward to $sha1"
+#~ msgstr "No se puede realizar avance rápido a $sha1"
+
+#, sh-format
+#~ msgid "Cannot move HEAD to $first_parent"
+#~ msgstr "No se puede mover HEAD a $first_parent"
+
+#, sh-format
+#~ msgid "Refusing to squash a merge: $sha1"
+#~ msgstr "Rehusando ejecutar squash en fusión: $sha1"
+
+#, sh-format
+#~ msgid "Error redoing merge $sha1"
+#~ msgstr "Error al rehacer fusión $sha1"
+
+#, sh-format
+#~ msgid "Could not pick $sha1"
+#~ msgstr "No se pudo coger $sha1"
+
+#, sh-format
+#~ msgid "This is the commit message #${n}:"
+#~ msgstr "Este es el mensaje del commit #${n}:"
+
+#, sh-format
+#~ msgid "The commit message #${n} will be skipped:"
+#~ msgstr "El mensaje del commit  #${n} será ignorado:"
+
+#, sh-format
+#~ msgid "This is a combination of $count commit."
+#~ msgid_plural "This is a combination of $count commits."
+#~ msgstr[0] "Esta es una combinación de $count commit."
+#~ msgstr[1] "Esta es la combinación de $count commits."
+
+#, sh-format
+#~ msgid "Cannot write $fixup_msg"
+#~ msgstr "No se puede escribir $fixup_msg"
+
+#~ msgid "This is a combination of 2 commits."
+#~ msgstr "Esto es una combinación de 2 commits."
+
+#, sh-format
+#~ msgid "Could not apply $sha1... $rest"
+#~ msgstr "No se pudo aplicar $sha1... $rest"
+
+#, sh-format
+#~ msgid ""
+#~ "Could not amend commit after successfully picking $sha1... $rest\n"
+#~ "This is most likely due to an empty commit message, or the pre-commit "
+#~ "hook\n"
+#~ "failed. If the pre-commit hook failed, you may need to resolve the issue "
+#~ "before\n"
+#~ "you are able to reword the commit."
+#~ msgstr ""
+#~ "No se pudo corregir commit después de seleccionar exitosamente $sha1 ... "
+#~ "$rest\n"
+#~ "Esto es probablemente debido a un mensaje de commit vacío, o el hook pre-"
+#~ "commit\n"
+#~ "ha fallado. Si el hook pre-commit falló, es posible que debas resolver el "
+#~ "problema antes\n"
+#~ "de que seas capaz de reformular el commit."
+
+#, sh-format
+#~ msgid "Stopped at $sha1_abbrev... $rest"
+#~ msgstr "Detenido en $sha1_abbrev... $rest"
+
+#, sh-format
+#~ msgid "Cannot '$squash_style' without a previous commit"
+#~ msgstr "No se puede '$squash_style' sin un commit previo"
+
+#, sh-format
+#~ msgid "Executing: $rest"
+#~ msgstr "Ejecutando: $rest"
+
+#, sh-format
+#~ msgid "Execution failed: $rest"
+#~ msgstr "Ejecución fallida: $rest"
+
+#~ msgid "and made changes to the index and/or the working tree"
+#~ msgstr "y hizo cambios al índice y/o al árbol de trabajo"
+
+#~ msgid ""
+#~ "You can fix the problem, and then run\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+#~ msgstr ""
+#~ "Puedes corregir el problema y entonces ejecutar\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+
+#, sh-format
+#~ msgid ""
+#~ "Execution succeeded: $rest\n"
+#~ "but left changes to the index and/or the working tree\n"
+#~ "Commit or stash your changes, and then run\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+#~ msgstr ""
+#~ "La ejecución tuvo éxito: $rest\n"
+#~ "Pero dejó cambios en el índice y/o en el árbol de trabajo\n"
+#~ "Realiza un commit o stash con los cambios y, a continuación, ejecuta\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+
+#, sh-format
+#~ msgid "Unknown command: $command $sha1 $rest"
+#~ msgstr "Comando desconocido: $command $sha1 $rest"
+
+#~ msgid "Please fix this using 'git rebase --edit-todo'."
+#~ msgstr "Por favor, corrige esto usando 'git rebase --edit-todo'."
+
+#, sh-format
+#~ msgid "Successfully rebased and updated $head_name."
+#~ msgstr "$head_name rebasado y actualizado satisfactoriamente."
+
+#~ msgid "Could not remove CHERRY_PICK_HEAD"
+#~ msgstr "No se pudo eliminar CHERRY_PICK_HEAD"
+
+#, sh-format
+#~ msgid ""
+#~ "You have staged changes in your working tree.\n"
+#~ "If these changes are meant to be\n"
+#~ "squashed into the previous commit, run:\n"
+#~ "\n"
+#~ "  git commit --amend $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "If they are meant to go into a new commit, run:\n"
+#~ "\n"
+#~ "  git commit $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "In both cases, once you're done, continue with:\n"
+#~ "\n"
+#~ "  git rebase --continue\n"
+#~ msgstr ""
+#~ "Tienes cambios en el área de stage de tu árbol de trabajo.\n"
+#~ "Si estos cambios están destinados a\n"
+#~ "ser aplastados en el commit previo, ejecuta:\n"
+#~ "\n"
+#~ "  git commit --amend $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "Si estos están destinados a ir en un nuevo commit, ejecuta:\n"
+#~ "\n"
+#~ "  git commit $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "En ambos casos, cuando termines, continúa con:\n"
+#~ "\n"
+#~ "  git rebase --continue\n"
+
+#~ msgid "Error trying to find the author identity to amend commit"
+#~ msgstr ""
+#~ "Error al tratar de encontrar la identidad del autor para remediar el "
+#~ "commit"
+
+#~ msgid ""
+#~ "You have uncommitted changes in your working tree. Please commit them\n"
+#~ "first and then run 'git rebase --continue' again."
+#~ msgstr ""
+#~ "Tienes cambios sin confirmar en tu árbol de trabajo. Por favor, "
+#~ "confírmalos\n"
+#~ "primero y entonces ejecuta 'git rebase --continue' de nuevo."
+
+#~ msgid "Could not commit staged changes."
+#~ msgstr "No se pudo realizar el commit con los cambios en el área de stage."
+
+#~ msgid "Could not execute editor"
+#~ msgstr "No se pudo ejecutar el editor"
+
+#, sh-format
+#~ msgid "Could not checkout $switch_to"
+#~ msgstr "No se pudo actualizar el árbol de trabajo a $switch_to"
+
+#~ msgid "No HEAD?"
+#~ msgstr "¿Sin HEAD?"
+
+#, sh-format
+#~ msgid "Could not create temporary $state_dir"
+#~ msgstr "No se pudo crear $state_dir temporalmente"
+
+#~ msgid "Could not mark as interactive"
+#~ msgstr "No se pudo marcar como interactivo"
+
+#, sh-format
+#~ msgid "Rebase $shortrevisions onto $shortonto ($todocount command)"
+#~ msgid_plural "Rebase $shortrevisions onto $shortonto ($todocount commands)"
+#~ msgstr[0] "Rebase $shortrevisions en $shortonto ($todocount comando)"
+#~ msgstr[1] "Rebase $shortrevisions en $shortonto ($todocount comandos)"
+
+#~ msgid "Note that empty commits are commented out"
+#~ msgstr "Ten en cuenta que los commits vacíos están comentados"
+
+#~ msgid "Could not init rewritten commits"
+#~ msgstr "No se pudo inicializar los commits reescritos"
+
+#~ msgid "Cannot rebase: You have unstaged changes."
+#~ msgstr ""
+#~ "No se puede aplicar rebase: Tienes cambios que no están en el área de "
+#~ "stage."
+
+#~ msgid "Cannot pull with rebase: You have unstaged changes."
+#~ msgstr ""
+#~ "No se puede aplicar pull con rebase: Tienes cambios que no están en el "
+#~ "área de stage."
+
+#~ msgid "Cannot rebase: Your index contains uncommitted changes."
+#~ msgstr ""
+#~ "No se puede hacer rebase: Tu índice contiene cambios que no están en un "
+#~ "commit."
+
+#~ msgid "Cannot pull with rebase: Your index contains uncommitted changes."
+#~ msgstr ""
+#~ "No se puede hacer pull con rebase: Tu índice contiene cambios que no "
+#~ "están en un commit."
 
 #~ msgid "unable to write stateless separator packet"
 #~ msgstr "no es posible escribir un paquete separador sin estado (stateless)"

--- a/po/fr.po
+++ b/po/fr.po
@@ -77,8 +77,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-11-04 08:34+0800\n"
-"PO-Revision-Date: 2021-11-05 20:38+0100\n"
+"POT-Creation-Date: 2021-11-10 08:55+0800\n"
+"PO-Revision-Date: 2021-11-10 22:00+0100\n"
 "Last-Translator: Cédric Malard <c.malard-git@valdun.net>\n"
 "Language-Team: Jean-Noël Avila <jn.avila@free.fr>\n"
 "Language: fr\n"
@@ -284,7 +284,7 @@ msgstr "non-indexé"
 
 #: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
 #: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:190
+#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:194
 #: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
 #: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
 #: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
@@ -10686,7 +10686,7 @@ msgstr ""
 "Les chemins suivants sont ignorés par un de vos fichiers .gitignore :\n"
 
 #: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
-#: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:550
+#: builtin/prune-packed.c:14 builtin/pull.c:208 builtin/push.c:550
 #: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr "simuler l'action"
@@ -11159,11 +11159,11 @@ msgstr "le passer jusqu'à git-apply"
 
 #: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
 #: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
-#: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
+#: builtin/pull.c:142 builtin/pull.c:204 builtin/pull.c:221
 #: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
 #: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
 #: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
-#: parse-options.h:316
+#: parse-options.h:315
 msgid "n"
 msgstr "n"
 
@@ -11214,7 +11214,7 @@ msgid "use current timestamp for author date"
 msgstr "utiliser l'horodatage actuel pour la date d'auteur"
 
 #: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
-#: builtin/merge.c:299 builtin/pull.c:175 builtin/rebase.c:1099
+#: builtin/merge.c:299 builtin/pull.c:179 builtin/rebase.c:1099
 #: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
 msgstr "id-clé"
@@ -11728,7 +11728,7 @@ msgstr "montrer les statistiques de coût d'activité"
 #: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
 #: builtin/merge.c:298 builtin/multi-pack-index.c:103
 #: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
-#: builtin/multi-pack-index.c:204 builtin/pull.c:119 builtin/push.c:566
+#: builtin/multi-pack-index.c:204 builtin/pull.c:120 builtin/push.c:566
 #: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "forcer l'affichage de l'état d'avancement"
@@ -13022,7 +13022,7 @@ msgstr "argument de branche ou de commit manquant"
 msgid "perform a 3-way merge with the new branch"
 msgstr "effectuer une fusion à 3 points avec la nouvelle branche"
 
-#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:322
+#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:321
 msgid "style"
 msgstr "style"
 
@@ -13450,7 +13450,7 @@ msgid "path to git-upload-pack on the remote"
 msgstr "chemin vers git-upload-pack sur le serveur distant"
 
 #: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
-#: builtin/pull.c:208
+#: builtin/pull.c:212
 msgid "depth"
 msgstr "profondeur"
 
@@ -13459,7 +13459,7 @@ msgid "create a shallow clone of that depth"
 msgstr "créer un clone superficiel de cette profondeur"
 
 #: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
-#: builtin/pull.c:211
+#: builtin/pull.c:215
 msgid "time"
 msgstr "heure"
 
@@ -13468,11 +13468,11 @@ msgid "create a shallow clone since a specific time"
 msgstr "créer un clone superficiel depuis une date spécifique"
 
 #: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1022
+#: builtin/pull.c:218 builtin/pull.c:243 builtin/rebase.c:1022
 msgid "revision"
 msgstr "révision"
 
-#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:215
+#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:219
 msgid "deepen history of shallow clone, excluding rev"
 msgstr ""
 "approfondir l'historique d'un clone superficiel en excluant une révision"
@@ -13509,21 +13509,21 @@ msgid "set config inside the new repository"
 msgstr "régler la configuration dans le nouveau dépôt"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:200
+#: builtin/pull.c:234 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "spécifique au serveur"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:201
+#: builtin/pull.c:235 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr "option à transmettre"
 
-#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:234
+#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:238
 #: builtin/push.c:576
 msgid "use IPv4 addresses only"
 msgstr "n'utiliser que des adresses IPv4"
 
-#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:237
+#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:241
 #: builtin/push.c:578
 msgid "use IPv6 addresses only"
 msgstr "n'utiliser que des adresses IPv6"
@@ -13926,7 +13926,7 @@ msgid "read commit log message from file"
 msgstr "lire le message de validation depuis un fichier"
 
 #: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
-#: builtin/pull.c:176 builtin/revert.c:118
+#: builtin/pull.c:180 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "signer la validation avec GPG"
 
@@ -14342,7 +14342,7 @@ msgstr "terminer les éléments par NUL"
 
 #: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
 #: builtin/fast-export.c:1199 builtin/fast-export.c:1202
-#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:336
+#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:335
 msgid "mode"
 msgstr "mode"
 
@@ -14424,7 +14424,7 @@ msgid "override date for commit"
 msgstr "remplacer la date pour la validation"
 
 #: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
-#: parse-options.h:328 ref-filter.h:92
+#: parse-options.h:327 ref-filter.h:92
 msgid "commit"
 msgstr "commit"
 
@@ -14469,7 +14469,7 @@ msgid "add custom trailer(s)"
 msgstr "ajouter des lignes terminales personnaliser"
 
 #: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
-#: builtin/pull.c:145 builtin/revert.c:110
+#: builtin/pull.c:146 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "ajouter une ligne terminale Signed-off-by"
 
@@ -15466,15 +15466,15 @@ msgstr "git fetch --all [<options>]"
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel ne peut pas être négatif"
 
-#: builtin/fetch.c:145 builtin/pull.c:185
+#: builtin/fetch.c:145 builtin/pull.c:189
 msgid "fetch from all remotes"
 msgstr "récupérer depuis tous les dépôts distants"
 
-#: builtin/fetch.c:147 builtin/pull.c:245
+#: builtin/fetch.c:147 builtin/pull.c:249
 msgid "set upstream for git pull/fetch"
 msgstr "définir la branche amont pour git pull/fetch"
 
-#: builtin/fetch.c:149 builtin/pull.c:188
+#: builtin/fetch.c:149 builtin/pull.c:192
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "ajouter à .git/FETCH_HEAD au lieu de l'écraser"
 
@@ -15482,7 +15482,7 @@ msgstr "ajouter à .git/FETCH_HEAD au lieu de l'écraser"
 msgid "use atomic transaction to update references"
 msgstr "utiliser une transaction atomique pour mettre à jour les références"
 
-#: builtin/fetch.c:153 builtin/pull.c:191
+#: builtin/fetch.c:153 builtin/pull.c:195
 msgid "path to upload pack on remote end"
 msgstr "chemin vers lequel télécharger le paquet sur le poste distant"
 
@@ -15494,7 +15494,7 @@ msgstr "forcer l'écrasement de la branche locale"
 msgid "fetch from multiple remotes"
 msgstr "récupérer depuis plusieurs dépôts distants"
 
-#: builtin/fetch.c:158 builtin/pull.c:195
+#: builtin/fetch.c:158 builtin/pull.c:199
 msgid "fetch all tags and associated objects"
 msgstr "récupérer toutes les étiquettes et leurs objets associés"
 
@@ -15512,7 +15512,7 @@ msgstr ""
 "modifier le spécificateur de référence pour placer les références dans refs/"
 "prefetch/"
 
-#: builtin/fetch.c:166 builtin/pull.c:198
+#: builtin/fetch.c:166 builtin/pull.c:202
 msgid "prune remote-tracking branches no longer on remote"
 msgstr ""
 "éliminer les branches de suivi distant si la branche n'existe plus dans le "
@@ -15524,7 +15524,7 @@ msgstr ""
 "éliminer les étiquettes locales qui ont disparu du dépôt distant et qui "
 "encombrent les étiquettes modifiées"
 
-#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:122
+#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:123
 msgid "on-demand"
 msgstr "à la demande"
 
@@ -15536,7 +15536,7 @@ msgstr "contrôler la récupération récursive dans les sous-modules"
 msgid "write fetched references to the FETCH_HEAD file"
 msgstr "écrire les références récupérées dans le fichier FETCH_HEAD"
 
-#: builtin/fetch.c:176 builtin/pull.c:206
+#: builtin/fetch.c:176 builtin/pull.c:210
 msgid "keep downloaded pack"
 msgstr "conserver le paquet téléchargé"
 
@@ -15544,16 +15544,16 @@ msgstr "conserver le paquet téléchargé"
 msgid "allow updating of HEAD ref"
 msgstr "permettre la mise à jour de la référence HEAD"
 
-#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:209
-#: builtin/pull.c:218
+#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:213
+#: builtin/pull.c:222
 msgid "deepen history of shallow clone"
 msgstr "approfondir l'historique d'un clone superficiel"
 
-#: builtin/fetch.c:183 builtin/pull.c:212
+#: builtin/fetch.c:183 builtin/pull.c:216
 msgid "deepen history of shallow repository based on time"
 msgstr "approfondir l'historique d'un clone superficiel en fonction d'une date"
 
-#: builtin/fetch.c:189 builtin/pull.c:221
+#: builtin/fetch.c:189 builtin/pull.c:225
 msgid "convert to a complete repository"
 msgstr "convertir en un dépôt complet"
 
@@ -15569,19 +15569,19 @@ msgstr ""
 "par défaut pour la récupération récursive de sous-modules (priorité plus "
 "basse que les fichiers de config)"
 
-#: builtin/fetch.c:199 builtin/pull.c:224
+#: builtin/fetch.c:199 builtin/pull.c:228
 msgid "accept refs that update .git/shallow"
 msgstr "accepter les références qui mettent à jour .git/shallow"
 
-#: builtin/fetch.c:200 builtin/pull.c:226
+#: builtin/fetch.c:200 builtin/pull.c:230
 msgid "refmap"
 msgstr "correspondance de référence"
 
-#: builtin/fetch.c:201 builtin/pull.c:227
+#: builtin/fetch.c:201 builtin/pull.c:231
 msgid "specify fetch refmap"
 msgstr "spécifier une correspondance de référence pour la récupération"
 
-#: builtin/fetch.c:208 builtin/pull.c:240
+#: builtin/fetch.c:208 builtin/pull.c:244
 msgid "report that we have only objects reachable from this object"
 msgstr "rapporte que nous n'avons que des objets joignables depuis cet objet"
 
@@ -15595,7 +15595,7 @@ msgstr ""
 msgid "run 'maintenance --auto' after fetching"
 msgstr "lancer 'maintenance --auto' après la récupération"
 
-#: builtin/fetch.c:217 builtin/pull.c:243
+#: builtin/fetch.c:217 builtin/pull.c:247
 msgid "check for forced-updates on all updated branches"
 msgstr ""
 "vérifier les mises à jour forcées (forced-updates) sur toutes les branches "
@@ -18307,33 +18307,33 @@ msgstr "Les stratégies disponibles sont :"
 msgid "Available custom strategies are:"
 msgstr "Les stratégies personnalisées sont :"
 
-#: builtin/merge.c:257 builtin/pull.c:133
+#: builtin/merge.c:257 builtin/pull.c:134
 msgid "do not show a diffstat at the end of the merge"
 msgstr "ne pas afficher un diffstat à la fin de la fusion"
 
-#: builtin/merge.c:260 builtin/pull.c:136
+#: builtin/merge.c:260 builtin/pull.c:137
 msgid "show a diffstat at the end of the merge"
 msgstr "afficher un diffstat à la fin de la fusion"
 
-#: builtin/merge.c:261 builtin/pull.c:139
+#: builtin/merge.c:261 builtin/pull.c:140
 msgid "(synonym to --stat)"
 msgstr "(synonyme de --stat)"
 
-#: builtin/merge.c:263 builtin/pull.c:142
+#: builtin/merge.c:263 builtin/pull.c:143
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "ajouter (au plus <n>) éléments du journal court au message de validation de "
 "la fusion"
 
-#: builtin/merge.c:266 builtin/pull.c:148
+#: builtin/merge.c:266 builtin/pull.c:149
 msgid "create a single commit instead of doing a merge"
 msgstr "créer une validation unique au lieu de faire une fusion"
 
-#: builtin/merge.c:268 builtin/pull.c:151
+#: builtin/merge.c:268 builtin/pull.c:152
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "effectuer une validation si la fusion réussit (défaut)"
 
-#: builtin/merge.c:270 builtin/pull.c:154
+#: builtin/merge.c:270 builtin/pull.c:155
 msgid "edit message before committing"
 msgstr "éditer le message avant la validation"
 
@@ -18341,28 +18341,28 @@ msgstr "éditer le message avant la validation"
 msgid "allow fast-forward (default)"
 msgstr "autoriser l'avance rapide (défaut)"
 
-#: builtin/merge.c:274 builtin/pull.c:161
+#: builtin/merge.c:274 builtin/pull.c:162
 msgid "abort if fast-forward is not possible"
 msgstr "abandonner si l'avance rapide n'est pas possible"
 
-#: builtin/merge.c:278 builtin/pull.c:164
+#: builtin/merge.c:278 builtin/pull.c:168
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "vérifier que le commit nommé a une signature GPG valide"
 
-#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:168
+#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:172
 #: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr "stratégie"
 
-#: builtin/merge.c:280 builtin/pull.c:169
+#: builtin/merge.c:280 builtin/pull.c:173
 msgid "merge strategy to use"
 msgstr "stratégie de fusion à utiliser"
 
-#: builtin/merge.c:281 builtin/pull.c:172
+#: builtin/merge.c:281 builtin/pull.c:176
 msgid "option=value"
 msgstr "option=valeur"
 
-#: builtin/merge.c:282 builtin/pull.c:173
+#: builtin/merge.c:282 builtin/pull.c:177
 msgid "option for selected merge strategy"
 msgstr "option pour la stratégie de fusion sélectionnée"
 
@@ -18383,7 +18383,7 @@ msgstr "--abort mais laisser l'index et l'arbre de travail inchangés"
 msgid "continue the current in-progress merge"
 msgstr "continuer la fusion en cours"
 
-#: builtin/merge.c:297 builtin/pull.c:180
+#: builtin/merge.c:297 builtin/pull.c:184
 msgid "allow merging unrelated histories"
 msgstr "permettre la fusion d'historiques sans rapport"
 
@@ -19818,44 +19818,48 @@ msgstr "Valeur invalide pour %s : %s"
 msgid "git pull [<options>] [<repository> [<refspec>...]]"
 msgstr "git pull [<options>] [<dépôt> [<spécification-de-référence>...]]"
 
-#: builtin/pull.c:123
+#: builtin/pull.c:124
 msgid "control for recursive fetching of submodules"
 msgstr "contrôler la récupération récursive dans les sous-modules"
 
-#: builtin/pull.c:127
+#: builtin/pull.c:128
 msgid "Options related to merging"
 msgstr "Options relatives à la fusion"
 
-#: builtin/pull.c:130
+#: builtin/pull.c:131
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "incorporer les modifications en rebasant plutôt qu'en fusionnant"
 
-#: builtin/pull.c:158 builtin/revert.c:126
+#: builtin/pull.c:159 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "autoriser l'avance rapide"
 
-#: builtin/pull.c:167 parse-options.h:339
+#: builtin/pull.c:165
+msgid "control use of pre-merge-commit and commit-msg hooks"
+msgstr "contrôler l'utilisation des crochets pre-merge-commit et commit-msg"
+
+#: builtin/pull.c:171 parse-options.h:338
 msgid "automatically stash/stash pop before and after"
 msgstr "remiser et réappliquer automatiquement avant et après"
 
-#: builtin/pull.c:183
+#: builtin/pull.c:187
 msgid "Options related to fetching"
 msgstr "Options relatives au rapatriement"
 
-#: builtin/pull.c:193
+#: builtin/pull.c:197
 msgid "force overwrite of local branch"
 msgstr "forcer l'écrasement de la branche locale"
 
-#: builtin/pull.c:201
+#: builtin/pull.c:205
 msgid "number of submodules pulled in parallel"
 msgstr "nombre de sous-modules tirés en parallèle"
 
-#: builtin/pull.c:317
+#: builtin/pull.c:321
 #, c-format
 msgid "Invalid value for pull.ff: %s"
 msgstr "Valeur invalide pour pull.ff : %s"
 
-#: builtin/pull.c:445
+#: builtin/pull.c:449
 msgid ""
 "There is no candidate for rebasing against among the refs that you just "
 "fetched."
@@ -19863,14 +19867,14 @@ msgstr ""
 "Il n'y a pas de candidate sur laquelle rebaser parmi les références que vous "
 "venez de récupérer."
 
-#: builtin/pull.c:447
+#: builtin/pull.c:451
 msgid ""
 "There are no candidates for merging among the refs that you just fetched."
 msgstr ""
 "Il n'y a pas de candidate avec laquelle fusionner parmi les références que "
 "vous venez de récupérer."
 
-#: builtin/pull.c:448
+#: builtin/pull.c:452
 msgid ""
 "Generally this means that you provided a wildcard refspec which had no\n"
 "matches on the remote end."
@@ -19878,7 +19882,7 @@ msgstr ""
 "Généralement, cela signifie que vous avez indiqué un spécificateur\n"
 "de référence joker qui n'a pas eu de correspondance sur le serveur distant."
 
-#: builtin/pull.c:451
+#: builtin/pull.c:455
 #, c-format
 msgid ""
 "You asked to pull from the remote '%s', but did not specify\n"
@@ -19890,43 +19894,43 @@ msgstr ""
 "configuration\n"
 "pour la branche actuelle, vous devez spécifier la branche avec la commande."
 
-#: builtin/pull.c:456 builtin/rebase.c:951
+#: builtin/pull.c:460 builtin/rebase.c:951
 msgid "You are not currently on a branch."
 msgstr "Vous n'êtes actuellement sur aucune branche."
 
-#: builtin/pull.c:458 builtin/pull.c:473
+#: builtin/pull.c:462 builtin/pull.c:477
 msgid "Please specify which branch you want to rebase against."
 msgstr "Veuillez spécifier sur quelle branche vous souhaiter rebaser."
 
-#: builtin/pull.c:460 builtin/pull.c:475
+#: builtin/pull.c:464 builtin/pull.c:479
 msgid "Please specify which branch you want to merge with."
 msgstr "Veuillez spécifier une branche avec laquelle fusionner."
 
-#: builtin/pull.c:461 builtin/pull.c:476
+#: builtin/pull.c:465 builtin/pull.c:480
 msgid "See git-pull(1) for details."
 msgstr "Référez-vous à git-pull(1) pour de plus amples détails."
 
-#: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
+#: builtin/pull.c:467 builtin/pull.c:473 builtin/pull.c:482
 #: builtin/rebase.c:957
 msgid "<remote>"
 msgstr "<distant>"
 
-#: builtin/pull.c:463 builtin/pull.c:478 builtin/pull.c:483
+#: builtin/pull.c:467 builtin/pull.c:482 builtin/pull.c:487
 msgid "<branch>"
 msgstr "<branche>"
 
-#: builtin/pull.c:471 builtin/rebase.c:949
+#: builtin/pull.c:475 builtin/rebase.c:949
 msgid "There is no tracking information for the current branch."
 msgstr "Pas d'information de suivi distant pour la branche actuelle."
 
-#: builtin/pull.c:480
+#: builtin/pull.c:484
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:"
 msgstr ""
 "Si vous souhaitez indiquer l'information de suivi distant pour cette "
 "branche, vous pouvez le faire avec :"
 
-#: builtin/pull.c:485
+#: builtin/pull.c:489
 #, c-format
 msgid ""
 "Your configuration specifies to merge with the ref '%s'\n"
@@ -19936,16 +19940,16 @@ msgstr ""
 "'%s'\n"
 "du serveur distant, mais cette référence n'a pas été récupérée."
 
-#: builtin/pull.c:596
+#: builtin/pull.c:600
 #, c-format
 msgid "unable to access commit %s"
 msgstr "impossible d'accéder le commit %s"
 
-#: builtin/pull.c:902
+#: builtin/pull.c:908
 msgid "ignoring --verify-signatures for rebase"
 msgstr "--verify-signatures est ignoré pour un rebasage"
 
-#: builtin/pull.c:936
+#: builtin/pull.c:942
 msgid ""
 "You have divergent branches and need to specify how to reconcile them.\n"
 "You can do so by running one of the following commands sometime before\n"
@@ -19974,21 +19978,21 @@ msgstr ""
 "passer --rebase, --no-rebase ou --ff-only sur la ligne de commande pour\n"
 "remplacer à l'invocation la valeur par défaut configurée.\n"
 
-#: builtin/pull.c:1010
+#: builtin/pull.c:1016
 msgid "Updating an unborn branch with changes added to the index."
 msgstr ""
 "Mise à jour d'une branche non encore créée avec les changements ajoutés dans "
 "l'index."
 
-#: builtin/pull.c:1014
+#: builtin/pull.c:1020
 msgid "pull with rebase"
 msgstr "tirer avec un rebasage"
 
-#: builtin/pull.c:1015
+#: builtin/pull.c:1021
 msgid "please commit or stash them."
 msgstr "veuillez les valider ou les remiser."
 
-#: builtin/pull.c:1040
+#: builtin/pull.c:1046
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -19999,7 +20003,7 @@ msgstr ""
 "avance rapide de votre copie de travail\n"
 "depuis le commit %s."
 
-#: builtin/pull.c:1046
+#: builtin/pull.c:1052
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -20016,23 +20020,23 @@ msgstr ""
 "$ git reset --hard\n"
 "pour régénérer."
 
-#: builtin/pull.c:1061
+#: builtin/pull.c:1067
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Impossible de fusionner de multiples branches sur une tête vide."
 
-#: builtin/pull.c:1066
+#: builtin/pull.c:1072
 msgid "Cannot rebase onto multiple branches."
 msgstr "Impossible de rebaser sur de multiples branches."
 
-#: builtin/pull.c:1068
+#: builtin/pull.c:1074
 msgid "Cannot fast-forward to multiple branches."
 msgstr "Impossible d'aller en avance rapide sur de multiples branches."
 
-#: builtin/pull.c:1082
+#: builtin/pull.c:1088
 msgid "Need to specify how to reconcile divergent branches."
 msgstr "Besoin de spécifier comment réconcilier des branches divergentes."
 
-#: builtin/pull.c:1096
+#: builtin/pull.c:1102
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "impossible de rebaser avec des modifications de sous-modules enregistrées "
@@ -25296,27 +25300,27 @@ msgstr "date-d'expiration"
 msgid "no-op (backward compatibility)"
 msgstr "sans action (rétrocompatibilité)"
 
-#: parse-options.h:309
+#: parse-options.h:308
 msgid "be more verbose"
 msgstr "être plus verbeux"
 
-#: parse-options.h:311
+#: parse-options.h:310
 msgid "be more quiet"
 msgstr "être plus silencieux"
 
-#: parse-options.h:317
+#: parse-options.h:316
 msgid "use <n> digits to display object names"
 msgstr "utiliser <n> chiffres pour afficher les noms des objets"
 
-#: parse-options.h:336
+#: parse-options.h:335
 msgid "how to strip spaces and #comments from message"
 msgstr "comment éliminer les espaces et les commentaires # du message"
 
-#: parse-options.h:337
+#: parse-options.h:336
 msgid "read pathspec from file"
 msgstr "lire les spécificateurs de fichier depuis fichier"
 
-#: parse-options.h:338
+#: parse-options.h:337
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""

--- a/po/git.pot
+++ b/po/git.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-11-04 08:34+0800\n"
+"POT-Creation-Date: 2021-11-10 08:55+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -211,7 +211,7 @@ msgstr ""
 
 #: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
 #: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:190
+#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:194
 #: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
 #: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
 #: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
@@ -9692,7 +9692,7 @@ msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr ""
 
 #: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
-#: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:550
+#: builtin/prune-packed.c:14 builtin/pull.c:208 builtin/push.c:550
 #: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr ""
@@ -10118,11 +10118,11 @@ msgstr ""
 
 #: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
 #: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
-#: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
+#: builtin/pull.c:142 builtin/pull.c:204 builtin/pull.c:221
 #: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
 #: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
 #: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
-#: parse-options.h:316
+#: parse-options.h:315
 msgid "n"
 msgstr ""
 
@@ -10173,7 +10173,7 @@ msgid "use current timestamp for author date"
 msgstr ""
 
 #: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
-#: builtin/merge.c:299 builtin/pull.c:175 builtin/rebase.c:1099
+#: builtin/merge.c:299 builtin/pull.c:179 builtin/rebase.c:1099
 #: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
 msgstr ""
@@ -10655,7 +10655,7 @@ msgstr ""
 #: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
 #: builtin/merge.c:298 builtin/multi-pack-index.c:103
 #: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
-#: builtin/multi-pack-index.c:204 builtin/pull.c:119 builtin/push.c:566
+#: builtin/multi-pack-index.c:204 builtin/pull.c:120 builtin/push.c:566
 #: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr ""
@@ -11845,7 +11845,7 @@ msgstr ""
 msgid "perform a 3-way merge with the new branch"
 msgstr ""
 
-#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:322
+#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:321
 msgid "style"
 msgstr ""
 
@@ -12244,7 +12244,7 @@ msgid "path to git-upload-pack on the remote"
 msgstr ""
 
 #: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
-#: builtin/pull.c:208
+#: builtin/pull.c:212
 msgid "depth"
 msgstr ""
 
@@ -12253,7 +12253,7 @@ msgid "create a shallow clone of that depth"
 msgstr ""
 
 #: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
-#: builtin/pull.c:211
+#: builtin/pull.c:215
 msgid "time"
 msgstr ""
 
@@ -12262,11 +12262,11 @@ msgid "create a shallow clone since a specific time"
 msgstr ""
 
 #: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1022
+#: builtin/pull.c:218 builtin/pull.c:243 builtin/rebase.c:1022
 msgid "revision"
 msgstr ""
 
-#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:215
+#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:219
 msgid "deepen history of shallow clone, excluding rev"
 msgstr ""
 
@@ -12300,21 +12300,21 @@ msgid "set config inside the new repository"
 msgstr ""
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:200
+#: builtin/pull.c:234 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr ""
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:201
+#: builtin/pull.c:235 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr ""
 
-#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:234
+#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:238
 #: builtin/push.c:576
 msgid "use IPv4 addresses only"
 msgstr ""
 
-#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:237
+#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:241
 #: builtin/push.c:578
 msgid "use IPv6 addresses only"
 msgstr ""
@@ -12692,7 +12692,7 @@ msgid "read commit log message from file"
 msgstr ""
 
 #: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
-#: builtin/pull.c:176 builtin/revert.c:118
+#: builtin/pull.c:180 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr ""
 
@@ -13059,7 +13059,7 @@ msgstr ""
 
 #: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
 #: builtin/fast-export.c:1199 builtin/fast-export.c:1202
-#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:336
+#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:335
 msgid "mode"
 msgstr ""
 
@@ -13132,7 +13132,7 @@ msgid "override date for commit"
 msgstr ""
 
 #: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
-#: parse-options.h:328 ref-filter.h:92
+#: parse-options.h:327 ref-filter.h:92
 msgid "commit"
 msgstr ""
 
@@ -13173,7 +13173,7 @@ msgid "add custom trailer(s)"
 msgstr ""
 
 #: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
-#: builtin/pull.c:145 builtin/revert.c:110
+#: builtin/pull.c:146 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr ""
 
@@ -14111,15 +14111,15 @@ msgstr ""
 msgid "fetch.parallel cannot be negative"
 msgstr ""
 
-#: builtin/fetch.c:145 builtin/pull.c:185
+#: builtin/fetch.c:145 builtin/pull.c:189
 msgid "fetch from all remotes"
 msgstr ""
 
-#: builtin/fetch.c:147 builtin/pull.c:245
+#: builtin/fetch.c:147 builtin/pull.c:249
 msgid "set upstream for git pull/fetch"
 msgstr ""
 
-#: builtin/fetch.c:149 builtin/pull.c:188
+#: builtin/fetch.c:149 builtin/pull.c:192
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr ""
 
@@ -14127,7 +14127,7 @@ msgstr ""
 msgid "use atomic transaction to update references"
 msgstr ""
 
-#: builtin/fetch.c:153 builtin/pull.c:191
+#: builtin/fetch.c:153 builtin/pull.c:195
 msgid "path to upload pack on remote end"
 msgstr ""
 
@@ -14139,7 +14139,7 @@ msgstr ""
 msgid "fetch from multiple remotes"
 msgstr ""
 
-#: builtin/fetch.c:158 builtin/pull.c:195
+#: builtin/fetch.c:158 builtin/pull.c:199
 msgid "fetch all tags and associated objects"
 msgstr ""
 
@@ -14155,7 +14155,7 @@ msgstr ""
 msgid "modify the refspec to place all refs within refs/prefetch/"
 msgstr ""
 
-#: builtin/fetch.c:166 builtin/pull.c:198
+#: builtin/fetch.c:166 builtin/pull.c:202
 msgid "prune remote-tracking branches no longer on remote"
 msgstr ""
 
@@ -14163,7 +14163,7 @@ msgstr ""
 msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr ""
 
-#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:122
+#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:123
 msgid "on-demand"
 msgstr ""
 
@@ -14175,7 +14175,7 @@ msgstr ""
 msgid "write fetched references to the FETCH_HEAD file"
 msgstr ""
 
-#: builtin/fetch.c:176 builtin/pull.c:206
+#: builtin/fetch.c:176 builtin/pull.c:210
 msgid "keep downloaded pack"
 msgstr ""
 
@@ -14183,16 +14183,16 @@ msgstr ""
 msgid "allow updating of HEAD ref"
 msgstr ""
 
-#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:209
-#: builtin/pull.c:218
+#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:213
+#: builtin/pull.c:222
 msgid "deepen history of shallow clone"
 msgstr ""
 
-#: builtin/fetch.c:183 builtin/pull.c:212
+#: builtin/fetch.c:183 builtin/pull.c:216
 msgid "deepen history of shallow repository based on time"
 msgstr ""
 
-#: builtin/fetch.c:189 builtin/pull.c:221
+#: builtin/fetch.c:189 builtin/pull.c:225
 msgid "convert to a complete repository"
 msgstr ""
 
@@ -14206,19 +14206,19 @@ msgid ""
 "files)"
 msgstr ""
 
-#: builtin/fetch.c:199 builtin/pull.c:224
+#: builtin/fetch.c:199 builtin/pull.c:228
 msgid "accept refs that update .git/shallow"
 msgstr ""
 
-#: builtin/fetch.c:200 builtin/pull.c:226
+#: builtin/fetch.c:200 builtin/pull.c:230
 msgid "refmap"
 msgstr ""
 
-#: builtin/fetch.c:201 builtin/pull.c:227
+#: builtin/fetch.c:201 builtin/pull.c:231
 msgid "specify fetch refmap"
 msgstr ""
 
-#: builtin/fetch.c:208 builtin/pull.c:240
+#: builtin/fetch.c:208 builtin/pull.c:244
 msgid "report that we have only objects reachable from this object"
 msgstr ""
 
@@ -14230,7 +14230,7 @@ msgstr ""
 msgid "run 'maintenance --auto' after fetching"
 msgstr ""
 
-#: builtin/fetch.c:217 builtin/pull.c:243
+#: builtin/fetch.c:217 builtin/pull.c:247
 msgid "check for forced-updates on all updated branches"
 msgstr ""
 
@@ -16834,31 +16834,31 @@ msgstr ""
 msgid "Available custom strategies are:"
 msgstr ""
 
-#: builtin/merge.c:257 builtin/pull.c:133
+#: builtin/merge.c:257 builtin/pull.c:134
 msgid "do not show a diffstat at the end of the merge"
 msgstr ""
 
-#: builtin/merge.c:260 builtin/pull.c:136
+#: builtin/merge.c:260 builtin/pull.c:137
 msgid "show a diffstat at the end of the merge"
 msgstr ""
 
-#: builtin/merge.c:261 builtin/pull.c:139
+#: builtin/merge.c:261 builtin/pull.c:140
 msgid "(synonym to --stat)"
 msgstr ""
 
-#: builtin/merge.c:263 builtin/pull.c:142
+#: builtin/merge.c:263 builtin/pull.c:143
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 
-#: builtin/merge.c:266 builtin/pull.c:148
+#: builtin/merge.c:266 builtin/pull.c:149
 msgid "create a single commit instead of doing a merge"
 msgstr ""
 
-#: builtin/merge.c:268 builtin/pull.c:151
+#: builtin/merge.c:268 builtin/pull.c:152
 msgid "perform a commit if the merge succeeds (default)"
 msgstr ""
 
-#: builtin/merge.c:270 builtin/pull.c:154
+#: builtin/merge.c:270 builtin/pull.c:155
 msgid "edit message before committing"
 msgstr ""
 
@@ -16866,28 +16866,28 @@ msgstr ""
 msgid "allow fast-forward (default)"
 msgstr ""
 
-#: builtin/merge.c:274 builtin/pull.c:161
+#: builtin/merge.c:274 builtin/pull.c:162
 msgid "abort if fast-forward is not possible"
 msgstr ""
 
-#: builtin/merge.c:278 builtin/pull.c:164
+#: builtin/merge.c:278 builtin/pull.c:168
 msgid "verify that the named commit has a valid GPG signature"
 msgstr ""
 
-#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:168
+#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:172
 #: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr ""
 
-#: builtin/merge.c:280 builtin/pull.c:169
+#: builtin/merge.c:280 builtin/pull.c:173
 msgid "merge strategy to use"
 msgstr ""
 
-#: builtin/merge.c:281 builtin/pull.c:172
+#: builtin/merge.c:281 builtin/pull.c:176
 msgid "option=value"
 msgstr ""
 
-#: builtin/merge.c:282 builtin/pull.c:173
+#: builtin/merge.c:282 builtin/pull.c:177
 msgid "option for selected merge strategy"
 msgstr ""
 
@@ -16907,7 +16907,7 @@ msgstr ""
 msgid "continue the current in-progress merge"
 msgstr ""
 
-#: builtin/merge.c:297 builtin/pull.c:180
+#: builtin/merge.c:297 builtin/pull.c:184
 msgid "allow merging unrelated histories"
 msgstr ""
 
@@ -18257,61 +18257,65 @@ msgstr ""
 msgid "git pull [<options>] [<repository> [<refspec>...]]"
 msgstr ""
 
-#: builtin/pull.c:123
+#: builtin/pull.c:124
 msgid "control for recursive fetching of submodules"
 msgstr ""
 
-#: builtin/pull.c:127
+#: builtin/pull.c:128
 msgid "Options related to merging"
 msgstr ""
 
-#: builtin/pull.c:130
+#: builtin/pull.c:131
 msgid "incorporate changes by rebasing rather than merging"
 msgstr ""
 
-#: builtin/pull.c:158 builtin/revert.c:126
+#: builtin/pull.c:159 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr ""
 
-#: builtin/pull.c:167 parse-options.h:339
+#: builtin/pull.c:165
+msgid "control use of pre-merge-commit and commit-msg hooks"
+msgstr ""
+
+#: builtin/pull.c:171 parse-options.h:338
 msgid "automatically stash/stash pop before and after"
 msgstr ""
 
-#: builtin/pull.c:183
+#: builtin/pull.c:187
 msgid "Options related to fetching"
 msgstr ""
 
-#: builtin/pull.c:193
+#: builtin/pull.c:197
 msgid "force overwrite of local branch"
 msgstr ""
 
-#: builtin/pull.c:201
+#: builtin/pull.c:205
 msgid "number of submodules pulled in parallel"
 msgstr ""
 
-#: builtin/pull.c:317
+#: builtin/pull.c:321
 #, c-format
 msgid "Invalid value for pull.ff: %s"
 msgstr ""
 
-#: builtin/pull.c:445
+#: builtin/pull.c:449
 msgid ""
 "There is no candidate for rebasing against among the refs that you just "
 "fetched."
 msgstr ""
 
-#: builtin/pull.c:447
+#: builtin/pull.c:451
 msgid ""
 "There are no candidates for merging among the refs that you just fetched."
 msgstr ""
 
-#: builtin/pull.c:448
+#: builtin/pull.c:452
 msgid ""
 "Generally this means that you provided a wildcard refspec which had no\n"
 "matches on the remote end."
 msgstr ""
 
-#: builtin/pull.c:451
+#: builtin/pull.c:455
 #, c-format
 msgid ""
 "You asked to pull from the remote '%s', but did not specify\n"
@@ -18319,57 +18323,57 @@ msgid ""
 "for your current branch, you must specify a branch on the command line."
 msgstr ""
 
-#: builtin/pull.c:456 builtin/rebase.c:951
+#: builtin/pull.c:460 builtin/rebase.c:951
 msgid "You are not currently on a branch."
 msgstr ""
 
-#: builtin/pull.c:458 builtin/pull.c:473
+#: builtin/pull.c:462 builtin/pull.c:477
 msgid "Please specify which branch you want to rebase against."
 msgstr ""
 
-#: builtin/pull.c:460 builtin/pull.c:475
+#: builtin/pull.c:464 builtin/pull.c:479
 msgid "Please specify which branch you want to merge with."
 msgstr ""
 
-#: builtin/pull.c:461 builtin/pull.c:476
+#: builtin/pull.c:465 builtin/pull.c:480
 msgid "See git-pull(1) for details."
 msgstr ""
 
-#: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
+#: builtin/pull.c:467 builtin/pull.c:473 builtin/pull.c:482
 #: builtin/rebase.c:957
 msgid "<remote>"
 msgstr ""
 
-#: builtin/pull.c:463 builtin/pull.c:478 builtin/pull.c:483
+#: builtin/pull.c:467 builtin/pull.c:482 builtin/pull.c:487
 msgid "<branch>"
 msgstr ""
 
-#: builtin/pull.c:471 builtin/rebase.c:949
+#: builtin/pull.c:475 builtin/rebase.c:949
 msgid "There is no tracking information for the current branch."
 msgstr ""
 
-#: builtin/pull.c:480
+#: builtin/pull.c:484
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:"
 msgstr ""
 
-#: builtin/pull.c:485
+#: builtin/pull.c:489
 #, c-format
 msgid ""
 "Your configuration specifies to merge with the ref '%s'\n"
 "from the remote, but no such ref was fetched."
 msgstr ""
 
-#: builtin/pull.c:596
+#: builtin/pull.c:600
 #, c-format
 msgid "unable to access commit %s"
 msgstr ""
 
-#: builtin/pull.c:902
+#: builtin/pull.c:908
 msgid "ignoring --verify-signatures for rebase"
 msgstr ""
 
-#: builtin/pull.c:936
+#: builtin/pull.c:942
 msgid ""
 "You have divergent branches and need to specify how to reconcile them.\n"
 "You can do so by running one of the following commands sometime before\n"
@@ -18386,19 +18390,19 @@ msgid ""
 "invocation.\n"
 msgstr ""
 
-#: builtin/pull.c:1010
+#: builtin/pull.c:1016
 msgid "Updating an unborn branch with changes added to the index."
 msgstr ""
 
-#: builtin/pull.c:1014
+#: builtin/pull.c:1020
 msgid "pull with rebase"
 msgstr ""
 
-#: builtin/pull.c:1015
+#: builtin/pull.c:1021
 msgid "please commit or stash them."
 msgstr ""
 
-#: builtin/pull.c:1040
+#: builtin/pull.c:1046
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -18406,7 +18410,7 @@ msgid ""
 "commit %s."
 msgstr ""
 
-#: builtin/pull.c:1046
+#: builtin/pull.c:1052
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -18417,23 +18421,23 @@ msgid ""
 "to recover."
 msgstr ""
 
-#: builtin/pull.c:1061
+#: builtin/pull.c:1067
 msgid "Cannot merge multiple branches into empty head."
 msgstr ""
 
-#: builtin/pull.c:1066
+#: builtin/pull.c:1072
 msgid "Cannot rebase onto multiple branches."
 msgstr ""
 
-#: builtin/pull.c:1068
+#: builtin/pull.c:1074
 msgid "Cannot fast-forward to multiple branches."
 msgstr ""
 
-#: builtin/pull.c:1082
+#: builtin/pull.c:1088
 msgid "Need to specify how to reconcile divergent branches."
 msgstr ""
 
-#: builtin/pull.c:1096
+#: builtin/pull.c:1102
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 
@@ -23239,27 +23243,27 @@ msgstr ""
 msgid "no-op (backward compatibility)"
 msgstr ""
 
-#: parse-options.h:309
+#: parse-options.h:308
 msgid "be more verbose"
 msgstr ""
 
-#: parse-options.h:311
+#: parse-options.h:310
 msgid "be more quiet"
 msgstr ""
 
-#: parse-options.h:317
+#: parse-options.h:316
 msgid "use <n> digits to display object names"
 msgstr ""
 
-#: parse-options.h:336
+#: parse-options.h:335
 msgid "how to strip spaces and #comments from message"
 msgstr ""
 
-#: parse-options.h:337
+#: parse-options.h:336
 msgid "read pathspec from file"
 msgstr ""
 
-#: parse-options.h:338
+#: parse-options.h:337
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -58,7 +58,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-10-30 09:36+0800\n"
+"POT-Creation-Date: 2021-11-04 08:34+0800\n"
 "PO-Revision-Date: 2021-11-03 11:38+0100\n"
 "Last-Translator: Arusekk <arek_koz@o2.pl>\n"
 "Language-Team: Polish\n"
@@ -66,8 +66,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10"
-" || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
 "X-Generator: Lokalize 21.08.2\n"
 
 #: add-interactive.c:380
@@ -75,8 +75,8 @@ msgstr ""
 msgid "Huh (%s)?"
 msgstr "Hę (%s)?"
 
-#: add-interactive.c:533 add-interactive.c:834 reset.c:65 sequencer.c:3510
-#: sequencer.c:3977 sequencer.c:4139 builtin/rebase.c:1233
+#: add-interactive.c:533 add-interactive.c:834 reset.c:65 sequencer.c:3512
+#: sequencer.c:3979 sequencer.c:4141 builtin/rebase.c:1233
 #: builtin/rebase.c:1642
 msgid "could not read index"
 msgstr "nie można odczytać indeksu"
@@ -105,7 +105,7 @@ msgstr "Aktualizacja"
 msgid "could not stage '%s'"
 msgstr "nie można przygotować „%s”"
 
-#: add-interactive.c:707 add-interactive.c:896 reset.c:89 sequencer.c:3716
+#: add-interactive.c:707 add-interactive.c:896 reset.c:89 sequencer.c:3718
 msgid "could not write index"
 msgstr "nie można zapisać indeksu"
 
@@ -1342,8 +1342,8 @@ msgstr "nie można utworzyć wspierającego składu dla nowo utworzonego pliku %
 msgid "unable to add cache entry for %s"
 msgstr "nie można dodać %s do pamięci podręcznej"
 
-#: apply.c:4398 builtin/bisect--helper.c:540 builtin/gc.c:2242
-#: builtin/gc.c:2277
+#: apply.c:4398 builtin/bisect--helper.c:540 builtin/gc.c:2241
+#: builtin/gc.c:2276
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "nie można pisać do „%s”"
@@ -1637,8 +1637,8 @@ msgstr "git archive --remote <repozytorium> [--exec <polecenie>] --list"
 msgid "cannot read %s"
 msgstr "nie można odczytać %s"
 
-#: archive.c:341 sequencer.c:473 sequencer.c:1930 sequencer.c:3112
-#: sequencer.c:3554 sequencer.c:3682 builtin/am.c:263 builtin/commit.c:834
+#: archive.c:341 sequencer.c:473 sequencer.c:1932 sequencer.c:3114
+#: sequencer.c:3556 sequencer.c:3684 builtin/am.c:263 builtin/commit.c:834
 #: builtin/merge.c:1145
 #, c-format
 msgid "could not read '%s'"
@@ -1923,7 +1923,7 @@ msgid "--reverse and --first-parent together require specified latest commit"
 msgstr "--reverse i --first-parent razem wymagają podanego ostatniego zapisu"
 
 #: blame.c:2820 bundle.c:224 midx.c:1039 ref-filter.c:2370 remote.c:2041
-#: sequencer.c:2348 sequencer.c:4900 submodule.c:883 builtin/commit.c:1114
+#: sequencer.c:2350 sequencer.c:4902 submodule.c:883 builtin/commit.c:1114
 #: builtin/log.c:414 builtin/log.c:1021 builtin/log.c:1629 builtin/log.c:2056
 #: builtin/log.c:2346 builtin/merge.c:429 builtin/pack-objects.c:3373
 #: builtin/pack-objects.c:3775 builtin/pack-objects.c:3790
@@ -2113,7 +2113,7 @@ msgstr "„%s” nie wygląda jak plik wiązki v2 ani v3"
 msgid "unrecognized header: %s%s (%d)"
 msgstr "nierozpoznany nagłówek: %s%s (%d)"
 
-#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2616 sequencer.c:3402
+#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2618 sequencer.c:3404
 #: builtin/commit.c:862
 #, c-format
 msgid "could not open '%s'"
@@ -2472,7 +2472,7 @@ msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 "data złożenia w zapisie %s w grafie zapisów to %<PRIuMAX> != %<PRIuMAX>"
 
-#: commit.c:53 sequencer.c:3105 builtin/am.c:373 builtin/am.c:418
+#: commit.c:53 sequencer.c:3107 builtin/am.c:373 builtin/am.c:418
 #: builtin/am.c:423 builtin/am.c:1421 builtin/am.c:2068 builtin/replace.c:457
 #, c-format
 msgid "could not parse %s"
@@ -2591,7 +2591,7 @@ msgstr "klucz nie zawiera rozdziału: %s"
 msgid "key does not contain variable name: %s"
 msgstr "klucz nie zawiera nazwy zmiennej: %s"
 
-#: config.c:470 sequencer.c:2802
+#: config.c:470 sequencer.c:2804
 #, c-format
 msgid "invalid key: %s"
 msgstr "nieprawidłowy klucz: %s"
@@ -4356,17 +4356,17 @@ msgstr "nie ma takiej zdalnej referencji %s"
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Serwer nie pozwala na żądanie o nieogłoszony obiekt %s"
 
-#: gpg-interface.c:329 gpg-interface.c:449 gpg-interface.c:900
-#: gpg-interface.c:916
+#: gpg-interface.c:329 gpg-interface.c:451 gpg-interface.c:902
+#: gpg-interface.c:918
 msgid "could not create temporary file"
 msgstr "nie można utworzyć pliku tymczasowego"
 
-#: gpg-interface.c:332 gpg-interface.c:452
+#: gpg-interface.c:332 gpg-interface.c:454
 #, c-format
 msgid "failed writing detached signature to '%s'"
 msgstr "nie można zapisać oddzielonego podpisu do „%s”"
 
-#: gpg-interface.c:443
+#: gpg-interface.c:445
 msgid ""
 "gpg.ssh.allowedSignersFile needs to be configured and exist for ssh "
 "signature verification"
@@ -4374,73 +4374,73 @@ msgstr ""
 "gpg.ssh.allowedSignersFile musi być ustawiony i istnieć, aby sprawdzać "
 "podpisy ssh"
 
-#: gpg-interface.c:467
+#: gpg-interface.c:469
 msgid ""
 "ssh-keygen -Y find-principals/verify is needed for ssh signature "
 "verification (available in openssh version 8.2p1+)"
 msgstr ""
-"potrzeba ssh-keygen -Y find-principals/verify, aby sprawdzać podpisy "
-"ssh (dostępne w wersji openssh 8.2p1+)"
+"potrzeba ssh-keygen -Y find-principals/verify, aby sprawdzać podpisy ssh "
+"(dostępne w wersji openssh 8.2p1+)"
 
-#: gpg-interface.c:521
+#: gpg-interface.c:523
 #, c-format
 msgid "ssh signing revocation file configured but not found: %s"
 msgstr "ustawiono plik odwołania podpisów ssh, ale go nie znaleziono: %s"
 
-#: gpg-interface.c:574
+#: gpg-interface.c:576
 #, c-format
 msgid "bad/incompatible signature '%s'"
 msgstr "zły/niekompatybilny podpis „%s”"
 
-#: gpg-interface.c:733 gpg-interface.c:738
+#: gpg-interface.c:735 gpg-interface.c:740
 #, c-format
 msgid "failed to get the ssh fingerprint for key '%s'"
 msgstr "nie można zdobyć odcisku klucza ssh „%s”"
 
-#: gpg-interface.c:760
+#: gpg-interface.c:762
 msgid ""
 "either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured"
 msgstr "należy ustawić user.signingkey lub gpg.ssh.defaultKeyCommand"
 
-#: gpg-interface.c:778
+#: gpg-interface.c:780
 #, c-format
-msgid "gpg.ssh.defaultKeycommand succeeded but returned no keys: %s %s"
+msgid "gpg.ssh.defaultKeyCommand succeeded but returned no keys: %s %s"
 msgstr ""
-"gpg.ssh.defaultKeycommand powiodło się, ale nie zwróciło żadnych kluczy: %s %s"
+"gpg.ssh.defaultKeyCommand powiodło się, ale nie zwróciło żadnych kluczy: %s "
+"%s"
 
-#: gpg-interface.c:784
+#: gpg-interface.c:786
 #, c-format
 msgid "gpg.ssh.defaultKeyCommand failed: %s %s"
 msgstr "gpg.ssh.defaultKeyCommand zawiodło: %s %s"
 
-#: gpg-interface.c:872
+#: gpg-interface.c:874
 msgid "gpg failed to sign the data"
 msgstr "gpg nie może podpisać danych"
 
-#: gpg-interface.c:893
+#: gpg-interface.c:895
 msgid "user.signingkey needs to be set for ssh signing"
 msgstr "do podpisywania ssh potrzeba user.signingkey"
 
-#: gpg-interface.c:904
+#: gpg-interface.c:906
 #, c-format
 msgid "failed writing ssh signing key to '%s'"
 msgstr "nie można zapisać klucza podpisującego ssh do „%s”"
 
-#: gpg-interface.c:922
+#: gpg-interface.c:924
 #, c-format
 msgid "failed writing ssh signing key buffer to '%s'"
 msgstr "nie można zapisać buforu klucza podpisującego ssh do „%s”"
 
-#: gpg-interface.c:940
+#: gpg-interface.c:942
 msgid ""
 "ssh-keygen -Y sign is needed for ssh signing (available in openssh version "
 "8.2p1+)"
 msgstr ""
-"do podpisywania ssh wymagany jest podpis ssh-keygen -Y (dostępne od wersji"
-" openssh "
-"8.2p1+)"
+"do podpisywania ssh wymagany jest podpis ssh-keygen -Y (dostępne od wersji "
+"openssh 8.2p1+)"
 
-#: gpg-interface.c:952
+#: gpg-interface.c:954
 #, c-format
 msgid "failed reading ssh signing data buffer from '%s'"
 msgstr "nie można odczytać bufora danych podpisu ssh z „%s”"
@@ -4450,7 +4450,7 @@ msgstr "nie można odczytać bufora danych podpisu ssh z „%s”"
 msgid "ignored invalid color '%.*s' in log.graphColors"
 msgstr "pominięto nieprawidłowy kolor „%.*s” w log.graphColors"
 
-#: grep.c:531
+#: grep.c:533
 msgid ""
 "given pattern contains NULL byte (via -f <file>). This is only supported "
 "with -P under PCRE v2"
@@ -4458,18 +4458,18 @@ msgstr ""
 "podany wzorzec zawiera znak NUL (przez -f <plik>). To jest wspierane tylko z "
 "-P pod PCRE v2"
 
-#: grep.c:1907
+#: grep.c:1928
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr "„%s”: nie można przeczytać %s"
 
-#: grep.c:1924 setup.c:176 builtin/clone.c:302 builtin/diff.c:90
+#: grep.c:1945 setup.c:176 builtin/clone.c:302 builtin/diff.c:90
 #: builtin/rm.c:136
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "nie można wykonać stat na „%s”'"
 
-#: grep.c:1935
+#: grep.c:1956
 #, c-format
 msgid "'%s': short read"
 msgstr "„%s”: przeczytano mniej niż powinno być"
@@ -6408,7 +6408,7 @@ msgstr "Odświeżanie indeksu"
 msgid "unable to create threaded lstat: %s"
 msgstr "nie można utworzyć wątkowanego lstat: %s"
 
-#: pretty.c:988
+#: pretty.c:1051
 msgid "unable to parse --pretty format"
 msgstr "nie można przetworzyć formatu --pretty"
 
@@ -6447,7 +6447,7 @@ msgstr "nie można uruchomić „log”"
 msgid "could not read `log` output"
 msgstr "nie można odczytać wyjścia „log”"
 
-#: range-diff.c:97 sequencer.c:5603
+#: range-diff.c:97 sequencer.c:5605
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr "nie można przetworzyć zapisu „%s”"
@@ -6794,8 +6794,8 @@ msgstr ""
 "Jeśli jednak usuniesz wszystko, przestawianie zostanie przerwane.\n"
 "\n"
 
-#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3886
-#: sequencer.c:3912 sequencer.c:5709 builtin/fsck.c:328 builtin/gc.c:1790
+#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3888
+#: sequencer.c:3914 sequencer.c:5711 builtin/fsck.c:328 builtin/gc.c:1789
 #: builtin/rebase.c:190
 #, c-format
 msgid "could not write '%s'"
@@ -7050,7 +7050,7 @@ msgstr "to polecenie odrzuca atom %%(%.*s)"
 
 #: ref-filter.c:1040
 #, c-format
-msgid "--format=%.*s cannot be used with--python, --shell, --tcl"
+msgid "--format=%.*s cannot be used with --python, --shell, --tcl"
 msgstr "--format=%.*s, --python, --shell i --tcl się wykluczają"
 
 #: ref-filter.c:1706
@@ -7535,7 +7535,7 @@ msgstr "nie można zapisać wpisu rerere"
 msgid "there were errors while writing '%s' (%s)"
 msgstr "wystąpiły błędy przy zapisywaniu „%s” (%s)"
 
-#: rerere.c:482 builtin/gc.c:2247 builtin/gc.c:2282
+#: rerere.c:482 builtin/gc.c:2246 builtin/gc.c:2281
 #, c-format
 msgid "failed to flush '%s'"
 msgstr "nie można wypróżnić „%s”'"
@@ -7619,7 +7619,7 @@ msgstr "nie można otworzyć katalogu pamięci podręcznej rr-cache"
 msgid "could not determine HEAD revision"
 msgstr "nie można ustalić rewizji HEAD"
 
-#: reset.c:70 reset.c:76 sequencer.c:3703
+#: reset.c:70 reset.c:76 sequencer.c:3705
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "nie znaleziono drzewa %s"
@@ -7715,7 +7715,7 @@ msgstr "nieprawidłowy tryb czyszczenia komunikatu zapisu „%s”"
 msgid "could not delete '%s'"
 msgstr "nie można usunąć „%s”"
 
-#: sequencer.c:345 sequencer.c:4752 builtin/rebase.c:563 builtin/rebase.c:1297
+#: sequencer.c:345 sequencer.c:4754 builtin/rebase.c:563 builtin/rebase.c:1297
 #: builtin/rm.c:408
 #, c-format
 msgid "could not remove '%s'"
@@ -7778,13 +7778,13 @@ msgstr ""
 "Aby przerwać i powrócić do stanu sprzed „git revert”,\n"
 "wykonaj „git revert --abort”."
 
-#: sequencer.c:448 sequencer.c:3288
+#: sequencer.c:448 sequencer.c:3290
 #, c-format
 msgid "could not lock '%s'"
 msgstr "nie można zablokować „%s”"
 
-#: sequencer.c:450 sequencer.c:3087 sequencer.c:3292 sequencer.c:3306
-#: sequencer.c:3564 sequencer.c:5619 strbuf.c:1176 wrapper.c:639
+#: sequencer.c:450 sequencer.c:3089 sequencer.c:3294 sequencer.c:3308
+#: sequencer.c:3566 sequencer.c:5621 strbuf.c:1176 wrapper.c:639
 #, c-format
 msgid "could not write to '%s'"
 msgstr "nie można pisać do „%s”"
@@ -7794,8 +7794,8 @@ msgstr "nie można pisać do „%s”"
 msgid "could not write eol to '%s'"
 msgstr "nie można pisać końca wiersza do „%s”"
 
-#: sequencer.c:460 sequencer.c:3092 sequencer.c:3294 sequencer.c:3308
-#: sequencer.c:3572
+#: sequencer.c:460 sequencer.c:3094 sequencer.c:3296 sequencer.c:3310
+#: sequencer.c:3574
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "nie można sfinalizować „%s”"
@@ -7909,11 +7909,11 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:1227
+#: sequencer.c:1229
 msgid "'prepare-commit-msg' hook failed"
 msgstr "skrypt „prepare-commit-msg” się nie powiódł"
 
-#: sequencer.c:1233
+#: sequencer.c:1235
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7941,7 +7941,7 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1246
+#: sequencer.c:1248
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7966,350 +7966,350 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1288
+#: sequencer.c:1290
 msgid "couldn't look up newly created commit"
 msgstr "nie odnaleziono nowo utworzonego zapisu"
 
-#: sequencer.c:1290
+#: sequencer.c:1292
 msgid "could not parse newly created commit"
 msgstr "nie można przetworzyć nowo utworzonego zapisu"
 
-#: sequencer.c:1336
+#: sequencer.c:1338
 msgid "unable to resolve HEAD after creating commit"
 msgstr "nie można rozwiązać HEAD po utworzeniu zapisu"
 
-#: sequencer.c:1338
+#: sequencer.c:1340
 msgid "detached HEAD"
 msgstr "oddzielone HEAD"
 
-#: sequencer.c:1342
+#: sequencer.c:1344
 msgid " (root-commit)"
 msgstr " (zapis-korzeń)"
 
-#: sequencer.c:1363
+#: sequencer.c:1365
 msgid "could not parse HEAD"
 msgstr "nie można przetworzyć HEAD"
 
-#: sequencer.c:1365
+#: sequencer.c:1367
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "HEAD %s nie jest zapisem!"
 
-#: sequencer.c:1369 sequencer.c:1447 builtin/commit.c:1707
+#: sequencer.c:1371 sequencer.c:1449 builtin/commit.c:1707
 msgid "could not parse HEAD commit"
 msgstr "nie można przetworzyć zapisu HEAD"
 
-#: sequencer.c:1425 sequencer.c:2310
+#: sequencer.c:1427 sequencer.c:2312
 msgid "unable to parse commit author"
 msgstr "nie można przetworzyć autora zapisu %s"
 
-#: sequencer.c:1436 builtin/am.c:1616 builtin/merge.c:708
+#: sequencer.c:1438 builtin/am.c:1616 builtin/merge.c:708
 msgid "git write-tree failed to write a tree"
 msgstr "git write-tree nie może zapisać drzewa"
 
-#: sequencer.c:1469 sequencer.c:1589
+#: sequencer.c:1471 sequencer.c:1591
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "nie można odczytać komunikatu zapisu z „%s”"
 
-#: sequencer.c:1500 sequencer.c:1532
+#: sequencer.c:1502 sequencer.c:1534
 #, c-format
 msgid "invalid author identity '%s'"
 msgstr "nieprawidłowa tożsamość autora „%s”"
 
-#: sequencer.c:1506
+#: sequencer.c:1508
 msgid "corrupt author: missing date information"
 msgstr "uszkodzony autor: brakuje informacji o dacie"
 
-#: sequencer.c:1545 builtin/am.c:1643 builtin/commit.c:1821 builtin/merge.c:913
+#: sequencer.c:1547 builtin/am.c:1643 builtin/commit.c:1821 builtin/merge.c:913
 #: builtin/merge.c:938 t/helper/test-fast-rebase.c:78
 msgid "failed to write commit object"
 msgstr "nie można zapisać obiektu zapisu"
 
-#: sequencer.c:1572 sequencer.c:4524 t/helper/test-fast-rebase.c:199
+#: sequencer.c:1574 sequencer.c:4526 t/helper/test-fast-rebase.c:199
 #: t/helper/test-fast-rebase.c:217
 #, c-format
 msgid "could not update %s"
 msgstr "nie można zaktualizować „%s”"
 
-#: sequencer.c:1621
+#: sequencer.c:1623
 #, c-format
 msgid "could not parse commit %s"
 msgstr "nie można przetworzyć zapisu %s"
 
-#: sequencer.c:1626
+#: sequencer.c:1628
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "nie można przetworzyć zapisu rodzica %s"
 
-#: sequencer.c:1709 sequencer.c:1990
+#: sequencer.c:1711 sequencer.c:1992
 #, c-format
 msgid "unknown command: %d"
 msgstr "nieznane pod-polecenie: %d"
 
-#: sequencer.c:1751
+#: sequencer.c:1753
 msgid "This is the 1st commit message:"
 msgstr "To jest komunikat pierwszego zapisu:"
 
-#: sequencer.c:1752
+#: sequencer.c:1754
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "To jest komunikat zapisu nr %d:"
 
-#: sequencer.c:1753
+#: sequencer.c:1755
 msgid "The 1st commit message will be skipped:"
 msgstr "Komunikat pierwszego zapisu zostanie pominięty:"
 
-#: sequencer.c:1754
+#: sequencer.c:1756
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "Komunikat zapisu nr %d zostanie pominięty:"
 
-#: sequencer.c:1755
+#: sequencer.c:1757
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr "To jest połączenie %d zapisów."
 
-#: sequencer.c:1902 sequencer.c:1959
+#: sequencer.c:1904 sequencer.c:1961
 #, c-format
 msgid "cannot write '%s'"
 msgstr "nie można pisać do „%s”"
 
-#: sequencer.c:1949
+#: sequencer.c:1951
 msgid "need a HEAD to fixup"
 msgstr "potrzeba HEAD do naprawienia"
 
-#: sequencer.c:1951 sequencer.c:3599
+#: sequencer.c:1953 sequencer.c:3601
 msgid "could not read HEAD"
 msgstr "nie można odczytać HEAD"
 
-#: sequencer.c:1953
+#: sequencer.c:1955
 msgid "could not read HEAD's commit message"
 msgstr "nie można odczytać komunikatu zapisu czoła HEAD"
 
-#: sequencer.c:1977
+#: sequencer.c:1979
 #, c-format
 msgid "could not read commit message of %s"
 msgstr "nie można odczytać komunikatu zapisu %s"
 
-#: sequencer.c:2087
+#: sequencer.c:2089
 msgid "your index file is unmerged."
 msgstr "plik indeksu jest niescalony."
 
-#: sequencer.c:2094
+#: sequencer.c:2096
 msgid "cannot fixup root commit"
 msgstr "nie można poprawić zapisu korzenia"
 
-#: sequencer.c:2113
+#: sequencer.c:2115
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "zapis %s jest scaleniem, a nie podano opcji -m."
 
-#: sequencer.c:2121 sequencer.c:2129
+#: sequencer.c:2123 sequencer.c:2131
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "zapis %s nie ma rodzica %d"
 
-#: sequencer.c:2135
+#: sequencer.c:2137
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "nie można uzyskać komunikatu zapisu dla %s"
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:2154
+#: sequencer.c:2156
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: nie można przetworzyć rodzica zapisu %s"
 
-#: sequencer.c:2220
+#: sequencer.c:2222
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "nie można zmienić nazwy „%s” na „%s”"
 
-#: sequencer.c:2280
+#: sequencer.c:2282
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "nie można odwrócić %s... %s"
 
-#: sequencer.c:2281
+#: sequencer.c:2283
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "nie można zastosować %s... %s"
 
-#: sequencer.c:2302
+#: sequencer.c:2304
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr "gubienie %s %s — zawartość łatki już wcielona w głównym nurcie\n"
 
-#: sequencer.c:2360
+#: sequencer.c:2362
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: nie można odczytać indeksu"
 
-#: sequencer.c:2368
+#: sequencer.c:2370
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: nie można odświeżyć indeksu"
 
-#: sequencer.c:2448
+#: sequencer.c:2450
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "%s nie przyjmuje argumentów: „%s”"
 
-#: sequencer.c:2457
+#: sequencer.c:2459
 #, c-format
 msgid "missing arguments for %s"
 msgstr "brakujące argumenty dla %s"
 
-#: sequencer.c:2500
+#: sequencer.c:2502
 #, c-format
 msgid "could not parse '%s'"
 msgstr "nie można przetworzyć „%s”"
 
-#: sequencer.c:2561
+#: sequencer.c:2563
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "nieprawidłowy wiersz %d: %.*s"
 
-#: sequencer.c:2572
+#: sequencer.c:2574
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "nie można użyć „%s” bez poprzedniego zapisu"
 
-#: sequencer.c:2620 builtin/rebase.c:184
+#: sequencer.c:2622 builtin/rebase.c:184
 #, c-format
 msgid "could not read '%s'."
 msgstr "nie można odczytać „%s”."
 
-#: sequencer.c:2658
+#: sequencer.c:2660
 msgid "cancelling a cherry picking in progress"
 msgstr "przerywanie trwającego dobierania"
 
-#: sequencer.c:2667
+#: sequencer.c:2669
 msgid "cancelling a revert in progress"
 msgstr "przerywanie trwającego odwracania"
 
-#: sequencer.c:2707
+#: sequencer.c:2709
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr "napraw to używając „git rebase --edit-todo”."
 
-#: sequencer.c:2709
+#: sequencer.c:2711
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "plik z instrukcjami się nie nadaje: „%s”"
 
-#: sequencer.c:2714
+#: sequencer.c:2716
 msgid "no commits parsed."
 msgstr "nie przetworzono żadnego zapisu."
 
-#: sequencer.c:2725
+#: sequencer.c:2727
 msgid "cannot cherry-pick during a revert."
 msgstr "nie można dobierać w czasie odwracania."
 
-#: sequencer.c:2727
+#: sequencer.c:2729
 msgid "cannot revert during a cherry-pick."
 msgstr "nie można odwrócić w czasie dobierania."
 
-#: sequencer.c:2805
+#: sequencer.c:2807
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr "nieprawidłowa wartość %s: %s"
 
-#: sequencer.c:2914
+#: sequencer.c:2916
 msgid "unusable squash-onto"
 msgstr "spłaszcz-na się nie nadaje"
 
-#: sequencer.c:2934
+#: sequencer.c:2936
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "nieprawidłowy plik opcji: „%s”"
 
-#: sequencer.c:3029 sequencer.c:4903
+#: sequencer.c:3031 sequencer.c:4905
 msgid "empty commit set passed"
 msgstr "podano pusty zbiór zapisów"
 
-#: sequencer.c:3046
+#: sequencer.c:3048
 msgid "revert is already in progress"
 msgstr "już trwa dobieranie"
 
-#: sequencer.c:3048
+#: sequencer.c:3050
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr "spróbuj „git revert (--continue | %s--abort | --quit)”"
 
-#: sequencer.c:3051
+#: sequencer.c:3053
 msgid "cherry-pick is already in progress"
 msgstr "już trwa dobieranie"
 
-#: sequencer.c:3053
+#: sequencer.c:3055
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr "spróbuj „git cherry-pick (--continue | %s--abort | --quit)”"
 
-#: sequencer.c:3067
+#: sequencer.c:3069
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr "nie można utworzyć katalogu sekwencjonowania „%s”"
 
-#: sequencer.c:3082
+#: sequencer.c:3084
 msgid "could not lock HEAD"
 msgstr "nie można zablokować HEAD"
 
-#: sequencer.c:3142 sequencer.c:4613
+#: sequencer.c:3144 sequencer.c:4615
 msgid "no cherry-pick or revert in progress"
 msgstr "nie trwa dobieranie ani odwracanie"
 
-#: sequencer.c:3144 sequencer.c:3155
+#: sequencer.c:3146 sequencer.c:3157
 msgid "cannot resolve HEAD"
 msgstr "nie można rozwiązać HEAD"
 
-#: sequencer.c:3146 sequencer.c:3190
+#: sequencer.c:3148 sequencer.c:3192
 msgid "cannot abort from a branch yet to be born"
 msgstr "nie można przerwać z gałęzi, która dopiero ma powstać"
 
-#: sequencer.c:3176 builtin/grep.c:772
+#: sequencer.c:3178 builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr "nie można otworzyć „%s”"
 
-#: sequencer.c:3178
+#: sequencer.c:3180
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "nie można odczytać „%s”: %s"
 
-#: sequencer.c:3179
+#: sequencer.c:3181
 msgid "unexpected end of file"
 msgstr "nieoczekiwany koniec pliku"
 
-#: sequencer.c:3185
+#: sequencer.c:3187
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr "zapisany plik HEAD sprzed dobierania „%s” jest uszkodzony"
 
-#: sequencer.c:3196
+#: sequencer.c:3198
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr ""
 "Wydaje się, że czoło HEAD się przesunęło.\n"
 "Nie cofam, sprawdź swoje HEAD!"
 
-#: sequencer.c:3237
+#: sequencer.c:3239
 msgid "no revert in progress"
 msgstr "nie trwa żadne odwracanie"
 
-#: sequencer.c:3246
+#: sequencer.c:3248
 msgid "no cherry-pick in progress"
 msgstr "nie trwa żadne dobieranie"
 
-#: sequencer.c:3256
+#: sequencer.c:3258
 msgid "failed to skip the commit"
 msgstr "nie udało się pominąć zapisu"
 
-#: sequencer.c:3263
+#: sequencer.c:3265
 msgid "there is nothing to skip"
 msgstr "nie ma nic do pominięcia"
 
-#: sequencer.c:3266
+#: sequencer.c:3268
 #, c-format
 msgid ""
 "have you committed already?\n"
@@ -8318,16 +8318,16 @@ msgstr ""
 "zapis już złożony?\n"
 "spróbuj „git %s --continue”"
 
-#: sequencer.c:3428 sequencer.c:4504
+#: sequencer.c:3430 sequencer.c:4506
 msgid "cannot read HEAD"
 msgstr "nie można odczytać HEAD"
 
-#: sequencer.c:3445
+#: sequencer.c:3447
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "nie można skopiować „%s” do „%s”"
 
-#: sequencer.c:3453
+#: sequencer.c:3455
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -8346,27 +8346,27 @@ msgstr ""
 "\n"
 "\tgit rebase --continue\n"
 
-#: sequencer.c:3463
+#: sequencer.c:3465
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "Nie można zastosować %s... %.*s"
 
-#: sequencer.c:3470
+#: sequencer.c:3472
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "Nie można scalić %.*s"
 
-#: sequencer.c:3484 sequencer.c:3488 builtin/difftool.c:639
+#: sequencer.c:3486 sequencer.c:3490 builtin/difftool.c:639
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "nie można skopiować „%s” do „%s”"
 
-#: sequencer.c:3500
+#: sequencer.c:3502
 #, c-format
 msgid "Executing: %s\n"
 msgstr "Wykonywanie: %s\n"
 
-#: sequencer.c:3515
+#: sequencer.c:3517
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -8381,11 +8381,11 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3521
+#: sequencer.c:3523
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "i pozostały zmiany w indeksie i/lub drzewie roboczym\n"
 
-#: sequencer.c:3527
+#: sequencer.c:3529
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -8402,90 +8402,90 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3589
+#: sequencer.c:3591
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "nieprawidłowa nazwa etykietki „%.*s”"
 
-#: sequencer.c:3662
+#: sequencer.c:3664
 msgid "writing fake root commit"
 msgstr "zapisywanie fałszywego zapisu korzenia"
 
-#: sequencer.c:3667
+#: sequencer.c:3669
 msgid "writing squash-onto"
 msgstr "zapisywanie spłaszcz-na"
 
-#: sequencer.c:3746
+#: sequencer.c:3748
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "nie można rozwiązać „%s”"
 
-#: sequencer.c:3778
+#: sequencer.c:3780
 msgid "cannot merge without a current revision"
 msgstr "nie można scalić bez bieżącej rewizji"
 
-#: sequencer.c:3800
+#: sequencer.c:3802
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "nie można przetworzyć „%.*s”"
 
-#: sequencer.c:3809
+#: sequencer.c:3811
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "nic do scalenia: „%.*s”"
 
-#: sequencer.c:3821
+#: sequencer.c:3823
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr "nie można wykonać ośmiorniczego scalenia na szczycie [nowego korzenia]"
 
-#: sequencer.c:3876
+#: sequencer.c:3878
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "nie można uzyskać komunikatu zapisu „%s”"
 
-#: sequencer.c:4022
+#: sequencer.c:4024
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "nie można nawet spróbować scalić „%.*s”"
 
-#: sequencer.c:4038
+#: sequencer.c:4040
 msgid "merge: Unable to write new index file"
 msgstr "scalanie: Nie można zapisać nowego pliku indeksu"
 
-#: sequencer.c:4119
+#: sequencer.c:4121
 msgid "Cannot autostash"
 msgstr "Nie można automatycznie dodać do schowka"
 
-#: sequencer.c:4122
+#: sequencer.c:4124
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Nieoczekiwana odpowiedź schowka: „%s”"
 
-#: sequencer.c:4128
+#: sequencer.c:4130
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "Nie można utworzyć katalogu dla „%s”"
 
-#: sequencer.c:4131
+#: sequencer.c:4133
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "Automatycznie zapisano w schowku: %s\n"
 
-#: sequencer.c:4135
+#: sequencer.c:4137
 msgid "could not reset --hard"
 msgstr "nie można zresetować --hard"
 
-#: sequencer.c:4160
+#: sequencer.c:4162
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "Zastosowano zmiany z automatycznego schowka.\n"
 
-#: sequencer.c:4172
+#: sequencer.c:4174
 #, c-format
 msgid "cannot store %s"
 msgstr "nie można zapisać %s"
 
-#: sequencer.c:4175
+#: sequencer.c:4177
 #, c-format
 msgid ""
 "%s\n"
@@ -8496,30 +8496,30 @@ msgstr ""
 "Twoje zmiany są bezpieczne w schowku.\n"
 "Możesz w każdej chwili wykonać „git stash pop” lub „git stash drop”.\n"
 
-#: sequencer.c:4180
+#: sequencer.c:4182
 msgid "Applying autostash resulted in conflicts."
 msgstr "Stosowanie zmian z automatycznego schowka spowodowało konflikty."
 
-#: sequencer.c:4181
+#: sequencer.c:4183
 msgid "Autostash exists; creating a new stash entry."
 msgstr ""
 "W schowku istnieje automatyczny wpis; tworzenie nowego wpisu w schowku."
 
-#: sequencer.c:4253
+#: sequencer.c:4255
 msgid "could not detach HEAD"
 msgstr "nie można odłączyć HEAD"
 
-#: sequencer.c:4268
+#: sequencer.c:4270
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Zatrzymano przy HEAD\n"
 
-#: sequencer.c:4270
+#: sequencer.c:4272
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Zatrzymano przy %s\n"
 
-#: sequencer.c:4302
+#: sequencer.c:4304
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -8540,58 +8540,58 @@ msgstr ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:4348
+#: sequencer.c:4350
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr "Przestawianie (%d/%d)%s"
 
-#: sequencer.c:4394
+#: sequencer.c:4396
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Zatrzymano na %s... %.*s\n"
 
-#: sequencer.c:4464
+#: sequencer.c:4466
 #, c-format
 msgid "unknown command %d"
 msgstr "nieznane polecenie %d"
 
-#: sequencer.c:4512
+#: sequencer.c:4514
 msgid "could not read orig-head"
 msgstr "nie można odczytać pierwotnego czoła"
 
-#: sequencer.c:4517
+#: sequencer.c:4519
 msgid "could not read 'onto'"
 msgstr "nie można odczytać „onto”"
 
-#: sequencer.c:4531
+#: sequencer.c:4533
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "nie można zapisać HEAD do %s"
 
-#: sequencer.c:4591
+#: sequencer.c:4593
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr "Pomyślnie przestawiono i zaktualizowano %s.\n"
 
-#: sequencer.c:4643
+#: sequencer.c:4645
 msgid "cannot rebase: You have unstaged changes."
 msgstr "nie można przestawić: Masz nieprzygotowane zmiany."
 
-#: sequencer.c:4652
+#: sequencer.c:4654
 msgid "cannot amend non-existing commit"
 msgstr "nie można poprawić nieistniejącego obiektu"
 
-#: sequencer.c:4654
+#: sequencer.c:4656
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "nieprawidłowy plik: „%s”"
 
-#: sequencer.c:4656
+#: sequencer.c:4658
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "nieprawidłowa zawartość: „%s”"
 
-#: sequencer.c:4659
+#: sequencer.c:4661
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -8601,59 +8601,59 @@ msgstr ""
 "Masz niezłożone zmiany w drzewie roboczym. Najpierw je złóż\n"
 "i wtedy ponownie wykonaj „git rebase --continue”."
 
-#: sequencer.c:4695 sequencer.c:4734
+#: sequencer.c:4697 sequencer.c:4736
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "nie można zapisać pliku: „%s”"
 
-#: sequencer.c:4750
+#: sequencer.c:4752
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "nie można usunąć CHERRY_PICK_HEAD"
 
-#: sequencer.c:4760
+#: sequencer.c:4762
 msgid "could not commit staged changes."
 msgstr "nie udało się złożyć zmian ze schowka."
 
-#: sequencer.c:4880
+#: sequencer.c:4882
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: nie można dobrać %s"
 
-#: sequencer.c:4884
+#: sequencer.c:4886
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: zła rewizja"
 
-#: sequencer.c:4919
+#: sequencer.c:4921
 msgid "can't revert as initial commit"
 msgstr "nie można odwrócić jako pierwszy zapis"
 
-#: sequencer.c:5190 sequencer.c:5419
+#: sequencer.c:5192 sequencer.c:5421
 #, c-format
 msgid "skipped previously applied commit %s"
 msgstr "pominięto uprzednio zastosowany zapis %s"
 
-#: sequencer.c:5260 sequencer.c:5435
+#: sequencer.c:5262 sequencer.c:5437
 msgid "use --reapply-cherry-picks to include skipped commits"
 msgstr "użyj --reapply-cherry-picks, by uwzględnić pominięte zapisy"
 
-#: sequencer.c:5406
+#: sequencer.c:5408
 msgid "make_script: unhandled options"
 msgstr "make_script: nieobsłużone opcje"
 
-#: sequencer.c:5409
+#: sequencer.c:5411
 msgid "make_script: error preparing revisions"
 msgstr "make_script: błąd przygotowania rewizji"
 
-#: sequencer.c:5667 sequencer.c:5684
+#: sequencer.c:5669 sequencer.c:5686
 msgid "nothing to do"
 msgstr "nic do zrobienia"
 
-#: sequencer.c:5703
+#: sequencer.c:5705
 msgid "could not skip unnecessary pick commands"
 msgstr "nie można pominąć niepotrzebnych poleceń pick"
 
-#: sequencer.c:5803
+#: sequencer.c:5805
 msgid "the script was already rearranged."
 msgstr "kolejność skryptu została już zmieniona."
 
@@ -11395,8 +11395,8 @@ msgid ""
 "bisect run failed: 'git bisect--helper --bisect-state %s' exited with error "
 "code %d"
 msgstr ""
-"przeszukanie nie powiodło się: „git bisect--helper --bisect-state %s”"
-" zakończył się z kodem błędu %d"
+"przeszukanie nie powiodło się: „git bisect--helper --bisect-state %s” "
+"zakończył się z kodem błędu %d"
 
 #: builtin/bisect--helper.c:1192
 msgid "reset the bisection state"
@@ -13637,7 +13637,7 @@ msgstr "maksymalna liczba filtrów Blooma zmienionych ścieżek do obliczenia"
 msgid "use at most one of --reachable, --stdin-commits, or --stdin-packs"
 msgstr "--reachable, --stdin-commits i --stdin-packs wykluczają się"
 
-#: builtin/commit-graph.c:283
+#: builtin/commit-graph.c:282
 msgid "Collecting commits from input"
 msgstr "Zbieranie zapisów z wejścia"
 
@@ -15951,16 +15951,16 @@ msgstr "pokazuj postęp"
 msgid "show verbose names for reachable objects"
 msgstr "pokaż rozwlekłe nazwy osiągalnych obiektów"
 
-#: builtin/fsck.c:860 builtin/index-pack.c:261
+#: builtin/fsck.c:861 builtin/index-pack.c:261
 msgid "Checking objects"
 msgstr "Sprawdzanie obiektów"
 
-#: builtin/fsck.c:888
+#: builtin/fsck.c:889
 #, c-format
 msgid "%s: object missing"
 msgstr "%s: brakujący obiekt"
 
-#: builtin/fsck.c:899
+#: builtin/fsck.c:900
 #, c-format
 msgid "invalid parameter: expected sha1, got '%s'"
 msgstr "nieprawidłowy parametr: oczekiwano SHA-1, otrzymano „%s”"
@@ -16095,175 +16095,175 @@ msgstr "nie można uruchomić procesu „git pack-objects”"
 msgid "failed to finish 'git pack-objects' process"
 msgstr "nie można ukończyć procesu „git pack-objects”"
 
-#: builtin/gc.c:1089
+#: builtin/gc.c:1088
 msgid "failed to write multi-pack-index"
 msgstr "nie można zapisać indeksu wielu paczek"
 
-#: builtin/gc.c:1105
+#: builtin/gc.c:1104
 msgid "'git multi-pack-index expire' failed"
 msgstr "„git multi-pack-index expire” nie powiodło się"
 
-#: builtin/gc.c:1164
+#: builtin/gc.c:1163
 msgid "'git multi-pack-index repack' failed"
 msgstr "„git multi-pack-index repack” nie powiodło się"
 
-#: builtin/gc.c:1173
+#: builtin/gc.c:1172
 msgid ""
 "skipping incremental-repack task because core.multiPackIndex is disabled"
 msgstr ""
 "pomijanie zadania przyrostowego przepakowania, bo core.multiPackIndex jest "
 "wyłączone"
 
-#: builtin/gc.c:1277
+#: builtin/gc.c:1276
 #, c-format
 msgid "lock file '%s' exists, skipping maintenance"
 msgstr "istnieje plik blokady „%s”, pomijanie porządków"
 
-#: builtin/gc.c:1307
+#: builtin/gc.c:1306
 #, c-format
 msgid "task '%s' failed"
 msgstr "zadanie „%s” nie powiodło się"
 
-#: builtin/gc.c:1389
+#: builtin/gc.c:1388
 #, c-format
 msgid "'%s' is not a valid task"
 msgstr "„%s” nie jest prawidłowym zadaniem"
 
-#: builtin/gc.c:1394
+#: builtin/gc.c:1393
 #, c-format
 msgid "task '%s' cannot be selected multiple times"
 msgstr "nie można wybrać wiele razy zadania „%s”"
 
-#: builtin/gc.c:1409
+#: builtin/gc.c:1408
 msgid "run tasks based on the state of the repository"
 msgstr "uruchamiaj zadania w oparciu o stan repozytorium"
 
-#: builtin/gc.c:1410
+#: builtin/gc.c:1409
 msgid "frequency"
 msgstr "częstotliwość"
 
-#: builtin/gc.c:1411
+#: builtin/gc.c:1410
 msgid "run tasks based on frequency"
 msgstr "uruchamiaj zadania w oparciu o częstotliwość"
 
-#: builtin/gc.c:1414
+#: builtin/gc.c:1413
 msgid "do not report progress or other information over stderr"
 msgstr ""
 "nie zgłaszaj postępu ani innych informacji na standardowe wyjście "
 "diagnostyczne"
 
-#: builtin/gc.c:1415
+#: builtin/gc.c:1414
 msgid "task"
 msgstr "zadanie"
 
-#: builtin/gc.c:1416
+#: builtin/gc.c:1415
 msgid "run a specific task"
 msgstr "uruchom konkretne zadanie"
 
-#: builtin/gc.c:1433
+#: builtin/gc.c:1432
 msgid "use at most one of --auto and --schedule=<frequency>"
 msgstr "--auto i --schedule=<frequency> się wykluczają"
 
-#: builtin/gc.c:1476
+#: builtin/gc.c:1475
 msgid "failed to run 'git config'"
 msgstr "nie można wykonać „git config”"
 
-#: builtin/gc.c:1628
+#: builtin/gc.c:1627
 #, c-format
 msgid "failed to expand path '%s'"
 msgstr "nie można rozwinąć ścieżki „%s”"
 
-#: builtin/gc.c:1655 builtin/gc.c:1693
+#: builtin/gc.c:1654 builtin/gc.c:1692
 msgid "failed to start launchctl"
 msgstr "nie można uruchomić launchctl"
 
-#: builtin/gc.c:1768 builtin/gc.c:2221
+#: builtin/gc.c:1767 builtin/gc.c:2220
 #, c-format
 msgid "failed to create directories for '%s'"
 msgstr "nie można utworzyć katalogów na „%s”"
 
-#: builtin/gc.c:1795
+#: builtin/gc.c:1794
 #, c-format
 msgid "failed to bootstrap service %s"
 msgstr "nie można wydostać usługi %s"
 
-#: builtin/gc.c:1888
+#: builtin/gc.c:1887
 msgid "failed to create temp xml file"
 msgstr "nie można utworzyć tymczasowego pliku XML"
 
-#: builtin/gc.c:1978
+#: builtin/gc.c:1977
 msgid "failed to start schtasks"
 msgstr "nie można uruchomić schtasks"
 
-#: builtin/gc.c:2047
+#: builtin/gc.c:2046
 msgid "failed to run 'crontab -l'; your system might not support 'cron'"
 msgstr "nie można wykonać „crontab -l”; ten system może nie wspierać crona"
 
-#: builtin/gc.c:2064
+#: builtin/gc.c:2063
 msgid "failed to run 'crontab'; your system might not support 'cron'"
 msgstr "nie można wykonać „crontab”; ten system może nie wspierać crona"
 
-#: builtin/gc.c:2068
+#: builtin/gc.c:2067
 msgid "failed to open stdin of 'crontab'"
 msgstr "nie można otworzyć standardowego wejścia „crontab”"
 
-#: builtin/gc.c:2110
+#: builtin/gc.c:2109
 msgid "'crontab' died"
 msgstr "„crontab” padł"
 
-#: builtin/gc.c:2175
+#: builtin/gc.c:2174
 msgid "failed to start systemctl"
 msgstr "nie można uruchomić systemctl"
 
-#: builtin/gc.c:2185
+#: builtin/gc.c:2184
 msgid "failed to run systemctl"
 msgstr "nie można wykonać systemctl"
 
-#: builtin/gc.c:2194 builtin/gc.c:2199 builtin/worktree.c:62
+#: builtin/gc.c:2193 builtin/gc.c:2198 builtin/worktree.c:62
 #: builtin/worktree.c:945
 #, c-format
 msgid "failed to delete '%s'"
 msgstr "nie można skasować „%s”"
 
-#: builtin/gc.c:2379
+#: builtin/gc.c:2378
 #, c-format
 msgid "unrecognized --scheduler argument '%s'"
 msgstr "nierozpoznany argument --scheduler „%s”"
 
-#: builtin/gc.c:2404
+#: builtin/gc.c:2403
 msgid "neither systemd timers nor crontab are available"
 msgstr "nie jest dostępny ani crontab, ani wyzwalacze systemd"
 
-#: builtin/gc.c:2419
+#: builtin/gc.c:2418
 #, c-format
 msgid "%s scheduler is not available"
 msgstr "planista %s nie jest dostępny"
 
-#: builtin/gc.c:2433
+#: builtin/gc.c:2432
 msgid "another process is scheduling background maintenance"
 msgstr "inny proces planuje porządki w tle"
 
-#: builtin/gc.c:2455
+#: builtin/gc.c:2454
 msgid "git maintenance start [--scheduler=<scheduler>]"
 msgstr "git maintenance start [--scheduler=<planista>]"
 
-#: builtin/gc.c:2464
+#: builtin/gc.c:2463
 msgid "scheduler"
 msgstr "planista"
 
-#: builtin/gc.c:2465
+#: builtin/gc.c:2464
 msgid "scheduler to trigger git maintenance run"
 msgstr "planista do wyzwolenia sprzątania repozytorium"
 
-#: builtin/gc.c:2479
+#: builtin/gc.c:2478
 msgid "failed to add repo to global config"
 msgstr "nie można dodać repozytorium do globalnej konfiguracji"
 
-#: builtin/gc.c:2488
+#: builtin/gc.c:2487
 msgid "git maintenance <subcommand> [<options>]"
 msgstr "git maintenance <pod-polecenie> [<opcje>]"
 
-#: builtin/gc.c:2507
+#: builtin/gc.c:2506
 #, c-format
 msgid "invalid subcommand: %s"
 msgstr "nieprawidłowe pod-polecenie: %s"
@@ -16921,7 +16921,7 @@ msgstr "nie można zamknąć zapisanego pliku %s „%s”"
 
 #: builtin/index-pack.c:1489
 #, c-format
-msgid "unable to rename temporary '*.%s' file to '%s"
+msgid "unable to rename temporary '*.%s' file to '%s'"
 msgstr "nie można zmienić nazwy pliku tymczasowego „*.%s” na „%s”"
 
 #: builtin/index-pack.c:1514
@@ -20068,10 +20068,9 @@ msgid ""
 "[-u | -i]] [--no-sparse-checkout] [--index-output=<file>] (--empty | <tree-"
 "ish1> [<tree-ish2> [<tree-ish3>]])"
 msgstr ""
-"git read-tree [(-m [--trivial] [--aggressive] | --reset | --prefix=<prefiks>) "
-"[-u | -i]] [--no-sparse-checkout] [--index-output=<plik>] (--empty | <drzewo1"
-"> "
-"[<drzewo2> [<drzewo3>]])"
+"git read-tree [(-m [--trivial] [--aggressive] | --reset | --"
+"prefix=<prefiks>) [-u | -i]] [--no-sparse-checkout] [--index-output=<plik>] "
+"(--empty | <drzewo1> [<drzewo2> [<drzewo3>]])"
 
 #: builtin/read-tree.c:116
 msgid "write resulting index to <file>"
@@ -22219,7 +22218,8 @@ msgstr ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
 "                [--current] [--color[=<kiedy>] | --no-color] [--sparse]\n"
 "                [--more=<n> | --list | --independent | --merge-base]\n"
-"                [--no-name | --sha1-name] [--topics] [(<rewizja> | <glob>)...]"
+"                [--no-name | --sha1-name] [--topics] [(<rewizja> | "
+"<glob>)...]"
 
 #: builtin/show-branch.c:17
 msgid "git show-branch (-g | --reflog)[=<n>[,<base>]] [--list] [<ref>]"
@@ -22423,8 +22423,8 @@ msgid ""
 "directory '%s' contains untracked files, but is not in the sparse-checkout "
 "cone"
 msgstr ""
-"katalog „%s” zawiera nieśledzone pliki, ale jest poza stożkiem rzadkiego"
-" wybrania"
+"katalog „%s” zawiera nieśledzone pliki, ale jest poza stożkiem rzadkiego "
+"wybrania"
 
 #: builtin/sparse-checkout.c:181
 #, c-format
@@ -23201,9 +23201,7 @@ msgstr "Nie można scalić „%s” w ścieżce podmodułu „%s”"
 #: builtin/submodule--helper.c:2384
 #, c-format
 msgid "Execution of '%s %s' failed in submodule path '%s'"
-msgstr ""
-"Wykonanie „%s %s” nie powiodło się w ścieżce podmodułu "
-"„%s”"
+msgstr "Wykonanie „%s %s” nie powiodło się w ścieżce podmodułu „%s”"
 
 #: builtin/submodule--helper.c:2408
 #, c-format
@@ -23229,8 +23227,7 @@ msgstr "Ścieżka podmodułu „%s”: „%s %s”\n"
 #, c-format
 msgid "Unable to fetch in submodule path '%s'; trying to directly fetch %s:"
 msgstr ""
-"Nie można pobrać w ścieżce podmodułu „%s”; próba bezpośredniego "
-"pobrania %s:"
+"Nie można pobrać w ścieżce podmodułu „%s”; próba bezpośredniego pobrania %s:"
 
 #: builtin/submodule--helper.c:2453
 #, c-format
@@ -23238,8 +23235,8 @@ msgid ""
 "Fetched in submodule path '%s', but it did not contain %s. Direct fetching "
 "of that commit failed."
 msgstr ""
-"Pobrano w ścieżce podmodułu „%s”, ale nie zawierał on %s. "
-"Bezpośrednie pobieranie tego zapisu nie powiodło się."
+"Pobrano w ścieżce podmodułu „%s”, ale nie zawierał on %s. Bezpośrednie "
+"pobieranie tego zapisu nie powiodło się."
 
 #: builtin/submodule--helper.c:2504 builtin/submodule--helper.c:2574
 #: builtin/submodule--helper.c:2812

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git 2.34.0\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-11-04 08:34+0800\n"
-"PO-Revision-Date: 2021-11-04 20:44+0100\n"
+"POT-Creation-Date: 2021-11-10 08:55+0800\n"
+"PO-Revision-Date: 2021-11-11 23:20+0100\n"
 "Last-Translator: Peter Krefting <peter@softwolves.pp.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
 "Language: sv\n"
@@ -211,7 +211,7 @@ msgstr "ej köad"
 
 #: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
 #: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:190
+#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:194
 #: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
 #: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
 #: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
@@ -10427,7 +10427,7 @@ msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr "Följande sökvägar ignoreras av en av dina .gitignore-filer:\n"
 
 #: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
-#: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:550
+#: builtin/prune-packed.c:14 builtin/pull.c:208 builtin/push.c:550
 #: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr "testkörning"
@@ -10890,11 +10890,11 @@ msgstr "sänd det genom git-apply"
 
 #: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
 #: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
-#: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
+#: builtin/pull.c:142 builtin/pull.c:204 builtin/pull.c:221
 #: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
 #: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
 #: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
-#: parse-options.h:316
+#: parse-options.h:315
 msgid "n"
 msgstr "n"
 
@@ -10945,7 +10945,7 @@ msgid "use current timestamp for author date"
 msgstr "använd nuvarande tidsstämpel för författardatum"
 
 #: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
-#: builtin/merge.c:299 builtin/pull.c:175 builtin/rebase.c:1099
+#: builtin/merge.c:299 builtin/pull.c:179 builtin/rebase.c:1099
 #: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
 msgstr "nyckel-id"
@@ -11452,7 +11452,7 @@ msgstr "visa statistik över arbetskostnad"
 #: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
 #: builtin/merge.c:298 builtin/multi-pack-index.c:103
 #: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
-#: builtin/multi-pack-index.c:204 builtin/pull.c:119 builtin/push.c:566
+#: builtin/multi-pack-index.c:204 builtin/pull.c:120 builtin/push.c:566
 #: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "tvinga förloppsrapportering"
@@ -12721,7 +12721,7 @@ msgstr "saknar gren- eller incheckingsargument"
 msgid "perform a 3-way merge with the new branch"
 msgstr "utför en 3-vägssammanslagning för den nya grenen"
 
-#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:322
+#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:321
 msgid "style"
 msgstr "stil"
 
@@ -13149,7 +13149,7 @@ msgid "path to git-upload-pack on the remote"
 msgstr "sökväg till git-upload-pack på fjärren"
 
 #: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
-#: builtin/pull.c:208
+#: builtin/pull.c:212
 msgid "depth"
 msgstr "djup"
 
@@ -13158,7 +13158,7 @@ msgid "create a shallow clone of that depth"
 msgstr "skapa en grund klon på detta djup"
 
 #: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
-#: builtin/pull.c:211
+#: builtin/pull.c:215
 msgid "time"
 msgstr "tid"
 
@@ -13167,11 +13167,11 @@ msgid "create a shallow clone since a specific time"
 msgstr "skapa en grund klon från en angiven tidpunkt"
 
 #: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1022
+#: builtin/pull.c:218 builtin/pull.c:243 builtin/rebase.c:1022
 msgid "revision"
 msgstr "revision"
 
-#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:215
+#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:219
 msgid "deepen history of shallow clone, excluding rev"
 msgstr "fördjupa historik för grund klon, exkludera revisionen"
 
@@ -13205,23 +13205,23 @@ msgid "set config inside the new repository"
 msgstr "ställ in konfiguration i det nya arkivet"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:200
+#: builtin/pull.c:234 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "serverspecifik"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:201
+#: builtin/pull.c:235 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr ""
 "inget att checka in\n"
 "flagga att sända"
 
-#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:234
+#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:238
 #: builtin/push.c:576
 msgid "use IPv4 addresses only"
 msgstr "använd endast IPv4-adresser"
 
-#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:237
+#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:241
 #: builtin/push.c:578
 msgid "use IPv6 addresses only"
 msgstr "använd endast IPv6-adresser"
@@ -13612,7 +13612,7 @@ msgid "read commit log message from file"
 msgstr "läs incheckningsloggmeddelande från fil"
 
 #: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
-#: builtin/pull.c:176 builtin/revert.c:118
+#: builtin/pull.c:180 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "GPG-signera incheckning"
 
@@ -14023,7 +14023,7 @@ msgstr "terminera poster med NUL"
 
 #: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
 #: builtin/fast-export.c:1199 builtin/fast-export.c:1202
-#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:336
+#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:335
 msgid "mode"
 msgstr "läge"
 
@@ -14100,7 +14100,7 @@ msgid "override date for commit"
 msgstr "överstyr datum för incheckningen"
 
 #: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
-#: parse-options.h:328 ref-filter.h:92
+#: parse-options.h:327 ref-filter.h:92
 msgid "commit"
 msgstr "incheckning"
 
@@ -14145,7 +14145,7 @@ msgid "add custom trailer(s)"
 msgstr "använd skräddarsydd(a) släprad(er)"
 
 #: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
-#: builtin/pull.c:145 builtin/revert.c:110
+#: builtin/pull.c:146 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "lägg till Signed-off-by-släprad"
 
@@ -15121,15 +15121,15 @@ msgstr "git fetch --all [<flaggor>]"
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel kan inte vara negativt"
 
-#: builtin/fetch.c:145 builtin/pull.c:185
+#: builtin/fetch.c:145 builtin/pull.c:189
 msgid "fetch from all remotes"
 msgstr "hämta från alla fjärrar"
 
-#: builtin/fetch.c:147 builtin/pull.c:245
+#: builtin/fetch.c:147 builtin/pull.c:249
 msgid "set upstream for git pull/fetch"
 msgstr "ställ in uppström för git pull/fetch"
 
-#: builtin/fetch.c:149 builtin/pull.c:188
+#: builtin/fetch.c:149 builtin/pull.c:192
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "lägg till i .git/FETCH_HEAD istället för att skriva över"
 
@@ -15137,7 +15137,7 @@ msgstr "lägg till i .git/FETCH_HEAD istället för att skriva över"
 msgid "use atomic transaction to update references"
 msgstr "använd atomiska transaktioner för att uppdatera referenser"
 
-#: builtin/fetch.c:153 builtin/pull.c:191
+#: builtin/fetch.c:153 builtin/pull.c:195
 msgid "path to upload pack on remote end"
 msgstr "sökväg till upload pack på fjärren"
 
@@ -15149,7 +15149,7 @@ msgstr "tvinga överskrivning av lokal referens"
 msgid "fetch from multiple remotes"
 msgstr "hämta från flera fjärrar"
 
-#: builtin/fetch.c:158 builtin/pull.c:195
+#: builtin/fetch.c:158 builtin/pull.c:199
 msgid "fetch all tags and associated objects"
 msgstr "hämta alla taggar och associerade objekt"
 
@@ -15167,7 +15167,7 @@ msgstr ""
 "modifiera referensspecifikationen så att alla referenser hamnar i refs/"
 "prefetch/"
 
-#: builtin/fetch.c:166 builtin/pull.c:198
+#: builtin/fetch.c:166 builtin/pull.c:202
 msgid "prune remote-tracking branches no longer on remote"
 msgstr "rensa fjärrspårande grenar ej längre på fjärren"
 
@@ -15176,7 +15176,7 @@ msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr ""
 "rensa lokala taggar inte längre på fjärren och skriv över ändrade taggar"
 
-#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:122
+#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:123
 msgid "on-demand"
 msgstr "on-demand"
 
@@ -15188,7 +15188,7 @@ msgstr "styr rekursiv hämtning av undermoduler"
 msgid "write fetched references to the FETCH_HEAD file"
 msgstr "skriv hämtade referenser till FETCH_HEAD-filen"
 
-#: builtin/fetch.c:176 builtin/pull.c:206
+#: builtin/fetch.c:176 builtin/pull.c:210
 msgid "keep downloaded pack"
 msgstr "behåll hämtade paket"
 
@@ -15196,16 +15196,16 @@ msgstr "behåll hämtade paket"
 msgid "allow updating of HEAD ref"
 msgstr "tillåt uppdatering av HEAD-referens"
 
-#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:209
-#: builtin/pull.c:218
+#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:213
+#: builtin/pull.c:222
 msgid "deepen history of shallow clone"
 msgstr "fördjupa historik för grund klon"
 
-#: builtin/fetch.c:183 builtin/pull.c:212
+#: builtin/fetch.c:183 builtin/pull.c:216
 msgid "deepen history of shallow repository based on time"
 msgstr "fördjupa historik för grund klon baserad på tid"
 
-#: builtin/fetch.c:189 builtin/pull.c:221
+#: builtin/fetch.c:189 builtin/pull.c:225
 msgid "convert to a complete repository"
 msgstr "konvertera till komplett arkiv"
 
@@ -15221,19 +15221,19 @@ msgstr ""
 "standard för rekursiv hämtning av undermoduler (lägre prioritet än "
 "konfigurationsfiler)"
 
-#: builtin/fetch.c:199 builtin/pull.c:224
+#: builtin/fetch.c:199 builtin/pull.c:228
 msgid "accept refs that update .git/shallow"
 msgstr "tar emot referenser som uppdaterar .git/shallow"
 
-#: builtin/fetch.c:200 builtin/pull.c:226
+#: builtin/fetch.c:200 builtin/pull.c:230
 msgid "refmap"
 msgstr "referenskarta"
 
-#: builtin/fetch.c:201 builtin/pull.c:227
+#: builtin/fetch.c:201 builtin/pull.c:231
 msgid "specify fetch refmap"
 msgstr "ange referenskarta för \"fetch\""
 
-#: builtin/fetch.c:208 builtin/pull.c:240
+#: builtin/fetch.c:208 builtin/pull.c:244
 msgid "report that we have only objects reachable from this object"
 msgstr "rapportera att vi bara har objekt nåbara från detta objektet"
 
@@ -15245,7 +15245,7 @@ msgstr "hämta inte paketfil; skriv istället förfäder till förhandlingstips"
 msgid "run 'maintenance --auto' after fetching"
 msgstr "kör \"maintenance --auto\" efter hämtning"
 
-#: builtin/fetch.c:217 builtin/pull.c:243
+#: builtin/fetch.c:217 builtin/pull.c:247
 msgid "check for forced-updates on all updated branches"
 msgstr "se efter tvingade uppdateringar i alla uppdaterade grenar"
 
@@ -17912,32 +17912,32 @@ msgstr "Tillgängliga strategier är:"
 msgid "Available custom strategies are:"
 msgstr "Tillgängliga skräddarsydda strategier är:"
 
-#: builtin/merge.c:257 builtin/pull.c:133
+#: builtin/merge.c:257 builtin/pull.c:134
 msgid "do not show a diffstat at the end of the merge"
 msgstr "visa inte en diffstat när sammanslagningen är färdig"
 
-#: builtin/merge.c:260 builtin/pull.c:136
+#: builtin/merge.c:260 builtin/pull.c:137
 msgid "show a diffstat at the end of the merge"
 msgstr "visa en diffstat när sammanslagningen är färdig"
 
-#: builtin/merge.c:261 builtin/pull.c:139
+#: builtin/merge.c:261 builtin/pull.c:140
 msgid "(synonym to --stat)"
 msgstr "(synonym till --stat)"
 
-#: builtin/merge.c:263 builtin/pull.c:142
+#: builtin/merge.c:263 builtin/pull.c:143
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "lägg till (som mest <n>) poster från shortlog till incheckningsmeddelandet"
 
-#: builtin/merge.c:266 builtin/pull.c:148
+#: builtin/merge.c:266 builtin/pull.c:149
 msgid "create a single commit instead of doing a merge"
 msgstr "skapa en ensam incheckning istället för en sammanslagning"
 
-#: builtin/merge.c:268 builtin/pull.c:151
+#: builtin/merge.c:268 builtin/pull.c:152
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "utför en incheckning om sammanslagningen lyckades (standard)"
 
-#: builtin/merge.c:270 builtin/pull.c:154
+#: builtin/merge.c:270 builtin/pull.c:155
 msgid "edit message before committing"
 msgstr "redigera meddelande innan incheckning"
 
@@ -17945,28 +17945,28 @@ msgstr "redigera meddelande innan incheckning"
 msgid "allow fast-forward (default)"
 msgstr "tillåt snabbspolning (standard)"
 
-#: builtin/merge.c:274 builtin/pull.c:161
+#: builtin/merge.c:274 builtin/pull.c:162
 msgid "abort if fast-forward is not possible"
 msgstr "avbryt om snabbspolning inte är möjlig"
 
-#: builtin/merge.c:278 builtin/pull.c:164
+#: builtin/merge.c:278 builtin/pull.c:168
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "bekräfta att den namngivna incheckningen har en giltig GPG-signatur"
 
-#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:168
+#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:172
 #: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr "strategi"
 
-#: builtin/merge.c:280 builtin/pull.c:169
+#: builtin/merge.c:280 builtin/pull.c:173
 msgid "merge strategy to use"
 msgstr "sammanslagningsstrategi att använda"
 
-#: builtin/merge.c:281 builtin/pull.c:172
+#: builtin/merge.c:281 builtin/pull.c:176
 msgid "option=value"
 msgstr "alternativ=värde"
 
-#: builtin/merge.c:282 builtin/pull.c:173
+#: builtin/merge.c:282 builtin/pull.c:177
 msgid "option for selected merge strategy"
 msgstr "alternativ för vald sammanslagningsstrategi"
 
@@ -17986,7 +17986,7 @@ msgstr "--abort men lämna index och arbetskatalog ensamma"
 msgid "continue the current in-progress merge"
 msgstr "fortsätt den pågående sammanslagningen"
 
-#: builtin/merge.c:297 builtin/pull.c:180
+#: builtin/merge.c:297 builtin/pull.c:184
 msgid "allow merging unrelated histories"
 msgstr "tillåt sammanslagning av orelaterade historier"
 
@@ -19397,44 +19397,48 @@ msgstr "Felaktigt värde för %s: %s"
 msgid "git pull [<options>] [<repository> [<refspec>...]]"
 msgstr "git pull [<flaggor>] [<arkiv> [<refspec>...]]"
 
-#: builtin/pull.c:123
+#: builtin/pull.c:124
 msgid "control for recursive fetching of submodules"
 msgstr "styrning för rekursiv hämtning av undermoduler"
 
-#: builtin/pull.c:127
+#: builtin/pull.c:128
 msgid "Options related to merging"
 msgstr "Alternativ gällande sammanslagning"
 
-#: builtin/pull.c:130
+#: builtin/pull.c:131
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "inlemma ändringar genom ombasering i stället för sammanslagning"
 
-#: builtin/pull.c:158 builtin/revert.c:126
+#: builtin/pull.c:159 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "tillåt snabbspolning"
 
-#: builtin/pull.c:167 parse-options.h:339
+#: builtin/pull.c:165
+msgid "control use of pre-merge-commit and commit-msg hooks"
+msgstr "styr användning av pre-merge-commit- och commit-msg-krokar"
+
+#: builtin/pull.c:171 parse-options.h:338
 msgid "automatically stash/stash pop before and after"
 msgstr "utför automatiskt stash/stash pop före och efter"
 
-#: builtin/pull.c:183
+#: builtin/pull.c:187
 msgid "Options related to fetching"
 msgstr "Alternativ gällande hämtningar"
 
-#: builtin/pull.c:193
+#: builtin/pull.c:197
 msgid "force overwrite of local branch"
 msgstr "tvinga överskrivning av lokal gren"
 
-#: builtin/pull.c:201
+#: builtin/pull.c:205
 msgid "number of submodules pulled in parallel"
 msgstr "antal undermoduler som hämtas parallellt"
 
-#: builtin/pull.c:317
+#: builtin/pull.c:321
 #, c-format
 msgid "Invalid value for pull.ff: %s"
 msgstr "Felaktigt värde för pull.ff: %s"
 
-#: builtin/pull.c:445
+#: builtin/pull.c:449
 msgid ""
 "There is no candidate for rebasing against among the refs that you just "
 "fetched."
@@ -19442,14 +19446,14 @@ msgstr ""
 "Det finns ingen kandidat för ombasering bland referenserna du precis har "
 "hämtat."
 
-#: builtin/pull.c:447
+#: builtin/pull.c:451
 msgid ""
 "There are no candidates for merging among the refs that you just fetched."
 msgstr ""
 "Det finns ingen kandidat för sammanslagning bland referenserna du precis har "
 "hämtat."
 
-#: builtin/pull.c:448
+#: builtin/pull.c:452
 msgid ""
 "Generally this means that you provided a wildcard refspec which had no\n"
 "matches on the remote end."
@@ -19457,7 +19461,7 @@ msgstr ""
 "Det betyder vanligtvis att du använt en jokertecken-refspec som inte\n"
 "motsvarade något i fjärränden."
 
-#: builtin/pull.c:451
+#: builtin/pull.c:455
 #, c-format
 msgid ""
 "You asked to pull from the remote '%s', but did not specify\n"
@@ -19468,41 +19472,41 @@ msgstr ""
 "gren. Eftersom det inte är den fjärr som är konfigurerad som\n"
 "standard för aktuell gren måste du ange en gren på kommandoraden."
 
-#: builtin/pull.c:456 builtin/rebase.c:951
+#: builtin/pull.c:460 builtin/rebase.c:951
 msgid "You are not currently on a branch."
 msgstr "Du är inte på någon gren för närvarande."
 
-#: builtin/pull.c:458 builtin/pull.c:473
+#: builtin/pull.c:462 builtin/pull.c:477
 msgid "Please specify which branch you want to rebase against."
 msgstr "Ange vilken gren du vill ombasera mot."
 
-#: builtin/pull.c:460 builtin/pull.c:475
+#: builtin/pull.c:464 builtin/pull.c:479
 msgid "Please specify which branch you want to merge with."
 msgstr "Ange vilken gren du vill slå samman med."
 
-#: builtin/pull.c:461 builtin/pull.c:476
+#: builtin/pull.c:465 builtin/pull.c:480
 msgid "See git-pull(1) for details."
 msgstr "Se git-pull(1) för detaljer."
 
-#: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
+#: builtin/pull.c:467 builtin/pull.c:473 builtin/pull.c:482
 #: builtin/rebase.c:957
 msgid "<remote>"
 msgstr "<fjärr>"
 
-#: builtin/pull.c:463 builtin/pull.c:478 builtin/pull.c:483
+#: builtin/pull.c:467 builtin/pull.c:482 builtin/pull.c:487
 msgid "<branch>"
 msgstr "<gren>"
 
-#: builtin/pull.c:471 builtin/rebase.c:949
+#: builtin/pull.c:475 builtin/rebase.c:949
 msgid "There is no tracking information for the current branch."
 msgstr "Det finns ingen spårningsinformation för aktuell gren."
 
-#: builtin/pull.c:480
+#: builtin/pull.c:484
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:"
 msgstr "Om du vill ange spårningsinformation för grenen kan du göra det med:"
 
-#: builtin/pull.c:485
+#: builtin/pull.c:489
 #, c-format
 msgid ""
 "Your configuration specifies to merge with the ref '%s'\n"
@@ -19511,16 +19515,16 @@ msgstr ""
 "Dina inställningar anger sammanslagning med referensen \"%s\"\n"
 "från fjärren, men någon sådan referens togs inte emot."
 
-#: builtin/pull.c:596
+#: builtin/pull.c:600
 #, c-format
 msgid "unable to access commit %s"
 msgstr "kunde inte komma åt incheckningen %s"
 
-#: builtin/pull.c:902
+#: builtin/pull.c:908
 msgid "ignoring --verify-signatures for rebase"
 msgstr "ignorera --verify-signatures för ombasering"
 
-#: builtin/pull.c:936
+#: builtin/pull.c:942
 msgid ""
 "You have divergent branches and need to specify how to reconcile them.\n"
 "You can do so by running one of the following commands sometime before\n"
@@ -19549,19 +19553,19 @@ msgstr ""
 "eller --ff-only på kommandoraden för att överstyra det konfigurerade\n"
 "förvalet vid körning.\n"
 
-#: builtin/pull.c:1010
+#: builtin/pull.c:1016
 msgid "Updating an unborn branch with changes added to the index."
 msgstr "Uppdaterar en ofödd gren med ändringar som lagts till i indexet."
 
-#: builtin/pull.c:1014
+#: builtin/pull.c:1020
 msgid "pull with rebase"
 msgstr "pull med ombasering"
 
-#: builtin/pull.c:1015
+#: builtin/pull.c:1021
 msgid "please commit or stash them."
 msgstr "checka in eller använd \"stash\" på dem."
 
-#: builtin/pull.c:1040
+#: builtin/pull.c:1046
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -19572,7 +19576,7 @@ msgstr ""
 "snabbspolar din arbetskatalog från\n"
 "incheckningen %s."
 
-#: builtin/pull.c:1046
+#: builtin/pull.c:1052
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -19589,23 +19593,23 @@ msgstr ""
 "$ git reset --hard\n"
 "för att återgå."
 
-#: builtin/pull.c:1061
+#: builtin/pull.c:1067
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Kan inte slå ihop flera grenar i ett tomt huvud."
 
-#: builtin/pull.c:1066
+#: builtin/pull.c:1072
 msgid "Cannot rebase onto multiple branches."
 msgstr "Kan inte ombasera ovanpå flera grenar."
 
-#: builtin/pull.c:1068
+#: builtin/pull.c:1074
 msgid "Cannot fast-forward to multiple branches."
 msgstr "Kan inte snabbspola till flera grenar."
 
-#: builtin/pull.c:1082
+#: builtin/pull.c:1088
 msgid "Need to specify how to reconcile divergent branches."
 msgstr "Måste ange hur avvikande grenar skall förlikas."
 
-#: builtin/pull.c:1096
+#: builtin/pull.c:1102
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr "kan inte ombasera med lokalt lagrade ändringar i undermoful"
 
@@ -24729,27 +24733,27 @@ msgstr "giltig-till"
 msgid "no-op (backward compatibility)"
 msgstr "ingen funktion (bakåtkompatibilitet)"
 
-#: parse-options.h:309
+#: parse-options.h:308
 msgid "be more verbose"
 msgstr "var mer pratsam"
 
-#: parse-options.h:311
+#: parse-options.h:310
 msgid "be more quiet"
 msgstr "var mer tyst"
 
-#: parse-options.h:317
+#: parse-options.h:316
 msgid "use <n> digits to display object names"
 msgstr "använd <n> siffror för att visa objektnamn"
 
-#: parse-options.h:336
+#: parse-options.h:335
 msgid "how to strip spaces and #comments from message"
 msgstr "hur blanksteg och #kommentarer ska tas bort från meddelande"
 
-#: parse-options.h:337
+#: parse-options.h:336
 msgid "read pathspec from file"
 msgstr "läs sökvägsangivelse från fil"
 
-#: parse-options.h:338
+#: parse-options.h:337
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr "med --pathspec-from-file, sökvägsangivelser avdelas med NUL-tecken"

--- a/po/tr.po
+++ b/po/tr.po
@@ -90,8 +90,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git Turkish Localization Project\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-11-04 08:34+0800\n"
-"PO-Revision-Date: 2021-11-04 18:00+0300\n"
+"POT-Creation-Date: 2021-11-10 08:55+0800\n"
+"PO-Revision-Date: 2021-11-10 18:00+0300\n"
 "Last-Translator: Emir SARI <emir_sari@msn.com>\n"
 "Language-Team: Turkish (https://github.com/bitigchi/git-po/)\n"
 "Language: tr\n"
@@ -293,7 +293,7 @@ msgstr "hazırlanmamış"
 
 #: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
 #: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:190
+#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:194
 #: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
 #: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
 #: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
@@ -10485,7 +10485,7 @@ msgstr ""
 "sayılıyor:\n"
 
 #: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
-#: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:550
+#: builtin/prune-packed.c:14 builtin/pull.c:208 builtin/push.c:550
 #: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr "sınama turu"
@@ -10955,11 +10955,11 @@ msgstr "git-apply aracılığıyla geçir"
 
 #: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
 #: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
-#: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
+#: builtin/pull.c:142 builtin/pull.c:204 builtin/pull.c:221
 #: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
 #: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
 #: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
-#: parse-options.h:316
+#: parse-options.h:315
 msgid "n"
 msgstr "n"
 
@@ -11010,7 +11010,7 @@ msgid "use current timestamp for author date"
 msgstr "yazar tarihi için geçerli zaman damgasını kullan"
 
 #: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
-#: builtin/merge.c:299 builtin/pull.c:175 builtin/rebase.c:1099
+#: builtin/merge.c:299 builtin/pull.c:179 builtin/rebase.c:1099
 #: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
 msgstr "key-id"
@@ -11515,7 +11515,7 @@ msgstr "iş maliyet istatistiklerini göster"
 #: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
 #: builtin/merge.c:298 builtin/multi-pack-index.c:103
 #: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
-#: builtin/multi-pack-index.c:204 builtin/pull.c:119 builtin/push.c:566
+#: builtin/multi-pack-index.c:204 builtin/pull.c:120 builtin/push.c:566
 #: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "durum belirtmeyi zorla"
@@ -12783,7 +12783,7 @@ msgstr "dal veya işleme argümanı eksik"
 msgid "perform a 3-way merge with the new branch"
 msgstr "yeni dal ile bir 3 yönlü birleştirme gerçekleştir"
 
-#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:322
+#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:321
 msgid "style"
 msgstr "stil"
 
@@ -13208,7 +13208,7 @@ msgid "path to git-upload-pack on the remote"
 msgstr "uzak konumdaki git-upload-pack'e olan yol"
 
 #: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
-#: builtin/pull.c:208
+#: builtin/pull.c:212
 msgid "depth"
 msgstr "derinlik"
 
@@ -13217,7 +13217,7 @@ msgid "create a shallow clone of that depth"
 msgstr "verilen derinlikte sığ bir depo oluştur"
 
 #: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
-#: builtin/pull.c:211
+#: builtin/pull.c:215
 msgid "time"
 msgstr "zaman"
 
@@ -13226,11 +13226,11 @@ msgid "create a shallow clone since a specific time"
 msgstr "verilen zamandan sonrasını içeren bir sığ depo oluştur"
 
 #: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1022
+#: builtin/pull.c:218 builtin/pull.c:243 builtin/rebase.c:1022
 msgid "revision"
 msgstr "revizyon"
 
-#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:215
+#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:219
 msgid "deepen history of shallow clone, excluding rev"
 msgstr "revizyonu hariç tutarak sığ klonun geçmişini derinleştir"
 
@@ -13264,21 +13264,21 @@ msgid "set config inside the new repository"
 msgstr "yapılandırmayı yeni deponun içinde ayarla"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:200
+#: builtin/pull.c:234 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "sunucuya özel"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:201
+#: builtin/pull.c:235 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr "iletme seçeneği"
 
-#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:234
+#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:238
 #: builtin/push.c:576
 msgid "use IPv4 addresses only"
 msgstr "yalnızca IPv4 adresleri kullan"
 
-#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:237
+#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:241
 #: builtin/push.c:578
 msgid "use IPv6 addresses only"
 msgstr "yalnızca IPv6 adresleri kullan"
@@ -13674,7 +13674,7 @@ msgid "read commit log message from file"
 msgstr "işleme günlük iletisini dosyadan oku"
 
 #: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
-#: builtin/pull.c:176 builtin/revert.c:118
+#: builtin/pull.c:180 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "işlemeyi GPG ile imzala"
 
@@ -14088,7 +14088,7 @@ msgstr "girdileri NUL ile sonlandır"
 
 #: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
 #: builtin/fast-export.c:1199 builtin/fast-export.c:1202
-#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:336
+#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:335
 msgid "mode"
 msgstr "kip"
 
@@ -14170,7 +14170,7 @@ msgid "override date for commit"
 msgstr "işleme tarihini geçersiz kıl"
 
 #: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
-#: parse-options.h:328 ref-filter.h:92
+#: parse-options.h:327 ref-filter.h:92
 msgid "commit"
 msgstr "işleme"
 
@@ -14216,7 +14216,7 @@ msgid "add custom trailer(s)"
 msgstr "özel artbilgiler ekle"
 
 #: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
-#: builtin/pull.c:145 builtin/revert.c:110
+#: builtin/pull.c:146 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "bir Signed-off-by artbilgisi ekle"
 
@@ -15196,15 +15196,15 @@ msgstr "git fetch --all [<seçenekler>]"
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel negatif olamaz"
 
-#: builtin/fetch.c:145 builtin/pull.c:185
+#: builtin/fetch.c:145 builtin/pull.c:189
 msgid "fetch from all remotes"
 msgstr "tüm uzak konumlardan getir"
 
-#: builtin/fetch.c:147 builtin/pull.c:245
+#: builtin/fetch.c:147 builtin/pull.c:249
 msgid "set upstream for git pull/fetch"
 msgstr "git pull/fetch için üstkaynak ayarla"
 
-#: builtin/fetch.c:149 builtin/pull.c:188
+#: builtin/fetch.c:149 builtin/pull.c:192
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr ".git/FETCH_HEAD'in üzerine yazmak yerine ona iliştir"
 
@@ -15212,7 +15212,7 @@ msgstr ".git/FETCH_HEAD'in üzerine yazmak yerine ona iliştir"
 msgid "use atomic transaction to update references"
 msgstr "başvuruları güncellemek için atomsal işlem kullan"
 
-#: builtin/fetch.c:153 builtin/pull.c:191
+#: builtin/fetch.c:153 builtin/pull.c:195
 msgid "path to upload pack on remote end"
 msgstr "uzak uçtaki yükleme paketine olan yol"
 
@@ -15224,7 +15224,7 @@ msgstr "yerel başvurunun üzerine zorla yaz"
 msgid "fetch from multiple remotes"
 msgstr "birden çok uzak konumdan getir"
 
-#: builtin/fetch.c:158 builtin/pull.c:195
+#: builtin/fetch.c:158 builtin/pull.c:199
 msgid "fetch all tags and associated objects"
 msgstr "tüm etiketleri ve ilişkilendirilen nesneleri getir"
 
@@ -15242,7 +15242,7 @@ msgstr ""
 "başvuru belirtecini tüm başvuruları refs/prefetch/'e yerleştirecek biçimde "
 "değiştir"
 
-#: builtin/fetch.c:166 builtin/pull.c:198
+#: builtin/fetch.c:166 builtin/pull.c:202
 msgid "prune remote-tracking branches no longer on remote"
 msgstr "artık uzak konumda olmayan uzak izleme dallarını buda"
 
@@ -15252,7 +15252,7 @@ msgstr ""
 "artık uzak konumda olmayan yerel etiketleri buda ve değiştirilen etiketleri "
 "güncelle"
 
-#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:122
+#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:123
 msgid "on-demand"
 msgstr "istek üzerine"
 
@@ -15264,7 +15264,7 @@ msgstr "altmodüllerin özyineli getirilmesini denetle"
 msgid "write fetched references to the FETCH_HEAD file"
 msgstr "getirilen başvuruları FETCH_HEAD dosyasına yaz"
 
-#: builtin/fetch.c:176 builtin/pull.c:206
+#: builtin/fetch.c:176 builtin/pull.c:210
 msgid "keep downloaded pack"
 msgstr "indirilen paketi tut"
 
@@ -15272,16 +15272,16 @@ msgstr "indirilen paketi tut"
 msgid "allow updating of HEAD ref"
 msgstr "HEAD başvurusunun güncellenmesine izin ver"
 
-#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:209
-#: builtin/pull.c:218
+#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:213
+#: builtin/pull.c:222
 msgid "deepen history of shallow clone"
 msgstr "sığ klonun geçmişini derinleştir"
 
-#: builtin/fetch.c:183 builtin/pull.c:212
+#: builtin/fetch.c:183 builtin/pull.c:216
 msgid "deepen history of shallow repository based on time"
 msgstr "zamana bağlı olarak sığ deponun geçmişini derinleştir"
 
-#: builtin/fetch.c:189 builtin/pull.c:221
+#: builtin/fetch.c:189 builtin/pull.c:225
 msgid "convert to a complete repository"
 msgstr "tam bir depoya dönüştür"
 
@@ -15297,19 +15297,19 @@ msgstr ""
 "altmodüllerin özyineli getirilmesi için öntanımlı (yapılandırma "
 "dosyalarından daha az önceliğe iye)"
 
-#: builtin/fetch.c:199 builtin/pull.c:224
+#: builtin/fetch.c:199 builtin/pull.c:228
 msgid "accept refs that update .git/shallow"
 msgstr ".git/shallow'u güncelleyen başvuruları kabul et"
 
-#: builtin/fetch.c:200 builtin/pull.c:226
+#: builtin/fetch.c:200 builtin/pull.c:230
 msgid "refmap"
 msgstr "ilgili başvuru"
 
-#: builtin/fetch.c:201 builtin/pull.c:227
+#: builtin/fetch.c:201 builtin/pull.c:231
 msgid "specify fetch refmap"
 msgstr "getirme ile ilgili başvuruları belirt"
 
-#: builtin/fetch.c:208 builtin/pull.c:240
+#: builtin/fetch.c:208 builtin/pull.c:244
 msgid "report that we have only objects reachable from this object"
 msgstr "yalnızca bu nesneden ulaşılabilir nesnelerimiz olduğunu bildir"
 
@@ -15323,7 +15323,7 @@ msgstr ""
 msgid "run 'maintenance --auto' after fetching"
 msgstr "getirme sonrasında 'maintenance --auto' çalıştır"
 
-#: builtin/fetch.c:217 builtin/pull.c:243
+#: builtin/fetch.c:217 builtin/pull.c:247
 msgid "check for forced-updates on all updated branches"
 msgstr "tüm güncellenmiş dalları zorlanmış güncellemeler için denetle"
 
@@ -17987,32 +17987,32 @@ msgstr "Kullanılabilir stratejiler:"
 msgid "Available custom strategies are:"
 msgstr "Kullanılabilir özel stratejiler:"
 
-#: builtin/merge.c:257 builtin/pull.c:133
+#: builtin/merge.c:257 builtin/pull.c:134
 msgid "do not show a diffstat at the end of the merge"
 msgstr "birleştirmenin sonunda bir diffstat gösterme"
 
-#: builtin/merge.c:260 builtin/pull.c:136
+#: builtin/merge.c:260 builtin/pull.c:137
 msgid "show a diffstat at the end of the merge"
 msgstr "birleştirmenin sonunda bir diffstat göster"
 
-#: builtin/merge.c:261 builtin/pull.c:139
+#: builtin/merge.c:261 builtin/pull.c:140
 msgid "(synonym to --stat)"
 msgstr "(--stat eşanlamlısı)"
 
-#: builtin/merge.c:263 builtin/pull.c:142
+#: builtin/merge.c:263 builtin/pull.c:143
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "kısa günlükten birleştirme işlemesi iletisine girdiler (en çok <n>) ekle"
 
-#: builtin/merge.c:266 builtin/pull.c:148
+#: builtin/merge.c:266 builtin/pull.c:149
 msgid "create a single commit instead of doing a merge"
 msgstr "birleştirme yerine tek bir işleme oluştur"
 
-#: builtin/merge.c:268 builtin/pull.c:151
+#: builtin/merge.c:268 builtin/pull.c:152
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "birleştirme başarılı olursa bir işleme gerçekleştir (öntanımlı)"
 
-#: builtin/merge.c:270 builtin/pull.c:154
+#: builtin/merge.c:270 builtin/pull.c:155
 msgid "edit message before committing"
 msgstr "göndermeden önce iletiyi düzenle"
 
@@ -18020,28 +18020,28 @@ msgstr "göndermeden önce iletiyi düzenle"
 msgid "allow fast-forward (default)"
 msgstr "ileri sarıma izin ver (öntanımlı)"
 
-#: builtin/merge.c:274 builtin/pull.c:161
+#: builtin/merge.c:274 builtin/pull.c:162
 msgid "abort if fast-forward is not possible"
 msgstr "ileri sarım olanaklı değilse iptal et"
 
-#: builtin/merge.c:278 builtin/pull.c:164
+#: builtin/merge.c:278 builtin/pull.c:168
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "adı verilen işlemenin geçerli bir GPG imzası olduğunu doğrula"
 
-#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:168
+#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:172
 #: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr "strateji"
 
-#: builtin/merge.c:280 builtin/pull.c:169
+#: builtin/merge.c:280 builtin/pull.c:173
 msgid "merge strategy to use"
 msgstr "kullanılacak birleştirme stratejisi"
 
-#: builtin/merge.c:281 builtin/pull.c:172
+#: builtin/merge.c:281 builtin/pull.c:176
 msgid "option=value"
 msgstr "seçenek=değer"
 
-#: builtin/merge.c:282 builtin/pull.c:173
+#: builtin/merge.c:282 builtin/pull.c:177
 msgid "option for selected merge strategy"
 msgstr "seçili birleştirme stratejisi için seçenekler"
 
@@ -18062,7 +18062,7 @@ msgstr "--abort; ancak indeksi ve çalışma ağacını değiştirmeden bırakı
 msgid "continue the current in-progress merge"
 msgstr "ilerlemekte olan geçerli birleştirmeyi sürdürün"
 
-#: builtin/merge.c:297 builtin/pull.c:180
+#: builtin/merge.c:297 builtin/pull.c:184
 msgid "allow merging unrelated histories"
 msgstr "birbiriyle ilişkisi olmayan geçmişlerin birleştirilmesine izin ver"
 
@@ -19472,56 +19472,60 @@ msgstr "%s için geçersiz değer: %s"
 msgid "git pull [<options>] [<repository> [<refspec>...]]"
 msgstr "git pull [<seçenekler>] [<depo> [<bşvr-blrtç>...]]"
 
-#: builtin/pull.c:123
+#: builtin/pull.c:124
 msgid "control for recursive fetching of submodules"
 msgstr "altmodüllerin özyineli getirilmesi için denetleme"
 
-#: builtin/pull.c:127
+#: builtin/pull.c:128
 msgid "Options related to merging"
 msgstr "Birleştirme ile ilgili seçenekler"
 
-#: builtin/pull.c:130
+#: builtin/pull.c:131
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "değişiklikleri birleştirme yerine yeniden temellendirme ile kat"
 
-#: builtin/pull.c:158 builtin/revert.c:126
+#: builtin/pull.c:159 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "ileri sarıma izin ver"
 
-#: builtin/pull.c:167 parse-options.h:339
+#: builtin/pull.c:165
+msgid "control use of pre-merge-commit and commit-msg hooks"
+msgstr "pre-merge-commit ve commit-msg kancalarının kullanımını denetle"
+
+#: builtin/pull.c:171 parse-options.h:338
 msgid "automatically stash/stash pop before and after"
 msgstr "öncesinde ve sonrasında kendiliğinden zulala/zulaları patlat"
 
-#: builtin/pull.c:183
+#: builtin/pull.c:187
 msgid "Options related to fetching"
 msgstr "Getirme ile ilgili seçenekler"
 
-#: builtin/pull.c:193
+#: builtin/pull.c:197
 msgid "force overwrite of local branch"
 msgstr "zorla yerel dalın üzerine yaz"
 
-#: builtin/pull.c:201
+#: builtin/pull.c:205
 msgid "number of submodules pulled in parallel"
 msgstr "paralelde çekilen altmodüllerin sayısı"
 
-#: builtin/pull.c:317
+#: builtin/pull.c:321
 #, c-format
 msgid "Invalid value for pull.ff: %s"
 msgstr "pull.ff için geçersiz değer: %s"
 
-#: builtin/pull.c:445
+#: builtin/pull.c:449
 msgid ""
 "There is no candidate for rebasing against among the refs that you just "
 "fetched."
 msgstr ""
 "Az önce getirdiğiniz başvurular arasında yeniden temellendirme için aday yok."
 
-#: builtin/pull.c:447
+#: builtin/pull.c:451
 msgid ""
 "There are no candidates for merging among the refs that you just fetched."
 msgstr "Az önce getirdiğiniz başvurular arasında birleştirme için aday yok."
 
-#: builtin/pull.c:448
+#: builtin/pull.c:452
 msgid ""
 "Generally this means that you provided a wildcard refspec which had no\n"
 "matches on the remote end."
@@ -19529,7 +19533,7 @@ msgstr ""
 "Genellikle bu, uzak uçta eşleşmesi olmayan bir joker başvuru belirteci\n"
 "sağladığınız anlamına gelir."
 
-#: builtin/pull.c:451
+#: builtin/pull.c:455
 #, c-format
 msgid ""
 "You asked to pull from the remote '%s', but did not specify\n"
@@ -19540,43 +19544,43 @@ msgstr ""
 "Bu, geçerli dalınız için öntanımlı yapılandırılmış uzak konum olmadığından,\n"
 "komut satırında bir dal belirtmeniz gerekir."
 
-#: builtin/pull.c:456 builtin/rebase.c:951
+#: builtin/pull.c:460 builtin/rebase.c:951
 msgid "You are not currently on a branch."
 msgstr "Şu anda bir dal üzerinde değilsiniz."
 
-#: builtin/pull.c:458 builtin/pull.c:473
+#: builtin/pull.c:462 builtin/pull.c:477
 msgid "Please specify which branch you want to rebase against."
 msgstr ""
 "Lütfen hangi dala karşı yeniden temellendirme yapmak istediğinizi belirtin."
 
-#: builtin/pull.c:460 builtin/pull.c:475
+#: builtin/pull.c:464 builtin/pull.c:479
 msgid "Please specify which branch you want to merge with."
 msgstr "Lütfen hangi dal ile birleştirmek istediğinizi belirtin."
 
-#: builtin/pull.c:461 builtin/pull.c:476
+#: builtin/pull.c:465 builtin/pull.c:480
 msgid "See git-pull(1) for details."
 msgstr "Ayrıntılar için: git-pull(1)"
 
-#: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
+#: builtin/pull.c:467 builtin/pull.c:473 builtin/pull.c:482
 #: builtin/rebase.c:957
 msgid "<remote>"
 msgstr "<uzak-konum>"
 
-#: builtin/pull.c:463 builtin/pull.c:478 builtin/pull.c:483
+#: builtin/pull.c:467 builtin/pull.c:482 builtin/pull.c:487
 msgid "<branch>"
 msgstr "<dal>"
 
-#: builtin/pull.c:471 builtin/rebase.c:949
+#: builtin/pull.c:475 builtin/rebase.c:949
 msgid "There is no tracking information for the current branch."
 msgstr "Geçerli dal için izleme bilgisi yok."
 
-#: builtin/pull.c:480
+#: builtin/pull.c:484
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:"
 msgstr ""
 "Eğer bu dal için izleme bilgisi ayarlamak isterseniz şununla yapabilirsiniz:"
 
-#: builtin/pull.c:485
+#: builtin/pull.c:489
 #, c-format
 msgid ""
 "Your configuration specifies to merge with the ref '%s'\n"
@@ -19585,16 +19589,16 @@ msgstr ""
 "Yapılandırmanız uzak konumdan '%s' başvurusu ile birleştirmeyi belirtiyor,\n"
 "ancak böyle bir başvuru getirilmedi."
 
-#: builtin/pull.c:596
+#: builtin/pull.c:600
 #, c-format
 msgid "unable to access commit %s"
 msgstr "%s işlemesine erişilemedi"
 
-#: builtin/pull.c:902
+#: builtin/pull.c:908
 msgid "ignoring --verify-signatures for rebase"
 msgstr "yeniden temellendirme için --verify-signatures yok sayılıyor"
 
-#: builtin/pull.c:936
+#: builtin/pull.c:942
 msgid ""
 "You have divergent branches and need to specify how to reconcile them.\n"
 "You can do so by running one of the following commands sometime before\n"
@@ -19623,19 +19627,19 @@ msgstr ""
 "yapılandırmayı yürütme sırasında --rebase, --no-rebase veya\n"
 "--ff-only ile bir kerelik geçersiz kılabilirsiniz.\n"
 
-#: builtin/pull.c:1010
+#: builtin/pull.c:1016
 msgid "Updating an unborn branch with changes added to the index."
 msgstr "İndekse eklenen değişikliklerle henüz doğmamış bir dal güncelleniyor."
 
-#: builtin/pull.c:1014
+#: builtin/pull.c:1020
 msgid "pull with rebase"
 msgstr "yeniden temellendirme ile çekim"
 
-#: builtin/pull.c:1015
+#: builtin/pull.c:1021
 msgid "please commit or stash them."
 msgstr "Lütfen onları işleyin veya zulalayın."
 
-#: builtin/pull.c:1040
+#: builtin/pull.c:1046
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -19646,7 +19650,7 @@ msgstr ""
 "Çalışma ağacınız %s işlemesinden\n"
 "ileri sarılıyor."
 
-#: builtin/pull.c:1046
+#: builtin/pull.c:1052
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -19663,23 +19667,23 @@ msgstr ""
 "$ git reset --hard\n"
 "komutunu çalıştırın."
 
-#: builtin/pull.c:1061
+#: builtin/pull.c:1067
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Boş dal ucuna birden çok dal birleştirilemez."
 
-#: builtin/pull.c:1066
+#: builtin/pull.c:1072
 msgid "Cannot rebase onto multiple branches."
 msgstr "Birden çok dala yeniden temellendirme yapılamaz."
 
-#: builtin/pull.c:1068
+#: builtin/pull.c:1074
 msgid "Cannot fast-forward to multiple branches."
 msgstr "Birden çok dala ileri sarım yapılamaz."
 
-#: builtin/pull.c:1082
+#: builtin/pull.c:1088
 msgid "Need to specify how to reconcile divergent branches."
 msgstr "Iraksak dalların nasıl uzlaştırılacağının belirtilmesi gerekiyor."
 
-#: builtin/pull.c:1096
+#: builtin/pull.c:1102
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "yerelde kaydı yazılmış altmodül değişiklikleriyle yeniden temellendirme "
@@ -24815,27 +24819,27 @@ msgstr "son kullanım tarihi"
 msgid "no-op (backward compatibility)"
 msgstr "işlem yok (geriye dönük uyumluluk için)"
 
-#: parse-options.h:309
+#: parse-options.h:308
 msgid "be more verbose"
 msgstr "daha ayrıntılı anlat"
 
-#: parse-options.h:311
+#: parse-options.h:310
 msgid "be more quiet"
 msgstr "daha sessiz ol"
 
-#: parse-options.h:317
+#: parse-options.h:316
 msgid "use <n> digits to display object names"
 msgstr "nesne adlarını görüntülemek için <n> basamak kullan"
 
-#: parse-options.h:336
+#: parse-options.h:335
 msgid "how to strip spaces and #comments from message"
 msgstr "iletiden boşlukları ve #yorumları çıkart"
 
-#: parse-options.h:337
+#: parse-options.h:336
 msgid "read pathspec from file"
 msgstr "yol belirtecini dosyadan oku"
 
-#: parse-options.h:338
+#: parse-options.h:337
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,10 +7,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git v2.34.0 round 2\n"
+"Project-Id-Version: git v2.34.0 round 3\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-11-04 08:34+0800\n"
-"PO-Revision-Date: 2021-11-08 08:35+0700\n"
+"POT-Creation-Date: 2021-11-10 08:55+0800\n"
+"PO-Revision-Date: 2021-11-11 13:18+0700\n"
 "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
 "Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
 "Language: vi\n"
@@ -217,7 +217,7 @@ msgstr "chưa đưa lên bệ phóng"
 
 #: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
 #: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:190
+#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:194
 #: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
 #: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
 #: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
@@ -768,22 +768,24 @@ msgstr ""
 #: advice.c:180
 msgid "Committing is not possible because you have unmerged files."
 msgstr ""
-"Commit là không thể thực hiện bởi vì bạn có những tập tin chưa được hòa trộn."
+"Không thể thực hiện chuyển giao được bởi vì bạn có những tập tin chưa được "
+"hòa trộn."
 
 #: advice.c:182
 msgid "Merging is not possible because you have unmerged files."
 msgstr ""
-"Merge là không thể thực hiện bởi vì bạn có những tập tin chưa được hòa trộn."
+"Không thể thực hiện hòa trộn bởi vì bạn có những tập tin chưa được hòa trộn."
 
 #: advice.c:184
 msgid "Pulling is not possible because you have unmerged files."
 msgstr ""
-"Pull là không thể thực hiện bởi vì bạn có những tập tin chưa được hòa trộn."
+"Không thể thực hiện kéo về bởi vì bạn có những tập tin chưa được hòa trộn."
 
 #: advice.c:186
 msgid "Reverting is not possible because you have unmerged files."
 msgstr ""
-"Revert là không thể thực hiện bởi vì bạn có những tập tin chưa được hòa trộn."
+"Không thể thực hiện hoàn nguyên bởi vì bạn có những tập tin chưa được hòa "
+"trộn."
 
 #: advice.c:188
 #, c-format
@@ -1525,7 +1527,7 @@ msgstr "không thể stream blob “%s”"
 #: archive-tar.c:265 archive-zip.c:358
 #, c-format
 msgid "unsupported file mode: 0%o (SHA1: %s)"
-msgstr "chế độ tập tin lục không được hỗ trợ: 0%o (SHA1: %s)"
+msgstr "chế độ tập tin không được hỗ trợ: 0%o (SHA1: %s)"
 
 #: archive-tar.c:450
 #, c-format
@@ -10481,7 +10483,7 @@ msgstr ""
 "của bạn:\n"
 
 #: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
-#: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:550
+#: builtin/prune-packed.c:14 builtin/pull.c:208 builtin/push.c:550
 #: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr "chạy thử"
@@ -10950,11 +10952,11 @@ msgstr "chuyển nó qua git-apply"
 
 #: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
 #: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
-#: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
+#: builtin/pull.c:142 builtin/pull.c:204 builtin/pull.c:221
 #: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
 #: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
 #: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
-#: parse-options.h:316
+#: parse-options.h:315
 msgid "n"
 msgstr "n"
 
@@ -11005,7 +11007,7 @@ msgid "use current timestamp for author date"
 msgstr "dùng dấu thời gian hiện tại cho ngày tác giả"
 
 #: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
-#: builtin/merge.c:299 builtin/pull.c:175 builtin/rebase.c:1099
+#: builtin/merge.c:299 builtin/pull.c:179 builtin/rebase.c:1099
 #: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
 msgstr "mã-số-khóa"
@@ -11428,7 +11430,7 @@ msgstr "bỏ qua một số lần chuyển giao để lấy ra"
 
 #: builtin/bisect--helper.c:1210
 msgid "visualize the bisection"
-msgstr "Trực quan việc di chuyển nửa bước"
+msgstr "trực quan việc di chuyển nửa bước"
 
 #: builtin/bisect--helper.c:1212
 msgid "use <cmd>... to automatically bisect."
@@ -11512,7 +11514,7 @@ msgstr "hiển thị thống kê công sức làm việc"
 #: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
 #: builtin/merge.c:298 builtin/multi-pack-index.c:103
 #: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
-#: builtin/multi-pack-index.c:204 builtin/pull.c:119 builtin/push.c:566
+#: builtin/multi-pack-index.c:204 builtin/pull.c:120 builtin/push.c:566
 #: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "ép buộc báo cáo tiến triển công việc"
@@ -12237,7 +12239,7 @@ msgstr "với đối tượng blob, chạy lệnh textconv trên nội dung củ
 
 #: builtin/cat-file.c:671
 msgid "for blob objects, run filters on object's content"
-msgstr "với đối tượng blob, chạy lệnh filters trên nội dung của đối tượng"
+msgstr "với đối tượng blob, chạy các bộ lọc nội dung của đối tượng"
 
 #: builtin/cat-file.c:672
 msgid "blob"
@@ -12773,7 +12775,7 @@ msgstr "thiếu tham số là nhánh hoặc lần chuyển giao"
 msgid "perform a 3-way merge with the new branch"
 msgstr "thực hiện hòa trộn kiểu 3-way với nhánh mới"
 
-#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:322
+#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:321
 msgid "style"
 msgstr "kiểu"
 
@@ -13202,7 +13204,7 @@ msgid "path to git-upload-pack on the remote"
 msgstr "đường dẫn đến git-upload-pack trên máy chủ"
 
 #: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
-#: builtin/pull.c:208
+#: builtin/pull.c:212
 msgid "depth"
 msgstr "độ-sâu"
 
@@ -13211,7 +13213,7 @@ msgid "create a shallow clone of that depth"
 msgstr "tạo bản sao không đầy đủ cho mức sâu đã cho"
 
 #: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
-#: builtin/pull.c:211
+#: builtin/pull.c:215
 msgid "time"
 msgstr "thời-gian"
 
@@ -13220,11 +13222,11 @@ msgid "create a shallow clone since a specific time"
 msgstr "tạo bản sao không đầy đủ từ thời điểm đã cho"
 
 #: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1022
+#: builtin/pull.c:218 builtin/pull.c:243 builtin/rebase.c:1022
 msgid "revision"
 msgstr "điểm xét duyệt"
 
-#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:215
+#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:219
 msgid "deepen history of shallow clone, excluding rev"
 msgstr "làm sâu hơn lịch sử của bản sao shallow, bằng điểm xét duyệt loại trừ"
 
@@ -13260,21 +13262,21 @@ msgid "set config inside the new repository"
 msgstr "đặt cấu hình bên trong một kho chứa mới"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:200
+#: builtin/pull.c:234 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "đặc-tả-máy-phục-vụ"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:201
+#: builtin/pull.c:235 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr "tùy chọn để chuyển giao"
 
-#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:234
+#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:238
 #: builtin/push.c:576
 msgid "use IPv4 addresses only"
 msgstr "chỉ dùng địa chỉ IPv4"
 
-#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:237
+#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:241
 #: builtin/push.c:578
 msgid "use IPv6 addresses only"
 msgstr "chỉ dùng địa chỉ IPv6"
@@ -13680,7 +13682,7 @@ msgid "read commit log message from file"
 msgstr "đọc chú thích nhật ký lần chuyển giao từ tập tin"
 
 #: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
-#: builtin/pull.c:176 builtin/revert.c:118
+#: builtin/pull.c:180 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "Ký lần chuyển giao dùng GPG"
 
@@ -14110,7 +14112,7 @@ msgstr "chấm dứt các mục bằng NUL"
 
 #: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
 #: builtin/fast-export.c:1199 builtin/fast-export.c:1202
-#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:336
+#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:335
 msgid "mode"
 msgstr "chế độ"
 
@@ -14190,7 +14192,7 @@ msgid "override date for commit"
 msgstr "ghi đè ngày tháng cho lần chuyển giao"
 
 #: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
-#: parse-options.h:328 ref-filter.h:92
+#: parse-options.h:327 ref-filter.h:92
 msgid "commit"
 msgstr "lần_chuyển_giao"
 
@@ -14236,7 +14238,7 @@ msgid "add custom trailer(s)"
 msgstr "thêm đuôi tự chọn"
 
 #: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
-#: builtin/pull.c:145 builtin/revert.c:110
+#: builtin/pull.c:146 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "thêm dòng Signed-off-by vào cuối"
 
@@ -15218,15 +15220,15 @@ msgstr "git fetch --all [<các tùy chọn>]"
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel không thể âm"
 
-#: builtin/fetch.c:145 builtin/pull.c:185
+#: builtin/fetch.c:145 builtin/pull.c:189
 msgid "fetch from all remotes"
 msgstr "lấy về từ tất cả các máy chủ"
 
-#: builtin/fetch.c:147 builtin/pull.c:245
+#: builtin/fetch.c:147 builtin/pull.c:249
 msgid "set upstream for git pull/fetch"
 msgstr "đặt thượng nguồn cho git pull/fetch"
 
-#: builtin/fetch.c:149 builtin/pull.c:188
+#: builtin/fetch.c:149 builtin/pull.c:192
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "nối thêm vào .git/FETCH_HEAD thay vì ghi đè lên nó"
 
@@ -15234,7 +15236,7 @@ msgstr "nối thêm vào .git/FETCH_HEAD thay vì ghi đè lên nó"
 msgid "use atomic transaction to update references"
 msgstr "sử dụng giao dịch hạt nhân bên phía máy chủ"
 
-#: builtin/fetch.c:153 builtin/pull.c:191
+#: builtin/fetch.c:153 builtin/pull.c:195
 msgid "path to upload pack on remote end"
 msgstr "đường dẫn đến gói tải lên trên máy chủ cuối"
 
@@ -15246,7 +15248,7 @@ msgstr "ép buộc ghi đè lên tham chiếu nội bộ"
 msgid "fetch from multiple remotes"
 msgstr "lấy từ nhiều máy chủ cùng lúc"
 
-#: builtin/fetch.c:158 builtin/pull.c:195
+#: builtin/fetch.c:158 builtin/pull.c:199
 msgid "fetch all tags and associated objects"
 msgstr "lấy tất cả các thẻ cùng với các đối tượng liên quan đến nó"
 
@@ -15263,7 +15265,7 @@ msgid "modify the refspec to place all refs within refs/prefetch/"
 msgstr ""
 "sửa đặc tả đường dẫn cho các tham chiếu mọi chỗ có trong refs/prefetch/"
 
-#: builtin/fetch.c:166 builtin/pull.c:198
+#: builtin/fetch.c:166 builtin/pull.c:202
 msgid "prune remote-tracking branches no longer on remote"
 msgstr ""
 "cắt cụt (prune) các nhánh “remote-tracking” không còn tồn tại trên máy chủ "
@@ -15273,7 +15275,7 @@ msgstr ""
 msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr "cắt xém các thẻ nội bộ không còn ở máy chủ và xóa các thẻ đã thay đổi"
 
-#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:122
+#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:123
 msgid "on-demand"
 msgstr "khi-cần"
 
@@ -15285,7 +15287,7 @@ msgstr "điều khiển việc lấy về đệ quy trong các mô-đun-con"
 msgid "write fetched references to the FETCH_HEAD file"
 msgstr "ghi các tham chiếu lấy về vào tập tin FETCH_HEAD"
 
-#: builtin/fetch.c:176 builtin/pull.c:206
+#: builtin/fetch.c:176 builtin/pull.c:210
 msgid "keep downloaded pack"
 msgstr "giữ lại gói đã tải về"
 
@@ -15293,16 +15295,16 @@ msgstr "giữ lại gói đã tải về"
 msgid "allow updating of HEAD ref"
 msgstr "cho phép cập nhật th.chiếu HEAD"
 
-#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:209
-#: builtin/pull.c:218
+#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:213
+#: builtin/pull.c:222
 msgid "deepen history of shallow clone"
 msgstr "làm sâu hơn lịch sử của bản sao"
 
-#: builtin/fetch.c:183 builtin/pull.c:212
+#: builtin/fetch.c:183 builtin/pull.c:216
 msgid "deepen history of shallow repository based on time"
 msgstr "làm sâu hơn lịch sử của kho bản sao shallow dựa trên thời gian"
 
-#: builtin/fetch.c:189 builtin/pull.c:221
+#: builtin/fetch.c:189 builtin/pull.c:225
 msgid "convert to a complete repository"
 msgstr "chuyển đổi hoàn toàn sang kho git"
 
@@ -15318,19 +15320,19 @@ msgstr ""
 "mặc định cho việc lấy đệ quy các mô-đun-con (có mức ưu tiên thấp hơn các tập "
 "tin cấu hình config)"
 
-#: builtin/fetch.c:199 builtin/pull.c:224
+#: builtin/fetch.c:199 builtin/pull.c:228
 msgid "accept refs that update .git/shallow"
 msgstr "chấp nhận tham chiếu cập nhật .git/shallow"
 
-#: builtin/fetch.c:200 builtin/pull.c:226
+#: builtin/fetch.c:200 builtin/pull.c:230
 msgid "refmap"
 msgstr "refmap"
 
-#: builtin/fetch.c:201 builtin/pull.c:227
+#: builtin/fetch.c:201 builtin/pull.c:231
 msgid "specify fetch refmap"
 msgstr "chỉ ra refmap cần lấy về"
 
-#: builtin/fetch.c:208 builtin/pull.c:240
+#: builtin/fetch.c:208 builtin/pull.c:244
 msgid "report that we have only objects reachable from this object"
 msgstr ""
 "báo cáo rằng chúng ta chỉ có các đối tượng tiếp cận được từ đối tượng này"
@@ -15344,7 +15346,7 @@ msgstr ""
 msgid "run 'maintenance --auto' after fetching"
 msgstr "chạy “maintenance --auto” sau khi lấy về"
 
-#: builtin/fetch.c:217 builtin/pull.c:243
+#: builtin/fetch.c:217 builtin/pull.c:247
 msgid "check for forced-updates on all updated branches"
 msgstr "kiểm cho các-cập-nhật-bắt-buộc trên mọi nhánh đã cập nhật"
 
@@ -18016,31 +18018,31 @@ msgstr "Các chiến lược sẵn sàng là:"
 msgid "Available custom strategies are:"
 msgstr "Các chiến lược tùy chỉnh sẵn sàng là:"
 
-#: builtin/merge.c:257 builtin/pull.c:133
+#: builtin/merge.c:257 builtin/pull.c:134
 msgid "do not show a diffstat at the end of the merge"
 msgstr "không hiển thị thống kê khác biệt tại cuối của lần hòa trộn"
 
-#: builtin/merge.c:260 builtin/pull.c:136
+#: builtin/merge.c:260 builtin/pull.c:137
 msgid "show a diffstat at the end of the merge"
 msgstr "hiển thị thống kê khác biệt tại cuối của hòa trộn"
 
-#: builtin/merge.c:261 builtin/pull.c:139
+#: builtin/merge.c:261 builtin/pull.c:140
 msgid "(synonym to --stat)"
 msgstr "(đồng nghĩa với --stat)"
 
-#: builtin/merge.c:263 builtin/pull.c:142
+#: builtin/merge.c:263 builtin/pull.c:143
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr "thêm (ít nhất <n>) mục từ shortlog cho ghi chú chuyển giao hòa trộn"
 
-#: builtin/merge.c:266 builtin/pull.c:148
+#: builtin/merge.c:266 builtin/pull.c:149
 msgid "create a single commit instead of doing a merge"
 msgstr "tạo một lần chuyển giao đưon thay vì thực hiện việc hòa trộn"
 
-#: builtin/merge.c:268 builtin/pull.c:151
+#: builtin/merge.c:268 builtin/pull.c:152
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "thực hiện chuyển giao nếu hòa trộn thành công (mặc định)"
 
-#: builtin/merge.c:270 builtin/pull.c:154
+#: builtin/merge.c:270 builtin/pull.c:155
 msgid "edit message before committing"
 msgstr "sửa chú thích trước khi chuyển giao"
 
@@ -18048,28 +18050,28 @@ msgstr "sửa chú thích trước khi chuyển giao"
 msgid "allow fast-forward (default)"
 msgstr "cho phép chuyển-tiếp-nhanh (mặc định)"
 
-#: builtin/merge.c:274 builtin/pull.c:161
+#: builtin/merge.c:274 builtin/pull.c:162
 msgid "abort if fast-forward is not possible"
 msgstr "bỏ qua nếu chuyển-tiếp-nhanh không thể được"
 
-#: builtin/merge.c:278 builtin/pull.c:164
+#: builtin/merge.c:278 builtin/pull.c:168
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "thẩm tra xem lần chuyển giao có tên đó có chữ ký GPG hợp lệ hay không"
 
-#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:168
+#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:172
 #: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr "chiến lược"
 
-#: builtin/merge.c:280 builtin/pull.c:169
+#: builtin/merge.c:280 builtin/pull.c:173
 msgid "merge strategy to use"
 msgstr "chiến lược hòa trộn sẽ dùng"
 
-#: builtin/merge.c:281 builtin/pull.c:172
+#: builtin/merge.c:281 builtin/pull.c:176
 msgid "option=value"
 msgstr "tùy_chọn=giá_trị"
 
-#: builtin/merge.c:282 builtin/pull.c:173
+#: builtin/merge.c:282 builtin/pull.c:177
 msgid "option for selected merge strategy"
 msgstr "tùy chọn cho chiến lược hòa trộn đã chọn"
 
@@ -18091,7 +18093,7 @@ msgstr "--abort nhưng để lại bảng mục lục và cây làm việc"
 msgid "continue the current in-progress merge"
 msgstr "tiếp tục quá trình hòa trộn hiện tại đang thực hiện"
 
-#: builtin/merge.c:297 builtin/pull.c:180
+#: builtin/merge.c:297 builtin/pull.c:184
 msgid "allow merging unrelated histories"
 msgstr "cho phép hòa trộn lịch sử không liên quan"
 
@@ -19513,44 +19515,48 @@ msgstr "Giá trị không hợp lệ %s: %s"
 msgid "git pull [<options>] [<repository> [<refspec>...]]"
 msgstr "git pull [<các tùy chọn>] [<kho-chứa> [<refspec>…]]"
 
-#: builtin/pull.c:123
+#: builtin/pull.c:124
 msgid "control for recursive fetching of submodules"
 msgstr "điều khiển việc lấy về đệ quy của các mô-đun-con"
 
-#: builtin/pull.c:127
+#: builtin/pull.c:128
 msgid "Options related to merging"
 msgstr "Các tùy chọn liên quan đến hòa trộn"
 
-#: builtin/pull.c:130
+#: builtin/pull.c:131
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "các thay đổi hợp nhất bằng cải tổ thay vì hòa trộn"
 
-#: builtin/pull.c:158 builtin/revert.c:126
+#: builtin/pull.c:159 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "cho phép chuyển-tiếp-nhanh"
 
-#: builtin/pull.c:167 parse-options.h:339
+#: builtin/pull.c:165
+msgid "control use of pre-merge-commit and commit-msg hooks"
+msgstr "điều khiển cách dùng các móc (hook) pre-merge-commit và commit-msg"
+
+#: builtin/pull.c:171 parse-options.h:338
 msgid "automatically stash/stash pop before and after"
 msgstr "tự động stash/stash pop trước và sau"
 
-#: builtin/pull.c:183
+#: builtin/pull.c:187
 msgid "Options related to fetching"
 msgstr "Các tùy chọn liên quan đến lệnh lấy về"
 
-#: builtin/pull.c:193
+#: builtin/pull.c:197
 msgid "force overwrite of local branch"
 msgstr "ép buộc ghi đè lên nhánh nội bộ"
 
-#: builtin/pull.c:201
+#: builtin/pull.c:205
 msgid "number of submodules pulled in parallel"
 msgstr "số lượng mô-đun-con được đẩy lên đồng thời"
 
-#: builtin/pull.c:317
+#: builtin/pull.c:321
 #, c-format
 msgid "Invalid value for pull.ff: %s"
 msgstr "Giá trị không hợp lệ cho pull.ff: %s"
 
-#: builtin/pull.c:445
+#: builtin/pull.c:449
 msgid ""
 "There is no candidate for rebasing against among the refs that you just "
 "fetched."
@@ -19558,14 +19564,14 @@ msgstr ""
 "Ở đây không có ứng cử nào để cải tổ lại trong số các tham chiếu mà bạn vừa "
 "lấy về."
 
-#: builtin/pull.c:447
+#: builtin/pull.c:451
 msgid ""
 "There are no candidates for merging among the refs that you just fetched."
 msgstr ""
 "Ở đây không có ứng cử nào để hòa trộn trong số các tham chiếu mà bạn vừa lấy "
 "về."
 
-#: builtin/pull.c:448
+#: builtin/pull.c:452
 msgid ""
 "Generally this means that you provided a wildcard refspec which had no\n"
 "matches on the remote end."
@@ -19574,7 +19580,7 @@ msgstr ""
 "tự\n"
 "đại diện mà nó lại không khớp trên điểm cuối máy phục vụ."
 
-#: builtin/pull.c:451
+#: builtin/pull.c:455
 #, c-format
 msgid ""
 "You asked to pull from the remote '%s', but did not specify\n"
@@ -19586,42 +19592,42 @@ msgstr ""
 "theo mặc định cho nhánh hiện tại của bạn, bạn phải chỉ định\n"
 "một nhánh trên dòng lệnh."
 
-#: builtin/pull.c:456 builtin/rebase.c:951
+#: builtin/pull.c:460 builtin/rebase.c:951
 msgid "You are not currently on a branch."
 msgstr "Hiện tại bạn chẳng ở nhánh nào cả."
 
-#: builtin/pull.c:458 builtin/pull.c:473
+#: builtin/pull.c:462 builtin/pull.c:477
 msgid "Please specify which branch you want to rebase against."
 msgstr "Vui lòng chỉ định nhánh nào bạn muốn cải tổ lại."
 
-#: builtin/pull.c:460 builtin/pull.c:475
+#: builtin/pull.c:464 builtin/pull.c:479
 msgid "Please specify which branch you want to merge with."
 msgstr "Vui lòng chỉ định nhánh nào bạn muốn hòa trộn vào."
 
-#: builtin/pull.c:461 builtin/pull.c:476
+#: builtin/pull.c:465 builtin/pull.c:480
 msgid "See git-pull(1) for details."
 msgstr "Xem git-pull(1) để biết thêm chi tiết."
 
-#: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
+#: builtin/pull.c:467 builtin/pull.c:473 builtin/pull.c:482
 #: builtin/rebase.c:957
 msgid "<remote>"
 msgstr "<máy chủ>"
 
-#: builtin/pull.c:463 builtin/pull.c:478 builtin/pull.c:483
+#: builtin/pull.c:467 builtin/pull.c:482 builtin/pull.c:487
 msgid "<branch>"
 msgstr "<nhánh>"
 
-#: builtin/pull.c:471 builtin/rebase.c:949
+#: builtin/pull.c:475 builtin/rebase.c:949
 msgid "There is no tracking information for the current branch."
 msgstr "Ở đây không có thông tin theo dõi cho nhánh hiện hành."
 
-#: builtin/pull.c:480
+#: builtin/pull.c:484
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:"
 msgstr ""
 "Nếu bạn muốn theo dõi thông tin cho nhánh này bạn có thể thực hiện bằng lệnh:"
 
-#: builtin/pull.c:485
+#: builtin/pull.c:489
 #, c-format
 msgid ""
 "Your configuration specifies to merge with the ref '%s'\n"
@@ -19630,16 +19636,16 @@ msgstr ""
 "Các đặc tả cấu hình của bạn để hòa trộn với tham chiếu “%s”\n"
 "từ máy dịch vụ, nhưng không có nhánh nào như thế được lấy về."
 
-#: builtin/pull.c:596
+#: builtin/pull.c:600
 #, c-format
 msgid "unable to access commit %s"
 msgstr "không thể truy cập lần chuyển giao “%s”"
 
-#: builtin/pull.c:902
+#: builtin/pull.c:908
 msgid "ignoring --verify-signatures for rebase"
 msgstr "bỏ qua --verify-signatures khi rebase"
 
-#: builtin/pull.c:936
+#: builtin/pull.c:942
 msgid ""
 "You have divergent branches and need to specify how to reconcile them.\n"
 "You can do so by running one of the following commands sometime before\n"
@@ -19670,21 +19676,21 @@ msgstr ""
 "hoặc --ff-only trên dòng lệnh để ghi đè các mặc định đã cấu hình cho mỗi\n"
 "lần gọi.\n"
 
-#: builtin/pull.c:1010
+#: builtin/pull.c:1016
 msgid "Updating an unborn branch with changes added to the index."
 msgstr ""
 "Đang cập nhật một nhánh chưa được sinh ra với các thay đổi được thêm vào "
 "bảng mục lục."
 
-#: builtin/pull.c:1014
+#: builtin/pull.c:1020
 msgid "pull with rebase"
 msgstr "pull với rebase"
 
-#: builtin/pull.c:1015
+#: builtin/pull.c:1021
 msgid "please commit or stash them."
 msgstr "xin hãy chuyển giao hoặc tạm cất (stash) chúng."
 
-#: builtin/pull.c:1040
+#: builtin/pull.c:1046
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -19695,7 +19701,7 @@ msgstr ""
 "đang chuyển-tiếp-nhanh cây làm việc của bạn từ\n"
 "lần chuyển giaot %s."
 
-#: builtin/pull.c:1046
+#: builtin/pull.c:1052
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -19713,23 +19719,23 @@ msgstr ""
 "$ git reset --hard\n"
 "để khôi phục lại."
 
-#: builtin/pull.c:1061
+#: builtin/pull.c:1067
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Không thể hòa trộn nhiều nhánh vào trong một head trống rỗng."
 
-#: builtin/pull.c:1066
+#: builtin/pull.c:1072
 msgid "Cannot rebase onto multiple branches."
 msgstr "Không thể thực hiện lệnh rebase (cải tổ) trên nhiều nhánh."
 
-#: builtin/pull.c:1068
+#: builtin/pull.c:1074
 msgid "Cannot fast-forward to multiple branches."
 msgstr "Không thể thực hiện chuyển tiếp nhanh trên nhiều nhánh."
 
-#: builtin/pull.c:1082
+#: builtin/pull.c:1088
 msgid "Need to specify how to reconcile divergent branches."
 msgstr "Caanfchir định làm thế nào để giải quyết các nhánh phân kỳ."
 
-#: builtin/pull.c:1096
+#: builtin/pull.c:1102
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "không thể cải tổ với các thay đổi mô-đun-con được ghi lại một cách cục bộ"
@@ -24898,27 +24904,27 @@ msgstr "ngày hết hạn"
 msgid "no-op (backward compatibility)"
 msgstr "no-op (tương thích ngược)"
 
-#: parse-options.h:309
+#: parse-options.h:308
 msgid "be more verbose"
 msgstr "chi tiết hơn nữa"
 
-#: parse-options.h:311
+#: parse-options.h:310
 msgid "be more quiet"
 msgstr "im lặng hơn nữa"
 
-#: parse-options.h:317
+#: parse-options.h:316
 msgid "use <n> digits to display object names"
 msgstr "sử dụng <n> chữ số để hiển thị tên đối tượng"
 
-#: parse-options.h:336
+#: parse-options.h:335
 msgid "how to strip spaces and #comments from message"
 msgstr "làm thế nào để cắt bỏ khoảng trắng và #ghichú từ mẩu tin nhắn"
 
-#: parse-options.h:337
+#: parse-options.h:336
 msgid "read pathspec from file"
 msgstr "đọc đặc tả đường dẫn từ tập tin"
 
-#: parse-options.h:338
+#: parse-options.h:337
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""

--- a/po/vi.po
+++ b/po/vi.po
@@ -7,10 +7,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git 2.33.0-rc2\n"
+"Project-Id-Version: git v2.34.0 round 2\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-08-14 07:56+0800\n"
-"PO-Revision-Date: 2021-08-14 14:53+0700\n"
+"POT-Creation-Date: 2021-11-04 08:34+0800\n"
+"PO-Revision-Date: 2021-11-08 08:35+0700\n"
 "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
 "Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
 "Language: vi\n"
@@ -21,216 +21,216 @@ msgstr ""
 "X-Language-Team-Website: <http://translationproject.org/team/vi.html>\n"
 "X-Generator: Poedit 3.0\n"
 
-#: add-interactive.c:376
+#: add-interactive.c:380
 #, c-format
 msgid "Huh (%s)?"
 msgstr "Hả (%s)?"
 
-#: add-interactive.c:529 add-interactive.c:830 reset.c:64 sequencer.c:3493
-#: sequencer.c:3964 sequencer.c:4119 builtin/rebase.c:1528
-#: builtin/rebase.c:1953
+#: add-interactive.c:533 add-interactive.c:834 reset.c:65 sequencer.c:3512
+#: sequencer.c:3979 sequencer.c:4141 builtin/rebase.c:1233
+#: builtin/rebase.c:1642
 msgid "could not read index"
 msgstr "không thể đọc bảng mục lục"
 
-#: add-interactive.c:584 git-add--interactive.perl:269
+#: add-interactive.c:588 git-add--interactive.perl:269
 #: git-add--interactive.perl:294
 msgid "binary"
 msgstr "nhị phân"
 
-#: add-interactive.c:642 git-add--interactive.perl:278
+#: add-interactive.c:646 git-add--interactive.perl:278
 #: git-add--interactive.perl:332
 msgid "nothing"
 msgstr "không có gì"
 
-#: add-interactive.c:643 git-add--interactive.perl:314
+#: add-interactive.c:647 git-add--interactive.perl:314
 #: git-add--interactive.perl:329
 msgid "unchanged"
 msgstr "không thay đổi"
 
-#: add-interactive.c:680 git-add--interactive.perl:641
+#: add-interactive.c:684 git-add--interactive.perl:641
 msgid "Update"
 msgstr "Cập nhật"
 
-#: add-interactive.c:697 add-interactive.c:885
+#: add-interactive.c:701 add-interactive.c:889
 #, c-format
 msgid "could not stage '%s'"
 msgstr "không thể đưa “%s” lên bệ phóng"
 
-#: add-interactive.c:703 add-interactive.c:892 reset.c:88 sequencer.c:3707
+#: add-interactive.c:707 add-interactive.c:896 reset.c:89 sequencer.c:3718
 msgid "could not write index"
 msgstr "không thể ghi bảng mục lục"
 
-#: add-interactive.c:706 git-add--interactive.perl:626
+#: add-interactive.c:710 git-add--interactive.perl:626
 #, c-format, perl-format
 msgid "updated %d path\n"
 msgid_plural "updated %d paths\n"
 msgstr[0] "đã cập nhật %d đường dẫn\n"
 
-#: add-interactive.c:724 git-add--interactive.perl:676
+#: add-interactive.c:728 git-add--interactive.perl:676
 #, c-format, perl-format
 msgid "note: %s is untracked now.\n"
 msgstr "chú ý: %s giờ đã bỏ theo dõi.\n"
 
-#: add-interactive.c:729 apply.c:4127 builtin/checkout.c:298
-#: builtin/reset.c:145
+#: add-interactive.c:733 apply.c:4149 builtin/checkout.c:298
+#: builtin/reset.c:151
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
 msgstr "make_cache_entry gặp lỗi đối với đường dẫn “%s”"
 
-#: add-interactive.c:759 git-add--interactive.perl:653
+#: add-interactive.c:763 git-add--interactive.perl:653
 msgid "Revert"
 msgstr "Hoàn nguyên"
 
-#: add-interactive.c:775
+#: add-interactive.c:779
 msgid "Could not parse HEAD^{tree}"
 msgstr "Không thể phân tích cú pháp HEAD^{tree}"
 
-#: add-interactive.c:813 git-add--interactive.perl:629
+#: add-interactive.c:817 git-add--interactive.perl:629
 #, c-format, perl-format
 msgid "reverted %d path\n"
 msgid_plural "reverted %d paths\n"
 msgstr[0] "đã hoàn nguyên %d đường dẫn\n"
 
-#: add-interactive.c:864 git-add--interactive.perl:693
+#: add-interactive.c:868 git-add--interactive.perl:693
 #, c-format
 msgid "No untracked files.\n"
 msgstr "Không có tập tin nào chưa được theo dõi.\n"
 
-#: add-interactive.c:868 git-add--interactive.perl:687
+#: add-interactive.c:872 git-add--interactive.perl:687
 msgid "Add untracked"
 msgstr "Thêm các cái chưa được theo dõi"
 
-#: add-interactive.c:895 git-add--interactive.perl:623
+#: add-interactive.c:899 git-add--interactive.perl:623
 #, c-format, perl-format
 msgid "added %d path\n"
 msgid_plural "added %d paths\n"
 msgstr[0] "đã thêm %d đường dẫn\n"
 
-#: add-interactive.c:925
+#: add-interactive.c:929
 #, c-format
 msgid "ignoring unmerged: %s"
 msgstr "bỏ qua những thứ chưa hòa trộn: %s"
 
-#: add-interactive.c:937 add-patch.c:1752 git-add--interactive.perl:1369
+#: add-interactive.c:941 add-patch.c:1752 git-add--interactive.perl:1369
 #, c-format
 msgid "Only binary files changed.\n"
 msgstr "Chỉ có các tập tin nhị phân là thay đổi.\n"
 
-#: add-interactive.c:939 add-patch.c:1750 git-add--interactive.perl:1371
+#: add-interactive.c:943 add-patch.c:1750 git-add--interactive.perl:1371
 #, c-format
 msgid "No changes.\n"
 msgstr "Không có thay đổi nào.\n"
 
-#: add-interactive.c:943 git-add--interactive.perl:1379
+#: add-interactive.c:947 git-add--interactive.perl:1379
 msgid "Patch update"
 msgstr "Cập nhật miếng vá"
 
-#: add-interactive.c:982 git-add--interactive.perl:1792
+#: add-interactive.c:986 git-add--interactive.perl:1792
 msgid "Review diff"
 msgstr "Xem xét lại diff"
 
-#: add-interactive.c:1010
+#: add-interactive.c:1014
 msgid "show paths with changes"
 msgstr "hiển thị đường dẫn với các thay đổi"
 
-#: add-interactive.c:1012
+#: add-interactive.c:1016
 msgid "add working tree state to the staged set of changes"
 msgstr ""
 "thêm trạng thái cây làm việc vào tập hợp các thay đổi đã được đưa lên bệ "
 "phóng"
 
-#: add-interactive.c:1014
+#: add-interactive.c:1018
 msgid "revert staged set of changes back to the HEAD version"
 msgstr ""
 "hoàn nguyên lại tập hợp các thay đổi đã được đưa lên bệ phóng trở lại phiên "
 "bản HEAD"
 
-#: add-interactive.c:1016
+#: add-interactive.c:1020
 msgid "pick hunks and update selectively"
 msgstr "chọn các “khúc” và cập nhật có tuyển chọn"
 
-#: add-interactive.c:1018
+#: add-interactive.c:1022
 msgid "view diff between HEAD and index"
 msgstr "xem khác biệt giữa HEAD và mục lục"
 
-#: add-interactive.c:1020
+#: add-interactive.c:1024
 msgid "add contents of untracked files to the staged set of changes"
 msgstr ""
 "thêm nội dung của các tập tin chưa được theo dõi vào tập hợp các thay đổi đã "
 "được đưa lên bệ phóng"
 
-#: add-interactive.c:1028 add-interactive.c:1077
+#: add-interactive.c:1032 add-interactive.c:1081
 msgid "Prompt help:"
 msgstr "Trợ giúp về nhắc:"
 
-#: add-interactive.c:1030
+#: add-interactive.c:1034
 msgid "select a single item"
 msgstr "chọn một mục đơn"
 
-#: add-interactive.c:1032
+#: add-interactive.c:1036
 msgid "select a range of items"
 msgstr "chọn một vùng các mục"
 
-#: add-interactive.c:1034
+#: add-interactive.c:1038
 msgid "select multiple ranges"
 msgstr "chọn nhiều vùng"
 
-#: add-interactive.c:1036 add-interactive.c:1081
+#: add-interactive.c:1040 add-interactive.c:1085
 msgid "select item based on unique prefix"
 msgstr "chọn mục dựa trên tiền tố duy nhất"
 
-#: add-interactive.c:1038
+#: add-interactive.c:1042
 msgid "unselect specified items"
 msgstr "bỏ chọn các mục đã cho"
 
-#: add-interactive.c:1040
+#: add-interactive.c:1044
 msgid "choose all items"
 msgstr "chọn tất cả các mục"
 
-#: add-interactive.c:1042
+#: add-interactive.c:1046
 msgid "(empty) finish selecting"
 msgstr "(để trống) hoàn tất chọn lựa"
 
-#: add-interactive.c:1079
+#: add-interactive.c:1083
 msgid "select a numbered item"
 msgstr "tùy chọn mục bằng số"
 
-#: add-interactive.c:1083
+#: add-interactive.c:1087
 msgid "(empty) select nothing"
 msgstr "(để trống) không chọn gì"
 
-#: add-interactive.c:1091 builtin/clean.c:813 git-add--interactive.perl:1896
+#: add-interactive.c:1095 builtin/clean.c:813 git-add--interactive.perl:1896
 msgid "*** Commands ***"
 msgstr "*** Lệnh ***"
 
-#: add-interactive.c:1092 builtin/clean.c:814 git-add--interactive.perl:1893
+#: add-interactive.c:1096 builtin/clean.c:814 git-add--interactive.perl:1893
 msgid "What now"
 msgstr "Giờ thì sao"
 
-#: add-interactive.c:1144 git-add--interactive.perl:213
+#: add-interactive.c:1148 git-add--interactive.perl:213
 msgid "staged"
 msgstr "đã đưa lên bệ phóng"
 
-#: add-interactive.c:1144 git-add--interactive.perl:213
+#: add-interactive.c:1148 git-add--interactive.perl:213
 msgid "unstaged"
 msgstr "chưa đưa lên bệ phóng"
 
-#: add-interactive.c:1144 apply.c:4994 apply.c:4997 builtin/am.c:2309
-#: builtin/am.c:2312 builtin/bugreport.c:135 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:285 builtin/pull.c:190
-#: builtin/submodule--helper.c:410 builtin/submodule--helper.c:1886
-#: builtin/submodule--helper.c:1889 builtin/submodule--helper.c:2343
-#: builtin/submodule--helper.c:2346 builtin/submodule--helper.c:2589
-#: builtin/submodule--helper.c:2890 builtin/submodule--helper.c:2893
+#: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
+#: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
+#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:190
+#: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
+#: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
+#: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
+#: builtin/submodule--helper.c:2578 builtin/submodule--helper.c:2811
 #: git-add--interactive.perl:213
 msgid "path"
 msgstr "đường-dẫn"
 
-#: add-interactive.c:1151
+#: add-interactive.c:1155
 msgid "could not refresh index"
 msgstr "không thể đọc lại bảng mục lục"
 
-#: add-interactive.c:1165 builtin/clean.c:778 git-add--interactive.perl:1803
+#: add-interactive.c:1169 builtin/clean.c:778 git-add--interactive.perl:1803
 #, c-format
 msgid "Bye.\n"
 msgstr "Tạm biệt.\n"
@@ -604,7 +604,7 @@ msgid ""
 "Lines starting with %c will be removed.\n"
 msgstr ""
 "---\n"
-"Để gỡ bỏ dòng “%c”, sửa chúng thành những dòng ' ' (ngữ cảnh).\n"
+"Để gỡ bỏ dòng “%c”, sửa chúng thành những dòng “ ” (ngữ cảnh).\n"
 "Để gõ bỏ dòng “%c”, xóa chúng đi.\n"
 "Những dòng bắt đầu bằng %c sẽ bị loại bỏ.\n"
 
@@ -745,7 +745,7 @@ msgstr "Rất tiếc, không thể sửa khúc này"
 msgid "'git apply' failed"
 msgstr "“git apply” gặp lỗi"
 
-#: advice.c:145
+#: advice.c:78
 #, c-format
 msgid ""
 "\n"
@@ -754,45 +754,45 @@ msgstr ""
 "\n"
 "Tắt lời nhắn này bằng \"git config advice.%s false\""
 
-#: advice.c:161
+#: advice.c:94
 #, c-format
 msgid "%shint: %.*s%s\n"
 msgstr "%sgợi ý: %.*s%s\n"
 
-#: advice.c:252
+#: advice.c:178
 msgid "Cherry-picking is not possible because you have unmerged files."
 msgstr ""
 "Cherry-picking là không thể thực hiện bởi vì bạn có những tập tin chưa được "
 "hòa trộn."
 
-#: advice.c:254
+#: advice.c:180
 msgid "Committing is not possible because you have unmerged files."
 msgstr ""
 "Commit là không thể thực hiện bởi vì bạn có những tập tin chưa được hòa trộn."
 
-#: advice.c:256
+#: advice.c:182
 msgid "Merging is not possible because you have unmerged files."
 msgstr ""
 "Merge là không thể thực hiện bởi vì bạn có những tập tin chưa được hòa trộn."
 
-#: advice.c:258
+#: advice.c:184
 msgid "Pulling is not possible because you have unmerged files."
 msgstr ""
 "Pull là không thể thực hiện bởi vì bạn có những tập tin chưa được hòa trộn."
 
-#: advice.c:260
+#: advice.c:186
 msgid "Reverting is not possible because you have unmerged files."
 msgstr ""
 "Revert là không thể thực hiện bởi vì bạn có những tập tin chưa được hòa trộn."
 
-#: advice.c:262
+#: advice.c:188
 #, c-format
 msgid "It is not possible to %s because you have unmerged files."
 msgstr ""
 "Việc này không thể thực hiện với %s bởi vì bạn có những tập tin chưa được "
 "hòa trộn."
 
-#: advice.c:270
+#: advice.c:196
 msgid ""
 "Fix them up in the work tree, and then use 'git add/rm <file>'\n"
 "as appropriate to mark resolution and make a commit."
@@ -800,41 +800,49 @@ msgstr ""
 "Sửa chúng trong cây làm việc, và sau đó dùng lệnh “git add/rm <tập-tin>”\n"
 "dành riêng cho việc đánh dấu cần giải quyết và tạo lần chuyển giao."
 
-#: advice.c:278
+#: advice.c:204
 msgid "Exiting because of an unresolved conflict."
 msgstr "Thoát ra bởi vì xung đột không thể giải quyết."
 
-#: advice.c:283 builtin/merge.c:1375
+#: advice.c:209 builtin/merge.c:1379
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "Bạn chưa kết thúc việc hòa trộn (MERGE_HEAD vẫn tồn tại)."
 
-#: advice.c:285
+#: advice.c:211
 msgid "Please, commit your changes before merging."
 msgstr "Vui lòng chuyển giao các thay đổi trước khi hòa trộn."
 
-#: advice.c:286
+#: advice.c:212
 msgid "Exiting because of unfinished merge."
 msgstr "Thoát ra bởi vì việc hòa trộn không hoàn tất."
 
-#: advice.c:296
+#: advice.c:217
+msgid "Not possible to fast-forward, aborting."
+msgstr "Thực hiện lệnh chuyển-tiếp-nhanh là không thể được, đang bỏ qua."
+
+#: advice.c:227
 #, c-format
 msgid ""
-"The following pathspecs didn't match any eligible path, but they do match "
-"index\n"
-"entries outside the current sparse checkout:\n"
+"The following paths and/or pathspecs matched paths that exist\n"
+"outside of your sparse-checkout definition, so will not be\n"
+"updated in the index:\n"
 msgstr ""
-"Các đặc tả đường dẫn sau đây không khớp với bất kỳ đường dẫn thích hợp nào,\n"
-"nhưng chúng khớp với các mục mục lục bên ngoài \"sparse checkout\" hiện "
-"tại:\n"
+"Các đường dẫn và/hoặc đặc tả đường dẫn sau đây khớp với các đường dẫn tồn "
+"tại\n"
+"bên ngoài định nghĩa “sparse-checkout” của bạn, vì vậy sẽ không\n"
+"cập nhật trong chỉ mục:\n"
 
-#: advice.c:303
+#: advice.c:234
 msgid ""
-"Disable or modify the sparsity rules if you intend to update such entries."
+"If you intend to update such entries, try one of the following:\n"
+"* Use the --sparse option.\n"
+"* Disable or modify the sparsity rules."
 msgstr ""
-"Vô hiệu hóa hoặc sửa đổi các quy tắc sparsity nếu bạn có ý định cập nhật các "
-"mục như vậy."
+"Nếu bạn có ý định cập nhật các mục như vậy, hãy thử một trong các mục sau:\n"
+"* Sử dụng tùy chọn --sparse.\n"
+"* Vô hiệu hóa hoặc sửa đổi các quy tắc thưa thớt."
 
-#: advice.c:310
+#: advice.c:242
 #, c-format
 msgid ""
 "Note: switching to '%s'.\n"
@@ -1013,48 +1021,48 @@ msgstr "tập tin đã xóa %s vẫn còn nội dung"
 msgid "** warning: file %s becomes empty but is not deleted"
 msgstr "** cảnh báo: tập tin %s trở nên trống rỗng nhưng không bị xóa"
 
-#: apply.c:1977
+#: apply.c:1978
 #, c-format
 msgid "corrupt binary patch at line %d: %.*s"
 msgstr "miếng vá định dạng nhị phân sai hỏng tại dòng %d: %.*s"
 
-#: apply.c:2014
+#: apply.c:2015
 #, c-format
 msgid "unrecognized binary patch at line %d"
 msgstr "miếng vá định dạng nhị phân không được nhận ra tại dòng %d"
 
-#: apply.c:2176
+#: apply.c:2177
 #, c-format
 msgid "patch with only garbage at line %d"
 msgstr "vá chỉ với “rác” tại dòng %d"
 
-#: apply.c:2262
+#: apply.c:2263
 #, c-format
 msgid "unable to read symlink %s"
 msgstr "không thể đọc liên kết mềm %s"
 
-#: apply.c:2266
+#: apply.c:2267
 #, c-format
 msgid "unable to open or read %s"
 msgstr "không thể mở hay đọc %s"
 
-#: apply.c:2935
+#: apply.c:2936
 #, c-format
 msgid "invalid start of line: '%c'"
 msgstr "sai khởi đầu dòng: “%c”"
 
-#: apply.c:3056
+#: apply.c:3057
 #, c-format
 msgid "Hunk #%d succeeded at %d (offset %d line)."
 msgid_plural "Hunk #%d succeeded at %d (offset %d lines)."
 msgstr[0] "Khối dữ liệu #%d thành công tại %d (offset %d dòng)."
 
-#: apply.c:3068
+#: apply.c:3069
 #, c-format
 msgid "Context reduced to (%ld/%ld) to apply fragment at %d"
 msgstr "Ngữ cảnh bị giảm xuống còn (%ld/%ld) để áp dụng mảnh dữ liệu tại %d"
 
-#: apply.c:3074
+#: apply.c:3075
 #, c-format
 msgid ""
 "while searching for:\n"
@@ -1063,448 +1071,449 @@ msgstr ""
 "trong khi đang tìm kiếm cho:\n"
 "%.*s"
 
-#: apply.c:3096
+#: apply.c:3097
 #, c-format
 msgid "missing binary patch data for '%s'"
 msgstr "thiếu dữ liệu của miếng vá định dạng nhị phân cho “%s”"
 
-#: apply.c:3104
+#: apply.c:3105
 #, c-format
 msgid "cannot reverse-apply a binary patch without the reverse hunk to '%s'"
 msgstr ""
 "không thể reverse-apply một miếng vá nhị phân mà không đảo ngược khúc thành "
 "“%s”"
 
-#: apply.c:3151
+#: apply.c:3152
 #, c-format
 msgid "cannot apply binary patch to '%s' without full index line"
 msgstr ""
 "không thể áp dụng miếng vá nhị phân thành “%s” mà không có dòng chỉ mục đầy "
 "đủ"
 
-#: apply.c:3162
+#: apply.c:3163
 #, c-format
 msgid ""
 "the patch applies to '%s' (%s), which does not match the current contents."
 msgstr ""
 "miếng vá áp dụng cho “%s” (%s), cái mà không khớp với các nội dung hiện tại."
 
-#: apply.c:3170
+#: apply.c:3171
 #, c-format
 msgid "the patch applies to an empty '%s' but it is not empty"
 msgstr "miếng vá áp dụng cho một “%s” trống rỗng nhưng nó lại không trống"
 
-#: apply.c:3188
+#: apply.c:3189
 #, c-format
 msgid "the necessary postimage %s for '%s' cannot be read"
 msgstr "không thể đọc postimage %s cần thiết cho “%s”"
 
-#: apply.c:3201
+#: apply.c:3202
 #, c-format
 msgid "binary patch does not apply to '%s'"
 msgstr "miếng vá định dạng nhị phân không được áp dụng cho “%s”"
 
-#: apply.c:3208
+#: apply.c:3209
 #, c-format
 msgid "binary patch to '%s' creates incorrect result (expecting %s, got %s)"
 msgstr ""
 "vá nhị phân cho “%s” tạo ra kết quả không chính xác (mong chờ %s, lại nhận "
 "%s)"
 
-#: apply.c:3229
+#: apply.c:3230
 #, c-format
 msgid "patch failed: %s:%ld"
 msgstr "gặp lỗi khi vá: %s:%ld"
 
-#: apply.c:3352
+#: apply.c:3353
 #, c-format
 msgid "cannot checkout %s"
 msgstr "không thể lấy ra %s"
 
-#: apply.c:3404 apply.c:3415 apply.c:3461 midx.c:98 pack-revindex.c:214
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:102 pack-revindex.c:214
 #: setup.c:308
 #, c-format
 msgid "failed to read %s"
 msgstr "gặp lỗi khi đọc %s"
 
-#: apply.c:3412
+#: apply.c:3413
 #, c-format
 msgid "reading from '%s' beyond a symbolic link"
 msgstr "đọc từ “%s” vượt ra ngoài liên kết mềm"
 
-#: apply.c:3441 apply.c:3687
+#: apply.c:3442 apply.c:3709
 #, c-format
 msgid "path %s has been renamed/deleted"
 msgstr "đường dẫn %s đã bị xóa hoặc đổi tên"
 
-#: apply.c:3527 apply.c:3702
+#: apply.c:3549 apply.c:3724
 #, c-format
 msgid "%s: does not exist in index"
 msgstr "%s: không tồn tại trong bảng mục lục"
 
-#: apply.c:3536 apply.c:3710 apply.c:3954
+#: apply.c:3558 apply.c:3732 apply.c:3976
 #, c-format
 msgid "%s: does not match index"
 msgstr "%s: không khớp trong mục lục"
 
-#: apply.c:3571
+#: apply.c:3593
 msgid "repository lacks the necessary blob to perform 3-way merge."
 msgstr "kho thiếu đối tượng blob cần thiết để thực hiện hòa trộn “3-way”."
 
-#: apply.c:3574
+#: apply.c:3596
 #, c-format
 msgid "Performing three-way merge...\n"
 msgstr "Đang thực hiện hòa trộn “3-đường”…\n"
 
-#: apply.c:3590 apply.c:3594
+#: apply.c:3612 apply.c:3616
 #, c-format
 msgid "cannot read the current contents of '%s'"
 msgstr "không thể đọc nội dung hiện hành của “%s”"
 
-#: apply.c:3606
+#: apply.c:3628
 #, c-format
 msgid "Failed to perform three-way merge...\n"
 msgstr "Gặp lỗi khi thực hiện hòa trộn kiểu “three-way”…\n"
 
-#: apply.c:3620
+#: apply.c:3642
 #, c-format
 msgid "Applied patch to '%s' with conflicts.\n"
 msgstr "Đã áp dụng miếng vá %s với các xung đột.\n"
 
-#: apply.c:3625
+#: apply.c:3647
 #, c-format
 msgid "Applied patch to '%s' cleanly.\n"
 msgstr "Đã áp dụng miếng vá %s một cách sạch sẽ.\n"
 
-#: apply.c:3642
+#: apply.c:3664
 #, c-format
 msgid "Falling back to direct application...\n"
 msgstr "Đang trở lại ứng dụng chi phối…\n"
 
-#: apply.c:3654
+#: apply.c:3676
 msgid "removal patch leaves file contents"
 msgstr "loại bỏ miếng vá để lại nội dung tập tin"
 
-#: apply.c:3727
+#: apply.c:3749
 #, c-format
 msgid "%s: wrong type"
 msgstr "%s: sai kiểu"
 
-#: apply.c:3729
+#: apply.c:3751
 #, c-format
 msgid "%s has type %o, expected %o"
 msgstr "%s có kiểu %o, cần %o"
 
-#: apply.c:3894 apply.c:3896 read-cache.c:863 read-cache.c:892
-#: read-cache.c:1353
+#: apply.c:3916 apply.c:3918 read-cache.c:876 read-cache.c:905
+#: read-cache.c:1368
 #, c-format
 msgid "invalid path '%s'"
 msgstr "đường dẫn không hợp lệ “%s”"
 
-#: apply.c:3952
+#: apply.c:3974
 #, c-format
 msgid "%s: already exists in index"
 msgstr "%s: đã có từ trước trong bảng mục lục"
 
-#: apply.c:3956
+#: apply.c:3978
 #, c-format
 msgid "%s: already exists in working directory"
 msgstr "%s: đã sẵn có trong thư mục đang làm việc"
 
-#: apply.c:3976
+#: apply.c:3998
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
 msgstr "chế độ mới (%o) của %s không khớp với chế độ cũ (%o)"
 
-#: apply.c:3981
+#: apply.c:4003
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
 msgstr "chế độ mới (%o) của %s không khớp với chế độ cũ (%o) của %s"
 
-#: apply.c:4001
+#: apply.c:4023
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
 msgstr "tập tin chịu tác động “%s” vượt ra ngoài liên kết mềm"
 
-#: apply.c:4005
+#: apply.c:4027
 #, c-format
 msgid "%s: patch does not apply"
 msgstr "%s: miếng vá không được áp dụng"
 
-#: apply.c:4020
+#: apply.c:4042
 #, c-format
 msgid "Checking patch %s..."
 msgstr "Đang kiểm tra miếng vá %s…"
 
-#: apply.c:4112
+#: apply.c:4134
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
 msgstr "thông tin sha1 thiếu hoặc không dùng được cho mô-đun %s"
 
-#: apply.c:4119
+#: apply.c:4141
 #, c-format
 msgid "mode change for %s, which is not in current HEAD"
 msgstr "thay đổi chế độ cho %s, cái mà không phải là HEAD hiện tại"
 
-#: apply.c:4122
+#: apply.c:4144
 #, c-format
 msgid "sha1 information is lacking or useless (%s)."
 msgstr "thông tin sha1 còn thiếu hay không dùng được(%s)."
 
-#: apply.c:4131
+#: apply.c:4153
 #, c-format
 msgid "could not add %s to temporary index"
 msgstr "không thể thêm %s vào chỉ mục tạm thời"
 
-#: apply.c:4141
+#: apply.c:4163
 #, c-format
 msgid "could not write temporary index to %s"
 msgstr "không thể ghi mục lục tạm vào %s"
 
-#: apply.c:4279
+#: apply.c:4301
 #, c-format
 msgid "unable to remove %s from index"
 msgstr "không thể gỡ bỏ %s từ mục lục"
 
-#: apply.c:4313
+#: apply.c:4335
 #, c-format
 msgid "corrupt patch for submodule %s"
 msgstr "miếng vá sai hỏng cho mô-đun-con %s"
 
-#: apply.c:4319
+#: apply.c:4341
 #, c-format
 msgid "unable to stat newly created file '%s'"
 msgstr "không thể lấy thống kê về tập tin %s mới hơn đã được tạo"
 
-#: apply.c:4327
+#: apply.c:4349
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr "không thể tạo “kho lưu đằng sau” cho tập tin được tạo mới hơn %s"
 
-#: apply.c:4333 apply.c:4478
+#: apply.c:4355 apply.c:4500
 #, c-format
 msgid "unable to add cache entry for %s"
 msgstr "không thể thêm mục nhớ đệm cho %s"
 
-#: apply.c:4376 builtin/bisect--helper.c:525
+#: apply.c:4398 builtin/bisect--helper.c:540 builtin/gc.c:2241
+#: builtin/gc.c:2276
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "gặp lỗi khi ghi vào “%s”"
 
-#: apply.c:4380
+#: apply.c:4402
 #, c-format
 msgid "closing file '%s'"
 msgstr "đang đóng tập tin “%s”"
 
-#: apply.c:4450
+#: apply.c:4472
 #, c-format
 msgid "unable to write file '%s' mode %o"
 msgstr "không thể ghi vào tập tin “%s” chế độ %o"
 
-#: apply.c:4548
+#: apply.c:4570
 #, c-format
 msgid "Applied patch %s cleanly."
 msgstr "Đã áp dụng miếng vá %s một cách sạch sẽ."
 
-#: apply.c:4556
+#: apply.c:4578
 msgid "internal error"
 msgstr "lỗi nội bộ"
 
-#: apply.c:4559
+#: apply.c:4581
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
 msgstr[0] "Đang áp dụng miếng vá %%s với %d lần từ chối…"
 
-#: apply.c:4570
+#: apply.c:4592
 #, c-format
 msgid "truncating .rej filename to %.*s.rej"
 msgstr "đang cắt ngắn tên tập tin .rej thành %.*s.rej"
 
-#: apply.c:4578 builtin/fetch.c:993 builtin/fetch.c:1394
+#: apply.c:4600 builtin/fetch.c:998 builtin/fetch.c:1408
 #, c-format
 msgid "cannot open %s"
 msgstr "không mở được “%s”"
 
-#: apply.c:4592
+#: apply.c:4614
 #, c-format
 msgid "Hunk #%d applied cleanly."
 msgstr "Khối nhớ #%d được áp dụng gọn gàng."
 
-#: apply.c:4596
+#: apply.c:4618
 #, c-format
 msgid "Rejected hunk #%d."
 msgstr "Đoạn dữ liệu #%d bị từ chối."
 
-#: apply.c:4725
+#: apply.c:4747
 #, c-format
 msgid "Skipped patch '%s'."
 msgstr "Bỏ qua đường dẫn “%s”."
 
-#: apply.c:4733
+#: apply.c:4755
 msgid "unrecognized input"
 msgstr "không thừa nhận đầu vào"
 
-#: apply.c:4753
+#: apply.c:4775
 msgid "unable to read index file"
 msgstr "không thể đọc tập tin lưu bảng mục lục"
 
-#: apply.c:4910
+#: apply.c:4932
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr "không thể mở miếng vá “%s”: %s"
 
-#: apply.c:4937
+#: apply.c:4959
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "đã chấm dứt %d lỗi khoảng trắng"
 
-#: apply.c:4943 apply.c:4958
+#: apply.c:4965 apply.c:4980
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] "%d dòng thêm khoảng trắng lỗi."
 
-#: apply.c:4951
+#: apply.c:4973
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
 msgstr[0] "%d dòng được áp dụng sau khi sửa các lỗi khoảng trắng."
 
-#: apply.c:4967 builtin/add.c:678 builtin/mv.c:304 builtin/rm.c:423
+#: apply.c:4989 builtin/add.c:707 builtin/mv.c:338 builtin/rm.c:429
 msgid "Unable to write new index file"
 msgstr "Không thể ghi tập tin lưu bảng mục lục mới"
 
-#: apply.c:4995
+#: apply.c:5017
 msgid "don't apply changes matching the given path"
 msgstr "không áp dụng các thay đổi khớp với đường dẫn đã cho"
 
-#: apply.c:4998
+#: apply.c:5020
 msgid "apply changes matching the given path"
 msgstr "áp dụng các thay đổi khớp với đường dẫn đã cho"
 
-#: apply.c:5000 builtin/am.c:2318
+#: apply.c:5022 builtin/am.c:2320
 msgid "num"
 msgstr "số"
 
-#: apply.c:5001
+#: apply.c:5023
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr "gỡ bỏ <số> dấu gạch chéo dẫn đầu từ đường dẫn diff cổ điển"
 
-#: apply.c:5004
+#: apply.c:5026
 msgid "ignore additions made by the patch"
 msgstr "lờ đi phần bổ xung được tạo ra bởi miếng vá"
 
-#: apply.c:5006
+#: apply.c:5028
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr ""
 "thay vì áp dụng một miếng vá, kết xuất kết quả từ lệnh diffstat cho đầu ra"
 
-#: apply.c:5010
+#: apply.c:5032
 msgid "show number of added and deleted lines in decimal notation"
 msgstr ""
 "hiển thị số lượng các dòng được thêm vào và xóa đi theo ký hiệu thập phân"
 
-#: apply.c:5012
+#: apply.c:5034
 msgid "instead of applying the patch, output a summary for the input"
 msgstr "thay vì áp dụng một miếng vá, kết xuất kết quả cho đầu vào"
 
-#: apply.c:5014
+#: apply.c:5036
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr "thay vì áp dụng miếng vá, hãy xem xem miếng vá có thích hợp không"
 
-#: apply.c:5016
+#: apply.c:5038
 msgid "make sure the patch is applicable to the current index"
 msgstr "hãy chắc chắn là miếng vá thích hợp với bảng mục lục hiện hành"
 
-#: apply.c:5018
+#: apply.c:5040
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "đánh dấu các tập tin mới với “git add --intent-to-add”"
 
-#: apply.c:5020
+#: apply.c:5042
 msgid "apply a patch without touching the working tree"
 msgstr "áp dụng một miếng vá mà không động chạm đến cây làm việc"
 
-#: apply.c:5022
+#: apply.c:5044
 msgid "accept a patch that touches outside the working area"
 msgstr "chấp nhận một miếng vá mà không động chạm đến cây làm việc"
 
-#: apply.c:5025
+#: apply.c:5047
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr ""
 "đồng thời áp dụng miếng vá (dùng với tùy chọn --stat/--summary/--check)"
 
-#: apply.c:5027
+#: apply.c:5049
 msgid "attempt three-way merge, fall back on normal patch if that fails"
 msgstr ""
 "thử hòa trộn kiểu three-way, quay lại dán bình thường nếu không thể thực "
 "hiện được"
 
-#: apply.c:5029
+#: apply.c:5051
 msgid "build a temporary index based on embedded index information"
 msgstr ""
 "xây dựng bảng mục lục tạm thời trên cơ sở thông tin bảng mục lục được nhúng"
 
-#: apply.c:5032 builtin/checkout-index.c:196 builtin/ls-files.c:617
+#: apply.c:5054 builtin/checkout-index.c:196
 msgid "paths are separated with NUL character"
 msgstr "các đường dẫn bị ngăn cách bởi ký tự NULL"
 
-#: apply.c:5034
+#: apply.c:5056
 msgid "ensure at least <n> lines of context match"
 msgstr "đảm bảo rằng có ít nhất <n> dòng ngữ cảnh khớp"
 
-#: apply.c:5035 builtin/am.c:2294 builtin/am.c:2297
+#: apply.c:5057 builtin/am.c:2296 builtin/am.c:2299
 #: builtin/interpret-trailers.c:98 builtin/interpret-trailers.c:100
-#: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3991
-#: builtin/rebase.c:1347
+#: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3960
+#: builtin/rebase.c:1051
 msgid "action"
 msgstr "hành động"
 
-#: apply.c:5036
+#: apply.c:5058
 msgid "detect new or modified lines that have whitespace errors"
 msgstr "tìm thấy một dòng mới hoặc bị sửa đổi mà nó có lỗi do khoảng trắng"
 
-#: apply.c:5039 apply.c:5042
+#: apply.c:5061 apply.c:5064
 msgid "ignore changes in whitespace when finding context"
 msgstr "lờ đi sự thay đổi do khoảng trắng gây ra khi tìm ngữ cảnh"
 
-#: apply.c:5045
+#: apply.c:5067
 msgid "apply the patch in reverse"
 msgstr "áp dụng miếng vá theo chiều ngược"
 
-#: apply.c:5047
+#: apply.c:5069
 msgid "don't expect at least one line of context"
 msgstr "đừng hy vọng có ít nhất một dòng ngữ cảnh"
 
-#: apply.c:5049
+#: apply.c:5071
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr "để lại khối dữ liệu bị từ chối trong các tập tin *.rej tương ứng"
 
-#: apply.c:5051
+#: apply.c:5073
 msgid "allow overlapping hunks"
 msgstr "cho phép chồng khối nhớ"
 
-#: apply.c:5052 builtin/add.c:364 builtin/check-ignore.c:22
-#: builtin/commit.c:1481 builtin/count-objects.c:98 builtin/fsck.c:756
-#: builtin/log.c:2297 builtin/mv.c:123 builtin/read-tree.c:128
+#: apply.c:5074 builtin/add.c:372 builtin/check-ignore.c:22
+#: builtin/commit.c:1483 builtin/count-objects.c:98 builtin/fsck.c:788
+#: builtin/log.c:2297 builtin/mv.c:123 builtin/read-tree.c:120
 msgid "be verbose"
 msgstr "chi tiết"
 
-#: apply.c:5054
+#: apply.c:5076
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr ""
 "đã dò tìm thấy dung sai không chính xác thiếu dòng mới tại cuối tập tin"
 
-#: apply.c:5057
+#: apply.c:5079
 msgid "do not trust the line counts in the hunk headers"
 msgstr "không tin số lượng dòng trong phần đầu khối dữ liệu"
 
-#: apply.c:5059 builtin/am.c:2306
+#: apply.c:5081 builtin/am.c:2308
 msgid "root"
 msgstr "gốc"
 
-#: apply.c:5060
+#: apply.c:5082
 msgid "prepend <root> to all filenames"
 msgstr "treo thêm <root> vào tất cả các tên tập tin"
 
@@ -1576,152 +1585,151 @@ msgstr "git archive --remote <kho> [--exec <lệnh>] --list"
 msgid "cannot read %s"
 msgstr "không thể đọc %s"
 
-#: archive.c:342 sequencer.c:460 sequencer.c:1915 sequencer.c:3095
-#: sequencer.c:3537 sequencer.c:3665 builtin/am.c:262 builtin/commit.c:833
-#: builtin/merge.c:1144
+#: archive.c:341 sequencer.c:473 sequencer.c:1932 sequencer.c:3114
+#: sequencer.c:3556 sequencer.c:3684 builtin/am.c:263 builtin/commit.c:834
+#: builtin/merge.c:1145
 #, c-format
 msgid "could not read '%s'"
 msgstr "không thể đọc “%s”"
 
-#: archive.c:427 builtin/add.c:205 builtin/add.c:645 builtin/rm.c:328
+#: archive.c:426 builtin/add.c:215 builtin/add.c:674 builtin/rm.c:334
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "đặc tả đường dẫn “%s” không khớp với bất kỳ tập tin nào"
 
-#: archive.c:451
+#: archive.c:450
 #, c-format
 msgid "no such ref: %.*s"
 msgstr "không có tham chiếu nào như thế: %.*s"
 
-#: archive.c:457
+#: archive.c:456
 #, c-format
 msgid "not a valid object name: %s"
 msgstr "không phải là tên đối tượng hợp lệ: “%s”"
 
-#: archive.c:470
+#: archive.c:469
 #, c-format
 msgid "not a tree object: %s"
 msgstr "không phải là đối tượng cây: “%s”"
 
-#: archive.c:482
+#: archive.c:481
 msgid "current working directory is untracked"
 msgstr "thư mục làm việc hiện hành chưa được theo dõi"
 
-#: archive.c:523
+#: archive.c:522
 #, c-format
 msgid "File not found: %s"
 msgstr "Không tìm thấy tập tin: %s"
 
-#: archive.c:525
+#: archive.c:524
 #, c-format
 msgid "Not a regular file: %s"
 msgstr "Không phải một tập tin thường: %s"
 
-#: archive.c:552
+#: archive.c:551
 msgid "fmt"
 msgstr "định_dạng"
 
-#: archive.c:552
+#: archive.c:551
 msgid "archive format"
 msgstr "định dạng lưu trữ"
 
-#: archive.c:553 builtin/log.c:1775
+#: archive.c:552 builtin/log.c:1775
 msgid "prefix"
 msgstr "tiền_tố"
 
-#: archive.c:554
+#: archive.c:553
 msgid "prepend prefix to each pathname in the archive"
 msgstr "nối thêm tiền tố vào từng đường dẫn tập tin trong kho lưu"
 
-#: archive.c:555 archive.c:558 builtin/blame.c:884 builtin/blame.c:888
-#: builtin/blame.c:889 builtin/commit-tree.c:117 builtin/config.c:135
-#: builtin/fast-export.c:1207 builtin/fast-export.c:1209
-#: builtin/fast-export.c:1213 builtin/grep.c:921 builtin/hash-object.c:105
-#: builtin/ls-files.c:653 builtin/ls-files.c:656 builtin/notes.c:412
-#: builtin/notes.c:578 builtin/read-tree.c:123 parse-options.h:191
+#: archive.c:554 archive.c:557 builtin/blame.c:880 builtin/blame.c:884
+#: builtin/blame.c:885 builtin/commit-tree.c:115 builtin/config.c:135
+#: builtin/fast-export.c:1208 builtin/fast-export.c:1210
+#: builtin/fast-export.c:1214 builtin/grep.c:935 builtin/hash-object.c:103
+#: builtin/ls-files.c:651 builtin/ls-files.c:654 builtin/notes.c:410
+#: builtin/notes.c:576 builtin/read-tree.c:115 parse-options.h:190
 msgid "file"
 msgstr "tập_tin"
 
-#: archive.c:556
+#: archive.c:555
 msgid "add untracked file to archive"
 msgstr "thêm các tập tin không được theo dõi vào kho lưu"
 
-#: archive.c:559 builtin/archive.c:90
+#: archive.c:558 builtin/archive.c:88
 msgid "write the archive to this file"
 msgstr "ghi kho lưu vào tập tin này"
 
-#: archive.c:561
+#: archive.c:560
 msgid "read .gitattributes in working directory"
 msgstr "đọc .gitattributes trong thư mục làm việc"
 
-#: archive.c:562
+#: archive.c:561
 msgid "report archived files on stderr"
 msgstr "liệt kê các tập tin được lưu trữ vào stderr (đầu ra lỗi tiêu chuẩn)"
 
-#: archive.c:564
+#: archive.c:563
 msgid "set compression level"
 msgstr "đặt mức nén"
 
-#: archive.c:567
+#: archive.c:566
 msgid "list supported archive formats"
 msgstr "liệt kê các kiểu nén được hỗ trợ"
 
-#: archive.c:569 builtin/archive.c:91 builtin/clone.c:118 builtin/clone.c:121
-#: builtin/submodule--helper.c:1898 builtin/submodule--helper.c:2352
-#: builtin/submodule--helper.c:2902
+#: archive.c:568 builtin/archive.c:89 builtin/clone.c:118 builtin/clone.c:121
+#: builtin/submodule--helper.c:1869 builtin/submodule--helper.c:2512
 msgid "repo"
 msgstr "kho"
 
-#: archive.c:570 builtin/archive.c:92
+#: archive.c:569 builtin/archive.c:90
 msgid "retrieve the archive from remote repository <repo>"
 msgstr "nhận kho nén từ kho chứa <kho> trên máy chủ"
 
-#: archive.c:571 builtin/archive.c:93 builtin/difftool.c:717
-#: builtin/notes.c:498
+#: archive.c:570 builtin/archive.c:91 builtin/difftool.c:714
+#: builtin/notes.c:496
 msgid "command"
 msgstr "lệnh"
 
-#: archive.c:572 builtin/archive.c:94
+#: archive.c:571 builtin/archive.c:92
 msgid "path to the remote git-upload-archive command"
 msgstr "đường dẫn đến lệnh git-upload-archive trên máy chủ"
 
-#: archive.c:579
+#: archive.c:578
 msgid "Unexpected option --remote"
 msgstr "Gặp tùy chọn không cần --remote"
 
-#: archive.c:581
+#: archive.c:580
 msgid "Option --exec can only be used together with --remote"
 msgstr "Tùy chọn --exec chỉ có thể được dùng cùng với --remote"
 
-#: archive.c:583
+#: archive.c:582
 msgid "Unexpected option --output"
 msgstr "Gặp tùy chọn không cần --output"
 
-#: archive.c:585
+#: archive.c:584
 msgid "Options --add-file and --remote cannot be used together"
 msgstr "Các tùy chọn --add-file và --remote không thể sử dụng cùng với nhau"
 
-#: archive.c:607
+#: archive.c:606
 #, c-format
 msgid "Unknown archive format '%s'"
 msgstr "Không hiểu định dạng “%s”"
 
-#: archive.c:616
+#: archive.c:615
 #, c-format
 msgid "Argument not supported for format '%s': -%d"
 msgstr "Tham số không được hỗ trợ cho định dạng “%s”: -%d"
 
-#: attr.c:202
+#: attr.c:203
 #, c-format
 msgid "%.*s is not a valid attribute name"
 msgstr "%.*s không phải tên thuộc tính hợp lệ"
 
-#: attr.c:363
+#: attr.c:364
 #, c-format
 msgid "%s not allowed: %s:%d"
 msgstr "%s không được phép: %s:%d"
 
-#: attr.c:403
+#: attr.c:404
 msgid ""
 "Negative patterns are ignored in git attributes\n"
 "Use '\\!' for literal leading exclamation."
@@ -1729,22 +1737,22 @@ msgstr ""
 "Các mẫu dạng phủ định bị cấm dùng cho các thuộc tính của git\n"
 "Dùng “\\!” cho các chuỗi văn bản có dấu chấm than dẫn đầu."
 
-#: bisect.c:489
+#: bisect.c:488
 #, c-format
 msgid "Badly quoted content in file '%s': %s"
 msgstr "Nội dung được trích dẫn sai trong tập tin “%s”: %s"
 
-#: bisect.c:699
+#: bisect.c:698
 #, c-format
 msgid "We cannot bisect more!\n"
 msgstr "Chúng tôi không bisect thêm nữa!\n"
 
-#: bisect.c:766
+#: bisect.c:764
 #, c-format
 msgid "Not a valid commit name %s"
 msgstr "Không phải tên đối tượng commit %s hợp lệ"
 
-#: bisect.c:791
+#: bisect.c:789
 #, c-format
 msgid ""
 "The merge base %s is bad.\n"
@@ -1753,7 +1761,7 @@ msgstr ""
 "Hòa trộn trên %s là sai.\n"
 "Điều đó có nghĩa là lỗi đã được sửa chữa giữa %s và [%s].\n"
 
-#: bisect.c:796
+#: bisect.c:794
 #, c-format
 msgid ""
 "The merge base %s is new.\n"
@@ -1762,7 +1770,7 @@ msgstr ""
 "Hòa trộn trên %s là mới.\n"
 "Gần như chắc chắn là có thay đổi giữa %s và [%s].\n"
 
-#: bisect.c:801
+#: bisect.c:799
 #, c-format
 msgid ""
 "The merge base %s is %s.\n"
@@ -1771,7 +1779,7 @@ msgstr ""
 "Hòa trộn trên %s là %s.\n"
 "Điều đó có nghĩa là lần chuyển giao “%s” đầu tiên là giữa %s và [%s].\n"
 
-#: bisect.c:809
+#: bisect.c:807
 #, c-format
 msgid ""
 "Some %s revs are not ancestors of the %s rev.\n"
@@ -1782,7 +1790,7 @@ msgstr ""
 "git bisect không thể làm việc đúng đắn trong trường hợp này.\n"
 "Liệu có phải bạn nhầm lẫn các điểm %s và %s không?\n"
 
-#: bisect.c:822
+#: bisect.c:820
 #, c-format
 msgid ""
 "the merge base between %s and [%s] must be skipped.\n"
@@ -1794,36 +1802,36 @@ msgstr ""
 "%s.\n"
 "Chúng tôi vẫn cứ tiếp tục."
 
-#: bisect.c:861
+#: bisect.c:859
 #, c-format
 msgid "Bisecting: a merge base must be tested\n"
 msgstr "Bisecting: nền hòa trộn cần phải được kiểm tra\n"
 
-#: bisect.c:911
+#: bisect.c:909
 #, c-format
 msgid "a %s revision is needed"
 msgstr "cần một điểm xét duyệt %s"
 
-#: bisect.c:941 builtin/notes.c:177 builtin/tag.c:298
+#: bisect.c:939
 #, c-format
 msgid "could not create file '%s'"
 msgstr "không thể tạo tập tin “%s”"
 
-#: bisect.c:987 builtin/merge.c:153
+#: bisect.c:985 builtin/merge.c:154
 #, c-format
 msgid "could not read file '%s'"
 msgstr "không thể đọc tập tin “%s”"
 
-#: bisect.c:1027
+#: bisect.c:1025
 msgid "reading bisect refs failed"
 msgstr "việc đọc tham chiếu bisect gặp lỗi"
 
-#: bisect.c:1057
+#: bisect.c:1055
 #, c-format
 msgid "%s was both %s and %s\n"
 msgstr "%s là cả %s và %s\n"
 
-#: bisect.c:1066
+#: bisect.c:1064
 #, c-format
 msgid ""
 "No testable commit found.\n"
@@ -1832,7 +1840,7 @@ msgstr ""
 "Không tìm thấy lần chuyển giao kiểm tra được nào.\n"
 "Có lẽ bạn bắt đầu với các tham số đường dẫn sai?\n"
 
-#: bisect.c:1095
+#: bisect.c:1093
 #, c-format
 msgid "(roughly %d step)"
 msgid_plural "(roughly %d steps)"
@@ -1841,7 +1849,7 @@ msgstr[0] "(ước chừng %d bước)"
 #. TRANSLATORS: the last %s will be replaced with "(roughly %d
 #. steps)" translation.
 #.
-#: bisect.c:1101
+#: bisect.c:1099
 #, c-format
 msgid "Bisecting: %d revision left to test after this %s\n"
 msgid_plural "Bisecting: %d revisions left to test after this %s\n"
@@ -1860,11 +1868,12 @@ msgid "--reverse and --first-parent together require specified latest commit"
 msgstr ""
 "cùng sử dụng --reverse và --first-parent cần chỉ định lần chuyển giao cuối"
 
-#: blame.c:2820 bundle.c:224 ref-filter.c:2278 remote.c:2041 sequencer.c:2333
-#: sequencer.c:4865 submodule.c:844 builtin/commit.c:1113 builtin/log.c:414
-#: builtin/log.c:1021 builtin/log.c:1629 builtin/log.c:2056 builtin/log.c:2346
-#: builtin/merge.c:428 builtin/pack-objects.c:3343 builtin/pack-objects.c:3806
-#: builtin/pack-objects.c:3821 builtin/shortlog.c:255
+#: blame.c:2820 bundle.c:224 midx.c:1039 ref-filter.c:2370 remote.c:2041
+#: sequencer.c:2350 sequencer.c:4902 submodule.c:883 builtin/commit.c:1114
+#: builtin/log.c:414 builtin/log.c:1021 builtin/log.c:1629 builtin/log.c:2056
+#: builtin/log.c:2346 builtin/merge.c:429 builtin/pack-objects.c:3373
+#: builtin/pack-objects.c:3775 builtin/pack-objects.c:3790
+#: builtin/shortlog.c:255
 msgid "revision walk setup failed"
 msgstr "cài đặt việc di chuyển qua các điểm xét duyệt gặp lỗi"
 
@@ -2046,8 +2055,8 @@ msgstr "“%s” không giống như tập tin v2 hay v3 bundle (định dạng 
 msgid "unrecognized header: %s%s (%d)"
 msgstr "phần đầu không được thừa nhận: %s%s (%d)"
 
-#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2593 sequencer.c:3385
-#: builtin/commit.c:861
+#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2618 sequencer.c:3404
+#: builtin/commit.c:862
 #, c-format
 msgid "could not open '%s'"
 msgstr "không thể mở “%s”"
@@ -2103,7 +2112,7 @@ msgstr "phiên bản bundle %d không được hỗ trợ"
 msgid "cannot write bundle version %d with algorithm %s"
 msgstr "không thể ghi phiên bản bundle %d với thuật toán %s"
 
-#: bundle.c:524 builtin/log.c:210 builtin/log.c:1938 builtin/shortlog.c:396
+#: bundle.c:524 builtin/log.c:210 builtin/log.c:1938 builtin/shortlog.c:399
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr "đối số không được thừa nhận: %s"
@@ -2145,7 +2154,7 @@ msgstr "mảnh cuối cùng có id không bằng không %<PRIx32>"
 msgid "invalid color value: %.*s"
 msgstr "giá trị màu không hợp lệ: %.*s"
 
-#: commit-graph.c:204 midx.c:47
+#: commit-graph.c:204 midx.c:51
 msgid "invalid hash version"
 msgstr "phiên bản băm không hợp lệ"
 
@@ -2192,202 +2201,202 @@ msgstr ""
 msgid "unable to find all commit-graph files"
 msgstr "không thể tìm thấy tất cả các tập tin đồ-thị-các-lần-chuyển-giao"
 
-#: commit-graph.c:745 commit-graph.c:782
+#: commit-graph.c:746 commit-graph.c:783
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr ""
 "vị trí lần chuyển giao không hợp lệ. đồ-thị-các-lần-chuyển-giao có vẻ như đã "
 "bị hỏng"
 
-#: commit-graph.c:766
+#: commit-graph.c:767
 #, c-format
 msgid "could not find commit %s"
 msgstr "không thể tìm thấy lần chuyển giao %s"
 
-#: commit-graph.c:799
+#: commit-graph.c:800
 msgid "commit-graph requires overflow generation data but has none"
 msgstr "commit-graph yêu cầu dữ liệu tạo tràn nhưng không có"
 
-#: commit-graph.c:1075 builtin/am.c:1341
+#: commit-graph.c:1105 builtin/am.c:1342
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "không thể phân tích lần chuyển giao “%s”"
 
-#: commit-graph.c:1337 builtin/pack-objects.c:3057
+#: commit-graph.c:1367 builtin/pack-objects.c:3070
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "không thể lấy kiểu của đối tượng “%s”"
 
-#: commit-graph.c:1368
+#: commit-graph.c:1398
 msgid "Loading known commits in commit graph"
 msgstr "Đang tải các lần chuyển giao chưa biết trong đồ thị lần chuyển giao"
 
-#: commit-graph.c:1385
+#: commit-graph.c:1415
 msgid "Expanding reachable commits in commit graph"
 msgstr ""
 "Mở rộng các lần chuyển giao có thể tiếp cận được trong trong đồ thị lần "
 "chuyển giao"
 
-#: commit-graph.c:1405
+#: commit-graph.c:1435
 msgid "Clearing commit marks in commit graph"
 msgstr "Đang dọn dẹp các đánh dấu lần chuyển giao trong đồ thị lần chuyển giao"
 
-#: commit-graph.c:1424
+#: commit-graph.c:1454
 msgid "Computing commit graph topological levels"
 msgstr "Đang tính mức hình học tô-pô tạo đồ thị các lần chuyển giao"
 
-#: commit-graph.c:1477
+#: commit-graph.c:1507
 msgid "Computing commit graph generation numbers"
 msgstr "Đang tính toán số tạo đồ thị các lần chuyển giao"
 
-#: commit-graph.c:1558
+#: commit-graph.c:1588
 msgid "Computing commit changed paths Bloom filters"
 msgstr "Đang tính toán chuyển giao các bộ lọc Bloom đường dẫn bị thay đổi"
 
-#: commit-graph.c:1635
+#: commit-graph.c:1665
 msgid "Collecting referenced commits"
 msgstr "Đang sưu tập các lần chuyển giao được tham chiếu"
 
-#: commit-graph.c:1660
+#: commit-graph.c:1690
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] ""
 "Đang tìm các lần chuyển giao cho đồ thị lần chuyển giao trong %d gói"
 
-#: commit-graph.c:1673
+#: commit-graph.c:1703
 #, c-format
 msgid "error adding pack %s"
 msgstr "gặp lỗi thêm gói %s"
 
-#: commit-graph.c:1677
+#: commit-graph.c:1707
 #, c-format
 msgid "error opening index for %s"
 msgstr "gặp lỗi khi mở mục lục cho “%s”"
 
-#: commit-graph.c:1714
+#: commit-graph.c:1744
 msgid "Finding commits for commit graph among packed objects"
 msgstr ""
 "Đang tìm các lần chuyển giao cho đồ thị lần chuyển giao trong số các đối "
 "tượng đã đóng gói"
 
-#: commit-graph.c:1732
+#: commit-graph.c:1762
 msgid "Finding extra edges in commit graph"
 msgstr "Đang tìm các cạnh mở tộng trong đồ thị lần chuyển giao"
 
-#: commit-graph.c:1781
+#: commit-graph.c:1811
 msgid "failed to write correct number of base graph ids"
 msgstr "gặp lỗi khi ghi số đúng của mã đồ họa cơ sở"
 
-#: commit-graph.c:1812 midx.c:911
+#: commit-graph.c:1842 midx.c:1146
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "không thể tạo các thư mục dẫn đầu của “%s”"
 
-#: commit-graph.c:1825
+#: commit-graph.c:1855
 msgid "unable to create temporary graph layer"
 msgstr "không thể tạo lớp sơ đồ tạm thời"
 
-#: commit-graph.c:1830
+#: commit-graph.c:1860
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "không thể chỉnh sửa quyền chia sẻ thành “%s”"
 
-#: commit-graph.c:1887
+#: commit-graph.c:1917
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "Đang ghi ra đồ thị các lần chuyển giao trong lần %d"
 
-#: commit-graph.c:1923
+#: commit-graph.c:1953
 msgid "unable to open commit-graph chain file"
 msgstr "không thể mở tập tin mắt xích đồ thị chuyển giao"
 
-#: commit-graph.c:1939
+#: commit-graph.c:1969
 msgid "failed to rename base commit-graph file"
 msgstr "gặp lỗi khi đổi tên tập tin đồ-thị-các-lần-chuyển-giao"
 
-#: commit-graph.c:1959
+#: commit-graph.c:1989
 msgid "failed to rename temporary commit-graph file"
 msgstr "gặp lỗi khi đổi tên tập tin đồ-thị-các-lần-chuyển-giao tạm thời"
 
-#: commit-graph.c:2092
+#: commit-graph.c:2122
 msgid "Scanning merged commits"
 msgstr "Đang quét các lần chuyển giao đã hòa trộn"
 
-#: commit-graph.c:2136
+#: commit-graph.c:2166
 msgid "Merging commit-graph"
 msgstr "Đang hòa trộn đồ-thị-các-lần-chuyển-giao"
 
-#: commit-graph.c:2244
+#: commit-graph.c:2274
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 "cố gắng để ghi một đồ thị các lần chuyển giao, nhưng “core.commitGraph” bị "
 "vô hiệu hóa"
 
-#: commit-graph.c:2351
+#: commit-graph.c:2381
 msgid "too many commits to write graph"
 msgstr "có quá nhiều lần chuyển giao để ghi đồ thị"
 
-#: commit-graph.c:2449
+#: commit-graph.c:2479
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "tập tin đồ-thị-các-lần-chuyển-giao có tổng kiểm không đúng và có vẻ như là "
 "đã hỏng"
 
-#: commit-graph.c:2459
+#: commit-graph.c:2489
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "đồ-thị-các-lần-chuyển-giao có thứ tự OID không đúng: %s sau %s"
 
-#: commit-graph.c:2469 commit-graph.c:2484
+#: commit-graph.c:2499 commit-graph.c:2514
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr ""
 "đồ-thị-các-lần-chuyển-giao có giá trị fanout không đúng: fanout[%d] = %u != "
 "%u"
 
-#: commit-graph.c:2476
+#: commit-graph.c:2506
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "gặp lỗi khi phân tích lần chuyển giao từ %s đồ-thị-các-lần-chuyển-giao"
 
-#: commit-graph.c:2494
+#: commit-graph.c:2524
 msgid "Verifying commits in commit graph"
 msgstr "Đang thẩm tra các lần chuyển giao trong đồ thị lần chuyển giao"
 
-#: commit-graph.c:2509
+#: commit-graph.c:2539
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "gặp lỗi khi phân tích lần chuyển giao %s từ cơ sở dữ liệu đối tượng cho đồ "
 "thị lần chuyển giao"
 
-#: commit-graph.c:2516
+#: commit-graph.c:2546
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 "OID cây gốc cho lần chuyển giao %s trong đồ-thị-các-lần-chuyển-giao là %s != "
 "%s"
 
-#: commit-graph.c:2526
+#: commit-graph.c:2556
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr ""
 "danh sách cha mẹ đồ-thị-các-lần-chuyển-giao cho lần chuyển giao %s là quá dài"
 
-#: commit-graph.c:2535
+#: commit-graph.c:2565
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "cha mẹ đồ-thị-các-lần-chuyển-giao cho %s là %s != %s"
 
-#: commit-graph.c:2549
+#: commit-graph.c:2579
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr ""
 "danh sách cha mẹ đồ-thị-các-lần-chuyển-giao cho lần chuyển giao %s bị chấm "
 "dứt quá sớm"
 
-#: commit-graph.c:2554
+#: commit-graph.c:2584
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2395,7 +2404,7 @@ msgstr ""
 "đồ-thị-các-lần-chuyển-giao có con số không lần tạo cho lần chuyển giao %s, "
 "nhưng không phải số không ở chỗ khác"
 
-#: commit-graph.c:2558
+#: commit-graph.c:2588
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2403,32 +2412,32 @@ msgstr ""
 "đồ-thị-các-lần-chuyển-giao có con số không phải không lần tạo cho lần chuyển "
 "giao %s, nhưng số không ở chỗ khác"
 
-#: commit-graph.c:2575
+#: commit-graph.c:2605
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr ""
 "tạo đồ-thị-các-lần-chuyển-giao cho lần chuyển giao %s là %<PRIuMAX> < "
 "%<PRIuMAX>"
 
-#: commit-graph.c:2581
+#: commit-graph.c:2611
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 "ngày chuyển giao cho lần chuyển giao %s trong đồ-thị-các-lần-chuyển-giao là "
 "%<PRIuMAX> != %<PRIuMAX>"
 
-#: commit.c:52 sequencer.c:3088 builtin/am.c:372 builtin/am.c:417
-#: builtin/am.c:422 builtin/am.c:1420 builtin/am.c:2067 builtin/replace.c:457
+#: commit.c:53 sequencer.c:3107 builtin/am.c:373 builtin/am.c:418
+#: builtin/am.c:423 builtin/am.c:1421 builtin/am.c:2068 builtin/replace.c:457
 #, c-format
 msgid "could not parse %s"
 msgstr "không thể phân tích cú pháp %s"
 
-#: commit.c:54
+#: commit.c:55
 #, c-format
 msgid "%s %s is not a commit!"
 msgstr "%s %s không phải là một lần chuyển giao!"
 
-#: commit.c:194
+#: commit.c:196
 msgid ""
 "Support for <GIT_DIR>/info/grafts is deprecated\n"
 "and will be removed in a future Git version.\n"
@@ -2448,28 +2457,28 @@ msgstr ""
 "Tắt lời nhắn này bằng cách chạy\n"
 "\"git config advice.graftFileDeprecated false\""
 
-#: commit.c:1237
+#: commit.c:1239
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
 msgstr ""
 "Lần chuyển giao %s có một chữ ký GPG không đáng tin, được cho là bởi %s."
 
-#: commit.c:1241
+#: commit.c:1243
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
 msgstr "Lần chuyển giao %s có một chữ ký GPG sai, được cho là bởi %s."
 
-#: commit.c:1244
+#: commit.c:1246
 #, c-format
 msgid "Commit %s does not have a GPG signature."
 msgstr "Lần chuyển giao %s không có chữ ký GPG."
 
-#: commit.c:1247
+#: commit.c:1249
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
 msgstr "Lần chuyển giao %s có một chữ ký GPG tốt bởi %s\n"
 
-#: commit.c:1501
+#: commit.c:1503
 msgid ""
 "Warning: commit message did not conform to UTF-8.\n"
 "You may want to amend it after fixing the message, or set the config\n"
@@ -2483,7 +2492,7 @@ msgstr ""
 msgid "memory exhausted"
 msgstr "hết bộ nhớ"
 
-#: config.c:126
+#: config.c:125
 #, c-format
 msgid ""
 "exceeded maximum include depth (%d) while including\n"
@@ -2498,35 +2507,35 @@ msgstr ""
 "\t%s\n"
 "Nguyên nhân có thể là gồm quẩn vòng."
 
-#: config.c:142
+#: config.c:141
 #, c-format
 msgid "could not expand include path '%s'"
 msgstr "không thể khai triển đường dẫn “%s”"
 
-#: config.c:153
+#: config.c:152
 msgid "relative config includes must come from files"
 msgstr "các bao gồm cấu hình liên quan phải đến từ các tập tin"
 
-#: config.c:199
+#: config.c:201
 msgid "relative config include conditionals must come from files"
 msgstr "các điều kiện bao gồm cấu hình liên quan phải đến từ các tập tin"
 
-#: config.c:396
+#: config.c:398
 #, c-format
 msgid "invalid config format: %s"
 msgstr "định dạng cấu hình không hợp lệ: %s"
 
-#: config.c:400
+#: config.c:402
 #, c-format
 msgid "missing environment variable name for configuration '%.*s'"
-msgstr "thiếu tên biến môi trường cho cấu hình '%.*s'"
+msgstr "thiếu tên biến môi trường cho cấu hình “%.*s”"
 
-#: config.c:405
+#: config.c:407
 #, c-format
 msgid "missing environment variable '%s' for configuration '%.*s'"
-msgstr "thiếu biến môi trường '%s' cho cấu hình '%.*s'"
+msgstr "thiếu biến môi trường “%s” cho cấu hình “%.*s”"
 
-#: config.c:442
+#: config.c:443
 #, c-format
 msgid "key does not contain a section: %s"
 msgstr "khóa không chứa một phần: %s"
@@ -2536,297 +2545,297 @@ msgstr "khóa không chứa một phần: %s"
 msgid "key does not contain variable name: %s"
 msgstr "khóa không chứa bất kỳ một tên biến nào: %s"
 
-#: config.c:472 sequencer.c:2785
+#: config.c:470 sequencer.c:2804
 #, c-format
 msgid "invalid key: %s"
 msgstr "khóa không đúng: %s"
 
-#: config.c:478
+#: config.c:475
 #, c-format
 msgid "invalid key (newline): %s"
 msgstr "khóa không hợp lệ (dòng mới): %s"
 
-#: config.c:511
+#: config.c:495
 msgid "empty config key"
 msgstr "khóa cấu hình trống rỗng"
 
-#: config.c:529 config.c:541
+#: config.c:513 config.c:525
 #, c-format
 msgid "bogus config parameter: %s"
 msgstr "tham số cấu hình không có thực: %s"
 
-#: config.c:555 config.c:572 config.c:579 config.c:588
+#: config.c:539 config.c:556 config.c:563 config.c:572
 #, c-format
 msgid "bogus format in %s"
 msgstr "định dạng không có thực trong %s"
 
-#: config.c:622
+#: config.c:606
 #, c-format
 msgid "bogus count in %s"
 msgstr "số lượng không có thực trong %s"
 
-#: config.c:626
+#: config.c:610
 #, c-format
 msgid "too many entries in %s"
 msgstr "quá nhiều mục tin trong %s"
 
-#: config.c:636
+#: config.c:620
 #, c-format
 msgid "missing config key %s"
 msgstr "thiếu khóa cấu hình “%s”"
 
-#: config.c:644
+#: config.c:628
 #, c-format
 msgid "missing config value %s"
 msgstr "thiếu giá trị cấu hình “%s”"
 
-#: config.c:995
+#: config.c:979
 #, c-format
 msgid "bad config line %d in blob %s"
 msgstr "tập tin cấu hình sai tại dòng %d trong blob %s"
 
-#: config.c:999
+#: config.c:983
 #, c-format
 msgid "bad config line %d in file %s"
 msgstr "cấu hình sai tại dòng %d trong tập tin %s"
 
-#: config.c:1003
+#: config.c:987
 #, c-format
 msgid "bad config line %d in standard input"
 msgstr "cấu hình sai tại dòng %d trong đầu vào tiêu chuẩn"
 
-#: config.c:1007
+#: config.c:991
 #, c-format
 msgid "bad config line %d in submodule-blob %s"
 msgstr "cấu hình sai tại dòng %d trong blob-mô-đun-con %s"
 
-#: config.c:1011
+#: config.c:995
 #, c-format
 msgid "bad config line %d in command line %s"
 msgstr "cấu hình sai tại dòng %d trong dòng lệnh %s"
 
-#: config.c:1015
+#: config.c:999
 #, c-format
 msgid "bad config line %d in %s"
 msgstr "cấu hình sai tại dòng %d trong %s"
 
-#: config.c:1152
+#: config.c:1136
 msgid "out of range"
 msgstr "nằm ngoài phạm vi"
 
-#: config.c:1152
+#: config.c:1136
 msgid "invalid unit"
 msgstr "đơn vị không hợp lệ"
 
-#: config.c:1153
+#: config.c:1137
 #, c-format
 msgid "bad numeric config value '%s' for '%s': %s"
 msgstr "sai giá trị bằng số của cấu hình “%s” cho “%s”: %s"
 
-#: config.c:1163
+#: config.c:1147
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in blob %s: %s"
 msgstr "sai giá trị bằng số của cấu hình “%s” cho “%s” trong blob %s: %s"
 
-#: config.c:1166
+#: config.c:1150
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in file %s: %s"
 msgstr "sai giá trị bằng số của cấu hình “%s” cho “%s” trong tập tin %s: %s"
 
-#: config.c:1169
+#: config.c:1153
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in standard input: %s"
 msgstr ""
 "sai giá trị bằng số của cấu hình “%s” cho “%s” trong đầu vào tiêu chuẩn: %s"
 
-#: config.c:1172
+#: config.c:1156
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in submodule-blob %s: %s"
 msgstr ""
 "sai giá trị bằng số của cấu hình “%s” cho “%s” trong submodule-blob %s: %s"
 
-#: config.c:1175
+#: config.c:1159
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in command line %s: %s"
 msgstr "sai giá trị bằng số của cấu hình “%s” cho “%s” trong dòng lệnh %s: %s"
 
-#: config.c:1178
+#: config.c:1162
 #, c-format
 msgid "bad numeric config value '%s' for '%s' in %s: %s"
 msgstr "sai giá trị bằng số của cấu hình “%s” cho “%s” trong %s: %s"
 
-#: config.c:1257
+#: config.c:1241
 #, c-format
 msgid "bad boolean config value '%s' for '%s'"
 msgstr "sai giá trị kiểu lô-gíc của cấu hình “%s” cho “%s”"
 
-#: config.c:1275
+#: config.c:1259
 #, c-format
 msgid "failed to expand user dir in: '%s'"
 msgstr "gặp lỗi mở rộng thư mục người dùng trong: “%s”"
 
-#: config.c:1284
+#: config.c:1268
 #, c-format
 msgid "'%s' for '%s' is not a valid timestamp"
 msgstr "“%s” dành cho “%s” không phải là dấu vết thời gian hợp lệ"
 
-#: config.c:1377
+#: config.c:1361
 #, c-format
 msgid "abbrev length out of range: %d"
 msgstr "chiều dài abbrev nằm ngoài phạm vi: %d"
 
-#: config.c:1391 config.c:1402
+#: config.c:1375 config.c:1386
 #, c-format
 msgid "bad zlib compression level %d"
 msgstr "mức nén zlib %d là sai"
 
-#: config.c:1494
+#: config.c:1476
 msgid "core.commentChar should only be one character"
 msgstr "core.commentChar chỉ được có một ký tự"
 
-#: config.c:1527
+#: config.c:1509
 #, c-format
 msgid "invalid mode for object creation: %s"
 msgstr "chế độ không hợp lệ đối với việc tạo đối tượng: %s"
 
-#: config.c:1599
+#: config.c:1581
 #, c-format
 msgid "malformed value for %s"
 msgstr "giá trị cho %s sai dạng"
 
-#: config.c:1625
+#: config.c:1607
 #, c-format
 msgid "malformed value for %s: %s"
 msgstr "giá trị cho %s sai dạng: %s"
 
-#: config.c:1626
+#: config.c:1608
 msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr "phải là một trong số nothing, matching, simple, upstream hay current"
 
-#: config.c:1687 builtin/pack-objects.c:4084
+#: config.c:1669 builtin/pack-objects.c:4053
 #, c-format
 msgid "bad pack compression level %d"
 msgstr "mức nén gói %d không hợp lệ"
 
-#: config.c:1809
+#: config.c:1792
 #, c-format
 msgid "unable to load config blob object '%s'"
 msgstr "không thể tải đối tượng blob cấu hình “%s”"
 
-#: config.c:1812
+#: config.c:1795
 #, c-format
 msgid "reference '%s' does not point to a blob"
 msgstr "tham chiếu “%s” không chỉ đến một blob nào cả"
 
-#: config.c:1829
+#: config.c:1813
 #, c-format
 msgid "unable to resolve config blob '%s'"
 msgstr "không thể phân giải điểm xét duyệt “%s”"
 
-#: config.c:1874
+#: config.c:1858
 #, c-format
 msgid "failed to parse %s"
 msgstr "gặp lỗi khi phân tích cú pháp %s"
 
-#: config.c:1930
+#: config.c:1914
 msgid "unable to parse command-line config"
 msgstr "không thể phân tích cấu hình dòng lệnh"
 
-#: config.c:2294
+#: config.c:2282
 msgid "unknown error occurred while reading the configuration files"
 msgstr "đã có lỗi chưa biết xảy ra trong khi đọc các tập tin cấu hình"
 
-#: config.c:2468
+#: config.c:2456
 #, c-format
 msgid "Invalid %s: '%s'"
 msgstr "%s không hợp lệ: “%s”"
 
-#: config.c:2513
+#: config.c:2501
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
 msgstr "giá trị splitIndex.maxPercentChange “%d” phải nằm giữa 0 và 100"
 
-#: config.c:2559
+#: config.c:2547
 #, c-format
 msgid "unable to parse '%s' from command-line config"
 msgstr "không thể phân tích “%s” từ cấu hình dòng lệnh"
 
-#: config.c:2561
+#: config.c:2549
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
 msgstr "sai biến cấu hình “%s” trong tập tin “%s” tại dòng %d"
 
-#: config.c:2645
+#: config.c:2633
 #, c-format
 msgid "invalid section name '%s'"
 msgstr "tên của phần không hợp lệ “%s”"
 
-#: config.c:2677
+#: config.c:2665
 #, c-format
 msgid "%s has multiple values"
 msgstr "%s có đa giá trị"
 
-#: config.c:2706
+#: config.c:2694
 #, c-format
 msgid "failed to write new configuration file %s"
 msgstr "gặp lỗi khi ghi tập tin cấu hình “%s”"
 
-#: config.c:2958 config.c:3285
+#: config.c:2946 config.c:3273
 #, c-format
 msgid "could not lock config file %s"
 msgstr "không thể khóa tập tin cấu hình %s"
 
-#: config.c:2969
+#: config.c:2957
 #, c-format
 msgid "opening %s"
 msgstr "đang mở “%s”"
 
-#: config.c:3006 builtin/config.c:361
+#: config.c:2994 builtin/config.c:361
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "mẫu không hợp lệ: %s"
 
-#: config.c:3031
+#: config.c:3019
 #, c-format
 msgid "invalid config file %s"
 msgstr "tập tin cấu hình “%s” không hợp lệ"
 
-#: config.c:3044 config.c:3298
+#: config.c:3032 config.c:3286
 #, c-format
 msgid "fstat on %s failed"
 msgstr "fstat trên %s gặp lỗi"
 
-#: config.c:3055
+#: config.c:3043
 #, c-format
 msgid "unable to mmap '%s'%s"
 msgstr "không thể mmap “%s”%s"
 
-#: config.c:3065 config.c:3303
+#: config.c:3053 config.c:3291
 #, c-format
 msgid "chmod on %s failed"
 msgstr "chmod trên %s gặp lỗi"
 
-#: config.c:3150 config.c:3400
+#: config.c:3138 config.c:3388
 #, c-format
 msgid "could not write config file %s"
 msgstr "không thể ghi tập tin cấu hình “%s”"
 
-#: config.c:3184
+#: config.c:3172
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "không thể đặt “%s” thành “%s”"
 
-#: config.c:3186 builtin/remote.c:657 builtin/remote.c:855 builtin/remote.c:863
+#: config.c:3174 builtin/remote.c:662 builtin/remote.c:860 builtin/remote.c:868
 #, c-format
 msgid "could not unset '%s'"
 msgstr "không thể thôi đặt “%s”"
 
-#: config.c:3276
+#: config.c:3264
 #, c-format
 msgid "invalid section name: %s"
 msgstr "tên của phần không hợp lệ: %s"
 
-#: config.c:3443
+#: config.c:3431
 #, c-format
 msgid "missing value for '%s'"
 msgstr "thiếu giá trị cho cho “%s”"
@@ -2861,72 +2870,72 @@ msgstr "máy chủ không hỗ trợ tính năng “%s”"
 msgid "expected flush after capabilities"
 msgstr "cần đẩy dữ liệu lên đĩa sau các capabilities"
 
-#: connect.c:263
+#: connect.c:265
 #, c-format
 msgid "ignoring capabilities after first line '%s'"
 msgstr "bỏ qua capabilities sau dòng đầu tiên “%s”"
 
-#: connect.c:284
+#: connect.c:286
 msgid "protocol error: unexpected capabilities^{}"
 msgstr "lỗi giao thức: không cần capabilities^{}"
 
-#: connect.c:306
+#: connect.c:308
 #, c-format
 msgid "protocol error: expected shallow sha-1, got '%s'"
 msgstr "lỗi giao thức: cần sha-1 shallow, nhưng lại nhận được “%s”"
 
-#: connect.c:308
+#: connect.c:310
 msgid "repository on the other end cannot be shallow"
 msgstr "kho đã ở điểm cuối khoác nên không thể được shallow"
 
-#: connect.c:347
+#: connect.c:349
 msgid "invalid packet"
 msgstr "gói không hợp lệ"
 
-#: connect.c:367
+#: connect.c:369
 #, c-format
 msgid "protocol error: unexpected '%s'"
 msgstr "lỗi giao thức: không cần “%s”"
 
-#: connect.c:497
+#: connect.c:499
 #, c-format
 msgid "unknown object format '%s' specified by server"
 msgstr "không hiểu định dạng đối tượng “%s” được chỉ định bởi máy phục vụ"
 
-#: connect.c:526
+#: connect.c:528
 #, c-format
 msgid "invalid ls-refs response: %s"
 msgstr "trả về của ls-refs không hợp lệ: %s"
 
-#: connect.c:530
+#: connect.c:532
 msgid "expected flush after ref listing"
 msgstr "cần đẩy dữ liệu lên đĩa sau khi liệt kê tham chiếu"
 
-#: connect.c:533
+#: connect.c:535
 msgid "expected response end packet after ref listing"
 msgstr "cần nhận được trả lời là kết thúc gói sau khi liệt kê tham chiếu"
 
-#: connect.c:666
+#: connect.c:670
 #, c-format
 msgid "protocol '%s' is not supported"
 msgstr "giao thức “%s” chưa được hỗ trợ"
 
-#: connect.c:717
+#: connect.c:721
 msgid "unable to set SO_KEEPALIVE on socket"
 msgstr "không thể đặt SO_KEEPALIVE trên ổ cắm"
 
-#: connect.c:757 connect.c:820
+#: connect.c:761 connect.c:824
 #, c-format
 msgid "Looking up %s ... "
 msgstr "Đang tìm kiếm %s … "
 
-#: connect.c:761
+#: connect.c:765
 #, c-format
 msgid "unable to look up %s (port %s) (%s)"
 msgstr "không tìm được %s (cổng %s) (%s)"
 
 #. TRANSLATORS: this is the end of "Looking up %s ... "
-#: connect.c:765 connect.c:836
+#: connect.c:769 connect.c:840
 #, c-format
 msgid ""
 "done.\n"
@@ -2935,7 +2944,7 @@ msgstr ""
 "xong.\n"
 "Đang kết nối đến %s (cổng %s) … "
 
-#: connect.c:787 connect.c:864
+#: connect.c:791 connect.c:868
 #, c-format
 msgid ""
 "unable to connect to %s:\n"
@@ -2945,77 +2954,77 @@ msgstr ""
 "%s"
 
 #. TRANSLATORS: this is the end of "Connecting to %s (port %s) ... "
-#: connect.c:793 connect.c:870
+#: connect.c:797 connect.c:874
 msgid "done."
 msgstr "hoàn tất."
 
-#: connect.c:824
+#: connect.c:828
 #, c-format
 msgid "unable to look up %s (%s)"
 msgstr "không thể tìm thấy %s (%s)"
 
-#: connect.c:830
+#: connect.c:834
 #, c-format
 msgid "unknown port %s"
 msgstr "không hiểu cổng %s"
 
-#: connect.c:967 connect.c:1299
+#: connect.c:971 connect.c:1303
 #, c-format
 msgid "strange hostname '%s' blocked"
 msgstr "đã khóa tên máy lạ “%s”"
 
-#: connect.c:969
+#: connect.c:973
 #, c-format
 msgid "strange port '%s' blocked"
 msgstr "đã khóa cổng lạ “%s”"
 
-#: connect.c:979
+#: connect.c:983
 #, c-format
 msgid "cannot start proxy %s"
 msgstr "không thể khởi chạy ủy nhiệm “%s”"
 
-#: connect.c:1050
+#: connect.c:1054
 msgid "no path specified; see 'git help pull' for valid url syntax"
 msgstr "chưa chỉ định đường dẫn; xem'git help pull” để biết cú pháp url hợp lệ"
 
-#: connect.c:1190
+#: connect.c:1194
 msgid "newline is forbidden in git:// hosts and repo paths"
 msgstr "newline bị cấm trong các git:// máy chủ và đường dẫn repo"
 
-#: connect.c:1247
+#: connect.c:1251
 msgid "ssh variant 'simple' does not support -4"
 msgstr "ssh biến thể “simple” không hỗ trợ -4"
 
-#: connect.c:1259
+#: connect.c:1263
 msgid "ssh variant 'simple' does not support -6"
 msgstr "ssh biến thể “simple” không hỗ trợ -6"
 
-#: connect.c:1276
+#: connect.c:1280
 msgid "ssh variant 'simple' does not support setting port"
 msgstr "ssh biến thể “simple” không hỗ trợ đặt cổng"
 
-#: connect.c:1388
+#: connect.c:1392
 #, c-format
 msgid "strange pathname '%s' blocked"
 msgstr "đã khóa tên đường dẫn lạ “%s”"
 
-#: connect.c:1436
+#: connect.c:1440
 msgid "unable to fork"
 msgstr "không thể rẽ nhánh tiến trình con"
 
-#: connected.c:108 builtin/fsck.c:189 builtin/prune.c:45
+#: connected.c:109 builtin/fsck.c:189 builtin/prune.c:45
 msgid "Checking connectivity"
 msgstr "Đang kiểm tra kết nối"
 
-#: connected.c:120
+#: connected.c:122
 msgid "Could not run 'git rev-list'"
 msgstr "Không thể chạy “git rev-list”"
 
-#: connected.c:144
+#: connected.c:146
 msgid "failed write to rev-list"
 msgstr "gặp lỗi khi ghi vào rev-list"
 
-#: connected.c:149
+#: connected.c:151
 msgid "failed to close rev-list's stdin"
 msgstr "gặp lỗi khi đóng đầu vào chuẩn stdin của rev-list"
 
@@ -3159,17 +3168,17 @@ msgstr "từ chối làm việc với giấy chứng thực thiếu trường m�
 msgid "refusing to work with credential missing protocol field"
 msgstr "từ chối làm việc với giấy chứng thực thiếu trường giao thức"
 
-#: credential.c:394
+#: credential.c:395
 #, c-format
 msgid "url contains a newline in its %s component: %s"
 msgstr "url có chứa một dấu xuống dòng trong thành phần %s của nó: %s"
 
-#: credential.c:438
+#: credential.c:439
 #, c-format
 msgid "url has no scheme: %s"
 msgstr "url không có lược đồ: %s"
 
-#: credential.c:511
+#: credential.c:512
 #, c-format
 msgid "credential url cannot be parsed: %s"
 msgstr "không thể phân tích cú pháp giấy chứng thực url: %s"
@@ -3263,23 +3272,23 @@ msgstr "Đã đánh dấu %d island, xong.\n"
 msgid "unknown value for --diff-merges: %s"
 msgstr "không hiểu giá trị cho --diff-merges: %s"
 
-#: diff-lib.c:557
+#: diff-lib.c:561
 msgid "--merge-base does not work with ranges"
 msgstr "--merge-base không hoạt động với phạm vi"
 
-#: diff-lib.c:559
+#: diff-lib.c:563
 msgid "--merge-base only works with commits"
 msgstr "--merge-base chỉ hoạt động với các lần chuyển giao"
 
-#: diff-lib.c:576
+#: diff-lib.c:580
 msgid "unable to get HEAD"
 msgstr "không thể lấy HEAD"
 
-#: diff-lib.c:583
+#: diff-lib.c:587
 msgid "no merge base found"
 msgstr "không tìm thấy cơ sở để hòa trộn"
 
-#: diff-lib.c:585
+#: diff-lib.c:589
 msgid "multiple merge bases found"
 msgstr "có nhiều cơ sở để hòa trộn"
 
@@ -3295,17 +3304,17 @@ msgstr ""
 "Không phải là một thư mục git. Dùng --no-index để so sánh hai đường dẫn bên "
 "ngoài một cây làm việc"
 
-#: diff.c:156
+#: diff.c:157
 #, c-format
 msgid "  Failed to parse dirstat cut-off percentage '%s'\n"
 msgstr "  Gặp lỗi khi phân tích dirstat cắt bỏ phần trăm “%s”\n"
 
-#: diff.c:161
+#: diff.c:162
 #, c-format
 msgid "  Unknown dirstat parameter '%s'\n"
 msgstr "  Không hiểu đối số dirstat “%s”\n"
 
-#: diff.c:297
+#: diff.c:298
 msgid ""
 "color moved setting must be one of 'no', 'default', 'blocks', 'zebra', "
 "'dimmed-zebra', 'plain'"
@@ -3313,7 +3322,7 @@ msgstr ""
 "cài đặt màu đã di chuyển phải là một trong “no”, “default”, “blocks”, "
 "“zebra”, “dimmed-zebra”, “plain”"
 
-#: diff.c:325
+#: diff.c:326
 #, c-format
 msgid ""
 "unknown color-moved-ws mode '%s', possible values are 'ignore-space-change', "
@@ -3323,7 +3332,7 @@ msgstr ""
 "change”, “ignore-space-at-eol”, “ignore-all-space”, “allow-indentation-"
 "change”"
 
-#: diff.c:333
+#: diff.c:334
 msgid ""
 "color-moved-ws: allow-indentation-change cannot be combined with other "
 "whitespace modes"
@@ -3331,12 +3340,12 @@ msgstr ""
 "color-moved-ws: allow-indentation-change không thể tổ hợp cùng với các chế "
 "độ khoảng trắng khác"
 
-#: diff.c:410
+#: diff.c:411
 #, c-format
 msgid "Unknown value for 'diff.submodule' config variable: '%s'"
 msgstr "Không hiểu giá trị cho biến cấu hình “diff.submodule”: “%s”"
 
-#: diff.c:470
+#: diff.c:471
 #, c-format
 msgid ""
 "Found errors in 'diff.dirstat' config variable:\n"
@@ -3345,26 +3354,26 @@ msgstr ""
 "Tìm thấy các lỗi trong biến cấu hình “diff.dirstat”:\n"
 "%s"
 
-#: diff.c:4282
+#: diff.c:4290
 #, c-format
 msgid "external diff died, stopping at %s"
 msgstr "phần mềm diff ở bên ngoài đã chết, dừng tại %s"
 
-#: diff.c:4634
+#: diff.c:4642
 msgid "--name-only, --name-status, --check and -s are mutually exclusive"
 msgstr "--name-only, --name-status, --check và -s loại từ lẫn nhau"
 
-#: diff.c:4637
+#: diff.c:4645
 msgid "-G, -S and --find-object are mutually exclusive"
 msgstr "Các tùy chọn -G, -S, và --find-object loại từ lẫn nhau"
 
-#: diff.c:4640
+#: diff.c:4648
 msgid ""
 "-G and --pickaxe-regex are mutually exclusive, use --pickaxe-regex with -S"
 msgstr ""
 "-G và --pickaxe-regex là loại trừ lẫn nhau, dùng --pickaxe-regex với -S"
 
-#: diff.c:4643
+#: diff.c:4651
 msgid ""
 "--pickaxe-all and --find-object are mutually exclusive, use --pickaxe-all "
 "with -G and -S"
@@ -3372,22 +3381,22 @@ msgstr ""
 "tùy chọn --pickaxe-all và --find-object loại từ lẫn nhau, hãy dùng --pickaxe-"
 "all với -G và -S"
 
-#: diff.c:4722
+#: diff.c:4730
 msgid "--follow requires exactly one pathspec"
 msgstr "--follow cần chính xác một đặc tả đường dẫn"
 
-#: diff.c:4770
+#: diff.c:4778
 #, c-format
 msgid "invalid --stat value: %s"
 msgstr "giá trị --stat không hợp lệ: “%s”"
 
-#: diff.c:4775 diff.c:4780 diff.c:4785 diff.c:4790 diff.c:5318
-#: parse-options.c:197 parse-options.c:201 builtin/commit-graph.c:180
+#: diff.c:4783 diff.c:4788 diff.c:4793 diff.c:4798 diff.c:5326
+#: parse-options.c:217 parse-options.c:221
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "tùy chọn “%s” cần một giá trị bằng số"
 
-#: diff.c:4807
+#: diff.c:4815
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -3396,42 +3405,42 @@ msgstr ""
 "Gặp lỗi khi phân tích đối số tùy chọn --dirstat/-X:\n"
 "%s"
 
-#: diff.c:4892
+#: diff.c:4900
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
 msgstr "không hiểu lớp thay đổi “%c” trong --diff-filter=%s"
 
-#: diff.c:4916
+#: diff.c:4924
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
 msgstr "không hiểu giá trị sau ws-error-highlight=%.*s"
 
-#: diff.c:4930
+#: diff.c:4938
 #, c-format
 msgid "unable to resolve '%s'"
 msgstr "không thể phân giải “%s”"
 
-#: diff.c:4980 diff.c:4986
+#: diff.c:4988 diff.c:4994
 #, c-format
 msgid "%s expects <n>/<m> form"
 msgstr "%s cần dạng <n>/<m>"
 
-#: diff.c:4998
+#: diff.c:5006
 #, c-format
 msgid "%s expects a character, got '%s'"
 msgstr "%s cần một ký tự, nhưng lại nhận được “%s”"
 
-#: diff.c:5019
+#: diff.c:5027
 #, c-format
 msgid "bad --color-moved argument: %s"
 msgstr "đối số --color-moved sai: %s"
 
-#: diff.c:5038
+#: diff.c:5046
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
 msgstr "chế độ “%s” không hợp lệ trong --color-moved-ws"
 
-#: diff.c:5078
+#: diff.c:5086
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
@@ -3439,155 +3448,155 @@ msgstr ""
 "tùy chọn  diff-algorithm chấp nhận \"myers\", \"minimal\", \"patience\" và "
 "\"histogram\""
 
-#: diff.c:5114 diff.c:5134
+#: diff.c:5122 diff.c:5142
 #, c-format
 msgid "invalid argument to %s"
 msgstr "tham số cho %s không hợp lệ"
 
-#: diff.c:5238
+#: diff.c:5246
 #, c-format
 msgid "invalid regex given to -I: '%s'"
 msgstr "đưa cho -I biểu thức chính quy không hợp lệ: “%s”"
 
-#: diff.c:5287
+#: diff.c:5295
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
 msgstr "gặp lỗi khi phân tích đối số tùy chọn --submodule: “%s”"
 
-#: diff.c:5343
+#: diff.c:5351
 #, c-format
 msgid "bad --word-diff argument: %s"
 msgstr "đối số --word-diff sai: %s"
 
-#: diff.c:5379
+#: diff.c:5387
 msgid "Diff output format options"
 msgstr "Các tùy chọn định dạng khi xuất các khác biệt"
 
-#: diff.c:5381 diff.c:5387
+#: diff.c:5389 diff.c:5395
 msgid "generate patch"
 msgstr "tạo miếng vá"
 
-#: diff.c:5384 builtin/log.c:179
+#: diff.c:5392 builtin/log.c:179
 msgid "suppress diff output"
 msgstr "chặn mọi kết xuất từ diff"
 
-#: diff.c:5389 diff.c:5503 diff.c:5510
+#: diff.c:5397 diff.c:5511 diff.c:5518
 msgid "<n>"
 msgstr "<n>"
 
-#: diff.c:5390 diff.c:5393
+#: diff.c:5398 diff.c:5401
 msgid "generate diffs with <n> lines context"
 msgstr "tạo khác biệt với <n> dòng ngữ cảnh"
 
-#: diff.c:5395
+#: diff.c:5403
 msgid "generate the diff in raw format"
 msgstr "tạo khác biệt ở định dạng thô"
 
-#: diff.c:5398
+#: diff.c:5406
 msgid "synonym for '-p --raw'"
 msgstr "đồng nghĩa với “-p --raw”"
 
-#: diff.c:5402
+#: diff.c:5410
 msgid "synonym for '-p --stat'"
 msgstr "đồng nghĩa với “-p --stat”"
 
-#: diff.c:5406
+#: diff.c:5414
 msgid "machine friendly --stat"
 msgstr "--stat thuận tiện cho máy đọc"
 
-#: diff.c:5409
+#: diff.c:5417
 msgid "output only the last line of --stat"
 msgstr "chỉ xuất những dòng cuối của --stat"
 
-#: diff.c:5411 diff.c:5419
+#: diff.c:5419 diff.c:5427
 msgid "<param1,param2>..."
 msgstr "<tham_số_1,tham_số_2>…"
 
-#: diff.c:5412
+#: diff.c:5420
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr "đầu ra phân phối của số lượng thay đổi tương đối cho mỗi thư mục con"
 
-#: diff.c:5416
+#: diff.c:5424
 msgid "synonym for --dirstat=cumulative"
 msgstr "đồng nghĩa với --dirstat=cumulative"
 
-#: diff.c:5420
+#: diff.c:5428
 msgid "synonym for --dirstat=files,param1,param2..."
 msgstr "đồng nghĩa với --dirstat=files,param1,param2…"
 
-#: diff.c:5424
+#: diff.c:5432
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
 "cảnh báo nếu các thay đổi đưa ra các bộ tạo xung đột hay lỗi khoảng trắng"
 
-#: diff.c:5427
+#: diff.c:5435
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr "tổng hợp dạng xúc tích như là tạo, đổi tên và các thay đổi chế độ"
 
-#: diff.c:5430
+#: diff.c:5438
 msgid "show only names of changed files"
 msgstr "chỉ hiển thị tên của các tập tin đổi"
 
-#: diff.c:5433
+#: diff.c:5441
 msgid "show only names and status of changed files"
 msgstr "chỉ hiển thị tên tập tin và tình trạng của các tập tin bị thay đổi"
 
-#: diff.c:5435
+#: diff.c:5443
 msgid "<width>[,<name-width>[,<count>]]"
 msgstr "<rộng>[,<name-width>[,<số-lượng>]]"
 
-#: diff.c:5436
+#: diff.c:5444
 msgid "generate diffstat"
 msgstr "tạo diffstat"
 
-#: diff.c:5438 diff.c:5441 diff.c:5444
+#: diff.c:5446 diff.c:5449 diff.c:5452
 msgid "<width>"
 msgstr "<rộng>"
 
-#: diff.c:5439
+#: diff.c:5447
 msgid "generate diffstat with a given width"
 msgstr "tạo diffstat với độ rộng đã cho"
 
-#: diff.c:5442
+#: diff.c:5450
 msgid "generate diffstat with a given name width"
 msgstr "tạo diffstat với tên độ rộng đã cho"
 
-#: diff.c:5445
+#: diff.c:5453
 msgid "generate diffstat with a given graph width"
 msgstr "tạo diffstat với độ rộng đồ thị đã cho"
 
-#: diff.c:5447
+#: diff.c:5455
 msgid "<count>"
 msgstr "<số_lượng>"
 
-#: diff.c:5448
+#: diff.c:5456
 msgid "generate diffstat with limited lines"
 msgstr "tạo diffstat với các dòng bị giới hạn"
 
-#: diff.c:5451
+#: diff.c:5459
 msgid "generate compact summary in diffstat"
 msgstr "tạo tổng hợp xúc tích trong diffstat"
 
-#: diff.c:5454
+#: diff.c:5462
 msgid "output a binary diff that can be applied"
 msgstr "xuất ra một khác biệt dạng nhị phân cái mà có thể được áp dụng"
 
-#: diff.c:5457
+#: diff.c:5465
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr ""
 "hiển thị đầy đủ các tên đối tượng pre- và post-image trên các dòng \"mục lục"
 "\""
 
-#: diff.c:5459
+#: diff.c:5467
 msgid "show colored diff"
 msgstr "hiển thị thay đổi được tô màu"
 
-#: diff.c:5460
+#: diff.c:5468
 msgid "<kind>"
 msgstr "<kiểu>"
 
-#: diff.c:5461
+#: diff.c:5469
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
@@ -3595,7 +3604,7 @@ msgstr ""
 "tô sáng các lỗi về khoảng trắng trong các dòng “context”, “old” và “new” "
 "trong khác biệt"
 
-#: diff.c:5464
+#: diff.c:5472
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
@@ -3603,89 +3612,89 @@ msgstr ""
 "không munge tên đường dẫn và sử dụng NUL làm bộ phân tách trường đầu ra "
 "trong --raw hay --numstat"
 
-#: diff.c:5467 diff.c:5470 diff.c:5473 diff.c:5582
+#: diff.c:5475 diff.c:5478 diff.c:5481 diff.c:5590
 msgid "<prefix>"
 msgstr "<tiền_tố>"
 
-#: diff.c:5468
+#: diff.c:5476
 msgid "show the given source prefix instead of \"a/\""
 msgstr "hiển thị tiền tố nguồn đã cho thay cho \"a/\""
 
-#: diff.c:5471
+#: diff.c:5479
 msgid "show the given destination prefix instead of \"b/\""
 msgstr "hiển thị tiền tố đích đã cho thay cho \"b/\""
 
-#: diff.c:5474
+#: diff.c:5482
 msgid "prepend an additional prefix to every line of output"
 msgstr "treo vào trước một tiền tố bổ sung cho mỗi dòng kết xuất"
 
-#: diff.c:5477
+#: diff.c:5485
 msgid "do not show any source or destination prefix"
 msgstr "đừng hiển thị bất kỳ tiền tố nguồn hay đích"
 
-#: diff.c:5480
+#: diff.c:5488
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
 "hiển thị ngữ cảnh giữa các khúc khác biệt khi đạt đến số lượng dòng đã chỉ "
 "định"
 
-#: diff.c:5484 diff.c:5489 diff.c:5494
+#: diff.c:5492 diff.c:5497 diff.c:5502
 msgid "<char>"
 msgstr "<ký_tự>"
 
-#: diff.c:5485
+#: diff.c:5493
 msgid "specify the character to indicate a new line instead of '+'"
 msgstr "chỉ định một ký tự để biểu thị một dòng được thêm mới thay cho “+”"
 
-#: diff.c:5490
+#: diff.c:5498
 msgid "specify the character to indicate an old line instead of '-'"
 msgstr "chỉ định một ký tự để biểu thị một dòng đã cũ thay cho “-”"
 
-#: diff.c:5495
+#: diff.c:5503
 msgid "specify the character to indicate a context instead of ' '"
 msgstr "chỉ định một ký tự để biểu thị một ngữ cảnh thay cho “”"
 
-#: diff.c:5498
+#: diff.c:5506
 msgid "Diff rename options"
 msgstr "Tùy chọn khác biệt đổi tên"
 
-#: diff.c:5499
+#: diff.c:5507
 msgid "<n>[/<m>]"
 msgstr "<n>[/<m>]"
 
-#: diff.c:5500
+#: diff.c:5508
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr "ngắt các thay đổi ghi lại hoàn thiện thành cặp của xóa và tạo"
 
-#: diff.c:5504
+#: diff.c:5512
 msgid "detect renames"
 msgstr "dò tìm các tên thay đổi"
 
-#: diff.c:5508
+#: diff.c:5516
 msgid "omit the preimage for deletes"
 msgstr "bỏ qua preimage (tiền ảnh??) cho các việc xóa"
 
-#: diff.c:5511
+#: diff.c:5519
 msgid "detect copies"
 msgstr "dò bản sao"
 
-#: diff.c:5515
+#: diff.c:5523
 msgid "use unmodified files as source to find copies"
 msgstr "dùng các tập tin không bị chỉnh sửa như là nguồn để tìm các bản sao"
 
-#: diff.c:5517
+#: diff.c:5525
 msgid "disable rename detection"
 msgstr "tắt dò tìm đổi tên"
 
-#: diff.c:5520
+#: diff.c:5528
 msgid "use empty blobs as rename source"
 msgstr "dùng các blob trống rống như là nguồn đổi tên"
 
-#: diff.c:5522
+#: diff.c:5530
 msgid "continue listing the history of a file beyond renames"
 msgstr "tiếp tục liệt kê lịch sử của một tập tin ngoài đổi tên"
 
-#: diff.c:5525
+#: diff.c:5533
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
@@ -3693,160 +3702,160 @@ msgstr ""
 "ngăn cản dò tìm đổi tên/bản sao nếu số lượng của đích đổi tên/bản sao vượt "
 "quá giới hạn đưa ra"
 
-#: diff.c:5527
+#: diff.c:5535
 msgid "Diff algorithm options"
 msgstr "Tùy chọn thuật toán khác biệt"
 
-#: diff.c:5529
+#: diff.c:5537
 msgid "produce the smallest possible diff"
 msgstr "sản sinh khác biệt ít nhất có thể"
 
-#: diff.c:5532
+#: diff.c:5540
 msgid "ignore whitespace when comparing lines"
 msgstr "lờ đi sự thay đổi do khoảng trắng gây ra khi so sánh các dòng"
 
-#: diff.c:5535
+#: diff.c:5543
 msgid "ignore changes in amount of whitespace"
 msgstr "lờ đi sự thay đổi do số lượng khoảng trắng gây ra"
 
-#: diff.c:5538
+#: diff.c:5546
 msgid "ignore changes in whitespace at EOL"
 msgstr "lờ đi sự thay đổi do khoảng trắng gây ra khi ở cuối dòng EOL"
 
-#: diff.c:5541
+#: diff.c:5549
 msgid "ignore carrier-return at the end of line"
 msgstr "bỏ qua ký tự về đầu dòng tại cuối dòng"
 
-#: diff.c:5544
+#: diff.c:5552
 msgid "ignore changes whose lines are all blank"
 msgstr "bỏ qua các thay đổi cho toàn bộ các dòng là trống"
 
-#: diff.c:5546 diff.c:5568 diff.c:5571 diff.c:5616
+#: diff.c:5554 diff.c:5576 diff.c:5579 diff.c:5624
 msgid "<regex>"
 msgstr "<regex>"
 
-#: diff.c:5547
+#: diff.c:5555
 msgid "ignore changes whose all lines match <regex>"
 msgstr "bỏ qua các thay đổi có tất cả các dòng khớp <regex>"
 
-#: diff.c:5550
+#: diff.c:5558
 msgid "heuristic to shift diff hunk boundaries for easy reading"
 msgstr "heuristic để dịch hạn biên của khối khác biệt cho dễ đọc"
 
-#: diff.c:5553
+#: diff.c:5561
 msgid "generate diff using the \"patience diff\" algorithm"
 msgstr "tạo khác biệt sử dung thuật toán \"patience diff\""
 
-#: diff.c:5557
+#: diff.c:5565
 msgid "generate diff using the \"histogram diff\" algorithm"
 msgstr "tạo khác biệt sử dung thuật toán \"histogram diff\""
 
-#: diff.c:5559
+#: diff.c:5567
 msgid "<algorithm>"
 msgstr "<thuật toán>"
 
-#: diff.c:5560
+#: diff.c:5568
 msgid "choose a diff algorithm"
 msgstr "chọn một thuật toán khác biệt"
 
-#: diff.c:5562
+#: diff.c:5570
 msgid "<text>"
 msgstr "<văn bản>"
 
-#: diff.c:5563
+#: diff.c:5571
 msgid "generate diff using the \"anchored diff\" algorithm"
 msgstr "tạo khác biệt sử dung thuật toán \"anchored diff\""
 
-#: diff.c:5565 diff.c:5574 diff.c:5577
+#: diff.c:5573 diff.c:5582 diff.c:5585
 msgid "<mode>"
 msgstr "<chế độ>"
 
-#: diff.c:5566
+#: diff.c:5574
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr ""
 "hiển thị khác biệt từ, sử dụng <chế độ> để bỏ giới hạn các từ bị thay đổi"
 
-#: diff.c:5569
+#: diff.c:5577
 msgid "use <regex> to decide what a word is"
 msgstr "dùng <regex> để quyết định từ là cái gì"
 
-#: diff.c:5572
+#: diff.c:5580
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
 msgstr "tương đương với --word-diff=color --word-diff-regex=<regex>"
 
-#: diff.c:5575
+#: diff.c:5583
 msgid "moved lines of code are colored differently"
 msgstr "các dòng di chuyển của mã mà được tô màu khác nhau"
 
-#: diff.c:5578
+#: diff.c:5586
 msgid "how white spaces are ignored in --color-moved"
 msgstr "cách bỏ qua khoảng trắng trong --color-moved"
 
-#: diff.c:5581
+#: diff.c:5589
 msgid "Other diff options"
 msgstr "Các tùy chọn khác biệt khác"
 
-#: diff.c:5583
+#: diff.c:5591
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
 "khi chạy từ thư mục con, thực thi các thay đổi bên ngoài và hiển thị các "
 "đường dẫn liên quan"
 
-#: diff.c:5587
+#: diff.c:5595
 msgid "treat all files as text"
 msgstr "coi mọi tập tin là dạng văn bản thường"
 
-#: diff.c:5589
+#: diff.c:5597
 msgid "swap two inputs, reverse the diff"
 msgstr "tráo đổi hai đầu vào, đảo ngược khác biệt"
 
-#: diff.c:5591
+#: diff.c:5599
 msgid "exit with 1 if there were differences, 0 otherwise"
 msgstr "thoát với mã 1 nếu không có khác biệt gì, 0 nếu ngược lại"
 
-#: diff.c:5593
+#: diff.c:5601
 msgid "disable all output of the program"
 msgstr "tắt mọi kết xuất của chương trình"
 
-#: diff.c:5595
+#: diff.c:5603
 msgid "allow an external diff helper to be executed"
 msgstr "cho phép mộ bộ hỗ trợ xuất khác biệt ở bên ngoài được phép thực thi"
 
-#: diff.c:5597
+#: diff.c:5605
 msgid "run external text conversion filters when comparing binary files"
 msgstr ""
 "chạy các bộ lọc văn bản thông thường bên ngoài khi so sánh các tập tin nhị "
 "phân"
 
-#: diff.c:5599
+#: diff.c:5607
 msgid "<when>"
 msgstr "<khi>"
 
-#: diff.c:5600
+#: diff.c:5608
 msgid "ignore changes to submodules in the diff generation"
 msgstr "bỏ qua các thay đổi trong mô-đun-con trong khi tạo khác biệt"
 
-#: diff.c:5603
+#: diff.c:5611
 msgid "<format>"
 msgstr "<định dạng>"
 
-#: diff.c:5604
+#: diff.c:5612
 msgid "specify how differences in submodules are shown"
 msgstr "chi định khác biệt bao nhiêu trong các mô đun con được hiển thị"
 
-#: diff.c:5608
+#: diff.c:5616
 msgid "hide 'git add -N' entries from the index"
 msgstr "ẩn các mục “git add -N” từ bảng mục lục"
 
-#: diff.c:5611
+#: diff.c:5619
 msgid "treat 'git add -N' entries as real in the index"
 msgstr "coi các mục “git add -N” như là có thật trong bảng mục lục"
 
-#: diff.c:5613
+#: diff.c:5621
 msgid "<string>"
 msgstr "<chuỗi>"
 
-#: diff.c:5614
+#: diff.c:5622
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
@@ -3854,7 +3863,7 @@ msgstr ""
 "tìm các khác biệt cái mà thay đổi số lượng xảy ra của các phát sinh của "
 "chuỗi được chỉ ra"
 
-#: diff.c:5617
+#: diff.c:5625
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
@@ -3862,35 +3871,35 @@ msgstr ""
 "tìm các khác biệt cái mà thay đổi số lượng xảy ra của các phát sinh của biểu "
 "thức chính quy được chỉ ra"
 
-#: diff.c:5620
+#: diff.c:5628
 msgid "show all changes in the changeset with -S or -G"
 msgstr "hiển thị tất cả các thay đổi trong một bộ các thay đổi với -S hay -G"
 
-#: diff.c:5623
+#: diff.c:5631
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr "coi <chuỗi> trong -S như là biểu thức chính qui POSIX có mở rộng"
 
-#: diff.c:5626
+#: diff.c:5634
 msgid "control the order in which files appear in the output"
 msgstr "điều khiển thứ tự xuát hiện các tập tin trong kết xuất"
 
-#: diff.c:5627 diff.c:5630
+#: diff.c:5635 diff.c:5638
 msgid "<path>"
 msgstr "<đường-dẫn>"
 
-#: diff.c:5628
+#: diff.c:5636
 msgid "show the change in the specified path first"
 msgstr "hiển thị các thay đổi trong đường dẫn đã cho đầu tiên"
 
-#: diff.c:5631
+#: diff.c:5639
 msgid "skip the output to the specified path"
 msgstr "bỏ qua đầu ra đến đường dẫn đã cho"
 
-#: diff.c:5633
+#: diff.c:5641
 msgid "<object-id>"
 msgstr "<mã-số-đối-tượng>"
 
-#: diff.c:5634
+#: diff.c:5642
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
@@ -3898,32 +3907,32 @@ msgstr ""
 "tìm các khác biệt cái mà thay đổi số lượng xảy ra của các phát sinh của đối "
 "tượng được chỉ ra"
 
-#: diff.c:5636
+#: diff.c:5644
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "[(A|C|D|M|R|T|U|X|B)…[*]]"
 
-#: diff.c:5637
+#: diff.c:5645
 msgid "select files by diff type"
 msgstr "chọn các tập tin theo kiểu khác biệt"
 
-#: diff.c:5639
+#: diff.c:5647
 msgid "<file>"
 msgstr "<tập_tin>"
 
-#: diff.c:5640
+#: diff.c:5648
 msgid "Output to a specific file"
 msgstr "Xuất ra một tập tin cụ thể"
 
-#: diff.c:6298
+#: diff.c:6306
 msgid "exhaustive rename detection was skipped due to too many files."
 msgstr "nhận thấy đổi tên toàn diện đã bị bỏ qua bởi có quá nhiều tập tin."
 
-#: diff.c:6301
+#: diff.c:6309
 msgid "only found copies from modified paths due to too many files."
 msgstr ""
 "chỉ tìm thấy các bản sao từ đường dẫn đã sửa đổi bởi vì có quá nhiều tập tin."
 
-#: diff.c:6304
+#: diff.c:6312
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
@@ -3936,7 +3945,7 @@ msgstr ""
 msgid "failed to read orderfile '%s'"
 msgstr "gặp lỗi khi đọc tập-tin-thứ-tự “%s”"
 
-#: diffcore-rename.c:1514
+#: diffcore-rename.c:1564
 msgid "Performing inexact rename detection"
 msgstr "Đang thực hiện dò tìm đổi tên không chính xác"
 
@@ -3974,338 +3983,417 @@ msgstr "vô hiệu khớp mẫu nón"
 msgid "cannot use %s as an exclude file"
 msgstr "không thể dùng %s như là một tập tin loại trừ"
 
-#: dir.c:2351
+#: dir.c:2464
 #, c-format
 msgid "could not open directory '%s'"
 msgstr "không thể mở thư mục “%s”"
 
-#: dir.c:2653
+#: dir.c:2766
 msgid "failed to get kernel name and information"
 msgstr "gặp lỗi khi lấy tên và thông tin của nhân"
 
-#: dir.c:2777
+#: dir.c:2890
 msgid "untracked cache is disabled on this system or location"
 msgstr "bộ nhớ tạm không theo vết bị tắt trên hệ thống hay vị trí này"
 
-#: dir.c:3610
+#: dir.c:3158
+msgid ""
+"No directory name could be guessed.\n"
+"Please specify a directory on the command line"
+msgstr ""
+"Không đoán được thư mục tên là gì.\n"
+"Vui lòng chỉ định tên một thư mục trên dòng lệnh"
+
+#: dir.c:3837
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "tập tin ghi bảng mục lục bị hỏng trong kho %s"
 
-#: dir.c:3657 dir.c:3662
+#: dir.c:3884 dir.c:3889
 #, c-format
 msgid "could not create directories for %s"
 msgstr "không thể tạo thư mục cho %s"
 
-#: dir.c:3691
+#: dir.c:3918
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "không thể di dời thư mục git từ “%s” sang “%s”"
 
-#: editor.c:74
+#: editor.c:77
 #, c-format
 msgid "hint: Waiting for your editor to close the file...%c"
 msgstr "gợi ý: Chờ trình biên soạn của bạn đóng tập tin…%c"
 
-#: entry.c:176
+#: entry.c:177
 msgid "Filtering content"
 msgstr "Nội dung lọc"
 
-#: entry.c:497
+#: entry.c:498
 #, c-format
 msgid "could not stat file '%s'"
 msgstr "không thể lấy thống kê tập tin “%s”"
 
-#: environment.c:152
+#: environment.c:143
 #, c-format
 msgid "bad git namespace path \"%s\""
 msgstr "đường dẫn không gian tên git \"%s\" sai"
-
-#: environment.c:334
-#, c-format
-msgid "could not set GIT_DIR to '%s'"
-msgstr "không thể đặt GIT_DIR thành “%s”"
 
 #: exec-cmd.c:363
 #, c-format
 msgid "too many args to run %s"
 msgstr "quá nhiều tham số để chạy %s"
 
-#: fetch-pack.c:182
+#: fetch-pack.c:193
 msgid "git fetch-pack: expected shallow list"
 msgstr "git fetch-pack: cần danh sách shallow"
 
-#: fetch-pack.c:185
+#: fetch-pack.c:196
 msgid "git fetch-pack: expected a flush packet after shallow list"
 msgstr "git fetch-pack: cần một gói đẩy sau danh sách shallow"
 
-#: fetch-pack.c:196
+#: fetch-pack.c:207
 msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
 msgstr "git fetch-pack: cần ACK/NAK, nhưng lại nhận được một gói flush"
 
-#: fetch-pack.c:216
+#: fetch-pack.c:227
 #, c-format
 msgid "git fetch-pack: expected ACK/NAK, got '%s'"
 msgstr "git fetch-pack: cần ACK/NAK, nhưng lại nhận được “%s”"
 
-#: fetch-pack.c:227
+#: fetch-pack.c:238
 msgid "unable to write to remote"
 msgstr "không thể ghi lên máy phục vụ"
 
-#: fetch-pack.c:288
+#: fetch-pack.c:299
 msgid "--stateless-rpc requires multi_ack_detailed"
 msgstr "--stateless-rpc cần multi_ack_detailed"
 
-#: fetch-pack.c:383 fetch-pack.c:1423
+#: fetch-pack.c:394 fetch-pack.c:1434
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "dòng shallow không hợp lệ: %s"
 
-#: fetch-pack.c:389 fetch-pack.c:1429
+#: fetch-pack.c:400 fetch-pack.c:1440
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "dòng unshallow không hợp lệ: %s"
 
-#: fetch-pack.c:391 fetch-pack.c:1431
+#: fetch-pack.c:402 fetch-pack.c:1442
 #, c-format
 msgid "object not found: %s"
 msgstr "không tìm thấy đối tượng: %s"
 
-#: fetch-pack.c:394 fetch-pack.c:1434
+#: fetch-pack.c:405 fetch-pack.c:1445
 #, c-format
 msgid "error in object: %s"
 msgstr "lỗi trong đối tượng: %s"
 
-#: fetch-pack.c:396 fetch-pack.c:1436
+#: fetch-pack.c:407 fetch-pack.c:1447
 #, c-format
 msgid "no shallow found: %s"
 msgstr "không tìm shallow nào: %s"
 
-#: fetch-pack.c:399 fetch-pack.c:1440
+#: fetch-pack.c:410 fetch-pack.c:1451
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "cần shallow/unshallow, nhưng lại nhận được %s"
 
-#: fetch-pack.c:439
+#: fetch-pack.c:450
 #, c-format
 msgid "got %s %d %s"
 msgstr "nhận %s %d - %s"
 
-#: fetch-pack.c:456
+#: fetch-pack.c:467
 #, c-format
 msgid "invalid commit %s"
 msgstr "lần chuyển giao %s không hợp lệ"
 
-#: fetch-pack.c:487
+#: fetch-pack.c:498
 msgid "giving up"
 msgstr "chịu thua"
 
-#: fetch-pack.c:500 progress.c:339
+#: fetch-pack.c:511 progress.c:339
 msgid "done"
 msgstr "xong"
 
-#: fetch-pack.c:512
+#: fetch-pack.c:523
 #, c-format
 msgid "got %s (%d) %s"
 msgstr "nhận %s (%d) %s"
 
-#: fetch-pack.c:548
+#: fetch-pack.c:559
 #, c-format
 msgid "Marking %s as complete"
 msgstr "Đánh dấu %s là đã hoàn thành"
 
-#: fetch-pack.c:763
+#: fetch-pack.c:774
 #, c-format
 msgid "already have %s (%s)"
 msgstr "đã sẵn có %s (%s)"
 
-#: fetch-pack.c:849
+#: fetch-pack.c:860
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-pack: không thể rẽ nhánh sideband demultiplexer"
 
-#: fetch-pack.c:857
+#: fetch-pack.c:868
 msgid "protocol error: bad pack header"
 msgstr "lỗi giao thức: phần đầu gói bị sai"
 
-#: fetch-pack.c:951
+#: fetch-pack.c:962
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-pack: không thể rẽ nhánh %s"
 
-#: fetch-pack.c:957
+#: fetch-pack.c:968
 msgid "fetch-pack: invalid index-pack output"
 msgstr "fetch-pack: kết xuất index-pack không hợp lệ"
 
-#: fetch-pack.c:974
+#: fetch-pack.c:985
 #, c-format
 msgid "%s failed"
 msgstr "%s gặp lỗi"
 
-#: fetch-pack.c:976
+#: fetch-pack.c:987
 msgid "error in sideband demultiplexer"
 msgstr "có lỗi trong sideband demultiplexer"
 
-#: fetch-pack.c:1019
+#: fetch-pack.c:1030
 #, c-format
 msgid "Server version is %.*s"
 msgstr "Phiên bản máy chủ là %.*s"
 
-#: fetch-pack.c:1027 fetch-pack.c:1033 fetch-pack.c:1036 fetch-pack.c:1042
-#: fetch-pack.c:1046 fetch-pack.c:1050 fetch-pack.c:1054 fetch-pack.c:1058
-#: fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070 fetch-pack.c:1074
-#: fetch-pack.c:1080 fetch-pack.c:1086 fetch-pack.c:1091 fetch-pack.c:1096
+#: fetch-pack.c:1038 fetch-pack.c:1044 fetch-pack.c:1047 fetch-pack.c:1053
+#: fetch-pack.c:1057 fetch-pack.c:1061 fetch-pack.c:1065 fetch-pack.c:1069
+#: fetch-pack.c:1073 fetch-pack.c:1077 fetch-pack.c:1081 fetch-pack.c:1085
+#: fetch-pack.c:1091 fetch-pack.c:1097 fetch-pack.c:1102 fetch-pack.c:1107
 #, c-format
 msgid "Server supports %s"
 msgstr "Máy chủ hỗ trợ %s"
 
-#: fetch-pack.c:1029
+#: fetch-pack.c:1040
 msgid "Server does not support shallow clients"
 msgstr "Máy chủ không hỗ trợ máy khách shallow"
 
-#: fetch-pack.c:1089
+#: fetch-pack.c:1100
 msgid "Server does not support --shallow-since"
 msgstr "Máy chủ không hỗ trợ --shallow-since"
 
-#: fetch-pack.c:1094
+#: fetch-pack.c:1105
 msgid "Server does not support --shallow-exclude"
 msgstr "Máy chủ không hỗ trợ --shallow-exclude"
 
-#: fetch-pack.c:1098
+#: fetch-pack.c:1109
 msgid "Server does not support --deepen"
 msgstr "Máy chủ không hỗ trợ --deepen"
 
-#: fetch-pack.c:1100
+#: fetch-pack.c:1111
 msgid "Server does not support this repository's object format"
 msgstr "Máy chủ không hỗ trợ định dạng đối tượng của kho này"
 
-#: fetch-pack.c:1113
+#: fetch-pack.c:1124
 msgid "no common commits"
 msgstr "không có lần chuyển giao chung nào"
 
-#: fetch-pack.c:1122 fetch-pack.c:1469 builtin/clone.c:1238
+#: fetch-pack.c:1133 fetch-pack.c:1480 builtin/clone.c:1130
 msgid "source repository is shallow, reject to clone."
 msgstr "kho nguồn là nông, nên bỏ từ chối nhân bản."
 
-#: fetch-pack.c:1128 fetch-pack.c:1660
+#: fetch-pack.c:1139 fetch-pack.c:1671
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack: fetch gặp lỗi."
 
-#: fetch-pack.c:1242
+#: fetch-pack.c:1253
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "các thuật toán không khớp nhau: máy khách %s; máy chủ %s"
 
-#: fetch-pack.c:1246
+#: fetch-pack.c:1257
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "máy chủ không hỗ trợ thuật toán “%s”"
 
-#: fetch-pack.c:1279
+#: fetch-pack.c:1290
 msgid "Server does not support shallow requests"
 msgstr "Máy chủ không hỗ trợ yêu cầu shallow"
 
-#: fetch-pack.c:1286
+#: fetch-pack.c:1297
 msgid "Server supports filter"
 msgstr "Máy chủ hỗ trợ bộ lọc"
 
-#: fetch-pack.c:1329 fetch-pack.c:2043
+#: fetch-pack.c:1340 fetch-pack.c:2053
 msgid "unable to write request to remote"
 msgstr "không thể ghi các yêu cầu lên máy phục vụ"
 
-#: fetch-pack.c:1347
+#: fetch-pack.c:1358
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "gặp lỗi khi đọc phần đầu của đoạn %s"
 
-#: fetch-pack.c:1353
+#: fetch-pack.c:1364
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "cần “%s”, nhưng lại nhận “%s”"
 
-#: fetch-pack.c:1387
+#: fetch-pack.c:1398
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "gặp dòng không được thừa nhận: “%s”"
 
-#: fetch-pack.c:1392
+#: fetch-pack.c:1403
 #, c-format
 msgid "error processing acks: %d"
 msgstr "gặp lỗi khi xử lý tín hiệu trả lời: %d"
 
-#: fetch-pack.c:1402
+#: fetch-pack.c:1413
 msgid "expected packfile to be sent after 'ready'"
 msgstr "cần tập tin gói để gửi sau “ready”"
 
-#: fetch-pack.c:1404
+#: fetch-pack.c:1415
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr "không cần thêm phần nào để gửi sau “ready”"
 
-#: fetch-pack.c:1445
+#: fetch-pack.c:1456
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "lỗi xử lý thông tin shallow: %d"
 
-#: fetch-pack.c:1494
+#: fetch-pack.c:1505
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "cần wanted-ref, nhưng lại nhận được “%s”"
 
-#: fetch-pack.c:1499
+#: fetch-pack.c:1510
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "wanted-ref không được mong đợi: “%s”"
 
-#: fetch-pack.c:1504
+#: fetch-pack.c:1515
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "lỗi khi xử lý wanted refs: %d"
 
-#: fetch-pack.c:1534
+#: fetch-pack.c:1545
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: cần nhận được trả lời là kết thúc gói"
 
-#: fetch-pack.c:1939
+#: fetch-pack.c:1949
 msgid "no matching remote head"
 msgstr "không khớp phần đầu máy chủ"
 
-#: fetch-pack.c:1962 builtin/clone.c:697
+#: fetch-pack.c:1972 builtin/clone.c:581
 msgid "remote did not send all necessary objects"
 msgstr "máy chủ đã không gửi tất cả các đối tượng cần thiết"
 
-#: fetch-pack.c:2065
+#: fetch-pack.c:2075
 msgid "unexpected 'ready' from remote"
-msgstr "gặp 'ready' đột xuất từ máy chủ"
+msgstr "gặp “ready” đột xuất từ máy chủ"
 
-#: fetch-pack.c:2088
+#: fetch-pack.c:2098
 #, c-format
 msgid "no such remote ref %s"
 msgstr "không có máy chủ tham chiếu nào như %s"
 
-#: fetch-pack.c:2091
+#: fetch-pack.c:2101
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr ""
 "Máy phục vụ không cho phép yêu cầu cho đối tượng không được báo trước %s"
 
-#: gpg-interface.c:273
+#: gpg-interface.c:329 gpg-interface.c:451 gpg-interface.c:902
+#: gpg-interface.c:918
 msgid "could not create temporary file"
 msgstr "không thể tạo tập tin tạm thời"
 
-#: gpg-interface.c:276
+#: gpg-interface.c:332 gpg-interface.c:454
 #, c-format
 msgid "failed writing detached signature to '%s'"
 msgstr "gặp lỗi khi ghi chữ ký đính kèm vào “%s”"
 
-#: gpg-interface.c:470
+#: gpg-interface.c:445
+msgid ""
+"gpg.ssh.allowedSignersFile needs to be configured and exist for ssh "
+"signature verification"
+msgstr ""
+"gpg.ssh.allowedSignersFile cần được cấu hình và tồn tại để xác minh chữ ký "
+"ssh"
+
+#: gpg-interface.c:469
+msgid ""
+"ssh-keygen -Y find-principals/verify is needed for ssh signature "
+"verification (available in openssh version 8.2p1+)"
+msgstr ""
+"ssh-keygen -Y find-principals/verify là cần thiết để xác minh chữ ký ssh (có "
+"sẵn trong phiên bản openssh 8.2p1+)"
+
+#: gpg-interface.c:523
+#, c-format
+msgid "ssh signing revocation file configured but not found: %s"
+msgstr "tập tin thu hồi chữ ký ssh đã được cấu hình nhưng không tìm thấy: %s"
+
+#: gpg-interface.c:576
+#, c-format
+msgid "bad/incompatible signature '%s'"
+msgstr "chữ sai / không tương thích “%s”"
+
+#: gpg-interface.c:735 gpg-interface.c:740
+#, c-format
+msgid "failed to get the ssh fingerprint for key '%s'"
+msgstr "gặp lỗi khi lấy dấu vân tay ssh cho khóa “%s”"
+
+#: gpg-interface.c:762
+msgid ""
+"either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured"
+msgstr ""
+"hoặc là user.signingkey hoặc gpg.ssh.defaultKeyCommand cần được cấu hình"
+
+#: gpg-interface.c:780
+#, c-format
+msgid "gpg.ssh.defaultKeyCommand succeeded but returned no keys: %s %s"
+msgstr ""
+"gpg.ssh.defaultKeyCommand thành công nhưng lại không trả về khóa nào: %s %s"
+
+#: gpg-interface.c:786
+#, c-format
+msgid "gpg.ssh.defaultKeyCommand failed: %s %s"
+msgstr "gpg.ssh.defaultKeyCommand gặp lỗi: %s %s"
+
+#: gpg-interface.c:874
 msgid "gpg failed to sign the data"
 msgstr "gpg gặp lỗi khi ký dữ liệu"
+
+#: gpg-interface.c:895
+msgid "user.signingkey needs to be set for ssh signing"
+msgstr "user.signingkey cần được đặt cho ký ssh"
+
+#: gpg-interface.c:906
+#, c-format
+msgid "failed writing ssh signing key to '%s'"
+msgstr "gặp lỗi khi ghi chìa khóa ký ssh vào “%s”"
+
+#: gpg-interface.c:924
+#, c-format
+msgid "failed writing ssh signing key buffer to '%s'"
+msgstr "gặp lỗi khi ghi bộ đệm chìa khóa ký ssh vào “%s”"
+
+#: gpg-interface.c:942
+msgid ""
+"ssh-keygen -Y sign is needed for ssh signing (available in openssh version "
+"8.2p1+)"
+msgstr ""
+"ssh-keygen -Y sign là cần thiết cho ký ssh (sẵn có trong openssh phiên bản "
+"8.2p1+)"
+
+#: gpg-interface.c:954
+#, c-format
+msgid "failed reading ssh signing data buffer from '%s'"
+msgstr "gặp lỗi khi đọc bộ đệm dữ liệu chữ ký ssh từ “%s”"
 
 #: graph.c:98
 #, c-format
 msgid "ignored invalid color '%.*s' in log.graphColors"
 msgstr "bỏ qua màu không hợp lệ “%.*s” trong log.graphColors"
 
-#: grep.c:531
+#: grep.c:533
 msgid ""
 "given pattern contains NULL byte (via -f <file>). This is only supported "
 "with -P under PCRE v2"
@@ -4313,109 +4401,109 @@ msgstr ""
 "mẫu đã cho có chứa NULL byte (qua -f <file>). Điều này chỉ được hỗ trợ với -"
 "P dưới PCRE v2"
 
-#: grep.c:1895
+#: grep.c:1928
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr "“%s”: không thể đọc %s"
 
-#: grep.c:1912 setup.c:176 builtin/clone.c:416 builtin/diff.c:90
+#: grep.c:1945 setup.c:176 builtin/clone.c:302 builtin/diff.c:90
 #: builtin/rm.c:136
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "gặp lỗi khi lấy thống kê về “%s”"
 
-#: grep.c:1923
+#: grep.c:1956
 #, c-format
 msgid "'%s': short read"
 msgstr "“%s”: đọc ngắn"
 
-#: help.c:23
+#: help.c:24
 msgid "start a working area (see also: git help tutorial)"
 msgstr "bắt đầu một vùng làm việc (xem thêm: git help tutorial)"
 
-#: help.c:24
+#: help.c:25
 msgid "work on the current change (see also: git help everyday)"
 msgstr "làm việc trên thay đổi hiện tại (xem thêm: git help everyday)"
 
-#: help.c:25
+#: help.c:26
 msgid "examine the history and state (see also: git help revisions)"
 msgstr "xem xét lịch sử tình trạng (xem thêm: git help revisions)"
 
-#: help.c:26
+#: help.c:27
 msgid "grow, mark and tweak your common history"
 msgstr "thêm, ghi dấu và chỉnh lịch sử chung của bạn"
 
-#: help.c:27
+#: help.c:28
 msgid "collaborate (see also: git help workflows)"
 msgstr "làm việc nhóm (xem thêm: git help workflows)"
 
-#: help.c:31
+#: help.c:32
 msgid "Main Porcelain Commands"
 msgstr "Các lệnh Porcelain chính"
 
-#: help.c:32
+#: help.c:33
 msgid "Ancillary Commands / Manipulators"
 msgstr "Lệnh/thao tác thứ cấp"
 
-#: help.c:33
+#: help.c:34
 msgid "Ancillary Commands / Interrogators"
 msgstr "Lệnh/bộ hỏi thứ cấp"
 
-#: help.c:34
+#: help.c:35
 msgid "Interacting with Others"
 msgstr "Tương tác với những cái khác"
 
-#: help.c:35
+#: help.c:36
 msgid "Low-level Commands / Manipulators"
 msgstr "Lệnh/thao tác ở mức thấp"
 
-#: help.c:36
+#: help.c:37
 msgid "Low-level Commands / Interrogators"
 msgstr "Lệnh/bộ hỏi ở mức thấp"
 
-#: help.c:37
+#: help.c:38
 msgid "Low-level Commands / Syncing Repositories"
 msgstr "Lệnh/Đồng bộ kho ở mức thấp"
 
-#: help.c:38
+#: help.c:39
 msgid "Low-level Commands / Internal Helpers"
 msgstr "Lệnh/Hỗ trợ nội tại ở mức thấp"
 
-#: help.c:300
+#: help.c:313
 #, c-format
 msgid "available git commands in '%s'"
 msgstr "các lệnh git sẵn có trong thư mục “%s”:"
 
-#: help.c:307
+#: help.c:320
 msgid "git commands available from elsewhere on your $PATH"
 msgstr "các lệnh git sẵn có từ một nơi khác trong $PATH của bạn"
 
-#: help.c:316
+#: help.c:329
 msgid "These are common Git commands used in various situations:"
 msgstr "Có các lệnh Git chung được sử dụng trong các tình huống khác nhau:"
 
-#: help.c:365 git.c:100
+#: help.c:378 git.c:100
 #, c-format
 msgid "unsupported command listing type '%s'"
 msgstr "không hỗ trợ liệt kê lệnh kiểu “%s”"
 
-#: help.c:405
+#: help.c:418
 msgid "The Git concept guides are:"
 msgstr "Các chỉ dẫn khái niệm về Git là:"
 
-#: help.c:429
+#: help.c:442
 msgid "See 'git help <command>' to read about a specific subcommand"
 msgstr "Xem “git help <lệnh>” để đọc các đặc tả của lệnh con"
 
-#: help.c:434
+#: help.c:447
 msgid "External commands"
 msgstr "Các lệnh bên ngoài"
 
-#: help.c:449
+#: help.c:462
 msgid "Command aliases"
 msgstr "Các bí danh lệnh"
 
-#: help.c:527
+#: help.c:543
 #, c-format
 msgid ""
 "'%s' appears to be a git command, but we were not\n"
@@ -4424,31 +4512,36 @@ msgstr ""
 "“%s” trông như là một lệnh git, nhưng chúng tôi không\n"
 "thể thực thi nó. Có lẽ là lệnh git-%s đã bị hỏng?"
 
-#: help.c:543 help.c:631
+#: help.c:565 help.c:662
 #, c-format
 msgid "git: '%s' is not a git command. See 'git --help'."
 msgstr "git: “%s” không phải là một lệnh của git. Xem “git --help”."
 
-#: help.c:591
+#: help.c:613
 msgid "Uh oh. Your system reports no Git commands at all."
 msgstr "Ối chà. Hệ thống của bạn báo rằng chẳng có lệnh Git nào cả."
 
-#: help.c:613
+#: help.c:635
 #, c-format
 msgid "WARNING: You called a Git command named '%s', which does not exist."
 msgstr "CẢNH BÁO: Bạn đã gọi lệnh Git có tên “%s”, mà nó lại không có sẵn."
 
-#: help.c:618
+#: help.c:640
 #, c-format
 msgid "Continuing under the assumption that you meant '%s'."
 msgstr "Tiếp tục và coi rằng ý bạn là “%s”."
 
-#: help.c:623
+#: help.c:646
+#, c-format
+msgid "Run '%s' instead? (y/N)"
+msgstr "Chạy “%s” để thay thế? (y/N)"
+
+#: help.c:654
 #, c-format
 msgid "Continuing in %0.1f seconds, assuming that you meant '%s'."
 msgstr "Tiếp tục trong %0.1f giây,và coi rằng ý bạn là “%s”."
 
-#: help.c:635
+#: help.c:666
 msgid ""
 "\n"
 "The most similar command is"
@@ -4459,16 +4552,16 @@ msgstr[0] ""
 "\n"
 "Những lệnh giống nhất là"
 
-#: help.c:675
+#: help.c:706
 msgid "git version [<options>]"
 msgstr "git version [<các tùy chọn>]"
 
-#: help.c:730
+#: help.c:761
 #, c-format
 msgid "%s: %s - %s"
 msgstr "%s: %s - %s"
 
-#: help.c:734
+#: help.c:765
 msgid ""
 "\n"
 "Did you mean this?"
@@ -4478,6 +4571,15 @@ msgid_plural ""
 msgstr[0] ""
 "\n"
 "Có phải ý bạn là một trong số những cái này không?"
+
+#: hook.c:27
+#, c-format
+msgid ""
+"The '%s' hook was ignored because it's not set as executable.\n"
+"You can disable this warning with `git config advice.ignoredHook false`."
+msgstr ""
+"Móc “%s” bị bỏ qua bởi vì nó không thể đặt là thực thi được.\n"
+"Bạn có thể tắt cảnh báo này bằng “git config advice.ignoredHook false“."
 
 #: ident.c:353
 msgid "Author identity unknown\n"
@@ -4541,7 +4643,7 @@ msgstr "không cho phép tên định danh là rỗng (cho <%s>)"
 msgid "name consists only of disallowed characters: %s"
 msgstr "tên chỉ được phép bao gồm các ký tự sau: %s"
 
-#: ident.c:454 builtin/commit.c:647
+#: ident.c:454 builtin/commit.c:648
 #, c-format
 msgid "invalid date format: %s"
 msgstr "ngày tháng không hợp lệ: %s"
@@ -4633,9 +4735,14 @@ msgstr "Không thể tạo “%s.lock”: %s"
 #: ls-refs.c:37
 #, c-format
 msgid "invalid value '%s' for lsrefs.unborn"
-msgstr "giá trị '%s' không hợp lệ cho lsrefs.unborn"
+msgstr "giá trị “%s” không hợp lệ cho lsrefs.unborn"
 
-#: ls-refs.c:167
+#: ls-refs.c:174
+#, c-format
+msgid "unexpected line: '%s'"
+msgstr "dòng không cần: “%s”"
+
+#: ls-refs.c:178
 msgid "expected flush after ls-refs arguments"
 msgstr "cần đẩy dữ liệu lên đĩa sau tham số ls-refs (liệt kê tham chiếu)"
 
@@ -4643,39 +4750,39 @@ msgstr "cần đẩy dữ liệu lên đĩa sau tham số ls-refs (liệt kê th
 msgid "quoted CRLF detected"
 msgstr "phát hiện CRLF được trích dẫn"
 
-#: mailinfo.c:1254 builtin/am.c:176 builtin/mailinfo.c:46
+#: mailinfo.c:1254 builtin/am.c:177 builtin/mailinfo.c:46
 #, c-format
 msgid "bad action '%s' for '%s'"
 msgstr "thao tác sai “%s” cho “%s”"
 
-#: merge-ort.c:1569 merge-recursive.c:1201
+#: merge-ort.c:1584 merge-recursive.c:1211
 #, c-format
 msgid "Failed to merge submodule %s (not checked out)"
 msgstr "Gặp lỗi khi hòa trộn mô-đun-con “%s” (không lấy ra được)"
 
-#: merge-ort.c:1578 merge-recursive.c:1208
+#: merge-ort.c:1593 merge-recursive.c:1218
 #, c-format
 msgid "Failed to merge submodule %s (commits not present)"
 msgstr "Gặp lỗi khi hòa trộn mô-đun-con “%s” (lần chuyển giao không hiện diện)"
 
-#: merge-ort.c:1587 merge-recursive.c:1215
+#: merge-ort.c:1602 merge-recursive.c:1225
 #, c-format
 msgid "Failed to merge submodule %s (commits don't follow merge-base)"
 msgstr ""
 "Gặp lỗi khi hòa trộn mô-đun-con “%s” (lần chuyển giao không theo sau nền-hòa-"
 "trộn)"
 
-#: merge-ort.c:1597 merge-ort.c:1604
+#: merge-ort.c:1612 merge-ort.c:1620
 #, c-format
 msgid "Note: Fast-forwarding submodule %s to %s"
 msgstr "Chú ý: Chuyển-tiếp-nhanh mô-đun-con “%s” sang “%s”"
 
-#: merge-ort.c:1625
+#: merge-ort.c:1642
 #, c-format
 msgid "Failed to merge submodule %s"
 msgstr "Gặp lỗi khi hòa trộn mô-đun-con “%s”"
 
-#: merge-ort.c:1632
+#: merge-ort.c:1649
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but a possible merge resolution exists:\n"
@@ -4684,7 +4791,7 @@ msgstr ""
 "Gặp lỗi khi hòa trộn mô-đun-con “%s”, nhưng có cách giải quyết:\n"
 "%s\n"
 
-#: merge-ort.c:1636 merge-recursive.c:1269
+#: merge-ort.c:1653 merge-recursive.c:1281
 #, c-format
 msgid ""
 "If this is correct simply add it to the index for example\n"
@@ -4701,7 +4808,7 @@ msgstr ""
 "\n"
 "cái mà sẽ chấp nhận gợi ý này.\n"
 
-#: merge-ort.c:1649
+#: merge-ort.c:1666
 #, c-format
 msgid ""
 "Failed to merge submodule %s, but multiple possible merges exist:\n"
@@ -4710,21 +4817,21 @@ msgstr ""
 "Gặp lỗi khi hòa trộn mô-đun-con “%s”, nhưng có nhiều cách giải quyết:\n"
 "%s"
 
-#: merge-ort.c:1868 merge-recursive.c:1358
+#: merge-ort.c:1887 merge-recursive.c:1372
 msgid "Failed to execute internal merge"
 msgstr "Gặp lỗi khi thực hiện trộn nội bộ"
 
-#: merge-ort.c:1873 merge-recursive.c:1363
+#: merge-ort.c:1892 merge-recursive.c:1377
 #, c-format
 msgid "Unable to add %s to database"
 msgstr "Không thể thêm %s vào cơ sở dữ liệu"
 
-#: merge-ort.c:1880 merge-recursive.c:1396
+#: merge-ort.c:1899 merge-recursive.c:1410
 #, c-format
 msgid "Auto-merging %s"
 msgstr "Tự-động-hòa-trộn %s"
 
-#: merge-ort.c:2019 merge-recursive.c:2118
+#: merge-ort.c:2038 merge-recursive.c:2132
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Existing file/dir at %s in the way of "
@@ -4733,7 +4840,7 @@ msgstr ""
 "XUNG ĐỘT: (ngầm đổi tên thư mục): Tập tin/thư mục đã sẵn có tại %s theo cách "
 "của các đổi tên thư mục ngầm đặt (các) đường dẫn sau ở đây: %s."
 
-#: merge-ort.c:2029 merge-recursive.c:2128
+#: merge-ort.c:2048 merge-recursive.c:2142
 #, c-format
 msgid ""
 "CONFLICT (implicit dir rename): Cannot map more than one path to %s; "
@@ -4742,7 +4849,7 @@ msgstr ""
 "XUNG ĐỘT: (ngầm đổi tên thư mục): Không thể ánh xạ một đường dẫn thành %s; "
 "các đổi tên thư mục ngầm cố đặt các đường dẫn ở đây: %s"
 
-#: merge-ort.c:2087
+#: merge-ort.c:2106
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to rename %s to; it was "
@@ -4753,7 +4860,7 @@ msgstr ""
 "thành; nó đã bị đổi tên thành nhiều thư mục khác, với không đích đến nhận "
 "một phần nhiều của các tập tin."
 
-#: merge-ort.c:2241 merge-recursive.c:2464
+#: merge-ort.c:2260 merge-recursive.c:2478
 #, c-format
 msgid ""
 "WARNING: Avoiding applying %s -> %s rename to %s, because %s itself was "
@@ -4762,7 +4869,7 @@ msgstr ""
 "CẢNH BÁO: tránh áp dụng %s -> %s đổi thên thành %s, bởi vì bản thân %s cũng "
 "bị đổi tên."
 
-#: merge-ort.c:2385 merge-recursive.c:3247
+#: merge-ort.c:2400 merge-recursive.c:3261
 #, c-format
 msgid ""
 "Path updated: %s added in %s inside a directory that was renamed in %s; "
@@ -4771,7 +4878,7 @@ msgstr ""
 "Đường dẫn đã được cập nhật: %s được thêm vào trong %s bên trong một thư mục "
 "đã được đổi tên trong %s; di chuyển nó đến %s."
 
-#: merge-ort.c:2392 merge-recursive.c:3254
+#: merge-ort.c:2407 merge-recursive.c:3268
 #, c-format
 msgid ""
 "Path updated: %s renamed to %s in %s, inside a directory that was renamed in "
@@ -4780,7 +4887,7 @@ msgstr ""
 "Đường dẫn đã được cập nhật: %s được đổi tên thành %s trong %s, bên trong một "
 "thư mục đã được đổi tên trong %s; di chuyển nó đến %s."
 
-#: merge-ort.c:2405 merge-recursive.c:3250
+#: merge-ort.c:2420 merge-recursive.c:3264
 #, c-format
 msgid ""
 "CONFLICT (file location): %s added in %s inside a directory that was renamed "
@@ -4789,7 +4896,7 @@ msgstr ""
 "XUNG ĐỘT (vị trí tệp): %s được thêm vào trong %s trong một thư mục đã được "
 "đổi tên thành %s, đoán là nó nên được di chuyển đến %s."
 
-#: merge-ort.c:2413 merge-recursive.c:3257
+#: merge-ort.c:2428 merge-recursive.c:3271
 #, c-format
 msgid ""
 "CONFLICT (file location): %s renamed to %s in %s, inside a directory that "
@@ -4798,13 +4905,13 @@ msgstr ""
 "XUNG ĐỘT (vị trí tệp): %s được đổi tên thành %s trong %s, bên trong một thư "
 "mục đã được đổi tên thành %s, đoán là nó nên được di chuyển đến %s."
 
-#: merge-ort.c:2569
+#: merge-ort.c:2584
 #, c-format
 msgid "CONFLICT (rename/rename): %s renamed to %s in %s and to %s in %s."
 msgstr ""
 "XUNG ĐỘT (đổi-tên/đổi-tên): Đổi tên %s->%s trong %s và thành %s trong %s."
 
-#: merge-ort.c:2664
+#: merge-ort.c:2679
 #, c-format
 msgid ""
 "CONFLICT (rename involved in collision): rename of %s -> %s has content "
@@ -4815,23 +4922,23 @@ msgstr ""
 "VÀ va chạm với một đường dẫn khác; điều này có thể dẫn đến tạo ra các xung "
 "đột lồng nhau."
 
-#: merge-ort.c:2683 merge-ort.c:2707
+#: merge-ort.c:2698 merge-ort.c:2722
 #, c-format
 msgid "CONFLICT (rename/delete): %s renamed to %s in %s, but deleted in %s."
 msgstr ""
 "XUNG ĐỘT (đổi-tên/xóa): Đổi tên %s->%s trong %s, nhưng lại bị xóa trong %s."
 
-#: merge-ort.c:3182 merge-recursive.c:3008
+#: merge-ort.c:3212 merge-recursive.c:3022
 #, c-format
 msgid "cannot read object %s"
 msgstr "không thể đọc đối tượng %s"
 
-#: merge-ort.c:3185 merge-recursive.c:3011
+#: merge-ort.c:3215 merge-recursive.c:3025
 #, c-format
 msgid "object %s is not a blob"
 msgstr "đối tượng %s không phải là một blob"
 
-#: merge-ort.c:3613
+#: merge-ort.c:3644
 #, c-format
 msgid ""
 "CONFLICT (file/directory): directory in the way of %s from %s; moving it to "
@@ -4840,7 +4947,7 @@ msgstr ""
 "XUNG ĐỘT (tập tin/thư mục): thư mục theo cách của %s từ %s; thay vào đó, di "
 "chuyển nó đến %s."
 
-#: merge-ort.c:3689
+#: merge-ort.c:3721
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed both "
@@ -4849,7 +4956,7 @@ msgstr ""
 "XUNG ĐỘT (các kiểu riêng biệt): %s có các kiểu khác nhau ở mỗi bên; đã đổi "
 "tên cả hai trong số chúng để mỗi cái có thể được ghi lại ở đâu đó."
 
-#: merge-ort.c:3696
+#: merge-ort.c:3728
 #, c-format
 msgid ""
 "CONFLICT (distinct types): %s had different types on each side; renamed one "
@@ -4858,24 +4965,24 @@ msgstr ""
 "XUNG ĐỘT (các kiểu riêng biệt): %s có các loại khác nhau ở mỗi bên; đã đổi "
 "tên một trong số chúng để mỗi cái có thể được ghi lại ở đâu đó."
 
-#: merge-ort.c:3796 merge-recursive.c:3087
+#: merge-ort.c:3819 merge-recursive.c:3101
 msgid "content"
 msgstr "nội dung"
 
-#: merge-ort.c:3798 merge-recursive.c:3091
+#: merge-ort.c:3821 merge-recursive.c:3105
 msgid "add/add"
 msgstr "thêm/thêm"
 
-#: merge-ort.c:3800 merge-recursive.c:3136
+#: merge-ort.c:3823 merge-recursive.c:3150
 msgid "submodule"
 msgstr "mô-đun-con"
 
-#: merge-ort.c:3802 merge-recursive.c:3137
+#: merge-ort.c:3825 merge-recursive.c:3151
 #, c-format
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "XUNG ĐỘT (%s): Xung đột hòa trộn trong %s"
 
-#: merge-ort.c:3833
+#: merge-ort.c:3856
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
@@ -4884,7 +4991,7 @@ msgstr ""
 "XUNG ĐỘT (sửa/xóa): %s bị xóa trong %s và sửa trong %s. Phiên bản %s của %s "
 "còn lại trong cây (tree)."
 
-#: merge-ort.c:4120
+#: merge-ort.c:4152
 #, c-format
 msgid ""
 "Note: %s not up to date and in way of checking out conflicted version; old "
@@ -4896,12 +5003,12 @@ msgstr ""
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
-#: merge-ort.c:4487
+#: merge-ort.c:4521
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
 msgstr "thu thập thông tin hòa trộn gặp lỗi cho cây %s, %s, %s"
 
-#: merge-ort-wrappers.c:13 merge-recursive.c:3702
+#: merge-ort-wrappers.c:13 merge-recursive.c:3716
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -4911,109 +5018,109 @@ msgstr ""
 "hòa trộn:\n"
 "  %s"
 
-#: merge-ort-wrappers.c:33 merge-recursive.c:3468 builtin/merge.c:402
+#: merge-ort-wrappers.c:33 merge-recursive.c:3482 builtin/merge.c:403
 msgid "Already up to date."
 msgstr "Đã cập nhật rồi."
 
-#: merge-recursive.c:352
+#: merge-recursive.c:353
 msgid "(bad commit)\n"
 msgstr "(commit sai)\n"
 
-#: merge-recursive.c:375
+#: merge-recursive.c:381
 #, c-format
 msgid "add_cacheinfo failed for path '%s'; merge aborting."
 msgstr "add_cacheinfo gặp lỗi đối với đường dẫn “%s”; việc hòa trộn bị bãi bỏ."
 
-#: merge-recursive.c:384
+#: merge-recursive.c:390
 #, c-format
 msgid "add_cacheinfo failed to refresh for path '%s'; merge aborting."
 msgstr ""
 "add_cacheinfo gặp lỗi khi làm mới đối với đường dẫn “%s”; việc hòa trộn bị "
 "bãi bỏ."
 
-#: merge-recursive.c:872
+#: merge-recursive.c:881
 #, c-format
 msgid "failed to create path '%s'%s"
 msgstr "gặp lỗi khi tạo đường dẫn “%s”%s"
 
-#: merge-recursive.c:883
+#: merge-recursive.c:892
 #, c-format
 msgid "Removing %s to make room for subdirectory\n"
 msgstr "Gỡ bỏ %s để tạo chỗ (room) cho thư mục con\n"
 
-#: merge-recursive.c:897 merge-recursive.c:916
+#: merge-recursive.c:906 merge-recursive.c:925
 msgid ": perhaps a D/F conflict?"
 msgstr ": có lẽ là một xung đột D/F?"
 
-#: merge-recursive.c:906
+#: merge-recursive.c:915
 #, c-format
 msgid "refusing to lose untracked file at '%s'"
 msgstr "từ chối đóng tập tin không được theo dõi tại “%s”"
 
-#: merge-recursive.c:947 builtin/cat-file.c:41
+#: merge-recursive.c:956 builtin/cat-file.c:41
 #, c-format
 msgid "cannot read object %s '%s'"
 msgstr "không thể đọc đối tượng %s “%s”"
 
-#: merge-recursive.c:952
+#: merge-recursive.c:961
 #, c-format
 msgid "blob expected for %s '%s'"
 msgstr "mong đợi đối tượng blob cho %s “%s”"
 
-#: merge-recursive.c:977
+#: merge-recursive.c:986
 #, c-format
 msgid "failed to open '%s': %s"
 msgstr "gặp lỗi khi mở “%s”: %s"
 
-#: merge-recursive.c:988
+#: merge-recursive.c:997
 #, c-format
 msgid "failed to symlink '%s': %s"
 msgstr "gặp lỗi khi tạo liên kết mềm (symlink) “%s”: %s"
 
-#: merge-recursive.c:993
+#: merge-recursive.c:1002
 #, c-format
 msgid "do not know what to do with %06o %s '%s'"
 msgstr "không hiểu phải làm gì với %06o %s “%s”"
 
-#: merge-recursive.c:1223 merge-recursive.c:1235
+#: merge-recursive.c:1233 merge-recursive.c:1246
 #, c-format
 msgid "Fast-forwarding submodule %s to the following commit:"
 msgstr "Chuyển-tiếp-nhanh mô-đun-con “%s” đến lần chuyển giao sau đây:"
 
-#: merge-recursive.c:1226 merge-recursive.c:1238
+#: merge-recursive.c:1236 merge-recursive.c:1249
 #, c-format
 msgid "Fast-forwarding submodule %s"
 msgstr "Chuyển-tiếp-nhanh mô-đun-con “%s”"
 
-#: merge-recursive.c:1261
+#: merge-recursive.c:1273
 #, c-format
 msgid "Failed to merge submodule %s (merge following commits not found)"
 msgstr ""
 "Gặp lỗi khi hòa trộn mô-đun-con “%s” (không tìm thấy các lần chuyển giao "
 "theo sau hòa trộn)"
 
-#: merge-recursive.c:1265
+#: merge-recursive.c:1277
 #, c-format
 msgid "Failed to merge submodule %s (not fast-forward)"
 msgstr "Gặp lỗi khi hòa trộn mô-đun-con “%s” (không chuyển tiếp nhanh được)"
 
-#: merge-recursive.c:1266
+#: merge-recursive.c:1278
 msgid "Found a possible merge resolution for the submodule:\n"
 msgstr "Tìm thấy một giải pháp hòa trộn có thể cho mô-đun-con:\n"
 
-#: merge-recursive.c:1278
+#: merge-recursive.c:1290
 #, c-format
 msgid "Failed to merge submodule %s (multiple merges found)"
 msgstr "Gặp lỗi khi hòa trộn mô-đun-con “%s” (thấy nhiều hòa trộn đa trùng)"
 
-#: merge-recursive.c:1420
+#: merge-recursive.c:1434
 #, c-format
 msgid "Error: Refusing to lose untracked file at %s; writing to %s instead."
 msgstr ""
 "Lỗi: từ chối đóng tập tin không được theo dõi tại “%s”; thay vào đó ghi vào "
 "%s."
 
-#: merge-recursive.c:1492
+#: merge-recursive.c:1506
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
@@ -5022,7 +5129,7 @@ msgstr ""
 "XUNG ĐỘT (%s/xóa): %s bị xóa trong %s và %s trong %s. Phiên bản %s của %s "
 "còn lại trong cây (tree)."
 
-#: merge-recursive.c:1497
+#: merge-recursive.c:1511
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
@@ -5031,7 +5138,7 @@ msgstr ""
 "XUNG ĐỘT (%s/xóa): %s bị xóa trong %s và %s đến %s trong %s. Phiên bản %s "
 "của %s còn lại trong cây (tree)."
 
-#: merge-recursive.c:1504
+#: merge-recursive.c:1518
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s in %s. Version %s of %s left "
@@ -5040,7 +5147,7 @@ msgstr ""
 "XUNG ĐỘT (%s/xóa): %s bị xóa trong %s và %s trong %s. Phiên bản %s của %s "
 "còn lại trong cây (tree) tại %s."
 
-#: merge-recursive.c:1509
+#: merge-recursive.c:1523
 #, c-format
 msgid ""
 "CONFLICT (%s/delete): %s deleted in %s and %s to %s in %s. Version %s of %s "
@@ -5049,45 +5156,45 @@ msgstr ""
 "XUNG ĐỘT (%s/xóa): %s bị xóa trong %s và %s đến %s trong %s. Phiên bản %s "
 "của %s còn lại trong cây (tree) tại %s."
 
-#: merge-recursive.c:1544
+#: merge-recursive.c:1558
 msgid "rename"
 msgstr "đổi tên"
 
-#: merge-recursive.c:1544
+#: merge-recursive.c:1558
 msgid "renamed"
 msgstr "đã đổi tên"
 
-#: merge-recursive.c:1595 merge-recursive.c:2501 merge-recursive.c:3164
+#: merge-recursive.c:1609 merge-recursive.c:2515 merge-recursive.c:3178
 #, c-format
 msgid "Refusing to lose dirty file at %s"
 msgstr "Từ chối đóng tập tin không được theo dõi tại “%s”"
 
-#: merge-recursive.c:1605
+#: merge-recursive.c:1619
 #, c-format
 msgid "Refusing to lose untracked file at %s, even though it's in the way."
 msgstr ""
 "Từ chối đóng tập tin không được theo dõi tại “%s”, ngay cả khi nó ở trên "
 "đường."
 
-#: merge-recursive.c:1663
+#: merge-recursive.c:1677
 #, c-format
 msgid "CONFLICT (rename/add): Rename %s->%s in %s.  Added %s in %s"
 msgstr ""
 "XUNG ĐỘT (đổi-tên/thêm): Đổi tên %s->%s trong %s. %s được thêm trong %s"
 
-#: merge-recursive.c:1694
+#: merge-recursive.c:1708
 #, c-format
 msgid "%s is a directory in %s adding as %s instead"
 msgstr "%s là một thư mục trong %s thay vào đó thêm vào như là %s"
 
-#: merge-recursive.c:1699
+#: merge-recursive.c:1713
 #, c-format
 msgid "Refusing to lose untracked file at %s; adding as %s instead"
 msgstr ""
 "Từ chối đóng tập tin không được theo dõi tại “%s”; thay vào đó đang thêm "
 "thành %s"
 
-#: merge-recursive.c:1726
+#: merge-recursive.c:1740
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename \"%s\"->\"%s\" in branch \"%s\" rename \"%s"
@@ -5096,17 +5203,17 @@ msgstr ""
 "XUNG ĐỘT (đổi-tên/đổi-tên): Đổi tên \"%s\"->\"%s\" trong nhánh \"%s\" đổi "
 "tên \"%s\"->\"%s\" trong \"%s\"%s"
 
-#: merge-recursive.c:1731
+#: merge-recursive.c:1745
 msgid " (left unresolved)"
 msgstr " (cần giải quyết)"
 
-#: merge-recursive.c:1823
+#: merge-recursive.c:1837
 #, c-format
 msgid "CONFLICT (rename/rename): Rename %s->%s in %s. Rename %s->%s in %s"
 msgstr ""
 "XUNG ĐỘT (đổi-tên/đổi-tên): Đổi tên %s->%s trong %s. Đổi tên %s->%s trong %s"
 
-#: merge-recursive.c:2086
+#: merge-recursive.c:2100
 #, c-format
 msgid ""
 "CONFLICT (directory rename split): Unclear where to place %s because "
@@ -5117,7 +5224,7 @@ msgstr ""
 "vì thư mục %s đã bị đổi tên thành nhiều thư mục khác, với không đích đến "
 "nhận một phần nhiều của các tập tin."
 
-#: merge-recursive.c:2220
+#: merge-recursive.c:2234
 #, c-format
 msgid ""
 "CONFLICT (rename/rename): Rename directory %s->%s in %s. Rename directory %s-"
@@ -5126,80 +5233,80 @@ msgstr ""
 "XUNG ĐỘT (đổi-tên/đổi-tên): Đổi tên thư mục %s->%s trong %s. Đổi tên thư mục "
 "%s->%s trong %s"
 
-#: merge-recursive.c:3075
+#: merge-recursive.c:3089
 msgid "modify"
 msgstr "sửa đổi"
 
-#: merge-recursive.c:3075
+#: merge-recursive.c:3089
 msgid "modified"
 msgstr "đã sửa"
 
-#: merge-recursive.c:3114
+#: merge-recursive.c:3128
 #, c-format
 msgid "Skipped %s (merged same as existing)"
 msgstr "Đã bỏ qua %s (đã có sẵn lần hòa trộn này)"
 
-#: merge-recursive.c:3167
+#: merge-recursive.c:3181
 #, c-format
 msgid "Adding as %s instead"
 msgstr "Thay vào đó thêm vào %s"
 
-#: merge-recursive.c:3371
+#: merge-recursive.c:3385
 #, c-format
 msgid "Removing %s"
 msgstr "Đang xóa %s"
 
-#: merge-recursive.c:3394
+#: merge-recursive.c:3408
 msgid "file/directory"
 msgstr "tập-tin/thư-mục"
 
-#: merge-recursive.c:3399
+#: merge-recursive.c:3413
 msgid "directory/file"
 msgstr "thư-mục/tập-tin"
 
-#: merge-recursive.c:3406
+#: merge-recursive.c:3420
 #, c-format
 msgid "CONFLICT (%s): There is a directory with name %s in %s. Adding %s as %s"
 msgstr ""
 "XUNG ĐỘT (%s): Ở đây không có thư mục nào có tên %s trong %s. Thêm %s như là "
 "%s"
 
-#: merge-recursive.c:3415
+#: merge-recursive.c:3429
 #, c-format
 msgid "Adding %s"
 msgstr "Thêm \"%s\""
 
-#: merge-recursive.c:3424
+#: merge-recursive.c:3438
 #, c-format
 msgid "CONFLICT (add/add): Merge conflict in %s"
 msgstr "XUNG ĐỘT (thêm/thêm): Xung đột hòa trộn trong %s"
 
-#: merge-recursive.c:3477
+#: merge-recursive.c:3491
 #, c-format
 msgid "merging of trees %s and %s failed"
 msgstr "hòa trộn các cây %s và %s gặp lỗi"
 
-#: merge-recursive.c:3571
+#: merge-recursive.c:3585
 msgid "Merging:"
 msgstr "Đang trộn:"
 
-#: merge-recursive.c:3584
+#: merge-recursive.c:3598
 #, c-format
 msgid "found %u common ancestor:"
 msgid_plural "found %u common ancestors:"
 msgstr[0] "tìm thấy %u tổ tiên chung:"
 
-#: merge-recursive.c:3634
+#: merge-recursive.c:3648
 msgid "merge returned no commit"
 msgstr "hòa trộn không trả về lần chuyển giao nào"
 
-#: merge-recursive.c:3799
+#: merge-recursive.c:3816
 #, c-format
 msgid "Could not parse object '%s'"
 msgstr "Không thể phân tích đối tượng “%s”"
 
-#: merge-recursive.c:3817 builtin/merge.c:717 builtin/merge.c:901
-#: builtin/stash.c:473
+#: merge-recursive.c:3834 builtin/merge.c:718 builtin/merge.c:904
+#: builtin/stash.c:489
 msgid "Unable to write index."
 msgstr "Không thể ghi bảng mục lục."
 
@@ -5207,190 +5314,222 @@ msgstr "Không thể ghi bảng mục lục."
 msgid "failed to read the cache"
 msgstr "gặp lỗi khi đọc bộ nhớ đệm"
 
-#: merge.c:108 rerere.c:704 builtin/am.c:1932 builtin/am.c:1966
-#: builtin/checkout.c:590 builtin/checkout.c:844 builtin/clone.c:821
-#: builtin/stash.c:267
+#: merge.c:102 rerere.c:704 builtin/am.c:1933 builtin/am.c:1967
+#: builtin/checkout.c:590 builtin/checkout.c:842 builtin/clone.c:706
+#: builtin/stash.c:269
 msgid "unable to write new index file"
 msgstr "không thể ghi tập tin lưu bảng mục lục mới"
 
-#: midx.c:74
+#: midx.c:78
 msgid "multi-pack-index OID fanout is of the wrong size"
 msgstr "fanout OID nhiều gói chỉ mục có kích thước sai"
 
-#: midx.c:105
+#: midx.c:109
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "tập tin đồ thị multi-pack-index %s quá nhỏ"
 
-#: midx.c:121
+#: midx.c:125
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr "chữ ký multi-pack-index 0x%08x không khớp chữ ký 0x%08x"
 
-#: midx.c:126
+#: midx.c:130
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "không nhận ra phiên bản %d của multi-pack-index"
 
-#: midx.c:131
+#: midx.c:135
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr "phiên bản băm multi-pack-index %u không khớp phiên bản %u"
 
-#: midx.c:148
+#: midx.c:152
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "multi-pack-index thiếu mảnh pack-name cần thiết"
 
-#: midx.c:150
+#: midx.c:154
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "multi-pack-index thiếu mảnh OID fanout cần thiết"
 
-#: midx.c:152
+#: midx.c:156
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr "multi-pack-index thiếu mảnh OID lookup cần thiết"
 
-#: midx.c:154
+#: midx.c:158
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr "multi-pack-index thiếu mảnh các khoảng bù đối tượng cần thiết"
 
-#: midx.c:170
+#: midx.c:174
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr "các tên gói multi-pack-index không đúng thứ tự: “%s” trước “%s”"
 
-#: midx.c:214
+#: midx.c:221
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr "pack-int-id sai: %u (%u các gói tổng)"
 
-#: midx.c:264
+#: midx.c:271
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr "multi-pack-index lưu trữ một khoảng bù 64-bít, nhưng off_t là quá nhỏ"
 
-#: midx.c:490
+#: midx.c:502
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "gặp lỗi khi thêm tập tin gói “%s”"
 
-#: midx.c:496
+#: midx.c:508
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "gặp lỗi khi mở pack-index “%s”"
 
-#: midx.c:564
+#: midx.c:576
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "gặp lỗi khi phân bổ đối tượng “%d” trong tập tin gói"
 
-#: midx.c:880 builtin/index-pack.c:1533
+#: midx.c:892
 msgid "cannot store reverse index file"
 msgstr "không thể lưu trữ tập tin ghi mục lục đảo ngược"
 
-#: midx.c:920
+#: midx.c:990
+#, c-format
+msgid "could not parse line: %s"
+msgstr "không thể phân tích cú pháp dòng: %s"
+
+#: midx.c:992
+#, c-format
+msgid "malformed line: %s"
+msgstr "dòng dị hình: %s"
+
+#: midx.c:1159
 msgid "ignoring existing multi-pack-index; checksum mismatch"
 msgstr "bỏ qua multi-pack-index sẵn có; tổng kiểm không khớp"
 
-#: midx.c:943
+#: midx.c:1184
+msgid "could not load pack"
+msgstr "không thể tải gói"
+
+#: midx.c:1190
+#, c-format
+msgid "could not open index for %s"
+msgstr "không thể mở mục lục cho %s"
+
+#: midx.c:1201
 msgid "Adding packfiles to multi-pack-index"
 msgstr "Đang thêm tập tin gói từ multi-pack-index"
 
-#: midx.c:989
-#, c-format
-msgid "did not see pack-file %s to drop"
-msgstr "đã không thấy tập tin gói %s để mà xóa"
-
-#: midx.c:1034
+#: midx.c:1244
 #, c-format
 msgid "unknown preferred pack: '%s'"
 msgstr "không hiểu \"preferred pack\": %s"
 
-#: midx.c:1039
+#: midx.c:1289
+#, c-format
+msgid "cannot select preferred pack %s with no objects"
+msgstr "không thể chọn gói ưa dùng %s với không đối tượng nào"
+
+#: midx.c:1321
+#, c-format
+msgid "did not see pack-file %s to drop"
+msgstr "đã không thấy tập tin gói %s để mà xóa"
+
+#: midx.c:1367
 #, c-format
 msgid "preferred pack '%s' is expired"
 msgstr "\"preferred pack\" “%s” đã hết hạn"
 
-#: midx.c:1055
+#: midx.c:1380
 msgid "no pack files to index."
 msgstr "không có tập tin gói để đánh mục lục."
 
-#: midx.c:1135 builtin/clean.c:37
+#: midx.c:1417
+msgid "could not write multi-pack bitmap"
+msgstr "không thể ghi “multi-pack bitmap”"
+
+#: midx.c:1427
+msgid "could not write multi-pack-index"
+msgstr "không thể ghi “multi-pack-index”"
+
+#: midx.c:1486 builtin/clean.c:37
 #, c-format
 msgid "failed to remove %s"
 msgstr "gặp lỗi khi gỡ bỏ %s"
 
-#: midx.c:1166
+#: midx.c:1517
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "gặp lỗi khi xóa multi-pack-index tại %s"
 
-#: midx.c:1225
+#: midx.c:1577
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr "đã có tập tin multi-pack-index, nhưng gặp lỗi khi phân tích cú pháp"
 
-#: midx.c:1233
+#: midx.c:1585
 msgid "incorrect checksum"
 msgstr "tổng kiểm không đúng"
 
-#: midx.c:1236
+#: midx.c:1588
 msgid "Looking for referenced packfiles"
 msgstr "Đang khóa cho các gói bị tham chiếu"
 
-#: midx.c:1251
+#: midx.c:1603
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 msgstr "fanout cũ sai thứ tự: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 
-#: midx.c:1256
+#: midx.c:1608
 msgid "the midx contains no oid"
 msgstr "midx chẳng chứa oid nào"
 
-#: midx.c:1265
+#: midx.c:1617
 msgid "Verifying OID order in multi-pack-index"
 msgstr "Thẩm tra thứ tự OID trong multi-pack-index"
 
-#: midx.c:1274
+#: midx.c:1626
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr "lookup cũ sai thứ tự: oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1294
+#: midx.c:1646
 msgid "Sorting objects by packfile"
 msgstr "Đang sắp xếp các đối tượng theo tập tin gói"
 
-#: midx.c:1301
+#: midx.c:1653
 msgid "Verifying object offsets"
 msgstr "Đang thẩm tra các khoảng bù đối tượng"
 
-#: midx.c:1317
+#: midx.c:1669
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "gặp lỗi khi tải mục gói cho oid[%d] = %s"
 
-#: midx.c:1323
+#: midx.c:1675
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "gặp lỗi khi tải pack-index cho tập tin gói %s"
 
-#: midx.c:1332
+#: midx.c:1684
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr ""
 "khoảng bù đối tượng không đúng cho oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#: midx.c:1357
+#: midx.c:1709
 msgid "Counting referenced objects"
 msgstr "Đang đếm các đối tượng được tham chiếu"
 
-#: midx.c:1367
+#: midx.c:1719
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "Đang tìm và xóa các gói không được tham chiếu"
 
-#: midx.c:1558
+#: midx.c:1911
 msgid "could not start pack-objects"
 msgstr "không thể lấy thông tin thống kê về các đối tượng gói"
 
-#: midx.c:1578
+#: midx.c:1931
 msgid "could not finish pack-objects"
 msgstr "không thể hoàn thiện các đối tượng gói"
 
@@ -5451,259 +5590,259 @@ msgstr "Từ chối ghi đè ghi chú trong %s (nằm ngoài refs/notes/)"
 msgid "Bad %s value: '%s'"
 msgstr "Giá trị %s sai: “%s”"
 
-#: object-file.c:526
+#: object-file.c:459
 #, c-format
 msgid "object directory %s does not exist; check .git/objects/info/alternates"
 msgstr ""
 "thư mục đối tượng %s không tồn tại; kiểm tra .git/objects/info/alternates"
 
-#: object-file.c:584
+#: object-file.c:517
 #, c-format
 msgid "unable to normalize alternate object path: %s"
 msgstr "không thể thường hóa đường dẫn đối tượng thay thế: “%s”"
 
-#: object-file.c:658
+#: object-file.c:591
 #, c-format
 msgid "%s: ignoring alternate object stores, nesting too deep"
 msgstr "%s: đang bỏ qua kho đối tượng thay thế, lồng nhau quá sâu"
 
-#: object-file.c:665
+#: object-file.c:598
 #, c-format
 msgid "unable to normalize object directory: %s"
 msgstr "không thể chuẩn hóa thư mục đối tượng: “%s”"
 
-#: object-file.c:708
+#: object-file.c:641
 msgid "unable to fdopen alternates lockfile"
 msgstr "không thể fdopen tập tin khóa thay thế"
 
-#: object-file.c:726
+#: object-file.c:659
 msgid "unable to read alternates file"
 msgstr "không thể đọc tập tin thay thế"
 
-#: object-file.c:733
+#: object-file.c:666
 msgid "unable to move new alternates file into place"
 msgstr "không thể di chuyển tập tin thay thế vào chỗ"
 
-#: object-file.c:768
+#: object-file.c:701
 #, c-format
 msgid "path '%s' does not exist"
 msgstr "đường dẫn “%s” không tồn tại"
 
-#: object-file.c:789
+#: object-file.c:722
 #, c-format
 msgid "reference repository '%s' as a linked checkout is not supported yet."
 msgstr "kho tham chiếu “%s” như là lấy ra liên kết vẫn chưa được hỗ trợ."
 
-#: object-file.c:795
+#: object-file.c:728
 #, c-format
 msgid "reference repository '%s' is not a local repository."
 msgstr "kho tham chiếu “%s” không phải là một kho nội bộ."
 
-#: object-file.c:801
+#: object-file.c:734
 #, c-format
 msgid "reference repository '%s' is shallow"
 msgstr "kho tham chiếu “%s” là nông"
 
-#: object-file.c:809
+#: object-file.c:742
 #, c-format
 msgid "reference repository '%s' is grafted"
 msgstr "kho tham chiếu “%s” bị cấy ghép"
 
-#: object-file.c:869
+#: object-file.c:773
+#, c-format
+msgid "could not find object directory matching %s"
+msgstr "không thể tìm thấy thư mục đối tượng khớp với “%s”"
+
+#: object-file.c:823
 #, c-format
 msgid "invalid line while parsing alternate refs: %s"
 msgstr "dòng không hợp lệ trong khi phân tích các tham chiếu thay thế: %s"
 
-#: object-file.c:1019
+#: object-file.c:973
 #, c-format
 msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
 msgstr "đang cố để mmap %<PRIuMAX> vượt quá giới hạn %<PRIuMAX>"
 
-#: object-file.c:1054
+#: object-file.c:1008
 #, c-format
 msgid "mmap failed%s"
 msgstr "mmap gặp lỗi%s"
 
-#: object-file.c:1218
+#: object-file.c:1174
 #, c-format
 msgid "object file %s is empty"
 msgstr "tập tin đối tượng %s trống rỗng"
 
-#: object-file.c:1353 object-file.c:2548
+#: object-file.c:1293 object-file.c:2499
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr "đối tượng mất hỏng “%s”"
 
-#: object-file.c:1355 object-file.c:2552
+#: object-file.c:1295 object-file.c:2503
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr "gặp rác tại cuối của đối tượng bị mất “%s”"
 
-#: object-file.c:1397
-msgid "invalid object type"
-msgstr "kiểu đối tượng không hợp lệ"
-
-#: object-file.c:1481
-#, c-format
-msgid "unable to unpack %s header with --allow-unknown-type"
-msgstr "không thể giải nén phần đầu gói %s với --allow-unknown-type"
-
-#: object-file.c:1484
-#, c-format
-msgid "unable to unpack %s header"
-msgstr "không thể giải gói phần đầu %s"
-
-#: object-file.c:1490
-#, c-format
-msgid "unable to parse %s header with --allow-unknown-type"
-msgstr "không thể phân tích phần đầu gói %s với --allow-unknown-type"
-
-#: object-file.c:1493
+#: object-file.c:1417
 #, c-format
 msgid "unable to parse %s header"
 msgstr "không thể phân tích phần đầu của “%s”"
 
-#: object-file.c:1717
+#: object-file.c:1419
+msgid "invalid object type"
+msgstr "kiểu đối tượng không hợp lệ"
+
+#: object-file.c:1430
+#, c-format
+msgid "unable to unpack %s header"
+msgstr "không thể giải gói phần đầu %s"
+
+#: object-file.c:1434
+#, c-format
+msgid "header for %s too long, exceeds %d bytes"
+msgstr "phần đầu cho %s quá dài, vượt quá %d byte"
+
+#: object-file.c:1664
 #, c-format
 msgid "failed to read object %s"
 msgstr "gặp lỗi khi đọc đối tượng “%s”"
 
-#: object-file.c:1721
+#: object-file.c:1668
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr "c%s thay thế không được tìm thấy cho %s"
 
-#: object-file.c:1725
+#: object-file.c:1672
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr "đối tượng mất %s (được lưu trong %s) bị hỏng"
 
-#: object-file.c:1729
+#: object-file.c:1676
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr "đối tượng đã đóng gói %s (được lưu trong %s) bị hỏng"
 
-#: object-file.c:1834
+#: object-file.c:1781
 #, c-format
 msgid "unable to write file %s"
 msgstr "không thể ghi tập tin %s"
 
-#: object-file.c:1841
+#: object-file.c:1788
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr "không thể đặt quyền thành “%s”"
 
-#: object-file.c:1848
+#: object-file.c:1795
 msgid "file write error"
 msgstr "lỗi ghi tập tin"
 
-#: object-file.c:1868
+#: object-file.c:1815
 msgid "error when closing loose object file"
 msgstr "gặp lỗi trong khi đóng tập tin đối tượng"
 
-#: object-file.c:1933
+#: object-file.c:1882
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 "không đủ thẩm quyền để thêm một đối tượng vào cơ sở dữ liệu kho chứa %s"
 
-#: object-file.c:1935
+#: object-file.c:1884
 msgid "unable to create temporary file"
 msgstr "không thể tạo tập tin tạm thời"
 
-#: object-file.c:1959
+#: object-file.c:1908
 msgid "unable to write loose object file"
 msgstr "không thể ghi tập tin đối tượng đã mất"
 
-#: object-file.c:1965
+#: object-file.c:1914
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr "không thể xả nén đối tượng mới %s (%d)"
 
-#: object-file.c:1969
+#: object-file.c:1918
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr "deflateEnd trên đối tượng %s gặp lỗi (%d)"
 
-#: object-file.c:1973
+#: object-file.c:1922
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr "chưa rõ ràng baowir dữ liệu nguồn đối tượng không ổn định cho %s"
 
-#: object-file.c:1983 builtin/pack-objects.c:1237
+#: object-file.c:1933 builtin/pack-objects.c:1243
 #, c-format
 msgid "failed utime() on %s"
 msgstr "gặp lỗi utime() trên “%s”"
 
-#: object-file.c:2060
+#: object-file.c:2011
 #, c-format
 msgid "cannot read object for %s"
 msgstr "không thể đọc đối tượng cho %s"
 
-#: object-file.c:2111
+#: object-file.c:2062
 msgid "corrupt commit"
 msgstr "lần chuyển giao sai hỏng"
 
-#: object-file.c:2119
+#: object-file.c:2070
 msgid "corrupt tag"
 msgstr "thẻ sai hỏng"
 
-#: object-file.c:2219
+#: object-file.c:2170
 #, c-format
 msgid "read error while indexing %s"
 msgstr "gặp lỗi đọc khi đánh mục lục %s"
 
-#: object-file.c:2222
+#: object-file.c:2173
 #, c-format
 msgid "short read while indexing %s"
 msgstr "không đọc ngắn khi đánh mục lục %s"
 
-#: object-file.c:2295 object-file.c:2305
+#: object-file.c:2246 object-file.c:2256
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr "%s: gặp lỗi khi thêm vào cơ sở dữ liệu"
 
-#: object-file.c:2311
+#: object-file.c:2262
 #, c-format
 msgid "%s: unsupported file type"
 msgstr "%s: kiểu tập tin không được hỗ trợ"
 
-#: object-file.c:2335
+#: object-file.c:2286 builtin/fetch.c:1445
 #, c-format
 msgid "%s is not a valid object"
 msgstr "%s không phải là một đối tượng hợp lệ"
 
-#: object-file.c:2337
+#: object-file.c:2288
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr "%s không phải là một đối tượng “%s” hợp lệ"
 
-#: object-file.c:2364 builtin/index-pack.c:192
+#: object-file.c:2315
 #, c-format
 msgid "unable to open %s"
 msgstr "không thể mở %s"
 
-#: object-file.c:2559 object-file.c:2612
+#: object-file.c:2510
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
 msgstr "mã băm không khớp cho %s (cần %s)"
 
-#: object-file.c:2583
+#: object-file.c:2533
 #, c-format
 msgid "unable to mmap %s"
 msgstr "không thể mmap %s"
 
-#: object-file.c:2588
+#: object-file.c:2539
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr "không thể giải gói phần đầu của “%s”"
 
-#: object-file.c:2594
+#: object-file.c:2544
 #, c-format
 msgid "unable to parse header of %s"
 msgstr "không thể phân tích phần đầu của “%s”"
 
-#: object-file.c:2605
+#: object-file.c:2555
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr "không thể giải gói nội dung của “%s”"
@@ -5832,12 +5971,25 @@ msgstr "không thể phân tích đối tượng: “%s”"
 msgid "hash mismatch %s"
 msgstr "mã băm không khớp %s"
 
-#: pack-bitmap.c:868 pack-bitmap.c:874 builtin/pack-objects.c:2411
+#: pack-bitmap.c:348
+msgid "multi-pack bitmap is missing required reverse index"
+msgstr "ánh xạ multi-pack thiếu mục lục để dành cần thiết"
+
+#: pack-bitmap.c:424
+msgid "load_reverse_index: could not open pack"
+msgstr "load_reverse_index: không thể mở gói"
+
+#: pack-bitmap.c:1064 pack-bitmap.c:1070 builtin/pack-objects.c:2424
 #, c-format
 msgid "unable to get size of %s"
 msgstr "không thể lấy kích cỡ của %s"
 
-#: pack-bitmap.c:1571 builtin/rev-list.c:92
+#: pack-bitmap.c:1916
+#, c-format
+msgid "could not find %s in pack %s at offset %<PRIuMAX>"
+msgstr "không thể tìm thấy %s trong gói “%s” tại vị trí %<PRIuMAX>"
+
+#: pack-bitmap.c:1952 builtin/rev-list.c:92
 #, c-format
 msgid "unable to get disk usage of %s"
 msgstr "không thể dung lượng đĩa đã dùng của %s"
@@ -5867,46 +6019,46 @@ msgstr "tệp chỉ mục ngược %s có phiên bản không được hỗ tr�
 msgid "reverse-index file %s has unsupported hash id %<PRIu32>"
 msgstr "tệp chỉ mục ngược %s có id mã băm không được hỗ trợ %<PRIu32>"
 
-#: pack-write.c:250
+#: pack-write.c:251
 msgid "cannot both write and verify reverse index"
 msgstr "không thể cùng lúc đọc và xác minh được bảng mục lục đảo ngược"
 
-#: pack-write.c:271
+#: pack-write.c:270
 #, c-format
 msgid "could not stat: %s"
 msgstr "không thể lấy thông tin thống kê: %s"
 
-#: pack-write.c:283
+#: pack-write.c:282
 #, c-format
 msgid "failed to make %s readable"
 msgstr "gặp lỗi làm cho %s đọc được"
 
-#: pack-write.c:522
+#: pack-write.c:520
 #, c-format
 msgid "could not write '%s' promisor file"
 msgstr "không thể ghi tập tin promisor “%s”"
 
-#: packfile.c:625
+#: packfile.c:626
 msgid "offset before end of packfile (broken .idx?)"
 msgstr "vị trí tương đối trước điểm kết thúc của tập tin gói (.idx hỏng à?)"
 
-#: packfile.c:655
+#: packfile.c:656
 #, c-format
 msgid "packfile %s cannot be mapped%s"
 msgstr "tập tin gói %s không thể được ánh xạ %s"
 
-#: packfile.c:1934
+#: packfile.c:1923
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr "vị trí tương đối nằm trước chỉ mục gói cho %s (mục lục bị hỏng à?)"
 
-#: packfile.c:1938
+#: packfile.c:1927
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr ""
 "vị trí tương đối vượt quá cuối của chỉ mục gói cho %s (mục lục bị cắt cụt à?)"
 
-#: parse-options-cb.c:20 parse-options-cb.c:24
+#: parse-options-cb.c:20 parse-options-cb.c:24 builtin/commit-graph.c:175
 #, c-format
 msgid "option `%s' expects a numerical value"
 msgstr "tùy chọn “%s” cần một giá trị bằng số"
@@ -5926,71 +6078,71 @@ msgstr "tùy chọn “%s” cần \"always\", \"auto\", hoặc \"never\""
 msgid "malformed object name '%s'"
 msgstr "tên đối tượng dị hình “%s”"
 
-#: parse-options.c:38
+#: parse-options.c:58
 #, c-format
 msgid "%s requires a value"
 msgstr "“%s” yêu cầu một giá trị"
 
-#: parse-options.c:73
+#: parse-options.c:93
 #, c-format
 msgid "%s is incompatible with %s"
 msgstr "%s là xung khắc với %s"
 
-#: parse-options.c:78
+#: parse-options.c:98
 #, c-format
 msgid "%s : incompatible with something else"
 msgstr "%s : xung khắc với các cái khác"
 
-#: parse-options.c:92 parse-options.c:96 parse-options.c:317
+#: parse-options.c:112 parse-options.c:116
 #, c-format
 msgid "%s takes no value"
 msgstr "%s k nhận giá trị"
 
-#: parse-options.c:94
+#: parse-options.c:114
 #, c-format
 msgid "%s isn't available"
 msgstr "%s không sẵn có"
 
-#: parse-options.c:217
+#: parse-options.c:237
 #, c-format
 msgid "%s expects a non-negative integer value with an optional k/m/g suffix"
 msgstr "%s cần một giá trị dạng số không âm với một hậu tố tùy chọn k/m/g"
 
-#: parse-options.c:386
+#: parse-options.c:393
 #, c-format
 msgid "ambiguous option: %s (could be --%s%s or --%s%s)"
 msgstr "tùy chọn chưa rõ rang: %s (nên là --%s%s hay --%s%s)"
 
-#: parse-options.c:420 parse-options.c:428
+#: parse-options.c:427 parse-options.c:435
 #, c-format
 msgid "did you mean `--%s` (with two dashes)?"
 msgstr "có phải ý bạn là “--%s“ (với hai dấu gạch ngang)?"
 
-#: parse-options.c:668 parse-options.c:988
+#: parse-options.c:677 parse-options.c:1053
 #, c-format
 msgid "alias of --%s"
 msgstr "bí danh của --%s"
 
-#: parse-options.c:879
+#: parse-options.c:891
 #, c-format
 msgid "unknown option `%s'"
 msgstr "không hiểu tùy chọn “%s”"
 
-#: parse-options.c:881
+#: parse-options.c:893
 #, c-format
 msgid "unknown switch `%c'"
 msgstr "không hiểu tùy chọn “%c”"
 
-#: parse-options.c:883
+#: parse-options.c:895
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
 msgstr "không hiểu tùy chọn non-ascii trong chuỗi: “%s”"
 
-#: parse-options.c:907
+#: parse-options.c:919
 msgid "..."
 msgstr "…"
 
-#: parse-options.c:926
+#: parse-options.c:933
 #, c-format
 msgid "usage: %s"
 msgstr "cách dùng: %s"
@@ -5998,49 +6150,73 @@ msgstr "cách dùng: %s"
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
 #.
-#: parse-options.c:932
+#: parse-options.c:948
 #, c-format
 msgid "   or: %s"
 msgstr "     hoặc: %s"
 
-#: parse-options.c:935
+#. TRANSLATORS: You should only need to translate this format
+#. string if your language is a RTL language (e.g. Arabic,
+#. Hebrew etc.), not if it's a LTR language (e.g. German,
+#. Russian, Chinese etc.).
+#. *
+#. When a translated usage string has an embedded "\n" it's
+#. because options have wrapped to the next line. The line
+#. after the "\n" will then be padded to align with the
+#. command name, such as N_("git cmd [opt]\n<8
+#. spaces>[opt2]"), where the 8 spaces are the same length as
+#. "git cmd ".
+#. *
+#. This format string prints out that already-translated
+#. line. The "%*s" is whitespace padding to account for the
+#. padding at the start of the line that we add in this
+#. function. The "%s" is a line in the (hopefully already
+#. translated) N_() usage string, which contained embedded
+#. newlines before we split it up.
+#.
+#: parse-options.c:969
+#, c-format
+msgid "%*s%s"
+msgstr "%*s%s"
+
+#: parse-options.c:992
 #, c-format
 msgid "    %s"
 msgstr "    %s"
 
-#: parse-options.c:974
+#: parse-options.c:1039
 msgid "-NUM"
 msgstr "-SỐ"
 
-#: path.c:915
+#: path.c:922
 #, c-format
 msgid "Could not make %s writable by group"
 msgstr "Không thể làm %s được ghi bởi nhóm"
 
-#: pathspec.c:151
+#: pathspec.c:150
 msgid "Escape character '\\' not allowed as last character in attr value"
 msgstr ""
 "Ký tự thoát chuỗi “\\” không được phép là ký tự cuối trong giá trị thuộc tính"
 
-#: pathspec.c:169
+#: pathspec.c:168
 msgid "Only one 'attr:' specification is allowed."
 msgstr "Chỉ có một đặc tả “attr:” là được phép."
 
-#: pathspec.c:172
+#: pathspec.c:171
 msgid "attr spec must not be empty"
 msgstr "đặc tả attr phải không được để trống"
 
-#: pathspec.c:215
+#: pathspec.c:214
 #, c-format
 msgid "invalid attribute name %s"
 msgstr "tên thuộc tính không hợp lệ %s"
 
-#: pathspec.c:280
+#: pathspec.c:279
 msgid "global 'glob' and 'noglob' pathspec settings are incompatible"
 msgstr ""
 "các cài đặt đặc tả đường dẫn “glob” và “noglob” toàn cục là xung khắc nhau"
 
-#: pathspec.c:287
+#: pathspec.c:286
 msgid ""
 "global 'literal' pathspec setting is incompatible with all other global "
 "pathspec settings"
@@ -6048,51 +6224,51 @@ msgstr ""
 "cài đặt đặc tả đường dẫn “literal” toàn cục là xung khắc với các cài đặt đặc "
 "tả đường dẫn toàn cục khác"
 
-#: pathspec.c:327
+#: pathspec.c:326
 msgid "invalid parameter for pathspec magic 'prefix'"
 msgstr "tham số không hợp lệ cho “tiền tố” màu nhiệm đặc tả đường đẫn"
 
-#: pathspec.c:348
+#: pathspec.c:347
 #, c-format
 msgid "Invalid pathspec magic '%.*s' in '%s'"
 msgstr "Số màu nhiệm đặc tả đường dẫn không hợp lệ “%.*s” trong “%s”"
 
-#: pathspec.c:353
+#: pathspec.c:352
 #, c-format
 msgid "Missing ')' at the end of pathspec magic in '%s'"
 msgstr "Thiếu “)” tại cuối của số màu nhiệm đặc tả đường dẫn trong “%s”"
 
-#: pathspec.c:391
+#: pathspec.c:390
 #, c-format
 msgid "Unimplemented pathspec magic '%c' in '%s'"
 msgstr "Chưa viết mã cho số màu nhiệm đặc tả đường dẫn “%c” trong “%s”"
 
-#: pathspec.c:450
+#: pathspec.c:449
 #, c-format
 msgid "%s: 'literal' and 'glob' are incompatible"
 msgstr "%s: “literal” và “glob” xung khắc nhau"
 
-#: pathspec.c:466
+#: pathspec.c:465
 #, c-format
 msgid "%s: '%s' is outside repository at '%s'"
 msgstr "%s: “%s” ngoài một kho chứa tại “%s”"
 
-#: pathspec.c:542
+#: pathspec.c:541
 #, c-format
 msgid "'%s' (mnemonic: '%c')"
 msgstr "“%s” (mnemonic: “%c”)"
 
-#: pathspec.c:552
+#: pathspec.c:551
 #, c-format
 msgid "%s: pathspec magic not supported by this command: %s"
 msgstr "%s: số mầu nhiệm đặc tả đường dẫn chưa được hỗ trợ bởi lệnh này: %s"
 
-#: pathspec.c:619
+#: pathspec.c:618
 #, c-format
 msgid "pathspec '%s' is beyond a symbolic link"
 msgstr "đặc tả đường dẫn “%s” vượt ra ngoài liên kết mềm"
 
-#: pathspec.c:664
+#: pathspec.c:663
 #, c-format
 msgid "line is badly quoted: %s"
 msgstr "dòng được trích dẫn sai: %s"
@@ -6113,7 +6289,7 @@ msgstr "không thể ghi gói cuối trả về"
 msgid "flush packet write failed"
 msgstr "gặp lỗi khi ghi vào tập tin gói lúc đẩy dữ liệu lên bộ nhớ"
 
-#: pkt-line.c:153 pkt-line.c:265
+#: pkt-line.c:153
 msgid "protocol error: impossibly long line"
 msgstr "lỗi giao thức: không thể làm được dòng dài"
 
@@ -6121,7 +6297,7 @@ msgstr "lỗi giao thức: không thể làm được dòng dài"
 msgid "packet write with format failed"
 msgstr "gặp lỗi khi ghi gói có định dạng"
 
-#: pkt-line.c:204
+#: pkt-line.c:204 pkt-line.c:252
 msgid "packet write failed - data exceeds max packet size"
 msgstr "gặp lỗi khi ghi gói - dữ liệu vượt quá cỡ vói tối đa"
 
@@ -6130,25 +6306,25 @@ msgstr "gặp lỗi khi ghi gói - dữ liệu vượt quá cỡ vói tối đa"
 msgid "packet write failed: %s"
 msgstr "gặp lỗi khi ghi gói: %s"
 
-#: pkt-line.c:328 pkt-line.c:329
+#: pkt-line.c:349 pkt-line.c:350
 msgid "read error"
 msgstr "lỗi đọc"
 
-#: pkt-line.c:339 pkt-line.c:340
+#: pkt-line.c:360 pkt-line.c:361
 msgid "the remote end hung up unexpectedly"
 msgstr "máy chủ bị treo bất ngờ"
 
-#: pkt-line.c:369 pkt-line.c:371
+#: pkt-line.c:390 pkt-line.c:392
 #, c-format
 msgid "protocol error: bad line length character: %.4s"
 msgstr "lỗi giao thức: ký tự chiều dài dòng bị sai: %.4s"
 
-#: pkt-line.c:386 pkt-line.c:388 pkt-line.c:394 pkt-line.c:396
+#: pkt-line.c:407 pkt-line.c:409 pkt-line.c:415 pkt-line.c:417
 #, c-format
 msgid "protocol error: bad line length %d"
 msgstr "lỗi giao thức: chiều dài dòng bị sai %d"
 
-#: pkt-line.c:413 sideband.c:165
+#: pkt-line.c:434 sideband.c:165
 #, c-format
 msgid "remote error: %s"
 msgstr "lỗi máy chủ: %s"
@@ -6162,7 +6338,7 @@ msgstr "Làm mới bảng mục lục"
 msgid "unable to create threaded lstat: %s"
 msgstr "không thể tạo tuyến trình lstat: %s"
 
-#: pretty.c:988
+#: pretty.c:1051
 msgid "unable to parse --pretty format"
 msgstr "không thể phân tích định dạng --pretty"
 
@@ -6192,20 +6368,20 @@ msgstr "object-info: cần đẩy dữ liệu lên đĩa sau các tham số"
 msgid "Removing duplicate objects"
 msgstr "Đang gỡ các đối tượng trùng lặp"
 
-#: range-diff.c:78
+#: range-diff.c:67
 msgid "could not start `log`"
 msgstr "không thể lấy thông tin thống kê về “log“"
 
-#: range-diff.c:80
+#: range-diff.c:69
 msgid "could not read `log` output"
 msgstr "không thể đọc kết xuất “log”"
 
-#: range-diff.c:101 sequencer.c:5550
+#: range-diff.c:97 sequencer.c:5605
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr "không thể phân tích lần chuyển giao “%s”"
 
-#: range-diff.c:115
+#: range-diff.c:111
 #, c-format
 msgid ""
 "could not parse first line of `log` output: did not start with 'commit ': "
@@ -6214,12 +6390,12 @@ msgstr ""
 "không thể phân tích cú pháp dòng đầu tiên của đầu ra “log”: không bắt đầu "
 "bằng “commit ”: “%s”"
 
-#: range-diff.c:140
+#: range-diff.c:137
 #, c-format
 msgid "could not parse git header '%.*s'"
 msgstr "không thể phân tích cú pháp phần đầu git “%.*s”"
 
-#: range-diff.c:307
+#: range-diff.c:304
 msgid "failed to generate diff"
 msgstr "gặp lỗi khi tạo khác biệt"
 
@@ -6248,7 +6424,7 @@ msgid "%s: can only add regular files, symbolic links or git-directories"
 msgstr ""
 "%s: chỉ có thể thêm tập tin thông thường, liên kết mềm hoặc git-directories"
 
-#: read-cache.c:753
+#: read-cache.c:753 builtin/submodule--helper.c:3241
 #, c-format
 msgid "'%s' does not have a commit checked out"
 msgstr "“%s” không có một lần chuyển giao nào được lấy ra"
@@ -6268,16 +6444,16 @@ msgstr "không thể thêm %s vào bảng mục lục"
 msgid "unable to stat '%s'"
 msgstr "không thể lấy thống kê “%s”"
 
-#: read-cache.c:1358
+#: read-cache.c:1373
 #, c-format
 msgid "'%s' appears as both a file and as a directory"
 msgstr "%s có vẻ không phải là tập tin và cũng chẳng phải là một thư mục"
 
-#: read-cache.c:1573
+#: read-cache.c:1588
 msgid "Refresh index"
 msgstr "Làm tươi mới bảng mục lục"
 
-#: read-cache.c:1705
+#: read-cache.c:1720
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -6286,7 +6462,7 @@ msgstr ""
 "index.version được đặt, nhưng giá trị của nó lại không hợp lệ.\n"
 "Dùng phiên bản %i"
 
-#: read-cache.c:1715
+#: read-cache.c:1730
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -6295,143 +6471,143 @@ msgstr ""
 "GIT_INDEX_VERSION được đặt, nhưng giá trị của nó lại không hợp lệ.\n"
 "Dùng phiên bản %i"
 
-#: read-cache.c:1771
+#: read-cache.c:1786
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr "chữ ký sai 0x%08x"
 
-#: read-cache.c:1774
+#: read-cache.c:1789
 #, c-format
 msgid "bad index version %d"
 msgstr "phiên bản mục lục sai %d"
 
-#: read-cache.c:1783
+#: read-cache.c:1798
 msgid "bad index file sha1 signature"
 msgstr "chữ ký dạng sha1 cho tập tin mục lục không đúng"
 
-#: read-cache.c:1817
+#: read-cache.c:1832
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr "mục lục dùng phần mở rộng %.4s, cái mà chúng tôi không hiểu được"
 
-#: read-cache.c:1819
+#: read-cache.c:1834
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr "đang lờ đi phần mở rộng %.4s"
 
-#: read-cache.c:1856
+#: read-cache.c:1871
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr "không hiểu định dạng mục lục 0x%08x"
 
-#: read-cache.c:1872
+#: read-cache.c:1887
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "trường tên sai sạng trong mục lục, gần đường dẫn “%s”"
 
-#: read-cache.c:1929
+#: read-cache.c:1944
 msgid "unordered stage entries in index"
 msgstr "các mục tin stage không đúng thứ tự trong mục lục"
 
-#: read-cache.c:1932
+#: read-cache.c:1947
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr "nhiều mục stage cho tập tin hòa trộn “%s”"
 
-#: read-cache.c:1935
+#: read-cache.c:1950
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr "các mục tin stage không đúng thứ tự cho “%s”"
 
-#: read-cache.c:2041 read-cache.c:2339 rerere.c:549 rerere.c:583 rerere.c:1095
-#: submodule.c:1622 builtin/add.c:575 builtin/check-ignore.c:183
-#: builtin/checkout.c:519 builtin/checkout.c:706 builtin/clean.c:987
-#: builtin/commit.c:377 builtin/diff-tree.c:122 builtin/grep.c:505
-#: builtin/mv.c:146 builtin/reset.c:247 builtin/rm.c:291
-#: builtin/submodule--helper.c:333
+#: read-cache.c:2065 read-cache.c:2363 rerere.c:549 rerere.c:583 rerere.c:1095
+#: submodule.c:1662 builtin/add.c:603 builtin/check-ignore.c:183
+#: builtin/checkout.c:519 builtin/checkout.c:708 builtin/clean.c:987
+#: builtin/commit.c:378 builtin/diff-tree.c:122 builtin/grep.c:519
+#: builtin/mv.c:148 builtin/reset.c:253 builtin/rm.c:293
+#: builtin/submodule--helper.c:327 builtin/submodule--helper.c:3201
 msgid "index file corrupt"
 msgstr "tập tin ghi bảng mục lục bị hỏng"
 
-#: read-cache.c:2185
+#: read-cache.c:2209
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr "không thể tạo tuyến load_cache_entries: %s"
 
-#: read-cache.c:2198
+#: read-cache.c:2222
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr "không thể gia nhập tuyến load_cache_entries: %s"
 
-#: read-cache.c:2231
+#: read-cache.c:2255
 #, c-format
 msgid "%s: index file open failed"
 msgstr "%s: mở tập tin mục lục gặp lỗi"
 
-#: read-cache.c:2235
+#: read-cache.c:2259
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr "%s: không thể lấy thống kê bảng mục lục đã mở"
 
-#: read-cache.c:2239
+#: read-cache.c:2263
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr "%s: tập tin mục lục nhỏ hơn mong đợi"
 
-#: read-cache.c:2243
+#: read-cache.c:2267
 #, c-format
 msgid "%s: unable to map index file%s"
 msgstr "%s: không thể ánh xạ tập tin mục lục%s"
 
-#: read-cache.c:2286
+#: read-cache.c:2310
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr "không thể tạo tuyến load_index_extensions: %s"
 
-#: read-cache.c:2313
+#: read-cache.c:2337
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr "không thể gia nhập tuyến load_index_extensions: %s"
 
-#: read-cache.c:2351
+#: read-cache.c:2375
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr "không thể làm tươi mới mục lục đã chia sẻ “%s”"
 
-#: read-cache.c:2398
+#: read-cache.c:2434
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr "mục lục bị hỏng, cần %s trong %s, nhưng lại nhận được %s"
 
-#: read-cache.c:3032 strbuf.c:1173 wrapper.c:633 builtin/merge.c:1146
+#: read-cache.c:3065 strbuf.c:1179 wrapper.c:641 builtin/merge.c:1147
 #, c-format
 msgid "could not close '%s'"
 msgstr "không thể đóng “%s”"
 
-#: read-cache.c:3075
+#: read-cache.c:3108
 msgid "failed to convert to a sparse-index"
 msgstr "gặp lỗi khi chuyển đổi sang \"sparse-index\""
 
-#: read-cache.c:3146 sequencer.c:2684 sequencer.c:4440
+#: read-cache.c:3179
 #, c-format
 msgid "could not stat '%s'"
 msgstr "không thể lấy thông tin thống kê về “%s”"
 
-#: read-cache.c:3159
+#: read-cache.c:3192
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "không thể mở thư mục git: %s"
 
-#: read-cache.c:3171
+#: read-cache.c:3204
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "không thể bỏ liên kết (unlink): “%s”"
 
-#: read-cache.c:3200
+#: read-cache.c:3233
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr "không thể sửa các bít phân quyền trên “%s”"
 
-#: read-cache.c:3349
+#: read-cache.c:3390
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr "%s: không thể xóa bỏ stage #0"
@@ -6513,7 +6689,7 @@ msgid "Rebase %s onto %s (%d command)"
 msgid_plural "Rebase %s onto %s (%d commands)"
 msgstr[0] "Cải tổ %s vào %s (%d lệnh )"
 
-#: rebase-interactive.c:75 git-rebase--preserve-merges.sh:218
+#: rebase-interactive.c:75
 msgid ""
 "\n"
 "Do not remove any line. Use 'drop' explicitly to remove a commit.\n"
@@ -6522,7 +6698,7 @@ msgstr ""
 "Đừng xóa bất kỳ dòng nào. Dùng “drop” một cách rõ ràng để xóa bỏ một lần "
 "chuyển giao.\n"
 
-#: rebase-interactive.c:78 git-rebase--preserve-merges.sh:222
+#: rebase-interactive.c:78
 msgid ""
 "\n"
 "If you remove a line here THAT COMMIT WILL BE LOST.\n"
@@ -6530,7 +6706,7 @@ msgstr ""
 "\n"
 "Nếu bạn xóa bỏ một dòng ở đây thì LẦN CHUYỂN GIAO ĐÓ SẼ MẤT.\n"
 
-#: rebase-interactive.c:84 git-rebase--preserve-merges.sh:861
+#: rebase-interactive.c:84
 msgid ""
 "\n"
 "You are editing the todo file of an ongoing interactive rebase.\n"
@@ -6544,7 +6720,7 @@ msgstr ""
 "    git rebase --continue\n"
 "\n"
 
-#: rebase-interactive.c:89 git-rebase--preserve-merges.sh:938
+#: rebase-interactive.c:89
 msgid ""
 "\n"
 "However, if you remove everything, the rebase will be aborted.\n"
@@ -6554,14 +6730,14 @@ msgstr ""
 "Tuy nhiên, nếu bạn xóa bỏ mọi thứ, việc cải tổ sẽ bị bãi bỏ.\n"
 "\n"
 
-#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3836
-#: sequencer.c:3862 sequencer.c:5656 builtin/fsck.c:328 builtin/rebase.c:271
+#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3888
+#: sequencer.c:3914 sequencer.c:5711 builtin/fsck.c:328 builtin/gc.c:1789
+#: builtin/rebase.c:190
 #, c-format
 msgid "could not write '%s'"
 msgstr "không thể ghi “%s”"
 
-#: rebase-interactive.c:119 builtin/rebase.c:203 builtin/rebase.c:229
-#: builtin/rebase.c:253
+#: rebase-interactive.c:119
 #, c-format
 msgid "could not write '%s'."
 msgstr "không thể ghi “%s”."
@@ -6593,12 +6769,10 @@ msgstr ""
 "Cánh ứng xử có thể là: ignore, warn, error.\n"
 "\n"
 
-#: rebase-interactive.c:236 rebase-interactive.c:241 sequencer.c:2597
-#: builtin/rebase.c:189 builtin/rebase.c:214 builtin/rebase.c:240
-#: builtin/rebase.c:265
+#: rebase.c:29
 #, c-format
-msgid "could not read '%s'."
-msgstr "không thể đọc “%s”."
+msgid "%s: 'preserve' superseded by 'merges'"
+msgstr "%s: “preserve” bị cấm bởi “merges”"
 
 #: ref-filter.c:42 wt-status.c:2036
 msgid "gone"
@@ -6619,132 +6793,142 @@ msgstr "đằng sau %d"
 msgid "ahead %d, behind %d"
 msgstr "trước %d, sau %d"
 
-#: ref-filter.c:230
+#: ref-filter.c:235
 #, c-format
 msgid "expected format: %%(color:<color>)"
 msgstr "cần định dạng: %%(color:<color>)"
 
-#: ref-filter.c:232
+#: ref-filter.c:237
 #, c-format
 msgid "unrecognized color: %%(color:%s)"
-msgstr "không nhận ra màu: %%(màu:%s)"
+msgstr "không nhận ra màu: %%(color:%s)"
 
-#: ref-filter.c:254
+#: ref-filter.c:259
 #, c-format
 msgid "Integer value expected refname:lstrip=%s"
 msgstr "Giá trị nguyên cần tên tham chiếu:lstrip=%s"
 
-#: ref-filter.c:258
+#: ref-filter.c:263
 #, c-format
 msgid "Integer value expected refname:rstrip=%s"
 msgstr "Giá trị nguyên cần tên tham chiếu:rstrip=%s"
 
-#: ref-filter.c:260
+#: ref-filter.c:265
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
 msgstr "đối số không được thừa nhận %%(%s): %s"
 
-#: ref-filter.c:315
+#: ref-filter.c:320
 #, c-format
 msgid "%%(objecttype) does not take arguments"
 msgstr "%%(objecttype) không nhận các đối số"
 
-#: ref-filter.c:339
+#: ref-filter.c:344
 #, c-format
 msgid "unrecognized %%(objectsize) argument: %s"
-msgstr "tham số không được thừa nhận %%(objectname): %s"
+msgstr "tham số không được thừa nhận %%(objectsize): %s"
 
-#: ref-filter.c:347
+#: ref-filter.c:352
 #, c-format
 msgid "%%(deltabase) does not take arguments"
 msgstr "%%(deltabase) không nhận các đối số"
 
-#: ref-filter.c:359
+#: ref-filter.c:364
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr "%%(body) không nhận các đối số"
 
-#: ref-filter.c:372
+#: ref-filter.c:377
 #, c-format
 msgid "unrecognized %%(subject) argument: %s"
 msgstr "tham số không được thừa nhận %%(subject): %s"
 
-#: ref-filter.c:391
+#: ref-filter.c:396
 #, c-format
 msgid "expected %%(trailers:key=<value>)"
 msgstr "cần %%(trailers:key=<giá trị>)"
 
-#: ref-filter.c:393
+#: ref-filter.c:398
 #, c-format
 msgid "unknown %%(trailers) argument: %s"
 msgstr "không hiểu tham số %%(trailers): %s"
 
-#: ref-filter.c:424
+#: ref-filter.c:429
 #, c-format
 msgid "positive value expected contents:lines=%s"
 msgstr "cần nội dung mang giá trị dương:lines=%s"
 
-#: ref-filter.c:426
+#: ref-filter.c:431
 #, c-format
 msgid "unrecognized %%(contents) argument: %s"
 msgstr "đối số không được thừa nhận %%(contents): %s"
 
-#: ref-filter.c:441
+#: ref-filter.c:443
+#, c-format
+msgid "unrecognized %%(raw) argument: %s"
+msgstr "đối số không được thừa nhận %%(raw): %s"
+
+#: ref-filter.c:458
 #, c-format
 msgid "positive value expected '%s' in %%(%s)"
 msgstr "cần giá trị dương “%s” trong %%(%s)"
 
-#: ref-filter.c:445
+#: ref-filter.c:462
 #, c-format
 msgid "unrecognized argument '%s' in %%(%s)"
 msgstr "đối số “%s” không được thừa nhận trong %%(%s)"
 
-#: ref-filter.c:459
+#: ref-filter.c:476
 #, c-format
 msgid "unrecognized email option: %s"
 msgstr "không nhận ra tùy chọn thư điện tử: “%s”"
 
-#: ref-filter.c:489
+#: ref-filter.c:506
 #, c-format
 msgid "expected format: %%(align:<width>,<position>)"
 msgstr "cần định dạng: %%(align:<width>,<position>)"
 
-#: ref-filter.c:501
+#: ref-filter.c:518
 #, c-format
 msgid "unrecognized position:%s"
 msgstr "vị trí không được thừa nhận:%s"
 
-#: ref-filter.c:508
+#: ref-filter.c:525
 #, c-format
 msgid "unrecognized width:%s"
 msgstr "chiều rộng không được thừa nhận:%s"
 
-#: ref-filter.c:517
+#: ref-filter.c:534
 #, c-format
 msgid "unrecognized %%(align) argument: %s"
 msgstr "đối số không được thừa nhận %%(align): %s"
 
-#: ref-filter.c:525
+#: ref-filter.c:542
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr "cần giá trị độ rộng dương với nguyên tử %%(align)"
 
-#: ref-filter.c:543
+#: ref-filter.c:560
 #, c-format
 msgid "unrecognized %%(if) argument: %s"
 msgstr "đối số không được thừa nhận %%(if): %s"
 
-#: ref-filter.c:645
+#: ref-filter.c:568
+#, c-format
+msgid "%%(rest) does not take arguments"
+msgstr "%%(rest) không nhận các đối số"
+
+#: ref-filter.c:680
 #, c-format
 msgid "malformed field name: %.*s"
 msgstr "tên trường dị hình: %.*s"
 
-#: ref-filter.c:672
+#: ref-filter.c:707
 #, c-format
 msgid "unknown field name: %.*s"
 msgstr "không hiểu tên trường: %.*s"
 
-#: ref-filter.c:676
+#: ref-filter.c:711
 #, c-format
 msgid ""
 "not a git repository, but the field '%.*s' requires access to object data"
@@ -6752,126 +6936,136 @@ msgstr ""
 "không phải là một kho git, nhưng trường “%.*s” yêu cầu truy cập vào dữ liệu "
 "đối tượng"
 
-#: ref-filter.c:801
+#: ref-filter.c:844
 #, c-format
 msgid "format: %%(if) atom used without a %%(then) atom"
 msgstr "định dạng: nguyên tử %%(if) được dùng mà không có nguyên tử %%(then)"
 
-#: ref-filter.c:865
+#: ref-filter.c:910
 #, c-format
 msgid "format: %%(then) atom used without an %%(if) atom"
 msgstr "định dạng: nguyên tử %%(then) được dùng mà không có nguyên tử %%(if)"
 
-#: ref-filter.c:867
+#: ref-filter.c:912
 #, c-format
 msgid "format: %%(then) atom used more than once"
 msgstr "định dạng: nguyên tử %%(then) được dùng nhiều hơn một lần"
 
-#: ref-filter.c:869
+#: ref-filter.c:914
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr "định dạng: nguyên tử %%(then) được dùng sau %%(else)"
 
-#: ref-filter.c:897
+#: ref-filter.c:946
 #, c-format
 msgid "format: %%(else) atom used without an %%(if) atom"
 msgstr "định dạng: nguyên tử %%(else) được dùng mà không có nguyên tử %%(if)"
 
-#: ref-filter.c:899
+#: ref-filter.c:948
 #, c-format
 msgid "format: %%(else) atom used without a %%(then) atom"
 msgstr "định dạng: nguyên tử %%(else) được dùng mà không có nguyên tử %%(then)"
 
-#: ref-filter.c:901
+#: ref-filter.c:950
 #, c-format
 msgid "format: %%(else) atom used more than once"
 msgstr "định dạng: nguyên tử %%(else) được dùng nhiều hơn một lần"
 
-#: ref-filter.c:916
+#: ref-filter.c:965
 #, c-format
 msgid "format: %%(end) atom used without corresponding atom"
 msgstr "định dạng: nguyên tử %%(end) được dùng mà không có nguyên tử tương ứng"
 
-#: ref-filter.c:973
+#: ref-filter.c:1027
 #, c-format
 msgid "malformed format string %s"
 msgstr "chuỗi định dạng dị hình %s"
 
-#: ref-filter.c:1621
+#: ref-filter.c:1033
+#, c-format
+msgid "this command reject atom %%(%.*s)"
+msgstr "lệnh này từ chối atom %%(%.*s)"
+
+#: ref-filter.c:1040
+#, c-format
+msgid "--format=%.*s cannot be used with --python, --shell, --tcl"
+msgstr "--format=%.*s không thể được dùng với --python, --shell, --tcl"
+
+#: ref-filter.c:1706
 #, c-format
 msgid "(no branch, rebasing %s)"
 msgstr "(không nhánh, đang cải tổ %s)"
 
-#: ref-filter.c:1624
+#: ref-filter.c:1709
 #, c-format
 msgid "(no branch, rebasing detached HEAD %s)"
 msgstr "(không nhánh, đang cải tổ HEAD %s đã tách rời)"
 
-#: ref-filter.c:1627
+#: ref-filter.c:1712
 #, c-format
 msgid "(no branch, bisect started on %s)"
 msgstr "(không nhánh, di chuyển nửa bước được bắt đầu tại %s)"
 
-#: ref-filter.c:1631
+#: ref-filter.c:1716
 #, c-format
 msgid "(HEAD detached at %s)"
 msgstr "(HEAD được tách rời tại %s)"
 
-#: ref-filter.c:1634
+#: ref-filter.c:1719
 #, c-format
 msgid "(HEAD detached from %s)"
-msgstr "(HEAD được tách rời từ %s)"
+msgstr "(HEAD được tách rời khỏi %s)"
 
-#: ref-filter.c:1637
+#: ref-filter.c:1722
 msgid "(no branch)"
 msgstr "(không nhánh)"
 
-#: ref-filter.c:1669 ref-filter.c:1880
+#: ref-filter.c:1754 ref-filter.c:1972
 #, c-format
 msgid "missing object %s for %s"
 msgstr "thiếu đối tượng %s cho %s"
 
-#: ref-filter.c:1679
+#: ref-filter.c:1764
 #, c-format
 msgid "parse_object_buffer failed on %s for %s"
 msgstr "parse_object_buffer gặp lỗi trên %s cho %s"
 
-#: ref-filter.c:2064
+#: ref-filter.c:2155
 #, c-format
 msgid "malformed object at '%s'"
 msgstr "đối tượng dị hình tại “%s”"
 
-#: ref-filter.c:2153
+#: ref-filter.c:2245
 #, c-format
 msgid "ignoring ref with broken name %s"
 msgstr "đang lờ đi tham chiếu với tên hỏng %s"
 
-#: ref-filter.c:2158 refs.c:676
+#: ref-filter.c:2250 refs.c:673
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "đang lờ đi tham chiếu hỏng %s"
 
-#: ref-filter.c:2502
+#: ref-filter.c:2623
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "định dạng: thiếu nguyên tử %%(end)"
 
-#: ref-filter.c:2596
+#: ref-filter.c:2726
 #, c-format
 msgid "malformed object name %s"
 msgstr "tên đối tượng dị hình %s"
 
-#: ref-filter.c:2601
+#: ref-filter.c:2731
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "tùy chọn “%s” phải chỉ đến một lần chuyển giao"
 
-#: refs.c:264
+#: refs.c:261
 #, c-format
 msgid "%s does not point to a valid object!"
 msgstr "“%s” không chỉ đến một lần chuyển giao hợp lệ nào cả!"
 
-#: refs.c:566
+#: refs.c:563
 #, c-format
 msgid ""
 "Using '%s' as the name for the initial branch. This default branch name\n"
@@ -6885,92 +7079,92 @@ msgid ""
 "\n"
 "\tgit branch -m <name>\n"
 msgstr ""
-"Sử dụng '%s' làm tên cho nhánh ban đầu. Tên nhánh mặc định này\n"
+"Sử dụng “%s” làm tên cho nhánh ban đầu. Tên nhánh mặc định này\n"
 "có thể thay đổi. Để cấu hình tên nhánh khởi đầu sử dụng trong tất cả\n"
 "kho lưu trữ mới của bạn, cái mà sẽ ngăn chặn cảnh báo này, gọi lệnh:\n"
 "\n"
 "\tgit config --global init.defaultBranch <tên>\n"
 "\n"
-"Tên thường được chọn thay cho 'master' là 'main', 'trunk' và\n"
-"'development'. Nhánh vừa tạo có thể được đổi tên thông qua lệnh:\n"
+"Tên thường được chọn thay cho “master” là “main”, “trunk” và\n"
+"“development”. Nhánh vừa tạo có thể được đổi tên thông qua lệnh:\n"
 "\n"
 "\tgit branch -m <tên>\n"
 
-#: refs.c:588
+#: refs.c:585
 #, c-format
 msgid "could not retrieve `%s`"
 msgstr "không thể lấy về “%s”"
 
-#: refs.c:598
+#: refs.c:595
 #, c-format
 msgid "invalid branch name: %s = %s"
 msgstr "tên nhánh không hợp lệ: %s = %s"
 
-#: refs.c:674
+#: refs.c:671
 #, c-format
 msgid "ignoring dangling symref %s"
 msgstr "đang lờ đi tham chiếu mềm thừa %s"
 
-#: refs.c:922
+#: refs.c:920
 #, c-format
 msgid "log for ref %s has gap after %s"
 msgstr "nhật ký cho tham chiếu %s có khoảng trống sau %s"
 
-#: refs.c:929
+#: refs.c:927
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
 msgstr "nhật ký cho tham chiếu %s kết thúc bất ngờ trên %s"
 
-#: refs.c:994
+#: refs.c:992
 #, c-format
 msgid "log for %s is empty"
 msgstr "nhật ký cho %s trống rỗng"
 
-#: refs.c:1086
+#: refs.c:1084
 #, c-format
 msgid "refusing to update ref with bad name '%s'"
 msgstr "từ chối cập nhật tham chiếu với tên sai “%s”"
 
-#: refs.c:1157
+#: refs.c:1155
 #, c-format
 msgid "update_ref failed for ref '%s': %s"
 msgstr "update_ref bị lỗi cho ref “%s”: %s"
 
-#: refs.c:2051
+#: refs.c:2062
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "không cho phép đa cập nhật cho tham chiếu “%s”"
 
-#: refs.c:2131
+#: refs.c:2142
 msgid "ref updates forbidden inside quarantine environment"
 msgstr "cập nhật tham chiếu bị cấm trong môi trường kiểm tra"
 
-#: refs.c:2142
+#: refs.c:2153
 msgid "ref updates aborted by hook"
 msgstr "các cập nhật tham chiếu bị bãi bỏ bởi móc"
 
-#: refs.c:2242 refs.c:2272
+#: refs.c:2253 refs.c:2283
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "“%s” sẵn có; không thể tạo “%s”"
 
-#: refs.c:2248 refs.c:2283
+#: refs.c:2259 refs.c:2294
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "không thể xử lý “%s” và “%s” cùng một lúc"
 
-#: refs/files-backend.c:1228
+#: refs/files-backend.c:1271
 #, c-format
 msgid "could not remove reference %s"
 msgstr "không thể gỡ bỏ tham chiếu: %s"
 
-#: refs/files-backend.c:1242 refs/packed-backend.c:1542
-#: refs/packed-backend.c:1552
+#: refs/files-backend.c:1285 refs/packed-backend.c:1549
+#: refs/packed-backend.c:1559
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr "không thể xóa bỏ tham chiếu %s: %s"
 
-#: refs/files-backend.c:1245 refs/packed-backend.c:1555
+#: refs/files-backend.c:1288 refs/packed-backend.c:1562
 #, c-format
 msgid "could not delete references: %s"
 msgstr "không thể xóa bỏ tham chiếu: %s"
@@ -7274,7 +7468,7 @@ msgstr "không thể ghi bản ghi rerere"
 msgid "there were errors while writing '%s' (%s)"
 msgstr "gặp lỗi đọc khi đang ghi “%s” (%s)"
 
-#: rerere.c:482
+#: rerere.c:482 builtin/gc.c:2246 builtin/gc.c:2281
 #, c-format
 msgid "failed to flush '%s'"
 msgstr "gặp lỗi khi đẩy dữ liệu “%s” lên đĩa"
@@ -7319,8 +7513,8 @@ msgstr "không thể unlink stray “%s”"
 msgid "Recorded preimage for '%s'"
 msgstr "Preimage đã được ghi lại cho “%s”"
 
-#: rerere.c:865 submodule.c:2076 builtin/log.c:2002
-#: builtin/submodule--helper.c:1805 builtin/submodule--helper.c:1848
+#: rerere.c:865 submodule.c:2121 builtin/log.c:2002
+#: builtin/submodule--helper.c:1776 builtin/submodule--helper.c:1819
 #, c-format
 msgid "could not create directory '%s'"
 msgstr "không thể tạo thư mục “%s”"
@@ -7358,45 +7552,40 @@ msgstr "không thể mở thư mục rr-cache"
 msgid "could not determine HEAD revision"
 msgstr "không thể dò tìm điểm xét duyệt HEAD"
 
-#: reset.c:69 reset.c:75 sequencer.c:3689
+#: reset.c:70 reset.c:76 sequencer.c:3705
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "gặp lỗi khi tìm cây của %s"
 
-#: revision.c:2344
+#: revision.c:2259
+msgid "--unsorted-input is incompatible with --no-walk"
+msgstr "--unsorted-input xung khắc với --no-walk"
+
+#: revision.c:2346
 msgid "--unpacked=<packfile> no longer supported"
 msgstr "--unpacked=<packfile> không còn được hỗ trợ nữa"
 
-#: revision.c:2684
+#: revision.c:2655 revision.c:2659
+msgid "--no-walk is incompatible with --unsorted-input"
+msgstr "--no-walk xung khắc với --unsorted-input"
+
+#: revision.c:2690
 msgid "your current branch appears to be broken"
 msgstr "nhánh hiện tại của bạn có vẻ như bị hỏng"
 
-#: revision.c:2687
+#: revision.c:2693
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
 msgstr "nhánh hiện tại của bạn “%s” không có một lần chuyển giao nào cả"
 
-#: revision.c:2893
+#: revision.c:2895
 msgid "-L does not yet support diff formats besides -p and -s"
 msgstr "-L vẫn chưa hỗ trợ định dạng khác biệt nào ngoài -p và -s"
 
-#: run-command.c:766
-msgid "open /dev/null failed"
-msgstr "gặp lỗi khi mở “/dev/null”"
-
-#: run-command.c:1274
+#: run-command.c:1278
 #, c-format
 msgid "cannot create async thread: %s"
-msgstr "không thể tạo tuyến async: %s"
-
-#: run-command.c:1344
-#, c-format
-msgid ""
-"The '%s' hook was ignored because it's not set as executable.\n"
-"You can disable this warning with `git config advice.ignoredHook false`."
-msgstr ""
-"Móc “%s” bị bỏ qua bởi vì nó không thể đặt là thực thi được.\n"
-"Bạn có thể tắt cảnh báo này bằng “git config advice.ignoredHook false“."
+msgstr "không thể tạo tuyến trình async: %s"
 
 #: send-pack.c:150
 msgid "unexpected flush packet while reading remote unpack status"
@@ -7417,23 +7606,23 @@ msgstr "máy chủ gặp lỗi unpack: %s"
 msgid "failed to sign the push certificate"
 msgstr "gặp lỗi khi ký chứng thực đẩy"
 
-#: send-pack.c:433
+#: send-pack.c:435
 msgid "send-pack: unable to fork off fetch subprocess"
 msgstr "send-pack: không thể rẽ nhánh tuyến trình con fetch"
 
-#: send-pack.c:455
+#: send-pack.c:457
 msgid "push negotiation failed; proceeding anyway with push"
 msgstr "đẩy đàm phán thất bại; vẫn tiếp tục xử lý bằng lệnh đẩy"
 
-#: send-pack.c:526
+#: send-pack.c:528
 msgid "the receiving end does not support this repository's hash algorithm"
 msgstr "kết thúc nhận không hỗ trợ các tùy chọn của lệnh push"
 
-#: send-pack.c:535
+#: send-pack.c:537
 msgid "the receiving end does not support --signed push"
 msgstr "kết thúc nhận không hỗ trợ đẩy --signed"
 
-#: send-pack.c:537
+#: send-pack.c:539
 msgid ""
 "not sending a push certificate since the receiving end does not support --"
 "signed push"
@@ -7441,47 +7630,48 @@ msgstr ""
 "đừng gửi giấy chứng nhận đẩy trước khi kết thúc nhận không hỗ trợ đẩy --"
 "signed"
 
-#: send-pack.c:544
+#: send-pack.c:546
 msgid "the receiving end does not support --atomic push"
 msgstr "kết thúc nhận không hỗ trợ đẩy --atomic"
 
-#: send-pack.c:549
+#: send-pack.c:551
 msgid "the receiving end does not support push options"
 msgstr "kết thúc nhận không hỗ trợ các tùy chọn của lệnh push"
 
-#: sequencer.c:196
+#: sequencer.c:197
 #, c-format
 msgid "invalid commit message cleanup mode '%s'"
 msgstr "chế độ dọn dẹp ghi chú các lần chuyển giao không hợp lệ “%s”"
 
-#: sequencer.c:324
+#: sequencer.c:325
 #, c-format
 msgid "could not delete '%s'"
 msgstr "không thể xóa bỏ “%s”"
 
-#: sequencer.c:344 builtin/rebase.c:757 builtin/rebase.c:1592 builtin/rm.c:402
+#: sequencer.c:345 sequencer.c:4754 builtin/rebase.c:563 builtin/rebase.c:1297
+#: builtin/rm.c:408
 #, c-format
 msgid "could not remove '%s'"
 msgstr "không thể gỡ bỏ “%s”"
 
-#: sequencer.c:354
+#: sequencer.c:355
 msgid "revert"
 msgstr "hoàn nguyên"
 
-#: sequencer.c:356
+#: sequencer.c:357
 msgid "cherry-pick"
 msgstr "cherry-pick"
 
-#: sequencer.c:358
+#: sequencer.c:359
 msgid "rebase"
 msgstr "rebase"
 
-#: sequencer.c:360
+#: sequencer.c:361
 #, c-format
 msgid "unknown action: %d"
 msgstr "không nhận ra thao tác: %d"
 
-#: sequencer.c:419
+#: sequencer.c:420
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'"
@@ -7489,53 +7679,75 @@ msgstr ""
 "sau khi giải quyết các xung đột, đánh dấu đường dẫn đã sửa\n"
 "với lệnh “git add </các/đường/dẫn>” hoặc “git rm </các/đường/dẫn>”"
 
-#: sequencer.c:422
+#: sequencer.c:423
 msgid ""
-"after resolving the conflicts, mark the corrected paths\n"
-"with 'git add <paths>' or 'git rm <paths>'\n"
-"and commit the result with 'git commit'"
+"After resolving the conflicts, mark them with\n"
+"\"git add/rm <pathspec>\", then run\n"
+"\"git cherry-pick --continue\".\n"
+"You can instead skip this commit with \"git cherry-pick --skip\".\n"
+"To abort and get back to the state before \"git cherry-pick\",\n"
+"run \"git cherry-pick --abort\"."
 msgstr ""
-"sau khi giải quyết các xung đột, đánh dấu đường dẫn đã sửa\n"
-"với lệnh “git add </các/đường/dẫn>” hoặc “git rm </các/đường/dẫn>”\n"
-"và chuyển giao kết quả bằng lệnh “git commit”"
+"Sau khi giải quyết vấn đề xung đột, hãy đánh dấu bằng\n"
+"\"git add/rm <pathspec>\", sai đó chạy\n"
+"\"git cherry-pick --continue\".\n"
+"Bạn có thể bỏ qua lần chuyển giao này với \"git cherry-pick --skip\".\n"
+"Để bãi bỏ và quay trở lại trạng thái trước khi \"git cherry-pick\",\n"
+"chạy \"git cherry-pick --abort\"."
 
-#: sequencer.c:435 sequencer.c:3271
+#: sequencer.c:430
+msgid ""
+"After resolving the conflicts, mark them with\n"
+"\"git add/rm <pathspec>\", then run\n"
+"\"git revert --continue\".\n"
+"You can instead skip this commit with \"git revert --skip\".\n"
+"To abort and get back to the state before \"git revert\",\n"
+"run \"git revert --abort\"."
+msgstr ""
+"Sau khi giải quyết vấn đề này, hãy đánh dấu chúng bằng\n"
+"\"git add/rm <đặc_tả_đường_dẫn_xung_đột>\", sau đó chạy\n"
+"\"git revert --continue\".\n"
+"Bạn có thể bỏ qua lần chuyển giao này với \"git rebase --skip\".\n"
+"Để bãi bỏ và quay trở lại trạng thái trước \"git revert\",\n"
+"chạy \"git revert --abort\"."
+
+#: sequencer.c:448 sequencer.c:3290
 #, c-format
 msgid "could not lock '%s'"
 msgstr "không thể khóa “%s”"
 
-#: sequencer.c:437 sequencer.c:3070 sequencer.c:3275 sequencer.c:3289
-#: sequencer.c:3547 sequencer.c:5566 strbuf.c:1170 wrapper.c:631
+#: sequencer.c:450 sequencer.c:3089 sequencer.c:3294 sequencer.c:3308
+#: sequencer.c:3566 sequencer.c:5621 strbuf.c:1176 wrapper.c:639
 #, c-format
 msgid "could not write to '%s'"
 msgstr "không thể ghi vào “%s”"
 
-#: sequencer.c:442
+#: sequencer.c:455
 #, c-format
 msgid "could not write eol to '%s'"
 msgstr "không thể ghi eol vào “%s”"
 
-#: sequencer.c:447 sequencer.c:3075 sequencer.c:3277 sequencer.c:3291
-#: sequencer.c:3555
+#: sequencer.c:460 sequencer.c:3094 sequencer.c:3296 sequencer.c:3310
+#: sequencer.c:3574
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "gặp lỗi khi hoàn thành “%s”"
 
-#: sequencer.c:486
+#: sequencer.c:499
 #, c-format
 msgid "your local changes would be overwritten by %s."
 msgstr "các thay đổi nội bộ của bạn có thể bị ghi đè bởi lệnh %s."
 
-#: sequencer.c:490
+#: sequencer.c:503
 msgid "commit your changes or stash them to proceed."
 msgstr "chuyển giao các thay đổi của bạn hay tạm cất (stash) chúng để xử lý."
 
-#: sequencer.c:522
+#: sequencer.c:535
 #, c-format
 msgid "%s: fast-forward"
 msgstr "%s: chuyển-tiếp-nhanh"
 
-#: sequencer.c:561 builtin/tag.c:609
+#: sequencer.c:574 builtin/tag.c:610
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Chế độ dọn dẹp không hợp lệ %s"
@@ -7543,65 +7755,65 @@ msgstr "Chế độ dọn dẹp không hợp lệ %s"
 #. TRANSLATORS: %s will be "revert", "cherry-pick" or
 #. "rebase".
 #.
-#: sequencer.c:671
+#: sequencer.c:685
 #, c-format
 msgid "%s: Unable to write new index file"
 msgstr "%s: Không thể ghi tập tin lưu bảng mục lục mới"
 
-#: sequencer.c:685
+#: sequencer.c:699
 msgid "unable to update cache tree"
 msgstr "không thể cập nhật cây bộ nhớ đệm"
 
-#: sequencer.c:699
+#: sequencer.c:713
 msgid "could not resolve HEAD commit"
 msgstr "không thể phân giải lần chuyển giao HEAD"
 
-#: sequencer.c:779
+#: sequencer.c:793
 #, c-format
 msgid "no key present in '%.*s'"
 msgstr "không có khóa hiện diện trong “%.*s”"
 
-#: sequencer.c:790
+#: sequencer.c:804
 #, c-format
 msgid "unable to dequote value of '%s'"
 msgstr "không thể giải trích dẫn giá trị của “%s”"
 
-#: sequencer.c:827 wrapper.c:201 wrapper.c:371 builtin/am.c:729
-#: builtin/am.c:821 builtin/merge.c:1141 builtin/rebase.c:910
+#: sequencer.c:841 wrapper.c:209 wrapper.c:379 builtin/am.c:730
+#: builtin/am.c:822 builtin/rebase.c:694
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "không thể mở “%s” để đọc"
 
-#: sequencer.c:837
+#: sequencer.c:851
 msgid "'GIT_AUTHOR_NAME' already given"
 msgstr "“GIT_AUTHOR_NAME” đã sẵn đưa ra rồi"
 
-#: sequencer.c:842
+#: sequencer.c:856
 msgid "'GIT_AUTHOR_EMAIL' already given"
 msgstr "“GIT_AUTHOR_EMAIL” đã sẵn đưa ra rồi"
 
-#: sequencer.c:847
+#: sequencer.c:861
 msgid "'GIT_AUTHOR_DATE' already given"
 msgstr "“GIT_AUTHOR_DATE” đã sẵn đưa ra rồi"
 
-#: sequencer.c:851
+#: sequencer.c:865
 #, c-format
 msgid "unknown variable '%s'"
 msgstr "không hiểu biến “%s”"
 
-#: sequencer.c:856
+#: sequencer.c:870
 msgid "missing 'GIT_AUTHOR_NAME'"
 msgstr "thiếu “GIT_AUTHOR_NAME”"
 
-#: sequencer.c:858
+#: sequencer.c:872
 msgid "missing 'GIT_AUTHOR_EMAIL'"
 msgstr "thiếu “GIT_AUTHOR_EMAIL”"
 
-#: sequencer.c:860
+#: sequencer.c:874
 msgid "missing 'GIT_AUTHOR_DATE'"
 msgstr "thiếu “GIT_AUTHOR_DATE”"
 
-#: sequencer.c:925
+#: sequencer.c:939
 #, c-format
 msgid ""
 "you have staged changes in your working tree\n"
@@ -7630,11 +7842,11 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:1212
+#: sequencer.c:1229
 msgid "'prepare-commit-msg' hook failed"
 msgstr "móc “prepare-commit-msg” bị lỗi"
 
-#: sequencer.c:1218
+#: sequencer.c:1235
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7665,7 +7877,7 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1231
+#: sequencer.c:1248
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7693,346 +7905,351 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1273
+#: sequencer.c:1290
 msgid "couldn't look up newly created commit"
 msgstr "không thể tìm thấy lần chuyển giao mới hơn đã được tạo"
 
-#: sequencer.c:1275
+#: sequencer.c:1292
 msgid "could not parse newly created commit"
 msgstr ""
 "không thể phân tích cú pháp của đối tượng chuyển giao mới hơn đã được tạo"
 
-#: sequencer.c:1321
+#: sequencer.c:1338
 msgid "unable to resolve HEAD after creating commit"
 msgstr "không thể phân giải HEAD sau khi tạo lần chuyển giao"
 
-#: sequencer.c:1323
+#: sequencer.c:1340
 msgid "detached HEAD"
 msgstr "đã rời khỏi HEAD"
 
-#: sequencer.c:1327
+#: sequencer.c:1344
 msgid " (root-commit)"
 msgstr " (root-commit)"
 
-#: sequencer.c:1348
+#: sequencer.c:1365
 msgid "could not parse HEAD"
 msgstr "không thể phân tích HEAD"
 
-#: sequencer.c:1350
+#: sequencer.c:1367
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "HEAD %s không phải là một lần chuyển giao!"
 
-#: sequencer.c:1354 sequencer.c:1432 builtin/commit.c:1705
+#: sequencer.c:1371 sequencer.c:1449 builtin/commit.c:1707
 msgid "could not parse HEAD commit"
 msgstr "không thể phân tích commit (lần chuyển giao) HEAD"
 
-#: sequencer.c:1410 sequencer.c:2295
+#: sequencer.c:1427 sequencer.c:2312
 msgid "unable to parse commit author"
 msgstr "không thể phân tích tác giả của lần chuyển giao"
 
-#: sequencer.c:1421 builtin/am.c:1615 builtin/merge.c:707
+#: sequencer.c:1438 builtin/am.c:1616 builtin/merge.c:708
 msgid "git write-tree failed to write a tree"
 msgstr "lệnh git write-tree gặp lỗi khi ghi một cây"
 
-#: sequencer.c:1454 sequencer.c:1574
+#: sequencer.c:1471 sequencer.c:1591
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "không thể đọc phần chú thích (message) từ “%s”"
 
-#: sequencer.c:1485 sequencer.c:1517
+#: sequencer.c:1502 sequencer.c:1534
 #, c-format
 msgid "invalid author identity '%s'"
 msgstr "định danh tác giả không hợp lệ “%s”"
 
-#: sequencer.c:1491
+#: sequencer.c:1508
 msgid "corrupt author: missing date information"
-msgstr "tác giả sai hỏng: thiếu thông tin này tháng"
+msgstr "tác giả sai hỏng: thiếu thông tin ngày tháng"
 
-#: sequencer.c:1530 builtin/am.c:1642 builtin/commit.c:1819 builtin/merge.c:910
-#: builtin/merge.c:935 t/helper/test-fast-rebase.c:78
+#: sequencer.c:1547 builtin/am.c:1643 builtin/commit.c:1821 builtin/merge.c:913
+#: builtin/merge.c:938 t/helper/test-fast-rebase.c:78
 msgid "failed to write commit object"
 msgstr "gặp lỗi khi ghi đối tượng chuyển giao"
 
-#: sequencer.c:1557 sequencer.c:4492 t/helper/test-fast-rebase.c:199
+#: sequencer.c:1574 sequencer.c:4526 t/helper/test-fast-rebase.c:199
 #: t/helper/test-fast-rebase.c:217
 #, c-format
 msgid "could not update %s"
 msgstr "không thể cập nhật %s"
 
-#: sequencer.c:1606
+#: sequencer.c:1623
 #, c-format
 msgid "could not parse commit %s"
 msgstr "không thể phân tích lần chuyển giao %s"
 
-#: sequencer.c:1611
+#: sequencer.c:1628
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "không thể phân tích lần chuyển giao cha mẹ “%s”"
 
-#: sequencer.c:1694 sequencer.c:1975
+#: sequencer.c:1711 sequencer.c:1992
 #, c-format
 msgid "unknown command: %d"
 msgstr "không hiểu câu lệnh %d"
 
-#: sequencer.c:1736 git-rebase--preserve-merges.sh:486
+#: sequencer.c:1753
 msgid "This is the 1st commit message:"
 msgstr "Đây là chú thích cho lần chuyển giao thứ nhất:"
 
-#: sequencer.c:1737
+#: sequencer.c:1754
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "Đây là chú thích cho lần chuyển giao thứ #%d:"
 
-#: sequencer.c:1738
+#: sequencer.c:1755
 msgid "The 1st commit message will be skipped:"
 msgstr "Chú thích cho lần chuyển giao thứ nhất sẽ bị bỏ qua:"
 
-#: sequencer.c:1739
+#: sequencer.c:1756
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "Chú thích cho lần chuyển giao thứ #%d sẽ bị bỏ qua:"
 
-#: sequencer.c:1740
+#: sequencer.c:1757
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr "Đây là tổ hợp của %d lần chuyển giao."
 
-#: sequencer.c:1887 sequencer.c:1944
+#: sequencer.c:1904 sequencer.c:1961
 #, c-format
 msgid "cannot write '%s'"
 msgstr "không thể ghi “%s”"
 
-#: sequencer.c:1934
+#: sequencer.c:1951
 msgid "need a HEAD to fixup"
 msgstr "cần một HEAD để sửa"
 
-#: sequencer.c:1936 sequencer.c:3582
+#: sequencer.c:1953 sequencer.c:3601
 msgid "could not read HEAD"
 msgstr "không thể đọc HEAD"
 
-#: sequencer.c:1938
+#: sequencer.c:1955
 msgid "could not read HEAD's commit message"
 msgstr "không thể đọc phần chú thích (message) của HEAD"
 
-#: sequencer.c:1962
+#: sequencer.c:1979
 #, c-format
 msgid "could not read commit message of %s"
 msgstr "không thể đọc phần chú thích (message) của %s"
 
-#: sequencer.c:2072
+#: sequencer.c:2089
 msgid "your index file is unmerged."
 msgstr "tập tin lưu mục lục của bạn không được hòa trộn."
 
-#: sequencer.c:2079
+#: sequencer.c:2096
 msgid "cannot fixup root commit"
 msgstr "không thể sửa chữa lần chuyển giao gốc"
 
-#: sequencer.c:2098
+#: sequencer.c:2115
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "lần chuyển giao %s là một lần hòa trộn nhưng không đưa ra tùy chọn -m."
 
-#: sequencer.c:2106 sequencer.c:2114
+#: sequencer.c:2123 sequencer.c:2131
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "lần chuyển giao %s không có cha mẹ %d"
 
-#: sequencer.c:2120
+#: sequencer.c:2137
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "không thể lấy ghi chú lần chuyển giao cho %s"
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:2139
+#: sequencer.c:2156
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: không thể phân tích lần chuyển giao mẹ của %s"
 
-#: sequencer.c:2205
+#: sequencer.c:2222
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "không thể đổi tên “%s” thành “%s”"
 
-#: sequencer.c:2265
+#: sequencer.c:2282
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "không thể hoàn nguyên %s… %s"
 
-#: sequencer.c:2266
+#: sequencer.c:2283
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "không thể áp dụng miếng vá %s… %s"
 
-#: sequencer.c:2287
+#: sequencer.c:2304
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr "xóa %s %s -- vá nội dung thượng nguồn đã có\n"
 
-#: sequencer.c:2345
+#: sequencer.c:2362
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: gặp lỗi đọc bảng mục lục"
 
-#: sequencer.c:2352
+#: sequencer.c:2370
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: gặp lỗi khi làm tươi mới bảng mục lục"
 
-#: sequencer.c:2425
+#: sequencer.c:2450
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "%s không nhận các đối số: “%s”"
 
-#: sequencer.c:2434
+#: sequencer.c:2459
 #, c-format
 msgid "missing arguments for %s"
 msgstr "thiếu đối số cho %s"
 
-#: sequencer.c:2477
+#: sequencer.c:2502
 #, c-format
 msgid "could not parse '%s'"
 msgstr "không thể phân tích cú pháp “%s”"
 
-#: sequencer.c:2538
+#: sequencer.c:2563
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "dòng không hợp lệ %d: %.*s"
 
-#: sequencer.c:2549
+#: sequencer.c:2574
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "không thể “%s” thể mà không có lần chuyển giao kế trước"
 
-#: sequencer.c:2635
+#: sequencer.c:2622 builtin/rebase.c:184
+#, c-format
+msgid "could not read '%s'."
+msgstr "không thể đọc “%s”."
+
+#: sequencer.c:2660
 msgid "cancelling a cherry picking in progress"
 msgstr "đang hủy bỏ thao tác cherry pick đang thực hiện"
 
-#: sequencer.c:2644
+#: sequencer.c:2669
 msgid "cancelling a revert in progress"
 msgstr "đang hủy bỏ các thao tác hoàn nguyên đang thực hiện"
 
-#: sequencer.c:2690
+#: sequencer.c:2709
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr "vui lòng sửa lỗi này bằng cách dùng “git rebase --edit-todo”."
 
-#: sequencer.c:2692
+#: sequencer.c:2711
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "bảng chỉ thị không thể dùng được: %s"
 
-#: sequencer.c:2697
+#: sequencer.c:2716
 msgid "no commits parsed."
 msgstr "không có lần chuyển giao nào được phân tích."
 
-#: sequencer.c:2708
+#: sequencer.c:2727
 msgid "cannot cherry-pick during a revert."
 msgstr "không thể cherry-pick trong khi hoàn nguyên."
 
-#: sequencer.c:2710
+#: sequencer.c:2729
 msgid "cannot revert during a cherry-pick."
 msgstr "không thể thực hiện việc hoàn nguyên trong khi đang cherry-pick."
 
-#: sequencer.c:2788
+#: sequencer.c:2807
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr "giá trị cho %s không hợp lệ: %s"
 
-#: sequencer.c:2897
+#: sequencer.c:2916
 msgid "unusable squash-onto"
 msgstr "squash-onto không dùng được"
 
-#: sequencer.c:2917
+#: sequencer.c:2936
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "bảng tùy chọn dị hình: “%s”"
 
-#: sequencer.c:3012 sequencer.c:4868
+#: sequencer.c:3031 sequencer.c:4905
 msgid "empty commit set passed"
 msgstr "lần chuyển giao trống rỗng đặt là hợp quy cách"
 
-#: sequencer.c:3029
+#: sequencer.c:3048
 msgid "revert is already in progress"
 msgstr "có thao tác hoàn nguyên đang được thực hiện"
 
-#: sequencer.c:3031
+#: sequencer.c:3050
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr "hãy thử \"git revert (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:3034
+#: sequencer.c:3053
 msgid "cherry-pick is already in progress"
 msgstr "có thao tác “cherry-pick” đang được thực hiện"
 
-#: sequencer.c:3036
+#: sequencer.c:3055
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr "hãy thử \"git cherry-pick (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:3050
+#: sequencer.c:3069
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr "không thể tạo thư mục xếp dãy “%s”"
 
-#: sequencer.c:3065
+#: sequencer.c:3084
 msgid "could not lock HEAD"
 msgstr "không thể khóa HEAD"
 
-#: sequencer.c:3125 sequencer.c:4581
+#: sequencer.c:3144 sequencer.c:4615
 msgid "no cherry-pick or revert in progress"
 msgstr "không cherry-pick hay hoàn nguyên trong tiến trình"
 
-#: sequencer.c:3127 sequencer.c:3138
+#: sequencer.c:3146 sequencer.c:3157
 msgid "cannot resolve HEAD"
 msgstr "không thể phân giải HEAD"
 
-#: sequencer.c:3129 sequencer.c:3173
+#: sequencer.c:3148 sequencer.c:3192
 msgid "cannot abort from a branch yet to be born"
 msgstr "không thể hủy bỏ từ một nhánh mà nó còn chưa được tạo ra"
 
-#: sequencer.c:3159 builtin/grep.c:758
+#: sequencer.c:3178 builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr "không mở được “%s”"
 
-#: sequencer.c:3161
+#: sequencer.c:3180
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "không thể đọc “%s”: %s"
 
-#: sequencer.c:3162
+#: sequencer.c:3181
 msgid "unexpected end of file"
 msgstr "gặp kết thúc tập tin đột xuất"
 
-#: sequencer.c:3168
+#: sequencer.c:3187
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr "tập tin HEAD “pre-cherry-pick” đã lưu “%s” bị hỏng"
 
-#: sequencer.c:3179
+#: sequencer.c:3198
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr ""
 "Bạn có lẽ đã có HEAD đã bị di chuyển đi, Không thể tua, kiểm tra HEAD của "
 "bạn!"
 
-#: sequencer.c:3220
+#: sequencer.c:3239
 msgid "no revert in progress"
 msgstr "không có tiến trình hoàn nguyên nào"
 
-#: sequencer.c:3229
+#: sequencer.c:3248
 msgid "no cherry-pick in progress"
 msgstr "không có cherry-pick đang được thực hiện"
 
-#: sequencer.c:3239
+#: sequencer.c:3258
 msgid "failed to skip the commit"
 msgstr "gặp lỗi khi bỏ qua đối tượng chuyển giao"
 
-#: sequencer.c:3246
+#: sequencer.c:3265
 msgid "there is nothing to skip"
 msgstr "ở đây không có gì để mà bỏ qua cả"
 
-#: sequencer.c:3249
+#: sequencer.c:3268
 #, c-format
 msgid ""
 "have you committed already?\n"
@@ -8041,16 +8258,16 @@ msgstr ""
 "bạn đã sẵn sàng chuyển giao chưa?\n"
 "thử \"git %s --continue\""
 
-#: sequencer.c:3411 sequencer.c:4472
+#: sequencer.c:3430 sequencer.c:4506
 msgid "cannot read HEAD"
 msgstr "không thể đọc HEAD"
 
-#: sequencer.c:3428
+#: sequencer.c:3447
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "không thể chép “%s” sang “%s”"
 
-#: sequencer.c:3436
+#: sequencer.c:3455
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -8069,27 +8286,27 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:3446
+#: sequencer.c:3465
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "Không thể áp dụng %s… %.*s"
 
-#: sequencer.c:3453
+#: sequencer.c:3472
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "Không hòa trộn %.*s"
 
-#: sequencer.c:3467 sequencer.c:3471 builtin/difftool.c:644
+#: sequencer.c:3486 sequencer.c:3490 builtin/difftool.c:639
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "không thể chép “%s” sang “%s”"
 
-#: sequencer.c:3483
+#: sequencer.c:3502
 #, c-format
 msgid "Executing: %s\n"
 msgstr "Đang thực thi: %s\n"
 
-#: sequencer.c:3498
+#: sequencer.c:3517
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -8104,11 +8321,11 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3504
+#: sequencer.c:3523
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "và tạo các thay đổi bảng mục lục và/hay cây làm việc\n"
 
-#: sequencer.c:3510
+#: sequencer.c:3529
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -8125,90 +8342,90 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3572
+#: sequencer.c:3591
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "tên nhãn dị hình: “%.*s”"
 
-#: sequencer.c:3645
+#: sequencer.c:3664
 msgid "writing fake root commit"
 msgstr "ghi lần chuyển giao gốc giả"
 
-#: sequencer.c:3650
+#: sequencer.c:3669
 msgid "writing squash-onto"
 msgstr "đang ghi squash-onto"
 
-#: sequencer.c:3734
+#: sequencer.c:3748
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "không thể phân giải “%s”"
 
-#: sequencer.c:3767
+#: sequencer.c:3780
 msgid "cannot merge without a current revision"
 msgstr "không thể hòa trộn mà không có một điểm xét duyệt hiện tại"
 
-#: sequencer.c:3789
+#: sequencer.c:3802
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "không thể phân tích “%.*s”"
 
-#: sequencer.c:3798
+#: sequencer.c:3811
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "chẳng có gì để hòa trộn: “%.*s”"
 
-#: sequencer.c:3810
+#: sequencer.c:3823
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr "hòa trộn octopus không thể được thực thi trên đỉnh của một [new root]"
 
-#: sequencer.c:3826
+#: sequencer.c:3878
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "không thể lấy chú thích của lần chuyển giao của “%s”"
 
-#: sequencer.c:4009
+#: sequencer.c:4024
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "không thể ngay cả khi thử hòa trộn “%.*s”"
 
-#: sequencer.c:4025
+#: sequencer.c:4040
 msgid "merge: Unable to write new index file"
 msgstr "merge: Không thể ghi tập tin lưu bảng mục lục mới"
 
-#: sequencer.c:4099
+#: sequencer.c:4121
 msgid "Cannot autostash"
 msgstr "Không thể autostash"
 
-#: sequencer.c:4102
+#: sequencer.c:4124
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Gặp đáp ứng stash không cần: “%s”"
 
-#: sequencer.c:4108
+#: sequencer.c:4130
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "Không thể tạo thư mục cho “%s”"
 
-#: sequencer.c:4111
+#: sequencer.c:4133
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "Đã tạo autostash: %s\n"
 
-#: sequencer.c:4115
+#: sequencer.c:4137
 msgid "could not reset --hard"
 msgstr "không thể reset --hard"
 
-#: sequencer.c:4140
+#: sequencer.c:4162
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "Đã áp dụng autostash.\n"
 
-#: sequencer.c:4152
+#: sequencer.c:4174
 #, c-format
 msgid "cannot store %s"
 msgstr "không thử lưu “%s”"
 
-#: sequencer.c:4155
+#: sequencer.c:4177
 #, c-format
 msgid ""
 "%s\n"
@@ -8220,29 +8437,29 @@ msgstr ""
 "Bạn có thể chạy lệnh \"git stash pop\" hay \"git stash drop\" bất kỳ lúc "
 "nào.\n"
 
-#: sequencer.c:4160
+#: sequencer.c:4182
 msgid "Applying autostash resulted in conflicts."
 msgstr "Áp dụng autostash có hiệu quả trong các xung đột."
 
-#: sequencer.c:4161
+#: sequencer.c:4183
 msgid "Autostash exists; creating a new stash entry."
 msgstr "Autostash đã sẵn có; nên tạo một mục stash mới."
 
-#: sequencer.c:4233 git-rebase--preserve-merges.sh:769
+#: sequencer.c:4255
 msgid "could not detach HEAD"
 msgstr "không thể tách rời HEAD"
 
-#: sequencer.c:4248
+#: sequencer.c:4270
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Dừng lại ở HEAD\n"
 
-#: sequencer.c:4250
+#: sequencer.c:4272
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Dừng lại ở %s\n"
 
-#: sequencer.c:4258
+#: sequencer.c:4304
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -8263,58 +8480,58 @@ msgstr ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:4304
+#: sequencer.c:4350
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr "Đang cải tổ (%d/%d)%s"
 
-#: sequencer.c:4350
+#: sequencer.c:4396
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Dừng lại ở %s…  %.*s\n"
 
-#: sequencer.c:4421
+#: sequencer.c:4466
 #, c-format
 msgid "unknown command %d"
 msgstr "không hiểu câu lệnh %d"
 
-#: sequencer.c:4480
+#: sequencer.c:4514
 msgid "could not read orig-head"
 msgstr "không thể đọc orig-head"
 
-#: sequencer.c:4485
+#: sequencer.c:4519
 msgid "could not read 'onto'"
 msgstr "không thể đọc “onto”."
 
-#: sequencer.c:4499
+#: sequencer.c:4533
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "không thể cập nhật HEAD thành %s"
 
-#: sequencer.c:4559
+#: sequencer.c:4593
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr "Cài tổ và cập nhật %s một cách thành công.\n"
 
-#: sequencer.c:4611
+#: sequencer.c:4645
 msgid "cannot rebase: You have unstaged changes."
 msgstr "không thể cải tổ: Bạn có các thay đổi chưa được đưa lên bệ phóng."
 
-#: sequencer.c:4620
+#: sequencer.c:4654
 msgid "cannot amend non-existing commit"
 msgstr "không thể tu bỏ một lần chuyển giao không tồn tại"
 
-#: sequencer.c:4622
+#: sequencer.c:4656
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "tập tin không hợp lệ: “%s”"
 
-#: sequencer.c:4624
+#: sequencer.c:4658
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "nội dung không hợp lệ: “%s”"
 
-#: sequencer.c:4627
+#: sequencer.c:4661
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -8324,50 +8541,60 @@ msgstr ""
 "Bạn có các thay đổi chưa chuyển giao trong thư mục làm việc. Vui lòng\n"
 "chuyển giao chúng trước và sau đó chạy lệnh “git rebase --continue” lần nữa."
 
-#: sequencer.c:4663 sequencer.c:4702
+#: sequencer.c:4697 sequencer.c:4736
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "không thể ghi tập tin: “%s”"
 
-#: sequencer.c:4718
+#: sequencer.c:4752
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "không thể xóa bỏ CHERRY_PICK_HEAD"
 
-#: sequencer.c:4725
+#: sequencer.c:4762
 msgid "could not commit staged changes."
 msgstr "không thể chuyển giao các thay đổi đã đưa lên bệ phóng."
 
-#: sequencer.c:4845
+#: sequencer.c:4882
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: không thể cherry-pick một %s"
 
-#: sequencer.c:4849
+#: sequencer.c:4886
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: điểm xét duyệt sai"
 
-#: sequencer.c:4884
+#: sequencer.c:4921
 msgid "can't revert as initial commit"
 msgstr "không thể hoàn nguyên một lần chuyển giao khởi tạo"
 
-#: sequencer.c:5361
+#: sequencer.c:5192 sequencer.c:5421
+#, c-format
+msgid "skipped previously applied commit %s"
+msgstr "bỏ qua lần chuyển giao được áp dụng kế trước %s"
+
+#: sequencer.c:5262 sequencer.c:5437
+msgid "use --reapply-cherry-picks to include skipped commits"
+msgstr ""
+"dùng --reapply-cherry-picks để bao gồm các lần chuyển giao đã bị bỏ qua"
+
+#: sequencer.c:5408
 msgid "make_script: unhandled options"
 msgstr "make_script: các tùy chọn được không xử lý"
 
-#: sequencer.c:5364
+#: sequencer.c:5411
 msgid "make_script: error preparing revisions"
 msgstr "make_script: lỗi chuẩn bị điểm hiệu chỉnh"
 
-#: sequencer.c:5614 sequencer.c:5631
+#: sequencer.c:5669 sequencer.c:5686
 msgid "nothing to do"
 msgstr "không có gì để làm"
 
-#: sequencer.c:5650
+#: sequencer.c:5705
 msgid "could not skip unnecessary pick commands"
 msgstr "không thể bỏ qua các lệnh cậy (pick) không cần thiết"
 
-#: sequencer.c:5750
+#: sequencer.c:5805
 msgid "the script was already rearranged."
 msgstr "văn lệnh đã sẵn được sắp đặt rồi."
 
@@ -8524,27 +8751,15 @@ msgstr ""
 "gặp vấn đề với giá trị chế độ tập tin core.sharedRepository (0%.3o).\n"
 "người sở hữu tập tin phải luôn có quyền đọc và ghi."
 
-#: setup.c:1430
-msgid "open /dev/null or dup failed"
-msgstr "gặp lỗi khi mở “/dev/null” hay dup"
-
-#: setup.c:1445
+#: setup.c:1443
 msgid "fork failed"
 msgstr "gặp lỗi khi rẽ nhánh tiến trình"
 
-#: setup.c:1450 t/helper/test-simple-ipc.c:285
+#: setup.c:1448
 msgid "setsid failed"
 msgstr "setsid gặp lỗi"
 
-#: sparse-index.c:162
-msgid "attempting to use sparse-index without cone mode"
-msgstr "cố gắng sử dụng chỉ mục thưa thớt mà không có chế độ hình nón"
-
-#: sparse-index.c:176
-msgid "unable to update cache-tree, staying full"
-msgstr "không thể cập nhật cây bộ nhớ đệm, chỗ chứa bị đầy"
-
-#: sparse-index.c:263
+#: sparse-index.c:273
 #, c-format
 msgid "index entry is a directory, but not sparse (%08x)"
 msgstr "mục tin mục lục là một thư mục, nhưng không \"sparse\" (%08x)"
@@ -8599,13 +8814,13 @@ msgid "%u byte/s"
 msgid_plural "%u bytes/s"
 msgstr[0] "%u byte/giây"
 
-#: strbuf.c:1168 wrapper.c:199 wrapper.c:369 builtin/am.c:738
-#: builtin/rebase.c:866
+#: strbuf.c:1174 wrapper.c:207 wrapper.c:377 builtin/am.c:739
+#: builtin/rebase.c:650
 #, c-format
 msgid "could not open '%s' for writing"
 msgstr "không thể mở “%s” để ghi"
 
-#: strbuf.c:1177
+#: strbuf.c:1183
 #, c-format
 msgid "could not edit '%s'"
 msgstr "không thể sửa “%s”"
@@ -8631,7 +8846,7 @@ msgstr ""
 msgid "invalid value for %s"
 msgstr "giá trị cho %s không hợp lệ"
 
-#: submodule-config.c:766
+#: submodule-config.c:767
 #, c-format
 msgid "Could not update .gitmodules entry %s"
 msgstr "Không thể cập nhật mục .gitmodules %s"
@@ -8656,22 +8871,22 @@ msgstr "Không thể gỡ bỏ mục .gitmodules dành cho %s"
 msgid "staging updated .gitmodules failed"
 msgstr "gặp lỗi khi tổ chức .gitmodules đã cập nhật"
 
-#: submodule.c:328
+#: submodule.c:358
 #, c-format
 msgid "in unpopulated submodule '%s'"
 msgstr "trong mô-đun-con không có gì “%s”"
 
-#: submodule.c:359
+#: submodule.c:389
 #, c-format
 msgid "Pathspec '%s' is in submodule '%.*s'"
 msgstr "Đặc tả đường dẫn “%s” thì ở trong mô-đun-con “%.*s”"
 
-#: submodule.c:436
+#: submodule.c:466
 #, c-format
 msgid "bad --ignore-submodules argument: %s"
 msgstr "đối số --ignore-submodules sai: %s"
 
-#: submodule.c:805
+#: submodule.c:844
 #, c-format
 msgid ""
 "Submodule in commit %s at path: '%s' collides with a submodule named the "
@@ -8680,13 +8895,13 @@ msgstr ""
 "Mô-đun-con trong lần chuyển giao %s tại đường dẫn: “%s” va chạm với mô-đun-"
 "con cùng tên. Nên bỏ qua nó."
 
-#: submodule.c:908
+#: submodule.c:954
 #, c-format
 msgid "submodule entry '%s' (%s) is a %s, not a commit"
 msgstr ""
 "mục tin mô-đun-con “%s” (%s) là một %s, không phải là một lần chuyển giao"
 
-#: submodule.c:993
+#: submodule.c:1042
 #, c-format
 msgid ""
 "Could not run 'git rev-list <commits> --not --remotes -n 1' command in "
@@ -8695,36 +8910,36 @@ msgstr ""
 "Không thể chạy lệnh “git rev-list <các lần chuyển giao> --not --remotes -n "
 "1” trong mô-đun-con “%s”"
 
-#: submodule.c:1116
+#: submodule.c:1165
 #, c-format
 msgid "process for submodule '%s' failed"
 msgstr "xử lý cho mô-đun-con “%s” gặp lỗi"
 
-#: submodule.c:1145 builtin/branch.c:691 builtin/submodule--helper.c:2486
+#: submodule.c:1194 builtin/branch.c:692 builtin/submodule--helper.c:2713
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "Gặp lỗi khi phân giải HEAD như là một tham chiếu hợp lệ."
 
-#: submodule.c:1156
+#: submodule.c:1205
 #, c-format
 msgid "Pushing submodule '%s'\n"
 msgstr "Đẩy lên mô-đun-con “%s”\n"
 
-#: submodule.c:1159
+#: submodule.c:1208
 #, c-format
 msgid "Unable to push submodule '%s'\n"
 msgstr "Không thể đẩy lên mô-đun-con “%s”\n"
 
-#: submodule.c:1451
+#: submodule.c:1491
 #, c-format
 msgid "Fetching submodule %s%s\n"
 msgstr "Đang lấy về mô-đun-con %s%s\n"
 
-#: submodule.c:1485
+#: submodule.c:1525
 #, c-format
 msgid "Could not access submodule '%s'\n"
 msgstr "Không thể truy cập mô-đun-con “%s”\n"
 
-#: submodule.c:1640
+#: submodule.c:1680
 #, c-format
 msgid ""
 "Errors during submodule fetch:\n"
@@ -8733,61 +8948,61 @@ msgstr ""
 "Có lỗi khi lấy về mô-đun-con:\n"
 " “%s”"
 
-#: submodule.c:1665
+#: submodule.c:1705
 #, c-format
 msgid "'%s' not recognized as a git repository"
 msgstr "không nhận ra “%s” là một kho git"
 
-#: submodule.c:1682
+#: submodule.c:1722
 #, c-format
 msgid "Could not run 'git status --porcelain=2' in submodule %s"
 msgstr "Không thể chạy “git status --porcelain=2” trong mô-đun-con “%s”"
 
-#: submodule.c:1723
+#: submodule.c:1763
 #, c-format
 msgid "'git status --porcelain=2' failed in submodule %s"
 msgstr "“git status --porcelain=2” gặp lỗi trong mô-đun-con “%s”"
 
-#: submodule.c:1798
+#: submodule.c:1838
 #, c-format
 msgid "could not start 'git status' in submodule '%s'"
 msgstr "không thể lấy thống kê “git status” trong mô-đun-con “%s”"
 
-#: submodule.c:1811
+#: submodule.c:1851
 #, c-format
 msgid "could not run 'git status' in submodule '%s'"
 msgstr "không thể chạy “git status” trong mô-đun-con “%s”"
 
-#: submodule.c:1826
+#: submodule.c:1868
 #, c-format
 msgid "Could not unset core.worktree setting in submodule '%s'"
 msgstr "Không thể đặt core.worktree trong mô-đun-con “%s”"
 
-#: submodule.c:1853 submodule.c:2163
+#: submodule.c:1895 submodule.c:2210
 #, c-format
 msgid "could not recurse into submodule '%s'"
 msgstr "không thể đệ quy vào trong mô-đun-con “%s”"
 
-#: submodule.c:1874
+#: submodule.c:1917
 msgid "could not reset submodule index"
 msgstr "không thể đặt lại mục lục của mô-đun-con"
 
-#: submodule.c:1916
+#: submodule.c:1959
 #, c-format
 msgid "submodule '%s' has dirty index"
 msgstr "mô-đun-con “%s” có mục lục còn bẩn"
 
-#: submodule.c:1968
+#: submodule.c:2013
 #, c-format
 msgid "Submodule '%s' could not be updated."
 msgstr "Mô-đun-con “%s” không thể được cập nhật."
 
-#: submodule.c:2036
+#: submodule.c:2081
 #, c-format
 msgid "submodule git dir '%s' is inside git dir '%.*s'"
 msgstr "thư mục git mô đun con “%s” là bên trong git DIR “%.*s”"
 
-#: submodule.c:2057
+#: submodule.c:2102
 #, c-format
 msgid ""
 "relocate_gitdir for submodule '%s' with more than one worktree not supported"
@@ -8795,17 +9010,17 @@ msgstr ""
 "relocate_gitdir cho mô-đun-con “%s” với nhiều hơn một cây làm việc là chưa "
 "được hỗ trợ"
 
-#: submodule.c:2069 submodule.c:2128
+#: submodule.c:2114 submodule.c:2174
 #, c-format
 msgid "could not lookup name for submodule '%s'"
 msgstr "không thể tìm kiếm tên cho mô-đun-con “%s”"
 
-#: submodule.c:2073
+#: submodule.c:2118
 #, c-format
 msgid "refusing to move '%s' into an existing git dir"
 msgstr "từ chối di chuyển “%s” vào trong một thư mục git sẵn có"
 
-#: submodule.c:2080
+#: submodule.c:2124
 #, c-format
 msgid ""
 "Migrating git directory of '%s%s' from\n"
@@ -8816,11 +9031,11 @@ msgstr ""
 "“%s” sang\n"
 "“%s”\n"
 
-#: submodule.c:2208
+#: submodule.c:2255
 msgid "could not start ls-files in .."
 msgstr "không thể lấy thông tin thống kê về ls-files trong .."
 
-#: submodule.c:2248
+#: submodule.c:2295
 #, c-format
 msgid "ls-tree returned unexpected return code %d"
 msgstr "ls-tree trả về mã không như mong đợi %d"
@@ -8842,7 +9057,7 @@ msgid "unknown value '%s' for key '%s'"
 msgstr "không hiểu giá trị “%s” cho khóa “%s”"
 
 #: trailer.c:547 trailer.c:552 trailer.c:557 builtin/remote.c:299
-#: builtin/remote.c:324
+#: builtin/remote.c:327
 #, c-format
 msgid "more than one %s"
 msgstr "nhiều hơn một %s"
@@ -8857,11 +9072,11 @@ msgstr "thẻ thừa trống rỗng trong phần thừa “%.*s”"
 msgid "could not read input file '%s'"
 msgstr "không đọc được tập tin đầu vào “%s”"
 
-#: trailer.c:766 builtin/mktag.c:88 imap-send.c:1577
+#: trailer.c:766 builtin/mktag.c:89 imap-send.c:1573
 msgid "could not read from stdin"
 msgstr "không thể đọc từ đầu vào tiêu chuẩn"
 
-#: trailer.c:1024 wrapper.c:676
+#: trailer.c:1024 wrapper.c:684
 #, c-format
 msgid "could not stat %s"
 msgstr "không thể lấy thông tin thống kê về %s"
@@ -8929,7 +9144,7 @@ msgstr "không thể chạy fast-import"
 msgid "error while running fast-import"
 msgstr "gặp lỗi trong khi chạy fast-import"
 
-#: transport-helper.c:549 transport-helper.c:1247
+#: transport-helper.c:549 transport-helper.c:1251
 #, c-format
 msgid "could not read ref %s"
 msgstr "không thể đọc tham chiếu %s"
@@ -8947,7 +9162,7 @@ msgstr "giao thức này không hỗ trợ cài đặt đường dẫn dịch v�
 msgid "invalid remote service path"
 msgstr "đường dẫn dịch vụ máy chủ không hợp lệ"
 
-#: transport-helper.c:661 transport.c:1477
+#: transport-helper.c:661 transport.c:1475
 msgid "operation not supported by protocol"
 msgstr "thao tác không được gia thức hỗ trợ"
 
@@ -8956,7 +9171,7 @@ msgstr "thao tác không được gia thức hỗ trợ"
 msgid "can't connect to subservice %s"
 msgstr "không thể kết nối đến dịch vụ phụ %s"
 
-#: transport-helper.c:693 transport.c:400
+#: transport-helper.c:693 transport.c:404
 msgid "--negotiate-only requires protocol v2"
 msgstr "--negotiate-only cần giao thức v2"
 
@@ -8969,59 +9184,59 @@ msgstr "“option” không có chỉ thị “ok/error” tương ứng"
 msgid "expected ok/error, helper said '%s'"
 msgstr "cần ok/error, nhưng bộ hỗ trợ lại nói “%s”"
 
-#: transport-helper.c:855
+#: transport-helper.c:859
 #, c-format
 msgid "helper reported unexpected status of %s"
 msgstr "bộ hỗ trợ báo cáo rằng không cần tình trạng của %s"
 
-#: transport-helper.c:938
+#: transport-helper.c:942
 #, c-format
 msgid "helper %s does not support dry-run"
 msgstr "helper %s không hỗ trợ dry-run"
 
-#: transport-helper.c:941
+#: transport-helper.c:945
 #, c-format
 msgid "helper %s does not support --signed"
 msgstr "helper %s không hỗ trợ --signed"
 
-#: transport-helper.c:944
+#: transport-helper.c:948
 #, c-format
 msgid "helper %s does not support --signed=if-asked"
 msgstr "helper %s không hỗ trợ --signed=if-asked"
 
-#: transport-helper.c:949
+#: transport-helper.c:953
 #, c-format
 msgid "helper %s does not support --atomic"
 msgstr "helper %s không hỗ trợ --atomic"
 
-#: transport-helper.c:953
+#: transport-helper.c:957
 #, c-format
 msgid "helper %s does not support --%s"
 msgstr "helper %s không hỗ trợ --%s"
 
-#: transport-helper.c:960
+#: transport-helper.c:964
 #, c-format
 msgid "helper %s does not support 'push-option'"
 msgstr "helper %s không hỗ trợ “push-option”"
 
-#: transport-helper.c:1060
+#: transport-helper.c:1064
 msgid "remote-helper doesn't support push; refspec needed"
 msgstr "remote-helper không hỗ trợ push; cần đặc tả tham chiếu"
 
-#: transport-helper.c:1065
+#: transport-helper.c:1069
 #, c-format
 msgid "helper %s does not support 'force'"
 msgstr "helper %s không hỗ trợ “force”"
 
-#: transport-helper.c:1112
+#: transport-helper.c:1116
 msgid "couldn't run fast-export"
 msgstr "không thể chạy fast-export"
 
-#: transport-helper.c:1117
+#: transport-helper.c:1121
 msgid "error while running fast-export"
 msgstr "gặp lỗi trong khi chạy fast-export"
 
-#: transport-helper.c:1142
+#: transport-helper.c:1146
 #, c-format
 msgid ""
 "No refs in common and none specified; doing nothing.\n"
@@ -9031,52 +9246,52 @@ msgstr ""
 "cả.\n"
 "Tuy nhiên bạn nên chỉ định một nhánh.\n"
 
-#: transport-helper.c:1224
+#: transport-helper.c:1228
 #, c-format
 msgid "unsupported object format '%s'"
 msgstr "không hỗ trợ định dạng đối tượng “%s”"
 
-#: transport-helper.c:1233
+#: transport-helper.c:1237
 #, c-format
 msgid "malformed response in ref list: %s"
 msgstr "đáp ứng sai dạng trong danh sách tham chiếu: %s"
 
-#: transport-helper.c:1385
+#: transport-helper.c:1389
 #, c-format
 msgid "read(%s) failed"
 msgstr "read(%s) gặp lỗi"
 
-#: transport-helper.c:1412
+#: transport-helper.c:1416
 #, c-format
 msgid "write(%s) failed"
 msgstr "write(%s) gặp lỗi"
 
-#: transport-helper.c:1461
+#: transport-helper.c:1465
 #, c-format
 msgid "%s thread failed"
 msgstr "tuyến trình %s gặp lỗi"
 
-#: transport-helper.c:1465
+#: transport-helper.c:1469
 #, c-format
 msgid "%s thread failed to join: %s"
 msgstr "tuyến trình %s gặp lỗi khi gia nhập: %s"
 
-#: transport-helper.c:1484 transport-helper.c:1488
+#: transport-helper.c:1488 transport-helper.c:1492
 #, c-format
 msgid "can't start thread for copying data: %s"
 msgstr "không thể khởi chạy tuyến trình để sao chép dữ liệu: %s"
 
-#: transport-helper.c:1525
+#: transport-helper.c:1529
 #, c-format
 msgid "%s process failed to wait"
 msgstr "xử lý %s gặp lỗi khi đợi"
 
-#: transport-helper.c:1529
+#: transport-helper.c:1533
 #, c-format
 msgid "%s process failed"
 msgstr "xử lý %s gặp lỗi"
 
-#: transport-helper.c:1547 transport-helper.c:1556
+#: transport-helper.c:1551 transport-helper.c:1560
 msgid "can't start thread for copying data"
 msgstr "không thể khởi chạy tuyến trình cho việc chép dữ liệu"
 
@@ -9090,46 +9305,46 @@ msgstr "Không thể đặt thượng nguồn của “%s” thành “%s” c�
 msgid "could not read bundle '%s'"
 msgstr "không thể đọc bó “%s”"
 
-#: transport.c:223
+#: transport.c:227
 #, c-format
 msgid "transport: invalid depth option '%s'"
 msgstr "vận chuyển: tùy chọn độ sâu “%s” không hợp lệ"
 
-#: transport.c:275
+#: transport.c:279
 msgid "see protocol.version in 'git help config' for more details"
 msgstr "xem protocol.version trong “git help config” để có thêm thông tin"
 
-#: transport.c:276
+#: transport.c:280
 msgid "server options require protocol version 2 or later"
 msgstr "các tùy chọn máy chủ yêu cầu giao thức phiên bản 2 hoặc mới hơn"
 
-#: transport.c:403
+#: transport.c:407
 msgid "server does not support wait-for-done"
 msgstr "máy chủ không hỗ trợ wait-for-done"
 
-#: transport.c:755
+#: transport.c:759
 msgid "could not parse transport.color.* config"
 msgstr "không thể phân tích cú pháp cấu hình transport.color.*"
 
-#: transport.c:830
+#: transport.c:834
 msgid "support for protocol v2 not implemented yet"
 msgstr "việc hỗ trợ giao thức v2 chưa được thực hiện"
 
-#: transport.c:965
+#: transport.c:967
 #, c-format
 msgid "unknown value for config '%s': %s"
 msgstr "không hiểu giá trị cho cho cấu hình “%s”: %s"
 
-#: transport.c:1031
+#: transport.c:1033
 #, c-format
 msgid "transport '%s' not allowed"
 msgstr "không cho phép phương thức vận chuyển “%s”"
 
-#: transport.c:1084
+#: transport.c:1082
 msgid "git-over-rsync is no longer supported"
 msgstr "git-over-rsync không còn được hỗ trợ nữa"
 
-#: transport.c:1187
+#: transport.c:1185
 #, c-format
 msgid ""
 "The following submodule paths contain changes that can\n"
@@ -9138,7 +9353,7 @@ msgstr ""
 "Các đường dẫn mô-đun-con sau đây có chứa các thay đổi cái mà\n"
 "có thể được tìm thấy trên mọi máy phục vụ:\n"
 
-#: transport.c:1191
+#: transport.c:1189
 #, c-format
 msgid ""
 "\n"
@@ -9165,11 +9380,11 @@ msgstr ""
 "để đẩy chúng lên máy phục vụ.\n"
 "\n"
 
-#: transport.c:1199
+#: transport.c:1197
 msgid "Aborting."
 msgstr "Bãi bỏ."
 
-#: transport.c:1346
+#: transport.c:1344
 msgid "failed to push all needed submodules"
 msgstr "gặp lỗi khi đẩy dữ liệu của tất cả các mô-đun-con cần thiết"
 
@@ -9455,17 +9670,17 @@ msgstr ""
 "HOA/thường trên một hệ thống tập tin không phân biệt HOA/thường)\n"
 "và chỉ một từ cùng một nhóm xung đột là trong cây làm việc hiện tại:\n"
 
-#: unpack-trees.c:1618
+#: unpack-trees.c:1620
 msgid "Updating index flags"
 msgstr "Đang cập nhật các cờ mục lục"
 
-#: unpack-trees.c:2718
+#: unpack-trees.c:2772
 #, c-format
 msgid "worktree and untracked commit have duplicate entries: %s"
 msgstr ""
 "cây làm việc và lần chuyển giao không được theo dõi có các mục trùng lặp: %s"
 
-#: upload-pack.c:1548
+#: upload-pack.c:1561
 msgid "expected flush after fetch arguments"
 msgstr "cần đẩy dữ liệu lên đĩa sau các tham số của lệnh fetch"
 
@@ -9502,7 +9717,7 @@ msgstr "đoạn đường dẫn “..” không hợp lệ"
 msgid "Fetching objects"
 msgstr "Đang lấy về các đối tượng"
 
-#: worktree.c:236 builtin/am.c:2152
+#: worktree.c:236 builtin/am.c:2154 builtin/bisect--helper.c:156
 #, c-format
 msgid "failed to read '%s'"
 msgstr "gặp lỗi khi đọc “%s”"
@@ -9599,17 +9814,27 @@ msgstr "tập tin gitdir (thư mục git) không hợp lệ"
 msgid "gitdir file points to non-existent location"
 msgstr "tập tin gitdir chỉ đến vị trí không tồn tại"
 
-#: wrapper.c:197 wrapper.c:367
+#: wrapper.c:151
+#, c-format
+msgid "could not setenv '%s'"
+msgstr "không thể setenv “%s”"
+
+#: wrapper.c:203
+#, c-format
+msgid "unable to create '%s'"
+msgstr "không thể tạo “%s”"
+
+#: wrapper.c:205 wrapper.c:375
 #, c-format
 msgid "could not open '%s' for reading and writing"
 msgstr "không thể mở “%s” để đọc và ghi"
 
-#: wrapper.c:398 wrapper.c:599
+#: wrapper.c:406 wrapper.c:607
 #, c-format
 msgid "unable to access '%s'"
 msgstr "không thể truy cập “%s”"
 
-#: wrapper.c:607
+#: wrapper.c:615
 msgid "unable to get current working directory"
 msgstr "không thể lấy thư mục làm việc hiện hành"
 
@@ -10172,25 +10397,25 @@ msgid "cannot %s: Your index contains uncommitted changes."
 msgstr ""
 "không thể %s: Mục lục của bạn có chứa các thay đổi chưa được chuyển giao."
 
-#: compat/simple-ipc/ipc-unix-socket.c:182
+#: compat/simple-ipc/ipc-unix-socket.c:183
 msgid "could not send IPC command"
 msgstr "không thể gửi lệnh IPC"
 
-#: compat/simple-ipc/ipc-unix-socket.c:189
+#: compat/simple-ipc/ipc-unix-socket.c:190
 msgid "could not read IPC response"
 msgstr "không thể đọc đáp ứng IPC"
 
-#: compat/simple-ipc/ipc-unix-socket.c:866
+#: compat/simple-ipc/ipc-unix-socket.c:870
 #, c-format
 msgid "could not start accept_thread '%s'"
 msgstr "không thể khởi chạy accept_thread “%s”"
 
-#: compat/simple-ipc/ipc-unix-socket.c:878
+#: compat/simple-ipc/ipc-unix-socket.c:882
 #, c-format
 msgid "could not start worker[0] for '%s'"
 msgstr "không thể khởi chạy bộ làm việc worker[0] cho “%s”"
 
-#: compat/precompose_utf8.c:58 builtin/clone.c:461
+#: compat/precompose_utf8.c:58 builtin/clone.c:347
 #, c-format
 msgid "failed to unlink '%s'"
 msgstr "gặp lỗi khi bỏ liên kết (unlink) “%s”"
@@ -10199,138 +10424,137 @@ msgstr "gặp lỗi khi bỏ liên kết (unlink) “%s”"
 msgid "git add [<options>] [--] <pathspec>..."
 msgstr "git add [<các tùy chọn>] [--]  <pathspec>…"
 
-#: builtin/add.c:61
+#: builtin/add.c:64
 #, c-format
 msgid "cannot chmod %cx '%s'"
-msgstr "không thể chmod %cx '%s'"
+msgstr "không thể chmod %cx “%s”"
 
-#: builtin/add.c:99
+#: builtin/add.c:106
 #, c-format
 msgid "unexpected diff status %c"
 msgstr "trạng thái lệnh diff không như mong đợi %c"
 
-#: builtin/add.c:104 builtin/commit.c:297
+#: builtin/add.c:111 builtin/commit.c:298
 msgid "updating files failed"
 msgstr "cập nhật tập tin gặp lỗi"
 
-#: builtin/add.c:114
+#: builtin/add.c:121
 #, c-format
 msgid "remove '%s'\n"
 msgstr "gỡ bỏ “%s”\n"
 
-#: builtin/add.c:198
+#: builtin/add.c:205
 msgid "Unstaged changes after refreshing the index:"
 msgstr ""
 "Đưa ra khỏi bệ phóng các thay đổi sau khi làm tươi mới lại bảng mục lục:"
 
-#: builtin/add.c:307 builtin/rev-parse.c:993
+#: builtin/add.c:317 builtin/rev-parse.c:993
 msgid "Could not read the index"
 msgstr "Không thể đọc bảng mục lục"
 
-#: builtin/add.c:318
-#, c-format
-msgid "Could not open '%s' for writing."
-msgstr "Không thể mở “%s” để ghi."
-
-#: builtin/add.c:322
+#: builtin/add.c:330
 msgid "Could not write patch"
 msgstr "Không thể ghi ra miếng vá"
 
-#: builtin/add.c:325
+#: builtin/add.c:333
 msgid "editing patch failed"
 msgstr "gặp lỗi khi sửa miếng vá"
 
-#: builtin/add.c:328
+#: builtin/add.c:336
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "Không thể lấy thông tin thống kê về “%s”"
 
-#: builtin/add.c:330
+#: builtin/add.c:338
 msgid "Empty patch. Aborted."
 msgstr "Miếng vá trống rỗng. Nên bỏ qua."
 
-#: builtin/add.c:335
+#: builtin/add.c:343
 #, c-format
 msgid "Could not apply '%s'"
 msgstr "Không thể áp dụng miếng vá “%s”"
 
-#: builtin/add.c:343
+#: builtin/add.c:351
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr ""
 "Các đường dẫn theo sau đây sẽ bị lờ đi bởi một trong các tập tin .gitignore "
 "của bạn:\n"
 
-#: builtin/add.c:363 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
+#: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
 #: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:550
-#: builtin/remote.c:1427 builtin/rm.c:243 builtin/send-pack.c:190
+#: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr "chạy thử"
 
-#: builtin/add.c:366
+#: builtin/add.c:374
 msgid "interactive picking"
 msgstr "sửa bằng cách tương tác"
 
-#: builtin/add.c:367 builtin/checkout.c:1562 builtin/reset.c:308
+#: builtin/add.c:375 builtin/checkout.c:1560 builtin/reset.c:314
 msgid "select hunks interactively"
 msgstr "chọn “hunks” theo kiểu tương tác"
 
-#: builtin/add.c:368
+#: builtin/add.c:376
 msgid "edit current diff and apply"
 msgstr "sửa diff hiện nay và áp dụng nó"
 
-#: builtin/add.c:369
+#: builtin/add.c:377
 msgid "allow adding otherwise ignored files"
 msgstr "cho phép thêm các tập tin bị bỏ qua khác"
 
-#: builtin/add.c:370
+#: builtin/add.c:378
 msgid "update tracked files"
 msgstr "cập nhật các tập tin được theo dõi"
 
-#: builtin/add.c:371
+#: builtin/add.c:379
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr "thường hóa lại EOL của các tập tin được theo dõi (ý là -u)"
 
-#: builtin/add.c:372
+#: builtin/add.c:380
 msgid "record only the fact that the path will be added later"
 msgstr "chỉ ghi lại sự việc mà đường dẫn sẽ được thêm vào sau"
 
-#: builtin/add.c:373
+#: builtin/add.c:381
 msgid "add changes from all tracked and untracked files"
 msgstr ""
 "thêm các thay đổi từ tất cả các tập tin có cũng như không được theo dõi dấu "
 "vết"
 
-#: builtin/add.c:376
+#: builtin/add.c:384
 msgid "ignore paths removed in the working tree (same as --no-all)"
 msgstr ""
 "lờ đi các đường dẫn bị gỡ bỏ trong cây thư mục làm việc (giống với --no-all)"
 
-#: builtin/add.c:378
+#: builtin/add.c:386
 msgid "don't add, only refresh the index"
 msgstr "không thêm, chỉ làm tươi mới bảng mục lục"
 
-#: builtin/add.c:379
+#: builtin/add.c:387
 msgid "just skip files which cannot be added because of errors"
 msgstr "chie bỏ qua những tập tin mà nó không thể được thêm vào bởi vì gặp lỗi"
 
-#: builtin/add.c:380
+#: builtin/add.c:388
 msgid "check if - even missing - files are ignored in dry run"
 msgstr ""
 "kiểm tra xem - thậm chí thiếu - tập tin bị bỏ qua trong quá trình chạy thử"
 
-#: builtin/add.c:382 builtin/update-index.c:1006
+#: builtin/add.c:389 builtin/mv.c:128 builtin/rm.c:251
+msgid "allow updating entries outside of the sparse-checkout cone"
+msgstr "cho phép cập nhật các mục ở ngoài “sparse-checkout cone”"
+
+#: builtin/add.c:391 builtin/update-index.c:1004
 msgid "override the executable bit of the listed files"
 msgstr "ghi đè lên bít thi hành của các tập tin được liệt kê"
 
-#: builtin/add.c:384
+#: builtin/add.c:393
 msgid "warn when adding an embedded repository"
 msgstr "cảnh báo khi thêm một kho nhúng"
 
-#: builtin/add.c:386
+#: builtin/add.c:395
 msgid "backend for `git stash -p`"
 msgstr "ứng dụng chạy phía sau cho “git stash -p”"
 
-#: builtin/add.c:404
+#: builtin/add.c:413
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -10361,12 +10585,12 @@ msgstr ""
 "\n"
 "Xem \"git help submodule\" để biết thêm chi tiết."
 
-#: builtin/add.c:432
+#: builtin/add.c:442
 #, c-format
 msgid "adding embedded git repository: %s"
 msgstr "thêm cần một kho git nhúng: %s"
 
-#: builtin/add.c:451
+#: builtin/add.c:462
 msgid ""
 "Use -f if you really want to add them.\n"
 "Turn this message off by running\n"
@@ -10376,51 +10600,51 @@ msgstr ""
 "Tắt thông báo này bằng cách chạy lệnh\n"
 "\"git config advice.addIgnoredFile false\""
 
-#: builtin/add.c:460
+#: builtin/add.c:477
 msgid "adding files failed"
 msgstr "thêm tập tin gặp lỗi"
 
-#: builtin/add.c:488
+#: builtin/add.c:513
 msgid "--dry-run is incompatible with --interactive/--patch"
 msgstr "--dry-run xung khắc với --interactive/--patch"
 
-#: builtin/add.c:490 builtin/commit.c:357
+#: builtin/add.c:515 builtin/commit.c:358
 msgid "--pathspec-from-file is incompatible with --interactive/--patch"
 msgstr "--pathspec-from-file xung khắc với --interactive/--patch"
 
-#: builtin/add.c:507
+#: builtin/add.c:532
 msgid "--pathspec-from-file is incompatible with --edit"
 msgstr "--pathspec-from-file xung khắc với --edit"
 
-#: builtin/add.c:519
+#: builtin/add.c:544
 msgid "-A and -u are mutually incompatible"
 msgstr "-A và -u xung khắc nhau"
 
-#: builtin/add.c:522
+#: builtin/add.c:547
 msgid "Option --ignore-missing can only be used together with --dry-run"
 msgstr "Tùy chọn --ignore-missing chỉ có thể được dùng cùng với --dry-run"
 
-#: builtin/add.c:526
+#: builtin/add.c:551
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "--chmod tham số “%s” phải hoặc là -x hay +x"
 
-#: builtin/add.c:544 builtin/checkout.c:1733 builtin/commit.c:363
-#: builtin/reset.c:328 builtin/rm.c:273 builtin/stash.c:1633
+#: builtin/add.c:572 builtin/checkout.c:1731 builtin/commit.c:364
+#: builtin/reset.c:334 builtin/rm.c:275 builtin/stash.c:1650
 msgid "--pathspec-from-file is incompatible with pathspec arguments"
 msgstr "--pathspec-from-file xung khắc với các tham số đặc tả đường dẫn"
 
-#: builtin/add.c:551 builtin/checkout.c:1745 builtin/commit.c:369
-#: builtin/reset.c:334 builtin/rm.c:279 builtin/stash.c:1639
+#: builtin/add.c:579 builtin/checkout.c:1743 builtin/commit.c:370
+#: builtin/reset.c:340 builtin/rm.c:281 builtin/stash.c:1656
 msgid "--pathspec-file-nul requires --pathspec-from-file"
 msgstr "--pathspec-file-nul cần --pathspec-from-file"
 
-#: builtin/add.c:555
+#: builtin/add.c:583
 #, c-format
 msgid "Nothing specified, nothing added.\n"
 msgstr "Không có gì được chỉ ra, không có gì được thêm vào.\n"
 
-#: builtin/add.c:557
+#: builtin/add.c:585
 msgid ""
 "Maybe you wanted to say 'git add .'?\n"
 "Turn this message off by running\n"
@@ -10430,109 +10654,109 @@ msgstr ""
 "Tắt thông báo này bằng cách chạy lệnh\n"
 "\"git config advice.addEmptyPathspec false\""
 
-#: builtin/am.c:365
+#: builtin/am.c:366
 msgid "could not parse author script"
 msgstr "không thể phân tích cú pháp văn lệnh tác giả"
 
-#: builtin/am.c:455
+#: builtin/am.c:456
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
 msgstr "“%s” bị xóa bởi móc applypatch-msg"
 
-#: builtin/am.c:497
+#: builtin/am.c:498
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr "Dòng đầu vào dị hình: “%s”."
 
-#: builtin/am.c:535
+#: builtin/am.c:536
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
 msgstr "Gặp lỗi khi sao chép ghi chú (note) từ “%s” tới “%s”"
 
-#: builtin/am.c:561
+#: builtin/am.c:562
 msgid "fseek failed"
 msgstr "fseek gặp lỗi"
 
-#: builtin/am.c:749
+#: builtin/am.c:750
 #, c-format
 msgid "could not parse patch '%s'"
 msgstr "không thể phân tích cú pháp “%s”"
 
-#: builtin/am.c:814
+#: builtin/am.c:815
 msgid "Only one StGIT patch series can be applied at once"
 msgstr "Chỉ có một sê-ri miếng vá StGIT được áp dụng một lúc"
 
-#: builtin/am.c:862
+#: builtin/am.c:863
 msgid "invalid timestamp"
 msgstr "dấu thời gian không hợp lệ"
 
-#: builtin/am.c:867 builtin/am.c:879
+#: builtin/am.c:868 builtin/am.c:880
 msgid "invalid Date line"
 msgstr "dòng Ngày tháng không hợp lệ"
 
-#: builtin/am.c:874
+#: builtin/am.c:875
 msgid "invalid timezone offset"
 msgstr "độ lệch múi giờ không hợp lệ"
 
-#: builtin/am.c:967
+#: builtin/am.c:968
 msgid "Patch format detection failed."
 msgstr "Dò tìm định dạng miếng vá gặp lỗi."
 
-#: builtin/am.c:972 builtin/clone.c:414
+#: builtin/am.c:973 builtin/clone.c:300
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "tạo thư mục \"%s\" gặp lỗi"
 
-#: builtin/am.c:977
+#: builtin/am.c:978
 msgid "Failed to split patches."
 msgstr "Gặp lỗi khi chia nhỏ các miếng vá."
 
-#: builtin/am.c:1126
+#: builtin/am.c:1127
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\"."
 msgstr "Khi bạn đã giải quyết xong trục trặc này, hãy chạy \"%s --continue\"."
 
-#: builtin/am.c:1127
+#: builtin/am.c:1128
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
 msgstr ""
 "Nếu bạn muốn bỏ qua miếng vá này, hãy chạy lệnh \"%s --skip\" để thay thế."
 
-#: builtin/am.c:1128
+#: builtin/am.c:1129
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr "Để phục hồi lại nhánh gốc và dừng vá, hãy chạy \"%s --abort\"."
 
-#: builtin/am.c:1223
+#: builtin/am.c:1224
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
 "Miếng vá được gửi với format=flowed; khoảng trống ở cuối của các dòng có thể "
 "bị mất."
 
-#: builtin/am.c:1251
+#: builtin/am.c:1252
 msgid "Patch is empty."
 msgstr "Miếng vá trống rỗng."
 
-#: builtin/am.c:1316
+#: builtin/am.c:1317
 #, c-format
 msgid "missing author line in commit %s"
 msgstr "thiếu dòng tác giả trong lần chuyển gia %s"
 
-#: builtin/am.c:1319
+#: builtin/am.c:1320
 #, c-format
 msgid "invalid ident line: %.*s"
 msgstr "dòng định danh không hợp lệ: %.*s"
 
-#: builtin/am.c:1538
+#: builtin/am.c:1539
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr "Kho thiếu đối tượng blob cần thiết để thực hiện “3-way merge”."
 
-#: builtin/am.c:1540
+#: builtin/am.c:1541
 msgid "Using index info to reconstruct a base tree..."
 msgstr ""
 "Sử dụng thông tin trong bảng mục lục để cấu trúc lại một cây (tree) cơ sở…"
 
-#: builtin/am.c:1559
+#: builtin/am.c:1560
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
@@ -10540,24 +10764,24 @@ msgstr ""
 "Bạn đã sửa miếng vá của mình bằng cách thủ công à?\n"
 "Nó không thể áp dụng các blob đã được ghi lại trong bảng mục lục của nó."
 
-#: builtin/am.c:1565
+#: builtin/am.c:1566
 msgid "Falling back to patching base and 3-way merge..."
 msgstr "Đang dùng phương án dự phòng: vá bản cơ sở và “hòa trộn 3-đường”…"
 
-#: builtin/am.c:1591
+#: builtin/am.c:1592
 msgid "Failed to merge in the changes."
 msgstr "Gặp lỗi khi trộn vào các thay đổi."
 
-#: builtin/am.c:1623
+#: builtin/am.c:1624
 msgid "applying to an empty history"
 msgstr "áp dụng vào một lịch sử trống rỗng"
 
-#: builtin/am.c:1675 builtin/am.c:1679
+#: builtin/am.c:1676 builtin/am.c:1680
 #, c-format
 msgid "cannot resume: %s does not exist."
 msgstr "không thể phục hồi: %s không tồn tại."
 
-#: builtin/am.c:1697
+#: builtin/am.c:1698
 msgid "Commit Body is:"
 msgstr "Thân của lần chuyển giao là:"
 
@@ -10565,37 +10789,37 @@ msgstr "Thân của lần chuyển giao là:"
 #. in your translation. The program will only accept English
 #. input at this point.
 #.
-#: builtin/am.c:1707
+#: builtin/am.c:1708
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr ""
 "Áp dụng? đồng ý [y]/khô[n]g/chỉnh sửa [e]/hiển thị miếng [v]á/chấp nhận tất "
 "cả [a]: "
 
-#: builtin/am.c:1753 builtin/commit.c:408
+#: builtin/am.c:1754 builtin/commit.c:409
 msgid "unable to write index file"
 msgstr "không thể ghi tập tin lưu mục lục"
 
-#: builtin/am.c:1757
+#: builtin/am.c:1758
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
 msgstr "Bảng mục lục bẩn: không thể áp dụng các miếng vá (bẩn: %s)"
 
-#: builtin/am.c:1797 builtin/am.c:1865
+#: builtin/am.c:1798 builtin/am.c:1865
 #, c-format
 msgid "Applying: %.*s"
 msgstr "Áp dụng: %.*s"
 
-#: builtin/am.c:1814
+#: builtin/am.c:1815
 msgid "No changes -- Patch already applied."
 msgstr "Không thay đổi gì cả -- Miếng vá đã được áp dụng rồi."
 
-#: builtin/am.c:1820
+#: builtin/am.c:1821
 #, c-format
 msgid "Patch failed at %s %.*s"
 msgstr "Gặp lỗi khi vá tại %s %.*s"
 
-#: builtin/am.c:1824
+#: builtin/am.c:1825
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr "Dùng “git am --show-current-patch=diff” để xem miếng vá bị lỗi"
 
@@ -10623,17 +10847,17 @@ msgstr ""
 "Bạn có lẽ muốn chạy “git rm“ trên một tập tin để chấp nhận \"được xóa bởi họ"
 "\" cho nó."
 
-#: builtin/am.c:1982 builtin/am.c:1986 builtin/am.c:1998 builtin/reset.c:347
-#: builtin/reset.c:355
+#: builtin/am.c:1983 builtin/am.c:1987 builtin/am.c:1999 builtin/reset.c:353
+#: builtin/reset.c:361
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "Không thể phân tích đối tượng “%s”."
 
-#: builtin/am.c:2034
+#: builtin/am.c:2035 builtin/am.c:2111
 msgid "failed to clean index"
 msgstr "gặp lỗi khi dọn bảng mục lục"
 
-#: builtin/am.c:2078
+#: builtin/am.c:2079
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
@@ -10641,160 +10865,160 @@ msgstr ""
 "Bạn có lẽ đã có HEAD đã bị di chuyển đi kể từ lần “am” thất bại cuối cùng.\n"
 "Không thể chuyển tới ORIG_HEAD"
 
-#: builtin/am.c:2185
+#: builtin/am.c:2187
 #, c-format
 msgid "Invalid value for --patch-format: %s"
 msgstr "Giá trị không hợp lệ cho --patch-format: %s"
 
-#: builtin/am.c:2227
+#: builtin/am.c:2229
 #, c-format
 msgid "Invalid value for --show-current-patch: %s"
 msgstr "Giá trị không hợp lệ cho --show-current-patch: %s"
 
-#: builtin/am.c:2231
+#: builtin/am.c:2233
 #, c-format
 msgid "--show-current-patch=%s is incompatible with --show-current-patch=%s"
 msgstr "--show-current-patch=%s xung khắc với --show-current-patch=%s"
 
-#: builtin/am.c:2262
+#: builtin/am.c:2264
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
 msgstr "git am [<các tùy chọn>] [(<mbox>|<Maildir>)…]"
 
-#: builtin/am.c:2263
+#: builtin/am.c:2265
 msgid "git am [<options>] (--continue | --skip | --abort)"
 msgstr "git am [<các tùy chọn>] (--continue | --skip | --abort)"
 
-#: builtin/am.c:2269
+#: builtin/am.c:2271
 msgid "run interactively"
 msgstr "chạy kiểu tương tác"
 
-#: builtin/am.c:2271
+#: builtin/am.c:2273
 msgid "historical option -- no-op"
 msgstr "tùy chọn lịch sử -- không-toán-tử"
 
-#: builtin/am.c:2273
+#: builtin/am.c:2275
 msgid "allow fall back on 3way merging if needed"
 msgstr "cho phép quay trở lại để hòa trộn kiểu “3way” nếu cần"
 
-#: builtin/am.c:2274 builtin/init-db.c:547 builtin/prune-packed.c:16
-#: builtin/repack.c:472 builtin/stash.c:945
+#: builtin/am.c:2276 builtin/init-db.c:547 builtin/prune-packed.c:16
+#: builtin/repack.c:640 builtin/stash.c:961
 msgid "be quiet"
 msgstr "im lặng"
 
-#: builtin/am.c:2276
+#: builtin/am.c:2278
 msgid "add a Signed-off-by trailer to the commit message"
 msgstr "thêm dòng Signed-off-by vào cuối ghi chú của lần chuyển giao"
 
-#: builtin/am.c:2279
+#: builtin/am.c:2281
 msgid "recode into utf8 (default)"
 msgstr "chuyển mã thành utf8 (mặc định)"
 
-#: builtin/am.c:2281
+#: builtin/am.c:2283
 msgid "pass -k flag to git-mailinfo"
 msgstr "chuyển cờ -k cho git-mailinfo"
 
-#: builtin/am.c:2283
+#: builtin/am.c:2285
 msgid "pass -b flag to git-mailinfo"
 msgstr "chuyển cờ -b cho git-mailinfo"
 
-#: builtin/am.c:2285
+#: builtin/am.c:2287
 msgid "pass -m flag to git-mailinfo"
 msgstr "chuyển cờ -m cho git-mailinfo"
 
-#: builtin/am.c:2287
+#: builtin/am.c:2289
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
 msgstr "chuyển cờ --keep-cr cho git-mailsplit với định dạng mbox"
 
-#: builtin/am.c:2290
+#: builtin/am.c:2292
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr ""
 "đừng chuyển cờ --keep-cr cho git-mailsplit không phụ thuộc vào am.keepcr"
 
-#: builtin/am.c:2293
+#: builtin/am.c:2295
 msgid "strip everything before a scissors line"
 msgstr "cắt mọi thứ trước dòng scissors"
 
-#: builtin/am.c:2295
+#: builtin/am.c:2297
 msgid "pass it through git-mailinfo"
 msgstr "chuyển nó qua git-mailinfo"
 
-#: builtin/am.c:2298 builtin/am.c:2301 builtin/am.c:2304 builtin/am.c:2307
-#: builtin/am.c:2310 builtin/am.c:2313 builtin/am.c:2316 builtin/am.c:2319
-#: builtin/am.c:2325
+#: builtin/am.c:2300 builtin/am.c:2303 builtin/am.c:2306 builtin/am.c:2309
+#: builtin/am.c:2312 builtin/am.c:2315 builtin/am.c:2318 builtin/am.c:2321
+#: builtin/am.c:2327
 msgid "pass it through git-apply"
 msgstr "chuyển nó qua git-apply"
 
-#: builtin/am.c:2315 builtin/commit.c:1512 builtin/fmt-merge-msg.c:17
-#: builtin/fmt-merge-msg.c:20 builtin/grep.c:905 builtin/merge.c:261
+#: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
+#: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
 #: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
-#: builtin/rebase.c:1342 builtin/repack.c:483 builtin/repack.c:487
-#: builtin/repack.c:489 builtin/show-branch.c:650 builtin/show-ref.c:172
-#: builtin/tag.c:447 parse-options.h:155 parse-options.h:176
-#: parse-options.h:317
+#: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
+#: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
+#: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
+#: parse-options.h:316
 msgid "n"
 msgstr "n"
 
-#: builtin/am.c:2321 builtin/branch.c:672 builtin/bugreport.c:137
-#: builtin/for-each-ref.c:40 builtin/replace.c:556 builtin/tag.c:481
+#: builtin/am.c:2323 builtin/branch.c:673 builtin/bugreport.c:109
+#: builtin/for-each-ref.c:40 builtin/replace.c:556 builtin/tag.c:479
 #: builtin/verify-tag.c:38
 msgid "format"
 msgstr "định dạng"
 
-#: builtin/am.c:2322
+#: builtin/am.c:2324
 msgid "format the patch(es) are in"
 msgstr "định dạng (các) miếng vá theo"
 
-#: builtin/am.c:2328
+#: builtin/am.c:2330
 msgid "override error message when patch failure occurs"
 msgstr "đè lên các lời nhắn lỗi khi xảy ra lỗi vá nghiêm trọng"
 
-#: builtin/am.c:2330
+#: builtin/am.c:2332
 msgid "continue applying patches after resolving a conflict"
 msgstr "tiếp tục áp dụng các miếng vá sau khi giải quyết xung đột"
 
-#: builtin/am.c:2333
+#: builtin/am.c:2335
 msgid "synonyms for --continue"
 msgstr "đồng nghĩa với --continue"
 
-#: builtin/am.c:2336
+#: builtin/am.c:2338
 msgid "skip the current patch"
 msgstr "bỏ qua miếng vá hiện hành"
 
-#: builtin/am.c:2339
+#: builtin/am.c:2341
 msgid "restore the original branch and abort the patching operation"
 msgstr "phục hồi lại nhánh gốc và loại bỏ thao tác vá"
 
-#: builtin/am.c:2342
+#: builtin/am.c:2344
 msgid "abort the patching operation but keep HEAD where it is"
 msgstr "bỏ qua thao tác vá nhưng vẫn giữ HEAD nơi nó chỉ đến"
 
-#: builtin/am.c:2346
+#: builtin/am.c:2348
 msgid "show the patch being applied"
 msgstr "hiển thị miếng vá đã được áp dụng rồi"
 
-#: builtin/am.c:2351
+#: builtin/am.c:2353
 msgid "lie about committer date"
 msgstr "nói dối về ngày chuyển giao"
 
-#: builtin/am.c:2353
+#: builtin/am.c:2355
 msgid "use current timestamp for author date"
 msgstr "dùng dấu thời gian hiện tại cho ngày tác giả"
 
-#: builtin/am.c:2355 builtin/commit-tree.c:120 builtin/commit.c:1640
-#: builtin/merge.c:298 builtin/pull.c:175 builtin/rebase.c:537
-#: builtin/rebase.c:1395 builtin/revert.c:117 builtin/tag.c:462
+#: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
+#: builtin/merge.c:299 builtin/pull.c:175 builtin/rebase.c:1099
+#: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
 msgstr "mã-số-khóa"
 
-#: builtin/am.c:2356 builtin/rebase.c:538 builtin/rebase.c:1396
+#: builtin/am.c:2358 builtin/rebase.c:1100
 msgid "GPG-sign commits"
 msgstr "Các lần chuyển giao ký-GPG"
 
-#: builtin/am.c:2359
+#: builtin/am.c:2361
 msgid "(internal use for git-rebase)"
 msgstr "(dùng nội bộ cho git-rebase)"
 
-#: builtin/am.c:2377
+#: builtin/am.c:2379
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
@@ -10802,16 +11026,16 @@ msgstr ""
 "Tùy chọn -b/--binary đã không dùng từ lâu rồi, và\n"
 "nó sẽ được bỏ đi. Xin đừng sử dụng nó thêm nữa."
 
-#: builtin/am.c:2384
+#: builtin/am.c:2386
 msgid "failed to read the index"
 msgstr "gặp lỗi đọc bảng mục lục"
 
-#: builtin/am.c:2399
+#: builtin/am.c:2401
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr "thư mục rebase trước %s không sẵn có nhưng mbox lại đưa ra."
 
-#: builtin/am.c:2423
+#: builtin/am.c:2425
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
@@ -10820,11 +11044,11 @@ msgstr ""
 "Tìm thấy thư mục lạc %s.\n"
 "Dùng \"git am --abort\" để loại bỏ nó đi."
 
-#: builtin/am.c:2429
+#: builtin/am.c:2431
 msgid "Resolve operation not in progress, we are not resuming."
 msgstr "Thao tác phân giải không được tiến hành, chúng ta không phục hồi lại."
 
-#: builtin/am.c:2439
+#: builtin/am.c:2441
 msgid "interactive mode requires patches on the command line"
 msgstr "chế độ tương tác yêu cầu có các miếng vá trên dòng lệnh"
 
@@ -10832,43 +11056,34 @@ msgstr "chế độ tương tác yêu cầu có các miếng vá trên dòng l�
 msgid "git apply [<options>] [<patch>...]"
 msgstr "git apply [<các tùy chọn>] [<miếng-vá>…]"
 
-#: builtin/archive.c:17
-#, c-format
-msgid "could not create archive file '%s'"
-msgstr "không thể tạo tập tin kho (lưu trữ, nén) “%s”"
-
-#: builtin/archive.c:20
+#: builtin/archive.c:18
 msgid "could not redirect output"
 msgstr "không thể chuyển hướng kết xuất"
 
-#: builtin/archive.c:37
+#: builtin/archive.c:35
 msgid "git archive: Remote with no URL"
 msgstr "git archive: Máy chủ không có địa chỉ URL"
 
-#: builtin/archive.c:61
+#: builtin/archive.c:59
 msgid "git archive: expected ACK/NAK, got a flush packet"
 msgstr "git archive: cần ACK/NAK, nhưng lại nhận được gói flush"
 
-#: builtin/archive.c:64
+#: builtin/archive.c:62
 #, c-format
 msgid "git archive: NACK %s"
 msgstr "git archive: NACK %s"
 
-#: builtin/archive.c:65
+#: builtin/archive.c:63
 msgid "git archive: protocol error"
 msgstr "git archive: lỗi giao thức"
 
-#: builtin/archive.c:69
+#: builtin/archive.c:67
 msgid "git archive: expected a flush"
 msgstr "git archive: cần một flush (đẩy dữ liệu lên đĩa)"
 
-#: builtin/bisect--helper.c:23
+#: builtin/bisect--helper.c:24
 msgid "git bisect--helper --bisect-reset [<commit>]"
 msgstr "git bisect--helper --bisect-reset [<lần_chuyển_giao>]"
-
-#: builtin/bisect--helper.c:24
-msgid "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
-msgstr "git bisect--helper --bisect-next-check <lúc_sai> <lúc_đúng> [<term>]"
 
 #: builtin/bisect--helper.c:25
 msgid ""
@@ -10906,48 +11121,61 @@ msgstr "git bisect--helper --bisect-replay <tên_tập_tin>"
 
 #: builtin/bisect--helper.c:32
 msgid "git bisect--helper --bisect-skip [(<rev>|<range>)...]"
-msgstr "git bisect--helper --bisect-skip [(<rev>|<vùng>)...]"
+msgstr "git bisect--helper --bisect-skip [(<rev>|<vùng>)…]"
 
-#: builtin/bisect--helper.c:107
+#: builtin/bisect--helper.c:33
+msgid "git bisect--helper --bisect-visualize"
+msgstr "git bisect--helper --bisect-visualize"
+
+#: builtin/bisect--helper.c:34
+msgid "git bisect--helper --bisect-run <cmd>..."
+msgstr "git bisect--helper --bisect-run <lệnh>…"
+
+#: builtin/bisect--helper.c:109
 #, c-format
 msgid "cannot open file '%s' in mode '%s'"
 msgstr "không thể mở tập tin “%s” ở chế độ “%s”"
 
-#: builtin/bisect--helper.c:114
+#: builtin/bisect--helper.c:116
 #, c-format
 msgid "could not write to file '%s'"
 msgstr "không thể ghi vào tập tin “%s”"
 
-#: builtin/bisect--helper.c:155
+#: builtin/bisect--helper.c:154
+#, c-format
+msgid "cannot open file '%s' for reading"
+msgstr "không thể mở tập tin “%s” để đọc"
+
+#: builtin/bisect--helper.c:170
 #, c-format
 msgid "'%s' is not a valid term"
 msgstr "“%s” không phải một thời hạn hợp lệ"
 
-#: builtin/bisect--helper.c:159
+#: builtin/bisect--helper.c:174
 #, c-format
 msgid "can't use the builtin command '%s' as a term"
 msgstr "không thể dùng lệnh tích hợp “%s” như là một thời kỳ"
 
-#: builtin/bisect--helper.c:169
+#: builtin/bisect--helper.c:184
 #, c-format
 msgid "can't change the meaning of the term '%s'"
 msgstr "không thể thay đổi nghĩa của thời kỳ “%s”"
 
-#: builtin/bisect--helper.c:179
+#: builtin/bisect--helper.c:194
 msgid "please use two different terms"
 msgstr "vui lòng dùng hai thời kỳ khác nhau"
 
-#: builtin/bisect--helper.c:195
+#: builtin/bisect--helper.c:210
 #, c-format
 msgid "We are not bisecting.\n"
 msgstr "Chúng tôi đang không bisect.\n"
 
-#: builtin/bisect--helper.c:203
+#: builtin/bisect--helper.c:218
 #, c-format
 msgid "'%s' is not a valid commit"
 msgstr "“%s” không phải một lần chuyển giao hợp lệ"
 
-#: builtin/bisect--helper.c:212
+#: builtin/bisect--helper.c:227
 #, c-format
 msgid ""
 "could not check out original HEAD '%s'. Try 'git bisect reset <commit>'."
@@ -10955,27 +11183,27 @@ msgstr ""
 "không thể lấy ra HEAD nguyên thủy của “%s”. Hãy thử “git bisect reset <lần-"
 "chuyển-giao>”."
 
-#: builtin/bisect--helper.c:256
+#: builtin/bisect--helper.c:271
 #, c-format
 msgid "Bad bisect_write argument: %s"
 msgstr "Đối số bisect_write sai: %s"
 
-#: builtin/bisect--helper.c:261
+#: builtin/bisect--helper.c:276
 #, c-format
 msgid "couldn't get the oid of the rev '%s'"
 msgstr "không thể lấy oid của điểm xét duyệt “%s”"
 
-#: builtin/bisect--helper.c:273
+#: builtin/bisect--helper.c:288
 #, c-format
 msgid "couldn't open the file '%s'"
 msgstr "không thể mở tập tin “%s”"
 
-#: builtin/bisect--helper.c:299
+#: builtin/bisect--helper.c:314
 #, c-format
 msgid "Invalid command: you're currently in a %s/%s bisect"
 msgstr "Lệnh không hợp lệ: bạn hiện đang ở một bisect %s/%s"
 
-#: builtin/bisect--helper.c:326
+#: builtin/bisect--helper.c:341
 #, c-format
 msgid ""
 "You need to give me at least one %s and %s revision.\n"
@@ -10984,7 +11212,7 @@ msgstr ""
 "Bạn phải chỉ cho tôi ít nhất một điểm %s và một %s.\n"
 "Bạn có thể sử dụng \"git bisect %s\" và \"git bisect %s\" cho cái đó."
 
-#: builtin/bisect--helper.c:330
+#: builtin/bisect--helper.c:345
 #, c-format
 msgid ""
 "You need to start by \"git bisect start\".\n"
@@ -10995,7 +11223,7 @@ msgstr ""
 "Bạn sau đó cần phải chỉ cho tôi ít nhất một điểm xét duyệt %s và một %s.\n"
 "Bạn có thể sử dụng \"git bisect %s\" và \"git bisect %s\" cho chúng."
 
-#: builtin/bisect--helper.c:350
+#: builtin/bisect--helper.c:365
 #, c-format
 msgid "bisecting only with a %s commit"
 msgstr "chỉ thực hiện việc bisect với một lần chuyển giao %s"
@@ -11004,15 +11232,15 @@ msgstr "chỉ thực hiện việc bisect với một lần chuyển giao %s"
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:358
+#: builtin/bisect--helper.c:373
 msgid "Are you sure [Y/n]? "
 msgstr "Bạn có chắc chắn chưa [Y/n]? "
 
-#: builtin/bisect--helper.c:419
+#: builtin/bisect--helper.c:434
 msgid "no terms defined"
 msgstr "chưa định nghĩa thời kỳ nào"
 
-#: builtin/bisect--helper.c:422
+#: builtin/bisect--helper.c:437
 #, c-format
 msgid ""
 "Your current terms are %s for the old state\n"
@@ -11021,7 +11249,7 @@ msgstr ""
 "Bạn hiện tại đang ở thời kỳ %s cho tình trạng cũ\n"
 "và %s cho tình trạng mới.\n"
 
-#: builtin/bisect--helper.c:432
+#: builtin/bisect--helper.c:447
 #, c-format
 msgid ""
 "invalid argument %s for 'git bisect terms'.\n"
@@ -11030,52 +11258,52 @@ msgstr ""
 "tham số không hợp lệ %s cho “git bisect terms”.\n"
 "Các tùy chọn hỗ trợ là: --term-good|--term-old và --term-bad|--term-new."
 
-#: builtin/bisect--helper.c:499 builtin/bisect--helper.c:1023
+#: builtin/bisect--helper.c:514 builtin/bisect--helper.c:1038
 msgid "revision walk setup failed\n"
 msgstr "gặp lỗi cài đặt việc di chuyển qua các điểm xét duyệt\n"
 
-#: builtin/bisect--helper.c:521
+#: builtin/bisect--helper.c:536
 #, c-format
 msgid "could not open '%s' for appending"
 msgstr "không thể mở “%s” để nối thêm"
 
-#: builtin/bisect--helper.c:640 builtin/bisect--helper.c:653
+#: builtin/bisect--helper.c:655 builtin/bisect--helper.c:668
 msgid "'' is not a valid term"
 msgstr "” không phải một thời hạn hợp lệ"
 
-#: builtin/bisect--helper.c:663
+#: builtin/bisect--helper.c:678
 #, c-format
 msgid "unrecognized option: '%s'"
 msgstr "tùy chọn không được thừa nhận: “%s”"
 
-#: builtin/bisect--helper.c:667
+#: builtin/bisect--helper.c:682
 #, c-format
 msgid "'%s' does not appear to be a valid revision"
 msgstr "“%s” không có vẻ như là một điểm xét duyệt hợp lệ"
 
-#: builtin/bisect--helper.c:698
+#: builtin/bisect--helper.c:713
 msgid "bad HEAD - I need a HEAD"
 msgstr "sai HEAD - Tôi cần một HEAD"
 
-#: builtin/bisect--helper.c:713
+#: builtin/bisect--helper.c:728
 #, c-format
 msgid "checking out '%s' failed. Try 'git bisect start <valid-branch>'."
 msgstr "lấy ra “%s” ra gặp lỗi. Hãy thử \"git bisect reset <nhánh_hợp_lệ>\"."
 
-#: builtin/bisect--helper.c:734
+#: builtin/bisect--helper.c:749
 msgid "won't bisect on cg-seek'ed tree"
 msgstr "sẽ không di chuyển nửa bước trên cây được cg-seek"
 
-#: builtin/bisect--helper.c:737
+#: builtin/bisect--helper.c:752
 msgid "bad HEAD - strange symbolic ref"
 msgstr "sai HEAD - tham chiếu mềm kỳ lạ"
 
-#: builtin/bisect--helper.c:757
+#: builtin/bisect--helper.c:772
 #, c-format
 msgid "invalid ref: '%s'"
 msgstr "refspec không hợp lệ: “%s”"
 
-#: builtin/bisect--helper.c:815
+#: builtin/bisect--helper.c:830
 msgid "You need to start by \"git bisect start\"\n"
 msgstr "Bạn cần khởi đầu bằng \"git bisect start\"\n"
 
@@ -11083,105 +11311,151 @@ msgstr "Bạn cần khởi đầu bằng \"git bisect start\"\n"
 #. translation. The program will only accept English input
 #. at this point.
 #.
-#: builtin/bisect--helper.c:826
+#: builtin/bisect--helper.c:841
 msgid "Do you want me to do it for you [Y/n]? "
 msgstr "Bạn có muốn tôi thực hiện điều này cho bạn không [Y/n]? "
 
-#: builtin/bisect--helper.c:844
+#: builtin/bisect--helper.c:859
 msgid "Please call `--bisect-state` with at least one argument"
 msgstr "Hãy gọi “--bisect-state” với ít nhất một đối số"
 
-#: builtin/bisect--helper.c:857
+#: builtin/bisect--helper.c:872
 #, c-format
 msgid "'git bisect %s' can take only one argument."
 msgstr "“git bisect %s” có thể lấy chỉ một đối số."
 
-#: builtin/bisect--helper.c:869 builtin/bisect--helper.c:882
+#: builtin/bisect--helper.c:884 builtin/bisect--helper.c:897
 #, c-format
 msgid "Bad rev input: %s"
 msgstr "Đầu vào rev sai: %s"
 
-#: builtin/bisect--helper.c:889
+#: builtin/bisect--helper.c:904
 #, c-format
 msgid "Bad rev input (not a commit): %s"
 msgstr "Đầu vào rev sai (không phải là lần chuyển giao): %s"
 
-#: builtin/bisect--helper.c:921
+#: builtin/bisect--helper.c:936
 msgid "We are not bisecting."
 msgstr "Chúng tôi không bisect."
 
-#: builtin/bisect--helper.c:971
+#: builtin/bisect--helper.c:986
 #, c-format
 msgid "'%s'?? what are you talking about?"
-msgstr "'%s'?? bạn đang nói gì thế?"
+msgstr "“%s”?? bạn đang nói gì thế?"
 
-#: builtin/bisect--helper.c:983
+#: builtin/bisect--helper.c:998
 #, c-format
 msgid "cannot read file '%s' for replaying"
-msgstr "không thể đọc tập tin '%s' để thao diễn lại"
+msgstr "không thể đọc tập tin “%s” để thao diễn lại"
 
-#: builtin/bisect--helper.c:1056
+#: builtin/bisect--helper.c:1107 builtin/bisect--helper.c:1274
+msgid "bisect run failed: no command provided."
+msgstr "bisect chạy gặp lỗi: không đưa ra lệnh."
+
+#: builtin/bisect--helper.c:1116
+#, c-format
+msgid "running %s\n"
+msgstr "đang chạy %s\n"
+
+#: builtin/bisect--helper.c:1120
+#, c-format
+msgid "bisect run failed: exit code %d from '%s' is < 0 or >= 128"
+msgstr "chạy bisect gặp lỗi: mã trả về %d từ lệnh “%s” là < 0 hoặc >= 128"
+
+#: builtin/bisect--helper.c:1136
+#, c-format
+msgid "cannot open file '%s' for writing"
+msgstr "không thể mở “%s” để ghi"
+
+#: builtin/bisect--helper.c:1152
+msgid "bisect run cannot continue any more"
+msgstr "bisect không thể tiếp tục thêm được nữa"
+
+#: builtin/bisect--helper.c:1154
+#, c-format
+msgid "bisect run success"
+msgstr "bisect chạy thành công"
+
+#: builtin/bisect--helper.c:1157
+#, c-format
+msgid "bisect found first bad commit"
+msgstr "bisect tìm thấy lần chuyển giao sai đầu tiên"
+
+#: builtin/bisect--helper.c:1160
+#, c-format
+msgid ""
+"bisect run failed: 'git bisect--helper --bisect-state %s' exited with error "
+"code %d"
+msgstr ""
+"chạy bisect gặp lỗi: “git bisect--helper --bisect-state %s” đã thoát ra với "
+"mã lỗi %d"
+
+#: builtin/bisect--helper.c:1192
 msgid "reset the bisection state"
 msgstr "đặt lại trạng di chuyển nửa bước"
 
-#: builtin/bisect--helper.c:1058
+#: builtin/bisect--helper.c:1194
 msgid "check whether bad or good terms exist"
 msgstr "kiểm tra xem các thời điểm xấu/tốt có tồn tại không"
 
-#: builtin/bisect--helper.c:1060
+#: builtin/bisect--helper.c:1196
 msgid "print out the bisect terms"
 msgstr "in ra các thời điểm di chuyển nửa bước"
 
-#: builtin/bisect--helper.c:1062
+#: builtin/bisect--helper.c:1198
 msgid "start the bisect session"
 msgstr "bắt đầu phiên di chuyển nửa bước"
 
-#: builtin/bisect--helper.c:1064
+#: builtin/bisect--helper.c:1200
 msgid "find the next bisection commit"
 msgstr "tìm lần chuyển giao không di chuyển phân đôi"
 
-#: builtin/bisect--helper.c:1066
+#: builtin/bisect--helper.c:1202
 msgid "mark the state of ref (or refs)"
 msgstr "đánh dấu trạng thái ref (hoặc refs)"
 
-#: builtin/bisect--helper.c:1068
+#: builtin/bisect--helper.c:1204
 msgid "list the bisection steps so far"
 msgstr "liệt kê các bước bisection đi quá xa"
 
-#: builtin/bisect--helper.c:1070
+#: builtin/bisect--helper.c:1206
 msgid "replay the bisection process from the given file"
 msgstr "phát lại quá trình bisection từ tệp đã cho"
 
-#: builtin/bisect--helper.c:1072
+#: builtin/bisect--helper.c:1208
 msgid "skip some commits for checkout"
 msgstr "bỏ qua một số lần chuyển giao để lấy ra"
 
-#: builtin/bisect--helper.c:1074
+#: builtin/bisect--helper.c:1210
+msgid "visualize the bisection"
+msgstr "Trực quan việc di chuyển nửa bước"
+
+#: builtin/bisect--helper.c:1212
+msgid "use <cmd>... to automatically bisect."
+msgstr "dùng <cmd>… để bisect một cách tự động."
+
+#: builtin/bisect--helper.c:1214
 msgid "no log for BISECT_WRITE"
 msgstr "không có nhật ký cho BISECT_WRITE"
 
-#: builtin/bisect--helper.c:1089
+#: builtin/bisect--helper.c:1229
 msgid "--bisect-reset requires either no argument or a commit"
 msgstr ""
 "--bisect-reset requires không nhận đối số cũng không nhận lần chuyển giao"
 
-#: builtin/bisect--helper.c:1094
-msgid "--bisect-next-check requires 2 or 3 arguments"
-msgstr "--bisect-next-check cần 2 hoặc 3 tham số"
-
-#: builtin/bisect--helper.c:1100
+#: builtin/bisect--helper.c:1234
 msgid "--bisect-terms requires 0 or 1 argument"
 msgstr "--bisect-terms cần 0 hoặc 1 tham số"
 
-#: builtin/bisect--helper.c:1109
+#: builtin/bisect--helper.c:1243
 msgid "--bisect-next requires 0 arguments"
 msgstr "--bisect-next cần 0 tham số"
 
-#: builtin/bisect--helper.c:1120
+#: builtin/bisect--helper.c:1254
 msgid "--bisect-log requires 0 arguments"
 msgstr "--bisect-log cần 0 tham số"
 
-#: builtin/bisect--helper.c:1125
+#: builtin/bisect--helper.c:1259
 msgid "no logfile given"
 msgstr "chưa chỉ ra tập tin ghi nhật ký"
 
@@ -11193,152 +11467,154 @@ msgstr "git blame [<các tùy chọn>] [<rev-opts>] [<rev>] [--] <tập-tin>"
 msgid "<rev-opts> are documented in git-rev-list(1)"
 msgstr "<rev-opts> được mô tả trong tài liệu git-rev-list(1)"
 
-#: builtin/blame.c:410
+#: builtin/blame.c:406
 #, c-format
 msgid "expecting a color: %s"
 msgstr "cần một màu: %s"
 
-#: builtin/blame.c:417
+#: builtin/blame.c:413
 msgid "must end with a color"
 msgstr "phải kết thúc bằng một màu"
 
-#: builtin/blame.c:728
+#: builtin/blame.c:724
 #, c-format
 msgid "invalid color '%s' in color.blame.repeatedLines"
 msgstr "màu không hợp lệ “%s” trong color.blame.repeatedLines"
 
-#: builtin/blame.c:746
+#: builtin/blame.c:742
 msgid "invalid value for blame.coloring"
 msgstr "màu không hợp lệ cho blame.coloring"
 
-#: builtin/blame.c:845
+#: builtin/blame.c:841
 #, c-format
 msgid "cannot find revision %s to ignore"
 msgstr "không thể tìm thấy điểm xét duyệt %s để mà bỏ qua"
 
-#: builtin/blame.c:867
+#: builtin/blame.c:863
 msgid "show blame entries as we find them, incrementally"
 msgstr "hiển thị các mục “blame” như là chúng ta thấy chúng, tăng dần"
 
-#: builtin/blame.c:868
+#: builtin/blame.c:864
 msgid "do not show object names of boundary commits (Default: off)"
 msgstr ""
 "đừng hiển thị tên đối tượng của những lần chuyển giao biên giới (Mặc định: "
 "off)"
 
-#: builtin/blame.c:869
+#: builtin/blame.c:865
 msgid "do not treat root commits as boundaries (Default: off)"
 msgstr "không coi các lần chuyển giao gốc là giới hạn (Mặc định: off)"
 
-#: builtin/blame.c:870
+#: builtin/blame.c:866
 msgid "show work cost statistics"
 msgstr "hiển thị thống kê công sức làm việc"
 
-#: builtin/blame.c:871 builtin/checkout.c:1519 builtin/clone.c:94
-#: builtin/commit-graph.c:84 builtin/commit-graph.c:222 builtin/fetch.c:179
-#: builtin/merge.c:297 builtin/multi-pack-index.c:55 builtin/pull.c:119
-#: builtin/push.c:566 builtin/send-pack.c:198
+#: builtin/blame.c:867 builtin/checkout.c:1517 builtin/clone.c:94
+#: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
+#: builtin/merge.c:298 builtin/multi-pack-index.c:103
+#: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
+#: builtin/multi-pack-index.c:204 builtin/pull.c:119 builtin/push.c:566
+#: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "ép buộc báo cáo tiến triển công việc"
 
-#: builtin/blame.c:872
+#: builtin/blame.c:868
 msgid "show output score for blame entries"
 msgstr "hiển thị kết xuất điểm số cho các mục tin “blame”"
 
-#: builtin/blame.c:873
+#: builtin/blame.c:869
 msgid "show original filename (Default: auto)"
 msgstr "hiển thị tên tập tin gốc (Mặc định: auto)"
 
-#: builtin/blame.c:874
+#: builtin/blame.c:870
 msgid "show original linenumber (Default: off)"
 msgstr "hiển thị số dòng gốc (Mặc định: off)"
 
-#: builtin/blame.c:875
+#: builtin/blame.c:871
 msgid "show in a format designed for machine consumption"
 msgstr "hiển thị ở định dạng đã thiết kế cho dùng bằng máy"
 
-#: builtin/blame.c:876
+#: builtin/blame.c:872
 msgid "show porcelain format with per-line commit information"
 msgstr "hiển thị định dạng “porcelain” với thông tin chuyển giao mỗi dòng"
 
-#: builtin/blame.c:877
+#: builtin/blame.c:873
 msgid "use the same output mode as git-annotate (Default: off)"
 msgstr "dùng cùng chế độ xuất ra với git-annotate (Mặc định: off)"
 
-#: builtin/blame.c:878
+#: builtin/blame.c:874
 msgid "show raw timestamp (Default: off)"
 msgstr "hiển thị dấu vết thời gian dạng thô (Mặc định: off)"
 
-#: builtin/blame.c:879
+#: builtin/blame.c:875
 msgid "show long commit SHA1 (Default: off)"
 msgstr "hiển thị SHA1 của lần chuyển giao dạng dài (Mặc định: off)"
 
-#: builtin/blame.c:880
+#: builtin/blame.c:876
 msgid "suppress author name and timestamp (Default: off)"
 msgstr "không hiển thị tên tác giả và dấu vết thời gian (Mặc định: off)"
 
-#: builtin/blame.c:881
+#: builtin/blame.c:877
 msgid "show author email instead of name (Default: off)"
 msgstr "hiển thị thư điện tử của tác giả thay cho tên (Mặc định: off)"
 
-#: builtin/blame.c:882
+#: builtin/blame.c:878
 msgid "ignore whitespace differences"
 msgstr "bỏ qua các khác biệt do khoảng trắng gây ra"
 
-#: builtin/blame.c:883 builtin/log.c:1823
+#: builtin/blame.c:879 builtin/log.c:1823
 msgid "rev"
 msgstr "rev"
 
-#: builtin/blame.c:883
+#: builtin/blame.c:879
 msgid "ignore <rev> when blaming"
 msgstr "bỏ qua <rev> khi blame"
 
-#: builtin/blame.c:884
+#: builtin/blame.c:880
 msgid "ignore revisions from <file>"
 msgstr "bỏ qua các điểm xét duyệt từ <tập tin>"
 
-#: builtin/blame.c:885
+#: builtin/blame.c:881
 msgid "color redundant metadata from previous line differently"
 msgstr "siêu dữ liệu dư thừa màu từ dòng trước khác hẳn"
 
-#: builtin/blame.c:886
+#: builtin/blame.c:882
 msgid "color lines by age"
 msgstr "các dòng màu theo tuổi"
 
-#: builtin/blame.c:887
+#: builtin/blame.c:883
 msgid "spend extra cycles to find better match"
 msgstr "tiêu thụ thêm năng tài nguyên máy móc để tìm kiếm tốt hơn nữa"
 
-#: builtin/blame.c:888
+#: builtin/blame.c:884
 msgid "use revisions from <file> instead of calling git-rev-list"
 msgstr ""
 "sử dụng các điểm xét duyệt (revision) từ <tập tin> thay vì gọi “git-rev-list”"
 
-#: builtin/blame.c:889
+#: builtin/blame.c:885
 msgid "use <file>'s contents as the final image"
 msgstr "sử dụng nội dung của <tập tin> như là ảnh cuối cùng"
 
-#: builtin/blame.c:890 builtin/blame.c:891
+#: builtin/blame.c:886 builtin/blame.c:887
 msgid "score"
 msgstr "điểm số"
 
-#: builtin/blame.c:890
+#: builtin/blame.c:886
 msgid "find line copies within and across files"
 msgstr "tìm các bản sao chép dòng trong và ngang qua tập tin"
 
-#: builtin/blame.c:891
+#: builtin/blame.c:887
 msgid "find line movements within and across files"
 msgstr "tìm các di chuyển dòng trong và ngang qua tập tin"
 
-#: builtin/blame.c:892
+#: builtin/blame.c:888
 msgid "range"
 msgstr "vùng"
 
-#: builtin/blame.c:893
+#: builtin/blame.c:889
 msgid "process only line range <start>,<end> or function :<funcname>"
 msgstr "xử lý chỉ dòng vùng <đầu>,<cuối> hoặc tính năng :<funcname>"
 
-#: builtin/blame.c:945
+#: builtin/blame.c:944
 msgid "--progress can't be used with --incremental or porcelain formats"
 msgstr ""
 "--progress không được dùng cùng với --incremental hay các định dạng porcelain"
@@ -11351,17 +11627,17 @@ msgstr ""
 #. your language may need more or fewer display
 #. columns.
 #.
-#: builtin/blame.c:996
+#: builtin/blame.c:995
 msgid "4 years, 11 months ago"
 msgstr "4 năm, 11 tháng trước"
 
-#: builtin/blame.c:1112
+#: builtin/blame.c:1111
 #, c-format
 msgid "file %s has only %lu line"
 msgid_plural "file %s has only %lu lines"
 msgstr[0] "tập tin %s chỉ có %lu dòng"
 
-#: builtin/blame.c:1157
+#: builtin/blame.c:1156
 msgid "Blaming lines"
 msgstr "Các dòng blame"
 
@@ -11462,74 +11738,74 @@ msgstr "Đã xóa nhánh theo dõi máy chủ \"%s\" (từng là %s).\n"
 msgid "Deleted branch %s (was %s).\n"
 msgstr "Nhánh “%s” đã bị xóa (từng là %s)\n"
 
-#: builtin/branch.c:440 builtin/tag.c:63
+#: builtin/branch.c:441 builtin/tag.c:63
 msgid "unable to parse format string"
 msgstr "không thể phân tích chuỗi định dạng"
 
-#: builtin/branch.c:471
+#: builtin/branch.c:472
 msgid "could not resolve HEAD"
 msgstr "không thể phân giải HEAD"
 
-#: builtin/branch.c:477
+#: builtin/branch.c:478
 #, c-format
 msgid "HEAD (%s) points outside of refs/heads/"
 msgstr "HEAD (%s) chỉ bên ngoài của refs/heads/"
 
-#: builtin/branch.c:492
+#: builtin/branch.c:493
 #, c-format
 msgid "Branch %s is being rebased at %s"
 msgstr "Nhánh %s đang được cải tổ lại tại %s"
 
-#: builtin/branch.c:496
+#: builtin/branch.c:497
 #, c-format
 msgid "Branch %s is being bisected at %s"
 msgstr "Nhánh %s đang được di chuyển phân đôi (bisect) tại %s"
 
-#: builtin/branch.c:513
+#: builtin/branch.c:514
 msgid "cannot copy the current branch while not on any."
 msgstr "không thể sao chép nhánh hiện hành trong khi nó chẳng ở đâu cả."
 
-#: builtin/branch.c:515
+#: builtin/branch.c:516
 msgid "cannot rename the current branch while not on any."
 msgstr "không thể đổi tên nhánh hiện hành trong khi nó chẳng ở đâu cả."
 
-#: builtin/branch.c:526
+#: builtin/branch.c:527
 #, c-format
 msgid "Invalid branch name: '%s'"
 msgstr "Tên nhánh không hợp lệ: “%s”"
 
-#: builtin/branch.c:555
+#: builtin/branch.c:556
 msgid "Branch rename failed"
 msgstr "Gặp lỗi khi đổi tên nhánh"
 
-#: builtin/branch.c:557
+#: builtin/branch.c:558
 msgid "Branch copy failed"
 msgstr "Gặp lỗi khi sao chép nhánh"
 
-#: builtin/branch.c:561
+#: builtin/branch.c:562
 #, c-format
 msgid "Created a copy of a misnamed branch '%s'"
 msgstr "Đã tạo một bản sao của nhánh khuyết danh “%s”"
 
-#: builtin/branch.c:564
+#: builtin/branch.c:565
 #, c-format
 msgid "Renamed a misnamed branch '%s' away"
 msgstr "Đã đổi tên nhánh khuyết danh “%s” đi"
 
-#: builtin/branch.c:570
+#: builtin/branch.c:571
 #, c-format
 msgid "Branch renamed to %s, but HEAD is not updated!"
 msgstr "Nhánh bị đổi tên thành %s, nhưng HEAD lại không được cập nhật!"
 
-#: builtin/branch.c:579
+#: builtin/branch.c:580
 msgid "Branch is renamed, but update of config-file failed"
 msgstr "Nhánh bị đổi tên, nhưng cập nhật tập tin cấu hình gặp lỗi"
 
-#: builtin/branch.c:581
+#: builtin/branch.c:582
 msgid "Branch is copied, but update of config-file failed"
 msgstr "Nhánh đã được sao chép, nhưng cập nhật tập tin cấu hình gặp lỗi"
 
-#: builtin/branch.c:597
+#: builtin/branch.c:598
 #, c-format
 msgid ""
 "Please edit the description for the branch\n"
@@ -11540,180 +11816,180 @@ msgstr ""
 "  %s\n"
 "Những dòng được bắt đầu bằng “%c” sẽ được cắt bỏ.\n"
 
-#: builtin/branch.c:631
+#: builtin/branch.c:632
 msgid "Generic options"
 msgstr "Tùy chọn chung"
 
-#: builtin/branch.c:633
+#: builtin/branch.c:634
 msgid "show hash and subject, give twice for upstream branch"
 msgstr "hiển thị mã băm và chủ đề, đưa ra hai lần cho nhánh thượng nguồn"
 
-#: builtin/branch.c:634
+#: builtin/branch.c:635
 msgid "suppress informational messages"
 msgstr "không xuất các thông tin"
 
-#: builtin/branch.c:635
+#: builtin/branch.c:636
 msgid "set up tracking mode (see git-pull(1))"
 msgstr "cài đặt chế độ theo dõi (xem git-pull(1))"
 
-#: builtin/branch.c:637
+#: builtin/branch.c:638
 msgid "do not use"
 msgstr "không dùng"
 
-#: builtin/branch.c:639 builtin/rebase.c:533
+#: builtin/branch.c:640
 msgid "upstream"
 msgstr "thượng nguồn"
 
-#: builtin/branch.c:639
+#: builtin/branch.c:640
 msgid "change the upstream info"
 msgstr "thay đổi thông tin thượng nguồn"
 
-#: builtin/branch.c:640
+#: builtin/branch.c:641
 msgid "unset the upstream info"
 msgstr "bỏ đặt thông tin thượng nguồn"
 
-#: builtin/branch.c:641
+#: builtin/branch.c:642
 msgid "use colored output"
 msgstr "tô màu kết xuất"
 
-#: builtin/branch.c:642
+#: builtin/branch.c:643
 msgid "act on remote-tracking branches"
 msgstr "thao tác trên nhánh “remote-tracking”"
 
-#: builtin/branch.c:644 builtin/branch.c:646
+#: builtin/branch.c:645 builtin/branch.c:647
 msgid "print only branches that contain the commit"
 msgstr "chỉ hiển thị những nhánh mà nó chứa lần chuyển giao"
 
-#: builtin/branch.c:645 builtin/branch.c:647
+#: builtin/branch.c:646 builtin/branch.c:648
 msgid "print only branches that don't contain the commit"
 msgstr "chỉ hiển thị những nhánh mà nó không chứa lần chuyển giao"
 
-#: builtin/branch.c:650
+#: builtin/branch.c:651
 msgid "Specific git-branch actions:"
 msgstr "Hành động git-branch:"
 
-#: builtin/branch.c:651
+#: builtin/branch.c:652
 msgid "list both remote-tracking and local branches"
 msgstr "liệt kê cả nhánh “remote-tracking” và nội bộ"
 
-#: builtin/branch.c:653
+#: builtin/branch.c:654
 msgid "delete fully merged branch"
 msgstr "xóa một toàn bộ nhánh đã hòa trộn"
 
-#: builtin/branch.c:654
+#: builtin/branch.c:655
 msgid "delete branch (even if not merged)"
 msgstr "xóa nhánh (cho dù là chưa được hòa trộn)"
 
-#: builtin/branch.c:655
+#: builtin/branch.c:656
 msgid "move/rename a branch and its reflog"
 msgstr "di chuyển hay đổi tên một nhánh và reflog của nó"
 
-#: builtin/branch.c:656
+#: builtin/branch.c:657
 msgid "move/rename a branch, even if target exists"
 msgstr "di chuyển hoặc đổi tên một nhánh ngay cả khi đích đã có sẵn"
 
-#: builtin/branch.c:657
+#: builtin/branch.c:658
 msgid "copy a branch and its reflog"
 msgstr "sao chép một nhánh và reflog của nó"
 
-#: builtin/branch.c:658
+#: builtin/branch.c:659
 msgid "copy a branch, even if target exists"
 msgstr "sao chép một nhánh ngay cả khi đích đã có sẵn"
 
-#: builtin/branch.c:659
+#: builtin/branch.c:660
 msgid "list branch names"
 msgstr "liệt kê các tên nhánh"
 
-#: builtin/branch.c:660
+#: builtin/branch.c:661
 msgid "show current branch name"
 msgstr "hiển thị nhánh hiện hành"
 
-#: builtin/branch.c:661
+#: builtin/branch.c:662
 msgid "create the branch's reflog"
 msgstr "tạo reflog của nhánh"
 
-#: builtin/branch.c:663
+#: builtin/branch.c:664
 msgid "edit the description for the branch"
 msgstr "sửa mô tả cho nhánh"
 
-#: builtin/branch.c:664
+#: builtin/branch.c:665
 msgid "force creation, move/rename, deletion"
 msgstr "buộc tạo, di chuyển/đổi tên, xóa"
 
-#: builtin/branch.c:665
+#: builtin/branch.c:666
 msgid "print only branches that are merged"
 msgstr "chỉ hiển thị những nhánh mà nó được hòa trộn"
 
-#: builtin/branch.c:666
+#: builtin/branch.c:667
 msgid "print only branches that are not merged"
 msgstr "chỉ hiển thị những nhánh mà nó không được hòa trộn"
 
-#: builtin/branch.c:667
+#: builtin/branch.c:668
 msgid "list branches in columns"
 msgstr "liệt kê các nhánh trong các cột"
 
-#: builtin/branch.c:669 builtin/for-each-ref.c:44 builtin/notes.c:415
-#: builtin/notes.c:418 builtin/notes.c:581 builtin/notes.c:584
-#: builtin/tag.c:477
+#: builtin/branch.c:670 builtin/for-each-ref.c:44 builtin/notes.c:413
+#: builtin/notes.c:416 builtin/notes.c:579 builtin/notes.c:582
+#: builtin/tag.c:475
 msgid "object"
 msgstr "đối tượng"
 
-#: builtin/branch.c:670
+#: builtin/branch.c:671
 msgid "print only branches of the object"
 msgstr "chỉ hiển thị các nhánh của đối tượng"
 
-#: builtin/branch.c:671 builtin/for-each-ref.c:50 builtin/tag.c:484
+#: builtin/branch.c:672 builtin/for-each-ref.c:50 builtin/tag.c:482
 msgid "sorting and filtering are case insensitive"
 msgstr "sắp xếp và lọc là phân biệt HOA thường"
 
-#: builtin/branch.c:672 builtin/for-each-ref.c:40 builtin/tag.c:482
+#: builtin/branch.c:673 builtin/for-each-ref.c:40 builtin/tag.c:480
 #: builtin/verify-tag.c:38
 msgid "format to use for the output"
 msgstr "định dạng sẽ dùng cho đầu ra"
 
-#: builtin/branch.c:695 builtin/clone.c:794
+#: builtin/branch.c:696 builtin/clone.c:678
 msgid "HEAD not found below refs/heads!"
 msgstr "Không tìm thấy HEAD ở dưới refs/heads!"
 
-#: builtin/branch.c:719
+#: builtin/branch.c:720
 msgid "--column and --verbose are incompatible"
 msgstr "tùy chọn --column và --verbose xung khắc nhau"
 
-#: builtin/branch.c:734 builtin/branch.c:790 builtin/branch.c:799
+#: builtin/branch.c:735 builtin/branch.c:792 builtin/branch.c:801
 msgid "branch name required"
 msgstr "cần chỉ ra tên nhánh"
 
-#: builtin/branch.c:766
+#: builtin/branch.c:768
 msgid "Cannot give description to detached HEAD"
 msgstr "Không thể đưa ra mô tả HEAD đã tách rời"
 
-#: builtin/branch.c:771
+#: builtin/branch.c:773
 msgid "cannot edit description of more than one branch"
 msgstr "không thể sửa mô tả cho nhiều hơn một nhánh"
 
-#: builtin/branch.c:778
+#: builtin/branch.c:780
 #, c-format
 msgid "No commit on branch '%s' yet."
 msgstr "Vẫn chưa chuyển giao trên nhánh “%s”."
 
-#: builtin/branch.c:781
+#: builtin/branch.c:783
 #, c-format
 msgid "No branch named '%s'."
 msgstr "Không có nhánh nào có tên “%s”."
 
-#: builtin/branch.c:796
+#: builtin/branch.c:798
 msgid "too many branches for a copy operation"
 msgstr "quá nhiều nhánh dành cho thao tác sao chép"
 
-#: builtin/branch.c:805
+#: builtin/branch.c:807
 msgid "too many arguments for a rename operation"
 msgstr "quá nhiều tham số cho thao tác đổi tên"
 
-#: builtin/branch.c:810
+#: builtin/branch.c:812
 msgid "too many arguments to set new upstream"
 msgstr "quá nhiều tham số để đặt thượng nguồn mới"
 
-#: builtin/branch.c:814
+#: builtin/branch.c:816
 #, c-format
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch."
@@ -11721,30 +11997,30 @@ msgstr ""
 "không thể đặt thượng nguồn của HEAD thành %s khi mà nó chẳng chỉ đến nhánh "
 "nào cả."
 
-#: builtin/branch.c:817 builtin/branch.c:840
+#: builtin/branch.c:819 builtin/branch.c:842
 #, c-format
 msgid "no such branch '%s'"
 msgstr "không có nhánh nào như thế “%s”"
 
-#: builtin/branch.c:821
+#: builtin/branch.c:823
 #, c-format
 msgid "branch '%s' does not exist"
 msgstr "chưa có nhánh “%s”"
 
-#: builtin/branch.c:834
+#: builtin/branch.c:836
 msgid "too many arguments to unset upstream"
 msgstr "quá nhiều tham số để bỏ đặt thượng nguồn"
 
-#: builtin/branch.c:838
+#: builtin/branch.c:840
 msgid "could not unset upstream of HEAD when it does not point to any branch."
 msgstr "không thể bỏ đặt thượng nguồn của HEAD không chỉ đến một nhánh nào cả."
 
-#: builtin/branch.c:844
+#: builtin/branch.c:846
 #, c-format
 msgid "Branch '%s' has no upstream information"
 msgstr "Nhánh “%s” không có thông tin thượng nguồn"
 
-#: builtin/branch.c:854
+#: builtin/branch.c:856
 msgid ""
 "The -a, and -r, options to 'git branch' do not take a branch name.\n"
 "Did you mean to use: -a|-r --list <pattern>?"
@@ -11753,7 +12029,7 @@ msgstr ""
 "nhánh.\n"
 "Có phải ý bạn là dùng: -a|-r --list <mẫu>?"
 
-#: builtin/branch.c:858
+#: builtin/branch.c:860
 msgid ""
 "the '--set-upstream' option is no longer supported. Please use '--track' or "
 "'--set-upstream-to' instead."
@@ -11761,33 +12037,33 @@ msgstr ""
 "tùy chọn --set-upstream đã không còn được hỗ trợ nữa. Vui lòng dùng “--"
 "track” hoặc “--set-upstream-to” để thay thế."
 
-#: builtin/bugreport.c:15
+#: builtin/bugreport.c:16
 msgid "git version:\n"
 msgstr "phiên bản git:\n"
 
-#: builtin/bugreport.c:21
+#: builtin/bugreport.c:22
 #, c-format
 msgid "uname() failed with error '%s' (%d)\n"
 msgstr "uname() gặp lỗi “%s” (%d)\n"
 
-#: builtin/bugreport.c:31
+#: builtin/bugreport.c:32
 msgid "compiler info: "
 msgstr "thông tin trình biên dịch: "
 
-#: builtin/bugreport.c:34
+#: builtin/bugreport.c:35
 msgid "libc info: "
 msgstr "thông tin libc: "
 
-#: builtin/bugreport.c:80
+#: builtin/bugreport.c:49
 msgid "not run from a git repository - no hooks to show\n"
 msgstr "không chạy từ một kho git - nên chẳng có móc nào để mà hiển thị cả\n"
 
-#: builtin/bugreport.c:90
+#: builtin/bugreport.c:62
 msgid "git bugreport [-o|--output-directory <file>] [-s|--suffix <format>]"
 msgstr ""
 "git bugreport [-o|--output-directory <tập_tin>] [-s|--suffix <định_dạng>]"
 
-#: builtin/bugreport.c:97
+#: builtin/bugreport.c:69
 msgid ""
 "Thank you for filling out a Git bug report!\n"
 "Please answer the following questions to help us understand your issue.\n"
@@ -11821,39 +12097,34 @@ msgstr ""
 "Vui lòng xen xét phần còn lại của báo cáo lỗi bên dưới.\n"
 "Bạn có thể xóa bất kỳ dòng nào bạn không muốn chia sẻ.\n"
 
-#: builtin/bugreport.c:136
+#: builtin/bugreport.c:108
 msgid "specify a destination for the bugreport file"
 msgstr "chỉ định thư mục định để tạo tập tin báo cáo lỗi"
 
-#: builtin/bugreport.c:138
+#: builtin/bugreport.c:110
 msgid "specify a strftime format suffix for the filename"
 msgstr ""
 "chỉ định chuỗi định dạng thời gian strftime dùng làm hậu tố cho tên tập tin"
 
-#: builtin/bugreport.c:160
+#: builtin/bugreport.c:132
 #, c-format
 msgid "could not create leading directories for '%s'"
 msgstr "không thể tạo các thư mục dẫn đầu cho “%s”"
 
-#: builtin/bugreport.c:167
+#: builtin/bugreport.c:139
 msgid "System Info"
 msgstr "Thông tin hệ thống"
 
-#: builtin/bugreport.c:170
+#: builtin/bugreport.c:142
 msgid "Enabled Hooks"
 msgstr "Các Móc đã được bật"
 
-#: builtin/bugreport.c:177
-#, c-format
-msgid "couldn't create a new file at '%s'"
-msgstr "không thể tạo tập tin mới tại “%s”"
-
-#: builtin/bugreport.c:180
+#: builtin/bugreport.c:149
 #, c-format
 msgid "unable to write to %s"
 msgstr "không thể ghi vào %s"
 
-#: builtin/bugreport.c:190
+#: builtin/bugreport.c:159
 #, c-format
 msgid "Created new report at '%s'.\n"
 msgstr "Đã tạo báo cáo mới tại “%s”\n"
@@ -11874,53 +12145,53 @@ msgstr "git bundle list-heads <tập tin> [<tên tham chiếu>…]"
 msgid "git bundle unbundle <file> [<refname>...]"
 msgstr "git bundle unbundle <tập tin> [<tên tham chiếu>…]"
 
-#: builtin/bundle.c:67 builtin/pack-objects.c:3907
+#: builtin/bundle.c:65 builtin/pack-objects.c:3876
 msgid "do not show progress meter"
 msgstr "không hiển thị bộ đo tiến trình"
 
-#: builtin/bundle.c:69 builtin/pack-objects.c:3909
+#: builtin/bundle.c:67 builtin/bundle.c:167 builtin/pack-objects.c:3878
 msgid "show progress meter"
 msgstr "hiển thị bộ đo tiến trình"
 
-#: builtin/bundle.c:71 builtin/pack-objects.c:3911
+#: builtin/bundle.c:69 builtin/pack-objects.c:3880
 msgid "show progress meter during object writing phase"
 msgstr "hiển thị bộ đo tiến triển trong suốt pha ghi đối tượng"
 
-#: builtin/bundle.c:74 builtin/pack-objects.c:3914
+#: builtin/bundle.c:72 builtin/pack-objects.c:3883
 msgid "similar to --all-progress when progress meter is shown"
 msgstr "tương tự --all-progress khi bộ đo tiến trình được xuất hiện"
 
-#: builtin/bundle.c:76
+#: builtin/bundle.c:74
 msgid "specify bundle format version"
 msgstr "chỉ điịnh định dạng cho bundle"
 
-#: builtin/bundle.c:96
+#: builtin/bundle.c:94
 msgid "Need a repository to create a bundle."
 msgstr "Cần một kho chứa để có thể tạo một bundle."
 
-#: builtin/bundle.c:109
+#: builtin/bundle.c:107
 msgid "do not show bundle details"
 msgstr "không hiển thị chi tiết bundle (bó)"
 
-#: builtin/bundle.c:128
+#: builtin/bundle.c:126
 #, c-format
 msgid "%s is okay\n"
 msgstr "“%s” tốt\n"
 
-#: builtin/bundle.c:179
+#: builtin/bundle.c:182
 msgid "Need a repository to unbundle."
 msgstr "Cần một kho chứa để có thể giải nén một bundle."
 
-#: builtin/bundle.c:191 builtin/remote.c:1700
-msgid "be verbose; must be placed before a subcommand"
-msgstr "chi tiết; phải được đặt trước một lệnh-con"
+#: builtin/bundle.c:185
+msgid "Unbundling objects"
+msgstr "Tháo rời các đối tượng"
 
-#: builtin/bundle.c:213 builtin/remote.c:1731
+#: builtin/bundle.c:219 builtin/remote.c:1733
 #, c-format
 msgid "Unknown subcommand: %s"
 msgstr "Không hiểu câu lệnh con: %s"
 
-#: builtin/cat-file.c:596
+#: builtin/cat-file.c:622
 msgid ""
 "git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e | -"
 "p | <type> | --textconv | --filters) [--path=<path>] <object>"
@@ -11928,7 +12199,7 @@ msgstr ""
 "git cat-file (-t [--allow-unknown-type] | -s [--allow-unknown-type] | -e | -"
 "p | <kiểu> | --textconv) | --filters) [--path=<đường/dẫn>] <đối_tượng>"
 
-#: builtin/cat-file.c:597
+#: builtin/cat-file.c:623
 msgid ""
 "git cat-file (--batch[=<format>] | --batch-check[=<format>]) [--follow-"
 "symlinks] [--textconv | --filters]"
@@ -11936,72 +12207,72 @@ msgstr ""
 "git cat-file (--batch[=<định dạng>] | --batch-check[=<định dạng>]) [--follow-"
 "symlinks] [--textconv | --filters]"
 
-#: builtin/cat-file.c:618
+#: builtin/cat-file.c:644
 msgid "only one batch option may be specified"
 msgstr "chỉ một tùy chọn batch được chỉ ra"
 
-#: builtin/cat-file.c:636
+#: builtin/cat-file.c:662
 msgid "<type> can be one of: blob, tree, commit, tag"
 msgstr "<kiểu> là một trong số: blob, tree, commit hoặc tag"
 
-#: builtin/cat-file.c:637
+#: builtin/cat-file.c:663
 msgid "show object type"
 msgstr "hiển thị kiểu đối tượng"
 
-#: builtin/cat-file.c:638
+#: builtin/cat-file.c:664
 msgid "show object size"
 msgstr "hiển thị kích thước đối tượng"
 
-#: builtin/cat-file.c:640
+#: builtin/cat-file.c:666
 msgid "exit with zero when there's no error"
 msgstr "thoát với 0 khi không có lỗi"
 
-#: builtin/cat-file.c:641
+#: builtin/cat-file.c:667
 msgid "pretty-print object's content"
 msgstr "in nội dung đối tượng dạng dễ đọc"
 
-#: builtin/cat-file.c:643
+#: builtin/cat-file.c:669
 msgid "for blob objects, run textconv on object's content"
 msgstr "với đối tượng blob, chạy lệnh textconv trên nội dung của đối tượng"
 
-#: builtin/cat-file.c:645
+#: builtin/cat-file.c:671
 msgid "for blob objects, run filters on object's content"
 msgstr "với đối tượng blob, chạy lệnh filters trên nội dung của đối tượng"
 
-#: builtin/cat-file.c:646
+#: builtin/cat-file.c:672
 msgid "blob"
 msgstr "blob"
 
-#: builtin/cat-file.c:647
+#: builtin/cat-file.c:673
 msgid "use a specific path for --textconv/--filters"
 msgstr "dùng một đường dẫn rõ ràng cho --textconv/--filters"
 
-#: builtin/cat-file.c:649
+#: builtin/cat-file.c:675
 msgid "allow -s and -t to work with broken/corrupt objects"
 msgstr "cho phép -s và -t để làm việc với các đối tượng sai/hỏng"
 
-#: builtin/cat-file.c:650
+#: builtin/cat-file.c:676
 msgid "buffer --batch output"
 msgstr "đệm kết xuất --batch"
 
-#: builtin/cat-file.c:652
+#: builtin/cat-file.c:678
 msgid "show info and content of objects fed from the standard input"
 msgstr ""
 "hiển thị thông tin và nội dung của các đối tượng lấy từ đầu vào tiêu chuẩn"
 
-#: builtin/cat-file.c:656
+#: builtin/cat-file.c:682
 msgid "show info about objects fed from the standard input"
 msgstr "hiển thị các thông tin về đối tượng fed  từ đầu vào tiêu chuẩn"
 
-#: builtin/cat-file.c:660
+#: builtin/cat-file.c:686
 msgid "follow in-tree symlinks (used with --batch or --batch-check)"
 msgstr "theo liên kết mềm trong-cây (được dùng với --batch hay --batch-check)"
 
-#: builtin/cat-file.c:662
+#: builtin/cat-file.c:688
 msgid "show all objects with --batch or --batch-check"
 msgstr "hiển thị mọi đối tượng với --batch hay --batch-check"
 
-#: builtin/cat-file.c:664
+#: builtin/cat-file.c:690
 msgid "do not order --batch-all-objects output"
 msgstr "đừng sắp xếp đầu ra --batch-all-objects"
 
@@ -12021,7 +12292,7 @@ msgstr "báo cáo tất cả các thuộc tính đặt trên tập tin"
 msgid "use .gitattributes only from the index"
 msgstr "chỉ dùng .gitattributes từ bảng mục lục"
 
-#: builtin/check-attr.c:23 builtin/check-ignore.c:25 builtin/hash-object.c:102
+#: builtin/check-attr.c:23 builtin/check-ignore.c:25 builtin/hash-object.c:100
 msgid "read file names from stdin"
 msgstr "đọc tên tập tin từ đầu vào tiêu chuẩn"
 
@@ -12029,8 +12300,8 @@ msgstr "đọc tên tập tin từ đầu vào tiêu chuẩn"
 msgid "terminate input and output records by a NUL character"
 msgstr "chấm dứt các bản ghi vào và ra bằng ký tự NULL"
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1515 builtin/gc.c:549
-#: builtin/worktree.c:493
+#: builtin/check-ignore.c:21 builtin/checkout.c:1513 builtin/gc.c:549
+#: builtin/worktree.c:494
 msgid "suppress progress reporting"
 msgstr "chặn các báo cáo tiến trình hoạt động"
 
@@ -12088,11 +12359,10 @@ msgid "git checkout--worker [<options>]"
 msgstr "git checkout--worker [<các tùy chọn>]"
 
 #: builtin/checkout--worker.c:118 builtin/checkout-index.c:201
-#: builtin/column.c:31 builtin/submodule--helper.c:1892
-#: builtin/submodule--helper.c:1895 builtin/submodule--helper.c:1903
-#: builtin/submodule--helper.c:2350 builtin/submodule--helper.c:2896
-#: builtin/submodule--helper.c:2899 builtin/worktree.c:491
-#: builtin/worktree.c:728
+#: builtin/column.c:31 builtin/column.c:32 builtin/submodule--helper.c:1863
+#: builtin/submodule--helper.c:1866 builtin/submodule--helper.c:1874
+#: builtin/submodule--helper.c:2510 builtin/submodule--helper.c:2576
+#: builtin/worktree.c:492 builtin/worktree.c:729
 msgid "string"
 msgstr "chuỗi"
 
@@ -12242,11 +12512,11 @@ msgstr "“%s” hay “%s” không thể được sử dụng với %s"
 msgid "path '%s' is unmerged"
 msgstr "đường dẫn “%s” không được hòa trộn"
 
-#: builtin/checkout.c:734
+#: builtin/checkout.c:736
 msgid "you need to resolve your current index first"
 msgstr "bạn cần phải giải quyết bảng mục lục hiện tại của bạn trước đã"
 
-#: builtin/checkout.c:788
+#: builtin/checkout.c:786
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -12256,50 +12526,50 @@ msgstr ""
 "sau:\n"
 "%s"
 
-#: builtin/checkout.c:881
+#: builtin/checkout.c:879
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Không thể thực hiện reflog cho “%s”: %s\n"
 
-#: builtin/checkout.c:923
+#: builtin/checkout.c:921
 msgid "HEAD is now at"
 msgstr "HEAD hiện giờ tại"
 
-#: builtin/checkout.c:927 builtin/clone.c:725 t/helper/test-fast-rebase.c:203
+#: builtin/checkout.c:925 builtin/clone.c:609 t/helper/test-fast-rebase.c:203
 msgid "unable to update HEAD"
 msgstr "không thể cập nhật HEAD"
 
-#: builtin/checkout.c:931
+#: builtin/checkout.c:929
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Đặt lại nhánh “%s”\n"
 
-#: builtin/checkout.c:934
+#: builtin/checkout.c:932
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Đã sẵn sàng trên “%s”\n"
 
-#: builtin/checkout.c:938
+#: builtin/checkout.c:936
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Đã chuyển tới và đặt lại nhánh “%s”\n"
 
-#: builtin/checkout.c:940 builtin/checkout.c:1371
+#: builtin/checkout.c:938 builtin/checkout.c:1369
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Đã chuyển đến nhánh mới “%s”\n"
 
-#: builtin/checkout.c:942
+#: builtin/checkout.c:940
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Đã chuyển đến nhánh “%s”\n"
 
-#: builtin/checkout.c:993
+#: builtin/checkout.c:991
 #, c-format
 msgid " ... and %d more.\n"
 msgstr " … và nhiều hơn %d.\n"
 
-#: builtin/checkout.c:999
+#: builtin/checkout.c:997
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -12318,7 +12588,7 @@ msgstr[0] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:1018
+#: builtin/checkout.c:1016
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -12339,19 +12609,19 @@ msgstr[0] ""
 " git branch <tên_nhánh_mới> %s\n"
 "\n"
 
-#: builtin/checkout.c:1053
+#: builtin/checkout.c:1051
 msgid "internal error in revision walk"
 msgstr "lỗi nội bộ trong khi di chuyển qua các điểm xét duyệt"
 
-#: builtin/checkout.c:1057
+#: builtin/checkout.c:1055
 msgid "Previous HEAD position was"
 msgstr "Vị trí trước kia của HEAD là"
 
-#: builtin/checkout.c:1097 builtin/checkout.c:1366
+#: builtin/checkout.c:1095 builtin/checkout.c:1364
 msgid "You are on a branch yet to be born"
 msgstr "Bạn tại nhánh mà nó chưa hề được sinh ra"
 
-#: builtin/checkout.c:1179
+#: builtin/checkout.c:1177
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
@@ -12360,7 +12630,7 @@ msgstr ""
 "“%s” không thể là cả tập tin nội bộ và một nhánh theo dõi.\n"
 "Vui long dùng -- (và tùy chọn thêm --no-guess) để tránh lẫn lộn"
 
-#: builtin/checkout.c:1186
+#: builtin/checkout.c:1184
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -12380,51 +12650,51 @@ msgstr ""
 "chưa rõ ràng, ví dụ máy chủ “origin”, cân nhắc cài đặt\n"
 "checkout.defaultRemote=origin trong cấu hình của bạn."
 
-#: builtin/checkout.c:1196
+#: builtin/checkout.c:1194
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "“%s” khớp với nhiều (%d) nhánh máy chủ được theo dõi"
 
-#: builtin/checkout.c:1262
+#: builtin/checkout.c:1260
 msgid "only one reference expected"
 msgstr "chỉ cần một tham chiếu"
 
-#: builtin/checkout.c:1279
+#: builtin/checkout.c:1277
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "chỉ cần một tham chiếu, nhưng lại đưa ra %d."
 
-#: builtin/checkout.c:1325 builtin/worktree.c:268 builtin/worktree.c:436
+#: builtin/checkout.c:1323 builtin/worktree.c:269 builtin/worktree.c:437
 #, c-format
 msgid "invalid reference: %s"
 msgstr "tham chiếu không hợp lệ: %s"
 
-#: builtin/checkout.c:1338 builtin/checkout.c:1707
+#: builtin/checkout.c:1336 builtin/checkout.c:1705
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "tham chiếu không phải là một cây:%s"
 
-#: builtin/checkout.c:1385
+#: builtin/checkout.c:1383
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "cần một nhánh, nhưng lại nhận được thẻ “%s”"
 
-#: builtin/checkout.c:1387
+#: builtin/checkout.c:1385
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "cần một nhánh, nhưng lại nhận được nhánh máy phục vụ “%s”"
 
-#: builtin/checkout.c:1388 builtin/checkout.c:1396
+#: builtin/checkout.c:1386 builtin/checkout.c:1394
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "cần một nhánh, nhưng lại nhận được “%s”"
 
-#: builtin/checkout.c:1391
+#: builtin/checkout.c:1389
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "cần một nhánh, nhưng lại nhận được “%s”"
 
-#: builtin/checkout.c:1407
+#: builtin/checkout.c:1405
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -12432,7 +12702,7 @@ msgstr ""
 "không thể chuyển nhánh trong khi đang hòa trộn\n"
 "Cân nhắc dung \"git merge --quit\" hoặc \"git worktree add\"."
 
-#: builtin/checkout.c:1411
+#: builtin/checkout.c:1409
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
@@ -12440,7 +12710,7 @@ msgstr ""
 "không thể chuyển nhanh ở giữa một phiên am\n"
 "Cân nhắc dùng \"git am --quit\" hoặc \"git worktree add\"."
 
-#: builtin/checkout.c:1415
+#: builtin/checkout.c:1413
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
@@ -12448,7 +12718,7 @@ msgstr ""
 "không thể chuyển nhánh trong khi cải tổ\n"
 "Cân nhắc dùng \"git rebase --quit\" hay \"git worktree add\"."
 
-#: builtin/checkout.c:1419
+#: builtin/checkout.c:1417
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
@@ -12456,7 +12726,7 @@ msgstr ""
 "không thể chuyển nhánh trong khi  cherry-picking\n"
 "Cân nhắc dùng \"git cherry-pick --quit\" hay \"git worktree add\"."
 
-#: builtin/checkout.c:1423
+#: builtin/checkout.c:1421
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -12464,143 +12734,143 @@ msgstr ""
 "không thể chuyển nhánh trong khi hoàn nguyên\n"
 "Cân nhắc dùng \"git revert --quit\" hoặc \"git worktree add\"."
 
-#: builtin/checkout.c:1427
+#: builtin/checkout.c:1425
 msgid "you are switching branch while bisecting"
 msgstr ""
 "bạn hiện tại đang thực hiện việc chuyển nhánh trong khi đang di chuyển nửa "
 "bước"
 
-#: builtin/checkout.c:1434
+#: builtin/checkout.c:1432
 msgid "paths cannot be used with switching branches"
 msgstr "các đường dẫn không thể dùng cùng với các nhánh chuyển"
 
-#: builtin/checkout.c:1437 builtin/checkout.c:1441 builtin/checkout.c:1445
+#: builtin/checkout.c:1435 builtin/checkout.c:1439 builtin/checkout.c:1443
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "“%s” không thể được sử dụng với các nhánh chuyển"
 
-#: builtin/checkout.c:1449 builtin/checkout.c:1452 builtin/checkout.c:1455
-#: builtin/checkout.c:1460 builtin/checkout.c:1465
+#: builtin/checkout.c:1447 builtin/checkout.c:1450 builtin/checkout.c:1453
+#: builtin/checkout.c:1458 builtin/checkout.c:1463
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "“%s” không thể được dùng với “%s”"
 
-#: builtin/checkout.c:1462
+#: builtin/checkout.c:1460
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "“%s” không thể nhận <điểm-đầu>"
 
-#: builtin/checkout.c:1470
+#: builtin/checkout.c:1468
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "Không thể chuyển nhánh đến một thứ không phải là lần chuyển giao “%s”"
 
-#: builtin/checkout.c:1477
+#: builtin/checkout.c:1475
 msgid "missing branch or commit argument"
 msgstr "thiếu tham số là nhánh hoặc lần chuyển giao"
 
-#: builtin/checkout.c:1520
+#: builtin/checkout.c:1518
 msgid "perform a 3-way merge with the new branch"
 msgstr "thực hiện hòa trộn kiểu 3-way với nhánh mới"
 
-#: builtin/checkout.c:1521 builtin/log.c:1810 parse-options.h:323
+#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:322
 msgid "style"
 msgstr "kiểu"
 
-#: builtin/checkout.c:1522
+#: builtin/checkout.c:1520
 msgid "conflict style (merge or diff3)"
 msgstr "xung đột kiểu (hòa trộn hoặc diff3)"
 
-#: builtin/checkout.c:1534 builtin/worktree.c:488
+#: builtin/checkout.c:1532 builtin/worktree.c:489
 msgid "detach HEAD at named commit"
 msgstr "rời bỏ HEAD tại lần chuyển giao theo tên"
 
-#: builtin/checkout.c:1535
+#: builtin/checkout.c:1533
 msgid "set upstream info for new branch"
 msgstr "đặt thông tin thượng nguồn cho nhánh mới"
 
-#: builtin/checkout.c:1537
+#: builtin/checkout.c:1535
 msgid "force checkout (throw away local modifications)"
 msgstr "ép buộc lấy ra (bỏ đi những thay đổi nội bộ)"
 
-#: builtin/checkout.c:1539
+#: builtin/checkout.c:1537
 msgid "new-branch"
 msgstr "nhánh-mới"
 
-#: builtin/checkout.c:1539
+#: builtin/checkout.c:1537
 msgid "new unparented branch"
 msgstr "nhánh không cha mới"
 
-#: builtin/checkout.c:1541 builtin/merge.c:301
+#: builtin/checkout.c:1539 builtin/merge.c:302
 msgid "update ignored files (default)"
 msgstr "cập nhật các tập tin bị bỏ qua (mặc định)"
 
-#: builtin/checkout.c:1544
+#: builtin/checkout.c:1542
 msgid "do not check if another worktree is holding the given ref"
 msgstr "không kiểm tra nếu cây làm việc khác đang giữ tham chiếu đã cho"
 
-#: builtin/checkout.c:1557
+#: builtin/checkout.c:1555
 msgid "checkout our version for unmerged files"
 msgstr ""
 "lấy ra (checkout) phiên bản của chúng ta cho các tập tin chưa được hòa trộn"
 
-#: builtin/checkout.c:1560
+#: builtin/checkout.c:1558
 msgid "checkout their version for unmerged files"
 msgstr ""
 "lấy ra (checkout) phiên bản của chúng họ cho các tập tin chưa được hòa trộn"
 
-#: builtin/checkout.c:1564
+#: builtin/checkout.c:1562
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "không giới hạn đặc tả đường dẫn thành chỉ các mục rải rác"
 
-#: builtin/checkout.c:1622
+#: builtin/checkout.c:1620
 #, c-format
 msgid "-%c, -%c and --orphan are mutually exclusive"
 msgstr "-%c, -%c và --orphan loại từ lẫn nhau"
 
-#: builtin/checkout.c:1626
+#: builtin/checkout.c:1624
 msgid "-p and --overlay are mutually exclusive"
 msgstr "-p và --overlay loại từ lẫn nhau"
 
-#: builtin/checkout.c:1663
+#: builtin/checkout.c:1661
 msgid "--track needs a branch name"
 msgstr "--track cần tên một nhánh"
 
-#: builtin/checkout.c:1668
+#: builtin/checkout.c:1666
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "thiếu tên nhánh; hãy thử -%c"
 
-#: builtin/checkout.c:1700
+#: builtin/checkout.c:1698
 #, c-format
 msgid "could not resolve %s"
 msgstr "không thể phân giải “%s”"
 
-#: builtin/checkout.c:1716
+#: builtin/checkout.c:1714
 msgid "invalid path specification"
 msgstr "đường dẫn đã cho không hợp lệ"
 
-#: builtin/checkout.c:1723
+#: builtin/checkout.c:1721
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr ""
 "“%s” không phải là một lần chuyển giao và một nhánh'%s” không thể được tạo "
 "từ đó"
 
-#: builtin/checkout.c:1727
+#: builtin/checkout.c:1725
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach không nhận một đối số đường dẫn “%s”"
 
-#: builtin/checkout.c:1736
+#: builtin/checkout.c:1734
 msgid "--pathspec-from-file is incompatible with --detach"
 msgstr "--pathspec-from-file xung khắc với --detach"
 
-#: builtin/checkout.c:1739 builtin/reset.c:325 builtin/stash.c:1630
+#: builtin/checkout.c:1737 builtin/reset.c:331 builtin/stash.c:1647
 msgid "--pathspec-from-file is incompatible with --patch"
 msgstr "--pathspec-from-file xung khắc với --patch"
 
-#: builtin/checkout.c:1752
+#: builtin/checkout.c:1750
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -12608,71 +12878,71 @@ msgstr ""
 "git checkout: --ours/--theirs, --force và --merge là xung khắc với nhau khi\n"
 "checkout bảng mục lục (index)."
 
-#: builtin/checkout.c:1757
+#: builtin/checkout.c:1755
 msgid "you must specify path(s) to restore"
 msgstr "bạn phải chỉ định các thư mục muốn hồi phục"
 
-#: builtin/checkout.c:1783 builtin/checkout.c:1785 builtin/checkout.c:1834
-#: builtin/checkout.c:1836 builtin/clone.c:126 builtin/remote.c:170
-#: builtin/remote.c:172 builtin/submodule--helper.c:2736
-#: builtin/submodule--helper.c:2887 builtin/worktree.c:484
-#: builtin/worktree.c:486
+#: builtin/checkout.c:1781 builtin/checkout.c:1783 builtin/checkout.c:1832
+#: builtin/checkout.c:1834 builtin/clone.c:126 builtin/remote.c:170
+#: builtin/remote.c:172 builtin/submodule--helper.c:2958
+#: builtin/submodule--helper.c:3252 builtin/worktree.c:485
+#: builtin/worktree.c:487
 msgid "branch"
 msgstr "nhánh"
 
-#: builtin/checkout.c:1784
+#: builtin/checkout.c:1782
 msgid "create and checkout a new branch"
 msgstr "tạo và checkout một nhánh mới"
 
-#: builtin/checkout.c:1786
+#: builtin/checkout.c:1784
 msgid "create/reset and checkout a branch"
 msgstr "tạo/đặt_lại và checkout một nhánh"
 
-#: builtin/checkout.c:1787
+#: builtin/checkout.c:1785
 msgid "create reflog for new branch"
 msgstr "tạo reflog cho nhánh mới"
 
-#: builtin/checkout.c:1789
+#: builtin/checkout.c:1787
 msgid "second guess 'git checkout <no-such-branch>' (default)"
-msgstr "đoán thứ hai “git checkout <không-nhánh-nào-như-vậy>” (mặc định)"
+msgstr "gợi ý thứ hai “git checkout <không-nhánh-nào-như-vậy>” (mặc định)"
 
-#: builtin/checkout.c:1790
+#: builtin/checkout.c:1788
 msgid "use overlay mode (default)"
 msgstr "dùng chế độ che phủ (mặc định)"
 
-#: builtin/checkout.c:1835
+#: builtin/checkout.c:1833
 msgid "create and switch to a new branch"
 msgstr "tạo và chuyển đến một nhánh mới"
 
-#: builtin/checkout.c:1837
+#: builtin/checkout.c:1835
 msgid "create/reset and switch to a branch"
 msgstr "tạo/đặt_lại và chuyển đến một nhánh"
 
-#: builtin/checkout.c:1839
+#: builtin/checkout.c:1837
 msgid "second guess 'git switch <no-such-branch>'"
-msgstr "gợi ý thứ hai \"git checkout <không-nhánh-nào-như-vậy>\""
+msgstr "gợi ý thứ hai \"git switch <không-nhánh-nào-như-vậy>\""
 
-#: builtin/checkout.c:1841
+#: builtin/checkout.c:1839
 msgid "throw away local modifications"
 msgstr "vứt bỏ các sửa đổi địa phương"
 
-#: builtin/checkout.c:1875
+#: builtin/checkout.c:1873
 msgid "which tree-ish to checkout from"
 msgstr "lấy ra từ tree-ish nào"
 
-#: builtin/checkout.c:1877
+#: builtin/checkout.c:1875
 msgid "restore the index"
 msgstr "phục hồi bảng mục lục"
 
-#: builtin/checkout.c:1879
+#: builtin/checkout.c:1877
 msgid "restore the working tree (default)"
 msgstr "phục hồi cây làm việc (mặc định)"
 
-#: builtin/checkout.c:1881
+#: builtin/checkout.c:1879
 msgid "ignore unmerged entries"
 msgstr "bỏ qua những thứ chưa hòa trộn: %s"
 
-#: builtin/checkout.c:1882
+#: builtin/checkout.c:1880
 msgid "use overlay mode"
 msgstr "dùng chế độ che phủ"
 
@@ -12812,8 +13082,8 @@ msgid "remove whole directories"
 msgstr "gỡ bỏ toàn bộ thư mục"
 
 #: builtin/clean.c:906 builtin/describe.c:565 builtin/describe.c:567
-#: builtin/grep.c:923 builtin/log.c:184 builtin/log.c:186
-#: builtin/ls-files.c:650 builtin/name-rev.c:526 builtin/name-rev.c:528
+#: builtin/grep.c:937 builtin/log.c:184 builtin/log.c:186
+#: builtin/ls-files.c:648 builtin/name-rev.c:526 builtin/name-rev.c:528
 #: builtin/show-ref.c:179
 msgid "pattern"
 msgstr "mẫu"
@@ -12902,19 +13172,20 @@ msgstr "thư-mục-mẫu"
 msgid "directory from which templates will be used"
 msgstr "thư mục mà tại đó các mẫu sẽ được dùng"
 
-#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1899
-#: builtin/submodule--helper.c:2353 builtin/submodule--helper.c:2903
+#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1870
+#: builtin/submodule--helper.c:2513 builtin/submodule--helper.c:3259
 msgid "reference repository"
 msgstr "kho tham chiếu"
 
-#: builtin/clone.c:123 builtin/submodule--helper.c:1901
-#: builtin/submodule--helper.c:2355 builtin/submodule--helper.c:2905
+#: builtin/clone.c:123 builtin/submodule--helper.c:1872
+#: builtin/submodule--helper.c:2515
 msgid "use --reference only while cloning"
 msgstr "chỉ dùng --reference khi nhân bản"
 
 #: builtin/clone.c:124 builtin/column.c:27 builtin/init-db.c:550
-#: builtin/merge-file.c:46 builtin/pack-objects.c:3975 builtin/repack.c:495
-#: t/helper/test-simple-ipc.c:696 t/helper/test-simple-ipc.c:698
+#: builtin/merge-file.c:46 builtin/pack-objects.c:3944 builtin/repack.c:663
+#: builtin/submodule--helper.c:3261 t/helper/test-simple-ipc.c:595
+#: t/helper/test-simple-ipc.c:597
 msgid "name"
 msgstr "tên"
 
@@ -12930,7 +13201,7 @@ msgstr "lấy ra <nhánh> thay cho HEAD của máy chủ"
 msgid "path to git-upload-pack on the remote"
 msgstr "đường dẫn đến git-upload-pack trên máy chủ"
 
-#: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:862
+#: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
 #: builtin/pull.c:208
 msgid "depth"
 msgstr "độ-sâu"
@@ -12939,7 +13210,7 @@ msgstr "độ-sâu"
 msgid "create a shallow clone of that depth"
 msgstr "tạo bản sao không đầy đủ cho mức sâu đã cho"
 
-#: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3964
+#: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
 #: builtin/pull.c:211
 msgid "time"
 msgstr "thời-gian"
@@ -12949,7 +13220,7 @@ msgid "create a shallow clone since a specific time"
 msgstr "tạo bản sao không đầy đủ từ thời điểm đã cho"
 
 #: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1318
+#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1022
 msgid "revision"
 msgstr "điểm xét duyệt"
 
@@ -12957,8 +13228,8 @@ msgstr "điểm xét duyệt"
 msgid "deepen history of shallow clone, excluding rev"
 msgstr "làm sâu hơn lịch sử của bản sao shallow, bằng điểm xét duyệt loại trừ"
 
-#: builtin/clone.c:137 builtin/submodule--helper.c:1911
-#: builtin/submodule--helper.c:2369
+#: builtin/clone.c:137 builtin/submodule--helper.c:1882
+#: builtin/submodule--helper.c:2529
 msgid "clone only one branch, HEAD or --branch"
 msgstr "chỉ nhân bản một nhánh, HEAD hoặc --branch"
 
@@ -12989,12 +13260,12 @@ msgid "set config inside the new repository"
 msgstr "đặt cấu hình bên trong một kho chứa mới"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:196
+#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "đặc-tả-máy-phục-vụ"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:197
+#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr "tùy chọn để chuyển giao"
 
@@ -13016,50 +13287,42 @@ msgstr "mọi mô-đun-con nhân bản sẽ dung nhánh theo dõi máy chủ c�
 msgid "initialize sparse-checkout file to include only files at root"
 msgstr "khởi tạo tập tin sparse-checkout để bao gồm chỉ các tập tin ở gốc"
 
-#: builtin/clone.c:292
-msgid ""
-"No directory name could be guessed.\n"
-"Please specify a directory on the command line"
-msgstr ""
-"Không đoán được thư mục tên là gì.\n"
-"Vui lòng chỉ định tên một thư mục trên dòng lệnh"
-
-#: builtin/clone.c:345
+#: builtin/clone.c:231
 #, c-format
 msgid "info: Could not add alternate for '%s': %s\n"
 msgstr "thông tin: không thể thêm thay thế cho “%s”: %s\n"
 
-#: builtin/clone.c:418
+#: builtin/clone.c:304
 #, c-format
 msgid "%s exists and is not a directory"
 msgstr "%s có tồn tại nhưng lại không phải là một thư mục"
 
-#: builtin/clone.c:436
+#: builtin/clone.c:322
 #, c-format
 msgid "failed to start iterator over '%s'"
 msgstr "gặp lỗi khi bắt đầu lặp qua “%s”"
 
-#: builtin/clone.c:467
+#: builtin/clone.c:353
 #, c-format
 msgid "failed to create link '%s'"
 msgstr "gặp lỗi khi tạo được liên kết mềm %s"
 
-#: builtin/clone.c:471
+#: builtin/clone.c:357
 #, c-format
 msgid "failed to copy file to '%s'"
 msgstr "gặp lỗi khi sao chép tập tin và “%s”"
 
-#: builtin/clone.c:476
+#: builtin/clone.c:362
 #, c-format
 msgid "failed to iterate over '%s'"
 msgstr "gặp lỗi khi lặp qua “%s”"
 
-#: builtin/clone.c:503
+#: builtin/clone.c:389
 #, c-format
 msgid "done.\n"
 msgstr "hoàn tất.\n"
 
-#: builtin/clone.c:517
+#: builtin/clone.c:403
 msgid ""
 "Clone succeeded, but checkout failed.\n"
 "You can inspect what was checked out with 'git status'\n"
@@ -13069,105 +13332,105 @@ msgstr ""
 "Bạn kiểm tra kỹ xem cái gì được lấy ra bằng lệnh “git status”\n"
 "và thử lấy ra với lệnh “git restore --source=HEAD :/”\n"
 
-#: builtin/clone.c:594
+#: builtin/clone.c:480
 #, c-format
 msgid "Could not find remote branch %s to clone."
 msgstr "Không tìm thấy nhánh máy chủ %s để nhân bản (clone)."
 
-#: builtin/clone.c:713
+#: builtin/clone.c:597
 #, c-format
 msgid "unable to update %s"
 msgstr "không thể cập nhật %s"
 
-#: builtin/clone.c:761
+#: builtin/clone.c:645
 msgid "failed to initialize sparse-checkout"
 msgstr "gặp lỗi khi khởi tạo sparse-checkout"
 
-#: builtin/clone.c:784
+#: builtin/clone.c:668
 msgid "remote HEAD refers to nonexistent ref, unable to checkout.\n"
 msgstr "refers HEAD máy chủ  chỉ đến ref không tồn tại, không thể lấy ra.\n"
 
-#: builtin/clone.c:816
+#: builtin/clone.c:701
 msgid "unable to checkout working tree"
 msgstr "không thể lấy ra (checkout) cây làm việc"
 
-#: builtin/clone.c:894
+#: builtin/clone.c:779
 msgid "unable to write parameters to config file"
 msgstr "không thể ghi các tham số vào tập tin cấu hình"
 
-#: builtin/clone.c:957
+#: builtin/clone.c:842
 msgid "cannot repack to clean up"
 msgstr "không thể đóng gói để dọn dẹp"
 
-#: builtin/clone.c:959
+#: builtin/clone.c:844
 msgid "cannot unlink temporary alternates file"
 msgstr "không thể bỏ liên kết tập tin thay thế tạm thời"
 
-#: builtin/clone.c:1001 builtin/receive-pack.c:2490
+#: builtin/clone.c:886 builtin/receive-pack.c:2493
 msgid "Too many arguments."
 msgstr "Có quá nhiều đối số."
 
-#: builtin/clone.c:1005
+#: builtin/clone.c:890
 msgid "You must specify a repository to clone."
 msgstr "Bạn phải chỉ định một kho để mà nhân bản (clone)."
 
-#: builtin/clone.c:1018
+#: builtin/clone.c:903
 #, c-format
 msgid "--bare and --origin %s options are incompatible."
 msgstr "tùy chọn --bare và --origin %s xung khắc nhau."
 
-#: builtin/clone.c:1021
+#: builtin/clone.c:906
 msgid "--bare and --separate-git-dir are incompatible."
 msgstr "tùy chọn --bare và --separate-git-dir xung khắc nhau."
 
-#: builtin/clone.c:1035
+#: builtin/clone.c:920
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "kho chứa “%s” chưa tồn tại"
 
-#: builtin/clone.c:1039 builtin/fetch.c:2014
+#: builtin/clone.c:924 builtin/fetch.c:2029
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "độ sâu %s không phải là một số nguyên dương"
 
-#: builtin/clone.c:1049
+#: builtin/clone.c:934
 #, c-format
 msgid "destination path '%s' already exists and is not an empty directory."
 msgstr "đường dẫn đích “%s” đã có từ trước và không phải là một thư mục rỗng."
 
-#: builtin/clone.c:1055
+#: builtin/clone.c:940
 #, c-format
 msgid "repository path '%s' already exists and is not an empty directory."
 msgstr ""
 "đường dẫn kho chứa “%s” đã có từ trước và không phải là một thư mục rỗng."
 
-#: builtin/clone.c:1069
+#: builtin/clone.c:954
 #, c-format
 msgid "working tree '%s' already exists."
 msgstr "cây làm việc “%s” đã sẵn tồn tại rồi."
 
-#: builtin/clone.c:1084 builtin/clone.c:1105 builtin/difftool.c:272
-#: builtin/log.c:1997 builtin/worktree.c:280 builtin/worktree.c:312
+#: builtin/clone.c:969 builtin/clone.c:990 builtin/difftool.c:262
+#: builtin/log.c:1997 builtin/worktree.c:281 builtin/worktree.c:313
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "không thể tạo các thư mục dẫn đầu của “%s”"
 
-#: builtin/clone.c:1089
+#: builtin/clone.c:974
 #, c-format
 msgid "could not create work tree dir '%s'"
 msgstr "không thể tạo cây thư mục làm việc dir “%s”"
 
-#: builtin/clone.c:1109
+#: builtin/clone.c:994
 #, c-format
 msgid "Cloning into bare repository '%s'...\n"
 msgstr "Đang nhân bản thành kho chứa bare “%s”…\n"
 
-#: builtin/clone.c:1111
+#: builtin/clone.c:996
 #, c-format
 msgid "Cloning into '%s'...\n"
 msgstr "Đang nhân bản thành “%s”…\n"
 
-#: builtin/clone.c:1135
+#: builtin/clone.c:1025
 msgid ""
 "clone --recursive is not compatible with both --reference and --reference-if-"
 "able"
@@ -13175,50 +13438,50 @@ msgstr ""
 "nhân bản --recursive không tương thích với cả hai --reference và --reference-"
 "if-able"
 
-#: builtin/clone.c:1188 builtin/remote.c:200 builtin/remote.c:705
+#: builtin/clone.c:1080 builtin/remote.c:200 builtin/remote.c:710
 #, c-format
 msgid "'%s' is not a valid remote name"
 msgstr "“%s” không phải tên máy chủ hợp lệ"
 
-#: builtin/clone.c:1229
+#: builtin/clone.c:1121
 msgid "--depth is ignored in local clones; use file:// instead."
 msgstr "--depth bị lờ đi khi nhân bản nội bộ; hãy sử dụng file:// để thay thế."
 
-#: builtin/clone.c:1231
+#: builtin/clone.c:1123
 msgid "--shallow-since is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-since bị lờ đi khi nhân bản nội bộ; hãy sử dụng file:// để thay "
 "thế."
 
-#: builtin/clone.c:1233
+#: builtin/clone.c:1125
 msgid "--shallow-exclude is ignored in local clones; use file:// instead."
 msgstr ""
 "--shallow-exclude bị lờ đi khi nhân bản nội bộ; hãy sử dụng file:// để thay "
 "thế."
 
-#: builtin/clone.c:1235
+#: builtin/clone.c:1127
 msgid "--filter is ignored in local clones; use file:// instead."
 msgstr ""
 "--filter bị lờ đi khi nhân bản nội bộ; hãy sử dụng file:// để thay thế."
 
-#: builtin/clone.c:1240
+#: builtin/clone.c:1132
 msgid "source repository is shallow, ignoring --local"
 msgstr "kho nguồn là nông, nên bỏ qua --local"
 
-#: builtin/clone.c:1245
+#: builtin/clone.c:1137
 msgid "--local is ignored"
 msgstr "--local bị lờ đi"
 
-#: builtin/clone.c:1324 builtin/clone.c:1383
+#: builtin/clone.c:1216 builtin/clone.c:1276
 msgid "remote transport reported error"
 msgstr "vận chuyển máy mạng đã báo cáo lỗi"
 
-#: builtin/clone.c:1336 builtin/clone.c:1344
+#: builtin/clone.c:1228 builtin/clone.c:1239
 #, c-format
 msgid "Remote branch %s not found in upstream %s"
 msgstr "Nhánh máy chủ %s không tìm thấy trong thượng nguồn %s"
 
-#: builtin/clone.c:1347
+#: builtin/clone.c:1242
 msgid "You appear to have cloned an empty repository."
 msgstr "Bạn hình như là đã nhân bản một kho trống rỗng."
 
@@ -13254,14 +13517,14 @@ msgstr "chèn thêm khoảng trắng giữa các cột"
 msgid "--command must be the first argument"
 msgstr "--command phải là đối số đầu tiên"
 
-#: builtin/commit-graph.c:13 builtin/commit-graph.c:22
+#: builtin/commit-graph.c:13
 msgid ""
 "git commit-graph verify [--object-dir <objdir>] [--shallow] [--[no-]progress]"
 msgstr ""
 "git commit-graph verify [--object-dir </thư/mục/đối/tượng>] [--shallow] [--"
 "[no-]progress]"
 
-#: builtin/commit-graph.c:14 builtin/commit-graph.c:27
+#: builtin/commit-graph.c:16
 msgid ""
 "git commit-graph write [--object-dir <objdir>] [--append] [--"
 "split[=<strategy>]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
@@ -13272,101 +13535,99 @@ msgstr ""
 "paths] [--[no-]max-new-filters <n>] [--[no-]progress] <các tùy chọn chia "
 "tách>"
 
-#: builtin/commit-graph.c:64
-#, c-format
-msgid "could not find object directory matching %s"
-msgstr "không thể tìm thấy thư mục đối tượng khớp với “%s”"
-
-#: builtin/commit-graph.c:80 builtin/commit-graph.c:210
-#: builtin/commit-graph.c:316 builtin/fetch.c:191 builtin/log.c:1779
+#: builtin/commit-graph.c:51 builtin/fetch.c:191 builtin/log.c:1779
 msgid "dir"
 msgstr "tmục"
 
-#: builtin/commit-graph.c:81 builtin/commit-graph.c:211
-#: builtin/commit-graph.c:317
+#: builtin/commit-graph.c:52
 msgid "the object directory to store the graph"
 msgstr "thư mục đối tượng để lưu đồ thị"
 
-#: builtin/commit-graph.c:83
+#: builtin/commit-graph.c:73
 msgid "if the commit-graph is split, only verify the tip file"
 msgstr ""
 "nếu đồ-thị-các-lần-chuyển-giao bị chia cắt, thì chỉ thẩm tra tập tin đỉnh"
 
-#: builtin/commit-graph.c:106
+#: builtin/commit-graph.c:100
 #, c-format
 msgid "Could not open commit-graph '%s'"
 msgstr "Không thể mở đồ thị chuyển giao “%s”"
 
-#: builtin/commit-graph.c:142
+#: builtin/commit-graph.c:137
 #, c-format
 msgid "unrecognized --split argument, %s"
 msgstr "đối số --split không được thừa nhận, %s"
 
-#: builtin/commit-graph.c:155
+#: builtin/commit-graph.c:150
 #, c-format
 msgid "unexpected non-hex object ID: %s"
 msgstr "nhận được ID đối tượng không phải dạng hex không cần: %s"
 
-#: builtin/commit-graph.c:160
+#: builtin/commit-graph.c:155
 #, c-format
 msgid "invalid object: %s"
 msgstr "đối tượng không hợp lệ: %s"
 
-#: builtin/commit-graph.c:213
+#: builtin/commit-graph.c:205
 msgid "start walk at all refs"
 msgstr "bắt đầu di chuyển tại mọi tham chiếu"
 
-#: builtin/commit-graph.c:215
+#: builtin/commit-graph.c:207
 msgid "scan pack-indexes listed by stdin for commits"
 msgstr ""
 "quét dó các mục lục gói được liệt kê bởi đầu vào tiêu chuẩn cho các lần "
 "chuyển giao"
 
-#: builtin/commit-graph.c:217
+#: builtin/commit-graph.c:209
 msgid "start walk at commits listed by stdin"
 msgstr ""
 "bắt đầu di chuyển tại các lần chuyển giao được liệt kê bởi đầu vào tiêu chuẩn"
 
-#: builtin/commit-graph.c:219
+#: builtin/commit-graph.c:211
 msgid "include all commits already in the commit-graph file"
 msgstr ""
 "bao gồm mọi lần chuyển giao đã sẵn có trongười tập tin đồ-thị-các-lần-chuyển-"
 "giao"
 
-#: builtin/commit-graph.c:221
+#: builtin/commit-graph.c:213
 msgid "enable computation for changed paths"
 msgstr "cho phép tính toán các đường dẫn đã bị thay đổi"
 
-#: builtin/commit-graph.c:224
+#: builtin/commit-graph.c:215
 msgid "allow writing an incremental commit-graph file"
 msgstr "cho phép ghi một tập tin đồ họa các lần chuyển giao lớn lên"
 
-#: builtin/commit-graph.c:228
+#: builtin/commit-graph.c:219
 msgid "maximum number of commits in a non-base split commit-graph"
 msgstr ""
 "số lượng tối đa của các lần chuyển giao trong một đồ-thị-các-lần-chuyển-giao "
 "chia cắt không-cơ-sở"
 
-#: builtin/commit-graph.c:230
+#: builtin/commit-graph.c:221
 msgid "maximum ratio between two levels of a split commit-graph"
 msgstr "tỷ lệ tối đa giữa hai mức của một đồ-thị-các-lần-chuyển-giao chia cắt"
 
-#: builtin/commit-graph.c:232
+#: builtin/commit-graph.c:223
 msgid "only expire files older than a given date-time"
 msgstr "chỉ làm hết hạn các tập tin khi nó cũ hơn khoảng <thời gian> đưa ra"
 
-#: builtin/commit-graph.c:234
+#: builtin/commit-graph.c:225
 msgid "maximum number of changed-path Bloom filters to compute"
 msgstr "số tối đa các bộ lọc các đường dẫn thay đổi Bloom để tính toán"
 
-#: builtin/commit-graph.c:255
+#: builtin/commit-graph.c:251
 msgid "use at most one of --reachable, --stdin-commits, or --stdin-packs"
 msgstr ""
 "không thể sử dụng hơn một --reachable, --stdin-commits, hay --stdin-packs"
 
-#: builtin/commit-graph.c:287
+#: builtin/commit-graph.c:282
 msgid "Collecting commits from input"
 msgstr "Sưu tập các lần chuyển giao từ đầu vào"
+
+#: builtin/commit-graph.c:328 builtin/multi-pack-index.c:255
+#, c-format
+msgid "unrecognized subcommand: %s"
+msgstr "không hiểu câu lệnh con: %s"
 
 #: builtin/commit-tree.c:18
 msgid ""
@@ -13381,70 +13642,65 @@ msgstr ""
 msgid "duplicate parent %s ignored"
 msgstr "cha mẹ bị trùng lặp %s đã bị bỏ qua"
 
-#: builtin/commit-tree.c:56 builtin/commit-tree.c:136 builtin/log.c:562
+#: builtin/commit-tree.c:56 builtin/commit-tree.c:134 builtin/log.c:562
 #, c-format
 msgid "not a valid object name %s"
 msgstr "không phải là tên đối tượng hợp lệ “%s”"
 
-#: builtin/commit-tree.c:93
-#, c-format
-msgid "git commit-tree: failed to open '%s'"
-msgstr "git commit-tree: gặp lỗi khi mở “%s”"
-
-#: builtin/commit-tree.c:96
+#: builtin/commit-tree.c:94
 #, c-format
 msgid "git commit-tree: failed to read '%s'"
 msgstr "git commit-tree: gặp lỗi khi đọc “%s”"
 
-#: builtin/commit-tree.c:98
+#: builtin/commit-tree.c:96
 #, c-format
 msgid "git commit-tree: failed to close '%s'"
 msgstr "git commit-tree: gặp lỗi khi đóng “%s”"
 
-#: builtin/commit-tree.c:111
+#: builtin/commit-tree.c:109
 msgid "parent"
 msgstr "cha-mẹ"
 
-#: builtin/commit-tree.c:112
+#: builtin/commit-tree.c:110
 msgid "id of a parent commit object"
 msgstr "mã số của đối tượng chuyển giao cha mẹ"
 
-#: builtin/commit-tree.c:114 builtin/commit.c:1624 builtin/merge.c:282
-#: builtin/notes.c:409 builtin/notes.c:575 builtin/stash.c:1601
-#: builtin/tag.c:456
+#: builtin/commit-tree.c:112 builtin/commit.c:1626 builtin/merge.c:283
+#: builtin/notes.c:407 builtin/notes.c:573 builtin/stash.c:1618
+#: builtin/tag.c:454
 msgid "message"
 msgstr "chú thích"
 
-#: builtin/commit-tree.c:115 builtin/commit.c:1624
+#: builtin/commit-tree.c:113 builtin/commit.c:1626
 msgid "commit message"
 msgstr "chú thích của lần chuyển giao"
 
-#: builtin/commit-tree.c:118
+#: builtin/commit-tree.c:116
 msgid "read commit log message from file"
 msgstr "đọc chú thích nhật ký lần chuyển giao từ tập tin"
 
-#: builtin/commit-tree.c:121 builtin/commit.c:1641 builtin/merge.c:299
+#: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
 #: builtin/pull.c:176 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "Ký lần chuyển giao dùng GPG"
 
-#: builtin/commit-tree.c:133
+#: builtin/commit-tree.c:131
 msgid "must give exactly one tree"
 msgstr "phải đưa ra chính xác một cây"
 
-#: builtin/commit-tree.c:140
+#: builtin/commit-tree.c:138
 msgid "git commit-tree: failed to read"
 msgstr "git commit-tree: gặp lỗi khi đọc"
 
-#: builtin/commit.c:41
+#: builtin/commit.c:42
 msgid "git commit [<options>] [--] <pathspec>..."
 msgstr "git commit [<các tùy chọn>] [--] <pathspec>…"
 
-#: builtin/commit.c:46
+#: builtin/commit.c:47
 msgid "git status [<options>] [--] <pathspec>..."
 msgstr "git status [<các tùy chọn>] [--] <pathspec>…"
 
-#: builtin/commit.c:51
+#: builtin/commit.c:52
 msgid ""
 "You asked to amend the most recent commit, but doing so would make\n"
 "it empty. You can repeat your command with --allow-empty, or you can\n"
@@ -13457,7 +13713,7 @@ msgstr ""
 "hoặc là bạn gỡ bỏ các lần chuyển giao một cách hoàn toàn bằng lệnh:\n"
 "\"git reset HEAD^\".\n"
 
-#: builtin/commit.c:56
+#: builtin/commit.c:57
 msgid ""
 "The previous cherry-pick is now empty, possibly due to conflict resolution.\n"
 "If you wish to commit it anyway, use:\n"
@@ -13472,15 +13728,15 @@ msgstr ""
 "    git commit --allow-empty\n"
 "\n"
 
-#: builtin/commit.c:63
+#: builtin/commit.c:64
 msgid "Otherwise, please use 'git rebase --skip'\n"
 msgstr "Nếu không được thì dùng lệnh \"git rebase --skip\"\n"
 
-#: builtin/commit.c:66
+#: builtin/commit.c:67
 msgid "Otherwise, please use 'git cherry-pick --skip'\n"
 msgstr "Nếu không được thì dùng lệnh \"git cherry-pick --skip\"\n"
 
-#: builtin/commit.c:69
+#: builtin/commit.c:70
 msgid ""
 "and then use:\n"
 "\n"
@@ -13502,76 +13758,76 @@ msgstr ""
 "    git cherry-pick --skip\n"
 "\n"
 
-#: builtin/commit.c:324
+#: builtin/commit.c:325
 msgid "failed to unpack HEAD tree object"
 msgstr "gặp lỗi khi tháo dỡ HEAD đối tượng cây"
 
-#: builtin/commit.c:360
+#: builtin/commit.c:361
 msgid "--pathspec-from-file with -a does not make sense"
 msgstr "--pathspec-from-file với -a là không có ý nghĩa gì"
 
-#: builtin/commit.c:374
+#: builtin/commit.c:375
 msgid "No paths with --include/--only does not make sense."
 msgstr "Không đường dẫn với các tùy chọn --include/--only không hợp lý."
 
-#: builtin/commit.c:386
+#: builtin/commit.c:387
 msgid "unable to create temporary index"
 msgstr "không thể tạo bảng mục lục tạm thời"
 
-#: builtin/commit.c:395
+#: builtin/commit.c:396
 msgid "interactive add failed"
 msgstr "gặp lỗi khi thêm bằng cách tương"
 
-#: builtin/commit.c:410
+#: builtin/commit.c:411
 msgid "unable to update temporary index"
 msgstr "không thể cập nhật bảng mục lục tạm thời"
 
-#: builtin/commit.c:412
+#: builtin/commit.c:413
 msgid "Failed to update main cache tree"
 msgstr "Gặp lỗi khi cập nhật cây bộ nhớ đệm"
 
-#: builtin/commit.c:437 builtin/commit.c:460 builtin/commit.c:508
+#: builtin/commit.c:438 builtin/commit.c:461 builtin/commit.c:509
 msgid "unable to write new_index file"
 msgstr "không thể ghi tập tin lưu bảng mục lục mới (new_index)"
 
-#: builtin/commit.c:489
+#: builtin/commit.c:490
 msgid "cannot do a partial commit during a merge."
 msgstr ""
 "không thể thực hiện việc chuyển giao cục bộ trong khi đang được hòa trộn."
 
-#: builtin/commit.c:491
+#: builtin/commit.c:492
 msgid "cannot do a partial commit during a cherry-pick."
 msgstr ""
 "không thể thực hiện việc chuyển giao bộ phận trong khi đang cherry-pick."
 
-#: builtin/commit.c:493
+#: builtin/commit.c:494
 msgid "cannot do a partial commit during a rebase."
 msgstr ""
 "không thể thực hiện việc chuyển giao cục bộ trong khi đang thực hiện cải tổ."
 
-#: builtin/commit.c:501
+#: builtin/commit.c:502
 msgid "cannot read the index"
 msgstr "không đọc được bảng mục lục"
 
-#: builtin/commit.c:520
+#: builtin/commit.c:521
 msgid "unable to write temporary index file"
 msgstr "không thể ghi tập tin lưu bảng mục lục tạm thời"
 
-#: builtin/commit.c:618
+#: builtin/commit.c:619
 #, c-format
 msgid "commit '%s' lacks author header"
 msgstr "lần chuyển giao “%s” thiếu phần tác giả ở đầu"
 
-#: builtin/commit.c:620
+#: builtin/commit.c:621
 #, c-format
 msgid "commit '%s' has malformed author line"
 msgstr "lần chuyển giao “%s” có phần tác giả ở đầu dị dạng"
 
-#: builtin/commit.c:639
+#: builtin/commit.c:640
 msgid "malformed --author parameter"
 msgstr "đối số cho --author bị dị hình"
 
-#: builtin/commit.c:692
+#: builtin/commit.c:693
 msgid ""
 "unable to select a comment character that is not used\n"
 "in the current commit message"
@@ -13579,43 +13835,43 @@ msgstr ""
 "không thể chọn một ký tự ghi chú cái mà không được dùng\n"
 "trong phần ghi chú hiện tại"
 
-#: builtin/commit.c:746 builtin/commit.c:780 builtin/commit.c:1165
+#: builtin/commit.c:747 builtin/commit.c:781 builtin/commit.c:1166
 #, c-format
 msgid "could not lookup commit %s"
 msgstr "không thể tìm kiếm commit (lần chuyển giao) %s"
 
-#: builtin/commit.c:758 builtin/shortlog.c:413
+#: builtin/commit.c:759 builtin/shortlog.c:416
 #, c-format
 msgid "(reading log message from standard input)\n"
 msgstr "(đang đọc thông điệp nhật ký từ đầu vào tiêu chuẩn)\n"
 
-#: builtin/commit.c:760
+#: builtin/commit.c:761
 msgid "could not read log from standard input"
 msgstr "không thể đọc nhật ký từ đầu vào tiêu chuẩn"
 
-#: builtin/commit.c:764
+#: builtin/commit.c:765
 #, c-format
 msgid "could not read log file '%s'"
 msgstr "không đọc được tệp nhật ký “%s”"
 
-#: builtin/commit.c:801
+#: builtin/commit.c:802
 #, c-format
 msgid "cannot combine -m with --fixup:%s"
 msgstr "không thể kết hợp “-m” với “--fixup”:%s"
 
-#: builtin/commit.c:813 builtin/commit.c:829
+#: builtin/commit.c:814 builtin/commit.c:830
 msgid "could not read SQUASH_MSG"
 msgstr "không thể đọc SQUASH_MSG"
 
-#: builtin/commit.c:820
+#: builtin/commit.c:821
 msgid "could not read MERGE_MSG"
 msgstr "không thể đọc MERGE_MSG"
 
-#: builtin/commit.c:880
+#: builtin/commit.c:881
 msgid "could not write commit template"
 msgstr "không thể ghi mẫu chuyển giao"
 
-#: builtin/commit.c:893
+#: builtin/commit.c:894
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13624,7 +13880,7 @@ msgstr ""
 "Hãy nhập vào các thông tin để giải thích các thay đổi của bạn. Những\n"
 "dòng được bắt đầu bằng “%c” sẽ được bỏ qua.\n"
 
-#: builtin/commit.c:895
+#: builtin/commit.c:896
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13635,7 +13891,7 @@ msgstr ""
 "bắt đầu bằng “%c” sẽ được bỏ qua, nếu phần chú thích rỗng sẽ hủy bỏ lần "
 "chuyển giao.\n"
 
-#: builtin/commit.c:899
+#: builtin/commit.c:900
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13645,7 +13901,7 @@ msgstr ""
 "được\n"
 "bắt đầu bằng “%c” sẽ được bỏ qua; bạn có thể xóa chúng đi nếu muốn thế.\n"
 
-#: builtin/commit.c:903
+#: builtin/commit.c:904
 #, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
@@ -13657,7 +13913,7 @@ msgstr ""
 "bắt đầu bằng “%c” sẽ được bỏ qua; bạn có thể xóa chúng đi nếu muốn thế.\n"
 "Phần chú thích này nếu trống rỗng sẽ hủy bỏ lần chuyển giao.\n"
 
-#: builtin/commit.c:915
+#: builtin/commit.c:916
 msgid ""
 "\n"
 "It looks like you may be committing a merge.\n"
@@ -13671,7 +13927,7 @@ msgstr ""
 "\tgit update-ref -d MERGE_HEAD\n"
 "và thử lại.\n"
 
-#: builtin/commit.c:920
+#: builtin/commit.c:921
 msgid ""
 "\n"
 "It looks like you may be committing a cherry-pick.\n"
@@ -13685,76 +13941,76 @@ msgstr ""
 "\tgit update-ref -d CHERRY_PICK_HEAD\n"
 "và thử lại.\n"
 
-#: builtin/commit.c:947
+#: builtin/commit.c:948
 #, c-format
 msgid "%sAuthor:    %.*s <%.*s>"
 msgstr "%sTác giả:           %.*s <%.*s>"
 
-#: builtin/commit.c:955
+#: builtin/commit.c:956
 #, c-format
 msgid "%sDate:      %s"
 msgstr "%sNgày tháng:        %s"
 
-#: builtin/commit.c:962
+#: builtin/commit.c:963
 #, c-format
 msgid "%sCommitter: %.*s <%.*s>"
 msgstr "%sNgười chuyển giao: %.*s <%.*s>"
 
-#: builtin/commit.c:980
+#: builtin/commit.c:981
 msgid "Cannot read index"
 msgstr "Không đọc được bảng mục lục"
 
-#: builtin/commit.c:1025
+#: builtin/commit.c:1026
 msgid "unable to pass trailers to --trailers"
 msgstr "không thể chuyển phần đuôi cho “--trailers”"
 
-#: builtin/commit.c:1065
+#: builtin/commit.c:1066
 msgid "Error building trees"
 msgstr "Gặp lỗi khi xây dựng cây"
 
-#: builtin/commit.c:1079 builtin/tag.c:319
+#: builtin/commit.c:1080 builtin/tag.c:317
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr "Xin hãy cung cấp lời chú giải hoặc là dùng tùy chọn -m hoặc là -F.\n"
 
-#: builtin/commit.c:1123
+#: builtin/commit.c:1124
 #, c-format
 msgid "--author '%s' is not 'Name <email>' and matches no existing author"
 msgstr ""
 "--author “%s” không phải là “Họ và tên <thư điện tửl>” và không khớp bất kỳ "
 "tác giả nào sẵn có"
 
-#: builtin/commit.c:1137
+#: builtin/commit.c:1138
 #, c-format
 msgid "Invalid ignored mode '%s'"
 msgstr "Chế độ bỏ qua không hợp lệ “%s”"
 
-#: builtin/commit.c:1155 builtin/commit.c:1448
+#: builtin/commit.c:1156 builtin/commit.c:1450
 #, c-format
 msgid "Invalid untracked files mode '%s'"
 msgstr "Chế độ cho các tập tin chưa được theo dõi không hợp lệ “%s”"
 
-#: builtin/commit.c:1195
+#: builtin/commit.c:1196
 msgid "--long and -z are incompatible"
 msgstr "hai tùy chọn --long và -z không tương thích với nhau"
 
-#: builtin/commit.c:1226
+#: builtin/commit.c:1227
 msgid "You are in the middle of a merge -- cannot reword."
 msgstr ""
 "Bạn đang ở giữa của quá trình hòa trộn -- không thể thực hiện việc “reword”."
 
-#: builtin/commit.c:1228
+#: builtin/commit.c:1229
 msgid "You are in the middle of a cherry-pick -- cannot reword."
 msgstr ""
 "Bạn đang ở giữa của quá trình cherry-pick -- không thể thực hiện việc "
 "“reword”."
 
-#: builtin/commit.c:1231
+#: builtin/commit.c:1232
 #, c-format
 msgid "cannot combine reword option of --fixup with path '%s'"
-msgstr "không thể tổ hợp tùy chọn \"reword\" của --fixup với đường dẫn '%s'"
+msgstr "không thể tổ hợp tùy chọn \"reword\" của --fixup với đường dẫn “%s”"
 
-#: builtin/commit.c:1233
+#: builtin/commit.c:1234
 msgid ""
 "reword option of --fixup is mutually exclusive with --patch/--interactive/--"
 "all/--include/--only"
@@ -13762,109 +14018,109 @@ msgstr ""
 "tùy chọn \"reword\" của --fixup là loại trừ qua lại với --patch/--"
 "interactive/--all/--include/--only"
 
-#: builtin/commit.c:1252
+#: builtin/commit.c:1253
 msgid "Using both --reset-author and --author does not make sense"
 msgstr "Sử dụng cả hai tùy chọn --reset-author và --author không hợp lý"
 
-#: builtin/commit.c:1261
+#: builtin/commit.c:1260
 msgid "You have nothing to amend."
 msgstr "Không có gì để mà “tu bổ” cả."
 
-#: builtin/commit.c:1264
+#: builtin/commit.c:1263
 msgid "You are in the middle of a merge -- cannot amend."
 msgstr ""
 "Bạn đang ở giữa của quá trình hòa trộn -- không thể thực hiện việc “tu bổ”."
 
-#: builtin/commit.c:1266
+#: builtin/commit.c:1265
 msgid "You are in the middle of a cherry-pick -- cannot amend."
 msgstr ""
 "Bạn đang ở giữa của quá trình cherry-pick -- không thể thực hiện việc “tu "
 "bổ”."
 
-#: builtin/commit.c:1268
+#: builtin/commit.c:1267
 msgid "You are in the middle of a rebase -- cannot amend."
 msgstr ""
 "Bạn đang ở giữa của quá trình cải tổ -- nên không thể thực hiện việc “tu bổ”."
 
-#: builtin/commit.c:1271
+#: builtin/commit.c:1270
 msgid "Options --squash and --fixup cannot be used together"
 msgstr "Các tùy chọn --squash và --fixup không thể sử dụng cùng với nhau"
 
-#: builtin/commit.c:1281
+#: builtin/commit.c:1280
 msgid "Only one of -c/-C/-F/--fixup can be used."
 msgstr "Chỉ được dùng một trong số tùy chọn trong số -c/-C/-F/--fixup."
 
-#: builtin/commit.c:1283
+#: builtin/commit.c:1282
 msgid "Option -m cannot be combined with -c/-C/-F."
 msgstr "Tùy chọn -m không thể được tổ hợp cùng với -c/-C/-F."
 
-#: builtin/commit.c:1292
+#: builtin/commit.c:1291
 msgid "--reset-author can be used only with -C, -c or --amend."
 msgstr ""
 "--reset-author chỉ có thể được sử dụng với tùy chọn -C, -c hay --amend."
 
-#: builtin/commit.c:1310
+#: builtin/commit.c:1309
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
 msgstr ""
 "Chỉ một trong các tùy chọn --include/--only/--all/--interactive/--patch được "
 "sử dụng."
 
-#: builtin/commit.c:1338
+#: builtin/commit.c:1337
 #, c-format
 msgid "unknown option: --fixup=%s:%s"
 msgstr "không hiểu tùy chọn: --fixup=%s:%s"
 
-#: builtin/commit.c:1352
+#: builtin/commit.c:1354
 #, c-format
 msgid "paths '%s ...' with -a does not make sense"
 msgstr "các đường dẫn “%s …” với tùy chọn -a không hợp lý"
 
-#: builtin/commit.c:1483 builtin/commit.c:1652
+#: builtin/commit.c:1485 builtin/commit.c:1654
 msgid "show status concisely"
 msgstr "hiển thị trạng thái ở dạng súc tích"
 
-#: builtin/commit.c:1485 builtin/commit.c:1654
+#: builtin/commit.c:1487 builtin/commit.c:1656
 msgid "show branch information"
 msgstr "hiển thị thông tin nhánh"
 
-#: builtin/commit.c:1487
+#: builtin/commit.c:1489
 msgid "show stash information"
 msgstr "hiển thị thông tin về tạm cất"
 
-#: builtin/commit.c:1489 builtin/commit.c:1656
+#: builtin/commit.c:1491 builtin/commit.c:1658
 msgid "compute full ahead/behind values"
 msgstr "tính đầy đủ giá trị trước/sau"
 
-#: builtin/commit.c:1491
+#: builtin/commit.c:1493
 msgid "version"
 msgstr "phiên bản"
 
-#: builtin/commit.c:1491 builtin/commit.c:1658 builtin/push.c:551
-#: builtin/worktree.c:690
+#: builtin/commit.c:1493 builtin/commit.c:1660 builtin/push.c:551
+#: builtin/worktree.c:691
 msgid "machine-readable output"
 msgstr "kết xuất dạng máy-có-thể-đọc"
 
-#: builtin/commit.c:1494 builtin/commit.c:1660
+#: builtin/commit.c:1496 builtin/commit.c:1662
 msgid "show status in long format (default)"
 msgstr "hiển thị trạng thái ở định dạng dài (mặc định)"
 
-#: builtin/commit.c:1497 builtin/commit.c:1663
+#: builtin/commit.c:1499 builtin/commit.c:1665
 msgid "terminate entries with NUL"
 msgstr "chấm dứt các mục bằng NUL"
 
-#: builtin/commit.c:1499 builtin/commit.c:1503 builtin/commit.c:1666
-#: builtin/fast-export.c:1198 builtin/fast-export.c:1201
-#: builtin/fast-export.c:1204 builtin/rebase.c:1407 parse-options.h:337
+#: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
+#: builtin/fast-export.c:1199 builtin/fast-export.c:1202
+#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:336
 msgid "mode"
 msgstr "chế độ"
 
-#: builtin/commit.c:1500 builtin/commit.c:1666
+#: builtin/commit.c:1502 builtin/commit.c:1668
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
 "hiển thị các tập tin chưa được theo dõi  dấu vết, các chế độ tùy chọn:  all, "
 "normal, no. (Mặc định: all)"
 
-#: builtin/commit.c:1504
+#: builtin/commit.c:1506
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
@@ -13872,11 +14128,11 @@ msgstr ""
 "hiển thị các tập tin bị bỏ qua, các chế độ tùy chọn: traditional, matching, "
 "no. (Mặc định: traditional)"
 
-#: builtin/commit.c:1506 parse-options.h:193
+#: builtin/commit.c:1508 parse-options.h:192
 msgid "when"
 msgstr "khi"
 
-#: builtin/commit.c:1507
+#: builtin/commit.c:1509
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
@@ -13884,199 +14140,199 @@ msgstr ""
 "bỏ qua các thay đổi trong mô-đun-con, tùy chọn khi: all, dirty, untracked. "
 "(Mặc định: all)"
 
-#: builtin/commit.c:1509
+#: builtin/commit.c:1511
 msgid "list untracked files in columns"
 msgstr "hiển thị danh sách các tập-tin chưa được theo dõi trong các cột"
 
-#: builtin/commit.c:1510
+#: builtin/commit.c:1512
 msgid "do not detect renames"
 msgstr "không dò tìm các tên thay đổi"
 
-#: builtin/commit.c:1512
+#: builtin/commit.c:1514
 msgid "detect renames, optionally set similarity index"
 msgstr "dò các tên thay đổi, tùy ý đặt mục lục tương tự"
 
-#: builtin/commit.c:1535
+#: builtin/commit.c:1537
 msgid "Unsupported combination of ignored and untracked-files arguments"
 msgstr ""
 "Không hỗ trỡ tổ hợp các tham số các tập tin bị bỏ qua và không được theo dõi"
 
-#: builtin/commit.c:1617
+#: builtin/commit.c:1619
 msgid "suppress summary after successful commit"
 msgstr "không hiển thị tổng kết sau khi chuyển giao thành công"
 
-#: builtin/commit.c:1618
+#: builtin/commit.c:1620
 msgid "show diff in commit message template"
 msgstr "hiển thị sự khác biệt trong mẫu tin nhắn chuyển giao"
 
-#: builtin/commit.c:1620
+#: builtin/commit.c:1622
 msgid "Commit message options"
 msgstr "Các tùy chọn ghi chú commit"
 
-#: builtin/commit.c:1621 builtin/merge.c:286 builtin/tag.c:458
+#: builtin/commit.c:1623 builtin/merge.c:287 builtin/tag.c:456
 msgid "read message from file"
 msgstr "đọc chú thích từ tập tin"
 
-#: builtin/commit.c:1622
+#: builtin/commit.c:1624
 msgid "author"
 msgstr "tác giả"
 
-#: builtin/commit.c:1622
+#: builtin/commit.c:1624
 msgid "override author for commit"
 msgstr "ghi đè tác giả cho commit"
 
-#: builtin/commit.c:1623 builtin/gc.c:550
+#: builtin/commit.c:1625 builtin/gc.c:550
 msgid "date"
 msgstr "ngày tháng"
 
-#: builtin/commit.c:1623
+#: builtin/commit.c:1625
 msgid "override date for commit"
 msgstr "ghi đè ngày tháng cho lần chuyển giao"
 
-#: builtin/commit.c:1625 builtin/commit.c:1626 builtin/commit.c:1632
-#: parse-options.h:329 ref-filter.h:90
+#: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
+#: parse-options.h:328 ref-filter.h:92
 msgid "commit"
 msgstr "lần_chuyển_giao"
 
-#: builtin/commit.c:1625
+#: builtin/commit.c:1627
 msgid "reuse and edit message from specified commit"
 msgstr "dùng lại các ghi chú từ lần chuyển giao đã cho nhưng có cho sửa chữa"
 
-#: builtin/commit.c:1626
+#: builtin/commit.c:1628
 msgid "reuse message from specified commit"
 msgstr "dùng lại các ghi chú từ lần chuyển giao đã cho"
 
 #. TRANSLATORS: Leave "[(amend|reword):]" as-is,
 #. and only translate <commit>.
 #.
-#: builtin/commit.c:1631
+#: builtin/commit.c:1633
 msgid "[(amend|reword):]commit"
 msgstr "[(amend|reword):]commit"
 
-#: builtin/commit.c:1631
+#: builtin/commit.c:1633
 msgid ""
 "use autosquash formatted message to fixup or amend/reword specified commit"
 msgstr ""
 "dùng ghi chú có định dạng autosquash để sửa chữa hoặc tu bổ/reword lần "
 "chuyển giao đã chỉ ra"
 
-#: builtin/commit.c:1632
+#: builtin/commit.c:1634
 msgid "use autosquash formatted message to squash specified commit"
 msgstr ""
 "dùng lời nhắn có định dạng tự động nén để nén lại các lần chuyển giao đã chỉ "
 "ra"
 
-#: builtin/commit.c:1633
+#: builtin/commit.c:1635
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr ""
 "lần chuyển giao nhận tôi là tác giả (được dùng với tùy chọn -C/-c/--amend)"
 
-#: builtin/commit.c:1634 builtin/interpret-trailers.c:111
+#: builtin/commit.c:1636 builtin/interpret-trailers.c:111
 msgid "trailer"
 msgstr "bộ dò vết"
 
-#: builtin/commit.c:1634
+#: builtin/commit.c:1636
 msgid "add custom trailer(s)"
 msgstr "thêm đuôi tự chọn"
 
-#: builtin/commit.c:1635 builtin/log.c:1754 builtin/merge.c:302
+#: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
 #: builtin/pull.c:145 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "thêm dòng Signed-off-by vào cuối"
 
-#: builtin/commit.c:1636
+#: builtin/commit.c:1638
 msgid "use specified template file"
 msgstr "sử dụng tập tin mẫu đã cho"
 
-#: builtin/commit.c:1637
+#: builtin/commit.c:1639
 msgid "force edit of commit"
 msgstr "ép buộc sửa lần commit"
 
-#: builtin/commit.c:1639
+#: builtin/commit.c:1641
 msgid "include status in commit message template"
 msgstr "bao gồm các trạng thái trong mẫu ghi chú chuyển giao"
 
-#: builtin/commit.c:1644
+#: builtin/commit.c:1646
 msgid "Commit contents options"
 msgstr "Các tùy nội dung ghi chú commit"
 
-#: builtin/commit.c:1645
+#: builtin/commit.c:1647
 msgid "commit all changed files"
 msgstr "chuyển giao tất cả các tập tin có thay đổi"
 
-#: builtin/commit.c:1646
+#: builtin/commit.c:1648
 msgid "add specified files to index for commit"
 msgstr "thêm các tập tin đã chỉ ra vào bảng mục lục để chuyển giao"
 
-#: builtin/commit.c:1647
+#: builtin/commit.c:1649
 msgid "interactively add files"
 msgstr "thêm các tập-tin bằng tương tác"
 
-#: builtin/commit.c:1648
+#: builtin/commit.c:1650
 msgid "interactively add changes"
 msgstr "thêm các thay đổi bằng tương tác"
 
-#: builtin/commit.c:1649
+#: builtin/commit.c:1651
 msgid "commit only specified files"
 msgstr "chỉ chuyển giao các tập tin đã chỉ ra"
 
-#: builtin/commit.c:1650
+#: builtin/commit.c:1652
 msgid "bypass pre-commit and commit-msg hooks"
 msgstr "vòng qua móc (hook) pre-commit và commit-msg"
 
-#: builtin/commit.c:1651
+#: builtin/commit.c:1653
 msgid "show what would be committed"
 msgstr "hiển thị xem cái gì có thể được chuyển giao"
 
-#: builtin/commit.c:1664
+#: builtin/commit.c:1666
 msgid "amend previous commit"
 msgstr "“tu bổ” (amend) lần commit trước"
 
-#: builtin/commit.c:1665
+#: builtin/commit.c:1667
 msgid "bypass post-rewrite hook"
 msgstr "vòng qua móc (hook) post-rewrite"
 
-#: builtin/commit.c:1672
+#: builtin/commit.c:1674
 msgid "ok to record an empty change"
 msgstr "ok để ghi lại một thay đổi trống rỗng"
 
-#: builtin/commit.c:1674
+#: builtin/commit.c:1676
 msgid "ok to record a change with an empty message"
 msgstr "ok để ghi các thay đổi với lời nhắn trống rỗng"
 
-#: builtin/commit.c:1750
+#: builtin/commit.c:1752
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
 msgstr "Tập tin MERGE_HEAD sai hỏng (%s)"
 
-#: builtin/commit.c:1757
+#: builtin/commit.c:1759
 msgid "could not read MERGE_MODE"
 msgstr "không thể đọc MERGE_MODE"
 
-#: builtin/commit.c:1778
+#: builtin/commit.c:1780
 #, c-format
 msgid "could not read commit message: %s"
 msgstr "không thể đọc phần chú thích (message) của lần chuyển giao: %s"
 
-#: builtin/commit.c:1785
+#: builtin/commit.c:1787
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
 msgstr "Bãi bỏ việc chuyển giao bởi vì phần chú thích của nó trống rỗng.\n"
 
-#: builtin/commit.c:1790
+#: builtin/commit.c:1792
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
 msgstr ""
 "Đang bỏ qua việc chuyển giao; bạn đã không biên soạn phần chú thích "
 "(message).\n"
 
-#: builtin/commit.c:1801
+#: builtin/commit.c:1803
 #, c-format
 msgid "Aborting commit due to empty commit message body.\n"
 msgstr ""
 "Bãi bỏ việc chuyển giao bởi vì phần thân chú thích của nó trống rỗng.\n"
 
-#: builtin/commit.c:1837
+#: builtin/commit.c:1839
 msgid ""
 "repository has been updated, but unable to write\n"
 "new_index file. Check that disk is not full and quota is\n"
@@ -14443,7 +14699,7 @@ msgstr "in thông tin gỡ lỗi ra đầu ra lỗi tiêu chuẩn"
 msgid "credential-cache--daemon unavailable; no unix socket support"
 msgstr "credential-cache--daemon không sẵn có; không hỗ trợ unix socket"
 
-#: builtin/credential-cache.c:154
+#: builtin/credential-cache.c:180
 msgid "credential-cache unavailable; no unix socket support"
 msgstr "credential-cache không sẵn có; không hỗ trợ unix socket"
 
@@ -14643,7 +14899,7 @@ msgstr "%s…%s: không có cơ sở hòa trộn"
 msgid "Not a git repository"
 msgstr "Không phải là kho git"
 
-#: builtin/diff.c:532 builtin/grep.c:684
+#: builtin/diff.c:532 builtin/grep.c:698
 #, c-format
 msgid "invalid object '%s' given."
 msgstr "đối tượng đã cho “%s” không hợp lệ."
@@ -14669,113 +14925,111 @@ msgstr ""
 "git difftool [<các tùy chọn>] [<lần_chuyển_giao> [<lần_chuyển_giao>]] [--] </"
 "đường/dẫn>…]"
 
-#: builtin/difftool.c:261
-#, c-format
-msgid "failed: %d"
-msgstr "gặp lỗi: %d"
-
-#: builtin/difftool.c:303
+#: builtin/difftool.c:293
 #, c-format
 msgid "could not read symlink %s"
 msgstr "không thể đọc liên kết mềm %s"
 
-#: builtin/difftool.c:305
+#: builtin/difftool.c:295
 #, c-format
 msgid "could not read symlink file %s"
 msgstr "không đọc được tập tin liên kết mềm %s"
 
-#: builtin/difftool.c:313
+#: builtin/difftool.c:303
 #, c-format
 msgid "could not read object %s for symlink %s"
 msgstr "không thể đọc đối tượng %s cho liên kết mềm %s"
 
-#: builtin/difftool.c:413
+#: builtin/difftool.c:427
 msgid ""
-"combined diff formats('-c' and '--cc') are not supported in\n"
-"directory diff mode('-d' and '--dir-diff')."
+"combined diff formats ('-c' and '--cc') are not supported in\n"
+"directory diff mode ('-d' and '--dir-diff')."
 msgstr ""
 "các định dạng diff tổ hợp(“-c” và “--cc”) chưa được hỗ trợ trong\n"
 "chế độ diff thư mục(“-d” và “--dir-diff”)."
 
-#: builtin/difftool.c:637
+#: builtin/difftool.c:632
 #, c-format
 msgid "both files modified: '%s' and '%s'."
 msgstr "cả hai tập tin đã bị sửa: “%s” và “%s”."
 
-#: builtin/difftool.c:639
+#: builtin/difftool.c:634
 msgid "working tree file has been left."
 msgstr "cây làm việc ở bên trái."
 
-#: builtin/difftool.c:650
+#: builtin/difftool.c:645
 #, c-format
 msgid "temporary files exist in '%s'."
 msgstr "các tập tin tạm đã sẵn có trong “%s”."
 
-#: builtin/difftool.c:651
+#: builtin/difftool.c:646
 msgid "you may want to cleanup or recover these."
 msgstr "bạn có lẽ muốn dọn dẹp hay phục hồi ở đây."
 
-#: builtin/difftool.c:699
+#: builtin/difftool.c:651
+#, c-format
+msgid "failed: %d"
+msgstr "gặp lỗi: %d"
+
+#: builtin/difftool.c:696
 msgid "use `diff.guitool` instead of `diff.tool`"
 msgstr "dùng “diff.guitool“ thay vì dùng “diff.tool“"
 
-#: builtin/difftool.c:701
+#: builtin/difftool.c:698
 msgid "perform a full-directory diff"
 msgstr "thực hiện một diff toàn thư mục"
 
-#: builtin/difftool.c:703
+#: builtin/difftool.c:700
 msgid "do not prompt before launching a diff tool"
 msgstr "đừng nhắc khi khởi chạy công cụ diff"
 
-#: builtin/difftool.c:708
+#: builtin/difftool.c:705
 msgid "use symlinks in dir-diff mode"
 msgstr "dùng liên kết mềm trong diff-thư-mục"
 
-#: builtin/difftool.c:709
+#: builtin/difftool.c:706
 msgid "tool"
 msgstr "công cụ"
 
-#: builtin/difftool.c:710
+#: builtin/difftool.c:707
 msgid "use the specified diff tool"
 msgstr "dùng công cụ diff đã cho"
 
-#: builtin/difftool.c:712
+#: builtin/difftool.c:709
 msgid "print a list of diff tools that may be used with `--tool`"
 msgstr "in ra danh sách các công cụ dif cái mà có thẻ dùng với “--tool“"
 
-#: builtin/difftool.c:715
+#: builtin/difftool.c:712
 msgid ""
-"make 'git-difftool' exit when an invoked diff tool returns a non - zero exit "
+"make 'git-difftool' exit when an invoked diff tool returns a non-zero exit "
 "code"
-msgstr ""
-"làm cho “git-difftool” thoát khi gọi công cụ diff trả về mã không phải số "
-"không"
+msgstr "làm cho “git-difftool” thoát khi gọi công cụ diff trả về mã khác không"
 
-#: builtin/difftool.c:718
+#: builtin/difftool.c:715
 msgid "specify a custom command for viewing diffs"
 msgstr "chỉ định một lệnh tùy ý để xem diff"
 
-#: builtin/difftool.c:719
+#: builtin/difftool.c:716
 msgid "passed to `diff`"
 msgstr "chuyển cho “diff”"
 
-#: builtin/difftool.c:734
+#: builtin/difftool.c:732
 msgid "difftool requires worktree or --no-index"
 msgstr "difftool cần cây làm việc hoặc --no-index"
 
-#: builtin/difftool.c:741
+#: builtin/difftool.c:739
 msgid "--dir-diff is incompatible with --no-index"
 msgstr "--dir-diff xung khắc với --no-index"
 
-#: builtin/difftool.c:744
+#: builtin/difftool.c:742
 msgid "--gui, --tool and --extcmd are mutually exclusive"
 msgstr "--gui, --tool và --extcmd loại từ lẫn nhau"
 
-#: builtin/difftool.c:752
+#: builtin/difftool.c:750
 msgid "no <tool> given for --tool=<tool>"
 msgstr "chưa đưa ra <công_cụ> cho --tool=<công_cụ>"
 
-#: builtin/difftool.c:759
+#: builtin/difftool.c:757
 msgid "no <cmd> given for --extcmd=<cmd>"
 msgstr "chưa đưa ra <lệnh> cho --extcmd=<lệnh>"
 
@@ -14783,7 +15037,7 @@ msgstr "chưa đưa ra <lệnh> cho --extcmd=<lệnh>"
 msgid "git env--helper --type=[bool|ulong] <options> <env-var>"
 msgstr "git env--helper --type=[bool|ulong] <các tùy chọn> <env-var>"
 
-#: builtin/env--helper.c:42 builtin/hash-object.c:98
+#: builtin/env--helper.c:42 builtin/hash-object.c:96
 msgid "type"
 msgstr "kiểu"
 
@@ -14814,98 +15068,98 @@ msgstr ""
 msgid "git fast-export [rev-list-opts]"
 msgstr "git fast-export [rev-list-opts]"
 
-#: builtin/fast-export.c:868
+#: builtin/fast-export.c:869
 msgid "Error: Cannot export nested tags unless --mark-tags is specified."
 msgstr "Lỗi: không thể xuất thẻ lồng nhau trừ khi --mark-tags được chỉ định."
 
-#: builtin/fast-export.c:1177
+#: builtin/fast-export.c:1178
 msgid "--anonymize-map token cannot be empty"
 msgstr "--anonymize-map thẻ không thể là rỗng"
 
-#: builtin/fast-export.c:1197
+#: builtin/fast-export.c:1198
 msgid "show progress after <n> objects"
 msgstr "hiển thị tiến triển sau <n> đối tượng"
 
-#: builtin/fast-export.c:1199
+#: builtin/fast-export.c:1200
 msgid "select handling of signed tags"
 msgstr "chọn điều khiển của thẻ đã ký"
 
-#: builtin/fast-export.c:1202
+#: builtin/fast-export.c:1203
 msgid "select handling of tags that tag filtered objects"
 msgstr "chọn sự xử lý của các thẻ, cái mà đánh thẻ các đối tượng được lọc ra"
 
-#: builtin/fast-export.c:1205
+#: builtin/fast-export.c:1206
 msgid "select handling of commit messages in an alternate encoding"
 msgstr ""
 "chọn bộ xử lý cho các ghi chú của lần chuyển giao theo một bộ mã thay thế"
 
-#: builtin/fast-export.c:1208
+#: builtin/fast-export.c:1209
 msgid "dump marks to this file"
 msgstr "đổ các đánh dấu này vào tập-tin"
 
-#: builtin/fast-export.c:1210
+#: builtin/fast-export.c:1211
 msgid "import marks from this file"
 msgstr "nhập vào đánh dấu từ tập tin này"
 
-#: builtin/fast-export.c:1214
+#: builtin/fast-export.c:1215
 msgid "import marks from this file if it exists"
 msgstr "nhập vào đánh dấu từ tập tin sẵn có"
 
-#: builtin/fast-export.c:1216
+#: builtin/fast-export.c:1217
 msgid "fake a tagger when tags lack one"
 msgstr "làm giả một cái thẻ khi thẻ bị thiếu một cái"
 
-#: builtin/fast-export.c:1218
+#: builtin/fast-export.c:1219
 msgid "output full tree for each commit"
 msgstr "xuất ra toàn bộ cây cho mỗi lần chuyển giao"
 
-#: builtin/fast-export.c:1220
+#: builtin/fast-export.c:1221
 msgid "use the done feature to terminate the stream"
 msgstr "sử dụng tính năng done để chấm dứt luồng dữ liệu"
 
-#: builtin/fast-export.c:1221
+#: builtin/fast-export.c:1222
 msgid "skip output of blob data"
 msgstr "bỏ qua kết xuất của dữ liệu blob"
 
-#: builtin/fast-export.c:1222 builtin/log.c:1826
+#: builtin/fast-export.c:1223 builtin/log.c:1826
 msgid "refspec"
 msgstr "refspec"
 
-#: builtin/fast-export.c:1223
+#: builtin/fast-export.c:1224
 msgid "apply refspec to exported refs"
 msgstr "áp dụng refspec cho refs đã xuất"
 
-#: builtin/fast-export.c:1224
+#: builtin/fast-export.c:1225
 msgid "anonymize output"
 msgstr "kết xuất anonymize"
 
-#: builtin/fast-export.c:1225
+#: builtin/fast-export.c:1226
 msgid "from:to"
 msgstr "từ:đến"
 
-#: builtin/fast-export.c:1226
+#: builtin/fast-export.c:1227
 msgid "convert <from> to <to> in anonymized output"
 msgstr "chuyển đổi <from> sang <to> đầu ra ẩn danh"
 
-#: builtin/fast-export.c:1229
+#: builtin/fast-export.c:1230
 msgid "reference parents which are not in fast-export stream by object id"
 msgstr ""
 "các cha mẹ tham chiếu cái mà không trong luồng dữ liệu fast-export bởi mã id "
 "đối tượng"
 
-#: builtin/fast-export.c:1231
+#: builtin/fast-export.c:1232
 msgid "show original object ids of blobs/commits"
 msgstr "hiển thị các mã id nguyên gốc của blobs/commits"
 
-#: builtin/fast-export.c:1233
+#: builtin/fast-export.c:1234
 msgid "label tags with mark ids"
 msgstr "gắn thẻ với các mã ID đánh dấu"
 
-#: builtin/fast-export.c:1256
+#: builtin/fast-export.c:1257
 msgid "--anonymize-map without --anonymize does not make sense"
 msgstr "--anonymize-map mà không có --anonymize là không hợp lý"
 
-#: builtin/fast-export.c:1271
+#: builtin/fast-export.c:1272
 msgid "Cannot pass both --import-marks and --import-marks-if-exists"
 msgstr "Không thể chuyển qua cả hai --import-marks và --import-marks-if-exists"
 
@@ -15106,62 +15360,62 @@ msgstr "chấp nhận tham chiếu từ đầu vào tiêu chuẩn"
 msgid "Couldn't find remote ref HEAD"
 msgstr "Không thể tìm thấy máy chủ cho tham chiếu HEAD"
 
-#: builtin/fetch.c:757
+#: builtin/fetch.c:760
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "phần cấu hình fetch.output có chứa giá-trị không hợp lệ %s"
 
-#: builtin/fetch.c:856
+#: builtin/fetch.c:862
 #, c-format
 msgid "object %s not found"
 msgstr "không tìm thấy đối tượng %s"
 
-#: builtin/fetch.c:860
+#: builtin/fetch.c:866
 msgid "[up to date]"
 msgstr "[đã cập nhật]"
 
-#: builtin/fetch.c:873 builtin/fetch.c:889 builtin/fetch.c:961
+#: builtin/fetch.c:879 builtin/fetch.c:895 builtin/fetch.c:967
 msgid "[rejected]"
 msgstr "[Bị từ chối]"
 
-#: builtin/fetch.c:874
+#: builtin/fetch.c:880
 msgid "can't fetch in current branch"
 msgstr "không thể fetch (lấy) về nhánh hiện hành"
 
-#: builtin/fetch.c:884
+#: builtin/fetch.c:890
 msgid "[tag update]"
 msgstr "[cập nhật thẻ]"
 
-#: builtin/fetch.c:885 builtin/fetch.c:922 builtin/fetch.c:944
-#: builtin/fetch.c:956
+#: builtin/fetch.c:891 builtin/fetch.c:928 builtin/fetch.c:950
+#: builtin/fetch.c:962
 msgid "unable to update local ref"
 msgstr "không thể cập nhật tham chiếu nội bộ"
 
-#: builtin/fetch.c:889
+#: builtin/fetch.c:895
 msgid "would clobber existing tag"
 msgstr "nên xóa chồng các thẻ có sẵn"
 
-#: builtin/fetch.c:911
+#: builtin/fetch.c:917
 msgid "[new tag]"
 msgstr "[thẻ mới]"
 
-#: builtin/fetch.c:914
+#: builtin/fetch.c:920
 msgid "[new branch]"
 msgstr "[nhánh mới]"
 
-#: builtin/fetch.c:917
+#: builtin/fetch.c:923
 msgid "[new ref]"
 msgstr "[ref (tham chiếu) mới]"
 
-#: builtin/fetch.c:956
+#: builtin/fetch.c:962
 msgid "forced update"
 msgstr "cưỡng bức cập nhật"
 
-#: builtin/fetch.c:961
+#: builtin/fetch.c:967
 msgid "non-fast-forward"
 msgstr "không-phải-chuyển-tiếp-nhanh"
 
-#: builtin/fetch.c:1065
+#: builtin/fetch.c:1070
 msgid ""
 "Fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled. To re-enable, use '--show-forced-updates'\n"
@@ -15171,7 +15425,7 @@ msgstr ""
 "nhưng lựa chọn bị tắt. Để kích hoạt lại, sử dụng cờ\n"
 "“--show-forced-updates” hoặc chạy “git config fetch.showForcedUpdates true”."
 
-#: builtin/fetch.c:1069
+#: builtin/fetch.c:1074
 #, c-format
 msgid ""
 "It took %.2f seconds to check forced updates. You can use\n"
@@ -15184,22 +15438,22 @@ msgstr ""
 "false”\n"
 "để tránh kiểm tra này.\n"
 
-#: builtin/fetch.c:1101
+#: builtin/fetch.c:1105
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s đã không gửi tất cả các đối tượng cần thiết\n"
 
-#: builtin/fetch.c:1129
+#: builtin/fetch.c:1134
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr "từ chối %s bởi vì các gốc nông thì không được phép cập nhật"
 
-#: builtin/fetch.c:1206 builtin/fetch.c:1357
+#: builtin/fetch.c:1223 builtin/fetch.c:1371
 #, c-format
 msgid "From %.*s\n"
 msgstr "Từ %.*s\n"
 
-#: builtin/fetch.c:1228
+#: builtin/fetch.c:1244
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -15208,58 +15462,63 @@ msgstr ""
 "một số tham chiếu nội bộ không thể được cập nhật; hãy thử chạy\n"
 " “git remote prune %s” để bỏ đi những nhánh cũ, hay bị xung đột"
 
-#: builtin/fetch.c:1327
+#: builtin/fetch.c:1341
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s sẽ trở thành không đầu (không được quản lý))"
 
-#: builtin/fetch.c:1328
+#: builtin/fetch.c:1342
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s đã trở thành không đầu (không được quản lý))"
 
-#: builtin/fetch.c:1360
+#: builtin/fetch.c:1374
 msgid "[deleted]"
 msgstr "[đã xóa]"
 
-#: builtin/fetch.c:1361 builtin/remote.c:1118
+#: builtin/fetch.c:1375 builtin/remote.c:1128
 msgid "(none)"
 msgstr "(không)"
 
-#: builtin/fetch.c:1384
+#: builtin/fetch.c:1398
 #, c-format
 msgid "Refusing to fetch into current branch %s of non-bare repository"
 msgstr ""
 "Từ chối việc lấy vào trong nhánh hiện tại %s của một kho chứa không phải kho "
 "trần (bare)"
 
-#: builtin/fetch.c:1403
+#: builtin/fetch.c:1417
 #, c-format
 msgid "Option \"%s\" value \"%s\" is not valid for %s"
 msgstr "Tùy chọn \"%s\" có giá trị \"%s\" là không hợp lệ cho %s"
 
-#: builtin/fetch.c:1406
+#: builtin/fetch.c:1420
 #, c-format
 msgid "Option \"%s\" is ignored for %s\n"
 msgstr "Tùy chọn \"%s\" bị bỏ qua với %s\n"
 
-#: builtin/fetch.c:1618
+#: builtin/fetch.c:1447
+#, c-format
+msgid "the object %s does not exist"
+msgstr "đối tượng “%s” không tồn tại"
+
+#: builtin/fetch.c:1633
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "phát hiện nhiều nhánh, không tương thích với --set-upstream"
 
-#: builtin/fetch.c:1633
+#: builtin/fetch.c:1648
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "không cài đặt thượng nguồn cho một nhánh được theo dõi trên máy chủ"
 
-#: builtin/fetch.c:1635
+#: builtin/fetch.c:1650
 msgid "not setting upstream for a remote tag"
 msgstr "không cài đặt thượng nguồn cho một thẻ nhánh trên máy chủ"
 
-#: builtin/fetch.c:1637
+#: builtin/fetch.c:1652
 msgid "unknown branch type"
 msgstr "không hiểu kiểu nhánh"
 
-#: builtin/fetch.c:1639
+#: builtin/fetch.c:1654
 msgid ""
 "no source branch found.\n"
 "you need to specify exactly one branch with the --set-upstream option."
@@ -15267,22 +15526,22 @@ msgstr ""
 "không tìm thấy nhánh nguồn.\n"
 "bạn cần phải chỉ định chính xác một nhánh với tùy chọn --set-upstream."
 
-#: builtin/fetch.c:1768 builtin/fetch.c:1831
+#: builtin/fetch.c:1783 builtin/fetch.c:1846
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Đang lấy “%s” về\n"
 
-#: builtin/fetch.c:1778 builtin/fetch.c:1833 builtin/remote.c:101
+#: builtin/fetch.c:1793 builtin/fetch.c:1848 builtin/remote.c:101
 #, c-format
 msgid "Could not fetch %s"
 msgstr "Không thể lấy“%s” về"
 
-#: builtin/fetch.c:1790
+#: builtin/fetch.c:1805
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "không thể lấy “%s” (mã thoát: %d)\n"
 
-#: builtin/fetch.c:1894
+#: builtin/fetch.c:1909
 msgid ""
 "No remote repository specified.  Please, specify either a URL or a\n"
 "remote name from which new revisions should be fetched."
@@ -15290,56 +15549,56 @@ msgstr ""
 "Chưa chỉ ra kho chứa máy chủ.  Xin hãy chỉ định hoặc là URL hoặc\n"
 "tên máy chủ từ cái mà những điểm xét duyệt mới có thể được fetch (lấy về)."
 
-#: builtin/fetch.c:1930
+#: builtin/fetch.c:1945
 msgid "You need to specify a tag name."
 msgstr "Bạn phải định rõ tên thẻ."
 
-#: builtin/fetch.c:1994
+#: builtin/fetch.c:2009
 msgid "--negotiate-only needs one or more --negotiate-tip=*"
 msgstr "--negotiate-only cần một tham số hay nhiều --negotiate-tip=* hơn"
 
-#: builtin/fetch.c:1998
+#: builtin/fetch.c:2013
 msgid "Negative depth in --deepen is not supported"
 msgstr "Mức sâu là số âm trong --deepen là không được hỗ trợ"
 
-#: builtin/fetch.c:2000
+#: builtin/fetch.c:2015
 msgid "--deepen and --depth are mutually exclusive"
 msgstr "Các tùy chọn --deepen và --depth loại từ lẫn nhau"
 
-#: builtin/fetch.c:2005
+#: builtin/fetch.c:2020
 msgid "--depth and --unshallow cannot be used together"
 msgstr "tùy chọn --depth và --unshallow không thể sử dụng cùng với nhau"
 
-#: builtin/fetch.c:2007
+#: builtin/fetch.c:2022
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "--unshallow trên kho hoàn chỉnh là không hợp lý"
 
-#: builtin/fetch.c:2024
+#: builtin/fetch.c:2039
 msgid "fetch --all does not take a repository argument"
 msgstr "lệnh lấy về \"fetch --all\" không lấy đối số kho chứa"
 
-#: builtin/fetch.c:2026
+#: builtin/fetch.c:2041
 msgid "fetch --all does not make sense with refspecs"
 msgstr "lệnh lấy về \"fetch --all\" không hợp lý với refspecs"
 
-#: builtin/fetch.c:2035
+#: builtin/fetch.c:2050
 #, c-format
 msgid "No such remote or remote group: %s"
 msgstr "Không có nhóm máy chủ hay máy chủ như thế: %s"
 
-#: builtin/fetch.c:2042
+#: builtin/fetch.c:2057
 msgid "Fetching a group and specifying refspecs does not make sense"
 msgstr "Việc lấy về cả một nhóm và chỉ định refspecs không hợp lý"
 
-#: builtin/fetch.c:2058
+#: builtin/fetch.c:2073
 msgid "must supply remote when using --negotiate-only"
 msgstr "phải cung cấp máy chủ khi sử dụng --negotiate-only"
 
-#: builtin/fetch.c:2063
+#: builtin/fetch.c:2078
 msgid "Protocol does not support --negotiate-only, exiting."
 msgstr "Giao thức không hỗ trợ --negotiate-only, nên thoát."
 
-#: builtin/fetch.c:2082
+#: builtin/fetch.c:2097
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -15347,11 +15606,11 @@ msgstr ""
 "--filter chỉ có thể được dùng với máy chủ được cấu hình bằng extensions."
 "partialclone"
 
-#: builtin/fetch.c:2086
+#: builtin/fetch.c:2101
 msgid "--atomic can only be used when fetching from one remote"
 msgstr "--atomic chỉ có thể dùng khi lấy về từ một máy chủ"
 
-#: builtin/fetch.c:2090
+#: builtin/fetch.c:2105
 msgid "--stdin can only be used when fetching from one remote"
 msgstr "--stdin chỉ có thể dùng khi lấy về từ một máy chủ"
 
@@ -15422,7 +15681,7 @@ msgstr "trích dẫn để phù hợp cho Tcl"
 msgid "show only <n> matched refs"
 msgstr "hiển thị chỉ <n> tham chiếu khớp"
 
-#: builtin/for-each-ref.c:41 builtin/tag.c:483
+#: builtin/for-each-ref.c:41 builtin/tag.c:481
 msgid "respect format colors"
 msgstr "các màu định dạng lưu tâm"
 
@@ -15578,129 +15837,139 @@ msgstr "%s: không phải là một lần chuyển giao"
 msgid "notice: No default references"
 msgstr "cảnh báo: Không có các tham chiếu mặc định"
 
-#: builtin/fsck.c:606
+#: builtin/fsck.c:621
+#, c-format
+msgid "%s: hash-path mismatch, found at: %s"
+msgstr "%s: đường dẫn mã băm không khớp, tìm thấy tại: %s"
+
+#: builtin/fsck.c:624
 #, c-format
 msgid "%s: object corrupt or missing: %s"
 msgstr "%s: thiếu đối tượng hoặc hỏng: %s"
 
-#: builtin/fsck.c:619
+#: builtin/fsck.c:628
+#, c-format
+msgid "%s: object is of unknown type '%s': %s"
+msgstr "%s: đối tượng có kiểu chưa biết “%s”: %s"
+
+#: builtin/fsck.c:644
 #, c-format
 msgid "%s: object could not be parsed: %s"
 msgstr "%s: không thể phân tích cú đối tượng: %s"
 
-#: builtin/fsck.c:639
+#: builtin/fsck.c:664
 #, c-format
 msgid "bad sha1 file: %s"
 msgstr "tập tin sha1 sai: %s"
 
-#: builtin/fsck.c:654
+#: builtin/fsck.c:685
 msgid "Checking object directory"
 msgstr "Đang kiểm tra thư mục đối tượng"
 
-#: builtin/fsck.c:657
+#: builtin/fsck.c:688
 msgid "Checking object directories"
 msgstr "Đang kiểm tra các thư mục đối tượng"
 
-#: builtin/fsck.c:672
+#: builtin/fsck.c:704
 #, c-format
 msgid "Checking %s link"
 msgstr "Đang lấy liên kết %s"
 
-#: builtin/fsck.c:677 builtin/index-pack.c:864
+#: builtin/fsck.c:709 builtin/index-pack.c:859
 #, c-format
 msgid "invalid %s"
 msgstr "%s không hợp lệ"
 
-#: builtin/fsck.c:684
+#: builtin/fsck.c:716
 #, c-format
 msgid "%s points to something strange (%s)"
 msgstr "%s chỉ đến thứ gì đó xa lạ (%s)"
 
-#: builtin/fsck.c:690
+#: builtin/fsck.c:722
 #, c-format
 msgid "%s: detached HEAD points at nothing"
 msgstr "%s: HEAD đã tách rời không chỉ vào đâu cả"
 
-#: builtin/fsck.c:694
+#: builtin/fsck.c:726
 #, c-format
 msgid "notice: %s points to an unborn branch (%s)"
 msgstr "chú ý: %s chỉ đến một nhánh chưa sinh (%s)"
 
-#: builtin/fsck.c:706
+#: builtin/fsck.c:738
 msgid "Checking cache tree"
 msgstr "Đang kiểm tra cây nhớ tạm"
 
-#: builtin/fsck.c:711
+#: builtin/fsck.c:743
 #, c-format
 msgid "%s: invalid sha1 pointer in cache-tree"
 msgstr "%s: con trỏ sha1 không hợp lệ trong cache-tree"
 
-#: builtin/fsck.c:720
+#: builtin/fsck.c:752
 msgid "non-tree in cache-tree"
 msgstr "non-tree trong cache-tree"
 
-#: builtin/fsck.c:751
+#: builtin/fsck.c:783
 msgid "git fsck [<options>] [<object>...]"
 msgstr "git fsck [<các tùy chọn>] [<đối-tượng>…]"
 
-#: builtin/fsck.c:757
+#: builtin/fsck.c:789
 msgid "show unreachable objects"
 msgstr "hiển thị các đối tượng không thể đọc được"
 
-#: builtin/fsck.c:758
+#: builtin/fsck.c:790
 msgid "show dangling objects"
 msgstr "hiển thị các đối tượng không được quản lý"
 
-#: builtin/fsck.c:759
+#: builtin/fsck.c:791
 msgid "report tags"
 msgstr "báo cáo các thẻ"
 
-#: builtin/fsck.c:760
+#: builtin/fsck.c:792
 msgid "report root nodes"
 msgstr "báo cáo node gốc"
 
-#: builtin/fsck.c:761
+#: builtin/fsck.c:793
 msgid "make index objects head nodes"
 msgstr "tạo “index objects head nodes”"
 
-#: builtin/fsck.c:762
+#: builtin/fsck.c:794
 msgid "make reflogs head nodes (default)"
 msgstr "tạo “reflogs head nodes” (mặc định)"
 
-#: builtin/fsck.c:763
+#: builtin/fsck.c:795
 msgid "also consider packs and alternate objects"
 msgstr "cũng cân nhắc đến các đối tượng gói và thay thế"
 
-#: builtin/fsck.c:764
+#: builtin/fsck.c:796
 msgid "check only connectivity"
 msgstr "chỉ kiểm tra kết nối"
 
-#: builtin/fsck.c:765 builtin/mktag.c:75
+#: builtin/fsck.c:797 builtin/mktag.c:76
 msgid "enable more strict checking"
 msgstr "cho phép kiểm tra hạn chế hơn"
 
-#: builtin/fsck.c:767
+#: builtin/fsck.c:799
 msgid "write dangling objects in .git/lost-found"
 msgstr "ghi các đối tượng không được quản lý trong .git/lost-found"
 
-#: builtin/fsck.c:768 builtin/prune.c:134
+#: builtin/fsck.c:800 builtin/prune.c:134
 msgid "show progress"
 msgstr "hiển thị quá trình"
 
-#: builtin/fsck.c:769
+#: builtin/fsck.c:801
 msgid "show verbose names for reachable objects"
 msgstr "hiển thị tên chi tiết cho các đối tượng đọc được"
 
-#: builtin/fsck.c:828 builtin/index-pack.c:262
+#: builtin/fsck.c:861 builtin/index-pack.c:261
 msgid "Checking objects"
 msgstr "Đang kiểm tra các đối tượng"
 
-#: builtin/fsck.c:856
+#: builtin/fsck.c:889
 #, c-format
 msgid "%s: object missing"
 msgstr "%s: thiếu đối tượng"
 
-#: builtin/fsck.c:867
+#: builtin/fsck.c:900
 #, c-format
 msgid "invalid parameter: expected sha1, got '%s'"
 msgstr "tham số không hợp lệ: cần sha1, nhưng lại nhận được “%s”"
@@ -15724,7 +15993,7 @@ msgstr "gặp lỗi khi phân tích “%s” giá trị “%s”"
 msgid "cannot stat '%s'"
 msgstr "không thể lấy thông tin thống kê về “%s”"
 
-#: builtin/gc.c:496 builtin/notes.c:240 builtin/tag.c:573
+#: builtin/gc.c:496 builtin/notes.c:238 builtin/tag.c:574
 #, c-format
 msgid "cannot read '%s'"
 msgstr "không thể đọc “%s”"
@@ -15733,7 +16002,7 @@ msgstr "không thể đọc “%s”"
 #, c-format
 msgid ""
 "The last gc run reported the following. Please correct the root cause\n"
-"and remove %s.\n"
+"and remove %s\n"
 "Automatic cleanup will not be performed until the file is removed.\n"
 "\n"
 "%s"
@@ -15821,148 +16090,188 @@ msgstr "--no-schedule không được phép"
 msgid "unrecognized --schedule argument '%s'"
 msgstr "đối số --schedule không được thừa nhận %s"
 
-#: builtin/gc.c:869
+#: builtin/gc.c:868
 msgid "failed to write commit-graph"
 msgstr "gặp lỗi khi ghi đồ thị các lần chuyển giao"
 
-#: builtin/gc.c:905
+#: builtin/gc.c:904
 msgid "failed to prefetch remotes"
 msgstr "gặp lỗi khi tải trước các máy chủ"
 
-#: builtin/gc.c:1022
+#: builtin/gc.c:1020
 msgid "failed to start 'git pack-objects' process"
 msgstr "gặp lỗi khi lấy thông tin thống kê về tiến trình “git pack-objects”"
 
-#: builtin/gc.c:1039
+#: builtin/gc.c:1037
 msgid "failed to finish 'git pack-objects' process"
 msgstr "gặp lỗi khi hoàn tất tiến trình “git pack-objects”"
 
-#: builtin/gc.c:1091
+#: builtin/gc.c:1088
 msgid "failed to write multi-pack-index"
 msgstr "gặp lỗi khi ghi multi-pack-index"
 
-#: builtin/gc.c:1109
+#: builtin/gc.c:1104
 msgid "'git multi-pack-index expire' failed"
 msgstr "gặp lỗi khi chạy “git multi-pack-index expire”"
 
-#: builtin/gc.c:1170
+#: builtin/gc.c:1163
 msgid "'git multi-pack-index repack' failed"
 msgstr "gặp lỗi khi chạy “git multi-pack-index repack”"
 
-#: builtin/gc.c:1179
+#: builtin/gc.c:1172
 msgid ""
 "skipping incremental-repack task because core.multiPackIndex is disabled"
 msgstr "bỏ qua tác vụ incremental-repack vì core.multiPackIndex bị vô hiệu hóa"
 
-#: builtin/gc.c:1283
+#: builtin/gc.c:1276
 #, c-format
 msgid "lock file '%s' exists, skipping maintenance"
 msgstr "đã có khóa của tập tin “%s”, bỏ qua bảo trì"
 
-#: builtin/gc.c:1313
+#: builtin/gc.c:1306
 #, c-format
 msgid "task '%s' failed"
 msgstr "gặp lỗi khi thực hiện nhiệm vụ “%s”"
 
-#: builtin/gc.c:1395
+#: builtin/gc.c:1388
 #, c-format
 msgid "'%s' is not a valid task"
 msgstr "“%s” không phải một nhiệm vụ hợp lệ"
 
-#: builtin/gc.c:1400
+#: builtin/gc.c:1393
 #, c-format
 msgid "task '%s' cannot be selected multiple times"
 msgstr "nhiệm vụ “%s” không được chọn nhiều lần"
 
-#: builtin/gc.c:1415
+#: builtin/gc.c:1408
 msgid "run tasks based on the state of the repository"
 msgstr "chạy nhiệm vụ dựa trên trạng thái của kho chứa"
 
-#: builtin/gc.c:1416
+#: builtin/gc.c:1409
 msgid "frequency"
 msgstr "tần số"
 
-#: builtin/gc.c:1417
+#: builtin/gc.c:1410
 msgid "run tasks based on frequency"
 msgstr "chạy nhiệm vụ dựa trên tần suất"
 
-#: builtin/gc.c:1420
+#: builtin/gc.c:1413
 msgid "do not report progress or other information over stderr"
 msgstr "đừng báo cáo diễn tiến hay các thông tin khác ra đầu lỗi tiêu chuẩn"
 
-#: builtin/gc.c:1421
+#: builtin/gc.c:1414
 msgid "task"
 msgstr "tác vụ"
 
-#: builtin/gc.c:1422
+#: builtin/gc.c:1415
 msgid "run a specific task"
 msgstr "chạy một nhiệm vụ cụ thể"
 
-#: builtin/gc.c:1439
+#: builtin/gc.c:1432
 msgid "use at most one of --auto and --schedule=<frequency>"
 msgstr "dùng nhiều nhất là một trong --auto và --schedule=<frequency>"
 
-#: builtin/gc.c:1482
+#: builtin/gc.c:1475
 msgid "failed to run 'git config'"
 msgstr "gặp lỗi khi chạy “git config”"
 
-#: builtin/gc.c:1547
+#: builtin/gc.c:1627
 #, c-format
 msgid "failed to expand path '%s'"
 msgstr "gặp lỗi khi khai triển đường dẫn “%s”"
 
-#: builtin/gc.c:1576
+#: builtin/gc.c:1654 builtin/gc.c:1692
 msgid "failed to start launchctl"
 msgstr "gặp lỗi khi khởi chạy launchctl"
 
-#: builtin/gc.c:1613
+#: builtin/gc.c:1767 builtin/gc.c:2220
 #, c-format
 msgid "failed to create directories for '%s'"
 msgstr "gặp lỗi khi tạo thư mục cho \"%s\""
 
-#: builtin/gc.c:1674
+#: builtin/gc.c:1794
 #, c-format
 msgid "failed to bootstrap service %s"
 msgstr "gặp lỗi khi mồi dịch vụ %s"
 
-#: builtin/gc.c:1745
+#: builtin/gc.c:1887
 msgid "failed to create temp xml file"
 msgstr "gặp lỗi khi tạo tập tin xml tạm thời"
 
-#: builtin/gc.c:1835
+#: builtin/gc.c:1977
 msgid "failed to start schtasks"
 msgstr "gặp lỗi khi lấy thông tin thống kê về schtasks"
 
-#: builtin/gc.c:1879
+#: builtin/gc.c:2046
 msgid "failed to run 'crontab -l'; your system might not support 'cron'"
 msgstr ""
 "gặp lỗi khi chạy “crontab -l”; hệ thống của bạn có thể không hỗ trợ “cron”"
 
-#: builtin/gc.c:1896
+#: builtin/gc.c:2063
 msgid "failed to run 'crontab'; your system might not support 'cron'"
 msgstr "gặp lỗi khi chạy “crontab”; hiển thị của bạn có lẽ không hỗ trợ “cron”"
 
-#: builtin/gc.c:1900
+#: builtin/gc.c:2067
 msgid "failed to open stdin of 'crontab'"
 msgstr "gặp lỗi khi mở đầu vào tiêu chuẩn của “crontab”"
 
-#: builtin/gc.c:1942
+#: builtin/gc.c:2109
 msgid "'crontab' died"
 msgstr "“crontab” đã chết"
 
-#: builtin/gc.c:1976
+#: builtin/gc.c:2174
+msgid "failed to start systemctl"
+msgstr "gặp lỗi khi khởi chạy systemctl"
+
+#: builtin/gc.c:2184
+msgid "failed to run systemctl"
+msgstr "gặp lỗi khi chạy systemctl"
+
+#: builtin/gc.c:2193 builtin/gc.c:2198 builtin/worktree.c:62
+#: builtin/worktree.c:945
+#, c-format
+msgid "failed to delete '%s'"
+msgstr "gặp lỗi khi xóa “%s”"
+
+#: builtin/gc.c:2378
+#, c-format
+msgid "unrecognized --scheduler argument '%s'"
+msgstr "đối số --scheduler không được thừa nhận “%s”"
+
+#: builtin/gc.c:2403
+msgid "neither systemd timers nor crontab are available"
+msgstr "hoặc là bộ lập lịch systemd hoặc là crontab không sẵn có"
+
+#: builtin/gc.c:2418
+#, c-format
+msgid "%s scheduler is not available"
+msgstr "bộ lên lịch %s không sẵn có"
+
+#: builtin/gc.c:2432
 msgid "another process is scheduling background maintenance"
 msgstr "một tiến trình khác được lập kế hoạch chạy nền để bảo trì"
 
-#: builtin/gc.c:2000
+#: builtin/gc.c:2454
+msgid "git maintenance start [--scheduler=<scheduler>]"
+msgstr "git maintenance start [--scheduler=<bộ lên lịch>]"
+
+#: builtin/gc.c:2463
+msgid "scheduler"
+msgstr "bộ lên lịch"
+
+#: builtin/gc.c:2464
+msgid "scheduler to trigger git maintenance run"
+msgstr "bộ lên lịch để kích hoạt chạy chương trình bảo trì git"
+
+#: builtin/gc.c:2478
 msgid "failed to add repo to global config"
 msgstr "gặp lỗi khi thêm cấu hình toàn cục"
 
-#: builtin/gc.c:2010
+#: builtin/gc.c:2487
 msgid "git maintenance <subcommand> [<options>]"
 msgstr "git maintenance run <lệnh_con> [<các tùy chọn>]"
 
-#: builtin/gc.c:2029
+#: builtin/gc.c:2506
 #, c-format
 msgid "invalid subcommand: %s"
 msgstr "lện con không hợp lệ: %s"
@@ -15971,12 +16280,12 @@ msgstr "lện con không hợp lệ: %s"
 msgid "git grep [<options>] [-e] <pattern> [<rev>...] [[--] <path>...]"
 msgstr "git grep [<các tùy chọn>] [-e] <mẫu> [<rev>…] [[--] </đường/dẫn>…]"
 
-#: builtin/grep.c:223
+#: builtin/grep.c:239
 #, c-format
 msgid "grep: failed to create thread: %s"
 msgstr "grep: gặp lỗi tạo tuyến (thread): %s"
 
-#: builtin/grep.c:277
+#: builtin/grep.c:293
 #, c-format
 msgid "invalid number of threads specified (%d) for %s"
 msgstr "số tuyến đã cho không hợp lệ (%d) cho %s"
@@ -15985,263 +16294,263 @@ msgstr "số tuyến đã cho không hợp lệ (%d) cho %s"
 #. variable for tweaking threads, currently
 #. grep.threads
 #.
-#: builtin/grep.c:285 builtin/index-pack.c:1588 builtin/index-pack.c:1791
-#: builtin/pack-objects.c:3129
+#: builtin/grep.c:301 builtin/index-pack.c:1582 builtin/index-pack.c:1785
+#: builtin/pack-objects.c:3142
 #, c-format
 msgid "no threads support, ignoring %s"
 msgstr "không hỗ trợ đa tuyến, bỏ qua %s"
 
-#: builtin/grep.c:473 builtin/grep.c:603 builtin/grep.c:643
+#: builtin/grep.c:488 builtin/grep.c:617 builtin/grep.c:657
 #, c-format
 msgid "unable to read tree (%s)"
 msgstr "không thể đọc cây (%s)"
 
-#: builtin/grep.c:658
+#: builtin/grep.c:672
 #, c-format
 msgid "unable to grep from object of type %s"
 msgstr "không thể thực hiện lệnh grep (lọc tìm) từ đối tượng thuộc kiểu %s"
 
-#: builtin/grep.c:738
+#: builtin/grep.c:752
 #, c-format
 msgid "switch `%c' expects a numerical value"
 msgstr "chuyển đến “%c” cần một giá trị bằng số"
 
-#: builtin/grep.c:837
+#: builtin/grep.c:851
 msgid "search in index instead of in the work tree"
 msgstr "tìm trong bảng mục lục thay vì trong cây làm việc"
 
-#: builtin/grep.c:839
+#: builtin/grep.c:853
 msgid "find in contents not managed by git"
 msgstr "tìm trong nội dung không được quản lý bởi git"
 
-#: builtin/grep.c:841
+#: builtin/grep.c:855
 msgid "search in both tracked and untracked files"
 msgstr "tìm kiếm các tập tin được và chưa được theo dõi dấu vết"
 
-#: builtin/grep.c:843
+#: builtin/grep.c:857
 msgid "ignore files specified via '.gitignore'"
 msgstr "các tập tin bị bỏ qua được chỉ định thông qua “.gitignore”"
 
-#: builtin/grep.c:845
+#: builtin/grep.c:859
 msgid "recursively search in each submodule"
 msgstr "tìm kiếm đệ quy trong từng mô-đun-con"
 
-#: builtin/grep.c:848
+#: builtin/grep.c:862
 msgid "show non-matching lines"
 msgstr "hiển thị những dòng không khớp với mẫu"
 
-#: builtin/grep.c:850
+#: builtin/grep.c:864
 msgid "case insensitive matching"
 msgstr "phân biệt HOA/thường"
 
-#: builtin/grep.c:852
+#: builtin/grep.c:866
 msgid "match patterns only at word boundaries"
 msgstr "chỉ khớp mẫu tại đường ranh giới từ"
 
-#: builtin/grep.c:854
+#: builtin/grep.c:868
 msgid "process binary files as text"
 msgstr "xử lý tập tin nhị phân như là dạng văn bản thường"
 
-#: builtin/grep.c:856
+#: builtin/grep.c:870
 msgid "don't match patterns in binary files"
 msgstr "không khớp mẫu trong các tập tin nhị phân"
 
-#: builtin/grep.c:859
+#: builtin/grep.c:873
 msgid "process binary files with textconv filters"
 msgstr "xử lý tập tin nhị phân với các bộ lọc “textconv”"
 
-#: builtin/grep.c:861
+#: builtin/grep.c:875
 msgid "search in subdirectories (default)"
 msgstr "tìm kiếm trong thư mục con (mặc định)"
 
-#: builtin/grep.c:863
+#: builtin/grep.c:877
 msgid "descend at most <depth> levels"
 msgstr "hạ xuống ít nhất là mức <sâu>"
 
-#: builtin/grep.c:867
+#: builtin/grep.c:881
 msgid "use extended POSIX regular expressions"
 msgstr "dùng biểu thức chính qui POSIX có mở rộng"
 
-#: builtin/grep.c:870
+#: builtin/grep.c:884
 msgid "use basic POSIX regular expressions (default)"
 msgstr "sử dụng biểu thức chính quy kiểu POSIX (mặc định)"
 
-#: builtin/grep.c:873
+#: builtin/grep.c:887
 msgid "interpret patterns as fixed strings"
 msgstr "diễn dịch các mẫu như là chuỗi cố định"
 
-#: builtin/grep.c:876
+#: builtin/grep.c:890
 msgid "use Perl-compatible regular expressions"
 msgstr "sử dụng biểu thức chính quy tương thích Perl"
 
-#: builtin/grep.c:879
+#: builtin/grep.c:893
 msgid "show line numbers"
 msgstr "hiển thị số của dòng"
 
-#: builtin/grep.c:880
+#: builtin/grep.c:894
 msgid "show column number of first match"
 msgstr "hiển thị số cột của khớp với mẫu đầu tiên"
 
-#: builtin/grep.c:881
+#: builtin/grep.c:895
 msgid "don't show filenames"
 msgstr "không hiển thị tên tập tin"
 
-#: builtin/grep.c:882
+#: builtin/grep.c:896
 msgid "show filenames"
 msgstr "hiển thị các tên tập tin"
 
-#: builtin/grep.c:884
+#: builtin/grep.c:898
 msgid "show filenames relative to top directory"
 msgstr "hiển thị tên tập tin tương đối với thư mục đỉnh (top)"
 
-#: builtin/grep.c:886
+#: builtin/grep.c:900
 msgid "show only filenames instead of matching lines"
 msgstr "chỉ hiển thị tên tập tin thay vì những dòng khớp với mẫu"
 
-#: builtin/grep.c:888
+#: builtin/grep.c:902
 msgid "synonym for --files-with-matches"
 msgstr "đồng nghĩa với --files-with-matches"
 
-#: builtin/grep.c:891
+#: builtin/grep.c:905
 msgid "show only the names of files without match"
 msgstr "chỉ hiển thị tên cho những tập tin không khớp với mẫu"
 
-#: builtin/grep.c:893
+#: builtin/grep.c:907
 msgid "print NUL after filenames"
 msgstr "thêm NUL vào sau tên tập tin"
 
-#: builtin/grep.c:896
+#: builtin/grep.c:910
 msgid "show only matching parts of a line"
 msgstr "chỉ hiển thị những phần khớp với mẫu của một dòng"
 
-#: builtin/grep.c:898
+#: builtin/grep.c:912
 msgid "show the number of matches instead of matching lines"
 msgstr "hiển thị số lượng khớp thay vì những dòng khớp với mẫu"
 
-#: builtin/grep.c:899
+#: builtin/grep.c:913
 msgid "highlight matches"
 msgstr "tô sáng phần khớp mẫu"
 
-#: builtin/grep.c:901
+#: builtin/grep.c:915
 msgid "print empty line between matches from different files"
 msgstr "hiển thị dòng trống giữa các lần khớp từ các tập tin khác biệt"
 
-#: builtin/grep.c:903
+#: builtin/grep.c:917
 msgid "show filename only once above matches from same file"
 msgstr ""
 "hiển thị tên tập tin một lần phía trên các lần khớp từ cùng một tập tin"
 
-#: builtin/grep.c:906
+#: builtin/grep.c:920
 msgid "show <n> context lines before and after matches"
 msgstr "hiển thị <n> dòng nội dung phía trước và sau các lần khớp"
 
-#: builtin/grep.c:909
+#: builtin/grep.c:923
 msgid "show <n> context lines before matches"
 msgstr "hiển thị <n> dòng nội dung trước khớp"
 
-#: builtin/grep.c:911
+#: builtin/grep.c:925
 msgid "show <n> context lines after matches"
 msgstr "hiển thị <n> dòng nội dung sau khớp"
 
-#: builtin/grep.c:913
+#: builtin/grep.c:927
 msgid "use <n> worker threads"
 msgstr "dùng <n> tuyến trình làm việc"
 
-#: builtin/grep.c:914
+#: builtin/grep.c:928
 msgid "shortcut for -C NUM"
 msgstr "dạng viết tắt của -C SỐ"
 
-#: builtin/grep.c:917
+#: builtin/grep.c:931
 msgid "show a line with the function name before matches"
 msgstr "hiển thị dòng vói tên hàm trước các lần khớp"
 
-#: builtin/grep.c:919
+#: builtin/grep.c:933
 msgid "show the surrounding function"
 msgstr "hiển thị hàm bao quanh"
 
-#: builtin/grep.c:922
+#: builtin/grep.c:936
 msgid "read patterns from file"
 msgstr "đọc mẫu từ tập-tin"
 
-#: builtin/grep.c:924
+#: builtin/grep.c:938
 msgid "match <pattern>"
 msgstr "match <mẫu>"
 
-#: builtin/grep.c:926
+#: builtin/grep.c:940
 msgid "combine patterns specified with -e"
 msgstr "tổ hợp mẫu được chỉ ra với tùy chọn -e"
 
-#: builtin/grep.c:938
+#: builtin/grep.c:952
 msgid "indicate hit with exit status without output"
 msgstr "đưa ra gợi ý với trạng thái thoát mà không có kết xuất"
 
-#: builtin/grep.c:940
+#: builtin/grep.c:954
 msgid "show only matches from files that match all patterns"
 msgstr "chỉ hiển thị những cái khớp từ tập tin mà nó khớp toàn bộ các mẫu"
 
-#: builtin/grep.c:943
+#: builtin/grep.c:957
 msgid "pager"
 msgstr "dàn trang"
 
-#: builtin/grep.c:943
+#: builtin/grep.c:957
 msgid "show matching files in the pager"
 msgstr "hiển thị các tập tin khớp trong trang giấy"
 
-#: builtin/grep.c:947
+#: builtin/grep.c:961
 msgid "allow calling of grep(1) (ignored by this build)"
 msgstr "cho phép gọi grep(1) (bị bỏ qua bởi lần dịch này)"
 
-#: builtin/grep.c:1013
+#: builtin/grep.c:1027
 msgid "no pattern given"
 msgstr "chưa chỉ ra mẫu"
 
-#: builtin/grep.c:1049
+#: builtin/grep.c:1063
 msgid "--no-index or --untracked cannot be used with revs"
 msgstr "--no-index hay --untracked không được sử dụng cùng với revs"
 
-#: builtin/grep.c:1057
+#: builtin/grep.c:1071
 #, c-format
 msgid "unable to resolve revision: %s"
 msgstr "không thể phân giải điểm xét duyệt: %s"
 
-#: builtin/grep.c:1087
+#: builtin/grep.c:1101
 msgid "--untracked not supported with --recurse-submodules"
 msgstr "tùy chọn --untracked không được hỗ trợ với --recurse-submodules"
 
-#: builtin/grep.c:1091
+#: builtin/grep.c:1105
 msgid "invalid option combination, ignoring --threads"
 msgstr "tổ hợp tùy chọn không hợp lệ, bỏ qua --threads"
 
-#: builtin/grep.c:1094 builtin/pack-objects.c:4090
+#: builtin/grep.c:1108 builtin/pack-objects.c:4059
 msgid "no threads support, ignoring --threads"
 msgstr "không hỗ trợ đa tuyến, bỏ qua --threads"
 
-#: builtin/grep.c:1097 builtin/index-pack.c:1585 builtin/pack-objects.c:3126
+#: builtin/grep.c:1111 builtin/index-pack.c:1579 builtin/pack-objects.c:3139
 #, c-format
 msgid "invalid number of threads specified (%d)"
 msgstr "số tuyến chỉ ra không hợp lệ (%d)"
 
-#: builtin/grep.c:1131
+#: builtin/grep.c:1145
 msgid "--open-files-in-pager only works on the worktree"
 msgstr "--open-files-in-pager chỉ làm việc trên cây-làm-việc"
 
-#: builtin/grep.c:1157
+#: builtin/grep.c:1171
 msgid "--cached or --untracked cannot be used with --no-index"
 msgstr "--cached hay --untracked không được sử dụng với --no-index"
 
-#: builtin/grep.c:1160
+#: builtin/grep.c:1174
 msgid "--untracked cannot be used with --cached"
 msgstr "--untracked không thể được sử dụng với tùy chọn --cached"
 
-#: builtin/grep.c:1166
+#: builtin/grep.c:1180
 msgid "--[no-]exclude-standard cannot be used for tracked contents"
 msgstr "--[no-]exclude-standard không thể sử dụng cho nội dung lưu dấu vết"
 
-#: builtin/grep.c:1174
+#: builtin/grep.c:1188
 msgid "both --cached and trees are given"
 msgstr "cả hai --cached và các cây phải được chỉ ra"
 
-#: builtin/hash-object.c:85
+#: builtin/hash-object.c:83
 msgid ""
 "git hash-object [-t <type>] [-w] [--path=<file> | --no-filters] [--stdin] "
 "[--] <file>..."
@@ -16249,95 +16558,107 @@ msgstr ""
 "git hash-object [-t <kiểu>] [-w] [--path=<tập-tin> | --no-filters] [--stdin] "
 "[--] <tập-tin>…"
 
-#: builtin/hash-object.c:86
+#: builtin/hash-object.c:84
 msgid "git hash-object  --stdin-paths"
 msgstr "git hash-object  --stdin-paths"
 
-#: builtin/hash-object.c:98
+#: builtin/hash-object.c:96
 msgid "object type"
 msgstr "kiểu đối tượng"
 
-#: builtin/hash-object.c:99
+#: builtin/hash-object.c:97
 msgid "write the object into the object database"
 msgstr "ghi đối tượng vào dữ liệu đối tượng"
 
-#: builtin/hash-object.c:101
+#: builtin/hash-object.c:99
 msgid "read the object from stdin"
 msgstr "đọc đối tượng từ đầu vào tiêu chuẩn stdin"
 
-#: builtin/hash-object.c:103
+#: builtin/hash-object.c:101
 msgid "store file as is without filters"
 msgstr "lưu các tập tin mà nó không có các bộ lọc"
 
-#: builtin/hash-object.c:104
+#: builtin/hash-object.c:102
 msgid ""
 "just hash any random garbage to create corrupt objects for debugging Git"
 msgstr "chỉ cần băm rác ngẫu nhiên để tạo một đối tượng hỏng để mà gỡ lỗi Git"
 
-#: builtin/hash-object.c:105
+#: builtin/hash-object.c:103
 msgid "process file as it were from this path"
 msgstr "xử lý tập tin như là nó đang ở thư mục này"
 
-#: builtin/help.c:47
+#: builtin/help.c:55
 msgid "print all available commands"
 msgstr "hiển thị danh sách các câu lệnh người dùng có thể sử dụng"
 
-#: builtin/help.c:48
+#: builtin/help.c:57
 msgid "exclude guides"
 msgstr "hướng dẫn loại trừ"
 
-#: builtin/help.c:49
-msgid "print list of useful guides"
-msgstr "hiển thị danh sách các hướng dẫn hữu dụng"
-
-#: builtin/help.c:50
-msgid "print all configuration variable names"
-msgstr "in ra tất cả các tên biến cấu hình"
-
-#: builtin/help.c:52
+#: builtin/help.c:58
 msgid "show man page"
 msgstr "hiển thị trang man"
 
-#: builtin/help.c:53
+#: builtin/help.c:59
 msgid "show manual in web browser"
 msgstr "hiển thị hướng dẫn sử dụng trong trình duyệt web"
 
-#: builtin/help.c:55
+#: builtin/help.c:61
 msgid "show info page"
-msgstr "hiện trang info"
+msgstr "hiển thị trang info"
 
-#: builtin/help.c:57
+#: builtin/help.c:63
 msgid "print command description"
 msgstr "hiển thị mô tả lệnh"
 
-#: builtin/help.c:62
-msgid "git help [--all] [--guides] [--man | --web | --info] [<command>]"
-msgstr "git help [--all] [--guides] [--man | --web | --info] [<lệnh>]"
+#: builtin/help.c:65
+msgid "print list of useful guides"
+msgstr "hiển thị danh sách các hướng dẫn hữu dụng"
 
-#: builtin/help.c:163
+#: builtin/help.c:67
+msgid "print all configuration variable names"
+msgstr "in ra tất cả các tên biến cấu hình"
+
+#: builtin/help.c:78
+msgid ""
+"git help [-a|--all] [--[no-]verbose]]\n"
+"         [[-i|--info] [-m|--man] [-w|--web]] [<command>]"
+msgstr ""
+"git help [-a|--all] [--[no-]verbose]]\n"
+"         [[-i|--info] [-m|--man] [-w|--web]] [<lệnh>]"
+
+#: builtin/help.c:80
+msgid "git help [-g|--guides]"
+msgstr "git help [-g|--guides]"
+
+#: builtin/help.c:81
+msgid "git help [-c|--config]"
+msgstr "git help [-c|--config]"
+
+#: builtin/help.c:196
 #, c-format
 msgid "unrecognized help format '%s'"
 msgstr "không nhận ra định dạng trợ giúp “%s”"
 
-#: builtin/help.c:190
+#: builtin/help.c:223
 msgid "Failed to start emacsclient."
 msgstr "Gặp lỗi khi khởi chạy emacsclient."
 
-#: builtin/help.c:203
+#: builtin/help.c:236
 msgid "Failed to parse emacsclient version."
 msgstr "Gặp lỗi khi phân tích phiên bản emacsclient."
 
-#: builtin/help.c:211
+#: builtin/help.c:244
 #, c-format
 msgid "emacsclient version '%d' too old (< 22)."
 msgstr "phiên bản của emacsclient “%d” quá cũ (< 22)."
 
-#: builtin/help.c:229 builtin/help.c:251 builtin/help.c:261 builtin/help.c:269
+#: builtin/help.c:262 builtin/help.c:284 builtin/help.c:294 builtin/help.c:302
 #, c-format
 msgid "failed to exec '%s'"
 msgstr "gặp lỗi khi thực thi “%s”"
 
-#: builtin/help.c:307
+#: builtin/help.c:340
 #, c-format
 msgid ""
 "'%s': path for unsupported man viewer.\n"
@@ -16346,7 +16667,7 @@ msgstr ""
 "“%s”: đường dẫn không hỗ trợ bộ trình chiếu man.\n"
 "Hãy cân nhắc đến việc sử dụng “man.<tool>.cmd” để thay thế."
 
-#: builtin/help.c:319
+#: builtin/help.c:352
 #, c-format
 msgid ""
 "'%s': cmd for supported man viewer.\n"
@@ -16355,325 +16676,316 @@ msgstr ""
 "“%s”: cmd (lệnh) hỗ trợ bộ trình chiếu man.\n"
 "Hãy cân nhắc đến việc sử dụng “man.<tool>.path” để thay thế."
 
-#: builtin/help.c:436
+#: builtin/help.c:467
 #, c-format
 msgid "'%s': unknown man viewer."
 msgstr "“%s”: không rõ chương trình xem man."
 
-#: builtin/help.c:452
+#: builtin/help.c:483
 msgid "no man viewer handled the request"
 msgstr "không có trình xem trợ giúp dạng manpage tiếp hợp với yêu cầu"
 
-#: builtin/help.c:459
+#: builtin/help.c:490
 msgid "no info viewer handled the request"
 msgstr "không có trình xem trợ giúp dạng info tiếp hợp với yêu cầu"
 
-#: builtin/help.c:517 builtin/help.c:528 git.c:348
+#: builtin/help.c:551 builtin/help.c:562 git.c:348
 #, c-format
 msgid "'%s' is aliased to '%s'"
 msgstr "“%s” được đặt bí danh thành “%s”"
 
-#: builtin/help.c:531 git.c:380
+#: builtin/help.c:565 git.c:380
 #, c-format
 msgid "bad alias.%s string: %s"
 msgstr "chuỗi alias.%s sai: %s"
 
-#: builtin/help.c:561 builtin/help.c:591
+#: builtin/help.c:581
+msgid "this option doesn't take any other arguments"
+msgstr "tùy chọn này không nhận tham số nào khác"
+
+#: builtin/help.c:602 builtin/help.c:629
 #, c-format
 msgid "usage: %s%s"
 msgstr "cách dùng: %s%s"
 
-#: builtin/help.c:575
+#: builtin/help.c:624
 msgid "'git help config' for more information"
 msgstr "Chạy lệnh “git help config” để có thêm thông tin"
 
-#: builtin/index-pack.c:222
+#: builtin/index-pack.c:221
 #, c-format
 msgid "object type mismatch at %s"
 msgstr "kiểu đối tượng không khớp tại %s"
 
-#: builtin/index-pack.c:242
+#: builtin/index-pack.c:241
 #, c-format
 msgid "did not receive expected object %s"
 msgstr "không thể lấy về đối tượng cần %s"
 
-#: builtin/index-pack.c:245
+#: builtin/index-pack.c:244
 #, c-format
 msgid "object %s: expected type %s, found %s"
 msgstr "đối tượng %s: cần kiểu %s nhưng lại nhận được %s"
 
-#: builtin/index-pack.c:295
+#: builtin/index-pack.c:294
 #, c-format
 msgid "cannot fill %d byte"
 msgid_plural "cannot fill %d bytes"
 msgstr[0] "không thể điền thêm vào %d byte"
 
-#: builtin/index-pack.c:305
+#: builtin/index-pack.c:304
 msgid "early EOF"
 msgstr "gặp kết thúc tập tin EOF quá sớm"
 
-#: builtin/index-pack.c:306
+#: builtin/index-pack.c:305
 msgid "read error on input"
 msgstr "lỗi đọc ở đầu vào"
 
-#: builtin/index-pack.c:318
+#: builtin/index-pack.c:317
 msgid "used more bytes than were available"
 msgstr "sử dụng nhiều hơn số lượng byte mà nó sẵn có"
 
-#: builtin/index-pack.c:325 builtin/pack-objects.c:756
+#: builtin/index-pack.c:324 builtin/pack-objects.c:756
 msgid "pack too large for current definition of off_t"
 msgstr "gói quá lớn so với định nghĩa hiện tại của kiểu off_t"
 
-#: builtin/index-pack.c:328 builtin/unpack-objects.c:95
+#: builtin/index-pack.c:327 builtin/unpack-objects.c:95
 msgid "pack exceeds maximum allowed size"
 msgstr "gói đã vượt quá cỡ tối đa được phép"
 
-#: builtin/index-pack.c:343
-#, c-format
-msgid "unable to create '%s'"
-msgstr "không thể tạo “%s”"
-
-#: builtin/index-pack.c:349
-#, c-format
-msgid "cannot open packfile '%s'"
-msgstr "không thể mở packfile “%s”"
-
-#: builtin/index-pack.c:363
+#: builtin/index-pack.c:358
 msgid "pack signature mismatch"
 msgstr "chữ ký cho gói không khớp"
 
-#: builtin/index-pack.c:365
+#: builtin/index-pack.c:360
 #, c-format
 msgid "pack version %<PRIu32> unsupported"
 msgstr "không hỗ trợ phiên bản gói %<PRIu32>"
 
-#: builtin/index-pack.c:381
+#: builtin/index-pack.c:376
 #, c-format
 msgid "pack has bad object at offset %<PRIuMAX>: %s"
 msgstr "gói có đối tượng sai tại khoảng bù %<PRIuMAX>: %s"
 
-#: builtin/index-pack.c:487
+#: builtin/index-pack.c:482
 #, c-format
 msgid "inflate returned %d"
 msgstr "xả nén trả về %d"
 
-#: builtin/index-pack.c:536
+#: builtin/index-pack.c:531
 msgid "offset value overflow for delta base object"
 msgstr "tràn giá trị khoảng bù cho đối tượng delta cơ sở"
 
-#: builtin/index-pack.c:544
+#: builtin/index-pack.c:539
 msgid "delta base offset is out of bound"
 msgstr "khoảng bù cơ sở cho delta nằm ngoài phạm vi"
 
-#: builtin/index-pack.c:552
+#: builtin/index-pack.c:547
 #, c-format
 msgid "unknown object type %d"
 msgstr "không hiểu kiểu đối tượng %d"
 
-#: builtin/index-pack.c:583
+#: builtin/index-pack.c:578
 msgid "cannot pread pack file"
 msgstr "không thể chạy hàm pread cho tập tin gói"
 
-#: builtin/index-pack.c:585
+#: builtin/index-pack.c:580
 #, c-format
 msgid "premature end of pack file, %<PRIuMAX> byte missing"
 msgid_plural "premature end of pack file, %<PRIuMAX> bytes missing"
 msgstr[0] "tập tin gói bị kết thúc sớm, thiếu %<PRIuMAX> byte"
 
-#: builtin/index-pack.c:611
+#: builtin/index-pack.c:606
 msgid "serious inflate inconsistency"
 msgstr "sự mâu thuẫn xả nén nghiêm trọng"
 
-#: builtin/index-pack.c:756 builtin/index-pack.c:762 builtin/index-pack.c:786
-#: builtin/index-pack.c:825 builtin/index-pack.c:834
+#: builtin/index-pack.c:751 builtin/index-pack.c:757 builtin/index-pack.c:781
+#: builtin/index-pack.c:820 builtin/index-pack.c:829
 #, c-format
 msgid "SHA1 COLLISION FOUND WITH %s !"
 msgstr "SỰ VA CHẠM SHA1 ĐÃ XẢY RA VỚI %s!"
 
-#: builtin/index-pack.c:759 builtin/pack-objects.c:292
+#: builtin/index-pack.c:754 builtin/pack-objects.c:292
 #: builtin/pack-objects.c:352 builtin/pack-objects.c:458
 #, c-format
 msgid "unable to read %s"
 msgstr "không thể đọc %s"
 
-#: builtin/index-pack.c:823
+#: builtin/index-pack.c:818
 #, c-format
 msgid "cannot read existing object info %s"
 msgstr "không thể đọc thông tin đối tượng sẵn có %s"
 
-#: builtin/index-pack.c:831
+#: builtin/index-pack.c:826
 #, c-format
 msgid "cannot read existing object %s"
 msgstr "không thể đọc đối tượng đã tồn tại %s"
 
-#: builtin/index-pack.c:845
+#: builtin/index-pack.c:840
 #, c-format
 msgid "invalid blob object %s"
 msgstr "đối tượng blob không hợp lệ %s"
 
-#: builtin/index-pack.c:848 builtin/index-pack.c:867
+#: builtin/index-pack.c:843 builtin/index-pack.c:862
 msgid "fsck error in packed object"
 msgstr "lỗi fsck trong đối tượng đóng gói"
 
-#: builtin/index-pack.c:869
+#: builtin/index-pack.c:864
 #, c-format
 msgid "Not all child objects of %s are reachable"
 msgstr "Không phải tất cả các đối tượng con của %s là có thể với tới được"
 
-#: builtin/index-pack.c:930 builtin/index-pack.c:977
+#: builtin/index-pack.c:925 builtin/index-pack.c:972
 msgid "failed to apply delta"
 msgstr "gặp lỗi khi áp dụng delta"
 
-#: builtin/index-pack.c:1160
+#: builtin/index-pack.c:1156
 msgid "Receiving objects"
 msgstr "Đang nhận về các đối tượng"
 
-#: builtin/index-pack.c:1160
+#: builtin/index-pack.c:1156
 msgid "Indexing objects"
 msgstr "Các đối tượng bảng mục lục"
 
-#: builtin/index-pack.c:1194
+#: builtin/index-pack.c:1190
 msgid "pack is corrupted (SHA1 mismatch)"
 msgstr "gói bị sai hỏng (SHA1 không khớp)"
 
-#: builtin/index-pack.c:1199
+#: builtin/index-pack.c:1195
 msgid "cannot fstat packfile"
 msgstr "không thể lấy thông tin thống kê packfile"
 
-#: builtin/index-pack.c:1202
+#: builtin/index-pack.c:1198
 msgid "pack has junk at the end"
 msgstr "pack có phần thừa ở cuối"
 
-#: builtin/index-pack.c:1214
+#: builtin/index-pack.c:1210
 msgid "confusion beyond insanity in parse_pack_objects()"
 msgstr "lộn xộn hơn cả điên rồ khi chạy hàm parse_pack_objects()"
 
-#: builtin/index-pack.c:1237
+#: builtin/index-pack.c:1233
 msgid "Resolving deltas"
 msgstr "Đang phân giải các delta"
 
-#: builtin/index-pack.c:1248 builtin/pack-objects.c:2892
+#: builtin/index-pack.c:1244 builtin/pack-objects.c:2905
 #, c-format
 msgid "unable to create thread: %s"
 msgstr "không thể tạo tuyến: %s"
 
-#: builtin/index-pack.c:1281
+#: builtin/index-pack.c:1277
 msgid "confusion beyond insanity"
 msgstr "lộn xộn hơn cả điên rồ"
 
-#: builtin/index-pack.c:1287
+#: builtin/index-pack.c:1283
 #, c-format
 msgid "completed with %d local object"
 msgid_plural "completed with %d local objects"
 msgstr[0] "đầy đủ với %d đối tượng nội bộ"
 
-#: builtin/index-pack.c:1299
+#: builtin/index-pack.c:1295
 #, c-format
 msgid "Unexpected tail checksum for %s (disk corruption?)"
 msgstr "Gặp tổng kiểm tra tail không cần cho %s (đĩa hỏng?)"
 
-#: builtin/index-pack.c:1303
+#: builtin/index-pack.c:1299
 #, c-format
 msgid "pack has %d unresolved delta"
 msgid_plural "pack has %d unresolved deltas"
 msgstr[0] "gói có %d delta chưa được giải quyết"
 
-#: builtin/index-pack.c:1327
+#: builtin/index-pack.c:1323
 #, c-format
 msgid "unable to deflate appended object (%d)"
 msgstr "không thể xả nén đối tượng nối thêm (%d)"
 
-#: builtin/index-pack.c:1423
+#: builtin/index-pack.c:1419
 #, c-format
 msgid "local object %s is corrupt"
 msgstr "đối tượng nội bộ %s bị hỏng"
 
-#: builtin/index-pack.c:1444
+#: builtin/index-pack.c:1440
 #, c-format
 msgid "packfile name '%s' does not end with '.%s'"
 msgstr "tên tập tin tập tin gói “%s” không được kết thúc “.%s”"
 
-#: builtin/index-pack.c:1468
+#: builtin/index-pack.c:1464
 #, c-format
 msgid "cannot write %s file '%s'"
 msgstr "không thể ghi %s tập tin “%s”"
 
-#: builtin/index-pack.c:1476
+#: builtin/index-pack.c:1472
 #, c-format
 msgid "cannot close written %s file '%s'"
 msgstr "không thể đóng tập tin được ghi %s “%s”"
 
-#: builtin/index-pack.c:1502
+#: builtin/index-pack.c:1489
+#, c-format
+msgid "unable to rename temporary '*.%s' file to '%s'"
+msgstr "không thể đổi tên tập tin tạm thời “*.%s” thành “%s”"
+
+#: builtin/index-pack.c:1514
 msgid "error while closing pack file"
 msgstr "gặp lỗi trong khi đóng tập tin gói"
 
-#: builtin/index-pack.c:1516
-msgid "cannot store pack file"
-msgstr "không thể lưu tập tin gói"
-
-#: builtin/index-pack.c:1524
-msgid "cannot store index file"
-msgstr "không thể lưu trữ tập tin ghi mục lục"
-
-#: builtin/index-pack.c:1579 builtin/pack-objects.c:3137
+#: builtin/index-pack.c:1573 builtin/pack-objects.c:3150
 #, c-format
 msgid "bad pack.indexversion=%<PRIu32>"
 msgstr "sai pack.indexversion=%<PRIu32>"
 
-#: builtin/index-pack.c:1649
+#: builtin/index-pack.c:1643
 #, c-format
 msgid "Cannot open existing pack file '%s'"
 msgstr "Không thể mở tập tin gói đã sẵn có “%s”"
 
-#: builtin/index-pack.c:1651
+#: builtin/index-pack.c:1645
 #, c-format
 msgid "Cannot open existing pack idx file for '%s'"
 msgstr "Không thể mở tập tin idx của gói cho “%s”"
 
-#: builtin/index-pack.c:1699
+#: builtin/index-pack.c:1693
 #, c-format
 msgid "non delta: %d object"
 msgid_plural "non delta: %d objects"
 msgstr[0] "không delta: %d đối tượng"
 
-#: builtin/index-pack.c:1706
+#: builtin/index-pack.c:1700
 #, c-format
 msgid "chain length = %d: %lu object"
 msgid_plural "chain length = %d: %lu objects"
 msgstr[0] "chiều dài xích = %d: %lu đối tượng"
 
-#: builtin/index-pack.c:1748
+#: builtin/index-pack.c:1742
 msgid "Cannot come back to cwd"
 msgstr "Không thể quay lại cwd"
 
-#: builtin/index-pack.c:1802 builtin/index-pack.c:1805
-#: builtin/index-pack.c:1821 builtin/index-pack.c:1825
+#: builtin/index-pack.c:1796 builtin/index-pack.c:1799
+#: builtin/index-pack.c:1819 builtin/index-pack.c:1823
 #, c-format
 msgid "bad %s"
 msgstr "%s sai"
 
-#: builtin/index-pack.c:1831 builtin/init-db.c:379 builtin/init-db.c:614
+#: builtin/index-pack.c:1829 builtin/init-db.c:379 builtin/init-db.c:614
 #, c-format
 msgid "unknown hash algorithm '%s'"
 msgstr "không hiểu thuật toán băm dữ liệu “%s”"
 
-#: builtin/index-pack.c:1850
+#: builtin/index-pack.c:1848
 msgid "--fix-thin cannot be used without --stdin"
 msgstr "--fix-thin không thể được dùng mà không có --stdin"
 
-#: builtin/index-pack.c:1852
+#: builtin/index-pack.c:1850
 msgid "--stdin requires a git repository"
 msgstr "--stdin cần một kho git"
 
-#: builtin/index-pack.c:1854
+#: builtin/index-pack.c:1852
 msgid "--object-format cannot be used with --stdin"
 msgstr "--object-format không thể được dùng với --stdin"
 
-#: builtin/index-pack.c:1869
+#: builtin/index-pack.c:1867
 msgid "--verify with no packfile name given"
 msgstr "dùng tùy chọn --verify mà không đưa ra tên packfile"
 
-#: builtin/index-pack.c:1935 builtin/unpack-objects.c:584
+#: builtin/index-pack.c:1933 builtin/unpack-objects.c:584
 msgid "fsck error in pack objects"
 msgstr "lỗi fsck trong các đối tượng gói"
 
@@ -17315,132 +17627,136 @@ msgstr ""
 "Không tìm thấy nhánh mạng được theo dõi, hãy chỉ định <thượng-nguồn> một "
 "cách thủ công.\n"
 
-#: builtin/ls-files.c:563
+#: builtin/ls-files.c:561
 msgid "git ls-files [<options>] [<file>...]"
 msgstr "git ls-files [<các tùy chọn>] [<tập-tin>…]"
 
-#: builtin/ls-files.c:619
+#: builtin/ls-files.c:615
+msgid "separate paths with the NUL character"
+msgstr "các đường dẫn được ngăn cách bởi ký tự NULL"
+
+#: builtin/ls-files.c:617
 msgid "identify the file status with tags"
 msgstr "nhận dạng các trạng thái tập tin với thẻ"
 
-#: builtin/ls-files.c:621
+#: builtin/ls-files.c:619
 msgid "use lowercase letters for 'assume unchanged' files"
 msgstr ""
 "dùng chữ cái viết thường cho các tập tin “assume unchanged” (giả định không "
 "thay đổi)"
 
-#: builtin/ls-files.c:623
+#: builtin/ls-files.c:621
 msgid "use lowercase letters for 'fsmonitor clean' files"
 msgstr "dùng chữ cái viết thường cho các tập tin “fsmonitor clean”"
 
-#: builtin/ls-files.c:625
+#: builtin/ls-files.c:623
 msgid "show cached files in the output (default)"
 msgstr "hiển thị các tập tin được nhớ tạm vào đầu ra (mặc định)"
 
-#: builtin/ls-files.c:627
+#: builtin/ls-files.c:625
 msgid "show deleted files in the output"
 msgstr "hiển thị các tập tin đã xóa trong kết xuất"
 
-#: builtin/ls-files.c:629
+#: builtin/ls-files.c:627
 msgid "show modified files in the output"
 msgstr "hiển thị các tập tin đã bị sửa đổi ra kết xuất"
 
-#: builtin/ls-files.c:631
+#: builtin/ls-files.c:629
 msgid "show other files in the output"
 msgstr "hiển thị các tập tin khác trong kết xuất"
 
-#: builtin/ls-files.c:633
+#: builtin/ls-files.c:631
 msgid "show ignored files in the output"
 msgstr "hiển thị các tập tin bị bỏ qua trong kết xuất"
 
-#: builtin/ls-files.c:636
+#: builtin/ls-files.c:634
 msgid "show staged contents' object name in the output"
 msgstr "hiển thị tên đối tượng của nội dung được đặt lên bệ phóng ra kết xuất"
 
-#: builtin/ls-files.c:638
+#: builtin/ls-files.c:636
 msgid "show files on the filesystem that need to be removed"
 msgstr "hiển thị các tập tin trên hệ thống tập tin mà nó cần được gỡ bỏ"
 
-#: builtin/ls-files.c:640
+#: builtin/ls-files.c:638
 msgid "show 'other' directories' names only"
 msgstr "chỉ hiển thị tên của các thư mục “khác”"
 
-#: builtin/ls-files.c:642
+#: builtin/ls-files.c:640
 msgid "show line endings of files"
 msgstr "hiển thị kết thúc dòng của các tập tin"
 
-#: builtin/ls-files.c:644
+#: builtin/ls-files.c:642
 msgid "don't show empty directories"
 msgstr "không hiển thị thư mục rỗng"
 
-#: builtin/ls-files.c:647
+#: builtin/ls-files.c:645
 msgid "show unmerged files in the output"
 msgstr "hiển thị các tập tin chưa hòa trộn trong kết xuất"
 
-#: builtin/ls-files.c:649
+#: builtin/ls-files.c:647
 msgid "show resolve-undo information"
 msgstr "hiển thị thông tin resolve-undo"
 
-#: builtin/ls-files.c:651
+#: builtin/ls-files.c:649
 msgid "skip files matching pattern"
 msgstr "bỏ qua những tập tin khớp với một mẫu"
 
-#: builtin/ls-files.c:654
-msgid "exclude patterns are read from <file>"
-msgstr "mẫu loại trừ được đọc từ <tập tin>"
+#: builtin/ls-files.c:652
+msgid "read exclude patterns from <file>"
+msgstr "đọc mẫu cần loại trừ từ <tập-tin>"
 
-#: builtin/ls-files.c:657
+#: builtin/ls-files.c:655
 msgid "read additional per-directory exclude patterns in <file>"
 msgstr "đọc thêm các mẫu ngoại trừ mỗi thư mục trong <tập tin>"
 
-#: builtin/ls-files.c:659
+#: builtin/ls-files.c:657
 msgid "add the standard git exclusions"
 msgstr "thêm loại trừ tiêu chuẩn kiểu git"
 
-#: builtin/ls-files.c:663
+#: builtin/ls-files.c:661
 msgid "make the output relative to the project top directory"
 msgstr "làm cho kết xuất liên quan đến thư mục ở mức cao nhất (gốc) của dự án"
 
-#: builtin/ls-files.c:666
+#: builtin/ls-files.c:664
 msgid "recurse through submodules"
 msgstr "đệ quy xuyên qua mô-đun con"
 
-#: builtin/ls-files.c:668
+#: builtin/ls-files.c:666
 msgid "if any <file> is not in the index, treat this as an error"
 msgstr "nếu <tập tin> bất kỳ không ở trong bảng mục lục, xử lý nó như một lỗi"
 
-#: builtin/ls-files.c:669
+#: builtin/ls-files.c:667
 msgid "tree-ish"
 msgstr "tree-ish"
 
-#: builtin/ls-files.c:670
+#: builtin/ls-files.c:668
 msgid "pretend that paths removed since <tree-ish> are still present"
 msgstr ""
 "giả định rằng các đường dẫn đã bị gỡ bỏ kể từ <tree-ish> nay vẫn hiện diện"
 
-#: builtin/ls-files.c:672
+#: builtin/ls-files.c:670
 msgid "show debugging data"
 msgstr "hiển thị dữ liệu gỡ lỗi"
 
-#: builtin/ls-files.c:674
+#: builtin/ls-files.c:672
 msgid "suppress duplicate entries"
 msgstr "chặn các mục tin trùng lặp"
 
 #: builtin/ls-remote.c:9
 msgid ""
 "git ls-remote [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
-"                     [-q | --quiet] [--exit-code] [--get-url]\n"
-"                     [--symref] [<repository> [<refs>...]]"
+"              [-q | --quiet] [--exit-code] [--get-url]\n"
+"              [--symref] [<repository> [<refs>...]]"
 msgstr ""
 "git ls-remote [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
-"                     [-q | --quiet] [--exit-code] [--get-url]\n"
-"                     [--symref] [<kho> [<các tham chiếu>…]]"
+"              [-q | --quiet] [--exit-code] [--get-url]\n"
+"              [--symref] [<kho> [<các tham chiếu>…]]"
 
 #: builtin/ls-remote.c:60
 msgid "do not print remote URL"
 msgstr "không hiển thị URL máy chủ"
 
-#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1399
+#: builtin/ls-remote.c:61 builtin/ls-remote.c:63 builtin/rebase.c:1103
 msgid "exec"
 msgstr "thực thi"
 
@@ -17557,7 +17873,7 @@ msgstr "hành động khi CR được trích dẫn được tìm thấy"
 msgid "use headers in message's body"
 msgstr "sử dụng phần đầu trong nội dung thư"
 
-#: builtin/mailsplit.c:241
+#: builtin/mailsplit.c:239
 #, c-format
 msgid "empty mbox: '%s'"
 msgstr "mbox trống rỗng: “%s”"
@@ -17672,144 +17988,144 @@ msgstr "không thể phân giải tham chiếu %s"
 msgid "Merging %s with %s\n"
 msgstr "Đang hòa trộn %s với %s\n"
 
-#: builtin/merge.c:58
+#: builtin/merge.c:59
 msgid "git merge [<options>] [<commit>...]"
 msgstr "git merge [<các tùy chọn>] [<commit>…]"
 
-#: builtin/merge.c:123
+#: builtin/merge.c:124
 msgid "switch `m' requires a value"
 msgstr "switch “m” yêu cầu một giá trị"
 
-#: builtin/merge.c:146
+#: builtin/merge.c:147
 #, c-format
 msgid "option `%s' requires a value"
 msgstr "tùy chọn “%s” yêu cầu một giá trị"
 
-#: builtin/merge.c:199
+#: builtin/merge.c:200
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
 msgstr "Không tìm thấy chiến lược hòa trộn “%s”.\n"
 
-#: builtin/merge.c:200
+#: builtin/merge.c:201
 #, c-format
 msgid "Available strategies are:"
 msgstr "Các chiến lược sẵn sàng là:"
 
-#: builtin/merge.c:205
+#: builtin/merge.c:206
 #, c-format
 msgid "Available custom strategies are:"
 msgstr "Các chiến lược tùy chỉnh sẵn sàng là:"
 
-#: builtin/merge.c:256 builtin/pull.c:133
+#: builtin/merge.c:257 builtin/pull.c:133
 msgid "do not show a diffstat at the end of the merge"
 msgstr "không hiển thị thống kê khác biệt tại cuối của lần hòa trộn"
 
-#: builtin/merge.c:259 builtin/pull.c:136
+#: builtin/merge.c:260 builtin/pull.c:136
 msgid "show a diffstat at the end of the merge"
 msgstr "hiển thị thống kê khác biệt tại cuối của hòa trộn"
 
-#: builtin/merge.c:260 builtin/pull.c:139
+#: builtin/merge.c:261 builtin/pull.c:139
 msgid "(synonym to --stat)"
 msgstr "(đồng nghĩa với --stat)"
 
-#: builtin/merge.c:262 builtin/pull.c:142
+#: builtin/merge.c:263 builtin/pull.c:142
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr "thêm (ít nhất <n>) mục từ shortlog cho ghi chú chuyển giao hòa trộn"
 
-#: builtin/merge.c:265 builtin/pull.c:148
+#: builtin/merge.c:266 builtin/pull.c:148
 msgid "create a single commit instead of doing a merge"
 msgstr "tạo một lần chuyển giao đưon thay vì thực hiện việc hòa trộn"
 
-#: builtin/merge.c:267 builtin/pull.c:151
+#: builtin/merge.c:268 builtin/pull.c:151
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "thực hiện chuyển giao nếu hòa trộn thành công (mặc định)"
 
-#: builtin/merge.c:269 builtin/pull.c:154
+#: builtin/merge.c:270 builtin/pull.c:154
 msgid "edit message before committing"
 msgstr "sửa chú thích trước khi chuyển giao"
 
-#: builtin/merge.c:271
+#: builtin/merge.c:272
 msgid "allow fast-forward (default)"
 msgstr "cho phép chuyển-tiếp-nhanh (mặc định)"
 
-#: builtin/merge.c:273 builtin/pull.c:161
+#: builtin/merge.c:274 builtin/pull.c:161
 msgid "abort if fast-forward is not possible"
 msgstr "bỏ qua nếu chuyển-tiếp-nhanh không thể được"
 
-#: builtin/merge.c:277 builtin/pull.c:164
+#: builtin/merge.c:278 builtin/pull.c:164
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "thẩm tra xem lần chuyển giao có tên đó có chữ ký GPG hợp lệ hay không"
 
-#: builtin/merge.c:278 builtin/notes.c:787 builtin/pull.c:168
-#: builtin/rebase.c:540 builtin/rebase.c:1413 builtin/revert.c:114
+#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:168
+#: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr "chiến lược"
 
-#: builtin/merge.c:279 builtin/pull.c:169
+#: builtin/merge.c:280 builtin/pull.c:169
 msgid "merge strategy to use"
 msgstr "chiến lược hòa trộn sẽ dùng"
 
-#: builtin/merge.c:280 builtin/pull.c:172
+#: builtin/merge.c:281 builtin/pull.c:172
 msgid "option=value"
 msgstr "tùy_chọn=giá_trị"
 
-#: builtin/merge.c:281 builtin/pull.c:173
+#: builtin/merge.c:282 builtin/pull.c:173
 msgid "option for selected merge strategy"
 msgstr "tùy chọn cho chiến lược hòa trộn đã chọn"
 
-#: builtin/merge.c:283
+#: builtin/merge.c:284
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr ""
 "hòa trộn ghi chú của lần chuyển giao (dành cho hòa trộn không-chuyển-tiếp-"
 "nhanh)"
 
-#: builtin/merge.c:290
+#: builtin/merge.c:291
 msgid "abort the current in-progress merge"
 msgstr "bãi bỏ quá trình hòa trộn hiện tại đang thực hiện"
 
-#: builtin/merge.c:292
+#: builtin/merge.c:293
 msgid "--abort but leave index and working tree alone"
 msgstr "--abort nhưng để lại bảng mục lục và cây làm việc"
 
-#: builtin/merge.c:294
+#: builtin/merge.c:295
 msgid "continue the current in-progress merge"
 msgstr "tiếp tục quá trình hòa trộn hiện tại đang thực hiện"
 
-#: builtin/merge.c:296 builtin/pull.c:180
+#: builtin/merge.c:297 builtin/pull.c:180
 msgid "allow merging unrelated histories"
 msgstr "cho phép hòa trộn lịch sử không liên quan"
 
-#: builtin/merge.c:303
+#: builtin/merge.c:304
 msgid "bypass pre-merge-commit and commit-msg hooks"
 msgstr "vòng qua móc (hook) pre-merge-commit và commit-msg"
 
-#: builtin/merge.c:320
+#: builtin/merge.c:321
 msgid "could not run stash."
 msgstr "không thể chạy stash."
 
-#: builtin/merge.c:325
+#: builtin/merge.c:326
 msgid "stash failed"
 msgstr "lệnh tạm cất gặp lỗi"
 
-#: builtin/merge.c:330
+#: builtin/merge.c:331
 #, c-format
 msgid "not a valid object: %s"
 msgstr "không phải là một đối tượng hợp lệ: %s"
 
-#: builtin/merge.c:352 builtin/merge.c:369
+#: builtin/merge.c:353 builtin/merge.c:370
 msgid "read-tree failed"
 msgstr "read-tree gặp lỗi"
 
-#: builtin/merge.c:400
+#: builtin/merge.c:401
 msgid "Already up to date. (nothing to squash)"
 msgstr "Đã cập nhật rồi. (không có gì để squash)"
 
-#: builtin/merge.c:414
+#: builtin/merge.c:415
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
 msgstr "Squash commit -- không cập nhật HEAD\n"
 
-#: builtin/merge.c:464
+#: builtin/merge.c:465
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
 msgstr "Không có lời chú thích hòa trộn -- nên không cập nhật HEAD\n"
@@ -17824,33 +18140,33 @@ msgstr "“%s” không chỉ đến một lần chuyển giao nào cả"
 msgid "Bad branch.%s.mergeoptions string: %s"
 msgstr "Chuỗi branch.%s.mergeoptions sai: %s"
 
-#: builtin/merge.c:729
+#: builtin/merge.c:730
 msgid "Not handling anything other than two heads merge."
 msgstr "Không cầm nắm gì ngoài hai head hòa trộn."
 
-#: builtin/merge.c:742
+#: builtin/merge.c:743
 #, c-format
-msgid "Unknown option for merge-recursive: -X%s"
-msgstr "Không hiểu tùy chọn cho merge-recursive: -X%s"
+msgid "unknown strategy option: -X%s"
+msgstr "không hiểu chiến lược: -X%s"
 
-#: builtin/merge.c:761 t/helper/test-fast-rebase.c:223
+#: builtin/merge.c:762 t/helper/test-fast-rebase.c:223
 #, c-format
 msgid "unable to write %s"
 msgstr "không thể ghi %s"
 
-#: builtin/merge.c:813
+#: builtin/merge.c:814
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "Không thể đọc từ “%s”"
 
-#: builtin/merge.c:822
+#: builtin/merge.c:823
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
 "Vẫn chưa hòa trộn các lần chuyển giao; sử dụng lệnh “git commit” để hoàn tất "
 "việc hòa trộn.\n"
 
-#: builtin/merge.c:828
+#: builtin/merge.c:829
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
@@ -17862,11 +18178,11 @@ msgstr ""
 "topic.\n"
 "\n"
 
-#: builtin/merge.c:833
+#: builtin/merge.c:834
 msgid "An empty message aborts the commit.\n"
 msgstr "Nếu phần chú thích rỗng sẽ hủy bỏ lần chuyển giao.\n"
 
-#: builtin/merge.c:836
+#: builtin/merge.c:837
 #, c-format
 msgid ""
 "Lines starting with '%c' will be ignored, and an empty message aborts\n"
@@ -17875,75 +18191,75 @@ msgstr ""
 "Những dòng được bắt đầu bằng “%c” sẽ được bỏ qua, và nếu phần chú\n"
 "thích rỗng sẽ hủy bỏ lần chuyển giao.\n"
 
-#: builtin/merge.c:889
+#: builtin/merge.c:892
 msgid "Empty commit message."
 msgstr "Chú thích của lần commit (chuyển giao) bị trống rỗng."
 
-#: builtin/merge.c:904
+#: builtin/merge.c:907
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Tuyệt vời.\n"
 
-#: builtin/merge.c:965
+#: builtin/merge.c:968
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
 "Việc tự động hòa trộn gặp lỗi; hãy sửa các xung đột sau đó chuyển giao kết "
 "quả.\n"
 
-#: builtin/merge.c:1004
+#: builtin/merge.c:1007
 msgid "No current branch."
 msgstr "Không phải nhánh hiện hành."
 
-#: builtin/merge.c:1006
+#: builtin/merge.c:1009
 msgid "No remote for the current branch."
 msgstr "Không có máy chủ cho nhánh hiện hành."
 
-#: builtin/merge.c:1008
+#: builtin/merge.c:1011
 msgid "No default upstream defined for the current branch."
 msgstr "Không có thượng nguồn mặc định được định nghĩa cho nhánh hiện hành."
 
-#: builtin/merge.c:1013
+#: builtin/merge.c:1016
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "Không nhánh mạng theo dõi cho %s từ %s"
 
-#: builtin/merge.c:1070
+#: builtin/merge.c:1073
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Giá trị sai “%s” trong biến môi trường “%s”"
 
-#: builtin/merge.c:1173
+#: builtin/merge.c:1174
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "không phải là một thứ gì đó mà chúng tôi có thể hòa trộn trong %s: %s"
 
-#: builtin/merge.c:1207
+#: builtin/merge.c:1208
 msgid "not something we can merge"
 msgstr "không phải là thứ gì đó mà chúng tôi có thể hòa trộn"
 
-#: builtin/merge.c:1317
+#: builtin/merge.c:1321
 msgid "--abort expects no arguments"
 msgstr "--abort không nhận các đối số"
 
-#: builtin/merge.c:1321
+#: builtin/merge.c:1325
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr ""
 "Ở đây không có lần hòa trộn nào được hủy bỏ giữa chừng cả (thiếu MERGE_HEAD)."
 
-#: builtin/merge.c:1339
+#: builtin/merge.c:1343
 msgid "--quit expects no arguments"
 msgstr "--quit không nhận các đối số"
 
-#: builtin/merge.c:1352
+#: builtin/merge.c:1356
 msgid "--continue expects no arguments"
 msgstr "--continue không nhận đối số"
 
-#: builtin/merge.c:1356
+#: builtin/merge.c:1360
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "Ở đây không có lần hòa trộn nào đang được xử lý cả (thiếu MERGE_HEAD)."
 
-#: builtin/merge.c:1372
+#: builtin/merge.c:1376
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17951,7 +18267,7 @@ msgstr ""
 "Bạn chưa kết thúc việc hòa trộn (MERGE_HEAD vẫn tồn tại).\n"
 "Hãy chuyển giao các thay đổi trước khi bạn có thể hòa trộn."
 
-#: builtin/merge.c:1379
+#: builtin/merge.c:1383
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -17959,90 +18275,86 @@ msgstr ""
 "Bạn chưa kết thúc việc cherry-pick (CHERRY_PICK_HEAD vẫn tồn tại).\n"
 "Hãy chuyển giao các thay đổi trước khi bạn có thể hòa trộn."
 
-#: builtin/merge.c:1382
+#: builtin/merge.c:1386
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr "Bạn chưa kết thúc việc cherry-pick (CHERRY_PICK_HEAD vẫn tồn tại)."
 
-#: builtin/merge.c:1396
+#: builtin/merge.c:1400
 msgid "You cannot combine --squash with --no-ff."
 msgstr "Bạn không thể kết hợp --squash với --no-ff."
 
-#: builtin/merge.c:1398
+#: builtin/merge.c:1402
 msgid "You cannot combine --squash with --commit."
 msgstr "Bạn không thể kết hợp --squash với --commit."
 
-#: builtin/merge.c:1414
+#: builtin/merge.c:1418
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr "Không chỉ ra lần chuyển giao và merge.defaultToUpstream chưa được đặt."
 
-#: builtin/merge.c:1431
+#: builtin/merge.c:1435
 msgid "Squash commit into empty head not supported yet"
 msgstr "Squash commit vào một head trống rỗng vẫn chưa được hỗ trợ"
 
-#: builtin/merge.c:1433
+#: builtin/merge.c:1437
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr ""
 "Chuyển giao không-chuyển-tiếp-nhanh không hợp lý ở trong một head trống rỗng"
 
-#: builtin/merge.c:1438
+#: builtin/merge.c:1442
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "%s - không phải là thứ gì đó mà chúng tôi có thể hòa trộn"
 
-#: builtin/merge.c:1440
+#: builtin/merge.c:1444
 msgid "Can merge only exactly one commit into empty head"
 msgstr ""
 "Không thể hòa trộn một cách đúng đắn một lần chuyển giao vào một head rỗng"
 
-#: builtin/merge.c:1521
+#: builtin/merge.c:1531
 msgid "refusing to merge unrelated histories"
 msgstr "từ chối hòa trộn lịch sử không liên quan"
 
-#: builtin/merge.c:1540
+#: builtin/merge.c:1550
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "Đang cập nhật %s..%s\n"
 
-#: builtin/merge.c:1587
+#: builtin/merge.c:1598
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "Đang thử hòa trộn kiểu “trivial in-index”…\n"
 
-#: builtin/merge.c:1594
+#: builtin/merge.c:1605
 #, c-format
 msgid "Nope.\n"
 msgstr "Không.\n"
 
-#: builtin/merge.c:1625
-msgid "Not possible to fast-forward, aborting."
-msgstr "Thực hiện lệnh chuyển-tiếp-nhanh là không thể được, đang bỏ qua."
-
-#: builtin/merge.c:1653 builtin/merge.c:1719
+#: builtin/merge.c:1664 builtin/merge.c:1730
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "Đang tua lại cây thành thời xa xưa…\n"
 
-#: builtin/merge.c:1657
+#: builtin/merge.c:1668
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Đang thử chiến lược hòa trộn %s…\n"
 
-#: builtin/merge.c:1709
+#: builtin/merge.c:1720
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Không có chiến lược hòa trộn nào được nắm giữ (handle) sự hòa trộn.\n"
 
-#: builtin/merge.c:1711
+#: builtin/merge.c:1722
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "Hòa trộn với chiến lược %s gặp lỗi.\n"
 
-#: builtin/merge.c:1721
+#: builtin/merge.c:1732
 #, c-format
 msgid "Using the %s strategy to prepare resolving by hand.\n"
 msgstr "Sử dụng chiến lược %s để chuẩn bị giải quyết bằng tay.\n"
 
-#: builtin/merge.c:1735
+#: builtin/merge.c:1746
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
@@ -18078,17 +18390,17 @@ msgstr "không thể đọc đối tượng được đánh thẻ %s"
 msgid "object '%s' tagged as '%s', but is a '%s' type"
 msgstr "đối tượng %s được đánh thẻ là %s, không phải là kiểu %s"
 
-#: builtin/mktag.c:97
+#: builtin/mktag.c:98
 msgid "tag on stdin did not pass our strict fsck check"
 msgstr ""
 "thẻ trên stdin đã không vượt qua kiểm tra fsck nghiêm ngặt của chúng tôi"
 
-#: builtin/mktag.c:100
+#: builtin/mktag.c:101
 msgid "tag on stdin did not refer to a valid object"
 msgstr ""
 "thẻ trên đầu vào tiêu chuẩn không chỉ đến một lần chuyển giao hợp lệ nào cả"
 
-#: builtin/mktag.c:103 builtin/tag.c:243
+#: builtin/mktag.c:104 builtin/tag.c:243
 msgid "unable to write tag file"
 msgstr "không thể ghi vào tập tin lưu thẻ"
 
@@ -18109,45 +18421,56 @@ msgid "allow creation of more than one tree"
 msgstr "cho phép tạo nhiều hơn một cây"
 
 #: builtin/multi-pack-index.c:10
-msgid "git multi-pack-index [<options>] write [--preferred-pack=<pack>]"
-msgstr "git multi-pack-index [<các tùy chọn>] write [--preferred-pack=<cỡ>]"
+msgid ""
+"git multi-pack-index [<options>] write [--preferred-pack=<pack>][--refs-"
+"snapshot=<path>]"
+msgstr ""
+"git multi-pack-index [<các tùy chọn>] write [--preferred-pack=<gói>][--refs-"
+"snapshot=</đường/dẫn>]"
 
-#: builtin/multi-pack-index.c:13
+#: builtin/multi-pack-index.c:14
 msgid "git multi-pack-index [<options>] verify"
 msgstr "git multi-pack-index [<các tùy chọn>] verify"
 
-#: builtin/multi-pack-index.c:16
+#: builtin/multi-pack-index.c:17
 msgid "git multi-pack-index [<options>] expire"
 msgstr "git multi-pack-index [<các tùy chọn>] expire"
 
-#: builtin/multi-pack-index.c:19
+#: builtin/multi-pack-index.c:20
 msgid "git multi-pack-index [<options>] repack [--batch-size=<size>]"
 msgstr "git multi-pack-index [<các-tùy-chọn>] repack [--batch-size=<cỡ>]"
 
-#: builtin/multi-pack-index.c:54
+#: builtin/multi-pack-index.c:57
 msgid "object directory containing set of packfile and pack-index pairs"
 msgstr "thư mục đối tượng có chứa một bộ các tập tin gói và cặp pack-index"
 
-#: builtin/multi-pack-index.c:69
+#: builtin/multi-pack-index.c:98
 msgid "preferred-pack"
 msgstr "preferred-pack"
 
-#: builtin/multi-pack-index.c:70
+#: builtin/multi-pack-index.c:99
 msgid "pack for reuse when computing a multi-pack bitmap"
 msgstr "gói được sử dụng khi tính toán một \"multi-pack bitmap\""
 
-#: builtin/multi-pack-index.c:128
+#: builtin/multi-pack-index.c:100
+msgid "write multi-pack bitmap"
+msgstr "ghi multi-pack bitmap"
+
+#: builtin/multi-pack-index.c:105
+msgid "write multi-pack index containing only given indexes"
+msgstr "ghi mục lục multi-pack chỉ chứa các mục lục đã cho"
+
+#: builtin/multi-pack-index.c:107
+msgid "refs snapshot for selecting bitmap commits"
+msgstr "ảnh chụp nhanh refs để chọn các lần chuyển giao ánh xạ"
+
+#: builtin/multi-pack-index.c:202
 msgid ""
 "during repack, collect pack-files of smaller size into a batch that is "
 "larger than this size"
 msgstr ""
 "trong suốt quá trình đóng gói lại, gom các tập tin gói có kích cỡ nhỏ hơn "
 "vào một bó cái mà lớn hơn kích thước này"
-
-#: builtin/multi-pack-index.c:179
-#, c-format
-msgid "unrecognized subcommand: %s"
-msgstr "không hiểu câu lệnh con: %s"
 
 #: builtin/mv.c:18
 msgid "git mv [<options>] <source>... <destination>"
@@ -18176,72 +18499,72 @@ msgstr "ép buộc di chuyển hay đổi tên thậm chí cả khi đích đã 
 msgid "skip move/rename errors"
 msgstr "bỏ qua các lỗi liên quan đến di chuyển, đổi tên"
 
-#: builtin/mv.c:170
+#: builtin/mv.c:172
 #, c-format
 msgid "destination '%s' is not a directory"
 msgstr "có đích “%s” nhưng đây không phải là một thư mục"
 
-#: builtin/mv.c:181
+#: builtin/mv.c:184
 #, c-format
 msgid "Checking rename of '%s' to '%s'\n"
 msgstr "Đang kiểm tra việc đổi tên của “%s” thành “%s”\n"
 
-#: builtin/mv.c:185
+#: builtin/mv.c:190
 msgid "bad source"
 msgstr "nguồn sai"
 
-#: builtin/mv.c:188
+#: builtin/mv.c:193
 msgid "can not move directory into itself"
 msgstr "không thể di chuyển một thư mục vào trong chính nó được"
 
-#: builtin/mv.c:191
+#: builtin/mv.c:196
 msgid "cannot move directory over file"
 msgstr "không di chuyển được thư mục thông qua tập tin"
 
-#: builtin/mv.c:200
+#: builtin/mv.c:205
 msgid "source directory is empty"
 msgstr "thư mục nguồn là trống rỗng"
 
-#: builtin/mv.c:225
+#: builtin/mv.c:231
 msgid "not under version control"
 msgstr "không nằm dưới sự quản lý mã nguồn"
 
-#: builtin/mv.c:227
+#: builtin/mv.c:233
 msgid "conflicted"
 msgstr "bị xung đột"
 
-#: builtin/mv.c:230
+#: builtin/mv.c:236
 msgid "destination exists"
 msgstr "đích đã tồn tại sẵn rồi"
 
-#: builtin/mv.c:238
+#: builtin/mv.c:244
 #, c-format
 msgid "overwriting '%s'"
 msgstr "đang ghi đè lên “%s”"
 
-#: builtin/mv.c:241
+#: builtin/mv.c:247
 msgid "Cannot overwrite"
 msgstr "Không thể ghi đè"
 
-#: builtin/mv.c:244
+#: builtin/mv.c:250
 msgid "multiple sources for the same target"
 msgstr "nhiều nguồn cho cùng một đích"
 
-#: builtin/mv.c:246
+#: builtin/mv.c:252
 msgid "destination directory does not exist"
 msgstr "thư mục đích không tồn tại"
 
-#: builtin/mv.c:253
+#: builtin/mv.c:280
 #, c-format
 msgid "%s, source=%s, destination=%s"
 msgstr "%s, nguồn=%s, đích=%s"
 
-#: builtin/mv.c:274
+#: builtin/mv.c:308
 #, c-format
 msgid "Renaming %s to %s\n"
 msgstr "Đổi tên %s thành %s\n"
 
-#: builtin/mv.c:280 builtin/remote.c:785 builtin/repack.c:667
+#: builtin/mv.c:314 builtin/remote.c:790 builtin/repack.c:853
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "gặp lỗi khi đổi tên “%s”"
@@ -18419,48 +18742,48 @@ msgstr "không thể đọc kết xuất “show”"
 msgid "failed to finish 'show' for object '%s'"
 msgstr "gặp lỗi khi hoàn thành “show” cho đối tượng “%s”"
 
-#: builtin/notes.c:197
+#: builtin/notes.c:195
 msgid "please supply the note contents using either -m or -F option"
 msgstr ""
 "xin hãy áp dụng nội dung của ghi chú sử dụng hoặc là tùy chọn -m hoặc là -F"
 
-#: builtin/notes.c:206
+#: builtin/notes.c:204
 msgid "unable to write note object"
 msgstr "không thể ghi đối tượng ghi chú (note)"
 
-#: builtin/notes.c:208
+#: builtin/notes.c:206
 #, c-format
 msgid "the note contents have been left in %s"
 msgstr "nội dung ghi chú còn lại %s"
 
-#: builtin/notes.c:242 builtin/tag.c:576
+#: builtin/notes.c:240 builtin/tag.c:577
 #, c-format
 msgid "could not open or read '%s'"
 msgstr "không thể mở hay đọc “%s”"
 
-#: builtin/notes.c:263 builtin/notes.c:313 builtin/notes.c:315
-#: builtin/notes.c:383 builtin/notes.c:438 builtin/notes.c:526
-#: builtin/notes.c:531 builtin/notes.c:610 builtin/notes.c:672
+#: builtin/notes.c:261 builtin/notes.c:311 builtin/notes.c:313
+#: builtin/notes.c:381 builtin/notes.c:436 builtin/notes.c:524
+#: builtin/notes.c:529 builtin/notes.c:608 builtin/notes.c:670
 #, c-format
 msgid "failed to resolve '%s' as a valid ref."
 msgstr "gặp lỗi khi phân giải “%s” như là một tham chiếu hợp lệ."
 
-#: builtin/notes.c:265
+#: builtin/notes.c:263
 #, c-format
 msgid "failed to read object '%s'."
 msgstr "gặp lỗi khi đọc đối tượng “%s”."
 
-#: builtin/notes.c:268
+#: builtin/notes.c:266
 #, c-format
 msgid "cannot read note data from non-blob object '%s'."
 msgstr "không thể đọc dữ liệu ghi chú từ đối tượng không-blob “%s”."
 
-#: builtin/notes.c:309
+#: builtin/notes.c:307
 #, c-format
 msgid "malformed input line: '%s'."
 msgstr "dòng đầu vào dị hình: “%s”."
 
-#: builtin/notes.c:324
+#: builtin/notes.c:322
 #, c-format
 msgid "failed to copy notes from '%s' to '%s'"
 msgstr "gặp lỗi khi sao chép ghi chú (note) từ “%s” sang “%s”"
@@ -18468,48 +18791,48 @@ msgstr "gặp lỗi khi sao chép ghi chú (note) từ “%s” sang “%s”"
 #. TRANSLATORS: the first %s will be replaced by a git
 #. notes command: 'add', 'merge', 'remove', etc.
 #.
-#: builtin/notes.c:356
+#: builtin/notes.c:354
 #, c-format
 msgid "refusing to %s notes in %s (outside of refs/notes/)"
 msgstr "từ chối %s ghi chú trong %s (nằm ngoài refs/notes/)"
 
-#: builtin/notes.c:376 builtin/notes.c:431 builtin/notes.c:509
-#: builtin/notes.c:521 builtin/notes.c:598 builtin/notes.c:665
-#: builtin/notes.c:815 builtin/notes.c:963 builtin/notes.c:985
-#: builtin/prune-packed.c:25 builtin/tag.c:586
+#: builtin/notes.c:374 builtin/notes.c:429 builtin/notes.c:507
+#: builtin/notes.c:519 builtin/notes.c:596 builtin/notes.c:663
+#: builtin/notes.c:813 builtin/notes.c:961 builtin/notes.c:983
+#: builtin/prune-packed.c:25 builtin/tag.c:587
 msgid "too many arguments"
 msgstr "có quá nhiều đối số"
 
-#: builtin/notes.c:389 builtin/notes.c:678
+#: builtin/notes.c:387 builtin/notes.c:676
 #, c-format
 msgid "no note found for object %s."
 msgstr "không tìm thấy ghi chú cho đối tượng %s."
 
-#: builtin/notes.c:410 builtin/notes.c:576
+#: builtin/notes.c:408 builtin/notes.c:574
 msgid "note contents as a string"
 msgstr "nội dung ghi chú (note) nằm trong một chuỗi"
 
-#: builtin/notes.c:413 builtin/notes.c:579
+#: builtin/notes.c:411 builtin/notes.c:577
 msgid "note contents in a file"
 msgstr "nội dung ghi chú (note) nằm trong một tập tin"
 
-#: builtin/notes.c:416 builtin/notes.c:582
+#: builtin/notes.c:414 builtin/notes.c:580
 msgid "reuse and edit specified note object"
 msgstr "dùng lại nhưng có sửa chữa đối tượng note đã chỉ ra"
 
-#: builtin/notes.c:419 builtin/notes.c:585
+#: builtin/notes.c:417 builtin/notes.c:583
 msgid "reuse specified note object"
 msgstr "dùng lại đối tượng ghi chú (note) đã chỉ ra"
 
-#: builtin/notes.c:422 builtin/notes.c:588
+#: builtin/notes.c:420 builtin/notes.c:586
 msgid "allow storing empty note"
 msgstr "cho lưu trữ ghi chú trống rỗng"
 
-#: builtin/notes.c:423 builtin/notes.c:496
+#: builtin/notes.c:421 builtin/notes.c:494
 msgid "replace existing notes"
 msgstr "thay thế ghi chú trước"
 
-#: builtin/notes.c:448
+#: builtin/notes.c:446
 #, c-format
 msgid ""
 "Cannot add notes. Found existing notes for object %s. Use '-f' to overwrite "
@@ -18518,29 +18841,29 @@ msgstr ""
 "Không thể thêm các ghi chú. Đã tìm thấy các ghi chú đã có sẵn cho đối tượng "
 "%s. Sử dụng tùy chọn “-f” để ghi đè lên các ghi chú cũ"
 
-#: builtin/notes.c:463 builtin/notes.c:544
+#: builtin/notes.c:461 builtin/notes.c:542
 #, c-format
 msgid "Overwriting existing notes for object %s\n"
 msgstr "Đang ghi đè lên ghi chú cũ cho đối tượng %s\n"
 
-#: builtin/notes.c:475 builtin/notes.c:637 builtin/notes.c:902
+#: builtin/notes.c:473 builtin/notes.c:635 builtin/notes.c:900
 #, c-format
 msgid "Removing note for object %s\n"
 msgstr "Đang gỡ bỏ ghi chú (note) cho đối tượng %s\n"
 
-#: builtin/notes.c:497
+#: builtin/notes.c:495
 msgid "read objects from stdin"
 msgstr "đọc các đối tượng từ đầu vào tiêu chuẩn"
 
-#: builtin/notes.c:499
+#: builtin/notes.c:497
 msgid "load rewriting config for <command> (implies --stdin)"
 msgstr "tải cấu hình chép lại cho <lệnh> (ngầm định là --stdin)"
 
-#: builtin/notes.c:517
+#: builtin/notes.c:515
 msgid "too few arguments"
 msgstr "quá ít đối số"
 
-#: builtin/notes.c:538
+#: builtin/notes.c:536
 #, c-format
 msgid ""
 "Cannot copy notes. Found existing notes for object %s. Use '-f' to overwrite "
@@ -18549,12 +18872,12 @@ msgstr ""
 "Không thể sao chép các ghi chú. Đã tìm thấy các ghi chú đã có sẵn cho đối "
 "tượng %s. Sử dụng tùy chọn “-f” để ghi đè lên các ghi chú cũ"
 
-#: builtin/notes.c:550
+#: builtin/notes.c:548
 #, c-format
 msgid "missing notes on source object %s. Cannot copy."
 msgstr "thiếu ghi chú trên đối tượng nguồn %s. Không thể sao chép."
 
-#: builtin/notes.c:603
+#: builtin/notes.c:601
 #, c-format
 msgid ""
 "The -m/-F/-c/-C options have been deprecated for the 'edit' subcommand.\n"
@@ -18563,52 +18886,52 @@ msgstr ""
 "Các tùy chọn -m/-F/-c/-C đã cổ không còn dùng nữa cho lệnh con “edit”.\n"
 "Xin hãy sử dụng lệnh sau để thay thế: “git notes add -f -m/-F/-c/-C”.\n"
 
-#: builtin/notes.c:698
+#: builtin/notes.c:696
 msgid "failed to delete ref NOTES_MERGE_PARTIAL"
 msgstr "gặp lỗi khi xóa tham chiếu NOTES_MERGE_PARTIAL"
 
-#: builtin/notes.c:700
+#: builtin/notes.c:698
 msgid "failed to delete ref NOTES_MERGE_REF"
 msgstr "gặp lỗi khi xóa tham chiếu NOTES_MERGE_REF"
 
-#: builtin/notes.c:702
+#: builtin/notes.c:700
 msgid "failed to remove 'git notes merge' worktree"
 msgstr "gặp lỗi khi gỡ bỏ cây làm việc “git notes merge”"
 
-#: builtin/notes.c:722
+#: builtin/notes.c:720
 msgid "failed to read ref NOTES_MERGE_PARTIAL"
 msgstr "gặp lỗi khi đọc tham chiếu NOTES_MERGE_PARTIAL"
 
-#: builtin/notes.c:724
+#: builtin/notes.c:722
 msgid "could not find commit from NOTES_MERGE_PARTIAL."
 msgstr "không thể tìm thấy lần chuyển giao từ NOTES_MERGE_PARTIAL."
 
-#: builtin/notes.c:726
+#: builtin/notes.c:724
 msgid "could not parse commit from NOTES_MERGE_PARTIAL."
 msgstr "không thể phân tích cú pháp lần chuyển giao từ NOTES_MERGE_PARTIAL."
 
-#: builtin/notes.c:739
+#: builtin/notes.c:737
 msgid "failed to resolve NOTES_MERGE_REF"
 msgstr "gặp lỗi khi phân giải NOTES_MERGE_REF"
 
-#: builtin/notes.c:742
+#: builtin/notes.c:740
 msgid "failed to finalize notes merge"
 msgstr "gặp lỗi khi hoàn thành hòa trộn ghi chú"
 
-#: builtin/notes.c:768
+#: builtin/notes.c:766
 #, c-format
 msgid "unknown notes merge strategy %s"
 msgstr "không hiểu chiến lược hòa trộn ghi chú %s"
 
-#: builtin/notes.c:784
+#: builtin/notes.c:782
 msgid "General options"
 msgstr "Tùy chọn chung"
 
-#: builtin/notes.c:786
+#: builtin/notes.c:784
 msgid "Merge options"
 msgstr "Tùy chọn về hòa trộn"
 
-#: builtin/notes.c:788
+#: builtin/notes.c:786
 msgid ""
 "resolve notes conflicts using the given strategy (manual/ours/theirs/union/"
 "cat_sort_uniq)"
@@ -18616,48 +18939,48 @@ msgstr ""
 "phân giải các xung đột “notes” sử dụng chiến lược đã đưa ra (manual/ours/"
 "theirs/union/cat_sort_uniq)"
 
-#: builtin/notes.c:790
+#: builtin/notes.c:788
 msgid "Committing unmerged notes"
 msgstr "Chuyển giao các note chưa được hòa trộn"
 
-#: builtin/notes.c:792
+#: builtin/notes.c:790
 msgid "finalize notes merge by committing unmerged notes"
 msgstr ""
 "các note cuối cùng được hòa trộn bởi các note chưa hòa trộn của lần chuyển "
 "giao"
 
-#: builtin/notes.c:794
+#: builtin/notes.c:792
 msgid "Aborting notes merge resolution"
 msgstr "Hủy bỏ phân giải ghi chú (note) hòa trộn"
 
-#: builtin/notes.c:796
+#: builtin/notes.c:794
 msgid "abort notes merge"
 msgstr "bỏ qua hòa trộn các ghi chú (note)"
 
-#: builtin/notes.c:807
+#: builtin/notes.c:805
 msgid "cannot mix --commit, --abort or -s/--strategy"
 msgstr "không thể trộn lẫn --commit, --abort hay -s/--strategy"
 
-#: builtin/notes.c:812
+#: builtin/notes.c:810
 msgid "must specify a notes ref to merge"
 msgstr "bạn phải chỉ định tham chiếu ghi chú để hòa trộn"
 
-#: builtin/notes.c:836
+#: builtin/notes.c:834
 #, c-format
 msgid "unknown -s/--strategy: %s"
 msgstr "không hiểu -s/--strategy: %s"
 
-#: builtin/notes.c:873
+#: builtin/notes.c:871
 #, c-format
 msgid "a notes merge into %s is already in-progress at %s"
 msgstr "một ghi chú hòa trộn vào %s đã sẵn trong quá trình xử lý tại %s"
 
-#: builtin/notes.c:876
+#: builtin/notes.c:874
 #, c-format
 msgid "failed to store link to current notes ref (%s)"
 msgstr "gặp lỗi khi lưu liên kết đến tham chiếu ghi chú hiện tại (%s)"
 
-#: builtin/notes.c:878
+#: builtin/notes.c:876
 #, c-format
 msgid ""
 "Automatic notes merge failed. Fix conflicts in %s and commit the result with "
@@ -18668,41 +18991,41 @@ msgstr ""
 "chuyển giao kết quả bằng “git notes merge --commit”, hoặc bãi bỏ việc hòa "
 "trộn bằng “git notes merge --abort”.\n"
 
-#: builtin/notes.c:897 builtin/tag.c:589
+#: builtin/notes.c:895 builtin/tag.c:590
 #, c-format
 msgid "Failed to resolve '%s' as a valid ref."
 msgstr "Gặp lỗi khi phân giải “%s” như là một tham chiếu hợp lệ."
 
-#: builtin/notes.c:900
+#: builtin/notes.c:898
 #, c-format
 msgid "Object %s has no note\n"
 msgstr "Đối tượng %s không có ghi chú (note)\n"
 
-#: builtin/notes.c:912
+#: builtin/notes.c:910
 msgid "attempt to remove non-existent note is not an error"
 msgstr "cố gắng gỡ bỏ một note chưa từng tồn tại không phải là một lỗi"
 
-#: builtin/notes.c:915
+#: builtin/notes.c:913
 msgid "read object names from the standard input"
 msgstr "đọc tên đối tượng từ thiết bị nhập chuẩn"
 
-#: builtin/notes.c:954 builtin/prune.c:132 builtin/worktree.c:146
+#: builtin/notes.c:952 builtin/prune.c:132 builtin/worktree.c:147
 msgid "do not remove, show only"
 msgstr "không gỡ bỏ, chỉ hiển thị"
 
-#: builtin/notes.c:955
+#: builtin/notes.c:953
 msgid "report pruned notes"
 msgstr "báo cáo các đối tượng đã prune"
 
-#: builtin/notes.c:998
+#: builtin/notes.c:996
 msgid "notes-ref"
 msgstr "notes-ref"
 
-#: builtin/notes.c:999
+#: builtin/notes.c:997
 msgid "use notes from <notes-ref>"
 msgstr "dùng “notes” từ <notes-ref>"
 
-#: builtin/notes.c:1034 builtin/stash.c:1735
+#: builtin/notes.c:1032 builtin/stash.c:1752
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr "không hiểu câu lệnh con: %s"
@@ -18755,83 +19078,87 @@ msgstr "đã sắp xếp %u đối tượng, cần %<PRIu32>"
 msgid "expected object at offset %<PRIuMAX> in pack %s"
 msgstr "cần đối tượng tại khoảng bù %<PRIuMAX> trong gói: %s"
 
-#: builtin/pack-objects.c:1155
+#: builtin/pack-objects.c:1160
 msgid "disabling bitmap writing, packs are split due to pack.packSizeLimit"
 msgstr "tắt ghi bitmap, các gói bị chia nhỏ bởi vì pack.packSizeLimit"
 
-#: builtin/pack-objects.c:1168
+#: builtin/pack-objects.c:1173
 msgid "Writing objects"
 msgstr "Đang ghi lại các đối tượng"
 
-#: builtin/pack-objects.c:1229 builtin/update-index.c:90
+#: builtin/pack-objects.c:1235 builtin/update-index.c:90
 #, c-format
 msgid "failed to stat %s"
 msgstr "gặp lỗi khi lấy thông tin thống kê về %s"
 
-#: builtin/pack-objects.c:1281
+#: builtin/pack-objects.c:1268
+msgid "failed to write bitmap index"
+msgstr "gặp lỗi khi ghi mục lục ánh xạ"
+
+#: builtin/pack-objects.c:1294
 #, c-format
 msgid "wrote %<PRIu32> objects while expecting %<PRIu32>"
 msgstr "đã ghi %<PRIu32> đối tượng trong khi cần %<PRIu32>"
 
-#: builtin/pack-objects.c:1523
+#: builtin/pack-objects.c:1536
 msgid "disabling bitmap writing, as some objects are not being packed"
 msgstr "tắt ghi bitmap, như vậy một số đối tượng sẽ không được đóng gói"
 
-#: builtin/pack-objects.c:1971
+#: builtin/pack-objects.c:1984
 #, c-format
 msgid "delta base offset overflow in pack for %s"
 msgstr "khoảng bù cơ sở cho delta bị tràn trong gói cho %s"
 
-#: builtin/pack-objects.c:1980
+#: builtin/pack-objects.c:1993
 #, c-format
 msgid "delta base offset out of bound for %s"
 msgstr "khoảng bù cơ sở cho delta nằm ngoài phạm cho %s"
 
-#: builtin/pack-objects.c:2261
+#: builtin/pack-objects.c:2274
 msgid "Counting objects"
 msgstr "Đang đếm các đối tượng"
 
-#: builtin/pack-objects.c:2426
+#: builtin/pack-objects.c:2439
 #, c-format
 msgid "unable to parse object header of %s"
 msgstr "không thể phân tích phần đầu đối tượng của “%s”"
 
-#: builtin/pack-objects.c:2496 builtin/pack-objects.c:2512
-#: builtin/pack-objects.c:2522
+#: builtin/pack-objects.c:2509 builtin/pack-objects.c:2525
+#: builtin/pack-objects.c:2535
 #, c-format
 msgid "object %s cannot be read"
 msgstr "không thể đọc đối tượng %s"
 
-#: builtin/pack-objects.c:2499 builtin/pack-objects.c:2526
+#: builtin/pack-objects.c:2512 builtin/pack-objects.c:2539
 #, c-format
 msgid "object %s inconsistent object length (%<PRIuMAX> vs %<PRIuMAX>)"
 msgstr ""
 "đối tượng %s không nhất quán về chiều dài đối tượng (%<PRIuMAX> so với "
 "%<PRIuMAX>)"
 
-#: builtin/pack-objects.c:2536
+#: builtin/pack-objects.c:2549
 msgid "suboptimal pack - out of memory"
 msgstr "suboptimal pack - hết bộ nhớ"
 
-#: builtin/pack-objects.c:2851
+#: builtin/pack-objects.c:2864
 #, c-format
 msgid "Delta compression using up to %d threads"
 msgstr "Nén delta dùng tới %d tuyến trình"
 
-#: builtin/pack-objects.c:2990
+#: builtin/pack-objects.c:3003
 #, c-format
 msgid "unable to pack objects reachable from tag %s"
 msgstr "không thể đóng gói các đối tượng tiếp cận được từ thẻ “%s”"
 
-#: builtin/pack-objects.c:3076
+#: builtin/pack-objects.c:3089
 msgid "Compressing objects"
 msgstr "Đang nén các đối tượng"
 
-#: builtin/pack-objects.c:3082
+#: builtin/pack-objects.c:3095
 msgid "inconsistency with delta count"
 msgstr "mâu thuẫn với số lượng delta"
 
-#: builtin/pack-objects.c:3161
+#: builtin/pack-objects.c:3174
 #, c-format
 msgid ""
 "value of uploadpack.blobpackfileuri must be of the form '<object-hash> <pack-"
@@ -18840,7 +19167,7 @@ msgstr ""
 "giá trị của uploadpack.blobpackfileuri phải có dạng “<object-hash> <pack-"
 "hash> <uri>” (nhận “%s”)"
 
-#: builtin/pack-objects.c:3164
+#: builtin/pack-objects.c:3177
 #, c-format
 msgid ""
 "object already configured in another uploadpack.blobpackfileuri (got '%s')"
@@ -18848,17 +19175,18 @@ msgstr ""
 "đối tượng đã được cấu hình trong một uploadpack.blobpackfileuri khác (đã "
 "nhận “%s”)"
 
-#: builtin/pack-objects.c:3199
+#: builtin/pack-objects.c:3212
 #, c-format
 msgid "could not get type of object %s in pack %s"
 msgstr "không thể lấy kiểu của đối tượng “%s” trong gói “%s”"
 
-#: builtin/pack-objects.c:3321 builtin/pack-objects.c:3335
+#: builtin/pack-objects.c:3340 builtin/pack-objects.c:3351
+#: builtin/pack-objects.c:3365
 #, c-format
 msgid "could not find pack '%s'"
 msgstr "không thể tìm thấy gói “%s”"
 
-#: builtin/pack-objects.c:3378
+#: builtin/pack-objects.c:3408
 #, c-format
 msgid ""
 "expected edge object ID, got garbage:\n"
@@ -18867,7 +19195,7 @@ msgstr ""
 "cần ID đối tượng cạnh, nhận được rác:\n"
 " %s"
 
-#: builtin/pack-objects.c:3384
+#: builtin/pack-objects.c:3414
 #, c-format
 msgid ""
 "expected object ID, got garbage:\n"
@@ -18876,248 +19204,248 @@ msgstr ""
 "cần ID đối tượng, nhận được rác:\n"
 " %s"
 
-#: builtin/pack-objects.c:3482
+#: builtin/pack-objects.c:3507
 msgid "invalid value for --missing"
 msgstr "giá trị cho --missing không hợp lệ"
 
-#: builtin/pack-objects.c:3541 builtin/pack-objects.c:3650
+#: builtin/pack-objects.c:3532 builtin/pack-objects.c:3619
 msgid "cannot open pack index"
 msgstr "không thể mở mục lục của gói"
 
-#: builtin/pack-objects.c:3572
+#: builtin/pack-objects.c:3541
 #, c-format
 msgid "loose object at %s could not be examined"
 msgstr "đối tượng mất tại %s không thể đã kiểm tra"
 
-#: builtin/pack-objects.c:3658
+#: builtin/pack-objects.c:3627
 msgid "unable to force loose object"
 msgstr "không thể buộc mất đối tượng"
 
-#: builtin/pack-objects.c:3788
+#: builtin/pack-objects.c:3757
 #, c-format
 msgid "not a rev '%s'"
 msgstr "không phải một rev “%s”"
 
-#: builtin/pack-objects.c:3791 builtin/rev-parse.c:1061
+#: builtin/pack-objects.c:3760 builtin/rev-parse.c:1061
 #, c-format
 msgid "bad revision '%s'"
 msgstr "điểm xem xét sai “%s”"
 
-#: builtin/pack-objects.c:3819
+#: builtin/pack-objects.c:3788
 msgid "unable to add recent objects"
 msgstr "không thể thêm các đối tượng mới dùng"
 
-#: builtin/pack-objects.c:3872
+#: builtin/pack-objects.c:3841
 #, c-format
 msgid "unsupported index version %s"
 msgstr "phiên bản mục lục không được hỗ trợ %s"
 
-#: builtin/pack-objects.c:3876
+#: builtin/pack-objects.c:3845
 #, c-format
 msgid "bad index version '%s'"
 msgstr "phiên bản mục lục sai “%s”"
 
-#: builtin/pack-objects.c:3915
+#: builtin/pack-objects.c:3884
 msgid "<version>[,<offset>]"
 msgstr "<phiên bản>[,offset]"
 
-#: builtin/pack-objects.c:3916
+#: builtin/pack-objects.c:3885
 msgid "write the pack index file in the specified idx format version"
 msgstr "ghi tập tin bảng mục lục gói (pack) ở phiên bản định dạng idx đã cho"
 
-#: builtin/pack-objects.c:3919
+#: builtin/pack-objects.c:3888
 msgid "maximum size of each output pack file"
 msgstr "kcíh thước tối đa cho tập tin gói được tạo"
 
-#: builtin/pack-objects.c:3921
+#: builtin/pack-objects.c:3890
 msgid "ignore borrowed objects from alternate object store"
 msgstr "bỏ qua các đối tượng vay mượn từ kho đối tượng thay thế"
 
-#: builtin/pack-objects.c:3923
+#: builtin/pack-objects.c:3892
 msgid "ignore packed objects"
 msgstr "bỏ qua các đối tượng đóng gói"
 
-#: builtin/pack-objects.c:3925
+#: builtin/pack-objects.c:3894
 msgid "limit pack window by objects"
 msgstr "giới hạn cửa sổ đóng gói theo đối tượng"
 
-#: builtin/pack-objects.c:3927
+#: builtin/pack-objects.c:3896
 msgid "limit pack window by memory in addition to object limit"
 msgstr "giới hạn cửa sổ đóng gói theo bộ nhớ cộng thêm với giới hạn đối tượng"
 
-#: builtin/pack-objects.c:3929
+#: builtin/pack-objects.c:3898
 msgid "maximum length of delta chain allowed in the resulting pack"
 msgstr "độ dài tối đa của chuỗi móc xích “delta” được phép trong gói kết quả"
 
-#: builtin/pack-objects.c:3931
+#: builtin/pack-objects.c:3900
 msgid "reuse existing deltas"
 msgstr "dùng lại các delta sẵn có"
 
-#: builtin/pack-objects.c:3933
+#: builtin/pack-objects.c:3902
 msgid "reuse existing objects"
 msgstr "dùng lại các đối tượng sẵn có"
 
-#: builtin/pack-objects.c:3935
+#: builtin/pack-objects.c:3904
 msgid "use OFS_DELTA objects"
 msgstr "dùng các đối tượng OFS_DELTA"
 
-#: builtin/pack-objects.c:3937
+#: builtin/pack-objects.c:3906
 msgid "use threads when searching for best delta matches"
 msgstr "sử dụng các tuyến trình khi tìm kiếm cho các mẫu khớp delta tốt nhất"
 
-#: builtin/pack-objects.c:3939
+#: builtin/pack-objects.c:3908
 msgid "do not create an empty pack output"
 msgstr "không thể tạo kết xuất gói trống rỗng"
 
-#: builtin/pack-objects.c:3941
+#: builtin/pack-objects.c:3910
 msgid "read revision arguments from standard input"
 msgstr "đọc tham số “revision” từ thiết bị nhập chuẩn"
 
-#: builtin/pack-objects.c:3943
+#: builtin/pack-objects.c:3912
 msgid "limit the objects to those that are not yet packed"
 msgstr "giới hạn các đối tượng thành những cái mà chúng vẫn chưa được đóng gói"
 
-#: builtin/pack-objects.c:3946
+#: builtin/pack-objects.c:3915
 msgid "include objects reachable from any reference"
 msgstr "bao gồm các đối tượng có thể đọc được từ bất kỳ tham chiếu nào"
 
-#: builtin/pack-objects.c:3949
+#: builtin/pack-objects.c:3918
 msgid "include objects referred by reflog entries"
 msgstr "bao gồm các đối tượng được tham chiếu bởi các mục reflog"
 
-#: builtin/pack-objects.c:3952
+#: builtin/pack-objects.c:3921
 msgid "include objects referred to by the index"
 msgstr "bao gồm các đối tượng được tham chiếu bởi mục lục"
 
-#: builtin/pack-objects.c:3955
+#: builtin/pack-objects.c:3924
 msgid "read packs from stdin"
 msgstr "đọc các gói từ đầu vào tiêu chuẩn"
 
-#: builtin/pack-objects.c:3957
+#: builtin/pack-objects.c:3926
 msgid "output pack to stdout"
 msgstr "xuất gói ra đầu ra tiêu chuẩn"
 
-#: builtin/pack-objects.c:3959
+#: builtin/pack-objects.c:3928
 msgid "include tag objects that refer to objects to be packed"
 msgstr "bao gồm các đối tượng tham chiếu đến các đối tượng được đóng gói"
 
-#: builtin/pack-objects.c:3961
+#: builtin/pack-objects.c:3930
 msgid "keep unreachable objects"
 msgstr "giữ lại các đối tượng không thể đọc được"
 
-#: builtin/pack-objects.c:3963
+#: builtin/pack-objects.c:3932
 msgid "pack loose unreachable objects"
 msgstr "pack mất các đối tượng không thể đọc được"
 
-#: builtin/pack-objects.c:3965
+#: builtin/pack-objects.c:3934
 msgid "unpack unreachable objects newer than <time>"
 msgstr ""
 "xả nén (gỡ khỏi gói) các đối tượng không thể đọc được mới hơn <thời-gian>"
 
-#: builtin/pack-objects.c:3968
+#: builtin/pack-objects.c:3937
 msgid "use the sparse reachability algorithm"
 msgstr "sử dụng thuật toán “sparse reachability”"
 
-#: builtin/pack-objects.c:3970
+#: builtin/pack-objects.c:3939
 msgid "create thin packs"
 msgstr "tạo gói nhẹ"
 
-#: builtin/pack-objects.c:3972
+#: builtin/pack-objects.c:3941
 msgid "create packs suitable for shallow fetches"
 msgstr "tạo gói để phù hợp cho lấy về nông (shallow)"
 
-#: builtin/pack-objects.c:3974
+#: builtin/pack-objects.c:3943
 msgid "ignore packs that have companion .keep file"
 msgstr "bỏ qua các gói mà nó có tập tin .keep đi kèm"
 
-#: builtin/pack-objects.c:3976
+#: builtin/pack-objects.c:3945
 msgid "ignore this pack"
 msgstr "bỏ qua gói này"
 
-#: builtin/pack-objects.c:3978
+#: builtin/pack-objects.c:3947
 msgid "pack compression level"
 msgstr "mức nén gói"
 
-#: builtin/pack-objects.c:3980
+#: builtin/pack-objects.c:3949
 msgid "do not hide commits by grafts"
 msgstr "không ẩn các lần chuyển giao bởi “grafts”"
 
-#: builtin/pack-objects.c:3982
+#: builtin/pack-objects.c:3951
 msgid "use a bitmap index if available to speed up counting objects"
 msgstr "dùng mục lục ánh xạ nếu có thể được để nâng cao tốc độ đếm đối tượng"
 
-#: builtin/pack-objects.c:3984
+#: builtin/pack-objects.c:3953
 msgid "write a bitmap index together with the pack index"
 msgstr "ghi một mục lục ánh xạ cùng với mục lục gói"
 
-#: builtin/pack-objects.c:3988
+#: builtin/pack-objects.c:3957
 msgid "write a bitmap index if possible"
 msgstr "ghi mục lục ánh xạ nếu được"
 
-#: builtin/pack-objects.c:3992
+#: builtin/pack-objects.c:3961
 msgid "handling for missing objects"
 msgstr "xử lý cho thiếu đối tượng"
 
-#: builtin/pack-objects.c:3995
+#: builtin/pack-objects.c:3964
 msgid "do not pack objects in promisor packfiles"
 msgstr "không thể đóng gói các đối tượng trong các tập tin gói hứa hẹn"
 
-#: builtin/pack-objects.c:3997
+#: builtin/pack-objects.c:3966
 msgid "respect islands during delta compression"
 msgstr "tôn trọng island trong suốt quá trình nén “delta”"
 
-#: builtin/pack-objects.c:3999
+#: builtin/pack-objects.c:3968
 msgid "protocol"
 msgstr "giao thức"
 
-#: builtin/pack-objects.c:4000
+#: builtin/pack-objects.c:3969
 msgid "exclude any configured uploadpack.blobpackfileuri with this protocol"
 msgstr "loại trừ bất kỳ cấu hình uploadpack.blobpackfileuri với giao thức này"
 
-#: builtin/pack-objects.c:4033
+#: builtin/pack-objects.c:4002
 #, c-format
 msgid "delta chain depth %d is too deep, forcing %d"
 msgstr "mức sau xích delta %d là quá sâu, buộc dùng %d"
 
-#: builtin/pack-objects.c:4038
+#: builtin/pack-objects.c:4007
 #, c-format
 msgid "pack.deltaCacheLimit is too high, forcing %d"
 msgstr "pack.deltaCacheLimit là quá cao, ép dùng %d"
 
-#: builtin/pack-objects.c:4094
+#: builtin/pack-objects.c:4063
 msgid "--max-pack-size cannot be used to build a pack for transfer"
 msgstr ""
 "--max-pack-size không thể được sử dụng để xây dựng một gói để vận chuyển"
 
-#: builtin/pack-objects.c:4096
+#: builtin/pack-objects.c:4065
 msgid "minimum pack size limit is 1 MiB"
 msgstr "giới hạn kích thước tối thiểu của gói là 1 MiB"
 
-#: builtin/pack-objects.c:4101
+#: builtin/pack-objects.c:4070
 msgid "--thin cannot be used to build an indexable pack"
 msgstr "--thin không thể được dùng để xây dựng gói đánh mục lục được"
 
-#: builtin/pack-objects.c:4104
+#: builtin/pack-objects.c:4073
 msgid "--keep-unreachable and --unpack-unreachable are incompatible"
 msgstr "--keep-unreachable và --unpack-unreachable xung khắc nhau"
 
-#: builtin/pack-objects.c:4110
+#: builtin/pack-objects.c:4079
 msgid "cannot use --filter without --stdout"
 msgstr "không thể dùng tùy chọn --filter mà không có --stdout"
 
-#: builtin/pack-objects.c:4112
+#: builtin/pack-objects.c:4081
 msgid "cannot use --filter with --stdin-packs"
 msgstr "không thể dùng tùy chọn --filter với --stdin-packs"
 
-#: builtin/pack-objects.c:4116
+#: builtin/pack-objects.c:4085
 msgid "cannot use internal rev list with --stdin-packs"
 msgstr "không thể dùng danh sách rev bên trong với --stdin-packs"
 
-#: builtin/pack-objects.c:4175
+#: builtin/pack-objects.c:4144
 msgid "Enumerating objects"
 msgstr "Đánh số các đối tượng"
 
-#: builtin/pack-objects.c:4212
+#: builtin/pack-objects.c:4181
 #, c-format
 msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
@@ -19134,9 +19462,9 @@ msgid ""
 "and let us know you still use it by sending an e-mail\n"
 "to <git@vger.kernel.org>.  Thanks.\n"
 msgstr ""
-"'git pack-redundant' được đề cử để loại bỏ.\n"
+"“git pack-redundant” được đề cử để loại bỏ.\n"
 "Nếu bạn vẫn sử dụng lệnh này, vui lòng bổ sung\n"
-"thêm một tùy chọn, '--i-still-use-this', trên dòng lệnh\n"
+"thêm một tùy chọn, “--i-still-use-this”, trên dòng lệnh\n"
 "và cho chúng tôi biết bạn vẫn sử dụng nó bằng cách gửi e-mail\n"
 "đến <git@vger.kernel.org>.  Cảm ơn.\n"
 
@@ -19172,7 +19500,7 @@ msgstr "các đối tượng hết hạn cũ hơn khoảng <thời gian>"
 msgid "limit traversal to objects outside promisor packfiles"
 msgstr "giới hạn giao đến các đối tượng nằm ngoài các tập tin gói hứa hẹn"
 
-#: builtin/prune.c:152
+#: builtin/prune.c:151
 msgid "cannot prune in a precious-objects repo"
 msgstr "không thể tỉa bớt trong một kho đối_tượng_vĩ_đại"
 
@@ -19197,11 +19525,11 @@ msgstr "Các tùy chọn liên quan đến hòa trộn"
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "các thay đổi hợp nhất bằng cải tổ thay vì hòa trộn"
 
-#: builtin/pull.c:158 builtin/rebase.c:491 builtin/revert.c:126
+#: builtin/pull.c:158 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "cho phép chuyển-tiếp-nhanh"
 
-#: builtin/pull.c:167 parse-options.h:340
+#: builtin/pull.c:167 parse-options.h:339
 msgid "automatically stash/stash pop before and after"
 msgstr "tự động stash/stash pop trước và sau"
 
@@ -19258,7 +19586,7 @@ msgstr ""
 "theo mặc định cho nhánh hiện tại của bạn, bạn phải chỉ định\n"
 "một nhánh trên dòng lệnh."
 
-#: builtin/pull.c:456 builtin/rebase.c:1248
+#: builtin/pull.c:456 builtin/rebase.c:951
 msgid "You are not currently on a branch."
 msgstr "Hiện tại bạn chẳng ở nhánh nào cả."
 
@@ -19275,7 +19603,7 @@ msgid "See git-pull(1) for details."
 msgstr "Xem git-pull(1) để biết thêm chi tiết."
 
 #: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
-#: builtin/rebase.c:1254
+#: builtin/rebase.c:957
 msgid "<remote>"
 msgstr "<máy chủ>"
 
@@ -19283,7 +19611,7 @@ msgstr "<máy chủ>"
 msgid "<branch>"
 msgstr "<nhánh>"
 
-#: builtin/pull.c:471 builtin/rebase.c:1246
+#: builtin/pull.c:471 builtin/rebase.c:949
 msgid "There is no tracking information for the current branch."
 msgstr "Ở đây không có thông tin theo dõi cho nhánh hiện hành."
 
@@ -19311,11 +19639,11 @@ msgstr "không thể truy cập lần chuyển giao “%s”"
 msgid "ignoring --verify-signatures for rebase"
 msgstr "bỏ qua --verify-signatures khi rebase"
 
-#: builtin/pull.c:930
+#: builtin/pull.c:936
 msgid ""
-"Pulling without specifying how to reconcile divergent branches is\n"
-"discouraged. You can squelch this message by running one of the following\n"
-"commands sometime before your next pull:\n"
+"You have divergent branches and need to specify how to reconcile them.\n"
+"You can do so by running one of the following commands sometime before\n"
+"your next pull:\n"
 "\n"
 "  git config pull.rebase false  # merge (the default strategy)\n"
 "  git config pull.rebase true   # rebase\n"
@@ -19327,11 +19655,9 @@ msgid ""
 "or --ff-only on the command line to override the configured default per\n"
 "invocation.\n"
 msgstr ""
-"Kéo mà không chỉ định làm thế nào để hòa giải các nhánh phân kỳ là khác nhau "
-"là\n"
-"không khuyến khích. Bạn có thể dịu thông báo này bằng cách chạy một trong "
-"những lệnh sau đây\n"
-"các lệnh thỉnh thoảng trước khi thực hiện lệnh pull tiếp theo của bạn:\n"
+"Bạn có các nhánh phân kỳ và cần chỉ định cách hòa hợp chúng.\n"
+"Bạn có thể làm như vậy bằng cách chạy một trong những lệnh sau đây\n"
+"thỉnh thoảng trước khi thực hiện lệnh pull tiếp theo của bạn:\n"
 "\n"
 "  git config pull.rebase false  # merge (chiến lược mặc định)\n"
 "  git config pull.rebase true   # rebase\n"
@@ -19341,24 +19667,24 @@ msgstr ""
 "mặc định\n"
 "ưu tiên cho tất cả các kho. Bạn cũng có thể chuyển qua --rebase, --no-"
 "rebase,\n"
-"hoặc --ff-only trên dòng lệnh để ghi đè mặc định được cấu hình cho mỗi\n"
+"hoặc --ff-only trên dòng lệnh để ghi đè các mặc định đã cấu hình cho mỗi\n"
 "lần gọi.\n"
 
-#: builtin/pull.c:990
+#: builtin/pull.c:1010
 msgid "Updating an unborn branch with changes added to the index."
 msgstr ""
 "Đang cập nhật một nhánh chưa được sinh ra với các thay đổi được thêm vào "
 "bảng mục lục."
 
-#: builtin/pull.c:994
+#: builtin/pull.c:1014
 msgid "pull with rebase"
 msgstr "pull với rebase"
 
-#: builtin/pull.c:995
+#: builtin/pull.c:1015
 msgid "please commit or stash them."
 msgstr "xin hãy chuyển giao hoặc tạm cất (stash) chúng."
 
-#: builtin/pull.c:1020
+#: builtin/pull.c:1040
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -19369,7 +19695,7 @@ msgstr ""
 "đang chuyển-tiếp-nhanh cây làm việc của bạn từ\n"
 "lần chuyển giaot %s."
 
-#: builtin/pull.c:1026
+#: builtin/pull.c:1046
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -19387,15 +19713,23 @@ msgstr ""
 "$ git reset --hard\n"
 "để khôi phục lại."
 
-#: builtin/pull.c:1041
+#: builtin/pull.c:1061
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Không thể hòa trộn nhiều nhánh vào trong một head trống rỗng."
 
-#: builtin/pull.c:1045
+#: builtin/pull.c:1066
 msgid "Cannot rebase onto multiple branches."
 msgstr "Không thể thực hiện lệnh rebase (cải tổ) trên nhiều nhánh."
 
-#: builtin/pull.c:1065
+#: builtin/pull.c:1068
+msgid "Cannot fast-forward to multiple branches."
+msgstr "Không thể thực hiện chuyển tiếp nhanh trên nhiều nhánh."
+
+#: builtin/pull.c:1082
+msgid "Need to specify how to reconcile divergent branches."
+msgstr "Caanfchir định làm thế nào để giải quyết các nhánh phân kỳ."
+
+#: builtin/pull.c:1096
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "không thể cải tổ với các thay đổi mô-đun-con được ghi lại một cách cục bộ"
@@ -19579,15 +19913,15 @@ msgstr "Đang đẩy lên %s\n"
 msgid "failed to push some refs to '%s'"
 msgstr "gặp lỗi khi đẩy tới một số tham chiếu đến “%s”"
 
-#: builtin/push.c:544
+#: builtin/push.c:544 builtin/submodule--helper.c:3258
 msgid "repository"
 msgstr "kho"
 
-#: builtin/push.c:545 builtin/send-pack.c:189
+#: builtin/push.c:545 builtin/send-pack.c:193
 msgid "push all refs"
 msgstr "đẩy tất cả các tham chiếu"
 
-#: builtin/push.c:546 builtin/send-pack.c:191
+#: builtin/push.c:546 builtin/send-pack.c:195
 msgid "mirror all refs"
 msgstr "mirror tất cả các tham chiếu"
 
@@ -19599,19 +19933,19 @@ msgstr "xóa các tham chiếu"
 msgid "push tags (can't be used with --all or --mirror)"
 msgstr "đẩy các thẻ (không dùng cùng với --all hay --mirror)"
 
-#: builtin/push.c:552 builtin/send-pack.c:192
+#: builtin/push.c:552 builtin/send-pack.c:196
 msgid "force updates"
 msgstr "ép buộc cập nhật"
 
-#: builtin/push.c:553 builtin/send-pack.c:204
+#: builtin/push.c:553 builtin/send-pack.c:208
 msgid "<refname>:<expect>"
 msgstr "<tên-tham-chiếu>:<cần>"
 
-#: builtin/push.c:554 builtin/send-pack.c:205
+#: builtin/push.c:554 builtin/send-pack.c:209
 msgid "require old value of ref to be at this value"
 msgstr "yêu cầu giá-trị cũ của tham chiếu thì là giá-trị này"
 
-#: builtin/push.c:557 builtin/send-pack.c:208
+#: builtin/push.c:557 builtin/send-pack.c:212
 msgid "require remote updates to be integrated locally"
 msgstr "yêu cầu máy chủ cập nhật để thích hợp với máy cục bộ"
 
@@ -19619,12 +19953,12 @@ msgstr "yêu cầu máy chủ cập nhật để thích hợp với máy cục b
 msgid "control recursive pushing of submodules"
 msgstr "điều khiển việc đẩy lên (push) đệ qui của mô-đun-con"
 
-#: builtin/push.c:561 builtin/send-pack.c:199
+#: builtin/push.c:561 builtin/send-pack.c:203
 msgid "use thin pack"
 msgstr "tạo gói nhẹ"
 
-#: builtin/push.c:562 builtin/push.c:563 builtin/send-pack.c:186
-#: builtin/send-pack.c:187
+#: builtin/push.c:562 builtin/push.c:563 builtin/send-pack.c:190
+#: builtin/send-pack.c:191
 msgid "receive pack program"
 msgstr "chương trình nhận gói"
 
@@ -19644,11 +19978,11 @@ msgstr "vòng qua móc tiền-đẩy (pre-push)"
 msgid "push missing but relevant tags"
 msgstr "push phần bị thiếu nhưng các thẻ lại thích hợp"
 
-#: builtin/push.c:572 builtin/send-pack.c:193
+#: builtin/push.c:572 builtin/send-pack.c:197
 msgid "GPG sign the push"
 msgstr "ký lần đẩy dùng GPG"
 
-#: builtin/push.c:574 builtin/send-pack.c:200
+#: builtin/push.c:574 builtin/send-pack.c:204
 msgid "request atomic transaction on remote side"
 msgstr "yêu cầu giao dịch hạt nhân bên phía máy chủ"
 
@@ -19759,84 +20093,83 @@ msgstr "cần hai vùng lần chuyển giao"
 #: builtin/read-tree.c:41
 msgid ""
 "git read-tree [(-m [--trivial] [--aggressive] | --reset | --prefix=<prefix>) "
-"[-u [--exclude-per-directory=<gitignore>] | -i]] [--no-sparse-checkout] [--"
-"index-output=<file>] (--empty | <tree-ish1> [<tree-ish2> [<tree-ish3>]])"
+"[-u | -i]] [--no-sparse-checkout] [--index-output=<file>] (--empty | <tree-"
+"ish1> [<tree-ish2> [<tree-ish3>]])"
 msgstr ""
-"git read-tree [(-m [--trivial] [--aggressive] | --reset | --prefix=<tiền-"
-"tố>) [-u [--exclude-per-directory=<gitignore>] | -i]] [--no-sparse-checkout] "
-"[--index-output=<tập-tin>] (--empty | <tree-ish1> [<tree-ish2> [<tree-"
-"ish3>]])"
+"git read-tree [(-m [--trivial] [--aggressive] | --reset | --"
+"prefix=<tiền_tố>) [-u | -i]] [--no-sparse-checkout] [--index-"
+"output=<tập_tin>] (--empty | <tree-ish1> [<tree-ish2> [<tree-ish3>]])"
 
-#: builtin/read-tree.c:124
+#: builtin/read-tree.c:116
 msgid "write resulting index to <file>"
 msgstr "ghi mục lục kết quả vào <tập-tin>"
 
-#: builtin/read-tree.c:127
+#: builtin/read-tree.c:119
 msgid "only empty the index"
 msgstr "chỉ với bảng mục lục trống rỗng"
 
-#: builtin/read-tree.c:129
+#: builtin/read-tree.c:121
 msgid "Merging"
 msgstr "Hòa trộn"
 
-#: builtin/read-tree.c:131
+#: builtin/read-tree.c:123
 msgid "perform a merge in addition to a read"
 msgstr "thực hiện một hòa trộn thêm vào việc đọc"
 
-#: builtin/read-tree.c:133
+#: builtin/read-tree.c:125
 msgid "3-way merge if no file level merging required"
 msgstr ""
 "hòa trộn kiểu “3-way” nếu không có tập tin mức hòa trộn nào được yêu cầu"
 
-#: builtin/read-tree.c:135
+#: builtin/read-tree.c:127
 msgid "3-way merge in presence of adds and removes"
 msgstr "hòa trộn 3-way trong sự hiện diện của “adds” và “removes”"
 
-#: builtin/read-tree.c:137
+#: builtin/read-tree.c:129
 msgid "same as -m, but discard unmerged entries"
 msgstr "giống với -m, nhưng bỏ qua các mục chưa được hòa trộn"
 
-#: builtin/read-tree.c:138
+#: builtin/read-tree.c:130
 msgid "<subdirectory>/"
 msgstr "<thư-mục-con>/"
 
-#: builtin/read-tree.c:139
+#: builtin/read-tree.c:131
 msgid "read the tree into the index under <subdirectory>/"
 msgstr "đọc cây vào trong bảng mục lục dưới <thư_mục_con>/"
 
-#: builtin/read-tree.c:142
+#: builtin/read-tree.c:134
 msgid "update working tree with merge result"
 msgstr "cập nhật cây làm việc với kết quả hòa trộn"
 
-#: builtin/read-tree.c:144
+#: builtin/read-tree.c:136
 msgid "gitignore"
 msgstr "gitignore"
 
-#: builtin/read-tree.c:145
+#: builtin/read-tree.c:137
 msgid "allow explicitly ignored files to be overwritten"
 msgstr "cho phép các tập tin rõ ràng bị lờ đi được ghi đè"
 
-#: builtin/read-tree.c:148
+#: builtin/read-tree.c:140
 msgid "don't check the working tree after merging"
 msgstr "không kiểm tra cây làm việc sau hòa trộn"
 
-#: builtin/read-tree.c:149
+#: builtin/read-tree.c:141
 msgid "don't update the index or the work tree"
 msgstr "không cập nhật bảng mục lục hay cây làm việc"
 
-#: builtin/read-tree.c:151
+#: builtin/read-tree.c:143
 msgid "skip applying sparse checkout filter"
 msgstr "bỏ qua áp dụng bộ lọc lấy ra (checkout) thưa thớt"
 
-#: builtin/read-tree.c:153
+#: builtin/read-tree.c:145
 msgid "debug unpack-trees"
 msgstr "gỡ lỗi “unpack-trees”"
 
-#: builtin/read-tree.c:157
+#: builtin/read-tree.c:149
 msgid "suppress feedback messages"
 msgstr "không xuất các thông tin phản hồi"
 
-#: builtin/read-tree.c:188
+#: builtin/read-tree.c:183
 msgid "You need to resolve your current index first"
 msgstr "Bạn cần phải giải quyết bảng mục lục hiện tại của bạn trước đã"
 
@@ -19859,193 +20192,44 @@ msgstr ""
 msgid "git rebase --continue | --abort | --skip | --edit-todo"
 msgstr "git rebase --continue | --abort | --skip | --edit-todo"
 
-#: builtin/rebase.c:194 builtin/rebase.c:218 builtin/rebase.c:245
-#, c-format
-msgid "unusable todo list: '%s'"
-msgstr "danh sách cần làm không dùng được: “%s”"
-
-#: builtin/rebase.c:311
+#: builtin/rebase.c:230
 #, c-format
 msgid "could not create temporary %s"
 msgstr "không thể tạo %s tạm thời"
 
-#: builtin/rebase.c:317
+#: builtin/rebase.c:236
 msgid "could not mark as interactive"
 msgstr "không thể đánh dấu là tương tác"
 
-#: builtin/rebase.c:370
+#: builtin/rebase.c:289
 msgid "could not generate todo list"
 msgstr "không thể tạo danh sách cần làm"
 
-#: builtin/rebase.c:412
+#: builtin/rebase.c:331
 msgid "a base commit must be provided with --upstream or --onto"
 msgstr "lần chuyển giao cơ sỏ phải được chỉ định với --upstream hoặc --onto"
 
-#: builtin/rebase.c:481
-msgid "git rebase--interactive [<options>]"
-msgstr "git rebase--interactive [<các tùy chọn>]"
-
-#: builtin/rebase.c:494 builtin/rebase.c:1389
-msgid "keep commits which start empty"
-msgstr "bỏ qua các lần chuyển giao mà nó bắt đầu trống rỗng"
-
-#: builtin/rebase.c:498 builtin/revert.c:128
-msgid "allow commits with empty messages"
-msgstr "chấp nhận chuyển giao mà không ghi chú gì"
-
-#: builtin/rebase.c:500
-msgid "rebase merge commits"
-msgstr "cải tổ các lần chuyển giao hòa trộn"
-
-#: builtin/rebase.c:502
-msgid "keep original branch points of cousins"
-msgstr "giữ các điểm nhánh nguyên bản của các anh em họ"
-
-#: builtin/rebase.c:504
-msgid "move commits that begin with squash!/fixup!"
-msgstr "di chuyển các lần chuyển giao bắt đầu bằng squash!/fixup!"
-
-#: builtin/rebase.c:505
-msgid "sign commits"
-msgstr "ký các lần chuyển giao"
-
-#: builtin/rebase.c:507 builtin/rebase.c:1328
-msgid "display a diffstat of what changed upstream"
-msgstr "hiển thị một diffstat của những thay đổi thượng nguồn"
-
-#: builtin/rebase.c:509
-msgid "continue rebase"
-msgstr "tiếp tục cải tổ"
-
-#: builtin/rebase.c:511
-msgid "skip commit"
-msgstr "bỏ qua lần chuyển giao"
-
-#: builtin/rebase.c:512
-msgid "edit the todo list"
-msgstr "sửa danh sách cần làm"
-
-#: builtin/rebase.c:514
-msgid "show the current patch"
-msgstr "hiển thị miếng vá hiện hành"
-
-#: builtin/rebase.c:517
-msgid "shorten commit ids in the todo list"
-msgstr "rút ngắn mã chuyển giao trong danh sách cần làm"
-
-#: builtin/rebase.c:519
-msgid "expand commit ids in the todo list"
-msgstr "khai triển mã chuyển giao trong danh sách cần làm"
-
-#: builtin/rebase.c:521
-msgid "check the todo list"
-msgstr "kiểm tra danh sách cần làm"
-
-#: builtin/rebase.c:523
-msgid "rearrange fixup/squash lines"
-msgstr "sắp xếp lại các dòng fixup/squash"
-
-#: builtin/rebase.c:525
-msgid "insert exec commands in todo list"
-msgstr "chèn các lệnh thực thi trong danh sách cần làm"
-
-#: builtin/rebase.c:526
-msgid "onto"
-msgstr "lên trên"
-
-#: builtin/rebase.c:529
-msgid "restrict-revision"
-msgstr "điểm-xét-duyệt-hạn-chế"
-
-#: builtin/rebase.c:529
-msgid "restrict revision"
-msgstr "điểm xét duyệt hạn chế"
-
-#: builtin/rebase.c:531
-msgid "squash-onto"
-msgstr "squash-lên-trên"
-
-#: builtin/rebase.c:532
-msgid "squash onto"
-msgstr "squash lên trên"
-
-#: builtin/rebase.c:534
-msgid "the upstream commit"
-msgstr "lần chuyển giao thượng nguồn"
-
-#: builtin/rebase.c:536
-msgid "head-name"
-msgstr "tên-đầu"
-
-#: builtin/rebase.c:536
-msgid "head name"
-msgstr "tên đầu"
-
-#: builtin/rebase.c:541
-msgid "rebase strategy"
-msgstr "chiến lược cải tổ"
-
-#: builtin/rebase.c:542
-msgid "strategy-opts"
-msgstr "tùy-chọn-chiến-lược"
-
-#: builtin/rebase.c:543
-msgid "strategy options"
-msgstr "các tùy chọn chiến lược"
-
-#: builtin/rebase.c:544
-msgid "switch-to"
-msgstr "chuyển-đến"
-
-#: builtin/rebase.c:545
-msgid "the branch or commit to checkout"
-msgstr "nhánh hay lần chuyển giao lần lấy ra"
-
-#: builtin/rebase.c:546
-msgid "onto-name"
-msgstr "onto-name"
-
-#: builtin/rebase.c:546
-msgid "onto name"
-msgstr "tên lên trên"
-
-#: builtin/rebase.c:547
-msgid "cmd"
-msgstr "lệnh"
-
-#: builtin/rebase.c:547
-msgid "the command to run"
-msgstr "lệnh muốn chạy"
-
-#: builtin/rebase.c:550 builtin/rebase.c:1422
-msgid "automatically re-schedule any `exec` that fails"
-msgstr "lập lịch lại một cách tự động bất kỳ “exec“ bị lỗi"
-
-#: builtin/rebase.c:566
-msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
-msgstr "--[no-]rebase-cousins không có tác dụng khi không có --rebase-merges"
-
-#: builtin/rebase.c:582
+#: builtin/rebase.c:390
 #, c-format
 msgid "%s requires the merge backend"
 msgstr "%s cần một ứng dụng hòa trộn chạy phía sau"
 
-#: builtin/rebase.c:625
+#: builtin/rebase.c:432
 #, c-format
 msgid "could not get 'onto': '%s'"
 msgstr "không thể đặt lấy “onto”: “%s”"
 
-#: builtin/rebase.c:642
+#: builtin/rebase.c:449
 #, c-format
 msgid "invalid orig-head: '%s'"
 msgstr "orig-head không hợp lệ: “%s”"
 
-#: builtin/rebase.c:667
+#: builtin/rebase.c:474
 #, c-format
 msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
 msgstr "đang bỏ qua allow_rerere_autoupdate không hợp lệ: “%s”"
 
-#: builtin/rebase.c:813 git-rebase--preserve-merges.sh:81
+#: builtin/rebase.c:597
 msgid ""
 "Resolve all conflicts manually, mark them as resolved with\n"
 "\"git add/rm <conflicted_files>\", then run \"git rebase --continue\".\n"
@@ -20060,7 +20244,7 @@ msgstr ""
 "Để bãi bỏ và quay trở lại trạng thái trước \"git rebase\", chạy \"git rebase "
 "--abort\"."
 
-#: builtin/rebase.c:896
+#: builtin/rebase.c:680
 #, c-format
 msgid ""
 "\n"
@@ -20079,7 +20263,7 @@ msgstr ""
 "\n"
 "Kết quả là git không thể cải tổ lại chúng."
 
-#: builtin/rebase.c:1222
+#: builtin/rebase.c:925
 #, c-format
 msgid ""
 "unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and \"ask"
@@ -20088,7 +20272,7 @@ msgstr ""
 "kiểu rỗng không được nhận dạng “%s”; giá trị hợp lệ là \"drop\", \"keep\", "
 "và \"ask\"."
 
-#: builtin/rebase.c:1240
+#: builtin/rebase.c:943
 #, c-format
 msgid ""
 "%s\n"
@@ -20105,7 +20289,7 @@ msgstr ""
 "    git rebase “<nhánh>”\n"
 "\n"
 
-#: builtin/rebase.c:1256
+#: builtin/rebase.c:959
 #, c-format
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:\n"
@@ -20119,188 +20303,197 @@ msgstr ""
 "    git branch --set-upstream-to=%s/<nhánh> %s\n"
 "\n"
 
-#: builtin/rebase.c:1286
+#: builtin/rebase.c:989
 msgid "exec commands cannot contain newlines"
 msgstr "các lệnh thực thi không thể chứa các ký tự dòng mới"
 
-#: builtin/rebase.c:1290
+#: builtin/rebase.c:993
 msgid "empty exec command"
 msgstr "lệnh thực thi trống rỗng"
 
-#: builtin/rebase.c:1319
+#: builtin/rebase.c:1023
 msgid "rebase onto given branch instead of upstream"
 msgstr "cải tổ vào nhánh đã cho thay cho thượng nguồn"
 
-#: builtin/rebase.c:1321
+#: builtin/rebase.c:1025
 msgid "use the merge-base of upstream and branch as the current base"
 msgstr ""
 "sử dụng các cơ sở hòa trộn của thượng nguồn và nhánh như là cơ sở hiện tại"
 
-#: builtin/rebase.c:1323
+#: builtin/rebase.c:1027
 msgid "allow pre-rebase hook to run"
 msgstr "cho phép móc (hook) pre-rebase được chạy"
 
-#: builtin/rebase.c:1325
+#: builtin/rebase.c:1029
 msgid "be quiet. implies --no-stat"
 msgstr "hãy im lặng. ý là --no-stat"
 
-#: builtin/rebase.c:1331
+#: builtin/rebase.c:1032
+msgid "display a diffstat of what changed upstream"
+msgstr "hiển thị một diffstat của những thay đổi thượng nguồn"
+
+#: builtin/rebase.c:1035
 msgid "do not show diffstat of what changed upstream"
 msgstr "đừng hiển thị diffstat của những thay đổi thượng nguồn"
 
-#: builtin/rebase.c:1334
+#: builtin/rebase.c:1038
 msgid "add a Signed-off-by trailer to each commit"
 msgstr "thêm dòng Signed-off-by vào cuối cho từng lần chuyển giao"
 
-#: builtin/rebase.c:1337
+#: builtin/rebase.c:1041
 msgid "make committer date match author date"
 msgstr "làm ngày tháng chuyển giao khớp với ngày của tác giả"
 
-#: builtin/rebase.c:1339
+#: builtin/rebase.c:1043
 msgid "ignore author date and use current date"
 msgstr "bỏ qua ngày tác giả và sử dụng ngày tháng hiện tại"
 
-#: builtin/rebase.c:1341
+#: builtin/rebase.c:1045
 msgid "synonym of --reset-author-date"
 msgstr "đồng nghĩa với --reset-author-date"
 
-#: builtin/rebase.c:1343 builtin/rebase.c:1347
+#: builtin/rebase.c:1047 builtin/rebase.c:1051
 msgid "passed to 'git apply'"
 msgstr "chuyển cho “git apply”"
 
-#: builtin/rebase.c:1345
+#: builtin/rebase.c:1049
 msgid "ignore changes in whitespace"
 msgstr "lờ đi sự thay đổi do khoảng trắng gây ra"
 
-#: builtin/rebase.c:1349 builtin/rebase.c:1352
+#: builtin/rebase.c:1053 builtin/rebase.c:1056
 msgid "cherry-pick all commits, even if unchanged"
 msgstr ""
 "cherry-pick tất cả các lần chuyển giao, ngay cả khi không có thay đổi gì"
 
-#: builtin/rebase.c:1354
+#: builtin/rebase.c:1058
 msgid "continue"
 msgstr "tiếp tục"
 
-#: builtin/rebase.c:1357
+#: builtin/rebase.c:1061
 msgid "skip current patch and continue"
 msgstr "bỏ qua miếng vá hiện hành và tiếp tục"
 
-#: builtin/rebase.c:1359
+#: builtin/rebase.c:1063
 msgid "abort and check out the original branch"
 msgstr "bãi bỏ và lấy ra nhánh nguyên thủy"
 
-#: builtin/rebase.c:1362
+#: builtin/rebase.c:1066
 msgid "abort but keep HEAD where it is"
 msgstr "bãi bỏ nhưng vẫn vẫn giữ HEAD chỉ đến nó"
 
-#: builtin/rebase.c:1363
+#: builtin/rebase.c:1067
 msgid "edit the todo list during an interactive rebase"
 msgstr "sửa danh sách cần làm trong quá trình “rebase” (cải tổ) tương tác"
 
-#: builtin/rebase.c:1366
+#: builtin/rebase.c:1070
 msgid "show the patch file being applied or merged"
 msgstr "hiển thị miếng vá đã được áp dụng hay hòa trộn"
 
-#: builtin/rebase.c:1369
+#: builtin/rebase.c:1073
 msgid "use apply strategies to rebase"
 msgstr "dùng chiến lược áp dụng để cải tổ"
 
-#: builtin/rebase.c:1373
+#: builtin/rebase.c:1077
 msgid "use merging strategies to rebase"
 msgstr "dùng chiến lược hòa trộn để cải tổ"
 
-#: builtin/rebase.c:1377
+#: builtin/rebase.c:1081
 msgid "let the user edit the list of commits to rebase"
 msgstr "để người dùng sửa danh sách các lần chuyển giao muốn cải tổ"
 
-#: builtin/rebase.c:1381
+#: builtin/rebase.c:1085
 msgid "(DEPRECATED) try to recreate merges instead of ignoring them"
 msgstr "(ĐÃ LẠC HẬU) hay thử tạo lại các hòa trộn thay vì bỏ qua chúng"
 
-#: builtin/rebase.c:1386
+#: builtin/rebase.c:1090
 msgid "how to handle commits that become empty"
 msgstr "xử lý các lần chuyển giao mà nó trở thành trống rỗng như thế nào"
 
-#: builtin/rebase.c:1393
+#: builtin/rebase.c:1093
+msgid "keep commits which start empty"
+msgstr "bỏ qua các lần chuyển giao mà nó bắt đầu trống rỗng"
+
+#: builtin/rebase.c:1097
 msgid "move commits that begin with squash!/fixup! under -i"
 msgstr "di chuyển các lần chuyển giao mà bắt đầu bằng squash!/fixup! dưới -i"
 
-#: builtin/rebase.c:1400
+#: builtin/rebase.c:1104
 msgid "add exec lines after each commit of the editable list"
 msgstr "thêm các dòng thực thi sau từng lần chuyển giao của danh sách sửa được"
 
-#: builtin/rebase.c:1404
+#: builtin/rebase.c:1108
 msgid "allow rebasing commits with empty messages"
 msgstr "chấp nhận cải tổ các chuyển giao mà không ghi chú gì"
 
-#: builtin/rebase.c:1408
+#: builtin/rebase.c:1112
 msgid "try to rebase merges instead of skipping them"
 msgstr "cố thử cải tổ các hòa trộn thay vì bỏ qua chúng"
 
-#: builtin/rebase.c:1411
+#: builtin/rebase.c:1115
 msgid "use 'merge-base --fork-point' to refine upstream"
 msgstr "dùng “merge-base --fork-point” để định nghĩa lại thượng nguồn"
 
-#: builtin/rebase.c:1413
+#: builtin/rebase.c:1117
 msgid "use the given merge strategy"
 msgstr "dùng chiến lược hòa trộn đã cho"
 
-#: builtin/rebase.c:1415 builtin/revert.c:115
+#: builtin/rebase.c:1119 builtin/revert.c:115
 msgid "option"
 msgstr "tùy chọn"
 
-#: builtin/rebase.c:1416
+#: builtin/rebase.c:1120
 msgid "pass the argument through to the merge strategy"
 msgstr "chuyển thao số đến chiến lược hòa trộn"
 
-#: builtin/rebase.c:1419
+#: builtin/rebase.c:1123
 msgid "rebase all reachable commits up to the root(s)"
 msgstr "cải tổ tất các các lần chuyển giao cho đến root"
 
-#: builtin/rebase.c:1424
+#: builtin/rebase.c:1126
+msgid "automatically re-schedule any `exec` that fails"
+msgstr "lập lịch lại một cách tự động bất kỳ “exec“ bị lỗi"
+
+#: builtin/rebase.c:1128
 msgid "apply all changes, even those already present upstream"
 msgstr ""
 "áp dụng mọi thay đổi, ngay cả khi những thứ đó đã sẵn có ở thượng nguồn"
 
-#: builtin/rebase.c:1442
+#: builtin/rebase.c:1149
 msgid "It looks like 'git am' is in progress. Cannot rebase."
 msgstr ""
 "Hình như đang trong quá trình thực hiện lệnh “git am”. Không thể rebase."
 
-#: builtin/rebase.c:1483
-msgid ""
-"git rebase --preserve-merges is deprecated. Use --rebase-merges instead."
-msgstr ""
-"git rebase --preserve-merges đã lạc hậu. Hãy dùng --rebase-merges để thay "
-"thế."
+#: builtin/rebase.c:1180
+msgid "--preserve-merges was replaced by --rebase-merges"
+msgstr "--preserve-merges đã bị thay thế bằng --rebase-merges"
 
-#: builtin/rebase.c:1488
+#: builtin/rebase.c:1193
 msgid "cannot combine '--keep-base' with '--onto'"
 msgstr "không thể kết hợp “--keep-base” với “--onto”"
 
-#: builtin/rebase.c:1490
+#: builtin/rebase.c:1195
 msgid "cannot combine '--keep-base' with '--root'"
 msgstr "không thể kết hợp “--keep-base” với “--root”"
 
-#: builtin/rebase.c:1494
+#: builtin/rebase.c:1199
 msgid "cannot combine '--root' with '--fork-point'"
 msgstr "không thể kết hợp “--root” với “--fork-point”"
 
-#: builtin/rebase.c:1497
+#: builtin/rebase.c:1202
 msgid "No rebase in progress?"
 msgstr "Không có tiến trình rebase nào phải không?"
 
-#: builtin/rebase.c:1501
+#: builtin/rebase.c:1206
 msgid "The --edit-todo action can only be used during interactive rebase."
 msgstr ""
 "Hành động “--edit-todo” chỉ có thể dùng trong quá trình “rebase” (sửa lịch "
 "sử) tương tác."
 
-#: builtin/rebase.c:1524 t/helper/test-fast-rebase.c:122
+#: builtin/rebase.c:1229 t/helper/test-fast-rebase.c:122
 msgid "Cannot read HEAD"
 msgstr "Không thể đọc HEAD"
 
-#: builtin/rebase.c:1536
+#: builtin/rebase.c:1241
 msgid ""
 "You must edit all merge conflicts and then\n"
 "mark them as resolved using git add"
@@ -20308,16 +20501,16 @@ msgstr ""
 "Bạn phải sửa tất cả các lần hòa trộn xung đột và sau\n"
 "đó đánh dấu chúng là cần xử lý sử dụng lệnh git add"
 
-#: builtin/rebase.c:1555
+#: builtin/rebase.c:1260
 msgid "could not discard worktree changes"
 msgstr "không thể loại bỏ các thay đổi cây-làm-việc"
 
-#: builtin/rebase.c:1574
+#: builtin/rebase.c:1279
 #, c-format
 msgid "could not move back to %s"
 msgstr "không thể quay trở lại %s"
 
-#: builtin/rebase.c:1620
+#: builtin/rebase.c:1325
 #, c-format
 msgid ""
 "It seems that there is already a %s directory, and\n"
@@ -20338,141 +20531,132 @@ msgstr ""
 "và chạy TÔI lần nữa. TÔI dừng lại trong trường hợp bạn vẫn\n"
 "có một số thứ quý giá ở đây.\n"
 
-#: builtin/rebase.c:1648
+#: builtin/rebase.c:1353
 msgid "switch `C' expects a numerical value"
 msgstr "tùy chọn “%c” cần một giá trị bằng số"
 
-#: builtin/rebase.c:1690
+#: builtin/rebase.c:1395
 #, c-format
 msgid "Unknown mode: %s"
 msgstr "Không hiểu chế độ: %s"
 
-#: builtin/rebase.c:1729
+#: builtin/rebase.c:1434
 msgid "--strategy requires --merge or --interactive"
 msgstr "--strategy cần --merge hay --interactive"
 
-#: builtin/rebase.c:1759
+#: builtin/rebase.c:1463
 msgid "cannot combine apply options with merge options"
 msgstr "không thể tổ hợp các tùy chọn áp dụng với các tùy chọn hòa trộn"
 
-#: builtin/rebase.c:1772
+#: builtin/rebase.c:1476
 #, c-format
 msgid "Unknown rebase backend: %s"
 msgstr "Không hiểu ứng dụng chạy phía sau lệnh cải tổ: %s"
 
-#: builtin/rebase.c:1802
+#: builtin/rebase.c:1505
 msgid "--reschedule-failed-exec requires --exec or --interactive"
 msgstr "--reschedule-failed-exec cần --exec hay --interactive"
 
-#: builtin/rebase.c:1822
-msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
-msgstr "không thể kết hợp “--preserve-merges” với “--rebase-merges”"
-
-#: builtin/rebase.c:1826
-msgid ""
-"error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
-msgstr "không thể kết hợp “--preserve-merges” với “--reschedule-failed-exec”"
-
-#: builtin/rebase.c:1850
+#: builtin/rebase.c:1536
 #, c-format
 msgid "invalid upstream '%s'"
 msgstr "thượng nguồn không hợp lệ “%s”"
 
-#: builtin/rebase.c:1856
+#: builtin/rebase.c:1542
 msgid "Could not create new root commit"
 msgstr "Không thể tạo lần chuyển giao gốc mới"
 
-#: builtin/rebase.c:1882
+#: builtin/rebase.c:1568
 #, c-format
 msgid "'%s': need exactly one merge base with branch"
 msgstr "“%s”: cần chính xác một cơ sở hòa trộn với nhánh"
 
-#: builtin/rebase.c:1885
+#: builtin/rebase.c:1571
 #, c-format
 msgid "'%s': need exactly one merge base"
 msgstr "“%s”: cần chính xác một cơ sở hòa trộn"
 
-#: builtin/rebase.c:1893
+#: builtin/rebase.c:1580
 #, c-format
 msgid "Does not point to a valid commit '%s'"
 msgstr "Không chỉ đến một lần chuyển giao không hợp lệ “%s”"
 
-#: builtin/rebase.c:1921
+#: builtin/rebase.c:1607
 #, c-format
-msgid "fatal: no such branch/commit '%s'"
-msgstr "nghiêm trọng: không có nhánh/lần chuyển giao “%s” như thế"
+msgid "no such branch/commit '%s'"
+msgstr "không có nhánh/lần chuyển giao “%s” như thế"
 
-#: builtin/rebase.c:1929 builtin/submodule--helper.c:39
-#: builtin/submodule--helper.c:2431
+#: builtin/rebase.c:1618 builtin/submodule--helper.c:39
+#: builtin/submodule--helper.c:2658
 #, c-format
 msgid "No such ref: %s"
 msgstr "Không có tham chiếu nào như thế: %s"
 
-#: builtin/rebase.c:1940
+#: builtin/rebase.c:1629
 msgid "Could not resolve HEAD to a revision"
 msgstr "Không thể phân giải lần chuyển giao HEAD đến một điểm xét duyệt"
 
-#: builtin/rebase.c:1961
+#: builtin/rebase.c:1650
 msgid "Please commit or stash them."
 msgstr "Xin hãy chuyển giao hoặc tạm cất (stash) chúng."
 
-#: builtin/rebase.c:1997
+#: builtin/rebase.c:1686
 #, c-format
 msgid "could not switch to %s"
 msgstr "không thể chuyển đến %s"
 
-#: builtin/rebase.c:2008
+#: builtin/rebase.c:1697
 msgid "HEAD is up to date."
 msgstr "HEAD đã cập nhật."
 
-#: builtin/rebase.c:2010
+#: builtin/rebase.c:1699
 #, c-format
 msgid "Current branch %s is up to date.\n"
 msgstr "Nhánh hiện tại %s đã được cập nhật rồi.\n"
 
-#: builtin/rebase.c:2018
+#: builtin/rebase.c:1707
 msgid "HEAD is up to date, rebase forced."
 msgstr "HEAD hiện đã được cập nhật rồi, bị ép buộc rebase."
 
-#: builtin/rebase.c:2020
+#: builtin/rebase.c:1709
 #, c-format
 msgid "Current branch %s is up to date, rebase forced.\n"
 msgstr "Nhánh hiện tại %s đã được cập nhật rồi, lệnh rebase ép buộc.\n"
 
-#: builtin/rebase.c:2028
+#: builtin/rebase.c:1717
 msgid "The pre-rebase hook refused to rebase."
 msgstr "Móc (hook) pre-rebase từ chối rebase."
 
-#: builtin/rebase.c:2035
+#: builtin/rebase.c:1724
 #, c-format
 msgid "Changes to %s:\n"
 msgstr "Thay đổi thành %s:\n"
 
-#: builtin/rebase.c:2038
+#: builtin/rebase.c:1727
 #, c-format
 msgid "Changes from %s to %s:\n"
 msgstr "Thay đổi từ %s thành %s:\n"
 
-#: builtin/rebase.c:2063
+#: builtin/rebase.c:1752
 #, c-format
 msgid "First, rewinding head to replay your work on top of it...\n"
 msgstr ""
 "Trước tiên, di chuyển head để xem lại các công việc trên đỉnh của nó…\n"
 
-#: builtin/rebase.c:2072
+#: builtin/rebase.c:1761
 msgid "Could not detach HEAD"
 msgstr "Không thể tách rời HEAD"
 
-#: builtin/rebase.c:2081
+#: builtin/rebase.c:1770
 #, c-format
 msgid "Fast-forwarded %s to %s.\n"
 msgstr "Chuyển-tiếp-nhanh %s đến %s.\n"
 
-#: builtin/receive-pack.c:34
+#: builtin/receive-pack.c:35
 msgid "git receive-pack <git-dir>"
 msgstr "git receive-pack <thư-mục-git>"
 
-#: builtin/receive-pack.c:1275
+#: builtin/receive-pack.c:1280
 msgid ""
 "By default, updating the current branch in a non-bare repository\n"
 "is denied, because it will make the index and work tree inconsistent\n"
@@ -20502,7 +20686,7 @@ msgstr ""
 "Để chấm dứt lời nhắn này và vẫn giữ cách ứng xử mặc định, hãy đặt\n"
 "biến cấu hình “receive.denyCurrentBranch” thành “refuse”."
 
-#: builtin/receive-pack.c:1295
+#: builtin/receive-pack.c:1300
 msgid ""
 "By default, deleting the current branch is denied, because the next\n"
 "'git clone' won't result in any file checked out, causing confusion.\n"
@@ -20523,11 +20707,11 @@ msgstr ""
 "\n"
 "Để chấm dứt lời nhắn này, bạn hãy đặt nó thành “refuse”."
 
-#: builtin/receive-pack.c:2478
+#: builtin/receive-pack.c:2480
 msgid "quiet"
 msgstr "im lặng"
 
-#: builtin/receive-pack.c:2492
+#: builtin/receive-pack.c:2495
 msgid "You must specify a directory."
 msgstr "Bạn phải chỉ định thư mục."
 
@@ -20568,7 +20752,7 @@ msgstr "Đánh dấu các đối tượng tiếp cận được…"
 msgid "%s points nowhere!"
 msgstr "%s chẳng chỉ đến đâu cả!"
 
-#: builtin/reflog.c:699
+#: builtin/reflog.c:700
 msgid "no reflog specified to delete"
 msgstr "chưa chỉ ra reflog để xóa"
 
@@ -20723,7 +20907,7 @@ msgstr "đang chỉ định một nhánh master không hợp lý với tùy ch�
 msgid "specifying branches to track makes sense only with fetch mirrors"
 msgstr "chỉ định những nhánh để theo dõi chỉ hợp lý với các “fetch mirror”"
 
-#: builtin/remote.c:195 builtin/remote.c:700
+#: builtin/remote.c:195 builtin/remote.c:705
 #, c-format
 msgid "remote %s already exists."
 msgstr "máy chủ %s đã tồn tại rồi."
@@ -20733,25 +20917,30 @@ msgstr "máy chủ %s đã tồn tại rồi."
 msgid "Could not setup master '%s'"
 msgstr "Không thể cài đặt nhánh master “%s”"
 
-#: builtin/remote.c:355
+#: builtin/remote.c:322
+#, c-format
+msgid "unhandled branch.%s.rebase=%s; assuming 'true'"
+msgstr "nhánh chưa được quản lý.%s.rebase=%s; giả định là “true”"
+
+#: builtin/remote.c:366
 #, c-format
 msgid "Could not get fetch map for refspec %s"
 msgstr "Không thể lấy ánh xạ (map) fetch cho đặc tả tham chiếu %s"
 
-#: builtin/remote.c:454 builtin/remote.c:462
+#: builtin/remote.c:460 builtin/remote.c:468
 msgid "(matching)"
 msgstr "(khớp)"
 
-#: builtin/remote.c:466
+#: builtin/remote.c:472
 msgid "(delete)"
 msgstr "(xóa)"
 
-#: builtin/remote.c:655
+#: builtin/remote.c:660
 #, c-format
 msgid "could not set '%s'"
 msgstr "không thể đặt “%s”"
 
-#: builtin/remote.c:660
+#: builtin/remote.c:665
 #, c-format
 msgid ""
 "The %s configuration remote.pushDefault in:\n"
@@ -20762,17 +20951,17 @@ msgstr ""
 "\t%s:%d\n"
 "bây giờ tên trên máy chủ không tồn tại “%s”"
 
-#: builtin/remote.c:691 builtin/remote.c:836 builtin/remote.c:943
+#: builtin/remote.c:696 builtin/remote.c:841 builtin/remote.c:948
 #, c-format
 msgid "No such remote: '%s'"
 msgstr "Không có máy chủ nào như vậy: “%s”"
 
-#: builtin/remote.c:710
+#: builtin/remote.c:715
 #, c-format
 msgid "Could not rename config section '%s' to '%s'"
 msgstr "Không thể đổi tên phần của cấu hình từ “%s” thành “%s”"
 
-#: builtin/remote.c:730
+#: builtin/remote.c:735
 #, c-format
 msgid ""
 "Not updating non-default fetch refspec\n"
@@ -20783,17 +20972,17 @@ msgstr ""
 "\t%s\n"
 "\tXin hãy cập nhật phần cấu hình một cách thủ công nếu thấy cần thiết."
 
-#: builtin/remote.c:770
+#: builtin/remote.c:775
 #, c-format
 msgid "deleting '%s' failed"
 msgstr "gặp lỗi khi xóa “%s”"
 
-#: builtin/remote.c:804
+#: builtin/remote.c:809
 #, c-format
 msgid "creating '%s' failed"
 msgstr "gặp lỗi khi tạo “%s”"
 
-#: builtin/remote.c:882
+#: builtin/remote.c:887
 msgid ""
 "Note: A branch outside the refs/remotes/ hierarchy was not removed;\n"
 "to delete it, use:"
@@ -20805,119 +20994,119 @@ msgstr[0] ""
 "đi;\n"
 "để xóa đi, sử dụng:"
 
-#: builtin/remote.c:896
+#: builtin/remote.c:901
 #, c-format
 msgid "Could not remove config section '%s'"
 msgstr "Không thể gỡ bỏ phần cấu hình “%s”"
 
-#: builtin/remote.c:999
+#: builtin/remote.c:1009
 #, c-format
 msgid " new (next fetch will store in remotes/%s)"
 msgstr " mới (lần lấy về tiếp theo sẽ lưu trong remotes/%s)"
 
-#: builtin/remote.c:1002
+#: builtin/remote.c:1012
 msgid " tracked"
 msgstr " được theo dõi"
 
-#: builtin/remote.c:1004
+#: builtin/remote.c:1014
 msgid " stale (use 'git remote prune' to remove)"
 msgstr " cũ rích (dùng “git remote prune” để gỡ bỏ)"
 
-#: builtin/remote.c:1006
+#: builtin/remote.c:1016
 msgid " ???"
 msgstr " ???"
 
-#: builtin/remote.c:1047
+#: builtin/remote.c:1057
 #, c-format
 msgid "invalid branch.%s.merge; cannot rebase onto > 1 branch"
 msgstr "branch.%s.merge không hợp lệ; không thể cải tổ về phía > 1 nhánh"
 
-#: builtin/remote.c:1056
+#: builtin/remote.c:1066
 #, c-format
 msgid "rebases interactively onto remote %s"
 msgstr "thực hiện rebase một cách tương tác trên máy chủ %s"
 
-#: builtin/remote.c:1058
+#: builtin/remote.c:1068
 #, c-format
 msgid "rebases interactively (with merges) onto remote %s"
 msgstr ""
 "thực hiện cải tổ (với các hòa trộn) một cách tương tác lên trên máy chủ %s"
 
-#: builtin/remote.c:1061
+#: builtin/remote.c:1071
 #, c-format
 msgid "rebases onto remote %s"
 msgstr "thực hiện rebase trên máy chủ %s"
 
-#: builtin/remote.c:1065
+#: builtin/remote.c:1075
 #, c-format
 msgid " merges with remote %s"
 msgstr " hòa trộn với máy chủ %s"
 
-#: builtin/remote.c:1068
+#: builtin/remote.c:1078
 #, c-format
 msgid "merges with remote %s"
 msgstr "hòa trộn với máy chủ %s"
 
-#: builtin/remote.c:1071
+#: builtin/remote.c:1081
 #, c-format
 msgid "%-*s    and with remote %s\n"
 msgstr "%-*s    và với máy chủ %s\n"
 
-#: builtin/remote.c:1114
+#: builtin/remote.c:1124
 msgid "create"
 msgstr "tạo"
 
-#: builtin/remote.c:1117
+#: builtin/remote.c:1127
 msgid "delete"
 msgstr "xóa"
 
-#: builtin/remote.c:1121
+#: builtin/remote.c:1131
 msgid "up to date"
 msgstr "đã cập nhật"
 
-#: builtin/remote.c:1124
+#: builtin/remote.c:1134
 msgid "fast-forwardable"
 msgstr "có-thể-chuyển-tiếp-nhanh"
 
-#: builtin/remote.c:1127
+#: builtin/remote.c:1137
 msgid "local out of date"
 msgstr "dữ liệu nội bộ đã cũ"
 
-#: builtin/remote.c:1134
+#: builtin/remote.c:1144
 #, c-format
 msgid "    %-*s forces to %-*s (%s)"
 msgstr "    %-*s ép buộc thành %-*s (%s)"
 
-#: builtin/remote.c:1137
+#: builtin/remote.c:1147
 #, c-format
 msgid "    %-*s pushes to %-*s (%s)"
 msgstr "    %-*s đẩy lên thành %-*s (%s)"
 
-#: builtin/remote.c:1141
+#: builtin/remote.c:1151
 #, c-format
 msgid "    %-*s forces to %s"
 msgstr "    %-*s ép buộc thành %s"
 
-#: builtin/remote.c:1144
+#: builtin/remote.c:1154
 #, c-format
 msgid "    %-*s pushes to %s"
 msgstr "    %-*s đẩy lên thành %s"
 
-#: builtin/remote.c:1212
+#: builtin/remote.c:1222
 msgid "do not query remotes"
 msgstr "không truy vấn các máy chủ"
 
-#: builtin/remote.c:1239
+#: builtin/remote.c:1243
 #, c-format
 msgid "* remote %s"
 msgstr "* máy chủ %s"
 
-#: builtin/remote.c:1240
+#: builtin/remote.c:1244
 #, c-format
 msgid "  Fetch URL: %s"
 msgstr "  URL để lấy về: %s"
 
-#: builtin/remote.c:1241 builtin/remote.c:1257 builtin/remote.c:1396
+#: builtin/remote.c:1245 builtin/remote.c:1261 builtin/remote.c:1398
 msgid "(no URL)"
 msgstr "(không có URL)"
 
@@ -20925,181 +21114,185 @@ msgstr "(không có URL)"
 #. with the one in " Fetch URL: %s"
 #. translation.
 #.
-#: builtin/remote.c:1255 builtin/remote.c:1257
+#: builtin/remote.c:1259 builtin/remote.c:1261
 #, c-format
 msgid "  Push  URL: %s"
 msgstr "  URL để đẩy lên: %s"
 
-#: builtin/remote.c:1259 builtin/remote.c:1261 builtin/remote.c:1263
+#: builtin/remote.c:1263 builtin/remote.c:1265 builtin/remote.c:1267
 #, c-format
 msgid "  HEAD branch: %s"
 msgstr "  Nhánh HEAD: %s"
 
-#: builtin/remote.c:1259
+#: builtin/remote.c:1263
 msgid "(not queried)"
 msgstr "(không yêu cầu)"
 
-#: builtin/remote.c:1261
+#: builtin/remote.c:1265
 msgid "(unknown)"
 msgstr "(không hiểu)"
 
-#: builtin/remote.c:1265
+#: builtin/remote.c:1269
 #, c-format
 msgid ""
 "  HEAD branch (remote HEAD is ambiguous, may be one of the following):\n"
 msgstr "  nhánh HEAD (HEAD máy chủ chưa rõ ràng, có lẽ là một trong số sau):\n"
 
-#: builtin/remote.c:1277
+#: builtin/remote.c:1281
 #, c-format
 msgid "  Remote branch:%s"
 msgid_plural "  Remote branches:%s"
 msgstr[0] "  Những nhánh trên máy chủ:%s"
 
-#: builtin/remote.c:1280 builtin/remote.c:1306
+#: builtin/remote.c:1284 builtin/remote.c:1310
 msgid " (status not queried)"
 msgstr " (trạng thái không được yêu cầu)"
 
-#: builtin/remote.c:1289
+#: builtin/remote.c:1293
 msgid "  Local branch configured for 'git pull':"
 msgid_plural "  Local branches configured for 'git pull':"
 msgstr[0] "  Những nhánh nội bộ đã được cấu hình cho lệnh “git pull”:"
 
-#: builtin/remote.c:1297
+#: builtin/remote.c:1301
 msgid "  Local refs will be mirrored by 'git push'"
 msgstr "  refs nội bộ sẽ được phản chiếu bởi lệnh “git push”"
 
-#: builtin/remote.c:1303
+#: builtin/remote.c:1307
 #, c-format
 msgid "  Local ref configured for 'git push'%s:"
 msgid_plural "  Local refs configured for 'git push'%s:"
 msgstr[0] "  Những tham chiếu nội bộ được cấu hình cho lệnh “git push”%s:"
 
-#: builtin/remote.c:1324
+#: builtin/remote.c:1328
 msgid "set refs/remotes/<name>/HEAD according to remote"
 msgstr "đặt refs/remotes/<tên>/HEAD cho phù hợp với máy chủ"
 
-#: builtin/remote.c:1326
+#: builtin/remote.c:1330
 msgid "delete refs/remotes/<name>/HEAD"
 msgstr "xóa refs/remotes/<tên>/HEAD"
 
-#: builtin/remote.c:1341
+#: builtin/remote.c:1344
 msgid "Cannot determine remote HEAD"
 msgstr "Không thể xác định được HEAD máy chủ"
 
-#: builtin/remote.c:1343
+#: builtin/remote.c:1346
 msgid "Multiple remote HEAD branches. Please choose one explicitly with:"
 msgstr "Nhiều nhánh HEAD máy chủ. Hãy chọn rõ ràng một:"
 
-#: builtin/remote.c:1353
+#: builtin/remote.c:1356
 #, c-format
 msgid "Could not delete %s"
 msgstr "Không thể xóa bỏ %s"
 
-#: builtin/remote.c:1361
+#: builtin/remote.c:1364
 #, c-format
 msgid "Not a valid ref: %s"
 msgstr "Không phải là tham chiếu hợp lệ: %s"
 
-#: builtin/remote.c:1363
+#: builtin/remote.c:1366
 #, c-format
 msgid "Could not setup %s"
 msgstr "Không thể cài đặt %s"
 
-#: builtin/remote.c:1381
+#: builtin/remote.c:1384
 #, c-format
 msgid " %s will become dangling!"
 msgstr " %s sẽ trở thành không đầu (không được quản lý)!"
 
-#: builtin/remote.c:1382
+#: builtin/remote.c:1385
 #, c-format
 msgid " %s has become dangling!"
 msgstr " %s đã trở thành không đầu (không được quản lý)!"
 
-#: builtin/remote.c:1392
+#: builtin/remote.c:1394
 #, c-format
 msgid "Pruning %s"
 msgstr "Đang xén bớt %s"
 
-#: builtin/remote.c:1393
+#: builtin/remote.c:1395
 #, c-format
 msgid "URL: %s"
 msgstr "URL: %s"
 
-#: builtin/remote.c:1409
+#: builtin/remote.c:1411
 #, c-format
 msgid " * [would prune] %s"
 msgstr " * [nên xén bớt] %s"
 
-#: builtin/remote.c:1412
+#: builtin/remote.c:1414
 #, c-format
 msgid " * [pruned] %s"
 msgstr " * [đã bị xén] %s"
 
-#: builtin/remote.c:1457
+#: builtin/remote.c:1459
 msgid "prune remotes after fetching"
 msgstr "cắt máy chủ sau khi lấy về"
 
-#: builtin/remote.c:1521 builtin/remote.c:1577 builtin/remote.c:1647
+#: builtin/remote.c:1523 builtin/remote.c:1579 builtin/remote.c:1649
 #, c-format
 msgid "No such remote '%s'"
 msgstr "Không có máy chủ nào có tên “%s”"
 
-#: builtin/remote.c:1539
+#: builtin/remote.c:1541
 msgid "add branch"
 msgstr "thêm nhánh"
 
-#: builtin/remote.c:1546
+#: builtin/remote.c:1548
 msgid "no remote specified"
 msgstr "chưa chỉ ra máy chủ nào"
 
-#: builtin/remote.c:1563
+#: builtin/remote.c:1565
 msgid "query push URLs rather than fetch URLs"
 msgstr "truy vấn đẩy URL thay vì lấy"
 
-#: builtin/remote.c:1565
+#: builtin/remote.c:1567
 msgid "return all URLs"
 msgstr "trả về mọi URL"
 
-#: builtin/remote.c:1595
+#: builtin/remote.c:1597
 #, c-format
 msgid "no URLs configured for remote '%s'"
 msgstr "không có URL nào được cấu hình cho nhánh “%s”"
 
-#: builtin/remote.c:1621
+#: builtin/remote.c:1623
 msgid "manipulate push URLs"
 msgstr "đẩy các “URL” bằng tay"
 
-#: builtin/remote.c:1623
+#: builtin/remote.c:1625
 msgid "add URL"
 msgstr "thêm URL"
 
-#: builtin/remote.c:1625
+#: builtin/remote.c:1627
 msgid "delete URLs"
 msgstr "xóa URLs"
 
-#: builtin/remote.c:1632
+#: builtin/remote.c:1634
 msgid "--add --delete doesn't make sense"
 msgstr "--add --delete không hợp lý"
 
-#: builtin/remote.c:1673
+#: builtin/remote.c:1675
 #, c-format
 msgid "Invalid old URL pattern: %s"
 msgstr "Kiểu mẫu URL cũ không hợp lệ: %s"
 
-#: builtin/remote.c:1681
+#: builtin/remote.c:1683
 #, c-format
 msgid "No such URL found: %s"
 msgstr "Không tìm thấy URL như vậy: %s"
 
-#: builtin/remote.c:1683
+#: builtin/remote.c:1685
 msgid "Will not delete all non-push URLs"
 msgstr "Sẽ không xóa những địa chỉ URL không-push"
 
-#: builtin/repack.c:26
+#: builtin/remote.c:1702
+msgid "be verbose; must be placed before a subcommand"
+msgstr "chi tiết; phải được đặt trước một lệnh-con"
+
+#: builtin/repack.c:28
 msgid "git repack [<options>]"
 msgstr "git repack [<các tùy chọn>]"
 
-#: builtin/repack.c:31
+#: builtin/repack.c:33
 msgid ""
 "Incremental repacks are incompatible with bitmap indexes.  Use\n"
 "--no-write-bitmap-index or disable the pack.writebitmaps configuration."
@@ -21107,143 +21300,156 @@ msgstr ""
 "Gia tăng repack là không tương thích với chỉ mục bitmap. Dùng\n"
 "--no-write-bitmap-index hay tắt cấu hình pack.writebitmaps."
 
-#: builtin/repack.c:198
+#: builtin/repack.c:201
 msgid "could not start pack-objects to repack promisor objects"
 msgstr ""
 "không thể lấy thông tin thống kê pack-objects để mà đóng gói lại các đối "
 "tượng hứa hẹn"
 
-#: builtin/repack.c:270 builtin/repack.c:630
+#: builtin/repack.c:273 builtin/repack.c:816
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
 msgstr ""
 "repack: Đang chỉ cần các dòng ID đối tượng dạng thập lục phân đầy dủ từ pack-"
 "objects."
 
-#: builtin/repack.c:294
+#: builtin/repack.c:297
 msgid "could not finish pack-objects to repack promisor objects"
 msgstr "không thể hoàn tất pack-objects để đóng gói các đối tượng hứa hẹn"
 
-#: builtin/repack.c:309
+#: builtin/repack.c:312
 #, c-format
 msgid "cannot open index for %s"
 msgstr "không thể mở mục lục cho “%s”"
 
-#: builtin/repack.c:368
+#: builtin/repack.c:371
 #, c-format
 msgid "pack %s too large to consider in geometric progression"
 msgstr "gói %s là quá lớn để được xem là trong tiến trình hình học"
 
-#: builtin/repack.c:401 builtin/repack.c:408 builtin/repack.c:413
+#: builtin/repack.c:404 builtin/repack.c:411 builtin/repack.c:416
 #, c-format
 msgid "pack %s too large to roll up"
 msgstr "gói %s là quá lớn để được cuộn lại"
 
-#: builtin/repack.c:460
+#: builtin/repack.c:496
+#, c-format
+msgid "could not open tempfile %s for writing"
+msgstr "không thể mở tập tin tạm %s để ghi"
+
+#: builtin/repack.c:514
+msgid "could not close refs snapshot tempfile"
+msgstr "không thể đóng tập tin tạm thời chụp nhanh các tham chiếu"
+
+#: builtin/repack.c:628
 msgid "pack everything in a single pack"
 msgstr "đóng gói mọi thứ trong một gói đơn"
 
-#: builtin/repack.c:462
+#: builtin/repack.c:630
 msgid "same as -a, and turn unreachable objects loose"
 msgstr "giống với -a, và chỉnh sửa các đối tượng không đọc được thiếu sót"
 
-#: builtin/repack.c:465
+#: builtin/repack.c:633
 msgid "remove redundant packs, and run git-prune-packed"
 msgstr "xóa bỏ các gói dư thừa, và chạy git-prune-packed"
 
-#: builtin/repack.c:467
+#: builtin/repack.c:635
 msgid "pass --no-reuse-delta to git-pack-objects"
 msgstr "chuyển --no-reuse-delta cho git-pack-objects"
 
-#: builtin/repack.c:469
+#: builtin/repack.c:637
 msgid "pass --no-reuse-object to git-pack-objects"
 msgstr "chuyển --no-reuse-object cho git-pack-objects"
 
-#: builtin/repack.c:471
+#: builtin/repack.c:639
 msgid "do not run git-update-server-info"
 msgstr "không chạy git-update-server-info"
 
-#: builtin/repack.c:474
+#: builtin/repack.c:642
 msgid "pass --local to git-pack-objects"
 msgstr "chuyển --local cho git-pack-objects"
 
-#: builtin/repack.c:476
+#: builtin/repack.c:644
 msgid "write bitmap index"
 msgstr "ghi mục lục ánh xạ"
 
-#: builtin/repack.c:478
+#: builtin/repack.c:646
 msgid "pass --delta-islands to git-pack-objects"
 msgstr "chuyển --delta-islands cho git-pack-objects"
 
-#: builtin/repack.c:479
+#: builtin/repack.c:647
 msgid "approxidate"
 msgstr "ngày ước tính"
 
-#: builtin/repack.c:480
+#: builtin/repack.c:648
 msgid "with -A, do not loosen objects older than this"
 msgstr "với -A, các đối tượng cũ hơn khoảng thời gian này thì không bị mất"
 
-#: builtin/repack.c:482
+#: builtin/repack.c:650
 msgid "with -a, repack unreachable objects"
 msgstr "với -a, đóng gói lại các đối tượng không thể đọc được"
 
-#: builtin/repack.c:484
+#: builtin/repack.c:652
 msgid "size of the window used for delta compression"
 msgstr "kích thước cửa sổ được dùng cho nén “delta”"
 
-#: builtin/repack.c:485 builtin/repack.c:491
+#: builtin/repack.c:653 builtin/repack.c:659
 msgid "bytes"
 msgstr "byte"
 
-#: builtin/repack.c:486
+#: builtin/repack.c:654
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr "giống như trên, nhưng giới hạn kích thước bộ nhớ hay vì số lượng"
 
-#: builtin/repack.c:488
+#: builtin/repack.c:656
 msgid "limits the maximum delta depth"
 msgstr "giới hạn độ sâu tối đa của “delta”"
 
-#: builtin/repack.c:490
+#: builtin/repack.c:658
 msgid "limits the maximum number of threads"
 msgstr "giới hạn số lượng tối đa tuyến trình"
 
-#: builtin/repack.c:492
+#: builtin/repack.c:660
 msgid "maximum size of each packfile"
 msgstr "kích thước tối đa cho từng tập tin gói"
 
-#: builtin/repack.c:494
+#: builtin/repack.c:662
 msgid "repack objects in packs marked with .keep"
 msgstr "đóng gói lại các đối tượng trong các gói đã đánh dấu bằng .keep"
 
-#: builtin/repack.c:496
+#: builtin/repack.c:664
 msgid "do not repack this pack"
 msgstr "đừng đóng gói lại gói này"
 
-#: builtin/repack.c:498
+#: builtin/repack.c:666
 msgid "find a geometric progression with factor <N>"
 msgstr "tìm một tiến trình hình học với hệ số <N>"
 
-#: builtin/repack.c:508
+#: builtin/repack.c:668
+msgid "write a multi-pack index of the resulting packs"
+msgstr "ghi mục lục “multi-pack” của các gói kết quả"
+
+#: builtin/repack.c:678
 msgid "cannot delete packs in a precious-objects repo"
 msgstr "không thể xóa các gói trong một kho đối_tượng_vĩ_đại"
 
-#: builtin/repack.c:512
+#: builtin/repack.c:682
 msgid "--keep-unreachable and -A are incompatible"
 msgstr "--keep-unreachable và -A xung khắc nhau"
 
-#: builtin/repack.c:527
+#: builtin/repack.c:713
 msgid "--geometric is incompatible with -A, -a"
 msgstr "--geometric là xung khắc với tùy chọn -A, -a"
 
-#: builtin/repack.c:639
+#: builtin/repack.c:825
 msgid "Nothing new to pack."
 msgstr "Không có gì mới để mà đóng gói."
 
-#: builtin/repack.c:669
+#: builtin/repack.c:855
 #, c-format
 msgid "missing required file: %s"
 msgstr "thiếu tập tin cần thiết: %s"
 
-#: builtin/repack.c:671
+#: builtin/repack.c:857
 #, c-format
 msgid "could not unlink: %s"
 msgstr "không thể bỏ liên kết: %s"
@@ -21554,93 +21760,93 @@ msgstr "hòa trộn"
 msgid "keep"
 msgstr "giữ lại"
 
-#: builtin/reset.c:83
+#: builtin/reset.c:89
 msgid "You do not have a valid HEAD."
 msgstr "Bạn không có HEAD nào hợp lệ."
 
-#: builtin/reset.c:85
+#: builtin/reset.c:91
 msgid "Failed to find tree of HEAD."
 msgstr "Gặp lỗi khi tìm cây của HEAD."
 
-#: builtin/reset.c:91
+#: builtin/reset.c:97
 #, c-format
 msgid "Failed to find tree of %s."
 msgstr "Gặp lỗi khi tìm cây của %s."
 
-#: builtin/reset.c:116
+#: builtin/reset.c:122
 #, c-format
 msgid "HEAD is now at %s"
 msgstr "HEAD hiện giờ tại %s"
 
-#: builtin/reset.c:195
+#: builtin/reset.c:201
 #, c-format
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "Không thể thực hiện một %s reset ở giữa của quá trình hòa trộn."
 
-#: builtin/reset.c:295 builtin/stash.c:589 builtin/stash.c:663
-#: builtin/stash.c:687
+#: builtin/reset.c:301 builtin/stash.c:605 builtin/stash.c:679
+#: builtin/stash.c:703
 msgid "be quiet, only report errors"
 msgstr "làm việc ở chế độ im lặng, chỉ hiển thị khi có lỗi"
 
-#: builtin/reset.c:297
+#: builtin/reset.c:303
 msgid "reset HEAD and index"
 msgstr "đặt lại (reset) HEAD và bảng mục lục"
 
-#: builtin/reset.c:298
+#: builtin/reset.c:304
 msgid "reset only HEAD"
 msgstr "chỉ đặt lại (reset) HEAD"
 
-#: builtin/reset.c:300 builtin/reset.c:302
+#: builtin/reset.c:306 builtin/reset.c:308
 msgid "reset HEAD, index and working tree"
 msgstr "đặt lại HEAD, bảng mục lục và cây làm việc"
 
-#: builtin/reset.c:304
+#: builtin/reset.c:310
 msgid "reset HEAD but keep local changes"
 msgstr "đặt lại HEAD nhưng giữ lại các thay đổi nội bộ"
 
-#: builtin/reset.c:310
+#: builtin/reset.c:316
 msgid "record only the fact that removed paths will be added later"
 msgstr "chỉ ghi lại những đường dẫn thực sự sẽ được thêm vào sau này"
 
-#: builtin/reset.c:344
+#: builtin/reset.c:350
 #, c-format
 msgid "Failed to resolve '%s' as a valid revision."
 msgstr "Gặp lỗi khi phân giải “%s” như là điểm xét duyệt hợp lệ."
 
-#: builtin/reset.c:352
+#: builtin/reset.c:358
 #, c-format
 msgid "Failed to resolve '%s' as a valid tree."
 msgstr "Gặp lỗi khi phân giải “%s” như là một cây (tree) hợp lệ."
 
-#: builtin/reset.c:361
+#: builtin/reset.c:367
 msgid "--patch is incompatible with --{hard,mixed,soft}"
 msgstr "--patch xung khắc với --{hard,mixed,soft}"
 
-#: builtin/reset.c:371
+#: builtin/reset.c:377
 msgid "--mixed with paths is deprecated; use 'git reset -- <paths>' instead."
 msgstr ""
 "--mixed với các đường dẫn không còn dùng nữa; hãy thay thế bằng lệnh “git "
 "reset -- </các/đường/dẫn>”."
 
-#: builtin/reset.c:373
+#: builtin/reset.c:379
 #, c-format
 msgid "Cannot do %s reset with paths."
 msgstr "Không thể thực hiện lệnh %s reset với các đường dẫn."
 
-#: builtin/reset.c:388
+#: builtin/reset.c:394
 #, c-format
 msgid "%s reset is not allowed in a bare repository"
 msgstr "%s reset không được phép trên kho thuần"
 
-#: builtin/reset.c:392
+#: builtin/reset.c:398
 msgid "-N can only be used with --mixed"
 msgstr "-N chỉ được dùng khi có --mixed"
 
-#: builtin/reset.c:413
+#: builtin/reset.c:419
 msgid "Unstaged changes after reset:"
 msgstr "Những thay đổi được đưa ra khỏi bệ phóng sau khi reset:"
 
-#: builtin/reset.c:416
+#: builtin/reset.c:422
 #, c-format
 msgid ""
 "\n"
@@ -21651,16 +21857,16 @@ msgstr ""
 "\n"
 "Cần %.2f giây để kiểm đếm các thay đổi chưa đưa lên bệ phóng sau khi đặt "
 "lại.\n"
-"Bạn có thể sử dụng '--quiet' để tránh việc này. Đặt reset.quiet thành true "
+"Bạn có thể sử dụng “--quiet” để tránh việc này. Đặt reset.quiet thành true "
 "trong\n"
 "cài đặt config nếu bạn muốn thực hiện nó như là mặc định.\n"
 
-#: builtin/reset.c:434
+#: builtin/reset.c:440
 #, c-format
 msgid "Could not reset index file to revision '%s'."
 msgstr "Không thể đặt lại (reset) bảng mục lục thành điểm xét duyệt “%s”."
 
-#: builtin/reset.c:439
+#: builtin/reset.c:445
 msgid "Could not write new index file."
 msgstr "Không thể ghi tập tin lưu bảng mục lục mới."
 
@@ -21702,7 +21908,7 @@ msgstr "đầu vào chấm dứt bất thường"
 
 #: builtin/rev-parse.c:442
 msgid "no usage string given before the `--' separator"
-msgstr "không có chuỗi cách dùng nào được đưa ra trước dấu phân cách '--'"
+msgstr "không có chuỗi cách dùng nào được đưa ra trước dấu phân cách “--”"
 
 #: builtin/rev-parse.c:548
 msgid "Needed a single revision"
@@ -21840,15 +22046,19 @@ msgstr "nối thêm tên lần chuyển giao"
 msgid "preserve initially empty commits"
 msgstr "cấm khởi tạo lần chuyển giao trống rỗng"
 
+#: builtin/revert.c:128
+msgid "allow commits with empty messages"
+msgstr "chấp nhận chuyển giao mà không ghi chú gì"
+
 #: builtin/revert.c:129
 msgid "keep redundant, empty commits"
 msgstr "giữ lại các lần chuyển giao dư thừa, rỗng"
 
-#: builtin/revert.c:237
+#: builtin/revert.c:241
 msgid "revert failed"
 msgstr "hoàn nguyên gặp lỗi"
 
-#: builtin/revert.c:250
+#: builtin/revert.c:254
 msgid "cherry-pick failed"
 msgstr "cherry-pick gặp lỗi"
 
@@ -21893,70 +22103,70 @@ msgid "the following file has local modifications:"
 msgid_plural "the following files have local modifications:"
 msgstr[0] "những tập tin sau đây có những thay đổi nội bộ:"
 
-#: builtin/rm.c:244
+#: builtin/rm.c:245
 msgid "do not list removed files"
 msgstr "không liệt kê các tập tin đã gỡ bỏ"
 
-#: builtin/rm.c:245
+#: builtin/rm.c:246
 msgid "only remove from the index"
 msgstr "chỉ gỡ bỏ từ mục lục"
 
-#: builtin/rm.c:246
+#: builtin/rm.c:247
 msgid "override the up-to-date check"
 msgstr "ghi đè lên kiểm tra cập nhật"
 
-#: builtin/rm.c:247
+#: builtin/rm.c:248
 msgid "allow recursive removal"
 msgstr "cho phép gỡ bỏ đệ qui"
 
-#: builtin/rm.c:249
+#: builtin/rm.c:250
 msgid "exit with a zero status even if nothing matched"
 msgstr "thoát ra với trạng thái khác không thậm chí nếu không có gì khớp"
 
-#: builtin/rm.c:283
+#: builtin/rm.c:285
 msgid "No pathspec was given. Which files should I remove?"
 msgstr "Không đưa ra đặc tả đường dẫn. Tôi nên loại bỏ các tập tin nào?"
 
-#: builtin/rm.c:310
+#: builtin/rm.c:315
 msgid "please stage your changes to .gitmodules or stash them to proceed"
 msgstr ""
 "hãy đưa các thay đổi của bạn vào .gitmodules hay tạm cất chúng đi để xử lý"
 
-#: builtin/rm.c:331
+#: builtin/rm.c:337
 #, c-format
 msgid "not removing '%s' recursively without -r"
 msgstr "không thể gỡ bỏ “%s” một cách đệ qui mà không có tùy chọn -r"
 
-#: builtin/rm.c:379
+#: builtin/rm.c:385
 #, c-format
 msgid "git rm: unable to remove %s"
 msgstr "git rm: không thể gỡ bỏ %s"
 
 #: builtin/send-pack.c:20
 msgid ""
-"git send-pack [--all | --mirror] [--dry-run] [--force] [--receive-pack=<git-"
-"receive-pack>] [--verbose] [--thin] [--atomic] [<host>:]<directory> "
-"[<ref>...]\n"
-"  --all and explicit <ref> specification are mutually exclusive."
+"git send-pack [--mirror] [--dry-run] [--force]\n"
+"              [--receive-pack=<git-receive-pack>]\n"
+"              [--verbose] [--thin] [--atomic]\n"
+"              [<host>:]<directory> (--all | <ref>...)"
 msgstr ""
-"git send-pack [--all | --mirror] [--dry-run] [--force] [--receive-pack=<git-"
-"receive-pack>] [--verbose] [--thin] [--atomic] [<máy>:]<thư/mục> [<các-tham-"
-"chiếu>…]\n"
-"  --all và đặc tả <ref> rõ ràng là loại trừ lẫn nhau."
+"git send-pack [--mirror] [--dry-run] [--force]\n"
+"              [--receive-pack=<git-receive-pack>]\n"
+"              [--verbose] [--thin] [--atomic]\n"
+"              [<host>:]<thư mục> (--all | <tham chiếu>…)"
 
-#: builtin/send-pack.c:188
+#: builtin/send-pack.c:192
 msgid "remote name"
 msgstr "tên máy dịch vụ"
 
-#: builtin/send-pack.c:201
+#: builtin/send-pack.c:205
 msgid "use stateless RPC protocol"
 msgstr "dùng giao thức RPC không ổn định"
 
-#: builtin/send-pack.c:202
+#: builtin/send-pack.c:206
 msgid "read refs from stdin"
 msgstr "đọc tham chiếu từ đầu vào tiêu chuẩn"
 
-#: builtin/send-pack.c:203
+#: builtin/send-pack.c:207
 msgid "print status from remote helper"
 msgstr "in các trạng thái từ phần hướng dẫn trên máy dịch vụ"
 
@@ -22014,21 +22224,21 @@ msgstr "trường"
 msgid "group by field"
 msgstr "nhóm theo trường"
 
-#: builtin/shortlog.c:391
+#: builtin/shortlog.c:394
 msgid "too many arguments given outside repository"
 msgstr "quá nhiều tham số đưa ra ngoài kho chứa"
 
 #: builtin/show-branch.c:13
 msgid ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
-"\t\t[--current] [--color[=<when>] | --no-color] [--sparse]\n"
-"\t\t[--more=<n> | --list | --independent | --merge-base]\n"
-"\t\t[--no-name | --sha1-name] [--topics] [(<rev> | <glob>)...]"
+"                [--current] [--color[=<when>] | --no-color] [--sparse]\n"
+"                [--more=<n> | --list | --independent | --merge-base]\n"
+"                [--no-name | --sha1-name] [--topics] [(<rev> | <glob>)...]"
 msgstr ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
-"\t\t[--current] [--color[=<khi>] | --no-color] [--sparse]\n"
-"\t\t[--more=<n> | --list | --independent | --merge-base]\n"
-"\t\t[--no-name | --sha1-name] [--topics] [(<rev> | <glob>)…]"
+"                [--current] [--color[=<when>] | --no-color] [--sparse]\n"
+"                [--more=<n> | --list | --independent | --merge-base]\n"
+"                [--no-name | --sha1-name] [--topics] [(<rev> | <glob>)…]"
 
 #: builtin/show-branch.c:17
 msgid "git show-branch (-g | --reflog)[=<n>[,<base>]] [--list] [<ref>]"
@@ -22040,113 +22250,113 @@ msgid "ignoring %s; cannot handle more than %d ref"
 msgid_plural "ignoring %s; cannot handle more than %d refs"
 msgstr[0] "đang bỏ qua %s; không thể xử lý nhiều hơn %d tham chiếu"
 
-#: builtin/show-branch.c:548
+#: builtin/show-branch.c:547
 #, c-format
 msgid "no matching refs with %s"
 msgstr "không tham chiếu nào khớp với %s"
 
-#: builtin/show-branch.c:645
+#: builtin/show-branch.c:644
 msgid "show remote-tracking and local branches"
 msgstr "hiển thị các nhánh remote-tracking và nội bộ"
 
-#: builtin/show-branch.c:647
+#: builtin/show-branch.c:646
 msgid "show remote-tracking branches"
 msgstr "hiển thị các nhánh remote-tracking"
 
-#: builtin/show-branch.c:649
+#: builtin/show-branch.c:648
 msgid "color '*!+-' corresponding to the branch"
 msgstr "màu “*!+-” tương ứng với nhánh"
 
-#: builtin/show-branch.c:651
+#: builtin/show-branch.c:650
 msgid "show <n> more commits after the common ancestor"
 msgstr "hiển thị thêm <n> lần chuyển giao sau cha mẹ chung"
 
-#: builtin/show-branch.c:653
+#: builtin/show-branch.c:652
 msgid "synonym to more=-1"
 msgstr "đồng nghĩa với more=-1"
 
-#: builtin/show-branch.c:654
+#: builtin/show-branch.c:653
 msgid "suppress naming strings"
 msgstr "chặn các chuỗi đặt tên"
 
-#: builtin/show-branch.c:656
+#: builtin/show-branch.c:655
 msgid "include the current branch"
 msgstr "bao gồm nhánh hiện hành"
 
-#: builtin/show-branch.c:658
+#: builtin/show-branch.c:657
 msgid "name commits with their object names"
 msgstr "đặt tên các lần chuyển giao bằng các tên của đối tượng của chúng"
 
-#: builtin/show-branch.c:660
+#: builtin/show-branch.c:659
 msgid "show possible merge bases"
 msgstr "hiển thị mọi cơ sở có thể dùng để hòa trộn"
 
-#: builtin/show-branch.c:662
+#: builtin/show-branch.c:661
 msgid "show refs unreachable from any other ref"
 msgstr "hiển thị các tham chiếu không thể được đọc bởi bất kỳ tham chiếu khác"
 
-#: builtin/show-branch.c:664
+#: builtin/show-branch.c:663
 msgid "show commits in topological order"
 msgstr "hiển thị các lần chuyển giao theo thứ tự tôpô"
 
-#: builtin/show-branch.c:667
+#: builtin/show-branch.c:666
 msgid "show only commits not on the first branch"
 msgstr "chỉ hiển thị các lần chuyển giao không nằm trên nhánh đầu tiên"
 
-#: builtin/show-branch.c:669
+#: builtin/show-branch.c:668
 msgid "show merges reachable from only one tip"
 msgstr "hiển thị các lần hòa trộn có thể đọc được chỉ từ một đầu mút"
 
-#: builtin/show-branch.c:671
+#: builtin/show-branch.c:670
 msgid "topologically sort, maintaining date order where possible"
 msgstr "sắp xếp hình thái học, bảo trì thứ tự ngày nếu có thể"
 
-#: builtin/show-branch.c:674
+#: builtin/show-branch.c:673
 msgid "<n>[,<base>]"
 msgstr "<n>[,<cơ_sở>]"
 
-#: builtin/show-branch.c:675
+#: builtin/show-branch.c:674
 msgid "show <n> most recent ref-log entries starting at base"
 msgstr "hiển thị <n> các mục “ref-log” gần nhất kể từ nền (base)"
 
-#: builtin/show-branch.c:711
+#: builtin/show-branch.c:710
 msgid ""
 "--reflog is incompatible with --all, --remotes, --independent or --merge-base"
 msgstr ""
 "--reflog là không tương thích với các tùy chọn --all, --remotes, --"
 "independent hay --merge-base"
 
-#: builtin/show-branch.c:735
+#: builtin/show-branch.c:734
 msgid "no branches given, and HEAD is not valid"
 msgstr "chưa đưa ra nhánh, và HEAD không hợp lệ"
 
-#: builtin/show-branch.c:738
+#: builtin/show-branch.c:737
 msgid "--reflog option needs one branch name"
 msgstr "--reflog cần tên một nhánh"
 
-#: builtin/show-branch.c:741
+#: builtin/show-branch.c:740
 #, c-format
 msgid "only %d entry can be shown at one time."
 msgid_plural "only %d entries can be shown at one time."
 msgstr[0] "chỉ có thể hiển thị cùng lúc %d hạng mục."
 
-#: builtin/show-branch.c:745
+#: builtin/show-branch.c:744
 #, c-format
 msgid "no such ref %s"
 msgstr "không có tham chiếu nào như thế %s"
 
-#: builtin/show-branch.c:831
+#: builtin/show-branch.c:828
 #, c-format
 msgid "cannot handle more than %d rev."
 msgid_plural "cannot handle more than %d revs."
 msgstr[0] "không thể xử lý nhiều hơn %d điểm xét duyệt."
 
-#: builtin/show-branch.c:835
+#: builtin/show-branch.c:832
 #, c-format
 msgid "'%s' is not a valid ref."
 msgstr "“%s” không phải tham chiếu hợp lệ."
 
-#: builtin/show-branch.c:838
+#: builtin/show-branch.c:835
 #, c-format
 msgid "cannot find commit %s (%s)"
 msgstr "không thể tìm thấy lần chuyển giao %s (%s)"
@@ -22221,70 +22431,84 @@ msgstr ""
 "không thể phân tích cú pháp cây làm việc này (tập tin sparse-checkout có lẽ "
 "không tồn tại)"
 
-#: builtin/sparse-checkout.c:227
+#: builtin/sparse-checkout.c:173
+#, c-format
+msgid ""
+"directory '%s' contains untracked files, but is not in the sparse-checkout "
+"cone"
+msgstr ""
+"thư mục “%s” có chứa các tập tin chưa được theo dõi, nhưng lại không trong "
+"“sparse-checkout cone”"
+
+#: builtin/sparse-checkout.c:181
+#, c-format
+msgid "failed to remove directory '%s'"
+msgstr "gặp lỗi khi gỡ bỏ thư mục \"%s\""
+
+#: builtin/sparse-checkout.c:321
 msgid "failed to create directory for sparse-checkout file"
 msgstr "gặp lỗi khi tạo thư mục cho tập tin sparse-checkout"
 
-#: builtin/sparse-checkout.c:268
+#: builtin/sparse-checkout.c:362
 msgid "unable to upgrade repository format to enable worktreeConfig"
 msgstr "không thể nâng cấp định dạng kho lưu trữ để kích hoạt worktreeConfig"
 
-#: builtin/sparse-checkout.c:270
+#: builtin/sparse-checkout.c:364
 msgid "failed to set extensions.worktreeConfig setting"
 msgstr "gặp lỗi khi đặt cài đặt extensions.worktreeConfig"
 
-#: builtin/sparse-checkout.c:290
+#: builtin/sparse-checkout.c:384
 msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
 msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
 
-#: builtin/sparse-checkout.c:310
+#: builtin/sparse-checkout.c:404
 msgid "initialize the sparse-checkout in cone mode"
 msgstr "khởi tạo sparse-checkout trong chế độ nón"
 
-#: builtin/sparse-checkout.c:312
+#: builtin/sparse-checkout.c:406
 msgid "toggle the use of a sparse index"
 msgstr "bật tắt việc sử dụng một \"sparse index\""
 
-#: builtin/sparse-checkout.c:340
+#: builtin/sparse-checkout.c:434
 msgid "failed to modify sparse-index config"
 msgstr "gặp lỗi khi sửa cấu hình \"sparse-index\""
 
-#: builtin/sparse-checkout.c:361
+#: builtin/sparse-checkout.c:455
 #, c-format
 msgid "failed to open '%s'"
 msgstr "gặp lỗi khi mở “%s”"
 
-#: builtin/sparse-checkout.c:413
+#: builtin/sparse-checkout.c:507
 #, c-format
 msgid "could not normalize path %s"
 msgstr "không thể thường hóa đường dẫn “%s”"
 
-#: builtin/sparse-checkout.c:425
+#: builtin/sparse-checkout.c:519
 msgid "git sparse-checkout (set|add) (--stdin | <patterns>)"
 msgstr "git sparse-checkout (set|add) (--stdin | <các mẫu>)"
 
-#: builtin/sparse-checkout.c:450
+#: builtin/sparse-checkout.c:544
 #, c-format
 msgid "unable to unquote C-style string '%s'"
 msgstr "không thể bỏ trích dẫn chuỗi kiểu C “%s”"
 
-#: builtin/sparse-checkout.c:504 builtin/sparse-checkout.c:528
+#: builtin/sparse-checkout.c:598 builtin/sparse-checkout.c:622
 msgid "unable to load existing sparse-checkout patterns"
 msgstr "không thể tải các mẫu sparse-checkout"
 
-#: builtin/sparse-checkout.c:573
+#: builtin/sparse-checkout.c:667
 msgid "read patterns from standard in"
 msgstr "đọc các mẫu từ đầu vào tiêu chuẩn"
 
-#: builtin/sparse-checkout.c:588
+#: builtin/sparse-checkout.c:682
 msgid "git sparse-checkout reapply"
 msgstr "git sparse-checkout reapply"
 
-#: builtin/sparse-checkout.c:607
+#: builtin/sparse-checkout.c:701
 msgid "git sparse-checkout disable"
 msgstr "git sparse-checkout disable"
 
-#: builtin/sparse-checkout.c:638
+#: builtin/sparse-checkout.c:732
 msgid "error while refreshing working directory"
 msgstr "gặp lỗi khi đọc lại thư mục làm việc"
 
@@ -22320,7 +22544,7 @@ msgstr ""
 "          [--pathspec-from-file=<tập_tin> [--pathspec-file-nul]]\n"
 "          [--] [<đặc/tả/đường/dẫn>…]]"
 
-#: builtin/stash.c:34 builtin/stash.c:87
+#: builtin/stash.c:34
 msgid ""
 "git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [<message>]"
@@ -22350,6 +22574,14 @@ msgstr ""
 "          [-u|--include-untracked] [-a|--all] [-m|--message <lời nhắn>]\n"
 "          [--] [<đặc/tả/đường/dẫn>…]]"
 
+#: builtin/stash.c:87
+msgid ""
+"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"               [-u|--include-untracked] [-a|--all] [<message>]"
+msgstr ""
+"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"               [-u|--include-untracked] [-a|--all] [<ghi chú>]"
+
 #: builtin/stash.c:130
 #, c-format
 msgid "'%s' is not a stash-like commit"
@@ -22373,7 +22605,7 @@ msgstr "“%s” không phải một tham chiếu hợp lệ"
 msgid "git stash clear with arguments is unimplemented"
 msgstr "git stash clear với các tham số là chưa được thực hiện"
 
-#: builtin/stash.c:431
+#: builtin/stash.c:447
 #, c-format
 msgid ""
 "WARNING: Untracked file in way of tracked file!  Renaming\n"
@@ -22384,166 +22616,166 @@ msgstr ""
 "            %s -> %s\n"
 "         để nhường chỗ.\n"
 
-#: builtin/stash.c:492
+#: builtin/stash.c:508
 msgid "cannot apply a stash in the middle of a merge"
 msgstr "không thể áp dụng một stash ở giữa của quá trình hòa trộn"
 
-#: builtin/stash.c:503
+#: builtin/stash.c:519
 #, c-format
 msgid "could not generate diff %s^!."
 msgstr "không thể tạo diff %s^!."
 
-#: builtin/stash.c:510
+#: builtin/stash.c:526
 msgid "conflicts in index. Try without --index."
 msgstr "xung đột trong bảng mục lục. Hãy thử mà không dùng tùy chọn --index."
 
-#: builtin/stash.c:516
+#: builtin/stash.c:532
 msgid "could not save index tree"
 msgstr "không thể ghi lại cây chỉ mục"
 
-#: builtin/stash.c:525
-msgid "could not restore untracked files from stash"
-msgstr "không thể phục hồi các tập tin chưa theo dõi từ mục cất đi (stash)"
-
-#: builtin/stash.c:539
+#: builtin/stash.c:552
 #, c-format
 msgid "Merging %s with %s"
 msgstr "Đang hòa trộn %s với %s"
 
-#: builtin/stash.c:549
+#: builtin/stash.c:562
 msgid "Index was not unstashed."
 msgstr "Bảng mục lục đã không được bỏ stash."
 
-#: builtin/stash.c:591 builtin/stash.c:689
+#: builtin/stash.c:575
+msgid "could not restore untracked files from stash"
+msgstr "không thể phục hồi các tập tin chưa theo dõi từ mục cất đi (stash)"
+
+#: builtin/stash.c:607 builtin/stash.c:705
 msgid "attempt to recreate the index"
 msgstr "gặp lỗi đọc bảng mục lục"
 
-#: builtin/stash.c:635
+#: builtin/stash.c:651
 #, c-format
 msgid "Dropped %s (%s)"
 msgstr "Đã xóa %s (%s)"
 
-#: builtin/stash.c:638
+#: builtin/stash.c:654
 #, c-format
 msgid "%s: Could not drop stash entry"
 msgstr "%s: Không thể xóa bỏ mục stash"
 
-#: builtin/stash.c:651
+#: builtin/stash.c:667
 #, c-format
 msgid "'%s' is not a stash reference"
 msgstr "”%s” không phải tham chiếu đến stash"
 
-#: builtin/stash.c:701
+#: builtin/stash.c:717
 msgid "The stash entry is kept in case you need it again."
 msgstr "Các mục tạm cất (stash) được giữ trong trường hợp bạn lại cần nó."
 
-#: builtin/stash.c:724
+#: builtin/stash.c:740
 msgid "No branch name specified"
 msgstr "Chưa chỉ ra tên của nhánh"
 
-#: builtin/stash.c:808
+#: builtin/stash.c:824
 msgid "failed to parse tree"
 msgstr "gặp lỗi khi phân tích cây"
 
-#: builtin/stash.c:819
+#: builtin/stash.c:835
 msgid "failed to unpack trees"
 msgstr "gặp lỗi khi tháo dỡ cây"
 
-#: builtin/stash.c:839
+#: builtin/stash.c:855
 msgid "include untracked files in the stash"
 msgstr "bao gồm các tập tin không được theo dõi trong stash"
 
-#: builtin/stash.c:842
+#: builtin/stash.c:858
 msgid "only show untracked files in the stash"
 msgstr "chỉ hiển thị các tập tin không được theo dõi trong stash"
 
-#: builtin/stash.c:929 builtin/stash.c:966
+#: builtin/stash.c:945 builtin/stash.c:982
 #, c-format
 msgid "Cannot update %s with %s"
 msgstr "Không thể cập nhật %s với %s"
 
-#: builtin/stash.c:947 builtin/stash.c:1602 builtin/stash.c:1667
+#: builtin/stash.c:963 builtin/stash.c:1619 builtin/stash.c:1684
 msgid "stash message"
 msgstr "phần chú thích cho stash"
 
-#: builtin/stash.c:957
+#: builtin/stash.c:973
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "\"git stash store\" cần một đối số <lần chuyển giao>"
 
-#: builtin/stash.c:1171
+#: builtin/stash.c:1187
 msgid "No changes selected"
 msgstr "Chưa có thay đổi nào được chọn"
 
-#: builtin/stash.c:1271
+#: builtin/stash.c:1287
 msgid "You do not have the initial commit yet"
 msgstr "Bạn chưa còn có lần chuyển giao khởi tạo"
 
-#: builtin/stash.c:1298
+#: builtin/stash.c:1314
 msgid "Cannot save the current index state"
 msgstr "Không thể ghi lại trạng thái bảng mục lục hiện hành"
 
-#: builtin/stash.c:1307
+#: builtin/stash.c:1323
 msgid "Cannot save the untracked files"
 msgstr "Không thể ghi lại các tập tin chưa theo dõi"
 
-#: builtin/stash.c:1318 builtin/stash.c:1327
+#: builtin/stash.c:1334 builtin/stash.c:1343
 msgid "Cannot save the current worktree state"
 msgstr "Không thể ghi lại trạng thái cây-làm-việc hiện hành"
 
-#: builtin/stash.c:1355
+#: builtin/stash.c:1371
 msgid "Cannot record working tree state"
 msgstr "Không thể ghi lại trạng thái cây làm việc hiện hành"
 
-#: builtin/stash.c:1404
+#: builtin/stash.c:1420
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr "Không thể dùng --patch và --include-untracked hay --all cùng một lúc"
 
-#: builtin/stash.c:1422
+#: builtin/stash.c:1438
 msgid "Did you forget to 'git add'?"
 msgstr "Có lẽ bạn đã quên “git add ” phải không?"
 
-#: builtin/stash.c:1437
+#: builtin/stash.c:1453
 msgid "No local changes to save"
 msgstr "Không có thay đổi nội bộ nào được ghi lại"
 
-#: builtin/stash.c:1444
+#: builtin/stash.c:1460
 msgid "Cannot initialize stash"
 msgstr "Không thể khởi tạo stash"
 
-#: builtin/stash.c:1459
+#: builtin/stash.c:1475
 msgid "Cannot save the current status"
 msgstr "Không thể ghi lại trạng thái hiện hành"
 
-#: builtin/stash.c:1464
+#: builtin/stash.c:1480
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "Đã ghi lại thư mục làm việc và trạng thái mục lục %s"
 
-#: builtin/stash.c:1554
+#: builtin/stash.c:1571
 msgid "Cannot remove worktree changes"
 msgstr "Không thể gỡ bỏ các thay đổi cây-làm-việc"
 
-#: builtin/stash.c:1593 builtin/stash.c:1658
+#: builtin/stash.c:1610 builtin/stash.c:1675
 msgid "keep index"
 msgstr "giữ nguyên bảng mục lục"
 
-#: builtin/stash.c:1595 builtin/stash.c:1660
+#: builtin/stash.c:1612 builtin/stash.c:1677
 msgid "stash in patch mode"
 msgstr "cất đi ở chế độ miếng vá"
 
-#: builtin/stash.c:1596 builtin/stash.c:1661
+#: builtin/stash.c:1613 builtin/stash.c:1678
 msgid "quiet mode"
 msgstr "chế độ im lặng"
 
-#: builtin/stash.c:1598 builtin/stash.c:1663
+#: builtin/stash.c:1615 builtin/stash.c:1680
 msgid "include untracked files in stash"
 msgstr "bao gồm các tập tin không được theo dõi trong stash"
 
-#: builtin/stash.c:1600 builtin/stash.c:1665
+#: builtin/stash.c:1617 builtin/stash.c:1682
 msgid "include ignore files"
 msgstr "bao gồm các tập tin bị bỏ qua"
 
-#: builtin/stash.c:1700
+#: builtin/stash.c:1717
 msgid ""
 "the stash.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -22567,7 +22799,7 @@ msgstr "giữ và xóa bỏ mọi dòng bắt đầu bằng ký tự ghi chú"
 msgid "prepend comment character and space to each line"
 msgstr "treo trước ký tự ghi chú và ký tự khoảng trắng cho từng dòng"
 
-#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2440
+#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2667
 #, c-format
 msgid "Expecting a full ref name, got %s"
 msgstr "Cần tên tham chiếu dạng đầy đủ, nhưng lại nhận được %s"
@@ -22581,27 +22813,35 @@ msgstr "submodule--helper print-default-remote takes không nhận tham số"
 msgid "cannot strip one component off url '%s'"
 msgstr "không thể cắt bỏ một thành phần ra khỏi “%s” url"
 
-#: builtin/submodule--helper.c:411 builtin/submodule--helper.c:1887
-#: builtin/submodule--helper.c:2891
+#: builtin/submodule--helper.c:211
+#, c-format
+msgid ""
+"could not look up configuration '%s'. Assuming this repository is its own "
+"authoritative upstream."
+msgstr ""
+"không thể tìm thấy cấu hình “%s”. Coi rằng đây là kho thượng nguồn có quyền "
+"sở hữu chính nó."
+
+#: builtin/submodule--helper.c:405 builtin/submodule--helper.c:1858
 msgid "alternative anchor for relative paths"
 msgstr "điểm neo thay thế cho các đường dẫn tương đối"
 
-#: builtin/submodule--helper.c:416
+#: builtin/submodule--helper.c:410
 msgid "git submodule--helper list [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper list [--prefix=</đường/dẫn>] [</đường/dẫn>…]"
 
-#: builtin/submodule--helper.c:474 builtin/submodule--helper.c:631
-#: builtin/submodule--helper.c:654
+#: builtin/submodule--helper.c:468 builtin/submodule--helper.c:605
+#: builtin/submodule--helper.c:628
 #, c-format
 msgid "No url found for submodule path '%s' in .gitmodules"
 msgstr "Không tìm thấy url cho đường dẫn mô-đun-con “%s” trong .gitmodules"
 
-#: builtin/submodule--helper.c:526
+#: builtin/submodule--helper.c:520
 #, c-format
 msgid "Entering '%s'\n"
 msgstr "Đang vào “%s”\n"
 
-#: builtin/submodule--helper.c:529
+#: builtin/submodule--helper.c:523
 #, c-format
 msgid ""
 "run_command returned non-zero status for %s\n"
@@ -22610,7 +22850,7 @@ msgstr ""
 "run_command trả về trạng thái khác không cho %s\n"
 "."
 
-#: builtin/submodule--helper.c:551
+#: builtin/submodule--helper.c:545
 #, c-format
 msgid ""
 "run_command returned non-zero status while recursing in the nested "
@@ -22621,78 +22861,69 @@ msgstr ""
 "con lồng nhau của %s\n"
 "."
 
-#: builtin/submodule--helper.c:567
+#: builtin/submodule--helper.c:561
 msgid "suppress output of entering each submodule command"
 msgstr "chặn kết xuất của từng lệnh mô-đun-con"
 
-#: builtin/submodule--helper.c:569 builtin/submodule--helper.c:890
-#: builtin/submodule--helper.c:1489
+#: builtin/submodule--helper.c:563 builtin/submodule--helper.c:864
+#: builtin/submodule--helper.c:1453
 msgid "recurse into nested submodules"
 msgstr "đệ quy vào trong mô-đun-con lồng nhau"
 
-#: builtin/submodule--helper.c:574
+#: builtin/submodule--helper.c:568
 msgid "git submodule--helper foreach [--quiet] [--recursive] [--] <command>"
 msgstr "git submodule--helper foreach [--quiet] [--recursive] [--]  <lệnh>"
 
-#: builtin/submodule--helper.c:601
-#, c-format
-msgid ""
-"could not look up configuration '%s'. Assuming this repository is its own "
-"authoritative upstream."
-msgstr ""
-"không thể tìm thấy cấu hình “%s”. Coi rằng đây là kho thượng nguồn có quyền "
-"sở hữu chính nó."
-
-#: builtin/submodule--helper.c:668
+#: builtin/submodule--helper.c:642
 #, c-format
 msgid "Failed to register url for submodule path '%s'"
 msgstr "Gặp lỗi khi đăng ký url cho đường dẫn mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:672
+#: builtin/submodule--helper.c:646
 #, c-format
 msgid "Submodule '%s' (%s) registered for path '%s'\n"
 msgstr "Mô-đun-con “%s” (%s) được đăng ký cho đường dẫn “%s”\n"
 
-#: builtin/submodule--helper.c:682
+#: builtin/submodule--helper.c:656
 #, c-format
 msgid "warning: command update mode suggested for submodule '%s'\n"
 msgstr "cảnh báo: chế độ lệnh cập nhật được gợi ý cho mô-đun-con “%s”\n"
 
-#: builtin/submodule--helper.c:689
+#: builtin/submodule--helper.c:663
 #, c-format
 msgid "Failed to register update mode for submodule path '%s'"
 msgstr "Gặp lỗi khi đăng ký chế độ cập nhật cho đường dẫn mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:711
+#: builtin/submodule--helper.c:685
 msgid "suppress output for initializing a submodule"
 msgstr "chặn kết xuất của khởi tạo một mô-đun-con"
 
-#: builtin/submodule--helper.c:716
+#: builtin/submodule--helper.c:690
 msgid "git submodule--helper init [<options>] [<path>]"
 msgstr "git submodule--helper init [<các tùy chọn>] [</đường/dẫn>]"
 
-#: builtin/submodule--helper.c:789 builtin/submodule--helper.c:924
+#: builtin/submodule--helper.c:763 builtin/submodule--helper.c:898
 #, c-format
 msgid "no submodule mapping found in .gitmodules for path '%s'"
 msgstr ""
 "không tìm thấy ánh xạ (mapping) mô-đun-con trong .gitmodules cho đường dẫn "
 "“%s”"
 
-#: builtin/submodule--helper.c:837
+#: builtin/submodule--helper.c:811
 #, c-format
 msgid "could not resolve HEAD ref inside the submodule '%s'"
 msgstr "không thể phân giải tham chiếu HEAD bên trong mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:864 builtin/submodule--helper.c:1459
+#: builtin/submodule--helper.c:838 builtin/submodule--helper.c:1423
 #, c-format
 msgid "failed to recurse into submodule '%s'"
 msgstr "gặp lỗi khi đệ quy vào trong mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:888 builtin/submodule--helper.c:1625
+#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1589
 msgid "suppress submodule status output"
 msgstr "chặn kết xuất về tình trạng mô-đun-con"
 
-#: builtin/submodule--helper.c:889
+#: builtin/submodule--helper.c:863
 msgid ""
 "use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
@@ -22700,102 +22931,102 @@ msgstr ""
 "dùng lần chuyển giao lưu trong mục lục thay cho cái được lưu trong HEAD mô-"
 "đun-con"
 
-#: builtin/submodule--helper.c:895
+#: builtin/submodule--helper.c:869
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
 msgstr ""
 "git submodule status [--quiet] [--cached] [--recursive] [</đường/dẫn>…]"
 
-#: builtin/submodule--helper.c:919
+#: builtin/submodule--helper.c:893
 msgid "git submodule--helper name <path>"
 msgstr "git submodule--helper name </đường/dẫn>"
 
-#: builtin/submodule--helper.c:991
+#: builtin/submodule--helper.c:965
 #, c-format
 msgid "* %s %s(blob)->%s(submodule)"
 msgstr ""
 "* %s %s(blob)->%s(\n"
 ")"
 
-#: builtin/submodule--helper.c:994
+#: builtin/submodule--helper.c:968
 #, c-format
 msgid "* %s %s(submodule)->%s(blob)"
 msgstr "* %s %s(mô-đun-con)->%s(blob)"
 
-#: builtin/submodule--helper.c:1007
+#: builtin/submodule--helper.c:981
 #, c-format
 msgid "%s"
 msgstr "%s"
 
-#: builtin/submodule--helper.c:1057
+#: builtin/submodule--helper.c:1031
 #, c-format
 msgid "couldn't hash object from '%s'"
 msgstr "không thể băm đối tượng từ “%s”"
 
-#: builtin/submodule--helper.c:1061
+#: builtin/submodule--helper.c:1035
 #, c-format
 msgid "unexpected mode %o\n"
 msgstr "gặp chế độ không như mong chờ %o\n"
 
-#: builtin/submodule--helper.c:1302
+#: builtin/submodule--helper.c:1276
 msgid "use the commit stored in the index instead of the submodule HEAD"
 msgstr "hùng lần chuyển giao đã lưu trong mục lục thay cho HEAD mô-đun-con"
 
-#: builtin/submodule--helper.c:1304
+#: builtin/submodule--helper.c:1278
 msgid "compare the commit in the index with that in the submodule HEAD"
 msgstr "để so sánh lần trong mục lục với cái trong HEAD mô-đun-con"
 
-#: builtin/submodule--helper.c:1306
+#: builtin/submodule--helper.c:1280
 msgid "skip submodules with 'ignore_config' value set to 'all'"
 msgstr ""
 "bỏ qua các mô-đun-con với giá trị của “ignore_config” được đặt thành “all”"
 
-#: builtin/submodule--helper.c:1308
+#: builtin/submodule--helper.c:1282
 msgid "limit the summary size"
 msgstr "giới hạn kích cỡ tổng hợp"
 
-#: builtin/submodule--helper.c:1313
+#: builtin/submodule--helper.c:1287
 msgid "git submodule--helper summary [<options>] [<commit>] [--] [<path>]"
 msgstr ""
 "git submodule--helper summary [<các tùy chọn>] [<lần_chuyển_giao>] [--] [</"
 "đường/dẫn>]"
 
-#: builtin/submodule--helper.c:1337
+#: builtin/submodule--helper.c:1311
 msgid "could not fetch a revision for HEAD"
 msgstr "không thể lấy về một điểm xem xét cho HEAD"
 
-#: builtin/submodule--helper.c:1342
+#: builtin/submodule--helper.c:1316
 msgid "--cached and --files are mutually exclusive"
 msgstr "Các tùy chọn --cached và --files loại từ lẫn nhau"
 
-#: builtin/submodule--helper.c:1409
+#: builtin/submodule--helper.c:1373
 #, c-format
 msgid "Synchronizing submodule url for '%s'\n"
 msgstr "Url mô-đun-con đồng bộ hóa cho “%s”\n"
 
-#: builtin/submodule--helper.c:1415
+#: builtin/submodule--helper.c:1379
 #, c-format
 msgid "failed to register url for submodule path '%s'"
 msgstr "gặp lỗi khi đăng ký url cho đường dẫn mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:1429
+#: builtin/submodule--helper.c:1393
 #, c-format
 msgid "failed to get the default remote for submodule '%s'"
 msgstr "gặp lỗi khi lấy máy chủ mặc định cho mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:1440
+#: builtin/submodule--helper.c:1404
 #, c-format
 msgid "failed to update remote for submodule '%s'"
 msgstr "gặp lỗi khi cập nhật cho mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:1487
+#: builtin/submodule--helper.c:1451
 msgid "suppress output of synchronizing submodule url"
 msgstr "chặn kết xuất của url mô-đun-con đồng bộ"
 
-#: builtin/submodule--helper.c:1494
+#: builtin/submodule--helper.c:1458
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
 msgstr "git submodule--helper sync [--quiet] [--recursive] [</đường/dẫn>]"
 
-#: builtin/submodule--helper.c:1548
+#: builtin/submodule--helper.c:1512
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains a .git directory (use 'rm -rf' if you "
@@ -22804,7 +23035,7 @@ msgstr ""
 "Cây làm việc mô-đun-con “%s” có chứa thư mục .git (dùng “rm -rf” nếu bạn "
 "thực sự muốn gỡ bỏ nó cùng với toàn bộ lịch sử của chúng)"
 
-#: builtin/submodule--helper.c:1560
+#: builtin/submodule--helper.c:1524
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
@@ -22813,45 +23044,45 @@ msgstr ""
 "Cây làm việc mô-đun-con “%s” chứa các thay đổi nội bộ; hãy dùng “-f” để loại "
 "bỏ chúng đi"
 
-#: builtin/submodule--helper.c:1568
+#: builtin/submodule--helper.c:1532
 #, c-format
 msgid "Cleared directory '%s'\n"
 msgstr "Đã xóa thư mục “%s”\n"
 
-#: builtin/submodule--helper.c:1570
+#: builtin/submodule--helper.c:1534
 #, c-format
 msgid "Could not remove submodule work tree '%s'\n"
 msgstr "Không thể gỡ bỏ cây làm việc mô-đun-con “%s”\n"
 
-#: builtin/submodule--helper.c:1581
+#: builtin/submodule--helper.c:1545
 #, c-format
 msgid "could not create empty submodule directory %s"
 msgstr "không thể tạo thư mục mô-đun-con rỗng “%s”"
 
-#: builtin/submodule--helper.c:1597
+#: builtin/submodule--helper.c:1561
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "Mô-đun-con “%s” (%s) được đăng ký cho đường dẫn “%s”\n"
 
-#: builtin/submodule--helper.c:1626
+#: builtin/submodule--helper.c:1590
 msgid "remove submodule working trees even if they contain local changes"
 msgstr "gỡ bỏ cây làm việc của mô-đun-con ngay cả khi nó có thay đổi nội bộ"
 
-#: builtin/submodule--helper.c:1627
+#: builtin/submodule--helper.c:1591
 msgid "unregister all submodules"
 msgstr "bỏ đăng ký tất cả các trong mô-đun-con"
 
-#: builtin/submodule--helper.c:1632
+#: builtin/submodule--helper.c:1596
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--]  [</đường/dẫn>…]]"
 
-#: builtin/submodule--helper.c:1646
+#: builtin/submodule--helper.c:1610
 msgid "Use '--all' if you really want to deinitialize all submodules"
 msgstr "Dùng “--all” nếu bạn thực sự muốn hủy khởi tạo mọi mô-đun-con"
 
-#: builtin/submodule--helper.c:1690
+#: builtin/submodule--helper.c:1655
 msgid ""
 "An alternate computed from a superproject's alternate is invalid.\n"
 "To allow Git to clone without an alternate in such a case, set\n"
@@ -22866,67 +23097,67 @@ msgstr ""
 "bằng\n"
 "“--reference-if-able” thay vì dùng “--reference”."
 
-#: builtin/submodule--helper.c:1729 builtin/submodule--helper.c:1732
+#: builtin/submodule--helper.c:1700 builtin/submodule--helper.c:1703
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
 msgstr "mô-đun-con “%s” không thể thêm thay thế: %s"
 
-#: builtin/submodule--helper.c:1768
+#: builtin/submodule--helper.c:1739
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
 msgstr "Giá trị “%s” cho submodule.alternateErrorStrategy không được thừa nhận"
 
-#: builtin/submodule--helper.c:1775
+#: builtin/submodule--helper.c:1746
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
 msgstr "Giá trị “%s” cho submodule.alternateLocation không được thừa nhận"
 
-#: builtin/submodule--helper.c:1800
+#: builtin/submodule--helper.c:1771
 #, c-format
 msgid "refusing to create/use '%s' in another submodule's git dir"
 msgstr "từ chối tạo/dùng “%s” trong một thư mục git của mô đun con"
 
-#: builtin/submodule--helper.c:1841
+#: builtin/submodule--helper.c:1812
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
 msgstr "việc sao “%s” vào đường dẫn mô-đun-con “%s” gặp lỗi"
 
-#: builtin/submodule--helper.c:1846
+#: builtin/submodule--helper.c:1817
 #, c-format
 msgid "directory not empty: '%s'"
 msgstr "thư mục không trống: “%s”"
 
-#: builtin/submodule--helper.c:1858
+#: builtin/submodule--helper.c:1829
 #, c-format
 msgid "could not get submodule directory for '%s'"
 msgstr "không thể lấy thư mục mô-đun-con cho “%s”"
 
-#: builtin/submodule--helper.c:1890 builtin/submodule--helper.c:2894
+#: builtin/submodule--helper.c:1861
 msgid "where the new submodule will be cloned to"
 msgstr "nhân bản mô-đun-con mới vào chỗ nào"
 
-#: builtin/submodule--helper.c:1893 builtin/submodule--helper.c:2897
+#: builtin/submodule--helper.c:1864
 msgid "name of the new submodule"
 msgstr "tên của mô-đun-con mới"
 
-#: builtin/submodule--helper.c:1896 builtin/submodule--helper.c:2900
+#: builtin/submodule--helper.c:1867
 msgid "url where to clone the submodule from"
 msgstr "url nơi mà nhân bản mô-đun-con từ đó"
 
-#: builtin/submodule--helper.c:1904 builtin/submodule--helper.c:2907
+#: builtin/submodule--helper.c:1875 builtin/submodule--helper.c:3264
 msgid "depth for shallow clones"
 msgstr "chiều sâu lịch sử khi tạo bản sao"
 
-#: builtin/submodule--helper.c:1907 builtin/submodule--helper.c:2365
-#: builtin/submodule--helper.c:2909
+#: builtin/submodule--helper.c:1878 builtin/submodule--helper.c:2525
+#: builtin/submodule--helper.c:3257
 msgid "force cloning progress"
 msgstr "ép buộc tiến trình nhân bản"
 
-#: builtin/submodule--helper.c:1909 builtin/submodule--helper.c:2367
+#: builtin/submodule--helper.c:1880 builtin/submodule--helper.c:2527
 msgid "disallow cloning into non-empty directory"
 msgstr "làm đầy đủ dữ liệu cho bản sao vào trong một thư mục trống rỗng"
 
-#: builtin/submodule--helper.c:1916
+#: builtin/submodule--helper.c:1887
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
 "<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
@@ -22936,85 +23167,183 @@ msgstr ""
 "<kho>] [--name <tên>] [--depth <sâu>] [--single-branch] --url <url> --path </"
 "đường/dẫn>"
 
-#: builtin/submodule--helper.c:1953
+#: builtin/submodule--helper.c:1924
 #, c-format
 msgid "Invalid update mode '%s' for submodule path '%s'"
 msgstr "Chế độ cập nhật “%s” không hợp lệ cho đường dẫn mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:1957
+#: builtin/submodule--helper.c:1928
 #, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
 msgstr ""
 "Chế độ cập nhật “%s” không hợp lệ được cấu hình cho đường dẫn mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:2058
+#: builtin/submodule--helper.c:2043
 #, c-format
 msgid "Submodule path '%s' not initialized"
 msgstr "Đường dẫn mô-đun-con “%s” chưa được khởi tạo"
 
-#: builtin/submodule--helper.c:2062
+#: builtin/submodule--helper.c:2047
 msgid "Maybe you want to use 'update --init'?"
 msgstr "Có lẽ bạn là bạn muốn dùng \"update --init\" phải không?"
 
-#: builtin/submodule--helper.c:2092
+#: builtin/submodule--helper.c:2077
 #, c-format
 msgid "Skipping unmerged submodule %s"
 msgstr "Bỏ qua các mô-đun-con chưa được hòa trộn %s"
 
-#: builtin/submodule--helper.c:2121
+#: builtin/submodule--helper.c:2106
 #, c-format
 msgid "Skipping submodule '%s'"
 msgstr "Bỏ qua mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:2271
+#: builtin/submodule--helper.c:2256
 #, c-format
 msgid "Failed to clone '%s'. Retry scheduled"
 msgstr "Gặp lỗi khi nhân bản “%s”. Thử lại lịch trình"
 
-#: builtin/submodule--helper.c:2282
+#: builtin/submodule--helper.c:2267
 #, c-format
 msgid "Failed to clone '%s' a second time, aborting"
 msgstr "Gặp lỗi khi nhân bản “%s” lần thứ hai nên bãi bỏ"
 
-#: builtin/submodule--helper.c:2344 builtin/submodule--helper.c:2590
+#: builtin/submodule--helper.c:2372
+#, c-format
+msgid "Unable to checkout '%s' in submodule path '%s'"
+msgstr "Không thể lấy ra “%s” trong đường dẫn mô-đun-con “%s”"
+
+#: builtin/submodule--helper.c:2376
+#, c-format
+msgid "Unable to rebase '%s' in submodule path '%s'"
+msgstr "Không thể cải tổ “%s” trong đường dẫn mô-đun-con “%s”"
+
+#: builtin/submodule--helper.c:2380
+#, c-format
+msgid "Unable to merge '%s' in submodule path '%s'"
+msgstr "Không thể hòa trộn (merge) “%s” trong đường dẫn mô-đun-con “%s”"
+
+#: builtin/submodule--helper.c:2384
+#, c-format
+msgid "Execution of '%s %s' failed in submodule path '%s'"
+msgstr ""
+"Thực hiện không thành công lệnh “%s %s” trong đường dẫn mô-đun-con “%s”"
+
+#: builtin/submodule--helper.c:2408
+#, c-format
+msgid "Submodule path '%s': checked out '%s'\n"
+msgstr "Đường dẫn mô-đun-con “%s”: đã checkout “%s”\n"
+
+#: builtin/submodule--helper.c:2412
+#, c-format
+msgid "Submodule path '%s': rebased into '%s'\n"
+msgstr "Đường dẫn mô-đun-con “%s”: được rebase vào trong “%s”\n"
+
+#: builtin/submodule--helper.c:2416
+#, c-format
+msgid "Submodule path '%s': merged in '%s'\n"
+msgstr "Đường dẫn mô-đun-con “%s”: được hòa trộn vào “%s”\n"
+
+#: builtin/submodule--helper.c:2420
+#, c-format
+msgid "Submodule path '%s': '%s %s'\n"
+msgstr "Đường dẫn mô-đun-con “%s”: “%s %s”\n"
+
+#: builtin/submodule--helper.c:2444
+#, c-format
+msgid "Unable to fetch in submodule path '%s'; trying to directly fetch %s:"
+msgstr ""
+"Không thể lấy về trong đường dẫn mô-đun-con “%s”; thử lấy về trực tiếp %s:"
+
+#: builtin/submodule--helper.c:2453
+#, c-format
+msgid ""
+"Fetched in submodule path '%s', but it did not contain %s. Direct fetching "
+"of that commit failed."
+msgstr ""
+"Đã lấy về từ đường dẫn mô-đun con “%s”, nhưng nó không chứa %s. Lấy về trực "
+"tiếp lần chuyển giao gặp lỗi đó."
+
+#: builtin/submodule--helper.c:2504 builtin/submodule--helper.c:2574
+#: builtin/submodule--helper.c:2812
 msgid "path into the working tree"
 msgstr "đường dẫn đến cây làm việc"
 
-#: builtin/submodule--helper.c:2347
+#: builtin/submodule--helper.c:2507 builtin/submodule--helper.c:2579
 msgid "path into the working tree, across nested submodule boundaries"
 msgstr "đường dẫn đến cây làm việc, chéo biên giới mô-đun-con lồng nhau"
 
-#: builtin/submodule--helper.c:2351
+#: builtin/submodule--helper.c:2511 builtin/submodule--helper.c:2577
 msgid "rebase, merge, checkout or none"
 msgstr "rebase, merge, checkout hoặc không làm gì cả"
 
-#: builtin/submodule--helper.c:2357
+#: builtin/submodule--helper.c:2517
 msgid "create a shallow clone truncated to the specified number of revisions"
 msgstr ""
 "tạo một bản sao nông được cắt ngắn thành số lượng điểm xét duyệt đã cho"
 
-#: builtin/submodule--helper.c:2360
+#: builtin/submodule--helper.c:2520
 msgid "parallel jobs"
 msgstr "công việc đồng thời"
 
-#: builtin/submodule--helper.c:2362
+#: builtin/submodule--helper.c:2522
 msgid "whether the initial clone should follow the shallow recommendation"
 msgstr "nhân bản lần đầu có nên theo khuyến nghị là nông hay không"
 
-#: builtin/submodule--helper.c:2363
+#: builtin/submodule--helper.c:2523
 msgid "don't print cloning progress"
 msgstr "đừng in tiến trình nhân bản"
 
-#: builtin/submodule--helper.c:2374
+#: builtin/submodule--helper.c:2534
 msgid "git submodule--helper update-clone [--prefix=<path>] [<path>...]"
 msgstr ""
 "git submodule--helper update-clone [--prefix=</đường/dẫn>] [</đường/dẫn>…]"
 
-#: builtin/submodule--helper.c:2387
+#: builtin/submodule--helper.c:2547
 msgid "bad value for update parameter"
 msgstr "giá trị cho  tham số cập nhật bị sai"
 
-#: builtin/submodule--helper.c:2435
+#: builtin/submodule--helper.c:2565
+msgid "suppress output for update by rebase or merge"
+msgstr "chặn kết xuất cho cập nhật bởi cải tổ hoặc hòa trộn"
+
+#: builtin/submodule--helper.c:2566
+msgid "force checkout updates"
+msgstr "ép buộc lấy ra các cập nhật"
+
+#: builtin/submodule--helper.c:2568
+msgid "don't fetch new objects from the remote site"
+msgstr "đừng lấy các đối tượng mới từ địa chỉ trên mạng"
+
+#: builtin/submodule--helper.c:2570
+msgid "overrides update mode in case the repository is a fresh clone"
+msgstr "ghi đè chế độ cập nhật trong trường hợp kho lưu trữ là bản sao mới"
+
+#: builtin/submodule--helper.c:2571
+msgid "depth for shallow fetch"
+msgstr "chiều sâu lịch sử muốn lấy về"
+
+#: builtin/submodule--helper.c:2581
+msgid "sha1"
+msgstr "sha1"
+
+#: builtin/submodule--helper.c:2582
+msgid "SHA1 expected by superproject"
+msgstr "SHA1 là cần thiết cho superproject"
+
+#: builtin/submodule--helper.c:2584
+msgid "subsha1"
+msgstr "subsha1"
+
+#: builtin/submodule--helper.c:2585
+msgid "SHA1 of submodule's HEAD"
+msgstr "SHA1 của HEAD của mô-đun-con"
+
+#: builtin/submodule--helper.c:2591
+msgid "git submodule--helper run-update-procedure [<options>] <path>"
+msgstr ""
+"git submodule--helper run-update-procedure [<các tùy chọn>] </đường/dẫn>"
+
+#: builtin/submodule--helper.c:2662
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
@@ -23023,143 +23352,194 @@ msgstr ""
 "Nhánh mô-đun-con (%s) được cấu hình kế thừa nhánh từ siêu dự án, nhưng siêu "
 "dự án lại không trên bất kỳ nhánh nào"
 
-#: builtin/submodule--helper.c:2558
+#: builtin/submodule--helper.c:2780
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
 msgstr "không thể lấy thẻ quản kho cho mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:2591
+#: builtin/submodule--helper.c:2813
 msgid "recurse into submodules"
 msgstr "đệ quy vào trong mô-đun-con"
 
-#: builtin/submodule--helper.c:2597
+#: builtin/submodule--helper.c:2819
 msgid "git submodule--helper absorb-git-dirs [<options>] [<path>...]"
 msgstr "git submodule--helper absorb-git-dirs [<các tùy chọn>] [</đường/dẫn>…]"
 
-#: builtin/submodule--helper.c:2653
+#: builtin/submodule--helper.c:2875
 msgid "check if it is safe to write to the .gitmodules file"
 msgstr "chọn nếu nó là an toàn để ghi vào tập tin .gitmodules"
 
-#: builtin/submodule--helper.c:2656
+#: builtin/submodule--helper.c:2878
 msgid "unset the config in the .gitmodules file"
 msgstr "bỏ đặt cấu hình trong tập tin .gitmodules"
 
-#: builtin/submodule--helper.c:2661
+#: builtin/submodule--helper.c:2883
 msgid "git submodule--helper config <name> [<value>]"
 msgstr "git submodule--helper config <tên> [<giá trị>]"
 
-#: builtin/submodule--helper.c:2662
+#: builtin/submodule--helper.c:2884
 msgid "git submodule--helper config --unset <name>"
 msgstr "git submodule--helper config --unset <tên>"
 
-#: builtin/submodule--helper.c:2663
+#: builtin/submodule--helper.c:2885
 msgid "git submodule--helper config --check-writeable"
 msgstr "git submodule--helper config --check-writeable"
 
-#: builtin/submodule--helper.c:2682 git-submodule.sh:150
-#, sh-format
+#: builtin/submodule--helper.c:2904 builtin/submodule--helper.c:3120
+#: builtin/submodule--helper.c:3276
 msgid "please make sure that the .gitmodules file is in the working tree"
 msgstr "hãy đảm bảo rằng tập tin .gitmodules có trong cây làm việc"
 
-#: builtin/submodule--helper.c:2698
+#: builtin/submodule--helper.c:2920
 msgid "suppress output for setting url of a submodule"
 msgstr "chặn kết xuất cho cài đặt url của một mô-đun-con"
 
-#: builtin/submodule--helper.c:2702
+#: builtin/submodule--helper.c:2924
 msgid "git submodule--helper set-url [--quiet] <path> <newurl>"
 msgstr "git submodule--helper set-url [--quiet] </đường/dẫn> <url_mới>"
 
-#: builtin/submodule--helper.c:2735
+#: builtin/submodule--helper.c:2957
 msgid "set the default tracking branch to master"
 msgstr "đặt nhánh theo dõi mặc định thành master"
 
-#: builtin/submodule--helper.c:2737
+#: builtin/submodule--helper.c:2959
 msgid "set the default tracking branch"
 msgstr "đặt nhánh theo dõi mặc định"
 
-#: builtin/submodule--helper.c:2741
+#: builtin/submodule--helper.c:2963
 msgid "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
 msgstr ""
 "git submodule--helper set-branch [-q|--quiet](-d|--default)</đường/dẫn>"
 
-#: builtin/submodule--helper.c:2742
+#: builtin/submodule--helper.c:2964
 msgid ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
 msgstr ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <nhánh> </đường/"
 "dẫn>"
 
-#: builtin/submodule--helper.c:2749
+#: builtin/submodule--helper.c:2971
 msgid "--branch or --default required"
 msgstr "cần --branch hoặc --default"
 
-#: builtin/submodule--helper.c:2752
+#: builtin/submodule--helper.c:2974
 msgid "--branch and --default are mutually exclusive"
 msgstr "Các tùy chọn --branch và --default loại từ lẫn nhau"
 
-#: builtin/submodule--helper.c:2815
+#: builtin/submodule--helper.c:3037
 #, c-format
 msgid "Adding existing repo at '%s' to the index\n"
 msgstr "Đang thêm repo có sẵn tại “%s” vào bảng mục lục\n"
 
-#: builtin/submodule--helper.c:2818
+#: builtin/submodule--helper.c:3040
 #, c-format
 msgid "'%s' already exists and is not a valid git repo"
 msgstr "“%s” đã tồn tại từ trước và không phải là một kho git hợp lệ"
 
-#: builtin/submodule--helper.c:2828
+#: builtin/submodule--helper.c:3053
 #, c-format
-msgid "A git directory for '%s' is found locally with remote(s):"
-msgstr "Thư mục git cho “%s” được tìm thấy một cách cục bộ với các máy chủ:"
+msgid "A git directory for '%s' is found locally with remote(s):\n"
+msgstr "Thư mục git cho “%s” được tìm thấy một cách cục bộ với các máy chủ:\n"
 
-#: builtin/submodule--helper.c:2833
+#: builtin/submodule--helper.c:3060
 #, c-format
 msgid ""
 "If you want to reuse this local git directory instead of cloning again from\n"
 "  %s\n"
 "use the '--force' option. If the local git directory is not the correct "
 "repo\n"
-"or if you are unsure what this means, choose another name with the '--name' "
-"option.\n"
+"or you are unsure what this means choose another name with the '--name' "
+"option."
 msgstr ""
-"Nếu bạn muốn sử dụng lại thư mục nội bộ này thay vì nhân bản lại lần nữa từ\n"
+"Nếu bạn muốn sử dụng lại thư mục git nội bộ này thay vì nhân bản lại lần nữa "
+"từ\n"
 "  %s\n"
-"dùng tùy chọn “--force”. Nếu thư mục git nội bộ không phải là một kho đúng\n"
-"hoặc là bạn không chắc chắn điều đó nghĩa là gì thì chọn tên khác với tùy "
-"chọn “--name”.\n"
+"dùng tùy chọn “--force”. Nếu thư mục git nội bộ không phải là một kho đúng "
+"hoặc\n"
+"là bạn không chắc chắn điều đó nghĩa là gì thì chọn tên khác với tùy chọn “--"
+"name”."
 
-#: builtin/submodule--helper.c:2842
+#: builtin/submodule--helper.c:3072
 #, c-format
 msgid "Reactivating local git directory for submodule '%s'\n"
 msgstr "Phục hồi sự hoạt động của thư mục git nội bộ cho mô-đun-con “%s”.\n"
 
-#: builtin/submodule--helper.c:2875
+#: builtin/submodule--helper.c:3109
 #, c-format
 msgid "unable to checkout submodule '%s'"
 msgstr "không thể lấy ra mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:2888
-msgid "branch of repository to checkout on cloning"
-msgstr "nhánh của kho để lấy ra khi nhân bản"
+#: builtin/submodule--helper.c:3148
+#, c-format
+msgid "Failed to add submodule '%s'"
+msgstr "Gặp lỗi khi thêm mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:2910
+#: builtin/submodule--helper.c:3152 builtin/submodule--helper.c:3157
+#: builtin/submodule--helper.c:3165
+#, c-format
+msgid "Failed to register submodule '%s'"
+msgstr "Gặp lỗi khi đăng ký mô-đun-con “%s”"
+
+#: builtin/submodule--helper.c:3221
+#, c-format
+msgid "'%s' already exists in the index"
+msgstr "”%s” thực sự đã tồn tại ở bảng mục lục rồi"
+
+#: builtin/submodule--helper.c:3224
+#, c-format
+msgid "'%s' already exists in the index and is not a submodule"
+msgstr ""
+"”%s” thực sự đã tồn tại ở bảng mục lục rồi và không phải là một mô-đun-con"
+
+#: builtin/submodule--helper.c:3253
+msgid "branch of repository to add as submodule"
+msgstr "nhánh của kho để thêm như là mô-đun-con"
+
+#: builtin/submodule--helper.c:3254
 msgid "allow adding an otherwise ignored submodule path"
 msgstr "cho phép thêm một đường dẫn mô-đun-con bị bỏ qua khác"
 
-#: builtin/submodule--helper.c:2917
-msgid ""
-"git submodule--helper add-clone [<options>...] --url <url> --path <path> --"
-"name <name>"
-msgstr ""
-"git submodule--helper add-clone [<các tùy chọn>...] --url <url> --path </"
-"đường/dẫn> --name <tên>"
+#: builtin/submodule--helper.c:3256
+msgid "print only error messages"
+msgstr "chỉ hiển thị các thông điệp báo lỗi"
 
-#: builtin/submodule--helper.c:2985 git.c:449 git.c:724
+#: builtin/submodule--helper.c:3260
+msgid "borrow the objects from reference repositories"
+msgstr "vay mượn các đối tượng từ kho thay thế"
+
+#: builtin/submodule--helper.c:3262
+msgid ""
+"sets the submodule’s name to the given string instead of defaulting to its "
+"path"
+msgstr ""
+"đặt tên của submodule bằng chuỗi đã cho thay vì mặc định là đường dẫn của nó"
+
+#: builtin/submodule--helper.c:3269
+msgid "git submodule--helper add [<options>] [--] <repository> [<path>]"
+msgstr "git submodule--helper add [<các tùy chọn>] [--] <kho> [</đường/dẫn>]"
+
+#: builtin/submodule--helper.c:3297
+msgid "Relative path can only be used from the toplevel of the working tree"
+msgstr ""
+"Đường dẫn tương đối chỉ có thể dùng từ thư mục ở mức cao nhất của cây làm "
+"việc"
+
+#: builtin/submodule--helper.c:3305
+#, c-format
+msgid "repo URL: '%s' must be absolute or begin with ./|../"
+msgstr "repo URL: “%s” phải là đường dẫn tuyệt đối hoặc là bắt đầu bằng ./|../"
+
+#: builtin/submodule--helper.c:3340
+#, c-format
+msgid "'%s' is not a valid submodule name"
+msgstr "“%s” không phải là một tên mô-đun-con hợp lệ"
+
+#: builtin/submodule--helper.c:3404 git.c:449 git.c:723
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s không hỗ trợ --super-prefix"
 
-#: builtin/submodule--helper.c:2991
+#: builtin/submodule--helper.c:3410
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
 msgstr "“%s” không phải là lệnh con submodule--helper hợp lệ"
@@ -23184,21 +23564,21 @@ msgstr "xóa tham chiếu mềm"
 msgid "shorten ref output"
 msgstr "làm ngắn kết xuất ref (tham chiếu)"
 
-#: builtin/symbolic-ref.c:45 builtin/update-ref.c:499
+#: builtin/symbolic-ref.c:45 builtin/update-ref.c:505
 msgid "reason"
 msgstr "lý do"
 
-#: builtin/symbolic-ref.c:45 builtin/update-ref.c:499
+#: builtin/symbolic-ref.c:45 builtin/update-ref.c:505
 msgid "reason of the update"
 msgstr "lý do cập nhật"
 
 #: builtin/tag.c:25
 msgid ""
 "git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <file>]\n"
-"\t\t<tagname> [<head>]"
+"        <tagname> [<head>]"
 msgstr ""
 "git tag [-a | -s | -u <key-id>] [-f] [-m <msg> | -F <tập-tin>]\n"
-"\t\t<tên-thẻ> [<head>]"
+"        <tên-thẻ> [<head>]"
 
 #: builtin/tag.c:27
 msgid "git tag -d <tagname>..."
@@ -23208,12 +23588,12 @@ msgstr "git tag -d <tên-thẻ>…"
 msgid ""
 "git tag -l [-n[<num>]] [--contains <commit>] [--no-contains <commit>] [--"
 "points-at <object>]\n"
-"\t\t[--format=<format>] [--merged <commit>] [--no-merged <commit>] "
+"        [--format=<format>] [--merged <commit>] [--no-merged <commit>] "
 "[<pattern>...]"
 msgstr ""
 "git tag -l [-n[<số>]] [--contains <lần_chuyển_giao>] [--no-contains "
 "<lần_chuyển_giao>] [--points-at <đối-tượng>]\n"
-"\t\t[--format=<định_dạng>] [--merged <lần_chuyển_giao>] [--no-merged "
+"        [--format=<định_dạng>] [--merged <lần_chuyển_giao>] [--no-merged "
 "[<lần_chuyển_giao>]] [<mẫu>…]"
 
 #: builtin/tag.c:30
@@ -23279,131 +23659,131 @@ msgstr ""
 msgid "bad object type."
 msgstr "kiểu đối tượng sai."
 
-#: builtin/tag.c:328
+#: builtin/tag.c:326
 msgid "no tag message?"
 msgstr "không có chú thích gì cho cho thẻ à?"
 
-#: builtin/tag.c:335
+#: builtin/tag.c:333
 #, c-format
 msgid "The tag message has been left in %s\n"
 msgstr "Nội dung ghi chú còn lại %s\n"
 
-#: builtin/tag.c:446
+#: builtin/tag.c:444
 msgid "list tag names"
 msgstr "chỉ liệt kê tên các thẻ"
 
-#: builtin/tag.c:448
+#: builtin/tag.c:446
 msgid "print <n> lines of each tag message"
 msgstr "hiển thị <n> dòng cho mỗi ghi chú"
 
-#: builtin/tag.c:450
+#: builtin/tag.c:448
 msgid "delete tags"
 msgstr "xóa thẻ"
 
-#: builtin/tag.c:451
+#: builtin/tag.c:449
 msgid "verify tags"
 msgstr "thẩm tra thẻ"
 
-#: builtin/tag.c:453
+#: builtin/tag.c:451
 msgid "Tag creation options"
 msgstr "Tùy chọn tạo thẻ"
 
-#: builtin/tag.c:455
+#: builtin/tag.c:453
 msgid "annotated tag, needs a message"
 msgstr "để chú giải cho thẻ, cần một lời ghi chú"
 
-#: builtin/tag.c:457
+#: builtin/tag.c:455
 msgid "tag message"
 msgstr "phần chú thích cho thẻ"
 
-#: builtin/tag.c:459
+#: builtin/tag.c:457
 msgid "force edit of tag message"
 msgstr "ép buộc sửa thẻ lần commit"
 
-#: builtin/tag.c:460
+#: builtin/tag.c:458
 msgid "annotated and GPG-signed tag"
 msgstr "thẻ chú giải và ký kiểu GPG"
 
-#: builtin/tag.c:463
+#: builtin/tag.c:461
 msgid "use another key to sign the tag"
 msgstr "dùng kháo khác để ký thẻ"
 
-#: builtin/tag.c:464
+#: builtin/tag.c:462
 msgid "replace the tag if exists"
 msgstr "thay thế nếu thẻ đó đã có trước"
 
-#: builtin/tag.c:465 builtin/update-ref.c:505
+#: builtin/tag.c:463 builtin/update-ref.c:511
 msgid "create a reflog"
 msgstr "tạo một reflog"
 
-#: builtin/tag.c:467
+#: builtin/tag.c:465
 msgid "Tag listing options"
 msgstr "Các tùy chọn liệt kê thẻ"
 
-#: builtin/tag.c:468
+#: builtin/tag.c:466
 msgid "show tag list in columns"
 msgstr "hiển thị danh sách thẻ trong các cột"
 
-#: builtin/tag.c:469 builtin/tag.c:471
+#: builtin/tag.c:467 builtin/tag.c:469
 msgid "print only tags that contain the commit"
 msgstr "chỉ hiển thị những nhánh mà nó chứa lần chuyển giao"
 
-#: builtin/tag.c:470 builtin/tag.c:472
+#: builtin/tag.c:468 builtin/tag.c:470
 msgid "print only tags that don't contain the commit"
 msgstr "chỉ hiển thị những thẻ mà nó không chứa lần chuyển giao"
 
-#: builtin/tag.c:473
+#: builtin/tag.c:471
 msgid "print only tags that are merged"
 msgstr "chỉ hiển thị những thẻ mà nó được hòa trộn"
 
-#: builtin/tag.c:474
+#: builtin/tag.c:472
 msgid "print only tags that are not merged"
 msgstr "chỉ hiển thị những thẻ mà nó không được hòa trộn"
 
-#: builtin/tag.c:478
+#: builtin/tag.c:476
 msgid "print only tags of the object"
 msgstr "chỉ hiển thị các thẻ của đối tượng"
 
-#: builtin/tag.c:526
+#: builtin/tag.c:525
 msgid "--column and -n are incompatible"
 msgstr "--column và -n xung khắc nhau"
 
-#: builtin/tag.c:548
+#: builtin/tag.c:546
 msgid "-n option is only allowed in list mode"
 msgstr "tùy chọn -n chỉ cho phép dùng trong chế độ liệt kê"
 
-#: builtin/tag.c:550
+#: builtin/tag.c:548
 msgid "--contains option is only allowed in list mode"
 msgstr "tùy chọn --contains chỉ cho phép dùng trong chế độ liệt kê"
 
-#: builtin/tag.c:552
+#: builtin/tag.c:550
 msgid "--no-contains option is only allowed in list mode"
 msgstr "tùy chọn --no-contains chỉ cho phép dùng trong chế độ liệt kê"
 
-#: builtin/tag.c:554
+#: builtin/tag.c:552
 msgid "--points-at option is only allowed in list mode"
 msgstr "tùy chọn --points-at chỉ cho phép dùng trong chế độ liệt kê"
 
-#: builtin/tag.c:556
+#: builtin/tag.c:554
 msgid "--merged and --no-merged options are only allowed in list mode"
 msgstr ""
 "tùy chọn --merged và --no-merged chỉ cho phép dùng trong chế độ liệt kê"
 
-#: builtin/tag.c:567
+#: builtin/tag.c:568
 msgid "only one -F or -m option is allowed."
 msgstr "chỉ có một tùy chọn -F hoặc -m là được phép."
 
-#: builtin/tag.c:592
+#: builtin/tag.c:593
 #, c-format
 msgid "'%s' is not a valid tag name."
 msgstr "“%s” không phải thẻ hợp lệ."
 
-#: builtin/tag.c:597
+#: builtin/tag.c:598
 #, c-format
 msgid "tag '%s' already exists"
 msgstr "thẻ “%s” đã tồn tại rồi"
 
-#: builtin/tag.c:628
+#: builtin/tag.c:629
 #, c-format
 msgid "Updated tag '%s' (was %s)\n"
 msgstr "Đã cập nhật thẻ “%s” (trước là %s)\n"
@@ -23417,201 +23797,196 @@ msgstr "Đang giải nén các đối tượng"
 msgid "failed to create directory %s"
 msgstr "tạo thư mục \"%s\" gặp lỗi"
 
-#: builtin/update-index.c:100
-#, c-format
-msgid "failed to create file %s"
-msgstr "gặp lỗi khi tạo tập tin %s"
-
-#: builtin/update-index.c:108
+#: builtin/update-index.c:106
 #, c-format
 msgid "failed to delete file %s"
 msgstr "gặp lỗi khi xóa tập tin %s"
 
-#: builtin/update-index.c:115 builtin/update-index.c:221
+#: builtin/update-index.c:113 builtin/update-index.c:219
 #, c-format
 msgid "failed to delete directory %s"
 msgstr "gặp lỗi khi xóa thư mục %s"
 
-#: builtin/update-index.c:140
+#: builtin/update-index.c:138
 #, c-format
 msgid "Testing mtime in '%s' "
 msgstr "Đang kiểm thử mtime trong “%s” "
 
-#: builtin/update-index.c:154
+#: builtin/update-index.c:152
 msgid "directory stat info does not change after adding a new file"
 msgstr "thông tin thống kê thư mục không thay đổi sau khi thêm tập tin mới"
 
-#: builtin/update-index.c:167
+#: builtin/update-index.c:165
 msgid "directory stat info does not change after adding a new directory"
 msgstr "thông tin thống kê thư mục không thay đổi sau khi thêm thư mục mới"
 
-#: builtin/update-index.c:180
+#: builtin/update-index.c:178
 msgid "directory stat info changes after updating a file"
 msgstr "thông tin thống kê thư mục thay đổi sau khi cập nhật tập tin"
 
-#: builtin/update-index.c:191
+#: builtin/update-index.c:189
 msgid "directory stat info changes after adding a file inside subdirectory"
 msgstr ""
 "thông tin thống kê thư mục thay đổi sau khi thêm tập tin mới vào trong thư "
 "mục con"
 
-#: builtin/update-index.c:202
+#: builtin/update-index.c:200
 msgid "directory stat info does not change after deleting a file"
 msgstr "thông tin thống kê thư mục không thay đổi sau khi xóa tập tin"
 
-#: builtin/update-index.c:215
+#: builtin/update-index.c:213
 msgid "directory stat info does not change after deleting a directory"
 msgstr "thông tin thống kê thư mục không thay đổi sau khi xóa thư mục"
 
-#: builtin/update-index.c:222
+#: builtin/update-index.c:220
 msgid " OK"
 msgstr " Đồng ý"
 
-#: builtin/update-index.c:591
+#: builtin/update-index.c:589
 msgid "git update-index [<options>] [--] [<file>...]"
 msgstr "git update-index [<các tùy chọn>] [--] [<tập-tin>…]"
 
-#: builtin/update-index.c:976
+#: builtin/update-index.c:974
 msgid "continue refresh even when index needs update"
 msgstr "tiếp tục làm mới ngay cả khi bảng mục lục cần được cập nhật"
 
-#: builtin/update-index.c:979
+#: builtin/update-index.c:977
 msgid "refresh: ignore submodules"
 msgstr "refresh: lờ đi mô-đun-con"
 
-#: builtin/update-index.c:982
+#: builtin/update-index.c:980
 msgid "do not ignore new files"
 msgstr "không bỏ qua các tập tin mới tạo"
 
-#: builtin/update-index.c:984
+#: builtin/update-index.c:982
 msgid "let files replace directories and vice-versa"
 msgstr "để các tập tin thay thế các thư mục và “vice-versa”"
 
-#: builtin/update-index.c:986
+#: builtin/update-index.c:984
 msgid "notice files missing from worktree"
 msgstr "thông báo các tập-tin thiếu trong thư-mục làm việc"
 
-#: builtin/update-index.c:988
+#: builtin/update-index.c:986
 msgid "refresh even if index contains unmerged entries"
 msgstr ""
 "làm tươi mới thậm chí khi bảng mục lục chứa các mục tin chưa được hòa trộn"
 
-#: builtin/update-index.c:991
+#: builtin/update-index.c:989
 msgid "refresh stat information"
 msgstr "lấy lại thông tin thống kê"
 
-#: builtin/update-index.c:995
+#: builtin/update-index.c:993
 msgid "like --refresh, but ignore assume-unchanged setting"
 msgstr "giống --refresh, nhưng bỏ qua các cài đặt “assume-unchanged”"
 
-#: builtin/update-index.c:999
+#: builtin/update-index.c:997
 msgid "<mode>,<object>,<path>"
 msgstr "<chế_độ>,<đối_tượng>,<đường_dẫn>"
 
-#: builtin/update-index.c:1000
+#: builtin/update-index.c:998
 msgid "add the specified entry to the index"
 msgstr "thêm các tập tin đã chỉ ra vào bảng mục lục"
 
-#: builtin/update-index.c:1010
+#: builtin/update-index.c:1008
 msgid "mark files as \"not changing\""
 msgstr "đánh dấu các tập tin là \"không thay đổi\""
 
-#: builtin/update-index.c:1013
+#: builtin/update-index.c:1011
 msgid "clear assumed-unchanged bit"
 msgstr "xóa bít assumed-unchanged (giả định là không thay đổi)"
 
-#: builtin/update-index.c:1016
+#: builtin/update-index.c:1014
 msgid "mark files as \"index-only\""
 msgstr "đánh dấu các tập tin là “chỉ-đọc”"
 
-#: builtin/update-index.c:1019
+#: builtin/update-index.c:1017
 msgid "clear skip-worktree bit"
 msgstr "xóa bít skip-worktree"
 
-#: builtin/update-index.c:1022
+#: builtin/update-index.c:1020
 msgid "do not touch index-only entries"
 msgstr "đừng động vào các mục index-only"
 
-#: builtin/update-index.c:1024
+#: builtin/update-index.c:1022
 msgid "add to index only; do not add content to object database"
 msgstr ""
 "chỉ thêm vào bảng mục lục; không thêm nội dung vào cơ sở dữ liệu đối tượng"
 
-#: builtin/update-index.c:1026
+#: builtin/update-index.c:1024
 msgid "remove named paths even if present in worktree"
 msgstr ""
 "gỡ bỏ các đường dẫn được đặt tên thậm chí cả khi nó hiện diện trong thư mục "
 "làm việc"
 
-#: builtin/update-index.c:1028
+#: builtin/update-index.c:1026
 msgid "with --stdin: input lines are terminated by null bytes"
 msgstr "với tùy chọn --stdin: các dòng đầu vào được chấm dứt bởi ký tự null"
 
-#: builtin/update-index.c:1030
+#: builtin/update-index.c:1028
 msgid "read list of paths to be updated from standard input"
 msgstr "đọc danh sách đường dẫn cần cập nhật từ đầu vào tiêu chuẩn"
 
-#: builtin/update-index.c:1034
+#: builtin/update-index.c:1032
 msgid "add entries from standard input to the index"
 msgstr "không thể đọc các mục từ đầu vào tiêu chuẩn vào bảng mục lục"
 
-#: builtin/update-index.c:1038
+#: builtin/update-index.c:1036
 msgid "repopulate stages #2 and #3 for the listed paths"
 msgstr "phục hồi các trạng thái #2 và #3 cho các đường dẫn được liệt kê"
 
-#: builtin/update-index.c:1042
+#: builtin/update-index.c:1040
 msgid "only update entries that differ from HEAD"
 msgstr "chỉ cập nhật các mục tin mà nó khác biệt so với HEAD"
 
-#: builtin/update-index.c:1046
+#: builtin/update-index.c:1044
 msgid "ignore files missing from worktree"
 msgstr "bỏ qua các tập-tin thiếu trong thư-mục làm việc"
 
-#: builtin/update-index.c:1049
+#: builtin/update-index.c:1047
 msgid "report actions to standard output"
 msgstr "báo cáo các thao tác ra thiết bị xuất chuẩn"
 
-#: builtin/update-index.c:1051
+#: builtin/update-index.c:1049
 msgid "(for porcelains) forget saved unresolved conflicts"
 msgstr "(cho “porcelains”) quên các xung đột chưa được giải quyết đã ghi"
 
-#: builtin/update-index.c:1055
+#: builtin/update-index.c:1053
 msgid "write index in this format"
 msgstr "ghi mục lục ở định dạng này"
 
-#: builtin/update-index.c:1057
+#: builtin/update-index.c:1055
 msgid "enable or disable split index"
 msgstr "bật/tắt chia cắt bảng mục lục"
 
-#: builtin/update-index.c:1059
+#: builtin/update-index.c:1057
 msgid "enable/disable untracked cache"
 msgstr "bật/tắt bộ đệm không theo vết"
 
-#: builtin/update-index.c:1061
+#: builtin/update-index.c:1059
 msgid "test if the filesystem supports untracked cache"
 msgstr "kiểm tra xem hệ thống tập tin có hỗ trợ đệm không theo dõi hay không"
 
-#: builtin/update-index.c:1063
+#: builtin/update-index.c:1061
 msgid "enable untracked cache without testing the filesystem"
 msgstr "bật bộ đệm không theo vết mà không kiểm tra hệ thống tập tin"
 
-#: builtin/update-index.c:1065
+#: builtin/update-index.c:1063
 msgid "write out the index even if is not flagged as changed"
 msgstr "ghi ra mục lục ngay cả khi không được đánh cờ là có thay đổi"
 
-#: builtin/update-index.c:1067
+#: builtin/update-index.c:1065
 msgid "enable or disable file system monitor"
 msgstr "bật/tắt theo dõi hệ thống tập tin"
 
-#: builtin/update-index.c:1069
+#: builtin/update-index.c:1067
 msgid "mark files as fsmonitor valid"
 msgstr "đánh dấu các tập tin là hợp lệ fsmonitor"
 
-#: builtin/update-index.c:1072
+#: builtin/update-index.c:1070
 msgid "clear fsmonitor valid bit"
 msgstr "xóa bít hợp lệ fsmonitor"
 
-#: builtin/update-index.c:1175
+#: builtin/update-index.c:1173
 msgid ""
 "core.splitIndex is set to false; remove or change it, if you really want to "
 "enable split index"
@@ -23619,7 +23994,7 @@ msgstr ""
 "core.splitIndex được đặt là sai; xóa bỏ hay thay đổi nó, nếu bạn thực sự "
 "muốn bật chia tách mục lục"
 
-#: builtin/update-index.c:1184
+#: builtin/update-index.c:1182
 msgid ""
 "core.splitIndex is set to true; remove or change it, if you really want to "
 "disable split index"
@@ -23627,7 +24002,7 @@ msgstr ""
 "core.splitIndex được đặt là đúng; xóa bỏ hay thay đổi nó, nếu bạn thực sự "
 "muốn tắt chia tách mục lục"
 
-#: builtin/update-index.c:1196
+#: builtin/update-index.c:1194
 msgid ""
 "core.untrackedCache is set to true; remove or change it, if you really want "
 "to disable the untracked cache"
@@ -23635,11 +24010,11 @@ msgstr ""
 "core.untrackedCache được đặt là đúng; xóa bỏ hay thay đổi nó, nếu bạn thực "
 "sự muốn tắt bộ đệm chưa theo dõi"
 
-#: builtin/update-index.c:1200
+#: builtin/update-index.c:1198
 msgid "Untracked cache disabled"
 msgstr "Nhớ đệm không theo vết bị tắt"
 
-#: builtin/update-index.c:1208
+#: builtin/update-index.c:1206
 msgid ""
 "core.untrackedCache is set to false; remove or change it, if you really want "
 "to enable the untracked cache"
@@ -23647,29 +24022,29 @@ msgstr ""
 "core.untrackedCache được đặt là sai; xóa bỏ hay thay đổi nó, nếu bạn thực sự "
 "muốn bật bộ đệm chưa theo dõi"
 
-#: builtin/update-index.c:1212
+#: builtin/update-index.c:1210
 #, c-format
 msgid "Untracked cache enabled for '%s'"
 msgstr "Nhớ đệm không theo vết được bật cho “%s”"
 
-#: builtin/update-index.c:1220
+#: builtin/update-index.c:1218
 msgid "core.fsmonitor is unset; set it if you really want to enable fsmonitor"
 msgstr ""
 "core.fsmonitor chưa được đặt; đặt nó nếu bạn thực sự muốn bật theo dõi hệ "
 "thống tập tin"
 
-#: builtin/update-index.c:1224
+#: builtin/update-index.c:1222
 msgid "fsmonitor enabled"
 msgstr "fsmonitor được bật"
 
-#: builtin/update-index.c:1227
+#: builtin/update-index.c:1225
 msgid ""
 "core.fsmonitor is set; remove it if you really want to disable fsmonitor"
 msgstr ""
 "core.fsmonitor đã được đặt; bỏ đặt nó nếu bạn thực sự muốn bật theo dõi hệ "
 "thống tập tin"
 
-#: builtin/update-index.c:1231
+#: builtin/update-index.c:1229
 msgid "fsmonitor disabled"
 msgstr "fsmonitor bị tắt"
 
@@ -23685,19 +24060,19 @@ msgstr "git update-ref [<các tùy chọn>]    <refname> <biến-mới> [<biến
 msgid "git update-ref [<options>] --stdin [-z]"
 msgstr "git update-ref [<các tùy chọn>] --stdin [-z]"
 
-#: builtin/update-ref.c:500
+#: builtin/update-ref.c:506
 msgid "delete the reference"
 msgstr "xóa tham chiếu"
 
-#: builtin/update-ref.c:502
+#: builtin/update-ref.c:508
 msgid "update <refname> not the one it points to"
 msgstr "cập nhật <tên-tham-chiếu> không phải cái nó chỉ tới"
 
-#: builtin/update-ref.c:503
+#: builtin/update-ref.c:509
 msgid "stdin has NUL-terminated arguments"
 msgstr "đầu vào tiêu chuẩn có các đối số được chấm dứt bởi NUL"
 
-#: builtin/update-ref.c:504
+#: builtin/update-ref.c:510
 msgid "read updates from stdin"
 msgstr "đọc cập nhật từ đầu vào tiêu chuẩn"
 
@@ -23713,19 +24088,19 @@ msgstr "cập nhật các tập tin thông tin từ điểm xuất phát"
 msgid "git upload-pack [<options>] <dir>"
 msgstr "git upload-pack [<các tùy chọn>] </đường/dẫn>"
 
-#: builtin/upload-pack.c:23 t/helper/test-serve-v2.c:17
+#: builtin/upload-pack.c:24 t/helper/test-serve-v2.c:17
 msgid "quit after a single request/response exchange"
 msgstr "thoát sau khi một trao đổi yêu cầu hay trả lời đơn"
 
-#: builtin/upload-pack.c:25
-msgid "exit immediately after initial ref advertisement"
-msgstr "thoát ngay sau khi khởi tạo quảng cáo tham chiếu"
+#: builtin/upload-pack.c:26
+msgid "serve up the info/refs for git-http-backend"
+msgstr "phục vụ info/refs (thông tin/tham chiếu) cho git-http-backend"
 
-#: builtin/upload-pack.c:27
+#: builtin/upload-pack.c:29
 msgid "do not try <directory>/.git/ if <directory> is no Git directory"
 msgstr "đừng thử <thư_mục>/.git/ nếu <thư_mục> không phải là thư mục Git"
 
-#: builtin/upload-pack.c:29
+#: builtin/upload-pack.c:31
 msgid "interrupt transfer after <n> seconds of inactivity"
 msgstr "ngắt truyền thông sau <n> giây không hoạt động"
 
@@ -23761,63 +24136,58 @@ msgstr "git verify-tag [-v | --verbose] [--format=<định_dạng>] <thẻ>…"
 msgid "print tag contents"
 msgstr "hiển thị nội dung của thẻ"
 
-#: builtin/worktree.c:18
+#: builtin/worktree.c:19
 msgid "git worktree add [<options>] <path> [<commit-ish>]"
 msgstr "git worktree add [<các tùy chọn>] </đường/dẫn> [<commit-ish>]"
 
-#: builtin/worktree.c:19
+#: builtin/worktree.c:20
 msgid "git worktree list [<options>]"
 msgstr "git worktree list [<các tùy chọn>]"
 
-#: builtin/worktree.c:20
+#: builtin/worktree.c:21
 msgid "git worktree lock [<options>] <path>"
 msgstr "git worktree lock [<các tùy chọn>] </đường/dẫn>"
 
-#: builtin/worktree.c:21
+#: builtin/worktree.c:22
 msgid "git worktree move <worktree> <new-path>"
 msgstr "git worktree move <worktree> </đường/dẫn/mới>"
 
-#: builtin/worktree.c:22
+#: builtin/worktree.c:23
 msgid "git worktree prune [<options>]"
 msgstr "git worktree prune [<các tùy chọn>]"
 
-#: builtin/worktree.c:23
+#: builtin/worktree.c:24
 msgid "git worktree remove [<options>] <worktree>"
 msgstr "git worktree remove [<các tùy chọn>] <worktree>"
 
-#: builtin/worktree.c:24
+#: builtin/worktree.c:25
 msgid "git worktree unlock <path>"
 msgstr "git worktree unlock </đường/dẫn>"
 
-#: builtin/worktree.c:61 builtin/worktree.c:944
-#, c-format
-msgid "failed to delete '%s'"
-msgstr "gặp lỗi khi xóa “%s”"
-
-#: builtin/worktree.c:74
+#: builtin/worktree.c:75
 #, c-format
 msgid "Removing %s/%s: %s"
 msgstr "Đang xóa %s/%s: %s"
 
-#: builtin/worktree.c:147
+#: builtin/worktree.c:148
 msgid "report pruned working trees"
 msgstr "báo cáo các cây làm việc đã prune"
 
-#: builtin/worktree.c:149
+#: builtin/worktree.c:150
 msgid "expire working trees older than <time>"
 msgstr "các cây làm việc hết hạn cũ hơn khoảng <thời gian>"
 
-#: builtin/worktree.c:219
+#: builtin/worktree.c:220
 #, c-format
 msgid "'%s' already exists"
 msgstr "“%s” đã có từ trước rồi"
 
-#: builtin/worktree.c:228
+#: builtin/worktree.c:229
 #, c-format
 msgid "unusable worktree destination '%s'"
 msgstr "đích cây làm việc không sử dụng được “%s”"
 
-#: builtin/worktree.c:233
+#: builtin/worktree.c:234
 #, c-format
 msgid ""
 "'%s' is a missing but locked worktree;\n"
@@ -23826,7 +24196,7 @@ msgstr ""
 "“%s” bị mất nhưng cây làm việc bị khóa;\n"
 "dùng “%s -f -f” để ghi đè, hoặc “unlock” và “prune” hay “remove” để xóa"
 
-#: builtin/worktree.c:235
+#: builtin/worktree.c:236
 #, c-format
 msgid ""
 "'%s' is a missing but already registered worktree;\n"
@@ -23835,141 +24205,141 @@ msgstr ""
 "“%s” bị mất nhưng cây làm việc đã được đăng ký;\n"
 "dùng “%s -f” để ghi đè, hoặc “prune” hay “remove” để xóa"
 
-#: builtin/worktree.c:286
+#: builtin/worktree.c:287
 #, c-format
 msgid "could not create directory of '%s'"
 msgstr "không thể tạo thư mục của “%s”"
 
-#: builtin/worktree.c:308
+#: builtin/worktree.c:309
 msgid "initializing"
 msgstr "khởi tạo"
 
-#: builtin/worktree.c:420 builtin/worktree.c:426
+#: builtin/worktree.c:421 builtin/worktree.c:427
 #, c-format
 msgid "Preparing worktree (new branch '%s')"
 msgstr "Đang chuẩn bị cây làm việc (nhánh mới “%s”)"
 
-#: builtin/worktree.c:422
+#: builtin/worktree.c:423
 #, c-format
 msgid "Preparing worktree (resetting branch '%s'; was at %s)"
 msgstr "Đang chuẩn bị cây làm việc (đang cài đặt nhánh “%s”, trước đây tại %s)"
 
-#: builtin/worktree.c:431
+#: builtin/worktree.c:432
 #, c-format
 msgid "Preparing worktree (checking out '%s')"
 msgstr "Đang chuẩn bị cây làm việc (đang lấy ra “%s”)"
 
-#: builtin/worktree.c:437
+#: builtin/worktree.c:438
 #, c-format
 msgid "Preparing worktree (detached HEAD %s)"
 msgstr "Đang chuẩn bị cây làm việc (HEAD đã tách rời “%s”)"
 
-#: builtin/worktree.c:482
+#: builtin/worktree.c:483
 msgid "checkout <branch> even if already checked out in other worktree"
 msgstr "lấy ra <nhánh> ngay cả khi nó đã được lấy ra ở cây làm việc khác"
 
-#: builtin/worktree.c:485
+#: builtin/worktree.c:486
 msgid "create a new branch"
 msgstr "tạo nhánh mới"
 
-#: builtin/worktree.c:487
+#: builtin/worktree.c:488
 msgid "create or reset a branch"
 msgstr "tạo hay đặt lại một nhánh"
 
-#: builtin/worktree.c:489
+#: builtin/worktree.c:490
 msgid "populate the new working tree"
 msgstr "di chuyển cây làm việc mới"
 
-#: builtin/worktree.c:490
+#: builtin/worktree.c:491
 msgid "keep the new working tree locked"
 msgstr "giữ cây làm việc mới bị khóa"
 
-#: builtin/worktree.c:492 builtin/worktree.c:729
+#: builtin/worktree.c:493 builtin/worktree.c:730
 msgid "reason for locking"
 msgstr "lý do khóa"
 
-#: builtin/worktree.c:495
+#: builtin/worktree.c:496
 msgid "set up tracking mode (see git-branch(1))"
 msgstr "cài đặt chế độ theo dõi (xem git-branch(1))"
 
-#: builtin/worktree.c:498
+#: builtin/worktree.c:499
 msgid "try to match the new branch name with a remote-tracking branch"
 msgstr "có khớp tên tên nhánh mới với một nhánh theo dõi máy chủ"
 
-#: builtin/worktree.c:506
+#: builtin/worktree.c:507
 msgid "-b, -B, and --detach are mutually exclusive"
 msgstr "Các tùy chọn -b, -B, và --detach loại từ lẫn nhau"
 
-#: builtin/worktree.c:508
+#: builtin/worktree.c:509
 msgid "--reason requires --lock"
 msgstr "--reason cần --lock"
 
-#: builtin/worktree.c:512
+#: builtin/worktree.c:513
 msgid "added with --lock"
 msgstr "được thêm với --lock"
 
-#: builtin/worktree.c:574
+#: builtin/worktree.c:575
 msgid "--[no-]track can only be used if a new branch is created"
 msgstr "--[no-]track chỉ có thể được dùng nếu một nhánh mới được tạo"
 
-#: builtin/worktree.c:691
+#: builtin/worktree.c:692
 msgid "show extended annotations and reasons, if available"
 msgstr "hiển thị chú thích và lý do mở rộng, nếu có"
 
-#: builtin/worktree.c:693
+#: builtin/worktree.c:694
 msgid "add 'prunable' annotation to worktrees older than <time>"
 msgstr ""
-"thêm chú thích kiểu 'prunable' cho các cây làm việc hết hạn cũ hơn khoảng "
+"thêm chú thích kiểu “prunable” cho các cây làm việc hết hạn cũ hơn khoảng "
 "<thời gian>"
 
-#: builtin/worktree.c:702
+#: builtin/worktree.c:703
 msgid "--verbose and --porcelain are mutually exclusive"
 msgstr "--verbose và --porcelain loại từ lẫn nhau"
 
-#: builtin/worktree.c:741 builtin/worktree.c:774 builtin/worktree.c:848
-#: builtin/worktree.c:972
+#: builtin/worktree.c:742 builtin/worktree.c:775 builtin/worktree.c:849
+#: builtin/worktree.c:973
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr "%s không phải là cây làm việc"
 
-#: builtin/worktree.c:743 builtin/worktree.c:776
+#: builtin/worktree.c:744 builtin/worktree.c:777
 msgid "The main working tree cannot be locked or unlocked"
 msgstr "Cây thư mục làm việc chính không thể khóa hay bỏ khóa được"
 
-#: builtin/worktree.c:748
+#: builtin/worktree.c:749
 #, c-format
 msgid "'%s' is already locked, reason: %s"
 msgstr "“%s” đã được khóa rồi, lý do: %s"
 
-#: builtin/worktree.c:750
+#: builtin/worktree.c:751
 #, c-format
 msgid "'%s' is already locked"
 msgstr "“%s” đã được khóa rồi"
 
-#: builtin/worktree.c:778
+#: builtin/worktree.c:779
 #, c-format
 msgid "'%s' is not locked"
 msgstr "“%s” chưa bị khóa"
 
-#: builtin/worktree.c:819
+#: builtin/worktree.c:820
 msgid "working trees containing submodules cannot be moved or removed"
 msgstr "cây làm việc có chứa mô-đun-con không thể di chuyển hay xóa bỏ"
 
-#: builtin/worktree.c:827
+#: builtin/worktree.c:828
 msgid "force move even if worktree is dirty or locked"
 msgstr "ép buộc ngay cả khi cây làm việc đang bẩn hay bị khóa"
 
-#: builtin/worktree.c:850 builtin/worktree.c:974
+#: builtin/worktree.c:851 builtin/worktree.c:975
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr "“%s” là cây làm việc chính"
 
-#: builtin/worktree.c:855
+#: builtin/worktree.c:856
 #, c-format
 msgid "could not figure out destination name from '%s'"
 msgstr "không thể phác họa ra tên đích đến “%s”"
 
-#: builtin/worktree.c:868
+#: builtin/worktree.c:869
 #, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
@@ -23978,7 +24348,7 @@ msgstr ""
 "không thể di chuyển một cây-làm-việc bị khóa, khóa vì: %s\n"
 "dùng “move -f -f” để ghi đè hoặc mở khóa trước đã"
 
-#: builtin/worktree.c:870
+#: builtin/worktree.c:871
 msgid ""
 "cannot move a locked working tree;\n"
 "use 'move -f -f' to override or unlock first"
@@ -23986,38 +24356,38 @@ msgstr ""
 "không thể di chuyển một cây-làm-việc bị khóa;\n"
 "dùng “move -f -f” để ghi đè hoặc mở khóa trước đã"
 
-#: builtin/worktree.c:873
+#: builtin/worktree.c:874
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
 msgstr "thẩm tra gặp lỗi, không thể di chuyển một cây-làm-việc: %s"
 
-#: builtin/worktree.c:878
+#: builtin/worktree.c:879
 #, c-format
 msgid "failed to move '%s' to '%s'"
 msgstr "gặp lỗi khi chuyển “%s” sang “%s”"
 
-#: builtin/worktree.c:924
+#: builtin/worktree.c:925
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr "gặp lỗi khi chạy “git status” vào “%s”"
 
-#: builtin/worktree.c:928
+#: builtin/worktree.c:929
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
 "“%s” có chứa các tập tin đã bị sửa chữa hoặc chưa được theo dõi, hãy dùng --"
 "force để xóa nó"
 
-#: builtin/worktree.c:933
+#: builtin/worktree.c:934
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr "gặp lỗi khi chạy “git status” trong “%s”, mã %d"
 
-#: builtin/worktree.c:956
+#: builtin/worktree.c:957
 msgid "force removal even if worktree is dirty or locked"
 msgstr "ép buộc di chuyển thậm chí cả khi cây làm việc đang bẩn hay bị khóa"
 
-#: builtin/worktree.c:979
+#: builtin/worktree.c:980
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
@@ -24026,7 +24396,7 @@ msgstr ""
 "không thể xóa bỏ một cây-làm-việc bị khóa, khóa vì: %s\n"
 "dùng “remove -f -f” để ghi đè hoặc mở khóa trước đã"
 
-#: builtin/worktree.c:981
+#: builtin/worktree.c:982
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
@@ -24034,17 +24404,17 @@ msgstr ""
 "không thể xóa bỏ một cây-làm-việc bị khóa;\n"
 "dùng “remove -f -f” để ghi đè hoặc mở khóa trước đã"
 
-#: builtin/worktree.c:984
+#: builtin/worktree.c:985
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr "thẩm tra gặp lỗi, không thể gỡ bỏ một cây-làm-việc: %s"
 
-#: builtin/worktree.c:1008
+#: builtin/worktree.c:1009
 #, c-format
 msgid "repair: %s: %s"
 msgstr "sửa chữa: %s: %s"
 
-#: builtin/worktree.c:1011
+#: builtin/worktree.c:1012
 #, c-format
 msgid "error: %s: %s"
 msgstr "lỗi: %s: %s"
@@ -24173,18 +24543,18 @@ msgstr "lỗi nghiêm trọng chưa biết khi ghi ra đầu ra tiêu chuẩn"
 msgid "close failed on standard output"
 msgstr "gặp lỗi khi đóng đầu ra tiêu chuẩn"
 
-#: git.c:833
+#: git.c:832
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr ""
 "dò tìm thấy các bí danh quẩn tròn: biểu thức của “%s” không có điểm kết:%s"
 
-#: git.c:883
+#: git.c:882
 #, c-format
 msgid "cannot handle %s as a builtin"
 msgstr "không thể xử lý %s như là một phần bổ sung"
 
-#: git.c:896
+#: git.c:895
 #, c-format
 msgid ""
 "usage: %s\n"
@@ -24193,12 +24563,12 @@ msgstr ""
 "cách dùng: %s\n"
 "\n"
 
-#: git.c:916
+#: git.c:915
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr "gặp lỗi khi khai triển bí danh “%s”; “%s” không phải là lệnh git\n"
 
-#: git.c:928
+#: git.c:927
 #, c-format
 msgid "failed to run command '%s': %s\n"
 msgstr "gặp lỗi khi chạy lệnh “%s”: %s\n"
@@ -24245,66 +24615,32 @@ msgstr "test-tool serve-v2 [<các tùy chọn>]"
 msgid "exit immediately after advertising capabilities"
 msgstr "thoát ngay sau khi khởi tạo quảng cáo capabilities"
 
-#: t/helper/test-simple-ipc.c:262
-#, c-format
-msgid "socket/pipe already in use: '%s'"
-msgstr "socket/pipe đã đang được sử dụng rồi: '%s'"
-
-#: t/helper/test-simple-ipc.c:264
-#, c-format
-msgid "could not start server on: '%s'"
-msgstr "không thể khởi động máy phục vụ lên: “%s”"
-
-#: t/helper/test-simple-ipc.c:295 t/helper/test-simple-ipc.c:331
-msgid "could not spawn daemon in the background"
-msgstr "không thể sinh ra daemon trong nền"
-
-#: t/helper/test-simple-ipc.c:356
-msgid "waitpid failed"
-msgstr "waitpid gặp lỗi"
-
-#: t/helper/test-simple-ipc.c:376
-msgid "daemon not online yet"
-msgstr "\"daemon\" vẫn chưa trực tuyến"
-
-#: t/helper/test-simple-ipc.c:406
-msgid "daemon failed to start"
-msgstr "daemon gặp lỗi khi khởi động"
-
-#: t/helper/test-simple-ipc.c:410
-msgid "waitpid is confused"
-msgstr "waitpid là chưa rõ ràng"
-
-#: t/helper/test-simple-ipc.c:541
-msgid "daemon has not shutdown yet"
-msgstr "\"daemon\" vẫn chưa được tắt đi"
-
-#: t/helper/test-simple-ipc.c:682
+#: t/helper/test-simple-ipc.c:581
 msgid "test-helper simple-ipc is-active    [<name>] [<options>]"
 msgstr "test-helper simple-ipc is-active    [<tên>] [<các tùy chọn>]"
 
-#: t/helper/test-simple-ipc.c:683
+#: t/helper/test-simple-ipc.c:582
 msgid "test-helper simple-ipc run-daemon   [<name>] [<threads>]"
 msgstr "test-helper simple-ipc run-daemon   [<tên>] [<các tiến trình>]"
 
-#: t/helper/test-simple-ipc.c:684
+#: t/helper/test-simple-ipc.c:583
 msgid "test-helper simple-ipc start-daemon [<name>] [<threads>] [<max-wait>]"
 msgstr ""
 "test-helper simple-ipc start-daemon [<tên>] [<các tiến trình>] [<chờ tối đa>]"
 
-#: t/helper/test-simple-ipc.c:685
+#: t/helper/test-simple-ipc.c:584
 msgid "test-helper simple-ipc stop-daemon  [<name>] [<max-wait>]"
 msgstr "test-helper simple-ipc stop-daemon  [<tên>] [<chờ tối đa>]"
 
-#: t/helper/test-simple-ipc.c:686
+#: t/helper/test-simple-ipc.c:585
 msgid "test-helper simple-ipc send         [<name>] [<token>]"
 msgstr "test-helper simple-ipc send         [<tên>] [<thẻ>]"
 
-#: t/helper/test-simple-ipc.c:687
+#: t/helper/test-simple-ipc.c:586
 msgid "test-helper simple-ipc sendbytes    [<name>] [<bytecount>] [<byte>]"
 msgstr "test-helper simple-ipc sendbytes    [<tên>] [<số lượng byte>] [<byte>]"
 
-#: t/helper/test-simple-ipc.c:688
+#: t/helper/test-simple-ipc.c:587
 msgid ""
 "test-helper simple-ipc multiple     [<name>] [<threads>] [<bytecount>] "
 "[<batchsize>]"
@@ -24312,87 +24648,83 @@ msgstr ""
 "test-helper simple-ipc multiple     [<tên>] [<các tiến trình>] [<số lượng "
 "byte>] [<cỡ bó>]"
 
-#: t/helper/test-simple-ipc.c:696
+#: t/helper/test-simple-ipc.c:595
 msgid "name or pathname of unix domain socket"
 msgstr "tên hoặc tên đường dẫn của ổ cắm miền unix"
 
-#: t/helper/test-simple-ipc.c:698
+#: t/helper/test-simple-ipc.c:597
 msgid "named-pipe name"
 msgstr "tên named-pipe"
 
-#: t/helper/test-simple-ipc.c:700
+#: t/helper/test-simple-ipc.c:599
 msgid "number of threads in server thread pool"
 msgstr "số lượng tiến trình trong kho tiến trình máy phục vụ"
 
-#: t/helper/test-simple-ipc.c:701
+#: t/helper/test-simple-ipc.c:600
 msgid "seconds to wait for daemon to start or stop"
 msgstr "số giây mà dịch vụ chạy nền chờ khi khởi động hoặc dừng"
 
-#: t/helper/test-simple-ipc.c:703
+#: t/helper/test-simple-ipc.c:602
 msgid "number of bytes"
 msgstr "số lượng byte"
 
-#: t/helper/test-simple-ipc.c:704
+#: t/helper/test-simple-ipc.c:603
 msgid "number of requests per thread"
 msgstr "số lượng yêu cầu mỗi tiến trình"
 
-#: t/helper/test-simple-ipc.c:706
+#: t/helper/test-simple-ipc.c:605
 msgid "byte"
 msgstr "byte"
 
-#: t/helper/test-simple-ipc.c:706
+#: t/helper/test-simple-ipc.c:605
 msgid "ballast character"
 msgstr "ký tự ballast"
 
-#: t/helper/test-simple-ipc.c:707
+#: t/helper/test-simple-ipc.c:606
 msgid "token"
 msgstr "thẻ bài"
 
-#: t/helper/test-simple-ipc.c:707
+#: t/helper/test-simple-ipc.c:606
 msgid "command token to send to the server"
 msgstr "thẻ bài lệnh để gửi lên cho máy phục vụ"
 
-#: http.c:399
+#: http.c:350
 #, c-format
 msgid "negative value for http.postbuffer; defaulting to %d"
 msgstr "giá trị âm cho http.postbuffer; đặt thành mặc định là %d"
 
-#: http.c:420
+#: http.c:371
 msgid "Delegation control is not supported with cURL < 7.22.0"
 msgstr "Điều khiển giao quyền không được hỗ trợ với cURL < 7.22.0"
 
-#: http.c:429
-msgid "Public key pinning not supported with cURL < 7.44.0"
-msgstr "Chốt khóa công không được hỗ trợ với cURL < 7.44.0"
+#: http.c:380
+msgid "Public key pinning not supported with cURL < 7.39.0"
+msgstr "Chốt khóa công không được hỗ trợ với cURL < 7.39.0"
 
-#: http.c:910
+#: http.c:812
 msgid "CURLSSLOPT_NO_REVOKE not supported with cURL < 7.44.0"
 msgstr "CURLSSLOPT_NO_REVOKE không được hỗ trợ với cURL < 7.44.0"
 
-#: http.c:989
-msgid "Protocol restrictions not supported with cURL < 7.19.4"
-msgstr "Các hạn chế giao thức không được hỗ trợ với cURL < 7.19.4"
-
-#: http.c:1132
+#: http.c:1016
 #, c-format
 msgid "Unsupported SSL backend '%s'. Supported SSL backends:"
 msgstr ""
 "Không hỗ trợ ứng dụng SSL chạy phía sau “%s”. Hỗ trợ ứng dụng SSL chạy phía "
 "sau:"
 
-#: http.c:1139
+#: http.c:1023
 #, c-format
 msgid "Could not set SSL backend to '%s': cURL was built without SSL backends"
 msgstr ""
 "Không thể đặt ứng dụng chạy SSL phía sau “%s”: cURL được biên dịch không có "
 "sự hỗ trợ ứng dụng chạy phía sau SSL"
 
-#: http.c:1143
+#: http.c:1027
 #, c-format
 msgid "Could not set SSL backend to '%s': already set"
 msgstr "Không thể đặt ứng dụng chạy sau SSL cho “%s”: đã đặt rồi"
 
-#: http.c:2034
+#: http.c:1876
 #, c-format
 msgid ""
 "unable to update url base from redirection:\n"
@@ -24408,47 +24740,52 @@ msgstr ""
 msgid "invalid quoting in push-option value: '%s'"
 msgstr "sai trích dẫn trong giá trị push-option :“%s”"
 
-#: remote-curl.c:307
+#: remote-curl.c:304
 #, c-format
 msgid "%sinfo/refs not valid: is this a git repository?"
 msgstr "%sinfo/refs không hợp lệ: đây có phải là một kho git?"
 
-#: remote-curl.c:408
+#: remote-curl.c:405
 msgid "invalid server response; expected service, got flush packet"
 msgstr ""
 "đáp ứng từ máy phục vụ không hợp lệ; cần dịch vụ, nhưng lại nhận được gói "
 "flush"
 
-#: remote-curl.c:439
+#: remote-curl.c:436
 #, c-format
 msgid "invalid server response; got '%s'"
 msgstr "trả về của máy phục vụ không hợp lệ; nhận được %s"
 
-#: remote-curl.c:499
+#: remote-curl.c:496
 #, c-format
 msgid "repository '%s' not found"
 msgstr "không tìm thấy kho “%s”"
 
-#: remote-curl.c:503
+#: remote-curl.c:500
 #, c-format
 msgid "Authentication failed for '%s'"
 msgstr "Xác thực gặp lỗi cho “%s”"
 
-#: remote-curl.c:507
+#: remote-curl.c:504
+#, c-format
+msgid "unable to access '%s' with http.pinnedPubkey configuration: %s"
+msgstr "không thể truy cập “%s” với cấu hình http.pinnedPubkey: %s"
+
+#: remote-curl.c:508
 #, c-format
 msgid "unable to access '%s': %s"
 msgstr "không thể truy cập “%s”: %s"
 
-#: remote-curl.c:513
+#: remote-curl.c:514
 #, c-format
 msgid "redirecting to %s"
 msgstr "chuyển hướng đến %s"
 
-#: remote-curl.c:644
+#: remote-curl.c:645
 msgid "shouldn't have EOF when not gentle on EOF"
 msgstr "không nên có EOF khi không gentle trên EOF"
 
-#: remote-curl.c:656
+#: remote-curl.c:657
 msgid "remote server sent unexpected response end packet"
 msgstr "máy phục vụ gửi gói kết thúc không cần"
 
@@ -24456,83 +24793,83 @@ msgstr "máy phục vụ gửi gói kết thúc không cần"
 msgid "unable to rewind rpc post data - try increasing http.postBuffer"
 msgstr "không thể tua lại dữ liệu post rpc - thử tăng http.postBuffer"
 
-#: remote-curl.c:756
+#: remote-curl.c:755
 #, c-format
 msgid "remote-curl: bad line length character: %.4s"
 msgstr "remote-curl: ký tự chiều dài dòng bị sai: %.4s"
 
-#: remote-curl.c:758
+#: remote-curl.c:757
 msgid "remote-curl: unexpected response end packet"
 msgstr "remote-curl: gặp đáp ứng là gói kết thúc bất ngờ"
 
-#: remote-curl.c:834
+#: remote-curl.c:833
 #, c-format
 msgid "RPC failed; %s"
 msgstr "RPC gặp lỗi; %s"
 
-#: remote-curl.c:874
+#: remote-curl.c:873
 msgid "cannot handle pushes this big"
 msgstr "không thể xử lý đẩy cái lớn này"
 
-#: remote-curl.c:989
+#: remote-curl.c:986
 #, c-format
 msgid "cannot deflate request; zlib deflate error %d"
 msgstr "không thể giải nén yêu cầu; có lỗi khi giải nén của zlib %d"
 
-#: remote-curl.c:993
+#: remote-curl.c:990
 #, c-format
 msgid "cannot deflate request; zlib end error %d"
 msgstr "không thể giải nén yêu cầu; có lỗi ở cuối %d"
 
-#: remote-curl.c:1043
+#: remote-curl.c:1040
 #, c-format
 msgid "%d bytes of length header were received"
 msgstr "đã nhận về phần đầu có chiều dài %d byte"
 
-#: remote-curl.c:1045
+#: remote-curl.c:1042
 #, c-format
 msgid "%d bytes of body are still expected"
 msgstr "phần thân vẫn còn cần %d byte"
 
-#: remote-curl.c:1134
+#: remote-curl.c:1131
 msgid "dumb http transport does not support shallow capabilities"
 msgstr "đổ vận chuyển http không hỗ trợ khả năng nông"
 
-#: remote-curl.c:1149
+#: remote-curl.c:1146
 msgid "fetch failed."
 msgstr "lấy về gặp lỗi."
 
-#: remote-curl.c:1195
+#: remote-curl.c:1192
 msgid "cannot fetch by sha1 over smart http"
 msgstr "không thể lấy về bằng sha1 thông qua smart http"
 
-#: remote-curl.c:1239 remote-curl.c:1245
+#: remote-curl.c:1236 remote-curl.c:1242
 #, c-format
 msgid "protocol error: expected sha/ref, got '%s'"
 msgstr "lỗi giao thức: cần sha/ref, nhưng lại nhận được “%s”"
 
-#: remote-curl.c:1257 remote-curl.c:1375
+#: remote-curl.c:1254 remote-curl.c:1372
 #, c-format
 msgid "http transport does not support %s"
 msgstr "vận chuyển http không hỗ trợ %s"
 
-#: remote-curl.c:1293
+#: remote-curl.c:1290
 msgid "git-http-push failed"
 msgstr "git-http-push gặp lỗi"
 
-#: remote-curl.c:1481
+#: remote-curl.c:1478
 msgid "remote-curl: usage: git remote-curl <remote> [<url>]"
 msgstr "remote-curl: usage: git remote-curl <máy chủ> [<url>]"
 
-#: remote-curl.c:1513
+#: remote-curl.c:1510
 msgid "remote-curl: error reading command stream from git"
 msgstr "remote-curl: gặp lỗi khi đọc luồng dữ liệu lệnh từ git"
 
-#: remote-curl.c:1520
+#: remote-curl.c:1517
 msgid "remote-curl: fetch attempted without a local repo"
 msgstr "remote-curl: đã cố gắng fetch mà không có kho nội bộ"
 
-#: remote-curl.c:1561
+#: remote-curl.c:1558
 #, c-format
 msgid "remote-curl: unknown command '%s' from git"
 msgstr "remote-curl: không hiểu lệnh “%s” từ git"
@@ -24553,46 +24890,46 @@ msgstr "các_tham_số"
 msgid "object filtering"
 msgstr "lọc đối tượng"
 
-#: parse-options.h:184
+#: parse-options.h:183
 msgid "expiry-date"
 msgstr "ngày hết hạn"
 
-#: parse-options.h:198
+#: parse-options.h:197
 msgid "no-op (backward compatibility)"
 msgstr "no-op (tương thích ngược)"
 
-#: parse-options.h:310
+#: parse-options.h:309
 msgid "be more verbose"
 msgstr "chi tiết hơn nữa"
 
-#: parse-options.h:312
+#: parse-options.h:311
 msgid "be more quiet"
 msgstr "im lặng hơn nữa"
 
-#: parse-options.h:318
+#: parse-options.h:317
 msgid "use <n> digits to display object names"
 msgstr "sử dụng <n> chữ số để hiển thị tên đối tượng"
 
-#: parse-options.h:337
+#: parse-options.h:336
 msgid "how to strip spaces and #comments from message"
 msgstr "làm thế nào để cắt bỏ khoảng trắng và #ghichú từ mẩu tin nhắn"
 
-#: parse-options.h:338
+#: parse-options.h:337
 msgid "read pathspec from file"
 msgstr "đọc đặc tả đường dẫn từ tập tin"
 
-#: parse-options.h:339
+#: parse-options.h:338
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""
 "với --pathspec-from-file, các phần tử đặc tả đường dẫn bị ngăn cách bởi ký "
 "tự NULL"
 
-#: ref-filter.h:99
+#: ref-filter.h:101
 msgid "key"
 msgstr "khóa"
 
-#: ref-filter.h:99
+#: ref-filter.h:101
 msgid "field name to sort on"
 msgstr "tên trường cần sắp xếp"
 
@@ -25292,41 +25629,6 @@ msgstr "Hướng dẫn cách dùng Git"
 msgid "An overview of recommended workflows with Git"
 msgstr "Tổng quan về luồng công việc khuyến nghị nên dùng với Git"
 
-#: git-bisect.sh:68
-msgid "bisect run failed: no command provided."
-msgstr "bisect chạy gặp lỗi: không đưa ra lệnh."
-
-#: git-bisect.sh:73
-#, sh-format
-msgid "running $command"
-msgstr "đang chạy lệnh $command"
-
-#: git-bisect.sh:80
-#, sh-format
-msgid ""
-"bisect run failed:\n"
-"exit code $res from '$command' is < 0 or >= 128"
-msgstr ""
-"chạy bisect gặp lỗi:\n"
-"mã trả về $res từ lệnh “$command” là < 0 hoặc >= 128"
-
-#: git-bisect.sh:105
-msgid "bisect run cannot continue any more"
-msgstr "bisect không thể tiếp tục thêm được nữa"
-
-#: git-bisect.sh:111
-#, sh-format
-msgid ""
-"bisect run failed:\n"
-"'bisect-state $state' exited with error code $res"
-msgstr ""
-"chạy bisect gặp lỗi:\n"
-"”bisect-state $state” đã thoát ra với mã lỗi $res"
-
-#: git-bisect.sh:118
-msgid "bisect run success"
-msgstr "bisect chạy thành công"
-
 #: git-merge-octopus.sh:46
 msgid ""
 "Error: Your local changes to the following files would be overwritten by "
@@ -25367,58 +25669,19 @@ msgstr "Đang thử hòa trộn đơn giản với $pretty_name"
 msgid "Simple merge did not work, trying automatic merge."
 msgstr "Hòa trộn đơn giản không làm việc, thử hòa trộn tự động."
 
-#: git-submodule.sh:179
-msgid "Relative path can only be used from the toplevel of the working tree"
-msgstr ""
-"Đường dẫn tương đối chỉ có thể dùng từ thư mục ở mức cao nhất của cây làm "
-"việc"
-
-#: git-submodule.sh:189
-#, sh-format
-msgid "repo URL: '$repo' must be absolute or begin with ./|../"
-msgstr ""
-"repo URL: “$repo” phải là đường dẫn tuyệt đối hoặc là bắt đầu bằng ./|../"
-
-#: git-submodule.sh:208
-#, sh-format
-msgid "'$sm_path' already exists in the index"
-msgstr "”$sm_path” thực sự đã tồn tại ở bảng mục lục rồi"
-
-#: git-submodule.sh:211
-#, sh-format
-msgid "'$sm_path' already exists in the index and is not a submodule"
-msgstr ""
-"”$sm_path” thực sự đã tồn tại ở bảng mục lục rồi và không phải là một mô-đun-"
-"con"
-
-#: git-submodule.sh:218
-#, sh-format
-msgid "'$sm_path' does not have a commit checked out"
-msgstr "“$sm_path” không có lần chuyển giao nào được lấy ra"
-
-#: git-submodule.sh:248
-#, sh-format
-msgid "Failed to add submodule '$sm_path'"
-msgstr "Gặp lỗi khi thêm mô-đun-con “$sm_path”"
-
-#: git-submodule.sh:257
-#, sh-format
-msgid "Failed to register submodule '$sm_path'"
-msgstr "Gặp lỗi khi đăng ký với hệ thống mô-đun-con “$sm_path”"
-
-#: git-submodule.sh:532
+#: git-submodule.sh:401
 #, sh-format
 msgid "Unable to find current revision in submodule path '$displaypath'"
 msgstr ""
 "Không tìm thấy điểm xét duyệt hiện hành trong đường dẫn mô-đun-con "
 "“$displaypath”"
 
-#: git-submodule.sh:542
+#: git-submodule.sh:411
 #, sh-format
 msgid "Unable to fetch in submodule path '$sm_path'"
 msgstr "Không thể lấy về trong đường dẫn mô-đun-con “$sm_path”"
 
-#: git-submodule.sh:547
+#: git-submodule.sh:416
 #, sh-format
 msgid ""
 "Unable to find current ${remote_name}/${branch} revision in submodule path "
@@ -25427,401 +25690,10 @@ msgstr ""
 "Không thể tìm thấy điểm xét duyệt hiện hành ${remote_name}/${branch} trong "
 "đường dẫn mô-đun-con “$sm_path”"
 
-#: git-submodule.sh:565
-#, sh-format
-msgid ""
-"Unable to fetch in submodule path '$displaypath'; trying to directly fetch "
-"$sha1:"
-msgstr ""
-"Không thể lấy về trong đường dẫn mô-đun-con “$displaypath”; thử lấy về trực "
-"tiếp $sha1:"
-
-#: git-submodule.sh:571
-#, sh-format
-msgid ""
-"Fetched in submodule path '$displaypath', but it did not contain $sha1. "
-"Direct fetching of that commit failed."
-msgstr ""
-"Đã lấy về từ đường dẫn mô-đun con “$displaypath”, nhưng nó không chứa $sha1. "
-"Lấy về theo định hướng của lần chuyển giao đó gặp lỗi."
-
-#: git-submodule.sh:578
-#, sh-format
-msgid "Unable to checkout '$sha1' in submodule path '$displaypath'"
-msgstr "Không thể lấy ra “$sha1” trong đường dẫn mô-đun-con “$displaypath”"
-
-#: git-submodule.sh:579
-#, sh-format
-msgid "Submodule path '$displaypath': checked out '$sha1'"
-msgstr "Đường dẫn mô-đun-con “$displaypath”: đã checkout “$sha1”"
-
-#: git-submodule.sh:583
-#, sh-format
-msgid "Unable to rebase '$sha1' in submodule path '$displaypath'"
-msgstr "Không thể cải tổ “$sha1” trong đường dẫn mô-đun-con “$displaypath”"
-
-#: git-submodule.sh:584
-#, sh-format
-msgid "Submodule path '$displaypath': rebased into '$sha1'"
-msgstr "Đường dẫn mô-đun-con “$displaypath”: được rebase vào trong “$sha1”"
-
-#: git-submodule.sh:589
-#, sh-format
-msgid "Unable to merge '$sha1' in submodule path '$displaypath'"
-msgstr ""
-"Không thể hòa trộn (merge) “$sha1” trong đường dẫn mô-đun-con “$displaypath”"
-
-#: git-submodule.sh:590
-#, sh-format
-msgid "Submodule path '$displaypath': merged in '$sha1'"
-msgstr "Đường dẫn mô-đun-con “$displaypath”: được hòa trộn vào “$sha1”"
-
-#: git-submodule.sh:595
-#, sh-format
-msgid "Execution of '$command $sha1' failed in submodule path '$displaypath'"
-msgstr ""
-"Thực hiện không thành công lệnh “$command $sha1” trong đường dẫn mô-đun-con "
-"“$displaypath”"
-
-#: git-submodule.sh:596
-#, sh-format
-msgid "Submodule path '$displaypath': '$command $sha1'"
-msgstr "Đường dẫn mô-đun-con “$displaypath”: “$command $sha1”"
-
-#: git-submodule.sh:627
+#: git-submodule.sh:464
 #, sh-format
 msgid "Failed to recurse into submodule path '$displaypath'"
 msgstr "Gặp lỗi khi đệ quy vào trong đường dẫn mô-đun-con “$displaypath”"
-
-#: git-rebase--preserve-merges.sh:109
-msgid "Applied autostash."
-msgstr "Đã áp dụng autostash."
-
-#: git-rebase--preserve-merges.sh:112
-#, sh-format
-msgid "Cannot store $stash_sha1"
-msgstr "Không thể lưu $stash_sha1"
-
-#: git-rebase--preserve-merges.sh:113
-msgid ""
-"Applying autostash resulted in conflicts.\n"
-"Your changes are safe in the stash.\n"
-"You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
-msgstr ""
-"Áp dụng autostash có hiệu quả trong các xung đột.\n"
-"Các thay đổi của bạn an toàn trong stash (tạm cất đi).\n"
-"Bạn có thể chạy lệnh \"git stash pop\" hay \"git stash drop\" bất kỳ lúc "
-"nào.\n"
-
-#: git-rebase--preserve-merges.sh:191
-#, sh-format
-msgid "Rebasing ($new_count/$total)"
-msgstr "Đang rebase ($new_count/$total)"
-
-#: git-rebase--preserve-merges.sh:197
-msgid ""
-"\n"
-"Commands:\n"
-"p, pick <commit> = use commit\n"
-"r, reword <commit> = use commit, but edit the commit message\n"
-"e, edit <commit> = use commit, but stop for amending\n"
-"s, squash <commit> = use commit, but meld into previous commit\n"
-"f, fixup <commit> = like \"squash\", but discard this commit's log message\n"
-"x, exec <commit> = run command (the rest of the line) using shell\n"
-"d, drop <commit> = remove commit\n"
-"l, label <label> = label current HEAD with a name\n"
-"t, reset <label> = reset HEAD to a label\n"
-"m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
-".       create a merge commit using the original merge commit's\n"
-".       message (or the oneline, if no original merge commit was\n"
-".       specified). Use -c <commit> to reword the commit message.\n"
-"\n"
-"These lines can be re-ordered; they are executed from top to bottom.\n"
-msgstr ""
-"\n"
-"Các lệnh:\n"
-"p, pick <commit> = dùng lần chuyển giao\n"
-"r, reword <commit> = dùng lần chuyển giao, nhưng sửa lại phần chú thích\n"
-"e, edit <commit> = dùng lần chuyển giao, nhưng dừng lại để tu bổ (amend)\n"
-"s, squash <commit> = dùng lần chuyển giao, nhưng meld vào lần chuyển giao kế "
-"trước\n"
-"f, fixup <commit> = giống như \"squash\", nhưng loại bỏ chú thích của lần "
-"chuyển giao này\n"
-"x, exec <commit> = chạy lệnh (phần còn lại của dòng) dùng hệ vỏ\n"
-"d, drop <commit> = xóa lần chuyển giao\n"
-"l, label <label> = đánh nhãn HEAD hiện tại bằng một tên\n"
-"t, reset <label> = đặt lại HEAD thành một nhãn\n"
-"m, merge [-C <commit> | -c <commit>] <nhãn> [# <một_dòng>]\n"
-".       tạo một lần chuyển giao hòa trộn sử dụng chú thích của lần chuyển\n"
-".       giao hòa trộn gốc (hoặc một_dòng, nếu không chỉ định lần chuyển giao "
-"hòa\n"
-".       trộn gốc). Dùng -c <commit> để reword chú thích của lần chuyển "
-"giao.\n"
-"\n"
-"Những dòng này có thể đảo ngược thứ tự; chúng chạy từ trên đỉnh xuống dưới "
-"đáy.\n"
-
-#: git-rebase--preserve-merges.sh:260
-#, sh-format
-msgid ""
-"You can amend the commit now, with\n"
-"\n"
-"\tgit commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"Once you are satisfied with your changes, run\n"
-"\n"
-"\tgit rebase --continue"
-msgstr ""
-"Bạn có thể tu bổ lần chuyển giao ngay bây giờ bằng:\n"
-"\n"
-"\tgit commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"Một khi đã hài lòng với những thay đổi của mình, thì chạy:\n"
-"\n"
-"\tgit rebase --continue"
-
-#: git-rebase--preserve-merges.sh:285
-#, sh-format
-msgid "$sha1: not a commit that can be picked"
-msgstr "$sha1: không phải là lần chuyển giao mà có thể lấy ra được"
-
-#: git-rebase--preserve-merges.sh:324
-#, sh-format
-msgid "Invalid commit name: $sha1"
-msgstr "Tên lần chuyển giao không hợp lệ: $sha1"
-
-#: git-rebase--preserve-merges.sh:354
-msgid "Cannot write current commit's replacement sha1"
-msgstr "Không thể ghi lại sha1 thay thế của lần chuyển giao"
-
-#: git-rebase--preserve-merges.sh:405
-#, sh-format
-msgid "Fast-forward to $sha1"
-msgstr "Chuyển-tiếp-nhanh đến $sha1"
-
-#: git-rebase--preserve-merges.sh:407
-#, sh-format
-msgid "Cannot fast-forward to $sha1"
-msgstr "Không thể chuyển-tiếp-nhanh đến $sha1"
-
-#: git-rebase--preserve-merges.sh:416
-#, sh-format
-msgid "Cannot move HEAD to $first_parent"
-msgstr "Không thể di chuyển HEAD đến $first_parent"
-
-#: git-rebase--preserve-merges.sh:421
-#, sh-format
-msgid "Refusing to squash a merge: $sha1"
-msgstr "Từ chối squash lần hòa trộn: $sha1"
-
-#: git-rebase--preserve-merges.sh:439
-#, sh-format
-msgid "Error redoing merge $sha1"
-msgstr "Gặp lỗi khi hoàn lại bước hòa trộn $sha1"
-
-#: git-rebase--preserve-merges.sh:448
-#, sh-format
-msgid "Could not pick $sha1"
-msgstr "Không thể lấy ra $sha1"
-
-#: git-rebase--preserve-merges.sh:457
-#, sh-format
-msgid "This is the commit message #${n}:"
-msgstr "Đây là chú thích cho lần chuyển giao thứ #${n}:"
-
-#: git-rebase--preserve-merges.sh:462
-#, sh-format
-msgid "The commit message #${n} will be skipped:"
-msgstr "Chú thích cho lần chuyển giao thứ #${n} sẽ bị bỏ qua:"
-
-#: git-rebase--preserve-merges.sh:473
-#, sh-format
-msgid "This is a combination of $count commit."
-msgid_plural "This is a combination of $count commits."
-msgstr[0] "Đây là tổ hợp của $count lần chuyển giao."
-
-#: git-rebase--preserve-merges.sh:482
-#, sh-format
-msgid "Cannot write $fixup_msg"
-msgstr "Không thể $fixup_msg"
-
-#: git-rebase--preserve-merges.sh:485
-msgid "This is a combination of 2 commits."
-msgstr "Đây là tổ hợp của 2 lần chuyển giao."
-
-#: git-rebase--preserve-merges.sh:526 git-rebase--preserve-merges.sh:569
-#: git-rebase--preserve-merges.sh:572
-#, sh-format
-msgid "Could not apply $sha1... $rest"
-msgstr "Không thể áp dụng $sha1… $rest"
-
-#: git-rebase--preserve-merges.sh:601
-#, sh-format
-msgid ""
-"Could not amend commit after successfully picking $sha1... $rest\n"
-"This is most likely due to an empty commit message, or the pre-commit hook\n"
-"failed. If the pre-commit hook failed, you may need to resolve the issue "
-"before\n"
-"you are able to reword the commit."
-msgstr ""
-"Không thể tu bổ lần chuyển giao sau khi lấy ra $sha1… $rest thành công\n"
-"Việc này có thể là do một ghi chú cho lần chuyển giao là trống rỗng, hoặc "
-"móc pre-commit\n"
-"gặp lỗi. Nếu là móc pre-commit bị lỗi, Bạn có lẽ cần giải quyết trục trặc "
-"này\n"
-"trước khi bạn có thể làm việc lại với lần chuyển giao."
-
-#: git-rebase--preserve-merges.sh:616
-#, sh-format
-msgid "Stopped at $sha1_abbrev... $rest"
-msgstr "Bị dừng tại $sha1_abbrev… $rest"
-
-#: git-rebase--preserve-merges.sh:631
-#, sh-format
-msgid "Cannot '$squash_style' without a previous commit"
-msgstr "Không “$squash_style” thể mà không có lần chuyển giao kế trước"
-
-#: git-rebase--preserve-merges.sh:673
-#, sh-format
-msgid "Executing: $rest"
-msgstr "Đang thực thi: $rest"
-
-#: git-rebase--preserve-merges.sh:681
-#, sh-format
-msgid "Execution failed: $rest"
-msgstr "Thực thi gặp lỗi: $rest"
-
-#: git-rebase--preserve-merges.sh:683
-msgid "and made changes to the index and/or the working tree"
-msgstr "và tạo các thay đổi bảng mục lục và/hay cây làm việc"
-
-#: git-rebase--preserve-merges.sh:685
-msgid ""
-"You can fix the problem, and then run\n"
-"\n"
-"\tgit rebase --continue"
-msgstr ""
-"Bạn có thể sửa các trục trặc, và sau đó chạy lệnh “cải tổ”:\n"
-"\n"
-"\tgit rebase --continue"
-
-#. TRANSLATORS: after these lines is a command to be issued by the user
-#: git-rebase--preserve-merges.sh:698
-#, sh-format
-msgid ""
-"Execution succeeded: $rest\n"
-"but left changes to the index and/or the working tree\n"
-"Commit or stash your changes, and then run\n"
-"\n"
-"\tgit rebase --continue"
-msgstr ""
-"Thực thi thành công: $rest\n"
-"nhưng còn các thay đổi trong mục lục và/hoặc cây làm việc\n"
-"Chuyển giao hay tạm cất các thay đổi này đi, rồi chạy\n"
-"\n"
-"\tgit rebase --continue"
-
-#: git-rebase--preserve-merges.sh:709
-#, sh-format
-msgid "Unknown command: $command $sha1 $rest"
-msgstr "Lệnh chưa biết: $command $sha1 $rest"
-
-#: git-rebase--preserve-merges.sh:710
-msgid "Please fix this using 'git rebase --edit-todo'."
-msgstr "Vui lòng sửa lỗi này bằng cách dùng “git rebase --edit-todo”."
-
-#: git-rebase--preserve-merges.sh:745
-#, sh-format
-msgid "Successfully rebased and updated $head_name."
-msgstr "Cài tổ và cập nhật $head_name một cách thành công."
-
-#: git-rebase--preserve-merges.sh:802
-msgid "Could not remove CHERRY_PICK_HEAD"
-msgstr "Không thể xóa bỏ CHERRY_PICK_HEAD"
-
-#: git-rebase--preserve-merges.sh:807
-#, sh-format
-msgid ""
-"You have staged changes in your working tree.\n"
-"If these changes are meant to be\n"
-"squashed into the previous commit, run:\n"
-"\n"
-"  git commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"If they are meant to go into a new commit, run:\n"
-"\n"
-"  git commit $gpg_sign_opt_quoted\n"
-"\n"
-"In both cases, once you're done, continue with:\n"
-"\n"
-"  git rebase --continue\n"
-msgstr ""
-"Bạn có các thay đổi so với trong bệ phóng trong\n"
-"thư mục làm việc của bạn. Nếu các thay đổi này là muốn\n"
-"squash vào lần chuyển giao kế trước, chạy:\n"
-"\n"
-"  git commit --amend $gpg_sign_opt_quoted\n"
-"\n"
-"Nếu chúng có ý là đi đến lần chuyển giao mới, thì chạy:\n"
-"\n"
-"  git commit $gpg_sign_opt_quoted\n"
-"\n"
-"Trong cả hai trường hợp, một khi bạn làm xong, tiếp tục bằng:\n"
-"\n"
-"  git rebase --continue\n"
-
-#: git-rebase--preserve-merges.sh:824
-msgid "Error trying to find the author identity to amend commit"
-msgstr "Lỗi khi cố tìm định danh của tác giả để tu bổ lần chuyển giao"
-
-#: git-rebase--preserve-merges.sh:829
-msgid ""
-"You have uncommitted changes in your working tree. Please commit them\n"
-"first and then run 'git rebase --continue' again."
-msgstr ""
-"Bạn có các thay đổi chưa chuyển giao trong thư mục làm việc.\n"
-"Vui lòng chuyển giao chúng và sau đó chạy lệnh “git rebase --continue” lần "
-"nữa."
-
-#: git-rebase--preserve-merges.sh:834 git-rebase--preserve-merges.sh:838
-msgid "Could not commit staged changes."
-msgstr "Không thể chuyển giao các thay đổi đã đưa lên bệ phóng."
-
-#: git-rebase--preserve-merges.sh:869 git-rebase--preserve-merges.sh:955
-msgid "Could not execute editor"
-msgstr "Không thể thực thi trình biên soạn"
-
-#: git-rebase--preserve-merges.sh:890
-#, sh-format
-msgid "Could not checkout $switch_to"
-msgstr "Không thể lấy ra $switch_to"
-
-#: git-rebase--preserve-merges.sh:897
-msgid "No HEAD?"
-msgstr "Không HEAD?"
-
-#: git-rebase--preserve-merges.sh:898
-#, sh-format
-msgid "Could not create temporary $state_dir"
-msgstr "Không thể tạo thư mục tạm thời $state_dir"
-
-#: git-rebase--preserve-merges.sh:901
-msgid "Could not mark as interactive"
-msgstr "Không thể đánh dấu là tương tác"
-
-#: git-rebase--preserve-merges.sh:933
-#, sh-format
-msgid "Rebase $shortrevisions onto $shortonto ($todocount command)"
-msgid_plural "Rebase $shortrevisions onto $shortonto ($todocount commands)"
-msgstr[0] "Cải tổ $shortrevisions vào $shortonto (các lệnh $todocount)"
-
-#: git-rebase--preserve-merges.sh:945
-msgid "Note that empty commits are commented out"
-msgstr "Chú ý rằng lần chuyển giao trống rỗng là ghi chú"
-
-#: git-rebase--preserve-merges.sh:987 git-rebase--preserve-merges.sh:992
-msgid "Could not init rewritten commits"
-msgstr "Không thể khởi tạo các lần chuyển giao ghi lại"
 
 #: git-sh-setup.sh:89 git-sh-setup.sh:94
 #, sh-format
@@ -25842,50 +25714,32 @@ msgstr ""
 "lỗi nghiêm trọng: $program_name không thể được dùng ngoaoif thư mục làm việc."
 
 #: git-sh-setup.sh:221
-msgid "Cannot rebase: You have unstaged changes."
-msgstr "Không thể cải tổ: Bạn có các thay đổi chưa được đưa lên bệ phóng."
-
-#: git-sh-setup.sh:224
 msgid "Cannot rewrite branches: You have unstaged changes."
 msgstr ""
 "Không thể ghi lại các nhánh: Bạn có các thay đổi chưa được đưa lên bệ phóng."
 
-#: git-sh-setup.sh:227
-msgid "Cannot pull with rebase: You have unstaged changes."
-msgstr ""
-"Không thể pull với cải tổ: Bạn có các thay đổi chưa được đưa lên bệ phóng."
-
-#: git-sh-setup.sh:230
+#: git-sh-setup.sh:224
 #, sh-format
 msgid "Cannot $action: You have unstaged changes."
 msgstr "Không thể $action: Bạn có các thay đổi chưa được đưa lên bệ phóng."
 
-#: git-sh-setup.sh:243
-msgid "Cannot rebase: Your index contains uncommitted changes."
-msgstr ""
-"Không thể cải tổ: Mục lục của bạn có chứa các thay đổi chưa được chuyển giao."
-
-#: git-sh-setup.sh:246
-msgid "Cannot pull with rebase: Your index contains uncommitted changes."
-msgstr "Không thể pull với cải tổ: Bạn có các thay đổi chưa được chuyển giao."
-
-#: git-sh-setup.sh:249
+#: git-sh-setup.sh:235
 #, sh-format
 msgid "Cannot $action: Your index contains uncommitted changes."
 msgstr ""
 "Không thể $action: Mục lục của bạn có chứa các thay đổi chưa được chuyển "
 "giao."
 
-#: git-sh-setup.sh:253
+#: git-sh-setup.sh:237
 msgid "Additionally, your index contains uncommitted changes."
 msgstr ""
 "Thêm vào đó, bảng mục lục của bạn có chứa các thay đổi chưa được chuyển giao."
 
-#: git-sh-setup.sh:373
+#: git-sh-setup.sh:357
 msgid "You need to run this command from the toplevel of the working tree."
 msgstr "Bạn cần chạy lệnh này từ thư mục ở mức cao nhất của cây làm việc."
 
-#: git-sh-setup.sh:378
+#: git-sh-setup.sh:362
 msgid "Unable to determine absolute path of git directory"
 msgstr "Không thể dò tìm đường dẫn tuyệt đối của thư mục git"
 
@@ -26232,7 +26086,7 @@ msgstr "khoảng bù thời gian nội bộ lớn hơn hoặc bằng 24 giờ\n"
 #: git-send-email.perl:214
 #, perl-format
 msgid "fatal: command '%s' died with exit code %d"
-msgstr "lỗi nghiêm trọng: lệnh '%s' chết với mã thoát %d"
+msgstr "lỗi nghiêm trọng: lệnh “%s” chết với mã thoát %d"
 
 #: git-send-email.perl:227
 msgid "the editor exited uncleanly, aborting everything"
@@ -26520,7 +26374,7 @@ msgstr "Kết quả: "
 msgid "Result: OK\n"
 msgstr "Kết quả: Tốt\n"
 
-#: git-send-email.perl:1709
+#: git-send-email.perl:1708
 #, perl-format
 msgid "can't open file %s"
 msgstr "không thể mở tập tin “%s”"
@@ -26545,30 +26399,30 @@ msgstr "(non-mbox) Thêm cc: %s từ dòng “%s”\n"
 msgid "(body) Adding cc: %s from line '%s'\n"
 msgstr "(body) Thêm cc: %s từ dòng “%s”\n"
 
-#: git-send-email.perl:1965
+#: git-send-email.perl:1973
 #, perl-format
 msgid "(%s) Could not execute '%s'"
 msgstr "(%s) Không thể thực thi “%s”"
 
-#: git-send-email.perl:1972
+#: git-send-email.perl:1980
 #, perl-format
 msgid "(%s) Adding %s: %s from: '%s'\n"
 msgstr "(%s) Đang thêm %s: %s từ: “%s”\n"
 
-#: git-send-email.perl:1976
+#: git-send-email.perl:1984
 #, perl-format
 msgid "(%s) failed to close pipe to '%s'"
 msgstr "(%s) gặp lỗi khi đóng đường ống đến “%s”"
 
-#: git-send-email.perl:2006
+#: git-send-email.perl:2014
 msgid "cannot send message as 7bit"
 msgstr "không thể lấy gửi thư dạng 7 bít"
 
-#: git-send-email.perl:2014
+#: git-send-email.perl:2022
 msgid "invalid transfer encoding"
 msgstr "bảng mã truyền không hợp lệ"
 
-#: git-send-email.perl:2051
+#: git-send-email.perl:2059
 #, perl-format
 msgid ""
 "fatal: %s: rejected by sendemail-validate hook\n"
@@ -26579,12 +26433,12 @@ msgstr ""
 "%s\n"
 "cảnh báo: không có miếng vá nào được gửi đi\n"
 
-#: git-send-email.perl:2061 git-send-email.perl:2114 git-send-email.perl:2124
+#: git-send-email.perl:2069 git-send-email.perl:2122 git-send-email.perl:2132
 #, perl-format
 msgid "unable to open %s: %s\n"
 msgstr "không thể mở %s: %s\n"
 
-#: git-send-email.perl:2064
+#: git-send-email.perl:2072
 #, perl-format
 msgid ""
 "fatal: %s:%d is longer than 998 characters\n"
@@ -26593,16 +26447,528 @@ msgstr ""
 "nghiêm trọng: %s: %d là dài hơn 998 ký tự\n"
 "cảnh báo: không có miếng vá nào được gửi đi\n"
 
-#: git-send-email.perl:2082
+#: git-send-email.perl:2090
 #, perl-format
 msgid "Skipping %s with backup suffix '%s'.\n"
 msgstr "Bỏ qua %s với hậu tố sao lưu dự phòng “%s”.\n"
 
 #. TRANSLATORS: please keep "[y|N]" as is.
-#: git-send-email.perl:2086
+#: git-send-email.perl:2094
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Bạn có thực sự muốn gửi %s? [y|N](có/KHÔNG): "
+
+#~ msgid ""
+#~ "The following pathspecs didn't match any eligible path, but they do match "
+#~ "index\n"
+#~ "entries outside the current sparse checkout:\n"
+#~ msgstr ""
+#~ "Các đặc tả đường dẫn sau đây không khớp với bất kỳ đường dẫn thích hợp "
+#~ "nào,\n"
+#~ "nhưng chúng khớp với các mục mục lục bên ngoài \"sparse checkout\" hiện "
+#~ "tại:\n"
+
+#~ msgid ""
+#~ "Disable or modify the sparsity rules if you intend to update such entries."
+#~ msgstr ""
+#~ "Vô hiệu hóa hoặc sửa đổi các quy tắc sparsity nếu bạn có ý định cập nhật "
+#~ "các mục như vậy."
+
+#~ msgid "could not set GIT_DIR to '%s'"
+#~ msgstr "không thể đặt GIT_DIR thành “%s”"
+
+#~ msgid "unable to unpack %s header with --allow-unknown-type"
+#~ msgstr "không thể giải nén phần đầu gói %s với --allow-unknown-type"
+
+#~ msgid "unable to parse %s header with --allow-unknown-type"
+#~ msgstr "không thể phân tích phần đầu gói %s với --allow-unknown-type"
+
+#~ msgid "open /dev/null failed"
+#~ msgstr "gặp lỗi khi mở “/dev/null”"
+
+#~ msgid ""
+#~ "after resolving the conflicts, mark the corrected paths\n"
+#~ "with 'git add <paths>' or 'git rm <paths>'\n"
+#~ "and commit the result with 'git commit'"
+#~ msgstr ""
+#~ "sau khi giải quyết các xung đột, đánh dấu đường dẫn đã sửa\n"
+#~ "với lệnh “git add </các/đường/dẫn>” hoặc “git rm </các/đường/dẫn>”\n"
+#~ "và chuyển giao kết quả bằng lệnh “git commit”"
+
+#~ msgid "open /dev/null or dup failed"
+#~ msgstr "gặp lỗi khi mở “/dev/null” hay dup"
+
+#~ msgid "attempting to use sparse-index without cone mode"
+#~ msgstr "cố gắng sử dụng chỉ mục thưa thớt mà không có chế độ hình nón"
+
+#~ msgid "unable to update cache-tree, staying full"
+#~ msgstr "không thể cập nhật cây bộ nhớ đệm, chỗ chứa bị đầy"
+
+#~ msgid "Could not open '%s' for writing."
+#~ msgstr "Không thể mở “%s” để ghi."
+
+#~ msgid "could not create archive file '%s'"
+#~ msgstr "không thể tạo tập tin kho (lưu trữ, nén) “%s”"
+
+#~ msgid ""
+#~ "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
+#~ msgstr ""
+#~ "git bisect--helper --bisect-next-check <lúc_sai> <lúc_đúng> [<term>]"
+
+#~ msgid "--bisect-next-check requires 2 or 3 arguments"
+#~ msgstr "--bisect-next-check cần 2 hoặc 3 tham số"
+
+#~ msgid "couldn't create a new file at '%s'"
+#~ msgstr "không thể tạo tập tin mới tại “%s”"
+
+#~ msgid "git commit-tree: failed to open '%s'"
+#~ msgstr "git commit-tree: gặp lỗi khi mở “%s”"
+
+#~ msgid "cannot open packfile '%s'"
+#~ msgstr "không thể mở packfile “%s”"
+
+#~ msgid "cannot store pack file"
+#~ msgstr "không thể lưu tập tin gói"
+
+#~ msgid "cannot store index file"
+#~ msgstr "không thể lưu trữ tập tin ghi mục lục"
+
+#~ msgid "exclude patterns are read from <file>"
+#~ msgstr "mẫu loại trừ được đọc từ <tập tin>"
+
+#~ msgid "Unknown option for merge-recursive: -X%s"
+#~ msgstr "Không hiểu tùy chọn cho merge-recursive: -X%s"
+
+#~ msgid "unusable todo list: '%s'"
+#~ msgstr "danh sách cần làm không dùng được: “%s”"
+
+#~ msgid "git rebase--interactive [<options>]"
+#~ msgstr "git rebase--interactive [<các tùy chọn>]"
+
+#~ msgid "rebase merge commits"
+#~ msgstr "cải tổ các lần chuyển giao hòa trộn"
+
+#~ msgid "keep original branch points of cousins"
+#~ msgstr "giữ các điểm nhánh nguyên bản của các anh em họ"
+
+#~ msgid "move commits that begin with squash!/fixup!"
+#~ msgstr "di chuyển các lần chuyển giao bắt đầu bằng squash!/fixup!"
+
+#~ msgid "sign commits"
+#~ msgstr "ký các lần chuyển giao"
+
+#~ msgid "continue rebase"
+#~ msgstr "tiếp tục cải tổ"
+
+#~ msgid "skip commit"
+#~ msgstr "bỏ qua lần chuyển giao"
+
+#~ msgid "edit the todo list"
+#~ msgstr "sửa danh sách cần làm"
+
+#~ msgid "show the current patch"
+#~ msgstr "hiển thị miếng vá hiện hành"
+
+#~ msgid "shorten commit ids in the todo list"
+#~ msgstr "rút ngắn mã chuyển giao trong danh sách cần làm"
+
+#~ msgid "expand commit ids in the todo list"
+#~ msgstr "khai triển mã chuyển giao trong danh sách cần làm"
+
+#~ msgid "check the todo list"
+#~ msgstr "kiểm tra danh sách cần làm"
+
+#~ msgid "rearrange fixup/squash lines"
+#~ msgstr "sắp xếp lại các dòng fixup/squash"
+
+#~ msgid "insert exec commands in todo list"
+#~ msgstr "chèn các lệnh thực thi trong danh sách cần làm"
+
+#~ msgid "onto"
+#~ msgstr "lên trên"
+
+#~ msgid "restrict-revision"
+#~ msgstr "điểm-xét-duyệt-hạn-chế"
+
+#~ msgid "restrict revision"
+#~ msgstr "điểm xét duyệt hạn chế"
+
+#~ msgid "squash-onto"
+#~ msgstr "squash-lên-trên"
+
+#~ msgid "squash onto"
+#~ msgstr "squash lên trên"
+
+#~ msgid "the upstream commit"
+#~ msgstr "lần chuyển giao thượng nguồn"
+
+#~ msgid "head-name"
+#~ msgstr "tên-đầu"
+
+#~ msgid "head name"
+#~ msgstr "tên đầu"
+
+#~ msgid "rebase strategy"
+#~ msgstr "chiến lược cải tổ"
+
+#~ msgid "strategy-opts"
+#~ msgstr "tùy-chọn-chiến-lược"
+
+#~ msgid "strategy options"
+#~ msgstr "các tùy chọn chiến lược"
+
+#~ msgid "switch-to"
+#~ msgstr "chuyển-đến"
+
+#~ msgid "the branch or commit to checkout"
+#~ msgstr "nhánh hay lần chuyển giao lần lấy ra"
+
+#~ msgid "onto-name"
+#~ msgstr "onto-name"
+
+#~ msgid "onto name"
+#~ msgstr "tên lên trên"
+
+#~ msgid "cmd"
+#~ msgstr "lệnh"
+
+#~ msgid "the command to run"
+#~ msgstr "lệnh muốn chạy"
+
+#~ msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
+#~ msgstr ""
+#~ "--[no-]rebase-cousins không có tác dụng khi không có --rebase-merges"
+
+#~ msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
+#~ msgstr "không thể kết hợp “--preserve-merges” với “--rebase-merges”"
+
+#~ msgid ""
+#~ "error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
+#~ msgstr ""
+#~ "không thể kết hợp “--preserve-merges” với “--reschedule-failed-exec”"
+
+#~ msgid ""
+#~ "git submodule--helper add-clone [<options>...] --url <url> --path <path> "
+#~ "--name <name>"
+#~ msgstr ""
+#~ "git submodule--helper add-clone [<các tùy chọn>…] --url <url> --path </"
+#~ "đường/dẫn> --name <tên>"
+
+#~ msgid "failed to create file %s"
+#~ msgstr "gặp lỗi khi tạo tập tin %s"
+
+#~ msgid "exit immediately after initial ref advertisement"
+#~ msgstr "thoát ngay sau khi khởi tạo quảng cáo tham chiếu"
+
+#~ msgid "socket/pipe already in use: '%s'"
+#~ msgstr "socket/pipe đã đang được sử dụng rồi: “%s”"
+
+#~ msgid "could not start server on: '%s'"
+#~ msgstr "không thể khởi động máy phục vụ lên: “%s”"
+
+#~ msgid "could not spawn daemon in the background"
+#~ msgstr "không thể sinh ra daemon trong nền"
+
+#~ msgid "waitpid failed"
+#~ msgstr "waitpid gặp lỗi"
+
+#~ msgid "daemon not online yet"
+#~ msgstr "\"daemon\" vẫn chưa trực tuyến"
+
+#~ msgid "daemon failed to start"
+#~ msgstr "daemon gặp lỗi khi khởi động"
+
+#~ msgid "waitpid is confused"
+#~ msgstr "waitpid là chưa rõ ràng"
+
+#~ msgid "daemon has not shutdown yet"
+#~ msgstr "\"daemon\" vẫn chưa được tắt đi"
+
+#~ msgid "Protocol restrictions not supported with cURL < 7.19.4"
+#~ msgstr "Các hạn chế giao thức không được hỗ trợ với cURL < 7.19.4"
+
+#~ msgid "running $command"
+#~ msgstr "đang chạy lệnh $command"
+
+#~ msgid "'$sm_path' does not have a commit checked out"
+#~ msgstr "“$sm_path” không có lần chuyển giao nào được lấy ra"
+
+#~ msgid "Submodule path '$displaypath': '$command $sha1'"
+#~ msgstr "Đường dẫn mô-đun-con “$displaypath”: “$command $sha1”"
+
+#~ msgid "Applied autostash."
+#~ msgstr "Đã áp dụng autostash."
+
+#~ msgid "Cannot store $stash_sha1"
+#~ msgstr "Không thể lưu $stash_sha1"
+
+#~ msgid ""
+#~ "Applying autostash resulted in conflicts.\n"
+#~ "Your changes are safe in the stash.\n"
+#~ "You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
+#~ msgstr ""
+#~ "Áp dụng autostash có hiệu quả trong các xung đột.\n"
+#~ "Các thay đổi của bạn an toàn trong stash (tạm cất đi).\n"
+#~ "Bạn có thể chạy lệnh \"git stash pop\" hay \"git stash drop\" bất kỳ lúc "
+#~ "nào.\n"
+
+#~ msgid "Rebasing ($new_count/$total)"
+#~ msgstr "Đang rebase ($new_count/$total)"
+
+#~ msgid ""
+#~ "\n"
+#~ "Commands:\n"
+#~ "p, pick <commit> = use commit\n"
+#~ "r, reword <commit> = use commit, but edit the commit message\n"
+#~ "e, edit <commit> = use commit, but stop for amending\n"
+#~ "s, squash <commit> = use commit, but meld into previous commit\n"
+#~ "f, fixup <commit> = like \"squash\", but discard this commit's log "
+#~ "message\n"
+#~ "x, exec <commit> = run command (the rest of the line) using shell\n"
+#~ "d, drop <commit> = remove commit\n"
+#~ "l, label <label> = label current HEAD with a name\n"
+#~ "t, reset <label> = reset HEAD to a label\n"
+#~ "m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
+#~ ".       create a merge commit using the original merge commit's\n"
+#~ ".       message (or the oneline, if no original merge commit was\n"
+#~ ".       specified). Use -c <commit> to reword the commit message.\n"
+#~ "\n"
+#~ "These lines can be re-ordered; they are executed from top to bottom.\n"
+#~ msgstr ""
+#~ "\n"
+#~ "Các lệnh:\n"
+#~ "p, pick <commit> = dùng lần chuyển giao\n"
+#~ "r, reword <commit> = dùng lần chuyển giao, nhưng sửa lại phần chú thích\n"
+#~ "e, edit <commit> = dùng lần chuyển giao, nhưng dừng lại để tu bổ (amend)\n"
+#~ "s, squash <commit> = dùng lần chuyển giao, nhưng meld vào lần chuyển giao "
+#~ "kế trước\n"
+#~ "f, fixup <commit> = giống như \"squash\", nhưng loại bỏ chú thích của lần "
+#~ "chuyển giao này\n"
+#~ "x, exec <commit> = chạy lệnh (phần còn lại của dòng) dùng hệ vỏ\n"
+#~ "d, drop <commit> = xóa lần chuyển giao\n"
+#~ "l, label <label> = đánh nhãn HEAD hiện tại bằng một tên\n"
+#~ "t, reset <label> = đặt lại HEAD thành một nhãn\n"
+#~ "m, merge [-C <commit> | -c <commit>] <nhãn> [# <một_dòng>]\n"
+#~ ".       tạo một lần chuyển giao hòa trộn sử dụng chú thích của lần "
+#~ "chuyển\n"
+#~ ".       giao hòa trộn gốc (hoặc một_dòng, nếu không chỉ định lần chuyển "
+#~ "giao hòa\n"
+#~ ".       trộn gốc). Dùng -c <commit> để reword chú thích của lần chuyển "
+#~ "giao.\n"
+#~ "\n"
+#~ "Những dòng này có thể đảo ngược thứ tự; chúng chạy từ trên đỉnh xuống "
+#~ "dưới đáy.\n"
+
+#~ msgid ""
+#~ "You can amend the commit now, with\n"
+#~ "\n"
+#~ "\tgit commit --amend $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "Once you are satisfied with your changes, run\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+#~ msgstr ""
+#~ "Bạn có thể tu bổ lần chuyển giao ngay bây giờ bằng:\n"
+#~ "\n"
+#~ "\tgit commit --amend $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "Một khi đã hài lòng với những thay đổi của mình, thì chạy:\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+
+#~ msgid "$sha1: not a commit that can be picked"
+#~ msgstr "$sha1: không phải là lần chuyển giao mà có thể lấy ra được"
+
+#~ msgid "Invalid commit name: $sha1"
+#~ msgstr "Tên lần chuyển giao không hợp lệ: $sha1"
+
+#~ msgid "Cannot write current commit's replacement sha1"
+#~ msgstr "Không thể ghi lại sha1 thay thế của lần chuyển giao"
+
+#~ msgid "Fast-forward to $sha1"
+#~ msgstr "Chuyển-tiếp-nhanh đến $sha1"
+
+#~ msgid "Cannot fast-forward to $sha1"
+#~ msgstr "Không thể chuyển-tiếp-nhanh đến $sha1"
+
+#~ msgid "Cannot move HEAD to $first_parent"
+#~ msgstr "Không thể di chuyển HEAD đến $first_parent"
+
+#~ msgid "Refusing to squash a merge: $sha1"
+#~ msgstr "Từ chối squash lần hòa trộn: $sha1"
+
+#~ msgid "Error redoing merge $sha1"
+#~ msgstr "Gặp lỗi khi hoàn lại bước hòa trộn $sha1"
+
+#~ msgid "Could not pick $sha1"
+#~ msgstr "Không thể lấy ra $sha1"
+
+#~ msgid "This is the commit message #${n}:"
+#~ msgstr "Đây là chú thích cho lần chuyển giao thứ #${n}:"
+
+#~ msgid "The commit message #${n} will be skipped:"
+#~ msgstr "Chú thích cho lần chuyển giao thứ #${n} sẽ bị bỏ qua:"
+
+#~ msgid "This is a combination of $count commit."
+#~ msgid_plural "This is a combination of $count commits."
+#~ msgstr[0] "Đây là tổ hợp của $count lần chuyển giao."
+
+#~ msgid "Cannot write $fixup_msg"
+#~ msgstr "Không thể $fixup_msg"
+
+#~ msgid "This is a combination of 2 commits."
+#~ msgstr "Đây là tổ hợp của 2 lần chuyển giao."
+
+#~ msgid "Could not apply $sha1... $rest"
+#~ msgstr "Không thể áp dụng $sha1… $rest"
+
+#~ msgid ""
+#~ "Could not amend commit after successfully picking $sha1... $rest\n"
+#~ "This is most likely due to an empty commit message, or the pre-commit "
+#~ "hook\n"
+#~ "failed. If the pre-commit hook failed, you may need to resolve the issue "
+#~ "before\n"
+#~ "you are able to reword the commit."
+#~ msgstr ""
+#~ "Không thể tu bổ lần chuyển giao sau khi lấy ra $sha1… $rest thành công\n"
+#~ "Việc này có thể là do một ghi chú cho lần chuyển giao là trống rỗng, hoặc "
+#~ "móc pre-commit\n"
+#~ "gặp lỗi. Nếu là móc pre-commit bị lỗi, Bạn có lẽ cần giải quyết trục trặc "
+#~ "này\n"
+#~ "trước khi bạn có thể làm việc lại với lần chuyển giao."
+
+#~ msgid "Stopped at $sha1_abbrev... $rest"
+#~ msgstr "Bị dừng tại $sha1_abbrev… $rest"
+
+#~ msgid "Cannot '$squash_style' without a previous commit"
+#~ msgstr "Không “$squash_style” thể mà không có lần chuyển giao kế trước"
+
+#~ msgid "Executing: $rest"
+#~ msgstr "Đang thực thi: $rest"
+
+#~ msgid "Execution failed: $rest"
+#~ msgstr "Thực thi gặp lỗi: $rest"
+
+#~ msgid "and made changes to the index and/or the working tree"
+#~ msgstr "và tạo các thay đổi bảng mục lục và/hay cây làm việc"
+
+#~ msgid ""
+#~ "You can fix the problem, and then run\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+#~ msgstr ""
+#~ "Bạn có thể sửa các trục trặc, và sau đó chạy lệnh “cải tổ”:\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+
+#~ msgid ""
+#~ "Execution succeeded: $rest\n"
+#~ "but left changes to the index and/or the working tree\n"
+#~ "Commit or stash your changes, and then run\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+#~ msgstr ""
+#~ "Thực thi thành công: $rest\n"
+#~ "nhưng còn các thay đổi trong mục lục và/hoặc cây làm việc\n"
+#~ "Chuyển giao hay tạm cất các thay đổi này đi, rồi chạy\n"
+#~ "\n"
+#~ "\tgit rebase --continue"
+
+#~ msgid "Unknown command: $command $sha1 $rest"
+#~ msgstr "Lệnh chưa biết: $command $sha1 $rest"
+
+#~ msgid "Please fix this using 'git rebase --edit-todo'."
+#~ msgstr "Vui lòng sửa lỗi này bằng cách dùng “git rebase --edit-todo”."
+
+#~ msgid "Successfully rebased and updated $head_name."
+#~ msgstr "Cài tổ và cập nhật $head_name một cách thành công."
+
+#~ msgid "Could not remove CHERRY_PICK_HEAD"
+#~ msgstr "Không thể xóa bỏ CHERRY_PICK_HEAD"
+
+#~ msgid ""
+#~ "You have staged changes in your working tree.\n"
+#~ "If these changes are meant to be\n"
+#~ "squashed into the previous commit, run:\n"
+#~ "\n"
+#~ "  git commit --amend $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "If they are meant to go into a new commit, run:\n"
+#~ "\n"
+#~ "  git commit $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "In both cases, once you're done, continue with:\n"
+#~ "\n"
+#~ "  git rebase --continue\n"
+#~ msgstr ""
+#~ "Bạn có các thay đổi so với trong bệ phóng trong\n"
+#~ "thư mục làm việc của bạn. Nếu các thay đổi này là muốn\n"
+#~ "squash vào lần chuyển giao kế trước, chạy:\n"
+#~ "\n"
+#~ "  git commit --amend $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "Nếu chúng có ý là đi đến lần chuyển giao mới, thì chạy:\n"
+#~ "\n"
+#~ "  git commit $gpg_sign_opt_quoted\n"
+#~ "\n"
+#~ "Trong cả hai trường hợp, một khi bạn làm xong, tiếp tục bằng:\n"
+#~ "\n"
+#~ "  git rebase --continue\n"
+
+#~ msgid "Error trying to find the author identity to amend commit"
+#~ msgstr "Lỗi khi cố tìm định danh của tác giả để tu bổ lần chuyển giao"
+
+#~ msgid ""
+#~ "You have uncommitted changes in your working tree. Please commit them\n"
+#~ "first and then run 'git rebase --continue' again."
+#~ msgstr ""
+#~ "Bạn có các thay đổi chưa chuyển giao trong thư mục làm việc.\n"
+#~ "Vui lòng chuyển giao chúng và sau đó chạy lệnh “git rebase --continue” "
+#~ "lần nữa."
+
+#~ msgid "Could not commit staged changes."
+#~ msgstr "Không thể chuyển giao các thay đổi đã đưa lên bệ phóng."
+
+#~ msgid "Could not execute editor"
+#~ msgstr "Không thể thực thi trình biên soạn"
+
+#~ msgid "Could not checkout $switch_to"
+#~ msgstr "Không thể lấy ra $switch_to"
+
+#~ msgid "No HEAD?"
+#~ msgstr "Không HEAD?"
+
+#~ msgid "Could not create temporary $state_dir"
+#~ msgstr "Không thể tạo thư mục tạm thời $state_dir"
+
+#~ msgid "Could not mark as interactive"
+#~ msgstr "Không thể đánh dấu là tương tác"
+
+#~ msgid "Rebase $shortrevisions onto $shortonto ($todocount command)"
+#~ msgid_plural "Rebase $shortrevisions onto $shortonto ($todocount commands)"
+#~ msgstr[0] "Cải tổ $shortrevisions vào $shortonto (các lệnh $todocount)"
+
+#~ msgid "Note that empty commits are commented out"
+#~ msgstr "Chú ý rằng lần chuyển giao trống rỗng là ghi chú"
+
+#~ msgid "Could not init rewritten commits"
+#~ msgstr "Không thể khởi tạo các lần chuyển giao ghi lại"
+
+#~ msgid "Cannot rebase: You have unstaged changes."
+#~ msgstr "Không thể cải tổ: Bạn có các thay đổi chưa được đưa lên bệ phóng."
+
+#~ msgid "Cannot pull with rebase: You have unstaged changes."
+#~ msgstr ""
+#~ "Không thể pull với cải tổ: Bạn có các thay đổi chưa được đưa lên bệ phóng."
+
+#~ msgid "Cannot rebase: Your index contains uncommitted changes."
+#~ msgstr ""
+#~ "Không thể cải tổ: Mục lục của bạn có chứa các thay đổi chưa được chuyển "
+#~ "giao."
+
+#~ msgid "Cannot pull with rebase: Your index contains uncommitted changes."
+#~ msgstr ""
+#~ "Không thể pull với cải tổ: Bạn có các thay đổi chưa được chuyển giao."
 
 #~ msgid "unable to write stateless separator packet"
 #~ msgstr "không thể ghi gói phân tách không trạng thái"
@@ -26628,7 +26994,6 @@ msgstr "Bạn có thực sự muốn gửi %s? [y|N](có/KHÔNG): "
 #~ msgid "one"
 #~ msgstr "một"
 
-#, c-format
 #~ msgid "Already up to date!"
 #~ msgstr "Đã cập nhật rồi!"
 
@@ -26648,7 +27013,6 @@ msgstr "Bạn có thực sự muốn gửi %s? [y|N](có/KHÔNG): "
 #~ "việc hỗ trợ rebase.useBuiltin đã bị xóa!\n"
 #~ "Xem mục tin của nó trong “ git help config” để biết chi tiết."
 
-#, perl-format
 #~ msgid "%s: patch contains a line longer than 998 characters"
 #~ msgstr "%s: miếng vá có chứa dòng dài hơn 998 ký tự"
 
@@ -26664,11 +27028,9 @@ msgstr "Bạn có thực sự muốn gửi %s? [y|N](có/KHÔNG): "
 #~ msgid "repository is shallow; skipping commit-graph"
 #~ msgstr "kho nguồn là nông, nên bỏ qua commit-graph"
 
-#, c-format
 #~ msgid "commit-graph improper chunk offset %08x%08x"
 #~ msgstr "bù mảnh đồ-thị-các-lần-chuyển-giao không đúng chỗ %08x%08x"
 
-#, c-format
 #~ msgid "commit-graph chunk id %08x appears multiple times"
 #~ msgstr "mã mảnh đồ-thị-các-lần-chuyển-giao %08x xuất hiện nhiều lần"
 
@@ -26721,11 +27083,9 @@ msgstr "Bạn có thực sự muốn gửi %s? [y|N](có/KHÔNG): "
 #~ msgid "Force progress reporting"
 #~ msgstr "Ép buộc báo cáo diễn biến công việc"
 
-#, c-format
 #~ msgid "Error deleting remote-tracking branch '%s'"
 #~ msgstr "Gặp lỗi khi đang xóa nhánh theo dõi máy chủ “%s”"
 
-#, c-format
 #~ msgid "Error deleting branch '%s'"
 #~ msgstr "Gặp lỗi khi xóa bỏ nhánh “%s”"
 
@@ -26744,14 +27104,12 @@ msgstr "Bạn có thực sự muốn gửi %s? [y|N](có/KHÔNG): "
 #~ msgid "too many params"
 #~ msgstr "quá nhiều đối số"
 
-#, sh-format
 #~ msgid "Bad rev input: $arg"
 #~ msgstr "Đầu vào rev sai: $arg"
 
 #~ msgid "Counting distinct commits in commit graph"
 #~ msgstr "Đang đếm các lần chuyển giao khác nhau trong đồ thị lần chuyển giao"
 
-#, c-format
 #~ msgid "the commit graph format cannot write %d commits"
 #~ msgstr ""
 #~ "định dạng đồ họa các lần chuyển giao không thể ghi %d lần chuyển giao"
@@ -27576,9 +27934,6 @@ msgstr "Bạn có thực sự muốn gửi %s? [y|N](có/KHÔNG): "
 #~ msgid "Failed to recurse into submodule path '$sm_path'"
 #~ msgstr "Gặp lỗi khi đệ quy vào trong đường dẫn mô-đun-con “$sm_path”"
 
-#~ msgid "%%(trailers) does not take arguments"
-#~ msgstr "%%(trailers) không nhận các đối số"
-
 #~ msgid "submodule update strategy not supported for submodule '%s'"
 #~ msgstr ""
 #~ "chiến lược cập nhật mô-đun-con không được hỗ trợ cho mô-đun-con “%s”"
@@ -27910,9 +28265,6 @@ msgstr "Bạn có thực sự muốn gửi %s? [y|N](có/KHÔNG): "
 #~ msgid "Can't cherry-pick into empty head"
 #~ msgstr "Không thể cherry-pick vào một đầu (head) trống rỗng"
 
-#~ msgid "could not open %s for writing"
-#~ msgstr "không thể mở %s để ghi"
-
 #~ msgid "bug: unhandled unmerged status %x"
 #~ msgstr "lỗi: không thể tiếp nhận trạng thái chưa hòa trộn %x"
 
@@ -28079,9 +28431,6 @@ msgstr "Bạn có thực sự muốn gửi %s? [y|N](có/KHÔNG): "
 
 #~ msgid "branch '%s' does not point at a commit"
 #~ msgstr "nhánh “%s” không chỉ đến một lần chuyển giao nào cả"
-
-#~ msgid "print only merged branches"
-#~ msgstr "chỉ hiển thị các nhánh đã hòa trộn"
 
 #~ msgid "--dissociate given, but there is no --reference"
 #~ msgstr "đã đưa ra --dissociate, nhưng ở đây lại không có --reference"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -142,8 +142,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-11-04 08:34+0800\n"
-"PO-Revision-Date: 2021-11-04 11:01+0000\n"
+"POT-Creation-Date: 2021-11-10 08:55+0800\n"
+"PO-Revision-Date: 2021-11-10 12:16+0000\n"
 "Last-Translator: Fangyi Zhou <me@fangyi.io>\n"
 "Language-Team: GitHub <https://github.com/jiangxin/git/>\n"
 "Language: zh_CN\n"
@@ -346,7 +346,7 @@ msgstr "未缓存"
 
 #: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
 #: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:190
+#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:194
 #: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
 #: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
 #: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
@@ -3423,7 +3423,7 @@ msgstr "-G 和 --pickaxe-regex 互斥，使用 --pickaxe-regex 和 -S"
 msgid ""
 "--pickaxe-all and --find-object are mutually exclusive, use --pickaxe-all "
 "with -G and -S"
-msgstr "---pickaxe-all 和 --find-object 互斥，使用 --pickaxe-all 与 -G 和 -S"
+msgstr "--pickaxe-all 和 --find-object 互斥，使用 --pickaxe-all 与 -G 和 -S"
 
 #: diff.c:4730
 msgid "--follow requires exactly one pathspec"
@@ -10362,7 +10362,7 @@ msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr "下列路径根据您的一个 .gitignore 文件而被忽略：\n"
 
 #: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
-#: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:550
+#: builtin/prune-packed.c:14 builtin/pull.c:208 builtin/push.c:550
 #: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr "演习"
@@ -10812,11 +10812,11 @@ msgstr "传递给 git-apply"
 
 #: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
 #: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
-#: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
+#: builtin/pull.c:142 builtin/pull.c:204 builtin/pull.c:221
 #: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
 #: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
 #: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
-#: parse-options.h:316
+#: parse-options.h:315
 msgid "n"
 msgstr "n"
 
@@ -10867,7 +10867,7 @@ msgid "use current timestamp for author date"
 msgstr "用当前时间作为作者日期"
 
 #: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
-#: builtin/merge.c:299 builtin/pull.c:175 builtin/rebase.c:1099
+#: builtin/merge.c:299 builtin/pull.c:179 builtin/rebase.c:1099
 #: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
 msgstr "key-id"
@@ -11364,7 +11364,7 @@ msgstr "显示工作消耗统计"
 #: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
 #: builtin/merge.c:298 builtin/multi-pack-index.c:103
 #: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
-#: builtin/multi-pack-index.c:204 builtin/pull.c:119 builtin/push.c:566
+#: builtin/multi-pack-index.c:204 builtin/pull.c:120 builtin/push.c:566
 #: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "强制显示进度报告"
@@ -12625,7 +12625,7 @@ msgstr "缺少分支或提交参数"
 msgid "perform a 3-way merge with the new branch"
 msgstr "和新的分支执行三方合并"
 
-#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:322
+#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:321
 msgid "style"
 msgstr "风格"
 
@@ -13047,7 +13047,7 @@ msgid "path to git-upload-pack on the remote"
 msgstr "远程 git-upload-pack 路径"
 
 #: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
-#: builtin/pull.c:208
+#: builtin/pull.c:212
 msgid "depth"
 msgstr "深度"
 
@@ -13056,7 +13056,7 @@ msgid "create a shallow clone of that depth"
 msgstr "创建一个指定深度的浅克隆"
 
 #: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
-#: builtin/pull.c:211
+#: builtin/pull.c:215
 msgid "time"
 msgstr "时间"
 
@@ -13065,11 +13065,11 @@ msgid "create a shallow clone since a specific time"
 msgstr "从一个特定时间创建一个浅克隆"
 
 #: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1022
+#: builtin/pull.c:218 builtin/pull.c:243 builtin/rebase.c:1022
 msgid "revision"
 msgstr "版本"
 
-#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:215
+#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:219
 msgid "deepen history of shallow clone, excluding rev"
 msgstr "深化浅克隆的历史，除了特定版本"
 
@@ -13103,21 +13103,21 @@ msgid "set config inside the new repository"
 msgstr "在新仓库中设置配置信息"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:200
+#: builtin/pull.c:234 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "server-specific"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:201
+#: builtin/pull.c:235 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr "传输选项"
 
-#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:234
+#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:238
 #: builtin/push.c:576
 msgid "use IPv4 addresses only"
 msgstr "只使用 IPv4 地址"
 
-#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:237
+#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:241
 #: builtin/push.c:578
 msgid "use IPv6 addresses only"
 msgstr "只使用 IPv6 地址"
@@ -13505,7 +13505,7 @@ msgid "read commit log message from file"
 msgstr "从文件中读取提交说明"
 
 #: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
-#: builtin/pull.c:176 builtin/revert.c:118
+#: builtin/pull.c:180 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "GPG 提交签名"
 
@@ -13905,7 +13905,7 @@ msgstr "条目以 NUL 字符结尾"
 
 #: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
 #: builtin/fast-export.c:1199 builtin/fast-export.c:1202
-#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:336
+#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:335
 msgid "mode"
 msgstr "模式"
 
@@ -13980,7 +13980,7 @@ msgid "override date for commit"
 msgstr "提交时覆盖日期"
 
 #: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
-#: parse-options.h:328 ref-filter.h:92
+#: parse-options.h:327 ref-filter.h:92
 msgid "commit"
 msgstr "提交"
 
@@ -14021,7 +14021,7 @@ msgid "add custom trailer(s)"
 msgstr "添加自定义尾注"
 
 #: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
-#: builtin/pull.c:145 builtin/revert.c:110
+#: builtin/pull.c:146 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "添加 Signed-off-by 尾注"
 
@@ -14982,15 +14982,15 @@ msgstr "git fetch --all [<选项>]"
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel 不能为负数"
 
-#: builtin/fetch.c:145 builtin/pull.c:185
+#: builtin/fetch.c:145 builtin/pull.c:189
 msgid "fetch from all remotes"
 msgstr "从所有的远程抓取"
 
-#: builtin/fetch.c:147 builtin/pull.c:245
+#: builtin/fetch.c:147 builtin/pull.c:249
 msgid "set upstream for git pull/fetch"
 msgstr "为 git pull/fetch 设置上游"
 
-#: builtin/fetch.c:149 builtin/pull.c:188
+#: builtin/fetch.c:149 builtin/pull.c:192
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "追加到 .git/FETCH_HEAD 而不是覆盖它"
 
@@ -14998,7 +14998,7 @@ msgstr "追加到 .git/FETCH_HEAD 而不是覆盖它"
 msgid "use atomic transaction to update references"
 msgstr "使用原子事务更新引用"
 
-#: builtin/fetch.c:153 builtin/pull.c:191
+#: builtin/fetch.c:153 builtin/pull.c:195
 msgid "path to upload pack on remote end"
 msgstr "上传包到远程的路径"
 
@@ -15010,7 +15010,7 @@ msgstr "强制覆盖本地引用"
 msgid "fetch from multiple remotes"
 msgstr "从多个远程抓取"
 
-#: builtin/fetch.c:158 builtin/pull.c:195
+#: builtin/fetch.c:158 builtin/pull.c:199
 msgid "fetch all tags and associated objects"
 msgstr "抓取所有的标签和关联对象"
 
@@ -15026,7 +15026,7 @@ msgstr "子模组获取的并发数"
 msgid "modify the refspec to place all refs within refs/prefetch/"
 msgstr "修改引用规格以将所有引用放入 refs/prefetch/"
 
-#: builtin/fetch.c:166 builtin/pull.c:198
+#: builtin/fetch.c:166 builtin/pull.c:202
 msgid "prune remote-tracking branches no longer on remote"
 msgstr "清除远程已经不存在的分支的跟踪分支"
 
@@ -15035,7 +15035,7 @@ msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr "清除远程不存在的本地标签，并且替换变更标签"
 
 #  译者：可选值，不能翻译
-#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:122
+#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:123
 msgid "on-demand"
 msgstr "on-demand"
 
@@ -15047,7 +15047,7 @@ msgstr "控制子模组的递归抓取"
 msgid "write fetched references to the FETCH_HEAD file"
 msgstr "将获取到的引用写入 FETCH_HEAD 文件"
 
-#: builtin/fetch.c:176 builtin/pull.c:206
+#: builtin/fetch.c:176 builtin/pull.c:210
 msgid "keep downloaded pack"
 msgstr "保持下载包"
 
@@ -15055,16 +15055,16 @@ msgstr "保持下载包"
 msgid "allow updating of HEAD ref"
 msgstr "允许更新 HEAD 引用"
 
-#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:209
-#: builtin/pull.c:218
+#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:213
+#: builtin/pull.c:222
 msgid "deepen history of shallow clone"
 msgstr "深化浅克隆的历史"
 
-#: builtin/fetch.c:183 builtin/pull.c:212
+#: builtin/fetch.c:183 builtin/pull.c:216
 msgid "deepen history of shallow repository based on time"
 msgstr "基于时间来深化浅克隆的历史"
 
-#: builtin/fetch.c:189 builtin/pull.c:221
+#: builtin/fetch.c:189 builtin/pull.c:225
 msgid "convert to a complete repository"
 msgstr "转换为一个完整的仓库"
 
@@ -15078,19 +15078,19 @@ msgid ""
 "files)"
 msgstr "递归获取子模组的缺省值（比配置文件优先级低）"
 
-#: builtin/fetch.c:199 builtin/pull.c:224
+#: builtin/fetch.c:199 builtin/pull.c:228
 msgid "accept refs that update .git/shallow"
 msgstr "接受更新 .git/shallow 的引用"
 
-#: builtin/fetch.c:200 builtin/pull.c:226
+#: builtin/fetch.c:200 builtin/pull.c:230
 msgid "refmap"
 msgstr "引用映射"
 
-#: builtin/fetch.c:201 builtin/pull.c:227
+#: builtin/fetch.c:201 builtin/pull.c:231
 msgid "specify fetch refmap"
 msgstr "指定获取操作的引用映射"
 
-#: builtin/fetch.c:208 builtin/pull.c:240
+#: builtin/fetch.c:208 builtin/pull.c:244
 msgid "report that we have only objects reachable from this object"
 msgstr "报告我们只拥有从该对象开始可达的对象"
 
@@ -15102,7 +15102,7 @@ msgstr "不获取包文件；而是打印协商的祖先提交"
 msgid "run 'maintenance --auto' after fetching"
 msgstr "获取后执行 'maintenance --auto'"
 
-#: builtin/fetch.c:217 builtin/pull.c:243
+#: builtin/fetch.c:217 builtin/pull.c:247
 msgid "check for forced-updates on all updated branches"
 msgstr "在所有更新分支上检查强制更新"
 
@@ -17745,31 +17745,31 @@ msgstr "可用的策略有："
 msgid "Available custom strategies are:"
 msgstr "可用的自定义策略有："
 
-#: builtin/merge.c:257 builtin/pull.c:133
+#: builtin/merge.c:257 builtin/pull.c:134
 msgid "do not show a diffstat at the end of the merge"
 msgstr "在合并的最后不显示差异统计"
 
-#: builtin/merge.c:260 builtin/pull.c:136
+#: builtin/merge.c:260 builtin/pull.c:137
 msgid "show a diffstat at the end of the merge"
 msgstr "在合并的最后显示差异统计"
 
-#: builtin/merge.c:261 builtin/pull.c:139
+#: builtin/merge.c:261 builtin/pull.c:140
 msgid "(synonym to --stat)"
 msgstr "（和 --stat 同义）"
 
-#: builtin/merge.c:263 builtin/pull.c:142
+#: builtin/merge.c:263 builtin/pull.c:143
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr "在合并提交信息中添加（最多 <n> 条）精简提交记录"
 
-#: builtin/merge.c:266 builtin/pull.c:148
+#: builtin/merge.c:266 builtin/pull.c:149
 msgid "create a single commit instead of doing a merge"
 msgstr "创建一个单独的提交而不是做一次合并"
 
-#: builtin/merge.c:268 builtin/pull.c:151
+#: builtin/merge.c:268 builtin/pull.c:152
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "如果合并成功，执行一次提交（默认）"
 
-#: builtin/merge.c:270 builtin/pull.c:154
+#: builtin/merge.c:270 builtin/pull.c:155
 msgid "edit message before committing"
 msgstr "在提交前编辑提交说明"
 
@@ -17777,28 +17777,28 @@ msgstr "在提交前编辑提交说明"
 msgid "allow fast-forward (default)"
 msgstr "允许快进（默认）"
 
-#: builtin/merge.c:274 builtin/pull.c:161
+#: builtin/merge.c:274 builtin/pull.c:162
 msgid "abort if fast-forward is not possible"
 msgstr "如果不能快进就放弃合并"
 
-#: builtin/merge.c:278 builtin/pull.c:164
+#: builtin/merge.c:278 builtin/pull.c:168
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "验证指定的提交是否包含一个有效的 GPG 签名"
 
-#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:168
+#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:172
 #: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr "策略"
 
-#: builtin/merge.c:280 builtin/pull.c:169
+#: builtin/merge.c:280 builtin/pull.c:173
 msgid "merge strategy to use"
 msgstr "要使用的合并策略"
 
-#: builtin/merge.c:281 builtin/pull.c:172
+#: builtin/merge.c:281 builtin/pull.c:176
 msgid "option=value"
 msgstr "option=value"
 
-#: builtin/merge.c:282 builtin/pull.c:173
+#: builtin/merge.c:282 builtin/pull.c:177
 msgid "option for selected merge strategy"
 msgstr "所选的合并策略的选项"
 
@@ -17819,7 +17819,7 @@ msgstr "--abort，但是保留索引和工作区"
 msgid "continue the current in-progress merge"
 msgstr "继续当前正在进行的合并"
 
-#: builtin/merge.c:297 builtin/pull.c:180
+#: builtin/merge.c:297 builtin/pull.c:184
 msgid "allow merging unrelated histories"
 msgstr "允许合并不相关的历史"
 
@@ -19199,61 +19199,65 @@ msgstr "%s 的值无效：%s"
 msgid "git pull [<options>] [<repository> [<refspec>...]]"
 msgstr "git pull [<选项>] [<仓库> [<引用规格>...]]"
 
-#: builtin/pull.c:123
+#: builtin/pull.c:124
 msgid "control for recursive fetching of submodules"
 msgstr "控制子模组的递归获取"
 
-#: builtin/pull.c:127
+#: builtin/pull.c:128
 msgid "Options related to merging"
 msgstr "和合并相关的选项"
 
-#: builtin/pull.c:130
+#: builtin/pull.c:131
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "使用变基操作取代合并操作以合入修改"
 
-#: builtin/pull.c:158 builtin/revert.c:126
+#: builtin/pull.c:159 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "允许快进式"
 
-#: builtin/pull.c:167 parse-options.h:339
+#: builtin/pull.c:165
+msgid "control use of pre-merge-commit and commit-msg hooks"
+msgstr "控制 pre-merge-commit 和 commit-msg 钩子的使用"
+
+#: builtin/pull.c:171 parse-options.h:338
 msgid "automatically stash/stash pop before and after"
 msgstr "在操作前后执行自动贮藏和弹出贮藏"
 
-#: builtin/pull.c:183
+#: builtin/pull.c:187
 msgid "Options related to fetching"
 msgstr "和获取相关的参数"
 
-#: builtin/pull.c:193
+#: builtin/pull.c:197
 msgid "force overwrite of local branch"
 msgstr "强制覆盖本地分支"
 
-#: builtin/pull.c:201
+#: builtin/pull.c:205
 msgid "number of submodules pulled in parallel"
 msgstr "并发拉取的子模组的数量"
 
-#: builtin/pull.c:317
+#: builtin/pull.c:321
 #, c-format
 msgid "Invalid value for pull.ff: %s"
 msgstr "pull.ff 的取值无效：%s"
 
-#: builtin/pull.c:445
+#: builtin/pull.c:449
 msgid ""
 "There is no candidate for rebasing against among the refs that you just "
 "fetched."
 msgstr "在您刚刚获取到的引用中没有变基操作的候选。"
 
-#: builtin/pull.c:447
+#: builtin/pull.c:451
 msgid ""
 "There are no candidates for merging among the refs that you just fetched."
 msgstr "在您刚刚获取到的引用中没有合并操作的候选。"
 
-#: builtin/pull.c:448
+#: builtin/pull.c:452
 msgid ""
 "Generally this means that you provided a wildcard refspec which had no\n"
 "matches on the remote end."
 msgstr "通常这意味着您提供了一个通配符引用规格但未能和远端匹配。"
 
-#: builtin/pull.c:451
+#: builtin/pull.c:455
 #, c-format
 msgid ""
 "You asked to pull from the remote '%s', but did not specify\n"
@@ -19263,41 +19267,41 @@ msgstr ""
 "您要求从远程 '%s' 拉取，但是未指定一个分支。因为这不是当前\n"
 "分支默认的远程仓库，您必须在命令行中指定一个分支名。"
 
-#: builtin/pull.c:456 builtin/rebase.c:951
+#: builtin/pull.c:460 builtin/rebase.c:951
 msgid "You are not currently on a branch."
 msgstr "您当前不在一个分支上。"
 
-#: builtin/pull.c:458 builtin/pull.c:473
+#: builtin/pull.c:462 builtin/pull.c:477
 msgid "Please specify which branch you want to rebase against."
 msgstr "请指定您要变基到哪一个分支。"
 
-#: builtin/pull.c:460 builtin/pull.c:475
+#: builtin/pull.c:464 builtin/pull.c:479
 msgid "Please specify which branch you want to merge with."
 msgstr "请指定您要合并哪一个分支。"
 
-#: builtin/pull.c:461 builtin/pull.c:476
+#: builtin/pull.c:465 builtin/pull.c:480
 msgid "See git-pull(1) for details."
 msgstr "详见 git-pull(1)。"
 
-#: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
+#: builtin/pull.c:467 builtin/pull.c:473 builtin/pull.c:482
 #: builtin/rebase.c:957
 msgid "<remote>"
 msgstr "<远程>"
 
-#: builtin/pull.c:463 builtin/pull.c:478 builtin/pull.c:483
+#: builtin/pull.c:467 builtin/pull.c:482 builtin/pull.c:487
 msgid "<branch>"
 msgstr "<分支>"
 
-#: builtin/pull.c:471 builtin/rebase.c:949
+#: builtin/pull.c:475 builtin/rebase.c:949
 msgid "There is no tracking information for the current branch."
 msgstr "当前分支没有跟踪信息。"
 
-#: builtin/pull.c:480
+#: builtin/pull.c:484
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:"
 msgstr "如果您想要为此分支创建跟踪信息，您可以执行："
 
-#: builtin/pull.c:485
+#: builtin/pull.c:489
 #, c-format
 msgid ""
 "Your configuration specifies to merge with the ref '%s'\n"
@@ -19306,16 +19310,16 @@ msgstr ""
 "您的配置中指定要合并远程的引用 '%s'，\n"
 "但是没有获取到这个引用。"
 
-#: builtin/pull.c:596
+#: builtin/pull.c:600
 #, c-format
 msgid "unable to access commit %s"
 msgstr "无法访问提交 %s"
 
-#: builtin/pull.c:902
+#: builtin/pull.c:908
 msgid "ignoring --verify-signatures for rebase"
 msgstr "为变基操作忽略 --verify-signatures"
 
-#: builtin/pull.c:936
+#: builtin/pull.c:942
 msgid ""
 "You have divergent branches and need to specify how to reconcile them.\n"
 "You can do so by running one of the following commands sometime before\n"
@@ -19342,19 +19346,19 @@ msgstr ""
 "缺省的配置项。您也可以在每次执行 pull 命令时添加 --rebase、--no-rebase，\n"
 "或者 --ff-only 参数覆盖缺省设置。\n"
 
-#: builtin/pull.c:1010
+#: builtin/pull.c:1016
 msgid "Updating an unborn branch with changes added to the index."
 msgstr "更新尚未诞生的分支，变更添加至索引。"
 
-#: builtin/pull.c:1014
+#: builtin/pull.c:1020
 msgid "pull with rebase"
 msgstr "变基式拉取"
 
-#: builtin/pull.c:1015
+#: builtin/pull.c:1021
 msgid "please commit or stash them."
 msgstr "请提交或贮藏它们。"
 
-#: builtin/pull.c:1040
+#: builtin/pull.c:1046
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -19364,7 +19368,7 @@ msgstr ""
 "fetch 更新了当前的分支。快进您的工作区\n"
 "至提交 %s。"
 
-#: builtin/pull.c:1046
+#: builtin/pull.c:1052
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -19381,23 +19385,23 @@ msgstr ""
 "$ git reset --hard\n"
 "恢复之前的状态。"
 
-#: builtin/pull.c:1061
+#: builtin/pull.c:1067
 msgid "Cannot merge multiple branches into empty head."
 msgstr "无法将多个分支合并到空分支。"
 
-#: builtin/pull.c:1066
+#: builtin/pull.c:1072
 msgid "Cannot rebase onto multiple branches."
 msgstr "无法变基到多个分支。"
 
-#: builtin/pull.c:1068
+#: builtin/pull.c:1074
 msgid "Cannot fast-forward to multiple branches."
 msgstr "无法快进到多个分支。"
 
-#: builtin/pull.c:1082
+#: builtin/pull.c:1088
 msgid "Need to specify how to reconcile divergent branches."
 msgstr "需要指定如何调和偏离的分支。"
 
-#: builtin/pull.c:1096
+#: builtin/pull.c:1102
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr "本地子模组中有修改，无法变基"
 
@@ -24437,27 +24441,27 @@ msgstr "到期时间"
 msgid "no-op (backward compatibility)"
 msgstr "空操作（向后兼容）"
 
-#: parse-options.h:309
+#: parse-options.h:308
 msgid "be more verbose"
 msgstr "更加详细"
 
-#: parse-options.h:311
+#: parse-options.h:310
 msgid "be more quiet"
 msgstr "更加安静"
 
-#: parse-options.h:317
+#: parse-options.h:316
 msgid "use <n> digits to display object names"
 msgstr "用 <n> 位数字显示对象名"
 
-#: parse-options.h:336
+#: parse-options.h:335
 msgid "how to strip spaces and #comments from message"
 msgstr "设置如何删除提交说明里的空格和#注释"
 
-#: parse-options.h:337
+#: parse-options.h:336
 msgid "read pathspec from file"
 msgstr "从文件读取路径表达式"
 
-#: parse-options.h:338
+#: parse-options.h:337
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr "使用 --pathspec-from-file，路径表达式用空字符分隔"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -22,8 +22,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-11-04 08:34+0800\n"
-"PO-Revision-Date: 2021-11-05 12:41+0800\n"
+"POT-Creation-Date: 2021-11-10 08:55+0800\n"
+"PO-Revision-Date: 2021-11-11 06:38+0800\n"
 "Last-Translator: Yi-Jyun Pan <pan93412@gmail.com>\n"
 "Language-Team: Chinese (Traditional) <http://weblate.slat.org/projects/git-"
 "po/git-cli/zh_Hant/>\n"
@@ -226,7 +226,7 @@ msgstr "未快取"
 
 #: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
 #: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:190
+#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:194
 #: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
 #: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
 #: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
@@ -10225,7 +10225,7 @@ msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr "下列路徑根據您的一個 .gitignore 檔案而被忽略：\n"
 
 #: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
-#: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:550
+#: builtin/prune-packed.c:14 builtin/pull.c:208 builtin/push.c:550
 #: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr "測試執行"
@@ -10677,11 +10677,11 @@ msgstr "傳遞給 git-apply"
 
 #: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
 #: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
-#: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
+#: builtin/pull.c:142 builtin/pull.c:204 builtin/pull.c:221
 #: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
 #: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
 #: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
-#: parse-options.h:316
+#: parse-options.h:315
 msgid "n"
 msgstr "n"
 
@@ -10732,7 +10732,7 @@ msgid "use current timestamp for author date"
 msgstr "用目前時間作為作者日期"
 
 #: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
-#: builtin/merge.c:299 builtin/pull.c:175 builtin/rebase.c:1099
+#: builtin/merge.c:299 builtin/pull.c:179 builtin/rebase.c:1099
 #: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
 msgstr "key-id"
@@ -11232,7 +11232,7 @@ msgstr "顯示工作量統計"
 #: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
 #: builtin/merge.c:298 builtin/multi-pack-index.c:103
 #: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
-#: builtin/multi-pack-index.c:204 builtin/pull.c:119 builtin/push.c:566
+#: builtin/multi-pack-index.c:204 builtin/pull.c:120 builtin/push.c:566
 #: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "強制顯示進度報告"
@@ -12479,7 +12479,7 @@ msgstr "缺少分支或提交參數"
 msgid "perform a 3-way merge with the new branch"
 msgstr "和新的分支執行三方合併"
 
-#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:322
+#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:321
 msgid "style"
 msgstr "風格"
 
@@ -12900,7 +12900,7 @@ msgid "path to git-upload-pack on the remote"
 msgstr "遠端 git-upload-pack 路徑"
 
 #: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
-#: builtin/pull.c:208
+#: builtin/pull.c:212
 msgid "depth"
 msgstr "深度"
 
@@ -12909,7 +12909,7 @@ msgid "create a shallow clone of that depth"
 msgstr "建立一個指定深度的淺複製"
 
 #: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
-#: builtin/pull.c:211
+#: builtin/pull.c:215
 msgid "time"
 msgstr "時間"
 
@@ -12918,11 +12918,11 @@ msgid "create a shallow clone since a specific time"
 msgstr "建立從指定時間到現在的淺複製"
 
 #: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1022
+#: builtin/pull.c:218 builtin/pull.c:243 builtin/rebase.c:1022
 msgid "revision"
 msgstr "修訂版"
 
-#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:215
+#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:219
 msgid "deepen history of shallow clone, excluding rev"
 msgstr "取得更多淺複製的過去歷史記錄，除了特定版本"
 
@@ -12956,21 +12956,21 @@ msgid "set config inside the new repository"
 msgstr "在新版本庫中設定設定訊息"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:200
+#: builtin/pull.c:234 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "server-specific"
 
 #: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:201
+#: builtin/pull.c:235 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr "傳輸選項"
 
-#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:234
+#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:238
 #: builtin/push.c:576
 msgid "use IPv4 addresses only"
 msgstr "只使用 IPv4 位址"
 
-#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:237
+#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:241
 #: builtin/push.c:578
 msgid "use IPv6 addresses only"
 msgstr "只使用 IPv6 位址"
@@ -13358,7 +13358,7 @@ msgid "read commit log message from file"
 msgstr "從檔案中讀取提交說明"
 
 #: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
-#: builtin/pull.c:176 builtin/revert.c:118
+#: builtin/pull.c:180 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "GPG 提交簽名"
 
@@ -13763,7 +13763,7 @@ msgstr "條目以 NUL 字元結尾"
 
 #: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
 #: builtin/fast-export.c:1199 builtin/fast-export.c:1202
-#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:336
+#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:335
 msgid "mode"
 msgstr "模式"
 
@@ -13839,7 +13839,7 @@ msgid "override date for commit"
 msgstr "提交時覆蓋日期"
 
 #: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
-#: parse-options.h:328 ref-filter.h:92
+#: parse-options.h:327 ref-filter.h:92
 msgid "commit"
 msgstr "提交"
 
@@ -13880,7 +13880,7 @@ msgid "add custom trailer(s)"
 msgstr "加入自訂尾部署名"
 
 #: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
-#: builtin/pull.c:145 builtin/revert.c:110
+#: builtin/pull.c:146 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "在結尾加入 Signed-off-by"
 
@@ -14843,15 +14843,15 @@ msgstr "git fetch --all [<選項>]"
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel 不能為負數"
 
-#: builtin/fetch.c:145 builtin/pull.c:185
+#: builtin/fetch.c:145 builtin/pull.c:189
 msgid "fetch from all remotes"
 msgstr "從所有的遠端抓取"
 
-#: builtin/fetch.c:147 builtin/pull.c:245
+#: builtin/fetch.c:147 builtin/pull.c:249
 msgid "set upstream for git pull/fetch"
 msgstr "為 git pull/fetch 設定上游"
 
-#: builtin/fetch.c:149 builtin/pull.c:188
+#: builtin/fetch.c:149 builtin/pull.c:192
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "追加到 .git/FETCH_HEAD 而不是覆蓋它"
 
@@ -14859,7 +14859,7 @@ msgstr "追加到 .git/FETCH_HEAD 而不是覆蓋它"
 msgid "use atomic transaction to update references"
 msgstr "使用 atomic 事務更新引用"
 
-#: builtin/fetch.c:153 builtin/pull.c:191
+#: builtin/fetch.c:153 builtin/pull.c:195
 msgid "path to upload pack on remote end"
 msgstr "上傳包到遠端的路徑"
 
@@ -14871,7 +14871,7 @@ msgstr "強制覆蓋本機引用"
 msgid "fetch from multiple remotes"
 msgstr "從多個遠端抓取"
 
-#: builtin/fetch.c:158 builtin/pull.c:195
+#: builtin/fetch.c:158 builtin/pull.c:199
 msgid "fetch all tags and associated objects"
 msgstr "抓取所有的標籤和關聯物件"
 
@@ -14887,7 +14887,7 @@ msgstr "並行取得的子模組數量"
 msgid "modify the refspec to place all refs within refs/prefetch/"
 msgstr "修改引用規格 (refspec) 以便將所有引用 (refs) 放置在 refs/prefetch/ 中"
 
-#: builtin/fetch.c:166 builtin/pull.c:198
+#: builtin/fetch.c:166 builtin/pull.c:202
 msgid "prune remote-tracking branches no longer on remote"
 msgstr "清除遠端已經不存在的分支的追蹤分支"
 
@@ -14896,7 +14896,7 @@ msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr "清除遠端不存在的本機標籤，並且取代變更標籤"
 
 #  譯者：可選值，不能翻譯
-#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:122
+#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:123
 msgid "on-demand"
 msgstr "on-demand"
 
@@ -14908,7 +14908,7 @@ msgstr "控制子模組的遞迴抓取"
 msgid "write fetched references to the FETCH_HEAD file"
 msgstr "將取得的引用寫入 FETCH_HEAD 檔案"
 
-#: builtin/fetch.c:176 builtin/pull.c:206
+#: builtin/fetch.c:176 builtin/pull.c:210
 msgid "keep downloaded pack"
 msgstr "保持下載包"
 
@@ -14916,16 +14916,16 @@ msgstr "保持下載包"
 msgid "allow updating of HEAD ref"
 msgstr "允許更新 HEAD 引用"
 
-#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:209
-#: builtin/pull.c:218
+#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:213
+#: builtin/pull.c:222
 msgid "deepen history of shallow clone"
 msgstr "取得淺複製的更多過去歷史記錄"
 
-#: builtin/fetch.c:183 builtin/pull.c:212
+#: builtin/fetch.c:183 builtin/pull.c:216
 msgid "deepen history of shallow repository based on time"
 msgstr "基於時間來深化淺複製的歷史"
 
-#: builtin/fetch.c:189 builtin/pull.c:221
+#: builtin/fetch.c:189 builtin/pull.c:225
 msgid "convert to a complete repository"
 msgstr "轉換為一個完整的版本庫"
 
@@ -14939,19 +14939,19 @@ msgid ""
 "files)"
 msgstr "遞迴取得子模組的預設值（比設定檔案優先度低）"
 
-#: builtin/fetch.c:199 builtin/pull.c:224
+#: builtin/fetch.c:199 builtin/pull.c:228
 msgid "accept refs that update .git/shallow"
 msgstr "接受更新 .git/shallow 的引用"
 
-#: builtin/fetch.c:200 builtin/pull.c:226
+#: builtin/fetch.c:200 builtin/pull.c:230
 msgid "refmap"
 msgstr "引用映射"
 
-#: builtin/fetch.c:201 builtin/pull.c:227
+#: builtin/fetch.c:201 builtin/pull.c:231
 msgid "specify fetch refmap"
 msgstr "指定取得動作的引用映射"
 
-#: builtin/fetch.c:208 builtin/pull.c:240
+#: builtin/fetch.c:208 builtin/pull.c:244
 msgid "report that we have only objects reachable from this object"
 msgstr "報告我們只擁有從該物件開始可以取得的物件"
 
@@ -14963,7 +14963,7 @@ msgstr "不取得包檔案，而是輸出交涉的祖先提交"
 msgid "run 'maintenance --auto' after fetching"
 msgstr "取得 (fetch) 後執行 'maintenance --auto'"
 
-#: builtin/fetch.c:217 builtin/pull.c:243
+#: builtin/fetch.c:217 builtin/pull.c:247
 msgid "check for forced-updates on all updated branches"
 msgstr "在所有更新分支上檢查強制更新"
 
@@ -17599,31 +17599,31 @@ msgstr "可用的策略有："
 msgid "Available custom strategies are:"
 msgstr "可用的自訂策略有："
 
-#: builtin/merge.c:257 builtin/pull.c:133
+#: builtin/merge.c:257 builtin/pull.c:134
 msgid "do not show a diffstat at the end of the merge"
 msgstr "在合併的最後不顯示差異統計"
 
-#: builtin/merge.c:260 builtin/pull.c:136
+#: builtin/merge.c:260 builtin/pull.c:137
 msgid "show a diffstat at the end of the merge"
 msgstr "在合併的最後顯示差異統計"
 
-#: builtin/merge.c:261 builtin/pull.c:139
+#: builtin/merge.c:261 builtin/pull.c:140
 msgid "(synonym to --stat)"
 msgstr "（和 --stat 同義）"
 
-#: builtin/merge.c:263 builtin/pull.c:142
+#: builtin/merge.c:263 builtin/pull.c:143
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr "在合併提交說明中新增（最多 <n> 條）精簡提交記錄"
 
-#: builtin/merge.c:266 builtin/pull.c:148
+#: builtin/merge.c:266 builtin/pull.c:149
 msgid "create a single commit instead of doing a merge"
 msgstr "建立一個單獨的提交而不是做一次合併"
 
-#: builtin/merge.c:268 builtin/pull.c:151
+#: builtin/merge.c:268 builtin/pull.c:152
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "如果合併成功，執行一次提交（預設）"
 
-#: builtin/merge.c:270 builtin/pull.c:154
+#: builtin/merge.c:270 builtin/pull.c:155
 msgid "edit message before committing"
 msgstr "在提交前編輯提交說明"
 
@@ -17631,28 +17631,28 @@ msgstr "在提交前編輯提交說明"
 msgid "allow fast-forward (default)"
 msgstr "允許快轉（預設）"
 
-#: builtin/merge.c:274 builtin/pull.c:161
+#: builtin/merge.c:274 builtin/pull.c:162
 msgid "abort if fast-forward is not possible"
 msgstr "如果不能快轉就放棄合併"
 
-#: builtin/merge.c:278 builtin/pull.c:164
+#: builtin/merge.c:278 builtin/pull.c:168
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "驗證指定的提交是否包含一個有效的 GPG 簽名"
 
-#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:168
+#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:172
 #: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr "策略"
 
-#: builtin/merge.c:280 builtin/pull.c:169
+#: builtin/merge.c:280 builtin/pull.c:173
 msgid "merge strategy to use"
 msgstr "要使用的合併策略"
 
-#: builtin/merge.c:281 builtin/pull.c:172
+#: builtin/merge.c:281 builtin/pull.c:176
 msgid "option=value"
 msgstr "option=value"
 
-#: builtin/merge.c:282 builtin/pull.c:173
+#: builtin/merge.c:282 builtin/pull.c:177
 msgid "option for selected merge strategy"
 msgstr "所選的合併策略的選項"
 
@@ -17673,7 +17673,7 @@ msgstr "--abort，但是保留索引和工作區"
 msgid "continue the current in-progress merge"
 msgstr "繼續目前正在進行的合併"
 
-#: builtin/merge.c:297 builtin/pull.c:180
+#: builtin/merge.c:297 builtin/pull.c:184
 msgid "allow merging unrelated histories"
 msgstr "允許合並不相關的歷史"
 
@@ -19055,61 +19055,65 @@ msgstr "%s 的值無效：%s"
 msgid "git pull [<options>] [<repository> [<refspec>...]]"
 msgstr "git pull [<選項>] [<版本庫> [<引用規格>...]]"
 
-#: builtin/pull.c:123
+#: builtin/pull.c:124
 msgid "control for recursive fetching of submodules"
 msgstr "控制子模組的遞迴取得"
 
-#: builtin/pull.c:127
+#: builtin/pull.c:128
 msgid "Options related to merging"
 msgstr "和合併相關的選項"
 
-#: builtin/pull.c:130
+#: builtin/pull.c:131
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "使用重定基底動作取代合併動作以套用修改"
 
-#: builtin/pull.c:158 builtin/revert.c:126
+#: builtin/pull.c:159 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "允許快轉式"
 
-#: builtin/pull.c:167 parse-options.h:339
+#: builtin/pull.c:165
+msgid "control use of pre-merge-commit and commit-msg hooks"
+msgstr "控制 pre-merge-commit 和 commit-msg 掛鉤的使用"
+
+#: builtin/pull.c:171 parse-options.h:338
 msgid "automatically stash/stash pop before and after"
 msgstr "在動作前後執行自動儲藏和彈出儲藏"
 
-#: builtin/pull.c:183
+#: builtin/pull.c:187
 msgid "Options related to fetching"
 msgstr "和取得相關的參數"
 
-#: builtin/pull.c:193
+#: builtin/pull.c:197
 msgid "force overwrite of local branch"
 msgstr "強制覆蓋本機分支"
 
-#: builtin/pull.c:201
+#: builtin/pull.c:205
 msgid "number of submodules pulled in parallel"
 msgstr "並行拉取的子模組數量"
 
-#: builtin/pull.c:317
+#: builtin/pull.c:321
 #, c-format
 msgid "Invalid value for pull.ff: %s"
 msgstr "pull.ff 的取值無效：%s"
 
-#: builtin/pull.c:445
+#: builtin/pull.c:449
 msgid ""
 "There is no candidate for rebasing against among the refs that you just "
 "fetched."
 msgstr "在您剛剛取得到的引用中沒有重定基底動作的候選。"
 
-#: builtin/pull.c:447
+#: builtin/pull.c:451
 msgid ""
 "There are no candidates for merging among the refs that you just fetched."
 msgstr "在您剛剛取得到的引用中沒有合併動作的候選。"
 
-#: builtin/pull.c:448
+#: builtin/pull.c:452
 msgid ""
 "Generally this means that you provided a wildcard refspec which had no\n"
 "matches on the remote end."
 msgstr "這通常表示您有提供萬用字元引用規格，但遠端沒有符合項目。"
 
-#: builtin/pull.c:451
+#: builtin/pull.c:455
 #, c-format
 msgid ""
 "You asked to pull from the remote '%s', but did not specify\n"
@@ -19119,41 +19123,41 @@ msgstr ""
 "您要求從遠端 '%s' 拉取，但是未指定一個分支。因為這不是目前\n"
 "分支預設的遠端版本庫，您必須在指令列中指定一個分支名。"
 
-#: builtin/pull.c:456 builtin/rebase.c:951
+#: builtin/pull.c:460 builtin/rebase.c:951
 msgid "You are not currently on a branch."
 msgstr "您目前不在一個分支上。"
 
-#: builtin/pull.c:458 builtin/pull.c:473
+#: builtin/pull.c:462 builtin/pull.c:477
 msgid "Please specify which branch you want to rebase against."
 msgstr "請指定您要重定基底到哪一個分支。"
 
-#: builtin/pull.c:460 builtin/pull.c:475
+#: builtin/pull.c:464 builtin/pull.c:479
 msgid "Please specify which branch you want to merge with."
 msgstr "請指定您要合併哪一個分支。"
 
-#: builtin/pull.c:461 builtin/pull.c:476
+#: builtin/pull.c:465 builtin/pull.c:480
 msgid "See git-pull(1) for details."
 msgstr "詳見 git-pull(1)。"
 
-#: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
+#: builtin/pull.c:467 builtin/pull.c:473 builtin/pull.c:482
 #: builtin/rebase.c:957
 msgid "<remote>"
 msgstr "<遠端>"
 
-#: builtin/pull.c:463 builtin/pull.c:478 builtin/pull.c:483
+#: builtin/pull.c:467 builtin/pull.c:482 builtin/pull.c:487
 msgid "<branch>"
 msgstr "<分支>"
 
-#: builtin/pull.c:471 builtin/rebase.c:949
+#: builtin/pull.c:475 builtin/rebase.c:949
 msgid "There is no tracking information for the current branch."
 msgstr "目前分支沒有追蹤訊息。"
 
-#: builtin/pull.c:480
+#: builtin/pull.c:484
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:"
 msgstr "如果您想要為此分支建立追蹤訊息，您可以執行："
 
-#: builtin/pull.c:485
+#: builtin/pull.c:489
 #, c-format
 msgid ""
 "Your configuration specifies to merge with the ref '%s'\n"
@@ -19162,16 +19166,16 @@ msgstr ""
 "您的設定中指定要合併遠端的引用 '%s'，\n"
 "但是沒有取得到這個引用。"
 
-#: builtin/pull.c:596
+#: builtin/pull.c:600
 #, c-format
 msgid "unable to access commit %s"
 msgstr "無法存取提交 %s"
 
-#: builtin/pull.c:902
+#: builtin/pull.c:908
 msgid "ignoring --verify-signatures for rebase"
 msgstr "為重定基底動作忽略 --verify-signatures"
 
-#: builtin/pull.c:936
+#: builtin/pull.c:942
 msgid ""
 "You have divergent branches and need to specify how to reconcile them.\n"
 "You can do so by running one of the following commands sometime before\n"
@@ -19200,19 +19204,19 @@ msgstr ""
 "pull 命令時傳遞 --rebase、--no-rebase 或 --ff-only 覆蓋\n"
 "設定的預設值。\n"
 
-#: builtin/pull.c:1010
+#: builtin/pull.c:1016
 msgid "Updating an unborn branch with changes added to the index."
 msgstr "更新尚未誕生的分支，變更新增至索引。"
 
-#: builtin/pull.c:1014
+#: builtin/pull.c:1020
 msgid "pull with rebase"
 msgstr "重定基底式拉取"
 
-#: builtin/pull.c:1015
+#: builtin/pull.c:1021
 msgid "please commit or stash them."
 msgstr "請提交或儲藏它們。"
 
-#: builtin/pull.c:1040
+#: builtin/pull.c:1046
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -19222,7 +19226,7 @@ msgstr ""
 "fetch 更新了目前的分支。快轉您的工作區\n"
 "至提交 %s。"
 
-#: builtin/pull.c:1046
+#: builtin/pull.c:1052
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -19239,23 +19243,23 @@ msgstr ""
 "$ git reset --hard\n"
 "復原之前的狀態。"
 
-#: builtin/pull.c:1061
+#: builtin/pull.c:1067
 msgid "Cannot merge multiple branches into empty head."
 msgstr "無法將多個分支合併到空分支。"
 
-#: builtin/pull.c:1066
+#: builtin/pull.c:1072
 msgid "Cannot rebase onto multiple branches."
 msgstr "無法重定基底到多個分支。"
 
-#: builtin/pull.c:1068
+#: builtin/pull.c:1074
 msgid "Cannot fast-forward to multiple branches."
 msgstr "無法快轉至多個分支。"
 
-#: builtin/pull.c:1082
+#: builtin/pull.c:1088
 msgid "Need to specify how to reconcile divergent branches."
 msgstr "需要指定如何調和偏離的分支。"
 
-#: builtin/pull.c:1096
+#: builtin/pull.c:1102
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr "本機子模組中有修改，無法重定基底"
 
@@ -24289,27 +24293,27 @@ msgstr "到期時間"
 msgid "no-op (backward compatibility)"
 msgstr "空動作（向後相容）"
 
-#: parse-options.h:309
+#: parse-options.h:308
 msgid "be more verbose"
 msgstr "更加詳細"
 
-#: parse-options.h:311
+#: parse-options.h:310
 msgid "be more quiet"
 msgstr "更加安靜"
 
-#: parse-options.h:317
+#: parse-options.h:316
 msgid "use <n> digits to display object names"
 msgstr "用 <n> 位數字顯示物件名稱"
 
-#: parse-options.h:336
+#: parse-options.h:335
 msgid "how to strip spaces and #comments from message"
 msgstr "設定如何刪除提交說明裡的空格和 #備註"
 
-#: parse-options.h:337
+#: parse-options.h:336
 msgid "read pathspec from file"
 msgstr "從檔案讀取 <路徑規格>"
 
-#: parse-options.h:338
+#: parse-options.h:337
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr "如使用 --pathspec-from-file，則 <路徑規格> 元件會使用 NUL 字元分隔"

--- a/run-command.c
+++ b/run-command.c
@@ -614,7 +614,7 @@ static NORETURN void die_async(const char *err, va_list params)
 static int async_die_is_recursing(void)
 {
 	void *ret = pthread_getspecific(async_die_counter);
-	pthread_setspecific(async_die_counter, (void *)1);
+	pthread_setspecific(async_die_counter, &async_die_counter); /* set to any non-NULL valid pointer */
 	return ret != NULL;
 }
 

--- a/t/lib-gpg.sh
+++ b/t/lib-gpg.sh
@@ -106,6 +106,7 @@ test_lazy_prereq GPGSSH '
 	test $? = 0 || exit 1;
 	mkdir -p "${GNUPGHOME}" &&
 	chmod 0700 "${GNUPGHOME}" &&
+	(setfacl -k "${GNUPGHOME}" 2>/dev/null || true) &&
 	ssh-keygen -t ed25519 -N "" -C "git ed25519 key" -f "${GPGSSH_KEY_PRIMARY}" >/dev/null &&
 	echo "\"principal with number 1\" $(cat "${GPGSSH_KEY_PRIMARY}.pub")" >> "${GPGSSH_ALLOWED_SIGNERS}" &&
 	ssh-keygen -t rsa -b 2048 -N "" -C "git rsa2048 key" -f "${GPGSSH_KEY_SECONDARY}" >/dev/null &&

--- a/t/t5521-pull-options.sh
+++ b/t/t5521-pull-options.sh
@@ -228,4 +228,28 @@ test_expect_success 'git pull --no-signoff flag cancels --signoff flag' '
 	test_must_be_empty actual
 '
 
+test_expect_success 'git pull --no-verify flag passed to merge' '
+	test_when_finished "rm -fr src dst actual" &&
+	git init src &&
+	test_commit -C src one &&
+	git clone src dst &&
+	write_script dst/.git/hooks/commit-msg <<-\EOF &&
+	false
+	EOF
+	test_commit -C src two &&
+	git -C dst pull --no-ff --no-verify
+'
+
+test_expect_success 'git pull --no-verify --verify passed to merge' '
+	test_when_finished "rm -fr src dst actual" &&
+	git init src &&
+	test_commit -C src one &&
+	git clone src dst &&
+	write_script dst/.git/hooks/commit-msg <<-\EOF &&
+	false
+	EOF
+	test_commit -C src two &&
+	test_must_fail git -C dst pull --no-ff --no-verify --verify
+'
+
 test_done

--- a/t/t7504-commit-msg-hook.sh
+++ b/t/t7504-commit-msg-hook.sh
@@ -133,6 +133,14 @@ test_expect_success '--no-verify with failing hook' '
 
 '
 
+test_expect_success '-n followed by --verify with failing hook' '
+
+	echo "even more" >> file &&
+	git add file &&
+	test_must_fail git commit -n --verify -m "even more"
+
+'
+
 test_expect_success '--no-verify with failing hook (editor)' '
 
 	echo "more stuff" >> file &&


### PR DESCRIPTION
@ralfth and @PhillipSz: please have a look at my suggestions for the German translation of Git v2.34.0. Only the commit 88bddee759 needs to be reviewed, the first commit is the automatically generated one to update the po file.