### PR TITLE
Review: Update German translation for Git v2.35.0

### DIFF
--- a/Documentation/RelNotes/2.35.0.txt
+++ b/Documentation/RelNotes/2.35.0.txt
@@ -100,7 +100,7 @@ Performance, Internal Implementation, Development Support etc.
  * Teach and encourage first-time contributors to this project to
    state the base commit when they submit their topic.
 
- * The command line complation for "git send-email" options have been
+ * The command line completion for "git send-email" options have been
    tweaked to make it easier to keep it in sync with the command itself.
 
  * Ensure that the sparseness of the in-core index matches the
@@ -367,6 +367,13 @@ Fixes since v2.34
    it failed to restore changes to tracked ones.
    (merge 71cade5a0b en/stash-df-fix later to maint).
 
+ * Calling dynamically loaded functions on Windows has been corrected.
+   (merge 4a9b204920 ma/windows-dynload-fix later to maint).
+
+ * Some lockfile code called free() in signal-death code path, which
+   has been corrected.
+   (merge 58d4d7f1c5 ps/lockfile-cleanup-fix later to maint).
+
  * Other code cleanup, docfix, build fix, etc.
    (merge 74db416c9c cw/protocol-v2-doc-fix later to maint).
    (merge f9b2b6684d ja/doc-cleanup later to maint).
@@ -391,3 +398,5 @@ Fixes since v2.34
    (merge 999bba3e0b rs/daemon-plug-leak later to maint).
    (merge 786eb1ba39 js/l10n-mention-ngettext-early-in-readme later to maint).
    (merge 2f12b31b74 ab/makefile-msgfmt-wo-stats later to maint).
+   (merge 0517f591ca fs/gpg-unknown-key-test-fix later to maint).
+   (merge 97d6fb5a1f ma/header-dup-cleanup later to maint).

--- a/GIT-VERSION-GEN
+++ b/GIT-VERSION-GEN
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 GVF=GIT-VERSION-FILE
-DEF_VER=v2.35.0-rc0
+DEF_VER=v2.35.0-rc1
 
 LF='
 '

--- a/branch.c
+++ b/branch.c
@@ -212,7 +212,7 @@ int validate_new_branchname(const char *name, struct strbuf *ref, int force)
 	worktrees = get_worktrees();
 	wt = find_shared_symref(worktrees, "HEAD", ref->buf);
 	if (wt && !wt->is_bare)
-		die(_("cannot force update the branch '%s'"
+		die(_("cannot force update the branch '%s' "
 		      "checked out at '%s'"),
 		    ref->buf + strlen("refs/heads/"), wt->path);
 	free_worktrees(worktrees);

--- a/builtin/clone.c
+++ b/builtin/clone.c
@@ -1290,7 +1290,7 @@ int cmd_clone(int argc, const char **argv, const char *prefix)
 	 */
 	submodule_progress = transport->progress;
 
-	transport_unlock_pack(transport);
+	transport_unlock_pack(transport, 0);
 	transport_disconnect(transport);
 
 	if (option_dissociate) {

--- a/cache.h
+++ b/cache.h
@@ -350,8 +350,6 @@ void add_name_hash(struct index_state *istate, struct cache_entry *ce);
 void remove_name_hash(struct index_state *istate, struct cache_entry *ce);
 void free_name_hash(struct index_state *istate);
 
-void ensure_full_index(struct index_state *istate);
-
 /* Cache entry creation and cleanup */
 
 /*

--- a/compat/mingw.c
+++ b/compat/mingw.c
@@ -8,6 +8,8 @@
 #include "win32/lazyload.h"
 #include "../config.h"
 #include "dir.h"
+#define SECURITY_WIN32
+#include <sspi.h>
 
 #define HCAST(type, handle) ((type)(intptr_t)handle)
 
@@ -1008,7 +1010,7 @@ size_t mingw_strftime(char *s, size_t max,
 	/* a pointer to the original strftime in case we can't find the UCRT version */
 	static size_t (*fallback)(char *, size_t, const char *, const struct tm *) = strftime;
 	size_t ret;
-	DECLARE_PROC_ADDR(ucrtbase.dll, size_t, strftime, char *, size_t,
+	DECLARE_PROC_ADDR(ucrtbase.dll, size_t, __cdecl, strftime, char *, size_t,
 		const char *, const struct tm *);
 
 	if (INIT_PROC_ADDR(strftime))
@@ -2183,7 +2185,7 @@ enum EXTENDED_NAME_FORMAT {
 
 static char *get_extended_user_info(enum EXTENDED_NAME_FORMAT type)
 {
-	DECLARE_PROC_ADDR(secur32.dll, BOOL, GetUserNameExW,
+	DECLARE_PROC_ADDR(secur32.dll, BOOL, SEC_ENTRY, GetUserNameExW,
 		enum EXTENDED_NAME_FORMAT, LPCWSTR, PULONG);
 	static wchar_t wbuffer[1024];
 	DWORD len;

--- a/compat/win32/lazyload.h
+++ b/compat/win32/lazyload.h
@@ -4,7 +4,7 @@
 /*
  * A pair of macros to simplify loading of DLL functions. Example:
  *
- *   DECLARE_PROC_ADDR(kernel32.dll, BOOL, CreateHardLinkW,
+ *   DECLARE_PROC_ADDR(kernel32.dll, BOOL, WINAPI, CreateHardLinkW,
  *                     LPCWSTR, LPCWSTR, LPSECURITY_ATTRIBUTES);
  *
  *   if (!INIT_PROC_ADDR(CreateHardLinkW))
@@ -25,10 +25,10 @@ struct proc_addr {
 };
 
 /* Declares a function to be loaded dynamically from a DLL. */
-#define DECLARE_PROC_ADDR(dll, rettype, function, ...) \
+#define DECLARE_PROC_ADDR(dll, rettype, convention, function, ...) \
 	static struct proc_addr proc_addr_##function = \
 	{ #dll, #function, NULL, 0 }; \
-	typedef rettype (WINAPI *proc_type_##function)(__VA_ARGS__); \
+	typedef rettype (convention *proc_type_##function)(__VA_ARGS__); \
 	static proc_type_##function function
 
 /*

--- a/compat/win32/trace2_win32_process_info.c
+++ b/compat/win32/trace2_win32_process_info.c
@@ -143,8 +143,8 @@ static void get_is_being_debugged(void)
  */
 static void get_peak_memory_info(void)
 {
-	DECLARE_PROC_ADDR(psapi.dll, BOOL, GetProcessMemoryInfo, HANDLE,
-			  PPROCESS_MEMORY_COUNTERS, DWORD);
+	DECLARE_PROC_ADDR(psapi.dll, BOOL, WINAPI, GetProcessMemoryInfo,
+			  HANDLE, PPROCESS_MEMORY_COUNTERS, DWORD);
 
 	if (INIT_PROC_ADDR(GetProcessMemoryInfo)) {
 		PROCESS_MEMORY_COUNTERS pmc;

--- a/compat/winansi.c
+++ b/compat/winansi.c
@@ -45,8 +45,9 @@ typedef struct _CONSOLE_FONT_INFOEX {
 static void warn_if_raster_font(void)
 {
 	DWORD fontFamily = 0;
-	DECLARE_PROC_ADDR(kernel32.dll, BOOL, GetCurrentConsoleFontEx,
-			HANDLE, BOOL, PCONSOLE_FONT_INFOEX);
+	DECLARE_PROC_ADDR(kernel32.dll, BOOL, WINAPI,
+			GetCurrentConsoleFontEx, HANDLE, BOOL,
+			PCONSOLE_FONT_INFOEX);
 
 	/* don't bother if output was ascii only */
 	if (!non_ascii_used)

--- a/config.mak.uname
+++ b/config.mak.uname
@@ -576,6 +576,7 @@ ifeq ($(uname_S),NONSTOP_KERNEL)
 	NO_SETENV = YesPlease
 	NO_UNSETENV = YesPlease
 	NO_MKDTEMP = YesPlease
+	NO_UNCOMPRESS2 = YesPlease
 	# Currently libiconv-1.9.1.
 	OLD_ICONV = UnfortunatelyYes
 	NO_REGEX = NeedsStartEnd

--- a/fmt-merge-msg.c
+++ b/fmt-merge-msg.c
@@ -541,7 +541,6 @@ static void fmt_merge_msg_sigs(struct strbuf *out)
 			else
 				strbuf_addstr(&sig, sigc.output);
 		}
-		signature_check_clear(&sigc);
 
 		if (!tag_number++) {
 			fmt_tag_signature(&tagbuf, &sig, buf, len);
@@ -565,6 +564,7 @@ static void fmt_merge_msg_sigs(struct strbuf *out)
 		}
 		strbuf_release(&payload);
 		strbuf_release(&sig);
+		signature_check_clear(&sigc);
 	next:
 		free(origbuf);
 	}

--- a/packfile.c
+++ b/packfile.c
@@ -1067,7 +1067,7 @@ unsigned long unpack_object_header_buffer(const unsigned char *buf,
 	size = c & 15;
 	shift = 4;
 	while (c & 0x80) {
-		if (len <= used || (bitsizeof(long) - 7) <= shift) {
+		if (len <= used || (bitsizeof(long) - 7) < shift) {
 			error("bad object header");
 			size = used = 0;
 			break;

--- a/po/bg.po
+++ b/po/bg.po
@@ -187,7 +187,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git 2.34\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2022-01-11 09:38+0800\n"
+"POT-Creation-Date: 2022-01-17 08:34+0800\n"
 "PO-Revision-Date: 2022-01-16 10:50+0100\n"
 "Last-Translator: Alexander Shopov <ash@kambanaria.org>\n"
 "Language-Team: Bulgarian <dict@fsa-bg.org>\n"
@@ -1095,8 +1095,8 @@ msgstr "непозната опция за игнориране на знаци�
 #: builtin/checkout.c:1644 builtin/checkout.c:1754 builtin/checkout.c:1757
 #: builtin/clone.c:906 builtin/commit.c:358 builtin/commit.c:361
 #: builtin/commit.c:1196 builtin/describe.c:593 builtin/diff-tree.c:155
-#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2033
-#: builtin/fetch.c:2038 builtin/index-pack.c:1852 builtin/init-db.c:560
+#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2038
+#: builtin/fetch.c:2043 builtin/index-pack.c:1852 builtin/init-db.c:560
 #: builtin/log.c:1946 builtin/log.c:1948 builtin/ls-files.c:778
 #: builtin/merge.c:1403 builtin/merge.c:1405 builtin/pack-objects.c:4073
 #: builtin/push.c:592 builtin/push.c:630 builtin/push.c:636 builtin/push.c:641
@@ -2184,7 +2184,7 @@ msgstr "вече съществува клон с име „%s“."
 # FIXME
 #: branch.c:313
 #, c-format
-msgid "cannot force update the branch '%s'checked out at '%s'"
+msgid "cannot force update the branch '%s' checked out at '%s'"
 msgstr ""
 "не може принудително да обновите клона „%s“, който е изтеглен в пътя „%s“"
 
@@ -6121,7 +6121,7 @@ msgstr "„%s“ не може да се вмъкне в базата от да�
 msgid "%s: unsupported file type"
 msgstr "неподдържан вид файл: „%s“"
 
-#: object-file.c:2329 builtin/fetch.c:1448
+#: object-file.c:2329 builtin/fetch.c:1453
 #, c-format
 msgid "%s is not a valid object"
 msgstr "„%s“ е неправилен обект"
@@ -7420,41 +7420,41 @@ msgstr "указател не може да се обнови с грешно и
 msgid "update_ref failed for ref '%s': %s"
 msgstr "неуспешно обновяване на указателя (update_ref) „%s“: %s"
 
-#: refs.c:2069
+#: refs.c:2067
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "не са позволени повече от една промени на указателя „%s“"
 
-#: refs.c:2152
+#: refs.c:2150
 msgid "ref updates forbidden inside quarantine environment"
 msgstr "обновяванията на указатели са забранени в среди под карантина"
 
-#: refs.c:2163
+#: refs.c:2161
 msgid "ref updates aborted by hook"
 msgstr "обновяванията на указатели са преустановени от кука"
 
-#: refs.c:2271 refs.c:2301
+#: refs.c:2269 refs.c:2299
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "„%s“ съществува, не може да се създаде „%s“"
 
-#: refs.c:2277 refs.c:2312
+#: refs.c:2275 refs.c:2310
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "невъзможно е едновременно да се обработват „%s“ и „%s“"
 
-#: refs/files-backend.c:1268
+#: refs/files-backend.c:1267
 #, c-format
 msgid "could not remove reference %s"
 msgstr "Указателят „%s“ не може да бъде изтрит"
 
-#: refs/files-backend.c:1282 refs/packed-backend.c:1549
+#: refs/files-backend.c:1281 refs/packed-backend.c:1549
 #: refs/packed-backend.c:1559
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr "Указателят „%s“ не може да бъде изтрит: %s"
 
-#: refs/files-backend.c:1285 refs/packed-backend.c:1562
+#: refs/files-backend.c:1284 refs/packed-backend.c:1562
 #, c-format
 msgid "could not delete references: %s"
 msgstr "Указателите не може да бъдат изтрити: %s"
@@ -8533,7 +8533,8 @@ msgstr ""
 "действието не може да бъде преустановено, когато сте на клон, който тепърва "
 "предстои да бъде създаден"
 
-#: sequencer.c:3180 builtin/fetch.c:999 builtin/fetch.c:1411 builtin/grep.c:772
+#: sequencer.c:3180 builtin/fetch.c:1004 builtin/fetch.c:1416
+#: builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr "„%s“ не може да бъде отворен"
@@ -9509,7 +9510,7 @@ msgstr "протоколът не поддържа задаването на п�
 msgid "invalid remote service path"
 msgstr "неправилен път на отдалечената услуга"
 
-#: transport-helper.c:661 transport.c:1474
+#: transport-helper.c:661 transport.c:1479
 msgid "operation not supported by protocol"
 msgstr "опцията не се поддържа от протокола"
 
@@ -13828,7 +13829,7 @@ msgstr "опциите „%s“ и „%s %s“ са несъвместими"
 msgid "repository '%s' does not exist"
 msgstr "не съществува хранилище „%s“"
 
-#: builtin/clone.c:924 builtin/fetch.c:2047
+#: builtin/clone.c:924 builtin/fetch.c:2052
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "дълбочината трябва да е положително цяло число, а не „%s“"
@@ -15778,70 +15779,70 @@ msgstr "запазване на гра̀фа с подаванията след 
 msgid "accept refspecs from stdin"
 msgstr "четене на указателите от стандартния вход"
 
-#: builtin/fetch.c:587
+#: builtin/fetch.c:592
 msgid "couldn't find remote ref HEAD"
 msgstr "указателят „HEAD“ в отдалеченото хранилище не може да бъде открит"
 
-#: builtin/fetch.c:761
+#: builtin/fetch.c:766
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "настройката „fetch.output“ е с неправилна стойност „%s“"
 
-#: builtin/fetch.c:862
+#: builtin/fetch.c:867
 #, c-format
 msgid "object %s not found"
 msgstr "обектът „%s“ липсва"
 
-#: builtin/fetch.c:866
+#: builtin/fetch.c:871
 msgid "[up to date]"
 msgstr "[актуален]"
 
-#: builtin/fetch.c:878 builtin/fetch.c:896 builtin/fetch.c:968
+#: builtin/fetch.c:883 builtin/fetch.c:901 builtin/fetch.c:973
 msgid "[rejected]"
 msgstr "[отхвърлен]"
 
-#: builtin/fetch.c:880
+#: builtin/fetch.c:885
 msgid "can't fetch in current branch"
 msgstr "в текущия клон не може да се доставя"
 
-#: builtin/fetch.c:881
+#: builtin/fetch.c:886
 msgid "checked out in another worktree"
 msgstr "изтеглен в друго работно дърво"
 
-#: builtin/fetch.c:891
+#: builtin/fetch.c:896
 msgid "[tag update]"
 msgstr "[обновяване на етикетите]"
 
-#: builtin/fetch.c:892 builtin/fetch.c:929 builtin/fetch.c:951
-#: builtin/fetch.c:963
+#: builtin/fetch.c:897 builtin/fetch.c:934 builtin/fetch.c:956
+#: builtin/fetch.c:968
 msgid "unable to update local ref"
 msgstr "локален указател не може да бъде обновен"
 
-#: builtin/fetch.c:896
+#: builtin/fetch.c:901
 msgid "would clobber existing tag"
 msgstr "съществуващ етикет ще бъде презаписан"
 
-#: builtin/fetch.c:918
+#: builtin/fetch.c:923
 msgid "[new tag]"
 msgstr "[нов етикет]"
 
-#: builtin/fetch.c:921
+#: builtin/fetch.c:926
 msgid "[new branch]"
 msgstr "[нов клон]"
 
-#: builtin/fetch.c:924
+#: builtin/fetch.c:929
 msgid "[new ref]"
 msgstr "[нов указател]"
 
-#: builtin/fetch.c:963
+#: builtin/fetch.c:968
 msgid "forced update"
 msgstr "принудително обновяване"
 
-#: builtin/fetch.c:968
+#: builtin/fetch.c:973
 msgid "non-fast-forward"
 msgstr "същинско сливане"
 
-#: builtin/fetch.c:1071
+#: builtin/fetch.c:1076
 msgid ""
 "fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled; to re-enable, use '--show-forced-updates'\n"
@@ -15854,7 +15855,7 @@ msgstr ""
 "\n"
 "    git config fetch.showForcedUpdates true"
 
-#: builtin/fetch.c:1075
+#: builtin/fetch.c:1080
 #, c-format
 msgid ""
 "it took %.2f seconds to check forced updates; you can use\n"
@@ -15868,23 +15869,23 @@ msgstr ""
 "\n"
 "    git config fetch.showForcedUpdates false\n"
 
-#: builtin/fetch.c:1107
+#: builtin/fetch.c:1112
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "хранилището „%s“ не изпрати всички необходими обекти\n"
 
-#: builtin/fetch.c:1136
+#: builtin/fetch.c:1141
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr ""
 "отхвърляне на „%s“, защото плитките върхове не може да бъдат обновявани"
 
-#: builtin/fetch.c:1226 builtin/fetch.c:1374
+#: builtin/fetch.c:1231 builtin/fetch.c:1379
 #, c-format
 msgid "From %.*s\n"
 msgstr "От %.*s\n"
 
-#: builtin/fetch.c:1247
+#: builtin/fetch.c:1252
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -15894,50 +15895,50 @@ msgstr ""
 "„git remote prune %s“, за да премахнете остарелите клони, които\n"
 "предизвикват конфликта"
 
-#: builtin/fetch.c:1344
+#: builtin/fetch.c:1349
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (обектът „%s“ ще се окаже извън клон)"
 
-#: builtin/fetch.c:1345
+#: builtin/fetch.c:1350
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (обектът „%s“ вече е извън клон)"
 
-#: builtin/fetch.c:1377
+#: builtin/fetch.c:1382
 msgid "[deleted]"
 msgstr "[изтрит]"
 
-#: builtin/fetch.c:1378 builtin/remote.c:1128
+#: builtin/fetch.c:1383 builtin/remote.c:1128
 msgid "(none)"
 msgstr "(нищо)"
 
-#: builtin/fetch.c:1400
+#: builtin/fetch.c:1405
 #, c-format
 msgid "refusing to fetch into branch '%s' checked out at '%s'"
 msgstr "не може да доставите в клона „%s“, който е изтеглен в пътя „%s“"
 
-#: builtin/fetch.c:1420
+#: builtin/fetch.c:1425
 #, c-format
 msgid "option \"%s\" value \"%s\" is not valid for %s"
 msgstr "стойността „%2$s“ за опцията „%1$s“ не е съвместима с „%3$s“"
 
-#: builtin/fetch.c:1423
+#: builtin/fetch.c:1428
 #, c-format
 msgid "option \"%s\" is ignored for %s\n"
 msgstr "опцията „%s“ се прескача при „%s“\n"
 
-#: builtin/fetch.c:1450
+#: builtin/fetch.c:1455
 #, c-format
 msgid "the object %s does not exist"
 msgstr "обектът „%s“ не съществува"
 
-#: builtin/fetch.c:1638
+#: builtin/fetch.c:1643
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr ""
 "засечени са множество клони, това е несъвместимо с опцията „--set-upstream“"
 
-#: builtin/fetch.c:1650
+#: builtin/fetch.c:1655
 #, c-format
 msgid ""
 "could not set upstream of HEAD to '%s' from '%s' when it does not point to "
@@ -15946,19 +15947,19 @@ msgstr ""
 "следеното от „HEAD“ не може да се смени от „%2$s“ на „%1$s“, защото второто "
 "не сочи към никой клон."
 
-#: builtin/fetch.c:1663
+#: builtin/fetch.c:1668
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "не може да указвате клон за следене на отдалечен етикет"
 
-#: builtin/fetch.c:1665
+#: builtin/fetch.c:1670
 msgid "not setting upstream for a remote tag"
 msgstr "не може да указвате клон за следене на отдалечен етикет"
 
-#: builtin/fetch.c:1667
+#: builtin/fetch.c:1672
 msgid "unknown branch type"
 msgstr "непознат вид клон"
 
-#: builtin/fetch.c:1669
+#: builtin/fetch.c:1674
 msgid ""
 "no source branch found;\n"
 "you need to specify exactly one branch with the --set-upstream option"
@@ -15966,22 +15967,22 @@ msgstr ""
 "не е открит клон за следене;\n"
 "трябва изрично да зададете точно един клон с опцията „--set-upstream“"
 
-#: builtin/fetch.c:1799 builtin/fetch.c:1862
+#: builtin/fetch.c:1804 builtin/fetch.c:1867
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Доставяне на „%s“\n"
 
-#: builtin/fetch.c:1809 builtin/fetch.c:1864
+#: builtin/fetch.c:1814 builtin/fetch.c:1869
 #, c-format
 msgid "could not fetch %s"
 msgstr "„%s“ не може да се достави"
 
-#: builtin/fetch.c:1821
+#: builtin/fetch.c:1826
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "„%s“ не може да се достави (изходният код е: %d)\n"
 
-#: builtin/fetch.c:1925
+#: builtin/fetch.c:1930
 msgid ""
 "no remote repository specified; please specify either a URL or a\n"
 "remote name from which new revisions should be fetched"
@@ -15989,49 +15990,49 @@ msgstr ""
 "не сте указали отдалечено хранилище; задайте или адрес, или име\n"
 "на отдалечено хранилище, откъдето да се доставят новите версии."
 
-#: builtin/fetch.c:1961
+#: builtin/fetch.c:1966
 msgid "you need to specify a tag name"
 msgstr "трябва да укажете име на етикет"
 
-#: builtin/fetch.c:2027
+#: builtin/fetch.c:2032
 msgid "--negotiate-only needs one or more --negotiate-tip=*"
 msgstr ""
 "Опцията „--negotiate-only“ изисква една или повече опции „--negotiate-tip=*“"
 
-#: builtin/fetch.c:2031
+#: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"
 msgstr "отрицателна дълбочина като аргумент на „--deepen“ не се поддържа"
 
-#: builtin/fetch.c:2040
+#: builtin/fetch.c:2045
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "не може да използвате опцията „--unshallow“ върху пълно хранилище"
 
-#: builtin/fetch.c:2057
+#: builtin/fetch.c:2062
 msgid "fetch --all does not take a repository argument"
 msgstr "към „git fetch --all“ не може да добавите аргумент-хранилище"
 
-#: builtin/fetch.c:2059
+#: builtin/fetch.c:2064
 msgid "fetch --all does not make sense with refspecs"
 msgstr "към „git fetch --all“ не може да добавите аргумент-указател на версия"
 
-#: builtin/fetch.c:2068
+#: builtin/fetch.c:2073
 #, c-format
 msgid "no such remote or remote group: %s"
 msgstr "няма нито отдалечено хранилище, нито група от хранилища на име „%s“"
 
-#: builtin/fetch.c:2076
+#: builtin/fetch.c:2081
 msgid "fetching a group and specifying refspecs does not make sense"
 msgstr "доставянето на група и указването на версия са несъвместими"
 
-#: builtin/fetch.c:2092
+#: builtin/fetch.c:2097
 msgid "must supply remote when using --negotiate-only"
 msgstr "опцията „--negotiate-only“ изисква хранилище"
 
-#: builtin/fetch.c:2097
+#: builtin/fetch.c:2102
 msgid "protocol does not support --negotiate-only, exiting"
 msgstr "протоколът не поддържа опцията „--negotiate-only“, изход от програмата"
 
-#: builtin/fetch.c:2116
+#: builtin/fetch.c:2121
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -16039,12 +16040,12 @@ msgstr ""
 "опцията „--filter“ може да се ползва само с отдалеченото хранилище указано в "
 "настройката „extensions.partialclone“"
 
-#: builtin/fetch.c:2120
+#: builtin/fetch.c:2125
 msgid "--atomic can only be used when fetching from one remote"
 msgstr ""
 "опцията „--atomic“ поддържа доставяне само от едно отдалечено хранилище"
 
-#: builtin/fetch.c:2124
+#: builtin/fetch.c:2129
 msgid "--stdin can only be used when fetching from one remote"
 msgstr "опцията „--stdin“ поддържа доставяне само от едно отдалечено хранилище"
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -1,7 +1,7 @@
 # Bulgarian translation of git po-file.
 # Copyright (C) 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021 Alexander Shopov <ash@kambanaria.org>.
 # This file is distributed under the same license as the git package.
-# Alexander Shopov <ash@kambanaria.org>, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021.
+# Alexander Shopov <ash@kambanaria.org>, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022.
 #
 # ========================
 # DICTIONARY TO MERGE IN GIT GUI
@@ -33,6 +33,7 @@
 # switch to branch преминавам към клон
 # sparse entry/blob частично изтеглена директория/път/обект-BLOB
 # sparse index частичен индекс
+# sparcity частичност
 # revision range диапазон на версиите
 # cover letter придружаващо писмо
 # reference repository еталонно хранилище
@@ -163,6 +164,10 @@
 # prefetch предварително доставяне
 # scheduler планиращ модул
 # snapshot снимка
+# enlistment зачислена директория
+# zealous merge засилено сливане
+# unregister отчислявам
+# marked counting изброяване
 # ------------------------
 # „$var“ - може да не сработва за shell има gettext и eval_gettext - проверка - намират се лесно по „$
 # ------------------------
@@ -177,12 +182,13 @@
 # msgcat todo1.po todo2.po > todo.po
 # grep '^#: ' todo.po | sed 's/^#: //' | tr ' ' '\n' | sed 's/:[0-9]*$//' > FILES
 # for i in `sort -u FILES`; do cnt=`grep $i FILES | wc -l`; echo $cnt $i ;done | sort -n
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: git 2.34\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-11-10 08:55+0800\n"
-"PO-Revision-Date: 2021-11-12 19:22+0100\n"
+"POT-Creation-Date: 2022-01-11 09:38+0800\n"
+"PO-Revision-Date: 2022-01-16 10:50+0100\n"
 "Last-Translator: Alexander Shopov <ash@kambanaria.org>\n"
 "Language-Team: Bulgarian <dict@fsa-bg.org>\n"
 "Language: bg\n"
@@ -196,8 +202,8 @@ msgstr ""
 msgid "Huh (%s)?"
 msgstr "Неуспешен анализ — „%s“."
 
-#: add-interactive.c:533 add-interactive.c:834 reset.c:65 sequencer.c:3512
-#: sequencer.c:3979 sequencer.c:4141 builtin/rebase.c:1233
+#: add-interactive.c:533 add-interactive.c:834 reset.c:65 sequencer.c:3509
+#: sequencer.c:3974 sequencer.c:4136 builtin/rebase.c:1233
 #: builtin/rebase.c:1642
 msgid "could not read index"
 msgstr "индексът не може да бъде прочетен"
@@ -226,7 +232,7 @@ msgstr "Обновяване"
 msgid "could not stage '%s'"
 msgstr "неуспешно добавяне в индекса на „%s“"
 
-#: add-interactive.c:707 add-interactive.c:896 reset.c:89 sequencer.c:3718
+#: add-interactive.c:707 add-interactive.c:896 reset.c:89 sequencer.c:3713
 msgid "could not write index"
 msgstr "индексът не може да бъде записан"
 
@@ -242,8 +248,8 @@ msgstr[1] "%d файла обновени\n"
 msgid "note: %s is untracked now.\n"
 msgstr "БЕЛЕЖКА: „%s“ вече не се следи.\n"
 
-#: add-interactive.c:733 apply.c:4149 builtin/checkout.c:298
-#: builtin/reset.c:151
+#: add-interactive.c:733 apply.c:4151 builtin/checkout.c:306
+#: builtin/reset.c:167
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
 msgstr "неуспешно създаване на запис в кеша чрез „make_cache_entry“ за „%s“"
@@ -284,21 +290,21 @@ msgstr[1] "%d файла добавени\n"
 msgid "ignoring unmerged: %s"
 msgstr "пренебрегване на неслятото: „%s“"
 
-#: add-interactive.c:941 add-patch.c:1752 git-add--interactive.perl:1369
+#: add-interactive.c:941 add-patch.c:1752 git-add--interactive.perl:1371
 #, c-format
 msgid "Only binary files changed.\n"
 msgstr "Само двоични файлове са променени.\n"
 
-#: add-interactive.c:943 add-patch.c:1750 git-add--interactive.perl:1371
+#: add-interactive.c:943 add-patch.c:1750 git-add--interactive.perl:1373
 #, c-format
 msgid "No changes.\n"
 msgstr "Няма промени.\n"
 
-#: add-interactive.c:947 git-add--interactive.perl:1379
+#: add-interactive.c:947 git-add--interactive.perl:1381
 msgid "Patch update"
 msgstr "Обновяване на кръпка"
 
-#: add-interactive.c:986 git-add--interactive.perl:1792
+#: add-interactive.c:986 git-add--interactive.perl:1794
 msgid "Review diff"
 msgstr "Преглед на разликата"
 
@@ -366,11 +372,11 @@ msgstr "избор на номериран елемент"
 msgid "(empty) select nothing"
 msgstr "(празно) без избор на нищо"
 
-#: add-interactive.c:1095 builtin/clean.c:813 git-add--interactive.perl:1896
+#: add-interactive.c:1095 builtin/clean.c:839 git-add--interactive.perl:1898
 msgid "*** Commands ***"
 msgstr "●●● Команди ●●●"
 
-#: add-interactive.c:1096 builtin/clean.c:814 git-add--interactive.perl:1893
+#: add-interactive.c:1096 builtin/clean.c:840 git-add--interactive.perl:1895
 msgid "What now"
 msgstr "Избор на следващо действие"
 
@@ -382,13 +388,13 @@ msgstr "в индекса"
 msgid "unstaged"
 msgstr "извън индекса"
 
-#: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
-#: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:194
-#: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
-#: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
-#: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
-#: builtin/submodule--helper.c:2578 builtin/submodule--helper.c:2811
+#: add-interactive.c:1148 apply.c:5020 apply.c:5023 builtin/am.c:2367
+#: builtin/am.c:2370 builtin/bugreport.c:107 builtin/clone.c:128
+#: builtin/fetch.c:153 builtin/merge.c:287 builtin/pull.c:194
+#: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1858
+#: builtin/submodule--helper.c:1861 builtin/submodule--helper.c:2504
+#: builtin/submodule--helper.c:2507 builtin/submodule--helper.c:2574
+#: builtin/submodule--helper.c:2579 builtin/submodule--helper.c:2812
 #: git-add--interactive.perl:213
 msgid "path"
 msgstr "път"
@@ -398,27 +404,27 @@ msgid "could not refresh index"
 msgstr "индексът не може да бъде обновен"
 
 #
-#: add-interactive.c:1169 builtin/clean.c:778 git-add--interactive.perl:1803
+#: add-interactive.c:1169 builtin/clean.c:804 git-add--interactive.perl:1805
 #, c-format
 msgid "Bye.\n"
 msgstr "Изход.\n"
 
-#: add-patch.c:34 git-add--interactive.perl:1431
+#: add-patch.c:34 git-add--interactive.perl:1433
 #, c-format, perl-format
 msgid "Stage mode change [y,n,q,a,d%s,?]? "
 msgstr "Добавяне на промяната на правата за достъп [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:35 git-add--interactive.perl:1432
+#: add-patch.c:35 git-add--interactive.perl:1434
 #, c-format, perl-format
 msgid "Stage deletion [y,n,q,a,d%s,?]? "
 msgstr "Добавяне на изтриването [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:36 git-add--interactive.perl:1433
+#: add-patch.c:36 git-add--interactive.perl:1435
 #, c-format, perl-format
 msgid "Stage addition [y,n,q,a,d%s,?]? "
 msgstr "Добавяне на добавянето [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:37 git-add--interactive.perl:1434
+#: add-patch.c:37 git-add--interactive.perl:1436
 #, c-format, perl-format
 msgid "Stage this hunk [y,n,q,a,d%s,?]? "
 msgstr "Добавяне на това парче [y,n,q,a,d%s,?]? "
@@ -445,22 +451,22 @@ msgstr ""
 "a — добавяне на това и всички следващи парчета от файла в индекса\n"
 "d — без добавяне на това и всички следващи парчета от файла в индекса\n"
 
-#: add-patch.c:56 git-add--interactive.perl:1437
+#: add-patch.c:56 git-add--interactive.perl:1439
 #, c-format, perl-format
 msgid "Stash mode change [y,n,q,a,d%s,?]? "
 msgstr "Скатаване на промяната на правата за достъп [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:57 git-add--interactive.perl:1438
+#: add-patch.c:57 git-add--interactive.perl:1440
 #, c-format, perl-format
 msgid "Stash deletion [y,n,q,a,d%s,?]? "
 msgstr "Скатаване на изтриването [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:58 git-add--interactive.perl:1439
+#: add-patch.c:58 git-add--interactive.perl:1441
 #, c-format, perl-format
 msgid "Stash addition [y,n,q,a,d%s,?]? "
 msgstr "Скатаване на добавянето [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:59 git-add--interactive.perl:1440
+#: add-patch.c:59 git-add--interactive.perl:1442
 #, c-format, perl-format
 msgid "Stash this hunk [y,n,q,a,d%s,?]? "
 msgstr "Скатаване на това парче [y,n,q,a,d%s,?]? "
@@ -487,22 +493,22 @@ msgstr ""
 "a — скатаване на това и всички следващи парчета от файла\n"
 "d — без скатаване на това и всички следващи парчета от файла\n"
 
-#: add-patch.c:80 git-add--interactive.perl:1443
+#: add-patch.c:80 git-add--interactive.perl:1445
 #, c-format, perl-format
 msgid "Unstage mode change [y,n,q,a,d%s,?]? "
 msgstr "Изваждане на промяната на правата за достъп [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:81 git-add--interactive.perl:1444
+#: add-patch.c:81 git-add--interactive.perl:1446
 #, c-format, perl-format
 msgid "Unstage deletion [y,n,q,a,d%s,?]? "
 msgstr "Изваждане на изтриването [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:82 git-add--interactive.perl:1445
+#: add-patch.c:82 git-add--interactive.perl:1447
 #, c-format, perl-format
 msgid "Unstage addition [y,n,q,a,d%s,?]? "
 msgstr "Изваждане на добавянето [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:83 git-add--interactive.perl:1446
+#: add-patch.c:83 git-add--interactive.perl:1448
 #, c-format, perl-format
 msgid "Unstage this hunk [y,n,q,a,d%s,?]? "
 msgstr "Изваждане на това парче [y,n,q,a,d%s,?]? "
@@ -529,23 +535,23 @@ msgstr ""
 "a — изваждане на това и всички следващи парчета от файла от индекса\n"
 "d — без изваждане на това и всички следващи парчета от файла от индекса\n"
 
-#: add-patch.c:103 git-add--interactive.perl:1449
+#: add-patch.c:103 git-add--interactive.perl:1451
 #, c-format, perl-format
 msgid "Apply mode change to index [y,n,q,a,d%s,?]? "
 msgstr ""
 "Прилагане на промяната на правата за достъп към индекса [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:104 git-add--interactive.perl:1450
+#: add-patch.c:104 git-add--interactive.perl:1452
 #, c-format, perl-format
 msgid "Apply deletion to index [y,n,q,a,d%s,?]? "
 msgstr "Прилагане на изтриването към индекса [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:105 git-add--interactive.perl:1451
+#: add-patch.c:105 git-add--interactive.perl:1453
 #, c-format, perl-format
 msgid "Apply addition to index [y,n,q,a,d%s,?]? "
 msgstr "Прилагане на добавянето към индекса [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:106 git-add--interactive.perl:1452
+#: add-patch.c:106 git-add--interactive.perl:1454
 #, c-format, perl-format
 msgid "Apply this hunk to index [y,n,q,a,d%s,?]? "
 msgstr "Прилагане на това парче към индекса [y,n,q,a,d%s,?]? "
@@ -572,28 +578,28 @@ msgstr ""
 "a — прилагане на това и всички следващи парчета от файла към индекса\n"
 "d — без прилагане на това и всички следващи парчета от файла към индекса\n"
 
-#: add-patch.c:126 git-add--interactive.perl:1455
-#: git-add--interactive.perl:1473
+#: add-patch.c:126 git-add--interactive.perl:1457
+#: git-add--interactive.perl:1475
 #, c-format, perl-format
 msgid "Discard mode change from worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Премахване на промяната в правата за достъп от работното дърво [y,n,q,a,d"
 "%s,?]? "
 
-#: add-patch.c:127 git-add--interactive.perl:1456
-#: git-add--interactive.perl:1474
+#: add-patch.c:127 git-add--interactive.perl:1458
+#: git-add--interactive.perl:1476
 #, c-format, perl-format
 msgid "Discard deletion from worktree [y,n,q,a,d%s,?]? "
 msgstr "Премахване на изтриването от работното дърво [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:128 git-add--interactive.perl:1457
-#: git-add--interactive.perl:1475
+#: add-patch.c:128 git-add--interactive.perl:1459
+#: git-add--interactive.perl:1477
 #, c-format, perl-format
 msgid "Discard addition from worktree [y,n,q,a,d%s,?]? "
 msgstr "Премахване на добавянето от работното дърво [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:129 git-add--interactive.perl:1458
-#: git-add--interactive.perl:1476
+#: add-patch.c:129 git-add--interactive.perl:1460
+#: git-add--interactive.perl:1478
 #, c-format, perl-format
 msgid "Discard this hunk from worktree [y,n,q,a,d%s,?]? "
 msgstr "Премахване на парчето от работното дърво [y,n,q,a,d%s,?]? "
@@ -623,26 +629,26 @@ msgstr ""
 "d — без премахване на това и всички следващи парчета от файла от работното "
 "дърво\n"
 
-#: add-patch.c:149 add-patch.c:194 git-add--interactive.perl:1461
+#: add-patch.c:149 add-patch.c:194 git-add--interactive.perl:1463
 #, c-format, perl-format
 msgid "Discard mode change from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Премахване на промяната в правата за достъп от индекса и работното дърво [y,"
 "n,q,a,d%s,?]? "
 
-#: add-patch.c:150 add-patch.c:195 git-add--interactive.perl:1462
+#: add-patch.c:150 add-patch.c:195 git-add--interactive.perl:1464
 #, c-format, perl-format
 msgid "Discard deletion from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Премахване на изтриването от индекса и работното дърво [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:151 add-patch.c:196 git-add--interactive.perl:1463
+#: add-patch.c:151 add-patch.c:196 git-add--interactive.perl:1465
 #, c-format, perl-format
 msgid "Discard addition from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Премахване на добавянето от индекса и работното дърво [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:152 add-patch.c:197 git-add--interactive.perl:1464
+#: add-patch.c:152 add-patch.c:197 git-add--interactive.perl:1466
 #, c-format, perl-format
 msgid "Discard this hunk from index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Премахване на парчето от индекса и работното дърво [y,n,q,a,d%s,?]? "
@@ -664,25 +670,25 @@ msgstr ""
 "d — без премахване на това и всички следващи парчета от файла от индекса и "
 "работното дърво\n"
 
-#: add-patch.c:171 add-patch.c:216 git-add--interactive.perl:1467
+#: add-patch.c:171 add-patch.c:216 git-add--interactive.perl:1469
 #, c-format, perl-format
 msgid "Apply mode change to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Прилагане на промяната в правата за достъп от индекса и работното дърво [y,n,"
 "q,a,d%s,?]? "
 
-#: add-patch.c:172 add-patch.c:217 git-add--interactive.perl:1468
+#: add-patch.c:172 add-patch.c:217 git-add--interactive.perl:1470
 #, c-format, perl-format
 msgid "Apply deletion to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Прилагане на изтриването от индекса и работното дърво [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:173 add-patch.c:218 git-add--interactive.perl:1469
+#: add-patch.c:173 add-patch.c:218 git-add--interactive.perl:1471
 #, c-format, perl-format
 msgid "Apply addition to index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Прилагане на добавянето от индекса и работното дърво [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1470
+#: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1472
 #, c-format, perl-format
 msgid "Apply this hunk to index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Прилагане на парчето от индекса и работното дърво [y,n,q,a,d%s,?]? "
@@ -824,7 +830,7 @@ msgstr "неуспешно изпълнение на „git apply --cached“"
 #. Consider translating (saying "no" discards!) as
 #. (saying "n" for "no" discards!) if the translation
 #. of the word "no" does not start with n.
-#: add-patch.c:1247 git-add--interactive.perl:1242
+#: add-patch.c:1247 git-add--interactive.perl:1244
 msgid ""
 "Your edited hunk does not apply. Edit again (saying \"no\" discards!) [y/n]? "
 msgstr ""
@@ -836,11 +842,11 @@ msgstr ""
 msgid "The selected hunks do not apply to the index!"
 msgstr "Избраните парчета не може да се добавят в индекса!"
 
-#: add-patch.c:1291 git-add--interactive.perl:1346
+#: add-patch.c:1291 git-add--interactive.perl:1348
 msgid "Apply them to the worktree anyway? "
 msgstr "Да се приложат ли към работното дърво? "
 
-#: add-patch.c:1298 git-add--interactive.perl:1349
+#: add-patch.c:1298 git-add--interactive.perl:1351
 msgid "Nothing was applied.\n"
 msgstr "Нищо не е приложено.\n"
 
@@ -878,11 +884,11 @@ msgstr "Няма друго парче след това"
 msgid "No other hunks to goto"
 msgstr "Няма други парчета"
 
-#: add-patch.c:1549 git-add--interactive.perl:1606
+#: add-patch.c:1549 git-add--interactive.perl:1608
 msgid "go to which hunk (<ret> to see more)? "
 msgstr "към кое парче да се придвижи (за повече варианти натиснете „enter“)? "
 
-#: add-patch.c:1550 git-add--interactive.perl:1608
+#: add-patch.c:1550 git-add--interactive.perl:1610
 msgid "go to which hunk? "
 msgstr "към кое парче да се придвижи? "
 
@@ -902,7 +908,7 @@ msgstr[1] "Има само %d парчета."
 msgid "No other hunks to search"
 msgstr "Няма други парчета за търсене"
 
-#: add-patch.c:1581 git-add--interactive.perl:1661
+#: add-patch.c:1581 git-add--interactive.perl:1663
 msgid "search for regex? "
 msgstr "да се търси с регулярен израз? "
 
@@ -984,7 +990,7 @@ msgstr ""
 msgid "Exiting because of an unresolved conflict."
 msgstr "Изход от програмата заради некоригиран конфликт."
 
-#: advice.c:209 builtin/merge.c:1379
+#: advice.c:209 builtin/merge.c:1382
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "Не сте завършили сливане.  (Указателят „MERGE_HEAD“ съществува)."
 
@@ -1081,21 +1087,33 @@ msgstr "непозната опция за знаците за интервал�
 msgid "unrecognized whitespace ignore option '%s'"
 msgstr "непозната опция за игнориране на знаците за интервали „%s“"
 
-#: apply.c:136
-msgid "--reject and --3way cannot be used together."
-msgstr "опциите „--reject“ и „--3way“ са несъвместими"
+#: apply.c:136 archive.c:584 range-diff.c:559 revision.c:2303 revision.c:2307
+#: revision.c:2316 revision.c:2321 revision.c:2527 revision.c:2870
+#: revision.c:2874 revision.c:2880 revision.c:2883 revision.c:2885
+#: builtin/add.c:510 builtin/add.c:512 builtin/add.c:529 builtin/add.c:541
+#: builtin/branch.c:727 builtin/checkout.c:467 builtin/checkout.c:470
+#: builtin/checkout.c:1644 builtin/checkout.c:1754 builtin/checkout.c:1757
+#: builtin/clone.c:906 builtin/commit.c:358 builtin/commit.c:361
+#: builtin/commit.c:1196 builtin/describe.c:593 builtin/diff-tree.c:155
+#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2033
+#: builtin/fetch.c:2038 builtin/index-pack.c:1852 builtin/init-db.c:560
+#: builtin/log.c:1946 builtin/log.c:1948 builtin/ls-files.c:778
+#: builtin/merge.c:1403 builtin/merge.c:1405 builtin/pack-objects.c:4073
+#: builtin/push.c:592 builtin/push.c:630 builtin/push.c:636 builtin/push.c:641
+#: builtin/rebase.c:1193 builtin/rebase.c:1195 builtin/rebase.c:1199
+#: builtin/repack.c:684 builtin/repack.c:715 builtin/reset.c:426
+#: builtin/reset.c:462 builtin/rev-list.c:541 builtin/show-branch.c:710
+#: builtin/stash.c:1707 builtin/stash.c:1710 builtin/submodule--helper.c:1316
+#: builtin/submodule--helper.c:2975 builtin/tag.c:526 builtin/tag.c:572
+#: builtin/worktree.c:702
+#, c-format
+msgid "options '%s' and '%s' cannot be used together"
+msgstr "опциите „%s“ и „%s“ са несъвместими"
 
-#: apply.c:139
-msgid "--3way outside a repository"
-msgstr "като „--3way“, но извън хранилище"
-
-#: apply.c:150
-msgid "--index outside a repository"
-msgstr "като „--index“, но извън хранилище"
-
-#: apply.c:153
-msgid "--cached outside a repository"
-msgstr "като „--cached“, но извън хранилище"
+#: apply.c:139 apply.c:150 apply.c:153
+#, c-format
+msgid "'%s' outside a repository"
+msgstr "„%s“ извън хранилище"
 
 #: apply.c:800
 #, c-format
@@ -1320,8 +1338,8 @@ msgstr "неуспешно прилагане на кръпка: „%s:%ld“"
 msgid "cannot checkout %s"
 msgstr "„%s“ не може да се изтегли"
 
-#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:102 pack-revindex.c:214
-#: setup.c:308
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:104 pack-revindex.c:214
+#: setup.c:309
 #, c-format
 msgid "failed to read %s"
 msgstr "файлът „%s“ не може да бъде прочетен"
@@ -1331,249 +1349,250 @@ msgstr "файлът „%s“ не може да бъде прочетен"
 msgid "reading from '%s' beyond a symbolic link"
 msgstr "изчитане на „%s“ след проследяване на символна връзка"
 
-#: apply.c:3442 apply.c:3709
+#: apply.c:3442 apply.c:3711
 #, c-format
 msgid "path %s has been renamed/deleted"
 msgstr "обектът с път „%s“ е преименуван или изтрит"
 
-#: apply.c:3549 apply.c:3724
+#: apply.c:3549 apply.c:3726
 #, c-format
 msgid "%s: does not exist in index"
 msgstr "„%s“ не съществува в индекса"
 
-#: apply.c:3558 apply.c:3732 apply.c:3976
+#: apply.c:3558 apply.c:3734 apply.c:3978
 #, c-format
 msgid "%s: does not match index"
 msgstr "„%s“ не съответства на индекса"
 
-#: apply.c:3593
+#: apply.c:3595
 msgid "repository lacks the necessary blob to perform 3-way merge."
 msgstr "в хранилището липсват необходимите обекти-BLOB, за тройно сливане."
 
-#: apply.c:3596
+#: apply.c:3598
 #, c-format
 msgid "Performing three-way merge...\n"
 msgstr "Тройно сливане…\n"
 
-#: apply.c:3612 apply.c:3616
+#: apply.c:3614 apply.c:3618
 #, c-format
 msgid "cannot read the current contents of '%s'"
 msgstr "текущото съдържание на „%s“ не може да бъде прочетено"
 
-#: apply.c:3628
+#: apply.c:3630
 #, c-format
 msgid "Failed to perform three-way merge...\n"
 msgstr "Неуспешно тройно сливане…\n"
 
-#: apply.c:3642
+#: apply.c:3644
 #, c-format
 msgid "Applied patch to '%s' with conflicts.\n"
 msgstr "Конфликти при прилагането на кръпката към „%s“.\n"
 
-#: apply.c:3647
+#: apply.c:3649
 #, c-format
 msgid "Applied patch to '%s' cleanly.\n"
 msgstr "Кръпката бе приложена чисто към „%s“.\n"
 
-#: apply.c:3664
+#: apply.c:3666
 #, c-format
 msgid "Falling back to direct application...\n"
 msgstr "Преминаване към пряко прилагане…\n"
 
-#: apply.c:3676
+#: apply.c:3678
 msgid "removal patch leaves file contents"
 msgstr "изтриващата кръпка оставя файла непразен"
 
-#: apply.c:3749
+#: apply.c:3751
 #, c-format
 msgid "%s: wrong type"
 msgstr "„%s“: неправилен вид"
 
-#: apply.c:3751
+#: apply.c:3753
 #, c-format
 msgid "%s has type %o, expected %o"
 msgstr "„%s“ е от вид „%o“, а се очакваше „%o“"
 
-#: apply.c:3916 apply.c:3918 read-cache.c:876 read-cache.c:905
-#: read-cache.c:1368
+#: apply.c:3918 apply.c:3920 read-cache.c:889 read-cache.c:918
+#: read-cache.c:1381
 #, c-format
 msgid "invalid path '%s'"
 msgstr "неправилен път: „%s“"
 
-#: apply.c:3974
+#: apply.c:3976
 #, c-format
 msgid "%s: already exists in index"
 msgstr "„%s“: вече съществува в индекса"
 
-#: apply.c:3978
+#: apply.c:3980
 #, c-format
 msgid "%s: already exists in working directory"
 msgstr "„%s“: вече съществува в работното дърво"
 
-#: apply.c:3998
+#: apply.c:4000
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
 msgstr "новите права за достъп (%o) на „%s“ не съвпадат със старите (%o)"
 
-#: apply.c:4003
+#: apply.c:4005
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
 msgstr ""
 "новите права за достъп (%o) на „%s“ не съвпадат със старите (%o) на „%s“"
 
-#: apply.c:4023
+#: apply.c:4025
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
 msgstr "засегнатият файл „%s“ е след символна връзка"
 
-#: apply.c:4027
+#: apply.c:4029
 #, c-format
 msgid "%s: patch does not apply"
 msgstr "Кръпката „%s“ не може да бъде приложена"
 
-#: apply.c:4042
+#: apply.c:4044
 #, c-format
 msgid "Checking patch %s..."
 msgstr "Проверяване на кръпката „%s“…"
 
-#: apply.c:4134
+#: apply.c:4136
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
 msgstr ""
 "информацията за сумата по SHA1 за подмодула липсва или не е достатъчна (%s)."
 
-#: apply.c:4141
+#: apply.c:4143
 #, c-format
 msgid "mode change for %s, which is not in current HEAD"
 msgstr "смяна на режима на достъпа на „%s“, който не е в текущия връх „HEAD“"
 
-#: apply.c:4144
+#: apply.c:4146
 #, c-format
 msgid "sha1 information is lacking or useless (%s)."
 msgstr "информацията за сумата по SHA1 липсва или не е достатъчна (%s)."
 
-#: apply.c:4153
+#: apply.c:4155
 #, c-format
 msgid "could not add %s to temporary index"
 msgstr "„%s“ не може да се добави към временния индекс"
 
-#: apply.c:4163
+#: apply.c:4165
 #, c-format
 msgid "could not write temporary index to %s"
 msgstr "временният индекс не може да се запази в „%s“"
 
-#: apply.c:4301
+#: apply.c:4303
 #, c-format
 msgid "unable to remove %s from index"
 msgstr "„%s“ не може да се извади от индекса"
 
-#: apply.c:4335
+#: apply.c:4337
 #, c-format
 msgid "corrupt patch for submodule %s"
 msgstr "повредена кръпка за модула „%s“"
 
-#: apply.c:4341
+#: apply.c:4343
 #, c-format
 msgid "unable to stat newly created file '%s'"
 msgstr ""
 "не може да се получи информация чрез „stat“ за новосъздадения файл „%s“"
 
-#: apply.c:4349
+#: apply.c:4351
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr ""
 "не може да се за създаде мястото за съхранение на новосъздадения файл „%s“"
 
-#: apply.c:4355 apply.c:4500
+#: apply.c:4357 apply.c:4502
 #, c-format
 msgid "unable to add cache entry for %s"
 msgstr "не може да се добави запис в кеша за „%s“"
 
-#: apply.c:4398 builtin/bisect--helper.c:540 builtin/gc.c:2241
-#: builtin/gc.c:2276
+#: apply.c:4400 builtin/bisect--helper.c:540 builtin/gc.c:2258
+#: builtin/gc.c:2293
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "в „%s“ не може да се пише"
 
-#: apply.c:4402
+#: apply.c:4404
 #, c-format
 msgid "closing file '%s'"
 msgstr "затваряне на файла „%s“"
 
-#: apply.c:4472
+#: apply.c:4474
 #, c-format
 msgid "unable to write file '%s' mode %o"
 msgstr "файлът „%s“ не може да се запише с режим на достъп „%o“"
 
-#: apply.c:4570
+#: apply.c:4572
 #, c-format
 msgid "Applied patch %s cleanly."
 msgstr "Кръпката „%s“ бе приложена чисто."
 
-#: apply.c:4578
+#: apply.c:4580
 msgid "internal error"
 msgstr "вътрешна грешка"
 
-#: apply.c:4581
+#: apply.c:4583
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
 msgstr[0] "Прилагане на кръпката „%%s“ с %d отхвърлено парче…"
 msgstr[1] "Прилагане на кръпката „%%s“ с %d отхвърлени парчета…"
 
-#: apply.c:4592
+#: apply.c:4594
 #, c-format
 msgid "truncating .rej filename to %.*s.rej"
-msgstr "съкращаване на името на файла с отхвърлените парчета на „ %.*s.rej“"
+msgstr "съкращаване на името на файла с отхвърлените парчета на „%.*s.rej“"
 
-#: apply.c:4600 builtin/fetch.c:998 builtin/fetch.c:1408
+#: apply.c:4602
 #, c-format
 msgid "cannot open %s"
 msgstr "„%s“ не може да бъде отворен"
 
-#: apply.c:4614
+#: apply.c:4616
 #, c-format
 msgid "Hunk #%d applied cleanly."
 msgstr "%d-то парче бе успешно приложено."
 
-#: apply.c:4618
+#: apply.c:4620
 #, c-format
 msgid "Rejected hunk #%d."
 msgstr "%d-то парче бе отхвърлено."
 
-#: apply.c:4747
+#: apply.c:4749
 #, c-format
 msgid "Skipped patch '%s'."
 msgstr "Пропусната кръпка: „%s“"
 
-#: apply.c:4755
-msgid "unrecognized input"
-msgstr "непознат вход"
+#: apply.c:4758
+msgid "No valid patches in input (allow with \"--allow-empty\")"
+msgstr ""
+"На входа няма непразни кръпки (те се приемат при опция „--allow-empty“)"
 
-#: apply.c:4775
+#: apply.c:4779
 msgid "unable to read index file"
 msgstr "индексът не може да бъде записан"
 
-#: apply.c:4932
+#: apply.c:4936
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr "кръпката „%s“ не може да бъде отворена: %s"
 
-#: apply.c:4959
+#: apply.c:4963
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "пренебрегната е %d грешка в знаците за интервали"
 msgstr[1] "пренебрегнати са %d грешки в знаците за интервали"
 
-#: apply.c:4965 apply.c:4980
+#: apply.c:4969 apply.c:4984
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] "%d ред добавя грешки в знаците за интервали."
 msgstr[1] "%d реда добавят грешки в знаците за интервали."
 
-#: apply.c:4973
+#: apply.c:4977
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
@@ -1582,140 +1601,138 @@ msgstr[0] ""
 msgstr[1] ""
 "Добавени са %d реда след корекцията на грешките в знаците за интервали."
 
-#: apply.c:4989 builtin/add.c:707 builtin/mv.c:338 builtin/rm.c:429
+#: apply.c:4993 builtin/add.c:704 builtin/mv.c:338 builtin/rm.c:430
 msgid "Unable to write new index file"
 msgstr "Новият индекс не може да бъде записан"
 
-#: apply.c:5017
+#: apply.c:5021
 msgid "don't apply changes matching the given path"
 msgstr "без прилагане на промените напасващи на дадения път"
 
-#: apply.c:5020
+#: apply.c:5024
 msgid "apply changes matching the given path"
 msgstr "прилагане на промените напасващи на дадения път"
 
-#: apply.c:5022 builtin/am.c:2320
+#: apply.c:5026 builtin/am.c:2376
 msgid "num"
 msgstr "БРОЙ"
 
-#: apply.c:5023
+#: apply.c:5027
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr "премахване на този БРОЙ водещи елементи от пътищата в разликата"
 
-#: apply.c:5026
+#: apply.c:5030
 msgid "ignore additions made by the patch"
 msgstr "игнориране на редовете добавени от тази кръпка"
 
-#: apply.c:5028
+#: apply.c:5032
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr "извеждане на статистика на промените без прилагане на кръпката"
 
-#: apply.c:5032
+#: apply.c:5036
 msgid "show number of added and deleted lines in decimal notation"
 msgstr "извеждане на броя на добавените и изтритите редове"
 
-#: apply.c:5034
+#: apply.c:5038
 msgid "instead of applying the patch, output a summary for the input"
 msgstr "извеждане на статистика на входните данни без прилагане на кръпката"
 
-#: apply.c:5036
+#: apply.c:5040
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr "проверка дали кръпката може да се приложи, без действително прилагане"
 
-#: apply.c:5038
+#: apply.c:5042
 msgid "make sure the patch is applicable to the current index"
 msgstr "проверка дали кръпката може да бъде приложена към текущия индекс"
 
-#: apply.c:5040
+#: apply.c:5044
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "отбелязване на новите файлове с „git add --intent-to-add“"
 
-#: apply.c:5042
+#: apply.c:5046
 msgid "apply a patch without touching the working tree"
 msgstr "прилагане на кръпката без промяна на работното дърво"
 
-#: apply.c:5044
+#: apply.c:5048
 msgid "accept a patch that touches outside the working area"
 msgstr "прилагане на кръпка, която променя и файлове извън работното дърво"
 
-#: apply.c:5047
+#: apply.c:5051
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr ""
 "кръпката да бъде приложена.  Опцията се комбинира с „--check“/„--stat“/„--"
 "summary“"
 
-#: apply.c:5049
+#: apply.c:5053
 msgid "attempt three-way merge, fall back on normal patch if that fails"
 msgstr ""
 "пробване с тройно сливане, ако това не сработи — стандартно прилагане на "
 "кръпка"
 
-#: apply.c:5051
+#: apply.c:5055
 msgid "build a temporary index based on embedded index information"
 msgstr ""
 "създаване на временен индекс на база на включената информация за индекса"
 
-#: apply.c:5054 builtin/checkout-index.c:196
+#: apply.c:5058 builtin/checkout-index.c:196
 msgid "paths are separated with NUL character"
 msgstr "разделяне на пътищата с нулевия знак „NUL“"
 
-#: apply.c:5056
+#: apply.c:5060
 msgid "ensure at least <n> lines of context match"
 msgstr "да се осигури контекст от поне такъв БРОЙ съвпадащи редове"
 
-#: apply.c:5057 builtin/am.c:2296 builtin/am.c:2299
+#: apply.c:5061 builtin/am.c:2352 builtin/am.c:2355
 #: builtin/interpret-trailers.c:98 builtin/interpret-trailers.c:100
 #: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3960
 #: builtin/rebase.c:1051
 msgid "action"
 msgstr "действие"
 
-#: apply.c:5058
+#: apply.c:5062
 msgid "detect new or modified lines that have whitespace errors"
 msgstr "засичане на нови или променени редове с грешки в знаците за интервали"
 
-#: apply.c:5061 apply.c:5064
+#: apply.c:5065 apply.c:5068
 msgid "ignore changes in whitespace when finding context"
 msgstr ""
 "игнориране на промените в знаците за интервали при откриване на контекста"
 
-#: apply.c:5067
+#: apply.c:5071
 msgid "apply the patch in reverse"
 msgstr "прилагане на кръпката в обратна посока"
 
-#: apply.c:5069
+#: apply.c:5073
 msgid "don't expect at least one line of context"
 msgstr "без изискване на дори и един ред контекст"
 
-#: apply.c:5071
+#: apply.c:5075
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr "оставяне на отхвърлените парчета във файлове с разширение „.rej“"
 
-#: apply.c:5073
+#: apply.c:5077
 msgid "allow overlapping hunks"
 msgstr "позволяване на застъпващи се парчета"
 
-#: apply.c:5074 builtin/add.c:372 builtin/check-ignore.c:22
-#: builtin/commit.c:1483 builtin/count-objects.c:98 builtin/fsck.c:788
-#: builtin/log.c:2297 builtin/mv.c:123 builtin/read-tree.c:120
-msgid "be verbose"
-msgstr "повече подробности"
-
-#: apply.c:5076
+#: apply.c:5080
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr "пренебрегване на неправилно липсващ знак за нов ред в края на файл"
 
-#: apply.c:5079
+#: apply.c:5083
 msgid "do not trust the line counts in the hunk headers"
 msgstr "без доверяване на номерата на редовете в заглавните части на парчетата"
 
-#: apply.c:5081 builtin/am.c:2308
+#: apply.c:5085 builtin/am.c:2364
 msgid "root"
 msgstr "НАЧАЛНА_ДИРЕКТОРИЯ"
 
-#: apply.c:5082
+#: apply.c:5086
 msgid "prepend <root> to all filenames"
 msgstr "добавяне на тази НАЧАЛНА_ДИРЕКТОРИЯ към имената на всички файлове"
+
+#: apply.c:5089
+msgid "don't return error for empty patches"
+msgstr "да не се връща грешка при празни кръпки"
 
 #: archive-tar.c:125 archive-zip.c:345
 #, c-format
@@ -1727,16 +1744,16 @@ msgstr "обектът-BLOB „%s“ не може да бъде обработ�
 msgid "unsupported file mode: 0%o (SHA1: %s)"
 msgstr "неподдържани права за достъп до файл: 0%o (SHA1: %s)"
 
-#: archive-tar.c:450
+#: archive-tar.c:447
 #, c-format
 msgid "unable to start '%s' filter"
 msgstr "филтърът „%s“ не може да бъде стартиран"
 
-#: archive-tar.c:453
+#: archive-tar.c:450
 msgid "unable to redirect descriptor"
 msgstr "дескрипторът не може да бъде пренасочен"
 
-#: archive-tar.c:460
+#: archive-tar.c:457
 #, c-format
 msgid "'%s' filter reported error"
 msgstr "филтърът „%s“ върна грешка"
@@ -1780,19 +1797,13 @@ msgstr ""
 msgid "git archive --remote <repo> [--exec <cmd>] --list"
 msgstr "git archive --remote ХРАНИЛИЩЕ [--exec КОМАНДА] --list"
 
-#: archive.c:188
+#: archive.c:188 archive.c:341 builtin/gc.c:497 builtin/notes.c:238
+#: builtin/tag.c:578
 #, c-format
-msgid "cannot read %s"
-msgstr "обектът „%s“ не може да бъде прочетен"
-
-#: archive.c:341 sequencer.c:473 sequencer.c:1932 sequencer.c:3114
-#: sequencer.c:3556 sequencer.c:3684 builtin/am.c:263 builtin/commit.c:834
-#: builtin/merge.c:1145
-#, c-format
-msgid "could not read '%s'"
+msgid "cannot read '%s'"
 msgstr "файлът „%s“ не може да бъде прочетен"
 
-#: archive.c:426 builtin/add.c:215 builtin/add.c:674 builtin/rm.c:334
+#: archive.c:426 builtin/add.c:215 builtin/add.c:671 builtin/rm.c:334
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "пътят „%s“ не съвпада с никой файл"
@@ -1834,7 +1845,7 @@ msgstr "ФОРМАТ"
 msgid "archive format"
 msgstr "ФОРМАТ на архива"
 
-#: archive.c:552 builtin/log.c:1775
+#: archive.c:552 builtin/log.c:1790
 msgid "prefix"
 msgstr "ПРЕФИКС"
 
@@ -1844,9 +1855,9 @@ msgstr "добавяне на този ПРЕФИКС към всеки път �
 
 #: archive.c:554 archive.c:557 builtin/blame.c:880 builtin/blame.c:884
 #: builtin/blame.c:885 builtin/commit-tree.c:115 builtin/config.c:135
-#: builtin/fast-export.c:1208 builtin/fast-export.c:1210
-#: builtin/fast-export.c:1214 builtin/grep.c:935 builtin/hash-object.c:103
-#: builtin/ls-files.c:651 builtin/ls-files.c:654 builtin/notes.c:410
+#: builtin/fast-export.c:1181 builtin/fast-export.c:1183
+#: builtin/fast-export.c:1187 builtin/grep.c:935 builtin/hash-object.c:103
+#: builtin/ls-files.c:654 builtin/ls-files.c:657 builtin/notes.c:410
 #: builtin/notes.c:576 builtin/read-tree.c:115 parse-options.h:190
 msgid "file"
 msgstr "ФАЙЛ"
@@ -1876,7 +1887,7 @@ msgid "list supported archive formats"
 msgstr "извеждане на списъка с поддържаните формати"
 
 #: archive.c:568 builtin/archive.c:89 builtin/clone.c:118 builtin/clone.c:121
-#: builtin/submodule--helper.c:1869 builtin/submodule--helper.c:2512
+#: builtin/submodule--helper.c:1870 builtin/submodule--helper.c:2513
 msgid "repo"
 msgstr "хранилище"
 
@@ -1884,7 +1895,7 @@ msgstr "хранилище"
 msgid "retrieve the archive from remote repository <repo>"
 msgstr "получаване на архива от отдалеченото ХРАНИЛИЩЕ"
 
-#: archive.c:570 builtin/archive.c:91 builtin/difftool.c:714
+#: archive.c:570 builtin/archive.c:91 builtin/difftool.c:708
 #: builtin/notes.c:496
 msgid "command"
 msgstr "команда"
@@ -1897,17 +1908,19 @@ msgstr "път към отдалечената команда „git-upload-arch
 msgid "Unexpected option --remote"
 msgstr "Неочаквана опция „--remote“"
 
-#: archive.c:580
-msgid "Option --exec can only be used together with --remote"
-msgstr "опцията „--exec“ изисква „--remote“"
+#: archive.c:580 fetch-pack.c:300 revision.c:2887 builtin/add.c:544
+#: builtin/add.c:576 builtin/checkout.c:1763 builtin/commit.c:370
+#: builtin/fast-export.c:1230 builtin/index-pack.c:1848 builtin/log.c:2115
+#: builtin/reset.c:435 builtin/reset.c:493 builtin/rm.c:281
+#: builtin/stash.c:1719 builtin/worktree.c:508 http-fetch.c:144
+#: http-fetch.c:153
+#, c-format
+msgid "the option '%s' requires '%s'"
+msgstr "опцията „%s“ изисква „%s“"
 
 #: archive.c:582
 msgid "Unexpected option --output"
 msgstr "Неочаквана опция „--output“"
-
-#: archive.c:584
-msgid "Options --add-file and --remote cannot be used together"
-msgstr "опциите „--add-file“ и „--remote“ са несъвместими"
 
 #: archive.c:606
 #, c-format
@@ -2016,7 +2029,7 @@ msgstr "необходима е версия „%s“"
 msgid "could not create file '%s'"
 msgstr "файлът „%s“ не може да бъде създаден"
 
-#: bisect.c:985 builtin/merge.c:154
+#: bisect.c:985 builtin/merge.c:155
 #, c-format
 msgid "could not read file '%s'"
 msgstr "файлът „%s“ не може да бъде прочетен"
@@ -2070,10 +2083,10 @@ msgstr ""
 "Едновременното задаване на опциите „--reverse“ и „--first-parent“ изисква "
 "указването на крайно подаване"
 
-#: blame.c:2820 bundle.c:224 midx.c:1039 ref-filter.c:2370 remote.c:2041
-#: sequencer.c:2350 sequencer.c:4902 submodule.c:883 builtin/commit.c:1114
-#: builtin/log.c:414 builtin/log.c:1021 builtin/log.c:1629 builtin/log.c:2056
-#: builtin/log.c:2346 builtin/merge.c:429 builtin/pack-objects.c:3373
+#: blame.c:2820 bundle.c:224 midx.c:1042 ref-filter.c:2370 remote.c:2158
+#: sequencer.c:2352 sequencer.c:4899 submodule.c:883 builtin/commit.c:1114
+#: builtin/log.c:429 builtin/log.c:1036 builtin/log.c:1644 builtin/log.c:2071
+#: builtin/log.c:2362 builtin/merge.c:431 builtin/pack-objects.c:3373
 #: builtin/pack-objects.c:3775 builtin/pack-objects.c:3790
 #: builtin/shortlog.c:255
 msgid "revision walk setup failed"
@@ -2096,101 +2109,97 @@ msgstr "няма път на име „%s“ в „%s“"
 msgid "cannot read blob %s for path %s"
 msgstr "обектът-BLOB „%s“ в пътя %s не може да бъде прочетен"
 
-#: branch.c:53
+#: branch.c:77
+msgid ""
+"cannot inherit upstream tracking configuration of multiple refs when "
+"rebasing is requested"
+msgstr ""
+"настроените множество указатели, които да се следят, не може да се наследят "
+"при пребазиране"
+
+#: branch.c:88
 #, c-format
+msgid "not setting branch '%s' as its own upstream"
+msgstr ""
+"клонът „%s“ не може да служи като източник за собствената си синхронизация"
+
+#: branch.c:144
+#, c-format
+msgid "branch '%s' set up to track '%s' by rebasing."
+msgstr "клонът „%s“ ще следи „%s“ чрез пребазиране."
+
+#: branch.c:145
+#, c-format
+msgid "branch '%s' set up to track '%s'."
+msgstr "клонът „%s“ ще следи „%s“."
+
+#: branch.c:148
+#, c-format
+msgid "branch '%s' set up to track:"
+msgstr "клонът „%s“ ще следи:"
+
+#: branch.c:160
+msgid "unable to write upstream branch configuration"
+msgstr "настройките за следения клон не може да бъдат записани"
+
+#: branch.c:162
 msgid ""
 "\n"
 "After fixing the error cause you may try to fix up\n"
-"the remote tracking information by invoking\n"
-"\"git branch --set-upstream-to=%s%s%s\"."
+"the remote tracking information by invoking:"
 msgstr ""
 "\n"
 "След корекция на грешката, може да обновите\n"
-"информацията за следения клон чрез:\n"
-"git branch --set-upstream-to=%s%s%s"
+"информацията за следения клон чрез:"
 
-#: branch.c:67
+#: branch.c:203
 #, c-format
-msgid "Not setting branch %s as its own upstream."
+msgid "asked to inherit tracking from '%s', but no remote is set"
 msgstr ""
-"Клонът „%s“ не може да служи като източник за собствената си синхронизация."
+"заявка за наследяване на следенето от „%s“, но не е зададено отдалечено "
+"хранилище"
 
-#: branch.c:93
+#: branch.c:209
 #, c-format
-msgid "Branch '%s' set up to track remote branch '%s' from '%s' by rebasing."
+msgid "asked to inherit tracking from '%s', but no merge configuration is set"
 msgstr ""
-"Клонът „%s“ ще следи отдалечения клон „%s“ от хранилището „%s“ чрез "
-"пребазиране."
+"заявка за наследяване на следенето от „%s“, но не е настроен режим за "
+"пребазиране"
 
-#: branch.c:94
+#: branch.c:252
 #, c-format
-msgid "Branch '%s' set up to track remote branch '%s' from '%s'."
-msgstr "Клонът „%s“ ще следи отдалечения клон „%s“ от хранилището „%s“."
+msgid "not tracking: ambiguous information for ref %s"
+msgstr "няма следене: информацията за указателя „%s“ не е еднозначна"
 
-#: branch.c:98
+#: branch.c:287
 #, c-format
-msgid "Branch '%s' set up to track local branch '%s' by rebasing."
-msgstr "Клонът „%s“ ще следи локалния клон „%s“ чрез пребазиране."
+msgid "'%s' is not a valid branch name"
+msgstr "„%s“ не е позволено име за клон"
 
-#: branch.c:99
+#: branch.c:307
 #, c-format
-msgid "Branch '%s' set up to track local branch '%s'."
-msgstr "Клонът „%s“ ще следи локалния клон „%s“."
+msgid "a branch named '%s' already exists"
+msgstr "вече съществува клон с име „%s“."
 
-#: branch.c:104
+# FIXME
+#: branch.c:313
 #, c-format
-msgid "Branch '%s' set up to track remote ref '%s' by rebasing."
-msgstr "Клонът „%s“ ще следи отдалечения указател „%s“ чрез пребазиране."
+msgid "cannot force update the branch '%s'checked out at '%s'"
+msgstr ""
+"не може принудително да обновите клона „%s“, който е изтеглен в пътя „%s“"
 
-#: branch.c:105
+#: branch.c:336
 #, c-format
-msgid "Branch '%s' set up to track remote ref '%s'."
-msgstr "Клонът „%s“ ще следи отдалечения указател „%s“."
+msgid "cannot set up tracking information; starting point '%s' is not a branch"
+msgstr ""
+"настройките за следенето не може да се зададат — началото „%s“ не е клон"
 
-#: branch.c:109
-#, c-format
-msgid "Branch '%s' set up to track local ref '%s' by rebasing."
-msgstr "Клонът „%s“ ще следи локалния указател „%s“ чрез пребазиране."
-
-#: branch.c:110
-#, c-format
-msgid "Branch '%s' set up to track local ref '%s'."
-msgstr "Клонът „%s“ ще следи локалния указател „%s“."
-
-#: branch.c:119
-msgid "Unable to write upstream branch configuration"
-msgstr "Настройките за следения клон не може да бъдат записани"
-
-#: branch.c:156
-#, c-format
-msgid "Not tracking: ambiguous information for ref %s"
-msgstr "Няма следене: информацията за указателя „%s“ не е еднозначна"
-
-#: branch.c:189
-#, c-format
-msgid "'%s' is not a valid branch name."
-msgstr "„%s“ не е позволено име за клон."
-
-#: branch.c:208
-#, c-format
-msgid "A branch named '%s' already exists."
-msgstr "Вече съществува клон с име „%s“."
-
-#: branch.c:213
-msgid "Cannot force update the current branch."
-msgstr "Текущият клон не може да бъде принудително обновен."
-
-#: branch.c:233
-#, c-format
-msgid "Cannot setup tracking information; starting point '%s' is not a branch."
-msgstr "Зададените настройки за следенето са грешни — началото „%s“ не е клон."
-
-#: branch.c:235
+#: branch.c:338
 #, c-format
 msgid "the requested upstream branch '%s' does not exist"
 msgstr "заявеният отдалечен клон „%s“ не съществува"
 
-#: branch.c:237
+#: branch.c:340
 msgid ""
 "\n"
 "If you are planning on basing your work on an upstream\n"
@@ -2209,27 +2218,28 @@ msgstr ""
 "може да използвате „git push -u“, за да настроите към кой клон да се "
 "изтласква."
 
-#: branch.c:281
+#: branch.c:384 builtin/replace.c:321 builtin/replace.c:377
+#: builtin/replace.c:423 builtin/replace.c:453
 #, c-format
-msgid "Not a valid object name: '%s'."
-msgstr "Неправилно име на обект: „%s“"
+msgid "not a valid object name: '%s'"
+msgstr "неправилно име на обект: „%s“"
 
-#: branch.c:301
+#: branch.c:404
 #, c-format
-msgid "Ambiguous object name: '%s'."
-msgstr "Името на обект не е еднозначно: „%s“"
+msgid "ambiguous object name: '%s'"
+msgstr "името на обект не е еднозначно: „%s“"
 
-#: branch.c:306
+#: branch.c:409
 #, c-format
-msgid "Not a valid branch point: '%s'."
-msgstr "Неправилно място за начало на клон: „%s“"
+msgid "not a valid branch point: '%s'"
+msgstr "неправилно място за начало на клон: „%s“"
 
-#: branch.c:366
+#: branch.c:469
 #, c-format
 msgid "'%s' is already checked out at '%s'"
 msgstr "„%s“ вече е изтеглен в „%s“"
 
-#: branch.c:389
+#: branch.c:494
 #, c-format
 msgid "HEAD of working tree %s is not updated"
 msgstr "Указателят „HEAD“ на работното дърво „%s“ не е обновен"
@@ -2254,7 +2264,7 @@ msgstr "Файлът „%s“ не изглежда да е пратка на gi
 msgid "unrecognized header: %s%s (%d)"
 msgstr "непозната заглавна част: %s%s (%d)"
 
-#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2618 sequencer.c:3404
+#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2620 sequencer.c:3406
 #: builtin/commit.c:862
 #, c-format
 msgid "could not open '%s'"
@@ -2314,7 +2324,7 @@ msgstr "неподдържана версия на индекса %d"
 msgid "cannot write bundle version %d with algorithm %s"
 msgstr "пратка %d не може да се запише с алгоритъм %s"
 
-#: bundle.c:524 builtin/log.c:210 builtin/log.c:1938 builtin/shortlog.c:399
+#: bundle.c:524 builtin/log.c:210 builtin/log.c:1953 builtin/shortlog.c:399
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr "непознат аргумент: %s"
@@ -2351,7 +2361,7 @@ msgstr "повтарящ се идентификатор на откъс %<PRIx3
 msgid "final chunk has non-zero id %<PRIx32>"
 msgstr "ненулев идентификатор за краен откъс %<PRIx32>"
 
-#: color.c:329
+#: color.c:354
 #, c-format
 msgid "invalid color value: %.*s"
 msgstr "неправилна стойност за цвят: %.*s"
@@ -2402,197 +2412,197 @@ msgstr ""
 msgid "unable to find all commit-graph files"
 msgstr "някои файлове на гра̀фа с подаванията не може да бъдат открити"
 
-#: commit-graph.c:746 commit-graph.c:783
+#: commit-graph.c:749 commit-graph.c:786
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr ""
 "неправилна позиция на подаването.  Вероятно графът с подаванията е повреден"
 
-#: commit-graph.c:767
+#: commit-graph.c:770
 #, c-format
 msgid "could not find commit %s"
 msgstr "подаването „%s“ не може да бъде открито"
 
-#: commit-graph.c:800
+#: commit-graph.c:803
 msgid "commit-graph requires overflow generation data but has none"
 msgstr ""
 "графът с подаванията изисква генериране на данни за отместването, но такива "
 "липсват"
 
-#: commit-graph.c:1105 builtin/am.c:1342
+#: commit-graph.c:1108 builtin/am.c:1369
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "подаването не може да бъде анализирано: %s"
 
-#: commit-graph.c:1367 builtin/pack-objects.c:3070
+#: commit-graph.c:1370 builtin/pack-objects.c:3070
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "видът на обекта „%s“ не може да бъде определен"
 
-#: commit-graph.c:1398
+#: commit-graph.c:1401
 msgid "Loading known commits in commit graph"
 msgstr "Зареждане на познатите подавания в гра̀фа с подаванията"
 
-#: commit-graph.c:1415
+#: commit-graph.c:1418
 msgid "Expanding reachable commits in commit graph"
 msgstr "Разширяване на достижимите подавания в гра̀фа"
 
-#: commit-graph.c:1435
+#: commit-graph.c:1438
 msgid "Clearing commit marks in commit graph"
 msgstr "Изчистване на отбелязванията на подаванията в гра̀фа с подаванията"
 
-#: commit-graph.c:1454
+#: commit-graph.c:1457
 msgid "Computing commit graph topological levels"
 msgstr "Изчисляване на топологичните нива в гра̀фа с подаванията"
 
-#: commit-graph.c:1507
+#: commit-graph.c:1510
 msgid "Computing commit graph generation numbers"
 msgstr "Изчисляване на номерата на поколенията в гра̀фа с подаванията"
 
-#: commit-graph.c:1588
+#: commit-graph.c:1591
 msgid "Computing commit changed paths Bloom filters"
 msgstr "Изчисляване на филтрите на Блум на пътищата с промяна при подаването"
 
-#: commit-graph.c:1665
+#: commit-graph.c:1668
 msgid "Collecting referenced commits"
 msgstr "Събиране на свързаните подавания"
 
-#: commit-graph.c:1690
+#: commit-graph.c:1693
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] "Откриване на подаванията в гра̀фа в %d пакетен файл"
 msgstr[1] "Откриване на подаванията в гра̀фа в %d пакетни файла"
 
-#: commit-graph.c:1703
+#: commit-graph.c:1706
 #, c-format
 msgid "error adding pack %s"
 msgstr "грешка при добавяне на пакетен файл „%s“"
 
-#: commit-graph.c:1707
+#: commit-graph.c:1710
 #, c-format
 msgid "error opening index for %s"
 msgstr "грешка при отваряне на индекса на „%s“"
 
-#: commit-graph.c:1744
+#: commit-graph.c:1747
 msgid "Finding commits for commit graph among packed objects"
 msgstr "Откриване на подаванията в гра̀фа измежду пакетираните обекти"
 
-#: commit-graph.c:1762
+#: commit-graph.c:1765
 msgid "Finding extra edges in commit graph"
 msgstr "Откриване на още върхове в гра̀фа с подаванията"
 
-#: commit-graph.c:1811
+#: commit-graph.c:1814
 msgid "failed to write correct number of base graph ids"
 msgstr "правилният брой на базовите идентификатори не може да се запише"
 
-#: commit-graph.c:1842 midx.c:1146
+#: commit-graph.c:1845 midx.c:1149
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "родителските директории на „%s“ не може да бъдат създадени"
 
-#: commit-graph.c:1855
+#: commit-graph.c:1858
 msgid "unable to create temporary graph layer"
 msgstr "не може да бъде създаден временен слой за гра̀фа с подаванията"
 
-#: commit-graph.c:1860
+#: commit-graph.c:1863
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "правата за споделен достъп до „%s“ не може да бъдат зададени"
 
-#: commit-graph.c:1917
+#: commit-graph.c:1920
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "Запазване на гра̀фа с подаванията в %d пас"
 msgstr[1] "Запазване на гра̀фа с подаванията в %d паса"
 
-#: commit-graph.c:1953
+#: commit-graph.c:1956
 msgid "unable to open commit-graph chain file"
 msgstr "файлът с веригата на гра̀фа с подаванията не може да се отвори"
 
-#: commit-graph.c:1969
+#: commit-graph.c:1972
 msgid "failed to rename base commit-graph file"
 msgstr "основният файл на гра̀фа с подаванията не може да бъде преименуван"
 
-#: commit-graph.c:1989
+#: commit-graph.c:1992
 msgid "failed to rename temporary commit-graph file"
 msgstr "временният файл на гра̀фа с подаванията не може да бъде преименуван"
 
-#: commit-graph.c:2122
+#: commit-graph.c:2125
 msgid "Scanning merged commits"
 msgstr "Търсене на подаванията със сливания"
 
-#: commit-graph.c:2166
+#: commit-graph.c:2169
 msgid "Merging commit-graph"
 msgstr "Сливане на гра̀фа с подаванията"
 
-#: commit-graph.c:2274
+#: commit-graph.c:2277
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 "опит за запис на гра̀фа с подаванията, но настройката „core.commitGraph“ е "
 "изключена"
 
-#: commit-graph.c:2381
+#: commit-graph.c:2384
 msgid "too many commits to write graph"
 msgstr "прекалено много подавания за записване на гра̀фа"
 
-#: commit-graph.c:2479
+#: commit-graph.c:2482
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr "графът с подаванията е с грешна сума за проверка — вероятно е повреден"
 
-#: commit-graph.c:2489
+#: commit-graph.c:2492
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr ""
 "неправилна подредба на обектите по идентификатор в гра̀фа с подаванията: „%s“ "
 "е преди „%s“, а не трябва"
 
-#: commit-graph.c:2499 commit-graph.c:2514
+#: commit-graph.c:2502 commit-graph.c:2517
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr ""
 "неправилна стойност за откъс в гра̀фа с подаванията: fanout[%d] = %u, а "
 "трябва да е %u"
 
-#: commit-graph.c:2506
+#: commit-graph.c:2509
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "подаване „%s“ в гра̀фа с подаванията не може да се анализира"
 
-#: commit-graph.c:2524
+#: commit-graph.c:2527
 msgid "Verifying commits in commit graph"
 msgstr "Проверка на подаванията в гра̀фа"
 
-#: commit-graph.c:2539
+#: commit-graph.c:2542
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "подаване „%s“ в базата от данни към гра̀фа с подаванията не може да се "
 "анализира"
 
-#: commit-graph.c:2546
+#: commit-graph.c:2549
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 "идентификаторът на обект за кореновото дърво за подаване „%s“ в гра̀фа с "
 "подаванията е „%s“, а трябва да е „%s“"
 
-#: commit-graph.c:2556
+#: commit-graph.c:2559
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr "списъкът с родители на „%s“ в гра̀фа с подаванията е прекалено дълъг"
 
-#: commit-graph.c:2565
+#: commit-graph.c:2568
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "родителят на „%s“ в гра̀фа с подаванията е „%s“, а трябва да е „%s“"
 
-#: commit-graph.c:2579
+#: commit-graph.c:2582
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr "списъкът с родители на „%s“ в гра̀фа с подаванията е прекалено къс"
 
-#: commit-graph.c:2584
+#: commit-graph.c:2587
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2600,7 +2610,7 @@ msgstr ""
 "номерът на поколението на подаване „%s“ в гра̀фа с подаванията е 0, а другаде "
 "не е"
 
-#: commit-graph.c:2588
+#: commit-graph.c:2591
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2608,22 +2618,22 @@ msgstr ""
 "номерът на поколението на подаване „%s“ в гра̀фа с подаванията не е 0, а "
 "другаде е"
 
-#: commit-graph.c:2605
+#: commit-graph.c:2608
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr ""
 "номерът на поколението на подаване „%s“ в гра̀фа с подаванията е %<PRIuMAX> < "
 "%<PRIuMAX>"
 
-#: commit-graph.c:2611
+#: commit-graph.c:2614
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 "датата на подаване на „%s“ в гра̀фа с подаванията е %<PRIuMAX>, а трябва да е "
 "%<PRIuMAX>"
 
-#: commit.c:53 sequencer.c:3107 builtin/am.c:373 builtin/am.c:418
-#: builtin/am.c:423 builtin/am.c:1421 builtin/am.c:2068 builtin/replace.c:457
+#: commit.c:53 sequencer.c:3109 builtin/am.c:399 builtin/am.c:444
+#: builtin/am.c:449 builtin/am.c:1448 builtin/am.c:2123 builtin/replace.c:456
 #, c-format
 msgid "could not parse %s"
 msgstr "„%s“ не може да се анализира"
@@ -2656,29 +2666,29 @@ msgstr ""
 "\n"
 "    git config advice.graftFileDeprecated false"
 
-#: commit.c:1239
+#: commit.c:1241
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
 msgstr ""
 "Подаването „%s“ е с недоверен подпис от GPG, който твърди, че е на „%s“."
 
-#: commit.c:1243
+#: commit.c:1245
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
 msgstr ""
 "Подаването „%s“ е с неправилен подпис от GPG, който твърди, че е на „%s“."
 
-#: commit.c:1246
+#: commit.c:1248
 #, c-format
 msgid "Commit %s does not have a GPG signature."
 msgstr "Подаването „%s“ е без подпис от GPG."
 
-#: commit.c:1249
+#: commit.c:1251
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
 msgstr "Подаването „%s“ е с коректен подпис от GPG на „%s“.\n"
 
-#: commit.c:1503
+#: commit.c:1505
 msgid ""
 "Warning: commit message did not conform to UTF-8.\n"
 "You may want to amend it after fixing the message, or set the config\n"
@@ -2745,7 +2755,7 @@ msgstr "ключът не съдържа раздел: „%s“"
 msgid "key does not contain variable name: %s"
 msgstr "ключът не съдържа име на променлива: „%s“"
 
-#: config.c:470 sequencer.c:2804
+#: config.c:470 sequencer.c:2806
 #, c-format
 msgid "invalid key: %s"
 msgstr "неправилен ключ: „%s“"
@@ -2896,17 +2906,17 @@ msgstr "настройката „core.commentChar“ трябва да е са�
 msgid "invalid mode for object creation: %s"
 msgstr "неправилен режим за създаването на обекти: %s"
 
-#: config.c:1581
+#: config.c:1584
 #, c-format
 msgid "malformed value for %s"
 msgstr "неправилна стойност за „%s“"
 
-#: config.c:1607
+#: config.c:1610
 #, c-format
 msgid "malformed value for %s: %s"
 msgstr "неправилна стойност за „%s“: „%s“"
 
-#: config.c:1608
+#: config.c:1611
 msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr ""
 "трябва да е една от следните стойности: „nothing“ (без изтласкване при липса "
@@ -2914,132 +2924,132 @@ msgstr ""
 "„simple“ (клонът със същото име, от който се издърпва), „upstream“ (клонът, "
 "от който се издърпва) или „current“ (клонът със същото име)"
 
-#: config.c:1669 builtin/pack-objects.c:4053
+#: config.c:1672 builtin/pack-objects.c:4053
 #, c-format
 msgid "bad pack compression level %d"
 msgstr "неправилно ниво на компресиране при пакетиране: %d"
 
-#: config.c:1792
+#: config.c:1795
 #, c-format
 msgid "unable to load config blob object '%s'"
 msgstr "обектът-BLOB „%s“ с конфигурации не може да се зареди"
 
-#: config.c:1795
+#: config.c:1798
 #, c-format
 msgid "reference '%s' does not point to a blob"
 msgstr "указателят „%s“ не сочи към обект-BLOB"
 
-#: config.c:1813
+#: config.c:1816
 #, c-format
 msgid "unable to resolve config blob '%s'"
 msgstr "обектът-BLOB „%s“ с конфигурации не може да бъде открит"
 
-#: config.c:1858
+#: config.c:1861
 #, c-format
 msgid "failed to parse %s"
 msgstr "„%s“ не може да бъде анализиран"
 
-#: config.c:1914
+#: config.c:1917
 msgid "unable to parse command-line config"
 msgstr "неправилни настройки от командния ред"
 
-#: config.c:2282
+#: config.c:2285
 msgid "unknown error occurred while reading the configuration files"
 msgstr "неочаквана грешка при изчитането на конфигурационните файлове"
 
-#: config.c:2456
+#: config.c:2459
 #, c-format
 msgid "Invalid %s: '%s'"
 msgstr "Неправилен %s: „%s“"
 
-#: config.c:2501
+#: config.c:2504
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
 msgstr ""
 "стойността на „splitIndex.maxPercentChange“ трябва да е между 1 и 100, а не "
 "%d"
 
-#: config.c:2547
+#: config.c:2550
 #, c-format
 msgid "unable to parse '%s' from command-line config"
 msgstr "неразпозната стойност „%s“ от командния ред"
 
-#: config.c:2549
+#: config.c:2552
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
 msgstr "неправилна настройка „%s“ във файла „%s“ на ред №%d"
 
-#: config.c:2633
+#: config.c:2637
 #, c-format
 msgid "invalid section name '%s'"
 msgstr "неправилно име на раздел: „%s“"
 
-#: config.c:2665
+#: config.c:2669
 #, c-format
 msgid "%s has multiple values"
 msgstr "зададени са няколко стойности за „%s“"
 
-#: config.c:2694
+#: config.c:2698
 #, c-format
 msgid "failed to write new configuration file %s"
 msgstr "новият конфигурационен файл „%s“ не може да бъде запазен"
 
-#: config.c:2946 config.c:3273
+#: config.c:2950 config.c:3277
 #, c-format
 msgid "could not lock config file %s"
 msgstr "конфигурационният файл „%s“ не може да бъде заключен"
 
-#: config.c:2957
+#: config.c:2961
 #, c-format
 msgid "opening %s"
 msgstr "отваряне на „%s“"
 
-#: config.c:2994 builtin/config.c:361
+#: config.c:2998 builtin/config.c:361
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "неправилен шаблон: %s"
 
-#: config.c:3019
+#: config.c:3023
 #, c-format
 msgid "invalid config file %s"
 msgstr "неправилен конфигурационен файл: „%s“"
 
-#: config.c:3032 config.c:3286
+#: config.c:3036 config.c:3290
 #, c-format
 msgid "fstat on %s failed"
 msgstr "неуспешно изпълнение на „fstat“ върху „%s“"
 
-#: config.c:3043
+#: config.c:3047
 #, c-format
 msgid "unable to mmap '%s'%s"
 msgstr "неуспешно изпълнение на „mmap“ върху „%s“%s"
 
-#: config.c:3053 config.c:3291
+#: config.c:3057 config.c:3295
 #, c-format
 msgid "chmod on %s failed"
 msgstr "неуспешна смяна на права с „chmod“ върху „%s“"
 
-#: config.c:3138 config.c:3388
+#: config.c:3142 config.c:3392
 #, c-format
 msgid "could not write config file %s"
 msgstr "конфигурационният файл „%s“ не може да бъде записан"
 
-#: config.c:3172
+#: config.c:3176
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "„%s“ не може да се зададе да е „%s“"
 
-#: config.c:3174 builtin/remote.c:662 builtin/remote.c:860 builtin/remote.c:868
+#: config.c:3178 builtin/remote.c:662 builtin/remote.c:860 builtin/remote.c:868
 #, c-format
 msgid "could not unset '%s'"
 msgstr "„%s“ не може да се премахне"
 
-#: config.c:3264
+#: config.c:3268
 #, c-format
 msgid "invalid section name: %s"
 msgstr "неправилно име на раздел: %s"
 
-#: config.c:3431
+#: config.c:3435
 #, c-format
 msgid "missing value for '%s'"
 msgstr "липсва стойност за „%s“"
@@ -3223,7 +3233,7 @@ msgstr "необичайният път „%s“ е блокиран"
 msgid "unable to fork"
 msgstr "неуспешно създаване на процес"
 
-#: connected.c:109 builtin/fsck.c:189 builtin/prune.c:45
+#: connected.c:109 builtin/fsck.c:189 builtin/prune.c:57
 msgid "Checking connectivity"
 msgstr "Проверка на свързаността"
 
@@ -3535,19 +3545,19 @@ msgstr ""
 "Не е хранилище на git.  Ползвайте опцията „--no-index“, за да сравните "
 "пътища извън работно дърво"
 
-#: diff.c:157
+#: diff.c:158
 #, c-format
 msgid "  Failed to parse dirstat cut-off percentage '%s'\n"
 msgstr ""
 "  Неуспешно разпознаване на „%s“ като процент-праг за статистиката по "
 "директории\n"
 
-#: diff.c:162
+#: diff.c:163
 #, c-format
 msgid "  Unknown dirstat parameter '%s'\n"
 msgstr "  Непознат параметър „%s“ за статистиката по директории'\n"
 
-#: diff.c:298
+#: diff.c:299
 msgid ""
 "color moved setting must be one of 'no', 'default', 'blocks', 'zebra', "
 "'dimmed-zebra', 'plain'"
@@ -3556,7 +3566,7 @@ msgstr ""
 "„default“ (стандартно), „blocks“ (парчета), „zebra“ (райе), „dimmed-"
 "zebra“ (тъмно райе), „plain“ (обикновено)"
 
-#: diff.c:326
+#: diff.c:327
 #, c-format
 msgid ""
 "unknown color-moved-ws mode '%s', possible values are 'ignore-space-change', "
@@ -3569,7 +3579,7 @@ msgstr ""
 "„allow-indentation-change“ (позволяване на промените в празните знаци за "
 "форматиране)"
 
-#: diff.c:334
+#: diff.c:335
 msgid ""
 "color-moved-ws: allow-indentation-change cannot be combined with other "
 "whitespace modes"
@@ -3577,12 +3587,12 @@ msgstr ""
 "„color-moved-ws“: „allow-indentation-change“ е несъвместима с другите режими "
 "за празни знаци"
 
-#: diff.c:411
+#: diff.c:412
 #, c-format
 msgid "Unknown value for 'diff.submodule' config variable: '%s'"
 msgstr "Непозната стойност „%s“ за настройката „diff.submodule“"
 
-#: diff.c:471
+#: diff.c:472
 #, c-format
 msgid ""
 "Found errors in 'diff.dirstat' config variable:\n"
@@ -3591,53 +3601,49 @@ msgstr ""
 "Грешки в настройката „diff.dirstat“:\n"
 "%s"
 
-#: diff.c:4290
+#: diff.c:4237
 #, c-format
 msgid "external diff died, stopping at %s"
 msgstr ""
 "външната програма за разлики завърши неуспешно.  Спиране на работата при „%s“"
 
-#: diff.c:4642
-msgid "--name-only, --name-status, --check and -s are mutually exclusive"
-msgstr ""
-"опциите „--name-only“, „--name-status“, „--check“ и „-s“ са несъвместими "
-"една с друга"
+#: diff.c:4589
+#, c-format
+msgid "options '%s', '%s', '%s', and '%s' cannot be used together"
+msgstr "опциите „%s“, „%s“, „%s“ и „%s“ са несъвместими"
 
-#: diff.c:4645
-msgid "-G, -S and --find-object are mutually exclusive"
-msgstr "опциите „-G“, „-S“ и „--find-object“ са несъвместими една с друга"
+#: diff.c:4593 builtin/difftool.c:736 builtin/log.c:1982 builtin/worktree.c:506
+#, c-format
+msgid "options '%s', '%s', and '%s' cannot be used together"
+msgstr "опциите „%s“, „%s“ и „%s“ са несъвместими"
 
-#: diff.c:4648
+#: diff.c:4597
+#, c-format
+msgid "options '%s' and '%s' cannot be used together, use '%s' with '%s'"
+msgstr "опциите „%s“ и „%s“ са несъвместими, използвайте „%s“ с „%s“"
+
+#: diff.c:4601
+#, c-format
 msgid ""
-"-G and --pickaxe-regex are mutually exclusive, use --pickaxe-regex with -S"
-msgstr ""
-"опциите „-G“ и „--pickaxe-regex“ са несъвместими една с друга.  Пробвайте „--"
-"pickaxe-regex“ със „-S“"
+"options '%s' and '%s' cannot be used together, use '%s' with '%s' and '%s'"
+msgstr "опциите „%s“ и „%s“ са несъвместими, използвайте „%s“ с „%s“ и „%s“"
 
-#: diff.c:4651
-msgid ""
-"--pickaxe-all and --find-object are mutually exclusive, use --pickaxe-all "
-"with -G and -S"
-msgstr ""
-"опциите „--pickaxe-all“ и „--find-object“ са несъвместими една с друга.  "
-"Пробвайте „--pickaxe-all“ с „-G“ и „-S“"
-
-#: diff.c:4730
+#: diff.c:4681
 msgid "--follow requires exactly one pathspec"
 msgstr "опцията „--follow“ изисква точно един път"
 
-#: diff.c:4778
+#: diff.c:4729
 #, c-format
 msgid "invalid --stat value: %s"
 msgstr "неправилна стойност за „--stat“: %s"
 
-#: diff.c:4783 diff.c:4788 diff.c:4793 diff.c:4798 diff.c:5326
+#: diff.c:4734 diff.c:4739 diff.c:4744 diff.c:4749 diff.c:5277
 #: parse-options.c:217 parse-options.c:221
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "опцията „%s“ очаква число за аргумент"
 
-#: diff.c:4815
+#: diff.c:4766
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -3646,44 +3652,44 @@ msgstr ""
 "Неразпознат параметър към опцията „--dirstat/-X“:\n"
 "%s"
 
-#: diff.c:4900
+#: diff.c:4851
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
 msgstr "непознат вид промяна: „%c“ в „--diff-filter=%s“"
 
-#: diff.c:4924
+#: diff.c:4875
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
 msgstr "непозната стойност след „ws-error-highlight=%.*s“"
 
-#: diff.c:4938
+#: diff.c:4889
 #, c-format
 msgid "unable to resolve '%s'"
 msgstr "„%s“ не може да се открие"
 
-#: diff.c:4988 diff.c:4994
+#: diff.c:4939 diff.c:4945
 #, c-format
 msgid "%s expects <n>/<m> form"
 msgstr ""
 "опцията „%s“ изисква стойности за МИНИМАЛЕН_%%_ПРОМЯНА_ЗА_ИЗТОЧНИК_/"
 "МАКСИМАЛЕН_%%_ПРОМЯНА_ЗА_ЗАМЯНА от"
 
-#: diff.c:5006
+#: diff.c:4957
 #, c-format
 msgid "%s expects a character, got '%s'"
 msgstr "опцията „%s“ изисква знак, а не: „%s“"
 
-#: diff.c:5027
+#: diff.c:4978
 #, c-format
 msgid "bad --color-moved argument: %s"
 msgstr "неправилен аргумент за „--color-moved“: „%s“"
 
-#: diff.c:5046
+#: diff.c:4997
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
 msgstr "неправилен режим „%s“ за „ --color-moved-ws“"
 
-#: diff.c:5086
+#: diff.c:5037
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
@@ -3692,158 +3698,158 @@ msgstr ""
 "Майерс), „minimal“ (минимизиране на разликите), „patience“ (пасианс) и "
 "„histogram“ (хистограмен)"
 
-#: diff.c:5122 diff.c:5142
+#: diff.c:5073 diff.c:5093
 #, c-format
 msgid "invalid argument to %s"
 msgstr "неправилен аргумент към „%s“"
 
-#: diff.c:5246
+#: diff.c:5197
 #, c-format
 msgid "invalid regex given to -I: '%s'"
 msgstr "неправилен регулярен израз подаден към „-I“: „%s“"
 
-#: diff.c:5295
+#: diff.c:5246
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
 msgstr "неразпознат параметър към опцията „--submodule“: „%s“"
 
-#: diff.c:5351
+#: diff.c:5302
 #, c-format
 msgid "bad --word-diff argument: %s"
 msgstr "неправилен аргумент към „--word-diff“: „%s“"
 
-#: diff.c:5387
+#: diff.c:5338
 msgid "Diff output format options"
 msgstr "Формат на изхода за разликите"
 
-#: diff.c:5389 diff.c:5395
+#: diff.c:5340 diff.c:5346
 msgid "generate patch"
 msgstr "създаване на кръпки"
 
-#: diff.c:5392 builtin/log.c:179
+#: diff.c:5343 builtin/log.c:179
 msgid "suppress diff output"
 msgstr "без извеждане на разликите"
 
-#: diff.c:5397 diff.c:5511 diff.c:5518
+#: diff.c:5348 diff.c:5462 diff.c:5469
 msgid "<n>"
 msgstr "БРОЙ"
 
-#: diff.c:5398 diff.c:5401
+#: diff.c:5349 diff.c:5352
 msgid "generate diffs with <n> lines context"
 msgstr "файловете с разлики да са с контекст с такъв БРОЙ редове"
 
-#: diff.c:5403
+#: diff.c:5354
 msgid "generate the diff in raw format"
 msgstr "файловете с разлики да са в суров формат"
 
-#: diff.c:5406
+#: diff.c:5357
 msgid "synonym for '-p --raw'"
 msgstr "псевдоним на „-p --raw“"
 
-#: diff.c:5410
+#: diff.c:5361
 msgid "synonym for '-p --stat'"
 msgstr "псевдоним на „-p --stat“"
 
-#: diff.c:5414
+#: diff.c:5365
 msgid "machine friendly --stat"
 msgstr "„--stat“ във формат за четене от програма"
 
-#: diff.c:5417
+#: diff.c:5368
 msgid "output only the last line of --stat"
 msgstr "извеждане само на последния ред на „--stat“"
 
-#: diff.c:5419 diff.c:5427
+#: diff.c:5370 diff.c:5378
 msgid "<param1,param2>..."
 msgstr "ПАРАМЕТЪР_1, ПАРАМЕТЪР_2, …"
 
-#: diff.c:5420
+#: diff.c:5371
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr "извеждане на разпределението на промените за всяка поддиректория"
 
-#: diff.c:5424
+#: diff.c:5375
 msgid "synonym for --dirstat=cumulative"
 msgstr "псевдоним на „--dirstat=cumulative“"
 
-#: diff.c:5428
+#: diff.c:5379
 msgid "synonym for --dirstat=files,param1,param2..."
 msgstr "псевдоним на „--dirstat=ФАЙЛ…,ПАРАМЕТЪР_1,ПАРАМЕТЪР_2,…“"
 
-#: diff.c:5432
+#: diff.c:5383
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
 "предупреждаване, ако промените водят до маркери за конфликт или грешки в "
 "празните знаци"
 
-#: diff.c:5435
+#: diff.c:5386
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr ""
 "съкратено резюме на създадените, преименуваните и файловете с промяна на "
 "режима на достъп"
 
-#: diff.c:5438
+#: diff.c:5389
 msgid "show only names of changed files"
 msgstr "извеждане само на имената на променените файлове"
 
-#: diff.c:5441
+#: diff.c:5392
 msgid "show only names and status of changed files"
 msgstr "извеждане само на имената и статистиката за променените файлове"
 
-#: diff.c:5443
+#: diff.c:5394
 msgid "<width>[,<name-width>[,<count>]]"
 msgstr "ШИРОЧИНА[,ИМЕ-ШИРОЧИНА[,БРОЙ]]"
 
-#: diff.c:5444
+#: diff.c:5395
 msgid "generate diffstat"
 msgstr "извеждане на статистика за промените"
 
-#: diff.c:5446 diff.c:5449 diff.c:5452
+#: diff.c:5397 diff.c:5400 diff.c:5403
 msgid "<width>"
 msgstr "ШИРОЧИНА"
 
-#: diff.c:5447
+#: diff.c:5398
 msgid "generate diffstat with a given width"
 msgstr "статистика с такава ШИРОЧИНА за промените"
 
-#: diff.c:5450
+#: diff.c:5401
 msgid "generate diffstat with a given name width"
 msgstr "статистика за промените с такава ШИРОЧИНА на имената"
 
-#: diff.c:5453
+#: diff.c:5404
 msgid "generate diffstat with a given graph width"
 msgstr "статистика за промените с такава ШИРОЧИНА на гра̀фа"
 
-#: diff.c:5455
+#: diff.c:5406
 msgid "<count>"
 msgstr "БРОЙ"
 
-#: diff.c:5456
+#: diff.c:5407
 msgid "generate diffstat with limited lines"
 msgstr "ограничаване на БРОя на редовете в статистиката за промените"
 
-#: diff.c:5459
+#: diff.c:5410
 msgid "generate compact summary in diffstat"
 msgstr "кратко резюме в статистиката за промените"
 
-#: diff.c:5462
+#: diff.c:5413
 msgid "output a binary diff that can be applied"
 msgstr "извеждане на двоична разлика във вид за прилагане"
 
-#: diff.c:5465
+#: diff.c:5416
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr ""
 "показване на пълните имена на обекти в редовете за индекса при вариантите "
 "преди и след промяната"
 
-#: diff.c:5467
+#: diff.c:5418
 msgid "show colored diff"
 msgstr "разлики в цвят"
 
-#: diff.c:5468
+#: diff.c:5419
 msgid "<kind>"
 msgstr "ВИД"
 
-#: diff.c:5469
+#: diff.c:5420
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
@@ -3851,7 +3857,7 @@ msgstr ""
 "грешките в празните знаци да се указват в редовете за контекста, вариантите "
 "преди и след разликата,"
 
-#: diff.c:5472
+#: diff.c:5423
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
@@ -3859,261 +3865,261 @@ msgstr ""
 "без преименуване на пътищата.  Да се използват нулеви байтове за разделители "
 "на полета в изхода при ползване на опцията „--raw“ или „--numstat“"
 
-#: diff.c:5475 diff.c:5478 diff.c:5481 diff.c:5590
+#: diff.c:5426 diff.c:5429 diff.c:5432 diff.c:5541
 msgid "<prefix>"
 msgstr "ПРЕФИКС"
 
-#: diff.c:5476
+#: diff.c:5427
 msgid "show the given source prefix instead of \"a/\""
 msgstr "префикс вместо „a/“ за източник"
 
-#: diff.c:5479
+#: diff.c:5430
 msgid "show the given destination prefix instead of \"b/\""
 msgstr "префикс вместо „b/“ за цел"
 
-#: diff.c:5482
+#: diff.c:5433
 msgid "prepend an additional prefix to every line of output"
 msgstr "добавяне на допълнителен префикс за всеки ред на изхода"
 
-#: diff.c:5485
+#: diff.c:5436
 msgid "do not show any source or destination prefix"
 msgstr "без префикс за източника и целта"
 
-#: diff.c:5488
+#: diff.c:5439
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
 "извеждане на контекст между последователните парчета с разлики от указания "
 "БРОЙ редове"
 
-#: diff.c:5492 diff.c:5497 diff.c:5502
+#: diff.c:5443 diff.c:5448 diff.c:5453
 msgid "<char>"
 msgstr "ЗНАК"
 
-#: diff.c:5493
+#: diff.c:5444
 msgid "specify the character to indicate a new line instead of '+'"
 msgstr "знак вместо „+“ за нов вариант на ред"
 
-#: diff.c:5498
+#: diff.c:5449
 msgid "specify the character to indicate an old line instead of '-'"
 msgstr "знак вместо „-“ за стар вариант на ред"
 
-#: diff.c:5503
+#: diff.c:5454
 msgid "specify the character to indicate a context instead of ' '"
 msgstr "знак вместо „ “ за контекст"
 
-#: diff.c:5506
+#: diff.c:5457
 msgid "Diff rename options"
 msgstr "Настройки за разлики с преименуване"
 
-#: diff.c:5507
+#: diff.c:5458
 msgid "<n>[/<m>]"
 msgstr "МИНИМАЛЕН_%_ПРОМЯНА_ЗА_ИЗТОЧНИК[/МАКСИМАЛEН_%_ПРОМЯНА_ЗА_ЗАМЯНА]"
 
-#: diff.c:5508
+#: diff.c:5459
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr ""
 "заместване на пълните промени с последователност от изтриване и създаване"
 
-#: diff.c:5512
+#: diff.c:5463
 msgid "detect renames"
 msgstr "засичане на преименуванията"
 
-#: diff.c:5516
+#: diff.c:5467
 msgid "omit the preimage for deletes"
 msgstr "без предварителен вариант при изтриване"
 
-#: diff.c:5519
+#: diff.c:5470
 msgid "detect copies"
 msgstr "засичане на копиранията"
 
-#: diff.c:5523
+#: diff.c:5474
 msgid "use unmodified files as source to find copies"
 msgstr "търсене на копирано и от непроменените файлове"
 
-#: diff.c:5525
+#: diff.c:5476
 msgid "disable rename detection"
 msgstr "без търсене на преименувания"
 
-#: diff.c:5528
+#: diff.c:5479
 msgid "use empty blobs as rename source"
 msgstr "празни обекти като източник при преименувания"
 
-#: diff.c:5530
+#: diff.c:5481
 msgid "continue listing the history of a file beyond renames"
 msgstr ""
 "продължаване на извеждането на историята — без отрязването при преименувания "
 "на файл"
 
-#: diff.c:5533
+#: diff.c:5484
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
 msgstr ""
 "без засичане на преименувания/копирания, ако броят им надвишава тази стойност"
 
-#: diff.c:5535
+#: diff.c:5486
 msgid "Diff algorithm options"
 msgstr "Опции към алгоритъма за разлики"
 
-#: diff.c:5537
+#: diff.c:5488
 msgid "produce the smallest possible diff"
 msgstr "търсене на възможно най-малка разлика"
 
-#: diff.c:5540
+#: diff.c:5491
 msgid "ignore whitespace when comparing lines"
 msgstr "без промени в празните знаци при сравняване на редове"
 
-#: diff.c:5543
+#: diff.c:5494
 msgid "ignore changes in amount of whitespace"
 msgstr "без промени в празните знаци"
 
-#: diff.c:5546
+#: diff.c:5497
 msgid "ignore changes in whitespace at EOL"
 msgstr "без промени в празните знаци в края на редовете"
 
-#: diff.c:5549
+#: diff.c:5500
 msgid "ignore carrier-return at the end of line"
 msgstr "без промени в знаците за край на ред"
 
-#: diff.c:5552
+#: diff.c:5503
 msgid "ignore changes whose lines are all blank"
 msgstr "без промени в редовете, които са изцяло от празни знаци"
 
-#: diff.c:5554 diff.c:5576 diff.c:5579 diff.c:5624
+#: diff.c:5505 diff.c:5527 diff.c:5530 diff.c:5575
 msgid "<regex>"
 msgstr "РЕГУЛЯРЕН_ИЗРАЗ"
 
-#: diff.c:5555
+#: diff.c:5506
 msgid "ignore changes whose all lines match <regex>"
 msgstr "без промени в редовете, които напасват РЕГУЛЯРНия_ИЗРАЗ"
 
-#: diff.c:5558
+#: diff.c:5509
 msgid "heuristic to shift diff hunk boundaries for easy reading"
 msgstr ""
 "евристика за преместване на границите на парчетата за улесняване на четенето"
 
-#: diff.c:5561
+#: diff.c:5512
 msgid "generate diff using the \"patience diff\" algorithm"
 msgstr "разлика чрез алгоритъм за подредба като пасианс"
 
-#: diff.c:5565
+#: diff.c:5516
 msgid "generate diff using the \"histogram diff\" algorithm"
 msgstr "разлика по хистограмния алгоритъм"
 
-#: diff.c:5567
+#: diff.c:5518
 msgid "<algorithm>"
 msgstr "АЛГОРИТЪМ"
 
-#: diff.c:5568
+#: diff.c:5519
 msgid "choose a diff algorithm"
 msgstr "избор на АЛГОРИТЪМа за разлики"
 
-#: diff.c:5570
+#: diff.c:5521
 msgid "<text>"
 msgstr "ТЕКСТ"
 
-#: diff.c:5571
+#: diff.c:5522
 msgid "generate diff using the \"anchored diff\" algorithm"
 msgstr "разлика чрез алгоритъма със закотвяне"
 
-#: diff.c:5573 diff.c:5582 diff.c:5585
+#: diff.c:5524 diff.c:5533 diff.c:5536
 msgid "<mode>"
 msgstr "РЕЖИМ"
 
-#: diff.c:5574
+#: diff.c:5525
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr ""
 "разлика по думи, като се ползва този РЕЖИМ за отделянето на променените думи"
 
-#: diff.c:5577
+#: diff.c:5528
 msgid "use <regex> to decide what a word is"
 msgstr "РЕГУЛЯРЕН_ИЗРАЗ за разделяне по думи"
 
-#: diff.c:5580
+#: diff.c:5531
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
 msgstr "псевдоним на „--word-diff=color --word-diff-regex=РЕГУЛЯРЕН_ИЗРАЗ“"
 
-#: diff.c:5583
+#: diff.c:5534
 msgid "moved lines of code are colored differently"
 msgstr "различен цвят за извеждане на преместените редове"
 
-#: diff.c:5586
+#: diff.c:5537
 msgid "how white spaces are ignored in --color-moved"
 msgstr ""
 "режим за прескачането на празните знаци при задаването на „--color-moved“"
 
-#: diff.c:5589
+#: diff.c:5540
 msgid "Other diff options"
 msgstr "Други опции за разлики"
 
-#: diff.c:5591
+#: diff.c:5542
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
 "при изпълнение от поддиректория да се пренебрегват разликите извън нея и да "
 "се ползват относителни пътища"
 
-#: diff.c:5595
+#: diff.c:5546
 msgid "treat all files as text"
 msgstr "обработка на всички файлове като текстови"
 
-#: diff.c:5597
+#: diff.c:5548
 msgid "swap two inputs, reverse the diff"
 msgstr "размяна на двата входа — обръщане на разликата"
 
-#: diff.c:5599
+#: diff.c:5550
 msgid "exit with 1 if there were differences, 0 otherwise"
 msgstr ""
 "завършване с код за състояние 1 при наличието на разлики, а в противен "
 "случай — с 0"
 
-#: diff.c:5601
+#: diff.c:5552
 msgid "disable all output of the program"
 msgstr "без всякакъв изход от програмата"
 
-#: diff.c:5603
+#: diff.c:5554
 msgid "allow an external diff helper to be executed"
 msgstr "позволяване на изпълнение на външна помощна програма за разлики"
 
-#: diff.c:5605
+#: diff.c:5556
 msgid "run external text conversion filters when comparing binary files"
 msgstr ""
 "изпълнение на външни програми-филтри при сравнението на двоични файлове"
 
-#: diff.c:5607
+#: diff.c:5558
 msgid "<when>"
 msgstr "КОГА"
 
-#: diff.c:5608
+#: diff.c:5559
 msgid "ignore changes to submodules in the diff generation"
 msgstr "игнориране на промените в подмодулите при извеждането на разликите"
 
-#: diff.c:5611
+#: diff.c:5562
 msgid "<format>"
 msgstr "ФОРМАТ"
 
-#: diff.c:5612
+#: diff.c:5563
 msgid "specify how differences in submodules are shown"
 msgstr "начин за извеждане на промените в подмодулите"
 
-#: diff.c:5616
+#: diff.c:5567
 msgid "hide 'git add -N' entries from the index"
 msgstr "без включване в индекса на записите, добавени с „git add -N“"
 
-#: diff.c:5619
+#: diff.c:5570
 msgid "treat 'git add -N' entries as real in the index"
 msgstr "включване в индекса на записите, добавени с „git add -N“"
 
-#: diff.c:5621
+#: diff.c:5572
 msgid "<string>"
 msgstr "НИЗ"
 
-#: diff.c:5622
+#: diff.c:5573
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
 msgstr "търсене на разлики, които променят броя на поява на указаните низове"
 
-#: diff.c:5625
+#: diff.c:5576
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
@@ -4121,69 +4127,69 @@ msgstr ""
 "търсене на разлики, които променят броя на поява на низовете, които напасват "
 "на регулярния израз"
 
-#: diff.c:5628
+#: diff.c:5579
 msgid "show all changes in the changeset with -S or -G"
 msgstr "извеждане на всички промени с „-G“/„-S“"
 
-#: diff.c:5631
+#: diff.c:5582
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr "НИЗът към „-S“ да се тълкува като разширен регулярен израз по POSIX"
 
-#: diff.c:5634
+#: diff.c:5585
 msgid "control the order in which files appear in the output"
 msgstr "управление на подредбата на файловете в изхода"
 
-#: diff.c:5635 diff.c:5638
+#: diff.c:5586 diff.c:5589
 msgid "<path>"
 msgstr "ПЪТ"
 
-#: diff.c:5636
+#: diff.c:5587
 msgid "show the change in the specified path first"
 msgstr "първо извеждане на промяната в указания път"
 
-#: diff.c:5639
+#: diff.c:5590
 msgid "skip the output to the specified path"
 msgstr "прескачане на изхода към указания път"
 
-#: diff.c:5641
+#: diff.c:5592
 msgid "<object-id>"
 msgstr "ИДЕНТИФИКАТОР_НА_ОБЕКТ"
 
-#: diff.c:5642
+#: diff.c:5593
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
 msgstr "търсене на разлики, които променят броя на поява на указания обект"
 
-#: diff.c:5644
+#: diff.c:5595
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "[(A|C|D|M|R|T|U|X|B)…[*]]"
 
-#: diff.c:5645
+#: diff.c:5596
 msgid "select files by diff type"
 msgstr "избор на файловете по вид разлика"
 
-#: diff.c:5647
+#: diff.c:5598
 msgid "<file>"
 msgstr "ФАЙЛ"
 
-#: diff.c:5648
+#: diff.c:5599
 msgid "Output to a specific file"
 msgstr "Изход към указания файл"
 
-#: diff.c:6306
+#: diff.c:6257
 msgid "exhaustive rename detection was skipped due to too many files."
 msgstr ""
 "пълното търсене на преименувания на обекти се прескача поради многото "
 "файлове."
 
-#: diff.c:6309
+#: diff.c:6260
 msgid "only found copies from modified paths due to too many files."
 msgstr ""
 "установени са само точните копия на променените пътища поради многото "
 "файлове."
 
-#: diff.c:6312
+#: diff.c:6263
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
@@ -4225,30 +4231,30 @@ msgstr ""
 "файлът определящ частичността на изтегленото хранилище може да има проблем: "
 "шаблонът „%s“ се повтаря"
 
-#: dir.c:830
+#: dir.c:828
 msgid "disabling cone pattern matching"
 msgstr "изключване на пътеводното напасване"
 
-#: dir.c:1214
+#: dir.c:1212
 #, c-format
 msgid "cannot use %s as an exclude file"
 msgstr "„%s“ не може да се ползва за игнорираните файлове (като gitignore)"
 
-#: dir.c:2464
+#: dir.c:2418
 #, c-format
 msgid "could not open directory '%s'"
 msgstr "директорията „%s“ не може да бъде отворена"
 
-#: dir.c:2766
+#: dir.c:2720
 msgid "failed to get kernel name and information"
 msgstr "името и версията на ядрото не бяха получени"
 
-#: dir.c:2890
+#: dir.c:2844
 msgid "untracked cache is disabled on this system or location"
 msgstr ""
 "кешът за неследените файлове е изключен на тази система или местоположение"
 
-#: dir.c:3158
+#: dir.c:3112
 msgid ""
 "No directory name could be guessed.\n"
 "Please specify a directory on the command line"
@@ -4256,36 +4262,36 @@ msgstr ""
 "Името на директорията не може да бъде отгатнато.\n"
 "Задайте директорията изрично на командния ред"
 
-#: dir.c:3837
+#: dir.c:3800
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "файлът с индекса е повреден в хранилището „%s“"
 
-#: dir.c:3884 dir.c:3889
+#: dir.c:3847 dir.c:3852
 #, c-format
 msgid "could not create directories for %s"
 msgstr "директориите за „%s“ не може да бъдат създадени"
 
-#: dir.c:3918
+#: dir.c:3881
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "директорията на git не може да се мигрира от „%s“ до „%s“"
 
-#: editor.c:77
+#: editor.c:74
 #, c-format
 msgid "hint: Waiting for your editor to close the file...%c"
 msgstr "Подсказка: чака се редакторът ви да затвори файла …%c"
 
-#: entry.c:177
+#: entry.c:179
 msgid "Filtering content"
 msgstr "Филтриране на съдържанието"
 
-#: entry.c:498
+#: entry.c:500
 #, c-format
 msgid "could not stat file '%s'"
 msgstr "неуспешно изпълнение на „stat“ върху файла „%s“"
 
-#: environment.c:143
+#: environment.c:145
 #, c-format
 msgid "bad git namespace path \"%s\""
 msgstr "неправилен път към пространства от имена „%s“"
@@ -4295,276 +4301,272 @@ msgstr "неправилен път към пространства от име�
 msgid "too many args to run %s"
 msgstr "прекалено много аргументи за изпълнение „%s“"
 
-#: fetch-pack.c:193
+#: fetch-pack.c:194
 msgid "git fetch-pack: expected shallow list"
 msgstr "git fetch-pack: очаква се плитък списък"
 
-#: fetch-pack.c:196
+#: fetch-pack.c:197
 msgid "git fetch-pack: expected a flush packet after shallow list"
 msgstr "git fetch-pack: след плитък списък се очаква изчистващ пакет „flush“"
 
-#: fetch-pack.c:207
+#: fetch-pack.c:208
 msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
 msgstr ""
 "git fetch-pack: очаква се „ACK“/„NAK“, а бе получен изчистващ пакет „flush“"
 
-#: fetch-pack.c:227
+#: fetch-pack.c:228
 #, c-format
 msgid "git fetch-pack: expected ACK/NAK, got '%s'"
 msgstr "git fetch-pack: очаква се „ACK“/„NAK“, а бе получено „%s“"
 
-#: fetch-pack.c:238
+#: fetch-pack.c:239
 msgid "unable to write to remote"
 msgstr "невъзможно писане към отдалечено хранилище"
 
-#: fetch-pack.c:299
-msgid "--stateless-rpc requires multi_ack_detailed"
-msgstr "опцията „--stateless-rpc“ изисква  „multi_ack_detailed“"
-
-#: fetch-pack.c:394 fetch-pack.c:1434
+#: fetch-pack.c:395 fetch-pack.c:1439
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "неправилен плитък ред: „%s“"
 
-#: fetch-pack.c:400 fetch-pack.c:1440
+#: fetch-pack.c:401 fetch-pack.c:1445
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "неправилен неплитък ред: „%s“"
 
-#: fetch-pack.c:402 fetch-pack.c:1442
+#: fetch-pack.c:403 fetch-pack.c:1447
 #, c-format
 msgid "object not found: %s"
 msgstr "обектът „%s“ липсва"
 
-#: fetch-pack.c:405 fetch-pack.c:1445
+#: fetch-pack.c:406 fetch-pack.c:1450
 #, c-format
 msgid "error in object: %s"
 msgstr "грешка в обекта: „%s“"
 
-#: fetch-pack.c:407 fetch-pack.c:1447
+#: fetch-pack.c:408 fetch-pack.c:1452
 #, c-format
 msgid "no shallow found: %s"
 msgstr "не е открит плитък обект: %s"
 
-#: fetch-pack.c:410 fetch-pack.c:1451
+#: fetch-pack.c:411 fetch-pack.c:1456
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "очаква се плитък или не обект, а бе получено: „%s“"
 
-#: fetch-pack.c:450
+#: fetch-pack.c:451
 #, c-format
 msgid "got %s %d %s"
 msgstr "получено бе %s %d %s"
 
-#: fetch-pack.c:467
+#: fetch-pack.c:468
 #, c-format
 msgid "invalid commit %s"
 msgstr "неправилно подаване: „%s“"
 
-#: fetch-pack.c:498
+#: fetch-pack.c:499
 msgid "giving up"
 msgstr "преустановяване"
 
-#: fetch-pack.c:511 progress.c:339
+#: fetch-pack.c:512 progress.c:339
 msgid "done"
 msgstr "действието завърши"
 
-#: fetch-pack.c:523
+#: fetch-pack.c:524
 #, c-format
 msgid "got %s (%d) %s"
 msgstr "получено бе %s (%d) %s"
 
-#: fetch-pack.c:559
+#: fetch-pack.c:560
 #, c-format
 msgid "Marking %s as complete"
 msgstr "Отбелязване на „%s“ като пълно"
 
-#: fetch-pack.c:774
+#: fetch-pack.c:775
 #, c-format
 msgid "already have %s (%s)"
 msgstr "вече има „%s“ (%s)"
 
-#: fetch-pack.c:860
+#: fetch-pack.c:861
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-pack: не може да се създаде процес за демултиплексора"
 
-#: fetch-pack.c:868
+#: fetch-pack.c:869
 msgid "protocol error: bad pack header"
 msgstr "протоколна грешка: неправилна заглавна част на пакет"
 
-#: fetch-pack.c:962
+#: fetch-pack.c:965
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-pack: не може да се създаде процес за „%s“"
 
-#: fetch-pack.c:968
+#: fetch-pack.c:971
 msgid "fetch-pack: invalid index-pack output"
 msgstr "fetch-pack: неправилен изход от командата „index-pack“"
 
-#: fetch-pack.c:985
+#: fetch-pack.c:988
 #, c-format
 msgid "%s failed"
 msgstr "неуспешно изпълнение на „%s“"
 
-#: fetch-pack.c:987
+#: fetch-pack.c:990
 msgid "error in sideband demultiplexer"
 msgstr "грешка в демултиплексора"
 
-#: fetch-pack.c:1030
+#: fetch-pack.c:1035
 #, c-format
 msgid "Server version is %.*s"
 msgstr "Версията на сървъра е: %.*s"
 
-#: fetch-pack.c:1038 fetch-pack.c:1044 fetch-pack.c:1047 fetch-pack.c:1053
-#: fetch-pack.c:1057 fetch-pack.c:1061 fetch-pack.c:1065 fetch-pack.c:1069
-#: fetch-pack.c:1073 fetch-pack.c:1077 fetch-pack.c:1081 fetch-pack.c:1085
-#: fetch-pack.c:1091 fetch-pack.c:1097 fetch-pack.c:1102 fetch-pack.c:1107
+#: fetch-pack.c:1043 fetch-pack.c:1049 fetch-pack.c:1052 fetch-pack.c:1058
+#: fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070 fetch-pack.c:1074
+#: fetch-pack.c:1078 fetch-pack.c:1082 fetch-pack.c:1086 fetch-pack.c:1090
+#: fetch-pack.c:1096 fetch-pack.c:1102 fetch-pack.c:1107 fetch-pack.c:1112
 #, c-format
 msgid "Server supports %s"
 msgstr "Сървърът поддържа „%s“"
 
-#: fetch-pack.c:1040
+#: fetch-pack.c:1045
 msgid "Server does not support shallow clients"
 msgstr "Сървърът не поддържа плитки клиенти"
 
-#: fetch-pack.c:1100
+#: fetch-pack.c:1105
 msgid "Server does not support --shallow-since"
 msgstr "Сървърът не поддържа опцията „--shallow-since“"
 
-#: fetch-pack.c:1105
+#: fetch-pack.c:1110
 msgid "Server does not support --shallow-exclude"
 msgstr "Сървърът не поддържа опцията „--shallow-exclude“"
 
-#: fetch-pack.c:1109
+#: fetch-pack.c:1114
 msgid "Server does not support --deepen"
 msgstr "Сървърът не поддържа опцията „--deepen“"
 
-#: fetch-pack.c:1111
+#: fetch-pack.c:1116
 msgid "Server does not support this repository's object format"
 msgstr "Сървърът не поддържа форма̀та на обектите на това хранилище"
 
-#: fetch-pack.c:1124
+#: fetch-pack.c:1129
 msgid "no common commits"
 msgstr "няма общи подавания"
 
-#: fetch-pack.c:1133 fetch-pack.c:1480 builtin/clone.c:1130
+#: fetch-pack.c:1138 fetch-pack.c:1485 builtin/clone.c:1130
 msgid "source repository is shallow, reject to clone."
 msgstr "клонираното хранилище е плитко, затова няма да се клонира."
 
-#: fetch-pack.c:1139 fetch-pack.c:1671
+#: fetch-pack.c:1144 fetch-pack.c:1681
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack: неуспешно доставяне."
 
-#: fetch-pack.c:1253
+#: fetch-pack.c:1258
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "различни алгоритми — на клиента: „%s“, на сървъра: „%s“"
 
-#: fetch-pack.c:1257
+#: fetch-pack.c:1262
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "сървърът не поддържа алгоритъм „%s“"
 
-#: fetch-pack.c:1290
+#: fetch-pack.c:1295
 msgid "Server does not support shallow requests"
 msgstr "Сървърът не поддържа плитки заявки"
 
-#: fetch-pack.c:1297
+#: fetch-pack.c:1302
 msgid "Server supports filter"
 msgstr "Сървърът поддържа филтри"
 
-#: fetch-pack.c:1340 fetch-pack.c:2053
+#: fetch-pack.c:1345 fetch-pack.c:2063
 msgid "unable to write request to remote"
 msgstr "невъзможно писане към отдалечено хранилище"
 
-#: fetch-pack.c:1358
+#: fetch-pack.c:1363
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "грешка при прочитане на заглавната част на раздел „%s“"
 
-#: fetch-pack.c:1364
+#: fetch-pack.c:1369
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "очаква се „%s“, а бе получено „%s“"
 
-#: fetch-pack.c:1398
+#: fetch-pack.c:1403
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "неочакван ред за потвърждение: „%s“"
 
-#: fetch-pack.c:1403
+#: fetch-pack.c:1408
 #, c-format
 msgid "error processing acks: %d"
 msgstr "грешка при обработка на потвържденията: %d"
 
-#: fetch-pack.c:1413
+#: fetch-pack.c:1418
 msgid "expected packfile to be sent after 'ready'"
 msgstr ""
 "очакваше се пакетният файл да бъде изпратен след отговор за готовност (ready)"
 
-#: fetch-pack.c:1415
+#: fetch-pack.c:1420
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr ""
 "очакваше се след липса на отговор за готовност (ready) да не се се пращат "
 "други раздели"
 
-#: fetch-pack.c:1456
+#: fetch-pack.c:1461
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "грешка при обработка на информация за дълбочината/плиткостта: %d"
 
-#: fetch-pack.c:1505
+#: fetch-pack.c:1510
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "очаква се искан указател, а бе получено: „%s“"
 
-#: fetch-pack.c:1510
+#: fetch-pack.c:1515
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "неочакван искан указател: „%s“"
 
-#: fetch-pack.c:1515
+#: fetch-pack.c:1520
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "грешка при обработката на исканите указатели: %d"
 
-#: fetch-pack.c:1545
+#: fetch-pack.c:1550
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: очаква се пакет за край на отговора"
 
-#: fetch-pack.c:1949
+#: fetch-pack.c:1959
 msgid "no matching remote head"
 msgstr "не може да бъде открит подходящ връх от отдалеченото хранилище"
 
-#: fetch-pack.c:1972 builtin/clone.c:581
+#: fetch-pack.c:1982 builtin/clone.c:581
 msgid "remote did not send all necessary objects"
 msgstr "отдалеченото хранилище не изпрати всички необходими обекти."
 
-#: fetch-pack.c:2075
+#: fetch-pack.c:2085
 msgid "unexpected 'ready' from remote"
 msgstr "неочаквано състояние за готовност от отдалечено хранилище"
 
-#: fetch-pack.c:2098
+#: fetch-pack.c:2108
 #, c-format
 msgid "no such remote ref %s"
 msgstr "такъв отдалечен указател няма: %s"
 
-#: fetch-pack.c:2101
+#: fetch-pack.c:2111
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "Сървърът не позволява заявка за необявен обект „%s“"
 
-#: gpg-interface.c:329 gpg-interface.c:451 gpg-interface.c:902
-#: gpg-interface.c:918
+#: gpg-interface.c:329 gpg-interface.c:457 gpg-interface.c:974
+#: gpg-interface.c:990
 msgid "could not create temporary file"
 msgstr "не може да се създаде временен файл"
 
-#: gpg-interface.c:332 gpg-interface.c:454
+#: gpg-interface.c:332 gpg-interface.c:460
 #, c-format
 msgid "failed writing detached signature to '%s'"
 msgstr "Програмата не успя да запише самостоятелния подпис в „%s“"
 
-#: gpg-interface.c:445
+#: gpg-interface.c:451
 msgid ""
 "gpg.ssh.allowedSignersFile needs to be configured and exist for ssh "
 "signature verification"
@@ -4572,7 +4574,7 @@ msgstr ""
 "настройката „gpg.ssh.allowedSignersFile“ трябва да е зададена за проверка на "
 "подписите на ssh"
 
-#: gpg-interface.c:469
+#: gpg-interface.c:480
 msgid ""
 "ssh-keygen -Y find-principals/verify is needed for ssh signature "
 "verification (available in openssh version 8.2p1+)"
@@ -4582,62 +4584,62 @@ msgstr ""
 "\n"
 "    ssh-keygen -Y find-principals/verify"
 
-#: gpg-interface.c:523
+#: gpg-interface.c:536
 #, c-format
 msgid "ssh signing revocation file configured but not found: %s"
 msgstr ""
 "файлът за отхвърляне на подписи на ssh е настроен, но не може да се открие: "
 "%s"
 
-#: gpg-interface.c:576
+#: gpg-interface.c:624
 #, c-format
 msgid "bad/incompatible signature '%s'"
 msgstr "лош/несъвместим подпис „%s“"
 
-#: gpg-interface.c:735 gpg-interface.c:740
+#: gpg-interface.c:801 gpg-interface.c:806
 #, c-format
 msgid "failed to get the ssh fingerprint for key '%s'"
 msgstr "отпечатъкът по ssh на ключа „%s“ не може да бъде получен"
 
-#: gpg-interface.c:762
+#: gpg-interface.c:829
 msgid ""
 "either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured"
 msgstr ""
 "Поне една от настройките „user.signingkey“ или „gpg.ssh.defaultKeyCommand“ "
 "трябва да е зададена"
 
-#: gpg-interface.c:780
+#: gpg-interface.c:851
 #, c-format
 msgid "gpg.ssh.defaultKeyCommand succeeded but returned no keys: %s %s"
 msgstr ""
 "командата „gpg.ssh.defaultKeyCommand“ завърши успешно, но не върна никакви "
 "ключове: %s %s"
 
-#: gpg-interface.c:786
+#: gpg-interface.c:857
 #, c-format
 msgid "gpg.ssh.defaultKeyCommand failed: %s %s"
 msgstr "неуспешно изпълнение на „gpg.ssh.defaultKeyCommand“: %s %s"
 
-#: gpg-interface.c:874
+#: gpg-interface.c:945
 msgid "gpg failed to sign the data"
 msgstr "Програмата „gpg“ не подписа данните"
 
-#: gpg-interface.c:895
+#: gpg-interface.c:967
 msgid "user.signingkey needs to be set for ssh signing"
 msgstr ""
 "за подписване със ssh е необходимо да зададете настройката „user.signingkey“"
 
-#: gpg-interface.c:906
+#: gpg-interface.c:978
 #, c-format
 msgid "failed writing ssh signing key to '%s'"
 msgstr "неуспешно запазване на ключа за подписване на ssh в „%s“"
 
-#: gpg-interface.c:924
+#: gpg-interface.c:996
 #, c-format
 msgid "failed writing ssh signing key buffer to '%s'"
 msgstr "неуспешно запазване на буфера за подписване на ssh в „%s“"
 
-#: gpg-interface.c:942
+#: gpg-interface.c:1014
 msgid ""
 "ssh-keygen -Y sign is needed for ssh signing (available in openssh version "
 "8.2p1+)"
@@ -4647,7 +4649,7 @@ msgstr ""
 "\n"
 "    ssh-keygen -Y"
 
-#: gpg-interface.c:954
+#: gpg-interface.c:1026
 #, c-format
 msgid "failed reading ssh signing data buffer from '%s'"
 msgstr "неуспешно прочитане на буфера за подписване на ssh от „%s“"
@@ -4657,7 +4659,7 @@ msgstr "неуспешно прочитане на буфера за подпи�
 msgid "ignored invalid color '%.*s' in log.graphColors"
 msgstr "прескачане на неправилния цвят „%.*s“ в „log.graphColors“"
 
-#: grep.c:533
+#: grep.c:531
 msgid ""
 "given pattern contains NULL byte (via -f <file>). This is only supported "
 "with -P under PCRE v2"
@@ -4665,18 +4667,18 @@ msgstr ""
 "зададеният шаблон съдържа нулев знак (идва от -f „ФАЙЛ“).  Това се поддържа "
 "в комбинация с „-P“ само при ползването на „PCRE v2“"
 
-#: grep.c:1928
+#: grep.c:1942
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr "„%s“: файлът сочен от „%s“ не може да бъде прочетен"
 
-#: grep.c:1945 setup.c:176 builtin/clone.c:302 builtin/diff.c:90
+#: grep.c:1959 setup.c:177 builtin/clone.c:302 builtin/diff.c:90
 #: builtin/rm.c:136
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "не може да бъде получена информация чрез „stat“ за „%s“"
 
-#: grep.c:1956
+#: grep.c:1970
 #, c-format
 msgid "'%s': short read"
 msgstr "„%s“: изчитането върна по-малко байтове от очакваното"
@@ -4800,8 +4802,8 @@ msgstr ""
 
 #: help.c:646
 #, c-format
-msgid "Run '%s' instead? (y/N)"
-msgstr "Да се изпълни „%s“ вместо това? (y/N)"
+msgid "Run '%s' instead [y/N]? "
+msgstr "Да се изпълни „%s“ вместо това [y/N]? "
 
 #: help.c:654
 #, c-format
@@ -5032,7 +5034,7 @@ msgstr "след аргументите към „ls-refs“ се очаква �
 msgid "quoted CRLF detected"
 msgstr "цитирани знаци CRLF"
 
-#: mailinfo.c:1254 builtin/am.c:177 builtin/mailinfo.c:46
+#: mailinfo.c:1254 builtin/am.c:184 builtin/mailinfo.c:46
 #, c-format
 msgid "bad action '%s' for '%s'"
 msgstr "неправилно действие „%s“ за „%s“"
@@ -5266,7 +5268,7 @@ msgstr "ПОДМОДУЛ"
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "КОНФЛИКТ (%s): Конфликт при сливане на „%s“"
 
-#: merge-ort.c:3856
+#: merge-ort.c:3869
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
@@ -5275,7 +5277,7 @@ msgstr ""
 "КОНФЛИКТ (промяна/изтриване): „%s“ е изтрит в %s, а е променен в %s.  Версия "
 "%s на „%s“ е оставена в дървото."
 
-#: merge-ort.c:4152
+#: merge-ort.c:4165
 #, c-format
 msgid ""
 "Note: %s not up to date and in way of checking out conflicted version; old "
@@ -5287,7 +5289,7 @@ msgstr ""
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
-#: merge-ort.c:4521
+#: merge-ort.c:4534
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
 msgstr "неуспешно събиране на информацията за сливането на „%s“, „%s“ и „%s“"
@@ -5301,7 +5303,7 @@ msgstr ""
 "Сливането ще презапише локалните промени на тези файлове:\n"
 "    %s"
 
-#: merge-ort-wrappers.c:33 merge-recursive.c:3482 builtin/merge.c:403
+#: merge-ort-wrappers.c:33 merge-recursive.c:3482 builtin/merge.c:405
 msgid "Already up to date."
 msgstr "Вече е обновено."
 
@@ -5594,7 +5596,7 @@ msgstr "сливането не върна подаване"
 msgid "Could not parse object '%s'"
 msgstr "Неуспешен анализ на обекта „%s“"
 
-#: merge-recursive.c:3834 builtin/merge.c:718 builtin/merge.c:904
+#: merge-recursive.c:3834 builtin/merge.c:720 builtin/merge.c:906
 #: builtin/stash.c:489
 msgid "Unable to write index."
 msgstr "Индексът не може да бъде прочетен"
@@ -5603,8 +5605,8 @@ msgstr "Индексът не може да бъде прочетен"
 msgid "failed to read the cache"
 msgstr "кешът не може да бъде прочетен"
 
-#: merge.c:102 rerere.c:704 builtin/am.c:1933 builtin/am.c:1967
-#: builtin/checkout.c:590 builtin/checkout.c:842 builtin/clone.c:706
+#: merge.c:102 rerere.c:704 builtin/am.c:1988 builtin/am.c:2022
+#: builtin/checkout.c:598 builtin/checkout.c:853 builtin/clone.c:706
 #: builtin/stash.c:269
 msgid "unable to write new index file"
 msgstr "неуспешно записване на новия индекс"
@@ -5613,166 +5615,166 @@ msgstr "неуспешно записване на новия индекс"
 msgid "multi-pack-index OID fanout is of the wrong size"
 msgstr "неправилен размер на откъс (OID fanout) на индекса за множество пакети"
 
-#: midx.c:109
+#: midx.c:111
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "файлът с индекса за множество пакети „%s“ е твърде малък"
 
-#: midx.c:125
+#: midx.c:127
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr "отпечатъкът на индекса за множество пакети 0x%08x не съвпада с 0x%08x"
 
-#: midx.c:130
+#: midx.c:132
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "непозната версия на индекс за множество пакети — %d"
 
-#: midx.c:135
+#: midx.c:137
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr ""
 "версията на контролната сума на индекса за множество пакети %u не съвпада с "
 "%u"
 
-#: midx.c:152
+#: midx.c:154
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "липсва откъс (pack-name) от индекс за множество пакети"
 
-#: midx.c:154
+#: midx.c:156
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "липсва откъс (OID fanout) от индекс за множество пакети"
 
-#: midx.c:156
+#: midx.c:158
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr "липсва откъс (OID lookup) от индекс за множество пакети"
 
-#: midx.c:158
+#: midx.c:160
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr "липсва откъс за отместванията на обекти от индекс за множество пакети"
 
-#: midx.c:174
+#: midx.c:176
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr ""
 "неправилна подредба на имената в индекс за множество пакети: „%s“ се появи "
 "преди „%s“"
 
-#: midx.c:221
+#: midx.c:224
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr ""
 "неправилен идентификатор на пакет (pack-int-id): %u (от общо %u пакети)"
 
-#: midx.c:271
+#: midx.c:274
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr ""
 "индексът за множество пакети съдържа 64-битови отмествания, но размерът на "
 "„off_t“ е недостатъчен"
 
-#: midx.c:502
+#: midx.c:505
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "пакетният файл „%s“ не може да бъде добавен"
 
-#: midx.c:508
+#: midx.c:511
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "индексът за пакети „%s“ не може да бъде отворен"
 
-#: midx.c:576
+#: midx.c:579
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "обект %d в пакетния файл липсва"
 
-#: midx.c:892
+#: midx.c:895
 msgid "cannot store reverse index file"
 msgstr "файлът за индекса не може да бъде съхранен"
 
-#: midx.c:990
+#: midx.c:993
 #, c-format
 msgid "could not parse line: %s"
 msgstr "редът не може да се анализира: „%s“"
 
-#: midx.c:992
+#: midx.c:995
 #, c-format
 msgid "malformed line: %s"
 msgstr "неправилен ред: „%s“."
 
-#: midx.c:1159
+#: midx.c:1162
 msgid "ignoring existing multi-pack-index; checksum mismatch"
 msgstr ""
 "индексът за множество пакети се прескача, защото контролната сума не съвпада"
 
-#: midx.c:1184
+#: midx.c:1187
 msgid "could not load pack"
 msgstr "пакетът не може да се зареди"
 
-#: midx.c:1190
+#: midx.c:1193
 #, c-format
 msgid "could not open index for %s"
 msgstr "индексът за „%s“ не може да се отвори"
 
-#: midx.c:1201
+#: midx.c:1204
 msgid "Adding packfiles to multi-pack-index"
 msgstr "Добавяне на пакетни файлове към индекс за множество пакети"
 
-#: midx.c:1244
+#: midx.c:1247
 #, c-format
 msgid "unknown preferred pack: '%s'"
 msgstr "непознат предпочитан пакет: %s"
 
-#: midx.c:1289
+#: midx.c:1292
 #, c-format
 msgid "cannot select preferred pack %s with no objects"
 msgstr ""
 "не може да изберете „%s“, който не съдържа обекти, за предпочитан пакет"
 
-#: midx.c:1321
+#: midx.c:1324
 #, c-format
 msgid "did not see pack-file %s to drop"
 msgstr "пакетният файл за триене „%s“ не може да се открие"
 
-#: midx.c:1367
+#: midx.c:1370
 #, c-format
 msgid "preferred pack '%s' is expired"
 msgstr "предпочитаният пакет „%s“ е остарял"
 
-#: midx.c:1380
+#: midx.c:1383
 msgid "no pack files to index."
 msgstr "няма пакетни файлове за индексиране"
 
-#: midx.c:1417
+#: midx.c:1420
 msgid "could not write multi-pack bitmap"
 msgstr "многопакетната битова маска не може да бъде запазена"
 
-#: midx.c:1427
+#: midx.c:1430
 msgid "could not write multi-pack-index"
 msgstr "индексът за множество пакети не може да бъде запазен"
 
-#: midx.c:1486 builtin/clean.c:37
+#: midx.c:1489 builtin/clean.c:37
 #, c-format
 msgid "failed to remove %s"
 msgstr "файлът „%s“ не може да бъде изтрит"
 
-#: midx.c:1517
+#: midx.c:1522
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "индексът за множество пакети не може да бъде изчистен при „%s“"
 
-#: midx.c:1577
+#: midx.c:1585
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr "файлът с индекса за множество пакети, но не може да бъде анализиран"
 
-#: midx.c:1585
+#: midx.c:1593
 msgid "incorrect checksum"
 msgstr "неправилна контролна сума"
 
-#: midx.c:1588
+#: midx.c:1596
 msgid "Looking for referenced packfiles"
 msgstr "Търсене на указаните пакетни файлове"
 
-#: midx.c:1603
+#: midx.c:1611
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
@@ -5780,58 +5782,58 @@ msgstr ""
 "неправилна подредба на откъси (OID fanout): fanout[%d] = %<PRIx32> > "
 "%<PRIx32> = fanout[%d]"
 
-#: midx.c:1608
+#: midx.c:1616
 msgid "the midx contains no oid"
 msgstr "във файла с индекса за множество пакети няма идентификатори на обекти"
 
-#: midx.c:1617
+#: midx.c:1625
 msgid "Verifying OID order in multi-pack-index"
 msgstr ""
 "Проверка на подредбата на идентификатори на обекти във файл с индекс към "
 "множество пакетни файлове"
 
-#: midx.c:1626
+#: midx.c:1634
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr ""
 "неправилна подредба на откъси (OID lookup): oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1646
+#: midx.c:1654
 msgid "Sorting objects by packfile"
 msgstr "Подредба на обектите по пакетни файлове"
 
-#: midx.c:1653
+#: midx.c:1661
 msgid "Verifying object offsets"
 msgstr "Проверка на отместването на обекти"
 
-#: midx.c:1669
+#: midx.c:1677
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "записът в пакета за обекта oid[%d] = %s не може да бъде зареден"
 
-#: midx.c:1675
+#: midx.c:1683
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "индексът на пакета „%s“ не може да бъде зареден"
 
-#: midx.c:1684
+#: midx.c:1692
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr "неправилно отместване на обект за oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#: midx.c:1709
+#: midx.c:1719
 msgid "Counting referenced objects"
 msgstr "Преброяване на свързаните обекти"
 
-#: midx.c:1719
+#: midx.c:1729
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "Търсене и изтриване на несвързаните пакетни файлове"
 
-#: midx.c:1911
+#: midx.c:1921
 msgid "could not start pack-objects"
 msgstr "командата „pack-objects“ не може да бъде стартирана"
 
-#: midx.c:1931
+#: midx.c:1941
 msgid "could not finish pack-objects"
 msgstr "командата „pack-objects“ не може да бъде завършена"
 
@@ -5898,263 +5900,263 @@ msgstr ""
 msgid "Bad %s value: '%s'"
 msgstr "Зададена е лоша стойност на променливата „%s“: „%s“"
 
-#: object-file.c:459
+#: object-file.c:456
 #, c-format
 msgid "object directory %s does not exist; check .git/objects/info/alternates"
 msgstr ""
 "директорията за обекти „%s“ не съществува, проверете „.git/objects/info/"
 "alternates“"
 
-#: object-file.c:517
+#: object-file.c:514
 #, c-format
 msgid "unable to normalize alternate object path: %s"
 msgstr "алтернативният път към обекти не може да бъде нормализиран: „%s“"
 
-#: object-file.c:591
+#: object-file.c:588
 #, c-format
 msgid "%s: ignoring alternate object stores, nesting too deep"
 msgstr ""
 "%s: алтернативните хранилища за обекти се пренебрегват поради прекалено "
 "дълбоко влагане"
 
-#: object-file.c:598
+#: object-file.c:595
 #, c-format
 msgid "unable to normalize object directory: %s"
 msgstr "директорията за обекти „%s“ не може да бъде нормализирана"
 
-#: object-file.c:641
+#: object-file.c:638
 msgid "unable to fdopen alternates lockfile"
 msgstr "заключващият файл за алтернативите не може да се отвори с „fdopen“"
 
-#: object-file.c:659
+#: object-file.c:656
 msgid "unable to read alternates file"
 msgstr "файлът с алтернативите не може да бъде прочетен"
 
-#: object-file.c:666
+#: object-file.c:663
 msgid "unable to move new alternates file into place"
 msgstr "новият файл с алтернативите не може да бъде преместен на мястото му"
 
-#: object-file.c:701
+#: object-file.c:741
 #, c-format
 msgid "path '%s' does not exist"
 msgstr "пътят „%s“ не съществува."
 
-#: object-file.c:722
+#: object-file.c:762
 #, c-format
 msgid "reference repository '%s' as a linked checkout is not supported yet."
 msgstr "все още не се поддържа еталонно хранилище „%s“ като свързано."
 
-#: object-file.c:728
+#: object-file.c:768
 #, c-format
 msgid "reference repository '%s' is not a local repository."
 msgstr "еталонното хранилище „%s“ не е локално"
 
-#: object-file.c:734
+#: object-file.c:774
 #, c-format
 msgid "reference repository '%s' is shallow"
 msgstr "еталонното хранилище „%s“ е плитко"
 
-#: object-file.c:742
+#: object-file.c:782
 #, c-format
 msgid "reference repository '%s' is grafted"
 msgstr "еталонното хранилище „%s“ е с присаждане"
 
-#: object-file.c:773
+#: object-file.c:813
 #, c-format
 msgid "could not find object directory matching %s"
 msgstr "директорията с обекти, която отговаря на „%s“, не може да бъде открита"
 
-#: object-file.c:823
+#: object-file.c:863
 #, c-format
 msgid "invalid line while parsing alternate refs: %s"
 msgstr "неправилен ред при анализа на алтернативните указатели: „%s“"
 
-#: object-file.c:973
+#: object-file.c:1013
 #, c-format
 msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
 msgstr ""
 "неуспешен опит за „mmap“ %<PRIuMAX>, което е над позволеното %<PRIuMAX>"
 
-#: object-file.c:1008
+#: object-file.c:1048
 #, c-format
 msgid "mmap failed%s"
 msgstr "неуспешно изпълнение на „mmap“%s"
 
-#: object-file.c:1174
+#: object-file.c:1214
 #, c-format
 msgid "object file %s is empty"
 msgstr "файлът с обектите „%s“ е празен"
 
-#: object-file.c:1293 object-file.c:2499
+#: object-file.c:1333 object-file.c:2542
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr "непакетираният обект „%s“ е повреден"
 
-#: object-file.c:1295 object-file.c:2503
+#: object-file.c:1335 object-file.c:2546
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr "грешни данни в края на непакетирания обект „%s“"
 
-#: object-file.c:1417
+#: object-file.c:1457
 #, c-format
 msgid "unable to parse %s header"
 msgstr "заглавната част на „%s“ не може да бъде анализирана"
 
-#: object-file.c:1419
+#: object-file.c:1459
 msgid "invalid object type"
 msgstr "неправилен вид обект"
 
-#: object-file.c:1430
+#: object-file.c:1470
 #, c-format
 msgid "unable to unpack %s header"
 msgstr "заглавната част на „%s“ не може да бъде разпакетирана"
 
-#: object-file.c:1434
+#: object-file.c:1474
 #, c-format
 msgid "header for %s too long, exceeds %d bytes"
 msgstr "заглавната част на „%s“ е прекалено дълга — надхвърля %d байта"
 
-#: object-file.c:1664
+#: object-file.c:1704
 #, c-format
 msgid "failed to read object %s"
 msgstr "обектът „%s“ не може да бъде прочетен"
 
-#: object-file.c:1668
+#: object-file.c:1708
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr "заместителят „%s“ на „%s“ не може да бъде открит"
 
-#: object-file.c:1672
+#: object-file.c:1712
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr "непакетираният обект „%s“ (в „%s“) е повреден"
 
-#: object-file.c:1676
+#: object-file.c:1716
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr "пакетираният обект „%s“ (в „%s“) е повреден"
 
-#: object-file.c:1781
+#: object-file.c:1821
 #, c-format
 msgid "unable to write file %s"
 msgstr "файлът „%s“ не може да бъде записан"
 
-#: object-file.c:1788
+#: object-file.c:1828
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr "правата за достъп до „%s“ не може да бъдат зададени"
 
-#: object-file.c:1795
+#: object-file.c:1835
 msgid "file write error"
 msgstr "грешка при запис на файл"
 
-#: object-file.c:1815
+#: object-file.c:1858
 msgid "error when closing loose object file"
 msgstr "грешка при затварянето на файла с непакетиран обект"
 
-#: object-file.c:1882
+#: object-file.c:1925
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 "няма права за добавяне на обект към базата от данни на хранилището „%s“"
 
-#: object-file.c:1884
+#: object-file.c:1927
 msgid "unable to create temporary file"
 msgstr "не може да бъде създаден временен файл"
 
-#: object-file.c:1908
+#: object-file.c:1951
 msgid "unable to write loose object file"
 msgstr "грешка при записа на файла с непакетиран обект"
 
-#: object-file.c:1914
+#: object-file.c:1957
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr "новият обект „%s“ не може да се компресира с „deflate“: %d"
 
-#: object-file.c:1918
+#: object-file.c:1961
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr "неуспешно приключване на „deflate“ върху „%s“: %d"
 
-#: object-file.c:1922
+#: object-file.c:1965
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr "грешка поради нестабилния източник данни за обектите „%s“"
 
-#: object-file.c:1933 builtin/pack-objects.c:1243
+#: object-file.c:1976 builtin/pack-objects.c:1243
 #, c-format
 msgid "failed utime() on %s"
 msgstr "неуспешно задаване на време на достъп/създаване чрез „utime“ на „%s“"
 
-#: object-file.c:2011
+#: object-file.c:2054
 #, c-format
 msgid "cannot read object for %s"
 msgstr "обектът за „%s“ не може да се прочете"
 
-#: object-file.c:2062
+#: object-file.c:2105
 msgid "corrupt commit"
 msgstr "повредено подаване"
 
-#: object-file.c:2070
+#: object-file.c:2113
 msgid "corrupt tag"
 msgstr "повреден етикет"
 
-#: object-file.c:2170
+#: object-file.c:2213
 #, c-format
 msgid "read error while indexing %s"
 msgstr "грешка при четене по време на индексиране на „%s“"
 
-#: object-file.c:2173
+#: object-file.c:2216
 #, c-format
 msgid "short read while indexing %s"
 msgstr "непълно прочитане по време на индексиране на „%s“"
 
-#: object-file.c:2246 object-file.c:2256
+#: object-file.c:2289 object-file.c:2299
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr "„%s“ не може да се вмъкне в базата от данни"
 
-#: object-file.c:2262
+#: object-file.c:2305
 #, c-format
 msgid "%s: unsupported file type"
 msgstr "неподдържан вид файл: „%s“"
 
-#: object-file.c:2286 builtin/fetch.c:1445
+#: object-file.c:2329 builtin/fetch.c:1448
 #, c-format
 msgid "%s is not a valid object"
 msgstr "„%s“ е неправилен обект"
 
-#: object-file.c:2288
+#: object-file.c:2331
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr "„%s“ е неправилен обект от вид „%s“"
 
-#: object-file.c:2315
+#: object-file.c:2358
 #, c-format
 msgid "unable to open %s"
 msgstr "обектът „%s“ не може да бъде отворен"
 
-#: object-file.c:2510
+#: object-file.c:2553
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
 msgstr "неправилна контролна сума за „%s“ (трябва да е %s)"
 
-#: object-file.c:2533
+#: object-file.c:2576
 #, c-format
 msgid "unable to mmap %s"
 msgstr "неуспешно изпълнение на „mmap“ върху „%s“"
 
-#: object-file.c:2539
+#: object-file.c:2582
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr "заглавната част на „%s“ не може да бъде разпакетирана"
 
-#: object-file.c:2544
+#: object-file.c:2587
 #, c-format
 msgid "unable to parse header of %s"
 msgstr "заглавната част на „%s“ не може да бъде анализирана"
 
-#: object-file.c:2555
+#: object-file.c:2598
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr "съдържанието на „%s“ не може да бъде разпакетирано"
@@ -6283,27 +6285,27 @@ msgstr "обектът „%s“ не може да бъде анализиран
 msgid "hash mismatch %s"
 msgstr "разлика в контролната сума: „%s“"
 
-#: pack-bitmap.c:348
+#: pack-bitmap.c:353
 msgid "multi-pack bitmap is missing required reverse index"
 msgstr "задължителният обратен индекс липсва в многопакетната битова маска"
 
-#: pack-bitmap.c:424
+#: pack-bitmap.c:429
 msgid "load_reverse_index: could not open pack"
 msgstr ""
 "load_reverse_index: пакетът не може да се отвори (при зареждане на обратния "
 "индекс)"
 
-#: pack-bitmap.c:1064 pack-bitmap.c:1070 builtin/pack-objects.c:2424
+#: pack-bitmap.c:1069 pack-bitmap.c:1075 builtin/pack-objects.c:2424
 #, c-format
 msgid "unable to get size of %s"
 msgstr "размерът на „%s“ не може да бъде получен"
 
-#: pack-bitmap.c:1916
+#: pack-bitmap.c:1935
 #, c-format
 msgid "could not find %s in pack %s at offset %<PRIuMAX>"
 msgstr "„%s“ липсва в пакет „%s“ при отместване %<PRIuMAX>"
 
-#: pack-bitmap.c:1952 builtin/rev-list.c:92
+#: pack-bitmap.c:1971 builtin/rev-list.c:92
 #, c-format
 msgid "unable to get disk usage of %s"
 msgstr "използваното място за „%s“ не може да бъде получено"
@@ -6354,51 +6356,56 @@ msgstr "не може да се дадат права за четене на „
 msgid "could not write '%s' promisor file"
 msgstr "гарантиращият файл „%s“ не може да се запише"
 
-#: packfile.c:626
+#: packfile.c:627
 msgid "offset before end of packfile (broken .idx?)"
 msgstr ""
 "отместване преди края на пакетния файл (възможно е индексът да е повреден)"
 
-#: packfile.c:656
+#: packfile.c:657
 #, c-format
 msgid "packfile %s cannot be mapped%s"
 msgstr "не може да се изпълни „mmap“ върху пакетния файл „%s“%s"
 
-#: packfile.c:1923
+#: packfile.c:1924
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr ""
 "отместване преди началото на индекса на пакетния файл „%s“ (възможно е "
 "индексът да е повреден)"
 
-#: packfile.c:1927
+#: packfile.c:1928
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr ""
 "отместване преди края на индекса на пакетния файл „%s“ (възможно е индексът "
 "да е отрязан)"
 
-#: parse-options-cb.c:20 parse-options-cb.c:24 builtin/commit-graph.c:175
+#: parse-options-cb.c:21 parse-options-cb.c:25 builtin/commit-graph.c:175
 #, c-format
 msgid "option `%s' expects a numerical value"
 msgstr "опцията „%s“ очаква число за аргумент"
 
-#: parse-options-cb.c:41
+#: parse-options-cb.c:42
 #, c-format
 msgid "malformed expiration date '%s'"
 msgstr "неправилна дата на срок: „%s“"
 
-#: parse-options-cb.c:54
+#: parse-options-cb.c:55
 #, c-format
 msgid "option `%s' expects \"always\", \"auto\", or \"never\""
 msgstr ""
 "опцията „%s“ изисква някоя от стойностите: „always“ (винаги), "
 "„auto“ (автоматично) или „never“ (никога)"
 
-#: parse-options-cb.c:132 parse-options-cb.c:149
+#: parse-options-cb.c:133 parse-options-cb.c:150
 #, c-format
 msgid "malformed object name '%s'"
 msgstr "неправилно име на обект „%s“"
+
+#: parse-options-cb.c:307
+#, c-format
+msgid "option `%s' expects \"%s\" or \"%s\""
+msgstr "опцията „%s“ изисква някоя от стойностите: „%s“ или „%s“"
 
 #: parse-options.c:58
 #, c-format
@@ -6436,36 +6443,36 @@ msgstr ""
 msgid "ambiguous option: %s (could be --%s%s or --%s%s)"
 msgstr "нееднозначна опция: „%s“ (може да е „--%s%s“ или „--%s%s“)"
 
-#: parse-options.c:427 parse-options.c:435
+#: parse-options.c:428 parse-options.c:436
 #, c-format
 msgid "did you mean `--%s` (with two dashes)?"
 msgstr "„--%s“ (с 2 тирета) ли имахте предвид?"
 
-#: parse-options.c:677 parse-options.c:1053
+#: parse-options.c:678 parse-options.c:1054
 #, c-format
 msgid "alias of --%s"
 msgstr "псевдоним на „--%s“"
 
-#: parse-options.c:891
+#: parse-options.c:892
 #, c-format
 msgid "unknown option `%s'"
 msgstr "непозната опция: „%s“"
 
-#: parse-options.c:893
+#: parse-options.c:894
 #, c-format
 msgid "unknown switch `%c'"
 msgstr "непознат флаг „%c“"
 
-#: parse-options.c:895
+#: parse-options.c:896
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
 msgstr "непозната стойност извън „ascii“ в низа: „%s“"
 
-#: parse-options.c:919
+#: parse-options.c:920
 msgid "..."
 msgstr "…"
 
-#: parse-options.c:933
+#: parse-options.c:934
 #, c-format
 msgid "usage: %s"
 msgstr "употреба: %s"
@@ -6473,7 +6480,7 @@ msgstr "употреба: %s"
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
 #.
-#: parse-options.c:948
+#: parse-options.c:949
 #, c-format
 msgid "   or: %s"
 msgstr "     или: %s"
@@ -6497,17 +6504,17 @@ msgstr "     или: %s"
 #. translated) N_() usage string, which contained embedded
 #. newlines before we split it up.
 #.
-#: parse-options.c:969
+#: parse-options.c:970
 #, c-format
 msgid "%*s%s"
 msgstr "%*s%s"
 
-#: parse-options.c:992
+#: parse-options.c:993
 #, c-format
 msgid "    %s"
 msgstr "    %s"
 
-#: parse-options.c:1039
+#: parse-options.c:1040
 msgid "-NUM"
 msgstr "-ЧИСЛО"
 
@@ -6638,17 +6645,17 @@ msgstr "грешка при четене"
 msgid "the remote end hung up unexpectedly"
 msgstr "отдалеченото хранилище неочаквано прекъсна връзката"
 
-#: pkt-line.c:390 pkt-line.c:392
+#: pkt-line.c:417 pkt-line.c:419
 #, c-format
 msgid "protocol error: bad line length character: %.4s"
 msgstr "протоколна грешка: неправилeн знак за дължина на ред: %.4s"
 
-#: pkt-line.c:407 pkt-line.c:409 pkt-line.c:415 pkt-line.c:417
+#: pkt-line.c:434 pkt-line.c:436 pkt-line.c:442 pkt-line.c:444
 #, c-format
 msgid "protocol error: bad line length %d"
 msgstr "протоколна грешка: неправилна дължина на ред: %d"
 
-#: pkt-line.c:434 sideband.c:165
+#: pkt-line.c:472 sideband.c:165
 #, c-format
 msgid "remote error: %s"
 msgstr "отдалечена грешка: %s"
@@ -6703,7 +6710,7 @@ msgid "could not read `log` output"
 msgstr ""
 "изходът от командата за журнала с подавания „log“ не може да се прочете"
 
-#: range-diff.c:97 sequencer.c:5605
+#: range-diff.c:97 sequencer.c:5602
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr "подаването „%s“ не може да бъде анализирано"
@@ -6726,62 +6733,58 @@ msgstr "заглавната част на git „%.*s“ не може да с�
 msgid "failed to generate diff"
 msgstr "неуспешно търсене на разлика"
 
-#: range-diff.c:559
-msgid "--left-only and --right-only are mutually exclusive"
-msgstr "опциите „--left-only“ и „--right-only“ са несъвместими"
-
 #: range-diff.c:562 range-diff.c:564
 #, c-format
 msgid "could not parse log for '%s'"
 msgstr "журналът с подаванията на „%s“ не може да бъде анализиран"
 
-#: read-cache.c:710
+#: read-cache.c:723
 #, c-format
 msgid "will not add file alias '%s' ('%s' already exists in index)"
 msgstr ""
 "няма да бъде добавен псевдоним за файл „%s“ („%s“ вече съществува в индекса)"
 
-#: read-cache.c:726
+#: read-cache.c:739
 msgid "cannot create an empty blob in the object database"
 msgstr "в базата от данни за обектите не може да се създаде празен обект-BLOB"
 
-#: read-cache.c:748
+#: read-cache.c:761
 #, c-format
 msgid "%s: can only add regular files, symbolic links or git-directories"
 msgstr ""
 "%s: може да добавяте само обикновени файлове, символни връзки и директории "
 "на git"
 
-#: read-cache.c:753 builtin/submodule--helper.c:3241
+#: read-cache.c:766 builtin/submodule--helper.c:3242
 #, c-format
 msgid "'%s' does not have a commit checked out"
 msgstr "не е изтеглено подаване в „%s“"
 
-#: read-cache.c:805
+#: read-cache.c:818
 #, c-format
 msgid "unable to index file '%s'"
 msgstr "файлът „%s“ не може да бъде индексиран"
 
-#: read-cache.c:824
+#: read-cache.c:837
 #, c-format
 msgid "unable to add '%s' to index"
 msgstr "„%s“ не може да се добави в индекса"
 
-#: read-cache.c:835
+#: read-cache.c:848
 #, c-format
 msgid "unable to stat '%s'"
 msgstr "„stat“ не може да се изпълни върху „%s“"
 
-#: read-cache.c:1373
+#: read-cache.c:1386
 #, c-format
 msgid "'%s' appears as both a file and as a directory"
 msgstr "„%s“ съществува и като файл, и като директория"
 
-#: read-cache.c:1588
+#: read-cache.c:1601
 msgid "Refresh index"
 msgstr "Обновяване на индекса"
 
-#: read-cache.c:1720
+#: read-cache.c:1733
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -6790,7 +6793,7 @@ msgstr ""
 "Зададена е неправилна стойност на настройката „index.version“.\n"
 "Ще се ползва версия %i"
 
-#: read-cache.c:1730
+#: read-cache.c:1743
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -6800,152 +6803,152 @@ msgstr ""
 "„GIT_INDEX_VERSION“.\n"
 "Ще се ползва версия %i"
 
-#: read-cache.c:1786
+#: read-cache.c:1799
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr "неправилен подпис: „0x%08x“"
 
-#: read-cache.c:1789
+#: read-cache.c:1802
 #, c-format
 msgid "bad index version %d"
 msgstr "неправилна версия на индекса %d"
 
-#: read-cache.c:1798
+#: read-cache.c:1811
 msgid "bad index file sha1 signature"
 msgstr "неправилен подпис за контролна сума по SHA1 на файла на индекса"
 
-#: read-cache.c:1832
+#: read-cache.c:1845
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr ""
 "индексът ползва разширение „%.4s“, което не се поддържа от тази версия на git"
 
-#: read-cache.c:1834
+#: read-cache.c:1847
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr "игнориране на разширението „%.4s“"
 
-#: read-cache.c:1871
+#: read-cache.c:1884
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr "непознат формат на запис в индекса: „0x%08x“"
 
-#: read-cache.c:1887
+#: read-cache.c:1900
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "неправилно име на поле в индекса близо до пътя „%s“"
 
-#: read-cache.c:1944
+#: read-cache.c:1957
 msgid "unordered stage entries in index"
 msgstr "неподредени записи в индекса"
 
-#: read-cache.c:1947
+#: read-cache.c:1960
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr "множество записи за слетия файл „%s“"
 
-#: read-cache.c:1950
+#: read-cache.c:1963
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr "неподредени записи за „%s“"
 
-#: read-cache.c:2065 read-cache.c:2363 rerere.c:549 rerere.c:583 rerere.c:1095
-#: submodule.c:1662 builtin/add.c:603 builtin/check-ignore.c:183
-#: builtin/checkout.c:519 builtin/checkout.c:708 builtin/clean.c:987
+#: read-cache.c:2078 read-cache.c:2384 rerere.c:549 rerere.c:583 rerere.c:1095
+#: submodule.c:1662 builtin/add.c:600 builtin/check-ignore.c:183
+#: builtin/checkout.c:527 builtin/checkout.c:719 builtin/clean.c:1013
 #: builtin/commit.c:378 builtin/diff-tree.c:122 builtin/grep.c:519
-#: builtin/mv.c:148 builtin/reset.c:253 builtin/rm.c:293
-#: builtin/submodule--helper.c:327 builtin/submodule--helper.c:3201
+#: builtin/mv.c:148 builtin/reset.c:499 builtin/rm.c:293
+#: builtin/submodule--helper.c:327 builtin/submodule--helper.c:3202
 msgid "index file corrupt"
 msgstr "файлът с индекса е повреден"
 
-#: read-cache.c:2209
+#: read-cache.c:2222
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr ""
 "не може да се създаде нишка за зареждане на обектите от кеша "
 "(load_cache_entries): %s"
 
-#: read-cache.c:2222
+#: read-cache.c:2235
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr ""
 "не може да се изчака нишка за зареждане на обектите от кеша "
 "(load_cache_entries): %s"
 
-#: read-cache.c:2255
+#: read-cache.c:2268
 #, c-format
 msgid "%s: index file open failed"
 msgstr "%s: неуспешно отваряне на файла на индекса"
 
-#: read-cache.c:2259
+#: read-cache.c:2272
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr "%s: не може да се получи информация за отворения индекс със „stat“"
 
-#: read-cache.c:2263
+#: read-cache.c:2276
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr "%s: файлът на индекса е по-малък от очакваното"
 
-#: read-cache.c:2267
+#: read-cache.c:2280
 #, c-format
 msgid "%s: unable to map index file%s"
 msgstr "%s: неуспешно изпълнение на „mmap“ върху индексния файл%s"
 
-#: read-cache.c:2310
+#: read-cache.c:2323
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr ""
 "не може да се създаде нишка за зареждане на разширенията на индекса "
 "(load_index_extensions): %s"
 
-#: read-cache.c:2337
+#: read-cache.c:2350
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr ""
 "не може да се създаде нишка за зареждане на разширенията на индекса "
 "(load_index_extensions): %s"
 
-#: read-cache.c:2375
+#: read-cache.c:2396
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr "споделеният индекс „%s“ не може да се обнови"
 
-#: read-cache.c:2434
+#: read-cache.c:2455
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr "грешки в индекса — в „%2$s“ се очаква „%1$s“, а бе получено „%3$s“"
 
-#: read-cache.c:3065 strbuf.c:1179 wrapper.c:641 builtin/merge.c:1147
+#: read-cache.c:3086 strbuf.c:1191 wrapper.c:641 builtin/merge.c:1150
 #, c-format
 msgid "could not close '%s'"
 msgstr "„%s“ не може да се затвори"
 
-#: read-cache.c:3108
+#: read-cache.c:3129
 msgid "failed to convert to a sparse-index"
 msgstr "индексът не може да бъде превърнат в частичен"
 
-#: read-cache.c:3179
+#: read-cache.c:3200
 #, c-format
 msgid "could not stat '%s'"
 msgstr "неуспешно изпълнение на „stat“ върху „%s“"
 
-#: read-cache.c:3192
+#: read-cache.c:3213
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "не може да се отвори директорията на git: %s"
 
-#: read-cache.c:3204
+#: read-cache.c:3225
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "неуспешно изтриване на „%s“"
 
-#: read-cache.c:3233
+#: read-cache.c:3254
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr "правата за достъп до „%s“ не може да бъдат поправени"
 
-#: read-cache.c:3390
+#: read-cache.c:3411
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr "%s: не може да се премине към етап №0"
@@ -7068,8 +7071,8 @@ msgstr ""
 "Ако изтриете всичко, пребазирането ще бъде преустановено.\n"
 "\n"
 
-#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3888
-#: sequencer.c:3914 sequencer.c:5711 builtin/fsck.c:328 builtin/gc.c:1789
+#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3883
+#: sequencer.c:3909 sequencer.c:5708 builtin/fsck.c:328 builtin/gc.c:1791
 #: builtin/rebase.c:190
 #, c-format
 msgid "could not write '%s'"
@@ -7111,7 +7114,7 @@ msgstr ""
 msgid "%s: 'preserve' superseded by 'merges'"
 msgstr "%s: „merges“ заменя „preserve“"
 
-#: ref-filter.c:42 wt-status.c:2036
+#: ref-filter.c:42 wt-status.c:2048
 msgid "gone"
 msgstr "изтрит"
 
@@ -7150,7 +7153,8 @@ msgstr "очаква се цяло число за „refname:lstrip=%s“"
 msgid "Integer value expected refname:rstrip=%s"
 msgstr "очаква се цяло число за „refname:rstrip=%s“"
 
-#: ref-filter.c:265
+#: ref-filter.c:265 ref-filter.c:344 ref-filter.c:377 ref-filter.c:431
+#: ref-filter.c:443 ref-filter.c:462 ref-filter.c:534 ref-filter.c:560
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
 msgstr "непознат аргумент за „%%(%s)“: %s"
@@ -7159,11 +7163,6 @@ msgstr "непознат аргумент за „%%(%s)“: %s"
 #, c-format
 msgid "%%(objecttype) does not take arguments"
 msgstr "%%(objecttype) не приема аргументи"
-
-#: ref-filter.c:344
-#, c-format
-msgid "unrecognized %%(objectsize) argument: %s"
-msgstr "непознат аргумент за %%(objectsize): %s"
 
 #: ref-filter.c:352
 #, c-format
@@ -7174,11 +7173,6 @@ msgstr "%%(deltabase) не приема аргументи"
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr "%%(body) не приема аргументи"
-
-#: ref-filter.c:377
-#, c-format
-msgid "unrecognized %%(subject) argument: %s"
-msgstr "непознат аргумент за %%(subject): %s"
 
 #: ref-filter.c:396
 #, c-format
@@ -7195,25 +7189,10 @@ msgstr "непознат аргумент „%%(trailers)“: %s"
 msgid "positive value expected contents:lines=%s"
 msgstr "очаква се положителна стойност за „contents:lines=%s“"
 
-#: ref-filter.c:431
-#, c-format
-msgid "unrecognized %%(contents) argument: %s"
-msgstr "непознат аргумент за %%(contents): %s"
-
-#: ref-filter.c:443
-#, c-format
-msgid "unrecognized %%(raw) argument: %s"
-msgstr "непознат аргумент за „%%(raw)“: %s"
-
 #: ref-filter.c:458
 #, c-format
 msgid "positive value expected '%s' in %%(%s)"
 msgstr "очаква се положителна стойност за „%s“ в %%(%s)"
-
-#: ref-filter.c:462
-#, c-format
-msgid "unrecognized argument '%s' in %%(%s)"
-msgstr "непознат аргумент „%s“ в %%(%s)"
 
 #: ref-filter.c:476
 #, c-format
@@ -7235,20 +7214,10 @@ msgstr "непозната позиция: %s"
 msgid "unrecognized width:%s"
 msgstr "непозната широчина: %s"
 
-#: ref-filter.c:534
-#, c-format
-msgid "unrecognized %%(align) argument: %s"
-msgstr "непознат аргумент за %%(align): %s"
-
 #: ref-filter.c:542
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr "очаква се положителна широчина с лексемата „%%(align)“"
-
-#: ref-filter.c:560
-#, c-format
-msgid "unrecognized %%(if) argument: %s"
-msgstr "непознат аргумент за „%%(if)“: %s"
 
 #: ref-filter.c:568
 #, c-format
@@ -7271,15 +7240,10 @@ msgid ""
 "not a git repository, but the field '%.*s' requires access to object data"
 msgstr "не е хранилище на git, а полето „%.*s“ изисква достъп данни на обектни"
 
-#: ref-filter.c:844
+#: ref-filter.c:844 ref-filter.c:910 ref-filter.c:946 ref-filter.c:948
 #, c-format
-msgid "format: %%(if) atom used without a %%(then) atom"
-msgstr "формат: лексемата %%(if) е използвана без съответната ѝ %%(then)"
-
-#: ref-filter.c:910
-#, c-format
-msgid "format: %%(then) atom used without an %%(if) atom"
-msgstr "формат: лексемата %%(then) е използвана без съответната ѝ %%(if)"
+msgid "format: %%(%s) atom used without a %%(%s) atom"
+msgstr "формат: лексемата %%(%s) е използвана без съответната ѝ %%(%s)"
 
 #: ref-filter.c:912
 #, c-format
@@ -7290,16 +7254,6 @@ msgstr "формат: лексемата %%(then) е използвана пов
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr "формат: лексемата %%(then) е използвана след %%(else)"
-
-#: ref-filter.c:946
-#, c-format
-msgid "format: %%(else) atom used without an %%(if) atom"
-msgstr "формат: лексемата %%(else) е използвана без съответната ѝ %%(if)"
-
-#: ref-filter.c:948
-#, c-format
-msgid "format: %%(else) atom used without a %%(then) atom"
-msgstr "формат: лексемата %%(else) е използвана без съответната ѝ %%(then)"
 
 #: ref-filter.c:950
 #, c-format
@@ -7376,22 +7330,22 @@ msgstr "обект със сгрешен формат при „%s“"
 msgid "ignoring ref with broken name %s"
 msgstr "игнориране на указателя с грешно име „%s“"
 
-#: ref-filter.c:2250 refs.c:673
+#: ref-filter.c:2250 refs.c:676
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "игнориране на повредения указател „%s“"
 
-#: ref-filter.c:2623
+#: ref-filter.c:2629
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "грешка във форма̀та: липсва лексемата %%(end)"
 
-#: ref-filter.c:2726
+#: ref-filter.c:2740
 #, c-format
 msgid "malformed object name %s"
 msgstr "неправилно име на обект „%s“"
 
-#: ref-filter.c:2731
+#: ref-filter.c:2745
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "опцията „%s“ не сочи към подаване"
@@ -7436,71 +7390,71 @@ msgstr "„%s“ не може да бъде получен"
 msgid "invalid branch name: %s = %s"
 msgstr "неправилно име на клон: „%s = %s“"
 
-#: refs.c:671
+#: refs.c:674
 #, c-format
 msgid "ignoring dangling symref %s"
 msgstr "игнориране на указател на обект извън клон „%s“"
 
-#: refs.c:920
+#: refs.c:925
 #, c-format
 msgid "log for ref %s has gap after %s"
 msgstr "има пропуски в журнала с подаванията за указателя „%s“ след „%s“"
 
-#: refs.c:927
+#: refs.c:932
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
 msgstr "журналът с подаванията за указателя „%s“ свършва неочаквано след „%s“"
 
-#: refs.c:992
+#: refs.c:997
 #, c-format
 msgid "log for %s is empty"
 msgstr "журналът с подаванията за указателя „%s“ е празен"
 
-#: refs.c:1084
+#: refs.c:1090
 #, c-format
 msgid "refusing to update ref with bad name '%s'"
 msgstr "указател не може да се обнови с грешно име „%s“"
 
-#: refs.c:1155
+#: refs.c:1168
 #, c-format
 msgid "update_ref failed for ref '%s': %s"
 msgstr "неуспешно обновяване на указателя (update_ref) „%s“: %s"
 
-#: refs.c:2062
+#: refs.c:2069
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "не са позволени повече от една промени на указателя „%s“"
 
-#: refs.c:2142
+#: refs.c:2152
 msgid "ref updates forbidden inside quarantine environment"
 msgstr "обновяванията на указатели са забранени в среди под карантина"
 
-#: refs.c:2153
+#: refs.c:2163
 msgid "ref updates aborted by hook"
 msgstr "обновяванията на указатели са преустановени от кука"
 
-#: refs.c:2253 refs.c:2283
+#: refs.c:2271 refs.c:2301
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "„%s“ съществува, не може да се създаде „%s“"
 
-#: refs.c:2259 refs.c:2294
+#: refs.c:2277 refs.c:2312
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "невъзможно е едновременно да се обработват „%s“ и „%s“"
 
-#: refs/files-backend.c:1271
+#: refs/files-backend.c:1268
 #, c-format
 msgid "could not remove reference %s"
 msgstr "Указателят „%s“ не може да бъде изтрит"
 
-#: refs/files-backend.c:1285 refs/packed-backend.c:1549
+#: refs/files-backend.c:1282 refs/packed-backend.c:1549
 #: refs/packed-backend.c:1559
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr "Указателят „%s“ не може да бъде изтрит: %s"
 
-#: refs/files-backend.c:1288 refs/packed-backend.c:1562
+#: refs/files-backend.c:1285 refs/packed-backend.c:1562
 #, c-format
 msgid "could not delete references: %s"
 msgstr "Указателите не може да бъдат изтрити: %s"
@@ -7510,51 +7464,51 @@ msgstr "Указателите не може да бъдат изтрити: %s"
 msgid "invalid refspec '%s'"
 msgstr "неправилен указател: „%s“"
 
-#: remote.c:351
+#: remote.c:402
 #, c-format
 msgid "config remote shorthand cannot begin with '/': %s"
 msgstr ""
 "съкращението за отдалечено хранилище не може за започва със знака „/“: %s"
 
-#: remote.c:399
+#: remote.c:450
 msgid "more than one receivepack given, using the first"
 msgstr "зададен е повече от един пакет за получаване, ще се ползва първият"
 
-#: remote.c:407
+#: remote.c:458
 msgid "more than one uploadpack given, using the first"
 msgstr "зададен е повече от един пакет за изпращане, ще се ползва първият"
 
-#: remote.c:590
+#: remote.c:699
 #, c-format
 msgid "Cannot fetch both %s and %s to %s"
 msgstr "Невъзможно е да се доставят едновременно и „%s“, и „%s“ към „%s“"
 
-#: remote.c:594
+#: remote.c:703
 #, c-format
 msgid "%s usually tracks %s, not %s"
 msgstr "„%s“ обикновено следи „%s“, а не „%s“"
 
-#: remote.c:598
+#: remote.c:707
 #, c-format
 msgid "%s tracks both %s and %s"
 msgstr "„%s“ следи както „%s“, така и „%s“"
 
-#: remote.c:666
+#: remote.c:775
 #, c-format
 msgid "key '%s' of pattern had no '*'"
 msgstr "ключ „%s“ на шаблона не съдържа „*“"
 
-#: remote.c:676
+#: remote.c:785
 #, c-format
 msgid "value '%s' of pattern has no '*'"
 msgstr "стойност „%s“ на шаблона не съдържа „*“"
 
-#: remote.c:1083
+#: remote.c:1192
 #, c-format
 msgid "src refspec %s does not match any"
 msgstr "указателят на версия-източник „%s“ не съвпада с никой обект"
 
-#: remote.c:1088
+#: remote.c:1197
 #, c-format
 msgid "src refspec %s matches more than one"
 msgstr "указателят на версия-източник „%s“ съвпада с повече от един обект"
@@ -7563,7 +7517,7 @@ msgstr "указателят на версия-източник „%s“ съв�
 #. <remote> <src>:<dst>" push, and "being pushed ('%s')" is
 #. the <src>.
 #.
-#: remote.c:1103
+#: remote.c:1212
 #, c-format
 msgid ""
 "The destination you provided is not a full refname (i.e.,\n"
@@ -7587,7 +7541,7 @@ msgstr ""
 "Никой от вариантите не сработи.  Трябва сами да укажете пълното име на\n"
 "указателя."
 
-#: remote.c:1123
+#: remote.c:1232
 #, c-format
 msgid ""
 "The <src> part of the refspec is a commit object.\n"
@@ -7598,7 +7552,7 @@ msgstr ""
 "като\n"
 "изтласкате към „%s:refs/heads/%s“?"
 
-#: remote.c:1128
+#: remote.c:1237
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tag object.\n"
@@ -7609,7 +7563,7 @@ msgstr ""
 "като\n"
 "изтласкате към „%s:refs/tags/%s“?"
 
-#: remote.c:1133
+#: remote.c:1242
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tree object.\n"
@@ -7619,7 +7573,7 @@ msgstr ""
 "ИЗТОЧНИКът е обект-дърво.  Не целите ли всъщност да създадете нов клон като\n"
 "изтласкате към „%s:refs/tags/%s“?"
 
-#: remote.c:1138
+#: remote.c:1247
 #, c-format
 msgid ""
 "The <src> part of the refspec is a blob object.\n"
@@ -7629,118 +7583,118 @@ msgstr ""
 "ИЗТОЧНИКът е обект-BLOB.  Не целите ли всъщност да създадете нов клон като\n"
 "изтласкате към „%s:refs/tags/%s“?"
 
-#: remote.c:1174
+#: remote.c:1283
 #, c-format
 msgid "%s cannot be resolved to branch"
 msgstr "не е открит клон съответстващ на „%s“"
 
-#: remote.c:1185
+#: remote.c:1294
 #, c-format
 msgid "unable to delete '%s': remote ref does not exist"
 msgstr "„%s“ не може да се изтрие: отдалечения указател не съществува"
 
-#: remote.c:1197
+#: remote.c:1306
 #, c-format
 msgid "dst refspec %s matches more than one"
 msgstr "указателят на версия-цел „%s“ съвпада с повече от един обект"
 
-#: remote.c:1204
+#: remote.c:1313
 #, c-format
 msgid "dst ref %s receives from more than one src"
 msgstr ""
 "указателят на версия-цел „%s“ съответства и ще получава от повече от един "
 "източник"
 
-#: remote.c:1724 remote.c:1825
+#: remote.c:1834 remote.c:1941
 msgid "HEAD does not point to a branch"
 msgstr "Указателят „HEAD“ не сочи към клон"
 
-#: remote.c:1733
+#: remote.c:1843
 #, c-format
 msgid "no such branch: '%s'"
 msgstr "няма клон на име „%s“"
 
-#: remote.c:1736
+#: remote.c:1846
 #, c-format
 msgid "no upstream configured for branch '%s'"
 msgstr "не е зададен клон-източник за клона „%s“"
 
-#: remote.c:1742
+#: remote.c:1852
 #, c-format
 msgid "upstream branch '%s' not stored as a remote-tracking branch"
 msgstr "клонът-източник „%s“ не е съхранен като следящ клон"
 
-#: remote.c:1757
+#: remote.c:1867
 #, c-format
 msgid "push destination '%s' on remote '%s' has no local tracking branch"
 msgstr ""
 "липсва локален следящ клон за местоположението за изтласкване „%s“ в "
 "хранилището „%s“"
 
-#: remote.c:1769
+#: remote.c:1882
 #, c-format
 msgid "branch '%s' has no remote for pushing"
 msgstr "няма информация клонът „%s“ да следи някой друг"
 
-#: remote.c:1779
+#: remote.c:1892
 #, c-format
 msgid "push refspecs for '%s' do not include '%s'"
 msgstr "указателят за изтласкване на „%s“ не включва „%s“"
 
-#: remote.c:1792
+#: remote.c:1905
 msgid "push has no destination (push.default is 'nothing')"
 msgstr "указателят за изтласкване не включва цел („push.default“ е „nothing“)"
 
-#: remote.c:1814
+#: remote.c:1927
 msgid "cannot resolve 'simple' push to a single destination"
 msgstr "простото (simple) изтласкване не съответства на една цел"
 
-#: remote.c:1943
+#: remote.c:2060
 #, c-format
 msgid "couldn't find remote ref %s"
 msgstr "отдалеченият указател „%s“ не може да бъде открит"
 
-#: remote.c:1956
+#: remote.c:2073
 #, c-format
 msgid "* Ignoring funny ref '%s' locally"
 msgstr "• прескачане на неочаквания локален указател „%s“"
 
-#: remote.c:2119
+#: remote.c:2236
 #, c-format
 msgid "Your branch is based on '%s', but the upstream is gone.\n"
 msgstr "Този клон следи „%s“, но следеният клон е изтрит.\n"
 
-#: remote.c:2123
+#: remote.c:2240
 msgid "  (use \"git branch --unset-upstream\" to fixup)\n"
 msgstr "  (за да коригирате това, използвайте „git branch --unset-upstream“)\n"
 
-#: remote.c:2126
+#: remote.c:2243
 #, c-format
 msgid "Your branch is up to date with '%s'.\n"
 msgstr "Клонът е обновен към „%s“.\n"
 
-#: remote.c:2130
+#: remote.c:2247
 #, c-format
 msgid "Your branch and '%s' refer to different commits.\n"
 msgstr "Клонът ви и „%s“ сочат към различни подавания.\n"
 
-#: remote.c:2133
+#: remote.c:2250
 #, c-format
 msgid "  (use \"%s\" for details)\n"
 msgstr "  (за повече информация ползвайте „%s“)\n"
 
-#: remote.c:2137
+#: remote.c:2254
 #, c-format
 msgid "Your branch is ahead of '%s' by %d commit.\n"
 msgid_plural "Your branch is ahead of '%s' by %d commits.\n"
 msgstr[0] "Клонът ви е с %2$d подаване пред „%1$s“.\n"
 msgstr[1] "Клонът ви е с %2$d подавания пред „%1$s“.\n"
 
-#: remote.c:2143
+#: remote.c:2260
 msgid "  (use \"git push\" to publish your local commits)\n"
 msgstr "  (публикувайте локалните си промени чрез „git push“)\n"
 
-#: remote.c:2146
+#: remote.c:2263
 #, c-format
 msgid "Your branch is behind '%s' by %d commit, and can be fast-forwarded.\n"
 msgid_plural ""
@@ -7748,11 +7702,11 @@ msgid_plural ""
 msgstr[0] "Клонът ви е с %2$d подаване зад „%1$s“ и може да бъде превъртян.\n"
 msgstr[1] "Клонът ви е с %2$d подавания зад „%1$s“ и може да бъде превъртян.\n"
 
-#: remote.c:2154
+#: remote.c:2271
 msgid "  (use \"git pull\" to update your local branch)\n"
 msgstr "  (обновете локалния си клон чрез „git pull“)\n"
 
-#: remote.c:2157
+#: remote.c:2274
 #, c-format
 msgid ""
 "Your branch and '%s' have diverged,\n"
@@ -7767,11 +7721,11 @@ msgstr[1] ""
 "Текущият клон се е отделил от „%s“,\n"
 "двата имат съответно по %d и %d несъвпадащи подавания.\n"
 
-#: remote.c:2167
+#: remote.c:2284
 msgid "  (use \"git pull\" to merge the remote branch into yours)\n"
 msgstr "  (слейте отдалечения клон в локалния чрез „git pull“)\n"
 
-#: remote.c:2359
+#: remote.c:2476
 #, c-format
 msgid "cannot parse expected object name '%s'"
 msgstr "очакваното име на обект „%s“ не може да бъде анализирано"
@@ -7804,7 +7758,7 @@ msgstr "приложеното коригиране на конфликт не �
 msgid "there were errors while writing '%s' (%s)"
 msgstr "грешки при записването на „%s“ (%s)"
 
-#: rerere.c:482 builtin/gc.c:2246 builtin/gc.c:2281
+#: rerere.c:482 builtin/gc.c:2263 builtin/gc.c:2298
 #, c-format
 msgid "failed to flush '%s'"
 msgstr "грешка при изчистването на буферите при записването на „%s“"
@@ -7852,8 +7806,8 @@ msgstr "излишният обект „%s“ не може да се изтр�
 msgid "Recorded preimage for '%s'"
 msgstr "Предварителният вариант на „%s“ е запазен"
 
-#: rerere.c:865 submodule.c:2121 builtin/log.c:2002
-#: builtin/submodule--helper.c:1776 builtin/submodule--helper.c:1819
+#: rerere.c:865 submodule.c:2121 builtin/log.c:2017
+#: builtin/submodule--helper.c:1777 builtin/submodule--helper.c:1820
 #, c-format
 msgid "could not create directory '%s'"
 msgstr "Директорията „%s“ не може да бъде създадена"
@@ -7891,39 +7845,31 @@ msgstr "директорията „rr-cache“ не може да се отво
 msgid "could not determine HEAD revision"
 msgstr "не може да се определи към какво да сочи указателят „HEAD“"
 
-#: reset.c:70 reset.c:76 sequencer.c:3705
+#: reset.c:70 reset.c:76 sequencer.c:3700
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "дървото, сочено от „%s“, не може да бъде открито"
 
-#: revision.c:2259
-msgid "--unsorted-input is incompatible with --no-walk"
-msgstr "опциите „--unsorted-input“ и „--no-walk“ са несъвместими"
-
-#: revision.c:2346
+#: revision.c:2347
 msgid "--unpacked=<packfile> no longer supported"
 msgstr "опцията „--unpacked=ПАКЕТЕН_ФАЙЛ“ вече не се поддържа"
 
-#: revision.c:2655 revision.c:2659
-msgid "--no-walk is incompatible with --unsorted-input"
-msgstr "опциите „--no-walk“ и „--unsorted-input“ са несъвместими"
-
-#: revision.c:2690
+#: revision.c:2686
 msgid "your current branch appears to be broken"
 msgstr "Текущият клон е повреден"
 
-#: revision.c:2693
+#: revision.c:2689
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
 msgstr "Текущият клон „%s“ е без подавания "
 
-#: revision.c:2895
+#: revision.c:2891
 msgid "-L does not yet support diff formats besides -p and -s"
 msgstr ""
 "опцията „-L“ поддържа единствено форматирането на разликите според опциите „-"
 "p“ и „-s“"
 
-#: run-command.c:1278
+#: run-command.c:1262
 #, c-format
 msgid "cannot create async thread: %s"
 msgstr "не може да се създаде асинхронна нишка: %s"
@@ -7992,8 +7938,8 @@ msgstr "несъществуващ режим на изчистване „%s“
 msgid "could not delete '%s'"
 msgstr "„%s“ не може да бъде изтрит"
 
-#: sequencer.c:345 sequencer.c:4754 builtin/rebase.c:563 builtin/rebase.c:1297
-#: builtin/rm.c:408
+#: sequencer.c:345 sequencer.c:4751 builtin/rebase.c:563 builtin/rebase.c:1297
+#: builtin/rm.c:409
 #, c-format
 msgid "could not remove '%s'"
 msgstr "„%s“ не може да бъде изтрит"
@@ -8080,13 +8026,13 @@ msgstr ""
 "\n"
 "    git revert --abort"
 
-#: sequencer.c:448 sequencer.c:3290
+#: sequencer.c:448 sequencer.c:3292
 #, c-format
 msgid "could not lock '%s'"
 msgstr "„%s“ не може да се заключи"
 
-#: sequencer.c:450 sequencer.c:3089 sequencer.c:3294 sequencer.c:3308
-#: sequencer.c:3566 sequencer.c:5621 strbuf.c:1176 wrapper.c:639
+#: sequencer.c:450 sequencer.c:3091 sequencer.c:3296 sequencer.c:3310
+#: sequencer.c:3561 sequencer.c:5618 strbuf.c:1188 wrapper.c:639
 #, c-format
 msgid "could not write to '%s'"
 msgstr "в „%s“ не може да се пише"
@@ -8096,11 +8042,17 @@ msgstr "в „%s“ не може да се пише"
 msgid "could not write eol to '%s'"
 msgstr "краят на ред не може да се запише в „%s“"
 
-#: sequencer.c:460 sequencer.c:3094 sequencer.c:3296 sequencer.c:3310
-#: sequencer.c:3574
+#: sequencer.c:460 sequencer.c:3096 sequencer.c:3298 sequencer.c:3312
+#: sequencer.c:3569
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "„%s“ не може да се завърши"
+
+#: sequencer.c:473 sequencer.c:1934 sequencer.c:3116 sequencer.c:3551
+#: sequencer.c:3679 builtin/am.c:289 builtin/commit.c:834 builtin/merge.c:1148
+#, c-format
+msgid "could not read '%s'"
+msgstr "файлът „%s“ не може да бъде прочетен"
 
 #: sequencer.c:499
 #, c-format
@@ -8116,7 +8068,7 @@ msgstr "подайте или скатайте промените, за да п�
 msgid "%s: fast-forward"
 msgstr "%s: превъртане"
 
-#: sequencer.c:574 builtin/tag.c:610
+#: sequencer.c:574 builtin/tag.c:614
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Несъществуващ режим на изчистване „%s“"
@@ -8147,8 +8099,8 @@ msgstr "в „%.*s“ няма ключове"
 msgid "unable to dequote value of '%s'"
 msgstr "цитирането на стойността на „%s“ не може да бъде изчистено"
 
-#: sequencer.c:841 wrapper.c:209 wrapper.c:379 builtin/am.c:730
-#: builtin/am.c:822 builtin/rebase.c:694
+#: sequencer.c:841 wrapper.c:209 wrapper.c:379 builtin/am.c:756
+#: builtin/am.c:848 builtin/rebase.c:694
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "файлът не може да бъде прочетен: „%s“"
@@ -8211,13 +8163,13 @@ msgstr ""
 "\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:1229
+#: sequencer.c:1225
 msgid "'prepare-commit-msg' hook failed"
 msgstr ""
 "неуспешно изпълнение на куката при промяна на съобщението при подаване "
 "(prepare-commit-msg)"
 
-#: sequencer.c:1235
+#: sequencer.c:1231
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -8245,7 +8197,7 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1248
+#: sequencer.c:1244
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -8270,361 +8222,361 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1290
+#: sequencer.c:1288
 msgid "couldn't look up newly created commit"
 msgstr "току що създаденото подаване не може да бъде открито"
 
-#: sequencer.c:1292
+#: sequencer.c:1290
 msgid "could not parse newly created commit"
 msgstr "току що създаденото подаване не може да бъде анализирано"
 
-#: sequencer.c:1338
+#: sequencer.c:1339
 msgid "unable to resolve HEAD after creating commit"
 msgstr ""
 "състоянието сочено от указателя „HEAD“ не може да бъде открито след "
 "подаването"
 
-#: sequencer.c:1340
+#: sequencer.c:1342
 msgid "detached HEAD"
 msgstr "несвързан връх „HEAD“"
 
-#: sequencer.c:1344
+#: sequencer.c:1346
 msgid " (root-commit)"
 msgstr " (начално подаване)"
 
-#: sequencer.c:1365
+#: sequencer.c:1367
 msgid "could not parse HEAD"
 msgstr "указателят „HEAD“ не може да бъде анализиран"
 
-#: sequencer.c:1367
+#: sequencer.c:1369
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "указателят „HEAD“ „%s“ сочи към нещо, което не е подаване!"
 
-#: sequencer.c:1371 sequencer.c:1449 builtin/commit.c:1707
+#: sequencer.c:1373 sequencer.c:1451 builtin/commit.c:1708
 msgid "could not parse HEAD commit"
 msgstr "върховото подаване „HEAD“ не може да бъде прочетено"
 
-#: sequencer.c:1427 sequencer.c:2312
+#: sequencer.c:1429 sequencer.c:2314
 msgid "unable to parse commit author"
 msgstr "авторът на подаването не може да бъде анализиран"
 
-#: sequencer.c:1438 builtin/am.c:1616 builtin/merge.c:708
+#: sequencer.c:1440 builtin/am.c:1643 builtin/merge.c:710
 msgid "git write-tree failed to write a tree"
 msgstr "Командата „git write-tree“ не успя да запише обект-дърво"
 
-#: sequencer.c:1471 sequencer.c:1591
+#: sequencer.c:1473 sequencer.c:1593
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "съобщението за подаване не може да бъде прочетено от „%s“"
 
-#: sequencer.c:1502 sequencer.c:1534
+#: sequencer.c:1504 sequencer.c:1536
 #, c-format
 msgid "invalid author identity '%s'"
 msgstr "неправилна самоличност за автор: „%s“"
 
-#: sequencer.c:1508
+#: sequencer.c:1510
 msgid "corrupt author: missing date information"
 msgstr "повредена информация за автор: липсва дата"
 
-#: sequencer.c:1547 builtin/am.c:1643 builtin/commit.c:1821 builtin/merge.c:913
-#: builtin/merge.c:938 t/helper/test-fast-rebase.c:78
+#: sequencer.c:1549 builtin/am.c:1670 builtin/commit.c:1822 builtin/merge.c:915
+#: builtin/merge.c:940 t/helper/test-fast-rebase.c:78
 msgid "failed to write commit object"
 msgstr "обектът за подаването не може да бъде записан"
 
-#: sequencer.c:1574 sequencer.c:4526 t/helper/test-fast-rebase.c:199
+#: sequencer.c:1576 sequencer.c:4523 t/helper/test-fast-rebase.c:199
 #: t/helper/test-fast-rebase.c:217
 #, c-format
 msgid "could not update %s"
 msgstr "„%s“ не може да се обнови"
 
-#: sequencer.c:1623
+#: sequencer.c:1625
 #, c-format
 msgid "could not parse commit %s"
 msgstr "подаването „%s“ не може да бъде анализирано"
 
-#: sequencer.c:1628
+#: sequencer.c:1630
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "родителското подаване „%s“ не може да бъде анализирано"
 
-#: sequencer.c:1711 sequencer.c:1992
+#: sequencer.c:1713 sequencer.c:1994
 #, c-format
 msgid "unknown command: %d"
 msgstr "непозната команда: %d"
 
-#: sequencer.c:1753
+#: sequencer.c:1755
 msgid "This is the 1st commit message:"
 msgstr "Това е 1-то съобщение при подаване:"
 
-#: sequencer.c:1754
+#: sequencer.c:1756
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "Това е съобщение при подаване №%d:"
 
-#: sequencer.c:1755
+#: sequencer.c:1757
 msgid "The 1st commit message will be skipped:"
 msgstr "Съобщението при подаване №1 ще бъде прескочено:"
 
-#: sequencer.c:1756
+#: sequencer.c:1758
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "Съобщението при подаване №%d ще бъде прескочено:"
 
-#: sequencer.c:1757
+#: sequencer.c:1759
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr "Това е обединение от %d подавания"
 
-#: sequencer.c:1904 sequencer.c:1961
+#: sequencer.c:1906 sequencer.c:1963
 #, c-format
 msgid "cannot write '%s'"
 msgstr "„%s“ не може да се запази"
 
-#: sequencer.c:1951
+#: sequencer.c:1953
 msgid "need a HEAD to fixup"
 msgstr "За вкарване в предходното подаване ви трябва указател „HEAD“"
 
-#: sequencer.c:1953 sequencer.c:3601
+#: sequencer.c:1955 sequencer.c:3596
 msgid "could not read HEAD"
 msgstr "указателят „HEAD“ не може да се прочете"
 
-#: sequencer.c:1955
+#: sequencer.c:1957
 msgid "could not read HEAD's commit message"
 msgstr ""
 "съобщението за подаване към указателя „HEAD“ не може да бъде прочетено: %s"
 
-#: sequencer.c:1979
+#: sequencer.c:1981
 #, c-format
 msgid "could not read commit message of %s"
 msgstr "съобщението за подаване към „%s“ не може да бъде прочетено"
 
-#: sequencer.c:2089
+#: sequencer.c:2091
 msgid "your index file is unmerged."
 msgstr "индексът не е слят."
 
-#: sequencer.c:2096
+#: sequencer.c:2098
 msgid "cannot fixup root commit"
 msgstr "началното подаване не може да се вкара в предходното му"
 
-#: sequencer.c:2115
+#: sequencer.c:2117
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "подаването „%s“ е сливане, но не е дадена опцията „-m“"
 
-#: sequencer.c:2123 sequencer.c:2131
+#: sequencer.c:2125 sequencer.c:2133
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "подаването „%s“ няма родител %d"
 
-#: sequencer.c:2137
+#: sequencer.c:2139
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "неуспешно извличане на съобщението за подаване на „%s“"
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:2156
+#: sequencer.c:2158
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: неразпозната стойност за родителското подаване „%s“"
 
-#: sequencer.c:2222
+#: sequencer.c:2224
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "„%s“ не може да се преименува на „%s“"
 
-#: sequencer.c:2282
+#: sequencer.c:2284
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "подаването „%s“… не може да бъде отменено: „%s“"
 
-#: sequencer.c:2283
+#: sequencer.c:2285
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "подаването „%s“… не може да бъде приложено: „%s“"
 
-#: sequencer.c:2304
+#: sequencer.c:2306
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr "прескачане на %s %s — кръпката вече е приложена\n"
 
-#: sequencer.c:2362
+#: sequencer.c:2364
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: неуспешно изчитане на индекса"
 
-#: sequencer.c:2370
+#: sequencer.c:2372
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: неуспешно обновяване на индекса"
 
-#: sequencer.c:2450
+#: sequencer.c:2452
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "„%s“ не приема аргументи: „%s“"
 
-#: sequencer.c:2459
+#: sequencer.c:2461
 #, c-format
 msgid "missing arguments for %s"
 msgstr "„%s“ изисква аргументи"
 
-#: sequencer.c:2502
+#: sequencer.c:2504
 #, c-format
 msgid "could not parse '%s'"
 msgstr "„%s“ не може да се анализира"
 
-#: sequencer.c:2563
+#: sequencer.c:2565
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "неправилен ред %d: %.*s"
 
-#: sequencer.c:2574
+#: sequencer.c:2576
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "Без предишно подаване не може да се изпълни „%s“"
 
-#: sequencer.c:2622 builtin/rebase.c:184
+#: sequencer.c:2624 builtin/rebase.c:184
 #, c-format
 msgid "could not read '%s'."
 msgstr "от „%s“ не може да се чете."
 
-#: sequencer.c:2660
+#: sequencer.c:2662
 msgid "cancelling a cherry picking in progress"
 msgstr "преустановяване на извършваното в момента отбиране на подавания"
 
-#: sequencer.c:2669
+#: sequencer.c:2671
 msgid "cancelling a revert in progress"
 msgstr "преустановяване на извършваното в момента отмяна на подаване"
 
-#: sequencer.c:2709
+#: sequencer.c:2711
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr "коригирайте това чрез „git rebase --edit-todo“."
 
-#: sequencer.c:2711
+#: sequencer.c:2713
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "неизползваем файл с описание на предстоящите действия: „%s“"
 
-#: sequencer.c:2716
+#: sequencer.c:2718
 msgid "no commits parsed."
 msgstr "никое от подаванията не може да се разпознае."
 
-#: sequencer.c:2727
+#: sequencer.c:2729
 msgid "cannot cherry-pick during a revert."
 msgstr ""
 "по време на отмяна на подаване не може да се извърши отбиране на подаване."
 
-#: sequencer.c:2729
+#: sequencer.c:2731
 msgid "cannot revert during a cherry-pick."
 msgstr "по време на отбиране не може да се извърши отмяна на подаване."
 
-#: sequencer.c:2807
+#: sequencer.c:2809
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr "неправилна стойност за „%s“: „%s“"
 
-#: sequencer.c:2916
+#: sequencer.c:2918
 msgid "unusable squash-onto"
 msgstr "подаването, в което другите да се вкарат, не може да се използва"
 
-#: sequencer.c:2936
+#: sequencer.c:2938
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "неправилен файл с опции: „%s“"
 
-#: sequencer.c:3031 sequencer.c:4905
+#: sequencer.c:3033 sequencer.c:4902
 msgid "empty commit set passed"
 msgstr "зададено е празно множество от подавания"
 
-#: sequencer.c:3048
+#: sequencer.c:3050
 msgid "revert is already in progress"
 msgstr "в момента вече се извършва отмяна на подавания"
 
-#: sequencer.c:3050
+#: sequencer.c:3052
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr "използвайте „git revert (--continue | %s--abort | --quit)“"
 
-#: sequencer.c:3053
+#: sequencer.c:3055
 msgid "cherry-pick is already in progress"
 msgstr "в момента вече се извършва отбиране на подавания"
 
-#: sequencer.c:3055
+#: sequencer.c:3057
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr "използвайте „git cherry-pick (--continue | %s--abort | --quit)“"
 
-#: sequencer.c:3069
+#: sequencer.c:3071
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr ""
 "директорията за определянето на последователността „%s“ не може да бъде "
 "създадена"
 
-#: sequencer.c:3084
+#: sequencer.c:3086
 msgid "could not lock HEAD"
 msgstr "указателят „HEAD“ не може да се заключи"
 
-#: sequencer.c:3144 sequencer.c:4615
+#: sequencer.c:3146 sequencer.c:4612
 msgid "no cherry-pick or revert in progress"
 msgstr ""
 "в момента не се извършва отбиране на подавания или пребазиране на клона"
 
-#: sequencer.c:3146 sequencer.c:3157
+#: sequencer.c:3148 sequencer.c:3159
 msgid "cannot resolve HEAD"
 msgstr "Подаването сочено от указателя „HEAD“ не може да бъде открито"
 
-#: sequencer.c:3148 sequencer.c:3192
+#: sequencer.c:3150 sequencer.c:3194
 msgid "cannot abort from a branch yet to be born"
 msgstr ""
 "действието не може да бъде преустановено, когато сте на клон, който тепърва "
 "предстои да бъде създаден"
 
-#: sequencer.c:3178 builtin/grep.c:772
+#: sequencer.c:3180 builtin/fetch.c:999 builtin/fetch.c:1411 builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr "„%s“ не може да бъде отворен"
 
-#: sequencer.c:3180
+#: sequencer.c:3182
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "„%s“ не може да бъде прочетен: %s"
 
-#: sequencer.c:3181
+#: sequencer.c:3183
 msgid "unexpected end of file"
 msgstr "неочакван край на файл"
 
-#: sequencer.c:3187
+#: sequencer.c:3189
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr ""
 "запазеният преди започването на отбирането файл за указателя „HEAD“ — „%s“ е "
 "повреден"
 
-#: sequencer.c:3198
+#: sequencer.c:3200
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr ""
 "Изглежда указателят „HEAD“ е променен.  Проверете към какво сочи.\n"
 "Не се правят промени."
 
-#: sequencer.c:3239
+#: sequencer.c:3241
 msgid "no revert in progress"
 msgstr "в момента не тече пребазиране"
 
-#: sequencer.c:3248
+#: sequencer.c:3250
 msgid "no cherry-pick in progress"
 msgstr "в момента не се извършва отбиране на подавания"
 
-#: sequencer.c:3258
+#: sequencer.c:3260
 msgid "failed to skip the commit"
 msgstr "неуспешно прескачане на подаването"
 
-#: sequencer.c:3265
+#: sequencer.c:3267
 msgid "there is nothing to skip"
 msgstr "няма какво да се прескочи"
 
-#: sequencer.c:3268
+#: sequencer.c:3270
 #, c-format
 msgid ""
 "have you committed already?\n"
@@ -8634,16 +8586,16 @@ msgstr ""
 "\n"
 "    git %s --continue"
 
-#: sequencer.c:3430 sequencer.c:4506
+#: sequencer.c:3432 sequencer.c:4503
 msgid "cannot read HEAD"
 msgstr "указателят „HEAD“ не може да бъде прочетен"
 
-#: sequencer.c:3447
+#: sequencer.c:3449
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "„%s“ не може да се копира като „%s“"
 
-#: sequencer.c:3455
+#: sequencer.c:3457
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -8662,27 +8614,27 @@ msgstr ""
 "\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:3465
+#: sequencer.c:3467
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "Подаването „%s“… не може да бъде приложено: „%.*s“"
 
-#: sequencer.c:3472
+#: sequencer.c:3474
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "Невъзможно сливане на „%.*s“"
 
-#: sequencer.c:3486 sequencer.c:3490 builtin/difftool.c:639
+#: sequencer.c:3488 sequencer.c:3492 builtin/difftool.c:633
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "„%s“ не може да се копира като „%s“"
 
-#: sequencer.c:3502
+#: sequencer.c:3503
 #, c-format
 msgid "Executing: %s\n"
 msgstr "В момента се изпълнява: %s\n"
 
-#: sequencer.c:3517
+#: sequencer.c:3514
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -8697,11 +8649,11 @@ msgstr ""
 "    git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3523
+#: sequencer.c:3520
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "и променѝ индекса и/или работното дърво\n"
 
-#: sequencer.c:3529
+#: sequencer.c:3526
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -8718,90 +8670,90 @@ msgstr ""
 "    git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3591
+#: sequencer.c:3586
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "неправилно име на етикет: „%.*s“"
 
-#: sequencer.c:3664
+#: sequencer.c:3659
 msgid "writing fake root commit"
 msgstr "запазване на фалшиво начално подаване"
 
-#: sequencer.c:3669
+#: sequencer.c:3664
 msgid "writing squash-onto"
 msgstr "запазване на подаването, в което другите да се вкарат"
 
-#: sequencer.c:3748
+#: sequencer.c:3743
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "„%s“ не може да бъде открит"
 
-#: sequencer.c:3780
+#: sequencer.c:3775
 msgid "cannot merge without a current revision"
 msgstr "без текущо подаване не може да се слива"
 
-#: sequencer.c:3802
+#: sequencer.c:3797
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "„%.*s“ не може да се анализира"
 
-#: sequencer.c:3811
+#: sequencer.c:3806
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "няма нищо за сливане: „%.*s“"
 
-#: sequencer.c:3823
+#: sequencer.c:3818
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr "върху начално подаване не може да се извърши множествено сливане"
 
-#: sequencer.c:3878
+#: sequencer.c:3873
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "съобщението за подаване към „%s“ не може да бъде получено"
 
-#: sequencer.c:4024
+#: sequencer.c:4019
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "сливането на „%.*s“ не може даже да започне"
 
-#: sequencer.c:4040
+#: sequencer.c:4035
 msgid "merge: Unable to write new index file"
 msgstr "сливане: новият индекс не може да бъде запазен"
 
-#: sequencer.c:4121
+#: sequencer.c:4116
 msgid "Cannot autostash"
 msgstr "Не може да се скатае автоматично"
 
-#: sequencer.c:4124
+#: sequencer.c:4119
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Неочакван резултат при скатаване: „%s“"
 
-#: sequencer.c:4130
+#: sequencer.c:4125
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "Директорията за „%s“ не може да бъде създадена"
 
-#: sequencer.c:4133
+#: sequencer.c:4128
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "Автоматично скатано: „%s“\n"
 
-#: sequencer.c:4137
+#: sequencer.c:4132
 msgid "could not reset --hard"
 msgstr "неуспешно изпълнение на „git reset --hard“"
 
-#: sequencer.c:4162
+#: sequencer.c:4157
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "Автоматично скатаното е приложено.\n"
 
-#: sequencer.c:4174
+#: sequencer.c:4169
 #, c-format
 msgid "cannot store %s"
 msgstr "„%s“ не може да бъде запазен"
 
-#: sequencer.c:4177
+#: sequencer.c:4172
 #, c-format
 msgid ""
 "%s\n"
@@ -8813,29 +8765,29 @@ msgstr ""
 "„git stash pop“ или да ги изхвърлите чрез „git stash drop“, когато "
 "поискате.\n"
 
-#: sequencer.c:4182
+#: sequencer.c:4177
 msgid "Applying autostash resulted in conflicts."
 msgstr "Конфликти при прилагането на автоматично скатаното."
 
-#: sequencer.c:4183
+#: sequencer.c:4178
 msgid "Autostash exists; creating a new stash entry."
 msgstr "Вече има запис за автоматично скатано, затова се създава нов запис."
 
-#: sequencer.c:4255
+#: sequencer.c:4252
 msgid "could not detach HEAD"
 msgstr "указателят „HEAD“ не може да се отдели"
 
-#: sequencer.c:4270
+#: sequencer.c:4267
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Бе спряно при „HEAD“\n"
 
-#: sequencer.c:4272
+#: sequencer.c:4269
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Бе спряно при „%s“\n"
 
-#: sequencer.c:4304
+#: sequencer.c:4301
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -8858,58 +8810,58 @@ msgstr ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:4350
+#: sequencer.c:4347
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr "Пребазиране (%d/%d)%s"
 
-#: sequencer.c:4396
+#: sequencer.c:4393
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Спиране при „%s“…  %.*s\n"
 
-#: sequencer.c:4466
+#: sequencer.c:4463
 #, c-format
 msgid "unknown command %d"
 msgstr "непозната команда %d"
 
-#: sequencer.c:4514
+#: sequencer.c:4511
 msgid "could not read orig-head"
 msgstr "указателят за „orig-head“ не може да се прочете"
 
-#: sequencer.c:4519
+#: sequencer.c:4516
 msgid "could not read 'onto'"
 msgstr "указателят за „onto“ не може да се прочете"
 
-#: sequencer.c:4533
+#: sequencer.c:4530
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "„HEAD“ не може да бъде обновен до „%s“"
 
-#: sequencer.c:4593
+#: sequencer.c:4590
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr "Успешно пребазиране и обновяване на „%s“.\n"
 
-#: sequencer.c:4645
+#: sequencer.c:4642
 msgid "cannot rebase: You have unstaged changes."
 msgstr "не може да пребазирате, защото има промени, които не са в индекса."
 
-#: sequencer.c:4654
+#: sequencer.c:4651
 msgid "cannot amend non-existing commit"
 msgstr "несъществуващо подаване не може да се поправи"
 
-#: sequencer.c:4656
+#: sequencer.c:4653
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "неправилен файл: „%s“"
 
-#: sequencer.c:4658
+#: sequencer.c:4655
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "неправилно съдържание: „%s“"
 
-#: sequencer.c:4661
+#: sequencer.c:4658
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -8919,69 +8871,69 @@ msgstr ""
 "В работното дърво има неподадени промени.  Първо ги подайте, а след това\n"
 "отново изпълнете „git rebase --continue“."
 
-#: sequencer.c:4697 sequencer.c:4736
+#: sequencer.c:4694 sequencer.c:4733
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "файлът „%s“ не може да бъде записан"
 
-#: sequencer.c:4752
+#: sequencer.c:4749
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "указателят „CHERRY_PICK_HEAD“ не може да бъде изтрит"
 
-#: sequencer.c:4762
+#: sequencer.c:4759
 msgid "could not commit staged changes."
 msgstr "промените в индекса не може да бъдат подадени."
 
-#: sequencer.c:4882
+#: sequencer.c:4879
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: не може да се отбере „%s“"
 
-#: sequencer.c:4886
+#: sequencer.c:4883
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: неправилна версия"
 
-#: sequencer.c:4921
+#: sequencer.c:4918
 msgid "can't revert as initial commit"
 msgstr "първоначалното подаване не може да бъде отменено"
 
-#: sequencer.c:5192 sequencer.c:5421
+#: sequencer.c:5189 sequencer.c:5418
 #, c-format
 msgid "skipped previously applied commit %s"
 msgstr "прескачане на вече приложеното подаване „%s“"
 
-#: sequencer.c:5262 sequencer.c:5437
+#: sequencer.c:5259 sequencer.c:5434
 msgid "use --reapply-cherry-picks to include skipped commits"
 msgstr ""
 "може да включите пропуснатите подавания с опцията „--reapply-cherry-picks“"
 
-#: sequencer.c:5408
+#: sequencer.c:5405
 msgid "make_script: unhandled options"
 msgstr "make_script: неподдържани опции"
 
-#: sequencer.c:5411
+#: sequencer.c:5408
 msgid "make_script: error preparing revisions"
 msgstr "make_script: грешка при подготовката на версии"
 
-#: sequencer.c:5669 sequencer.c:5686
+#: sequencer.c:5666 sequencer.c:5683
 msgid "nothing to do"
 msgstr "няма какво да се прави"
 
-#: sequencer.c:5705
+#: sequencer.c:5702
 msgid "could not skip unnecessary pick commands"
 msgstr "излишните команди за отбиране не бяха прескочени"
 
-#: sequencer.c:5805
+#: sequencer.c:5802
 msgid "the script was already rearranged."
 msgstr "скриптът вече е преподреден."
 
-#: setup.c:133
+#: setup.c:134
 #, c-format
 msgid "'%s' is outside repository at '%s'"
 msgstr "„%s“ е извън хранилището при „%s“"
 
-#: setup.c:185
+#: setup.c:186
 #, c-format
 msgid ""
 "%s: no such path in the working tree.\n"
@@ -8992,7 +8944,7 @@ msgstr ""
 "\n"
 "    git КОМАНДА -- ПЪТ…"
 
-#: setup.c:198
+#: setup.c:199
 #, c-format
 msgid ""
 "ambiguous argument '%s': unknown revision or path not in the working tree.\n"
@@ -9005,12 +8957,12 @@ msgstr ""
 "\n"
 "    git КОМАНДА [ВЕРСИЯ…] -- [ФАЙЛ…]"
 
-#: setup.c:264
+#: setup.c:265
 #, c-format
 msgid "option '%s' must come before non-option arguments"
 msgstr "опцията „%s“ трябва да е преди първия аргумент, който не е опция"
 
-#: setup.c:283
+#: setup.c:284
 #, c-format
 msgid ""
 "ambiguous argument '%s': both revision and filename\n"
@@ -9022,103 +8974,103 @@ msgstr ""
 "\n"
 "    git КОМАНДА [ВЕРСИЯ…] -- [ФАЙЛ…]"
 
-#: setup.c:419
+#: setup.c:420
 msgid "unable to set up work tree using invalid config"
 msgstr ""
 "не може да се зададе текуща работна директория при неправилни настройки"
 
-#: setup.c:423 builtin/rev-parse.c:895
+#: setup.c:424 builtin/rev-parse.c:895
 msgid "this operation must be run in a work tree"
 msgstr "тази команда трябва да се изпълни в работно дърво"
 
-#: setup.c:658
+#: setup.c:722
 #, c-format
 msgid "Expected git repo version <= %d, found %d"
 msgstr "Очаква се версия на хранилището на git <= %d, а не %d"
 
-#: setup.c:666
+#: setup.c:730
 msgid "unknown repository extension found:"
 msgid_plural "unknown repository extensions found:"
 msgstr[0] "открито е непознато разширение в хранилището:"
 msgstr[1] "открити са непознати разширения в хранилището:"
 
-#: setup.c:680
+#: setup.c:744
 msgid "repo version is 0, but v1-only extension found:"
 msgid_plural "repo version is 0, but v1-only extensions found:"
 msgstr[0] "версията на хранилището е 0, но е открито разширение за версия 1:"
 msgstr[1] "версията на хранилището е 0, но са открити разширения за версия 1:"
 
-#: setup.c:701
+#: setup.c:765
 #, c-format
 msgid "error opening '%s'"
 msgstr "„%s“ не може да се отвори"
 
-#: setup.c:703
+#: setup.c:767
 #, c-format
 msgid "too large to be a .git file: '%s'"
 msgstr "прекалено голям файл „.git“: „%s“"
 
-#: setup.c:705
+#: setup.c:769
 #, c-format
 msgid "error reading %s"
 msgstr "грешка при прочитане на „%s“"
 
-#: setup.c:707
+#: setup.c:771
 #, c-format
 msgid "invalid gitfile format: %s"
 msgstr "неправилен формат на gitfile: %s"
 
-#: setup.c:709
+#: setup.c:773
 #, c-format
 msgid "no path in gitfile: %s"
 msgstr "липсва път в gitfile: „%s“"
 
-#: setup.c:711
+#: setup.c:775
 #, c-format
 msgid "not a git repository: %s"
 msgstr "не е хранилище на Git: %s"
 
-#: setup.c:813
+#: setup.c:877
 #, c-format
 msgid "'$%s' too big"
 msgstr "„%s“ е прекалено голям"
 
-#: setup.c:827
+#: setup.c:891
 #, c-format
 msgid "not a git repository: '%s'"
 msgstr "не е хранилище на git: „%s“"
 
-#: setup.c:856 setup.c:858 setup.c:889
+#: setup.c:920 setup.c:922 setup.c:953
 #, c-format
 msgid "cannot chdir to '%s'"
 msgstr "не може да се влезе в директорията „%s“"
 
-#: setup.c:861 setup.c:917 setup.c:927 setup.c:966 setup.c:974
+#: setup.c:925 setup.c:981 setup.c:991 setup.c:1030 setup.c:1038
 msgid "cannot come back to cwd"
 msgstr "процесът не може да се върне към предишната работна директория"
 
-#: setup.c:988
+#: setup.c:1052
 #, c-format
 msgid "failed to stat '%*s%s%s'"
 msgstr "не може да бъде получена информация чрез „stat“ за „%*s%s%s“"
 
-#: setup.c:1231
+#: setup.c:1295
 msgid "Unable to read current working directory"
 msgstr "Текущата работна директория не може да бъде прочетена"
 
-#: setup.c:1240 setup.c:1246
+#: setup.c:1304 setup.c:1310
 #, c-format
 msgid "cannot change to '%s'"
 msgstr "не може да се влезе в директорията „%s“"
 
-#: setup.c:1251
+#: setup.c:1315
 #, c-format
 msgid "not a git repository (or any of the parent directories): %s"
 msgstr ""
 "нито тази, нито която и да е от по-горните директории, не е хранилище на "
 "git: %s"
 
-#: setup.c:1257
+#: setup.c:1321
 #, c-format
 msgid ""
 "not a git repository (or any parent up to mount point %s)\n"
@@ -9129,7 +9081,7 @@ msgstr ""
 "Git работи в рамките на една файлова система, защото променливата на средата "
 "„GIT_DISCOVERY_ACROSS_FILESYSTEM“ не е зададена."
 
-#: setup.c:1381
+#: setup.c:1446
 #, c-format
 msgid ""
 "problem with core.sharedRepository filemode value (0%.3o).\n"
@@ -9139,15 +9091,15 @@ msgstr ""
 "(0%.3o).\n"
 "Собственикът на файла трябва да има права за писане и четене."
 
-#: setup.c:1443
+#: setup.c:1508
 msgid "fork failed"
 msgstr "неуспешно създаване на процес чрез „fork“"
 
-#: setup.c:1448
+#: setup.c:1513
 msgid "setsid failed"
 msgstr "неуспешно изпълнение на „setsid“"
 
-#: sparse-index.c:273
+#: sparse-index.c:289
 #, c-format
 msgid "index entry is a directory, but not sparse (%08x)"
 msgstr "обектът в индекса е директория, но не частично изтеглена (%08x)"
@@ -9204,13 +9156,13 @@ msgid_plural "%u bytes/s"
 msgstr[0] "%u байт/сек."
 msgstr[1] "%u байта/сек."
 
-#: strbuf.c:1174 wrapper.c:207 wrapper.c:377 builtin/am.c:739
+#: strbuf.c:1186 wrapper.c:207 wrapper.c:377 builtin/am.c:765
 #: builtin/rebase.c:650
 #, c-format
 msgid "could not open '%s' for writing"
 msgstr "„%s“ не може да бъде отворен за запис"
 
-#: strbuf.c:1183
+#: strbuf.c:1195
 #, c-format
 msgid "could not edit '%s'"
 msgstr "„%s“ не може да се редактира"
@@ -9304,7 +9256,7 @@ msgstr ""
 msgid "process for submodule '%s' failed"
 msgstr "процесът за подмодула „%s“ завърши неуспешно"
 
-#: submodule.c:1194 builtin/branch.c:692 builtin/submodule--helper.c:2713
+#: submodule.c:1194 builtin/branch.c:699 builtin/submodule--helper.c:2714
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "Не може да се открие към какво сочи указателят „HEAD“"
 
@@ -9557,7 +9509,7 @@ msgstr "протоколът не поддържа задаването на п�
 msgid "invalid remote service path"
 msgstr "неправилен път на отдалечената услуга"
 
-#: transport-helper.c:661 transport.c:1475
+#: transport-helper.c:661 transport.c:1474
 msgid "operation not supported by protocol"
 msgstr "опцията не се поддържа от протокола"
 
@@ -9781,7 +9733,7 @@ msgstr ""
 msgid "Aborting."
 msgstr "Преустановяване на действието."
 
-#: transport.c:1344
+#: transport.c:1343
 msgid "failed to push all needed submodules"
 msgstr "неуспешно изтласкване на всички необходими подмодули"
 
@@ -9801,7 +9753,7 @@ msgstr "празно име на файл в запис в дърво"
 msgid "too-short tree file"
 msgstr "прекалено кратък файл-дърво"
 
-#: unpack-trees.c:115
+#: unpack-trees.c:118
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by checkout:\n"
@@ -9810,7 +9762,7 @@ msgstr ""
 "Изтеглянето ще презапише локалните промени на тези файлове:\n"
 "%%sПодайте или скатайте промените, за да преминете към нов клон."
 
-#: unpack-trees.c:117
+#: unpack-trees.c:120
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by checkout:\n"
@@ -9819,7 +9771,7 @@ msgstr ""
 "Изтеглянето ще презапише локалните промени на тези файлове:\n"
 "%%s"
 
-#: unpack-trees.c:120
+#: unpack-trees.c:123
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -9828,7 +9780,7 @@ msgstr ""
 "Сливането ще презапише локалните промени на тези файлове:\n"
 "%%sПодайте или скатайте промените, за да слеете."
 
-#: unpack-trees.c:122
+#: unpack-trees.c:125
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -9837,7 +9789,7 @@ msgstr ""
 "Сливането ще презапише локалните промени на тези файлове:\n"
 "%%s"
 
-#: unpack-trees.c:125
+#: unpack-trees.c:128
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by %s:\n"
@@ -9846,7 +9798,7 @@ msgstr ""
 "„%s“ ще презапише локалните промени на тези файлове:\n"
 "%%sПодайте или скатайте промените, за да извършите „%s“."
 
-#: unpack-trees.c:127
+#: unpack-trees.c:130
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by %s:\n"
@@ -9855,7 +9807,7 @@ msgstr ""
 "„%s“ ще презапише локалните промени на тези файлове:\n"
 "%%s"
 
-#: unpack-trees.c:132
+#: unpack-trees.c:135
 #, c-format
 msgid ""
 "Updating the following directories would lose untracked files in them:\n"
@@ -9864,7 +9816,16 @@ msgstr ""
 "Обновяването на следните директории ще изтрие неследените файлове в тях:\n"
 "%s"
 
-#: unpack-trees.c:136
+#: unpack-trees.c:138
+#, c-format
+msgid ""
+"Refusing to remove the current working directory:\n"
+"%s"
+msgstr ""
+"Текущата работна директория няма да бъде изтрита:\n"
+"%s"
+
+#: unpack-trees.c:142
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by checkout:\n"
@@ -9873,7 +9834,7 @@ msgstr ""
 "Изтеглянето ще изтрие тези неследени файлове в работното дърво:\n"
 "%%sПреместете ги или ги изтрийте, за да преминете на друг клон."
 
-#: unpack-trees.c:138
+#: unpack-trees.c:144
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by checkout:\n"
@@ -9882,7 +9843,7 @@ msgstr ""
 "Изтеглянето ще изтрие тези неследени файлове в работното дърво:\n"
 "%%s"
 
-#: unpack-trees.c:141
+#: unpack-trees.c:147
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by merge:\n"
@@ -9891,7 +9852,7 @@ msgstr ""
 "Сливането ще изтрие тези неследени файлове в работното дърво:\n"
 "%%sПреместете ги или ги изтрийте, за да слеете."
 
-#: unpack-trees.c:143
+#: unpack-trees.c:149
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by merge:\n"
@@ -9900,7 +9861,7 @@ msgstr ""
 "Сливането ще изтрие тези неследени файлове в работното дърво:\n"
 "%%s"
 
-#: unpack-trees.c:146
+#: unpack-trees.c:152
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by %s:\n"
@@ -9909,7 +9870,7 @@ msgstr ""
 "„%s“ ще изтрие тези неследени файлове в работното дърво:\n"
 "%%sПреместете ги или ги изтрийте, за да извършите „%s“."
 
-#: unpack-trees.c:148
+#: unpack-trees.c:154
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by %s:\n"
@@ -9918,7 +9879,7 @@ msgstr ""
 "„%s“ ще изтрие тези неследени файлове в работното дърво:\n"
 "%%s"
 
-#: unpack-trees.c:154
+#: unpack-trees.c:160
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by "
@@ -9928,7 +9889,7 @@ msgstr ""
 "Изтеглянето ще презапише тези неследени файлове в работното дърво:\n"
 "%%sПреместете ги или ги изтрийте, за да смените клон."
 
-#: unpack-trees.c:156
+#: unpack-trees.c:162
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by "
@@ -9938,7 +9899,7 @@ msgstr ""
 "Изтеглянето ще презапише тези неследени файлове в работното дърво:\n"
 "%%s"
 
-#: unpack-trees.c:159
+#: unpack-trees.c:165
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by merge:\n"
@@ -9947,7 +9908,7 @@ msgstr ""
 "Сливането ще презапише тези неследени файлове в работното дърво:\n"
 "%%sПреместете ги или ги изтрийте, за да слеете."
 
-#: unpack-trees.c:161
+#: unpack-trees.c:167
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by merge:\n"
@@ -9956,7 +9917,7 @@ msgstr ""
 "Сливането ще презапише тези неследени файлове в работното дърво:\n"
 "%%s"
 
-#: unpack-trees.c:164
+#: unpack-trees.c:170
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by %s:\n"
@@ -9965,7 +9926,7 @@ msgstr ""
 "„%s“ ще презапише тези неследени файлове в работното дърво:\n"
 "%%sПреместете ги или ги изтрийте, за да извършите „%s“."
 
-#: unpack-trees.c:166
+#: unpack-trees.c:172
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by %s:\n"
@@ -9974,12 +9935,12 @@ msgstr ""
 "„%s“ ще презапише тези неследени файлове в работното дърво:\n"
 "%%s"
 
-#: unpack-trees.c:174
+#: unpack-trees.c:180
 #, c-format
 msgid "Entry '%s' overlaps with '%s'.  Cannot bind."
 msgstr "Записът за „%s“ съвпада с този за „%s“.  Не може да се присвои."
 
-#: unpack-trees.c:177
+#: unpack-trees.c:183
 #, c-format
 msgid ""
 "Cannot update submodule:\n"
@@ -9988,7 +9949,7 @@ msgstr ""
 "Подмодулът не може да бъде обновен:\n"
 "„%s“"
 
-#: unpack-trees.c:180
+#: unpack-trees.c:186
 #, c-format
 msgid ""
 "The following paths are not up to date and were left despite sparse "
@@ -9999,7 +9960,7 @@ msgstr ""
 "изтегляне:\n"
 "%s"
 
-#: unpack-trees.c:182
+#: unpack-trees.c:188
 #, c-format
 msgid ""
 "The following paths are unmerged and were left despite sparse patterns:\n"
@@ -10009,7 +9970,7 @@ msgstr ""
 "изтегляне:\n"
 "%s"
 
-#: unpack-trees.c:184
+#: unpack-trees.c:190
 #, c-format
 msgid ""
 "The following paths were already present and thus not updated despite sparse "
@@ -10020,12 +9981,12 @@ msgstr ""
 "частично изтегляне:\n"
 "%s"
 
-#: unpack-trees.c:264
+#: unpack-trees.c:270
 #, c-format
 msgid "Aborting\n"
 msgstr "Преустановяване на действието\n"
 
-#: unpack-trees.c:291
+#: unpack-trees.c:297
 #, c-format
 msgid ""
 "After fixing the above paths, you may want to run `git sparse-checkout "
@@ -10036,11 +9997,11 @@ msgstr ""
 "\n"
 "    git sparse-checkout reapply\n"
 
-#: unpack-trees.c:352
+#: unpack-trees.c:358
 msgid "Updating files"
 msgstr "Обновяване на файлове"
 
-#: unpack-trees.c:384
+#: unpack-trees.c:390
 msgid ""
 "the following paths have collided (e.g. case-sensitive paths\n"
 "on a case-insensitive filesystem) and only one from the same\n"
@@ -10050,17 +10011,17 @@ msgstr ""
 "във файлови системи, които не различават главни от малки букви)\n"
 "и само един от участниците в конфликта е в работното дърво:\n"
 
-#: unpack-trees.c:1620
+#: unpack-trees.c:1636
 msgid "Updating index flags"
 msgstr "Обновяване на флаговете на индекса"
 
-#: unpack-trees.c:2772
+#: unpack-trees.c:2803
 #, c-format
 msgid "worktree and untracked commit have duplicate entries: %s"
 msgstr ""
 "работното дърво и неследеното подаване съдържат повтарящи се обекти: %s"
 
-#: upload-pack.c:1561
+#: upload-pack.c:1565
 msgid "expected flush after fetch arguments"
 msgstr "след аргументите на „fetch“ се очаква изчистване на буферите"
 
@@ -10097,102 +10058,102 @@ msgstr "неправилна част от пътя „..“"
 msgid "Fetching objects"
 msgstr "Доставяне на обектите"
 
-#: worktree.c:236 builtin/am.c:2154 builtin/bisect--helper.c:156
+#: worktree.c:238 builtin/am.c:2209 builtin/bisect--helper.c:156
 #, c-format
 msgid "failed to read '%s'"
 msgstr "„%s“ не може да бъде прочетен"
 
-#: worktree.c:303
+#: worktree.c:305
 #, c-format
 msgid "'%s' at main working tree is not the repository directory"
 msgstr "„%s“ в основното работно дърво не е директорията на хранилището"
 
-#: worktree.c:314
+#: worktree.c:316
 #, c-format
 msgid "'%s' file does not contain absolute path to the working tree location"
 msgstr ""
 "файлът „%s“ не съдържа абсолютния път към местоположението на работното дърво"
 
-#: worktree.c:326
+#: worktree.c:328
 #, c-format
 msgid "'%s' does not exist"
 msgstr "„%s“ не съществува."
 
-#: worktree.c:332
+#: worktree.c:334
 #, c-format
 msgid "'%s' is not a .git file, error code %d"
 msgstr "„%s“ не е файл на .git, код за грешка: %d"
 
-#: worktree.c:341
+#: worktree.c:343
 #, c-format
 msgid "'%s' does not point back to '%s'"
 msgstr "„%s“ не сочи към обратно към „%s“"
 
-#: worktree.c:603
+#: worktree.c:604
 msgid "not a directory"
 msgstr "не е директория"
 
-#: worktree.c:612
+#: worktree.c:613
 msgid ".git is not a file"
 msgstr "„.git“ не е файл"
 
-#: worktree.c:614
+#: worktree.c:615
 msgid ".git file broken"
 msgstr "„.git“ е повреден"
 
-#: worktree.c:616
+#: worktree.c:617
 msgid ".git file incorrect"
 msgstr "„.git“ е неправилен"
 
-#: worktree.c:722
+#: worktree.c:723
 msgid "not a valid path"
 msgstr "неправилен път"
 
-#: worktree.c:728
+#: worktree.c:729
 msgid "unable to locate repository; .git is not a file"
 msgstr "не може да се открие хранилище: „.git“ не е файл"
 
-#: worktree.c:732
+#: worktree.c:733
 msgid "unable to locate repository; .git file does not reference a repository"
 msgstr "не може да се открие хранилище: файлът „.git“ не сочи към хранилище"
 
-#: worktree.c:736
+#: worktree.c:737
 msgid "unable to locate repository; .git file broken"
 msgstr "не може да се открие хранилище: „.git“ е повреден"
 
-#: worktree.c:742
+#: worktree.c:743
 msgid "gitdir unreadable"
 msgstr "директорията „gitdir“ не може да се прочете"
 
-#: worktree.c:746
+#: worktree.c:747
 msgid "gitdir incorrect"
 msgstr "неправилна директория „gitdir“"
 
-#: worktree.c:771
+#: worktree.c:772
 msgid "not a valid directory"
 msgstr "не е валидна директория"
 
-#: worktree.c:777
+#: worktree.c:778
 msgid "gitdir file does not exist"
 msgstr "файлът „gitdir“ не съществува"
 
-#: worktree.c:782 worktree.c:791
+#: worktree.c:783 worktree.c:792
 #, c-format
 msgid "unable to read gitdir file (%s)"
 msgstr "файлът „gitdir“ не може да бъде прочетен (%s)"
 
-#: worktree.c:801
+#: worktree.c:802
 #, c-format
 msgid "short read (expected %<PRIuMAX> bytes, read %<PRIuMAX>)"
 msgstr ""
 "изчитането върна по-малко байтове от очакваното (очаквани: %<PRIuMAX> байта, "
 "получени: %<PRIuMAX>)"
 
-#: worktree.c:809
+#: worktree.c:810
 msgid "invalid gitdir file"
 msgstr "неправилен файл „gitdir“"
 
-#: worktree.c:817
+#: worktree.c:818
 msgid "gitdir file points to non-existent location"
 msgstr "файлът „gitdir“ сочи несъществуващо местоположение"
 
@@ -10257,11 +10218,11 @@ msgid "  (use \"git rm <file>...\" to mark resolution)"
 msgstr ""
 "  (използвайте „git rm ФАЙЛ…“, за да укажете разрешаването на конфликта)"
 
-#: wt-status.c:211 wt-status.c:1125
+#: wt-status.c:211 wt-status.c:1131
 msgid "Changes to be committed:"
 msgstr "Промени, които ще бъдат подадени:"
 
-#: wt-status.c:234 wt-status.c:1134
+#: wt-status.c:234 wt-status.c:1140
 msgid "Changes not staged for commit:"
 msgstr "Промени, които не са в индекса за подаване:"
 
@@ -10366,22 +10327,22 @@ msgstr "променено съдържание, "
 msgid "untracked content, "
 msgstr "неследено съдържание, "
 
-#: wt-status.c:958
+#: wt-status.c:964
 #, c-format
 msgid "Your stash currently has %d entry"
 msgid_plural "Your stash currently has %d entries"
 msgstr[0] "Има %d скатаване."
 msgstr[1] "Има %d скатавания."
 
-#: wt-status.c:989
+#: wt-status.c:995
 msgid "Submodules changed but not updated:"
 msgstr "Подмодулите са променени, но не са обновени:"
 
-#: wt-status.c:991
+#: wt-status.c:997
 msgid "Submodule changes to be committed:"
 msgstr "Промени в подмодулите за подаване:"
 
-#: wt-status.c:1073
+#: wt-status.c:1079
 msgid ""
 "Do not modify or remove the line above.\n"
 "Everything below it will be ignored."
@@ -10389,7 +10350,7 @@ msgstr ""
 "Не променяйте и не изтривайте горния ред.\n"
 "Всичко отдолу ще бъде изтрито."
 
-#: wt-status.c:1165
+#: wt-status.c:1171
 #, c-format
 msgid ""
 "\n"
@@ -10400,275 +10361,282 @@ msgstr ""
 "Изчисляването на броя различаващи се подавания отне %.2f сек.\n"
 "За да избегнете това, ползвайте „--no-ahead-behind“.\n"
 
-#: wt-status.c:1195
+#: wt-status.c:1201
 msgid "You have unmerged paths."
 msgstr "Някои пътища не са слети."
 
-#: wt-status.c:1198
+#: wt-status.c:1204
 msgid "  (fix conflicts and run \"git commit\")"
 msgstr "  (коригирайте конфликтите и изпълнете „git commit“)"
 
-#: wt-status.c:1200
+#: wt-status.c:1206
 msgid "  (use \"git merge --abort\" to abort the merge)"
 msgstr "  (използвайте „git merge --abort“, за да преустановите сливането)"
 
-#: wt-status.c:1204
+#: wt-status.c:1210
 msgid "All conflicts fixed but you are still merging."
 msgstr "Всички конфликти са решени, но продължавате сливането."
 
-#: wt-status.c:1207
+#: wt-status.c:1213
 msgid "  (use \"git commit\" to conclude merge)"
 msgstr "  (използвайте „git commit“, за да завършите сливането)"
 
-#: wt-status.c:1216
+#: wt-status.c:1224
 msgid "You are in the middle of an am session."
 msgstr "В момента прилагате поредица от кръпки чрез „git am“."
 
-#: wt-status.c:1219
+#: wt-status.c:1227
 msgid "The current patch is empty."
 msgstr "Текущата кръпка е празна."
 
-#: wt-status.c:1223
+#: wt-status.c:1232
 msgid "  (fix conflicts and then run \"git am --continue\")"
 msgstr "  (коригирайте конфликтите и изпълнете „git am --continue“)"
 
-#: wt-status.c:1225
+#: wt-status.c:1234
 msgid "  (use \"git am --skip\" to skip this patch)"
 msgstr "  (използвайте „git am --skip“, за да пропуснете тази кръпка)"
 
-#: wt-status.c:1227
+#: wt-status.c:1237
+msgid ""
+"  (use \"git am --allow-empty\" to record this patch as an empty commit)"
+msgstr ""
+"  (използвайте „git am --allow-empty“, за да включите кръпката като празно "
+"подаване)"
+
+#: wt-status.c:1239
 msgid "  (use \"git am --abort\" to restore the original branch)"
 msgstr ""
 "  (използвайте „git am --abort“, за да възстановите първоначалния клон)"
 
-#: wt-status.c:1360
+#: wt-status.c:1372
 msgid "git-rebase-todo is missing."
 msgstr "„git-rebase-todo“ липсва."
 
-#: wt-status.c:1362
+#: wt-status.c:1374
 msgid "No commands done."
 msgstr "Не са изпълнени команди."
 
-#: wt-status.c:1365
+#: wt-status.c:1377
 #, c-format
 msgid "Last command done (%d command done):"
 msgid_plural "Last commands done (%d commands done):"
 msgstr[0] "Последно изпълнена команда (изпълнена е общо %d команда):"
 msgstr[1] "Последно изпълнени команди (изпълнени са общо %d команди):"
 
-#: wt-status.c:1376
+#: wt-status.c:1388
 #, c-format
 msgid "  (see more in file %s)"
 msgstr "  (повече информация има във файла „%s“)"
 
-#: wt-status.c:1381
+#: wt-status.c:1393
 msgid "No commands remaining."
 msgstr "Не остават повече команди."
 
-#: wt-status.c:1384
+#: wt-status.c:1396
 #, c-format
 msgid "Next command to do (%d remaining command):"
 msgid_plural "Next commands to do (%d remaining commands):"
 msgstr[0] "Следваща команда за изпълнение (остава още %d команда):"
 msgstr[1] "Следващи команди за изпълнение (остават още %d команди):"
 
-#: wt-status.c:1392
+#: wt-status.c:1404
 msgid "  (use \"git rebase --edit-todo\" to view and edit)"
 msgstr ""
 "  (използвайте „git rebase --edit-todo“, за да разгледате и редактирате)"
 
-#: wt-status.c:1404
+#: wt-status.c:1416
 #, c-format
 msgid "You are currently rebasing branch '%s' on '%s'."
 msgstr "В момента пребазирате клона „%s“ върху „%s“."
 
-#: wt-status.c:1409
+#: wt-status.c:1421
 msgid "You are currently rebasing."
 msgstr "В момента пребазирате."
 
-#: wt-status.c:1422
+#: wt-status.c:1434
 msgid "  (fix conflicts and then run \"git rebase --continue\")"
 msgstr "  (коригирайте конфликтите и използвайте „git rebase --continue“)"
 
-#: wt-status.c:1424
+#: wt-status.c:1436
 msgid "  (use \"git rebase --skip\" to skip this patch)"
 msgstr "  (използвайте „git rebase --skip“, за да пропуснете тази кръпка)"
 
-#: wt-status.c:1426
+#: wt-status.c:1438
 msgid "  (use \"git rebase --abort\" to check out the original branch)"
 msgstr ""
 "  (използвайте „git rebase --abort“, за да възстановите първоначалния клон)"
 
-#: wt-status.c:1433
+#: wt-status.c:1445
 msgid "  (all conflicts fixed: run \"git rebase --continue\")"
 msgstr "  (всички конфликти са коригирани: изпълнете „git rebase --continue“)"
 
-#: wt-status.c:1437
+#: wt-status.c:1449
 #, c-format
 msgid ""
 "You are currently splitting a commit while rebasing branch '%s' on '%s'."
 msgstr "В момента разделяте подаване докато пребазирате клона „%s“ върху „%s“."
 
-#: wt-status.c:1442
+#: wt-status.c:1454
 msgid "You are currently splitting a commit during a rebase."
 msgstr "В момента разделяте подаване докато пребазирате."
 
-#: wt-status.c:1445
+#: wt-status.c:1457
 msgid "  (Once your working directory is clean, run \"git rebase --continue\")"
 msgstr ""
 "  (След като работното ви дърво стане чисто, използвайте „git rebase --"
 "continue“)"
 
-#: wt-status.c:1449
+#: wt-status.c:1461
 #, c-format
 msgid "You are currently editing a commit while rebasing branch '%s' on '%s'."
 msgstr ""
 "В момента редактирате подаване докато пребазирате клона „%s“ върху „%s“."
 
-#: wt-status.c:1454
+#: wt-status.c:1466
 msgid "You are currently editing a commit during a rebase."
 msgstr "В момента редактирате подаване докато пребазирате."
 
-#: wt-status.c:1457
+#: wt-status.c:1469
 msgid "  (use \"git commit --amend\" to amend the current commit)"
 msgstr ""
 "  (използвайте „git commit --amend“, за да редактирате текущото подаване)"
 
-#: wt-status.c:1459
+#: wt-status.c:1471
 msgid ""
 "  (use \"git rebase --continue\" once you are satisfied with your changes)"
 msgstr ""
 "  (използвайте „git rebase --continue“, след като завършите промените си)"
 
-#: wt-status.c:1470
+#: wt-status.c:1482
 msgid "Cherry-pick currently in progress."
 msgstr "В момента се извършва отбиране на подавания."
 
-#: wt-status.c:1473
+#: wt-status.c:1485
 #, c-format
 msgid "You are currently cherry-picking commit %s."
 msgstr "В момента отбирате подаването „%s“."
 
-#: wt-status.c:1480
+#: wt-status.c:1492
 msgid "  (fix conflicts and run \"git cherry-pick --continue\")"
 msgstr "  (коригирайте конфликтите и изпълнете „git cherry-pick --continue“)"
 
-#: wt-status.c:1483
+#: wt-status.c:1495
 msgid "  (run \"git cherry-pick --continue\" to continue)"
 msgstr "  (за да продължите, изпълнете „git cherry-pick --continue“)"
 
-#: wt-status.c:1486
+#: wt-status.c:1498
 msgid "  (all conflicts fixed: run \"git cherry-pick --continue\")"
 msgstr ""
 "  (всички конфликти са коригирани, изпълнете „git cherry-pick --continue“)"
 
-#: wt-status.c:1488
+#: wt-status.c:1500
 msgid "  (use \"git cherry-pick --skip\" to skip this patch)"
 msgstr "  (използвайте „git cherry-pick --skip“, за да пропуснете тази кръпка)"
 
-#: wt-status.c:1490
+#: wt-status.c:1502
 msgid "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)"
 msgstr ""
 "  (използвайте „git cherry-pick --abort“, за да отмените всички действия с "
 "отбиране)"
 
-#: wt-status.c:1500
+#: wt-status.c:1512
 msgid "Revert currently in progress."
 msgstr "В момента тече отмяна на подаване."
 
-#: wt-status.c:1503
+#: wt-status.c:1515
 #, c-format
 msgid "You are currently reverting commit %s."
 msgstr "В момента отменяте подаване „%s“."
 
-#: wt-status.c:1509
+#: wt-status.c:1521
 msgid "  (fix conflicts and run \"git revert --continue\")"
 msgstr "  (коригирайте конфликтите и изпълнете „git revert --continue“)"
 
-#: wt-status.c:1512
+#: wt-status.c:1524
 msgid "  (run \"git revert --continue\" to continue)"
 msgstr "  (за да продължите, изпълнете „git revert --continue“)"
 
-#: wt-status.c:1515
+#: wt-status.c:1527
 msgid "  (all conflicts fixed: run \"git revert --continue\")"
 msgstr "  (всички конфликти са коригирани, изпълнете „git revert --continue“)"
 
-#: wt-status.c:1517
+#: wt-status.c:1529
 msgid "  (use \"git revert --skip\" to skip this patch)"
 msgstr "  (използвайте „git revert --skip“, за да пропуснете тази кръпка)"
 
-#: wt-status.c:1519
+#: wt-status.c:1531
 msgid "  (use \"git revert --abort\" to cancel the revert operation)"
 msgstr ""
 "  (използвайте „git revert --abort“, за да преустановите отмяната на "
 "подаване)"
 
-#: wt-status.c:1529
+#: wt-status.c:1541
 #, c-format
 msgid "You are currently bisecting, started from branch '%s'."
 msgstr "В момента търсите двоично, като сте стартирали от клон „%s“."
 
-#: wt-status.c:1533
+#: wt-status.c:1545
 msgid "You are currently bisecting."
 msgstr "В момента търсите двоично."
 
-#: wt-status.c:1536
+#: wt-status.c:1548
 msgid "  (use \"git bisect reset\" to get back to the original branch)"
 msgstr ""
 "  (използвайте „git bisect reset“, за да се върнете към първоначалното "
 "състояние и клон)"
 
-#: wt-status.c:1547
+#: wt-status.c:1559
 msgid "You are in a sparse checkout."
 msgstr "Вие сте в частично изтегляне."
 
-#: wt-status.c:1550
+#: wt-status.c:1562
 #, c-format
 msgid "You are in a sparse checkout with %d%% of tracked files present."
 msgstr ""
 "Намирате се в частично изтеглено хранилище с %d%% налични, следени файла."
 
-#: wt-status.c:1794
+#: wt-status.c:1806
 msgid "On branch "
 msgstr "На клон "
 
-#: wt-status.c:1801
+#: wt-status.c:1813
 msgid "interactive rebase in progress; onto "
 msgstr "извършвате интерактивно пребазиране върху "
 
-#: wt-status.c:1803
+#: wt-status.c:1815
 msgid "rebase in progress; onto "
 msgstr "извършвате пребазиране върху "
 
-#: wt-status.c:1808
+#: wt-status.c:1820
 msgid "HEAD detached at "
 msgstr "Указателят „HEAD“ не е свързан и е при "
 
-#: wt-status.c:1810
+#: wt-status.c:1822
 msgid "HEAD detached from "
 msgstr "Указателят „HEAD“ не е свързан и е отделѐн от "
 
-#: wt-status.c:1813
+#: wt-status.c:1825
 msgid "Not currently on any branch."
 msgstr "Извън всички клони."
 
-#: wt-status.c:1830
+#: wt-status.c:1842
 msgid "Initial commit"
 msgstr "Първоначално подаване"
 
-#: wt-status.c:1831
+#: wt-status.c:1843
 msgid "No commits yet"
 msgstr "Все още липсват подавания"
 
-#: wt-status.c:1845
+#: wt-status.c:1857
 msgid "Untracked files"
 msgstr "Неследени файлове"
 
-#: wt-status.c:1847
+#: wt-status.c:1859
 msgid "Ignored files"
 msgstr "Игнорирани файлове"
 
-#: wt-status.c:1851
+#: wt-status.c:1863
 #, c-format
 msgid ""
 "It took %.2f seconds to enumerate untracked files. 'status -uno'\n"
@@ -10680,32 +10648,32 @@ msgstr ""
 "изпълнението, но ще трябва да добавяте новите файлове ръчно.\n"
 "За повече подробности погледнете „git status help“."
 
-#: wt-status.c:1857
+#: wt-status.c:1869
 #, c-format
 msgid "Untracked files not listed%s"
 msgstr "Неследените файлове не са изведени%s"
 
-#: wt-status.c:1859
+#: wt-status.c:1871
 msgid " (use -u option to show untracked files)"
 msgstr " (използвайте опцията „-u“, за да изведете неследените файлове)"
 
-#: wt-status.c:1865
+#: wt-status.c:1877
 msgid "No changes"
 msgstr "Няма промени"
 
-#: wt-status.c:1870
+#: wt-status.c:1882
 #, c-format
 msgid "no changes added to commit (use \"git add\" and/or \"git commit -a\")\n"
 msgstr ""
 "към индекса за подаване не са добавени промени (използвайте „git add“ и/или "
 "„git commit -a“)\n"
 
-#: wt-status.c:1874
+#: wt-status.c:1886
 #, c-format
 msgid "no changes added to commit\n"
 msgstr "към индекса за подаване не са добавени промени\n"
 
-#: wt-status.c:1878
+#: wt-status.c:1890
 #, c-format
 msgid ""
 "nothing added to commit but untracked files present (use \"git add\" to "
@@ -10714,84 +10682,84 @@ msgstr ""
 "към индекса за подаване не са добавени промени, но има нови файлове "
 "(използвайте „git add“, за да започне тяхното следене)\n"
 
-#: wt-status.c:1882
+#: wt-status.c:1894
 #, c-format
 msgid "nothing added to commit but untracked files present\n"
 msgstr "към индекса за подаване не са добавени промени, но има нови файлове\n"
 
-#: wt-status.c:1886
+#: wt-status.c:1898
 #, c-format
 msgid "nothing to commit (create/copy files and use \"git add\" to track)\n"
 msgstr ""
 "липсват каквито и да е промени (създайте или копирайте файлове и използвайте "
 "„git add“, за да започне тяхното следене)\n"
 
-#: wt-status.c:1890 wt-status.c:1896
+#: wt-status.c:1902 wt-status.c:1908
 #, c-format
 msgid "nothing to commit\n"
 msgstr "липсват каквито и да е промени\n"
 
-#: wt-status.c:1893
+#: wt-status.c:1905
 #, c-format
 msgid "nothing to commit (use -u to show untracked files)\n"
 msgstr ""
 "липсват каквито и да е промени (използвайте опцията „-u“, за да се изведат и "
 "неследените файлове)\n"
 
-#: wt-status.c:1898
+#: wt-status.c:1910
 #, c-format
 msgid "nothing to commit, working tree clean\n"
 msgstr "липсват каквито и да е промени, работното дърво е чисто\n"
 
-#: wt-status.c:2003
+#: wt-status.c:2015
 msgid "No commits yet on "
 msgstr "Все още липсват подавания в "
 
-#: wt-status.c:2007
+#: wt-status.c:2019
 msgid "HEAD (no branch)"
 msgstr "HEAD (извън клон)"
 
-#: wt-status.c:2038
+#: wt-status.c:2050
 msgid "different"
 msgstr "различен"
 
-#: wt-status.c:2040 wt-status.c:2048
+#: wt-status.c:2052 wt-status.c:2060
 msgid "behind "
 msgstr "назад с "
 
-#: wt-status.c:2043 wt-status.c:2046
+#: wt-status.c:2055 wt-status.c:2058
 msgid "ahead "
 msgstr "напред с "
 
 #. TRANSLATORS: the action is e.g. "pull with rebase"
-#: wt-status.c:2569
+#: wt-status.c:2596
 #, c-format
 msgid "cannot %s: You have unstaged changes."
 msgstr "не може да извършите „%s“, защото има промени, които не са в индекса."
 
-#: wt-status.c:2575
+#: wt-status.c:2602
 msgid "additionally, your index contains uncommitted changes."
 msgstr "освен това в индекса има неподадени промени."
 
-#: wt-status.c:2577
+#: wt-status.c:2604
 #, c-format
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr "не може да извършите „%s“, защото в индекса има неподадени промени."
 
-#: compat/simple-ipc/ipc-unix-socket.c:183
+#: compat/simple-ipc/ipc-unix-socket.c:205
 msgid "could not send IPC command"
 msgstr "командата за комуникация между процеси не може да бъде пратена"
 
-#: compat/simple-ipc/ipc-unix-socket.c:190
+#: compat/simple-ipc/ipc-unix-socket.c:212
 msgid "could not read IPC response"
 msgstr "отговорът за комуникацията между процеси не може да бъде прочетен"
 
-#: compat/simple-ipc/ipc-unix-socket.c:870
+#: compat/simple-ipc/ipc-unix-socket.c:892
 #, c-format
 msgid "could not start accept_thread '%s'"
 msgstr "неуспешно изпълнение на „accept_thread“ върху нишката „%s“"
 
-#: compat/simple-ipc/ipc-unix-socket.c:882
+#: compat/simple-ipc/ipc-unix-socket.c:904
 #, c-format
 msgid "could not start worker[0] for '%s'"
 msgstr "не може да се стартира нишката worker[0] за „%s“"
@@ -10828,113 +10796,119 @@ msgstr "изтриване на „%s“\n"
 msgid "Unstaged changes after refreshing the index:"
 msgstr "Промени, които и след обновяването на индекса не са добавени към него:"
 
-#: builtin/add.c:317 builtin/rev-parse.c:993
+#: builtin/add.c:313 builtin/rev-parse.c:993
 msgid "Could not read the index"
 msgstr "Индексът не може да бъде прочетен"
 
-#: builtin/add.c:330
+#: builtin/add.c:326
 msgid "Could not write patch"
 msgstr "Кръпката не може да бъде записана"
 
-#: builtin/add.c:333
+#: builtin/add.c:329
 msgid "editing patch failed"
 msgstr "неуспешно редактиране на кръпка"
 
-#: builtin/add.c:336
+#: builtin/add.c:332
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "Не може да се получи информация чрез „stat“ за файла „%s“"
 
-#: builtin/add.c:338
+#: builtin/add.c:334
 msgid "Empty patch. Aborted."
 msgstr "Празна кръпка, преустановяване на действието."
 
-#: builtin/add.c:343
+#: builtin/add.c:340
 #, c-format
 msgid "Could not apply '%s'"
 msgstr "Кръпката „%s“ не може да бъде приложена"
 
-#: builtin/add.c:351
+#: builtin/add.c:348
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr ""
 "Следните пътища ще бъдат игнорирани според някой от файловете „.gitignore“:\n"
 
-#: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
+#: builtin/add.c:368 builtin/clean.c:927 builtin/fetch.c:174 builtin/mv.c:124
 #: builtin/prune-packed.c:14 builtin/pull.c:208 builtin/push.c:550
 #: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr "пробно изпълнение"
 
-#: builtin/add.c:374
+#: builtin/add.c:369 builtin/check-ignore.c:22 builtin/commit.c:1484
+#: builtin/count-objects.c:98 builtin/fsck.c:789 builtin/log.c:2313
+#: builtin/mv.c:123 builtin/read-tree.c:120
+msgid "be verbose"
+msgstr "повече подробности"
+
+#: builtin/add.c:371
 msgid "interactive picking"
 msgstr "интерактивно отбиране на промени"
 
-#: builtin/add.c:375 builtin/checkout.c:1560 builtin/reset.c:314
+#: builtin/add.c:372 builtin/checkout.c:1581 builtin/reset.c:409
 msgid "select hunks interactively"
 msgstr "интерактивен избор на парчета код"
 
-#: builtin/add.c:376
+#: builtin/add.c:373
 msgid "edit current diff and apply"
 msgstr "редактиране на текущата разлика и прилагане"
 
-#: builtin/add.c:377
+#: builtin/add.c:374
 msgid "allow adding otherwise ignored files"
 msgstr "добавяне и на иначе игнорираните файлове"
 
-#: builtin/add.c:378
+#: builtin/add.c:375
 msgid "update tracked files"
 msgstr "обновяване на следените файлове"
 
-#: builtin/add.c:379
+#: builtin/add.c:376
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr "уеднаквяване на знаците за край на файл (включва опцията „-u“)"
 
-#: builtin/add.c:380
+#: builtin/add.c:377
 msgid "record only the fact that the path will be added later"
 msgstr "отбелязване само на факта, че пътят ще бъде добавен по-късно"
 
-#: builtin/add.c:381
+#: builtin/add.c:378
 msgid "add changes from all tracked and untracked files"
 msgstr "добавяне на всички промени в следените и неследените файлове"
 
-#: builtin/add.c:384
+#: builtin/add.c:381
 msgid "ignore paths removed in the working tree (same as --no-all)"
 msgstr ""
 "игнориране на пътищата, които са изтрити от работното дърво (същото като „--"
 "no-all“)"
 
-#: builtin/add.c:386
+#: builtin/add.c:383
 msgid "don't add, only refresh the index"
 msgstr "без добавяне на нови файлове, само обновяване на индекса"
 
-#: builtin/add.c:387
+#: builtin/add.c:384
 msgid "just skip files which cannot be added because of errors"
 msgstr "прескачане на файловете, които не може да бъдат добавени поради грешки"
 
-#: builtin/add.c:388
+#: builtin/add.c:385
 msgid "check if - even missing - files are ignored in dry run"
 msgstr ""
 "проверка, че при пробно изпълнение всички файлове, дори и изтритите, се "
 "игнорират"
 
-#: builtin/add.c:389 builtin/mv.c:128 builtin/rm.c:251
+#: builtin/add.c:386 builtin/mv.c:128 builtin/rm.c:251
 msgid "allow updating entries outside of the sparse-checkout cone"
 msgstr ""
 "обновяване и на записите извън пътеводния сегмент на частичното изтегляне"
 
-#: builtin/add.c:391 builtin/update-index.c:1004
+#: builtin/add.c:388 builtin/update-index.c:1004
 msgid "override the executable bit of the listed files"
 msgstr "изрично задаване на стойността на флага дали файлът е изпълним"
 
-#: builtin/add.c:393
+#: builtin/add.c:390
 msgid "warn when adding an embedded repository"
 msgstr "предупреждаване при добавяне на вградено хранилище"
 
-#: builtin/add.c:395
+#: builtin/add.c:392
 msgid "backend for `git stash -p`"
 msgstr "реализация на „git stash -p“"
 
-#: builtin/add.c:413
+#: builtin/add.c:410
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -10965,12 +10939,12 @@ msgstr ""
 "\n"
 "За повече информация погледнете „git help submodule“."
 
-#: builtin/add.c:442
+#: builtin/add.c:439
 #, c-format
 msgid "adding embedded git repository: %s"
 msgstr "добавяне на вградено хранилище: %s"
 
-#: builtin/add.c:462
+#: builtin/add.c:459
 msgid ""
 "Use -f if you really want to add them.\n"
 "Turn this message off by running\n"
@@ -10981,56 +10955,27 @@ msgstr ""
 "\n"
 "    git config advice.addIgnoredFile false"
 
-#: builtin/add.c:477
+#: builtin/add.c:474
 msgid "adding files failed"
 msgstr "неуспешно добавяне на файлове"
 
-#: builtin/add.c:513
-msgid "--dry-run is incompatible with --interactive/--patch"
-msgstr ""
-"опцията „--dry-run“ е несъвместима с всяка от опциите „--interactive“/„--"
-"patch“"
-
-#: builtin/add.c:515 builtin/commit.c:358
-msgid "--pathspec-from-file is incompatible with --interactive/--patch"
-msgstr ""
-"опцията „--pathspec-from-file“ е несъвместима с всяка от опциите „--"
-"interactive“/„--patch“"
-
-#: builtin/add.c:532
-msgid "--pathspec-from-file is incompatible with --edit"
-msgstr "опциите „--pathspec-from-file“ и „--edit“ са несъвместими"
-
-#: builtin/add.c:544
-msgid "-A and -u are mutually incompatible"
-msgstr "опциите „-A“ и „-u“ са несъвместими"
-
-#: builtin/add.c:547
-msgid "Option --ignore-missing can only be used together with --dry-run"
-msgstr "опцията „--ignore-missing“ изисква „--dry-run“"
-
-#: builtin/add.c:551
+#: builtin/add.c:548
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "параметърът към „--chmod“ — „%s“ може да е или „-x“, или „+x“"
 
-#: builtin/add.c:572 builtin/checkout.c:1731 builtin/commit.c:364
-#: builtin/reset.c:334 builtin/rm.c:275 builtin/stash.c:1650
-msgid "--pathspec-from-file is incompatible with pathspec arguments"
-msgstr ""
-"опцията „--pathspec-from-file“ е несъвместима с аргументи, указващи пътища"
+#: builtin/add.c:569 builtin/checkout.c:1751 builtin/commit.c:364
+#: builtin/reset.c:429 builtin/rm.c:275 builtin/stash.c:1713
+#, c-format
+msgid "'%s' and pathspec arguments cannot be used together"
+msgstr "опцията „%s“ и път са несъвместими"
 
-#: builtin/add.c:579 builtin/checkout.c:1743 builtin/commit.c:370
-#: builtin/reset.c:340 builtin/rm.c:281 builtin/stash.c:1656
-msgid "--pathspec-file-nul requires --pathspec-from-file"
-msgstr "опцията „--pathspec-file-nul“ изисква опция „--pathspec-from-file“"
-
-#: builtin/add.c:583
+#: builtin/add.c:580
 #, c-format
 msgid "Nothing specified, nothing added.\n"
 msgstr "Нищо не е зададено и нищо не е добавено.\n"
 
-#: builtin/add.c:585
+#: builtin/add.c:582
 msgid ""
 "Maybe you wanted to say 'git add .'?\n"
 "Turn this message off by running\n"
@@ -11041,110 +10986,128 @@ msgstr ""
 "\n"
 "    git config advice.addEmptyPathspec false"
 
-#: builtin/am.c:366
+#: builtin/am.c:202
+#, c-format
+msgid "Invalid value for --empty: %s"
+msgstr "Неправилна стойност за „--empty“: „%s“"
+
+#: builtin/am.c:392
 msgid "could not parse author script"
 msgstr "скриптът за автор не може да се анализира"
 
-#: builtin/am.c:456
+#: builtin/am.c:482
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
 msgstr "„%s“ бе изтрит от куката „applypatch-msg“"
 
-#: builtin/am.c:498
+#: builtin/am.c:524
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr "Даденият входен ред е с неправилен формат: „%s“."
 
-#: builtin/am.c:536
+#: builtin/am.c:562
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
 msgstr "Бележката не може да се копира от „%s“ към „%s“"
 
-#: builtin/am.c:562
+#: builtin/am.c:588
 msgid "fseek failed"
 msgstr "неуспешно изпълнение на „fseek“"
 
-#: builtin/am.c:750
+#: builtin/am.c:776
 #, c-format
 msgid "could not parse patch '%s'"
 msgstr "кръпката „%s“ не може да се анализира"
 
-#: builtin/am.c:815
+#: builtin/am.c:841
 msgid "Only one StGIT patch series can be applied at once"
 msgstr ""
 "Само една поредица от кръпки от „StGIT“ може да бъде прилагана в даден момент"
 
-#: builtin/am.c:863
+#: builtin/am.c:889
 msgid "invalid timestamp"
 msgstr "неправилна стойност за време"
 
-#: builtin/am.c:868 builtin/am.c:880
+#: builtin/am.c:894 builtin/am.c:906
 msgid "invalid Date line"
 msgstr "неправилен ред за дата „Date“"
 
-#: builtin/am.c:875
+#: builtin/am.c:901
 msgid "invalid timezone offset"
 msgstr "неправилно отместване на часовия пояс"
 
-#: builtin/am.c:968
+#: builtin/am.c:994
 msgid "Patch format detection failed."
 msgstr "Форматът на кръпката не може да бъде определен."
 
-#: builtin/am.c:973 builtin/clone.c:300
+#: builtin/am.c:999 builtin/clone.c:300
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "директорията „%s“ не може да бъде създадена"
 
-#: builtin/am.c:978
+#: builtin/am.c:1004
 msgid "Failed to split patches."
 msgstr "Кръпките не може да бъдат разделени."
 
-#: builtin/am.c:1127
+#: builtin/am.c:1153
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\"."
-msgstr "След коригирането на този проблем изпълнете „%s --continue“."
+msgstr ""
+"След коригирането на този проблем изпълнете:\n"
+"\n"
+"    %s --continue“"
 
-#: builtin/am.c:1128
+#: builtin/am.c:1154
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
-msgstr "Ако предпочитате да прескочите тази кръпка, изпълнете „%s --skip“."
+msgstr ""
+"Ако предпочитате да прескочите тази кръпка, изпълнете:\n"
+"\n"
+"    %s --skip"
 
-#: builtin/am.c:1129
+#: builtin/am.c:1159
+#, c-format
+msgid "To record the empty patch as an empty commit, run \"%s --allow-empty\"."
+msgstr ""
+"За да включите празната кръпка като празно подаване, изпълнете:\n"
+"\n"
+"    %s --allow-empty"
+
+#: builtin/am.c:1161
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
-msgstr "За да се върнете към първоначалното състояние, изпълнете „%s --abort“."
+msgstr ""
+"За да се върнете към първоначалното състояние, изпълнете:\n"
+"\n"
+"    %s --abort"
 
-#: builtin/am.c:1224
+#: builtin/am.c:1256
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
 "Кръпката е пратена с форматиране „format=flowed“.  Празните знаци в края на "
 "редовете може да се загубят."
 
-#: builtin/am.c:1252
-msgid "Patch is empty."
-msgstr "Кръпката е празна."
-
-#: builtin/am.c:1317
+#: builtin/am.c:1344
 #, c-format
 msgid "missing author line in commit %s"
 msgstr "липсва ред за авторство в подаването „%s“"
 
-#: builtin/am.c:1320
+#: builtin/am.c:1347
 #, c-format
 msgid "invalid ident line: %.*s"
 msgstr "грешен ред с идентичност: %.*s"
 
-#: builtin/am.c:1539
+#: builtin/am.c:1566
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
 "В хранилището липсват необходимите обекти-BLOB, за да се премине към тройно "
 "сливане."
 
-#: builtin/am.c:1541
+#: builtin/am.c:1568
 msgid "Using index info to reconstruct a base tree..."
 msgstr "Базовото дърво се реконструира от информацията в индекса…"
 
-#: builtin/am.c:1560
+#: builtin/am.c:1587
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
@@ -11152,24 +11115,24 @@ msgstr ""
 "Кръпката не може да се приложи към обектите-BLOB в индекса.\n"
 "Да не би да сте я редактирали на ръка?"
 
-#: builtin/am.c:1566
+#: builtin/am.c:1593
 msgid "Falling back to patching base and 3-way merge..."
 msgstr "Преминаване към прилагане на кръпка към базата и тройно сливане…"
 
-#: builtin/am.c:1592
+#: builtin/am.c:1619
 msgid "Failed to merge in the changes."
 msgstr "Неуспешно сливане на промените."
 
-#: builtin/am.c:1624
+#: builtin/am.c:1651
 msgid "applying to an empty history"
 msgstr "прилагане върху празна история"
 
-#: builtin/am.c:1676 builtin/am.c:1680
+#: builtin/am.c:1703 builtin/am.c:1707
 #, c-format
 msgid "cannot resume: %s does not exist."
 msgstr "не може да се продължи — „%s“ не съществува."
 
-#: builtin/am.c:1698
+#: builtin/am.c:1725
 msgid "Commit Body is:"
 msgstr "Тялото на кръпката за прилагане е:"
 
@@ -11177,45 +11140,63 @@ msgstr "Тялото на кръпката за прилагане е:"
 #. in your translation. The program will only accept English
 #. input at this point.
 #.
-#: builtin/am.c:1708
+#: builtin/am.c:1735
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr ""
 "Прилагане? „y“ — да/„n“ — не/„e“ — редактиране/„v“ — преглед/„a“ — приемане "
 "на всичко:"
 
-#: builtin/am.c:1754 builtin/commit.c:409
+#: builtin/am.c:1781 builtin/commit.c:409
 msgid "unable to write index file"
 msgstr "индексът не може да бъде записан"
 
-#: builtin/am.c:1758
+#: builtin/am.c:1785
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
 msgstr ""
 "Индексът не е чист: кръпките не може да бъдат приложени (замърсени са: %s)"
 
-#: builtin/am.c:1798 builtin/am.c:1865
+#: builtin/am.c:1827
+#, c-format
+msgid "Skipping: %.*s"
+msgstr "Прескачане: %.*s"
+
+#: builtin/am.c:1832
+#, c-format
+msgid "Creating an empty commit: %.*s"
+msgstr "Създаване на празно подаване: %.*s"
+
+#: builtin/am.c:1836
+msgid "Patch is empty."
+msgstr "Кръпката е празна."
+
+#: builtin/am.c:1847 builtin/am.c:1916
 #, c-format
 msgid "Applying: %.*s"
 msgstr "Прилагане: %.*s"
 
-#: builtin/am.c:1815
+#: builtin/am.c:1864
 msgid "No changes -- Patch already applied."
 msgstr "Без промени — кръпката вече е приложена."
 
-#: builtin/am.c:1821
+#: builtin/am.c:1870
 #, c-format
 msgid "Patch failed at %s %.*s"
 msgstr "Неуспешно прилагане на кръпка при %s %.*s“"
 
-#: builtin/am.c:1825
+#: builtin/am.c:1874
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr ""
 "За да видите неуспешно приложени кръпки, използвайте:\n"
 "\n"
 "    git am --show-current-patch=diff"
 
-#: builtin/am.c:1868
+#: builtin/am.c:1920
+msgid "No changes - recorded it as an empty commit."
+msgstr "Няма промени — създаване на празно подаване."
+
+#: builtin/am.c:1922
 msgid ""
 "No changes - did you forget to use 'git add'?\n"
 "If there is nothing left to stage, chances are that something else\n"
@@ -11225,7 +11206,7 @@ msgstr ""
 "Ако няма друга промяна за включване в индекса, най-вероятно някоя друга\n"
 "кръпка е довела до същите промени и в такъв случай просто пропуснете тази."
 
-#: builtin/am.c:1875
+#: builtin/am.c:1930
 msgid ""
 "You still have unmerged paths in your index.\n"
 "You should 'git add' each file with resolved conflicts to mark them as "
@@ -11236,17 +11217,17 @@ msgstr ""
 "След корекция на конфликтите изпълнете „git add“ върху поправените файлове.\n"
 "За да приемете „изтрити от тях“, изпълнете „git rm“ върху изтритите файлове."
 
-#: builtin/am.c:1983 builtin/am.c:1987 builtin/am.c:1999 builtin/reset.c:353
-#: builtin/reset.c:361
+#: builtin/am.c:2038 builtin/am.c:2042 builtin/am.c:2054 builtin/reset.c:448
+#: builtin/reset.c:456
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "„%s“ не е разпознат като обект."
 
-#: builtin/am.c:2035 builtin/am.c:2111
+#: builtin/am.c:2090 builtin/am.c:2166
 msgid "failed to clean index"
 msgstr "индексът не може да бъде изчистен"
 
-#: builtin/am.c:2079
+#: builtin/am.c:2134
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
@@ -11257,166 +11238,173 @@ msgstr ""
 "сочи към\n"
 "„ORIG_HEAD“"
 
-#: builtin/am.c:2187
+#: builtin/am.c:2242
 #, c-format
 msgid "Invalid value for --patch-format: %s"
 msgstr "Неправилна стойност за „--patch-format“: „%s“"
 
-#: builtin/am.c:2229
+#: builtin/am.c:2285
 #, c-format
 msgid "Invalid value for --show-current-patch: %s"
 msgstr "Неправилна стойност за „--show-current-patch“: „%s“"
 
-#: builtin/am.c:2233
+#: builtin/am.c:2289
 #, c-format
-msgid "--show-current-patch=%s is incompatible with --show-current-patch=%s"
-msgstr ""
-"опциите „--show-current-patch=%s“ и „--show-current-patch=%s“ са несъвместими"
+msgid "options '%s=%s' and '%s=%s' cannot be used together"
+msgstr "опциите „%s=%s“ и „%s=%s“ са несъвместими"
 
-#: builtin/am.c:2264
+#: builtin/am.c:2320
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
 msgstr "git am [ОПЦИЯ…] [(ФАЙЛ_С_ПОЩА|ДИРЕКТОРИЯ_С_ПОЩА)…]"
 
-#: builtin/am.c:2265
+#: builtin/am.c:2321
 msgid "git am [<options>] (--continue | --skip | --abort)"
 msgstr "git am [ОПЦИЯ…] (--continue | --skip | --abort)"
 
-#: builtin/am.c:2271
+#: builtin/am.c:2327
 msgid "run interactively"
 msgstr "интерактивна работа"
 
-#: builtin/am.c:2273
+#: builtin/am.c:2329
 msgid "historical option -- no-op"
 msgstr "изоставена опция, съществува по исторически причини, нищо не прави"
 
-#: builtin/am.c:2275
+#: builtin/am.c:2331
 msgid "allow fall back on 3way merging if needed"
 msgstr "да се преминава към тройно сливане при нужда."
 
-#: builtin/am.c:2276 builtin/init-db.c:547 builtin/prune-packed.c:16
-#: builtin/repack.c:640 builtin/stash.c:961
+#: builtin/am.c:2332 builtin/init-db.c:547 builtin/prune-packed.c:16
+#: builtin/repack.c:642 builtin/stash.c:962
 msgid "be quiet"
 msgstr "без извеждане на информация"
 
-#: builtin/am.c:2278
+#: builtin/am.c:2334
 msgid "add a Signed-off-by trailer to the commit message"
 msgstr "добавяне на епилог за подпис „Signed-off-by“ в съобщението за подаване"
 
-#: builtin/am.c:2281
+#: builtin/am.c:2337
 msgid "recode into utf8 (default)"
 msgstr "прекодиране в UTF-8 (стандартно)"
 
-#: builtin/am.c:2283
+#: builtin/am.c:2339
 msgid "pass -k flag to git-mailinfo"
 msgstr "подаване на опцията „-k“ на командата „git-mailinfo“"
 
-#: builtin/am.c:2285
+#: builtin/am.c:2341
 msgid "pass -b flag to git-mailinfo"
 msgstr "подаване на опцията „-b“ на командата „git-mailinfo“"
 
-#: builtin/am.c:2287
+#: builtin/am.c:2343
 msgid "pass -m flag to git-mailinfo"
 msgstr "подаване на опцията „-m“ на командата „git-mailinfo“"
 
-#: builtin/am.c:2289
+#: builtin/am.c:2345
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
 msgstr ""
 "подаване на опцията „--keep-cr“ на командата „git-mailsplit“ за формат „mbox“"
 
-#: builtin/am.c:2292
+#: builtin/am.c:2348
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr ""
 "без подаване на опцията „--keep-cr“ на командата „git-mailsplit“ независимо "
 "от „am.keepcr“"
 
-#: builtin/am.c:2295
+#: builtin/am.c:2351
 msgid "strip everything before a scissors line"
 msgstr "пропускане на всичко преди реда за отрязване"
 
-#: builtin/am.c:2297
+#: builtin/am.c:2353
 msgid "pass it through git-mailinfo"
 msgstr "прекарване през „git-mailinfo“"
 
-#: builtin/am.c:2300 builtin/am.c:2303 builtin/am.c:2306 builtin/am.c:2309
-#: builtin/am.c:2312 builtin/am.c:2315 builtin/am.c:2318 builtin/am.c:2321
-#: builtin/am.c:2327
+#: builtin/am.c:2356 builtin/am.c:2359 builtin/am.c:2362 builtin/am.c:2365
+#: builtin/am.c:2368 builtin/am.c:2371 builtin/am.c:2374 builtin/am.c:2377
+#: builtin/am.c:2383
 msgid "pass it through git-apply"
 msgstr "прекарване през „git-apply“"
 
-#: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
-#: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
+#: builtin/am.c:2373 builtin/commit.c:1515 builtin/fmt-merge-msg.c:18
+#: builtin/fmt-merge-msg.c:21 builtin/grep.c:919 builtin/merge.c:263
 #: builtin/pull.c:142 builtin/pull.c:204 builtin/pull.c:221
-#: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
-#: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
+#: builtin/rebase.c:1046 builtin/repack.c:653 builtin/repack.c:657
+#: builtin/repack.c:659 builtin/show-branch.c:649 builtin/show-ref.c:172
 #: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
-#: parse-options.h:315
+#: parse-options.h:317
 msgid "n"
 msgstr "БРОЙ"
 
-#: builtin/am.c:2323 builtin/branch.c:673 builtin/bugreport.c:109
-#: builtin/for-each-ref.c:40 builtin/replace.c:556 builtin/tag.c:479
+#: builtin/am.c:2379 builtin/branch.c:680 builtin/bugreport.c:109
+#: builtin/for-each-ref.c:41 builtin/replace.c:555 builtin/tag.c:479
 #: builtin/verify-tag.c:38
 msgid "format"
 msgstr "ФОРМАТ"
 
-#: builtin/am.c:2324
+#: builtin/am.c:2380
 msgid "format the patch(es) are in"
 msgstr "формат на кръпките"
 
-#: builtin/am.c:2330
+#: builtin/am.c:2386
 msgid "override error message when patch failure occurs"
 msgstr "избрано от вас съобщение за грешка при прилагане на кръпки"
 
-#: builtin/am.c:2332
+#: builtin/am.c:2388
 msgid "continue applying patches after resolving a conflict"
 msgstr "продължаване на прилагането на кръпки след коригирането на конфликт"
 
-#: builtin/am.c:2335
+#: builtin/am.c:2391
 msgid "synonyms for --continue"
 msgstr "псевдоними на „--continue“"
 
-#: builtin/am.c:2338
+#: builtin/am.c:2394
 msgid "skip the current patch"
 msgstr "прескачане на текущата кръпка"
 
-#: builtin/am.c:2341
+#: builtin/am.c:2397
 msgid "restore the original branch and abort the patching operation"
 msgstr ""
 "възстановяване на първоначалното състояние на клона и преустановяване на "
 "прилагането на кръпката"
 
-#: builtin/am.c:2344
+#: builtin/am.c:2400
 msgid "abort the patching operation but keep HEAD where it is"
 msgstr ""
 "преустановяване на прилагането на кръпката без промяна към кое сочи „HEAD“"
 
-#: builtin/am.c:2348
+#: builtin/am.c:2404
 msgid "show the patch being applied"
 msgstr "показване на прилаганата кръпка"
 
-#: builtin/am.c:2353
+#: builtin/am.c:2408
+msgid "record the empty patch as an empty commit"
+msgstr "прилагане на празна кръпка като празно подаване"
+
+#: builtin/am.c:2412
 msgid "lie about committer date"
 msgstr "дата за подаване различна от първоначалната"
 
-#: builtin/am.c:2355
+#: builtin/am.c:2414
 msgid "use current timestamp for author date"
 msgstr "използване на текущото време като това за автор"
 
-#: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
-#: builtin/merge.c:299 builtin/pull.c:179 builtin/rebase.c:1099
+#: builtin/am.c:2416 builtin/commit-tree.c:118 builtin/commit.c:1643
+#: builtin/merge.c:302 builtin/pull.c:179 builtin/rebase.c:1099
 #: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
 msgstr "ИДЕНТИФИКАТОР_НА_КЛЮЧ"
 
-#: builtin/am.c:2358 builtin/rebase.c:1100
+#: builtin/am.c:2417 builtin/rebase.c:1100
 msgid "GPG-sign commits"
 msgstr "подписване на подаванията с GPG"
 
-#: builtin/am.c:2361
+#: builtin/am.c:2420
+msgid "how to handle empty patches"
+msgstr "как да се обработват празните подавания"
+
+#: builtin/am.c:2423
 msgid "(internal use for git-rebase)"
 msgstr "(ползва се вътрешно за „git-rebase“)"
 
-#: builtin/am.c:2379
+#: builtin/am.c:2441
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
@@ -11424,18 +11412,18 @@ msgstr ""
 "Опциите „-b“/„--binary“ отдавна не правят нищо и\n"
 "ще бъдат премахнати в бъдеще.  Не ги ползвайте."
 
-#: builtin/am.c:2386
+#: builtin/am.c:2448
 msgid "failed to read the index"
 msgstr "неуспешно изчитане на индекса"
 
-#: builtin/am.c:2401
+#: builtin/am.c:2463
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr ""
 "предишната директория за пребазиране „%s“ все още съществува, а е зададен "
 "файл „mbox“."
 
-#: builtin/am.c:2425
+#: builtin/am.c:2487
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
@@ -11444,11 +11432,11 @@ msgstr ""
 "Открита е излишна директория „%s“.\n"
 "Може да я изтриете с командата „git am --abort“."
 
-#: builtin/am.c:2431
+#: builtin/am.c:2493
 msgid "Resolve operation not in progress, we are not resuming."
 msgstr "В момента не тече операция по коригиране и няма как да се продължи."
 
-#: builtin/am.c:2441
+#: builtin/am.c:2503
 msgid "interactive mode requires patches on the command line"
 msgstr "интерактивният режим изисква кръпки на командния ред"
 
@@ -11921,11 +11909,11 @@ msgstr ""
 msgid "show work cost statistics"
 msgstr "извеждане на статистика за извършените действия"
 
-#: builtin/blame.c:867 builtin/checkout.c:1517 builtin/clone.c:94
-#: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
-#: builtin/merge.c:298 builtin/multi-pack-index.c:103
-#: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
-#: builtin/multi-pack-index.c:204 builtin/pull.c:120 builtin/push.c:566
+#: builtin/blame.c:867 builtin/checkout.c:1536 builtin/clone.c:94
+#: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:180
+#: builtin/merge.c:301 builtin/multi-pack-index.c:103
+#: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:180
+#: builtin/multi-pack-index.c:208 builtin/pull.c:120 builtin/push.c:566
 #: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "извеждане на напредъка"
@@ -11982,7 +11970,7 @@ msgstr ""
 msgid "ignore whitespace differences"
 msgstr "без разлики в знаците за интервали"
 
-#: builtin/blame.c:879 builtin/log.c:1823
+#: builtin/blame.c:879 builtin/log.c:1838
 msgid "rev"
 msgstr "ВЕРС"
 
@@ -12040,7 +12028,7 @@ msgid "process only line range <start>,<end> or function :<funcname>"
 msgstr ""
 "информация само за редовете в диапазона НАЧАЛО,КРАЙ или само на :ФУНКЦИЯта"
 
-#: builtin/blame.c:944
+#: builtin/blame.c:947
 msgid "--progress can't be used with --incremental or porcelain formats"
 msgstr ""
 "опцията „--progress“ е несъвместима с „--incremental“ и форма̀та на командите "
@@ -12054,18 +12042,18 @@ msgstr ""
 #. your language may need more or fewer display
 #. columns.
 #.
-#: builtin/blame.c:995
+#: builtin/blame.c:998
 msgid "4 years, 11 months ago"
 msgstr "преди 4 години и 11 месеца"
 
-#: builtin/blame.c:1111
+#: builtin/blame.c:1114
 #, c-format
 msgid "file %s has only %lu line"
 msgid_plural "file %s has only %lu lines"
 msgstr[0] "има само %2$lu ред във файла „%1$s“"
 msgstr[1] "има само %2$lu реда във файла „%1$s“"
 
-#: builtin/blame.c:1156
+#: builtin/blame.c:1159
 msgid "Blaming lines"
 msgstr "Редове с авторство"
 
@@ -12097,7 +12085,7 @@ msgstr "git branch [ОПЦИЯ…] [-r | -a] [--points-at]"
 msgid "git branch [<options>] [-r | -a] [--format]"
 msgstr "git branch [ОПЦИЯ…] [-r | -a] [--format]"
 
-#: builtin/branch.c:154
+#: builtin/branch.c:153
 #, c-format
 msgid ""
 "deleting branch '%s' that has been merged to\n"
@@ -12106,7 +12094,7 @@ msgstr ""
 "изтриване на клона „%s“, който е слят към „%s“,\n"
 "    но още не е слят към върха „HEAD“."
 
-#: builtin/branch.c:158
+#: builtin/branch.c:157
 #, c-format
 msgid ""
 "not deleting branch '%s' that is not yet merged to\n"
@@ -12115,12 +12103,12 @@ msgstr ""
 "отказване на изтриване на клона „%s“, който не е слят към\n"
 "    „%s“, но е слят към върха „HEAD“."
 
-#: builtin/branch.c:172
+#: builtin/branch.c:171
 #, c-format
 msgid "Couldn't look up commit object for '%s'"
 msgstr "Обектът-подаване за „%s“ не може да бъде открит"
 
-#: builtin/branch.c:176
+#: builtin/branch.c:175
 #, c-format
 msgid ""
 "The branch '%s' is not fully merged.\n"
@@ -12129,7 +12117,7 @@ msgstr ""
 "Клонът „%s“ не е слят напълно.  Ако сте сигурни, че искате\n"
 "да го изтриете, изпълнете „git branch -D %s“."
 
-#: builtin/branch.c:189
+#: builtin/branch.c:188
 msgid "Update of config-file failed"
 msgstr "Неуспешно обновяване на конфигурационния файл"
 
@@ -12141,100 +12129,100 @@ msgstr "опциите „-a“ и „-d“ са несъвместими"
 msgid "Couldn't look up commit object for HEAD"
 msgstr "Обектът-подаване, сочен от указателя „HEAD“, не може да бъде открит"
 
-#: builtin/branch.c:244
+#: builtin/branch.c:247
 #, c-format
 msgid "Cannot delete branch '%s' checked out at '%s'"
 msgstr "Не може да изтриете клона „%s“, който е изтеглен в пътя „%s“"
 
-#: builtin/branch.c:259
+#: builtin/branch.c:262
 #, c-format
 msgid "remote-tracking branch '%s' not found."
 msgstr "следящият клон „%s“ не може да бъде открит."
 
-#: builtin/branch.c:260
+#: builtin/branch.c:263
 #, c-format
 msgid "branch '%s' not found."
 msgstr "клонът „%s“ не може да бъде открит."
 
-#: builtin/branch.c:291
+#: builtin/branch.c:294
 #, c-format
 msgid "Deleted remote-tracking branch %s (was %s).\n"
 msgstr "Изтрит следящ клон „%s“ (той сочеше към „%s“).\n"
 
-#: builtin/branch.c:292
+#: builtin/branch.c:295
 #, c-format
 msgid "Deleted branch %s (was %s).\n"
 msgstr "Изтрит клон „%s“ (той сочеше към „%s“).\n"
 
-#: builtin/branch.c:441 builtin/tag.c:63
+#: builtin/branch.c:445 builtin/tag.c:63
 msgid "unable to parse format string"
 msgstr "форматиращият низ не може да бъде анализиран: %s"
 
-#: builtin/branch.c:472
+#: builtin/branch.c:476
 msgid "could not resolve HEAD"
 msgstr "подаването, сочено от указателя „HEAD“, не може да се установи"
 
-#: builtin/branch.c:478
+#: builtin/branch.c:482
 #, c-format
 msgid "HEAD (%s) points outside of refs/heads/"
 msgstr "„HEAD“ (%s) сочи извън директорията „refs/heads“"
 
-#: builtin/branch.c:493
+#: builtin/branch.c:497
 #, c-format
 msgid "Branch %s is being rebased at %s"
 msgstr "Клонът „%s“ се пребазира върху „%s“"
 
-#: builtin/branch.c:497
+#: builtin/branch.c:501
 #, c-format
 msgid "Branch %s is being bisected at %s"
 msgstr "Търси се двоично в клона „%s“ при „%s“"
 
-#: builtin/branch.c:514
+#: builtin/branch.c:518
 msgid "cannot copy the current branch while not on any."
 msgstr "не може да копирате текущия клон, защото сте извън който и да е клон"
 
-#: builtin/branch.c:516
+#: builtin/branch.c:520
 msgid "cannot rename the current branch while not on any."
 msgstr ""
 "не може да преименувате текущия клон, защото сте извън който и да е клон"
 
-#: builtin/branch.c:527
+#: builtin/branch.c:531
 #, c-format
 msgid "Invalid branch name: '%s'"
 msgstr "Неправилно име на клон: „%s“"
 
-#: builtin/branch.c:556
+#: builtin/branch.c:560
 msgid "Branch rename failed"
 msgstr "Неуспешно преименуване на клон"
 
-#: builtin/branch.c:558
+#: builtin/branch.c:562
 msgid "Branch copy failed"
 msgstr "Неуспешно копиране на клон"
 
-#: builtin/branch.c:562
+#: builtin/branch.c:566
 #, c-format
 msgid "Created a copy of a misnamed branch '%s'"
 msgstr "Клонът с неправилно име „%s“ е копиран"
 
-#: builtin/branch.c:565
+#: builtin/branch.c:569
 #, c-format
 msgid "Renamed a misnamed branch '%s' away"
 msgstr "Клонът с неправилно име „%s“ е преименуван"
 
-#: builtin/branch.c:571
+#: builtin/branch.c:575
 #, c-format
 msgid "Branch renamed to %s, but HEAD is not updated!"
 msgstr "Клонът е преименуван на „%s“, но указателят „HEAD“ не е обновен"
 
-#: builtin/branch.c:580
+#: builtin/branch.c:584
 msgid "Branch is renamed, but update of config-file failed"
 msgstr "Клонът е преименуван, но конфигурационният файл не е обновен"
 
-#: builtin/branch.c:582
+#: builtin/branch.c:586
 msgid "Branch is copied, but update of config-file failed"
 msgstr "Клонът е копиран, но конфигурационният файл не е обновен"
 
-#: builtin/branch.c:598
+#: builtin/branch.c:602
 #, c-format
 msgid ""
 "Please edit the description for the branch\n"
@@ -12245,183 +12233,179 @@ msgstr ""
 "    %s\n"
 "Редовете, които започват с „%c“, ще бъдат пропуснати.\n"
 
-#: builtin/branch.c:632
+#: builtin/branch.c:637
 msgid "Generic options"
 msgstr "Общи настройки"
 
-#: builtin/branch.c:634
+#: builtin/branch.c:639
 msgid "show hash and subject, give twice for upstream branch"
 msgstr ""
 "извеждане на контролната сума и темата.  Повтарянето на опцията прибавя "
 "отдалечените клони"
 
-#: builtin/branch.c:635
+#: builtin/branch.c:640
 msgid "suppress informational messages"
 msgstr "без информационни съобщения"
 
-#: builtin/branch.c:636
-msgid "set up tracking mode (see git-pull(1))"
-msgstr "задаване на режима на следене (виж git-pull(1))"
+#: builtin/branch.c:642
+msgid "set branch tracking configuration"
+msgstr "настройване кой клон да се следи"
 
-#: builtin/branch.c:638
+#: builtin/branch.c:645
 msgid "do not use"
 msgstr "да не се ползва"
 
-#: builtin/branch.c:640
+#: builtin/branch.c:647
 msgid "upstream"
 msgstr "клон-източник"
 
-#: builtin/branch.c:640
+#: builtin/branch.c:647
 msgid "change the upstream info"
 msgstr "смяна на клона-източник"
 
-#: builtin/branch.c:641
+#: builtin/branch.c:648
 msgid "unset the upstream info"
 msgstr "изчистване на информацията за клон-източник"
 
-#: builtin/branch.c:642
+#: builtin/branch.c:649
 msgid "use colored output"
 msgstr "цветен изход"
 
-#: builtin/branch.c:643
+#: builtin/branch.c:650
 msgid "act on remote-tracking branches"
 msgstr "действие върху следящите клони"
 
-#: builtin/branch.c:645 builtin/branch.c:647
+#: builtin/branch.c:652 builtin/branch.c:654
 msgid "print only branches that contain the commit"
 msgstr "извеждане само на клоните, които съдържат това ПОДАВАНЕ"
 
-#: builtin/branch.c:646 builtin/branch.c:648
+#: builtin/branch.c:653 builtin/branch.c:655
 msgid "print only branches that don't contain the commit"
 msgstr "извеждане само на клоните, които не съдържат това ПОДАВАНЕ"
 
-#: builtin/branch.c:651
+#: builtin/branch.c:658
 msgid "Specific git-branch actions:"
 msgstr "Специални действия на „git-branch“:"
 
-#: builtin/branch.c:652
+#: builtin/branch.c:659
 msgid "list both remote-tracking and local branches"
 msgstr "извеждане както на следящите, така и на локалните клони"
 
-#: builtin/branch.c:654
+#: builtin/branch.c:661
 msgid "delete fully merged branch"
 msgstr "изтриване на клони, които са напълно слети"
 
-#: builtin/branch.c:655
+#: builtin/branch.c:662
 msgid "delete branch (even if not merged)"
 msgstr "изтриване и на клони, които не са напълно слети"
 
-#: builtin/branch.c:656
+#: builtin/branch.c:663
 msgid "move/rename a branch and its reflog"
 msgstr ""
 "преместване/преименуване на клон и принадлежащият му журнал на указателите"
 
-#: builtin/branch.c:657
+#: builtin/branch.c:664
 msgid "move/rename a branch, even if target exists"
 msgstr "преместване/преименуване на клон, дори ако има вече клон с такова име"
 
-#: builtin/branch.c:658
+#: builtin/branch.c:665
 msgid "copy a branch and its reflog"
 msgstr "копиране на клон и принадлежащия му журнал на указателите"
 
-#: builtin/branch.c:659
+#: builtin/branch.c:666
 msgid "copy a branch, even if target exists"
 msgstr "копиране на клон, дори ако има вече клон с такова име"
 
-#: builtin/branch.c:660
+#: builtin/branch.c:667
 msgid "list branch names"
 msgstr "извеждане на имената на клоните"
 
-#: builtin/branch.c:661
+#: builtin/branch.c:668
 msgid "show current branch name"
 msgstr "извеждане на името на текущия клон"
 
-#: builtin/branch.c:662
+#: builtin/branch.c:669
 msgid "create the branch's reflog"
 msgstr "създаване на журнала на указателите на клона"
 
-#: builtin/branch.c:664
+#: builtin/branch.c:671
 msgid "edit the description for the branch"
 msgstr "редактиране на описанието на клона"
 
-#: builtin/branch.c:665
+#: builtin/branch.c:672
 msgid "force creation, move/rename, deletion"
 msgstr "принудително създаване, преместване, преименуване, изтриване"
 
-#: builtin/branch.c:666
+#: builtin/branch.c:673
 msgid "print only branches that are merged"
 msgstr "извеждане само на слетите клони"
 
-#: builtin/branch.c:667
+#: builtin/branch.c:674
 msgid "print only branches that are not merged"
 msgstr "извеждане само на неслетите клони"
 
-#: builtin/branch.c:668
+#: builtin/branch.c:675
 msgid "list branches in columns"
 msgstr "извеждане по колони"
 
-#: builtin/branch.c:670 builtin/for-each-ref.c:44 builtin/notes.c:413
+#: builtin/branch.c:677 builtin/for-each-ref.c:45 builtin/notes.c:413
 #: builtin/notes.c:416 builtin/notes.c:579 builtin/notes.c:582
 #: builtin/tag.c:475
 msgid "object"
 msgstr "ОБЕКТ"
 
-#: builtin/branch.c:671
+#: builtin/branch.c:678
 msgid "print only branches of the object"
 msgstr "извеждане само на клоните на ОБЕКТА"
 
-#: builtin/branch.c:672 builtin/for-each-ref.c:50 builtin/tag.c:482
+#: builtin/branch.c:679 builtin/for-each-ref.c:51 builtin/tag.c:482
 msgid "sorting and filtering are case insensitive"
 msgstr "подредбата и филтрирането третират еднакво малките и главните букви"
 
-#: builtin/branch.c:673 builtin/for-each-ref.c:40 builtin/tag.c:480
+#: builtin/branch.c:680 builtin/for-each-ref.c:41 builtin/tag.c:480
 #: builtin/verify-tag.c:38
 msgid "format to use for the output"
 msgstr "ФОРМАТ за изхода"
 
-#: builtin/branch.c:696 builtin/clone.c:678
+#: builtin/branch.c:703 builtin/clone.c:678
 msgid "HEAD not found below refs/heads!"
 msgstr "В директорията „refs/heads“ липсва файл „HEAD“"
 
-#: builtin/branch.c:720
-msgid "--column and --verbose are incompatible"
-msgstr "опциите „--column“ и „--verbose“ са несъвместими"
-
-#: builtin/branch.c:735 builtin/branch.c:792 builtin/branch.c:801
+#: builtin/branch.c:742 builtin/branch.c:798 builtin/branch.c:807
 msgid "branch name required"
 msgstr "Необходимо е име на клон"
 
-#: builtin/branch.c:768
+#: builtin/branch.c:774
 msgid "Cannot give description to detached HEAD"
 msgstr "Не може да зададете описание на несвързан „HEAD“"
 
-#: builtin/branch.c:773
+#: builtin/branch.c:779
 msgid "cannot edit description of more than one branch"
 msgstr "Не може да редактирате описанието на повече от един клон едновременно"
 
-#: builtin/branch.c:780
+#: builtin/branch.c:786
 #, c-format
 msgid "No commit on branch '%s' yet."
 msgstr "В клона „%s“ все още няма подавания."
 
-#: builtin/branch.c:783
+#: builtin/branch.c:789
 #, c-format
 msgid "No branch named '%s'."
 msgstr "Липсва клон на име „%s“."
 
-#: builtin/branch.c:798
+#: builtin/branch.c:804
 msgid "too many branches for a copy operation"
 msgstr "прекалено много клони за копиране"
 
-#: builtin/branch.c:807
+#: builtin/branch.c:813
 msgid "too many arguments for a rename operation"
 msgstr "прекалено много аргументи към командата за преименуване"
 
-#: builtin/branch.c:812
+#: builtin/branch.c:818
 msgid "too many arguments to set new upstream"
 msgstr "прекалено много аргументи към командата за следене"
 
-#: builtin/branch.c:816
+#: builtin/branch.c:822
 #, c-format
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch."
@@ -12429,31 +12413,31 @@ msgstr ""
 "Следеното от „HEAD“ не може да се зададе да е „%s“, защото то не сочи към "
 "никой клон."
 
-#: builtin/branch.c:819 builtin/branch.c:842
+#: builtin/branch.c:825 builtin/branch.c:848
 #, c-format
 msgid "no such branch '%s'"
 msgstr "Няма клон на име „%s“."
 
-#: builtin/branch.c:823
+#: builtin/branch.c:829
 #, c-format
 msgid "branch '%s' does not exist"
 msgstr "Не съществува клон на име „%s“."
 
-#: builtin/branch.c:836
+#: builtin/branch.c:842
 msgid "too many arguments to unset upstream"
 msgstr "прекалено много аргументи към командата за спиране на следене"
 
-#: builtin/branch.c:840
+#: builtin/branch.c:846
 msgid "could not unset upstream of HEAD when it does not point to any branch."
 msgstr ""
 "Следеното от „HEAD“ не може да махне, защото то не сочи към никой клон."
 
-#: builtin/branch.c:846
+#: builtin/branch.c:852
 #, c-format
 msgid "Branch '%s' has no upstream information"
 msgstr "Няма информация клонът „%s“ да следи някой друг"
 
-#: builtin/branch.c:856
+#: builtin/branch.c:862
 msgid ""
 "The -a, and -r, options to 'git branch' do not take a branch name.\n"
 "Did you mean to use: -a|-r --list <pattern>?"
@@ -12461,7 +12445,7 @@ msgstr ""
 "опциите „-a“ и „-r“ на „git branch“ са несъвместими с име на клон.\n"
 "Пробвайте с: „-a|-r --list ШАБЛОН“"
 
-#: builtin/branch.c:860
+#: builtin/branch.c:866
 msgid ""
 "the '--set-upstream' option is no longer supported. Please use '--track' or "
 "'--set-upstream-to' instead."
@@ -12740,8 +12724,8 @@ msgstr "изчитане на имената на файловете от ста
 msgid "terminate input and output records by a NUL character"
 msgstr "разделяне на входните и изходните записи с нулевия знак „NUL“"
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1513 builtin/gc.c:549
-#: builtin/worktree.c:494
+#: builtin/check-ignore.c:21 builtin/checkout.c:1532 builtin/gc.c:550
+#: builtin/worktree.c:493
 msgid "suppress progress reporting"
 msgstr "без показване на напредъка"
 
@@ -12799,10 +12783,10 @@ msgid "git checkout--worker [<options>]"
 msgstr "git checkout--worker [ОПЦИЯ…]"
 
 #: builtin/checkout--worker.c:118 builtin/checkout-index.c:201
-#: builtin/column.c:31 builtin/column.c:32 builtin/submodule--helper.c:1863
-#: builtin/submodule--helper.c:1866 builtin/submodule--helper.c:1874
-#: builtin/submodule--helper.c:2510 builtin/submodule--helper.c:2576
-#: builtin/worktree.c:492 builtin/worktree.c:729
+#: builtin/column.c:31 builtin/column.c:32 builtin/submodule--helper.c:1864
+#: builtin/submodule--helper.c:1867 builtin/submodule--helper.c:1875
+#: builtin/submodule--helper.c:2511 builtin/submodule--helper.c:2577
+#: builtin/worktree.c:491 builtin/worktree.c:728
 msgid "string"
 msgstr "НИЗ"
 
@@ -12866,99 +12850,94 @@ msgstr "git switch [ОПЦИЯ…] КЛОН"
 msgid "git restore [<options>] [--source=<branch>] <file>..."
 msgstr "git restore [ОПЦИЯ…] [--source=КЛОН] ФАЙЛ…"
 
-#: builtin/checkout.c:190 builtin/checkout.c:229
+#: builtin/checkout.c:198 builtin/checkout.c:237
 #, c-format
 msgid "path '%s' does not have our version"
 msgstr "вашата версия липсва в пътя „%s“"
 
-#: builtin/checkout.c:192 builtin/checkout.c:231
+#: builtin/checkout.c:200 builtin/checkout.c:239
 #, c-format
 msgid "path '%s' does not have their version"
 msgstr "чуждата версия липсва в пътя „%s“"
 
-#: builtin/checkout.c:208
+#: builtin/checkout.c:216
 #, c-format
 msgid "path '%s' does not have all necessary versions"
 msgstr "някоя от необходимите версии липсва в пътя „%s“"
 
-#: builtin/checkout.c:261
+#: builtin/checkout.c:269
 #, c-format
 msgid "path '%s' does not have necessary versions"
 msgstr "някоя от необходимите версии липсва в пътя „%s“"
 
-#: builtin/checkout.c:278
+#: builtin/checkout.c:286
 #, c-format
 msgid "path '%s': cannot merge"
 msgstr "пътят „%s“ не може да бъде слян"
 
-#: builtin/checkout.c:294
+#: builtin/checkout.c:302
 #, c-format
 msgid "Unable to add merge result for '%s'"
 msgstr "Резултатът за „%s“ не може да бъде слян"
 
-#: builtin/checkout.c:411
+#: builtin/checkout.c:419
 #, c-format
 msgid "Recreated %d merge conflict"
 msgid_plural "Recreated %d merge conflicts"
 msgstr[0] "Пресъздаден е %d конфликт при сливане"
 msgstr[1] "Пресъздадени са %d конфликта при сливане"
 
-#: builtin/checkout.c:416
+#: builtin/checkout.c:424
 #, c-format
 msgid "Updated %d path from %s"
 msgid_plural "Updated %d paths from %s"
 msgstr[0] "Обновен е %d път от „%s“"
 msgstr[1] "Обновени са %d пътя от „%s“"
 
-#: builtin/checkout.c:423
+#: builtin/checkout.c:431
 #, c-format
 msgid "Updated %d path from the index"
 msgid_plural "Updated %d paths from the index"
 msgstr[0] "Обновен е %d път от индекса"
 msgstr[1] "Обновени са %d пътя от индекса"
 
-#: builtin/checkout.c:446 builtin/checkout.c:449 builtin/checkout.c:452
-#: builtin/checkout.c:456
+#: builtin/checkout.c:454 builtin/checkout.c:457 builtin/checkout.c:460
+#: builtin/checkout.c:464
 #, c-format
 msgid "'%s' cannot be used with updating paths"
 msgstr "опцията „%s“ е несъвместима с обновяването на пътища"
 
-#: builtin/checkout.c:459 builtin/checkout.c:462
-#, c-format
-msgid "'%s' cannot be used with %s"
-msgstr "опциите „%s“ и „%s“ са несъвместими"
-
-#: builtin/checkout.c:466
+#: builtin/checkout.c:474
 #, c-format
 msgid "Cannot update paths and switch to branch '%s' at the same time."
 msgstr ""
 "Невъзможно е едновременно да обновявате пътища и да преминете към клона „%s“."
 
-#: builtin/checkout.c:470
+#: builtin/checkout.c:478
 #, c-format
 msgid "neither '%s' or '%s' is specified"
 msgstr "не е указано нито „%s“, нито „%s“"
 
-#: builtin/checkout.c:474
+#: builtin/checkout.c:482
 #, c-format
 msgid "'%s' must be used when '%s' is not specified"
 msgstr "опцията „%s“ е задължителна, когато „%s“ не е зададена"
 
-#: builtin/checkout.c:479 builtin/checkout.c:484
+#: builtin/checkout.c:487 builtin/checkout.c:492
 #, c-format
 msgid "'%s' or '%s' cannot be used with %s"
 msgstr "опцията „%3$s“ е несъвместима както с „%1$s“, така и с „%2$s“"
 
-#: builtin/checkout.c:558 builtin/checkout.c:565
+#: builtin/checkout.c:566 builtin/checkout.c:573
 #, c-format
 msgid "path '%s' is unmerged"
 msgstr "пътят „%s“ не е слят"
 
-#: builtin/checkout.c:736
+#: builtin/checkout.c:747
 msgid "you need to resolve your current index first"
 msgstr "първо трябва да коригирате индекса си"
 
-#: builtin/checkout.c:786
+#: builtin/checkout.c:797
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -12968,50 +12947,50 @@ msgstr ""
 "индекса:\n"
 "%s"
 
-#: builtin/checkout.c:879
+#: builtin/checkout.c:890
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Журналът на указателите за „%s“ не може да се проследи: %s\n"
 
-#: builtin/checkout.c:921
+#: builtin/checkout.c:934
 msgid "HEAD is now at"
 msgstr "Указателят „HEAD“ в момента сочи към"
 
-#: builtin/checkout.c:925 builtin/clone.c:609 t/helper/test-fast-rebase.c:203
+#: builtin/checkout.c:938 builtin/clone.c:609 t/helper/test-fast-rebase.c:203
 msgid "unable to update HEAD"
 msgstr "Указателят „HEAD“ не може да бъде обновен"
 
-#: builtin/checkout.c:929
+#: builtin/checkout.c:942
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Зануляване на клона „%s“\n"
 
-#: builtin/checkout.c:932
+#: builtin/checkout.c:945
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Вече сте на „%s“\n"
 
-#: builtin/checkout.c:936
+#: builtin/checkout.c:949
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Преминаване към клона „%s“ и зануляване на промените\n"
 
-#: builtin/checkout.c:938 builtin/checkout.c:1369
+#: builtin/checkout.c:951 builtin/checkout.c:1388
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Преминахте към новия клон „%s“\n"
 
-#: builtin/checkout.c:940
+#: builtin/checkout.c:953
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Преминахте към клона „%s“\n"
 
-#: builtin/checkout.c:991
+#: builtin/checkout.c:1004
 #, c-format
 msgid " ... and %d more.\n"
 msgstr "… и още %d.\n"
 
-#: builtin/checkout.c:997
+#: builtin/checkout.c:1010
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -13033,7 +13012,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:1016
+#: builtin/checkout.c:1029
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -13060,19 +13039,19 @@ msgstr[1] ""
 "    git branch ИМЕ_НА_НОВИЯ_КЛОН %s\n"
 "\n"
 
-#: builtin/checkout.c:1051
+#: builtin/checkout.c:1064
 msgid "internal error in revision walk"
 msgstr "вътрешна грешка при обхождането на версиите"
 
-#: builtin/checkout.c:1055
+#: builtin/checkout.c:1068
 msgid "Previous HEAD position was"
 msgstr "Преди това „HEAD“ сочеше към"
 
-#: builtin/checkout.c:1095 builtin/checkout.c:1364
+#: builtin/checkout.c:1114 builtin/checkout.c:1383
 msgid "You are on a branch yet to be born"
 msgstr "В момента сте на клон, който все още не е създаден"
 
-#: builtin/checkout.c:1177
+#: builtin/checkout.c:1196
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
@@ -13081,7 +13060,7 @@ msgstr ""
 "„%s“ може да е както локален файл, така и следящ клон.  За уточняване\n"
 "ползвайте разделителя „--“ (и евентуално опцията „--no-guess“)"
 
-#: builtin/checkout.c:1184
+#: builtin/checkout.c:1203
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -13103,51 +13082,51 @@ msgstr ""
 "\n"
 "    checkout.defaultRemote=origin"
 
-#: builtin/checkout.c:1194
+#: builtin/checkout.c:1213
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "„%s“ напасва с множество (%d) отдалечени клони"
 
-#: builtin/checkout.c:1260
+#: builtin/checkout.c:1279
 msgid "only one reference expected"
 msgstr "очаква се само един указател"
 
-#: builtin/checkout.c:1277
+#: builtin/checkout.c:1296
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "очаква се един указател, а сте подали %d."
 
-#: builtin/checkout.c:1323 builtin/worktree.c:269 builtin/worktree.c:437
+#: builtin/checkout.c:1342 builtin/worktree.c:269 builtin/worktree.c:436
 #, c-format
 msgid "invalid reference: %s"
 msgstr "неправилен указател: %s"
 
-#: builtin/checkout.c:1336 builtin/checkout.c:1705
+#: builtin/checkout.c:1355 builtin/checkout.c:1725
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "указателят не сочи към обект-дърво: %s"
 
-#: builtin/checkout.c:1383
+#: builtin/checkout.c:1402
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "очаква се клон, а не етикет — „%s“"
 
-#: builtin/checkout.c:1385
+#: builtin/checkout.c:1404
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "очаква се локален, а не отдалечен клон — „%s“"
 
-#: builtin/checkout.c:1386 builtin/checkout.c:1394
+#: builtin/checkout.c:1405 builtin/checkout.c:1413
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "очаква се клон, а не „%s“"
 
-#: builtin/checkout.c:1389
+#: builtin/checkout.c:1408
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "очаква се клон, а не подаване — „%s“"
 
-#: builtin/checkout.c:1405
+#: builtin/checkout.c:1424
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -13155,7 +13134,7 @@ msgstr ""
 "по време на сливане не може да преминете към друг клон.\n"
 "Пробвайте с „git merge --quit“ или „git worktree add“."
 
-#: builtin/checkout.c:1409
+#: builtin/checkout.c:1428
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
@@ -13164,7 +13143,7 @@ msgstr ""
 "клон.\n"
 "Пробвайте с „git am --quit“ или „git worktree add“."
 
-#: builtin/checkout.c:1413
+#: builtin/checkout.c:1432
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
@@ -13172,7 +13151,7 @@ msgstr ""
 "по време на пребазиране не може да преминете към друг клон.\n"
 "Пробвайте с „git rebase --quit“ или „git worktree add“."
 
-#: builtin/checkout.c:1417
+#: builtin/checkout.c:1436
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
@@ -13180,7 +13159,7 @@ msgstr ""
 "по време на отбиране на подавания не може да преминете към друг клон.\n"
 "Пробвайте с „git cherry-pick --quit“ или „git worktree add“."
 
-#: builtin/checkout.c:1421
+#: builtin/checkout.c:1440
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -13188,139 +13167,129 @@ msgstr ""
 "по време на отмяна на подавания не може да преминете към друг клон.\n"
 "Пробвайте с „git revert --quit“ или „git worktree add“."
 
-#: builtin/checkout.c:1425
+#: builtin/checkout.c:1444
 msgid "you are switching branch while bisecting"
 msgstr "преминаване към друг клон по време на двоично търсене"
 
-#: builtin/checkout.c:1432
+#: builtin/checkout.c:1451
 msgid "paths cannot be used with switching branches"
 msgstr "задаването на път е несъвместимо с преминаването от един клон към друг"
 
-#: builtin/checkout.c:1435 builtin/checkout.c:1439 builtin/checkout.c:1443
+#: builtin/checkout.c:1454 builtin/checkout.c:1458 builtin/checkout.c:1462
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "опцията „%s“ е несъвместима с преминаването от един клон към друг"
 
-#: builtin/checkout.c:1447 builtin/checkout.c:1450 builtin/checkout.c:1453
-#: builtin/checkout.c:1458 builtin/checkout.c:1463
+#: builtin/checkout.c:1466 builtin/checkout.c:1469 builtin/checkout.c:1472
+#: builtin/checkout.c:1477 builtin/checkout.c:1482
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "опцията „%s“ е несъвместима с „%s“"
 
-#: builtin/checkout.c:1460
+#: builtin/checkout.c:1479
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "опцията „%s“ е несъвместима със задаването на НАЧАЛО"
 
-#: builtin/checkout.c:1468
+#: builtin/checkout.c:1487
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr ""
 "За да преминете към клон, подайте указател, който сочи към подаване.  „%s“ "
 "не е такъв"
 
-#: builtin/checkout.c:1475
+#: builtin/checkout.c:1494
 msgid "missing branch or commit argument"
 msgstr "липсва аргумент — клон или подаване"
 
-#: builtin/checkout.c:1518
+#: builtin/checkout.c:1537
 msgid "perform a 3-way merge with the new branch"
 msgstr "извършване на тройно сливане с новия клон"
 
-#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:321
+#: builtin/checkout.c:1538 builtin/log.c:1825 parse-options.h:323
 msgid "style"
 msgstr "СТИЛ"
 
-#: builtin/checkout.c:1520
-msgid "conflict style (merge or diff3)"
-msgstr "действие при конфликт (сливане или тройна разлика)"
+#: builtin/checkout.c:1539
+msgid "conflict style (merge, diff3, or zdiff3)"
+msgstr ""
+"действие при конфликт („merge“ — сливане или тройна разлика с „diff3“ или "
+"„zdiff3“)"
 
-#: builtin/checkout.c:1532 builtin/worktree.c:489
+#: builtin/checkout.c:1551 builtin/worktree.c:488
 msgid "detach HEAD at named commit"
 msgstr "отделяне на указателя „HEAD“ към указаното подаване"
 
-#: builtin/checkout.c:1533
-msgid "set upstream info for new branch"
-msgstr "задаване на кой клон бива следен при създаването на новия клон"
+#: builtin/checkout.c:1553
+msgid "set up tracking mode (see git-pull(1))"
+msgstr "задаване на режима на следене (виж git-pull(1))"
 
-#: builtin/checkout.c:1535
+#: builtin/checkout.c:1556
 msgid "force checkout (throw away local modifications)"
 msgstr "принудително изтегляне (вашите промени ще бъдат занулени)"
 
-#: builtin/checkout.c:1537
+#: builtin/checkout.c:1558
 msgid "new-branch"
 msgstr "НОВ_КЛОН"
 
-#: builtin/checkout.c:1537
+#: builtin/checkout.c:1558
 msgid "new unparented branch"
 msgstr "нов клон без родител"
 
-#: builtin/checkout.c:1539 builtin/merge.c:302
+#: builtin/checkout.c:1560 builtin/merge.c:305
 msgid "update ignored files (default)"
 msgstr "обновяване на игнорираните файлове (стандартно)"
 
-#: builtin/checkout.c:1542
+#: builtin/checkout.c:1563
 msgid "do not check if another worktree is holding the given ref"
 msgstr "без проверка дали друго работно дърво държи указателя"
 
-#: builtin/checkout.c:1555
+#: builtin/checkout.c:1576
 msgid "checkout our version for unmerged files"
 msgstr "изтегляне на вашата версия на неслетите файлове"
 
-#: builtin/checkout.c:1558
+#: builtin/checkout.c:1579
 msgid "checkout their version for unmerged files"
 msgstr "изтегляне на чуждата версия на неслетите файлове"
 
-#: builtin/checkout.c:1562
+#: builtin/checkout.c:1583
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "без ограничаване на изброените пътища само до частично изтеглените"
 
-#: builtin/checkout.c:1620
+#: builtin/checkout.c:1640
 #, c-format
-msgid "-%c, -%c and --orphan are mutually exclusive"
-msgstr "опциите „-%c“, „-%c“ и „--orphan“ са несъвместими една с друга"
+msgid "options '-%c', '-%c', and '%s' cannot be used together"
+msgstr "опциите „-%c“, „-%c“ и „%s“ са несъвместими"
 
-#: builtin/checkout.c:1624
-msgid "-p and --overlay are mutually exclusive"
-msgstr "опциите „-p“ и „--overlay“ са несъвместими"
-
-#: builtin/checkout.c:1661
+#: builtin/checkout.c:1681
 msgid "--track needs a branch name"
 msgstr "опцията „--track“ изисква име на клон"
 
-#: builtin/checkout.c:1666
+#: builtin/checkout.c:1686
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "липсва име на клон, използвайте опцията „-%c“"
 
-#: builtin/checkout.c:1698
+#: builtin/checkout.c:1718
 #, c-format
 msgid "could not resolve %s"
 msgstr "„%s“ не може да бъде открит"
 
-#: builtin/checkout.c:1714
+#: builtin/checkout.c:1734
 msgid "invalid path specification"
 msgstr "указан е неправилен път"
 
-#: builtin/checkout.c:1721
+#: builtin/checkout.c:1741
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr "„%s“ не е подаване, затова от него не може да се създаде клон „%s“"
 
-#: builtin/checkout.c:1725
+#: builtin/checkout.c:1745
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: опцията „--detach“ не приема аргумент-път „%s“"
 
-#: builtin/checkout.c:1734
-msgid "--pathspec-from-file is incompatible with --detach"
-msgstr "опциите „--pathspec-from-file“ и „--detach“ са несъвместими"
-
-#: builtin/checkout.c:1737 builtin/reset.c:331 builtin/stash.c:1647
-msgid "--pathspec-from-file is incompatible with --patch"
-msgstr "опциите „--pathspec-from-file“ и „--patch“ са несъвместими"
-
-#: builtin/checkout.c:1750
+#: builtin/checkout.c:1770
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -13328,75 +13297,75 @@ msgstr ""
 "git checkout: опциите „--ours“/„--theirs“, „--force“ и „--merge“\n"
 "са несъвместими с изтегляне от индекса."
 
-#: builtin/checkout.c:1755
+#: builtin/checkout.c:1775
 msgid "you must specify path(s) to restore"
 msgstr "трябва да укажете поне един път за възстановяване"
 
-#: builtin/checkout.c:1781 builtin/checkout.c:1783 builtin/checkout.c:1832
-#: builtin/checkout.c:1834 builtin/clone.c:126 builtin/remote.c:170
-#: builtin/remote.c:172 builtin/submodule--helper.c:2958
-#: builtin/submodule--helper.c:3252 builtin/worktree.c:485
-#: builtin/worktree.c:487
+#: builtin/checkout.c:1800 builtin/checkout.c:1802 builtin/checkout.c:1854
+#: builtin/checkout.c:1856 builtin/clone.c:126 builtin/remote.c:170
+#: builtin/remote.c:172 builtin/submodule--helper.c:2959
+#: builtin/submodule--helper.c:3253 builtin/worktree.c:484
+#: builtin/worktree.c:486
 msgid "branch"
 msgstr "клон"
 
-#: builtin/checkout.c:1782
+#: builtin/checkout.c:1801
 msgid "create and checkout a new branch"
 msgstr "създаване и преминаване към нов клон"
 
-#: builtin/checkout.c:1784
+#: builtin/checkout.c:1803
 msgid "create/reset and checkout a branch"
 msgstr "създаване/зануляване на клон и преминаване към него"
 
-#: builtin/checkout.c:1785
+#: builtin/checkout.c:1804
 msgid "create reflog for new branch"
 msgstr "създаване на журнал на указателите за нов клон"
 
-#: builtin/checkout.c:1787
+#: builtin/checkout.c:1806
 msgid "second guess 'git checkout <no-such-branch>' (default)"
 msgstr ""
 "опит за отгатване на име на клон след неуспешен опит с „git checkout "
 "НЕСЪЩЕСТВУВАЩ_КЛОН“ (стандартно)"
 
-#: builtin/checkout.c:1788
+#: builtin/checkout.c:1807
 msgid "use overlay mode (default)"
 msgstr "използване на припокриващ режим (стандартно)"
 
-#: builtin/checkout.c:1833
+#: builtin/checkout.c:1855
 msgid "create and switch to a new branch"
 msgstr "създаване и преминаване към нов клон"
 
-#: builtin/checkout.c:1835
+#: builtin/checkout.c:1857
 msgid "create/reset and switch to a branch"
 msgstr "създаване/зануляване на клон и преминаване към него"
 
-#: builtin/checkout.c:1837
+#: builtin/checkout.c:1859
 msgid "second guess 'git switch <no-such-branch>'"
 msgstr ""
 "опит за отгатване на име на клон след неуспешен опит с „git switch "
 "НЕСЪЩЕСТВУВАЩ_КЛОН“"
 
-#: builtin/checkout.c:1839
+#: builtin/checkout.c:1861
 msgid "throw away local modifications"
 msgstr "зануляване на локалните промени"
 
-#: builtin/checkout.c:1873
+#: builtin/checkout.c:1897
 msgid "which tree-ish to checkout from"
 msgstr "към кой указател към дърво да се премине"
 
-#: builtin/checkout.c:1875
+#: builtin/checkout.c:1899
 msgid "restore the index"
 msgstr "възстановяване на индекса"
 
-#: builtin/checkout.c:1877
+#: builtin/checkout.c:1901
 msgid "restore the working tree (default)"
 msgstr "възстановяване на работното дърво (стандартно)"
 
-#: builtin/checkout.c:1879
+#: builtin/checkout.c:1903
 msgid "ignore unmerged entries"
 msgstr "пренебрегване на неслетите елементи"
 
-#: builtin/checkout.c:1880
+#: builtin/checkout.c:1904
 msgid "use overlay mode"
 msgstr "използване на припокриващ режим"
 
@@ -13430,7 +13399,15 @@ msgstr "Хранилището „%s“ ще бъде прескочено\n"
 msgid "could not lstat %s\n"
 msgstr "не може да се получи информация чрез „lstat“ за „%s“\n"
 
-#: builtin/clean.c:300 git-add--interactive.perl:593
+#: builtin/clean.c:39
+msgid "Refusing to remove current working directory\n"
+msgstr "Текущата работна директория няма да бъде изтрита\n"
+
+#: builtin/clean.c:40
+msgid "Would refuse to remove current working directory\n"
+msgstr "Текущата работна директория няма да бъде изтрита\n"
+
+#: builtin/clean.c:326 git-add--interactive.perl:593
 #, c-format
 msgid ""
 "Prompt help:\n"
@@ -13443,7 +13420,7 @@ msgstr ""
 "ПРЕФИКС    — избор на единствен обект по този уникален префикс\n"
 "           — (празно) нищо да не се избира\n"
 
-#: builtin/clean.c:304 git-add--interactive.perl:602
+#: builtin/clean.c:330 git-add--interactive.perl:602
 #, c-format
 msgid ""
 "Prompt help:\n"
@@ -13464,33 +13441,33 @@ msgstr ""
 "*          — избиране на всички обекти\n"
 "           — (празно) завършване на избирането\n"
 
-#: builtin/clean.c:519 git-add--interactive.perl:568
+#: builtin/clean.c:545 git-add--interactive.perl:568
 #: git-add--interactive.perl:573
 #, c-format, perl-format
 msgid "Huh (%s)?\n"
 msgstr "Неправилен избор (%s).\n"
 
-#: builtin/clean.c:659
+#: builtin/clean.c:685
 #, c-format
 msgid "Input ignore patterns>> "
 msgstr "Шаблони за игнорирани елементи≫ "
 
-#: builtin/clean.c:693
+#: builtin/clean.c:719
 #, c-format
 msgid "WARNING: Cannot find items matched by: %s"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: Никой обект не напасва на „%s“"
 
-#: builtin/clean.c:714
+#: builtin/clean.c:740
 msgid "Select items to delete"
 msgstr "Избиране на обекти за изтриване"
 
 #. TRANSLATORS: Make sure to keep [y/N] as is
-#: builtin/clean.c:755
+#: builtin/clean.c:781
 #, c-format
 msgid "Remove %s [y/N]? "
 msgstr "Да се изтрие ли „%s“? „y“ —  да, „N“ — НЕ"
 
-#: builtin/clean.c:786
+#: builtin/clean.c:812
 msgid ""
 "clean               - start cleaning\n"
 "filter by pattern   - exclude items from deletion\n"
@@ -13508,52 +13485,52 @@ msgstr ""
 "help                — този край\n"
 "?                   — подсказка за шаблоните"
 
-#: builtin/clean.c:822
+#: builtin/clean.c:848
 msgid "Would remove the following item:"
 msgid_plural "Would remove the following items:"
 msgstr[0] "Следният обект ще бъде изтрит:"
 msgstr[1] "Следните обекти ще бъдат изтрити:"
 
-#: builtin/clean.c:838
+#: builtin/clean.c:864
 msgid "No more files to clean, exiting."
 msgstr "Файловете за изчистване свършиха.  Изход от програмата."
 
-#: builtin/clean.c:900
+#: builtin/clean.c:926
 msgid "do not print names of files removed"
 msgstr "без извеждане на имената на файловете, които ще бъдат изтрити"
 
-#: builtin/clean.c:902
+#: builtin/clean.c:928
 msgid "force"
 msgstr "принудително изтриване"
 
-#: builtin/clean.c:903
+#: builtin/clean.c:929
 msgid "interactive cleaning"
 msgstr "интерактивно изтриване"
 
-#: builtin/clean.c:905
+#: builtin/clean.c:931
 msgid "remove whole directories"
 msgstr "изтриване на цели директории"
 
-#: builtin/clean.c:906 builtin/describe.c:565 builtin/describe.c:567
+#: builtin/clean.c:932 builtin/describe.c:565 builtin/describe.c:567
 #: builtin/grep.c:937 builtin/log.c:184 builtin/log.c:186
-#: builtin/ls-files.c:648 builtin/name-rev.c:526 builtin/name-rev.c:528
+#: builtin/ls-files.c:651 builtin/name-rev.c:535 builtin/name-rev.c:537
 #: builtin/show-ref.c:179
 msgid "pattern"
 msgstr "ШАБЛОН"
 
-#: builtin/clean.c:907
+#: builtin/clean.c:933
 msgid "add <pattern> to ignore rules"
 msgstr "добавяне на ШАБЛОН от файлове, които да не се трият"
 
-#: builtin/clean.c:908
+#: builtin/clean.c:934
 msgid "remove ignored files, too"
 msgstr "изтриване и на игнорираните файлове"
 
-#: builtin/clean.c:910
+#: builtin/clean.c:936
 msgid "remove only ignored files"
 msgstr "изтриване само на игнорирани файлове"
 
-#: builtin/clean.c:925
+#: builtin/clean.c:951
 msgid ""
 "clean.requireForce set to true and neither -i, -n, nor -f given; refusing to "
 "clean"
@@ -13561,7 +13538,7 @@ msgstr ""
 "Настройката „clean.requireForce“ е зададена като истина, което изисква някоя "
 "от опциите „-i“, „-n“ или „-f“.  Няма да се извърши изчистване"
 
-#: builtin/clean.c:928
+#: builtin/clean.c:954
 msgid ""
 "clean.requireForce defaults to true and neither -i, -n, nor -f given; "
 "refusing to clean"
@@ -13570,7 +13547,7 @@ msgstr ""
 "което изисква някоя от опциите „-i“, „-n“ или „-f“.  Няма да се извърши "
 "изчистване"
 
-#: builtin/clean.c:940
+#: builtin/clean.c:966
 msgid "-x and -X cannot be used together"
 msgstr "опциите „-x“ и „-X“ са несъвместими"
 
@@ -13627,19 +13604,20 @@ msgstr "директория с шаблони"
 msgid "directory from which templates will be used"
 msgstr "директория, която съдържа шаблоните, които да се ползват"
 
-#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1870
-#: builtin/submodule--helper.c:2513 builtin/submodule--helper.c:3259
+#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1871
+#: builtin/submodule--helper.c:2514 builtin/submodule--helper.c:3260
 msgid "reference repository"
 msgstr "еталонно хранилище"
 
-#: builtin/clone.c:123 builtin/submodule--helper.c:1872
-#: builtin/submodule--helper.c:2515
+#: builtin/clone.c:123 builtin/submodule--helper.c:1873
+#: builtin/submodule--helper.c:2516
 msgid "use --reference only while cloning"
 msgstr "опцията „--reference“ може да се използва само при клониране"
 
-#: builtin/clone.c:124 builtin/column.c:27 builtin/init-db.c:550
-#: builtin/merge-file.c:46 builtin/pack-objects.c:3944 builtin/repack.c:663
-#: builtin/submodule--helper.c:3261 t/helper/test-simple-ipc.c:595
+#: builtin/clone.c:124 builtin/column.c:27 builtin/fmt-merge-msg.c:27
+#: builtin/init-db.c:550 builtin/merge-file.c:48 builtin/merge.c:290
+#: builtin/pack-objects.c:3944 builtin/repack.c:665
+#: builtin/submodule--helper.c:3262 t/helper/test-simple-ipc.c:595
 #: t/helper/test-simple-ipc.c:597
 msgid "name"
 msgstr "ИМЕ"
@@ -13656,7 +13634,7 @@ msgstr "изтегляне на този КЛОН, а не соченият от
 msgid "path to git-upload-pack on the remote"
 msgstr "път към командата „git-upload-pack“ на отдалеченото хранилище"
 
-#: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
+#: builtin/clone.c:130 builtin/fetch.c:181 builtin/grep.c:876
 #: builtin/pull.c:212
 msgid "depth"
 msgstr "ДЪЛБОЧИНА"
@@ -13665,7 +13643,7 @@ msgstr "ДЪЛБОЧИНА"
 msgid "create a shallow clone of that depth"
 msgstr "плитко клониране до тази ДЪЛБОЧИНА"
 
-#: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
+#: builtin/clone.c:132 builtin/fetch.c:183 builtin/pack-objects.c:3933
 #: builtin/pull.c:215
 msgid "time"
 msgstr "ВРЕМЕ"
@@ -13674,17 +13652,17 @@ msgstr "ВРЕМЕ"
 msgid "create a shallow clone since a specific time"
 msgstr "плитко клониране до момент във времето"
 
-#: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
+#: builtin/clone.c:134 builtin/fetch.c:185 builtin/fetch.c:208
 #: builtin/pull.c:218 builtin/pull.c:243 builtin/rebase.c:1022
 msgid "revision"
 msgstr "ВЕРСИЯ"
 
-#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:219
+#: builtin/clone.c:135 builtin/fetch.c:186 builtin/pull.c:219
 msgid "deepen history of shallow clone, excluding rev"
 msgstr "задълбочаване на историята на плитко хранилище до изключващ указател"
 
-#: builtin/clone.c:137 builtin/submodule--helper.c:1882
-#: builtin/submodule--helper.c:2529
+#: builtin/clone.c:137 builtin/submodule--helper.c:1883
+#: builtin/submodule--helper.c:2530
 msgid "clone only one branch, HEAD or --branch"
 msgstr ""
 "клониране само на един клон — или сочения от отдалечения „HEAD“, или изрично "
@@ -13715,22 +13693,22 @@ msgstr "КЛЮЧ=СТОЙНОСТ"
 msgid "set config inside the new repository"
 msgstr "задаване на настройките на новото хранилище"
 
-#: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
+#: builtin/clone.c:147 builtin/fetch.c:203 builtin/ls-remote.c:77
 #: builtin/pull.c:234 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "специфични за сървъра"
 
-#: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
+#: builtin/clone.c:147 builtin/fetch.c:203 builtin/ls-remote.c:77
 #: builtin/pull.c:235 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr "опция за пренос"
 
-#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:238
+#: builtin/clone.c:148 builtin/fetch.c:204 builtin/pull.c:238
 #: builtin/push.c:576
 msgid "use IPv4 addresses only"
 msgstr "само адреси IPv4"
 
-#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:241
+#: builtin/clone.c:150 builtin/fetch.c:206 builtin/pull.c:241
 #: builtin/push.c:578
 msgid "use IPv6 addresses only"
 msgstr "само адреси IPv6"
@@ -13832,29 +13810,25 @@ msgstr "не може да се извърши пакетиране за изч�
 msgid "cannot unlink temporary alternates file"
 msgstr "временният файл за алтернативни обекти не може да бъде изтрит"
 
-#: builtin/clone.c:886 builtin/receive-pack.c:2493
+#: builtin/clone.c:886
 msgid "Too many arguments."
 msgstr "Прекалено много аргументи."
 
-#: builtin/clone.c:890
+#: builtin/clone.c:890 contrib/scalar/scalar.c:414
 msgid "You must specify a repository to clone."
 msgstr "Трябва да укажете кое хранилище искате да клонирате."
 
 #: builtin/clone.c:903
 #, c-format
-msgid "--bare and --origin %s options are incompatible."
-msgstr "опциите „--bare“ и „--origin %s“ са несъвместими."
-
-#: builtin/clone.c:906
-msgid "--bare and --separate-git-dir are incompatible."
-msgstr "опциите „--bare“ и „--separate-git-dir“ са несъвместими."
+msgid "options '%s' and '%s %s' cannot be used together"
+msgstr "опциите „%s“ и „%s %s“ са несъвместими"
 
 #: builtin/clone.c:920
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "не съществува хранилище „%s“"
 
-#: builtin/clone.c:924 builtin/fetch.c:2029
+#: builtin/clone.c:924 builtin/fetch.c:2047
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "дълбочината трябва да е положително цяло число, а не „%s“"
@@ -13874,8 +13848,8 @@ msgstr "пътят в хранилището „%s“ съществува и н
 msgid "working tree '%s' already exists."
 msgstr "в „%s“ вече съществува работно дърво."
 
-#: builtin/clone.c:969 builtin/clone.c:990 builtin/difftool.c:262
-#: builtin/log.c:1997 builtin/worktree.c:281 builtin/worktree.c:313
+#: builtin/clone.c:969 builtin/clone.c:990 builtin/difftool.c:256
+#: builtin/log.c:2012 builtin/worktree.c:281 builtin/worktree.c:313
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "родителските директории на „%s“ не може да бъдат създадени"
@@ -14002,7 +13976,7 @@ msgstr ""
 "split[=СТРАТЕГИЯ]] [--reachable|--stdin-packs|--stdin-commits] [--changed-"
 "paths] [--[no-]max-new-filters <n>] [--[no-]progress] ОПЦИИ_ЗА_РАЗДЕЛЯНЕ"
 
-#: builtin/commit-graph.c:51 builtin/fetch.c:191 builtin/log.c:1779
+#: builtin/commit-graph.c:51 builtin/fetch.c:192 builtin/log.c:1794
 msgid "dir"
 msgstr "директория"
 
@@ -14088,7 +14062,7 @@ msgstr ""
 msgid "Collecting commits from input"
 msgstr "Получаване на подаванията от входа"
 
-#: builtin/commit-graph.c:328 builtin/multi-pack-index.c:255
+#: builtin/commit-graph.c:328 builtin/multi-pack-index.c:259
 #, c-format
 msgid "unrecognized subcommand: %s"
 msgstr "непозната подкоманда: %s"
@@ -14106,7 +14080,7 @@ msgstr ""
 msgid "duplicate parent %s ignored"
 msgstr "прескачане на повтарящ се родител: „%s“"
 
-#: builtin/commit-tree.c:56 builtin/commit-tree.c:134 builtin/log.c:562
+#: builtin/commit-tree.c:56 builtin/commit-tree.c:134 builtin/log.c:577
 #, c-format
 msgid "not a valid object name %s"
 msgstr "неправилно име на обект: „%s“"
@@ -14129,13 +14103,13 @@ msgstr "родител"
 msgid "id of a parent commit object"
 msgstr "ИДЕНТИФИКАТОР на обекта за подаването-родител"
 
-#: builtin/commit-tree.c:112 builtin/commit.c:1626 builtin/merge.c:283
-#: builtin/notes.c:407 builtin/notes.c:573 builtin/stash.c:1618
+#: builtin/commit-tree.c:112 builtin/commit.c:1627 builtin/merge.c:284
+#: builtin/notes.c:407 builtin/notes.c:573 builtin/stash.c:1677
 #: builtin/tag.c:454
 msgid "message"
 msgstr "СЪОБЩЕНИЕ"
 
-#: builtin/commit-tree.c:113 builtin/commit.c:1626
+#: builtin/commit-tree.c:113 builtin/commit.c:1627
 msgid "commit message"
 msgstr "СЪОБЩЕНИЕ при подаване"
 
@@ -14143,7 +14117,7 @@ msgstr "СЪОБЩЕНИЕ при подаване"
 msgid "read commit log message from file"
 msgstr "изчитане на съобщението за подаване от ФАЙЛ"
 
-#: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
+#: builtin/commit-tree.c:119 builtin/commit.c:1644 builtin/merge.c:303
 #: builtin/pull.c:180 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "подписване на подаването с GPG"
@@ -14230,10 +14204,6 @@ msgstr ""
 #: builtin/commit.c:325
 msgid "failed to unpack HEAD tree object"
 msgstr "върховото дърво (HEAD tree object) не може да бъде извадено от пакет"
-
-#: builtin/commit.c:361
-msgid "--pathspec-from-file with -a does not make sense"
-msgstr "опциите „-a“ и „--pathspec-from-file“ са несъвместими"
 
 #: builtin/commit.c:375
 msgid "No paths with --include/--only does not make sense."
@@ -14322,8 +14292,8 @@ msgstr "файлът със съобщението за подаване „%s�
 
 #: builtin/commit.c:802
 #, c-format
-msgid "cannot combine -m with --fixup:%s"
-msgstr "опциите „-m“ и „--fixup“ са несъвместими:%s"
+msgid "options '%s' and '%s:%s' cannot be used together"
+msgstr "опциите „--%s“ и „--%s:%s“ са несъвместими"
 
 #: builtin/commit.c:814 builtin/commit.c:830
 msgid "could not read SQUASH_MSG"
@@ -14432,7 +14402,7 @@ msgstr "епилогът не може да се подаде на „--trailers
 msgid "Error building trees"
 msgstr "Грешка при изграждане на дърветата"
 
-#: builtin/commit.c:1080 builtin/tag.c:317
+#: builtin/commit.c:1080 builtin/tag.c:316
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr "Подайте съобщението с някоя от опциите „-m“ или „-F“.\n"
@@ -14449,14 +14419,10 @@ msgstr ""
 msgid "Invalid ignored mode '%s'"
 msgstr "Неправилен режим за игнорираните файлове: „%s“"
 
-#: builtin/commit.c:1156 builtin/commit.c:1450
+#: builtin/commit.c:1156 builtin/commit.c:1451
 #, c-format
 msgid "Invalid untracked files mode '%s'"
 msgstr "Неправилен режим за неследените файлове: „%s“"
-
-#: builtin/commit.c:1196
-msgid "--long and -z are incompatible"
-msgstr "опциите „--long“ и „-z“ са несъвместими."
 
 #: builtin/commit.c:1227
 msgid "You are in the middle of a merge -- cannot reword."
@@ -14471,120 +14437,115 @@ msgstr ""
 
 #: builtin/commit.c:1232
 #, c-format
-msgid "cannot combine reword option of --fixup with path '%s'"
-msgstr ""
-"опцията за промяна на съобщението на „--fixup“ и указването на път „%s“ са "
-"несъвместими"
+msgid "reword option of '%s' and path '%s' cannot be used together"
+msgstr "опцията за промяна на съобщението „%s“ и пътят „%s“ са несъвместими"
 
 #: builtin/commit.c:1234
-msgid ""
-"reword option of --fixup is mutually exclusive with --patch/--interactive/--"
-"all/--include/--only"
-msgstr ""
-"опцията за промяна на съобщението на „--fixup“ и „--patch“/„--interactive“/"
-"„--all“/„--include“/„--only“ са несъвместими"
+#, c-format
+msgid "reword option of '%s' and '%s' cannot be used together"
+msgstr "опциите „%s“ и „%s“ са несъвместими"
 
-#: builtin/commit.c:1253
+#: builtin/commit.c:1254
 msgid "Using both --reset-author and --author does not make sense"
-msgstr "опциите „--reset-author“ и „--author“ са несъвместими."
+msgstr "опциите „--reset-author“ и „--author“ са несъвместими"
 
-#: builtin/commit.c:1260
+#: builtin/commit.c:1261
 msgid "You have nothing to amend."
 msgstr "Няма какво да бъде поправено."
 
-#: builtin/commit.c:1263
+#: builtin/commit.c:1264
 msgid "You are in the middle of a merge -- cannot amend."
 msgstr "В момента се извършва сливане, не може да поправяте."
 
-#: builtin/commit.c:1265
+#: builtin/commit.c:1266
 msgid "You are in the middle of a cherry-pick -- cannot amend."
 msgstr "В момента се извършва отбиране на подаване, не може да поправяте."
 
-#: builtin/commit.c:1267
+#: builtin/commit.c:1268
 msgid "You are in the middle of a rebase -- cannot amend."
 msgstr "В момента се извършва пребазиране, не може да поправяте."
 
-#: builtin/commit.c:1270
+#: builtin/commit.c:1271
 msgid "Options --squash and --fixup cannot be used together"
 msgstr "опциите „--squash“ и „--fixup“ са несъвместими."
 
-#: builtin/commit.c:1280
+#: builtin/commit.c:1281
 msgid "Only one of -c/-C/-F/--fixup can be used."
 msgstr "опциите „-c“, „-C“, „-F“ и „--fixup““ са несъвместими."
 
-#: builtin/commit.c:1282
+#: builtin/commit.c:1283
 msgid "Option -m cannot be combined with -c/-C/-F."
 msgstr "опцията „-m“ е несъвместима с „-c“, „-C“ и „-F“."
 
-#: builtin/commit.c:1291
+#: builtin/commit.c:1292
 msgid "--reset-author can be used only with -C, -c or --amend."
 msgstr ""
 "опцията „--reset-author“ може да се използва само заедно с „-C“, „-c“ или\n"
 "„--amend“."
 
-#: builtin/commit.c:1309
+#: builtin/commit.c:1310
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
 msgstr ""
 "опциите „--include“, „--only“, „--all“, „--interactive“ и „--patch“ са\n"
 "несъвместими."
 
-#: builtin/commit.c:1337
+#: builtin/commit.c:1338
 #, c-format
 msgid "unknown option: --fixup=%s:%s"
 msgstr "непозната опция: --fixup=%s:%s"
 
-#: builtin/commit.c:1354
+#: builtin/commit.c:1355
 #, c-format
 msgid "paths '%s ...' with -a does not make sense"
 msgstr "опцията „-a“ е несъвместима със задаването на пътища: „%s…“"
 
-#: builtin/commit.c:1485 builtin/commit.c:1654
+#: builtin/commit.c:1486 builtin/commit.c:1655
 msgid "show status concisely"
 msgstr "кратка информация за състоянието"
 
-#: builtin/commit.c:1487 builtin/commit.c:1656
+#: builtin/commit.c:1488 builtin/commit.c:1657
 msgid "show branch information"
 msgstr "информация за клоните"
 
-#: builtin/commit.c:1489
+#: builtin/commit.c:1490
 msgid "show stash information"
 msgstr "информация за скатаното"
 
-#: builtin/commit.c:1491 builtin/commit.c:1658
+#: builtin/commit.c:1492 builtin/commit.c:1659
 msgid "compute full ahead/behind values"
 msgstr "изчисляване на точните стойности напред/назад"
 
-#: builtin/commit.c:1493
+#: builtin/commit.c:1494
 msgid "version"
 msgstr "версия"
 
-#: builtin/commit.c:1493 builtin/commit.c:1660 builtin/push.c:551
-#: builtin/worktree.c:691
+#: builtin/commit.c:1494 builtin/commit.c:1661 builtin/push.c:551
+#: builtin/worktree.c:690
 msgid "machine-readable output"
 msgstr "формат на изхода за четене от програма"
 
-#: builtin/commit.c:1496 builtin/commit.c:1662
+#: builtin/commit.c:1497 builtin/commit.c:1663
 msgid "show status in long format (default)"
 msgstr "подробна информация за състоянието (стандартно)"
 
-#: builtin/commit.c:1499 builtin/commit.c:1665
+#: builtin/commit.c:1500 builtin/commit.c:1666
 msgid "terminate entries with NUL"
 msgstr "разделяне на елементите с нулевия знак „NUL“"
 
-#: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
-#: builtin/fast-export.c:1199 builtin/fast-export.c:1202
-#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:335
+#: builtin/commit.c:1502 builtin/commit.c:1506 builtin/commit.c:1669
+#: builtin/fast-export.c:1172 builtin/fast-export.c:1175
+#: builtin/fast-export.c:1178 builtin/rebase.c:1111 parse-options.h:337
 msgid "mode"
 msgstr "РЕЖИМ"
 
-#: builtin/commit.c:1502 builtin/commit.c:1668
+#: builtin/commit.c:1503 builtin/commit.c:1669
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
 "извеждане на неследените файлове.  Възможните РЕЖИМи са „all“ (подробна "
 "информация), „normal“ (кратка информация), „no“ (без неследените файлове).  "
 "Стандартният РЕЖИМ е: „all“."
 
-#: builtin/commit.c:1506
+#: builtin/commit.c:1507
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
@@ -14593,11 +14554,11 @@ msgstr ""
 "„traditional“ (традиционен), „matching“ (напасващи), „no“ (без игнорираните "
 "файлове).  Стандартният РЕЖИМ е: „traditional“."
 
-#: builtin/commit.c:1508 parse-options.h:192
+#: builtin/commit.c:1509 parse-options.h:192
 msgid "when"
 msgstr "КОГА"
 
-#: builtin/commit.c:1509
+#: builtin/commit.c:1510
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
@@ -14606,197 +14567,197 @@ msgstr ""
 "една от „all“ (всички), „dirty“ (тези с неподадени промени), "
 "„untracked“ (неследени)"
 
-#: builtin/commit.c:1511
+#: builtin/commit.c:1512
 msgid "list untracked files in columns"
 msgstr "извеждане на неследените файлове в колони"
 
-#: builtin/commit.c:1512
+#: builtin/commit.c:1513
 msgid "do not detect renames"
 msgstr "без засичане на преименуванията"
 
-#: builtin/commit.c:1514
+#: builtin/commit.c:1515
 msgid "detect renames, optionally set similarity index"
 msgstr "засичане на преименуванията, може да се зададе коефициент на прилика"
 
-#: builtin/commit.c:1537
+#: builtin/commit.c:1538
 msgid "Unsupported combination of ignored and untracked-files arguments"
 msgstr "Неподдържана комбинация от аргументи за игнорирани и неследени файлове"
 
-#: builtin/commit.c:1619
+#: builtin/commit.c:1620
 msgid "suppress summary after successful commit"
 msgstr "без информация след успешно подаване"
 
-#: builtin/commit.c:1620
+#: builtin/commit.c:1621
 msgid "show diff in commit message template"
 msgstr "добавяне на разликата към шаблона за съобщението при подаване"
 
-#: builtin/commit.c:1622
+#: builtin/commit.c:1623
 msgid "Commit message options"
 msgstr "Опции за съобщението при подаване"
 
-#: builtin/commit.c:1623 builtin/merge.c:287 builtin/tag.c:456
+#: builtin/commit.c:1624 builtin/merge.c:288 builtin/tag.c:456
 msgid "read message from file"
 msgstr "взимане на съобщението от ФАЙЛ"
 
-#: builtin/commit.c:1624
+#: builtin/commit.c:1625
 msgid "author"
 msgstr "АВТОР"
 
-#: builtin/commit.c:1624
+#: builtin/commit.c:1625
 msgid "override author for commit"
 msgstr "задаване на АВТОР за подаването"
 
-#: builtin/commit.c:1625 builtin/gc.c:550
+#: builtin/commit.c:1626 builtin/gc.c:551
 msgid "date"
 msgstr "ДАТА"
 
-#: builtin/commit.c:1625
+#: builtin/commit.c:1626
 msgid "override date for commit"
 msgstr "задаване на ДАТА за подаването"
 
-#: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
-#: parse-options.h:327 ref-filter.h:92
+#: builtin/commit.c:1628 builtin/commit.c:1629 builtin/commit.c:1635
+#: parse-options.h:329 ref-filter.h:89
 msgid "commit"
 msgstr "ПОДАВАНЕ"
 
-#: builtin/commit.c:1627
+#: builtin/commit.c:1628
 msgid "reuse and edit message from specified commit"
 msgstr "преизползване и редактиране на съобщението от указаното ПОДАВАНЕ"
 
-#: builtin/commit.c:1628
+#: builtin/commit.c:1629
 msgid "reuse message from specified commit"
 msgstr "преизползване на съобщението от указаното ПОДАВАНЕ"
 
 #. TRANSLATORS: Leave "[(amend|reword):]" as-is,
 #. and only translate <commit>.
 #.
-#: builtin/commit.c:1633
+#: builtin/commit.c:1634
 msgid "[(amend|reword):]commit"
 msgstr "[(amend|reword):]подаване"
 
-#: builtin/commit.c:1633
+#: builtin/commit.c:1634
 msgid ""
 "use autosquash formatted message to fixup or amend/reword specified commit"
 msgstr ""
 "използване на автоматичното съобщение за вкарване на указаното ПОДАВАНЕ в "
 "предходното без следа или за промяна на подаването или съобщението"
 
-#: builtin/commit.c:1634
+#: builtin/commit.c:1635
 msgid "use autosquash formatted message to squash specified commit"
 msgstr ""
 "използване на автоматичното съобщение за вкарване на указаното ПОДАВАНЕ в "
 "предното"
 
-#: builtin/commit.c:1635
+#: builtin/commit.c:1636
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr ""
 "смяна на автора да съвпада с подаващия (използва се с „-C“/„-c“/„--amend“)"
 
-#: builtin/commit.c:1636 builtin/interpret-trailers.c:111
+#: builtin/commit.c:1637 builtin/interpret-trailers.c:111
 msgid "trailer"
 msgstr "ЕПИЛОГ"
 
-#: builtin/commit.c:1636
+#: builtin/commit.c:1637
 msgid "add custom trailer(s)"
 msgstr "добавяне на друг ЕПИЛОГ"
 
-#: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
+#: builtin/commit.c:1638 builtin/log.c:1769 builtin/merge.c:306
 #: builtin/pull.c:146 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "добавяне на епилог за подпис „Signed-off-by“"
 
-#: builtin/commit.c:1638
+#: builtin/commit.c:1639
 msgid "use specified template file"
 msgstr "използване на указания шаблонен ФАЙЛ"
 
-#: builtin/commit.c:1639
+#: builtin/commit.c:1640
 msgid "force edit of commit"
 msgstr "редактиране на подаване"
 
-#: builtin/commit.c:1641
+#: builtin/commit.c:1642
 msgid "include status in commit message template"
 msgstr "вмъкване на състоянието в шаблона за съобщението при подаване"
 
-#: builtin/commit.c:1646
+#: builtin/commit.c:1647
 msgid "Commit contents options"
 msgstr "Опции за избор на файлове при подаване"
 
-#: builtin/commit.c:1647
+#: builtin/commit.c:1648
 msgid "commit all changed files"
 msgstr "подаване на всички променени файлове"
 
-#: builtin/commit.c:1648
+#: builtin/commit.c:1649
 msgid "add specified files to index for commit"
 msgstr "добавяне на указаните файлове към индекса за подаване"
 
-#: builtin/commit.c:1649
+#: builtin/commit.c:1650
 msgid "interactively add files"
 msgstr "интерактивно добавяне на файлове"
 
-#: builtin/commit.c:1650
+#: builtin/commit.c:1651
 msgid "interactively add changes"
 msgstr "интерактивно добавяне на промени"
 
-#: builtin/commit.c:1651
+#: builtin/commit.c:1652
 msgid "commit only specified files"
 msgstr "подаване само на указаните файлове"
 
-#: builtin/commit.c:1652
+#: builtin/commit.c:1653
 msgid "bypass pre-commit and commit-msg hooks"
 msgstr ""
 "без изпълнение на куките преди подаване и при промяна на съобщението за "
 "подаване (pre-commit и commit-msg)"
 
-#: builtin/commit.c:1653
+#: builtin/commit.c:1654
 msgid "show what would be committed"
 msgstr "отпечатване на това, което би било подадено"
 
-#: builtin/commit.c:1666
+#: builtin/commit.c:1667
 msgid "amend previous commit"
 msgstr "поправяне на предишното подаване"
 
-#: builtin/commit.c:1667
+#: builtin/commit.c:1668
 msgid "bypass post-rewrite hook"
 msgstr "без изпълнение на куката след презаписване (post-rewrite)"
 
-#: builtin/commit.c:1674
+#: builtin/commit.c:1675
 msgid "ok to record an empty change"
 msgstr "позволяване на празни подавания"
 
-#: builtin/commit.c:1676
+#: builtin/commit.c:1677
 msgid "ok to record a change with an empty message"
 msgstr "позволяване на подавания с празни съобщения"
 
-#: builtin/commit.c:1752
+#: builtin/commit.c:1753
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
 msgstr "Повреден файл за върха за сливането „MERGE_HEAD“ (%s)"
 
-#: builtin/commit.c:1759
+#: builtin/commit.c:1760
 msgid "could not read MERGE_MODE"
 msgstr "режимът на сливане „MERGE_MODE“ не може да бъде прочетен"
 
-#: builtin/commit.c:1780
+#: builtin/commit.c:1781
 #, c-format
 msgid "could not read commit message: %s"
 msgstr "съобщението за подаване не може да бъде прочетено: %s"
 
-#: builtin/commit.c:1787
+#: builtin/commit.c:1788
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
 msgstr "Неизвършване на подаване поради празно съобщение.\n"
 
-#: builtin/commit.c:1792
+#: builtin/commit.c:1793
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
 msgstr "Неизвършване на подаване поради нередактирано съобщение.\n"
 
-#: builtin/commit.c:1803
+#: builtin/commit.c:1804
 #, c-format
 msgid "Aborting commit due to empty commit message body.\n"
 msgstr "Неизвършване на подаване поради празно съобщение.\n"
 
-#: builtin/commit.c:1839
+#: builtin/commit.c:1840
 msgid ""
 "repository has been updated, but unable to write\n"
 "new_index file. Check that disk is not full and quota is\n"
@@ -15322,7 +15283,7 @@ msgstr "да се търси само измежду етикетите напа
 msgid "do not consider tags matching <pattern>"
 msgstr "да не се търси измежду етикетите напасващи този ШАБЛОН"
 
-#: builtin/describe.c:570 builtin/name-rev.c:535
+#: builtin/describe.c:570 builtin/name-rev.c:544
 msgid "show abbreviated commit object as fallback"
 msgstr "извеждане на съкратено име на обект като резервен вариант"
 
@@ -15339,25 +15300,14 @@ msgid "append <mark> on broken working tree (default: \"-broken\")"
 msgstr ""
 "добавяне на такъв МАРКЕР на счупеното работно дърво (стандартно е „-broken“)"
 
-#: builtin/describe.c:593
-msgid "--long is incompatible with --abbrev=0"
-msgstr "опциите „--long“ и „--abbrev=0“ са несъвместими"
-
 #: builtin/describe.c:622
 msgid "No names found, cannot describe anything."
 msgstr "Не са открити имена — нищо не може да бъде описано."
 
-#: builtin/describe.c:673
-msgid "--dirty is incompatible with commit-ishes"
-msgstr "опцията „--dirty“ е несъвместима с указател към подаване"
-
-#: builtin/describe.c:675
-msgid "--broken is incompatible with commit-ishes"
-msgstr "опцията „--broken“ е несъвместима с указател към подаване"
-
-#: builtin/diff-tree.c:155
-msgid "--stdin and --merge-base are mutually exclusive"
-msgstr "опциите „--stdin“ и „--merge-base“ са несъвместими"
+#: builtin/describe.c:673 builtin/describe.c:675
+#, c-format
+msgid "option '%s' and commit-ishes cannot be used together"
+msgstr "опциите „%s“ и указателите към обекти са несъвместими"
 
 #: builtin/diff-tree.c:157
 msgid "--merge-base only works with two commits"
@@ -15378,26 +15328,26 @@ msgstr "неправилна опция: %s"
 msgid "%s...%s: no merge base"
 msgstr "„%s..%s“: липсва база за сливане"
 
-#: builtin/diff.c:486
+#: builtin/diff.c:491
 msgid "Not a git repository"
 msgstr "Не е хранилище на Git"
 
-#: builtin/diff.c:532 builtin/grep.c:698
+#: builtin/diff.c:537 builtin/grep.c:698
 #, c-format
 msgid "invalid object '%s' given."
 msgstr "зададен е неправилен обект „%s“."
 
-#: builtin/diff.c:543
+#: builtin/diff.c:548
 #, c-format
 msgid "more than two blobs given: '%s'"
 msgstr "зададени са повече от 2 обекта-BLOB: „%s“"
 
-#: builtin/diff.c:548
+#: builtin/diff.c:553
 #, c-format
 msgid "unhandled object '%s' given."
 msgstr "зададен е неподдържан обект „%s“."
 
-#: builtin/diff.c:582
+#: builtin/diff.c:587
 #, c-format
 msgid "%s...%s: multiple merge bases, using %s"
 msgstr "%s...%s: много бази за сливане, ще се ползва „%s“"
@@ -15406,22 +15356,22 @@ msgstr "%s...%s: много бази за сливане, ще се ползва
 msgid "git difftool [<options>] [<commit> [<commit>]] [--] [<path>...]"
 msgstr "git difftool [ОПЦИЯ…] [ПОДАВАНЕ [ПОДАВАНЕ]] [[--] ПЪТ…]"
 
-#: builtin/difftool.c:293
+#: builtin/difftool.c:287
 #, c-format
 msgid "could not read symlink %s"
 msgstr "символната връзка „%s“ не може да бъде прочетена"
 
-#: builtin/difftool.c:295
+#: builtin/difftool.c:289
 #, c-format
 msgid "could not read symlink file %s"
 msgstr "файлът, сочен от символната връзка „%s“, не може да бъде прочетен"
 
-#: builtin/difftool.c:303
+#: builtin/difftool.c:297
 #, c-format
 msgid "could not read object %s for symlink %s"
 msgstr "обектът „%s“ за символната връзка „%s“ не може да бъде прочетен"
 
-#: builtin/difftool.c:427
+#: builtin/difftool.c:421
 msgid ""
 "combined diff formats ('-c' and '--cc') are not supported in\n"
 "directory diff mode ('-d' and '--dir-diff')."
@@ -15429,60 +15379,60 @@ msgstr ""
 "комбинираните формати на разликите („-c“ и „--cc“) не се поддържат\n"
 "в режима за разлики върху директории („-d“ и „--dir-diff“)."
 
-#: builtin/difftool.c:632
+#: builtin/difftool.c:626
 #, c-format
 msgid "both files modified: '%s' and '%s'."
 msgstr "и двата файла са променени: „%s“ и „%s“."
 
-#: builtin/difftool.c:634
+#: builtin/difftool.c:628
 msgid "working tree file has been left."
 msgstr "работното дърво е изоставено."
 
-#: builtin/difftool.c:645
+#: builtin/difftool.c:639
 #, c-format
 msgid "temporary files exist in '%s'."
 msgstr "в „%s“ има временни файлове."
 
-#: builtin/difftool.c:646
+#: builtin/difftool.c:640
 msgid "you may want to cleanup or recover these."
 msgstr "възможно е да ги изчистите или възстановите"
 
-#: builtin/difftool.c:651
+#: builtin/difftool.c:645
 #, c-format
 msgid "failed: %d"
 msgstr "неуспешно действие с изходен код: %d"
 
-#: builtin/difftool.c:696
+#: builtin/difftool.c:690
 msgid "use `diff.guitool` instead of `diff.tool`"
 msgstr "използвайте „diff.guitool“ вместо „diff.tool“"
 
-#: builtin/difftool.c:698
+#: builtin/difftool.c:692
 msgid "perform a full-directory diff"
 msgstr "разлика по директории"
 
-#: builtin/difftool.c:700
+#: builtin/difftool.c:694
 msgid "do not prompt before launching a diff tool"
 msgstr "стартиране на ПРОГРАМАта за разлики без предупреждение"
 
-#: builtin/difftool.c:705
+#: builtin/difftool.c:699
 msgid "use symlinks in dir-diff mode"
 msgstr "следване на символните връзки при разлика по директории"
 
-#: builtin/difftool.c:706
+#: builtin/difftool.c:700
 msgid "tool"
 msgstr "ПРОГРАМА"
 
-#: builtin/difftool.c:707
+#: builtin/difftool.c:701
 msgid "use the specified diff tool"
 msgstr "използване на указаната ПРОГРАМА"
 
-#: builtin/difftool.c:709
+#: builtin/difftool.c:703
 msgid "print a list of diff tools that may be used with `--tool`"
 msgstr ""
 "извеждане на списък с всички ПРОГРАМи, които може да се ползват с опцията „--"
 "tool“"
 
-#: builtin/difftool.c:712
+#: builtin/difftool.c:706
 msgid ""
 "make 'git-difftool' exit when an invoked diff tool returns a non-zero exit "
 "code"
@@ -15490,31 +15440,23 @@ msgstr ""
 "„git-difftool“ да спре работа, когато стартираната ПРОГРАМА за разлики "
 "завърши с ненулев код"
 
-#: builtin/difftool.c:715
+#: builtin/difftool.c:709
 msgid "specify a custom command for viewing diffs"
 msgstr "команда за разглеждане на разлики"
 
-#: builtin/difftool.c:716
+#: builtin/difftool.c:710
 msgid "passed to `diff`"
 msgstr "подава се към „diff“"
 
-#: builtin/difftool.c:732
+#: builtin/difftool.c:726
 msgid "difftool requires worktree or --no-index"
 msgstr "„git-difftool“ изисква работно дърво или опцията „--no-index“"
 
-#: builtin/difftool.c:739
-msgid "--dir-diff is incompatible with --no-index"
-msgstr "опциите „--dir-diff“ и „--no-index“ са несъвместими"
-
-#: builtin/difftool.c:742
-msgid "--gui, --tool and --extcmd are mutually exclusive"
-msgstr "опциите „--gui“, „--tool“ и „--extcmd“ са несъвместими една с друга"
-
-#: builtin/difftool.c:750
+#: builtin/difftool.c:744
 msgid "no <tool> given for --tool=<tool>"
 msgstr "не е зададена програма за „--tool=ПРОГРАМА“"
 
-#: builtin/difftool.c:757
+#: builtin/difftool.c:751
 msgid "no <cmd> given for --extcmd=<cmd>"
 msgstr "не е зададена команда за „--extcmd=КОМАНДА“"
 
@@ -15554,128 +15496,120 @@ msgstr ""
 msgid "git fast-export [rev-list-opts]"
 msgstr "git fast-export [ОПЦИИ_ЗА_СПИСЪКА_С_ВЕРСИИ]"
 
-#: builtin/fast-export.c:869
+#: builtin/fast-export.c:843
 msgid "Error: Cannot export nested tags unless --mark-tags is specified."
 msgstr ""
 "Грешка: непреките етикети не се изнасят, освен ако не зададете „--mark-tags“."
 
-#: builtin/fast-export.c:1178
+#: builtin/fast-export.c:1152
 msgid "--anonymize-map token cannot be empty"
 msgstr "опцията „--anonymize-map“ изисква аргумент"
 
-#: builtin/fast-export.c:1198
+#: builtin/fast-export.c:1171
 msgid "show progress after <n> objects"
 msgstr "Съобщение за напредъка на всеки такъв БРОЙ обекта"
 
-#: builtin/fast-export.c:1200
+#: builtin/fast-export.c:1173
 msgid "select handling of signed tags"
 msgstr "Как да се обработват подписаните етикети"
 
-#: builtin/fast-export.c:1203
+#: builtin/fast-export.c:1176
 msgid "select handling of tags that tag filtered objects"
 msgstr "Как да се обработват етикетите на филтрираните обекти"
 
-#: builtin/fast-export.c:1206
+#: builtin/fast-export.c:1179
 msgid "select handling of commit messages in an alternate encoding"
 msgstr ""
 "как да се обработват съобщенията за подаване, които са в друго кодиране"
 
-#: builtin/fast-export.c:1209
+#: builtin/fast-export.c:1182
 msgid "dump marks to this file"
 msgstr "запазване на маркерите в този ФАЙЛ"
 
-#: builtin/fast-export.c:1211
+#: builtin/fast-export.c:1184
 msgid "import marks from this file"
 msgstr "внасяне на маркерите от този ФАЙЛ"
 
-#: builtin/fast-export.c:1215
+#: builtin/fast-export.c:1188
 msgid "import marks from this file if it exists"
 msgstr "внасяне на маркерите от този ФАЙЛ, ако съществува"
 
-#: builtin/fast-export.c:1217
+#: builtin/fast-export.c:1190
 msgid "fake a tagger when tags lack one"
 msgstr ""
 "да се използва изкуствено име на човек при липса на създател на етикета"
 
-#: builtin/fast-export.c:1219
+#: builtin/fast-export.c:1192
 msgid "output full tree for each commit"
 msgstr "извеждане на цялото дърво за всяко подаване"
 
-#: builtin/fast-export.c:1221
+#: builtin/fast-export.c:1194
 msgid "use the done feature to terminate the stream"
 msgstr "използване на маркер за завършване на потока"
 
-#: builtin/fast-export.c:1222
+#: builtin/fast-export.c:1195
 msgid "skip output of blob data"
 msgstr "без извеждане на съдържанието на обектите-BLOB"
 
-#: builtin/fast-export.c:1223 builtin/log.c:1826
+#: builtin/fast-export.c:1196 builtin/log.c:1841
 msgid "refspec"
 msgstr "УКАЗАТЕЛ_НА_ВЕРСИЯ"
 
-#: builtin/fast-export.c:1224
+#: builtin/fast-export.c:1197
 msgid "apply refspec to exported refs"
 msgstr "прилагане на УКАЗАТЕЛя_НА_ВЕРСИЯ към изнесените указатели"
 
-#: builtin/fast-export.c:1225
+#: builtin/fast-export.c:1198
 msgid "anonymize output"
 msgstr "анонимизиране на извежданата информация"
 
-#: builtin/fast-export.c:1226
+#: builtin/fast-export.c:1199
 msgid "from:to"
 msgstr "ОТ:КЪМ"
 
-#: builtin/fast-export.c:1227
+#: builtin/fast-export.c:1200
 msgid "convert <from> to <to> in anonymized output"
 msgstr "заместване ОТ със КЪМ в анонимизирания изход"
 
-#: builtin/fast-export.c:1230
+#: builtin/fast-export.c:1203
 msgid "reference parents which are not in fast-export stream by object id"
 msgstr ""
 "указване на родителите, които не са в потока на бързо изнасяне, с "
 "идентификатор на обект"
 
-#: builtin/fast-export.c:1232
+#: builtin/fast-export.c:1205
 msgid "show original object ids of blobs/commits"
 msgstr "извеждане на първоначалните идентификатори на обектите BLOB/подавяния"
 
-#: builtin/fast-export.c:1234
+#: builtin/fast-export.c:1207
 msgid "label tags with mark ids"
 msgstr "задаване на идентификатори на маркери на етикетите"
 
-#: builtin/fast-export.c:1257
-msgid "--anonymize-map without --anonymize does not make sense"
-msgstr "опцията „--anonymize-map“ изисква „--anonymize“"
-
-#: builtin/fast-export.c:1272
-msgid "Cannot pass both --import-marks and --import-marks-if-exists"
-msgstr "опциите „--import-marks“ и „--import-marks-if-exists“ са несъвместими"
-
-#: builtin/fast-import.c:3088
+#: builtin/fast-import.c:3090
 #, c-format
 msgid "Missing from marks for submodule '%s'"
 msgstr "Липсват маркери „от“ за подмодула „%s“"
 
-#: builtin/fast-import.c:3090
+#: builtin/fast-import.c:3092
 #, c-format
 msgid "Missing to marks for submodule '%s'"
 msgstr "Липсват маркери „до“ за подмодула „%s“"
 
-#: builtin/fast-import.c:3225
+#: builtin/fast-import.c:3227
 #, c-format
 msgid "Expected 'mark' command, got %s"
 msgstr "Очаква се команда „mark“, а бе получена: „%s“"
 
-#: builtin/fast-import.c:3230
+#: builtin/fast-import.c:3232
 #, c-format
 msgid "Expected 'to' command, got %s"
 msgstr "Очаква се команда „to“, а бе получена: „%s“"
 
-#: builtin/fast-import.c:3322
+#: builtin/fast-import.c:3324
 msgid "Expected format name:filename for submodule rewrite option"
 msgstr "опцията за презапис на подмодул изисква формат: име:име_на_файл"
 
-#: builtin/fast-import.c:3377
+#: builtin/fast-import.c:3379
 #, c-format
 msgid "feature '%s' forbidden in input without --allow-unsafe-features"
 msgstr "„%s“ изисква изричното задаване на опцията „--allow-unsafe-features“"
@@ -15685,120 +15619,120 @@ msgstr "„%s“ изисква изричното задаване на опц�
 msgid "Lockfile created but not reported: %s"
 msgstr "Заключващият файл е създаден, но не е докладван: „%s“"
 
-#: builtin/fetch.c:35
+#: builtin/fetch.c:36
 msgid "git fetch [<options>] [<repository> [<refspec>...]]"
 msgstr "git fetch [ОПЦИЯ…] [ХРАНИЛИЩЕ [УКАЗАТЕЛ…]]"
 
-#: builtin/fetch.c:36
+#: builtin/fetch.c:37
 msgid "git fetch [<options>] <group>"
 msgstr "git fetch [ОПЦИЯ…] ГРУПА"
 
-#: builtin/fetch.c:37
+#: builtin/fetch.c:38
 msgid "git fetch --multiple [<options>] [(<repository> | <group>)...]"
 msgstr "git fetch --multiple [ОПЦИЯ…] [(ХРАНИЛИЩЕ | ГРУПА)…]"
 
-#: builtin/fetch.c:38
+#: builtin/fetch.c:39
 msgid "git fetch --all [<options>]"
 msgstr "git fetch --all [ОПЦИЯ…]"
 
-#: builtin/fetch.c:122
+#: builtin/fetch.c:123
 msgid "fetch.parallel cannot be negative"
 msgstr "опцията „fetch.parallel“ трябва да е неотрицателна"
 
-#: builtin/fetch.c:145 builtin/pull.c:189
+#: builtin/fetch.c:146 builtin/pull.c:189
 msgid "fetch from all remotes"
 msgstr "доставяне от всички отдалечени хранилища"
 
-#: builtin/fetch.c:147 builtin/pull.c:249
+#: builtin/fetch.c:148 builtin/pull.c:249
 msgid "set upstream for git pull/fetch"
 msgstr "задаване на клон за следене за издърпване/доставяне"
 
-#: builtin/fetch.c:149 builtin/pull.c:192
+#: builtin/fetch.c:150 builtin/pull.c:192
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "добавяне към „.git/FETCH_HEAD“ вместо замяна"
 
-#: builtin/fetch.c:151
+#: builtin/fetch.c:152
 msgid "use atomic transaction to update references"
 msgstr "изискване на атомарни операции за обновяване на указателите"
 
-#: builtin/fetch.c:153 builtin/pull.c:195
+#: builtin/fetch.c:154 builtin/pull.c:195
 msgid "path to upload pack on remote end"
 msgstr "отдалечен път, където да се качи пакетът"
 
-#: builtin/fetch.c:154
+#: builtin/fetch.c:155
 msgid "force overwrite of local reference"
 msgstr "принудително презаписване на локален указател"
 
-#: builtin/fetch.c:156
+#: builtin/fetch.c:157
 msgid "fetch from multiple remotes"
 msgstr "доставяне от множество отдалечени хранилища"
 
-#: builtin/fetch.c:158 builtin/pull.c:199
+#: builtin/fetch.c:159 builtin/pull.c:199
 msgid "fetch all tags and associated objects"
 msgstr "доставяне на всички етикети и принадлежащи обекти"
 
-#: builtin/fetch.c:160
+#: builtin/fetch.c:161
 msgid "do not fetch all tags (--no-tags)"
 msgstr "без доставянето на всички етикети „--no-tags“"
 
-#: builtin/fetch.c:162
+#: builtin/fetch.c:163
 msgid "number of submodules fetched in parallel"
 msgstr "брой подмодули доставени паралелно"
 
-#: builtin/fetch.c:164
+#: builtin/fetch.c:165
 msgid "modify the refspec to place all refs within refs/prefetch/"
 msgstr ""
 "промяна на указателя, така че и той, както останалите, да бъде в „refs/"
 "prefetch/“"
 
-#: builtin/fetch.c:166 builtin/pull.c:202
+#: builtin/fetch.c:167 builtin/pull.c:202
 msgid "prune remote-tracking branches no longer on remote"
 msgstr "окастряне на клоните следящи вече несъществуващи отдалечени клони"
 
-#: builtin/fetch.c:168
+#: builtin/fetch.c:169
 msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr ""
 "окастряне на локалните етикети, които вече не съществуват в отдалеченото "
 "хранилище и презаписване на променените"
 
-#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:123
+#: builtin/fetch.c:170 builtin/fetch.c:195 builtin/pull.c:123
 msgid "on-demand"
 msgstr "ПРИ НУЖДА"
 
-#: builtin/fetch.c:170
+#: builtin/fetch.c:171
 msgid "control recursive fetching of submodules"
 msgstr "управление на рекурсивното доставяне на подмодулите"
 
-#: builtin/fetch.c:175
+#: builtin/fetch.c:176
 msgid "write fetched references to the FETCH_HEAD file"
 msgstr "запазване на доставените указатели във файла „FETCH_HEAD“"
 
-#: builtin/fetch.c:176 builtin/pull.c:210
+#: builtin/fetch.c:177 builtin/pull.c:210
 msgid "keep downloaded pack"
 msgstr "запазване на изтеглените пакети с обекти"
 
-#: builtin/fetch.c:178
+#: builtin/fetch.c:179
 msgid "allow updating of HEAD ref"
 msgstr "позволяване на обновяването на указателя „HEAD“"
 
-#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:213
+#: builtin/fetch.c:182 builtin/fetch.c:188 builtin/pull.c:213
 #: builtin/pull.c:222
 msgid "deepen history of shallow clone"
 msgstr "задълбочаване на историята на плитко хранилище"
 
-#: builtin/fetch.c:183 builtin/pull.c:216
+#: builtin/fetch.c:184 builtin/pull.c:216
 msgid "deepen history of shallow repository based on time"
 msgstr "задълбочаване на историята на плитко хранилище до определено време"
 
-#: builtin/fetch.c:189 builtin/pull.c:225
+#: builtin/fetch.c:190 builtin/pull.c:225
 msgid "convert to a complete repository"
 msgstr "превръщане в пълно хранилище"
 
-#: builtin/fetch.c:192
+#: builtin/fetch.c:193
 msgid "prepend this to submodule path output"
 msgstr "добавяне на това пред пътя на подмодула"
 
-#: builtin/fetch.c:195
+#: builtin/fetch.c:196
 msgid ""
 "default for recursive fetching of submodules (lower priority than config "
 "files)"
@@ -15806,49 +15740,49 @@ msgstr ""
 "стандартно рекурсивно изтегляне на подмодулите (файловете с настройки са с "
 "приоритет)"
 
-#: builtin/fetch.c:199 builtin/pull.c:228
+#: builtin/fetch.c:200 builtin/pull.c:228
 msgid "accept refs that update .git/shallow"
 msgstr "приемане на указатели, които обновяват „.git/shallow“"
 
-#: builtin/fetch.c:200 builtin/pull.c:230
+#: builtin/fetch.c:201 builtin/pull.c:230
 msgid "refmap"
 msgstr "КАРТА_С_УКАЗАТЕЛИ"
 
-#: builtin/fetch.c:201 builtin/pull.c:231
+#: builtin/fetch.c:202 builtin/pull.c:231
 msgid "specify fetch refmap"
 msgstr "указване на КАРТАта_С_УКАЗАТЕЛИ за доставяне"
 
-#: builtin/fetch.c:208 builtin/pull.c:244
+#: builtin/fetch.c:209 builtin/pull.c:244
 msgid "report that we have only objects reachable from this object"
 msgstr "докладване, че всички обекти може са достижими при започване от този"
 
-#: builtin/fetch.c:210
+#: builtin/fetch.c:211
 msgid "do not fetch a packfile; instead, print ancestors of negotiation tips"
 msgstr ""
 "без доставяне на пакетни файлове, вместо това да се извеждат предшественици "
 "на договорните върхове"
 
-#: builtin/fetch.c:213 builtin/fetch.c:215
+#: builtin/fetch.c:214 builtin/fetch.c:216
 msgid "run 'maintenance --auto' after fetching"
 msgstr "изпълняване на „maintenance --auto“ след доставяне"
 
-#: builtin/fetch.c:217 builtin/pull.c:247
+#: builtin/fetch.c:218 builtin/pull.c:247
 msgid "check for forced-updates on all updated branches"
 msgstr "проверка за принудителни обновявания на всички клони"
 
-#: builtin/fetch.c:219
+#: builtin/fetch.c:220
 msgid "write the commit-graph after fetching"
 msgstr "запазване на гра̀фа с подаванията след доставяне"
 
-#: builtin/fetch.c:221
+#: builtin/fetch.c:222
 msgid "accept refspecs from stdin"
 msgstr "четене на указателите от стандартния вход"
 
-#: builtin/fetch.c:586
-msgid "Couldn't find remote ref HEAD"
-msgstr "Указателят „HEAD“ в отдалеченото хранилище не може да бъде открит"
+#: builtin/fetch.c:587
+msgid "couldn't find remote ref HEAD"
+msgstr "указателят „HEAD“ в отдалеченото хранилище не може да бъде открит"
 
-#: builtin/fetch.c:760
+#: builtin/fetch.c:761
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "настройката „fetch.output“ е с неправилна стойност „%s“"
@@ -15862,7 +15796,7 @@ msgstr "обектът „%s“ липсва"
 msgid "[up to date]"
 msgstr "[актуален]"
 
-#: builtin/fetch.c:879 builtin/fetch.c:895 builtin/fetch.c:967
+#: builtin/fetch.c:878 builtin/fetch.c:896 builtin/fetch.c:968
 msgid "[rejected]"
 msgstr "[отхвърлен]"
 
@@ -15870,57 +15804,63 @@ msgstr "[отхвърлен]"
 msgid "can't fetch in current branch"
 msgstr "в текущия клон не може да се доставя"
 
-#: builtin/fetch.c:890
+#: builtin/fetch.c:881
+msgid "checked out in another worktree"
+msgstr "изтеглен в друго работно дърво"
+
+#: builtin/fetch.c:891
 msgid "[tag update]"
 msgstr "[обновяване на етикетите]"
 
-#: builtin/fetch.c:891 builtin/fetch.c:928 builtin/fetch.c:950
-#: builtin/fetch.c:962
+#: builtin/fetch.c:892 builtin/fetch.c:929 builtin/fetch.c:951
+#: builtin/fetch.c:963
 msgid "unable to update local ref"
 msgstr "локален указател не може да бъде обновен"
 
-#: builtin/fetch.c:895
+#: builtin/fetch.c:896
 msgid "would clobber existing tag"
 msgstr "съществуващ етикет ще бъде презаписан"
 
-#: builtin/fetch.c:917
+#: builtin/fetch.c:918
 msgid "[new tag]"
 msgstr "[нов етикет]"
 
-#: builtin/fetch.c:920
+#: builtin/fetch.c:921
 msgid "[new branch]"
 msgstr "[нов клон]"
 
-#: builtin/fetch.c:923
+#: builtin/fetch.c:924
 msgid "[new ref]"
 msgstr "[нов указател]"
 
-#: builtin/fetch.c:962
+#: builtin/fetch.c:963
 msgid "forced update"
 msgstr "принудително обновяване"
 
-#: builtin/fetch.c:967
+#: builtin/fetch.c:968
 msgid "non-fast-forward"
 msgstr "същинско сливане"
 
-#: builtin/fetch.c:1070
+#: builtin/fetch.c:1071
 msgid ""
-"Fetch normally indicates which branches had a forced update,\n"
-"but that check has been disabled. To re-enable, use '--show-forced-updates'\n"
-"flag or run 'git config fetch.showForcedUpdates true'."
+"fetch normally indicates which branches had a forced update,\n"
+"but that check has been disabled; to re-enable, use '--show-forced-updates'\n"
+"flag or run 'git config fetch.showForcedUpdates true'"
 msgstr ""
-"За да я включите еднократно ползвайте опцията „--show-forced-updates“, а за "
-"да я включите за постоянно, изпълнете:\n"
+"Обичайно при доставяне се извежда, кои клони са били принудително обновени,\n"
+"но тази проверка е изключена.  За да я включите за командата, ползвайте "
+"опцията\n"
+"„--show-forced-updates“, а за да я включите за постоянно, изпълнете:\n"
 "\n"
 "    git config fetch.showForcedUpdates true"
 
-#: builtin/fetch.c:1074
+#: builtin/fetch.c:1075
 #, c-format
 msgid ""
-"It took %.2f seconds to check forced updates. You can use\n"
+"it took %.2f seconds to check forced updates; you can use\n"
 "'--no-show-forced-updates' or run 'git config fetch.showForcedUpdates "
 "false'\n"
-" to avoid this check.\n"
+"to avoid this check\n"
 msgstr ""
 "Проверката за принудителни изтласквания отне %.2f сек.  Може да я прескочите "
 "еднократно с опцията „--no-show-forced-updates“, а за да я изключите за "
@@ -15928,23 +15868,23 @@ msgstr ""
 "\n"
 "    git config fetch.showForcedUpdates false\n"
 
-#: builtin/fetch.c:1105
+#: builtin/fetch.c:1107
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "хранилището „%s“ не изпрати всички необходими обекти\n"
 
-#: builtin/fetch.c:1134
+#: builtin/fetch.c:1136
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr ""
 "отхвърляне на „%s“, защото плитките върхове не може да бъдат обновявани"
 
-#: builtin/fetch.c:1223 builtin/fetch.c:1371
+#: builtin/fetch.c:1226 builtin/fetch.c:1374
 #, c-format
 msgid "From %.*s\n"
 msgstr "От %.*s\n"
 
-#: builtin/fetch.c:1244
+#: builtin/fetch.c:1247
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -15954,143 +15894,144 @@ msgstr ""
 "„git remote prune %s“, за да премахнете остарелите клони, които\n"
 "предизвикват конфликта"
 
-#: builtin/fetch.c:1341
+#: builtin/fetch.c:1344
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (обектът „%s“ ще се окаже извън клон)"
 
-#: builtin/fetch.c:1342
+#: builtin/fetch.c:1345
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (обектът „%s“ вече е извън клон)"
 
-#: builtin/fetch.c:1374
+#: builtin/fetch.c:1377
 msgid "[deleted]"
 msgstr "[изтрит]"
 
-#: builtin/fetch.c:1375 builtin/remote.c:1128
+#: builtin/fetch.c:1378 builtin/remote.c:1128
 msgid "(none)"
 msgstr "(нищо)"
 
-#: builtin/fetch.c:1398
+#: builtin/fetch.c:1400
 #, c-format
-msgid "Refusing to fetch into current branch %s of non-bare repository"
-msgstr "Не може да доставите в текущия клон „%s“ на хранилище, което не е голо"
-
-#: builtin/fetch.c:1417
-#, c-format
-msgid "Option \"%s\" value \"%s\" is not valid for %s"
-msgstr "Стойността „%2$s“ за опцията „%1$s“ не е съвместима с „%3$s“"
+msgid "refusing to fetch into branch '%s' checked out at '%s'"
+msgstr "не може да доставите в клона „%s“, който е изтеглен в пътя „%s“"
 
 #: builtin/fetch.c:1420
 #, c-format
-msgid "Option \"%s\" is ignored for %s\n"
+msgid "option \"%s\" value \"%s\" is not valid for %s"
+msgstr "стойността „%2$s“ за опцията „%1$s“ не е съвместима с „%3$s“"
+
+#: builtin/fetch.c:1423
+#, c-format
+msgid "option \"%s\" is ignored for %s\n"
 msgstr "опцията „%s“ се прескача при „%s“\n"
 
-#: builtin/fetch.c:1447
+#: builtin/fetch.c:1450
 #, c-format
 msgid "the object %s does not exist"
 msgstr "обектът „%s“ не съществува"
 
-#: builtin/fetch.c:1633
+#: builtin/fetch.c:1638
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr ""
 "засечени са множество клони, това е несъвместимо с опцията „--set-upstream“"
 
-#: builtin/fetch.c:1648
+#: builtin/fetch.c:1650
+#, c-format
+msgid ""
+"could not set upstream of HEAD to '%s' from '%s' when it does not point to "
+"any branch."
+msgstr ""
+"следеното от „HEAD“ не може да се смени от „%2$s“ на „%1$s“, защото второто "
+"не сочи към никой клон."
+
+#: builtin/fetch.c:1663
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "не може да указвате клон за следене на отдалечен етикет"
 
-#: builtin/fetch.c:1650
+#: builtin/fetch.c:1665
 msgid "not setting upstream for a remote tag"
 msgstr "не може да указвате клон за следене на отдалечен етикет"
 
-#: builtin/fetch.c:1652
+#: builtin/fetch.c:1667
 msgid "unknown branch type"
 msgstr "непознат вид клон"
 
-#: builtin/fetch.c:1654
+#: builtin/fetch.c:1669
 msgid ""
-"no source branch found.\n"
-"you need to specify exactly one branch with the --set-upstream option."
+"no source branch found;\n"
+"you need to specify exactly one branch with the --set-upstream option"
 msgstr ""
-"не е открит клон за следене.\n"
-"Трябва изрично да зададете един клон с опцията „--set-upstream option“."
+"не е открит клон за следене;\n"
+"трябва изрично да зададете точно един клон с опцията „--set-upstream“"
 
-#: builtin/fetch.c:1783 builtin/fetch.c:1846
+#: builtin/fetch.c:1799 builtin/fetch.c:1862
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Доставяне на „%s“\n"
 
-#: builtin/fetch.c:1793 builtin/fetch.c:1848 builtin/remote.c:101
+#: builtin/fetch.c:1809 builtin/fetch.c:1864
 #, c-format
-msgid "Could not fetch %s"
+msgid "could not fetch %s"
 msgstr "„%s“ не може да се достави"
 
-#: builtin/fetch.c:1805
+#: builtin/fetch.c:1821
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "„%s“ не може да се достави (изходният код е: %d)\n"
 
-#: builtin/fetch.c:1909
+#: builtin/fetch.c:1925
 msgid ""
-"No remote repository specified.  Please, specify either a URL or a\n"
-"remote name from which new revisions should be fetched."
+"no remote repository specified; please specify either a URL or a\n"
+"remote name from which new revisions should be fetched"
 msgstr ""
-"Не сте указали отдалечено хранилище.  Задайте или адрес, или име\n"
+"не сте указали отдалечено хранилище; задайте или адрес, или име\n"
 "на отдалечено хранилище, откъдето да се доставят новите версии."
 
-#: builtin/fetch.c:1945
-msgid "You need to specify a tag name."
-msgstr "Трябва да укажете име на етикет."
+#: builtin/fetch.c:1961
+msgid "you need to specify a tag name"
+msgstr "трябва да укажете име на етикет"
 
-#: builtin/fetch.c:2009
+#: builtin/fetch.c:2027
 msgid "--negotiate-only needs one or more --negotiate-tip=*"
 msgstr ""
 "Опцията „--negotiate-only“ изисква една или повече опции „--negotiate-tip=*“"
 
-#: builtin/fetch.c:2013
-msgid "Negative depth in --deepen is not supported"
-msgstr "Отрицателна дълбочина като аргумент на „--deepen“ не се поддържа"
+#: builtin/fetch.c:2031
+msgid "negative depth in --deepen is not supported"
+msgstr "отрицателна дълбочина като аргумент на „--deepen“ не се поддържа"
 
-#: builtin/fetch.c:2015
-msgid "--deepen and --depth are mutually exclusive"
-msgstr "опциите „--deepen“ и „--depth“ са несъвместими"
-
-#: builtin/fetch.c:2020
-msgid "--depth and --unshallow cannot be used together"
-msgstr "опциите „--depth“ и „--unshallow“ са несъвместими"
-
-#: builtin/fetch.c:2022
+#: builtin/fetch.c:2040
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "не може да използвате опцията „--unshallow“ върху пълно хранилище"
 
-#: builtin/fetch.c:2039
+#: builtin/fetch.c:2057
 msgid "fetch --all does not take a repository argument"
 msgstr "към „git fetch --all“ не може да добавите аргумент-хранилище"
 
-#: builtin/fetch.c:2041
+#: builtin/fetch.c:2059
 msgid "fetch --all does not make sense with refspecs"
 msgstr "към „git fetch --all“ не може да добавите аргумент-указател на версия"
 
-#: builtin/fetch.c:2050
+#: builtin/fetch.c:2068
 #, c-format
-msgid "No such remote or remote group: %s"
-msgstr "Няма нито отдалечено хранилище, нито група от хранилища на име „%s“"
+msgid "no such remote or remote group: %s"
+msgstr "няма нито отдалечено хранилище, нито група от хранилища на име „%s“"
 
-#: builtin/fetch.c:2057
-msgid "Fetching a group and specifying refspecs does not make sense"
-msgstr "Указването на група и указването на версия са несъвместими"
+#: builtin/fetch.c:2076
+msgid "fetching a group and specifying refspecs does not make sense"
+msgstr "доставянето на група и указването на версия са несъвместими"
 
-#: builtin/fetch.c:2073
+#: builtin/fetch.c:2092
 msgid "must supply remote when using --negotiate-only"
 msgstr "опцията „--negotiate-only“ изисква хранилище"
 
-#: builtin/fetch.c:2078
-msgid "Protocol does not support --negotiate-only, exiting."
-msgstr "Протоколът не поддържа опцията „--negotiate-only“, изход от прогамата."
-
 #: builtin/fetch.c:2097
+msgid "protocol does not support --negotiate-only, exiting"
+msgstr "протоколът не поддържа опцията „--negotiate-only“, изход от програмата"
+
+#: builtin/fetch.c:2116
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -16098,12 +16039,12 @@ msgstr ""
 "опцията „--filter“ може да се ползва само с отдалеченото хранилище указано в "
 "настройката „extensions.partialclone“"
 
-#: builtin/fetch.c:2101
+#: builtin/fetch.c:2120
 msgid "--atomic can only be used when fetching from one remote"
 msgstr ""
 "опцията „--atomic“ поддържа доставяне само от едно отдалечено хранилище"
 
-#: builtin/fetch.c:2105
+#: builtin/fetch.c:2124
 msgid "--stdin can only be used when fetching from one remote"
 msgstr "опцията „--stdin“ поддържа доставяне само от едно отдалечено хранилище"
 
@@ -16113,25 +16054,29 @@ msgid ""
 msgstr ""
 "git fmt-merge-msg [-m СЪОБЩЕНИЕ] [--log[=БРОЙ] | --no-log] [--file ФАЙЛ]"
 
-#: builtin/fmt-merge-msg.c:18
+#: builtin/fmt-merge-msg.c:19
 msgid "populate log with at most <n> entries from shortlog"
 msgstr ""
 "вмъкване на журнал състоящ се от не повече от БРОЙ записа от съкратения "
 "журнал"
 
-#: builtin/fmt-merge-msg.c:21
+#: builtin/fmt-merge-msg.c:22
 msgid "alias for --log (deprecated)"
 msgstr "псевдоним на „--log“ (ОСТАРЯЛО)"
 
-#: builtin/fmt-merge-msg.c:24
+#: builtin/fmt-merge-msg.c:25
 msgid "text"
 msgstr "ТЕКСТ"
 
-#: builtin/fmt-merge-msg.c:25
+#: builtin/fmt-merge-msg.c:26
 msgid "use <text> as start of message"
 msgstr "за начало на съобщението да се ползва ТЕКСТ"
 
-#: builtin/fmt-merge-msg.c:26
+#: builtin/fmt-merge-msg.c:28
+msgid "use <name> instead of the real target branch"
+msgstr "използване на това ИМЕ вместо истинския клон-цел"
+
+#: builtin/fmt-merge-msg.c:29
 msgid "file to read from"
 msgstr "файл, от който да се чете"
 
@@ -16151,47 +16096,47 @@ msgstr "git for-each-ref [--merged [ПОДАВАНЕ]] [--no-merged [ПОДАВ�
 msgid "git for-each-ref [--contains [<commit>]] [--no-contains [<commit>]]"
 msgstr "git for-each-ref [--contains [ПОДАВАНЕ]] [--no-contains [ПОДАВАНЕ]]"
 
-#: builtin/for-each-ref.c:30
+#: builtin/for-each-ref.c:31
 msgid "quote placeholders suitably for shells"
 msgstr "цитиране подходящо за командни интерпретатори на обвивката"
 
-#: builtin/for-each-ref.c:32
+#: builtin/for-each-ref.c:33
 msgid "quote placeholders suitably for perl"
 msgstr "цитиране подходящо за perl"
 
-#: builtin/for-each-ref.c:34
+#: builtin/for-each-ref.c:35
 msgid "quote placeholders suitably for python"
 msgstr "цитиране подходящо за python"
 
-#: builtin/for-each-ref.c:36
+#: builtin/for-each-ref.c:37
 msgid "quote placeholders suitably for Tcl"
 msgstr "цитиране подходящо за tcl"
 
-#: builtin/for-each-ref.c:39
+#: builtin/for-each-ref.c:40
 msgid "show only <n> matched refs"
 msgstr "извеждане само на този БРОЙ напаснати указатели"
 
-#: builtin/for-each-ref.c:41 builtin/tag.c:481
+#: builtin/for-each-ref.c:42 builtin/tag.c:481
 msgid "respect format colors"
 msgstr "спазване на цветовете на форма̀та"
 
-#: builtin/for-each-ref.c:44
+#: builtin/for-each-ref.c:45
 msgid "print only refs which points at the given object"
 msgstr "извеждане само на указателите, сочещи към ОБЕКТА"
 
-#: builtin/for-each-ref.c:46
+#: builtin/for-each-ref.c:47
 msgid "print only refs that are merged"
 msgstr "извеждане само на слетите указатели"
 
-#: builtin/for-each-ref.c:47
+#: builtin/for-each-ref.c:48
 msgid "print only refs that are not merged"
 msgstr "извеждане само на неслетите указатели"
 
-#: builtin/for-each-ref.c:48
+#: builtin/for-each-ref.c:49
 msgid "print only refs which contain the commit"
 msgstr "извеждане само на указателите, които съдържат това ПОДАВАНЕ"
 
-#: builtin/for-each-ref.c:49
+#: builtin/for-each-ref.c:50
 msgid "print only refs which don't contain the commit"
 msgstr "извеждане само на указателите, които не съдържат това ПОДАВАНЕ"
 
@@ -16342,125 +16287,125 @@ msgstr "%s: развален или липсващ обект: %s"
 msgid "%s: object is of unknown type '%s': %s"
 msgstr "%s: обектът е непознат вид „%s“: %s"
 
-#: builtin/fsck.c:644
+#: builtin/fsck.c:645
 #, c-format
 msgid "%s: object could not be parsed: %s"
 msgstr "„%s“: не може да се анализира: „%s“"
 
-#: builtin/fsck.c:664
+#: builtin/fsck.c:665
 #, c-format
 msgid "bad sha1 file: %s"
 msgstr "неправилен ред с контролна сума по SHA1: „%s“"
 
-#: builtin/fsck.c:685
+#: builtin/fsck.c:686
 msgid "Checking object directory"
 msgstr "Проверка на директория с обекти"
 
-#: builtin/fsck.c:688
+#: builtin/fsck.c:689
 msgid "Checking object directories"
 msgstr "Проверка на директориите с обекти"
 
-#: builtin/fsck.c:704
+#: builtin/fsck.c:705
 #, c-format
 msgid "Checking %s link"
 msgstr "Проверка на връзките на „%s“"
 
 #
-#: builtin/fsck.c:709 builtin/index-pack.c:859
+#: builtin/fsck.c:710 builtin/index-pack.c:859
 #, c-format
 msgid "invalid %s"
 msgstr "неправилен указател „%s“"
 
-#: builtin/fsck.c:716
+#: builtin/fsck.c:717
 #, c-format
 msgid "%s points to something strange (%s)"
 msgstr "„%s“ сочи към нещо необичайно (%s)"
 
-#: builtin/fsck.c:722
+#: builtin/fsck.c:723
 #, c-format
 msgid "%s: detached HEAD points at nothing"
 msgstr "%s: несвързаният връх „HEAD“ не сочи към нищо"
 
-#: builtin/fsck.c:726
+#: builtin/fsck.c:727
 #, c-format
 msgid "notice: %s points to an unborn branch (%s)"
 msgstr "предупреждение: „%s“ сочи към все още несъществуващ клон (%s)"
 
-#: builtin/fsck.c:738
+#: builtin/fsck.c:739
 msgid "Checking cache tree"
 msgstr "Проверка на дървото на кеша"
 
-#: builtin/fsck.c:743
+#: builtin/fsck.c:744
 #, c-format
 msgid "%s: invalid sha1 pointer in cache-tree"
 msgstr "„%s“: неправилен указател за SHA1 в дървото на кеша"
 
-#: builtin/fsck.c:752
+#: builtin/fsck.c:753
 msgid "non-tree in cache-tree"
 msgstr "в дървото на кеша има нещо, което не е дърво"
 
-#: builtin/fsck.c:783
+#: builtin/fsck.c:784
 msgid "git fsck [<options>] [<object>...]"
 msgstr "git fsck [ОПЦИЯ…] [ОБЕКТ…]"
 
-#: builtin/fsck.c:789
+#: builtin/fsck.c:790
 msgid "show unreachable objects"
 msgstr "показване на недостижимите обекти"
 
-#: builtin/fsck.c:790
+#: builtin/fsck.c:791
 msgid "show dangling objects"
 msgstr "показване на обектите извън клоните"
 
-#: builtin/fsck.c:791
+#: builtin/fsck.c:792
 msgid "report tags"
 msgstr "показване на етикетите"
 
-#: builtin/fsck.c:792
+#: builtin/fsck.c:793
 msgid "report root nodes"
 msgstr "показване на кореновите възли"
 
-#: builtin/fsck.c:793
+#: builtin/fsck.c:794
 msgid "make index objects head nodes"
 msgstr "задаване на обекти от индекса да са коренови"
 
-#: builtin/fsck.c:794
+#: builtin/fsck.c:795
 msgid "make reflogs head nodes (default)"
 msgstr "проследяване и на указателите от журнала с указателите (стандартно)"
 
-#: builtin/fsck.c:795
+#: builtin/fsck.c:796
 msgid "also consider packs and alternate objects"
 msgstr "допълнително да се проверяват пакетите и алтернативните обекти"
 
-#: builtin/fsck.c:796
+#: builtin/fsck.c:797
 msgid "check only connectivity"
 msgstr "проверка само на връзката"
 
-#: builtin/fsck.c:797 builtin/mktag.c:76
+#: builtin/fsck.c:798 builtin/mktag.c:76
 msgid "enable more strict checking"
 msgstr "по-строги проверки"
 
-#: builtin/fsck.c:799
+#: builtin/fsck.c:800
 msgid "write dangling objects in .git/lost-found"
 msgstr "запазване на обектите извън клоните в директорията „.git/lost-found“"
 
-#: builtin/fsck.c:800 builtin/prune.c:134
+#: builtin/fsck.c:801 builtin/prune.c:146
 msgid "show progress"
 msgstr "показване на напредъка"
 
-#: builtin/fsck.c:801
+#: builtin/fsck.c:802
 msgid "show verbose names for reachable objects"
 msgstr "показване на подробни имена на достижимите обекти"
 
-#: builtin/fsck.c:861 builtin/index-pack.c:261
+#: builtin/fsck.c:862 builtin/index-pack.c:261
 msgid "Checking objects"
 msgstr "Проверка на обектите"
 
-#: builtin/fsck.c:889
+#: builtin/fsck.c:890
 #, c-format
 msgid "%s: object missing"
 msgstr "„%s“: липсващ обект"
 
-#: builtin/fsck.c:900
+#: builtin/fsck.c:901
 #, c-format
 msgid "invalid parameter: expected sha1, got '%s'"
 msgstr "неправилен параметър: очаква се SHA1, а бе получено: „%s“"
@@ -16479,17 +16424,12 @@ msgstr "Неуспешно изпълнение на „fstat“ върху „%
 msgid "failed to parse '%s' value '%s'"
 msgstr "стойността на „%s“ — „%s“ не може да се анализира"
 
-#: builtin/gc.c:487 builtin/init-db.c:57
+#: builtin/gc.c:488 builtin/init-db.c:57
 #, c-format
 msgid "cannot stat '%s'"
 msgstr "не може да се получи информация чрез „stat“ за директорията „%s“"
 
-#: builtin/gc.c:496 builtin/notes.c:238 builtin/tag.c:574
-#, c-format
-msgid "cannot read '%s'"
-msgstr "файлът „%s“ не може да бъде прочетен"
-
-#: builtin/gc.c:503
+#: builtin/gc.c:504
 #, c-format
 msgid ""
 "The last gc run reported the following. Please correct the root cause\n"
@@ -16505,58 +16445,58 @@ msgstr ""
 "\n"
 "%s"
 
-#: builtin/gc.c:551
+#: builtin/gc.c:552
 msgid "prune unreferenced objects"
 msgstr "окастряне на обектите, към които нищо не сочи"
 
-#: builtin/gc.c:553
+#: builtin/gc.c:554
 msgid "be more thorough (increased runtime)"
 msgstr "изчерпателно търсене на боклука (за сметка на повече време работа)"
 
-#: builtin/gc.c:554
+#: builtin/gc.c:555
 msgid "enable auto-gc mode"
 msgstr "включване на автоматичното събиране на боклука (auto-gc)"
 
-#: builtin/gc.c:557
+#: builtin/gc.c:558
 msgid "force running gc even if there may be another gc running"
 msgstr ""
 "изрично стартиране на събирането на боклука, дори и ако вече работи друго "
 "събиране"
 
-#: builtin/gc.c:560
+#: builtin/gc.c:561
 msgid "repack all other packs except the largest pack"
 msgstr "препакетиране на всичко без най-големия пакет"
 
-#: builtin/gc.c:576
+#: builtin/gc.c:577
 #, c-format
 msgid "failed to parse gc.logexpiry value %s"
 msgstr "неразпозната стойност на „gc.logexpiry“ %s"
 
-#: builtin/gc.c:587
+#: builtin/gc.c:588
 #, c-format
 msgid "failed to parse prune expiry value %s"
 msgstr "неразпозната стойност на периода за окастряне: %s"
 
-#: builtin/gc.c:607
+#: builtin/gc.c:608
 #, c-format
 msgid "Auto packing the repository in background for optimum performance.\n"
 msgstr ""
 "Автоматично пакетиране на заден фон на хранилището за по-добра "
 "производителност.\n"
 
-#: builtin/gc.c:609
+#: builtin/gc.c:610
 #, c-format
 msgid "Auto packing the repository for optimum performance.\n"
 msgstr "Автоматично пакетиране на хранилището за по-добра производителност.\n"
 
-#: builtin/gc.c:610
+#: builtin/gc.c:611
 #, c-format
 msgid "See \"git help gc\" for manual housekeeping.\n"
 msgstr ""
 "Погледнете ръководството за повече информация как да изпълните „git help "
 "gc“.\n"
 
-#: builtin/gc.c:650
+#: builtin/gc.c:652
 #, c-format
 msgid ""
 "gc is already running on machine '%s' pid %<PRIuMAX> (use --force if not)"
@@ -16565,214 +16505,214 @@ msgstr ""
 "процеса: %<PRIuMAX> (ако сте сигурни, че това не е вярно, това използвайте\n"
 "опцията „--force“)"
 
-#: builtin/gc.c:705
+#: builtin/gc.c:707
 msgid ""
 "There are too many unreachable loose objects; run 'git prune' to remove them."
 msgstr ""
 "Има прекалено много недостижими, непакетирани обекти.\n"
 "Използвайте „git prune“, за да ги окастрите."
 
-#: builtin/gc.c:715
+#: builtin/gc.c:717
 msgid ""
 "git maintenance run [--auto] [--[no-]quiet] [--task=<task>] [--schedule]"
 msgstr ""
 "git maintenance run [--auto] [--[no-]quiet] [--task=ЗАДАЧА] [--schedule]"
 
-#: builtin/gc.c:745
+#: builtin/gc.c:747
 msgid "--no-schedule is not allowed"
 msgstr "опцията „--no-schedule“ не е позволена"
 
-#: builtin/gc.c:750
+#: builtin/gc.c:752
 #, c-format
 msgid "unrecognized --schedule argument '%s'"
 msgstr "непознат аргумент към „--schedule“: %s"
 
-#: builtin/gc.c:868
+#: builtin/gc.c:870
 msgid "failed to write commit-graph"
 msgstr "графът с подаванията не може да бъде записан"
 
-#: builtin/gc.c:904
+#: builtin/gc.c:906
 msgid "failed to prefetch remotes"
 msgstr "неуспешно предварително доставяне на отдалечените клони"
 
-#: builtin/gc.c:1020
+#: builtin/gc.c:1022
 msgid "failed to start 'git pack-objects' process"
 msgstr "процесът за командата „git pack-objects“ не може да бъде стартиран"
 
-#: builtin/gc.c:1037
+#: builtin/gc.c:1039
 msgid "failed to finish 'git pack-objects' process"
 msgstr "процесът за командата „git pack-objects“ не може да завърши"
 
-#: builtin/gc.c:1088
+#: builtin/gc.c:1090
 msgid "failed to write multi-pack-index"
 msgstr "индексът за множество пакети не може да бъде записан"
 
-#: builtin/gc.c:1104
+#: builtin/gc.c:1106
 msgid "'git multi-pack-index expire' failed"
 msgstr "неуспешно изпълнение на „git multi-pack-index expire“"
 
-#: builtin/gc.c:1163
+#: builtin/gc.c:1165
 msgid "'git multi-pack-index repack' failed"
 msgstr "неуспешно изпълнение на „git multi-pack-index repack“"
 
-#: builtin/gc.c:1172
+#: builtin/gc.c:1174
 msgid ""
 "skipping incremental-repack task because core.multiPackIndex is disabled"
 msgstr ""
 "задачата „incremental-repack“ се прескача, защото настройката „core."
 "multiPackIndex“ е изключена"
 
-#: builtin/gc.c:1276
+#: builtin/gc.c:1278
 #, c-format
 msgid "lock file '%s' exists, skipping maintenance"
 msgstr "заключващият файл „%s“ съществува.  Действието се прескача"
 
-#: builtin/gc.c:1306
+#: builtin/gc.c:1308
 #, c-format
 msgid "task '%s' failed"
 msgstr "неуспешно изпълнение на задачата „%s“"
 
-#: builtin/gc.c:1388
+#: builtin/gc.c:1390
 #, c-format
 msgid "'%s' is not a valid task"
 msgstr "„%s“ не е правилна задача"
 
-#: builtin/gc.c:1393
+#: builtin/gc.c:1395
 #, c-format
 msgid "task '%s' cannot be selected multiple times"
 msgstr "задачата „%s“ не може да се избере повече от веднъж"
 
-#: builtin/gc.c:1408
+#: builtin/gc.c:1410
 msgid "run tasks based on the state of the repository"
 msgstr "изпълняване на задачи според състоянието на хранилището"
 
-#: builtin/gc.c:1409
+#: builtin/gc.c:1411
 msgid "frequency"
 msgstr "честота"
 
-#: builtin/gc.c:1410
+#: builtin/gc.c:1412
 msgid "run tasks based on frequency"
 msgstr "изпълняване на задачи по график"
 
-#: builtin/gc.c:1413
+#: builtin/gc.c:1415
 msgid "do not report progress or other information over stderr"
 msgstr "без извеждане на напредъка и друга информация на стандартния изход"
 
-#: builtin/gc.c:1414
+#: builtin/gc.c:1416
 msgid "task"
 msgstr "задача"
 
-#: builtin/gc.c:1415
+#: builtin/gc.c:1417
 msgid "run a specific task"
 msgstr "изпълнение на определена задача"
 
-#: builtin/gc.c:1432
+#: builtin/gc.c:1434
 msgid "use at most one of --auto and --schedule=<frequency>"
 msgstr "опциите „--auto“ и „--schedule=ЧЕСТОТА“ са несъвместими"
 
-#: builtin/gc.c:1475
+#: builtin/gc.c:1477
 msgid "failed to run 'git config'"
 msgstr "неуспешно изпълнение на „git config“"
 
-#: builtin/gc.c:1627
+#: builtin/gc.c:1629
 #, c-format
 msgid "failed to expand path '%s'"
 msgstr "грешка при заместването на пътя „%s“"
 
-#: builtin/gc.c:1654 builtin/gc.c:1692
+#: builtin/gc.c:1656 builtin/gc.c:1694
 msgid "failed to start launchctl"
 msgstr "неуспешно стартиране на „launchctl“."
 
-#: builtin/gc.c:1767 builtin/gc.c:2220
+#: builtin/gc.c:1769 builtin/gc.c:2237
 #, c-format
 msgid "failed to create directories for '%s'"
 msgstr "директориите за „%s“ не може да бъдат създадени"
 
-#: builtin/gc.c:1794
+#: builtin/gc.c:1796
 #, c-format
 msgid "failed to bootstrap service %s"
 msgstr "услугата „%s“ не може се настрои първоначално"
 
-#: builtin/gc.c:1887
+#: builtin/gc.c:1889
 msgid "failed to create temp xml file"
 msgstr "неуспешно създаване на временен файл за xml"
 
-#: builtin/gc.c:1977
+#: builtin/gc.c:1979
 msgid "failed to start schtasks"
 msgstr "задачите за периодично изпълнение не може да се стартират"
 
-#: builtin/gc.c:2046
+#: builtin/gc.c:2063
 msgid "failed to run 'crontab -l'; your system might not support 'cron'"
 msgstr ""
 "неуспешно изпълнение на „crontab -l“.  Системата ви може да не поддържа "
 "„cron“"
 
-#: builtin/gc.c:2063
+#: builtin/gc.c:2080
 msgid "failed to run 'crontab'; your system might not support 'cron'"
 msgstr ""
 "неуспешно изпълнение на „crontab“.  Системата ви може да не поддържа „cron“"
 
-#: builtin/gc.c:2067
+#: builtin/gc.c:2084
 msgid "failed to open stdin of 'crontab'"
 msgstr "стандартният вход на „crontab“ не може да се отвори"
 
-#: builtin/gc.c:2109
+#: builtin/gc.c:2126
 msgid "'crontab' died"
 msgstr "процесът на „crontab“ умря"
 
-#: builtin/gc.c:2174
+#: builtin/gc.c:2191
 msgid "failed to start systemctl"
 msgstr "неуспешно стартиране на „systemctl“"
 
-#: builtin/gc.c:2184
+#: builtin/gc.c:2201
 msgid "failed to run systemctl"
 msgstr "неуспешно изпълнение на „systemctl“"
 
-#: builtin/gc.c:2193 builtin/gc.c:2198 builtin/worktree.c:62
-#: builtin/worktree.c:945
+#: builtin/gc.c:2210 builtin/gc.c:2215 builtin/worktree.c:62
+#: builtin/worktree.c:944
 #, c-format
 msgid "failed to delete '%s'"
 msgstr "неуспешно изтриване на „%s“"
 
-#: builtin/gc.c:2378
+#: builtin/gc.c:2395
 #, c-format
 msgid "unrecognized --scheduler argument '%s'"
 msgstr "непознат аргумент към „--scheduler“: %s"
 
-#: builtin/gc.c:2403
+#: builtin/gc.c:2420
 msgid "neither systemd timers nor crontab are available"
 msgstr "липсват както таймери на systemd, така и crontab"
 
-#: builtin/gc.c:2418
+#: builtin/gc.c:2435
 #, c-format
 msgid "%s scheduler is not available"
 msgstr "планиращият модул „%s“ липсва"
 
-#: builtin/gc.c:2432
+#: builtin/gc.c:2449
 msgid "another process is scheduling background maintenance"
 msgstr "друг процес задава поддръжката на заден фон"
 
-#: builtin/gc.c:2454
+#: builtin/gc.c:2471
 msgid "git maintenance start [--scheduler=<scheduler>]"
 msgstr "git maintenance start [--scheduler=ПЛАНИРАЩ_МОДУЛ]"
 
-#: builtin/gc.c:2463
+#: builtin/gc.c:2480
 msgid "scheduler"
 msgstr "ПЛАНИРАЩ_МОДУЛ"
 
-#: builtin/gc.c:2464
+#: builtin/gc.c:2481
 msgid "scheduler to trigger git maintenance run"
 msgstr "ПЛАНИРАЩият_МОДУЛ, който да изпълнява задачите"
 
-#: builtin/gc.c:2478
+#: builtin/gc.c:2495
 msgid "failed to add repo to global config"
 msgstr "неуспешно добавяне на хранилище към файла с глобални настройки"
 
-#: builtin/gc.c:2487
+#: builtin/gc.c:2504
 msgid "git maintenance <subcommand> [<options>]"
 msgstr "git maintenance ПОДКОМАНДА [ОПЦИЯ…]"
 
-#: builtin/gc.c:2506
+#: builtin/gc.c:2523
 #, c-format
 msgid "invalid subcommand: %s"
 msgstr "неправилна подкоманда: „%s“"
@@ -17155,25 +17095,25 @@ msgstr "git help [-c|--config]"
 msgid "unrecognized help format '%s'"
 msgstr "непознат формат на помощта „%s“"
 
-#: builtin/help.c:223
+#: builtin/help.c:222
 msgid "Failed to start emacsclient."
 msgstr "Неуспешно стартиране на „emacsclient“."
 
-#: builtin/help.c:236
+#: builtin/help.c:235
 msgid "Failed to parse emacsclient version."
 msgstr "Версията на „emacsclient“ не може да се анализира."
 
-#: builtin/help.c:244
+#: builtin/help.c:243
 #, c-format
 msgid "emacsclient version '%d' too old (< 22)."
 msgstr "Прекалено стара версия на „emacsclient“ — %d (< 22)."
 
-#: builtin/help.c:262 builtin/help.c:284 builtin/help.c:294 builtin/help.c:302
+#: builtin/help.c:261 builtin/help.c:283 builtin/help.c:293 builtin/help.c:301
 #, c-format
 msgid "failed to exec '%s'"
 msgstr "неуспешно изпълнение на „%s“"
 
-#: builtin/help.c:340
+#: builtin/help.c:339
 #, c-format
 msgid ""
 "'%s': path for unsupported man viewer.\n"
@@ -17182,7 +17122,7 @@ msgstr ""
 "„%s“: път към неподдържана програма за преглед на\n"
 " ръководството.  Вместо нея пробвайте „man.<tool>.cmd“."
 
-#: builtin/help.c:352
+#: builtin/help.c:351
 #, c-format
 msgid ""
 "'%s': cmd for supported man viewer.\n"
@@ -17191,41 +17131,41 @@ msgstr ""
 "„%s“: команда за поддържана програма за преглед на\n"
 " ръководството.  Вместо нея пробвайте „man.<tool>.path“."
 
-#: builtin/help.c:467
+#: builtin/help.c:466
 #, c-format
 msgid "'%s': unknown man viewer."
 msgstr "„%s“: непозната програма за преглед на ръководството."
 
-#: builtin/help.c:483
+#: builtin/help.c:482
 msgid "no man viewer handled the request"
 msgstr "никоя програма за преглед на ръководство не успя да обработи заявката"
 
-#: builtin/help.c:490
+#: builtin/help.c:489
 msgid "no info viewer handled the request"
 msgstr ""
 "никоя програма за преглед на информационните страници не успя да обработи "
 "заявката"
 
-#: builtin/help.c:551 builtin/help.c:562 git.c:348
+#: builtin/help.c:550 builtin/help.c:561 git.c:348
 #, c-format
 msgid "'%s' is aliased to '%s'"
 msgstr "„%s“ е псевдоним на „%s“"
 
-#: builtin/help.c:565 git.c:380
+#: builtin/help.c:564 git.c:380
 #, c-format
 msgid "bad alias.%s string: %s"
 msgstr "неправилен низ за настройката „alias.%s“: „%s“"
 
-#: builtin/help.c:581
+#: builtin/help.c:580
 msgid "this option doesn't take any other arguments"
 msgstr "опцията не приема аргументи"
 
-#: builtin/help.c:602 builtin/help.c:629
+#: builtin/help.c:601 builtin/help.c:628
 #, c-format
 msgid "usage: %s%s"
 msgstr "употреба: %s%s"
 
-#: builtin/help.c:624
+#: builtin/help.c:623
 msgid "'git help config' for more information"
 msgstr "За повече информация изпълнете „git help config“"
 
@@ -17495,17 +17435,9 @@ msgstr "неправилна стойност „%s“"
 msgid "unknown hash algorithm '%s'"
 msgstr "непознат алгоритъм за контролни суми „%s“"
 
-#: builtin/index-pack.c:1848
-msgid "--fix-thin cannot be used without --stdin"
-msgstr "опцията „--fix-thin“ изисква „--stdin“"
-
 #: builtin/index-pack.c:1850
 msgid "--stdin requires a git repository"
 msgstr "„--stdin“ изисква хранилище на git"
-
-#: builtin/index-pack.c:1852
-msgid "--object-format cannot be used with --stdin"
-msgstr "опцията „--object-format“ и „--stdin“ са несъвместими"
 
 #: builtin/index-pack.c:1867
 msgid "--verify with no packfile name given"
@@ -17636,10 +17568,6 @@ msgstr "алгоритъм"
 #: builtin/init-db.c:553 builtin/show-index.c:22 builtin/verify-pack.c:75
 msgid "specify the hash algorithm to use"
 msgstr "указване на алгоритъм за контролна сума"
-
-#: builtin/init-db.c:560
-msgid "--separate-git-dir and --bare are mutually exclusive"
-msgstr "опциите „--separate-git-dir“ и „--bare“ са несъвместими"
 
 #: builtin/init-db.c:591 builtin/init-db.c:596
 #, c-format
@@ -17776,85 +17704,85 @@ msgstr ""
 msgid "-L<range>:<file> cannot be used with pathspec"
 msgstr "опцията „-LДИАПАЗОН:ФАЙЛ“ не може да се ползва с път"
 
-#: builtin/log.c:306
+#: builtin/log.c:321
 #, c-format
 msgid "Final output: %d %s\n"
 msgstr "Резултат: %d %s\n"
 
-#: builtin/log.c:571
+#: builtin/log.c:586
 #, c-format
 msgid "git show %s: bad file"
 msgstr "git show %s: повреден файл"
 
-#: builtin/log.c:586 builtin/log.c:676
+#: builtin/log.c:601 builtin/log.c:691
 #, c-format
 msgid "could not read object %s"
 msgstr "обектът не може да бъде прочетен: %s"
 
-#: builtin/log.c:701
+#: builtin/log.c:716
 #, c-format
 msgid "unknown type: %d"
 msgstr "неизвестен вид: %d"
 
-#: builtin/log.c:846
+#: builtin/log.c:861
 #, c-format
 msgid "%s: invalid cover from description mode"
 msgstr "%s: неправилно придружаващо писмо от режима на описание"
 
-#: builtin/log.c:853
+#: builtin/log.c:868
 msgid "format.headers without value"
 msgstr "не е зададена стойност на „format.headers“"
 
-#: builtin/log.c:982
+#: builtin/log.c:997
 #, c-format
 msgid "cannot open patch file %s"
 msgstr "файлът-кръпка „%s“ не може да бъде отворен"
 
-#: builtin/log.c:999
+#: builtin/log.c:1014
 msgid "need exactly one range"
 msgstr "трябва да зададете точно един диапазон"
 
-#: builtin/log.c:1009
+#: builtin/log.c:1024
 msgid "not a range"
 msgstr "не е диапазон"
 
-#: builtin/log.c:1173
+#: builtin/log.c:1188
 msgid "cover letter needs email format"
 msgstr "придружаващото писмо трябва да е форматирано като е-писмо"
 
-#: builtin/log.c:1179
+#: builtin/log.c:1194
 msgid "failed to create cover-letter file"
 msgstr "неуспешно създаване на придружаващо писмо"
 
-#: builtin/log.c:1266
+#: builtin/log.c:1281
 #, c-format
 msgid "insane in-reply-to: %s"
 msgstr "неправилен формат на заглавната част за отговор „in-reply-to“: %s"
 
-#: builtin/log.c:1293
+#: builtin/log.c:1308
 msgid "git format-patch [<options>] [<since> | <revision-range>]"
 msgstr "git format-patch [ОПЦИЯ…] [ОТ | ДИАПАЗОН_НА_ВЕРСИИТЕ]"
 
-#: builtin/log.c:1351
+#: builtin/log.c:1366
 msgid "two output directories?"
 msgstr "може да укажете максимум една директория за изход"
 
-#: builtin/log.c:1502 builtin/log.c:2328 builtin/log.c:2330 builtin/log.c:2342
+#: builtin/log.c:1517 builtin/log.c:2344 builtin/log.c:2346 builtin/log.c:2358
 #, c-format
 msgid "unknown commit %s"
 msgstr "непознато подаване: „%s“"
 
-#: builtin/log.c:1513 builtin/replace.c:58 builtin/replace.c:207
+#: builtin/log.c:1528 builtin/replace.c:58 builtin/replace.c:207
 #: builtin/replace.c:210
 #, c-format
 msgid "failed to resolve '%s' as a valid ref"
 msgstr "„%s“ не е указател или не сочи към нищо"
 
-#: builtin/log.c:1522
+#: builtin/log.c:1537
 msgid "could not find exact merge base"
 msgstr "точната база за сливане не може да бъде открита"
 
-#: builtin/log.c:1532
+#: builtin/log.c:1547
 msgid ""
 "failed to get upstream, if you want to record base commit automatically,\n"
 "please use git branch --set-upstream-to to track a remote branch.\n"
@@ -17865,307 +17793,289 @@ msgstr ""
 "Може ръчно да зададете базово подаване чрез „--"
 "base=<ИДЕНТИФИКАТОР_НА_БАЗОВО_ПОДАВАНЕ>“."
 
-#: builtin/log.c:1555
+#: builtin/log.c:1570
 msgid "failed to find exact merge base"
 msgstr "точната база при сливане не може да бъде открита"
 
-#: builtin/log.c:1572
+#: builtin/log.c:1587
 msgid "base commit should be the ancestor of revision list"
 msgstr "базовото подаване трябва да е предшественикът на списъка с версиите"
 
-#: builtin/log.c:1582
+#: builtin/log.c:1597
 msgid "base commit shouldn't be in revision list"
 msgstr "базовото подаване не може да е в списъка с версиите"
 
-#: builtin/log.c:1640
+#: builtin/log.c:1655
 msgid "cannot get patch id"
 msgstr "идентификаторът на кръпката не може да бъде получен"
 
-#: builtin/log.c:1703
+#: builtin/log.c:1718
 msgid "failed to infer range-diff origin of current series"
 msgstr ""
 "неуспешно определяне на началото на диапазонната разлика на текущата поредица"
 
-#: builtin/log.c:1705
+#: builtin/log.c:1720
 #, c-format
 msgid "using '%s' as range-diff origin of current series"
 msgstr ""
 "„%s“ се ползва като началото на диапазонната разлика на текущата поредица"
 
-#: builtin/log.c:1749
+#: builtin/log.c:1764
 msgid "use [PATCH n/m] even with a single patch"
 msgstr "номерация „[PATCH n/m]“ дори и при единствена кръпка"
 
-#: builtin/log.c:1752
+#: builtin/log.c:1767
 msgid "use [PATCH] even with multiple patches"
 msgstr "номерация „[PATCH]“ дори и при множество кръпки"
 
-#: builtin/log.c:1756
+#: builtin/log.c:1771
 msgid "print patches to standard out"
 msgstr "извеждане на кръпките на стандартния изход"
 
-#: builtin/log.c:1758
+#: builtin/log.c:1773
 msgid "generate a cover letter"
 msgstr "създаване на придружаващо писмо"
 
-#: builtin/log.c:1760
+#: builtin/log.c:1775
 msgid "use simple number sequence for output file names"
 msgstr "проста числова последователност за имената на файловете-кръпки"
 
-#: builtin/log.c:1761
+#: builtin/log.c:1776
 msgid "sfx"
 msgstr "ЗНАЦИ"
 
-#: builtin/log.c:1762
+#: builtin/log.c:1777
 msgid "use <sfx> instead of '.patch'"
 msgstr "използване на тези ЗНАЦИ за суфикс вместо „.patch“"
 
-#: builtin/log.c:1764
+#: builtin/log.c:1779
 msgid "start numbering patches at <n> instead of 1"
 msgstr "номерирането на кръпките да започва от този БРОЙ, а не с 1"
 
-#: builtin/log.c:1765
+#: builtin/log.c:1780
 msgid "reroll-count"
 msgstr "номер на редакция"
 
-#: builtin/log.c:1766
+#: builtin/log.c:1781
 msgid "mark the series as Nth re-roll"
 msgstr "отбелязване, че това е N-тата поредна редакция на поредицата от кръпки"
 
-#: builtin/log.c:1768
+#: builtin/log.c:1783
 msgid "max length of output filename"
 msgstr "максимална дължина на име на всеки пакетен файл"
 
-#: builtin/log.c:1770
+#: builtin/log.c:1785
 msgid "use [RFC PATCH] instead of [PATCH]"
 msgstr "използване на „[RFC PATCH]“ вместо „[PATCH]“"
 
-#: builtin/log.c:1773
+#: builtin/log.c:1788
 msgid "cover-from-description-mode"
 msgstr "режим-придружаващо-писмо-по-описание"
 
-#: builtin/log.c:1774
+#: builtin/log.c:1789
 msgid "generate parts of a cover letter based on a branch's description"
 msgstr ""
 "генериране на частите на придружаващото писмо на базата на описанието на "
 "клона"
 
-#: builtin/log.c:1776
+#: builtin/log.c:1791
 msgid "use [<prefix>] instead of [PATCH]"
 msgstr "използване на този „[ПРЕФИКС]“ вместо „[PATCH]“"
 
-#: builtin/log.c:1779
+#: builtin/log.c:1794
 msgid "store resulting files in <dir>"
 msgstr "запазване на изходните файлове в тази ДИРЕКТОРИЯ"
 
-#: builtin/log.c:1782
+#: builtin/log.c:1797
 msgid "don't strip/add [PATCH]"
 msgstr "без добавяне/махане на префикса „[PATCH]“"
 
-#: builtin/log.c:1785
+#: builtin/log.c:1800
 msgid "don't output binary diffs"
 msgstr "без извеждане на разлики между двоични файлове"
 
-#: builtin/log.c:1787
+#: builtin/log.c:1802
 msgid "output all-zero hash in From header"
 msgstr "в заглавната част „From:“ (от) контролната сума да е само от нули"
 
-#: builtin/log.c:1789
+#: builtin/log.c:1804
 msgid "don't include a patch matching a commit upstream"
 msgstr "без кръпки, които присъстват в следения клон"
 
-#: builtin/log.c:1791
+#: builtin/log.c:1806
 msgid "show patch format instead of default (patch + stat)"
 msgstr ""
 "извеждане във формат за кръпки, а на в стандартния (кръпка и статистика)"
 
-#: builtin/log.c:1793
+#: builtin/log.c:1808
 msgid "Messaging"
 msgstr "Опции при изпращане"
 
-#: builtin/log.c:1794
+#: builtin/log.c:1809
 msgid "header"
 msgstr "ЗАГЛАВНА_ЧАСТ"
 
-#: builtin/log.c:1795
+#: builtin/log.c:1810
 msgid "add email header"
 msgstr "добавяне на тази ЗАГЛАВНА_ЧАСТ"
 
-#: builtin/log.c:1796 builtin/log.c:1797
+#: builtin/log.c:1811 builtin/log.c:1812
 msgid "email"
 msgstr "Е-ПОЩА"
 
-#: builtin/log.c:1796
+#: builtin/log.c:1811
 msgid "add To: header"
 msgstr "добавяне на заглавна част „To:“ (до)"
 
-#: builtin/log.c:1797
+#: builtin/log.c:1812
 msgid "add Cc: header"
 msgstr "добавяне на заглавна част „Cc:“ (и до)"
 
-#: builtin/log.c:1798
+#: builtin/log.c:1813
 msgid "ident"
 msgstr "ИДЕНТИЧНОСТ"
 
-#: builtin/log.c:1799
+#: builtin/log.c:1814
 msgid "set From address to <ident> (or committer ident if absent)"
 msgstr ""
 "задаване на адреса в заглавната част „From“ (от) да е тази ИДЕНТИЧНОСТ.  Ако "
 "не е зададена такава, се взима адреса на подаващия"
 
-#: builtin/log.c:1801
+#: builtin/log.c:1816
 msgid "message-id"
 msgstr "ИДЕНТИФИКАТОР_НА_СЪОБЩЕНИЕ"
 
-#: builtin/log.c:1802
+#: builtin/log.c:1817
 msgid "make first mail a reply to <message-id>"
 msgstr ""
 "първото съобщение да е в отговор на е-писмото с този "
 "ИДЕНТИФИКАТОР_НА_СЪОБЩЕНИЕ"
 
-#: builtin/log.c:1803 builtin/log.c:1806
+#: builtin/log.c:1818 builtin/log.c:1821
 msgid "boundary"
 msgstr "граница"
 
-#: builtin/log.c:1804
+#: builtin/log.c:1819
 msgid "attach the patch"
 msgstr "прикрепяне на кръпката"
 
-#: builtin/log.c:1807
+#: builtin/log.c:1822
 msgid "inline the patch"
 msgstr "включване на кръпката в текста на писмата"
 
-#: builtin/log.c:1811
+#: builtin/log.c:1826
 msgid "enable message threading, styles: shallow, deep"
 msgstr ""
 "използване на нишки за съобщенията.  СТИЛът е „shallow“ (плитък) или "
 "„deep“ (дълбок)"
 
-#: builtin/log.c:1813
+#: builtin/log.c:1828
 msgid "signature"
 msgstr "подпис"
 
-#: builtin/log.c:1814
+#: builtin/log.c:1829
 msgid "add a signature"
 msgstr "добавяне на поле за подпис"
 
-#: builtin/log.c:1815
+#: builtin/log.c:1830
 msgid "base-commit"
 msgstr "БАЗОВО_ПОДАВАНЕ"
 
-#: builtin/log.c:1816
+#: builtin/log.c:1831
 msgid "add prerequisite tree info to the patch series"
 msgstr "добавяне на необходимото БАЗово дърво към поредицата от кръпки"
 
-#: builtin/log.c:1819
+#: builtin/log.c:1834
 msgid "add a signature from a file"
 msgstr "добавяне на подпис от файл"
 
-#: builtin/log.c:1820
+#: builtin/log.c:1835
 msgid "don't print the patch filenames"
 msgstr "без извеждане на имената на кръпките"
 
-#: builtin/log.c:1822
+#: builtin/log.c:1837
 msgid "show progress while generating patches"
 msgstr "извеждане на напредъка във фазата на създаване на кръпките"
 
-#: builtin/log.c:1824
+#: builtin/log.c:1839
 msgid "show changes against <rev> in cover letter or single patch"
 msgstr ""
 "показване на промените спрямо ВЕРСията в придружаващото писмо или единствена "
 "кръпка"
 
-#: builtin/log.c:1827
+#: builtin/log.c:1842
 msgid "show changes against <refspec> in cover letter or single patch"
 msgstr ""
 "показване на промените спрямо указателя на ВЕРСията в придружаващото писмо "
 "или единствена кръпка"
 
-#: builtin/log.c:1829 builtin/range-diff.c:28
+#: builtin/log.c:1844 builtin/range-diff.c:28
 msgid "percentage by which creation is weighted"
 msgstr "процент за претегляне при оценка на създаването"
 
-#: builtin/log.c:1916
+#: builtin/log.c:1931
 #, c-format
 msgid "invalid ident line: %s"
 msgstr "грешна идентичност: %s"
 
-#: builtin/log.c:1931
-msgid "-n and -k are mutually exclusive"
-msgstr "опциите „-n“ и „-k“ са несъвместими"
-
-#: builtin/log.c:1933
-msgid "--subject-prefix/--rfc and -k are mutually exclusive"
-msgstr "опциите „--subject-prefix“/„--rfc“ и „-k“ са несъвместими"
-
-#: builtin/log.c:1941
+#: builtin/log.c:1956
 msgid "--name-only does not make sense"
 msgstr "опцията „--name-only“ е несъвместима с генерирането на кръпки"
 
-#: builtin/log.c:1943
+#: builtin/log.c:1958
 msgid "--name-status does not make sense"
 msgstr "опцията „--name-status“ е несъвместима с генерирането на кръпки"
 
-#: builtin/log.c:1945
+#: builtin/log.c:1960
 msgid "--check does not make sense"
 msgstr "опцията „--check“ е несъвместима с генерирането на кръпки"
 
-#: builtin/log.c:1967
-msgid "--stdout, --output, and --output-directory are mutually exclusive"
-msgstr ""
-"опциите „--stdout“, „--output“ и „--output-directory“ са несъвместими една с "
-"друга"
-
-#: builtin/log.c:2089
+#: builtin/log.c:2104
 msgid "--interdiff requires --cover-letter or single patch"
 msgstr ""
 "опцията „--interdiff“ изисква опция „--cover-letter“ или единствена кръпка"
 
-#: builtin/log.c:2093
+#: builtin/log.c:2108
 msgid "Interdiff:"
 msgstr "Разлика в разликите:"
 
-#: builtin/log.c:2094
+#: builtin/log.c:2109
 #, c-format
 msgid "Interdiff against v%d:"
 msgstr "Разлика в разликите спрямо v%d:"
 
-#: builtin/log.c:2100
-msgid "--creation-factor requires --range-diff"
-msgstr "опцията „--creation-factor“ изисква опция „--range-diff“"
-
-#: builtin/log.c:2104
+#: builtin/log.c:2119
 msgid "--range-diff requires --cover-letter or single patch"
 msgstr ""
 "опцията „--range-diff“ изисква опция „--cover-letter“ или единствена кръпка"
 
-#: builtin/log.c:2112
+#: builtin/log.c:2127
 msgid "Range-diff:"
 msgstr "Диапазонна разлика:"
 
-#: builtin/log.c:2113
+#: builtin/log.c:2128
 #, c-format
 msgid "Range-diff against v%d:"
 msgstr "Диапазонна разлика спрямо v%d:"
 
-#: builtin/log.c:2124
+#: builtin/log.c:2139
 #, c-format
 msgid "unable to read signature file '%s'"
 msgstr "файлът „%s“ с подпис не може да бъде прочетен"
 
-#: builtin/log.c:2160
+#: builtin/log.c:2175
 msgid "Generating patches"
 msgstr "Създаване на кръпки"
 
-#: builtin/log.c:2204
+#: builtin/log.c:2219
 msgid "failed to create output files"
 msgstr "неуспешно създаване на изходни файлове"
 
-#: builtin/log.c:2263
+#: builtin/log.c:2279
 msgid "git cherry [-v] [<upstream> [<head> [<limit>]]]"
 msgstr "git cherry [-v] [ОТДАЛЕЧЕН_КЛОН [ВРЪХ [ПРЕДЕЛ]]]"
 
-#: builtin/log.c:2317
+#: builtin/log.c:2333
 #, c-format
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> manually.\n"
@@ -18173,119 +18083,124 @@ msgstr ""
 "Следеният отдалечен клон не бе открит, затова изрично задайте "
 "ОТДАЛЕЧЕН_КЛОН.\n"
 
-#: builtin/ls-files.c:561
+#: builtin/ls-files.c:564
 msgid "git ls-files [<options>] [<file>...]"
 msgstr "git ls-files [ОПЦИЯ…] [ФАЙЛ…]"
 
-#: builtin/ls-files.c:615
+#: builtin/ls-files.c:618
 msgid "separate paths with the NUL character"
 msgstr "разделяне на пътищата с нулевия знак „NUL“"
 
-#: builtin/ls-files.c:617
+#: builtin/ls-files.c:620
 msgid "identify the file status with tags"
 msgstr "извеждане на състоянието на файловете с еднобуквени флагове"
 
-#: builtin/ls-files.c:619
+#: builtin/ls-files.c:622
 msgid "use lowercase letters for 'assume unchanged' files"
 msgstr "малки букви за файловете, които да се счетат за непроменени"
 
-#: builtin/ls-files.c:621
+#: builtin/ls-files.c:624
 msgid "use lowercase letters for 'fsmonitor clean' files"
 msgstr "малки букви за файловете за командата „fsmonitor clean“"
 
-#: builtin/ls-files.c:623
+#: builtin/ls-files.c:626
 msgid "show cached files in the output (default)"
 msgstr "извеждане на кешираните файлове (стандартно)"
 
-#: builtin/ls-files.c:625
+#: builtin/ls-files.c:628
 msgid "show deleted files in the output"
 msgstr "извеждане на изтритите файлове"
 
-#: builtin/ls-files.c:627
+#: builtin/ls-files.c:630
 msgid "show modified files in the output"
 msgstr "извеждане на променените файлове"
 
-#: builtin/ls-files.c:629
+#: builtin/ls-files.c:632
 msgid "show other files in the output"
 msgstr "извеждане на другите файлове"
 
-#: builtin/ls-files.c:631
+#: builtin/ls-files.c:634
 msgid "show ignored files in the output"
 msgstr "извеждане на игнорираните файлове"
 
-#: builtin/ls-files.c:634
+#: builtin/ls-files.c:637
 msgid "show staged contents' object name in the output"
 msgstr "извеждане на името на обекта за съдържанието на индекса"
 
-#: builtin/ls-files.c:636
+#: builtin/ls-files.c:639
 msgid "show files on the filesystem that need to be removed"
 msgstr "извеждане на файловете, които трябва да бъдат изтрити"
 
-#: builtin/ls-files.c:638
+#: builtin/ls-files.c:641
 msgid "show 'other' directories' names only"
 msgstr "извеждане само на името на другите (неследените) директории"
 
-#: builtin/ls-files.c:640
+#: builtin/ls-files.c:643
 msgid "show line endings of files"
 msgstr "извеждане на знаците за край на ред във файловете"
 
-#: builtin/ls-files.c:642
+#: builtin/ls-files.c:645
 msgid "don't show empty directories"
 msgstr "без извеждане на празните директории"
 
-#: builtin/ls-files.c:645
+#: builtin/ls-files.c:648
 msgid "show unmerged files in the output"
 msgstr "извеждане на неслетите файлове"
 
-#: builtin/ls-files.c:647
+#: builtin/ls-files.c:650
 msgid "show resolve-undo information"
 msgstr "извеждане на информацията за отмяна на разрешените подавания"
 
-#: builtin/ls-files.c:649
+#: builtin/ls-files.c:652
 msgid "skip files matching pattern"
 msgstr "прескачане на файловете напасващи ШАБЛОНа"
 
-#: builtin/ls-files.c:652
+#: builtin/ls-files.c:655
 msgid "read exclude patterns from <file>"
 msgstr "изчитане на шаблоните за игнориране от ФАЙЛ"
 
-#: builtin/ls-files.c:655
+#: builtin/ls-files.c:658
 msgid "read additional per-directory exclude patterns in <file>"
 msgstr ""
 "изчитане на допълнителните шаблони за игнориране по директория от този ФАЙЛ"
 
-#: builtin/ls-files.c:657
+#: builtin/ls-files.c:660
 msgid "add the standard git exclusions"
 msgstr "добавяне на стандартно игнорираните от Git файлове"
 
-#: builtin/ls-files.c:661
+#: builtin/ls-files.c:664
 msgid "make the output relative to the project top directory"
 msgstr "пътищата да са относителни спрямо основната директория на проекта"
 
-#: builtin/ls-files.c:664
+#: builtin/ls-files.c:667
 msgid "recurse through submodules"
 msgstr "рекурсивно обхождане подмодулите"
 
-#: builtin/ls-files.c:666
+#: builtin/ls-files.c:669
 msgid "if any <file> is not in the index, treat this as an error"
 msgstr "грешка, ако някой от тези ФАЙЛове не е в индекса"
 
-#: builtin/ls-files.c:667
+#: builtin/ls-files.c:670
 msgid "tree-ish"
 msgstr "УКАЗАТЕЛ_КЪМ_ДЪРВО"
 
-#: builtin/ls-files.c:668
+#: builtin/ls-files.c:671
 msgid "pretend that paths removed since <tree-ish> are still present"
 msgstr ""
 "считане, че пътищата изтрити след УКАЗАТЕЛя_КЪМ_ДЪРВО все още съществуват"
 
-#: builtin/ls-files.c:670
+#: builtin/ls-files.c:673
 msgid "show debugging data"
 msgstr "извеждане на информацията за изчистване на грешки"
 
-#: builtin/ls-files.c:672
+#: builtin/ls-files.c:675
 msgid "suppress duplicate entries"
 msgstr "без повтаряне на записите"
+
+#: builtin/ls-files.c:677
+msgid "show sparse directories in the presence of a sparse index"
+msgstr ""
+"указване на частично изтеглените директории при наличието на частичен индекс"
 
 #: builtin/ls-remote.c:9
 msgid ""
@@ -18486,26 +18401,30 @@ msgid "use a diff3 based merge"
 msgstr "сливане на базата на „diff3“"
 
 #: builtin/merge-file.c:37
+msgid "use a zealous diff3 based merge"
+msgstr "засилено сливане на базата на „diff3“"
+
+#: builtin/merge-file.c:39
 msgid "for conflicts, use our version"
 msgstr "при конфликти да се ползва локалната версия"
 
-#: builtin/merge-file.c:39
+#: builtin/merge-file.c:41
 msgid "for conflicts, use their version"
 msgstr "при конфликти да се ползва чуждата версия"
 
-#: builtin/merge-file.c:41
+#: builtin/merge-file.c:43
 msgid "for conflicts, use a union version"
 msgstr "при конфликти да се ползва обединена версия"
 
-#: builtin/merge-file.c:44
+#: builtin/merge-file.c:46
 msgid "for conflicts, use this marker size"
 msgstr "при конфликти да се ползва маркер с такъв БРОЙ знаци"
 
-#: builtin/merge-file.c:45
+#: builtin/merge-file.c:47
 msgid "do not warn about conflicts"
 msgstr "без предупреждения при конфликти"
 
-#: builtin/merge-file.c:47
+#: builtin/merge-file.c:49
 msgid "set labels for file1/orig-file/file2"
 msgstr "задаване на етикети за ФАЙЛ_1/ОРИГИНАЛ/ФАЙЛ_2"
 
@@ -18544,184 +18463,188 @@ msgstr "Сливане на „%s“ с „%s“\n"
 msgid "git merge [<options>] [<commit>...]"
 msgstr "git merge [ОПЦИЯ…] [ПОДАВАНЕ…]"
 
-#: builtin/merge.c:124
+#: builtin/merge.c:125
 msgid "switch `m' requires a value"
 msgstr "опцията „-m“ изисква стойност"
 
-#: builtin/merge.c:147
+#: builtin/merge.c:148
 #, c-format
 msgid "option `%s' requires a value"
 msgstr "опцията „%s“ изисква стойност"
 
-#: builtin/merge.c:200
+#: builtin/merge.c:201
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
 msgstr "Няма такава стратегия за сливане: „%s“.\n"
 
-#: builtin/merge.c:201
+#: builtin/merge.c:202
 #, c-format
 msgid "Available strategies are:"
 msgstr "Наличните стратегии са:"
 
-#: builtin/merge.c:206
+#: builtin/merge.c:207
 #, c-format
 msgid "Available custom strategies are:"
 msgstr "Допълнителните стратегии са:"
 
-#: builtin/merge.c:257 builtin/pull.c:134
+#: builtin/merge.c:258 builtin/pull.c:134
 msgid "do not show a diffstat at the end of the merge"
 msgstr "без извеждане на статистиката след завършване на сливане"
 
-#: builtin/merge.c:260 builtin/pull.c:137
+#: builtin/merge.c:261 builtin/pull.c:137
 msgid "show a diffstat at the end of the merge"
 msgstr "извеждане на статистиката след завършване на сливане"
 
-#: builtin/merge.c:261 builtin/pull.c:140
+#: builtin/merge.c:262 builtin/pull.c:140
 msgid "(synonym to --stat)"
 msgstr "(псевдоним на „--stat“)"
 
-#: builtin/merge.c:263 builtin/pull.c:143
+#: builtin/merge.c:264 builtin/pull.c:143
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "добавяне (на максимум такъв БРОЙ) записи от съкратения журнал в съобщението "
 "за подаване"
 
-#: builtin/merge.c:266 builtin/pull.c:149
+#: builtin/merge.c:267 builtin/pull.c:149
 msgid "create a single commit instead of doing a merge"
 msgstr "създаване на едно подаване вместо извършване на сливане"
 
-#: builtin/merge.c:268 builtin/pull.c:152
+#: builtin/merge.c:269 builtin/pull.c:152
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "извършване на подаване при успешно сливане (стандартно действие)"
 
-#: builtin/merge.c:270 builtin/pull.c:155
+#: builtin/merge.c:271 builtin/pull.c:155
 msgid "edit message before committing"
 msgstr "редактиране на съобщението преди подаване"
 
-#: builtin/merge.c:272
+#: builtin/merge.c:273
 msgid "allow fast-forward (default)"
 msgstr "позволяване на превъртане (стандартно действие)"
 
-#: builtin/merge.c:274 builtin/pull.c:162
+#: builtin/merge.c:275 builtin/pull.c:162
 msgid "abort if fast-forward is not possible"
 msgstr "преустановяване, ако превъртането е невъзможно"
 
-#: builtin/merge.c:278 builtin/pull.c:168
+#: builtin/merge.c:279 builtin/pull.c:168
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "проверка, че указаното подаване е с правилен подпис на GPG"
 
-#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:172
+#: builtin/merge.c:280 builtin/notes.c:785 builtin/pull.c:172
 #: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr "СТРАТЕГИЯ"
 
-#: builtin/merge.c:280 builtin/pull.c:173
+#: builtin/merge.c:281 builtin/pull.c:173
 msgid "merge strategy to use"
 msgstr "СТРАТЕГИЯ за сливане, която да се ползва"
 
-#: builtin/merge.c:281 builtin/pull.c:176
+#: builtin/merge.c:282 builtin/pull.c:176
 msgid "option=value"
 msgstr "ОПЦИЯ=СТОЙНОСТ"
 
-#: builtin/merge.c:282 builtin/pull.c:177
+#: builtin/merge.c:283 builtin/pull.c:177
 msgid "option for selected merge strategy"
 msgstr "ОПЦИЯ за избраната стратегия за сливане"
 
-#: builtin/merge.c:284
+#: builtin/merge.c:285
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr "СЪОБЩЕНИЕ при подаването със сливане (при същински сливания)"
 
 #: builtin/merge.c:291
+msgid "use <name> instead of the real target"
+msgstr "използване на това ИМЕ вместо истинския клон-цел"
+
+#: builtin/merge.c:294
 msgid "abort the current in-progress merge"
 msgstr "преустановяване на текущото сливане"
 
-#: builtin/merge.c:293
+#: builtin/merge.c:296
 msgid "--abort but leave index and working tree alone"
 msgstr "преустановяване (--abort) без промяна на индекса и работното дърво"
 
-#: builtin/merge.c:295
+#: builtin/merge.c:298
 msgid "continue the current in-progress merge"
 msgstr "продължаване на текущото сливане"
 
-#: builtin/merge.c:297 builtin/pull.c:184
+#: builtin/merge.c:300 builtin/pull.c:184
 msgid "allow merging unrelated histories"
 msgstr "позволяване на сливане на независими истории"
 
-#: builtin/merge.c:304
+#: builtin/merge.c:307
 msgid "bypass pre-merge-commit and commit-msg hooks"
 msgstr ""
 "без изпълнение на куките преди подаване и сливане и при промяна на "
 "съобщението за подаване (pre-merge-commit и commit-msg)"
 
-#: builtin/merge.c:321
+#: builtin/merge.c:323
 msgid "could not run stash."
 msgstr "не може да се извърши скатаване"
 
-#: builtin/merge.c:326
+#: builtin/merge.c:328
 msgid "stash failed"
 msgstr "неуспешно скатаване"
 
-#: builtin/merge.c:331
+#: builtin/merge.c:333
 #, c-format
 msgid "not a valid object: %s"
 msgstr "неправилен обект: „%s“"
 
-#: builtin/merge.c:353 builtin/merge.c:370
+#: builtin/merge.c:355 builtin/merge.c:372
 msgid "read-tree failed"
 msgstr "неуспешно прочитане на обект-дърво"
 
-#: builtin/merge.c:401
+#: builtin/merge.c:403
 msgid "Already up to date. (nothing to squash)"
 msgstr "Вече е обновено (няма какво да се вкара)"
 
-#: builtin/merge.c:415
+#: builtin/merge.c:417
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
 msgstr "Вкарано подаване — указателят „HEAD“ няма да бъде обновен\n"
 
-#: builtin/merge.c:465
+#: builtin/merge.c:467
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
 msgstr ""
 "Липсва съобщение при подаване — указателят „HEAD“ няма да бъде обновен\n"
 
-#: builtin/merge.c:515
+#: builtin/merge.c:517
 #, c-format
 msgid "'%s' does not point to a commit"
 msgstr "„%s“ не сочи към подаване"
 
-#: builtin/merge.c:603
+#: builtin/merge.c:605
 #, c-format
 msgid "Bad branch.%s.mergeoptions string: %s"
 msgstr "Неправилен низ за настройката „branch.%s.mergeoptions“: „%s“"
 
-#: builtin/merge.c:730
+#: builtin/merge.c:732
 msgid "Not handling anything other than two heads merge."
 msgstr "Поддържа се само сливане на точно две истории."
 
-#: builtin/merge.c:743
+#: builtin/merge.c:745
 #, c-format
 msgid "unknown strategy option: -X%s"
 msgstr "непозната опция за стратегия: -X%s"
 
-#: builtin/merge.c:762 t/helper/test-fast-rebase.c:223
+#: builtin/merge.c:764 t/helper/test-fast-rebase.c:223
 #, c-format
 msgid "unable to write %s"
 msgstr "„%s“ не може да бъде записан"
 
-#: builtin/merge.c:814
+#: builtin/merge.c:816
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "От „%s“ не може да се чете"
 
-#: builtin/merge.c:823
+#: builtin/merge.c:825
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
 "Сливането няма да бъде подадено.  За завършването му и подаването му "
 "използвайте командата „git commit“.\n"
 
-#: builtin/merge.c:829
+#: builtin/merge.c:831
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
@@ -18730,11 +18653,11 @@ msgstr ""
 "В съобщението при подаване добавете информация за причината за\n"
 "сливането, особено ако сливате обновен отдалечен клон в тематичен клон.\n"
 
-#: builtin/merge.c:834
+#: builtin/merge.c:836
 msgid "An empty message aborts the commit.\n"
 msgstr "Празно съобщение предотвратява подаването.\n"
 
-#: builtin/merge.c:837
+#: builtin/merge.c:839
 #, c-format
 msgid ""
 "Lines starting with '%c' will be ignored, and an empty message aborts\n"
@@ -18743,76 +18666,76 @@ msgstr ""
 "Редовете, които започват с „%c“, ще бъдат пропуснати, а празно\n"
 "съобщение преустановява подаването.\n"
 
-#: builtin/merge.c:892
+#: builtin/merge.c:894
 msgid "Empty commit message."
 msgstr "Празно съобщение при подаване."
 
-#: builtin/merge.c:907
+#: builtin/merge.c:909
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Първият етап на сливането завърши.\n"
 
-#: builtin/merge.c:968
+#: builtin/merge.c:970
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
 "Неуспешно автоматично сливане — коригирайте конфликтите и подайте "
 "резултата.\n"
 
-#: builtin/merge.c:1007
+#: builtin/merge.c:1009
 msgid "No current branch."
 msgstr "Няма текущ клон."
 
-#: builtin/merge.c:1009
+#: builtin/merge.c:1011
 msgid "No remote for the current branch."
 msgstr "Текущият клон не следи никой."
 
-#: builtin/merge.c:1011
+#: builtin/merge.c:1013
 msgid "No default upstream defined for the current branch."
 msgstr "Текущият клон не следи никой клон."
 
-#: builtin/merge.c:1016
+#: builtin/merge.c:1018
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "Никой клон не следи клона „%s“ от хранилището „%s“"
 
-#: builtin/merge.c:1073
+#: builtin/merge.c:1075
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Неправилна стойност „%s“ в средата „%s“"
 
-#: builtin/merge.c:1174
+#: builtin/merge.c:1177
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "не може да се слее в „%s“: %s"
 
-#: builtin/merge.c:1208
+#: builtin/merge.c:1211
 msgid "not something we can merge"
 msgstr "не може да се слее"
 
-#: builtin/merge.c:1321
+#: builtin/merge.c:1324
 msgid "--abort expects no arguments"
 msgstr "опцията „--abort“ не приема аргументи"
 
-#: builtin/merge.c:1325
+#: builtin/merge.c:1328
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr ""
 "Не може да преустановите сливане, защото в момента не се извършва такова "
 "(липсва указател „MERGE_HEAD“)."
 
-#: builtin/merge.c:1343
+#: builtin/merge.c:1346
 msgid "--quit expects no arguments"
 msgstr "опцията „--quit“ не приема аргументи"
 
-#: builtin/merge.c:1356
+#: builtin/merge.c:1359
 msgid "--continue expects no arguments"
 msgstr "опцията „--continue“ не приема аргументи"
 
-#: builtin/merge.c:1360
+#: builtin/merge.c:1363
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "В момента не се извършва сливане (липсва указател „MERGE_HEAD“)."
 
-#: builtin/merge.c:1376
+#: builtin/merge.c:1379
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -18820,7 +18743,7 @@ msgstr ""
 "Не сте завършили сливане.  (Указателят „MERGE_HEAD“ съществува).\n"
 "Подайте промените си, преди да започнете ново сливане."
 
-#: builtin/merge.c:1383
+#: builtin/merge.c:1386
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -18828,90 +18751,82 @@ msgstr ""
 "Не сте завършили отбиране на подаване (указателят „CHERRY_PICK_HEAD“\n"
 "съществува).  Подайте промените си, преди да започнете ново сливане."
 
-#: builtin/merge.c:1386
+#: builtin/merge.c:1389
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr ""
 "Не сте завършили отбиране на подаване (указателят „CHERRY_PICK_HEAD“\n"
 "съществува)."
 
-#: builtin/merge.c:1400
-msgid "You cannot combine --squash with --no-ff."
-msgstr "опциите „--squash“ и „--no-ff“ са несъвместими."
-
-#: builtin/merge.c:1402
-msgid "You cannot combine --squash with --commit."
-msgstr "опциите „--squash“ и „--commit“ са несъвместими."
-
-#: builtin/merge.c:1418
+#: builtin/merge.c:1421
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr ""
 "Не е указано подаване и настройката „merge.defaultToUpstream“ не е зададена."
 
-#: builtin/merge.c:1435
+#: builtin/merge.c:1438
 msgid "Squash commit into empty head not supported yet"
 msgstr "Вкарване на подаване във връх без история все още не се поддържа"
 
-#: builtin/merge.c:1437
+#: builtin/merge.c:1440
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr ""
 "Понеже върхът е без история, сливания, които не са превъртания, са невъзможни"
 
-#: builtin/merge.c:1442
+#: builtin/merge.c:1445
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "„%s“ — не е нещо, което може да се слее"
 
-#: builtin/merge.c:1444
+#: builtin/merge.c:1447
 msgid "Can merge only exactly one commit into empty head"
 msgstr "Може да слеете точно едно подаване във връх без история"
 
-#: builtin/merge.c:1531
+#: builtin/merge.c:1534
 msgid "refusing to merge unrelated histories"
 msgstr "независими истории не може да се слеят"
 
-#: builtin/merge.c:1550
+#: builtin/merge.c:1553
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "Обновяване „%s..%s“\n"
 
-#: builtin/merge.c:1598
+#: builtin/merge.c:1601
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "Проба със сливане в рамките на индекса…\n"
 
-#: builtin/merge.c:1605
+#: builtin/merge.c:1608
 #, c-format
 msgid "Nope.\n"
 msgstr "Неуспешно сливане.\n"
 
-#: builtin/merge.c:1664 builtin/merge.c:1730
+#: builtin/merge.c:1667 builtin/merge.c:1733
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "Привеждане на дървото към първоначалното…\n"
 
-#: builtin/merge.c:1668
+#: builtin/merge.c:1671
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Пробване със стратегията за сливане „%s“…\n"
 
-#: builtin/merge.c:1720
+#: builtin/merge.c:1723
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Никоя стратегия за сливане не може да извърши сливането.\n"
 
-#: builtin/merge.c:1722
+#: builtin/merge.c:1725
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "Неуспешно сливане със стратегия „%s“.\n"
 
-#: builtin/merge.c:1732
+#: builtin/merge.c:1735
 #, c-format
 msgid "Using the %s strategy to prepare resolving by hand.\n"
 msgstr ""
 "Ползва се стратегията „%s“, която ще подготви дървото за коригиране на "
 "ръка.\n"
 
-#: builtin/merge.c:1746
+#: builtin/merge.c:1749
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
@@ -18954,7 +18869,7 @@ msgstr "етикетът на стандартния вход не премин�
 msgid "tag on stdin did not refer to a valid object"
 msgstr "етикетът на стандартния вход не сочи към правилен обект"
 
-#: builtin/mktag.c:104 builtin/tag.c:243
+#: builtin/mktag.c:104 builtin/tag.c:242
 msgid "unable to write tag file"
 msgstr "файлът за етикета не може да бъде запазен"
 
@@ -19023,7 +18938,7 @@ msgstr ""
 msgid "refs snapshot for selecting bitmap commits"
 msgstr "снимка на указателите за избор на подавания по битова маска"
 
-#: builtin/multi-pack-index.c:202
+#: builtin/multi-pack-index.c:206
 msgid ""
 "during repack, collect pack-files of smaller size into a batch that is "
 "larger than this size"
@@ -19124,54 +19039,54 @@ msgstr "%s, обект: „%s“, цел: „%s“"
 msgid "Renaming %s to %s\n"
 msgstr "Преименуване на „%s“ на „%s“\n"
 
-#: builtin/mv.c:314 builtin/remote.c:790 builtin/repack.c:853
+#: builtin/mv.c:314 builtin/remote.c:790 builtin/repack.c:857
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "неуспешно преименуване на „%s“"
 
-#: builtin/name-rev.c:465
+#: builtin/name-rev.c:474
 msgid "git name-rev [<options>] <commit>..."
 msgstr "git name-rev [ОПЦИЯ…] ПОДАВАНЕ…"
 
-#: builtin/name-rev.c:466
+#: builtin/name-rev.c:475
 msgid "git name-rev [<options>] --all"
 msgstr "git name-rev [ОПЦИЯ…] --all"
 
-#: builtin/name-rev.c:467
+#: builtin/name-rev.c:476
 msgid "git name-rev [<options>] --stdin"
 msgstr "git name-rev [ОПЦИЯ…] --stdin"
 
-#: builtin/name-rev.c:524
+#: builtin/name-rev.c:533
 msgid "print only ref-based names (no object names)"
 msgstr "извеждане само на имена на базата на указатели (а не имена на обекти)"
 
-#: builtin/name-rev.c:525
+#: builtin/name-rev.c:534
 msgid "only use tags to name the commits"
 msgstr "използване само на етикетите за именуване на подаванията"
 
-#: builtin/name-rev.c:527
+#: builtin/name-rev.c:536
 msgid "only use refs matching <pattern>"
 msgstr "използване само на указателите напасващи на ШАБЛОНа"
 
-#: builtin/name-rev.c:529
+#: builtin/name-rev.c:538
 msgid "ignore refs matching <pattern>"
 msgstr "игнориране на указателите напасващи на ШАБЛОНа"
 
-#: builtin/name-rev.c:531
+#: builtin/name-rev.c:540
 msgid "list all commits reachable from all refs"
 msgstr ""
 "извеждане на всички подавания, които може да бъдат достигнати от всички "
 "указатели"
 
-#: builtin/name-rev.c:532
+#: builtin/name-rev.c:541
 msgid "read from stdin"
 msgstr "четене от стандартния вход"
 
-#: builtin/name-rev.c:533
+#: builtin/name-rev.c:542
 msgid "allow to print `undefined` names (default)"
 msgstr "да се извеждат и недефинираните имена (стандартна стойност на опцията)"
 
-#: builtin/name-rev.c:539
+#: builtin/name-rev.c:548
 msgid "dereference tags in the input (internal use)"
 msgstr "извеждане на идентификаторите на обекти-етикети (за вътрешни нужди)"
 
@@ -19291,25 +19206,25 @@ msgstr "git notes get-ref"
 msgid "Write/edit the notes for the following object:"
 msgstr "Записване/редактиране на бележките за следния обект:"
 
-#: builtin/notes.c:150
+#: builtin/notes.c:149
 #, c-format
 msgid "unable to start 'show' for object '%s'"
 msgstr "действието „show“ не може да се изпълни за обект „%s“"
 
-#: builtin/notes.c:154
+#: builtin/notes.c:153
 msgid "could not read 'show' output"
 msgstr "изведената информация от действието „show“ не може да се прочете"
 
-#: builtin/notes.c:162
+#: builtin/notes.c:161
 #, c-format
 msgid "failed to finish 'show' for object '%s'"
 msgstr "действието „show“ не може да се завърши за обект „%s“"
 
-#: builtin/notes.c:195
+#: builtin/notes.c:194
 msgid "please supply the note contents using either -m or -F option"
 msgstr "задайте съдържанието на бележката с някоя от опциите „-m“ или „-F“"
 
-#: builtin/notes.c:204
+#: builtin/notes.c:203
 msgid "unable to write note object"
 msgstr "обектът-бележка не може да бъде записан"
 
@@ -19318,7 +19233,7 @@ msgstr "обектът-бележка не може да бъде записан
 msgid "the note contents have been left in %s"
 msgstr "съдържанието на бележката е във файла „%s“"
 
-#: builtin/notes.c:240 builtin/tag.c:577
+#: builtin/notes.c:240 builtin/tag.c:581
 #, c-format
 msgid "could not open or read '%s'"
 msgstr "файлът „%s“ не може да бъде отворен или прочетен"
@@ -19363,8 +19278,8 @@ msgstr ""
 
 #: builtin/notes.c:374 builtin/notes.c:429 builtin/notes.c:507
 #: builtin/notes.c:519 builtin/notes.c:596 builtin/notes.c:663
-#: builtin/notes.c:813 builtin/notes.c:961 builtin/notes.c:983
-#: builtin/prune-packed.c:25 builtin/tag.c:587
+#: builtin/notes.c:813 builtin/notes.c:965 builtin/notes.c:987
+#: builtin/prune-packed.c:25 builtin/receive-pack.c:2487 builtin/tag.c:591
 msgid "too many arguments"
 msgstr "прекалено много аргументи"
 
@@ -19411,7 +19326,7 @@ msgstr ""
 msgid "Overwriting existing notes for object %s\n"
 msgstr "Презаписване на съществуващите бележки за обекта „%s“\n"
 
-#: builtin/notes.c:473 builtin/notes.c:635 builtin/notes.c:900
+#: builtin/notes.c:473 builtin/notes.c:635 builtin/notes.c:904
 #, c-format
 msgid "Removing note for object %s\n"
 msgstr "Изтриване на бележката за обекта „%s“\n"
@@ -19539,17 +19454,17 @@ msgstr "трябва да укажете указател към бележка 
 msgid "unknown -s/--strategy: %s"
 msgstr "неизвестна стратегия към опцията „-s“/„--strategy“: „%s“"
 
-#: builtin/notes.c:871
+#: builtin/notes.c:874
 #, c-format
 msgid "a notes merge into %s is already in-progress at %s"
 msgstr "в момента се извършва сливане на бележките в „%s“ при „%s“"
 
-#: builtin/notes.c:874
+#: builtin/notes.c:878
 #, c-format
 msgid "failed to store link to current notes ref (%s)"
 msgstr "не може да се запази връзка към указателя на текущата бележка („%s“)."
 
-#: builtin/notes.c:876
+#: builtin/notes.c:880
 #, c-format
 msgid ""
 "Automatic notes merge failed. Fix conflicts in %s and commit the result with "
@@ -19560,41 +19475,41 @@ msgstr ""
 "резултата с „git notes merge --commit“ или преустановете сливането с "
 "командата „git notes merge --abort“.\n"
 
-#: builtin/notes.c:895 builtin/tag.c:590
+#: builtin/notes.c:899 builtin/tag.c:594
 #, c-format
 msgid "Failed to resolve '%s' as a valid ref."
 msgstr "Не може да се открие към какво сочи „%s“."
 
-#: builtin/notes.c:898
+#: builtin/notes.c:902
 #, c-format
 msgid "Object %s has no note\n"
 msgstr "Няма бележки за обекта „%s“\n"
 
-#: builtin/notes.c:910
+#: builtin/notes.c:914
 msgid "attempt to remove non-existent note is not an error"
 msgstr "опитът за изтриването на несъществуваща бележка не се счита за грешка"
 
-#: builtin/notes.c:913
+#: builtin/notes.c:917
 msgid "read object names from the standard input"
 msgstr "изчитане на имената на обектите от стандартния вход"
 
-#: builtin/notes.c:952 builtin/prune.c:132 builtin/worktree.c:147
+#: builtin/notes.c:956 builtin/prune.c:144 builtin/worktree.c:147
 msgid "do not remove, show only"
 msgstr "само извеждане без действително окастряне"
 
-#: builtin/notes.c:953
+#: builtin/notes.c:957
 msgid "report pruned notes"
 msgstr "докладване на окастрените обекти"
 
-#: builtin/notes.c:996
+#: builtin/notes.c:1000
 msgid "notes-ref"
 msgstr "УКАЗАТЕЛ_ЗА_БЕЛЕЖКА"
 
-#: builtin/notes.c:997
+#: builtin/notes.c:1001
 msgid "use notes from <notes-ref>"
 msgstr "да се използва бележката сочена от този УКАЗАТЕЛ_ЗА_БЕЛЕЖКА"
 
-#: builtin/notes.c:1032 builtin/stash.c:1752
+#: builtin/notes.c:1036 builtin/stash.c:1818
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr "непозната подкоманда: %s"
@@ -20012,10 +19927,6 @@ msgstr ""
 "опцията „--thin“не може да се използва за създаване на пакетни файлове с "
 "индекс"
 
-#: builtin/pack-objects.c:4073
-msgid "--keep-unreachable and --unpack-unreachable are incompatible"
-msgstr "опциите „--keep-unreachable“ и „--unpack-unreachable“ са несъвместими"
-
 #: builtin/pack-objects.c:4079
 msgid "cannot use --filter without --stdout"
 msgstr "опцията „--filter“ изисква „--stdout“"
@@ -20033,7 +19944,7 @@ msgstr ""
 msgid "Enumerating objects"
 msgstr "Изброяване на обектите"
 
-#: builtin/pack-objects.c:4181
+#: builtin/pack-objects.c:4180
 #, c-format
 msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
@@ -20076,19 +19987,19 @@ msgstr "git prune-packed [-n | --dry-run] [-q | --quiet]"
 msgid "git prune [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]"
 msgstr "git prune [-n] [-v] [--progress] [--expire ВРЕМЕ] [--] [ВРЪХ…]"
 
-#: builtin/prune.c:133
+#: builtin/prune.c:145
 msgid "report pruned objects"
 msgstr "информация за окастрените обекти"
 
-#: builtin/prune.c:136
+#: builtin/prune.c:148
 msgid "expire objects older than <time>"
 msgstr "обявяване на обектите по-стари от това ВРЕМЕ за остарели"
 
-#: builtin/prune.c:138
+#: builtin/prune.c:150
 msgid "limit traversal to objects outside promisor packfiles"
 msgstr "ограничаване на обхождането до обекти извън гарантиращи пакети"
 
-#: builtin/prune.c:151
+#: builtin/prune.c:163
 msgid "cannot prune in a precious-objects repo"
 msgstr "хранилище с важни обекти не може да се окастря"
 
@@ -20123,7 +20034,7 @@ msgstr ""
 "дали куките преди подаване и сливане и при промяна на съобщението за "
 "подаване (pre-merge-commit и commit-msg) да се изпълнят"
 
-#: builtin/pull.c:171 parse-options.h:338
+#: builtin/pull.c:171 parse-options.h:340
 msgid "automatically stash/stash pop before and after"
 msgstr "автоматично скатаване/прилагане на скатаното преди и след пребазиране"
 
@@ -20200,6 +20111,7 @@ msgid "<remote>"
 msgstr "ОТДАЛЕЧЕНО_ХРАНИЛИЩЕ"
 
 #: builtin/pull.c:467 builtin/pull.c:482 builtin/pull.c:487
+#: contrib/scalar/scalar.c:375
 msgid "<branch>"
 msgstr "КЛОН"
 
@@ -20232,13 +20144,13 @@ msgstr "недостъпно подаване: %s"
 msgid "ignoring --verify-signatures for rebase"
 msgstr "без „--verify-signatures“ при пребазиране"
 
-#: builtin/pull.c:942
+#: builtin/pull.c:969
 msgid ""
 "You have divergent branches and need to specify how to reconcile them.\n"
 "You can do so by running one of the following commands sometime before\n"
 "your next pull:\n"
 "\n"
-"  git config pull.rebase false  # merge (the default strategy)\n"
+"  git config pull.rebase false  # merge\n"
 "  git config pull.rebase true   # rebase\n"
 "  git config pull.ff only       # fast-forward only\n"
 "\n"
@@ -20252,28 +20164,28 @@ msgstr ""
 "това.  За да заглушите това съобщение, изпълнете някоя от следните\n"
 "команди преди следващото издърпване:\n"
 "\n"
-"  git config pull.rebase false  # сливане (стандартна стратегия)\n"
-"  git config pull.rebase true   # пребазиране\n"
-"  git config pull.ff only       # само превъртане\n"
+"    git config pull.rebase false  # сливане\n"
+"    git config pull.rebase true   # пребазиране\n"
+"    git config pull.ff only       # само превъртане\n"
 "\n"
 "За да зададете стандартната настройка за всички свои хранилища, добавете и\n"
 "опцията „--global“.  За да укажете стратегия при конкретно издърпване,\n"
 "използвайте опциите „--rebase“, „--no-rebase“, „--ff-only“.  Те са с\n"
 "приоритет пред настройките.\n"
 
-#: builtin/pull.c:1016
+#: builtin/pull.c:1046
 msgid "Updating an unborn branch with changes added to the index."
 msgstr "Обновяване на все още несъздаден клон с промените от индекса"
 
-#: builtin/pull.c:1020
+#: builtin/pull.c:1050
 msgid "pull with rebase"
 msgstr "издърпване с пребазиране"
 
-#: builtin/pull.c:1021
+#: builtin/pull.c:1051
 msgid "please commit or stash them."
 msgstr "трябва да подадете или скатаете промените."
 
-#: builtin/pull.c:1046
+#: builtin/pull.c:1076
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -20283,7 +20195,7 @@ msgstr ""
 "доставянето обнови върха на текущия клон.  Работното\n"
 "ви копие бе превъртяно от подаване „%s“."
 
-#: builtin/pull.c:1052
+#: builtin/pull.c:1082
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -20300,24 +20212,24 @@ msgstr ""
 "    git reset --hard\n"
 "за връщане към нормално състояние."
 
-#: builtin/pull.c:1067
+#: builtin/pull.c:1097
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Не може да сливате множество клони в празен върхов указател."
 
-#: builtin/pull.c:1072
+#: builtin/pull.c:1102
 msgid "Cannot rebase onto multiple branches."
 msgstr "Не може да пребазирате върху повече от един клон."
 
-#: builtin/pull.c:1074
+#: builtin/pull.c:1104
 msgid "Cannot fast-forward to multiple branches."
 msgstr "Не може да превъртите към повече от един клон."
 
-#: builtin/pull.c:1088
+#: builtin/pull.c:1119
 msgid "Need to specify how to reconcile divergent branches."
 msgstr ""
 "Трябва да укажете как да се решават разликите при разминаване на клоните."
 
-#: builtin/pull.c:1102
+#: builtin/pull.c:1133
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "пребазирането е невъзможно заради локално записаните промени по подмодулите"
@@ -20507,7 +20419,7 @@ msgstr "Изтласкване към „%s“\n"
 msgid "failed to push some refs to '%s'"
 msgstr "част от указателите не бяха изтласкани към „%s“"
 
-#: builtin/push.c:544 builtin/submodule--helper.c:3258
+#: builtin/push.c:544 builtin/submodule--helper.c:3259
 msgid "repository"
 msgstr "хранилище"
 
@@ -20583,11 +20495,6 @@ msgstr "подписване на изтласкването с GPG"
 msgid "request atomic transaction on remote side"
 msgstr "изискване на атомарни операции от отсрещната страна"
 
-#: builtin/push.c:592
-msgid "--delete is incompatible with --all, --mirror and --tags"
-msgstr ""
-"опцията „--delete“ е несъвместима с опциите  „--all“, „--mirror“ и „--tags“"
-
 #: builtin/push.c:594
 msgid "--delete doesn't make sense without any refs"
 msgstr "опцията „--delete“ изисква поне един указател на версия"
@@ -20619,25 +20526,13 @@ msgstr ""
 "\n"
 "    git push ИМЕ\n"
 
-#: builtin/push.c:630
-msgid "--all and --tags are incompatible"
-msgstr "опциите „--all“ и „--tags“ са несъвместими"
-
 #: builtin/push.c:632
 msgid "--all can't be combined with refspecs"
 msgstr "опцията „--all“ е несъвместима с указването на версия"
 
-#: builtin/push.c:636
-msgid "--mirror and --tags are incompatible"
-msgstr "опциите „--mirror“ и „--tags“ са несъвместими"
-
 #: builtin/push.c:638
 msgid "--mirror can't be combined with refspecs"
 msgstr "опцията „--mirror“ е несъвместима с указването на версия"
-
-#: builtin/push.c:641
-msgid "--all and --mirror are incompatible"
-msgstr "опциите „--all“ и „--mirror“ са несъвместими"
 
 #: builtin/push.c:648
 msgid "push options must not have new line characters"
@@ -21066,18 +20961,6 @@ msgstr ""
 msgid "--preserve-merges was replaced by --rebase-merges"
 msgstr "Опцията „--preserve-merges“ е заменена с „--rebase-merges“."
 
-#: builtin/rebase.c:1193
-msgid "cannot combine '--keep-base' with '--onto'"
-msgstr "опциите „--keep-base“ и „--onto“ са несъвместими"
-
-#: builtin/rebase.c:1195
-msgid "cannot combine '--keep-base' with '--root'"
-msgstr "опциите „--keep-base“ и „--root“ са несъвместими"
-
-#: builtin/rebase.c:1199
-msgid "cannot combine '--root' with '--fork-point'"
-msgstr "опциите „--root“ и „--fork-point“ са несъвместими"
-
 #: builtin/rebase.c:1202
 msgid "No rebase in progress?"
 msgstr "Изглежда в момента не тече пребазиране"
@@ -21144,8 +21027,8 @@ msgstr ""
 "опцията „--strategy“ изисква някоя от опциите „--merge“ или „--interactive“"
 
 #: builtin/rebase.c:1463
-msgid "cannot combine apply options with merge options"
-msgstr "опциите за „apply“ са несъвместими с опциите за сливане"
+msgid "apply options and merge options cannot be used together"
+msgstr "опциите за прилагане и сливане са несъвместими"
 
 #: builtin/rebase.c:1476
 #, c-format
@@ -21188,7 +21071,7 @@ msgid "no such branch/commit '%s'"
 msgstr "не съществува клон/подаване „%s“"
 
 #: builtin/rebase.c:1618 builtin/submodule--helper.c:39
-#: builtin/submodule--helper.c:2658
+#: builtin/submodule--helper.c:2659
 #, c-format
 msgid "No such ref: %s"
 msgstr "Такъв указател няма: %s"
@@ -21258,7 +21141,7 @@ msgstr "Превъртане на „%s“ към „%s“.\n"
 msgid "git receive-pack <git-dir>"
 msgstr "git receive-pack ДИРЕКТОРИЯ_НА_GIT"
 
-#: builtin/receive-pack.c:1280
+#: builtin/receive-pack.c:1275
 msgid ""
 "By default, updating the current branch in a non-bare repository\n"
 "is denied, because it will make the index and work tree inconsistent\n"
@@ -21291,7 +21174,7 @@ msgstr ""
 "За да заглушите това съобщение, като запазите стандартното поведение,\n"
 "задайте настройката „receive.denyCurrentBranch“ да е „refuse“ (отказ)."
 
-#: builtin/receive-pack.c:1300
+#: builtin/receive-pack.c:1295
 msgid ""
 "By default, deleting the current branch is denied, because the next\n"
 "'git clone' won't result in any file checked out, causing confusion.\n"
@@ -21312,13 +21195,13 @@ msgstr ""
 "За да заглушите това съобщение, задайте настройката\n"
 "„receive.denyDeleteCurrent“ да е „refuse“ (отказ)."
 
-#: builtin/receive-pack.c:2480
+#: builtin/receive-pack.c:2474
 msgid "quiet"
 msgstr "без извеждане на информация"
 
-#: builtin/receive-pack.c:2495
-msgid "You must specify a directory."
-msgstr "Трябва да укажете директория."
+#: builtin/receive-pack.c:2489
+msgid "you must specify a directory"
+msgstr "трябва да укажете директория"
 
 #: builtin/reflog.c:17
 msgid ""
@@ -21341,41 +21224,41 @@ msgstr ""
 msgid "git reflog exists <ref>"
 msgstr "git reflog exists УКАЗАТЕЛ"
 
-#: builtin/reflog.c:568 builtin/reflog.c:573
+#: builtin/reflog.c:585 builtin/reflog.c:590
 #, c-format
 msgid "'%s' is not a valid timestamp"
 msgstr "„%s“ не е правилна стойност за време"
 
-#: builtin/reflog.c:609
+#: builtin/reflog.c:631
 #, c-format
 msgid "Marking reachable objects..."
 msgstr "Отбелязване на достижимите обекти…"
 
-#: builtin/reflog.c:647
+#: builtin/reflog.c:675
 #, c-format
 msgid "%s points nowhere!"
 msgstr "„%s“ не сочи наникъде!"
 
-#: builtin/reflog.c:700
+#: builtin/reflog.c:731
 msgid "no reflog specified to delete"
 msgstr "не е указан журнал с подавания за изтриване"
 
-#: builtin/reflog.c:708
+#: builtin/reflog.c:742
 #, c-format
 msgid "not a reflog: %s"
 msgstr "„%s“ не е журнал с подавания"
 
-#: builtin/reflog.c:713
+#: builtin/reflog.c:747
 #, c-format
 msgid "no reflog for '%s'"
 msgstr "липсва журнал с подаванията за „%s“"
 
-#: builtin/reflog.c:759
+#: builtin/reflog.c:794
 #, c-format
 msgid "invalid ref format: %s"
 msgstr "неправилен формат на указател: %s"
 
-#: builtin/reflog.c:768
+#: builtin/reflog.c:803
 msgid "git reflog [ show | expire | delete | exists ]"
 msgstr "git reflog [ show | expire | delete | exists ]"
 
@@ -21466,6 +21349,11 @@ msgstr "git remote update [ОПЦИЯ…] [ГРУПА | ОТДАЛЕЧЕНО_Х�
 #, c-format
 msgid "Updating %s"
 msgstr "Обновяване на „%s“"
+
+#: builtin/remote.c:101
+#, c-format
+msgid "Could not fetch %s"
+msgstr "„%s“ не може да се достави"
 
 #: builtin/remote.c:131
 msgid ""
@@ -21927,161 +21815,153 @@ msgstr ""
 "командата „pack-objects“ не може да се стартира за препакетирането на "
 "гарантиращите обекти"
 
-#: builtin/repack.c:273 builtin/repack.c:816
+#: builtin/repack.c:275 builtin/repack.c:820
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
 msgstr ""
 "repack: от „pack-objects“ се изискват редове само с пълни шестнайсетични "
 "указатели."
 
-#: builtin/repack.c:297
+#: builtin/repack.c:299
 msgid "could not finish pack-objects to repack promisor objects"
 msgstr ""
 "командата „pack-objects“ не може да завърши за препакетирането на "
 "гарантиращите обекти"
 
-#: builtin/repack.c:312
+#: builtin/repack.c:314
 #, c-format
 msgid "cannot open index for %s"
 msgstr "грешка при отваряне на индекса за „%s“"
 
-#: builtin/repack.c:371
+#: builtin/repack.c:373
 #, c-format
 msgid "pack %s too large to consider in geometric progression"
 msgstr "пакет „%s“ е твърде голям, за да е част от геометрична прогресия"
 
-#: builtin/repack.c:404 builtin/repack.c:411 builtin/repack.c:416
+#: builtin/repack.c:406 builtin/repack.c:413 builtin/repack.c:418
 #, c-format
 msgid "pack %s too large to roll up"
 msgstr "пакет „%s“ е твърде голям за свиване"
 
-#: builtin/repack.c:496
+#: builtin/repack.c:498
 #, c-format
 msgid "could not open tempfile %s for writing"
 msgstr "временният файл „%s“ не може да бъде отворен за запис"
 
-#: builtin/repack.c:514
+#: builtin/repack.c:516
 msgid "could not close refs snapshot tempfile"
 msgstr "временният файл със снимка на указателите не може да се затвори"
 
-#: builtin/repack.c:628
+#: builtin/repack.c:630
 msgid "pack everything in a single pack"
 msgstr "пакетиране на всичко в пакет"
 
-#: builtin/repack.c:630
+#: builtin/repack.c:632
 msgid "same as -a, and turn unreachable objects loose"
 msgstr ""
 "същото като опцията „-a“.  Допълнително — недостижимите обекти да станат "
 "непакетирани"
 
-#: builtin/repack.c:633
+#: builtin/repack.c:635
 msgid "remove redundant packs, and run git-prune-packed"
 msgstr ""
 "премахване на ненужните пакетирани файлове и изпълнение на командата „git-"
 "prune-packed“"
 
-#: builtin/repack.c:635
+#: builtin/repack.c:637
 msgid "pass --no-reuse-delta to git-pack-objects"
 msgstr "подаване на опцията „--no-reuse-delta“ на командата „git-pack-objects“"
 
-#: builtin/repack.c:637
+#: builtin/repack.c:639
 msgid "pass --no-reuse-object to git-pack-objects"
 msgstr ""
 "подаване на опцията „--no-reuse-object“ на командата „git-pack-objects“"
 
-#: builtin/repack.c:639
+#: builtin/repack.c:641
 msgid "do not run git-update-server-info"
 msgstr "без изпълнение на командата „git-update-server-info“"
 
-#: builtin/repack.c:642
+#: builtin/repack.c:644
 msgid "pass --local to git-pack-objects"
 msgstr "подаване на опцията „--local“ на командата „git-pack-objects“"
 
-#: builtin/repack.c:644
+#: builtin/repack.c:646
 msgid "write bitmap index"
 msgstr "създаване и записване на индекси на база битови маски"
 
-#: builtin/repack.c:646
+#: builtin/repack.c:648
 msgid "pass --delta-islands to git-pack-objects"
 msgstr "подаване на опцията „--delta-islands“ на командата „git-pack-objects“"
 
-#: builtin/repack.c:647
+#: builtin/repack.c:649
 msgid "approxidate"
 msgstr "евристична дата"
 
-#: builtin/repack.c:648
+#: builtin/repack.c:650
 msgid "with -A, do not loosen objects older than this"
 msgstr ""
 "при комбинирането с опцията „-A“ — без разпакетиране на обектите по стари от "
 "това"
 
-#: builtin/repack.c:650
+#: builtin/repack.c:652
 msgid "with -a, repack unreachable objects"
 msgstr "с „-a“ — препакетиране на недостижимите обекти"
 
-#: builtin/repack.c:652
+#: builtin/repack.c:654
 msgid "size of the window used for delta compression"
 msgstr "размер на прозореца за делта компресията"
 
-#: builtin/repack.c:653 builtin/repack.c:659
+#: builtin/repack.c:655 builtin/repack.c:661
 msgid "bytes"
 msgstr "байтове"
 
-#: builtin/repack.c:654
+#: builtin/repack.c:656
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr ""
 "същото като горната опция, но ограничението да е по размер на паметта, а не "
 "по броя на обектите"
 
-#: builtin/repack.c:656
+#: builtin/repack.c:658
 msgid "limits the maximum delta depth"
 msgstr "ограничаване на максималната дълбочина на делтата"
 
-#: builtin/repack.c:658
+#: builtin/repack.c:660
 msgid "limits the maximum number of threads"
 msgstr "ограничаване на максималния брой нишки"
 
-#: builtin/repack.c:660
+#: builtin/repack.c:662
 msgid "maximum size of each packfile"
 msgstr "максимален размер на всеки пакет"
 
-#: builtin/repack.c:662
+#: builtin/repack.c:664
 msgid "repack objects in packs marked with .keep"
 msgstr "препакетиране на обектите в пакети белязани с „.keep“"
 
-#: builtin/repack.c:664
+#: builtin/repack.c:666
 msgid "do not repack this pack"
 msgstr "без препакетиране на този пакет"
 
-#: builtin/repack.c:666
+#: builtin/repack.c:668
 msgid "find a geometric progression with factor <N>"
 msgstr "откриване на геометрична прогресия с частно <N>"
 
-#: builtin/repack.c:668
+#: builtin/repack.c:670
 msgid "write a multi-pack index of the resulting packs"
 msgstr "запазване на многопакетен индекс за създадените пакети"
 
-#: builtin/repack.c:678
+#: builtin/repack.c:680
 msgid "cannot delete packs in a precious-objects repo"
 msgstr "пакетите в хранилище с важни обекти не може да се трият"
 
-#: builtin/repack.c:682
-msgid "--keep-unreachable and -A are incompatible"
-msgstr "опциите „--keep-unreachable“ и „-A“ са несъвместими"
-
-#: builtin/repack.c:713
-msgid "--geometric is incompatible with -A, -a"
-msgstr "опциите „--geometric“ и „-A“/„-a“ са несъвместими"
-
-#: builtin/repack.c:825
+#: builtin/repack.c:829
 msgid "Nothing new to pack."
 msgstr "Нищо ново за пакетиране"
 
-#: builtin/repack.c:855
+#: builtin/repack.c:859
 #, c-format
 msgid "missing required file: %s"
 msgstr "липсва задължителния файл „%s“"
 
-#: builtin/repack.c:857
+#: builtin/repack.c:861
 #, c-format
 msgid "could not unlink: %s"
 msgstr "неуспешно изтриване на „%s“"
@@ -22164,67 +22044,61 @@ msgstr "изпълнението на „cat-file“ завърши с греш�
 msgid "unable to open %s for reading"
 msgstr "„%s“ не може да бъде отворен за четене"
 
-#: builtin/replace.c:272
+#: builtin/replace.c:271
 msgid "unable to spawn mktree"
 msgstr "не може да се създаде процес за „mktree“"
 
-#: builtin/replace.c:276
+#: builtin/replace.c:275
 msgid "unable to read from mktree"
 msgstr "не може да се прочете от „mktree“"
 
-#: builtin/replace.c:285
+#: builtin/replace.c:284
 msgid "mktree reported failure"
 msgstr "„mktree“ завърши с грешка"
 
-#: builtin/replace.c:289
+#: builtin/replace.c:288
 msgid "mktree did not return an object name"
 msgstr "„mktree“ не върна име на обект"
 
-#: builtin/replace.c:298
+#: builtin/replace.c:297
 #, c-format
 msgid "unable to fstat %s"
 msgstr "„fstat“ не може да се изпълни върху „%s“"
 
-#: builtin/replace.c:303
+#: builtin/replace.c:302
 msgid "unable to write object to database"
 msgstr "обектът не може да бъде записан в базата от данни"
 
-#: builtin/replace.c:322 builtin/replace.c:378 builtin/replace.c:424
-#: builtin/replace.c:454
-#, c-format
-msgid "not a valid object name: '%s'"
-msgstr "неправилно име на обект: „%s“"
-
-#: builtin/replace.c:326
+#: builtin/replace.c:325
 #, c-format
 msgid "unable to get object type for %s"
 msgstr "не може да се определи видът на обекта „%s“"
 
-#: builtin/replace.c:342
+#: builtin/replace.c:341
 msgid "editing object file failed"
 msgstr "неуспешно редактиране на файла с обектите"
 
-#: builtin/replace.c:351
+#: builtin/replace.c:350
 #, c-format
 msgid "new object is the same as the old one: '%s'"
 msgstr "новият и старият обект са един и същ: „%s“"
 
-#: builtin/replace.c:384
+#: builtin/replace.c:383
 #, c-format
 msgid "could not parse %s as a commit"
 msgstr "„%s“ не може да се анализира като подаване"
 
-#: builtin/replace.c:416
+#: builtin/replace.c:415
 #, c-format
 msgid "bad mergetag in commit '%s'"
 msgstr "етикетът при сливане в подаването „%s“ e неправилен"
 
-#: builtin/replace.c:418
+#: builtin/replace.c:417
 #, c-format
 msgid "malformed mergetag in commit '%s'"
 msgstr "етикетът при сливане в подаването „%s“ e неправилен"
 
-#: builtin/replace.c:430
+#: builtin/replace.c:429
 #, c-format
 msgid ""
 "original commit '%s' contains mergetag '%s' that is discarded; use --edit "
@@ -22233,31 +22107,31 @@ msgstr ""
 "Първоначалното подаване „%s“ съдържа етикета при сливане „%s“, който е "
 "изхвърлен, затова използвайте опцията „--edit“, а не „--graft“."
 
-#: builtin/replace.c:469
+#: builtin/replace.c:468
 #, c-format
 msgid "the original commit '%s' has a gpg signature"
 msgstr "първоначалното подаване „%s“ е с подпис на GPG"
 
-#: builtin/replace.c:470
+#: builtin/replace.c:469
 msgid "the signature will be removed in the replacement commit!"
 msgstr "Подписът ще бъде премахнат в заменящото подаване!"
 
-#: builtin/replace.c:480
+#: builtin/replace.c:479
 #, c-format
 msgid "could not write replacement commit for: '%s'"
 msgstr "заменящото подаване за „%s“ не може да бъде записано"
 
-#: builtin/replace.c:488
+#: builtin/replace.c:487
 #, c-format
 msgid "graft for '%s' unnecessary"
 msgstr "присадката за „%s“ е излишна"
 
-#: builtin/replace.c:492
+#: builtin/replace.c:491
 #, c-format
 msgid "new commit is the same as the old one: '%s'"
 msgstr "новото и старото подаване са едно и също: „%s“"
 
-#: builtin/replace.c:527
+#: builtin/replace.c:526
 #, c-format
 msgid ""
 "could not convert the following graft(s):\n"
@@ -22266,71 +22140,71 @@ msgstr ""
 "следните присадки не може да се преобразуват:\n"
 "%s"
 
-#: builtin/replace.c:548
+#: builtin/replace.c:547
 msgid "list replace refs"
 msgstr "извеждане на списъка с указателите за замяна"
 
-#: builtin/replace.c:549
+#: builtin/replace.c:548
 msgid "delete replace refs"
 msgstr "изтриване на указателите за замяна"
 
-#: builtin/replace.c:550
+#: builtin/replace.c:549
 msgid "edit existing object"
 msgstr "редактиране на съществуващ обект"
 
-#: builtin/replace.c:551
+#: builtin/replace.c:550
 msgid "change a commit's parents"
 msgstr "смяна на родителите на подаване"
 
-#: builtin/replace.c:552
+#: builtin/replace.c:551
 msgid "convert existing graft file"
 msgstr "преобразуване на файла за присадките"
 
-#: builtin/replace.c:553
+#: builtin/replace.c:552
 msgid "replace the ref if it exists"
 msgstr "замяна на указателя, ако съществува"
 
-#: builtin/replace.c:555
+#: builtin/replace.c:554
 msgid "do not pretty-print contents for --edit"
 msgstr "без форматирано извеждане на съдържанието — за опцията „--edit“"
 
-#: builtin/replace.c:556
+#: builtin/replace.c:555
 msgid "use this format"
 msgstr "използване на този ФОРМАТ"
 
-#: builtin/replace.c:569
+#: builtin/replace.c:568
 msgid "--format cannot be used when not listing"
 msgstr "опцията „--format“ изисква извеждане на списък"
 
-#: builtin/replace.c:577
+#: builtin/replace.c:576
 msgid "-f only makes sense when writing a replacement"
 msgstr "опцията „-f“ изисква запазването на заместител"
 
-#: builtin/replace.c:581
+#: builtin/replace.c:580
 msgid "--raw only makes sense with --edit"
 msgstr "опцията „--raw“ изисква „--edit“"
 
-#: builtin/replace.c:587
+#: builtin/replace.c:586
 msgid "-d needs at least one argument"
 msgstr "опцията „-d“ изисква поне един аргумент"
 
-#: builtin/replace.c:593
+#: builtin/replace.c:592
 msgid "bad number of arguments"
 msgstr "неправилен брой аргументи"
 
-#: builtin/replace.c:599
+#: builtin/replace.c:598
 msgid "-e needs exactly one argument"
 msgstr "опцията „-e“ изисква поне един аргумент"
 
-#: builtin/replace.c:605
+#: builtin/replace.c:604
 msgid "-g needs at least one argument"
 msgstr "опцията „-g“ изисква поне един аргумент"
 
-#: builtin/replace.c:611
+#: builtin/replace.c:610
 msgid "--convert-graft-file takes no argument"
 msgstr "опцията „--convert-graft-file“ не приема аргументи"
 
-#: builtin/replace.c:617
+#: builtin/replace.c:616
 msgid "only one pattern can be given with -l"
 msgstr "опцията „-l“ приема точно един шаблон"
 
@@ -22351,137 +22225,127 @@ msgstr "командата „git rerere forget“ изисква указван
 msgid "unable to generate diff for '%s'"
 msgstr "неуспешно генериране на разлика за „%s“"
 
-#: builtin/reset.c:32
+#: builtin/reset.c:33
 msgid ""
 "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<commit>]"
 msgstr ""
 "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [ПОДАВАНЕ]"
 
-#: builtin/reset.c:33
+#: builtin/reset.c:34
 msgid "git reset [-q] [<tree-ish>] [--] <pathspec>..."
 msgstr "git reset [-q] [УКАЗАТЕЛ_КЪМ_ДЪРВО] [--] ПЪТИЩА…"
 
-#: builtin/reset.c:34
+#: builtin/reset.c:35
 msgid ""
 "git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<tree-ish>]"
 msgstr ""
 "git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] "
 "[УКАЗАТЕЛ_КЪМ_ДЪРВО]"
 
-#: builtin/reset.c:35
+#: builtin/reset.c:36
 msgid "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
 msgstr "git reset --patch [УКАЗАТЕЛ_КЪМ_ДЪРВО] [--] [ПЪТИЩА…]"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "mixed"
 msgstr "смесено (mixed)"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "soft"
 msgstr "меко (soft)"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "hard"
 msgstr "пълно (hard)"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "merge"
 msgstr "слято (merge)"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "keep"
 msgstr "запазващо (keep)"
 
-#: builtin/reset.c:89
+#: builtin/reset.c:90
 msgid "You do not have a valid HEAD."
 msgstr "Указателят „HEAD“ е повреден."
 
-#: builtin/reset.c:91
+#: builtin/reset.c:92
 msgid "Failed to find tree of HEAD."
 msgstr "Дървото, сочено от указателя „HEAD“, не може да бъде открито."
 
-#: builtin/reset.c:97
+#: builtin/reset.c:98
 #, c-format
 msgid "Failed to find tree of %s."
 msgstr "Дървото, сочено от „%s“, не може да бъде открито."
 
-#: builtin/reset.c:122
+#: builtin/reset.c:123
 #, c-format
 msgid "HEAD is now at %s"
 msgstr "Указателят „HEAD“ сочи към „%s“"
 
-#: builtin/reset.c:201
+#: builtin/reset.c:299
 #, c-format
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "Не може да се извърши %s зануляване по време на сливане."
 
-#: builtin/reset.c:301 builtin/stash.c:605 builtin/stash.c:679
-#: builtin/stash.c:703
+#: builtin/reset.c:396 builtin/stash.c:606 builtin/stash.c:680
+#: builtin/stash.c:704
 msgid "be quiet, only report errors"
 msgstr "по-малко подробности, да се извеждат само грешките"
 
-#: builtin/reset.c:303
+#: builtin/reset.c:398
 msgid "reset HEAD and index"
 msgstr "индекса и указателя „HEAD“, без работното дърво"
 
-#: builtin/reset.c:304
+#: builtin/reset.c:399
 msgid "reset only HEAD"
 msgstr "само указателя „HEAD“, без индекса и работното дърво"
 
-#: builtin/reset.c:306 builtin/reset.c:308
+#: builtin/reset.c:401 builtin/reset.c:403
 msgid "reset HEAD, index and working tree"
 msgstr "указателя „HEAD“, индекса и работното дърво"
 
-#: builtin/reset.c:310
+#: builtin/reset.c:405
 msgid "reset HEAD but keep local changes"
 msgstr "зануляване на указателя „HEAD“, но запазване на локалните промени"
 
-#: builtin/reset.c:316
+#: builtin/reset.c:411
 msgid "record only the fact that removed paths will be added later"
 msgstr ""
 "отбелязване само на факта, че изтритите пътища ще бъдат добавени по-късно"
 
-#: builtin/reset.c:350
+#: builtin/reset.c:445
 #, c-format
 msgid "Failed to resolve '%s' as a valid revision."
 msgstr "Стойността „%s“ не е разпозната като съществуваща версия."
 
-#: builtin/reset.c:358
+#: builtin/reset.c:453
 #, c-format
 msgid "Failed to resolve '%s' as a valid tree."
 msgstr "„%s“ не е разпознат като дърво."
 
-#: builtin/reset.c:367
-msgid "--patch is incompatible with --{hard,mixed,soft}"
-msgstr ""
-"опцията „--patch“ е несъвместима с всяка от опциите „--hard“/„--mixed“/„--"
-"soft“"
-
-#: builtin/reset.c:377
+#: builtin/reset.c:472
 msgid "--mixed with paths is deprecated; use 'git reset -- <paths>' instead."
 msgstr ""
 "опцията „--mixed“ не бива да се използва заедно с пътища.  Вместо това "
 "изпълнете „git reset -- ПЪТ…“."
 
-#: builtin/reset.c:379
+#: builtin/reset.c:474
 #, c-format
 msgid "Cannot do %s reset with paths."
 msgstr "Не може да извършите %s зануляване, когато сте задали ПЪТ."
 
-#: builtin/reset.c:394
+#: builtin/reset.c:489
 #, c-format
 msgid "%s reset is not allowed in a bare repository"
 msgstr "В голо хранилище не може да извършите %s зануляване"
 
-#: builtin/reset.c:398
-msgid "-N can only be used with --mixed"
-msgstr "опцията „-N“ изисква опцията „--mixed“"
-
-#: builtin/reset.c:419
+#: builtin/reset.c:520
 msgid "Unstaged changes after reset:"
 msgstr "Промени извън индекса след зануляването:"
 
-#: builtin/reset.c:422
+#: builtin/reset.c:523
 #, c-format
 msgid ""
 "\n"
@@ -22494,18 +22358,14 @@ msgstr ""
 "Опцията „--quiet“ заглушава това съобщение еднократно.  За постоянно\n"
 "заглушаване задайте настройката „reset.quiet“ да е „true“ (истина).\n"
 
-#: builtin/reset.c:440
+#: builtin/reset.c:541
 #, c-format
 msgid "Could not reset index file to revision '%s'."
 msgstr "Индексът не може да бъде занулен към версия „%s“."
 
-#: builtin/reset.c:445
+#: builtin/reset.c:546
 msgid "Could not write new index file."
 msgstr "Новият индекс не може да бъде записан."
-
-#: builtin/rev-list.c:541
-msgid "cannot combine --exclude-promisor-objects and --missing"
-msgstr "опциите „--exclude-promisor-objects“ и „--missing“ и са несъвместими"
 
 #: builtin/rev-list.c:602
 msgid "object filtering requires --objects"
@@ -22516,8 +22376,9 @@ msgid "rev-list does not support display of notes"
 msgstr "командата „rev-list“ не поддържа извеждането на бележки"
 
 #: builtin/rev-list.c:679
-msgid "marked counting is incompatible with --objects"
-msgstr "опцията „--objects“ е несъвместима с изброяването"
+#, c-format
+msgid "marked counting and '%s' cannot be used together"
+msgstr "опцията „%s“ е несъвместима с изброяването"
 
 #: builtin/rev-parse.c:409
 msgid "git rev-parse --parseopt [<options>] -- [<args>...]"
@@ -22966,13 +22827,6 @@ msgstr "БРОЙ[,БАЗА]"
 msgid "show <n> most recent ref-log entries starting at base"
 msgstr "показване на най-много БРОЙ журнални записа с начало съответната БАЗА"
 
-#: builtin/show-branch.c:710
-msgid ""
-"--reflog is incompatible with --all, --remotes, --independent or --merge-base"
-msgstr ""
-"опцията „--reflog“ е несъвместима с опциите  „--all“, „--remotes“, „--"
-"independent“ и „--merge-base“"
-
 #: builtin/show-branch.c:734
 msgid "no branches given, and HEAD is not valid"
 msgstr "не е зададен клон, а указателят „HEAD“ е неправилен"
@@ -22993,19 +22847,19 @@ msgstr[1] "само %d записа може да бъде показани на
 msgid "no such ref %s"
 msgstr "такъв указател няма: %s"
 
-#: builtin/show-branch.c:828
+#: builtin/show-branch.c:830
 #, c-format
 msgid "cannot handle more than %d rev."
 msgid_plural "cannot handle more than %d revs."
 msgstr[0] "не може да се обработи повече от %d указател."
 msgstr[1] "не може да се обработят повече от %d указатели."
 
-#: builtin/show-branch.c:832
+#: builtin/show-branch.c:834
 #, c-format
 msgid "'%s' is not a valid ref."
 msgstr "„%s“ е неправилен указател."
 
-#: builtin/show-branch.c:835
+#: builtin/show-branch.c:837
 #, c-format
 msgid "cannot find commit %s (%s)"
 msgstr "подаването „%s“ (%s) липсва"
@@ -23074,12 +22928,16 @@ msgstr "git sparse-checkout (init|list|set|add|reapply|disable) ОПЦИЯ…"
 msgid "git sparse-checkout list"
 msgstr "git sparse-checkout list"
 
-#: builtin/sparse-checkout.c:72
+#: builtin/sparse-checkout.c:60
+msgid "this worktree is not sparse"
+msgstr "това работно дърво не е частично"
+
+#: builtin/sparse-checkout.c:75
 msgid "this worktree is not sparse (sparse-checkout file may not exist)"
 msgstr ""
 "това не е частично работно дърво (вероятно липсва файл „sparse-checkout“)"
 
-#: builtin/sparse-checkout.c:173
+#: builtin/sparse-checkout.c:176
 #, c-format
 msgid ""
 "directory '%s' contains untracked files, but is not in the sparse-checkout "
@@ -23088,77 +22946,102 @@ msgstr ""
 "директорията „%s“ съдържа неследени файлове, но не е в пътищата на "
 "пътеводното напасване на частичното изтегляне"
 
-#: builtin/sparse-checkout.c:181
+#: builtin/sparse-checkout.c:184
 #, c-format
 msgid "failed to remove directory '%s'"
 msgstr "директорията „%s“ не може да бъде изтрита"
 
-#: builtin/sparse-checkout.c:321
+#: builtin/sparse-checkout.c:324
 msgid "failed to create directory for sparse-checkout file"
 msgstr "директорията за частично изтегляне „%s“ не може да бъде създадена"
 
-#: builtin/sparse-checkout.c:362
+#: builtin/sparse-checkout.c:365
 msgid "unable to upgrade repository format to enable worktreeConfig"
 msgstr ""
 "настройката „worktreeConfig“ не може да се включи, защото форматът на "
 "хранилището не може да се обнови"
 
-#: builtin/sparse-checkout.c:364
+#: builtin/sparse-checkout.c:367
 msgid "failed to set extensions.worktreeConfig setting"
 msgstr "неуспешно задаване на настройката „extensions.worktreeConfig“"
 
-#: builtin/sparse-checkout.c:384
-msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
-msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
-
-#: builtin/sparse-checkout.c:404
-msgid "initialize the sparse-checkout in cone mode"
-msgstr "инициализиране на частичното изтегляне в пътеводен режим"
-
-#: builtin/sparse-checkout.c:406
-msgid "toggle the use of a sparse index"
-msgstr "превключване на ползването на частичен индекс"
-
-#: builtin/sparse-checkout.c:434
+#: builtin/sparse-checkout.c:411
 msgid "failed to modify sparse-index config"
 msgstr "настройките на частичния индекс не може да се променят"
 
-#: builtin/sparse-checkout.c:455
+#: builtin/sparse-checkout.c:422
+msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
+msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
+
+#: builtin/sparse-checkout.c:441 builtin/sparse-checkout.c:729
+#: builtin/sparse-checkout.c:778
+msgid "initialize the sparse-checkout in cone mode"
+msgstr "инициализиране на частичното изтегляне в пътеводен режим"
+
+#: builtin/sparse-checkout.c:443 builtin/sparse-checkout.c:731
+#: builtin/sparse-checkout.c:780
+msgid "toggle the use of a sparse index"
+msgstr "превключване на ползването на частичен индекс"
+
+#: builtin/sparse-checkout.c:476
 #, c-format
 msgid "failed to open '%s'"
 msgstr "„%s“ не може да се отвори"
 
-#: builtin/sparse-checkout.c:507
+#: builtin/sparse-checkout.c:528
 #, c-format
 msgid "could not normalize path %s"
 msgstr "пътят „%s“  не може да се нормализира"
 
-#: builtin/sparse-checkout.c:519
-msgid "git sparse-checkout (set|add) (--stdin | <patterns>)"
-msgstr "git sparse-checkout (set|add) (--stdin | ШАБЛОН…)"
-
-#: builtin/sparse-checkout.c:544
+#: builtin/sparse-checkout.c:557
 #, c-format
 msgid "unable to unquote C-style string '%s'"
 msgstr "цитирането на низ, форматиран за C — „%s“ не може да бъде изчистено"
 
-#: builtin/sparse-checkout.c:598 builtin/sparse-checkout.c:622
+#: builtin/sparse-checkout.c:612 builtin/sparse-checkout.c:640
 msgid "unable to load existing sparse-checkout patterns"
 msgstr "шаблоните за частично изтегляне не може да се заредят"
 
-#: builtin/sparse-checkout.c:667
+#: builtin/sparse-checkout.c:616
+msgid "existing sparse-checkout patterns do not use cone mode"
+msgstr ""
+"съществуващите шаблони за частично изтегляне не използват пътеводни сегменти"
+
+#: builtin/sparse-checkout.c:682
+msgid "git sparse-checkout add (--stdin | <patterns>)"
+msgstr "git sparse-checkout add (--stdin | ШАБЛОН…)"
+
+#: builtin/sparse-checkout.c:694 builtin/sparse-checkout.c:733
 msgid "read patterns from standard in"
 msgstr "изчитане на шаблоните от стандартния вход"
 
-#: builtin/sparse-checkout.c:682
-msgid "git sparse-checkout reapply"
-msgstr "git sparse-checkout reapply"
+#: builtin/sparse-checkout.c:699
+msgid "no sparse-checkout to add to"
+msgstr "няма частично изтегляне, към което да се добавя"
 
-#: builtin/sparse-checkout.c:701
+#: builtin/sparse-checkout.c:712
+msgid ""
+"git sparse-checkout set [--[no-]cone] [--[no-]sparse-index] (--stdin | "
+"<patterns>)"
+msgstr ""
+"git sparse-checkout set [--[no-]cone] [--[no-]sparse-index] (--stdin | "
+"ШАБЛОН…)"
+
+#: builtin/sparse-checkout.c:765
+msgid "git sparse-checkout reapply [--[no-]cone] [--[no-]sparse-index]"
+msgstr "git sparse-checkout reapply [--[no-]cone] [--[no-]sparse-index]"
+
+#: builtin/sparse-checkout.c:785
+msgid "must be in a sparse-checkout to reapply sparsity patterns"
+msgstr ""
+"шаблоните за частичност може да бъдат приложени наново само в частично "
+"изтеглено хранилище"
+
+#: builtin/sparse-checkout.c:803
 msgid "git sparse-checkout disable"
 msgstr "git sparse-checkout disable"
 
-#: builtin/sparse-checkout.c:732
+#: builtin/sparse-checkout.c:845
 msgid "error while refreshing working directory"
 msgstr "грешка при обновяване на работната директория"
 
@@ -23184,22 +23067,26 @@ msgstr "git stash branch КЛОН [СКАТАНО]"
 
 #: builtin/stash.c:30
 msgid ""
-"git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"git stash [push [-p|--patch] [-S|--staged] [-k|--[no-]keep-index] [-q|--"
+"quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [-m|--message <message>]\n"
 "          [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
 "          [--] [<pathspec>...]]"
 msgstr ""
-"git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"git stash [push [-p|--patch] [-S|--staged] [-k|--[no-]keep-index] [-q|--"
+"quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [-m|--message СЪОБЩЕНИЕ]\n"
 "          [--pathspec-from-file=ФАЙЛ [--pathspec-file-nul]]\n"
 "          [--] [ПЪТ…]]"
 
 #: builtin/stash.c:34
 msgid ""
-"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"git stash save [-p|--patch] [-S|--staged] [-k|--[no-]keep-index] [-q|--"
+"quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [<message>]"
 msgstr ""
-"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"git stash save [-p|--patch] [-S|--staged] [-k|--[no-]keep-index] [-q|--"
+"quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [СЪОБЩЕНИЕ]"
 
 #: builtin/stash.c:55
@@ -23294,140 +23181,158 @@ msgstr "Сливане на „%s“ с „%s“"
 msgid "Index was not unstashed."
 msgstr "Индексът не е изваден от скатаното."
 
-#: builtin/stash.c:575
+#: builtin/stash.c:576
 msgid "could not restore untracked files from stash"
 msgstr "неследени файлове не може да се възстановят от скатаното"
 
-#: builtin/stash.c:607 builtin/stash.c:705
+#: builtin/stash.c:608 builtin/stash.c:706
 msgid "attempt to recreate the index"
 msgstr "опит за повторно създаване на индекса"
 
-#: builtin/stash.c:651
+#: builtin/stash.c:652
 #, c-format
 msgid "Dropped %s (%s)"
 msgstr "Изтрито: „%s“ (%s)"
 
-#: builtin/stash.c:654
+#: builtin/stash.c:655
 #, c-format
 msgid "%s: Could not drop stash entry"
 msgstr "Скатаното „%s“ не може да бъде изтрито"
 
-#: builtin/stash.c:667
+#: builtin/stash.c:668
 #, c-format
 msgid "'%s' is not a stash reference"
 msgstr "„%s“ не е указател към нещо скатано"
 
-#: builtin/stash.c:717
+#: builtin/stash.c:718
 msgid "The stash entry is kept in case you need it again."
 msgstr "Скатаното е запазено в случай, че ви потрябва отново."
 
-#: builtin/stash.c:740
+#: builtin/stash.c:741
 msgid "No branch name specified"
 msgstr "Не е указано име на клон"
 
-#: builtin/stash.c:824
+#: builtin/stash.c:825
 msgid "failed to parse tree"
 msgstr "дървото не може да бъде анализирано"
 
-#: builtin/stash.c:835
+#: builtin/stash.c:836
 msgid "failed to unpack trees"
 msgstr "дървото не може да бъде разпакетирано"
 
-#: builtin/stash.c:855
+#: builtin/stash.c:856
 msgid "include untracked files in the stash"
 msgstr "скатаване и на неследените файлове"
 
-#: builtin/stash.c:858
+#: builtin/stash.c:859
 msgid "only show untracked files in the stash"
 msgstr "извеждане само на неследените файлове в скатаното"
 
-#: builtin/stash.c:945 builtin/stash.c:982
+#: builtin/stash.c:946 builtin/stash.c:983
 #, c-format
 msgid "Cannot update %s with %s"
 msgstr "Указателят „%s“ не може да бъде обновен да сочи към „%s“"
 
-#: builtin/stash.c:963 builtin/stash.c:1619 builtin/stash.c:1684
+#: builtin/stash.c:964 builtin/stash.c:1678 builtin/stash.c:1750
 msgid "stash message"
 msgstr "съобщение при скатаване"
 
-#: builtin/stash.c:973
+#: builtin/stash.c:974
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "командата „git stash store“ изисква точно един аргумент-ПОДАВАНЕ"
 
-#: builtin/stash.c:1187
+#: builtin/stash.c:1159
+msgid "No staged changes"
+msgstr "Няма промени в индекса"
+
+#: builtin/stash.c:1220
 msgid "No changes selected"
 msgstr "Не са избрани никакви промени"
 
-#: builtin/stash.c:1287
+#: builtin/stash.c:1320
 msgid "You do not have the initial commit yet"
 msgstr "Все още липсва първоначално подаване"
 
-#: builtin/stash.c:1314
+#: builtin/stash.c:1347
 msgid "Cannot save the current index state"
 msgstr "Състоянието на текущия индекс не може да бъде запазено"
 
-#: builtin/stash.c:1323
+#: builtin/stash.c:1356
 msgid "Cannot save the untracked files"
 msgstr "Неследените файлове не може да се запазят"
 
-#: builtin/stash.c:1334 builtin/stash.c:1343
+#: builtin/stash.c:1367 builtin/stash.c:1386
 msgid "Cannot save the current worktree state"
 msgstr "Състоянието на работното дърво не може да бъде запазено"
 
-#: builtin/stash.c:1371
+#: builtin/stash.c:1377
+msgid "Cannot save the current staged state"
+msgstr "Състоянието на текущия индекс не може да бъде запазено"
+
+#: builtin/stash.c:1414
 msgid "Cannot record working tree state"
 msgstr "Състоянието на работното дърво не може да бъде запазено"
 
-#: builtin/stash.c:1420
+#: builtin/stash.c:1463
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr "опцията „--patch“ е несъвместима с „--include-untracked“ и „--all“"
 
-#: builtin/stash.c:1438
+#: builtin/stash.c:1474
+msgid "Can't use --staged and --include-untracked or --all at the same time"
+msgstr ""
+"опцията „--staged“ е несъвместима както с „--include-untracked“, така и с „--"
+"all“"
+
+#: builtin/stash.c:1492
 msgid "Did you forget to 'git add'?"
 msgstr "Пробвайте да използвате „git add“"
 
-#: builtin/stash.c:1453
+#: builtin/stash.c:1507
 msgid "No local changes to save"
 msgstr "Няма никакви локални промени за скатаване"
 
-#: builtin/stash.c:1460
+#: builtin/stash.c:1514
 msgid "Cannot initialize stash"
 msgstr "Скатаването не може да стартира"
 
-#: builtin/stash.c:1475
+#: builtin/stash.c:1529
 msgid "Cannot save the current status"
 msgstr "Текущото състояние не може да бъде запазено"
 
-#: builtin/stash.c:1480
+#: builtin/stash.c:1534
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "Състоянието на работната директория и индекса e запазено: „%s“"
 
-#: builtin/stash.c:1571
+#: builtin/stash.c:1627
 msgid "Cannot remove worktree changes"
 msgstr "Промените в работното дърво не може да бъдат занулени"
 
-#: builtin/stash.c:1610 builtin/stash.c:1675
+#: builtin/stash.c:1667 builtin/stash.c:1739
 msgid "keep index"
 msgstr "запазване на индекса"
 
-#: builtin/stash.c:1612 builtin/stash.c:1677
+#: builtin/stash.c:1669 builtin/stash.c:1741
+msgid "stash staged changes only"
+msgstr "скатаване само на промените, вкарани в индекса"
+
+#: builtin/stash.c:1671 builtin/stash.c:1743
 msgid "stash in patch mode"
 msgstr "скатаване в режим за кръпки"
 
-#: builtin/stash.c:1613 builtin/stash.c:1678
+#: builtin/stash.c:1672 builtin/stash.c:1744
 msgid "quiet mode"
 msgstr "без извеждане на информация"
 
-#: builtin/stash.c:1615 builtin/stash.c:1680
+#: builtin/stash.c:1674 builtin/stash.c:1746
 msgid "include untracked files in stash"
 msgstr "скатаване и на неследените файлове"
 
-#: builtin/stash.c:1617 builtin/stash.c:1682
+#: builtin/stash.c:1676 builtin/stash.c:1748
 msgid "include ignore files"
 msgstr "скатаване и на игнорираните файлове"
 
-#: builtin/stash.c:1717
+#: builtin/stash.c:1783
 msgid ""
 "the stash.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -23451,7 +23356,7 @@ msgstr "пропускане на всички редове, които запо
 msgid "prepend comment character and space to each line"
 msgstr "добавяне на „# “ в началото на всеки ред"
 
-#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2667
+#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2668
 #, c-format
 msgid "Expecting a full ref name, got %s"
 msgstr "Очаква се пълно име на указател, а не „%s“"
@@ -23475,7 +23380,7 @@ msgstr ""
 "настройката „%s“ липсва.  Приема се, че това хранилище е правилният източник "
 "за себе си."
 
-#: builtin/submodule--helper.c:405 builtin/submodule--helper.c:1858
+#: builtin/submodule--helper.c:405 builtin/submodule--helper.c:1859
 msgid "alternative anchor for relative paths"
 msgstr "директория за определянето на относителните пътища"
 
@@ -23571,7 +23476,7 @@ msgstr "указателят сочен от „HEAD“ в подмодула �
 msgid "failed to recurse into submodule '%s'"
 msgstr "неуспешно рекурсивно обхождане на подмодула „%s“"
 
-#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1589
+#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1590
 msgid "suppress submodule status output"
 msgstr "без изход за състоянието на подмодула"
 
@@ -23644,10 +23549,6 @@ msgstr "git submodule--helper summary [ОПЦИЯ…] [ПОДАВАНЕ] [--] [�
 msgid "could not fetch a revision for HEAD"
 msgstr "не може да се достави версия за „HEAD“"
 
-#: builtin/submodule--helper.c:1316
-msgid "--cached and --files are mutually exclusive"
-msgstr "опциите „--cached“ и „--files“ са несъвместими"
-
 #: builtin/submodule--helper.c:1373
 #, c-format
 msgid "Synchronizing submodule url for '%s'\n"
@@ -23676,16 +23577,17 @@ msgstr "без извеждане на информация при синхро�
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
 msgstr "git submodule--helper sync [--quiet] [--recursive] [ПЪТ]"
 
-#: builtin/submodule--helper.c:1512
+#: builtin/submodule--helper.c:1508
 #, c-format
 msgid ""
-"Submodule work tree '%s' contains a .git directory (use 'rm -rf' if you "
-"really want to remove it including all of its history)"
+"Submodule work tree '%s' contains a .git directory. This will be replaced "
+"with a .git file by using absorbgitdirs."
 msgstr ""
-"Работното дърво на подмодул „%s“ съдържа директория „.git“.\n"
-"(ако искате да ги изтриете заедно с цялата им история, използвайте „rm -rf“)"
+"Работното дърво на подмодул „%s“ съдържа директория „.git“.  Тя ще се "
+"заменени\n"
+"с файл „.git“ чрез командата „absorbgitdirs“."
 
-#: builtin/submodule--helper.c:1524
+#: builtin/submodule--helper.c:1525
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
@@ -23694,47 +23596,47 @@ msgstr ""
 "Работното дърво на подмодул „%s“ съдържа локални промени.  Може да ги "
 "отхвърлите с опцията „-f“"
 
-#: builtin/submodule--helper.c:1532
+#: builtin/submodule--helper.c:1533
 #, c-format
 msgid "Cleared directory '%s'\n"
 msgstr "Директорията „%s“ е изчистена\n"
 
-#: builtin/submodule--helper.c:1534
+#: builtin/submodule--helper.c:1535
 #, c-format
 msgid "Could not remove submodule work tree '%s'\n"
 msgstr ""
 "Директорията към работното дърво на подмодула „%s“ не може да бъде изтрита\n"
 
-#: builtin/submodule--helper.c:1545
+#: builtin/submodule--helper.c:1546
 #, c-format
 msgid "could not create empty submodule directory %s"
 msgstr "празната директория за подмодула „%s“ не може да бъде създадена"
 
-#: builtin/submodule--helper.c:1561
+#: builtin/submodule--helper.c:1562
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "Регистрацията на подмодула „%s“ (%s) за пътя „%s“ е премахната\n"
 
-#: builtin/submodule--helper.c:1590
+#: builtin/submodule--helper.c:1591
 msgid "remove submodule working trees even if they contain local changes"
 msgstr ""
 "изтриване на работните дървета на подмодулите, дори когато те съдържат "
 "локални промени"
 
-#: builtin/submodule--helper.c:1591
+#: builtin/submodule--helper.c:1592
 msgid "unregister all submodules"
 msgstr "премахване на регистрациите на всички подмодули"
 
-#: builtin/submodule--helper.c:1596
+#: builtin/submodule--helper.c:1597
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr "git submodule deinit [--quiet] [-f | --force] [--all | [--] [ПЪТ…]]"
 
-#: builtin/submodule--helper.c:1610
+#: builtin/submodule--helper.c:1611
 msgid "Use '--all' if you really want to deinitialize all submodules"
 msgstr "Използвайте „--all“, за да премахнете всички подмодули"
 
-#: builtin/submodule--helper.c:1655
+#: builtin/submodule--helper.c:1656
 msgid ""
 "An alternate computed from a superproject's alternate is invalid.\n"
 "To allow Git to clone without an alternate in such a case, set\n"
@@ -23746,70 +23648,70 @@ msgstr ""
 "задайте настройката „submodule.alternateErrorStrategy“ да е „info“ или\n"
 "при клониране ползвайте опцията „--reference-if-able“ вместо „--reference“."
 
-#: builtin/submodule--helper.c:1700 builtin/submodule--helper.c:1703
+#: builtin/submodule--helper.c:1701 builtin/submodule--helper.c:1704
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
 msgstr "към подмодула „%s“ не може да се добави алтернативен източник: %s"
 
-#: builtin/submodule--helper.c:1739
+#: builtin/submodule--helper.c:1740
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
 msgstr ""
 "Непозната стойност „%s“ за настройката „submodule.alternateErrorStrategy“"
 
-#: builtin/submodule--helper.c:1746
+#: builtin/submodule--helper.c:1747
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
 msgstr "Непозната стойност „%s“ за настройката „submodule.alternateLocation“"
 
-#: builtin/submodule--helper.c:1771
+#: builtin/submodule--helper.c:1772
 #, c-format
 msgid "refusing to create/use '%s' in another submodule's git dir"
 msgstr ""
 "„%s“ не може нито да се създаде, нито да се ползва в директорията на git на "
 "друг подмодул"
 
-#: builtin/submodule--helper.c:1812
+#: builtin/submodule--helper.c:1813
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
 msgstr "Неуспешно клониране на адреса „%s“ в пътя „%s“ като подмодул"
 
-#: builtin/submodule--helper.c:1817
+#: builtin/submodule--helper.c:1818
 #, c-format
 msgid "directory not empty: '%s'"
 msgstr "директорията не е празна: „%s“"
 
-#: builtin/submodule--helper.c:1829
+#: builtin/submodule--helper.c:1830
 #, c-format
 msgid "could not get submodule directory for '%s'"
 msgstr "директорията на подмодула „%s“ не може да бъде получена"
 
-#: builtin/submodule--helper.c:1861
+#: builtin/submodule--helper.c:1862
 msgid "where the new submodule will be cloned to"
 msgstr "къде да се клонира новият подмодул"
 
-#: builtin/submodule--helper.c:1864
+#: builtin/submodule--helper.c:1865
 msgid "name of the new submodule"
 msgstr "име на новия подмодул"
 
-#: builtin/submodule--helper.c:1867
+#: builtin/submodule--helper.c:1868
 msgid "url where to clone the submodule from"
 msgstr "адрес, от който да се клонира новият подмодул"
 
-#: builtin/submodule--helper.c:1875 builtin/submodule--helper.c:3264
+#: builtin/submodule--helper.c:1876 builtin/submodule--helper.c:3265
 msgid "depth for shallow clones"
 msgstr "дълбочина на плитките хранилища"
 
-#: builtin/submodule--helper.c:1878 builtin/submodule--helper.c:2525
-#: builtin/submodule--helper.c:3257
+#: builtin/submodule--helper.c:1879 builtin/submodule--helper.c:2526
+#: builtin/submodule--helper.c:3258
 msgid "force cloning progress"
 msgstr "извеждане на напредъка на клонирането"
 
-#: builtin/submodule--helper.c:1880 builtin/submodule--helper.c:2527
+#: builtin/submodule--helper.c:1881 builtin/submodule--helper.c:2528
 msgid "disallow cloning into non-empty directory"
 msgstr "предотвратяване на клониране в непразна история"
 
-#: builtin/submodule--helper.c:1887
+#: builtin/submodule--helper.c:1888
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
 "<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
@@ -23818,95 +23720,95 @@ msgstr ""
 "git submodule--helper clone [--prefix=ПЪТ] [--quiet] [--reference ХРАНИЛИЩЕ] "
 "[--name ИМЕ] [--depth ДЪЛБОЧИНА] [--single-branch] --url АДРЕС --path ПЪТ"
 
-#: builtin/submodule--helper.c:1924
+#: builtin/submodule--helper.c:1925
 #, c-format
 msgid "Invalid update mode '%s' for submodule path '%s'"
 msgstr "Неправилен режим на обновяване „%s“ за пътя към подмодул „%s“"
 
-#: builtin/submodule--helper.c:1928
+#: builtin/submodule--helper.c:1929
 #, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
 msgstr ""
 "Настроен е неправилен режим на обновяване „%s“ за пътя към подмодул „%s“"
 
-#: builtin/submodule--helper.c:2043
+#: builtin/submodule--helper.c:2044
 #, c-format
 msgid "Submodule path '%s' not initialized"
 msgstr "Пътят на подмодула „%s“ не е инициализиран"
 
-#: builtin/submodule--helper.c:2047
+#: builtin/submodule--helper.c:2048
 msgid "Maybe you want to use 'update --init'?"
 msgstr "Вероятно искахте да използвате „update --init“?"
 
-#: builtin/submodule--helper.c:2077
+#: builtin/submodule--helper.c:2078
 #, c-format
 msgid "Skipping unmerged submodule %s"
 msgstr "Прескачане на неслетия подмодул „%s“"
 
-#: builtin/submodule--helper.c:2106
+#: builtin/submodule--helper.c:2107
 #, c-format
 msgid "Skipping submodule '%s'"
 msgstr "Прескачане на подмодула „%s“"
 
-#: builtin/submodule--helper.c:2256
+#: builtin/submodule--helper.c:2257
 #, c-format
 msgid "Failed to clone '%s'. Retry scheduled"
 msgstr "Неуспешен опит за клониране на „%s“.  Насрочен е втори опит"
 
-#: builtin/submodule--helper.c:2267
+#: builtin/submodule--helper.c:2268
 #, c-format
 msgid "Failed to clone '%s' a second time, aborting"
 msgstr ""
 "Втори неуспешен опит за клониране на „%s“.  Действието се преустановява"
 
-#: builtin/submodule--helper.c:2372
+#: builtin/submodule--helper.c:2373
 #, c-format
 msgid "Unable to checkout '%s' in submodule path '%s'"
 msgstr "Неуспешно изтегляне на версия „%s“ в пътя към подмодул „%s“'"
 
-#: builtin/submodule--helper.c:2376
+#: builtin/submodule--helper.c:2377
 #, c-format
 msgid "Unable to rebase '%s' in submodule path '%s'"
 msgstr "Неуспешно пребазиране на версия „%s“ в пътя към подмодул „%s“"
 
-#: builtin/submodule--helper.c:2380
+#: builtin/submodule--helper.c:2381
 #, c-format
 msgid "Unable to merge '%s' in submodule path '%s'"
 msgstr "Неуспешно сливане на версия „%s“ в пътя към подмодул „%s“"
 
-#: builtin/submodule--helper.c:2384
+#: builtin/submodule--helper.c:2385
 #, c-format
 msgid "Execution of '%s %s' failed in submodule path '%s'"
 msgstr "Неуспешно изпълнение на командата „%s %s“ в пътя към подмодул „%s“"
 
-#: builtin/submodule--helper.c:2408
+#: builtin/submodule--helper.c:2409
 #, c-format
 msgid "Submodule path '%s': checked out '%s'\n"
 msgstr "Път към подмодул „%s“: изтеглена е версия „%s“\n"
 
-#: builtin/submodule--helper.c:2412
+#: builtin/submodule--helper.c:2413
 #, c-format
 msgid "Submodule path '%s': rebased into '%s'\n"
 msgstr "Път към подмодул „%s“: пребазиран към „%s“\n"
 
-#: builtin/submodule--helper.c:2416
+#: builtin/submodule--helper.c:2417
 #, c-format
 msgid "Submodule path '%s': merged in '%s'\n"
 msgstr "Път към подмодул „%s“: слят в „%s“\n"
 
-#: builtin/submodule--helper.c:2420
+#: builtin/submodule--helper.c:2421
 #, c-format
 msgid "Submodule path '%s': '%s %s'\n"
 msgstr "Пътят на подмодула „%s“: „%s %s“\n"
 
-#: builtin/submodule--helper.c:2444
+#: builtin/submodule--helper.c:2445
 #, c-format
 msgid "Unable to fetch in submodule path '%s'; trying to directly fetch %s:"
 msgstr ""
 "Неуспешно доставяне в пътя към подмодул „%s“, опит за директно доставяне на "
 "„%s“"
 
-#: builtin/submodule--helper.c:2453
+#: builtin/submodule--helper.c:2454
 #, c-format
 msgid ""
 "Fetched in submodule path '%s', but it did not contain %s. Direct fetching "
@@ -23915,88 +23817,88 @@ msgstr ""
 "Подмодулът в пътя „%s“ е доставен, но не съдържа обекта със сума\n"
 "„%s“.  Директното доставяне на това подаване е неуспешно."
 
-#: builtin/submodule--helper.c:2504 builtin/submodule--helper.c:2574
-#: builtin/submodule--helper.c:2812
+#: builtin/submodule--helper.c:2505 builtin/submodule--helper.c:2575
+#: builtin/submodule--helper.c:2813
 msgid "path into the working tree"
 msgstr "път към работното дърво"
 
-#: builtin/submodule--helper.c:2507 builtin/submodule--helper.c:2579
+#: builtin/submodule--helper.c:2508 builtin/submodule--helper.c:2580
 msgid "path into the working tree, across nested submodule boundaries"
 msgstr "път към работното дърво, през границите на вложените подмодули"
 
-#: builtin/submodule--helper.c:2511 builtin/submodule--helper.c:2577
+#: builtin/submodule--helper.c:2512 builtin/submodule--helper.c:2578
 msgid "rebase, merge, checkout or none"
 msgstr ""
 "„rebase“ (пребазиране), „merge“ (сливане), „checkout“ (изтегляне) или "
 "„none“ (нищо да не се прави)"
 
-#: builtin/submodule--helper.c:2517
+#: builtin/submodule--helper.c:2518
 msgid "create a shallow clone truncated to the specified number of revisions"
 msgstr "извършване на плитко клониране, отрязано до указания брой версии"
 
-#: builtin/submodule--helper.c:2520
+#: builtin/submodule--helper.c:2521
 msgid "parallel jobs"
 msgstr "брой паралелни процеси"
 
-#: builtin/submodule--helper.c:2522
+#: builtin/submodule--helper.c:2523
 msgid "whether the initial clone should follow the shallow recommendation"
 msgstr "дали първоначалното клониране да е плитко, както се препоръчва"
 
-#: builtin/submodule--helper.c:2523
+#: builtin/submodule--helper.c:2524
 msgid "don't print cloning progress"
 msgstr "без извеждане на напредъка на клонирането"
 
-#: builtin/submodule--helper.c:2534
+#: builtin/submodule--helper.c:2535
 msgid "git submodule--helper update-clone [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper update-clone [--prefix=ПЪТ] [ПЪТ…]"
 
-#: builtin/submodule--helper.c:2547
+#: builtin/submodule--helper.c:2548
 msgid "bad value for update parameter"
 msgstr "неправилен параметър към опцията „--update“"
 
-#: builtin/submodule--helper.c:2565
+#: builtin/submodule--helper.c:2566
 msgid "suppress output for update by rebase or merge"
 msgstr ""
 "без извеждане на информация при обновяване чрез пребазиране или сливане"
 
-#: builtin/submodule--helper.c:2566
+#: builtin/submodule--helper.c:2567
 msgid "force checkout updates"
 msgstr "принудително изтегляне на обновленията"
 
-#: builtin/submodule--helper.c:2568
+#: builtin/submodule--helper.c:2569
 msgid "don't fetch new objects from the remote site"
 msgstr "без доставяне на новите обекти от отдалеченото хранилище"
 
-#: builtin/submodule--helper.c:2570
+#: builtin/submodule--helper.c:2571
 msgid "overrides update mode in case the repository is a fresh clone"
 msgstr ""
 "различен режим на обновяване, когато хранилището е чисто ново изтеглено"
 
-#: builtin/submodule--helper.c:2571
+#: builtin/submodule--helper.c:2572
 msgid "depth for shallow fetch"
 msgstr "дълбочина на плиткото доставяне"
 
-#: builtin/submodule--helper.c:2581
+#: builtin/submodule--helper.c:2582
 msgid "sha1"
 msgstr "сума по SHA1"
 
-#: builtin/submodule--helper.c:2582
+#: builtin/submodule--helper.c:2583
 msgid "SHA1 expected by superproject"
 msgstr "сумата по SHA1, очаквана от обхващащия модул"
 
-#: builtin/submodule--helper.c:2584
+#: builtin/submodule--helper.c:2585
 msgid "subsha1"
 msgstr "сумата по SHA1 на подмодула"
 
-#: builtin/submodule--helper.c:2585
+#: builtin/submodule--helper.c:2586
 msgid "SHA1 of submodule's HEAD"
 msgstr "сумата по SHA1 за указателя HEAD на подмодула"
 
-#: builtin/submodule--helper.c:2591
+#: builtin/submodule--helper.c:2592
 msgid "git submodule--helper run-update-procedure [<options>] <path>"
 msgstr "git submodule--helper run-update-procedure [ОПЦИЯ…] [ПЪТ]"
 
-#: builtin/submodule--helper.c:2662
+#: builtin/submodule--helper.c:2663
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
@@ -24005,95 +23907,91 @@ msgstr ""
 "Клонът на подмодула „%s“ е настроен да наследява клона от обхващащия проект, "
 "но той не е на никой клон"
 
-#: builtin/submodule--helper.c:2780
+#: builtin/submodule--helper.c:2781
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
 msgstr "не може да се получи връзка към хранилище за подмодула „%s“"
 
-#: builtin/submodule--helper.c:2813
+#: builtin/submodule--helper.c:2814
 msgid "recurse into submodules"
 msgstr "рекурсивно обхождане подмодулите"
 
-#: builtin/submodule--helper.c:2819
+#: builtin/submodule--helper.c:2820
 msgid "git submodule--helper absorb-git-dirs [<options>] [<path>...]"
 msgstr "git submodule--helper absorb-git-dirs [ОПЦИЯ…] [ПЪТ…]"
 
-#: builtin/submodule--helper.c:2875
+#: builtin/submodule--helper.c:2876
 msgid "check if it is safe to write to the .gitmodules file"
 msgstr "проверка дали писането във файла „.gitmodules“ е безопасно"
 
-#: builtin/submodule--helper.c:2878
+#: builtin/submodule--helper.c:2879
 msgid "unset the config in the .gitmodules file"
 msgstr "изтриване на настройка във файла „.gitmodules“"
 
-#: builtin/submodule--helper.c:2883
+#: builtin/submodule--helper.c:2884
 msgid "git submodule--helper config <name> [<value>]"
 msgstr "git submodule--helper config ИМЕ [СТОЙНОСТ]"
 
-#: builtin/submodule--helper.c:2884
+#: builtin/submodule--helper.c:2885
 msgid "git submodule--helper config --unset <name>"
 msgstr "git submodule--helper config --unset ИМЕ"
 
-#: builtin/submodule--helper.c:2885
+#: builtin/submodule--helper.c:2886
 msgid "git submodule--helper config --check-writeable"
 msgstr "git submodule--helper config --check-writeable"
 
-#: builtin/submodule--helper.c:2904 builtin/submodule--helper.c:3120
-#: builtin/submodule--helper.c:3276
+#: builtin/submodule--helper.c:2905 builtin/submodule--helper.c:3121
+#: builtin/submodule--helper.c:3277
 msgid "please make sure that the .gitmodules file is in the working tree"
 msgstr "файлът „.gitmodules“ трябва да е в работното дърво"
 
-#: builtin/submodule--helper.c:2920
+#: builtin/submodule--helper.c:2921
 msgid "suppress output for setting url of a submodule"
 msgstr "без извеждане на информация при задаването на адреса на подмодул"
 
-#: builtin/submodule--helper.c:2924
+#: builtin/submodule--helper.c:2925
 msgid "git submodule--helper set-url [--quiet] <path> <newurl>"
 msgstr "git submodule--helper set-url [--quiet] [ПЪТ] [НОВ_ПЪТ]"
 
-#: builtin/submodule--helper.c:2957
+#: builtin/submodule--helper.c:2958
 msgid "set the default tracking branch to master"
 msgstr "задаване на стандартния следящ клон да е „master“"
 
-#: builtin/submodule--helper.c:2959
+#: builtin/submodule--helper.c:2960
 msgid "set the default tracking branch"
 msgstr "задаване на стандартния следящ клон"
 
-#: builtin/submodule--helper.c:2963
+#: builtin/submodule--helper.c:2964
 msgid "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
 msgstr "git submodule--helper set-branch [-q|--quiet] (-d|--default) ПЪТ"
 
-#: builtin/submodule--helper.c:2964
+#: builtin/submodule--helper.c:2965
 msgid ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
 msgstr "git submodule--helper set-branch [-q|--quiet] (-b|--branch) КЛОН ПЪТ"
 
-#: builtin/submodule--helper.c:2971
+#: builtin/submodule--helper.c:2972
 msgid "--branch or --default required"
 msgstr "необходимо е една от опциите „--branch“ и „--default“"
 
-#: builtin/submodule--helper.c:2974
-msgid "--branch and --default are mutually exclusive"
-msgstr "опциите „--branch“ и „--default“ са несъвместими"
-
-#: builtin/submodule--helper.c:3037
+#: builtin/submodule--helper.c:3038
 #, c-format
 msgid "Adding existing repo at '%s' to the index\n"
 msgstr "Добавяне на съществуващото хранилище в „%s“ към индекса\n"
 
-#: builtin/submodule--helper.c:3040
+#: builtin/submodule--helper.c:3041
 #, c-format
 msgid "'%s' already exists and is not a valid git repo"
 msgstr "„%s“ съществува, а не е хранилище на Git"
 
-#: builtin/submodule--helper.c:3053
+#: builtin/submodule--helper.c:3054
 #, c-format
 msgid "A git directory for '%s' is found locally with remote(s):\n"
 msgstr ""
 "Открита е локална директория на Git — „%s“, която сочи към отдалечените "
 "хранилища:\n"
 
-#: builtin/submodule--helper.c:3060
+#: builtin/submodule--helper.c:3061
 #, c-format
 msgid ""
 "If you want to reuse this local git directory instead of cloning again from\n"
@@ -24110,87 +24008,87 @@ msgstr ""
 "правилното хранилище или ако не знаете какво означава това, използвайте\n"
 "друго име като аргумент към опцията „--name“."
 
-#: builtin/submodule--helper.c:3072
+#: builtin/submodule--helper.c:3073
 #, c-format
 msgid "Reactivating local git directory for submodule '%s'\n"
 msgstr "Активиране на локалното хранилище за подмодула „%s“ наново.\n"
 
-#: builtin/submodule--helper.c:3109
+#: builtin/submodule--helper.c:3110
 #, c-format
 msgid "unable to checkout submodule '%s'"
 msgstr "Подмодулът „%s“ не може да бъде изтеглен"
 
-#: builtin/submodule--helper.c:3148
+#: builtin/submodule--helper.c:3149
 #, c-format
 msgid "Failed to add submodule '%s'"
 msgstr "Неуспешно добавяне на подмодула „%s“"
 
-#: builtin/submodule--helper.c:3152 builtin/submodule--helper.c:3157
-#: builtin/submodule--helper.c:3165
+#: builtin/submodule--helper.c:3153 builtin/submodule--helper.c:3158
+#: builtin/submodule--helper.c:3166
 #, c-format
 msgid "Failed to register submodule '%s'"
 msgstr "Неуспешно регистриране на подмодула „%s“"
 
-#: builtin/submodule--helper.c:3221
+#: builtin/submodule--helper.c:3222
 #, c-format
 msgid "'%s' already exists in the index"
 msgstr "„%s“ вече съществува в индекса"
 
-#: builtin/submodule--helper.c:3224
+#: builtin/submodule--helper.c:3225
 #, c-format
 msgid "'%s' already exists in the index and is not a submodule"
 msgstr "„%s“ вече съществува в индекса и не е подмодул"
 
-#: builtin/submodule--helper.c:3253
+#: builtin/submodule--helper.c:3254
 msgid "branch of repository to add as submodule"
 msgstr "клон на хранилище, който да се добави като подмодул"
 
-#: builtin/submodule--helper.c:3254
+#: builtin/submodule--helper.c:3255
 msgid "allow adding an otherwise ignored submodule path"
 msgstr "позволяване на добавяне и на иначе игнорираните файлове"
 
-#: builtin/submodule--helper.c:3256
+#: builtin/submodule--helper.c:3257
 msgid "print only error messages"
 msgstr "извеждане само на съобщенията за грешка"
 
-#: builtin/submodule--helper.c:3260
+#: builtin/submodule--helper.c:3261
 msgid "borrow the objects from reference repositories"
 msgstr "заемане на обектите от еталонните хранилища"
 
-#: builtin/submodule--helper.c:3262
+#: builtin/submodule--helper.c:3263
 msgid ""
 "sets the submodule’s name to the given string instead of defaulting to its "
 "path"
 msgstr "името на подмодула да е указаното, а не да е същото като пътя"
 
-#: builtin/submodule--helper.c:3269
+#: builtin/submodule--helper.c:3270
 msgid "git submodule--helper add [<options>] [--] <repository> [<path>]"
 msgstr "git submodule--helper add [ОПЦИЯ…] [--] ХРАНИЛИЩЕ [ПЪТ]"
 
-#: builtin/submodule--helper.c:3297
+#: builtin/submodule--helper.c:3298
 msgid "Relative path can only be used from the toplevel of the working tree"
 msgstr ""
 "Относителен път може да се ползва само от основната директория на работното "
 "дърво"
 
-#: builtin/submodule--helper.c:3305
+#: builtin/submodule--helper.c:3306
 #, c-format
 msgid "repo URL: '%s' must be absolute or begin with ./|../"
 msgstr ""
 "адрес на хранилище: „%s“ трябва или да е абсолютен, или да започва с „./“ "
 "или „../“"
 
-#: builtin/submodule--helper.c:3340
+#: builtin/submodule--helper.c:3341
 #, c-format
 msgid "'%s' is not a valid submodule name"
 msgstr "„%s“ е неправилно име за подмодул"
 
-#: builtin/submodule--helper.c:3404 git.c:449 git.c:723
+#: builtin/submodule--helper.c:3405 git.c:452 git.c:726
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "„%s“ не поддържа опцията „--super-prefix“"
 
-#: builtin/submodule--helper.c:3410
+#: builtin/submodule--helper.c:3411
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
 msgstr "„%s“ не е подкоманда на „submodule--helper“"
@@ -24288,11 +24186,11 @@ msgstr ""
 "Редовете, които започват с „%c“, също ще бъдат включени — може да ги "
 "изтриете вие.\n"
 
-#: builtin/tag.c:241
+#: builtin/tag.c:240
 msgid "unable to sign the tag"
 msgstr "етикетът не може да бъде подписан"
 
-#: builtin/tag.c:259
+#: builtin/tag.c:258
 #, c-format
 msgid ""
 "You have created a nested tag. The object referred to by your new tag is\n"
@@ -24306,15 +24204,15 @@ msgstr ""
 "\n"
 "    git tag -f %s %s^{}"
 
-#: builtin/tag.c:275
+#: builtin/tag.c:274
 msgid "bad object type."
 msgstr "неправилен вид обект."
 
-#: builtin/tag.c:326
+#: builtin/tag.c:325
 msgid "no tag message?"
 msgstr "липсва съобщение за етикета"
 
-#: builtin/tag.c:333
+#: builtin/tag.c:332
 #, c-format
 msgid "The tag message has been left in %s\n"
 msgstr "Съобщението за етикета е запазено във файла „%s“\n"
@@ -24395,45 +24293,22 @@ msgstr "извеждане само на неслетите етикети"
 msgid "print only tags of the object"
 msgstr "извеждане само на етикетите на ОБЕКТА"
 
-#: builtin/tag.c:525
-msgid "--column and -n are incompatible"
-msgstr "опциите „--column“ и „-n“ са несъвместими"
+#: builtin/tag.c:558
+#, c-format
+msgid "the '%s' option is only allowed in list mode"
+msgstr "опцията „%s“ изисква режим на списък"
 
-#: builtin/tag.c:546
-msgid "-n option is only allowed in list mode"
-msgstr "опцията „-n“ изисква режим на списък."
-
-#: builtin/tag.c:548
-msgid "--contains option is only allowed in list mode"
-msgstr "опцията „--contains“ изисква режим на списък."
-
-#: builtin/tag.c:550
-msgid "--no-contains option is only allowed in list mode"
-msgstr "опцията „--no-contains“ изисква  режим на списък."
-
-#: builtin/tag.c:552
-msgid "--points-at option is only allowed in list mode"
-msgstr "опцията „--points-at“ изисква режим на списък."
-
-#: builtin/tag.c:554
-msgid "--merged and --no-merged options are only allowed in list mode"
-msgstr "опциите „--merged“ и „--no-merged“ изискват режим на списък."
-
-#: builtin/tag.c:568
-msgid "only one -F or -m option is allowed."
-msgstr "опциите „-F“ и „-m“ са несъвместими."
-
-#: builtin/tag.c:593
+#: builtin/tag.c:597
 #, c-format
 msgid "'%s' is not a valid tag name."
 msgstr "„%s“ е неправилно име за етикет."
 
-#: builtin/tag.c:598
+#: builtin/tag.c:602
 #, c-format
 msgid "tag '%s' already exists"
 msgstr "етикетът „%s“ вече съществува"
 
-#: builtin/tag.c:629
+#: builtin/tag.c:633
 #, c-format
 msgid "Updated tag '%s' (was %s)\n"
 msgstr "Обновен етикет „%s“ (бе „%s“)\n"
@@ -24885,136 +24760,124 @@ msgstr "директорията „%s“ не може да бъде създа
 msgid "initializing"
 msgstr "инициализация"
 
-#: builtin/worktree.c:421 builtin/worktree.c:427
+#: builtin/worktree.c:420 builtin/worktree.c:426
 #, c-format
 msgid "Preparing worktree (new branch '%s')"
 msgstr "Приготвяне на работното дърво (нов клон „%s“)"
 
-#: builtin/worktree.c:423
+#: builtin/worktree.c:422
 #, c-format
 msgid "Preparing worktree (resetting branch '%s'; was at %s)"
 msgstr ""
 "Приготвяне на работното дърво (зануляване на клона „%s“, който сочеше към "
 "„%s“)"
 
-#: builtin/worktree.c:432
+#: builtin/worktree.c:431
 #, c-format
 msgid "Preparing worktree (checking out '%s')"
 msgstr "Приготвяне на работното дърво (изтегляне на „%s“)"
 
-#: builtin/worktree.c:438
+#: builtin/worktree.c:437
 #, c-format
 msgid "Preparing worktree (detached HEAD %s)"
 msgstr "Подготвяне на работно дърво (указателят „HEAD“ не свързан: %s)"
 
-#: builtin/worktree.c:483
+#: builtin/worktree.c:482
 msgid "checkout <branch> even if already checked out in other worktree"
 msgstr "Изтегляне КЛОНа, дори и да е изтеглен в друго работно дърво"
 
-#: builtin/worktree.c:486
+#: builtin/worktree.c:485
 msgid "create a new branch"
 msgstr "създаване на нов клон"
 
-#: builtin/worktree.c:488
+#: builtin/worktree.c:487
 msgid "create or reset a branch"
 msgstr "създаване или зануляване на клони"
 
-#: builtin/worktree.c:490
+#: builtin/worktree.c:489
 msgid "populate the new working tree"
 msgstr "подготвяне на новото работно дърво"
 
-#: builtin/worktree.c:491
+#: builtin/worktree.c:490
 msgid "keep the new working tree locked"
 msgstr "новото работно дърво да остане заключено"
 
-#: builtin/worktree.c:493 builtin/worktree.c:730
+#: builtin/worktree.c:492 builtin/worktree.c:729
 msgid "reason for locking"
 msgstr "причина за заключване"
 
-#: builtin/worktree.c:496
+#: builtin/worktree.c:495
 msgid "set up tracking mode (see git-branch(1))"
 msgstr "задаване на режима на следене (виж git-branch(1))"
 
-#: builtin/worktree.c:499
+#: builtin/worktree.c:498
 msgid "try to match the new branch name with a remote-tracking branch"
 msgstr "опит за напасване на името на новия клон с това на следящ клон"
 
-#: builtin/worktree.c:507
-msgid "-b, -B, and --detach are mutually exclusive"
-msgstr "опциите „-b“, „-B“ и „--detach“ са несъвместими една с друга"
-
-#: builtin/worktree.c:509
-msgid "--reason requires --lock"
-msgstr "опцията „--reason“ изисква „--lock“"
-
-#: builtin/worktree.c:513
+#: builtin/worktree.c:512
 msgid "added with --lock"
 msgstr "добавена с „--lock“"
 
-#: builtin/worktree.c:575
+#: builtin/worktree.c:574
 msgid "--[no-]track can only be used if a new branch is created"
 msgstr "„--[no-]track“ може да се използва само при създаването на нов клон"
 
-#: builtin/worktree.c:692
+#: builtin/worktree.c:691
 msgid "show extended annotations and reasons, if available"
 msgstr "извеждане на подробни анотации и обяснения, ако такива са налични"
 
-#: builtin/worktree.c:694
+#: builtin/worktree.c:693
 msgid "add 'prunable' annotation to worktrees older than <time>"
 msgstr ""
 "добавяне на анотация за окастряне на работните копия по-стари от това ВРЕМЕ"
 
-#: builtin/worktree.c:703
-msgid "--verbose and --porcelain are mutually exclusive"
-msgstr "опциите „--verbose“ и „--porcelain“ са несъвместими"
-
-#: builtin/worktree.c:742 builtin/worktree.c:775 builtin/worktree.c:849
-#: builtin/worktree.c:973
+#: builtin/worktree.c:741 builtin/worktree.c:774 builtin/worktree.c:848
+#: builtin/worktree.c:972
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr "„%s“ не е работно дърво"
 
-#: builtin/worktree.c:744 builtin/worktree.c:777
+#: builtin/worktree.c:743 builtin/worktree.c:776
 msgid "The main working tree cannot be locked or unlocked"
 msgstr "Основното дърво не може да се отключи или заключи"
 
-#: builtin/worktree.c:749
+#: builtin/worktree.c:748
 #, c-format
 msgid "'%s' is already locked, reason: %s"
 msgstr "„%s“ вече е заключено, защото „%s“"
 
-#: builtin/worktree.c:751
+#: builtin/worktree.c:750
 #, c-format
 msgid "'%s' is already locked"
 msgstr "„%s“ вече е заключено"
 
-#: builtin/worktree.c:779
+#: builtin/worktree.c:778
 #, c-format
 msgid "'%s' is not locked"
 msgstr "„%s“ не е заключено"
 
-#: builtin/worktree.c:820
+#: builtin/worktree.c:819
 msgid "working trees containing submodules cannot be moved or removed"
 msgstr ""
 "не може да местите или изтривате работни дървета, в които има подмодули"
 
-#: builtin/worktree.c:828
+#: builtin/worktree.c:827
 msgid "force move even if worktree is dirty or locked"
 msgstr ""
 "принудително преместване, дори работното дърво да не е чисто или да е "
 "заключено"
 
-#: builtin/worktree.c:851 builtin/worktree.c:975
+#: builtin/worktree.c:850 builtin/worktree.c:974
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr "„%s“ е основно работно дърво"
 
-#: builtin/worktree.c:856
+#: builtin/worktree.c:855
 #, c-format
 msgid "could not figure out destination name from '%s'"
 msgstr "името на целта не може да се определи от „%s“"
 
-#: builtin/worktree.c:869
+#: builtin/worktree.c:868
 #, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
@@ -25023,7 +24886,7 @@ msgstr ""
 "не може да преместите заключено работно дърво, причина за заключването: %s\n"
 "или го отключете, или го преместете принудително с „move -f -f“"
 
-#: builtin/worktree.c:871
+#: builtin/worktree.c:870
 msgid ""
 "cannot move a locked working tree;\n"
 "use 'move -f -f' to override or unlock first"
@@ -25031,41 +24894,41 @@ msgstr ""
 "не може да преместите заключено работно дърво:\n"
 "или го отключете, или го преместете принудително с „move -f -f“"
 
-#: builtin/worktree.c:874
+#: builtin/worktree.c:873
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
 msgstr ""
 "проверките са неуспешни, работното дърво не може да бъде преместено: %s"
 
-#: builtin/worktree.c:879
+#: builtin/worktree.c:878
 #, c-format
 msgid "failed to move '%s' to '%s'"
 msgstr "„%s“ не може да се премести в „%s“"
 
-#: builtin/worktree.c:925
+#: builtin/worktree.c:924
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr "неуспешно изпълнение на „git status“ върху „%s“"
 
-#: builtin/worktree.c:929
+#: builtin/worktree.c:928
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
 "„%s“ съдържа променени или нови файлове, за принудително изтриване е "
 "необходима опцията „--force“"
 
-#: builtin/worktree.c:934
+#: builtin/worktree.c:933
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr ""
 "командата „git status“ не може да се изпълни за „%s“, код за грешка: %d"
 
-#: builtin/worktree.c:957
+#: builtin/worktree.c:956
 msgid "force removal even if worktree is dirty or locked"
 msgstr ""
 "принудително изтриване, дори работното дърво да не е чисто или да е заключено"
 
-#: builtin/worktree.c:980
+#: builtin/worktree.c:979
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
@@ -25074,7 +24937,7 @@ msgstr ""
 "не може да изтриете заключено работно дърво, причина за заключването: %s\n"
 "или го отключете, или го изтрийте принудително с „remove -f -f“"
 
-#: builtin/worktree.c:982
+#: builtin/worktree.c:981
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
@@ -25082,17 +24945,17 @@ msgstr ""
 "не може да изтриете заключено работно дърво:\n"
 "или го отключете, или го изтрийте принудително с „remove -f -f“"
 
-#: builtin/worktree.c:985
+#: builtin/worktree.c:984
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr "проверките са неуспешни, работното дърво не може да бъде изтрито: %s"
 
-#: builtin/worktree.c:1009
+#: builtin/worktree.c:1008
 #, c-format
 msgid "repair: %s: %s"
 msgstr "поправяне: %s: „%s“"
 
-#: builtin/worktree.c:1012
+#: builtin/worktree.c:1011
 #, c-format
 msgid "error: %s: %s"
 msgstr "грешка: %s: „%s“"
@@ -25145,20 +25008,15 @@ msgstr ""
 "някое определено ПОНЯТИЕ използвайте „git help ПОНЯТИЕ“.  За преглед на\n"
 "системата за помощ използвайте „git help git“."
 
-#: git.c:188
+#: git.c:188 git.c:216 git.c:300
 #, c-format
-msgid "no directory given for --git-dir\n"
-msgstr "опцията „--git-dir“ изисква директория\n"
+msgid "no directory given for '%s' option\n"
+msgstr "опцията „%s“ изисква директория\n"
 
 #: git.c:202
 #, c-format
 msgid "no namespace given for --namespace\n"
 msgstr "опцията „--namespace“ изисква име\n"
-
-#: git.c:216
-#, c-format
-msgid "no directory given for --work-tree\n"
-msgstr "опцията „--work-tree“ изисква директория\n"
 
 #: git.c:230
 #, c-format
@@ -25174,11 +25032,6 @@ msgstr "опцията „-c“ изисква низ за настройка\n"
 #, c-format
 msgid "no config key given for --config-env\n"
 msgstr "опцията „--config-env“ изисква ключ\n"
-
-#: git.c:300
-#, c-format
-msgid "no directory given for -C\n"
-msgstr "опцията „-C“ изисква директория\n"
 
 #: git.c:326
 #, c-format
@@ -25209,29 +25062,29 @@ msgstr "празен псевдоним за „%s“"
 msgid "recursive alias: %s"
 msgstr "зациклен псевдоним: „%s“"
 
-#: git.c:476
+#: git.c:479
 msgid "write failure on standard output"
 msgstr "грешка при запис на стандартния изход"
 
-#: git.c:478
+#: git.c:481
 msgid "unknown write failure on standard output"
 msgstr "неизвестна грешка при запис на стандартния изход"
 
-#: git.c:480
+#: git.c:483
 msgid "close failed on standard output"
 msgstr "грешка при затваряне на стандартния изход"
 
-#: git.c:832
+#: git.c:835
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr "зацикляне в псевдонимите: заместванията на „%s“ не приключват:%s"
 
-#: git.c:882
+#: git.c:885
 #, c-format
 msgid "cannot handle %s as a builtin"
 msgstr "„%s“ не може да се обработи като вградена команда"
 
-#: git.c:895
+#: git.c:898
 #, c-format
 msgid ""
 "usage: %s\n"
@@ -25240,34 +25093,26 @@ msgstr ""
 "употреба: %s\n"
 "\n"
 
-#: git.c:915
+#: git.c:918
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr ""
 "неуспешно заместване на псевдонима „%s“ — резултатът „%s“ не е команда на "
 "git\n"
 
-#: git.c:927
+#: git.c:930
 #, c-format
 msgid "failed to run command '%s': %s\n"
 msgstr "командата „%s“ не може да се изпълни: %s\n"
 
-#: http-fetch.c:118
+#: http-fetch.c:128
 #, c-format
 msgid "argument to --packfile must be a valid hash (got '%s')"
 msgstr "опцията „--packfile“ изисква валидна контролна сума (а не „%s“)"
 
-#: http-fetch.c:128
+#: http-fetch.c:138
 msgid "not a git repository"
 msgstr "не е хранилище на Git"
-
-#: http-fetch.c:134
-msgid "--packfile requires --index-pack-args"
-msgstr "опцията „--packfile“ изисква опция „--index-pack-args“"
-
-#: http-fetch.c:143
-msgid "--index-pack-args can only be used with --packfile"
-msgstr "опцията „--index-pack-args“ изисква опция „--packfile“"
 
 #: t/helper/test-fast-rebase.c:141
 msgid "unhandled options"
@@ -25560,6 +25405,177 @@ msgstr "remote-curl: опит за доставяне без локално хр
 msgid "remote-curl: unknown command '%s' from git"
 msgstr "remote-curl: непозната команда „%s“ от git"
 
+#: contrib/scalar/scalar.c:49
+msgid "need a working directory"
+msgstr "необходима е работна директория"
+
+#: contrib/scalar/scalar.c:86
+msgid "could not find enlistment root"
+msgstr "началната зачислена директория не може да бъде открита"
+
+#: contrib/scalar/scalar.c:89 contrib/scalar/scalar.c:351
+#: contrib/scalar/scalar.c:436 contrib/scalar/scalar.c:579
+#, c-format
+msgid "could not switch to '%s'"
+msgstr "не може да се премине към „%s“"
+
+#: contrib/scalar/scalar.c:180
+#, c-format
+msgid "could not configure %s=%s"
+msgstr "настройката „%s=%s“ не може да се зададе"
+
+#: contrib/scalar/scalar.c:198
+msgid "could not configure log.excludeDecoration"
+msgstr "„log.excludeDecoration“ не може да се настрои"
+
+#: contrib/scalar/scalar.c:219
+msgid "Scalar enlistments require a worktree"
+msgstr "Зачисляването на директории чрез „scalar“ изисква работно дърво"
+
+#: contrib/scalar/scalar.c:311
+#, c-format
+msgid "remote HEAD is not a branch: '%.*s'"
+msgstr "отдалеченият указател „HEAD“ не сочи към клон: „%.*s“"
+
+#: contrib/scalar/scalar.c:317
+msgid "failed to get default branch name from remote; using local default"
+msgstr ""
+"името на стандартния клон на отдалеченото хранилище не може да се получи, "
+"затова ще се ползва локално настроеното име на стандартния клон"
+
+#: contrib/scalar/scalar.c:330
+msgid "failed to get default branch name"
+msgstr "неуспешно получаване на името на стандартния клон"
+
+#: contrib/scalar/scalar.c:341
+msgid "failed to unregister repository"
+msgstr "хранилището не може да бъде отчислено"
+
+#: contrib/scalar/scalar.c:356
+msgid "failed to delete enlistment directory"
+msgstr "зачислената директория не може да бъде изтрита"
+
+#: contrib/scalar/scalar.c:376
+msgid "branch to checkout after clone"
+msgstr "към кой клон да се премине след клониране"
+
+#: contrib/scalar/scalar.c:378
+msgid "when cloning, create full working directory"
+msgstr "при клониране да се създава пълна работна директория"
+
+#: contrib/scalar/scalar.c:380
+msgid "only download metadata for the branch that will be checked out"
+msgstr "да се свалят метаданните само за изтегляния клон"
+
+#: contrib/scalar/scalar.c:385
+msgid "scalar clone [<options>] [--] <repo> [<dir>]"
+msgstr "scalar clone [ОПЦИЯ…] [--] ХРАНИЛИЩЕ [ДИРЕКТОРИЯ]"
+
+#: contrib/scalar/scalar.c:410
+#, c-format
+msgid "cannot deduce worktree name from '%s'"
+msgstr "името на работното дърво не може да се извлече от „%s“"
+
+#: contrib/scalar/scalar.c:419
+#, c-format
+msgid "directory '%s' exists already"
+msgstr "директорията „%s“ вече съществува"
+
+#: contrib/scalar/scalar.c:446
+#, c-format
+msgid "failed to get default branch for '%s'"
+msgstr "основният клон на „%s“ не може да бъде получен"
+
+#: contrib/scalar/scalar.c:457
+#, c-format
+msgid "could not configure remote in '%s'"
+msgstr "отдалеченото хранилище в „%s“ не може да се настрои"
+
+#: contrib/scalar/scalar.c:466
+#, c-format
+msgid "could not configure '%s'"
+msgstr "„%s“ не може да се настрои"
+
+#: contrib/scalar/scalar.c:469
+msgid "partial clone failed; attempting full clone"
+msgstr "неуспешно създаване на непълно хранилище, ще се опита пълно хранилище"
+
+#: contrib/scalar/scalar.c:473
+msgid "could not configure for full clone"
+msgstr "не може да се настрои пълно клониране"
+
+#: contrib/scalar/scalar.c:505
+msgid "`scalar list` does not take arguments"
+msgstr "„scalar list“ не приема аргументи"
+
+#: contrib/scalar/scalar.c:518
+msgid "scalar register [<enlistment>]"
+msgstr "scalar register [ЗАЧИСЛЕНА_ДИРЕКТОРИЯ]"
+
+#: contrib/scalar/scalar.c:545
+msgid "reconfigure all registered enlistments"
+msgstr "пренастройване на всички зачислени директории"
+
+#: contrib/scalar/scalar.c:549
+msgid "scalar reconfigure [--all | <enlistment>]"
+msgstr "scalar reconfigure [--all | ЗАЧИСЛЕНА_ДИРЕКТОРИЯ]"
+
+#: contrib/scalar/scalar.c:567
+msgid "--all or <enlistment>, but not both"
+msgstr "опцията „--all“ и указването на зачислена директория не са съвместими"
+
+#: contrib/scalar/scalar.c:582
+#, c-format
+msgid "git repository gone in '%s'"
+msgstr "вече няма хранилище на git в „%s“"
+
+#: contrib/scalar/scalar.c:622
+msgid ""
+"scalar run <task> [<enlistment>]\n"
+"Tasks:\n"
+msgstr ""
+"scalar run ЗАДАЧА [ЗАЧИСЛЕНА_ДИРЕКТОРИЯ]\n"
+"Задачи:\n"
+
+#: contrib/scalar/scalar.c:640
+#, c-format
+msgid "no such task: '%s'"
+msgstr "няма задача с име „%s“"
+
+#: contrib/scalar/scalar.c:690
+msgid "scalar unregister [<enlistment>]"
+msgstr "scalar unregister [ЗАЧИСЛЕНА_ДИРЕКТОРИЯ]"
+
+#: contrib/scalar/scalar.c:737
+msgid "scalar delete <enlistment>"
+msgstr "scalar delete ЗАЧИСЛЕНА_ДИРЕКТОРИЯ"
+
+#: contrib/scalar/scalar.c:752
+msgid "refusing to delete current working directory"
+msgstr "текущата работна директория няма да бъде изтрита"
+
+#: contrib/scalar/scalar.c:767
+msgid "include Git version"
+msgstr "включване и на версията на git"
+
+#: contrib/scalar/scalar.c:769
+msgid "include Git's build options"
+msgstr "включване и на опциите за компилиране на git"
+
+#: contrib/scalar/scalar.c:773
+msgid "scalar verbose [-v | --verbose] [--build-options]"
+msgstr "scalar verbose [-v | --verbose] [--build-options]"
+
+#: contrib/scalar/scalar.c:821
+msgid ""
+"scalar <command> [<options>]\n"
+"\n"
+"Commands:\n"
+msgstr ""
+"scalar КОМАНДА [ОПЦИЯ…]<\n"
+"\n"
+"Команди:\n"
+
 #: compat/compiler.h:26
 msgid "no compiler information available\n"
 msgstr "липсва информация за компилатора\n"
@@ -25584,38 +25600,38 @@ msgstr "период на валидност/запазване"
 msgid "no-op (backward compatibility)"
 msgstr "нулева операция (за съвместимост с предишни версии)"
 
-#: parse-options.h:308
+#: parse-options.h:310
 msgid "be more verbose"
 msgstr "повече подробности"
 
-#: parse-options.h:310
+#: parse-options.h:312
 msgid "be more quiet"
 msgstr "по-малко подробности"
 
-#: parse-options.h:316
+#: parse-options.h:318
 msgid "use <n> digits to display object names"
 msgstr "да се показват такъв БРОЙ цифри от имената на обектите"
 
-#: parse-options.h:335
+#: parse-options.h:337
 msgid "how to strip spaces and #comments from message"
 msgstr "кои празни знаци и #коментари да се махат от съобщенията"
 
-#: parse-options.h:336
+#: parse-options.h:338
 msgid "read pathspec from file"
 msgstr "изчитане на пътищата от ФАЙЛ"
 
-#: parse-options.h:337
+#: parse-options.h:339
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""
 "при ползването на „--pathspec-from-file“, пътищата са разделени с нулевия "
 "знак „NUL“"
 
-#: ref-filter.h:101
+#: ref-filter.h:98
 msgid "key"
 msgstr "КЛЮЧ"
 
-#: ref-filter.h:101
+#: ref-filter.h:98
 msgid "field name to sort on"
 msgstr "име на полето, по което да е подредбата"
 
@@ -25689,17 +25705,17 @@ msgid "Show canonical names and email addresses of contacts"
 msgstr "Извеждане на каноничните име и адрес на е-поща на контактите"
 
 #: command-list.h:65
+msgid "Ensures that a reference name is well formed"
+msgstr "Проверка дали името на указателя е по правилата"
+
+#: command-list.h:66
 msgid "Switch branches or restore working tree files"
 msgstr ""
 "Преминаване към друг клон или възстановяване на файловете в работното дърво"
 
-#: command-list.h:66
+#: command-list.h:67
 msgid "Copy files from the index to the working tree"
 msgstr "Копиране на файлове от индекса към работното дърво"
-
-#: command-list.h:67
-msgid "Ensures that a reference name is well formed"
-msgstr "Проверка дали името на указателя е по правилата"
 
 #: command-list.h:68
 msgid "Find commits yet to be applied to upstream"
@@ -25906,413 +25922,413 @@ msgstr ""
 "Добавяне или обработка на структурирана информация в съобщенията при подаване"
 
 #: command-list.h:116
-msgid "The Git repository browser"
-msgstr "Разглеждане на хранилище на Git"
-
-#: command-list.h:117
 msgid "Show commit logs"
 msgstr "Извеждане на журнала с подаванията"
 
-#: command-list.h:118
+#: command-list.h:117
 msgid "Show information about files in the index and the working tree"
 msgstr "Извеждане на информация за файловете в индекса и работното дърво"
 
-#: command-list.h:119
+#: command-list.h:118
 msgid "List references in a remote repository"
 msgstr "Извеждане на указателите в отдалечено хранилище"
 
-#: command-list.h:120
+#: command-list.h:119
 msgid "List the contents of a tree object"
 msgstr "Извеждане на съдържанието на обект-дърво"
 
-#: command-list.h:121
+#: command-list.h:120
 msgid "Extracts patch and authorship from a single e-mail message"
 msgstr "Изваждане на кръпка и авторството от е-писмо"
 
-#: command-list.h:122
+#: command-list.h:121
 msgid "Simple UNIX mbox splitter program"
 msgstr "Проста програма за разделяне на файлове във формат UNIX mbox"
 
-#: command-list.h:123
+#: command-list.h:122
 msgid "Run tasks to optimize Git repository data"
 msgstr "Изпълнение на задачи за оптимизиране на хранилището на Git"
 
-#: command-list.h:124
+#: command-list.h:123
 msgid "Join two or more development histories together"
 msgstr "Сливане на две или повече поредици/истории от промени"
 
-#: command-list.h:125
+#: command-list.h:124
 msgid "Find as good common ancestors as possible for a merge"
 msgstr "Откриване на най-подходящите общи предшественици за сливане"
 
-#: command-list.h:126
+#: command-list.h:125
 msgid "Run a three-way file merge"
 msgstr "Изпълнение на тройно сливане"
 
-#: command-list.h:127
+#: command-list.h:126
 msgid "Run a merge for files needing merging"
 msgstr "Сливане на файловете, които се нуждаят от това"
 
-#: command-list.h:128
+#: command-list.h:127
 msgid "The standard helper program to use with git-merge-index"
 msgstr "Стандартната помощна програма за „git-merge-index“"
+
+#: command-list.h:128
+msgid "Show three-way merge without touching index"
+msgstr "Извеждане на тройно сливане без промяна на индекса"
 
 #: command-list.h:129
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
 msgstr "Изпълнение на програмите за коригиране на конфликтите при сливане"
 
 #: command-list.h:130
-msgid "Show three-way merge without touching index"
-msgstr "Извеждане на тройно сливане без промяна на индекса"
-
-#: command-list.h:131
-msgid "Write and verify multi-pack-indexes"
-msgstr "Запис и проверка на индексите за множество пакети"
-
-#: command-list.h:132
 msgid "Creates a tag object with extra validation"
 msgstr "Създаване на обект-етикет с допълнителни проверки"
 
-#: command-list.h:133
+#: command-list.h:131
 msgid "Build a tree-object from ls-tree formatted text"
 msgstr "Създаване на обект-дърво от текст във формат „ls-tree“"
 
-#: command-list.h:134
+#: command-list.h:132
+msgid "Write and verify multi-pack-indexes"
+msgstr "Запис и проверка на индексите за множество пакети"
+
+#: command-list.h:133
 msgid "Move or rename a file, a directory, or a symlink"
 msgstr "Преместване или преименуване на файл, директория или символна връзка"
 
-#: command-list.h:135
+#: command-list.h:134
 msgid "Find symbolic names for given revs"
 msgstr "Откриване на имената дадени на версия"
 
-#: command-list.h:136
+#: command-list.h:135
 msgid "Add or inspect object notes"
 msgstr "Добавяне или преглед на бележки към обект"
 
-#: command-list.h:137
+#: command-list.h:136
 msgid "Import from and submit to Perforce repositories"
 msgstr "Внасяне и подаване към хранилища на Perforce"
 
-#: command-list.h:138
+#: command-list.h:137
 msgid "Create a packed archive of objects"
 msgstr "Създаване на пакетиран архив от обекти"
 
-#: command-list.h:139
+#: command-list.h:138
 msgid "Find redundant pack files"
 msgstr "Намиране на повтарящи се пакетни файлове"
 
-#: command-list.h:140
+#: command-list.h:139
 msgid "Pack heads and tags for efficient repository access"
 msgstr "Пакетиране на върховете и етикетите за бърз достъп до хранилище"
 
-#: command-list.h:141
+#: command-list.h:140
 msgid "Compute unique ID for a patch"
 msgstr "Генериране на уникален идентификатор на кръпка"
 
-#: command-list.h:142
+#: command-list.h:141
 msgid "Prune all unreachable objects from the object database"
 msgstr "Окастряне на всички недостижими обекти в базата от данни за обектите"
 
-#: command-list.h:143
+#: command-list.h:142
 msgid "Remove extra objects that are already in pack files"
 msgstr "Изтриване на допълнителните обекти, които вече са в пакетни файлове"
 
-#: command-list.h:144
+#: command-list.h:143
 msgid "Fetch from and integrate with another repository or a local branch"
 msgstr "Доставяне и внасяне на промените от друго хранилище или клон"
 
-#: command-list.h:145
+#: command-list.h:144
 msgid "Update remote refs along with associated objects"
 msgstr "Обновяване на отдалечените указатели и свързаните с тях обекти"
 
-#: command-list.h:146
+#: command-list.h:145
 msgid "Applies a quilt patchset onto the current branch"
 msgstr "Прилагане на поредица от кръпки от quilt към текущия клон"
 
-#: command-list.h:147
+#: command-list.h:146
 msgid "Compare two commit ranges (e.g. two versions of a branch)"
 msgstr "Сравняване на два диапазона от подавания (напр. две версии на клон)"
 
-#: command-list.h:148
+#: command-list.h:147
 msgid "Reads tree information into the index"
 msgstr "Изчитане на информация за обект-дърво в индекса"
 
-#: command-list.h:149
+#: command-list.h:148
 msgid "Reapply commits on top of another base tip"
 msgstr "Прилагане на подаванията върху друг връх"
 
-#: command-list.h:150
+#: command-list.h:149
 msgid "Receive what is pushed into the repository"
 msgstr "Получаване на изтласканото в хранилището"
 
-#: command-list.h:151
+#: command-list.h:150
 msgid "Manage reflog information"
 msgstr "Управление на информацията в журнала на указателите"
 
-#: command-list.h:152
+#: command-list.h:151
 msgid "Manage set of tracked repositories"
 msgstr "Управление на набор от следени хранилища"
 
-#: command-list.h:153
+#: command-list.h:152
 msgid "Pack unpacked objects in a repository"
 msgstr "Пакетиране на непакетираните обекти в хранилище"
 
-#: command-list.h:154
+#: command-list.h:153
 msgid "Create, list, delete refs to replace objects"
 msgstr "Създаване, извеждане, изтриване на указатели за замяна на обекти"
 
-#: command-list.h:155
+#: command-list.h:154
 msgid "Generates a summary of pending changes"
 msgstr "Обобщение на предстоящите промени"
 
-#: command-list.h:156
+#: command-list.h:155
 msgid "Reuse recorded resolution of conflicted merges"
 msgstr "Преизползване на вече запазено коригиране на конфликт при сливане"
 
-#: command-list.h:157
+#: command-list.h:156
 msgid "Reset current HEAD to the specified state"
 msgstr "Привеждане на указателя „HEAD“ към зададеното състояние"
 
-#: command-list.h:158
+#: command-list.h:157
 msgid "Restore working tree files"
 msgstr "Възстановяване на файловете в работното дърво"
 
-#: command-list.h:159
-msgid "Revert some existing commits"
-msgstr "Отменяне на съществуващи подавания"
-
-#: command-list.h:160
+#: command-list.h:158
 msgid "Lists commit objects in reverse chronological order"
 msgstr "Извеждане на подаванията в обратна хронологическа подредба"
 
-#: command-list.h:161
+#: command-list.h:159
 msgid "Pick out and massage parameters"
 msgstr "Избор и промяна на параметри"
 
-#: command-list.h:162
+#: command-list.h:160
+msgid "Revert some existing commits"
+msgstr "Отменяне на съществуващи подавания"
+
+#: command-list.h:161
 msgid "Remove files from the working tree and from the index"
 msgstr "Изтриване на файлове от работното дърво и индекса"
 
-#: command-list.h:163
+#: command-list.h:162
 msgid "Send a collection of patches as emails"
 msgstr "Изпращане на поредица от кръпки по е-поща"
 
-#: command-list.h:164
+#: command-list.h:163
 msgid "Push objects over Git protocol to another repository"
 msgstr "Изтласкване на обекти по протокола на Git към друго хранилище"
 
-#: command-list.h:165
-msgid "Restricted login shell for Git-only SSH access"
-msgstr "Ограничена входна обвивка за достъп през SSH само до Git"
-
-#: command-list.h:166
-msgid "Summarize 'git log' output"
-msgstr "Обобщен изход от „git log“"
-
-#: command-list.h:167
-msgid "Show various types of objects"
-msgstr "Извеждане на различните видове обекти в Git"
-
-#: command-list.h:168
-msgid "Show branches and their commits"
-msgstr "Извеждане на клоните и подаванията в тях"
-
-#: command-list.h:169
-msgid "Show packed archive index"
-msgstr "Извеждане на индекса на пакетирания архив"
-
-#: command-list.h:170
-msgid "List references in a local repository"
-msgstr "Извеждане на указателите в локално хранилище"
-
-#: command-list.h:171
+#: command-list.h:164
 msgid "Git's i18n setup code for shell scripts"
 msgstr "Настройки на Git за интернационализация на скриптовете на обвивката"
 
-#: command-list.h:172
+#: command-list.h:165
 msgid "Common Git shell script setup code"
 msgstr "Настройки на Git за скриптовете на обвивката"
 
-#: command-list.h:173
+#: command-list.h:166
+msgid "Restricted login shell for Git-only SSH access"
+msgstr "Ограничена входна обвивка за достъп през SSH само до Git"
+
+#: command-list.h:167
+msgid "Summarize 'git log' output"
+msgstr "Обобщен изход от „git log“"
+
+#: command-list.h:168
+msgid "Show various types of objects"
+msgstr "Извеждане на различните видове обекти в Git"
+
+#: command-list.h:169
+msgid "Show branches and their commits"
+msgstr "Извеждане на клоните и подаванията в тях"
+
+#: command-list.h:170
+msgid "Show packed archive index"
+msgstr "Извеждане на индекса на пакетирания архив"
+
+#: command-list.h:171
+msgid "List references in a local repository"
+msgstr "Извеждане на указателите в локално хранилище"
+
+#: command-list.h:172
 msgid "Initialize and modify the sparse-checkout"
 msgstr "Инициализиране и промяна на частичното изтегляне"
+
+#: command-list.h:173
+msgid "Add file contents to the staging area"
+msgstr "Добавяне на съдържанието на файла към индекса"
 
 #: command-list.h:174
 msgid "Stash the changes in a dirty working directory away"
 msgstr "Скатаване на неподадените промени в работното дърво"
 
 #: command-list.h:175
-msgid "Add file contents to the staging area"
-msgstr "Добавяне на съдържанието на файла към индекса"
-
-#: command-list.h:176
 msgid "Show the working tree status"
 msgstr "Извеждане на състоянието на работното дърво"
 
-#: command-list.h:177
+#: command-list.h:176
 msgid "Remove unnecessary whitespace"
 msgstr "Премахване на излишните знаци за интервали"
 
-#: command-list.h:178
+#: command-list.h:177
 msgid "Initialize, update or inspect submodules"
 msgstr "Инициализиране, обновяване или разглеждане на подмодули"
 
-#: command-list.h:179
+#: command-list.h:178
 msgid "Bidirectional operation between a Subversion repository and Git"
 msgstr "Двупосочна работа между хранилища под Subversion и Git"
 
-#: command-list.h:180
+#: command-list.h:179
 msgid "Switch branches"
 msgstr "Преминаване към друг клон"
 
-#: command-list.h:181
+#: command-list.h:180
 msgid "Read, modify and delete symbolic refs"
 msgstr "Извеждане, промяна и изтриване на символни указатели"
 
-#: command-list.h:182
+#: command-list.h:181
 msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr "Извеждане, създаване, изтриване, проверка на етикети подписани с GPG"
 
-#: command-list.h:183
+#: command-list.h:182
 msgid "Creates a temporary file with a blob's contents"
 msgstr "Създаване на временен файл със същото съдържание като обектът-BLOB"
 
-#: command-list.h:184
+#: command-list.h:183
 msgid "Unpack objects from a packed archive"
 msgstr "Разпакетиране на обекти от пакетиран архив"
 
-#: command-list.h:185
+#: command-list.h:184
 msgid "Register file contents in the working tree to the index"
 msgstr "Регистриране на съдържанието на файловете от работното дърво в индекса"
 
-#: command-list.h:186
+#: command-list.h:185
 msgid "Update the object name stored in a ref safely"
 msgstr "Безопасно обновяване на името на обект в указател"
 
-#: command-list.h:187
+#: command-list.h:186
 msgid "Update auxiliary info file to help dumb servers"
 msgstr ""
 "Обновяване на файла с допълнителна информация в помощ на опростените сървъри"
 
-#: command-list.h:188
+#: command-list.h:187
 msgid "Send archive back to git-archive"
 msgstr "Изпращане на архива обратно към „git-archive“"
 
-#: command-list.h:189
+#: command-list.h:188
 msgid "Send objects packed back to git-fetch-pack"
 msgstr "Изпращане на пакетираните обекти обратно към „git-fetch-pack“"
 
-#: command-list.h:190
+#: command-list.h:189
 msgid "Show a Git logical variable"
 msgstr "Извеждане на логическа променлива на Git"
 
-#: command-list.h:191
+#: command-list.h:190
 msgid "Check the GPG signature of commits"
 msgstr "Проверка на подписите GPG върху подаванията"
 
-#: command-list.h:192
+#: command-list.h:191
 msgid "Validate packed Git archive files"
 msgstr "Проверка на пакетираните архивни файлове на Git"
 
-#: command-list.h:193
+#: command-list.h:192
 msgid "Check the GPG signature of tags"
 msgstr "Проверка на подписите GPG върху етикетите"
 
-#: command-list.h:194
-msgid "Git web interface (web frontend to Git repositories)"
-msgstr "Уеб интерфейс на Git"
-
-#: command-list.h:195
+#: command-list.h:193
 msgid "Show logs with difference each commit introduces"
 msgstr "Извеждане на журнал с разликите, въведени с всяко подаване"
 
-#: command-list.h:196
+#: command-list.h:194
 msgid "Manage multiple working trees"
 msgstr "Управление на множество работни дървета"
 
-#: command-list.h:197
+#: command-list.h:195
 msgid "Create a tree object from the current index"
 msgstr "Създаване на обект-дърво от текущия индекс"
 
-#: command-list.h:198
+#: command-list.h:196
 msgid "Defining attributes per path"
 msgstr "Указване на атрибути към път"
 
-#: command-list.h:199
+#: command-list.h:197
 msgid "Git command-line interface and conventions"
 msgstr "Команден ред и конвенции на Git"
 
-#: command-list.h:200
+#: command-list.h:198
 msgid "A Git core tutorial for developers"
 msgstr "Въвеждащ урок в Git за разработчици"
 
-#: command-list.h:201
+#: command-list.h:199
 msgid "Providing usernames and passwords to Git"
 msgstr "Въвеждане на имена и пароли към Git"
 
-#: command-list.h:202
+#: command-list.h:200
 msgid "Git for CVS users"
 msgstr "Git за потребители на CVS"
 
-#: command-list.h:203
+#: command-list.h:201
 msgid "Tweaking diff output"
 msgstr "Настройване на изгледа на разликите"
 
-#: command-list.h:204
+#: command-list.h:202
 msgid "A useful minimum set of commands for Everyday Git"
 msgstr "Полезен минимален набор от команди за ежедневната работа с Git"
 
-#: command-list.h:205
+#: command-list.h:203
 msgid "Frequently asked questions about using Git"
 msgstr "Често задавани въпроси за употребата на Git"
 
-#: command-list.h:206
+#: command-list.h:204
 msgid "A Git Glossary"
 msgstr "Речник с термините на Git"
 
-#: command-list.h:207
+#: command-list.h:205
 msgid "Hooks used by Git"
 msgstr "Куки на Git"
 
-#: command-list.h:208
+#: command-list.h:206
 msgid "Specifies intentionally untracked files to ignore"
 msgstr "Указване на неследени файлове, които да бъдат нарочно пренебрегвани"
 
-#: command-list.h:209
+#: command-list.h:207
+msgid "The Git repository browser"
+msgstr "Разглеждане на хранилище на Git"
+
+#: command-list.h:208
 msgid "Map author/committer names and/or E-Mail addresses"
 msgstr "Съответствия на имена на автор/подаващ и/или адреси на е-поща"
 
-#: command-list.h:210
+#: command-list.h:209
 msgid "Defining submodule properties"
 msgstr "Дефиниране на свойствата на подмодулите"
 
-#: command-list.h:211
+#: command-list.h:210
 msgid "Git namespaces"
 msgstr "Пространства от имена на Git"
 
-#: command-list.h:212
+#: command-list.h:211
 msgid "Helper programs to interact with remote repositories"
 msgstr "Помощни програми за работа с отдалечените хранилища"
 
-#: command-list.h:213
+#: command-list.h:212
 msgid "Git Repository Layout"
 msgstr "Устройство на хранилището на Git"
 
-#: command-list.h:214
+#: command-list.h:213
 msgid "Specifying revisions and ranges for Git"
 msgstr "Указване на версии и диапазони в Git"
 
-#: command-list.h:215
+#: command-list.h:214
 msgid "Mounting one repository inside another"
 msgstr "Монтиране на едно хранилище в друго"
+
+#: command-list.h:215
+msgid "A tutorial introduction to Git"
+msgstr "Въвеждащ урок за Git"
 
 #: command-list.h:216
 msgid "A tutorial introduction to Git: part two"
 msgstr "Въвеждащ урок за Git: втора част"
 
 #: command-list.h:217
-msgid "A tutorial introduction to Git"
-msgstr "Въвеждащ урок за Git"
+msgid "Git web interface (web frontend to Git repositories)"
+msgstr "Уеб интерфейс на Git"
 
 #: command-list.h:218
 msgid "An overview of recommended workflows with Git"
@@ -26386,45 +26402,45 @@ msgstr ""
 msgid "usage: $dashless $USAGE"
 msgstr "Употреба: $dashless $USAGE"
 
-#: git-sh-setup.sh:191
+#: git-sh-setup.sh:183
 #, sh-format
 msgid "Cannot chdir to $cdup, the toplevel of the working tree"
 msgstr ""
 "Не може да се премине към „$cdup“ — основната директория на работното дърво."
 
-#: git-sh-setup.sh:200 git-sh-setup.sh:207
+#: git-sh-setup.sh:192 git-sh-setup.sh:199
 #, sh-format
 msgid "fatal: $program_name cannot be used without a working tree."
 msgstr ""
 "ФАТАЛНА ГРЕШКА: „$program_name“ не може да се ползва без работно дърво."
 
-#: git-sh-setup.sh:221
+#: git-sh-setup.sh:213
 msgid "Cannot rewrite branches: You have unstaged changes."
 msgstr ""
 "Не може да презапишете клоните, защото има промени, които не са в индекса."
 
-#: git-sh-setup.sh:224
+#: git-sh-setup.sh:216
 #, sh-format
 msgid "Cannot $action: You have unstaged changes."
 msgstr ""
 "Не може да изпълните „$action“, защото има промени, които не са в индекса."
 
-#: git-sh-setup.sh:235
+#: git-sh-setup.sh:227
 #, sh-format
 msgid "Cannot $action: Your index contains uncommitted changes."
 msgstr ""
 "Не може да изпълните „$action“, защото в индекса има неподадени промени."
 
-#: git-sh-setup.sh:237
+#: git-sh-setup.sh:229
 msgid "Additionally, your index contains uncommitted changes."
 msgstr "Освен това в индекса има неподадени промени."
 
-#: git-sh-setup.sh:357
+#: git-sh-setup.sh:349
 msgid "You need to run this command from the toplevel of the working tree."
 msgstr ""
 "Тази команда трябва да се изпълни от основната директория на работното дърво"
 
-#: git-sh-setup.sh:362
+#: git-sh-setup.sh:354
 msgid "Unable to determine absolute path of git directory"
 msgstr "Абсолютният път на работното дърво не може да се определи"
 
@@ -26513,7 +26529,7 @@ msgid "failed to open hunk edit file for reading: %s"
 msgstr ""
 "файлът за редактиране на парчето код не може да бъде отворен за четене: „%s“"
 
-#: git-add--interactive.perl:1251
+#: git-add--interactive.perl:1253
 msgid ""
 "y - stage this hunk\n"
 "n - do not stage this hunk\n"
@@ -26527,7 +26543,7 @@ msgstr ""
 "a — добавяне на това и всички следващи парчета от файла в индекса\n"
 "d — без добавяне на това и всички следващи парчета от файла в индекса"
 
-#: git-add--interactive.perl:1257
+#: git-add--interactive.perl:1259
 msgid ""
 "y - stash this hunk\n"
 "n - do not stash this hunk\n"
@@ -26541,7 +26557,7 @@ msgstr ""
 "a — скатаване на това и всички следващи парчета от файла\n"
 "d — без скатаване на това и всички следващи парчета от файла"
 
-#: git-add--interactive.perl:1263
+#: git-add--interactive.perl:1265
 msgid ""
 "y - unstage this hunk\n"
 "n - do not unstage this hunk\n"
@@ -26555,7 +26571,7 @@ msgstr ""
 "a — изваждане на това и всички следващи парчета от файла от индекса\n"
 "d — без изваждане на това и всички следващи парчета от файла от индекса"
 
-#: git-add--interactive.perl:1269
+#: git-add--interactive.perl:1271
 msgid ""
 "y - apply this hunk to index\n"
 "n - do not apply this hunk to index\n"
@@ -26569,7 +26585,7 @@ msgstr ""
 "a — прилагане на това и всички следващи парчета от файла към индекса\n"
 "d — без прилагане на това и всички следващи парчета от файла към индекса"
 
-#: git-add--interactive.perl:1275 git-add--interactive.perl:1293
+#: git-add--interactive.perl:1277 git-add--interactive.perl:1295
 msgid ""
 "y - discard this hunk from worktree\n"
 "n - do not discard this hunk from worktree\n"
@@ -26586,7 +26602,7 @@ msgstr ""
 "d — без премахване на това и всички следващи парчета от файла от работното "
 "дърво"
 
-#: git-add--interactive.perl:1281
+#: git-add--interactive.perl:1283
 msgid ""
 "y - discard this hunk from index and worktree\n"
 "n - do not discard this hunk from index and worktree\n"
@@ -26603,7 +26619,7 @@ msgstr ""
 "d — без премахване на това и всички следващи парчета от файла от индекса и "
 "работното дърво"
 
-#: git-add--interactive.perl:1287
+#: git-add--interactive.perl:1289
 msgid ""
 "y - apply this hunk to index and worktree\n"
 "n - do not apply this hunk to index and worktree\n"
@@ -26620,7 +26636,7 @@ msgstr ""
 "d — без прилагане на това и всички следващи парчета от файла от индекса и "
 "работното дърво"
 
-#: git-add--interactive.perl:1299
+#: git-add--interactive.perl:1301
 msgid ""
 "y - apply this hunk to worktree\n"
 "n - do not apply this hunk to worktree\n"
@@ -26634,7 +26650,7 @@ msgstr ""
 "a — прилагане на това и всички следващи парчета от файла\n"
 "d — без прилагане на това и всички следващи парчета от файла"
 
-#: git-add--interactive.perl:1314
+#: git-add--interactive.perl:1316
 msgid ""
 "g - select a hunk to go to\n"
 "/ - search for a hunk matching the given regex\n"
@@ -26656,92 +26672,92 @@ msgstr ""
 "e — ръчно редактиране на текущото парче\n"
 "? — извеждане не помощта\n"
 
-#: git-add--interactive.perl:1345
+#: git-add--interactive.perl:1347
 msgid "The selected hunks do not apply to the index!\n"
 msgstr "Избраните парчета не може да се добавят в индекса!\n"
 
-#: git-add--interactive.perl:1360
+#: git-add--interactive.perl:1362
 #, perl-format
 msgid "ignoring unmerged: %s\n"
 msgstr "пренебрегване на неслятото: „%s“\n"
 
-#: git-add--interactive.perl:1479
+#: git-add--interactive.perl:1481
 #, perl-format
 msgid "Apply mode change to worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Прилагане на промяната в правата за достъп към работното дърво [y,n,q,a,d"
 "%s,?]? "
 
-#: git-add--interactive.perl:1480
+#: git-add--interactive.perl:1482
 #, perl-format
 msgid "Apply deletion to worktree [y,n,q,a,d%s,?]? "
 msgstr "Прилагане на изтриването към работното дърво [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1481
+#: git-add--interactive.perl:1483
 #, perl-format
 msgid "Apply addition to worktree [y,n,q,a,d%s,?]? "
 msgstr "Прилагане на добавянето към работното дърво [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1482
+#: git-add--interactive.perl:1484
 #, perl-format
 msgid "Apply this hunk to worktree [y,n,q,a,d%s,?]? "
 msgstr "Прилагане на парчето към работното дърво [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1599
+#: git-add--interactive.perl:1601
 msgid "No other hunks to goto\n"
 msgstr "Няма други парчета\n"
 
-#: git-add--interactive.perl:1617
+#: git-add--interactive.perl:1619
 #, perl-format
 msgid "Invalid number: '%s'\n"
 msgstr "Неправилен номер: „%s“\n"
 
-#: git-add--interactive.perl:1622
+#: git-add--interactive.perl:1624
 #, perl-format
 msgid "Sorry, only %d hunk available.\n"
 msgid_plural "Sorry, only %d hunks available.\n"
 msgstr[0] "Има само %d парче.\n"
 msgstr[1] "Има само %d парчета.\n"
 
-#: git-add--interactive.perl:1657
+#: git-add--interactive.perl:1659
 msgid "No other hunks to search\n"
 msgstr "Няма други парчета за търсене\n"
 
-#: git-add--interactive.perl:1674
+#: git-add--interactive.perl:1676
 #, perl-format
 msgid "Malformed search regexp %s: %s\n"
 msgstr "Сгрешен регулярен израз „%s“: %s\n"
 
-#: git-add--interactive.perl:1684
+#: git-add--interactive.perl:1686
 msgid "No hunk matches the given pattern\n"
 msgstr "Никое парче не напасва на регулярния израз\n"
 
-#: git-add--interactive.perl:1696 git-add--interactive.perl:1718
+#: git-add--interactive.perl:1698 git-add--interactive.perl:1720
 msgid "No previous hunk\n"
 msgstr "Няма друго парче преди това\n"
 
-#: git-add--interactive.perl:1705 git-add--interactive.perl:1724
+#: git-add--interactive.perl:1707 git-add--interactive.perl:1726
 msgid "No next hunk\n"
 msgstr "Няма друго парче след това\n"
 
-#: git-add--interactive.perl:1730
+#: git-add--interactive.perl:1732
 msgid "Sorry, cannot split this hunk\n"
 msgstr "Това парче не може да бъде разделено\n"
 
-#: git-add--interactive.perl:1736
+#: git-add--interactive.perl:1738
 #, perl-format
 msgid "Split into %d hunk.\n"
 msgid_plural "Split into %d hunks.\n"
 msgstr[0] "Разделяне на %d парче.\n"
 msgstr[1] "Разделяне на %d парчета.\n"
 
-#: git-add--interactive.perl:1746
+#: git-add--interactive.perl:1748
 msgid "Sorry, cannot edit this hunk\n"
 msgstr "Това парче не може да бъде редактирано\n"
 
 #. TRANSLATORS: please do not translate the command names
 #. 'status', 'update', 'revert', etc.
-#: git-add--interactive.perl:1811
+#: git-add--interactive.perl:1813
 msgid ""
 "status        - show paths with changes\n"
 "update        - add working tree state to the staged set of changes\n"
@@ -26762,59 +26778,59 @@ msgstr ""
 "                и индекса\n"
 "add untracked — добавяне на неследените файлове към промените в индекса\n"
 
-#: git-add--interactive.perl:1828 git-add--interactive.perl:1840
-#: git-add--interactive.perl:1843 git-add--interactive.perl:1850
-#: git-add--interactive.perl:1853 git-add--interactive.perl:1860
-#: git-add--interactive.perl:1864 git-add--interactive.perl:1870
+#: git-add--interactive.perl:1830 git-add--interactive.perl:1842
+#: git-add--interactive.perl:1845 git-add--interactive.perl:1852
+#: git-add--interactive.perl:1855 git-add--interactive.perl:1862
+#: git-add--interactive.perl:1866 git-add--interactive.perl:1872
 msgid "missing --"
 msgstr "„--“ липсва"
 
-#: git-add--interactive.perl:1866
+#: git-add--interactive.perl:1868
 #, perl-format
 msgid "unknown --patch mode: %s"
 msgstr "неизвестна стратегия за прилагане на кръпка към „--patch“: „%s“"
 
-#: git-add--interactive.perl:1872 git-add--interactive.perl:1878
+#: git-add--interactive.perl:1874 git-add--interactive.perl:1880
 #, perl-format
 msgid "invalid argument %s, expecting --"
 msgstr "указан е неправилен аргумент „%s“, а се очаква „--“."
 
-#: git-send-email.perl:129
+#: git-send-email.perl:159
 msgid "local zone differs from GMT by a non-minute interval\n"
 msgstr ""
 "разликата между местния часови пояс и GMT съдържа дробна част от минута\n"
 "\n"
 
-#: git-send-email.perl:136 git-send-email.perl:142
+#: git-send-email.perl:166 git-send-email.perl:172
 msgid "local time offset greater than or equal to 24 hours\n"
 msgstr "разликата между местния часовия пояс и GMT е 24 часа или повече\n"
 
-#: git-send-email.perl:214
+#: git-send-email.perl:244
 #, perl-format
 msgid "fatal: command '%s' died with exit code %d"
 msgstr "ФАТАЛНА ГРЕШКА: „%s“ не завърши успешно, а с код %d"
 
-#: git-send-email.perl:227
+#: git-send-email.perl:257
 msgid "the editor exited uncleanly, aborting everything"
 msgstr ""
 "текстовият редактор приключи работата с грешка, всичко се преустановява"
 
-#: git-send-email.perl:316
+#: git-send-email.perl:346
 #, perl-format
 msgid ""
 "'%s' contains an intermediate version of the email you were composing.\n"
 msgstr "„%s“ съдържа временна версия на подготвяното е-писмо.\n"
 
-#: git-send-email.perl:321
+#: git-send-email.perl:351
 #, perl-format
 msgid "'%s.final' contains the composed email.\n"
 msgstr "„%s.final“ съдържа подготвеното е-писмо.\n"
 
-#: git-send-email.perl:450
+#: git-send-email.perl:484
 msgid "--dump-aliases incompatible with other options\n"
 msgstr "опцията „--dump-aliases“ е несъвместима с другите опции\n"
 
-#: git-send-email.perl:525
+#: git-send-email.perl:561
 msgid ""
 "fatal: found configuration options for 'sendmail'\n"
 "git-send-email is configured with the sendemail.* options - note the 'e'.\n"
@@ -26825,11 +26841,11 @@ msgstr ""
 "забележете знака „e“.  За да изключите тази проверка, задайте\n"
 "настройката „sendemail.forbidSendmailVariables“ да е „false“ (лъжа̀).\n"
 
-#: git-send-email.perl:530 git-send-email.perl:746
+#: git-send-email.perl:566 git-send-email.perl:782
 msgid "Cannot run git format-patch from outside a repository\n"
 msgstr "Командата „git format-patch“ не може да се изпълни извън хранилище\n"
 
-#: git-send-email.perl:533
+#: git-send-email.perl:569
 msgid ""
 "`batch-size` and `relogin` must be specified together (via command-line or "
 "configuration option)\n"
@@ -26837,40 +26853,40 @@ msgstr ""
 "„batch-size“ и „relogin“ трябва да се указват заедно (или чрез командния "
 "ред, или чрез настройките)\n"
 
-#: git-send-email.perl:546
+#: git-send-email.perl:582
 #, perl-format
 msgid "Unknown --suppress-cc field: '%s'\n"
 msgstr "Непознато поле за опцията „--suppress-cc“: „%s“\n"
 
-#: git-send-email.perl:577
+#: git-send-email.perl:613
 #, perl-format
 msgid "Unknown --confirm setting: '%s'\n"
 msgstr "Непозната стойност за „--confirm“: %s\n"
 
-#: git-send-email.perl:617
+#: git-send-email.perl:653
 #, perl-format
 msgid "warning: sendmail alias with quotes is not supported: %s\n"
 msgstr ""
 "ПРЕДУПРЕЖДЕНИЕ: псевдоними за sendmail съдържащи кавички („\"“) не се "
 "поддържат: %s\n"
 
-#: git-send-email.perl:619
+#: git-send-email.perl:655
 #, perl-format
 msgid "warning: `:include:` not supported: %s\n"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: „:include:“ не се поддържа: %s\n"
 
-#: git-send-email.perl:621
+#: git-send-email.perl:657
 #, perl-format
 msgid "warning: `/file` or `|pipe` redirection not supported: %s\n"
 msgstr ""
 "ПРЕДУПРЕЖДЕНИЕ: пренасочвания „/file“ или „|pipe“ не се поддържат: %s\n"
 
-#: git-send-email.perl:626
+#: git-send-email.perl:662
 #, perl-format
 msgid "warning: sendmail line is not recognized: %s\n"
 msgstr "ПРЕДУПРЕЖДЕНИЕ: редът за „sendmail“ не е разпознат: %s\n"
 
-#: git-send-email.perl:711
+#: git-send-email.perl:747
 #, perl-format
 msgid ""
 "File '%s' exists but it could also be the range of commits\n"
@@ -26885,12 +26901,12 @@ msgstr ""
 "    ● укажете „./%s“ за файл;\n"
 "    ● използвате опцията „--format-patch“ за диапазон.\n"
 
-#: git-send-email.perl:732
+#: git-send-email.perl:768
 #, perl-format
 msgid "Failed to opendir %s: %s"
 msgstr "Директорията „%s“ не може да се отвори: %s"
 
-#: git-send-email.perl:767
+#: git-send-email.perl:803
 msgid ""
 "\n"
 "No patch files specified!\n"
@@ -26900,17 +26916,17 @@ msgstr ""
 "Не са указани кръпки!\n"
 "\n"
 
-#: git-send-email.perl:780
+#: git-send-email.perl:816
 #, perl-format
 msgid "No subject line in %s?"
 msgstr "В „%s“ липсва тема"
 
-#: git-send-email.perl:791
+#: git-send-email.perl:827
 #, perl-format
 msgid "Failed to open for writing %s: %s"
 msgstr "„%s“ не може да се отвори за запис: %s"
 
-#: git-send-email.perl:802
+#: git-send-email.perl:838
 msgid ""
 "Lines beginning in \"GIT:\" will be removed.\n"
 "Consider including an overall diffstat or table of contents\n"
@@ -26925,27 +26941,27 @@ msgstr ""
 "\n"
 "Изтрийте всичко, ако не искате да изпратите обобщаващо писмо.\n"
 
-#: git-send-email.perl:826
+#: git-send-email.perl:862
 #, perl-format
 msgid "Failed to open %s: %s"
 msgstr "„%s“ не може да се отвори: %s"
 
-#: git-send-email.perl:843
+#: git-send-email.perl:879
 #, perl-format
 msgid "Failed to open %s.final: %s"
 msgstr "„%s.final“ не може да се отвори: %s"
 
-#: git-send-email.perl:886
+#: git-send-email.perl:922
 msgid "Summary email is empty, skipping it\n"
 msgstr "Обобщаващото писмо е празно и се прескача\n"
 
 #. TRANSLATORS: please keep [y/N] as is.
-#: git-send-email.perl:935
+#: git-send-email.perl:971
 #, perl-format
 msgid "Are you sure you want to use <%s> [y/N]? "
 msgstr "Сигурни ли сте, че искате да ползвате „%s“ [y/N]? "
 
-#: git-send-email.perl:990
+#: git-send-email.perl:1026
 msgid ""
 "The following files are 8bit, but do not declare a Content-Transfer-"
 "Encoding.\n"
@@ -26953,11 +26969,11 @@ msgstr ""
 "Следните файлове са 8 битови, но не са с обявена заглавна част „Content-"
 "Transfer-Encoding“.\n"
 
-#: git-send-email.perl:995
+#: git-send-email.perl:1031
 msgid "Which 8bit encoding should I declare [UTF-8]? "
 msgstr "Кое 8 битово кодиране се ползва [стандартно: UTF-8]? "
 
-#: git-send-email.perl:1003
+#: git-send-email.perl:1039
 #, perl-format
 msgid ""
 "Refusing to send because the patch\n"
@@ -26970,22 +26986,22 @@ msgstr ""
 "все още е с шаблонното заглавие „*** SUBJECT HERE ***“.  Ползвайте опцията\n"
 "„--force“, ако сте сигурни, че точно това искате да изпратите.\n"
 
-#: git-send-email.perl:1022
+#: git-send-email.perl:1058
 msgid "To whom should the emails be sent (if anyone)?"
 msgstr "На кой да се пратят е-писмата (незадължително поле)"
 
-#: git-send-email.perl:1040
+#: git-send-email.perl:1076
 #, perl-format
 msgid "fatal: alias '%s' expands to itself\n"
 msgstr "ФАТАЛНА ГРЕШКА: „%s“ е псевдоним на себе си\n"
 
-#: git-send-email.perl:1052
+#: git-send-email.perl:1088
 msgid "Message-ID to be used as In-Reply-To for the first email (if any)? "
 msgstr ""
 "Идентификатор на съобщение „Message-ID“, което да се използва за обявяването "
 "на отговор „In-Reply-To“ (незадължително поле)"
 
-#: git-send-email.perl:1114 git-send-email.perl:1122
+#: git-send-email.perl:1150 git-send-email.perl:1158
 #, perl-format
 msgid "error: unable to extract a valid address from: %s\n"
 msgstr "ГРЕШКА: не може да се извлече адрес от „%s“\n"
@@ -26993,18 +27009,18 @@ msgstr "ГРЕШКА: не може да се извлече адрес от „
 #. TRANSLATORS: Make sure to include [q] [d] [e] in your
 #. translation. The program will only accept English input
 #. at this point.
-#: git-send-email.perl:1126
+#: git-send-email.perl:1162
 msgid "What to do with this address? ([q]uit|[d]rop|[e]dit): "
 msgstr ""
 "Какво да се направи с този адрес? „q“ (спиране), „d“ (изтриване), "
 "„e“ (редактиране): "
 
-#: git-send-email.perl:1446
+#: git-send-email.perl:1482
 #, perl-format
 msgid "CA path \"%s\" does not exist"
 msgstr "Пътят към сертификат „%s“ не съществува."
 
-#: git-send-email.perl:1529
+#: git-send-email.perl:1565
 msgid ""
 "    The Cc list above has been expanded by additional\n"
 "    addresses found in the patch commit message. By default\n"
@@ -27032,116 +27048,116 @@ msgstr ""
 #. TRANSLATORS: Make sure to include [y] [n] [e] [q] [a] in your
 #. translation. The program will only accept English input
 #. at this point.
-#: git-send-email.perl:1544
+#: git-send-email.perl:1580
 msgid "Send this email? ([y]es|[n]o|[e]dit|[q]uit|[a]ll): "
 msgstr ""
 "Изпращане на е-писмото? „y“ (да), „n“ (не), „e“ (редактиране), „q“ (изход), "
 "„a“ (всичко): "
 
-#: git-send-email.perl:1547
+#: git-send-email.perl:1583
 msgid "Send this email reply required"
 msgstr "Изискване на отговор към това е-писмо"
 
-#: git-send-email.perl:1581
+#: git-send-email.perl:1617
 msgid "The required SMTP server is not properly defined."
 msgstr "Сървърът за SMTP не е настроен правилно."
 
-#: git-send-email.perl:1628
+#: git-send-email.perl:1664
 #, perl-format
 msgid "Server does not support STARTTLS! %s"
 msgstr "Сървърът не поддържа „STARTTLS“! %s"
 
-#: git-send-email.perl:1633 git-send-email.perl:1637
+#: git-send-email.perl:1669 git-send-email.perl:1673
 #, perl-format
 msgid "STARTTLS failed! %s"
 msgstr "Неуспешно изпълнение на STARTTLS! %s"
 
-#: git-send-email.perl:1646
+#: git-send-email.perl:1682
 msgid "Unable to initialize SMTP properly. Check config and use --smtp-debug."
 msgstr ""
 "Подсистемата за SMTP не може да се инициализира.  Проверете настройките и "
 "използвайте опцията: „--smtp-debug“."
 
-#: git-send-email.perl:1664
+#: git-send-email.perl:1700
 #, perl-format
 msgid "Failed to send %s\n"
 msgstr "„%s“ не може да бъде изпратен\n"
 
-#: git-send-email.perl:1667
+#: git-send-email.perl:1703
 #, perl-format
 msgid "Dry-Sent %s\n"
 msgstr "Проба за изпращане на „%s“\n"
 
-#: git-send-email.perl:1667
+#: git-send-email.perl:1703
 #, perl-format
 msgid "Sent %s\n"
 msgstr "Изпращане на „%s“\n"
 
-#: git-send-email.perl:1669
+#: git-send-email.perl:1705
 msgid "Dry-OK. Log says:\n"
 msgstr "Успех при пробата.  От журнала:\n"
 
-#: git-send-email.perl:1669
+#: git-send-email.perl:1705
 msgid "OK. Log says:\n"
 msgstr "Успех.  От журнала:\n"
 
-#: git-send-email.perl:1688
+#: git-send-email.perl:1724
 msgid "Result: "
 msgstr "Резултат: "
 
-#: git-send-email.perl:1691
+#: git-send-email.perl:1727
 msgid "Result: OK\n"
 msgstr "Резултат: успех\n"
 
-#: git-send-email.perl:1708
+#: git-send-email.perl:1744
 #, perl-format
 msgid "can't open file %s"
 msgstr "файлът „%s“ не може да бъде отворен"
 
-#: git-send-email.perl:1756 git-send-email.perl:1776
+#: git-send-email.perl:1792 git-send-email.perl:1812
 #, perl-format
 msgid "(mbox) Adding cc: %s from line '%s'\n"
 msgstr "(mbox) Добавяне на „як: %s“ от ред „%s“\n"
 
-#: git-send-email.perl:1762
+#: git-send-email.perl:1798
 #, perl-format
 msgid "(mbox) Adding to: %s from line '%s'\n"
 msgstr "(mbox) Добавяне на „до: %s“ от ред „%s“\n"
 
-#: git-send-email.perl:1819
+#: git-send-email.perl:1855
 #, perl-format
 msgid "(non-mbox) Adding cc: %s from line '%s'\n"
 msgstr "(не-mbox) Добавяне на „як: %s“ от ред „%s“\n"
 
-#: git-send-email.perl:1854
+#: git-send-email.perl:1890
 #, perl-format
 msgid "(body) Adding cc: %s from line '%s'\n"
 msgstr "(тяло) Добавяне на „як: %s“ от ред „%s“\n"
 
-#: git-send-email.perl:1973
+#: git-send-email.perl:2009
 #, perl-format
 msgid "(%s) Could not execute '%s'"
 msgstr "(%s) Не може да бъде се изпълни „%s“"
 
-#: git-send-email.perl:1980
+#: git-send-email.perl:2016
 #, perl-format
 msgid "(%s) Adding %s: %s from: '%s'\n"
 msgstr "(%s) Добавяне на „%s: %s“ от: „%s“\n"
 
-#: git-send-email.perl:1984
+#: git-send-email.perl:2020
 #, perl-format
 msgid "(%s) failed to close pipe to '%s'"
 msgstr "(%s) програмният канал не може да се затвори за изпълнението на „%s“"
 
-#: git-send-email.perl:2014
+#: git-send-email.perl:2050
 msgid "cannot send message as 7bit"
 msgstr "съобщението не може да се изпрати чрез 7 битови знаци"
 
-#: git-send-email.perl:2022
+#: git-send-email.perl:2058
 msgid "invalid transfer encoding"
 msgstr "неправилно кодиране за пренос"
 
-#: git-send-email.perl:2059
+#: git-send-email.perl:2095
 #, perl-format
 msgid ""
 "fatal: %s: rejected by sendemail-validate hook\n"
@@ -27152,12 +27168,12 @@ msgstr ""
 "%s\n"
 "ПРЕДУПРЕЖДЕНИЕ: не са пратени никакви кръпки\n"
 
-#: git-send-email.perl:2069 git-send-email.perl:2122 git-send-email.perl:2132
+#: git-send-email.perl:2105 git-send-email.perl:2158 git-send-email.perl:2168
 #, perl-format
 msgid "unable to open %s: %s\n"
 msgstr "„%s“ не може да се отвори: %s\n"
 
-#: git-send-email.perl:2072
+#: git-send-email.perl:2108
 #, perl-format
 msgid ""
 "fatal: %s:%d is longer than 998 characters\n"
@@ -27166,13 +27182,13 @@ msgstr ""
 "ФАТАЛНА ГРЕШКА: %s: %d е повече от 998 знака\n"
 "ПРЕДУПРЕЖДЕНИЕ: не са пратени никакви кръпки\n"
 
-#: git-send-email.perl:2090
+#: git-send-email.perl:2126
 #, perl-format
 msgid "Skipping %s with backup suffix '%s'.\n"
 msgstr "„%s“ се пропуска, защото е с разширение за архивен файл: „%s“.\n"
 
 #. TRANSLATORS: please keep "[y|N]" as is.
-#: git-send-email.perl:2094
+#: git-send-email.perl:2130
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Наистина ли искате да изпратите „%s“? [y|N]: "

--- a/po/ca.po
+++ b/po/ca.po
@@ -1,7 +1,7 @@
 # Catalan translations for Git.
 # This file is distributed under the same license as the Git package.
 # Alex Henrie <alexhenrie24@gmail.com>, 2014-2016.
-# Jordi Mas i Hernàndez <jmas@softcatala.org>, 2016-2021
+# Jordi Mas i Hernàndez <jmas@softcatala.org>, 2016-2022
 #
 # Terminologia i criteris utilitzats
 #
@@ -9,14 +9,16 @@
 #   -----------------+---------------------------------
 #   ahead            |  davant per
 #   amend            |  esmenar
-#   bundle           |  farcell
 #   broken           |  malmès
+#   bundle           |  farcell
 #   chunk            |  fragment
+#   cover letter     |  carta de presentació
 #   delta            |  diferència
 #   deprecated       |  en desús
 #   detached         |  separat
 #   dry-run          |  fer una prova
 #   fatal            |  fatal
+#   fetch            |  obtenir
 #   flush            |  buidar / buidatge
 #   hint             |  consell
 #   hook             |  lligam
@@ -27,8 +29,9 @@
 #   setting          |  paràmetre
 #   shallow          |  superficial
 #   skip             |  ometre
+#   sparse           |  dispers
 #   squelch          |  silenciar
-#   sparse-index     |  índex dispers
+#   supported        |  admetre
 #   token            |  testimoni
 #   unset            |  desassignar
 #   upstream         |  font
@@ -44,7 +47,7 @@
 #   Anglès           |  Català
 #   -----------------+---------------------------------
 #   blame            |  «blame»
-#   HEAD             |  HEAD (f, la branca) - (no s'apostrofa)
+#   HEAD             |  HEAD (f, la branca actual) - (no s'apostrofa)
 #   cherry pick      |  «cherry pick»
 #   promisor         |  «promisor»
 #   rebase           |  «rebase»
@@ -57,8 +60,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-10-30 09:36+0800\n"
-"PO-Revision-Date: 2021-05-14 10:22-0600\n"
+"POT-Creation-Date: 2022-01-17 08:31+0800\n"
+"PO-Revision-Date: 2021-12-28 16:00-0600\n"
 "Last-Translator: Jordi Mas i Hernàndez <jmas@softcatala.org>\n"
 "Language-Team: Catalan\n"
 "Language: ca\n"
@@ -73,8 +76,8 @@ msgstr ""
 msgid "Huh (%s)?"
 msgstr "Perdó (%s)?"
 
-#: add-interactive.c:533 add-interactive.c:834 reset.c:65 sequencer.c:3510
-#: sequencer.c:3977 sequencer.c:4139 builtin/rebase.c:1233
+#: add-interactive.c:533 add-interactive.c:834 reset.c:65 sequencer.c:3509
+#: sequencer.c:3974 sequencer.c:4136 builtin/rebase.c:1233
 #: builtin/rebase.c:1642
 msgid "could not read index"
 msgstr "no s'ha pogut llegir l'índex"
@@ -103,7 +106,7 @@ msgstr "Actualitza"
 msgid "could not stage '%s'"
 msgstr "no s'ha pogut fer «stage» «%s»"
 
-#: add-interactive.c:707 add-interactive.c:896 reset.c:89 sequencer.c:3716
+#: add-interactive.c:707 add-interactive.c:896 reset.c:89 sequencer.c:3713
 msgid "could not write index"
 msgstr "no s'ha pogut escriure l'índex"
 
@@ -119,8 +122,8 @@ msgstr[1] "actualitzats %d camins\n"
 msgid "note: %s is untracked now.\n"
 msgstr "nota: %s està ara sense seguiment.\n"
 
-#: add-interactive.c:733 apply.c:4149 builtin/checkout.c:298
-#: builtin/reset.c:151
+#: add-interactive.c:733 apply.c:4151 builtin/checkout.c:306
+#: builtin/reset.c:167
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
 msgstr "make_cache_entry ha fallat per al camí «%s»"
@@ -161,21 +164,21 @@ msgstr[1] "afegits %d camins\n"
 msgid "ignoring unmerged: %s"
 msgstr "s'està ignorant allò no fusionat: %s"
 
-#: add-interactive.c:941 add-patch.c:1752 git-add--interactive.perl:1369
+#: add-interactive.c:941 add-patch.c:1752 git-add--interactive.perl:1371
 #, c-format
 msgid "Only binary files changed.\n"
 msgstr "Només s'han canviat els fitxers binaris.\n"
 
-#: add-interactive.c:943 add-patch.c:1750 git-add--interactive.perl:1371
+#: add-interactive.c:943 add-patch.c:1750 git-add--interactive.perl:1373
 #, c-format
 msgid "No changes.\n"
 msgstr "Sense canvis.\n"
 
-#: add-interactive.c:947 git-add--interactive.perl:1379
+#: add-interactive.c:947 git-add--interactive.perl:1381
 msgid "Patch update"
 msgstr "Actualització del pedaç"
 
-#: add-interactive.c:986 git-add--interactive.perl:1792
+#: add-interactive.c:986 git-add--interactive.perl:1794
 msgid "Review diff"
 msgstr "Reviseu les diferències"
 
@@ -243,11 +246,11 @@ msgstr "seleccioneu un ítem numerat"
 msgid "(empty) select nothing"
 msgstr "(buit) no seleccionis res"
 
-#: add-interactive.c:1095 builtin/clean.c:813 git-add--interactive.perl:1896
+#: add-interactive.c:1095 builtin/clean.c:839 git-add--interactive.perl:1898
 msgid "*** Commands ***"
 msgstr "*** Ordres ***"
 
-#: add-interactive.c:1096 builtin/clean.c:814 git-add--interactive.perl:1893
+#: add-interactive.c:1096 builtin/clean.c:840 git-add--interactive.perl:1895
 msgid "What now"
 msgstr "I ara què"
 
@@ -259,13 +262,13 @@ msgstr "staged"
 msgid "unstaged"
 msgstr "unstaged"
 
-#: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
-#: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:190
-#: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
-#: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
-#: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
-#: builtin/submodule--helper.c:2578 builtin/submodule--helper.c:2811
+#: add-interactive.c:1148 apply.c:5020 apply.c:5023 builtin/am.c:2367
+#: builtin/am.c:2370 builtin/bugreport.c:107 builtin/clone.c:128
+#: builtin/fetch.c:153 builtin/merge.c:287 builtin/pull.c:194
+#: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1858
+#: builtin/submodule--helper.c:1861 builtin/submodule--helper.c:2504
+#: builtin/submodule--helper.c:2507 builtin/submodule--helper.c:2574
+#: builtin/submodule--helper.c:2579 builtin/submodule--helper.c:2812
 #: git-add--interactive.perl:213
 msgid "path"
 msgstr "camí"
@@ -274,27 +277,27 @@ msgstr "camí"
 msgid "could not refresh index"
 msgstr "no s'ha pogut actualitzar l'índex"
 
-#: add-interactive.c:1169 builtin/clean.c:778 git-add--interactive.perl:1803
+#: add-interactive.c:1169 builtin/clean.c:804 git-add--interactive.perl:1805
 #, c-format
 msgid "Bye.\n"
 msgstr "Adeu.\n"
 
-#: add-patch.c:34 git-add--interactive.perl:1431
+#: add-patch.c:34 git-add--interactive.perl:1433
 #, c-format, perl-format
 msgid "Stage mode change [y,n,q,a,d%s,?]? "
 msgstr "Canvia el mode de «stage» [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:35 git-add--interactive.perl:1432
+#: add-patch.c:35 git-add--interactive.perl:1434
 #, c-format, perl-format
 msgid "Stage deletion [y,n,q,a,d%s,?]? "
 msgstr "Suprimeix «stage» [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:36 git-add--interactive.perl:1433
+#: add-patch.c:36 git-add--interactive.perl:1435
 #, c-format, perl-format
 msgid "Stage addition [y,n,q,a,d%s,?]? "
 msgstr "Afegeix a «stage» [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:37 git-add--interactive.perl:1434
+#: add-patch.c:37 git-add--interactive.perl:1436
 #, c-format, perl-format
 msgid "Stage this hunk [y,n,q,a,d%s,?]? "
 msgstr "Fer un «stage» d'aquest tros [y,n,q,a,d%s,?]? "
@@ -321,22 +324,22 @@ msgstr ""
 "a - fes «stage» d'aquest tros i de tota la resta de trossos del fitxer\n"
 "d - no facis «stage» d'aquest tros ni de cap altre restant del fitxer\n"
 
-#: add-patch.c:56 git-add--interactive.perl:1437
+#: add-patch.c:56 git-add--interactive.perl:1439
 #, c-format, perl-format
 msgid "Stash mode change [y,n,q,a,d%s,?]? "
 msgstr "Canvia el mode de «stash» [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:57 git-add--interactive.perl:1438
+#: add-patch.c:57 git-add--interactive.perl:1440
 #, c-format, perl-format
 msgid "Stash deletion [y,n,q,a,d%s,?]? "
 msgstr "Suprimeix «stash» [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:58 git-add--interactive.perl:1439
+#: add-patch.c:58 git-add--interactive.perl:1441
 #, c-format, perl-format
 msgid "Stash addition [y,n,q,a,d%s,?]? "
 msgstr "Afegeix a «stash» [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:59 git-add--interactive.perl:1440
+#: add-patch.c:59 git-add--interactive.perl:1442
 #, c-format, perl-format
 msgid "Stash this hunk [y,n,q,a,d%s,?]? "
 msgstr "Fer un «stash» d'aquest tros [y,n,q,a,d%s,?]? "
@@ -363,22 +366,22 @@ msgstr ""
 "a - fes «stash» d'aquest tros i de tota la resta de trossos del fitxer\n"
 "d - no facis «stash» d'aquest tros ni de cap altre restant del fitxer\n"
 
-#: add-patch.c:80 git-add--interactive.perl:1443
+#: add-patch.c:80 git-add--interactive.perl:1445
 #, c-format, perl-format
 msgid "Unstage mode change [y,n,q,a,d%s,?]? "
 msgstr "Canvia el mode de «unstage» [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:81 git-add--interactive.perl:1444
+#: add-patch.c:81 git-add--interactive.perl:1446
 #, c-format, perl-format
 msgid "Unstage deletion [y,n,q,a,d%s,?]? "
 msgstr "Suprimeix «Unstage» [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:82 git-add--interactive.perl:1445
+#: add-patch.c:82 git-add--interactive.perl:1447
 #, c-format, perl-format
 msgid "Unstage addition [y,n,q,a,d%s,?]? "
 msgstr "Afegeix a «unstage» [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:83 git-add--interactive.perl:1446
+#: add-patch.c:83 git-add--interactive.perl:1448
 #, c-format, perl-format
 msgid "Unstage this hunk [y,n,q,a,d%s,?]? "
 msgstr "Fer un «unstage» d'aquest tros [y,n,q,a,d%s,?]? "
@@ -405,22 +408,22 @@ msgstr ""
 "a - fes «unstage» d'aquest tros i de tota la resta de trossos del fitxer\n"
 "d - no facis «unstage» d'aquest tros ni de cap altre restant del fitxer\n"
 
-#: add-patch.c:103 git-add--interactive.perl:1449
+#: add-patch.c:103 git-add--interactive.perl:1451
 #, c-format, perl-format
 msgid "Apply mode change to index [y,n,q,a,d%s,?]? "
 msgstr "Aplica el canvi de mode a l'índex [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:104 git-add--interactive.perl:1450
+#: add-patch.c:104 git-add--interactive.perl:1452
 #, c-format, perl-format
 msgid "Apply deletion to index [y,n,q,a,d%s,?]? "
 msgstr "Aplica la supressió a l'índex [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:105 git-add--interactive.perl:1451
+#: add-patch.c:105 git-add--interactive.perl:1453
 #, c-format, perl-format
 msgid "Apply addition to index [y,n,q,a,d%s,?]? "
 msgstr "Aplica l'addició a l'índex [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:106 git-add--interactive.perl:1452
+#: add-patch.c:106 git-add--interactive.perl:1454
 #, c-format, perl-format
 msgid "Apply this hunk to index [y,n,q,a,d%s,?]? "
 msgstr "Aplica aquest tros a l'índex [y,n,q,a,d%s,?]? "
@@ -447,26 +450,26 @@ msgstr ""
 "a - aplica aquest tros i tots els trossos posteriors en el fitxer\n"
 "d - no apliquis aquest tros ni cap dels trossos posteriors en el fitxer\n"
 
-#: add-patch.c:126 git-add--interactive.perl:1455
-#: git-add--interactive.perl:1473
+#: add-patch.c:126 git-add--interactive.perl:1457
+#: git-add--interactive.perl:1475
 #, c-format, perl-format
 msgid "Discard mode change from worktree [y,n,q,a,d%s,?]? "
 msgstr "Descarta el canvi de mode de l'arbre de treball [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:127 git-add--interactive.perl:1456
-#: git-add--interactive.perl:1474
+#: add-patch.c:127 git-add--interactive.perl:1458
+#: git-add--interactive.perl:1476
 #, c-format, perl-format
 msgid "Discard deletion from worktree [y,n,q,a,d%s,?]? "
 msgstr "Descarta suprimir de l'arbre de treball [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:128 git-add--interactive.perl:1457
-#: git-add--interactive.perl:1475
+#: add-patch.c:128 git-add--interactive.perl:1459
+#: git-add--interactive.perl:1477
 #, c-format, perl-format
 msgid "Discard addition from worktree [y,n,q,a,d%s,?]? "
 msgstr "Descarta l'addició de l'arbre de treball [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:129 git-add--interactive.perl:1458
-#: git-add--interactive.perl:1476
+#: add-patch.c:129 git-add--interactive.perl:1460
+#: git-add--interactive.perl:1478
 #, c-format, perl-format
 msgid "Discard this hunk from worktree [y,n,q,a,d%s,?]? "
 msgstr "Descarta aquest tros de l'arbre de treball [y,n,q,a,d%s,?]? "
@@ -493,26 +496,26 @@ msgstr ""
 "a - descarta aquest tros i tots els trossos posteriors en el fitxer\n"
 "d - no descartis aquest tros ni cap dels trossos posteriors en el fitxer\n"
 
-#: add-patch.c:149 add-patch.c:194 git-add--interactive.perl:1461
+#: add-patch.c:149 add-patch.c:194 git-add--interactive.perl:1463
 #, c-format, perl-format
 msgid "Discard mode change from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Descarta el canvi de mode de l'índex i de l'arbre de treball "
 "[y,n,q,a,d%s,?]? "
 
-#: add-patch.c:150 add-patch.c:195 git-add--interactive.perl:1462
+#: add-patch.c:150 add-patch.c:195 git-add--interactive.perl:1464
 #, c-format, perl-format
 msgid "Discard deletion from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Descarta suprimir de l'índex i de l'arbre de treball [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:151 add-patch.c:196 git-add--interactive.perl:1463
+#: add-patch.c:151 add-patch.c:196 git-add--interactive.perl:1465
 #, c-format, perl-format
 msgid "Discard addition from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Descarta l'addició de l'índex i de l'arbre de treball [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:152 add-patch.c:197 git-add--interactive.perl:1464
+#: add-patch.c:152 add-patch.c:197 git-add--interactive.perl:1466
 #, c-format, perl-format
 msgid "Discard this hunk from index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
@@ -532,24 +535,24 @@ msgstr ""
 "a - descarta aquest tros i tots els trossos posteriors en el fitxer\n"
 "d - no descartis aquest tros ni cap dels trossos posteriors en el fitxer\n"
 
-#: add-patch.c:171 add-patch.c:216 git-add--interactive.perl:1467
+#: add-patch.c:171 add-patch.c:216 git-add--interactive.perl:1469
 #, c-format, perl-format
 msgid "Apply mode change to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Aplica el canvi de mode a l'índex i a l'arbre de treball [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:172 add-patch.c:217 git-add--interactive.perl:1468
+#: add-patch.c:172 add-patch.c:217 git-add--interactive.perl:1470
 #, c-format, perl-format
 msgid "Apply deletion to index and worktree [y,n,q,a,d%s,?]? "
 msgstr ""
 "Aplica la supressió a l'índex i a l'arbre de treball [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:173 add-patch.c:218 git-add--interactive.perl:1469
+#: add-patch.c:173 add-patch.c:218 git-add--interactive.perl:1471
 #, c-format, perl-format
 msgid "Apply addition to index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Aplica l'addició a l'índex i a l'arbre de treball [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1470
+#: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1472
 #, c-format, perl-format
 msgid "Apply this hunk to index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Aplica aquest tros a l'índex i a l'arbre de treball [y,n,q,a,d%s,?]? "
@@ -687,7 +690,7 @@ msgstr "«git apply --cached» ha fallat"
 #. Consider translating (saying "no" discards!) as
 #. (saying "n" for "no" discards!) if the translation
 #. of the word "no" does not start with n.
-#: add-patch.c:1247 git-add--interactive.perl:1242
+#: add-patch.c:1247 git-add--interactive.perl:1244
 msgid ""
 "Your edited hunk does not apply. Edit again (saying \"no\" discards!) [y/n]?"
 " "
@@ -699,11 +702,11 @@ msgstr ""
 msgid "The selected hunks do not apply to the index!"
 msgstr "Els trossos seleccionats no s'apliquen a l'índex!"
 
-#: add-patch.c:1291 git-add--interactive.perl:1346
+#: add-patch.c:1291 git-add--interactive.perl:1348
 msgid "Apply them to the worktree anyway? "
 msgstr "Voleu aplicar-los igualment a l'arbre de treball? "
 
-#: add-patch.c:1298 git-add--interactive.perl:1349
+#: add-patch.c:1298 git-add--interactive.perl:1351
 msgid "Nothing was applied.\n"
 msgstr "No s'ha aplicat res.\n"
 
@@ -741,11 +744,11 @@ msgstr "No hi ha tros següent"
 msgid "No other hunks to goto"
 msgstr "No hi ha altres trossos on anar-hi"
 
-#: add-patch.c:1549 git-add--interactive.perl:1606
+#: add-patch.c:1549 git-add--interactive.perl:1608
 msgid "go to which hunk (<ret> to see more)? "
 msgstr "ves a quin tros (<ret> per a veure'n més)? "
 
-#: add-patch.c:1550 git-add--interactive.perl:1608
+#: add-patch.c:1550 git-add--interactive.perl:1610
 msgid "go to which hunk? "
 msgstr "ves a quin tros? "
 
@@ -765,7 +768,7 @@ msgstr[1] "Només %d trossos disponibles."
 msgid "No other hunks to search"
 msgstr "No hi ha cap altre tros a cercar"
 
-#: add-patch.c:1581 git-add--interactive.perl:1661
+#: add-patch.c:1581 git-add--interactive.perl:1663
 msgid "search for regex? "
 msgstr "cerca per expressió regular? "
 
@@ -847,7 +850,7 @@ msgstr ""
 msgid "Exiting because of an unresolved conflict."
 msgstr "S'està sortint a causa d'un conflicte no resolt."
 
-#: advice.c:209 builtin/merge.c:1379
+#: advice.c:209 builtin/merge.c:1382
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "No heu conclòs la vostra fusió (MERGE_HEAD existeix)."
 
@@ -864,26 +867,25 @@ msgid "Not possible to fast-forward, aborting."
 msgstr "No és possible avançar ràpidament, s'està avortant."
 
 #: advice.c:227
-#, c-format, fuzzy
+#, c-format
 msgid ""
 "The following paths and/or pathspecs matched paths that exist\n"
 "outside of your sparse-checkout definition, so will not be\n"
 "updated in the index:\n"
 msgstr ""
-"Els camins següents i/o les especificacions de camí coincideixen amb els camins que existeixen\n"
-"fora de la vostra definició de restricció de proves, no serà\n"
-"actualitzat en l'índex:"
+"Els camins següents i/o les especificacions de camins coincideixen\n"
+"amb camins que existeixen fora de la vostra definició de\n"
+"«sparse-checkout», així que no serà actualitzaran en l'índex:\n"
 
 #: advice.c:234
-#, fuzzy
 msgid ""
 "If you intend to update such entries, try one of the following:\n"
 "* Use the --sparse option.\n"
 "* Disable or modify the sparsity rules."
 msgstr ""
-"Si té intenció d'actualitzar aquestes entrades, intenti una de les següents:\n"
+"Si voleu actualitzar aquestes entrades, proveu les següents solucions:\n"
 "* Utilitzeu l'opció --sparse.\n"
-"* Inhabilita o modifica les regles d'escassetat."
+"* Inhabiliteu o modifiqueu les regles de dispersió."
 
 #: advice.c:242
 #, c-format
@@ -942,21 +944,33 @@ msgstr "opció d'espai en blanc «%s» no reconeguda"
 msgid "unrecognized whitespace ignore option '%s'"
 msgstr "opció ignora l'espai en blanc «%s» no reconeguda"
 
-#: apply.c:136
-msgid "--reject and --3way cannot be used together."
-msgstr "--reject i --3way no es poden usar junts."
+#: apply.c:136 archive.c:584 range-diff.c:559 revision.c:2303 revision.c:2307
+#: revision.c:2316 revision.c:2321 revision.c:2527 revision.c:2870
+#: revision.c:2874 revision.c:2880 revision.c:2883 revision.c:2885
+#: builtin/add.c:510 builtin/add.c:512 builtin/add.c:529 builtin/add.c:541
+#: builtin/branch.c:727 builtin/checkout.c:467 builtin/checkout.c:470
+#: builtin/checkout.c:1644 builtin/checkout.c:1754 builtin/checkout.c:1757
+#: builtin/clone.c:906 builtin/commit.c:358 builtin/commit.c:361
+#: builtin/commit.c:1196 builtin/describe.c:593 builtin/diff-tree.c:155
+#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2038
+#: builtin/fetch.c:2043 builtin/index-pack.c:1852 builtin/init-db.c:560
+#: builtin/log.c:1946 builtin/log.c:1948 builtin/ls-files.c:778
+#: builtin/merge.c:1403 builtin/merge.c:1405 builtin/pack-objects.c:4073
+#: builtin/push.c:592 builtin/push.c:630 builtin/push.c:636 builtin/push.c:641
+#: builtin/rebase.c:1193 builtin/rebase.c:1195 builtin/rebase.c:1199
+#: builtin/repack.c:684 builtin/repack.c:715 builtin/reset.c:426
+#: builtin/reset.c:462 builtin/rev-list.c:541 builtin/show-branch.c:710
+#: builtin/stash.c:1707 builtin/stash.c:1710 builtin/submodule--helper.c:1316
+#: builtin/submodule--helper.c:2975 builtin/tag.c:526 builtin/tag.c:572
+#: builtin/worktree.c:702
+#, c-format
+msgid "options '%s' and '%s' cannot be used together"
+msgstr "Les opcions «%s» i «%s» no es poden usar juntes"
 
-#: apply.c:139
-msgid "--3way outside a repository"
-msgstr "--3way fora d'un repositori"
-
-#: apply.c:150
-msgid "--index outside a repository"
-msgstr "--index fora d'un repositori"
-
-#: apply.c:153
-msgid "--cached outside a repository"
-msgstr "--cached fora d'un repositori"
+#: apply.c:139 apply.c:150 apply.c:153
+#, c-format
+msgid "'%s' outside a repository"
+msgstr "«%s» fora d'un repositori"
 
 #: apply.c:800
 #, c-format
@@ -1175,8 +1189,8 @@ msgstr "el pedaç ha fallat: %s:%ld"
 msgid "cannot checkout %s"
 msgstr "no es pot agafar %s"
 
-#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:102 pack-revindex.c:214
-#: setup.c:308
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:104 pack-revindex.c:214
+#: setup.c:309
 #, c-format
 msgid "failed to read %s"
 msgstr "s'ha produït un error en llegir %s"
@@ -1186,247 +1200,247 @@ msgstr "s'ha produït un error en llegir %s"
 msgid "reading from '%s' beyond a symbolic link"
 msgstr "s'està llegint de «%s» més enllà d'un enllaç simbòlic"
 
-#: apply.c:3442 apply.c:3709
+#: apply.c:3442 apply.c:3711
 #, c-format
 msgid "path %s has been renamed/deleted"
 msgstr "el camí %s s'ha canviat de nom / s'ha suprimit"
 
-#: apply.c:3549 apply.c:3724
+#: apply.c:3549 apply.c:3726
 #, c-format
 msgid "%s: does not exist in index"
 msgstr "%s: no existeix en l'índex"
 
-#: apply.c:3558 apply.c:3732 apply.c:3976
+#: apply.c:3558 apply.c:3734 apply.c:3978
 #, c-format
 msgid "%s: does not match index"
 msgstr "%s: no coincideix amb l'índex"
 
-#: apply.c:3593
+#: apply.c:3595
 msgid "repository lacks the necessary blob to perform 3-way merge."
 msgstr ""
 "al repositori li manca el blob necessari per a fer a una fusió de 3 vies."
 
-#: apply.c:3596
+#: apply.c:3598
 #, c-format
 msgid "Performing three-way merge...\n"
 msgstr "S'està fent una fusió de 3 vies...\n"
 
-#: apply.c:3612 apply.c:3616
+#: apply.c:3614 apply.c:3618
 #, c-format
 msgid "cannot read the current contents of '%s'"
 msgstr "no es poden llegir els continguts actuals de «%s»"
 
-#: apply.c:3628
+#: apply.c:3630
 #, c-format
 msgid "Failed to perform three-way merge...\n"
 msgstr "S'ha produït un error en fer una fusió de tres vies...\n"
 
-#: apply.c:3642
+#: apply.c:3644
 #, c-format
 msgid "Applied patch to '%s' with conflicts.\n"
 msgstr "S'ha aplicat el pedaç a «%s» amb conflictes.\n"
 
-#: apply.c:3647
+#: apply.c:3649
 #, c-format
 msgid "Applied patch to '%s' cleanly.\n"
 msgstr "S'ha aplicat el pedaç a «%s» netament.\n"
 
-#: apply.c:3664
+#: apply.c:3666
 #, c-format
 msgid "Falling back to direct application...\n"
 msgstr "S'està usant alternativament l'aplicació directa...\n"
 
-#: apply.c:3676
+#: apply.c:3678
 msgid "removal patch leaves file contents"
 msgstr "el pedaç d'eliminació deixa els continguts dels fitxers"
 
-#: apply.c:3749
+#: apply.c:3751
 #, c-format
 msgid "%s: wrong type"
 msgstr "%s: tipus erroni"
 
-#: apply.c:3751
+#: apply.c:3753
 #, c-format
 msgid "%s has type %o, expected %o"
 msgstr "%s és del tipus %o, s'esperava %o"
 
-#: apply.c:3916 apply.c:3918 read-cache.c:876 read-cache.c:905
-#: read-cache.c:1368
+#: apply.c:3918 apply.c:3920 read-cache.c:889 read-cache.c:918
+#: read-cache.c:1381
 #, c-format
 msgid "invalid path '%s'"
 msgstr "camí no vàlid: «%s»"
 
-#: apply.c:3974
+#: apply.c:3976
 #, c-format
 msgid "%s: already exists in index"
 msgstr "%s: ja existeix en l'índex"
 
-#: apply.c:3978
+#: apply.c:3980
 #, c-format
 msgid "%s: already exists in working directory"
 msgstr "%s: ja existeix en el directori de treball"
 
-#: apply.c:3998
+#: apply.c:4000
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
 msgstr "el mode nou (%o) de %s no coincideix amb el mode antic (%o)"
 
-#: apply.c:4003
+#: apply.c:4005
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
 msgstr "el mode nou (%o) de %s no coincideix amb el mode antic (%o) de %s"
 
-#: apply.c:4023
+#: apply.c:4025
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
 msgstr "el fitxer afectat «%s» és més enllà d'un enllaç simbòlic"
 
-#: apply.c:4027
+#: apply.c:4029
 #, c-format
 msgid "%s: patch does not apply"
 msgstr "%s: el pedaç no s'aplica"
 
-#: apply.c:4042
+#: apply.c:4044
 #, c-format
 msgid "Checking patch %s..."
 msgstr "S'està comprovant el pedaç %s..."
 
-#: apply.c:4134
+#: apply.c:4136
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
 msgstr "falta la informació sha1 o és inútil per al submòdul %s"
 
-#: apply.c:4141
+#: apply.c:4143
 #, c-format
 msgid "mode change for %s, which is not in current HEAD"
 msgstr "canvi de mode per a %s, el qual no està en la HEAD actual"
 
-#: apply.c:4144
+#: apply.c:4146
 #, c-format
 msgid "sha1 information is lacking or useless (%s)."
 msgstr "falta informació sha1 o és inútil (%s)."
 
-#: apply.c:4153
+#: apply.c:4155
 #, c-format
 msgid "could not add %s to temporary index"
 msgstr "no s'ha pogut afegir %s a l'índex temporal"
 
-#: apply.c:4163
+#: apply.c:4165
 #, c-format
 msgid "could not write temporary index to %s"
 msgstr "no s'ha pogut escriure l'índex temporal a %s"
 
-#: apply.c:4301
+#: apply.c:4303
 #, c-format
 msgid "unable to remove %s from index"
 msgstr "no s'ha pogut eliminar %s de l'índex"
 
-#: apply.c:4335
+#: apply.c:4337
 #, c-format
 msgid "corrupt patch for submodule %s"
 msgstr "pedaç malmès per al submòdul %s"
 
-#: apply.c:4341
+#: apply.c:4343
 #, c-format
 msgid "unable to stat newly created file '%s'"
 msgstr "no s'ha pogut fer stat al fitxer novament creat «%s»"
 
-#: apply.c:4349
+#: apply.c:4351
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr ""
 "no s'ha pogut crear un magatzem de suport per al fitxer novament creat %s"
 
-#: apply.c:4355 apply.c:4500
+#: apply.c:4357 apply.c:4502
 #, c-format
 msgid "unable to add cache entry for %s"
 msgstr "no s'ha pogut afegir una entrada de cau per a %s"
 
-#: apply.c:4398 builtin/bisect--helper.c:540 builtin/gc.c:2242
-#: builtin/gc.c:2277
+#: apply.c:4400 builtin/bisect--helper.c:540 builtin/gc.c:2258
+#: builtin/gc.c:2293
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "no s'ha pogut escriure a «%s»"
 
-#: apply.c:4402
+#: apply.c:4404
 #, c-format
 msgid "closing file '%s'"
 msgstr "s'està tancant el fitxer «%s»"
 
-#: apply.c:4472
+#: apply.c:4474
 #, c-format
 msgid "unable to write file '%s' mode %o"
 msgstr "no s'ha pogut escriure el fitxer «%s» mode %o"
 
-#: apply.c:4570
+#: apply.c:4572
 #, c-format
 msgid "Applied patch %s cleanly."
 msgstr "El pedaç %s s'ha aplicat netament."
 
-#: apply.c:4578
+#: apply.c:4580
 msgid "internal error"
 msgstr "error intern"
 
-#: apply.c:4581
+#: apply.c:4583
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
 msgstr[0] "S'està aplicant el pedaç %%s amb %d rebuig..."
 msgstr[1] "S'està aplicant el pedaç %%s amb %d rebutjos..."
 
-#: apply.c:4592
+#: apply.c:4594
 #, c-format
 msgid "truncating .rej filename to %.*s.rej"
 msgstr "s'està truncant el nom del fitxer .rej a %.*s.rej"
 
-#: apply.c:4600 builtin/fetch.c:998 builtin/fetch.c:1408
+#: apply.c:4602
 #, c-format
 msgid "cannot open %s"
 msgstr "no es pot obrir %s"
 
-#: apply.c:4614
+#: apply.c:4616
 #, c-format
 msgid "Hunk #%d applied cleanly."
 msgstr "El tros #%d s'ha aplicat netament."
 
-#: apply.c:4618
+#: apply.c:4620
 #, c-format
 msgid "Rejected hunk #%d."
 msgstr "S'ha rebutjat el tros #%d."
 
-#: apply.c:4747
+#: apply.c:4749
 #, c-format
 msgid "Skipped patch '%s'."
 msgstr "S'ha omès el pedaç «%s»."
 
-#: apply.c:4755
-msgid "unrecognized input"
-msgstr "entrada no reconeguda"
+#: apply.c:4758
+msgid "No valid patches in input (allow with \"--allow-empty\")"
+msgstr "No hi ha pedaços vàlids a l'entrada (permeteu-los amb «--allow-empty»)"
 
-#: apply.c:4775
+#: apply.c:4779
 msgid "unable to read index file"
 msgstr "no es pot llegir el fitxer d'índex"
 
-#: apply.c:4932
+#: apply.c:4936
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr "no es pot obrir el pedaç «%s»: %s"
 
-#: apply.c:4959
+#: apply.c:4963
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "s'ha silenciat %d error d'espai en blanc"
 msgstr[1] "s'han silenciat %d errors d'espai en blanc"
 
-#: apply.c:4965 apply.c:4980
+#: apply.c:4969 apply.c:4984
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] "%d línia afegeix errors d'espai en blanc."
 msgstr[1] "%d línies afegeixen errors d'espai en blanc."
 
-#: apply.c:4973
+#: apply.c:4977
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
@@ -1435,141 +1449,139 @@ msgstr[0] ""
 msgstr[1] ""
 "S'han aplicat %d línies després d'arreglar els errors d'espai en blanc."
 
-#: apply.c:4989 builtin/add.c:707 builtin/mv.c:338 builtin/rm.c:429
+#: apply.c:4993 builtin/add.c:704 builtin/mv.c:338 builtin/rm.c:430
 msgid "Unable to write new index file"
 msgstr "No s'ha pogut escriure un fitxer d'índex nou"
 
-#: apply.c:5017
+#: apply.c:5021
 msgid "don't apply changes matching the given path"
 msgstr "no apliquis els canvis que coincideixin amb el camí donat"
 
-#: apply.c:5020
+#: apply.c:5024
 msgid "apply changes matching the given path"
 msgstr "aplica els canvis que coincideixin amb el camí donat"
 
-#: apply.c:5022 builtin/am.c:2320
+#: apply.c:5026 builtin/am.c:2376
 msgid "num"
 msgstr "número"
 
-#: apply.c:5023
+#: apply.c:5027
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr ""
 "elimina <nombre> barres obliqües inicials dels camins de diferència "
 "tradicionals"
 
-#: apply.c:5026
+#: apply.c:5030
 msgid "ignore additions made by the patch"
 msgstr "ignora afegiments fets pel pedaç"
 
-#: apply.c:5028
+#: apply.c:5032
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr ""
 "en lloc d'aplicar el pedaç, emet les estadístiques de diferència de "
 "l'entrada"
 
-#: apply.c:5032
+#: apply.c:5036
 msgid "show number of added and deleted lines in decimal notation"
 msgstr "mostra el nombre de línies afegides i suprimides en notació decimal"
 
-#: apply.c:5034
+#: apply.c:5038
 msgid "instead of applying the patch, output a summary for the input"
 msgstr "en lloc d'aplicar el pedaç, emet un resum de l'entrada"
 
-#: apply.c:5036
+#: apply.c:5040
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr "en lloc d'aplicar el pedaç, veges si el pedaç és aplicable"
 
-#: apply.c:5038
+#: apply.c:5042
 msgid "make sure the patch is applicable to the current index"
 msgstr "assegura que el pedaç sigui aplicable a l'índex actual"
 
-#: apply.c:5040
+#: apply.c:5044
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "marca els fitxers nous amb «git add --intent-to-add»"
 
-#: apply.c:5042
+#: apply.c:5046
 msgid "apply a patch without touching the working tree"
 msgstr "aplica un pedaç sense tocar l'arbre de treball"
 
-#: apply.c:5044
+#: apply.c:5048
 msgid "accept a patch that touches outside the working area"
 msgstr "accepta un pedaç que toqui fora de l'àrea de treball"
 
-#: apply.c:5047
+#: apply.c:5051
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr "aplica el pedaç també (useu amb --stat/--summary/--check)"
 
-#: apply.c:5049
+#: apply.c:5053
 msgid "attempt three-way merge, fall back on normal patch if that fails"
 msgstr ""
 "intenta una fusió de tres vies, si falla intenta llavors un pedaç normal"
 
-#: apply.c:5051
+#: apply.c:5055
 msgid "build a temporary index based on embedded index information"
 msgstr ""
 "construeix un índex temporal basat en la informació d'índex incrustada"
 
-#: apply.c:5054 builtin/checkout-index.c:196
+#: apply.c:5058 builtin/checkout-index.c:196
 msgid "paths are separated with NUL character"
 msgstr "els camins se separen amb el caràcter NUL"
 
-#: apply.c:5056
+#: apply.c:5060
 msgid "ensure at least <n> lines of context match"
 msgstr "assegura't que almenys <n> línies de context coincideixin"
 
-#: apply.c:5057 builtin/am.c:2296 builtin/am.c:2299
+#: apply.c:5061 builtin/am.c:2352 builtin/am.c:2355
 #: builtin/interpret-trailers.c:98 builtin/interpret-trailers.c:100
 #: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3960
 #: builtin/rebase.c:1051
 msgid "action"
 msgstr "acció"
 
-#: apply.c:5058
+#: apply.c:5062
 msgid "detect new or modified lines that have whitespace errors"
 msgstr ""
 "detecta les línies noves o modificades que tinguin errors d'espai en blanc"
 
-#: apply.c:5061 apply.c:5064
+#: apply.c:5065 apply.c:5068
 msgid "ignore changes in whitespace when finding context"
 msgstr "ignora els canvis d'espai en blanc en cercar context"
 
-#: apply.c:5067
+#: apply.c:5071
 msgid "apply the patch in reverse"
 msgstr "aplica el pedaç al revés"
 
-#: apply.c:5069
+#: apply.c:5073
 msgid "don't expect at least one line of context"
 msgstr "no esperis almenys una línia de context"
 
-#: apply.c:5071
+#: apply.c:5075
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr "deixa els trossos rebutjats en fitxers *.rej corresponents"
 
-#: apply.c:5073
+#: apply.c:5077
 msgid "allow overlapping hunks"
 msgstr "permet trossos encavalcants"
 
-#: apply.c:5074 builtin/add.c:372 builtin/check-ignore.c:22
-#: builtin/commit.c:1483 builtin/count-objects.c:98 builtin/fsck.c:788
-#: builtin/log.c:2297 builtin/mv.c:123 builtin/read-tree.c:120
-msgid "be verbose"
-msgstr "sigues detallat"
-
-#: apply.c:5076
+#: apply.c:5080
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr "tolera una línia nova incorrectament detectada al final del fitxer"
 
-#: apply.c:5079
+#: apply.c:5083
 msgid "do not trust the line counts in the hunk headers"
 msgstr "no confiïs en els recomptes de línia en les capçaleres dels trossos"
 
-#: apply.c:5081 builtin/am.c:2308
+#: apply.c:5085 builtin/am.c:2364
 msgid "root"
 msgstr "arrel"
 
-#: apply.c:5082
+#: apply.c:5086
 msgid "prepend <root> to all filenames"
 msgstr "anteposa <arrel> a tots els noms de fitxer"
+
+#: apply.c:5089
+msgid "don't return error for empty patches"
+msgstr "no retornis l'error per als pedaços buits"
 
 #: archive-tar.c:125 archive-zip.c:345
 #, c-format
@@ -1581,16 +1593,16 @@ msgstr "no es pot transmetre el blob %s"
 msgid "unsupported file mode: 0%o (SHA1: %s)"
 msgstr "mode de fitxer no compatible: 0%o (SHA1: %s)"
 
-#: archive-tar.c:450
+#: archive-tar.c:447
 #, c-format
 msgid "unable to start '%s' filter"
 msgstr "no s'ha pogut iniciar el filtre «%s»"
 
-#: archive-tar.c:453
+#: archive-tar.c:450
 msgid "unable to redirect descriptor"
 msgstr "no s'ha pogut redirigir el descriptor"
 
-#: archive-tar.c:460
+#: archive-tar.c:457
 #, c-format
 msgid "'%s' filter reported error"
 msgstr "«%s» error reportat pel filtre"
@@ -1635,19 +1647,13 @@ msgstr ""
 msgid "git archive --remote <repo> [--exec <cmd>] --list"
 msgstr "git archive --remote <repositori> [--exec <ordre>] --list"
 
-#: archive.c:188
+#: archive.c:188 archive.c:341 builtin/gc.c:497 builtin/notes.c:238
+#: builtin/tag.c:578
 #, c-format
-msgid "cannot read %s"
+msgid "cannot read '%s'"
 msgstr "no es pot llegir «%s»"
 
-#: archive.c:341 sequencer.c:473 sequencer.c:1930 sequencer.c:3112
-#: sequencer.c:3554 sequencer.c:3682 builtin/am.c:263 builtin/commit.c:834
-#: builtin/merge.c:1145
-#, c-format
-msgid "could not read '%s'"
-msgstr "no s'ha pogut llegir «%s»"
-
-#: archive.c:426 builtin/add.c:215 builtin/add.c:674 builtin/rm.c:334
+#: archive.c:426 builtin/add.c:215 builtin/add.c:671 builtin/rm.c:334
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "l'especificació de camí «%s» no ha coincidit amb cap fitxer"
@@ -1689,7 +1695,7 @@ msgstr "format"
 msgid "archive format"
 msgstr "format d'arxiu"
 
-#: archive.c:552 builtin/log.c:1775
+#: archive.c:552 builtin/log.c:1790
 msgid "prefix"
 msgstr "prefix"
 
@@ -1699,9 +1705,9 @@ msgstr "anteposa el prefix a cada nom de camí en l'arxiu"
 
 #: archive.c:554 archive.c:557 builtin/blame.c:880 builtin/blame.c:884
 #: builtin/blame.c:885 builtin/commit-tree.c:115 builtin/config.c:135
-#: builtin/fast-export.c:1208 builtin/fast-export.c:1210
-#: builtin/fast-export.c:1214 builtin/grep.c:935 builtin/hash-object.c:103
-#: builtin/ls-files.c:651 builtin/ls-files.c:654 builtin/notes.c:410
+#: builtin/fast-export.c:1181 builtin/fast-export.c:1183
+#: builtin/fast-export.c:1187 builtin/grep.c:935 builtin/hash-object.c:103
+#: builtin/ls-files.c:654 builtin/ls-files.c:657 builtin/notes.c:410
 #: builtin/notes.c:576 builtin/read-tree.c:115 parse-options.h:190
 msgid "file"
 msgstr "fitxer"
@@ -1731,7 +1737,7 @@ msgid "list supported archive formats"
 msgstr "llista els formats d'arxiu admesos"
 
 #: archive.c:568 builtin/archive.c:89 builtin/clone.c:118 builtin/clone.c:121
-#: builtin/submodule--helper.c:1869 builtin/submodule--helper.c:2512
+#: builtin/submodule--helper.c:1870 builtin/submodule--helper.c:2513
 msgid "repo"
 msgstr "repositori"
 
@@ -1739,7 +1745,7 @@ msgstr "repositori"
 msgid "retrieve the archive from remote repository <repo>"
 msgstr "recupera l'arxiu del repositori remot <repositori>"
 
-#: archive.c:570 builtin/archive.c:91 builtin/difftool.c:714
+#: archive.c:570 builtin/archive.c:91 builtin/difftool.c:708
 #: builtin/notes.c:496
 msgid "command"
 msgstr "ordre"
@@ -1752,17 +1758,19 @@ msgstr "camí a l'ordre git-upload-archive remota"
 msgid "Unexpected option --remote"
 msgstr "Opció inesperada --remote"
 
-#: archive.c:580
-msgid "Option --exec can only be used together with --remote"
-msgstr "L'opció --exec només es pot usar juntament amb --remote"
+#: archive.c:580 fetch-pack.c:300 revision.c:2887 builtin/add.c:544
+#: builtin/add.c:576 builtin/checkout.c:1763 builtin/commit.c:370
+#: builtin/fast-export.c:1230 builtin/index-pack.c:1848 builtin/log.c:2115
+#: builtin/reset.c:435 builtin/reset.c:493 builtin/rm.c:281
+#: builtin/stash.c:1719 builtin/worktree.c:508 http-fetch.c:144
+#: http-fetch.c:153
+#, c-format
+msgid "the option '%s' requires '%s'"
+msgstr "l'opció «%s» requereix «%s»"
 
 #: archive.c:582
 msgid "Unexpected option --output"
 msgstr "Opció inesperada --output"
-
-#: archive.c:584
-msgid "Options --add-file and --remote cannot be used together"
-msgstr "Les opcions --add-file i --remote no es poden usar juntes"
 
 #: archive.c:606
 #, c-format
@@ -1871,7 +1879,7 @@ msgstr "es necessita una revisió %s"
 msgid "could not create file '%s'"
 msgstr "no s'ha pogut crear el fitxer «%s»"
 
-#: bisect.c:985 builtin/merge.c:154
+#: bisect.c:985 builtin/merge.c:155
 #, c-format
 msgid "could not read file '%s'"
 msgstr "no s'ha pogut llegir el fitxer «%s»"
@@ -1924,21 +1932,21 @@ msgstr ""
 "--reverse i --first-parent junts requereixen una última comissió "
 "especificada"
 
-#: blame.c:2820 bundle.c:224 midx.c:1039 ref-filter.c:2370 remote.c:2041
-#: sequencer.c:2348 sequencer.c:4900 submodule.c:883 builtin/commit.c:1114
-#: builtin/log.c:414 builtin/log.c:1021 builtin/log.c:1629 builtin/log.c:2056
-#: builtin/log.c:2346 builtin/merge.c:429 builtin/pack-objects.c:3373
+#: blame.c:2820 bundle.c:224 midx.c:1042 ref-filter.c:2370 remote.c:2158
+#: sequencer.c:2352 sequencer.c:4899 submodule.c:883 builtin/commit.c:1114
+#: builtin/log.c:429 builtin/log.c:1036 builtin/log.c:1644 builtin/log.c:2071
+#: builtin/log.c:2362 builtin/merge.c:431 builtin/pack-objects.c:3373
 #: builtin/pack-objects.c:3775 builtin/pack-objects.c:3790
 #: builtin/shortlog.c:255
 msgid "revision walk setup failed"
-msgstr "la configuració del passeig per revisions ha fallat"
+msgstr "la configuració del recorregut de revisions ha fallat"
 
 #: blame.c:2838
 msgid ""
 "--reverse --first-parent together require range along first-parent chain"
 msgstr ""
-"--reverse --first-parent junts requereixen un rang de la cadena de mares "
-"primeres"
+"--reverse --first-parent junts requereixen un rang de la cadena de pares "
+"primers"
 
 #: blame.c:2849
 #, c-format
@@ -1950,112 +1958,99 @@ msgstr "no hi ha tal camí %s en %s"
 msgid "cannot read blob %s for path %s"
 msgstr "no es pot llegir el blob %s per al camí %s"
 
-#: branch.c:53
+#: branch.c:77
+msgid ""
+"cannot inherit upstream tracking configuration of multiple refs when "
+"rebasing is requested"
+msgstr ""
+"no es pot heretar la configuració del seguiment de la font de múltiples "
+"referències quan es demana fer «rebase»"
+
+#: branch.c:88
 #, c-format
+msgid "not setting branch '%s' as its own upstream"
+msgstr "no s'està establert la branca «%s» com a la seva pròpia font."
+
+#: branch.c:144
+#, c-format
+msgid "branch '%s' set up to track '%s' by rebasing."
+msgstr ""
+"La branca «%s» està configurada per a seguir «%s» fent "
+"«rebase»."
+
+#: branch.c:145
+#, c-format
+msgid "branch '%s' set up to track '%s'."
+msgstr ""
+"La branca «%s» està configurada per a seguir «%s»."
+
+#: branch.c:148
+#, c-format
+msgid "branch '%s' set up to track:"
+msgstr "La branca «%s» està configurada per a seguir:"
+
+#: branch.c:160
+msgid "unable to write upstream branch configuration"
+msgstr "no es pot escriure la configuració de la branca font"
+
+#: branch.c:162
 msgid ""
 "\n"
 "After fixing the error cause you may try to fix up\n"
-"the remote tracking information by invoking\n"
-"\"git branch --set-upstream-to=%s%s%s\"."
+"the remote tracking information by invoking:"
 msgstr ""
 "\n"
-"Després de corregir la causa de l'error, podeu\n"
-"intentar corregir la informació de seguiment remot\n"
-"invocant «git branch --set-upstream-to=%s%s%s»."
+"Després de corregir la causa de l'error, podeu intentar\n"
+"corregir la informació de seguiment remot executant:"
 
-#: branch.c:67
+#: branch.c:203
 #, c-format
-msgid "Not setting branch %s as its own upstream."
-msgstr "No s'està establint la branca %s com a la seva pròpia font."
-
-#: branch.c:93
-#, c-format
-msgid "Branch '%s' set up to track remote branch '%s' from '%s' by rebasing."
+msgid "asked to inherit tracking from '%s', but no remote is set"
 msgstr ""
-"La branca «%s» està configurada per a seguir la branca remota «%s» de «%s» "
-"fent «rebase»."
+"s'ha demanat que hereti el seguiment de «%s», però no s'ha establert cap"
+" remot"
 
-#: branch.c:94
+#: branch.c:209
 #, c-format
-msgid "Branch '%s' set up to track remote branch '%s' from '%s'."
+msgid "asked to inherit tracking from '%s', but no merge configuration is set"
 msgstr ""
-"La branca «%s» està configurada per a seguir la branca remota «%s» de «%s»."
+"s'ha demanat que hereti el seguiment de «%s», però no s'ha establert cap"
+" configuració de fusionat"
 
-#: branch.c:98
+#: branch.c:252
 #, c-format
-msgid "Branch '%s' set up to track local branch '%s' by rebasing."
-msgstr ""
-"La branca «%s» està configurada per a seguir la branca local «%s» fent "
-"«rebase»."
+msgid "not tracking: ambiguous information for ref %s"
+msgstr "no s'està seguint: informació ambigua per a la referència %s"
 
-#: branch.c:99
+#: branch.c:287
 #, c-format
-msgid "Branch '%s' set up to track local branch '%s'."
-msgstr "La branca «%s» està configurada per a seguir la branca local «%s»."
-
-#: branch.c:104
-#, c-format
-msgid "Branch '%s' set up to track remote ref '%s' by rebasing."
-msgstr ""
-"La branca «%s» està configurada per a seguir la referència remota «%s» fent "
-"«rebase»."
-
-#: branch.c:105
-#, c-format
-msgid "Branch '%s' set up to track remote ref '%s'."
-msgstr ""
-"La branca «%s» està configurada per a seguir la referència remota «%s»."
-
-#: branch.c:109
-#, c-format
-msgid "Branch '%s' set up to track local ref '%s' by rebasing."
-msgstr ""
-"La branca «%s» està configurada per a seguir la referència local «%s» fent "
-"«rebase»."
-
-#: branch.c:110
-#, c-format
-msgid "Branch '%s' set up to track local ref '%s'."
-msgstr ""
-"La branca «%s» està configurada per a seguir la referència local «%s»."
-
-#: branch.c:119
-msgid "Unable to write upstream branch configuration"
-msgstr "No es pot escriure la configuració de la branca font"
-
-#: branch.c:156
-#, c-format
-msgid "Not tracking: ambiguous information for ref %s"
-msgstr "No seguint: informació ambigua per a la referència %s"
-
-#: branch.c:189
-#, c-format
-msgid "'%s' is not a valid branch name."
+msgid "'%s' is not a valid branch name"
 msgstr "«%s» no és un nom de branca vàlid."
 
-#: branch.c:208
+#: branch.c:307
 #, c-format
-msgid "A branch named '%s' already exists."
-msgstr "Una branca amb nom «%s» ja existeix."
+msgid "a branch named '%s' already exists"
+msgstr "ja existeix una branca amb nom «%s»."
 
-#: branch.c:213
-msgid "Cannot force update the current branch."
-msgstr "No es pot actualitzar la branca actual a la força."
+#: branch.c:313
+#, c-format
+msgid "cannot force update the branch '%s' checked out at '%s'"
+msgstr "no es pot forçar l'actualització de la branca «%s», agafada a «%s»"
 
-#: branch.c:233
+#: branch.c:336
 #, c-format
 msgid ""
-"Cannot setup tracking information; starting point '%s' is not a branch."
+"cannot set up tracking information; starting point '%s' is not a branch"
 msgstr ""
-"No es pot configurar la informació de seguiment; el punt inicial «%s» no és "
+"no es pot configurar la informació de seguiment; el punt inicial «%s» no és "
 "una branca."
 
-#: branch.c:235
+#: branch.c:338
 #, c-format
 msgid "the requested upstream branch '%s' does not exist"
 msgstr "la branca font demanada «%s» no existeix"
 
-#: branch.c:237
+#: branch.c:340
 msgid ""
 "\n"
 "If you are planning on basing your work on an upstream\n"
@@ -2076,27 +2071,28 @@ msgstr ""
 "«git push -u» per a establir la configuració font\n"
 "mentre pugeu."
 
-#: branch.c:281
+#: branch.c:384 builtin/replace.c:321 builtin/replace.c:377
+#: builtin/replace.c:423 builtin/replace.c:453
 #, c-format
-msgid "Not a valid object name: '%s'."
-msgstr "No és un nom d'objecte vàlid: «%s»."
+msgid "not a valid object name: '%s'"
+msgstr "no és un nom d'objecte vàlid: «%s»"
 
-#: branch.c:301
+#: branch.c:404
 #, c-format
-msgid "Ambiguous object name: '%s'."
-msgstr "Nom d'objecte ambigu: «%s»."
+msgid "ambiguous object name: '%s'"
+msgstr "nom d'objecte ambigu: «%s»."
 
-#: branch.c:306
+#: branch.c:409
 #, c-format
-msgid "Not a valid branch point: '%s'."
-msgstr "No és un punt de ramificació vàlid: «%s»."
+msgid "not a valid branch point: '%s'"
+msgstr "no és un punt de ramificació vàlid: «%s»"
 
-#: branch.c:366
+#: branch.c:469
 #, c-format
 msgid "'%s' is already checked out at '%s'"
 msgstr "«%s» ja s'ha agafat a «%s»"
 
-#: branch.c:389
+#: branch.c:494
 #, c-format
 msgid "HEAD of working tree %s is not updated"
 msgstr "HEAD de l'arbre de treball %s no està actualitzat"
@@ -2121,7 +2117,7 @@ msgstr "«%s» no sembla un fitxer de farcell v2 o v3"
 msgid "unrecognized header: %s%s (%d)"
 msgstr "capçalera no reconeguda: %s%s (%d)"
 
-#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2616 sequencer.c:3402
+#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2620 sequencer.c:3406
 #: builtin/commit.c:862
 #, c-format
 msgid "could not open '%s'"
@@ -2180,7 +2176,7 @@ msgstr "versió del farcell no compatible %d"
 msgid "cannot write bundle version %d with algorithm %s"
 msgstr "no es pot escriure la versió %d amb l'algorisme %s"
 
-#: bundle.c:524 builtin/log.c:210 builtin/log.c:1938 builtin/shortlog.c:399
+#: bundle.c:524 builtin/log.c:210 builtin/log.c:1953 builtin/shortlog.c:399
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr "argument no reconegut: %s"
@@ -2218,7 +2214,7 @@ msgstr "S'ha trobat un ID del fragment %<PRIx32> duplicat"
 msgid "final chunk has non-zero id %<PRIx32>"
 msgstr "El fragment final té un id %<PRIx32> que no és zero"
 
-#: color.c:329
+#: color.c:354
 #, c-format
 msgid "invalid color value: %.*s"
 msgstr "valor de color no vàlid: %.*s"
@@ -2272,64 +2268,63 @@ msgstr ""
 msgid "unable to find all commit-graph files"
 msgstr "no es poden trobar tots els fitxers del graf de comissions"
 
-#: commit-graph.c:746 commit-graph.c:783
+#: commit-graph.c:749 commit-graph.c:786
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr ""
 "posició de la comissió no vàlida. Probablement el graf de comissions està "
 "malmès"
 
-#: commit-graph.c:767
+#: commit-graph.c:770
 #, c-format
 msgid "could not find commit %s"
 msgstr "no s'ha pogut trobar la comissió %s"
 
-#: commit-graph.c:800
-#, fuzzy
+#: commit-graph.c:803
 msgid "commit-graph requires overflow generation data but has none"
 msgstr ""
 "el graf de comissions requereix dades de generació de desbordaments però no "
-"en té"
+"en té cap"
 
-#: commit-graph.c:1105 builtin/am.c:1342
+#: commit-graph.c:1108 builtin/am.c:1369
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "no s'ha pogut analitzar la comissió %s"
 
-#: commit-graph.c:1367 builtin/pack-objects.c:3070
+#: commit-graph.c:1370 builtin/pack-objects.c:3070
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "no s'ha pogut obtenir el tipus de l'objecte: %s"
 
-#: commit-graph.c:1398
+#: commit-graph.c:1401
 msgid "Loading known commits in commit graph"
 msgstr "S'estan carregant comissions conegudes al graf de comissions"
 
-#: commit-graph.c:1415
+#: commit-graph.c:1418
 msgid "Expanding reachable commits in commit graph"
 msgstr "S'estan expandint les comissions abastables al graf de comissions"
 
-#: commit-graph.c:1435
+#: commit-graph.c:1438
 msgid "Clearing commit marks in commit graph"
 msgstr "S'estan esborrant les marques de comissions al graf de comissions"
 
-#: commit-graph.c:1454
+#: commit-graph.c:1457
 msgid "Computing commit graph topological levels"
 msgstr "S'estan calculant els nivells topològics del graf de comissions"
 
-#: commit-graph.c:1507
+#: commit-graph.c:1510
 msgid "Computing commit graph generation numbers"
 msgstr "S'estan calculant els nombres de generació del graf de comissions"
 
-#: commit-graph.c:1588
+#: commit-graph.c:1591
 msgid "Computing commit changed paths Bloom filters"
 msgstr ""
 "S'estan calculant els canvis les rutes de la comissió en els filtres Bloom"
 
-#: commit-graph.c:1665
+#: commit-graph.c:1668
 msgid "Collecting referenced commits"
 msgstr "S'estan recollint els objectes referenciats"
 
-#: commit-graph.c:1690
+#: commit-graph.c:1693
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
@@ -2337,143 +2332,143 @@ msgstr[0] "S'estan cercant les comissions pel graf de comissions en %d paquet"
 msgstr[1] ""
 "S'estan cercant les comissions pel graf de comissions en %d paquets"
 
-#: commit-graph.c:1703
+#: commit-graph.c:1706
 #, c-format
 msgid "error adding pack %s"
 msgstr "error en afegir paquet %s"
 
-#: commit-graph.c:1707
+#: commit-graph.c:1710
 #, c-format
 msgid "error opening index for %s"
 msgstr "s'ha produït un error en obrir l'índex per «%s»"
 
-#: commit-graph.c:1744
+#: commit-graph.c:1747
 msgid "Finding commits for commit graph among packed objects"
 msgstr ""
 "S'estan cercant les comissions pel graf de comissions entre els objectes "
 "empaquetats"
 
-#: commit-graph.c:1762
+#: commit-graph.c:1765
 msgid "Finding extra edges in commit graph"
 msgstr "S'estan cercant les vores addicionals al graf de comissions"
 
-#: commit-graph.c:1811
+#: commit-graph.c:1814
 msgid "failed to write correct number of base graph ids"
 msgstr ""
 "s'ha produït un error en escriure el nombre correcte d'ids base del graf"
 
-#: commit-graph.c:1842 midx.c:1146
+#: commit-graph.c:1845 midx.c:1149
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "no s'han pogut crear els directoris inicials de «%s»"
 
-#: commit-graph.c:1855
+#: commit-graph.c:1858
 msgid "unable to create temporary graph layer"
 msgstr "no s'ha pogut crear una capa de graf temporal"
 
-#: commit-graph.c:1860
+#: commit-graph.c:1863
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "no s'han pogut ajustar els permisos compartits per a «%s»"
 
-#: commit-graph.c:1917
+#: commit-graph.c:1920
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "S'està escrivint el graf de comissions en %d pas"
 msgstr[1] "S'està escrivint el graf de comissions en %d passos"
 
-#: commit-graph.c:1953
+#: commit-graph.c:1956
 msgid "unable to open commit-graph chain file"
 msgstr "no s'ha pogut obrir el fitxer d'encadenament del graf de comissions"
 
-#: commit-graph.c:1969
+#: commit-graph.c:1972
 msgid "failed to rename base commit-graph file"
 msgstr "no s'ha pogut canviar el nom del fitxer base del graf de comissions"
 
-#: commit-graph.c:1989
+#: commit-graph.c:1992
 msgid "failed to rename temporary commit-graph file"
 msgstr ""
 "no s'ha pogut canviar el nom del fitxer temporal del graf de comissions"
 
-#: commit-graph.c:2122
+#: commit-graph.c:2125
 msgid "Scanning merged commits"
 msgstr "S'estan escanejant les comissions fusionades"
 
-#: commit-graph.c:2166
+#: commit-graph.c:2169
 msgid "Merging commit-graph"
 msgstr "S'està fusionant el graf de comissions"
 
-#: commit-graph.c:2274
+#: commit-graph.c:2277
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 "s'està intentant escriure un graf de comissions, però «core.commitGraph» "
 "està desactivat"
 
-#: commit-graph.c:2381
+#: commit-graph.c:2384
 msgid "too many commits to write graph"
 msgstr "massa comissions per escriure un graf"
 
-#: commit-graph.c:2479
+#: commit-graph.c:2482
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "el fitxer commit-graph (graf de comissions) té una suma de verificació "
 "incorrecta i probablement és corrupte"
 
-#: commit-graph.c:2489
+#: commit-graph.c:2492
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "el gràfic de comissions té una ordre OID incorrecta; %s llavors %s"
 
-#: commit-graph.c:2499 commit-graph.c:2514
+#: commit-graph.c:2502 commit-graph.c:2517
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr ""
 "el graf de comissions té un valor de «fanout» incorrecte: fanout[%d] = %u !="
 " %u"
 
-#: commit-graph.c:2506
+#: commit-graph.c:2509
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr ""
 "s'ha produït un error en analitzar la comissió %s del graf de comissions"
 
-#: commit-graph.c:2524
+#: commit-graph.c:2527
 msgid "Verifying commits in commit graph"
 msgstr "S'estan verificant les comissions al graf de comissions"
 
-#: commit-graph.c:2539
+#: commit-graph.c:2542
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "no s'han pogut analitzar la comissió %s de la base de dades d'objectes per "
 "al graf de comissions"
 
-#: commit-graph.c:2546
+#: commit-graph.c:2549
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 "OID de l'arbre arrel per a comissions %s en el graf de comissions és %s != "
 "%s"
 
-#: commit-graph.c:2556
+#: commit-graph.c:2559
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr ""
 "la llista de pares del graf de comissions per a la comissió %s és massa "
 "llarga"
 
-#: commit-graph.c:2565
+#: commit-graph.c:2568
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "el pare pel graf de comissions %s és %s != %s"
 
-#: commit-graph.c:2579
+#: commit-graph.c:2582
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr "la llista pare del graf de comissions per %s acaba aviat"
 
-#: commit-graph.c:2584
+#: commit-graph.c:2587
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero "
@@ -2482,7 +2477,7 @@ msgstr ""
 "El graf de comissions té nombre de generació zero per a la comissió %s, però"
 " té no zero en altres llocs"
 
-#: commit-graph.c:2588
+#: commit-graph.c:2591
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero "
@@ -2491,22 +2486,22 @@ msgstr ""
 "El graf de comissions té un nombre de generació diferent de zero per a "
 "comissió %s però té zero en altres llocs"
 
-#: commit-graph.c:2605
+#: commit-graph.c:2608
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr ""
 "generació del graf de comissions per a la comissió %s és %<PRIuMAX> < "
 "%<PRIuMAX>"
 
-#: commit-graph.c:2611
+#: commit-graph.c:2614
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 "La data d'enviament per a la comissió %s en el graf de comissions és "
 "%<PRIuMAX> != %<PRIuMAX>"
 
-#: commit.c:53 sequencer.c:3105 builtin/am.c:373 builtin/am.c:418
-#: builtin/am.c:423 builtin/am.c:1421 builtin/am.c:2068 builtin/replace.c:457
+#: commit.c:53 sequencer.c:3109 builtin/am.c:399 builtin/am.c:444
+#: builtin/am.c:449 builtin/am.c:1448 builtin/am.c:2123 builtin/replace.c:456
 #, c-format
 msgid "could not parse %s"
 msgstr "no s'ha pogut analitzar %s"
@@ -2530,31 +2525,33 @@ msgstr ""
 "La compatibilitat amb <GIT_DIR>/info/grafts és obsoleta\n"
 "i s'eliminarà en una futura versió del Git.\n"
 "\n"
-"Si us plau useu «git replace --convert-graft-file»\n"
-"per convertir els grafs en substitució de referències. Desactiveu aquest missatge executant\n"
+"Useu «git replace --convert-graft-file»\n"
+"per convertir els grafs en referències de reemplaçament.\n"
+"\n"
+"Desactiveu aquest missatge executant\n"
 "«git config advice.graftFileDeprecated false»"
 
-#: commit.c:1239
+#: commit.c:1241
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
 msgstr "La comissió %s té una signatura GPG no fiable, suposadament de %s."
 
-#: commit.c:1243
+#: commit.c:1245
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
 msgstr "La comissió %s té una signatura GPG incorrecta suposadament de %s."
 
-#: commit.c:1246
+#: commit.c:1248
 #, c-format
 msgid "Commit %s does not have a GPG signature."
 msgstr "La comissió %s no té signatura GPG."
 
-#: commit.c:1249
+#: commit.c:1251
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
 msgstr "La comissió %s té una signatura GPG bona de %s\n"
 
-#: commit.c:1503
+#: commit.c:1505
 msgid ""
 "Warning: commit message did not conform to UTF-8.\n"
 "You may want to amend it after fixing the message, or set the config\n"
@@ -2623,7 +2620,7 @@ msgstr "la clau no conté una secció: «%s»"
 msgid "key does not contain variable name: %s"
 msgstr "la clau no conté un nom de variable: «%s»"
 
-#: config.c:470 sequencer.c:2802
+#: config.c:470 sequencer.c:2806
 #, c-format
 msgid "invalid key: %s"
 msgstr "clau no vàlida: %s"
@@ -2781,148 +2778,148 @@ msgstr "core.commentChar només hauria de ser un caràcter"
 msgid "invalid mode for object creation: %s"
 msgstr "mode de creació d'objecte no vàlid: %s"
 
-#: config.c:1581
+#: config.c:1584
 #, c-format
 msgid "malformed value for %s"
 msgstr "valor no vàlid per a %s"
 
-#: config.c:1607
+#: config.c:1610
 #, c-format
 msgid "malformed value for %s: %s"
 msgstr "valor no vàlid per a %s: %s"
 
-#: config.c:1608
+#: config.c:1611
 msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr ""
 "ha de ser un dels elements següents: nothing, matching, simple, upstream o "
 "current"
 
-#: config.c:1669 builtin/pack-objects.c:4053
+#: config.c:1672 builtin/pack-objects.c:4053
 #, c-format
 msgid "bad pack compression level %d"
 msgstr "nivell de compressió de paquet %d erroni"
 
-#: config.c:1792
+#: config.c:1795
 #, c-format
 msgid "unable to load config blob object '%s'"
 msgstr "no s'ha pogut carregar l'objecte blob de configuració «%s»"
 
-#: config.c:1795
+#: config.c:1798
 #, c-format
 msgid "reference '%s' does not point to a blob"
 msgstr "la referència «%s» no assenyala a un blob"
 
-#: config.c:1813
+#: config.c:1816
 #, c-format
 msgid "unable to resolve config blob '%s'"
 msgstr "no s'ha pogut resoldre el blob de configuració: «%s»"
 
-#: config.c:1858
+#: config.c:1861
 #, c-format
 msgid "failed to parse %s"
 msgstr "s'ha produït un error en analitzar %s"
 
-#: config.c:1914
+#: config.c:1917
 msgid "unable to parse command-line config"
 msgstr "no s'ha pogut analitzar la configuració de la línia d'ordres"
 
-#: config.c:2282
+#: config.c:2285
 msgid "unknown error occurred while reading the configuration files"
 msgstr ""
 "un error desconegut ha ocorregut en llegir els fitxers de configuració"
 
-#: config.c:2456
+#: config.c:2459
 #, c-format
 msgid "Invalid %s: '%s'"
 msgstr "%s no vàlid: «%s»"
 
-#: config.c:2501
+#: config.c:2504
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
 msgstr "valor «%d» a splitIndex.maxPercentChange ha d'estar entre 0 i 100"
 
-#: config.c:2547
+#: config.c:2550
 #, c-format
 msgid "unable to parse '%s' from command-line config"
 msgstr "no s'ha pogut analitzar «%s» de la configuració de la línia d'ordres"
 
-#: config.c:2549
+#: config.c:2552
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
 msgstr "variable de configuració «%s» errònia en el fitxer «%s» a la línia %d"
 
-#: config.c:2633
+#: config.c:2637
 #, c-format
 msgid "invalid section name '%s'"
 msgstr "nom de secció no vàlid «%s»"
 
-#: config.c:2665
+#: config.c:2669
 #, c-format
 msgid "%s has multiple values"
 msgstr "%s té múltiples valors"
 
-#: config.c:2694
+#: config.c:2698
 #, c-format
 msgid "failed to write new configuration file %s"
 msgstr "no es pot escriure un nou fitxer de configuració %s"
 
-#: config.c:2946 config.c:3273
+#: config.c:2950 config.c:3277
 #, c-format
 msgid "could not lock config file %s"
 msgstr "no s'ha pogut blocar el fitxer de configuració %s"
 
-#: config.c:2957
+#: config.c:2961
 #, c-format
 msgid "opening %s"
 msgstr "s'està obrint %s"
 
-#: config.c:2994 builtin/config.c:361
+#: config.c:2998 builtin/config.c:361
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "patró no vàlid: %s"
 
-#: config.c:3019
+#: config.c:3023
 #, c-format
 msgid "invalid config file %s"
 msgstr "fitxer de configuració no vàlid %s"
 
-#: config.c:3032 config.c:3286
+#: config.c:3036 config.c:3290
 #, c-format
 msgid "fstat on %s failed"
 msgstr "ha fallat «fstat» a %s"
 
-#: config.c:3043
+#: config.c:3047
 #, c-format
 msgid "unable to mmap '%s'%s"
 msgstr "no s'ha pogut fer «mmap» «%s»%s"
 
-#: config.c:3053 config.c:3291
+#: config.c:3057 config.c:3295
 #, c-format
 msgid "chmod on %s failed"
 msgstr "ha fallat chmod a %s"
 
-#: config.c:3138 config.c:3388
+#: config.c:3142 config.c:3392
 #, c-format
 msgid "could not write config file %s"
 msgstr "no s'ha pogut escriure el fitxer de configuració «%s»"
 
-#: config.c:3172
+#: config.c:3176
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "no s'ha pogut establir «%s» a «%s»"
 
-#: config.c:3174 builtin/remote.c:662 builtin/remote.c:860
+#: config.c:3178 builtin/remote.c:662 builtin/remote.c:860
 #: builtin/remote.c:868
 #, c-format
 msgid "could not unset '%s'"
 msgstr "no s'ha pogut desassignar «%s»"
 
-#: config.c:3264
+#: config.c:3268
 #, c-format
 msgid "invalid section name: %s"
 msgstr "nom de secció no vàlida: %s"
 
-#: config.c:3431
+#: config.c:3435
 #, c-format
 msgid "missing value for '%s'"
 msgstr "falta el valor per «%s»"
@@ -3105,7 +3102,7 @@ msgstr "s'ha bloquejat el nom de fitxer estrany «%s»"
 msgid "unable to fork"
 msgstr "no s'ha pogut bifurcar"
 
-#: connected.c:109 builtin/fsck.c:189 builtin/prune.c:45
+#: connected.c:109 builtin/fsck.c:189 builtin/prune.c:57
 msgid "Checking connectivity"
 msgstr "S'està comprovant la connectivitat"
 
@@ -3411,19 +3408,19 @@ msgstr ""
 "No és un repositori Git. Useu --no-index per a comparar dos camins fora del "
 "directori de treball"
 
-#: diff.c:157
+#: diff.c:158
 #, c-format
 msgid "  Failed to parse dirstat cut-off percentage '%s'\n"
 msgstr ""
 "  S'ha produït un error en analitzar el percentatge limitant de dirstat "
 "«%s»\n"
 
-#: diff.c:162
+#: diff.c:163
 #, c-format
 msgid "  Unknown dirstat parameter '%s'\n"
 msgstr "  Paràmetre de dirstat desconegut «%s»\n"
 
-#: diff.c:298
+#: diff.c:299
 msgid ""
 "color moved setting must be one of 'no', 'default', 'blocks', 'zebra', "
 "'dimmed-zebra', 'plain'"
@@ -3431,7 +3428,7 @@ msgstr ""
 "el paràmetre de color en moviment ha de ser «no», «default», «blocks», "
 "«zebra», «dimmed-zebra» o «plain»"
 
-#: diff.c:326
+#: diff.c:327
 #, c-format
 msgid ""
 "unknown color-moved-ws mode '%s', possible values are 'ignore-space-change',"
@@ -3441,7 +3438,7 @@ msgstr ""
 "«ignore-space-change», «ignore-space-at-eol», «ignore-all-space», «allow-"
 "indentation-change»"
 
-#: diff.c:334
+#: diff.c:335
 msgid ""
 "color-moved-ws: allow-indentation-change cannot be combined with other "
 "whitespace modes"
@@ -3449,13 +3446,13 @@ msgstr ""
 "color-moved-ws: allow-indentation-change no es pot combinar amb altres modes"
 " d'espai en blanc"
 
-#: diff.c:411
+#: diff.c:412
 #, c-format
 msgid "Unknown value for 'diff.submodule' config variable: '%s'"
 msgstr ""
 "Valor desconegut de la variable de configuració de «diff.submodule»: «%s»"
 
-#: diff.c:471
+#: diff.c:472
 #, c-format
 msgid ""
 "Found errors in 'diff.dirstat' config variable:\n"
@@ -3464,49 +3461,49 @@ msgstr ""
 "S'han trobat errors en la variable de configuració «diff.dirstat»:\n"
 "%s"
 
-#: diff.c:4290
+#: diff.c:4237
 #, c-format
 msgid "external diff died, stopping at %s"
 msgstr "el diff external s'ha mort, s'està aturant a %s"
 
-#: diff.c:4642
-msgid "--name-only, --name-status, --check and -s are mutually exclusive"
-msgstr "--name-only, --name-status, --check i -s són mútuament excloents"
+#: diff.c:4589
+#, c-format
+msgid "options '%s', '%s', '%s', and '%s' cannot be used together"
+msgstr "les opcions «%s», «%s», «%s», i «%s» no es poden usar juntes"
 
-#: diff.c:4645
-msgid "-G, -S and --find-object are mutually exclusive"
-msgstr "-G, -S and --find-object són mútuament excloents"
+#: diff.c:4593 builtin/difftool.c:736 builtin/log.c:1982
+#: builtin/worktree.c:506
+#, c-format
+msgid "options '%s', '%s', and '%s' cannot be used together"
+msgstr "les opcions «%s», «%s», i «%s» no es poden usar juntes"
 
-#: diff.c:4648
+#: diff.c:4597
+#, c-format
+msgid "options '%s' and '%s' cannot be used together, use '%s' with '%s'"
+msgstr "les opcions «%s» i «%s» no es poden usar juntes, useu «%s» amb «%s»"
+
+#: diff.c:4601
+#, c-format
 msgid ""
-"-G and --pickaxe-regex are mutually exclusive, use --pickaxe-regex with -S"
-msgstr ""
-"-G i --pickaxe-regex són mútuament excloents, useu --pickaxe-regex amb -S"
+"options '%s' and '%s' cannot be used together, use '%s' with '%s' and '%s'"
+msgstr "les opcions «%s» i «%s» no es poden usar juntes, useu «%s» amb «%s» i «%s»"
 
-#: diff.c:4651
-msgid ""
-"--pickaxe-all and --find-object are mutually exclusive, use --pickaxe-all "
-"with -G and -S"
-msgstr ""
-"--pickaxe-all i --find-object són mútuament excloents, useu --pickaxe-all "
-"amb -G i -S"
-
-#: diff.c:4730
+#: diff.c:4681
 msgid "--follow requires exactly one pathspec"
 msgstr "--follow requereix exactament una especificació de camí"
 
-#: diff.c:4778
+#: diff.c:4729
 #, c-format
 msgid "invalid --stat value: %s"
 msgstr "valor --stat no vàlid: %s"
 
-#: diff.c:4783 diff.c:4788 diff.c:4793 diff.c:4798 diff.c:5326
+#: diff.c:4734 diff.c:4739 diff.c:4744 diff.c:4749 diff.c:5277
 #: parse-options.c:217 parse-options.c:221
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "%s espera un valor numèric"
 
-#: diff.c:4815
+#: diff.c:4766
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -3515,199 +3512,199 @@ msgstr ""
 "S'ha produït un error en analitzar el paràmetre d'opció de --dirstat/-X:\n"
 "%s"
 
-#: diff.c:4900
+#: diff.c:4851
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
 msgstr "classe de canvi «%c» desconeguda a --diff-filter=%s"
 
-#: diff.c:4924
+#: diff.c:4875
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
 msgstr "valor desconegut després de ws-error-highlight=%.*s"
 
-#: diff.c:4938
+#: diff.c:4889
 #, c-format
 msgid "unable to resolve '%s'"
 msgstr "no s'ha pogut resoldre «%s»"
 
-#: diff.c:4988 diff.c:4994
+#: diff.c:4939 diff.c:4945
 #, c-format
 msgid "%s expects <n>/<m> form"
 msgstr "%s espera una forma <n>/<m>"
 
-#: diff.c:5006
+#: diff.c:4957
 #, c-format
 msgid "%s expects a character, got '%s'"
 msgstr "%s esperava un caràcter, s'ha rebut «%s»"
 
-#: diff.c:5027
+#: diff.c:4978
 #, c-format
 msgid "bad --color-moved argument: %s"
 msgstr "argument --color-moved incorrecte: %s"
 
-#: diff.c:5046
+#: diff.c:4997
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
 msgstr "mode «%s» no vàlid en --color-moved-ws"
 
-#: diff.c:5086
+#: diff.c:5037
 msgid "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and \"histogram\""
 msgstr ""
 "l'opció diff-algorithm accepta «myers», «minimal», «patience» i «histogram»"
 
-#: diff.c:5122 diff.c:5142
+#: diff.c:5073 diff.c:5093
 #, c-format
 msgid "invalid argument to %s"
 msgstr "argument no vàlid a %s"
 
-#: diff.c:5246
+#: diff.c:5197
 #, c-format
 msgid "invalid regex given to -I: '%s'"
 msgstr "expressió regular donada a -I: no vàlida: «%s»"
 
-#: diff.c:5295
+#: diff.c:5246
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
 msgstr ""
 "s'ha produït un error en analitzar el paràmetre d'opció de --submodule: «%s»"
 
-#: diff.c:5351
+#: diff.c:5302
 #, c-format
 msgid "bad --word-diff argument: %s"
 msgstr "argument --word-diff incorrecte: %s"
 
-#: diff.c:5387
+#: diff.c:5338
 msgid "Diff output format options"
 msgstr "Opcions del format de sortida del diff"
 
-#: diff.c:5389 diff.c:5395
+#: diff.c:5340 diff.c:5346
 msgid "generate patch"
 msgstr "generant pedaç"
 
-#: diff.c:5392 builtin/log.c:179
+#: diff.c:5343 builtin/log.c:179
 msgid "suppress diff output"
 msgstr "omet la sortida de diferències"
 
-#: diff.c:5397 diff.c:5511 diff.c:5518
+#: diff.c:5348 diff.c:5462 diff.c:5469
 msgid "<n>"
 msgstr "<n>"
 
-#: diff.c:5398 diff.c:5401
+#: diff.c:5349 diff.c:5352
 msgid "generate diffs with <n> lines context"
 msgstr "genera diffs amb <n> línies de context"
 
-#: diff.c:5403
+#: diff.c:5354
 msgid "generate the diff in raw format"
 msgstr "genera el diff en format cru"
 
-#: diff.c:5406
+#: diff.c:5357
 msgid "synonym for '-p --raw'"
 msgstr "sinònim de «-p --raw»"
 
-#: diff.c:5410
+#: diff.c:5361
 msgid "synonym for '-p --stat'"
 msgstr "sinònim de «-p --stat»"
 
-#: diff.c:5414
+#: diff.c:5365
 msgid "machine friendly --stat"
 msgstr "llegible per màquina --stat"
 
-#: diff.c:5417
+#: diff.c:5368
 msgid "output only the last line of --stat"
 msgstr "mostra només l'última línia de --stat"
 
-#: diff.c:5419 diff.c:5427
+#: diff.c:5370 diff.c:5378
 msgid "<param1,param2>..."
 msgstr "<param1,param2>..."
 
-#: diff.c:5420
+#: diff.c:5371
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr ""
 "genera la distribució de la quantitat relativa de canvis per a cada "
 "subdirectori"
 
-#: diff.c:5424
+#: diff.c:5375
 msgid "synonym for --dirstat=cumulative"
 msgstr "sinònim de --dirstat=cumulative"
 
-#: diff.c:5428
+#: diff.c:5379
 msgid "synonym for --dirstat=files,param1,param2..."
 msgstr "sinònim de --dirstat=files,param1,param2..."
 
-#: diff.c:5432
+#: diff.c:5383
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
 "avisa si els canvis introdueixen marcadors en conflicte o errors d'espai en "
 "blanc"
 
-#: diff.c:5435
+#: diff.c:5386
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr "resum condensat com ara creacions, canvis de nom i mode"
 
-#: diff.c:5438
+#: diff.c:5389
 msgid "show only names of changed files"
 msgstr "mostra només els noms de fitxers canviats"
 
-#: diff.c:5441
+#: diff.c:5392
 msgid "show only names and status of changed files"
 msgstr "mostra només els noms i l'estat dels fitxers canviats"
 
-#: diff.c:5443
+#: diff.c:5394
 msgid "<width>[,<name-width>[,<count>]]"
 msgstr "<amplada>[<amplada-nom>[,<recompte>]]"
 
-#: diff.c:5444
+#: diff.c:5395
 msgid "generate diffstat"
 msgstr "genera diffstat"
 
-#: diff.c:5446 diff.c:5449 diff.c:5452
+#: diff.c:5397 diff.c:5400 diff.c:5403
 msgid "<width>"
 msgstr "<amplada>"
 
-#: diff.c:5447
+#: diff.c:5398
 msgid "generate diffstat with a given width"
 msgstr "genera diffstat amb una amplada donada"
 
-#: diff.c:5450
+#: diff.c:5401
 msgid "generate diffstat with a given name width"
 msgstr "genera diffstat amb un nom d'amplada donat"
 
-#: diff.c:5453
+#: diff.c:5404
 msgid "generate diffstat with a given graph width"
 msgstr "genera diffstat amb una amplada de graf donada"
 
-#: diff.c:5455
+#: diff.c:5406
 msgid "<count>"
 msgstr "<comptador>"
 
-#: diff.c:5456
+#: diff.c:5407
 msgid "generate diffstat with limited lines"
 msgstr "genera diffstat amb línies limitades"
 
-#: diff.c:5459
+#: diff.c:5410
 msgid "generate compact summary in diffstat"
 msgstr "genera un resum compacte a diffstat"
 
-#: diff.c:5462
+#: diff.c:5413
 msgid "output a binary diff that can be applied"
 msgstr "diff amb sortida binària que pot ser aplicada"
 
-#: diff.c:5465
+#: diff.c:5416
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr ""
 "mostra els noms complets dels objectes pre i post-imatge a les línies "
 "«index»"
 
-#: diff.c:5467
+#: diff.c:5418
 msgid "show colored diff"
 msgstr "mostra un diff amb colors"
 
-#: diff.c:5468
+#: diff.c:5419
 msgid "<kind>"
 msgstr "<kind>"
 
-#: diff.c:5469
+#: diff.c:5420
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
@@ -3715,7 +3712,7 @@ msgstr ""
 "ressalta els errors d'espai en blanc a les línies «context», «old» o «new» "
 "al diff"
 
-#: diff.c:5472
+#: diff.c:5423
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
@@ -3723,92 +3720,92 @@ msgstr ""
 "no consolidis els noms de camí i utilitza NULs com a terminadors de camp de "
 "sortida en --raw o --numstat"
 
-#: diff.c:5475 diff.c:5478 diff.c:5481 diff.c:5590
+#: diff.c:5426 diff.c:5429 diff.c:5432 diff.c:5541
 msgid "<prefix>"
 msgstr "<prefix>"
 
-#: diff.c:5476
+#: diff.c:5427
 msgid "show the given source prefix instead of \"a/\""
 msgstr "mostra el prefix d'origen donat en lloc de «a/»"
 
-#: diff.c:5479
+#: diff.c:5430
 msgid "show the given destination prefix instead of \"b/\""
 msgstr "mostra el prefix de destinació indicat en lloc de «b/»"
 
-#: diff.c:5482
+#: diff.c:5433
 msgid "prepend an additional prefix to every line of output"
 msgstr "afegir un prefix addicional per a cada línia de sortida"
 
-#: diff.c:5485
+#: diff.c:5436
 msgid "do not show any source or destination prefix"
 msgstr "no mostris cap prefix d'origen o destí"
 
-#: diff.c:5488
+#: diff.c:5439
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
 "mostra el context entre trossos de diferència fins al nombre especificat de "
 "línies"
 
-#: diff.c:5492 diff.c:5497 diff.c:5502
+#: diff.c:5443 diff.c:5448 diff.c:5453
 msgid "<char>"
 msgstr "<char>"
 
-#: diff.c:5493
+#: diff.c:5444
 msgid "specify the character to indicate a new line instead of '+'"
 msgstr ""
 "especifiqueu el caràcter per a indicar una línia nova en comptes de «+»"
 
-#: diff.c:5498
+#: diff.c:5449
 msgid "specify the character to indicate an old line instead of '-'"
 msgstr ""
 "especifiqueu el caràcter per a indicar una línia antiga en comptes de «-»"
 
-#: diff.c:5503
+#: diff.c:5454
 msgid "specify the character to indicate a context instead of ' '"
 msgstr "especifiqueu el caràcter per a indicar context en comptes de « »"
 
-#: diff.c:5506
+#: diff.c:5457
 msgid "Diff rename options"
 msgstr "Opcions de canvi de nom del diff"
 
-#: diff.c:5507
+#: diff.c:5458
 msgid "<n>[/<m>]"
 msgstr "<n>[/<m>]"
 
-#: diff.c:5508
+#: diff.c:5459
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr ""
 "divideix els canvis de reescriptura completa en parells de suprimir i crear"
 
-#: diff.c:5512
+#: diff.c:5463
 msgid "detect renames"
 msgstr "detecta els canvis de noms"
 
-#: diff.c:5516
+#: diff.c:5467
 msgid "omit the preimage for deletes"
 msgstr "omet les preimatges per les supressions"
 
-#: diff.c:5519
+#: diff.c:5470
 msgid "detect copies"
 msgstr "detecta còpies"
 
-#: diff.c:5523
+#: diff.c:5474
 msgid "use unmodified files as source to find copies"
 msgstr "usa els fitxers no modificats com a font per trobar còpies"
 
-#: diff.c:5525
+#: diff.c:5476
 msgid "disable rename detection"
 msgstr "inhabilita la detecció de canvis de nom"
 
-#: diff.c:5528
+#: diff.c:5479
 msgid "use empty blobs as rename source"
 msgstr "usa els blobs buits com a font de canvi de nom"
 
-#: diff.c:5530
+#: diff.c:5481
 msgid "continue listing the history of a file beyond renames"
 msgstr "continua llistant l'històric d'un fitxer més enllà dels canvis de nom"
 
-#: diff.c:5533
+#: diff.c:5484
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
@@ -3816,162 +3813,162 @@ msgstr ""
 "Evita la detecció de canvi de nom/còpia si el nombre d'objectius de canvi de"
 " nom/còpia supera el límit indicat"
 
-#: diff.c:5535
+#: diff.c:5486
 msgid "Diff algorithm options"
 msgstr "Opcions de l'algorisme Diff"
 
-#: diff.c:5537
+#: diff.c:5488
 msgid "produce the smallest possible diff"
 msgstr "produeix el diff més petit possible"
 
-#: diff.c:5540
+#: diff.c:5491
 msgid "ignore whitespace when comparing lines"
 msgstr "ignora els espais en blanc en comparar línies"
 
-#: diff.c:5543
+#: diff.c:5494
 msgid "ignore changes in amount of whitespace"
 msgstr "ignora els canvis en la quantitat d'espai en blanc"
 
-#: diff.c:5546
+#: diff.c:5497
 msgid "ignore changes in whitespace at EOL"
 msgstr "ignora els canvis d'espai en blanc al final de la línia"
 
-#: diff.c:5549
+#: diff.c:5500
 msgid "ignore carrier-return at the end of line"
 msgstr "ignora els retorns de línia al final de la línia"
 
-#: diff.c:5552
+#: diff.c:5503
 msgid "ignore changes whose lines are all blank"
 msgstr "ignora els canvis en línies que estan en blanc"
 
-#: diff.c:5554 diff.c:5576 diff.c:5579 diff.c:5624
+#: diff.c:5505 diff.c:5527 diff.c:5530 diff.c:5575
 msgid "<regex>"
 msgstr "<regex>"
 
-#: diff.c:5555
+#: diff.c:5506
 msgid "ignore changes whose all lines match <regex>"
 msgstr "ignora els canvis en les línies que coincideixen amb <regex>"
 
-#: diff.c:5558
+#: diff.c:5509
 msgid "heuristic to shift diff hunk boundaries for easy reading"
 msgstr ""
 "heurística per a desplaçar els límits del tros de diferència per a una "
 "lectura fàcil"
 
-#: diff.c:5561
+#: diff.c:5512
 msgid "generate diff using the \"patience diff\" algorithm"
 msgstr "genera diff usant l'algorisme «patience diff»"
 
-#: diff.c:5565
+#: diff.c:5516
 msgid "generate diff using the \"histogram diff\" algorithm"
 msgstr "genera diff usant l'algorisme «histogram diff»"
 
-#: diff.c:5567
+#: diff.c:5518
 msgid "<algorithm>"
 msgstr "<algorisme>"
 
-#: diff.c:5568
+#: diff.c:5519
 msgid "choose a diff algorithm"
 msgstr "trieu un algorisme per al diff"
 
-#: diff.c:5570
+#: diff.c:5521
 msgid "<text>"
 msgstr "<text>"
 
-#: diff.c:5571
+#: diff.c:5522
 msgid "generate diff using the \"anchored diff\" algorithm"
 msgstr "genera diff usant l'algorisme «anchored diff»"
 
-#: diff.c:5573 diff.c:5582 diff.c:5585
+#: diff.c:5524 diff.c:5533 diff.c:5536
 msgid "<mode>"
 msgstr "<mode>"
 
-#: diff.c:5574
+#: diff.c:5525
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr ""
 "mostra el diff de paraules usant <mode> per delimitar les paraules "
 "modificades"
 
-#: diff.c:5577
+#: diff.c:5528
 msgid "use <regex> to decide what a word is"
 msgstr "utilitza <regex> per a decidir què és una paraula"
 
-#: diff.c:5580
+#: diff.c:5531
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
 msgstr "equivalent a --word-diff=color --word-diff-regex=<regex>"
 
-#: diff.c:5583
+#: diff.c:5534
 msgid "moved lines of code are colored differently"
 msgstr "les línies de codi que s'ha mogut s'acoloreixen diferent"
 
-#: diff.c:5586
+#: diff.c:5537
 msgid "how white spaces are ignored in --color-moved"
 msgstr "com s'ignoren els espais en blanc a --color-moved"
 
-#: diff.c:5589
+#: diff.c:5540
 msgid "Other diff options"
 msgstr "Altres opcions diff"
 
-#: diff.c:5591
+#: diff.c:5542
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
 "quan s'executa des d'un subdirectori, exclou els canvis de fora i mostra els"
 " camins relatius"
 
-#: diff.c:5595
+#: diff.c:5546
 msgid "treat all files as text"
 msgstr "tracta tots els fitxers com a text"
 
-#: diff.c:5597
+#: diff.c:5548
 msgid "swap two inputs, reverse the diff"
 msgstr "intercanvia les dues entrades, inverteix el diff"
 
-#: diff.c:5599
+#: diff.c:5550
 msgid "exit with 1 if there were differences, 0 otherwise"
 msgstr "surt amb 1 si hi ha diferències, 0 en cas contrari"
 
-#: diff.c:5601
+#: diff.c:5552
 msgid "disable all output of the program"
 msgstr "inhabilita totes les sortides del programa"
 
-#: diff.c:5603
+#: diff.c:5554
 msgid "allow an external diff helper to be executed"
 msgstr "permet executar un ajudant de diff extern"
 
-#: diff.c:5605
+#: diff.c:5556
 msgid "run external text conversion filters when comparing binary files"
 msgstr ""
 "executa els filtres externs de conversió de text en comparar fitxers binaris"
 
-#: diff.c:5607
+#: diff.c:5558
 msgid "<when>"
 msgstr "<quan>"
 
-#: diff.c:5608
+#: diff.c:5559
 msgid "ignore changes to submodules in the diff generation"
 msgstr "ignora els canvis als submòduls en la generació del diff"
 
-#: diff.c:5611
+#: diff.c:5562
 msgid "<format>"
 msgstr "<format>"
 
-#: diff.c:5612
+#: diff.c:5563
 msgid "specify how differences in submodules are shown"
 msgstr "especifiqueu com es mostren els canvis als submòduls"
 
-#: diff.c:5616
+#: diff.c:5567
 msgid "hide 'git add -N' entries from the index"
 msgstr "amaga les entrades «git add -N» de l'índex"
 
-#: diff.c:5619
+#: diff.c:5570
 msgid "treat 'git add -N' entries as real in the index"
 msgstr "tracta les entrades «git add -N» com a reals a l'índex"
 
-#: diff.c:5621
+#: diff.c:5572
 msgid "<string>"
 msgstr "<cadena>"
 
-#: diff.c:5622
+#: diff.c:5573
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
@@ -3979,7 +3976,7 @@ msgstr ""
 "cerca les diferències que canvien el nombre d'ocurrències de la cadena "
 "especificada"
 
-#: diff.c:5625
+#: diff.c:5576
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
@@ -3987,35 +3984,35 @@ msgstr ""
 "cerca les diferències que canvien el nombre d'ocurrències de l'expressió "
 "regular especificada"
 
-#: diff.c:5628
+#: diff.c:5579
 msgid "show all changes in the changeset with -S or -G"
 msgstr "mostra tots els canvis amb el conjunt de canvis amb -S o -G"
 
-#: diff.c:5631
+#: diff.c:5582
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr "tracta <cadena> a -S com a expressió regular POSIX ampliada"
 
-#: diff.c:5634
+#: diff.c:5585
 msgid "control the order in which files appear in the output"
 msgstr "controla l'ordre amb el qual els fitxers apareixen en la sortida"
 
-#: diff.c:5635 diff.c:5638
+#: diff.c:5586 diff.c:5589
 msgid "<path>"
 msgstr "<camí>"
 
-#: diff.c:5636
+#: diff.c:5587
 msgid "show the change in the specified path first"
 msgstr "mostra el canvi primer al camí especificat"
 
-#: diff.c:5639
+#: diff.c:5590
 msgid "skip the output to the specified path"
 msgstr "omet la sortida al camí especificat"
 
-#: diff.c:5641
+#: diff.c:5592
 msgid "<object-id>"
 msgstr "<id de l'objecte>"
 
-#: diff.c:5642
+#: diff.c:5593
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
@@ -4023,33 +4020,33 @@ msgstr ""
 "cerca les diferències que canvien el nombre d'ocurrències de l'objecte "
 "especificat"
 
-#: diff.c:5644
+#: diff.c:5595
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "[(A|C|D|M|R|T|U|X|B)...[*]]"
 
-#: diff.c:5645
+#: diff.c:5596
 msgid "select files by diff type"
 msgstr "seleccioneu els fitxers per tipus de diff"
 
-#: diff.c:5647
+#: diff.c:5598
 msgid "<file>"
 msgstr "<fitxer>"
 
-#: diff.c:5648
+#: diff.c:5599
 msgid "Output to a specific file"
 msgstr "Sortida a un fitxer específic"
 
-#: diff.c:6306
+#: diff.c:6257
 msgid "exhaustive rename detection was skipped due to too many files."
 msgstr ""
 "s'ha omès la detecció de canvi de nom exhaustiva perquè hi ha massa fitxers."
 
-#: diff.c:6309
+#: diff.c:6260
 msgid "only found copies from modified paths due to too many files."
 msgstr ""
 "només s'han trobat còpies des de camins modificats perquè de massa fitxers."
 
-#: diff.c:6312
+#: diff.c:6263
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
@@ -4094,30 +4091,30 @@ msgstr ""
 "el vostre fitxer «sparse-checkout» pot tenir problemes el patró «%s» es "
 "repeteix"
 
-#: dir.c:830
+#: dir.c:828
 msgid "disabling cone pattern matching"
 msgstr "inhabilita la coincidència de patrons «cone»"
 
-#: dir.c:1214
+#: dir.c:1212
 #, c-format
 msgid "cannot use %s as an exclude file"
 msgstr "no es pot usar %s com a fitxer d'exclusió"
 
-#: dir.c:2464
+#: dir.c:2418
 #, c-format
 msgid "could not open directory '%s'"
 msgstr "no s'ha pogut obrir el directori «%s»"
 
-#: dir.c:2766
+#: dir.c:2720
 msgid "failed to get kernel name and information"
 msgstr "s'ha produït un error en obtenir el nombre i la informació del nucli"
 
-#: dir.c:2890
+#: dir.c:2844
 msgid "untracked cache is disabled on this system or location"
 msgstr ""
 "la memòria cau no seguida està inhabilitada en aquest sistema o ubicació"
 
-#: dir.c:3158
+#: dir.c:3112
 msgid ""
 "No directory name could be guessed.\n"
 "Please specify a directory on the command line"
@@ -4125,36 +4122,36 @@ msgstr ""
 "No s'ha pogut endevinar cap nom de directori.\n"
 "Especifiqueu un directori en la línia d'ordres"
 
-#: dir.c:3837
+#: dir.c:3800
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "el fitxer d'índex al repositori %s és malmès"
 
-#: dir.c:3884 dir.c:3889
+#: dir.c:3847 dir.c:3852
 #, c-format
 msgid "could not create directories for %s"
 msgstr "no s'han pogut crear directoris per %s"
 
-#: dir.c:3918
+#: dir.c:3881
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "no s'ha pogut migrar el directori de «%s» a «%s»"
 
-#: editor.c:77
+#: editor.c:74
 #, c-format
 msgid "hint: Waiting for your editor to close the file...%c"
 msgstr "consell: s'està esperant que el vostre editor tanqui el fitxer...%c"
 
-#: entry.c:177
+#: entry.c:179
 msgid "Filtering content"
 msgstr "S'està filtrant el contingut"
 
-#: entry.c:498
+#: entry.c:500
 #, c-format
 msgid "could not stat file '%s'"
 msgstr "no s'ha pogut fer «stat» sobre el fitxer «%s»"
 
-#: environment.c:143
+#: environment.c:145
 #, c-format
 msgid "bad git namespace path \"%s\""
 msgstr "camí d'espai de noms git incorrecte «%s»"
@@ -4164,277 +4161,273 @@ msgstr "camí d'espai de noms git incorrecte «%s»"
 msgid "too many args to run %s"
 msgstr "hi ha massa arguments per a executar %s"
 
-#: fetch-pack.c:193
+#: fetch-pack.c:194
 msgid "git fetch-pack: expected shallow list"
 msgstr "git fetch-pack: llista shallow esperada"
 
-#: fetch-pack.c:196
+#: fetch-pack.c:197
 msgid "git fetch-pack: expected a flush packet after shallow list"
 msgstr ""
 "git fetch-pack: s'esperava un paquet de buidatge després d'una llista "
 "shallow"
 
-#: fetch-pack.c:207
+#: fetch-pack.c:208
 msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
 msgstr "git fetch-pack: s'esperava ACK/NAK, s'ha rebut un paquet de buidatge"
 
-#: fetch-pack.c:227
+#: fetch-pack.c:228
 #, c-format
 msgid "git fetch-pack: expected ACK/NAK, got '%s'"
 msgstr "git fetch-pack: s'esperava ACK/NAK, s'ha rebut «%s»"
 
-#: fetch-pack.c:238
+#: fetch-pack.c:239
 msgid "unable to write to remote"
 msgstr "no s'ha pogut escriure al remot"
 
-#: fetch-pack.c:299
-msgid "--stateless-rpc requires multi_ack_detailed"
-msgstr "--stateless-rpc requereix multi_ack_detailed"
-
-#: fetch-pack.c:394 fetch-pack.c:1434
+#: fetch-pack.c:395 fetch-pack.c:1439
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "línia de shallow no vàlida: %s"
 
-#: fetch-pack.c:400 fetch-pack.c:1440
+#: fetch-pack.c:401 fetch-pack.c:1445
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "línia d'unshallow no vàlida: %s"
 
-#: fetch-pack.c:402 fetch-pack.c:1442
+#: fetch-pack.c:403 fetch-pack.c:1447
 #, c-format
 msgid "object not found: %s"
 msgstr "objecte no trobat: %s"
 
-#: fetch-pack.c:405 fetch-pack.c:1445
+#: fetch-pack.c:406 fetch-pack.c:1450
 #, c-format
 msgid "error in object: %s"
 msgstr "error en objecte: %s"
 
-#: fetch-pack.c:407 fetch-pack.c:1447
+#: fetch-pack.c:408 fetch-pack.c:1452
 #, c-format
 msgid "no shallow found: %s"
 msgstr "no s'ha trobat cap shallow: %s"
 
-#: fetch-pack.c:410 fetch-pack.c:1451
+#: fetch-pack.c:411 fetch-pack.c:1456
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "s'esperava shallow/unshallow, s'ha rebut %s"
 
-#: fetch-pack.c:450
+#: fetch-pack.c:451
 #, c-format
 msgid "got %s %d %s"
 msgstr "s'ha rebut %s %d %s"
 
-#: fetch-pack.c:467
+#: fetch-pack.c:468
 #, c-format
 msgid "invalid commit %s"
 msgstr "comissió no vàlida %s"
 
-#: fetch-pack.c:498
+#: fetch-pack.c:499
 msgid "giving up"
 msgstr "s'abandona"
 
-#: fetch-pack.c:511 progress.c:339
+#: fetch-pack.c:512 progress.c:339
 msgid "done"
 msgstr "fet"
 
-#: fetch-pack.c:523
+#: fetch-pack.c:524
 #, c-format
 msgid "got %s (%d) %s"
 msgstr "s'ha rebut %s (%d) %s"
 
-#: fetch-pack.c:559
+#: fetch-pack.c:560
 #, c-format
 msgid "Marking %s as complete"
 msgstr "S'està marcant %s com a complet"
 
-#: fetch-pack.c:774
+#: fetch-pack.c:775
 #, c-format
 msgid "already have %s (%s)"
 msgstr "ja es té %s (%s)"
 
-#: fetch-pack.c:860
+#: fetch-pack.c:861
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr ""
 "fetch-pack: no s'ha pogut bifurcar del desmultiplexor de banda lateral"
 
-#: fetch-pack.c:868
+#: fetch-pack.c:869
 msgid "protocol error: bad pack header"
 msgstr "error de protocol: capçalera de paquet errònia"
 
-#: fetch-pack.c:962
+#: fetch-pack.c:965
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-pack: no es pot bifurcar de %s"
 
-#: fetch-pack.c:968
+#: fetch-pack.c:971
 msgid "fetch-pack: invalid index-pack output"
 msgstr "fetch-pack: sortida d'index-pack no vàlida"
 
-#: fetch-pack.c:985
+#: fetch-pack.c:988
 #, c-format
 msgid "%s failed"
 msgstr "%s ha fallat"
 
-#: fetch-pack.c:987
+#: fetch-pack.c:990
 msgid "error in sideband demultiplexer"
 msgstr "error en desmultiplexor de banda lateral"
 
-#: fetch-pack.c:1030
+#: fetch-pack.c:1035
 #, c-format
 msgid "Server version is %.*s"
 msgstr "La versió del servidor és %.*s"
 
-#: fetch-pack.c:1038 fetch-pack.c:1044 fetch-pack.c:1047 fetch-pack.c:1053
-#: fetch-pack.c:1057 fetch-pack.c:1061 fetch-pack.c:1065 fetch-pack.c:1069
-#: fetch-pack.c:1073 fetch-pack.c:1077 fetch-pack.c:1081 fetch-pack.c:1085
-#: fetch-pack.c:1091 fetch-pack.c:1097 fetch-pack.c:1102 fetch-pack.c:1107
+#: fetch-pack.c:1043 fetch-pack.c:1049 fetch-pack.c:1052 fetch-pack.c:1058
+#: fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070 fetch-pack.c:1074
+#: fetch-pack.c:1078 fetch-pack.c:1082 fetch-pack.c:1086 fetch-pack.c:1090
+#: fetch-pack.c:1096 fetch-pack.c:1102 fetch-pack.c:1107 fetch-pack.c:1112
 #, c-format
 msgid "Server supports %s"
 msgstr "El servidor accepta %s"
 
-#: fetch-pack.c:1040
+#: fetch-pack.c:1045
 msgid "Server does not support shallow clients"
 msgstr "El servidor no permet clients superficials"
 
-#: fetch-pack.c:1100
+#: fetch-pack.c:1105
 msgid "Server does not support --shallow-since"
 msgstr "El servidor no admet --shallow-since"
 
-#: fetch-pack.c:1105
+#: fetch-pack.c:1110
 msgid "Server does not support --shallow-exclude"
 msgstr "El servidor no admet --shallow-exclude"
 
-#: fetch-pack.c:1109
+#: fetch-pack.c:1114
 msgid "Server does not support --deepen"
 msgstr "El servidor no admet --deepen"
 
-#: fetch-pack.c:1111
+#: fetch-pack.c:1116
 msgid "Server does not support this repository's object format"
 msgstr ""
 "El servidor no és compatible amb el format d'objecte d'aquest repositori"
 
-#: fetch-pack.c:1124
+#: fetch-pack.c:1129
 msgid "no common commits"
 msgstr "cap comissió en comú"
 
-#: fetch-pack.c:1133 fetch-pack.c:1480 builtin/clone.c:1130
+#: fetch-pack.c:1138 fetch-pack.c:1485 builtin/clone.c:1130
 msgid "source repository is shallow, reject to clone."
 msgstr "el repositori font és superficial, es rebutja clonar-ho."
 
-#: fetch-pack.c:1139 fetch-pack.c:1671
+#: fetch-pack.c:1144 fetch-pack.c:1681
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack: l'obtenció ha fallat."
 
-#: fetch-pack.c:1253
+#: fetch-pack.c:1258
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "algoritmes no coincidents: client %s; servidor %s"
 
-#: fetch-pack.c:1257
+#: fetch-pack.c:1262
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "el servidor no és compatible amb l'algorisme «%s»"
 
-#: fetch-pack.c:1290
+#: fetch-pack.c:1295
 msgid "Server does not support shallow requests"
 msgstr "El servidor no permet sol·licituds superficials"
 
-#: fetch-pack.c:1297
+#: fetch-pack.c:1302
 msgid "Server supports filter"
 msgstr "El servidor accepta filtratge"
 
-#: fetch-pack.c:1340 fetch-pack.c:2053
+#: fetch-pack.c:1345 fetch-pack.c:2063
 msgid "unable to write request to remote"
 msgstr "no s'ha pogut escriure la sol·licitud al remot"
 
-#: fetch-pack.c:1358
+#: fetch-pack.c:1363
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "error en llegir la capçalera de la secció «%s»"
 
-#: fetch-pack.c:1364
+#: fetch-pack.c:1369
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "s'esperava «%s», s'ha rebut «%s»"
 
-#: fetch-pack.c:1398
+#: fetch-pack.c:1403
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "línia de confirmació inesperada: «%s»"
 
-#: fetch-pack.c:1403
+#: fetch-pack.c:1408
 #, c-format
 msgid "error processing acks: %d"
 msgstr "s'ha produït un error en processar els acks: %d"
 
-#: fetch-pack.c:1413
+#: fetch-pack.c:1418
 msgid "expected packfile to be sent after 'ready'"
 msgstr "s'esperava l'enviament del fitxer de paquet després de «ready»"
 
-#: fetch-pack.c:1415
+#: fetch-pack.c:1420
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr "s'esperava que no s'enviés cap altra secció després de no «ready»"
 
-#: fetch-pack.c:1456
+#: fetch-pack.c:1461
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "s'ha produït un error en processar la informació superficial: %d"
 
-#: fetch-pack.c:1505
+#: fetch-pack.c:1510
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "s'esperava wanted-ref, s'ha rebut «%s»"
 
-#: fetch-pack.c:1510
+#: fetch-pack.c:1515
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "wanted-ref inesperat: «%s»"
 
-#: fetch-pack.c:1515
+#: fetch-pack.c:1520
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "s'ha produït un error en processar les referències desitjades: %d"
 
-#: fetch-pack.c:1545
+#: fetch-pack.c:1550
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: s'esperava un paquet de final de resposta"
 
-#: fetch-pack.c:1949
+#: fetch-pack.c:1959
 msgid "no matching remote head"
 msgstr "no hi ha cap HEAD remot coincident"
 
-#: fetch-pack.c:1972 builtin/clone.c:581
+#: fetch-pack.c:1982 builtin/clone.c:581
 msgid "remote did not send all necessary objects"
 msgstr "el remot no ha enviat tots els objectes necessaris"
 
-#: fetch-pack.c:2075
+#: fetch-pack.c:2085
 msgid "unexpected 'ready' from remote"
 msgstr "«ready» no esperat des del remot"
 
-#: fetch-pack.c:2098
+#: fetch-pack.c:2108
 #, c-format
 msgid "no such remote ref %s"
 msgstr "no existeix la referència remota %s"
 
-#: fetch-pack.c:2101
+#: fetch-pack.c:2111
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr "El servidor no permet sol·licitar objectes no anunciats %s"
 
-#: gpg-interface.c:329 gpg-interface.c:449 gpg-interface.c:900
-#: gpg-interface.c:916
+#: gpg-interface.c:329 gpg-interface.c:457 gpg-interface.c:974
+#: gpg-interface.c:990
 msgid "could not create temporary file"
 msgstr "no s'ha pogut crear el fitxer temporal"
 
-#: gpg-interface.c:332 gpg-interface.c:452
+#: gpg-interface.c:332 gpg-interface.c:460
 #, c-format
 msgid "failed writing detached signature to '%s'"
-msgstr "s'ha produït un error en escriure la signatura separada a «%s»"
+msgstr ""
+"s'ha produït un error en escriure la clau de signatura separada a «%s»"
 
-#: gpg-interface.c:443
-#, fuzzy
+#: gpg-interface.c:451
 msgid ""
 "gpg.ssh.allowedSignersFile needs to be configured and exist for ssh "
 "signature verification"
@@ -4442,8 +4435,7 @@ msgstr ""
 "gpg.ssh.allowedSignersFile s'ha de configurar i existeix per a la "
 "verificació de la signatura ssh"
 
-#: gpg-interface.c:467
-#, fuzzy
+#: gpg-interface.c:480
 msgid ""
 "ssh-keygen -Y find-principals/verify is needed for ssh signature "
 "verification (available in openssh version 8.2p1+)"
@@ -4451,73 +4443,68 @@ msgstr ""
 "ssh-keygen -Y find-principals/verify és necessari per a la verificació de la"
 " signatura ssh (disponible a opensh versió 8.2p1+)"
 
-#: gpg-interface.c:521
-#, c-format, fuzzy
+#: gpg-interface.c:536
+#, c-format
 msgid "ssh signing revocation file configured but not found: %s"
-msgstr ""
-"ssh signatura fitxer de revocació configurat però no trobat: percentatges"
+msgstr "fitxer de revocació de la signatura ssh configurat però no trobat: %s"
 
-#: gpg-interface.c:574
-#, fuzzy, c-format
+#: gpg-interface.c:624
+#, c-format
 msgid "bad/incompatible signature '%s'"
-msgstr "%s és incompatible amb %s"
+msgstr "la signatura «%s» és incompatible o està malmesa"
 
-#: gpg-interface.c:733 gpg-interface.c:738
-#, fuzzy, c-format
+#: gpg-interface.c:801 gpg-interface.c:806
+#, c-format
 msgid "failed to get the ssh fingerprint for key '%s'"
-msgstr ""
-"s'ha produït un error en obtenir el remot per defecte pel submòdul «%s»"
+msgstr "no s'ha pogut obtenir l'empremta ssh de la clau  «%s»"
 
-#: gpg-interface.c:760
-#, fuzzy
+#: gpg-interface.c:829
 msgid ""
 "either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured"
-msgstr "usuari.signingkey o gpg.ssh.defaultKeyCommand ha de ser configurat"
-
-#: gpg-interface.c:778
-#, c-format, fuzzy
-msgid "gpg.ssh.defaultKeycommand succeeded but returned no keys: %s %s"
 msgstr ""
-"gpg.ssh.defaultKeycommand ha tingut èxit però no ha retornat cap clau: "
-"percentatge"
+"O bé user.signingkey o gpg.ssh.defaultKeyCommand han de ser configurats"
 
-#: gpg-interface.c:784
-#, c-format, fuzzy
+#: gpg-interface.c:851
+#, c-format
+msgid "gpg.ssh.defaultKeyCommand succeeded but returned no keys: %s %s"
+msgstr ""
+"gpg.ssh.defaultKeyCommand ha tingut èxit però no ha retornat cap clau: %s %s"
+
+#: gpg-interface.c:857
+#, c-format
 msgid "gpg.ssh.defaultKeyCommand failed: %s %s"
-msgstr "gpg.ssh.defaultKeyCommand ha fallat: percentatge"
+msgstr "gpg.ssh.defaultKeyCommand ha fallat: %s %s"
 
-#: gpg-interface.c:872
+#: gpg-interface.c:945
 msgid "gpg failed to sign the data"
 msgstr "gpg ha fallat en signar les dades"
 
-#: gpg-interface.c:893
-#, fuzzy
+#: gpg-interface.c:967
 msgid "user.signingkey needs to be set for ssh signing"
-msgstr "usuari.signingkey s'ha d'establir per signar ssh"
+msgstr "user.signingkey s'ha d'establir per signar ssh"
 
-#: gpg-interface.c:904
-#, fuzzy, c-format
+#: gpg-interface.c:978
+#, c-format
 msgid "failed writing ssh signing key to '%s'"
-msgstr "s'ha produït un error en escriure la signatura separada a «%s»"
+msgstr "s'ha produït un error en escriure la clau de signatura ssh a «%s»"
 
-#: gpg-interface.c:922
-#, fuzzy, c-format
+#: gpg-interface.c:996
+#, c-format
 msgid "failed writing ssh signing key buffer to '%s'"
-msgstr "s'ha produït un error en escriure la signatura separada a «%s»"
+msgstr "s'ha produït un error en escriure la clau de signatura ssh a «%s»"
 
-#: gpg-interface.c:940
-#, fuzzy
+#: gpg-interface.c:1014
 msgid ""
 "ssh-keygen -Y sign is needed for ssh signing (available in openssh version "
 "8.2p1+)"
 msgstr ""
-"ssh-keygen el signe -Y és necessari per signar ssh (disponible a opensh "
-"versió 8.2p1+)"
+"ssh-keygen -Y sign és necessari per signar ssh (disponible a openssh versió "
+"8.2p1+)"
 
-#: gpg-interface.c:952
-#, fuzzy, c-format
+#: gpg-interface.c:1026
+#, c-format
 msgid "failed reading ssh signing data buffer from '%s'"
-msgstr "s'ha produït un error en escriure la signatura separada a «%s»"
+msgstr "s'ha produït un error en llegir la signatura ssh des de «%s»"
 
 #: graph.c:98
 #, c-format
@@ -4532,18 +4519,18 @@ msgstr ""
 "el patró indicat conté byte NULL (via -f <fitxer>). Això només és compatible"
 " amb -P sota PCRE v2"
 
-#: grep.c:1907
+#: grep.c:1942
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr "«%s»: no s'ha pogut llegir %s"
 
-#: grep.c:1924 setup.c:176 builtin/clone.c:302 builtin/diff.c:90
+#: grep.c:1959 setup.c:177 builtin/clone.c:302 builtin/diff.c:90
 #: builtin/rm.c:136
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "s'ha produït un error en fer stat a «%s»"
 
-#: grep.c:1935
+#: grep.c:1970
 #, c-format
 msgid "'%s': short read"
 msgstr "«%s»: lectura curta"
@@ -4664,9 +4651,9 @@ msgid "Continuing under the assumption that you meant '%s'."
 msgstr "El procés continuarà, pressuposant que volíeu dir «%s»."
 
 #: help.c:646
-#, c-format, fuzzy
-msgid "Run '%s' instead? (y/N)"
-msgstr "Voleu executar «%s»? (s/N)"
+#, c-format
+msgid "Run '%s' instead [y/N]? "
+msgstr "Voleu executar «%s» en el seu lloc? [y/N]? "
 
 #: help.c:654
 #, c-format
@@ -4884,9 +4871,9 @@ msgid "invalid value '%s' for lsrefs.unborn"
 msgstr "valor «%s» no vàlid per a «lsrefs.unborn»"
 
 #: ls-refs.c:174
-#, fuzzy, c-format
+#, c-format
 msgid "unexpected line: '%s'"
-msgstr "wanted-ref inesperat: «%s»"
+msgstr "línia inesperada: «%s»"
 
 #: ls-refs.c:178
 msgid "expected flush after ls-refs arguments"
@@ -4896,7 +4883,7 @@ msgstr "s'esperava una neteja després dels arguments ls-refs"
 msgid "quoted CRLF detected"
 msgstr "CRLF citat detectat"
 
-#: mailinfo.c:1254 builtin/am.c:177 builtin/mailinfo.c:46
+#: mailinfo.c:1254 builtin/am.c:184 builtin/mailinfo.c:46
 #, c-format
 msgid "bad action '%s' for '%s'"
 msgstr "acció «%s» incorrecta per a «%s»"
@@ -5134,7 +5121,7 @@ msgstr "submòdul"
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "CONFLICTE (%s): Conflicte de fusió en %s"
 
-#: merge-ort.c:3856
+#: merge-ort.c:3869
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
@@ -5143,8 +5130,8 @@ msgstr ""
 "CONFLICTE: (modificació/supressió): %s suprimit a %s i modificat a %s. La "
 "versió %s de %s s'ha deixat en l'arbre."
 
-#: merge-ort.c:4152
-#, fuzzy, c-format
+#: merge-ort.c:4165
+#, c-format
 msgid ""
 "Note: %s not up to date and in way of checking out conflicted version; old "
 "copy renamed to %s"
@@ -5154,7 +5141,7 @@ msgstr ""
 
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
-#: merge-ort.c:4521
+#: merge-ort.c:4534
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
 msgstr ""
@@ -5169,7 +5156,7 @@ msgstr ""
 "Els canvis locals als fitxers següents se sobreescriuran per la fusió:\n"
 "  %s"
 
-#: merge-ort-wrappers.c:33 merge-recursive.c:3482 builtin/merge.c:403
+#: merge-ort-wrappers.c:33 merge-recursive.c:3482 builtin/merge.c:405
 msgid "Already up to date."
 msgstr "Ja està al dia."
 
@@ -5462,7 +5449,7 @@ msgstr "la fusió no ha retornat cap comissió"
 msgid "Could not parse object '%s'"
 msgstr "No s'ha pogut analitzar l'objecte «%s»"
 
-#: merge-recursive.c:3834 builtin/merge.c:718 builtin/merge.c:904
+#: merge-recursive.c:3834 builtin/merge.c:720 builtin/merge.c:906
 #: builtin/stash.c:489
 msgid "Unable to write index."
 msgstr "No s'ha pogut escriure l'índex."
@@ -5471,8 +5458,8 @@ msgstr "No s'ha pogut escriure l'índex."
 msgid "failed to read the cache"
 msgstr "s'ha produït un error en llegir la memòria cau"
 
-#: merge.c:102 rerere.c:704 builtin/am.c:1933 builtin/am.c:1967
-#: builtin/checkout.c:590 builtin/checkout.c:842 builtin/clone.c:706
+#: merge.c:102 rerere.c:704 builtin/am.c:1988 builtin/am.c:2022
+#: builtin/checkout.c:598 builtin/checkout.c:853 builtin/clone.c:706
 #: builtin/stash.c:269
 msgid "unable to write new index file"
 msgstr "no s'ha pogut escriure un fitxer d'índex nou"
@@ -5481,227 +5468,224 @@ msgstr "no s'ha pogut escriure un fitxer d'índex nou"
 msgid "multi-pack-index OID fanout is of the wrong size"
 msgstr "l'OID de l'índex multipaquet és d'una mida incorrecta"
 
-#: midx.c:109
+#: midx.c:111
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "el fitxer de l'índex multipaquet %s és massa petit"
 
-#: midx.c:125
+#: midx.c:127
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr ""
 "la signatura de l'índex multipaquet 0x%08x no coincideix amb la signatura "
 "0x%08x"
 
-#: midx.c:130
+#: midx.c:132
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "no es reconeix la versió %d de l'índex multipaquet"
 
-#: midx.c:135
+#: midx.c:137
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr ""
 "la versió del hash índex multipaquet %u no coincideix amb la versió %u"
 
-#: midx.c:152
+#: midx.c:154
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "falta un fragment de nom de paquet necessari al multi-index"
 
-#: midx.c:154
+#: midx.c:156
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "falta un fragment «fanout» OID necessari al multi-pack-index"
 
-#: midx.c:156
+#: midx.c:158
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr "falta un fragment de cerca «fanout» OID necessari al multi-pack-index"
 
-#: midx.c:158
+#: midx.c:160
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr "falta un fragment necessari dels desplaçaments al multi-pack-index"
 
-#: midx.c:174
+#: midx.c:176
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr ""
 "els noms de paquet de l'índex multipaquet estan desordenats «%s» abans de "
 "«%s»"
 
-#: midx.c:221
+#: midx.c:224
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr "pack-int-id: %u incorrecte (%u paquets en total)"
 
-#: midx.c:271
+#: midx.c:274
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr ""
 "l'índex multipaquet emmagatzema un desplaçament de 64 bits, però off_t és "
 "massa petit"
 
-#: midx.c:502
+#: midx.c:505
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "no s'ha pogut afegir el fitxer de paquet «%s»"
 
-#: midx.c:508
+#: midx.c:511
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "no s'ha pogut obrir l'índex del paquet «%s»"
 
-#: midx.c:576
+#: midx.c:579
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "no s'ha pogut localitzar l'objecte %d en el fitxer de paquet"
 
-#: midx.c:892
+#: midx.c:895
 msgid "cannot store reverse index file"
 msgstr "no es pot emmagatzemar el fitxer d'índex invers"
 
-#: midx.c:990
-#, fuzzy, c-format
+#: midx.c:993
+#, c-format
 msgid "could not parse line: %s"
-msgstr "no s'ha pogut analitzar %s"
+msgstr "no s'ha pogut analitzar la línia: %s"
 
-#: midx.c:992
-#, fuzzy, c-format
+#: midx.c:995
+#, c-format
 msgid "malformed line: %s"
-msgstr "línia d'entrada mal formada: «%s»."
+msgstr "línia mal formada: «%s»."
 
-#: midx.c:1159
+#: midx.c:1162
 msgid "ignoring existing multi-pack-index; checksum mismatch"
 msgstr ""
 "s'està ignorant l'índex multipaquet existent; la suma de verificació no "
 "coincideix"
 
-#: midx.c:1184
-#, fuzzy
+#: midx.c:1187
 msgid "could not load pack"
-msgstr "no s'ha pogut finalitzar «%s»"
+msgstr "no s'ha pogut carregar el paquet"
 
-#: midx.c:1190
-#, fuzzy, c-format
+#: midx.c:1193
+#, c-format
 msgid "could not open index for %s"
 msgstr "s'ha produït un error en obrir l'índex per «%s»"
 
-#: midx.c:1201
+#: midx.c:1204
 msgid "Adding packfiles to multi-pack-index"
 msgstr "S'estan afegint fitxers empaquetats a l'índex multipaquet"
 
-#: midx.c:1244
+#: midx.c:1247
 #, c-format
 msgid "unknown preferred pack: '%s'"
 msgstr "paquet preferit desconegut: «%s»"
 
-#: midx.c:1289
-#, fuzzy, c-format
+#: midx.c:1292
+#, c-format
 msgid "cannot select preferred pack %s with no objects"
-msgstr "no es poden suprimir paquets en un repositori d'objectes preciosos"
+msgstr "no es pot selecionar un paquet preferit %s sense objectes"
 
-#: midx.c:1321
+#: midx.c:1324
 #, c-format
 msgid "did not see pack-file %s to drop"
 msgstr "no s'ha vist caure el fitxer empaquetat %s"
 
-#: midx.c:1367
+#: midx.c:1370
 #, c-format
 msgid "preferred pack '%s' is expired"
 msgstr "el paquet preferit «%s» ha caducat"
 
-#: midx.c:1380
+#: midx.c:1383
 msgid "no pack files to index."
 msgstr "no hi ha fitxers empaquetats a indexar."
 
-#: midx.c:1417
-#, fuzzy
+#: midx.c:1420
 msgid "could not write multi-pack bitmap"
-msgstr "no s'ha pogut escriure la plantilla de comissió"
+msgstr "no s'han pogut escriure els mapes de bits dels multipaquets"
 
-#: midx.c:1427
-#, fuzzy
+#: midx.c:1430
 msgid "could not write multi-pack-index"
-msgstr "no s'han pogut netejar els percentatges multi-paquet"
+msgstr "no s'ha pogut escriure l'índex multipaquet"
 
-#: midx.c:1486 builtin/clean.c:37
+#: midx.c:1489 builtin/clean.c:37
 #, c-format
 msgid "failed to remove %s"
 msgstr "s'ha produït un error en eliminar %s"
 
-#: midx.c:1517
+#: midx.c:1522
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "no s'ha pogut netejar l'índex multipaquet a %s"
 
-#: midx.c:1577
+#: midx.c:1585
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr ""
 "el fitxer de l'índex multipaquet existeix, però no s'ha pogut analitzar"
 
-#: midx.c:1585
+#: midx.c:1593
 msgid "incorrect checksum"
 msgstr "suma de verificació incorrecta"
 
-#: midx.c:1588
+#: midx.c:1596
 msgid "Looking for referenced packfiles"
 msgstr "S'estan cercant fitxers empaquetats referenciats"
 
-#: midx.c:1603
+#: midx.c:1611
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 msgstr ""
 "oid fanout desordenat: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 
-#: midx.c:1608
+#: midx.c:1616
 msgid "the midx contains no oid"
 msgstr "el midx no conté cap oid"
 
-#: midx.c:1617
+#: midx.c:1625
 msgid "Verifying OID order in multi-pack-index"
 msgstr "S'està verificant l'ordre OID a l'índex multipaquet"
 
-#: midx.c:1626
+#: midx.c:1634
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr "oid lookup desordenat: oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1646
+#: midx.c:1654
 msgid "Sorting objects by packfile"
 msgstr "S'estan ordenant els objectes per fitxer empaquetats"
 
-#: midx.c:1653
+#: midx.c:1661
 msgid "Verifying object offsets"
 msgstr "S'estan verificant els desplaçaments dels objectes"
 
-#: midx.c:1669
+#: midx.c:1677
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "no s'ha pogut carregar l'entrada del paquet per a oid[%d] = %s"
 
-#: midx.c:1675
+#: midx.c:1683
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "no s'ha pogut carregar l'índex del paquet per al fitxer empaquetat %s"
 
-#: midx.c:1684
+#: midx.c:1692
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr ""
 "desplaçament incorrecte de l'objecte per a oid[%d] = %s: %<PRIx64> != "
 "%<PRIx64>"
 
-#: midx.c:1709
+#: midx.c:1719
 msgid "Counting referenced objects"
 msgstr "S'estan comptant els objectes referenciats"
 
-#: midx.c:1719
+#: midx.c:1729
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "S'estan cercant i suprimint els fitxers de paquets no referenciats"
 
-#: midx.c:1911
+#: midx.c:1921
 msgid "could not start pack-objects"
 msgstr "no s'ha pogut iniciar el pack-objects"
 
-#: midx.c:1931
+#: midx.c:1941
 msgid "could not finish pack-objects"
 msgstr "no s'ha pogut finalitzar el pack-objects"
 
@@ -5756,265 +5740,265 @@ msgstr "S'està refusant reescriure les notes en %s (fora de refs/notes/)"
 msgid "Bad %s value: '%s'"
 msgstr "Valor erroni de %s: «%s»"
 
-#: object-file.c:459
+#: object-file.c:456
 #, c-format
 msgid "object directory %s does not exist; check .git/objects/info/alternates"
 msgstr ""
 "no existeix el directori d'objecte %s; comproveu "
 ".git/objects/info/alternates"
 
-#: object-file.c:517
+#: object-file.c:514
 #, c-format
 msgid "unable to normalize alternate object path: %s"
 msgstr "no s'ha pogut normalitzar el camí a l'objecte alternatiu: %s"
 
-#: object-file.c:591
+#: object-file.c:588
 #, c-format
 msgid "%s: ignoring alternate object stores, nesting too deep"
 msgstr ""
 "%s: s'estan ignorant els emmagatzematges alternatius d'objectes, imbricació "
 "massa profunda"
 
-#: object-file.c:598
+#: object-file.c:595
 #, c-format
 msgid "unable to normalize object directory: %s"
 msgstr "no s'ha pogut normalitzar el directori de l'objecte: %s"
 
-#: object-file.c:641
+#: object-file.c:638
 msgid "unable to fdopen alternates lockfile"
 msgstr "no s'ha pogut fer «fdopen» al fitxer de bloqueig alternatiu"
 
-#: object-file.c:659
+#: object-file.c:656
 msgid "unable to read alternates file"
 msgstr "no es pot llegir el fitxer «alternates»"
 
-#: object-file.c:666
+#: object-file.c:663
 msgid "unable to move new alternates file into place"
 msgstr "no s'ha pogut moure el nou fitxer «alternates» al lloc"
 
-#: object-file.c:701
+#: object-file.c:741
 #, c-format
 msgid "path '%s' does not exist"
 msgstr "el camí «%s» no existeix"
 
-#: object-file.c:722
+#: object-file.c:762
 #, c-format
 msgid "reference repository '%s' as a linked checkout is not supported yet."
 msgstr ""
 "encara no s'admet el repositori de referència «%s» com a agafament enllaçat."
 
-#: object-file.c:728
+#: object-file.c:768
 #, c-format
 msgid "reference repository '%s' is not a local repository."
 msgstr "el repositori de referència «%s» no és un repositori local."
 
-#: object-file.c:734
+#: object-file.c:774
 #, c-format
 msgid "reference repository '%s' is shallow"
 msgstr "el repositori de referència «%s» és superficial"
 
-#: object-file.c:742
+#: object-file.c:782
 #, c-format
 msgid "reference repository '%s' is grafted"
 msgstr "el repositori de referència «%s» és empeltat"
 
-#: object-file.c:773
+#: object-file.c:813
 #, c-format
 msgid "could not find object directory matching %s"
 msgstr "no s'ha pogut trobar el directori de l'objecte que coincideixi amb %s"
 
-#: object-file.c:823
+#: object-file.c:863
 #, c-format
 msgid "invalid line while parsing alternate refs: %s"
 msgstr ""
 "línia no vàlida quan s'analitzaven les referències de l'«alternate»: %s"
 
-#: object-file.c:973
+#: object-file.c:1013
 #, c-format
 msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
 msgstr "s'està intentant fer mmap %<PRIuMAX> per sobre del límit %<PRIuMAX>"
 
-#: object-file.c:1008
+#: object-file.c:1048
 #, c-format
 msgid "mmap failed%s"
 msgstr "mmap ha fallat%s"
 
-#: object-file.c:1174
+#: object-file.c:1214
 #, c-format
 msgid "object file %s is empty"
 msgstr "el tipus d'objecte %s és buit"
 
-#: object-file.c:1293 object-file.c:2499
+#: object-file.c:1333 object-file.c:2542
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr "objecte solt corrupte «%s»"
 
-#: object-file.c:1295 object-file.c:2503
+#: object-file.c:1335 object-file.c:2546
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr "brossa al final de l'objecte solt «%s»"
 
-#: object-file.c:1417
+#: object-file.c:1457
 #, c-format
 msgid "unable to parse %s header"
 msgstr "no s'ha pogut analitzar la capçalera %s"
 
-#: object-file.c:1419
+#: object-file.c:1459
 msgid "invalid object type"
 msgstr "tipus d'objecte és incorrecte"
 
-#: object-file.c:1430
+#: object-file.c:1470
 #, c-format
 msgid "unable to unpack %s header"
 msgstr "no s'ha pogut desempaquetar la capçalera %s"
 
-#: object-file.c:1434
-#, c-format, fuzzy
+#: object-file.c:1474
+#, c-format
 msgid "header for %s too long, exceeds %d bytes"
-msgstr "la capçalera per a percentatges és massa llarga, supera els bytes"
+msgstr "la capçalera per a %s és massa llarga, supera els %d bytes"
 
-#: object-file.c:1664
+#: object-file.c:1704
 #, c-format
 msgid "failed to read object %s"
 msgstr "s'ha produït un error en llegir l'objecte %s"
 
-#: object-file.c:1668
+#: object-file.c:1708
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr "no s'ha trobat el reemplaçament %s per a %s"
 
-#: object-file.c:1672
+#: object-file.c:1712
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr "l'objecte solt %s (emmagatzemat a %s) és corrupte"
 
-#: object-file.c:1676
+#: object-file.c:1716
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr "l'objecte empaquetat %s (emmagatzemat a %s) és corrupte"
 
-#: object-file.c:1781
+#: object-file.c:1821
 #, c-format
 msgid "unable to write file %s"
 msgstr "no s'ha pogut escriure al fitxer %s"
 
-#: object-file.c:1788
+#: object-file.c:1828
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr "no s'ha pogut establir el permís a «%s»"
 
-#: object-file.c:1795
+#: object-file.c:1835
 msgid "file write error"
 msgstr "s'ha produït un error en escriure al fitxer"
 
-#: object-file.c:1815
+#: object-file.c:1858
 msgid "error when closing loose object file"
 msgstr "error en tancar el fitxer d'objecte solt"
 
-#: object-file.c:1882
+#: object-file.c:1925
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 "permisos insuficients per a afegir un objecte a la base de dades del "
 "repositori %s"
 
-#: object-file.c:1884
+#: object-file.c:1927
 msgid "unable to create temporary file"
 msgstr "no s'ha pogut crear un fitxer temporal"
 
-#: object-file.c:1908
+#: object-file.c:1951
 msgid "unable to write loose object file"
 msgstr "no s'ha pogut escriure el fitxer d'objecte solt"
 
-#: object-file.c:1914
+#: object-file.c:1957
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr "no s'ha pogut desinflar l'object nou %s (%d)"
 
-#: object-file.c:1918
+#: object-file.c:1961
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr "ha fallat deflateEnd a l'objecte %s(%d)"
 
-#: object-file.c:1922
+#: object-file.c:1965
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr "confós per la font de dades inestable de l'objecte per a %s"
 
-#: object-file.c:1933 builtin/pack-objects.c:1243
+#: object-file.c:1976 builtin/pack-objects.c:1243
 #, c-format
 msgid "failed utime() on %s"
 msgstr "ha fallat utime() a %s"
 
-#: object-file.c:2011
+#: object-file.c:2054
 #, c-format
 msgid "cannot read object for %s"
 msgstr "no es pot llegir l'objecte per a %s"
 
-#: object-file.c:2062
+#: object-file.c:2105
 msgid "corrupt commit"
 msgstr "comissió corrupta"
 
-#: object-file.c:2070
+#: object-file.c:2113
 msgid "corrupt tag"
 msgstr "etiqueta corrupta"
 
-#: object-file.c:2170
+#: object-file.c:2213
 #, c-format
 msgid "read error while indexing %s"
 msgstr "error de lectura mentre s'indexava %s"
 
-#: object-file.c:2173
+#: object-file.c:2216
 #, c-format
 msgid "short read while indexing %s"
 msgstr "lectura curta mentre s'indexa %s"
 
-#: object-file.c:2246 object-file.c:2256
+#: object-file.c:2289 object-file.c:2299
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr "%s: no s'han pogut inserir a la base de dades"
 
-#: object-file.c:2262
+#: object-file.c:2305
 #, c-format
 msgid "%s: unsupported file type"
 msgstr "%s: tipus de fitxer no suportat"
 
-#: object-file.c:2286 builtin/fetch.c:1445
+#: object-file.c:2329 builtin/fetch.c:1453
 #, c-format
 msgid "%s is not a valid object"
 msgstr "%s no és un objecte vàlid"
 
-#: object-file.c:2288
+#: object-file.c:2331
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr "%s no és un objecte de «%s» vàlid"
 
-#: object-file.c:2315
+#: object-file.c:2358
 #, c-format
 msgid "unable to open %s"
 msgstr "no s'ha pogut obrir %s"
 
-#: object-file.c:2510
+#: object-file.c:2553
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
 msgstr "no coincideix la suma per a %s (s'esperava %s)"
 
-#: object-file.c:2533
+#: object-file.c:2576
 #, c-format
 msgid "unable to mmap %s"
 msgstr "no s'ha pogut fer «mmap» %s"
 
-#: object-file.c:2539
+#: object-file.c:2582
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr "no s'ha pogut desempaquetar la capçalera de %s"
 
-#: object-file.c:2544
+#: object-file.c:2587
 #, c-format
 msgid "unable to parse header of %s"
 msgstr "no s'ha pogut analitzar la capçalera de %s"
 
-#: object-file.c:2555
+#: object-file.c:2598
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr "no s'han pogut desempaquetar els continguts de %s"
@@ -6144,27 +6128,25 @@ msgstr "no s'ha pogut analitzar l'objecte: %s"
 msgid "hash mismatch %s"
 msgstr "el resum no coincideix %s"
 
-#: pack-bitmap.c:348
-#, fuzzy
+#: pack-bitmap.c:353
 msgid "multi-pack bitmap is missing required reverse index"
-msgstr "falta un fragment necessari dels desplaçaments al multi-pack-index"
+msgstr "falta l'índex invers necessari al mapa de bits multipaquet"
 
-#: pack-bitmap.c:424
-#, fuzzy
+#: pack-bitmap.c:429
 msgid "load_reverse_index: could not open pack"
-msgstr "Loadreverseindex: no s'ha pogut obrir el paquet"
+msgstr "load_reverse_index: no s'ha pogut obrir el paquet"
 
-#: pack-bitmap.c:1064 pack-bitmap.c:1070 builtin/pack-objects.c:2424
+#: pack-bitmap.c:1069 pack-bitmap.c:1075 builtin/pack-objects.c:2424
 #, c-format
 msgid "unable to get size of %s"
 msgstr "no s'ha pogut obtenir la mida de %s"
 
-#: pack-bitmap.c:1916
-#, fuzzy, c-format
+#: pack-bitmap.c:1935
+#, c-format
 msgid "could not find %s in pack %s at offset %<PRIuMAX>"
-msgstr "no s'ha pogut finalitzar «%s»"
+msgstr "no s'ha pogut trobar %s al paquet %s al desplaçament %<PRIuMAX>"
 
-#: pack-bitmap.c:1952 builtin/rev-list.c:92
+#: pack-bitmap.c:1971 builtin/rev-list.c:92
 #, c-format
 msgid "unable to get disk usage of %s"
 msgstr "no s'ha pogut obtenir l'ús del disc de %s"
@@ -6213,46 +6195,51 @@ msgstr "s'ha produït un error en fer %s llegible"
 msgid "could not write '%s' promisor file"
 msgstr "no s'ha pogut escriure «%s» al fitxer «promisor»"
 
-#: packfile.c:626
+#: packfile.c:627
 msgid "offset before end of packfile (broken .idx?)"
 msgstr "desplaçament abans de la fi del fitxer de paquet (.idx trencat?)"
 
-#: packfile.c:656
+#: packfile.c:657
 #, c-format
 msgid "packfile %s cannot be mapped%s"
 msgstr "el fitxer de paquet %s no es pot mapar%s"
 
-#: packfile.c:1923
+#: packfile.c:1924
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr ""
 "desplaçament abans d'inici d'índex de paquet per a %s (índex corromput?)"
 
-#: packfile.c:1927
+#: packfile.c:1928
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr ""
 "desplaçament més enllà de la fi d'índex de paquet per a %s (índex truncat?)"
 
-#: parse-options-cb.c:20 parse-options-cb.c:24 builtin/commit-graph.c:175
+#: parse-options-cb.c:21 parse-options-cb.c:25 builtin/commit-graph.c:175
 #, c-format
 msgid "option `%s' expects a numerical value"
 msgstr "l'opció «%s» espera un valor numèric"
 
-#: parse-options-cb.c:41
+#: parse-options-cb.c:42
 #, c-format
 msgid "malformed expiration date '%s'"
 msgstr "data de venciment «%s» mal formada"
 
-#: parse-options-cb.c:54
+#: parse-options-cb.c:55
 #, c-format
 msgid "option `%s' expects \"always\", \"auto\", or \"never\""
 msgstr "l'opció «%s» espera «always», «auto» o «never»"
 
-#: parse-options-cb.c:132 parse-options-cb.c:149
+#: parse-options-cb.c:133 parse-options-cb.c:150
 #, c-format
 msgid "malformed object name '%s'"
 msgstr "nom d'objecte «%s» mal format"
+
+#: parse-options-cb.c:307
+#,  c-format
+msgid "option `%s' expects \"%s\" or \"%s\""
+msgstr "l'opció «%s» espera «%s» o «%s»"
 
 #: parse-options.c:58
 #, c-format
@@ -6289,43 +6276,43 @@ msgstr "%s espera un valor enter no negatiu amb un sufix opcional k/m/g"
 msgid "ambiguous option: %s (could be --%s%s or --%s%s)"
 msgstr "opció ambigua: %s (pot ser --%s%s o --%s%s)"
 
-#: parse-options.c:427 parse-options.c:435
+#: parse-options.c:428 parse-options.c:436
 #, c-format
 msgid "did you mean `--%s` (with two dashes)?"
 msgstr "voleu dir «--%s» (amb dos guionets)?"
 
-#: parse-options.c:677 parse-options.c:1053
+#: parse-options.c:678 parse-options.c:1054
 #, c-format
 msgid "alias of --%s"
 msgstr "àlies de --%s"
 
-#: parse-options.c:891
+#: parse-options.c:892
 #, c-format
 msgid "unknown option `%s'"
 msgstr "opció desconeguda «%s»"
 
-#: parse-options.c:893
+#: parse-options.c:894
 #, c-format
 msgid "unknown switch `%c'"
 msgstr "«switch» «%c» desconegut"
 
-#: parse-options.c:895
+#: parse-options.c:896
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
 msgstr "opció no ascii desconeguda en la cadena: «%s»"
 
-#: parse-options.c:919
+#: parse-options.c:920
 msgid "..."
 msgstr "..."
 
-#: parse-options.c:933
+#: parse-options.c:934
 #, c-format
 msgid "usage: %s"
 msgstr "ús: %s"
 
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
-#: parse-options.c:948
+#: parse-options.c:949
 #, c-format
 msgid "   or: %s"
 msgstr "   o: %s"
@@ -6348,17 +6335,17 @@ msgstr "   o: %s"
 #. function. The "%s" is a line in the (hopefully already
 #. translated) N_() usage string, which contained embedded
 #. newlines before we split it up.
-#: parse-options.c:969
-#, c-format, fuzzy
+#: parse-options.c:970
+#, c-format
 msgid "%*s%s"
-msgstr "%*s%"
+msgstr "%*s%s"
 
-#: parse-options.c:992
+#: parse-options.c:993
 #, c-format
 msgid "    %s"
 msgstr "    %s"
 
-#: parse-options.c:1039
+#: parse-options.c:1040
 msgid "-NUM"
 msgstr "-NUM"
 
@@ -6493,17 +6480,17 @@ msgstr "error de lectura"
 msgid "the remote end hung up unexpectedly"
 msgstr "el remot ha penjat inesperadament"
 
-#: pkt-line.c:390 pkt-line.c:392
+#: pkt-line.c:417 pkt-line.c:419
 #, c-format
 msgid "protocol error: bad line length character: %.4s"
 msgstr "error de protocol: caràcter de longitud de línia erroni: %.4s"
 
-#: pkt-line.c:407 pkt-line.c:409 pkt-line.c:415 pkt-line.c:417
+#: pkt-line.c:434 pkt-line.c:436 pkt-line.c:442 pkt-line.c:444
 #, c-format
 msgid "protocol error: bad line length %d"
 msgstr "error de protocol: longitud de línia errònia %d"
 
-#: pkt-line.c:434 sideband.c:165
+#: pkt-line.c:472 sideband.c:165
 #, c-format
 msgid "remote error: %s"
 msgstr "error remot: %s"
@@ -6517,7 +6504,7 @@ msgstr "S'està actualitzant l'índex"
 msgid "unable to create threaded lstat: %s"
 msgstr "no s'han pogut crear lstat amb fils %s"
 
-#: pretty.c:988
+#: pretty.c:1051
 msgid "unable to parse --pretty format"
 msgstr "no s'ha pogut analitzar el format --pretty"
 
@@ -6554,7 +6541,7 @@ msgstr "no s'ha pogut iniciar «log»"
 msgid "could not read `log` output"
 msgstr "no s'ha pogut llegir la sortida de «log»"
 
-#: range-diff.c:97 sequencer.c:5603
+#: range-diff.c:97 sequencer.c:5602
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr "no s'ha pogut analitzar la comissió «%s»"
@@ -6577,60 +6564,56 @@ msgstr "no s'ha pogut llegir la capçalera de la gif «%.*s»"
 msgid "failed to generate diff"
 msgstr "s'ha produït un error en generar el diff"
 
-#: range-diff.c:559
-msgid "--left-only and --right-only are mutually exclusive"
-msgstr "--left-only i --right-only són mútuament excloents"
-
 #: range-diff.c:562 range-diff.c:564
 #, c-format
 msgid "could not parse log for '%s'"
 msgstr "no s'ha pogut llegir el fitxer de registre per a «%s»"
 
-#: read-cache.c:710
+#: read-cache.c:723
 #, c-format
 msgid "will not add file alias '%s' ('%s' already exists in index)"
 msgstr "no s'afegirà l'àlies «%s»: («%s» ja existeix en l'índex)"
 
-#: read-cache.c:726
+#: read-cache.c:739
 msgid "cannot create an empty blob in the object database"
 msgstr "no es pot crear un blob buit a la base de dades d'objectes"
 
-#: read-cache.c:748
+#: read-cache.c:761
 #, c-format
 msgid "%s: can only add regular files, symbolic links or git-directories"
 msgstr ""
 "%s: només pot afegir fitxers normals, enllaços simbòlics o directoris git"
 
-#: read-cache.c:753 builtin/submodule--helper.c:3241
+#: read-cache.c:766 builtin/submodule--helper.c:3242
 #, c-format
 msgid "'%s' does not have a commit checked out"
 msgstr "«%s» no té una comissió comprovada"
 
-#: read-cache.c:805
+#: read-cache.c:818
 #, c-format
 msgid "unable to index file '%s'"
 msgstr "no es pot llegir indexar el fitxer «%s»"
 
-#: read-cache.c:824
+#: read-cache.c:837
 #, c-format
 msgid "unable to add '%s' to index"
 msgstr "no s'ha pogut afegir «%s» a l'índex"
 
-#: read-cache.c:835
+#: read-cache.c:848
 #, c-format
 msgid "unable to stat '%s'"
 msgstr "no s'ha pogut fer «stat» a «%s»"
 
-#: read-cache.c:1373
+#: read-cache.c:1386
 #, c-format
 msgid "'%s' appears as both a file and as a directory"
 msgstr "«%s» apareix com a fitxer i com a directori"
 
-#: read-cache.c:1588
+#: read-cache.c:1601
 msgid "Refresh index"
 msgstr "Actualitza l'índex"
 
-#: read-cache.c:1720
+#: read-cache.c:1733
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -6639,7 +6622,7 @@ msgstr ""
 "index.version està establerta, però el valor no és vàlid.\n"
 "S'està usant la versió %i"
 
-#: read-cache.c:1730
+#: read-cache.c:1743
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -6648,143 +6631,143 @@ msgstr ""
 "GIT_INDEX_VERSION està establerta, però el valor no és vàlid.\n"
 "S'està usant la versió %i"
 
-#: read-cache.c:1786
+#: read-cache.c:1799
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr "signatura malmesa 0x%08x"
 
-#: read-cache.c:1789
+#: read-cache.c:1802
 #, c-format
 msgid "bad index version %d"
 msgstr "versió d'índex incorrecta %d"
 
-#: read-cache.c:1798
+#: read-cache.c:1811
 msgid "bad index file sha1 signature"
 msgstr "signatura sha1 malmesa al fitxer d'índex"
 
-#: read-cache.c:1832
+#: read-cache.c:1845
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr "l'índex usa l'extensió %.4s, que no es pot entendre"
 
-#: read-cache.c:1834
+#: read-cache.c:1847
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr "s'està ignorant l'extensió %.4s"
 
-#: read-cache.c:1871
+#: read-cache.c:1884
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr "format d'entrada d'índex desconeguda «0x%08x»"
 
-#: read-cache.c:1887
+#: read-cache.c:1900
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "camp del nom mal formatat l'índex, camí a prop «%s»"
 
-#: read-cache.c:1944
+#: read-cache.c:1957
 msgid "unordered stage entries in index"
 msgstr "entrades «stage» no ordenades en l'índex"
 
-#: read-cache.c:1947
+#: read-cache.c:1960
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr "múltiples entrades «stage» per al fitxer fusionat «%s»"
 
-#: read-cache.c:1950
+#: read-cache.c:1963
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr "entrades «stage» no ordenades per a «%s»"
 
-#: read-cache.c:2065 read-cache.c:2363 rerere.c:549 rerere.c:583 rerere.c:1095
-#: submodule.c:1662 builtin/add.c:603 builtin/check-ignore.c:183
-#: builtin/checkout.c:519 builtin/checkout.c:708 builtin/clean.c:987
+#: read-cache.c:2078 read-cache.c:2384 rerere.c:549 rerere.c:583 rerere.c:1095
+#: submodule.c:1662 builtin/add.c:600 builtin/check-ignore.c:183
+#: builtin/checkout.c:527 builtin/checkout.c:719 builtin/clean.c:1013
 #: builtin/commit.c:378 builtin/diff-tree.c:122 builtin/grep.c:519
-#: builtin/mv.c:148 builtin/reset.c:253 builtin/rm.c:293
-#: builtin/submodule--helper.c:327 builtin/submodule--helper.c:3201
+#: builtin/mv.c:148 builtin/reset.c:499 builtin/rm.c:293
+#: builtin/submodule--helper.c:327 builtin/submodule--helper.c:3202
 msgid "index file corrupt"
 msgstr "fitxer d'índex malmès"
 
-#: read-cache.c:2209
+#: read-cache.c:2222
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr "no s'ha pogut crear fil «load_cache_entries»: %s"
 
-#: read-cache.c:2222
+#: read-cache.c:2235
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr "no s'ha pogut unir al fil «load_cache_entries»: %s"
 
-#: read-cache.c:2255
+#: read-cache.c:2268
 #, c-format
 msgid "%s: index file open failed"
 msgstr "%s: ha fallat l'obertura del fitxer d'índex"
 
-#: read-cache.c:2259
+#: read-cache.c:2272
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr "%s: no es pot fer «stat» a l'índex obert"
 
-#: read-cache.c:2263
+#: read-cache.c:2276
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr "%s: fitxer d'índex més petit que s'esperava"
 
-#: read-cache.c:2267
+#: read-cache.c:2280
 #, c-format
 msgid "%s: unable to map index file%s"
 msgstr "%s: no es pot mapar el fitxer d'índex%s"
 
-#: read-cache.c:2310
+#: read-cache.c:2323
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr "no s'ha pogut crear un fil «load_index_extensions»: %s"
 
-#: read-cache.c:2337
+#: read-cache.c:2350
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr "no s'ha pogut unir un fil «load_index_extensions»: %s"
 
-#: read-cache.c:2375
+#: read-cache.c:2396
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr "no s'ha pogut refrescar l'índex compartit «%s»"
 
-#: read-cache.c:2434
+#: read-cache.c:2455
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr "índex malmès, s'esperava %s a %s, s'ha rebut %s"
 
-#: read-cache.c:3065 strbuf.c:1179 wrapper.c:641 builtin/merge.c:1147
+#: read-cache.c:3086 strbuf.c:1191 wrapper.c:641 builtin/merge.c:1150
 #, c-format
 msgid "could not close '%s'"
 msgstr "no s'ha pogut tancar «%s»"
 
-#: read-cache.c:3108
+#: read-cache.c:3129
 msgid "failed to convert to a sparse-index"
 msgstr "s'ha produït un error en convertir a un índex dispers"
 
-#: read-cache.c:3179
+#: read-cache.c:3200
 #, c-format
 msgid "could not stat '%s'"
 msgstr "no s'ha pogut fer stat a «%s»"
 
-#: read-cache.c:3192
+#: read-cache.c:3213
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "no s'ha pogut obrir el directori git: %s"
 
-#: read-cache.c:3204
+#: read-cache.c:3225
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "no s'ha pogut desenllaçar: %s"
 
-#: read-cache.c:3233
+#: read-cache.c:3254
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr "no s'han pogut corregir els bits de permisos en «%s»"
 
-#: read-cache.c:3390
+#: read-cache.c:3411
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr "%s: no es pot baixar fins al «stage» #0"
@@ -6898,8 +6881,8 @@ msgstr ""
 "No obstant, si elimineu tot, s'avortarà el «rebase».\n"
 "\n"
 
-#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3886
-#: sequencer.c:3912 sequencer.c:5709 builtin/fsck.c:328 builtin/gc.c:1790
+#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3883
+#: sequencer.c:3909 sequencer.c:5708 builtin/fsck.c:328 builtin/gc.c:1791
 #: builtin/rebase.c:190
 #, c-format
 msgid "could not write '%s'"
@@ -6934,11 +6917,11 @@ msgstr ""
 "Els comportaments possibles són: ignore, warn, error.\n"
 
 #: rebase.c:29
-#, c-format, fuzzy
+#, c-format
 msgid "%s: 'preserve' superseded by 'merges'"
-msgstr "percentatges: \"preservei\" substituït per \"merges\""
+msgstr "%s: «conserva» substituït per «fusiona»"
 
-#: ref-filter.c:42 wt-status.c:2036
+#: ref-filter.c:42 wt-status.c:2048
 msgid "gone"
 msgstr "no hi és"
 
@@ -6977,7 +6960,8 @@ msgstr "Valor enter esperat pel nom de referència:lstrip=%s"
 msgid "Integer value expected refname:rstrip=%s"
 msgstr "Valor enter esperat pel nom de referència:rstrip=%s"
 
-#: ref-filter.c:265
+#: ref-filter.c:265 ref-filter.c:344 ref-filter.c:377 ref-filter.c:431
+#: ref-filter.c:443 ref-filter.c:462 ref-filter.c:534 ref-filter.c:560
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
 msgstr "argument %%(%s) desconegut: %s"
@@ -6986,11 +6970,6 @@ msgstr "argument %%(%s) desconegut: %s"
 #, c-format
 msgid "%%(objecttype) does not take arguments"
 msgstr "%%(objecttype) no accepta arguments"
-
-#: ref-filter.c:344
-#, c-format
-msgid "unrecognized %%(objectsize) argument: %s"
-msgstr "argument %%(objectsize) no reconegut: %s"
 
 #: ref-filter.c:352
 #, c-format
@@ -7001,11 +6980,6 @@ msgstr "%%(deltabase) no accepta arguments"
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr "%%(body) no accepta arguments"
-
-#: ref-filter.c:377
-#, c-format
-msgid "unrecognized %%(subject) argument: %s"
-msgstr "argument %%(subject) no reconegut: %s"
 
 #: ref-filter.c:396
 #, c-format
@@ -7022,25 +6996,10 @@ msgstr "argument %%(trailers) desconegut: %s"
 msgid "positive value expected contents:lines=%s"
 msgstr "valor positiu esperat conté:lines=%s"
 
-#: ref-filter.c:431
-#, c-format
-msgid "unrecognized %%(contents) argument: %s"
-msgstr "argument %%(contents) no reconegut: %s"
-
-#: ref-filter.c:443
-#, fuzzy, c-format
-msgid "unrecognized %%(raw) argument: %s"
-msgstr "argument %%(%s) desconegut: %s"
-
 #: ref-filter.c:458
 #, c-format
 msgid "positive value expected '%s' in %%(%s)"
 msgstr "valor positiu esperat «%s» a %%(%s)"
-
-#: ref-filter.c:462
-#, c-format
-msgid "unrecognized argument '%s' in %%(%s)"
-msgstr "argument no reconegut «%s» a %%(%s)"
 
 #: ref-filter.c:476
 #, c-format
@@ -7062,25 +7021,15 @@ msgstr "posició no reconeguda:%s"
 msgid "unrecognized width:%s"
 msgstr "amplada no reconeguda:%s"
 
-#: ref-filter.c:534
-#, c-format
-msgid "unrecognized %%(align) argument: %s"
-msgstr "argument %%(align) no reconegut: %s"
-
 #: ref-filter.c:542
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr "amplada positiva esperada amb l'àtom %%(align)"
 
-#: ref-filter.c:560
-#, c-format
-msgid "unrecognized %%(if) argument: %s"
-msgstr "argument %%(if) no reconegut: %s"
-
 #: ref-filter.c:568
-#, fuzzy, c-format
+#, c-format
 msgid "%%(rest) does not take arguments"
-msgstr "%%(body) no accepta arguments"
+msgstr "%%(rest) no accepta arguments"
 
 #: ref-filter.c:680
 #, c-format
@@ -7100,15 +7049,10 @@ msgstr ""
 "no és un repositori, git però el camp «%.*s» requereix accés a les dades de "
 "l'objecte"
 
-#: ref-filter.c:844
+#: ref-filter.c:844 ref-filter.c:910 ref-filter.c:946 ref-filter.c:948
 #, c-format
-msgid "format: %%(if) atom used without a %%(then) atom"
-msgstr "format: s'ha usat l'àtom %%(if) sense un àtom %%(then)"
-
-#: ref-filter.c:910
-#, c-format
-msgid "format: %%(then) atom used without an %%(if) atom"
-msgstr "format: s'ha usat l'àtom %%(then) sense un àtom %%(if)"
+msgid "format: %%(%s) atom used without a %%(%s) atom"
+msgstr "format: l'àtom %%(%s) usat sense un àtom %%(%s)"
 
 #: ref-filter.c:912
 #, c-format
@@ -7119,16 +7063,6 @@ msgstr "format: s'ha usat l'àtom %%(then) més d'un cop"
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr "format: s'ha usat l'àtom %%(then) després de %%(else)"
-
-#: ref-filter.c:946
-#, c-format
-msgid "format: %%(else) atom used without an %%(if) atom"
-msgstr "format: s'ha usat l'àtom %%(else) sense un àtom %%(if)"
-
-#: ref-filter.c:948
-#, c-format
-msgid "format: %%(else) atom used without a %%(then) atom"
-msgstr "format: s'ha usat l'àtom %%(else) sense un àtom %%(then)"
 
 #: ref-filter.c:950
 #, c-format
@@ -7146,14 +7080,14 @@ msgid "malformed format string %s"
 msgstr "cadena de format mal format %s"
 
 #: ref-filter.c:1033
-#, c-format, fuzzy
+#, c-format
 msgid "this command reject atom %%(%.*s)"
-msgstr "aquesta ordre rebutja l'àtom%(%.*s)"
+msgstr "aquesta ordre rebutja l'àtom %%(%.*s)"
 
 #: ref-filter.c:1040
-#, fuzzy, c-format
-msgid "--format=%.*s cannot be used with--python, --shell, --tcl"
-msgstr "--object-format no es pot usar sense --stdin"
+#, c-format
+msgid "--format=%.*s cannot be used with --python, --shell, --tcl"
+msgstr "no es pot usar --format=%.*s amb --python, --shell, --tcl"
 
 #: ref-filter.c:1706
 #, c-format
@@ -7204,22 +7138,22 @@ msgstr "objecte mal format a «%s»"
 msgid "ignoring ref with broken name %s"
 msgstr "s'està ignorant la referència amb nom malmès %s"
 
-#: ref-filter.c:2250 refs.c:673
+#: ref-filter.c:2250 refs.c:676
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "s'està ignorant la referència trencada %s"
 
-#: ref-filter.c:2623
+#: ref-filter.c:2629
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "format: manca l'àtom %%(end)"
 
-#: ref-filter.c:2726
+#: ref-filter.c:2740
 #, c-format
 msgid "malformed object name %s"
 msgstr "nom d'objecte %s mal format"
 
-#: ref-filter.c:2731
+#: ref-filter.c:2745
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "l'opció «%s» ha d'apuntar a una comissió"
@@ -7230,7 +7164,7 @@ msgid "%s does not point to a valid object!"
 msgstr "%s no apunta a un objecte vàlid"
 
 #: refs.c:563
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Using '%s' as the name for the initial branch. This default branch name\n"
 "is subject to change. To configure the initial branch name to use in all\n"
@@ -7243,16 +7177,16 @@ msgid ""
 "\n"
 "\tgit branch -m <name>\n"
 msgstr ""
-"S'està utilitzant «%s» com a nom de la branca inicial. Aquest nom de branca per defecte\n"
-"està subjecte a canvis. Per a configurar el nom inicial de la branca que s'utilitzarà en tots\n"
-"els repositoris nous, i que suprimirà aquest avís, useu:\n"
+"S'està utilitzant «%s» com a nom de la branca inicial. Aquest nom de branca\n"
+"per defecte es pot canviar. Per a configurar el nom inicial de la branca que\n"
+"s'utilitzarà en tots els repositoris nous, i que suprimirà aquest avís, useu:\n"
 "\n"
 "\tgit config --global init.defaultBranch <nom>\n"
 "\n"
-"Els noms escollits habitualment en lloc de «master» són «main», «trunk» i «development»\n"
-"La branca acabada de crear es pot canviar de nom amb aquesta ordre:\n"
+"Els noms més usats habitualment en lloc de «master» són «main», «trunk» i\n"
+"«development». La branca acabada de crear es pot canviar de nom amb l'ordre:\n"
 "\n"
-"\tgit branch -m <nom>"
+"\tgit branch -m <nom>\n"
 
 #: refs.c:585
 #, c-format
@@ -7264,71 +7198,71 @@ msgstr "no s'ha pogut recuperar «%s»"
 msgid "invalid branch name: %s = %s"
 msgstr "nom de branca no vàlida: %s = %s"
 
-#: refs.c:671
+#: refs.c:674
 #, c-format
 msgid "ignoring dangling symref %s"
 msgstr "s'està ignorant symref penjant %s"
 
-#: refs.c:920
+#: refs.c:925
 #, c-format
 msgid "log for ref %s has gap after %s"
 msgstr "registre per a ref %s té un buit després de %s"
 
-#: refs.c:927
+#: refs.c:932
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
 msgstr "registre per als ref %s ha acabat inesperadament a %s"
 
-#: refs.c:992
+#: refs.c:997
 #, c-format
 msgid "log for %s is empty"
 msgstr "el registre per a %s és buit"
 
-#: refs.c:1084
+#: refs.c:1090
 #, c-format
 msgid "refusing to update ref with bad name '%s'"
 msgstr "s'està refusant la referència amb nom malmès «%s»"
 
-#: refs.c:1155
+#: refs.c:1168
 #, c-format
 msgid "update_ref failed for ref '%s': %s"
 msgstr "ha fallat update_ref per a la ref «%s»: %s"
 
-#: refs.c:2062
+#: refs.c:2067
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "no es permeten múltiples actualitzacions per a la referència «%s»"
 
-#: refs.c:2142
+#: refs.c:2150
 msgid "ref updates forbidden inside quarantine environment"
 msgstr "no està permès actualitzar les referències en un entorn de quarantena"
 
-#: refs.c:2153
+#: refs.c:2161
 msgid "ref updates aborted by hook"
 msgstr "les actualitzacions de referències s'han avortat per un lligam"
 
-#: refs.c:2253 refs.c:2283
+#: refs.c:2269 refs.c:2299
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "«%s» existeix; no es pot crear «%s»"
 
-#: refs.c:2259 refs.c:2294
+#: refs.c:2275 refs.c:2310
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "no es poden processar «%s» i «%s» a la vegada"
 
-#: refs/files-backend.c:1271
+#: refs/files-backend.c:1267
 #, c-format
 msgid "could not remove reference %s"
 msgstr "no s'ha pogut eliminar la referència %s"
 
-#: refs/files-backend.c:1285 refs/packed-backend.c:1549
+#: refs/files-backend.c:1281 refs/packed-backend.c:1549
 #: refs/packed-backend.c:1559
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr "no s'ha pogut suprimir la referència %s: %s"
 
-#: refs/files-backend.c:1288 refs/packed-backend.c:1562
+#: refs/files-backend.c:1284 refs/packed-backend.c:1562
 #, c-format
 msgid "could not delete references: %s"
 msgstr "no s'han pogut suprimir les referències: %s"
@@ -7338,51 +7272,51 @@ msgstr "no s'han pogut suprimir les referències: %s"
 msgid "invalid refspec '%s'"
 msgstr "refspec no vàlida: «%s»"
 
-#: remote.c:351
+#: remote.c:402
 #, c-format
 msgid "config remote shorthand cannot begin with '/': %s"
 msgstr ""
 "l'abreviatura del fitxer de configuració remot no pot començar amb «/»: %s"
 
-#: remote.c:399
+#: remote.c:450
 msgid "more than one receivepack given, using the first"
 msgstr "més d'un paquet de recepció donat, usant el primer"
 
-#: remote.c:407
+#: remote.c:458
 msgid "more than one uploadpack given, using the first"
 msgstr "més d'un paquet de càrrega donat, usant el primer"
 
-#: remote.c:590
+#: remote.c:699
 #, c-format
 msgid "Cannot fetch both %s and %s to %s"
 msgstr "No es poden obtenir ambdós %s i %s a %s"
 
-#: remote.c:594
+#: remote.c:703
 #, c-format
 msgid "%s usually tracks %s, not %s"
 msgstr "%s generalment segueix %s, no %s"
 
-#: remote.c:598
+#: remote.c:707
 #, c-format
 msgid "%s tracks both %s and %s"
 msgstr "%s segueix ambdós %s i %s"
 
-#: remote.c:666
+#: remote.c:775
 #, c-format
 msgid "key '%s' of pattern had no '*'"
 msgstr "la clau «%s» del patró no té «*»"
 
-#: remote.c:676
+#: remote.c:785
 #, c-format
 msgid "value '%s' of pattern has no '*'"
 msgstr "el valor «%s» del patró no té «*»"
 
-#: remote.c:1083
+#: remote.c:1192
 #, c-format
 msgid "src refspec %s does not match any"
 msgstr "l'especificació de referència src %s no coincideix amb cap referència"
 
-#: remote.c:1088
+#: remote.c:1197
 #, c-format
 msgid "src refspec %s matches more than one"
 msgstr ""
@@ -7391,8 +7325,8 @@ msgstr ""
 #. TRANSLATORS: "matches '%s'%" is the <dst> part of "git push
 #. <remote> <src>:<dst>" push, and "being pushed ('%s')" is
 #. the <src>.
-#: remote.c:1103
-#, fuzzy, c-format
+#: remote.c:1212
+#, c-format
 msgid ""
 "The destination you provided is not a full refname (i.e.,\n"
 "starting with \"refs/\"). We tried to guess what you meant by:\n"
@@ -7404,13 +7338,17 @@ msgid ""
 "\n"
 "Neither worked, so we gave up. You must fully qualify the ref."
 msgstr ""
-"La destinació que heu proporcionat no és un nom de referència complet (és a "
-"dir començant per \"refs/\"). Hem intentat endevinar el que voleu dir amb - "
-"Buscant una referència que coincideixi amb '%s' al costat remot. - Comprovar"
-" si el <src> ser empès ('%s') és una referència a \"refs/{headtags}/\". Si "
-"és així afegirem un refs/{headstags que no ha funcionat completament."
+"El destinació que heu proporcionat no és un nom de referència complet\n"
+"(p. ex., que comenci amb «refs/»). Hem intentat deduir el que voleu dir:\n"
+"\n"
+"- Buscant una referència que coincideixi amb «%s» al costat remot.\n"
+"- Comprovant si el <src> que s'ha pujat («%s»)\n"
+"  és una referència «refs/{heads,tags}/». Si és així, afegim el prefix\n"
+"  refs/{heads,tags}/ corresponent al costat remot.\n"
+"\n"
+"Res d'això ha funcionat. Cal que proporcioneu una referència completa."
 
-#: remote.c:1123
+#: remote.c:1232
 #, c-format
 msgid ""
 "The <src> part of the refspec is a commit object.\n"
@@ -7421,7 +7359,7 @@ msgstr ""
 "Voleu crear una branca nova empenyent a\n"
 "«%s:refs/heads/%s»?"
 
-#: remote.c:1128
+#: remote.c:1237
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tag object.\n"
@@ -7431,7 +7369,7 @@ msgstr ""
 "La part <src> de l'especificació de la referència és un objecte d'etiqueta.\n"
 "Voleu crear una etiqueta pujant-la a «%srefs/tags/%s»?"
 
-#: remote.c:1133
+#: remote.c:1242
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tree object.\n"
@@ -7441,7 +7379,7 @@ msgstr ""
 "La part <src> de l'especificació de la referència és un objecte d'arbre.\n"
 "Voleu crear una etiqueta pujant-la a «%srefs/tags/%s»?"
 
-#: remote.c:1138
+#: remote.c:1247
 #, c-format
 msgid ""
 "The <src> part of the refspec is a blob object.\n"
@@ -7452,118 +7390,118 @@ msgstr ""
 "Voleu posar una etiqueta al blob nou mitjançant la pujada a\n"
 "?«%s:refs/tags/%s»?"
 
-#: remote.c:1174
+#: remote.c:1283
 #, c-format
 msgid "%s cannot be resolved to branch"
 msgstr "«%s» no es pot resoldre a una branca"
 
-#: remote.c:1185
+#: remote.c:1294
 #, c-format
 msgid "unable to delete '%s': remote ref does not exist"
 msgstr "no s'ha pogut suprimir «%s»: la referència remota no existeix"
 
-#: remote.c:1197
+#: remote.c:1306
 #, c-format
 msgid "dst refspec %s matches more than one"
 msgstr ""
 "l'especificació de la referència dst %s coincideixen amb més d'una "
 "referència"
 
-#: remote.c:1204
+#: remote.c:1313
 #, c-format
 msgid "dst ref %s receives from more than one src"
 msgstr "l'especificació de la referència dst %s rep més d'una referència src"
 
-#: remote.c:1724 remote.c:1825
+#: remote.c:1834 remote.c:1941
 msgid "HEAD does not point to a branch"
 msgstr "HEAD no assenyala cap branca"
 
-#: remote.c:1733
+#: remote.c:1843
 #, c-format
 msgid "no such branch: '%s'"
 msgstr "no existeix la branca: «%s»"
 
-#: remote.c:1736
+#: remote.c:1846
 #, c-format
 msgid "no upstream configured for branch '%s'"
 msgstr "cap font configurada per a la branca «%s»"
 
-#: remote.c:1742
+#: remote.c:1852
 #, c-format
 msgid "upstream branch '%s' not stored as a remote-tracking branch"
 msgstr "la branca font «%s» no s'emmagatzema com a branca amb seguiment remot"
 
-#: remote.c:1757
+#: remote.c:1867
 #, c-format
 msgid "push destination '%s' on remote '%s' has no local tracking branch"
 msgstr ""
 "el destí de pujada «%s» en el remot «%s» no té cap branca amb seguiment "
 "remot"
 
-#: remote.c:1769
+#: remote.c:1882
 #, c-format
 msgid "branch '%s' has no remote for pushing"
 msgstr "la branca «%s» no té cap remot al qual pujar"
 
-#: remote.c:1779
+#: remote.c:1892
 #, c-format
 msgid "push refspecs for '%s' do not include '%s'"
 msgstr "les especificacions de referència de «%s» no inclouen «%s»"
 
-#: remote.c:1792
+#: remote.c:1905
 msgid "push has no destination (push.default is 'nothing')"
 msgstr "push no té destí (push.default és «nothing»)"
 
-#: remote.c:1814
+#: remote.c:1927
 msgid "cannot resolve 'simple' push to a single destination"
 msgstr "no es pot resoldre una pujada «simple» a un sol destí"
 
-#: remote.c:1943
+#: remote.c:2060
 #, c-format
 msgid "couldn't find remote ref %s"
 msgstr "no s'ha pogut trobar la referència remota %s"
 
-#: remote.c:1956
+#: remote.c:2073
 #, c-format
 msgid "* Ignoring funny ref '%s' locally"
 msgstr "* S'estan ignorant les referències «%s» localment"
 
-#: remote.c:2119
+#: remote.c:2236
 #, c-format
 msgid "Your branch is based on '%s', but the upstream is gone.\n"
 msgstr "La vostra branca està basada en «%s», però la font no hi és.\n"
 
-#: remote.c:2123
+#: remote.c:2240
 msgid "  (use \"git branch --unset-upstream\" to fixup)\n"
 msgstr "  (useu «git branch --unset-upstream» per a arreglar-ho)\n"
 
-#: remote.c:2126
+#: remote.c:2243
 #, c-format
 msgid "Your branch is up to date with '%s'.\n"
 msgstr "La vostra branca està al dia amb «%s».\n"
 
-#: remote.c:2130
+#: remote.c:2247
 #, c-format
 msgid "Your branch and '%s' refer to different commits.\n"
 msgstr "La vostra branca i «%s» es refereixen a diferents comissions.\n"
 
-#: remote.c:2133
+#: remote.c:2250
 #, c-format
 msgid "  (use \"%s\" for details)\n"
 msgstr "  (useu «%s» per a detalls)\n"
 
-#: remote.c:2137
+#: remote.c:2254
 #, c-format
 msgid "Your branch is ahead of '%s' by %d commit.\n"
 msgid_plural "Your branch is ahead of '%s' by %d commits.\n"
 msgstr[0] "La vostra branca està %2$d comissió per davant de «%1$s».\n"
 msgstr[1] "La vostra branca està %2$d comissions per davant de «%1$s».\n"
 
-#: remote.c:2143
+#: remote.c:2260
 msgid "  (use \"git push\" to publish your local commits)\n"
 msgstr "  (useu «git push» per a publicar les vostres comissions locals)\n"
 
-#: remote.c:2146
+#: remote.c:2263
 #, c-format
 msgid "Your branch is behind '%s' by %d commit, and can be fast-forwarded.\n"
 msgid_plural ""
@@ -7575,11 +7513,11 @@ msgstr[1] ""
 "La vostra branca està %2$d comissions per darrere de «%1$s», i pot avançar-"
 "se ràpidament.\n"
 
-#: remote.c:2154
+#: remote.c:2271
 msgid "  (use \"git pull\" to update your local branch)\n"
 msgstr "  (useu «git pull» per a actualitzar la vostra branca local)\n"
 
-#: remote.c:2157
+#: remote.c:2274
 #, c-format
 msgid ""
 "Your branch and '%s' have diverged,\n"
@@ -7594,11 +7532,11 @@ msgstr[1] ""
 "La vostra branca i «%s» han divergit,\n"
 "i tenen %d i %d comissions distintes cada una, respectivament.\n"
 
-#: remote.c:2167
+#: remote.c:2284
 msgid "  (use \"git pull\" to merge the remote branch into yours)\n"
 msgstr "  (useu «git pull» per a fusionar la branca remota amb la vostra)\n"
 
-#: remote.c:2359
+#: remote.c:2476
 #, c-format
 msgid "cannot parse expected object name '%s'"
 msgstr "no es pot analitzar el nom de l'objecte esperat «%s»"
@@ -7631,7 +7569,7 @@ msgstr "no s'ha pogut escriure el registre «rerere»"
 msgid "there were errors while writing '%s' (%s)"
 msgstr "s'han produït errors en escriure «%s» (%s)"
 
-#: rerere.c:482 builtin/gc.c:2247 builtin/gc.c:2282
+#: rerere.c:482 builtin/gc.c:2263 builtin/gc.c:2298
 #, c-format
 msgid "failed to flush '%s'"
 msgstr "no s'ha pogut buidar «%s»"
@@ -7676,8 +7614,8 @@ msgstr "no es pot desenllaçar «%s» (extraviat)"
 msgid "Recorded preimage for '%s'"
 msgstr "Imatge prèvia registrada per a «%s»"
 
-#: rerere.c:865 submodule.c:2121 builtin/log.c:2002
-#: builtin/submodule--helper.c:1776 builtin/submodule--helper.c:1819
+#: rerere.c:865 submodule.c:2121 builtin/log.c:2017
+#: builtin/submodule--helper.c:1777 builtin/submodule--helper.c:1820
 #, c-format
 msgid "could not create directory '%s'"
 msgstr "no s'ha pogut crear el directori «%s»"
@@ -7715,39 +7653,29 @@ msgstr "no s'ha pogut obrir el directori rr-cache"
 msgid "could not determine HEAD revision"
 msgstr "no s'ha pogut determinar la revisió de HEAD"
 
-#: reset.c:70 reset.c:76 sequencer.c:3703
+#: reset.c:70 reset.c:76 sequencer.c:3700
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "s'ha produït un error en cercar l'arbre de %s"
 
-#: revision.c:2259
-#, fuzzy
-msgid "--unsorted-input is incompatible with --no-walk"
-msgstr "--dir-diff és incompatible amb --no-index"
-
-#: revision.c:2346
+#: revision.c:2347
 msgid "--unpacked=<packfile> no longer supported"
 msgstr "--unpacked=<packfile> ja no s'admet"
 
-#: revision.c:2655 revision.c:2659
-#, fuzzy
-msgid "--no-walk is incompatible with --unsorted-input"
-msgstr "--dir-diff és incompatible amb --no-index"
-
-#: revision.c:2690
+#: revision.c:2686
 msgid "your current branch appears to be broken"
 msgstr "la vostra branca actual sembla malmesa"
 
-#: revision.c:2693
+#: revision.c:2689
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
 msgstr "la branca actual «%s» encara no té cap comissió"
 
-#: revision.c:2895
+#: revision.c:2891
 msgid "-L does not yet support diff formats besides -p and -s"
 msgstr "-L no és encara compatible amb formats que no siguin «-p» o «-s»"
 
-#: run-command.c:1278
+#: run-command.c:1262
 #, c-format
 msgid "cannot create async thread: %s"
 msgstr "no s'ha pogut crear fil «async»: %s"
@@ -7777,7 +7705,6 @@ msgid "send-pack: unable to fork off fetch subprocess"
 msgstr "send-pack: no es pot bifurcar obtenint un subprocés"
 
 #: send-pack.c:457
-#, fuzzy
 msgid "push negotiation failed; proceeding anyway with push"
 msgstr ""
 "ha fallat la negociació de l'empenta; s'està procedint igualment amb "
@@ -7817,8 +7744,8 @@ msgstr "mode de neteja «%s» no vàlid en la comissió del missatge"
 msgid "could not delete '%s'"
 msgstr "no s'ha pogut suprimir «%s»"
 
-#: sequencer.c:345 sequencer.c:4752 builtin/rebase.c:563 builtin/rebase.c:1297
-#: builtin/rm.c:408
+#: sequencer.c:345 sequencer.c:4751 builtin/rebase.c:563 builtin/rebase.c:1297
+#: builtin/rm.c:409
 #, c-format
 msgid "could not remove '%s'"
 msgstr "no s'ha pogut eliminar «%s»"
@@ -7849,7 +7776,6 @@ msgstr ""
 "corregits amb «git add <camins>» o «git rm <camins>»"
 
 #: sequencer.c:423
-#, fuzzy
 msgid ""
 "After resolving the conflicts, mark them with\n"
 "\"git add/rm <pathspec>\", then run\n"
@@ -7858,13 +7784,14 @@ msgid ""
 "To abort and get back to the state before \"git cherry-pick\",\n"
 "run \"git cherry-pick --abort\"."
 msgstr ""
-"Resoleu tots els conflictes manualment, marqueu-los com a resolts amb\n"
-"«git add/rm <fitxers_amb_conflicte>», llavors executeu «git rebase --continue».\n"
-"Alternativament podeu ometre aquesta comissió: executeu «git rebase --skip».\n"
-"Per a avortar i tornar a l'estat anterior abans de l'ordre «git rebase», executeu «git rebase --abort»."
+"Després de resoldre els conflictes, marqueu-los amb\n"
+"«git add/rm <pathspec>», llavors executeu\n"
+"«git cherry-pick --continue».\n"
+"Podeu també ometre aquesta comissió amb «git cherry-pick --skip».\n"
+"Per a interrompre i tornar a l'estat anterior abans de «git cherry-pick»,\n"
+"executeu «git cherry-pick --abort»."
 
 #: sequencer.c:430
-#, fuzzy
 msgid ""
 "After resolving the conflicts, mark them with\n"
 "\"git add/rm <pathspec>\", then run\n"
@@ -7873,18 +7800,20 @@ msgid ""
 "To abort and get back to the state before \"git revert\",\n"
 "run \"git revert --abort\"."
 msgstr ""
-"Resoleu tots els conflictes manualment, marqueu-los com a resolts amb\n"
-"«git add/rm <fitxers_amb_conflicte>», llavors executeu «git rebase --continue».\n"
-"Alternativament podeu ometre aquesta comissió: executeu «git rebase --skip».\n"
-"Per a avortar i tornar a l'estat anterior abans de l'ordre «git rebase», executeu «git rebase --abort»."
+"Després de resoldre els conflictes, marqueu-los amb\n"
+"«git add/rm <pathspec>», llavors executeu\n"
+"«git revert --continue».\n"
+"Podeu també ometre aquesta comissió amb «git revert --skip».\n"
+"Per a interrompre i tornar a l'estat anterior abans de «git revert»,\n"
+"executeu «git revert --abort»."
 
-#: sequencer.c:448 sequencer.c:3288
+#: sequencer.c:448 sequencer.c:3292
 #, c-format
 msgid "could not lock '%s'"
 msgstr "no s'ha pogut bloquejar «%s»"
 
-#: sequencer.c:450 sequencer.c:3087 sequencer.c:3292 sequencer.c:3306
-#: sequencer.c:3564 sequencer.c:5619 strbuf.c:1176 wrapper.c:639
+#: sequencer.c:450 sequencer.c:3091 sequencer.c:3296 sequencer.c:3310
+#: sequencer.c:3561 sequencer.c:5618 strbuf.c:1188 wrapper.c:639
 #, c-format
 msgid "could not write to '%s'"
 msgstr "no s'ha pogut escriure a «%s»"
@@ -7894,11 +7823,17 @@ msgstr "no s'ha pogut escriure a «%s»"
 msgid "could not write eol to '%s'"
 msgstr "no s'ha pogut escriure el terminador de línia a «%s»"
 
-#: sequencer.c:460 sequencer.c:3092 sequencer.c:3294 sequencer.c:3308
-#: sequencer.c:3572
+#: sequencer.c:460 sequencer.c:3096 sequencer.c:3298 sequencer.c:3312
+#: sequencer.c:3569
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "s'ha produït un error en finalitzar «%s»"
+
+#: sequencer.c:473 sequencer.c:1934 sequencer.c:3116 sequencer.c:3551
+#: sequencer.c:3679 builtin/am.c:289 builtin/commit.c:834 builtin/merge.c:1148
+#, c-format
+msgid "could not read '%s'"
+msgstr "no s'ha pogut llegir «%s»"
 
 #: sequencer.c:499
 #, c-format
@@ -7914,7 +7849,7 @@ msgstr "cometeu els vostres canvis o feu un «stash» per a procedir."
 msgid "%s: fast-forward"
 msgstr "%s: avanç ràpid"
 
-#: sequencer.c:574 builtin/tag.c:610
+#: sequencer.c:574 builtin/tag.c:614
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Mode de neteja no vàlid %s"
@@ -7944,8 +7879,8 @@ msgstr "no hi ha una clau a «%.*s»"
 msgid "unable to dequote value of '%s'"
 msgstr "no s'han pogut treure les cometes del valor de «%s»"
 
-#: sequencer.c:841 wrapper.c:209 wrapper.c:379 builtin/am.c:730
-#: builtin/am.c:822 builtin/rebase.c:694
+#: sequencer.c:841 wrapper.c:209 wrapper.c:379 builtin/am.c:756
+#: builtin/am.c:848 builtin/rebase.c:694
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "no s'ha pogut obrir «%s» per a lectura"
@@ -8008,11 +7943,11 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:1227
+#: sequencer.c:1225
 msgid "'prepare-commit-msg' hook failed"
 msgstr "el lligam «prepare-commit-msg» ha fallat"
 
-#: sequencer.c:1233
+#: sequencer.c:1231
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -8039,7 +7974,7 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1246
+#: sequencer.c:1244
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -8073,340 +8008,341 @@ msgstr "no s'ha pogut trobar la comissió novament creada"
 msgid "could not parse newly created commit"
 msgstr "no s'ha pogut analitzar la comissió novament creada"
 
-#: sequencer.c:1336
+#: sequencer.c:1339
 msgid "unable to resolve HEAD after creating commit"
 msgstr "no s'ha pogut resoldre HEAD després de crear la comissió"
 
-#: sequencer.c:1338
+#: sequencer.c:1342
 msgid "detached HEAD"
 msgstr "HEAD separat"
 
-#: sequencer.c:1342
+#: sequencer.c:1346
 msgid " (root-commit)"
 msgstr " (comissió arrel)"
 
-#: sequencer.c:1363
+#: sequencer.c:1367
 msgid "could not parse HEAD"
 msgstr "no s'ha pogut analitzar HEAD"
 
-#: sequencer.c:1365
+#: sequencer.c:1369
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "HEAD %s no és una comissió!"
 
-#: sequencer.c:1369 sequencer.c:1447 builtin/commit.c:1707
+#: sequencer.c:1373 sequencer.c:1451 builtin/commit.c:1708
 msgid "could not parse HEAD commit"
 msgstr "no s'ha pogut analitzar la comissió HEAD"
 
-#: sequencer.c:1425 sequencer.c:2310
+#: sequencer.c:1429 sequencer.c:2314
 msgid "unable to parse commit author"
 msgstr "no s'ha pogut analitzar l'autor de la comissió"
 
-#: sequencer.c:1436 builtin/am.c:1616 builtin/merge.c:708
+#: sequencer.c:1440 builtin/am.c:1643 builtin/merge.c:710
 msgid "git write-tree failed to write a tree"
 msgstr "git write-tree ha fallat en escriure un arbre"
 
-#: sequencer.c:1469 sequencer.c:1589
+#: sequencer.c:1473 sequencer.c:1593
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "no s'ha pogut llegir el missatge de comissió des de «%s»"
 
-#: sequencer.c:1500 sequencer.c:1532
+#: sequencer.c:1504 sequencer.c:1536
 #, c-format
 msgid "invalid author identity '%s'"
 msgstr "identitat d'autor no vàlida: «%s»"
 
-#: sequencer.c:1506
+#: sequencer.c:1510
 msgid "corrupt author: missing date information"
 msgstr "autor malmès: falta la informació de la data"
 
-#: sequencer.c:1545 builtin/am.c:1643 builtin/commit.c:1821
-#: builtin/merge.c:913 builtin/merge.c:938 t/helper/test-fast-rebase.c:78
+#: sequencer.c:1549 builtin/am.c:1670 builtin/commit.c:1822
+#: builtin/merge.c:915 builtin/merge.c:940 t/helper/test-fast-rebase.c:78
 msgid "failed to write commit object"
 msgstr "s'ha produït un error en escriure l'objecte de comissió"
 
-#: sequencer.c:1572 sequencer.c:4524 t/helper/test-fast-rebase.c:199
+#: sequencer.c:1576 sequencer.c:4523 t/helper/test-fast-rebase.c:199
 #: t/helper/test-fast-rebase.c:217
 #, c-format
 msgid "could not update %s"
 msgstr "no s'ha pogut actualitzar %s"
 
-#: sequencer.c:1621
+#: sequencer.c:1625
 #, c-format
 msgid "could not parse commit %s"
 msgstr "no s'ha pogut analitzar la comissió %s"
 
-#: sequencer.c:1626
+#: sequencer.c:1630
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "no s'ha pogut analitzar la comissió pare %s"
 
-#: sequencer.c:1709 sequencer.c:1990
+#: sequencer.c:1713 sequencer.c:1994
 #, c-format
 msgid "unknown command: %d"
 msgstr "ordre desconeguda: %d"
 
-#: sequencer.c:1751
+#: sequencer.c:1755
 msgid "This is the 1st commit message:"
 msgstr "Aquest és el 1r missatge de comissió:"
 
-#: sequencer.c:1752
+#: sequencer.c:1756
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "Aquest és el missatge de comissió #%d:"
 
-#: sequencer.c:1753
+#: sequencer.c:1757
 msgid "The 1st commit message will be skipped:"
 msgstr "El primer missatge de comissió s'ometrà:"
 
-#: sequencer.c:1754
+#: sequencer.c:1758
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "El missatge de comissió núm. #%d s'ometrà:"
 
-#: sequencer.c:1755
+#: sequencer.c:1759
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr "Això és una combinació de %d comissions."
 
-#: sequencer.c:1902 sequencer.c:1959
+#: sequencer.c:1906 sequencer.c:1963
 #, c-format
 msgid "cannot write '%s'"
 msgstr "no es pot escriure «%s»"
 
-#: sequencer.c:1949
+#: sequencer.c:1953
 msgid "need a HEAD to fixup"
 msgstr "cal un HEAD per reparar-ho"
 
-#: sequencer.c:1951 sequencer.c:3599
+#: sequencer.c:1955 sequencer.c:3596
 msgid "could not read HEAD"
 msgstr "no s'ha pogut llegir HEAD"
 
-#: sequencer.c:1953
+#: sequencer.c:1957
 msgid "could not read HEAD's commit message"
 msgstr "no s'ha pogut llegir el missatge de comissió de HEAD"
 
-#: sequencer.c:1977
+#: sequencer.c:1981
 #, c-format
 msgid "could not read commit message of %s"
 msgstr "no s'ha pogut llegir el missatge de comissió: %s"
 
-#: sequencer.c:2087
+#: sequencer.c:2091
 msgid "your index file is unmerged."
 msgstr "el vostre fitxer d'índex està sense fusionar."
 
-#: sequencer.c:2094
+#: sequencer.c:2098
 msgid "cannot fixup root commit"
 msgstr "no es pot arreglar la comissió arrel"
 
-#: sequencer.c:2113
+#: sequencer.c:2117
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "la comissió %s és una fusió però no s'ha donat cap opció -m."
 
-#: sequencer.c:2121 sequencer.c:2129
+#: sequencer.c:2125 sequencer.c:2133
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "la comissió %s no té pare %d"
 
-#: sequencer.c:2135
+#: sequencer.c:2139
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "no es pot obtenir el missatge de comissió de %s"
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:2154
+#: sequencer.c:2158
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: no es pot analitzar la comissió pare %s"
 
-#: sequencer.c:2220
+#: sequencer.c:2224
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "no s'ha pogut canviar el nom «%s» a «%s»"
 
-#: sequencer.c:2280
+#: sequencer.c:2284
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "no s'ha pogut revertir %s... %s"
 
-#: sequencer.c:2281
+#: sequencer.c:2285
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "no s'ha pogut aplicar %s... %s"
 
-#: sequencer.c:2302
+#: sequencer.c:2306
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr "descartant %s %s -- el contingut del pedaç ja està a la font\n"
 
-#: sequencer.c:2360
+#: sequencer.c:2364
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: s'ha produït un error en llegir l'índex"
 
-#: sequencer.c:2368
+#: sequencer.c:2372
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: s'ha produït un error en actualitzar l'índex"
 
-#: sequencer.c:2448
+#: sequencer.c:2452
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "%s no accepta arguments: «%s»"
 
-#: sequencer.c:2457
+#: sequencer.c:2461
 #, c-format
 msgid "missing arguments for %s"
 msgstr "falten els arguments per a %s"
 
-#: sequencer.c:2500
+#: sequencer.c:2504
 #, c-format
 msgid "could not parse '%s'"
 msgstr "no s'ha pogut analitzar «%s»"
 
-#: sequencer.c:2561
+#: sequencer.c:2565
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "línia no vàlida %d: %.*s"
 
-#: sequencer.c:2572
+#: sequencer.c:2576
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "no es pot «%s» sense una comissió prèvia"
 
-#: sequencer.c:2620 builtin/rebase.c:184
+#: sequencer.c:2624 builtin/rebase.c:184
 #, c-format
 msgid "could not read '%s'."
 msgstr "no s'ha pogut llegir «%s»."
 
-#: sequencer.c:2658
+#: sequencer.c:2662
 msgid "cancelling a cherry picking in progress"
 msgstr "s'està cancel·lant un «cherry pick» en curs"
 
-#: sequencer.c:2667
+#: sequencer.c:2671
 msgid "cancelling a revert in progress"
 msgstr "s'està cancel·lant la reversió en curs"
 
-#: sequencer.c:2707
+#: sequencer.c:2711
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr "corregiu-ho usant «git rebase --edit-todo»."
 
-#: sequencer.c:2709
+#: sequencer.c:2713
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "full d'instruccions inusable: «%s»"
 
-#: sequencer.c:2714
+#: sequencer.c:2718
 msgid "no commits parsed."
 msgstr "no s'ha analitzat cap comissió."
 
-#: sequencer.c:2725
+#: sequencer.c:2729
 msgid "cannot cherry-pick during a revert."
 msgstr "no es pot fer «cherry pick» durant una reversió."
 
-#: sequencer.c:2727
+#: sequencer.c:2731
 msgid "cannot revert during a cherry-pick."
 msgstr "no es pot revertir durant un «cherry pick»."
 
-#: sequencer.c:2805
+#: sequencer.c:2809
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr "valor no vàlid per a %s: %s"
 
-#: sequencer.c:2914
+#: sequencer.c:2918
 msgid "unusable squash-onto"
 msgstr "«squash-onto» no usable"
 
-#: sequencer.c:2934
+#: sequencer.c:2938
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "full d'opcions mal format: «%s»"
 
-#: sequencer.c:3029 sequencer.c:4903
+#: sequencer.c:3033 sequencer.c:4902
 msgid "empty commit set passed"
 msgstr "conjunt de comissions buit passat"
 
-#: sequencer.c:3046
+#: sequencer.c:3050
 msgid "revert is already in progress"
 msgstr "una reversió ja està en curs"
 
-#: sequencer.c:3048
+#: sequencer.c:3052
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr "intenteu «git revert (--continue | %s--abort | --quit)»"
 
-#: sequencer.c:3051
+#: sequencer.c:3055
 msgid "cherry-pick is already in progress"
 msgstr "un «cherry pick» ja està en curs"
 
-#: sequencer.c:3053
+#: sequencer.c:3057
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr "intenteu «git cherry-pick (--continue | %s--abort | --quit)»"
 
-#: sequencer.c:3067
+#: sequencer.c:3071
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr "no s'ha pogut crear el directori de seqüenciador «%s»"
 
-#: sequencer.c:3082
+#: sequencer.c:3086
 msgid "could not lock HEAD"
 msgstr "no s'ha pogut bloquejar HEAD"
 
-#: sequencer.c:3142 sequencer.c:4613
+#: sequencer.c:3146 sequencer.c:4612
 msgid "no cherry-pick or revert in progress"
 msgstr "ni hi ha cap «cherry pick» ni cap reversió en curs"
 
-#: sequencer.c:3144 sequencer.c:3155
+#: sequencer.c:3148 sequencer.c:3159
 msgid "cannot resolve HEAD"
 msgstr "no es pot resoldre HEAD"
 
-#: sequencer.c:3146 sequencer.c:3190
+#: sequencer.c:3150 sequencer.c:3194
 msgid "cannot abort from a branch yet to be born"
 msgstr "no es pot avortar des d'una branca que encara ha de nàixer"
 
-#: sequencer.c:3176 builtin/grep.c:772
+#: sequencer.c:3180 builtin/fetch.c:1004 builtin/fetch.c:1416
+#: builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr "no es pot obrir «%s»"
 
-#: sequencer.c:3178
+#: sequencer.c:3182
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "no es pot llegir «%s»: %s"
 
-#: sequencer.c:3179
+#: sequencer.c:3183
 msgid "unexpected end of file"
 msgstr "final de fitxer inesperat"
 
-#: sequencer.c:3185
+#: sequencer.c:3189
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr "el fitxer HEAD emmagatzemat abans de fer «cherry pick» «%s» és malmès"
 
-#: sequencer.c:3196
+#: sequencer.c:3200
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr "Sembla que heu mogut HEAD sense rebobinar, comproveu-ho HEAD"
 
-#: sequencer.c:3237
+#: sequencer.c:3241
 msgid "no revert in progress"
 msgstr "no hi ha cap reversió en curs"
 
-#: sequencer.c:3246
+#: sequencer.c:3250
 msgid "no cherry-pick in progress"
 msgstr "ni hi ha cap «cherry pick» en curs"
 
-#: sequencer.c:3256
+#: sequencer.c:3260
 msgid "failed to skip the commit"
 msgstr "s'ha produït un error en ometre la comissió"
 
-#: sequencer.c:3263
+#: sequencer.c:3267
 msgid "there is nothing to skip"
 msgstr "no hi ha res a ometre"
 
-#: sequencer.c:3266
+#: sequencer.c:3270
 #, c-format
 msgid ""
 "have you committed already?\n"
@@ -8415,16 +8351,16 @@ msgstr ""
 "heu fet ja una comissió?\n"
 "proveu «git %s --continue»"
 
-#: sequencer.c:3428 sequencer.c:4504
+#: sequencer.c:3432 sequencer.c:4503
 msgid "cannot read HEAD"
 msgstr "no es pot llegir HEAD"
 
-#: sequencer.c:3445
+#: sequencer.c:3449
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "no s'ha pogut copiar «%s» a «%s»"
 
-#: sequencer.c:3453
+#: sequencer.c:3457
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -8443,27 +8379,27 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:3463
+#: sequencer.c:3467
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "No s'ha pogut aplicar %s... %.*s"
 
-#: sequencer.c:3470
+#: sequencer.c:3474
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "No s'ha pogut fusionar %.*s"
 
-#: sequencer.c:3484 sequencer.c:3488 builtin/difftool.c:639
+#: sequencer.c:3488 sequencer.c:3492 builtin/difftool.c:633
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "no s'ha pogut copiar «%s» a «%s»"
 
-#: sequencer.c:3500
+#: sequencer.c:3503
 #, c-format
 msgid "Executing: %s\n"
 msgstr "S'està executant: %s\n"
 
-#: sequencer.c:3515
+#: sequencer.c:3514
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -8478,11 +8414,11 @@ msgstr ""
 " git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3521
+#: sequencer.c:3520
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "i ha fet canvis a l'índex i/o l'arbre de treball\n"
 
-#: sequencer.c:3527
+#: sequencer.c:3526
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -8498,92 +8434,91 @@ msgstr ""
 "\n"
 " git rebase --continue\n"
 
-#: sequencer.c:3589
+#: sequencer.c:3586
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "nom d'etiqueta no permès: «%.*s»"
 
-#: sequencer.c:3662
+#: sequencer.c:3659
 msgid "writing fake root commit"
 msgstr "s'està escrivint una comissió arrel falsa"
 
-#: sequencer.c:3667
+#: sequencer.c:3664
 msgid "writing squash-onto"
 msgstr "s'està escrivint «squash-onto»"
 
-#: sequencer.c:3746
+#: sequencer.c:3743
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "no s'ha pogut resoldre «%s»"
 
-#: sequencer.c:3778
+#: sequencer.c:3775
 msgid "cannot merge without a current revision"
 msgstr "no es pot fusionar sense una revisió actual"
 
-#: sequencer.c:3800
+#: sequencer.c:3797
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "no s'ha pogut analitzar «%.*s»"
 
-#: sequencer.c:3809
+#: sequencer.c:3806
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "no hi ha res per fusionar «%.*s»"
 
-#: sequencer.c:3821
-#, fuzzy
+#: sequencer.c:3818
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr ""
-"no es pot executar la fusió del pop a la part superior d'una [arrel nova]"
+"no es pot executar la fusió «octopus» a la part superior d'una [arrel nova]"
 
-#: sequencer.c:3876
+#: sequencer.c:3873
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "no s'ha pogut llegir el missatge de comissió de «%s»"
 
-#: sequencer.c:4022
+#: sequencer.c:4019
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "no s'ha pogut fusionar «%.*s»"
 
-#: sequencer.c:4038
+#: sequencer.c:4035
 msgid "merge: Unable to write new index file"
 msgstr "fusió: no s'ha pogut escriure un fitxer d'índex nou"
 
-#: sequencer.c:4119
+#: sequencer.c:4116
 msgid "Cannot autostash"
 msgstr "no es pot fer un «stash» automàticament"
 
-#: sequencer.c:4122
+#: sequencer.c:4119
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Resposta de «stash» inesperada: «%s»"
 
-#: sequencer.c:4128
+#: sequencer.c:4125
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "No s'ha pogut crear el directori per a «%s»"
 
-#: sequencer.c:4131
+#: sequencer.c:4128
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "S'ha creat un «stash» automàticament: %s\n"
 
-#: sequencer.c:4135
+#: sequencer.c:4132
 msgid "could not reset --hard"
 msgstr "no s'ha pogut fer reset --hard"
 
-#: sequencer.c:4160
+#: sequencer.c:4157
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "S'ha aplicat el «stash» automàticament.\n"
 
-#: sequencer.c:4172
+#: sequencer.c:4169
 #, c-format
 msgid "cannot store %s"
 msgstr "no es pot emmagatzemar %s"
 
-#: sequencer.c:4175
+#: sequencer.c:4172
 #, c-format
 msgid ""
 "%s\n"
@@ -8594,30 +8529,30 @@ msgstr ""
 "Els vostres canvis estan segurs en el «stash».\n"
 "Podeu executar «git stash pop» o «git stash drop» en qualsevol moment.\n"
 
-#: sequencer.c:4180
+#: sequencer.c:4177
 msgid "Applying autostash resulted in conflicts."
 msgstr "L'aplicació del «stash» automàticament ha donat conflictes."
 
-#: sequencer.c:4181
+#: sequencer.c:4178
 msgid "Autostash exists; creating a new stash entry."
 msgstr ""
 "El «stash» automàtic ja existeix; s'està creant una entrada «stash» nova."
 
-#: sequencer.c:4253
+#: sequencer.c:4252
 msgid "could not detach HEAD"
 msgstr "no s'ha pogut separar HEAD"
 
-#: sequencer.c:4268
+#: sequencer.c:4267
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Aturat a HEAD\n"
 
-#: sequencer.c:4270
+#: sequencer.c:4269
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Aturat a %s\n"
 
-#: sequencer.c:4302
+#: sequencer.c:4301
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -8638,58 +8573,58 @@ msgstr ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:4348
+#: sequencer.c:4347
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr "S'està fent «rebase» (%d/%d)%s"
 
-#: sequencer.c:4394
+#: sequencer.c:4393
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Aturat a %s...  %.*s\n"
 
-#: sequencer.c:4464
+#: sequencer.c:4463
 #, c-format
 msgid "unknown command %d"
 msgstr "ordre %d desconeguda"
 
-#: sequencer.c:4512
+#: sequencer.c:4511
 msgid "could not read orig-head"
 msgstr "no s'ha pogut llegir orig-head"
 
-#: sequencer.c:4517
+#: sequencer.c:4516
 msgid "could not read 'onto'"
 msgstr "no s'ha pogut llegir «onto»"
 
-#: sequencer.c:4531
+#: sequencer.c:4530
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "no s'ha pogut actualitzar HEAD a %s"
 
-#: sequencer.c:4591
+#: sequencer.c:4590
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr "S'ha fet «rebase» i actualitzat %s amb èxit.\n"
 
-#: sequencer.c:4643
+#: sequencer.c:4642
 msgid "cannot rebase: You have unstaged changes."
 msgstr "No es pot fer «rebase»: teniu canvis «unstaged»."
 
-#: sequencer.c:4652
+#: sequencer.c:4651
 msgid "cannot amend non-existing commit"
 msgstr "no es pot esmenar una comissió no existent"
 
-#: sequencer.c:4654
+#: sequencer.c:4653
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "fitxer no vàlid: «%s»"
 
-#: sequencer.c:4656
+#: sequencer.c:4655
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "contingut no vàlid: «%s»"
 
-#: sequencer.c:4659
+#: sequencer.c:4658
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -8699,69 +8634,68 @@ msgstr ""
 "Teniu canvis no comesos en el vostre arbre de treball. \n"
 "Cometeu-los primer i després executeu «git rebase --continue» de nou."
 
-#: sequencer.c:4695 sequencer.c:4734
+#: sequencer.c:4694 sequencer.c:4733
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "no s'ha pogut escriure el fitxer: «%s»"
 
-#: sequencer.c:4750
+#: sequencer.c:4749
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "No s'ha pogut eliminar CHERRY_PICK_HEAD"
 
-#: sequencer.c:4760
+#: sequencer.c:4759
 msgid "could not commit staged changes."
 msgstr "no s'han pogut cometre els canvis «staged»."
 
-#: sequencer.c:4880
+#: sequencer.c:4879
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: no es pot fer «cherry pick» a %s"
 
-#: sequencer.c:4884
+#: sequencer.c:4883
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: revisió incorrecta"
 
-#: sequencer.c:4919
+#: sequencer.c:4918
 msgid "can't revert as initial commit"
 msgstr "no es pot revertir com a comissió inicial"
 
-#: sequencer.c:5190 sequencer.c:5419
-#, fuzzy, c-format
+#: sequencer.c:5189 sequencer.c:5418
+#, c-format
 msgid "skipped previously applied commit %s"
-msgstr "esmena la comissió anterior"
+msgstr "omet les comissions aplicades anteriorment %s"
 
-#: sequencer.c:5260 sequencer.c:5435
-#, fuzzy
+#: sequencer.c:5259 sequencer.c:5434
 msgid "use --reapply-cherry-picks to include skipped commits"
 msgstr "useu --reapply-cherry-picks per incloure les comissions omeses"
 
-#: sequencer.c:5406
+#: sequencer.c:5405
 msgid "make_script: unhandled options"
 msgstr "make_script: opcions no gestionades"
 
-#: sequencer.c:5409
+#: sequencer.c:5408
 msgid "make_script: error preparing revisions"
 msgstr "make_script: s'ha produït un error en preparar les revisions"
 
-#: sequencer.c:5667 sequencer.c:5684
+#: sequencer.c:5666 sequencer.c:5683
 msgid "nothing to do"
 msgstr "res a fer"
 
-#: sequencer.c:5703
+#: sequencer.c:5702
 msgid "could not skip unnecessary pick commands"
 msgstr "no s'han pogut ometre les ordres «picks» no necessàries"
 
-#: sequencer.c:5803
+#: sequencer.c:5802
 msgid "the script was already rearranged."
 msgstr "l'script ja estava endreçat."
 
-#: setup.c:133
+#: setup.c:134
 #, c-format
 msgid "'%s' is outside repository at '%s'"
 msgstr "«%s» està fora del repositori a «%s»"
 
-#: setup.c:185
+#: setup.c:186
 #, c-format
 msgid ""
 "%s: no such path in the working tree.\n"
@@ -8770,7 +8704,7 @@ msgstr ""
 "%s: no hi ha tal camí en l'arbre de treball.\n"
 "Useu «git <ordre> -- <camí>...» per a especificar camins que no existeixin localment."
 
-#: setup.c:198
+#: setup.c:199
 #, c-format
 msgid ""
 "ambiguous argument '%s': unknown revision or path not in the working tree.\n"
@@ -8781,12 +8715,12 @@ msgstr ""
 "Useu «--» per a separar els camins de les revisions:\n"
 "«git <ordre> [<revisió>...] -- [<fitxer>...]»"
 
-#: setup.c:264
+#: setup.c:265
 #, c-format
 msgid "option '%s' must come before non-option arguments"
 msgstr "l'opció «%s» ha d'aparèixer abans que els arguments opcionals"
 
-#: setup.c:283
+#: setup.c:284
 #, c-format
 msgid ""
 "ambiguous argument '%s': both revision and filename\n"
@@ -8797,103 +8731,103 @@ msgstr ""
 "Useu «--» per a separar els camins de les revisions:\n"
 "«git <ordre> [<revisió>...] -- [<fitxer>...]»"
 
-#: setup.c:419
+#: setup.c:420
 msgid "unable to set up work tree using invalid config"
 msgstr ""
 "no s'ha pogut configurar un arbre de treball utilitzant una configuració no "
 "vàlida"
 
-#: setup.c:423 builtin/rev-parse.c:895
+#: setup.c:424 builtin/rev-parse.c:895
 msgid "this operation must be run in a work tree"
 msgstr "aquesta operació s'ha d'executar en un arbre de treball"
 
-#: setup.c:658
+#: setup.c:722
 #, c-format
 msgid "Expected git repo version <= %d, found %d"
 msgstr "S'esperava una versió de repositori de git <= %d, s'ha trobat %d"
 
-#: setup.c:666
+#: setup.c:730
 msgid "unknown repository extension found:"
 msgid_plural "unknown repository extensions found:"
 msgstr[0] "s'ha trobat una extensió de repositori desconeguda:"
 msgstr[1] "s'han trobat extensions de repositori desconegudes:"
 
-#: setup.c:680
+#: setup.c:744
 msgid "repo version is 0, but v1-only extension found:"
 msgid_plural "repo version is 0, but v1-only extensions found:"
 msgstr[0] ""
 "el repositori és versió 0, però només s'han trobat una extensió v1:"
 msgstr[1] "el repositori és versió 0, però només s'han trobat extensions v1:"
 
-#: setup.c:701
+#: setup.c:765
 #, c-format
 msgid "error opening '%s'"
 msgstr "s'ha produït un error en obrir «%s»"
 
-#: setup.c:703
+#: setup.c:767
 #, c-format
 msgid "too large to be a .git file: '%s'"
 msgstr "massa gran per a ser un fitxer .git: «%s»"
 
-#: setup.c:705
+#: setup.c:769
 #, c-format
 msgid "error reading %s"
 msgstr "error en llegir %s"
 
-#: setup.c:707
+#: setup.c:771
 #, c-format
 msgid "invalid gitfile format: %s"
 msgstr "format gitfile no vàlid: %s"
 
-#: setup.c:709
+#: setup.c:773
 #, c-format
 msgid "no path in gitfile: %s"
 msgstr "sense camí al gitfile: %s"
 
-#: setup.c:711
+#: setup.c:775
 #, c-format
 msgid "not a git repository: %s"
 msgstr "no és un repositori de git: %s"
 
-#: setup.c:813
+#: setup.c:877
 #, c-format
 msgid "'$%s' too big"
 msgstr "«$%s» massa gran"
 
-#: setup.c:827
+#: setup.c:891
 #, c-format
 msgid "not a git repository: '%s'"
 msgstr "no és un repositori de git: «%s»"
 
-#: setup.c:856 setup.c:858 setup.c:889
+#: setup.c:920 setup.c:922 setup.c:953
 #, c-format
 msgid "cannot chdir to '%s'"
 msgstr "no es pot canviar de directori a «%s»"
 
-#: setup.c:861 setup.c:917 setup.c:927 setup.c:966 setup.c:974
+#: setup.c:925 setup.c:981 setup.c:991 setup.c:1030 setup.c:1038
 msgid "cannot come back to cwd"
 msgstr "no es pot tornar al directori de treball actual"
 
-#: setup.c:988
+#: setup.c:1052
 #, c-format
 msgid "failed to stat '%*s%s%s'"
 msgstr "s'ha produït un error en fer stat a «%*s%s%s»"
 
-#: setup.c:1231
+#: setup.c:1295
 msgid "Unable to read current working directory"
 msgstr "No s'ha pogut llegir el directori de treball actual"
 
-#: setup.c:1240 setup.c:1246
+#: setup.c:1304 setup.c:1310
 #, c-format
 msgid "cannot change to '%s'"
 msgstr "no es pot canviar a «%s»"
 
-#: setup.c:1251
+#: setup.c:1315
 #, c-format
 msgid "not a git repository (or any of the parent directories): %s"
 msgstr "no és un repositori de git (ni cap dels directoris pares): %s"
 
-#: setup.c:1257
+#: setup.c:1321
 #, c-format
 msgid ""
 "not a git repository (or any parent up to mount point %s)\n"
@@ -8902,7 +8836,7 @@ msgstr ""
 "no és un repositori de git (ni cap pare fins al punt de muntatge %s)\n"
 "S'atura a la frontera de sistema de fitxers (GIT_DISCOVERY_ACROSS_FILESYSTEM no està establert)."
 
-#: setup.c:1381
+#: setup.c:1446
 #, c-format
 msgid ""
 "problem with core.sharedRepository filemode value (0%.3o).\n"
@@ -8911,16 +8845,16 @@ msgstr ""
 "hi ha un problema amb el valor de mode de fitxer core.sharedRepository (0%.3o).\n"
 "El propietari dels fitxers sempre ha de tenir permisos de lectura i escriptura."
 
-#: setup.c:1443
+#: setup.c:1508
 msgid "fork failed"
 msgstr "el «fork» ha fallat"
 
-#: setup.c:1448
+#: setup.c:1513
 msgid "setsid failed"
 msgstr "«setsid» ha fallat"
 
-#: sparse-index.c:273
-#, fuzzy, c-format
+#: sparse-index.c:289
+#, c-format
 msgid "index entry is a directory, but not sparse (%08x)"
 msgstr "l'entrada d'índex és un directori, però no dispers (%08x)"
 
@@ -8976,13 +8910,13 @@ msgid_plural "%u bytes/s"
 msgstr[0] "%u byte/s"
 msgstr[1] "%u bytes/s"
 
-#: strbuf.c:1174 wrapper.c:207 wrapper.c:377 builtin/am.c:739
+#: strbuf.c:1186 wrapper.c:207 wrapper.c:377 builtin/am.c:765
 #: builtin/rebase.c:650
 #, c-format
 msgid "could not open '%s' for writing"
 msgstr "no s'ha pogut obrir «%s» per a escriptura"
 
-#: strbuf.c:1183
+#: strbuf.c:1195
 #, c-format
 msgid "could not edit '%s'"
 msgstr "no s'ha pogut editar «%s»"
@@ -9076,7 +9010,7 @@ msgstr ""
 msgid "process for submodule '%s' failed"
 msgstr "ha fallat el procés per al submòdul «%s»"
 
-#: submodule.c:1194 builtin/branch.c:692 builtin/submodule--helper.c:2713
+#: submodule.c:1194 builtin/branch.c:699 builtin/submodule--helper.c:2714
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "S'ha produït un error en resoldre HEAD com a referència vàlida."
 
@@ -9211,7 +9145,7 @@ msgstr "s'ha produït un error en fer lstat a «%s»"
 #: trailer.c:244
 #, c-format
 msgid "running trailer command '%s' failed"
-msgstr "l'execució de l'ordre de remolc «%s» ha fallat"
+msgstr "l'execució de l'ordre «trailer» «%s» ha fallat"
 
 #: trailer.c:493 trailer.c:498 trailer.c:503 trailer.c:562 trailer.c:566
 #: trailer.c:570
@@ -9228,7 +9162,7 @@ msgstr "més d'un %s"
 #: trailer.c:743
 #, c-format
 msgid "empty trailer token in trailer '%.*s'"
-msgstr "testimoni de remolc buit en el remolc «%.*s»"
+msgstr "testimoni de «trailer» buit en el «trailer» «%.*s»"
 
 #: trailer.c:763
 #, c-format
@@ -9325,7 +9259,7 @@ msgstr "el protocol no permet establir el camí del servei remot"
 msgid "invalid remote service path"
 msgstr "el camí del servei remot no és vàlid"
 
-#: transport-helper.c:661 transport.c:1475
+#: transport-helper.c:661 transport.c:1479
 msgid "operation not supported by protocol"
 msgstr "opció no admesa pel protocol"
 
@@ -9335,7 +9269,6 @@ msgid "can't connect to subservice %s"
 msgstr "no es pot connectar al subservei %s"
 
 #: transport-helper.c:693 transport.c:404
-#, fuzzy
 msgid "--negotiate-only requires protocol v2"
 msgstr "--negotiate-only requereix el protocol v2"
 
@@ -9344,55 +9277,54 @@ msgid "'option' without a matching 'ok/error' directive"
 msgstr "«option» sense una directiva «ok/error» coincident"
 
 #: transport-helper.c:798
-#, fuzzy, c-format
+#, c-format
 msgid "expected ok/error, helper said '%s'"
-msgstr "s'esperava un ajudant d'error/OK ha dit \"%s\""
+msgstr "s'esperava error/OK, l'ajudant ha dit «%s»"
 
 #: transport-helper.c:859
-#, fuzzy, c-format
+#, c-format
 msgid "helper reported unexpected status of %s"
-msgstr "l'ajudant ha informat d'un estat inesperat dels percentatges"
+msgstr "l'ajudant ha informat d'un estat inesperat de %s"
 
 #: transport-helper.c:942
-#, fuzzy, c-format
+#, c-format
 msgid "helper %s does not support dry-run"
-msgstr "els ajudants no donen suport a l'execució seca"
+msgstr "l'ajudant %s no admet dry-run"
 
 #: transport-helper.c:945
-#, fuzzy, c-format
+#, c-format
 msgid "helper %s does not support --signed"
-msgstr "els ajudants per cents no són compatibles --signed"
+msgstr "l'ajudant %s no admet --signed"
 
 #: transport-helper.c:948
-#, fuzzy, c-format
+#, c-format
 msgid "helper %s does not support --signed=if-asked"
-msgstr "l'ajudant per cents no admet --signed=if-asked"
+msgstr "l'ajudant %s no admet --signed=if-asked"
 
 #: transport-helper.c:953
-#, fuzzy, c-format
+#, c-format
 msgid "helper %s does not support --atomic"
-msgstr "els ajudants no admeten --atomic"
+msgstr "l'ajudant %s no admet --atomic"
 
 #: transport-helper.c:957
-#, fuzzy, c-format
+#, c-format
 msgid "helper %s does not support --%s"
-msgstr "els ajudants per cents no són compatibles --signed"
+msgstr "l'ajudant %s no admet --%s"
 
 #: transport-helper.c:964
-#, fuzzy, c-format
+#, c-format
 msgid "helper %s does not support 'push-option'"
-msgstr "els ajudants no donen suport a «push-option»"
+msgstr "l'ajudant %s no admet «push-option»"
 
 #: transport-helper.c:1064
-#, fuzzy
 msgid "remote-helper doesn't support push; refspec needed"
 msgstr ""
-"remot-helper no permet prémer; es necessiten especificacions de referència"
+"remot-helper no permet pujar; es necessiten especificacions de referència"
 
 #: transport-helper.c:1069
-#, fuzzy, c-format
+#, c-format
 msgid "helper %s does not support 'force'"
-msgstr "els ajudants no donen suport a «force»"
+msgstr "l'ajudant %s no admet «force»"
 
 #: transport-helper.c:1116
 msgid "couldn't run fast-export"
@@ -9403,33 +9335,33 @@ msgid "error while running fast-export"
 msgstr "error en executar l'exportació ràpida"
 
 #: transport-helper.c:1146
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "No refs in common and none specified; doing nothing.\n"
 "Perhaps you should specify a branch.\n"
 msgstr ""
-"No hi ha referències en comú i no n'hi ha cap especificat. Potser hauríeu "
-"d'especificar una branca com ara «master»."
+"No hi ha referències en comú i no n'hi ha cap d'especificada.\n"
+"No es farà res. Potser hauríeu d'especificar una branca.\n"
 
 #: transport-helper.c:1228
-#, fuzzy, c-format
+#, c-format
 msgid "unsupported object format '%s'"
-msgstr "objecte mal format a «%s»"
+msgstr "format d'objecte no suportat «%s»"
 
 #: transport-helper.c:1237
-#, fuzzy, c-format
+#, c-format
 msgid "malformed response in ref list: %s"
-msgstr "resposta mal formada en la llista de referències"
+msgstr "resposta mal formada al llistat de referències: %s"
 
 #: transport-helper.c:1389
-#, fuzzy, c-format
+#, c-format
 msgid "read(%s) failed"
-msgstr "ha fallat read(%)"
+msgstr "ha fallat la lectura(%s)"
 
 #: transport-helper.c:1416
-#, fuzzy, c-format
+#, c-format
 msgid "write(%s) failed"
-msgstr "ha fallat l(%)"
+msgstr "ha fallat l'escriptura(%s)"
 
 #: transport-helper.c:1465
 #, c-format
@@ -9437,9 +9369,9 @@ msgid "%s thread failed"
 msgstr "%s ha fallat el fil"
 
 #: transport-helper.c:1469
-#, fuzzy, c-format
+#, c-format
 msgid "%s thread failed to join: %s"
-msgstr "el fil per cents no s'ha pogut unir als percentatges"
+msgstr "el fil %s no s'ha pogut unir: %s"
 
 #: transport-helper.c:1488 transport-helper.c:1492
 #, c-format
@@ -9549,10 +9481,9 @@ msgstr ""
 msgid "Aborting."
 msgstr "S'està avortant."
 
-#: transport.c:1344
-#, fuzzy
+#: transport.c:1343
 msgid "failed to push all needed submodules"
-msgstr "no s'ha pogut prémer tots els submòduls necessaris"
+msgstr "no s'han pogut pujar tots els submòduls necessaris"
 
 #: tree-walk.c:33
 msgid "too-short tree object"
@@ -9570,7 +9501,7 @@ msgstr "nom de fitxer buit en una entrada d'arbre"
 msgid "too-short tree file"
 msgstr "fitxer d'arbre massa curt"
 
-#: unpack-trees.c:115
+#: unpack-trees.c:118
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by checkout:\n"
@@ -9579,7 +9510,7 @@ msgstr ""
 "Els vostres canvis locals als fitxers següents se sobreescriurien per agafar:\n"
 "%%sCometeu els vostres canvis o feu «stash» abans de canviar de branca."
 
-#: unpack-trees.c:117
+#: unpack-trees.c:120
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by checkout:\n"
@@ -9588,7 +9519,7 @@ msgstr ""
 "Els vostres canvis locals als fitxers següents se sobreescriurien per agafar:\n"
 "%%s"
 
-#: unpack-trees.c:120
+#: unpack-trees.c:123
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -9597,7 +9528,7 @@ msgstr ""
 "Els vostres canvis locals als fitxers següents se sobreescriurien per fusionar:\n"
 "%%sCometeu els vostres canvis o feu «stash» abans de fusionar."
 
-#: unpack-trees.c:122
+#: unpack-trees.c:125
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -9606,7 +9537,7 @@ msgstr ""
 "Els vostres canvis locals als fitxers següents se sobreescriurien per fusionar:\n"
 "%%s"
 
-#: unpack-trees.c:125
+#: unpack-trees.c:128
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by %s:\n"
@@ -9615,7 +9546,7 @@ msgstr ""
 "Els vostres canvis locals als fitxers següents se sobreescriurien per %s:\n"
 "%%sCometeu els vostres canvis o feu «stash» abans de %s."
 
-#: unpack-trees.c:127
+#: unpack-trees.c:130
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by %s:\n"
@@ -9624,7 +9555,7 @@ msgstr ""
 "Els vostres canvis locals als fitxers següents se sobreescriurien per %s:\n"
 "%%s"
 
-#: unpack-trees.c:132
+#: unpack-trees.c:135
 #, c-format
 msgid ""
 "Updating the following directories would lose untracked files in them:\n"
@@ -9633,7 +9564,15 @@ msgstr ""
 "En actualitzar els directoris següents perdria fitxers no seguits en el:\n"
 "%s"
 
-#: unpack-trees.c:136
+#: unpack-trees.c:138
+#, c-format
+msgid ""
+"Refusing to remove the current working directory:\n"
+"%s"
+msgstr "S'ha rebutjat suprimir el directori de treball actual:\n"
+"%s"
+
+#: unpack-trees.c:142
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by checkout:\n"
@@ -9642,7 +9581,7 @@ msgstr ""
 "Els següents fitxers no seguits en l'arbre de treball s'eliminarien per agafar:\n"
 "%%sMoveu-los o elimineu-los abans de canviar de branca."
 
-#: unpack-trees.c:138
+#: unpack-trees.c:144
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by checkout:\n"
@@ -9651,7 +9590,7 @@ msgstr ""
 "Els següents fitxers no seguits en l'arbre de treball s'eliminarien en agafar:\n"
 "%%s"
 
-#: unpack-trees.c:141
+#: unpack-trees.c:147
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by merge:\n"
@@ -9660,7 +9599,7 @@ msgstr ""
 "Els següents fitxers no seguits en l'arbre de treball s'eliminarien en fusionar:\n"
 "%%sMoveu-los o elimineu-los abans de fusionar."
 
-#: unpack-trees.c:143
+#: unpack-trees.c:149
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by merge:\n"
@@ -9669,7 +9608,7 @@ msgstr ""
 "Els següents fitxers no seguits en l'arbre de treball s'eliminarien en fusionar:\n"
 "%%s"
 
-#: unpack-trees.c:146
+#: unpack-trees.c:152
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by %s:\n"
@@ -9678,7 +9617,7 @@ msgstr ""
 "Els següents fitxers no seguits en l'arbre de treball s'eliminarien per %s:\n"
 "%%sMoveu-los o elimineu-los abans de %s."
 
-#: unpack-trees.c:148
+#: unpack-trees.c:154
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by %s:\n"
@@ -9687,7 +9626,7 @@ msgstr ""
 "Els següents fitxers no seguits en l'arbre de treball s'eliminarien per %s:\n"
 "%%s"
 
-#: unpack-trees.c:154
+#: unpack-trees.c:160
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by checkout:\n"
@@ -9696,7 +9635,7 @@ msgstr ""
 "Els següents fitxers no seguits en l'arbre de treball se sobreescriurien per agafar:\n"
 "%%sMoveu-los o elimineu-los abans de canviar de branca."
 
-#: unpack-trees.c:156
+#: unpack-trees.c:162
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by checkout:\n"
@@ -9705,7 +9644,7 @@ msgstr ""
 "Els següents fitxers no seguits en l'arbre de treball se sobreescriurien per agafar:\n"
 "%%s"
 
-#: unpack-trees.c:159
+#: unpack-trees.c:165
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by merge:\n"
@@ -9714,7 +9653,7 @@ msgstr ""
 "Els següents fitxers no seguits en l'arbre de treball se sobreescriurien per fusionar:\n"
 "%%sMoveu-los o elimineu-los abans de fusionar."
 
-#: unpack-trees.c:161
+#: unpack-trees.c:167
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by merge:\n"
@@ -9723,7 +9662,7 @@ msgstr ""
 "Els següents fitxers no seguits en l'arbre de treball se sobreescriurien per fusionar:\n"
 "%%s"
 
-#: unpack-trees.c:164
+#: unpack-trees.c:170
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by %s:\n"
@@ -9732,7 +9671,7 @@ msgstr ""
 "Els següents fitxers no seguits en l'arbre de treball se sobreescriurien per %s:\n"
 "%%sMoveu-los o elimineu-los abans de %s."
 
-#: unpack-trees.c:166
+#: unpack-trees.c:172
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by %s:\n"
@@ -9741,12 +9680,12 @@ msgstr ""
 "Els següents fitxers no seguits en l'arbre de treball se sobreescriurien per %s:\n"
 "%%s"
 
-#: unpack-trees.c:174
+#: unpack-trees.c:180
 #, c-format
 msgid "Entry '%s' overlaps with '%s'.  Cannot bind."
 msgstr "L'entrada «%s» encavalca amb «%s».  No es pot vincular."
 
-#: unpack-trees.c:177
+#: unpack-trees.c:183
 #, c-format
 msgid ""
 "Cannot update submodule:\n"
@@ -9755,76 +9694,75 @@ msgstr ""
 "No es pot actualitzar el submòdul:\n"
 "%s"
 
-#: unpack-trees.c:180
-#, fuzzy, c-format
+#: unpack-trees.c:186
+#, c-format
 msgid ""
 "The following paths are not up to date and were left despite sparse patterns:\n"
 "%s"
 msgstr ""
-"Els camins següents no estan actualitzats i es van deixar a pesar que s'han "
-"dispersat els percentatges"
+"Els camins següents no estan actualitzats, i es van deixar, malgrat els patrons dispersos:\n"
+"%s"
 
-#: unpack-trees.c:182
-#, fuzzy, c-format
+#: unpack-trees.c:188
+#, c-format
 msgid ""
 "The following paths are unmerged and were left despite sparse patterns:\n"
 "%s"
-msgstr "Els camins següents s'ignoren per un dels vostres fitxers .gitignore:\n"
+msgstr ""
+"Els camins següents no es fusionen, i es van deixar, malgrat els patrons dispersos:\n"
+"%s"
 
-#: unpack-trees.c:184
-#, fuzzy, c-format
+#: unpack-trees.c:190
+#, c-format
 msgid ""
 "The following paths were already present and thus not updated despite sparse patterns:\n"
 "%s"
 msgstr ""
-"Els camins següents ja estaven presents i, per tant, no s'han actualitzat "
-"malgrat els patrons escassos."
+"Els camins següents ja estaven presents i, per tant, no s'han actualitzat malgrat els patrons dispersos.:\n"
+"%s"
 
-#: unpack-trees.c:264
+#: unpack-trees.c:270
 #, c-format
 msgid "Aborting\n"
 msgstr "S'està avortant\n"
 
-#: unpack-trees.c:291
-#, fuzzy, c-format
+#: unpack-trees.c:297
+#, c-format
 msgid ""
 "After fixing the above paths, you may want to run `git sparse-checkout "
 "reapply`.\n"
 msgstr ""
 "Després de corregir els camins anteriors és possible que vulgueu executar "
-"`git sparse-checkout reapply`."
+"`git sparse-checkout reapply`.\n"
 
-#: unpack-trees.c:352
+#: unpack-trees.c:358
 msgid "Updating files"
 msgstr "S'estan actualitzant els fitxers"
 
-#: unpack-trees.c:384
-#, fuzzy
+#: unpack-trees.c:390
 msgid ""
 "the following paths have collided (e.g. case-sensitive paths\n"
 "on a case-insensitive filesystem) and only one from the same\n"
 "colliding group is in the working tree:\n"
 msgstr ""
-"els camins següents han xocat (p. ex. camins sensibles a majúscules i "
-"minúscules en un sistema de fitxers que no distingeix entre majúscules i "
-"minúscules) i només un del mateix grup de col·lisió es troba a l'arbre de "
-"treball"
+"els camins següents han col·lisionat (p. ex. camins sensibles a majúscules\n"
+"i minúscules en un sistema de fitxers que no distingeix entre majúscules i\n"
+"minúscules). Només un camí del mateix grup de col·lisió es troba a l'arbre\n"
+"de treball:\n"
 
-#: unpack-trees.c:1620
-#, fuzzy
+#: unpack-trees.c:1636
 msgid "Updating index flags"
-msgstr "Actualitzant els indicadors d’índex"
+msgstr "Actualitzant els indicadors d'índex"
 
-#: unpack-trees.c:2772
-#, fuzzy, c-format
+#: unpack-trees.c:2803
+#, c-format
 msgid "worktree and untracked commit have duplicate entries: %s"
 msgstr ""
 "l'arbre de treball i la comissió no seguida tenen entrades duplicades: %s"
 
-#: upload-pack.c:1561
-#, fuzzy
+#: upload-pack.c:1565
 msgid "expected flush after fetch arguments"
-msgstr "s'esperava una neteja després de les capacitats"
+msgstr "s'esperava una neteja després dels arguments del «fetch»"
 
 #: urlmatch.c:163
 msgid "invalid URL scheme name or missing '://' suffix"
@@ -9859,109 +9797,109 @@ msgstr "segment de camí «..» no vàlid"
 msgid "Fetching objects"
 msgstr "S'estan obtenint objectes"
 
-#: worktree.c:236 builtin/am.c:2154 builtin/bisect--helper.c:156
+#: worktree.c:238 builtin/am.c:2209 builtin/bisect--helper.c:156
 #, c-format
 msgid "failed to read '%s'"
 msgstr "s'ha produït un error en llegir «%s»"
 
-#: worktree.c:303
+#: worktree.c:305
 #, c-format
 msgid "'%s' at main working tree is not the repository directory"
 msgstr "«%s» a l'arbre de treball principal no és al directori del repositori"
 
-#: worktree.c:314
+#: worktree.c:316
 #, c-format
 msgid "'%s' file does not contain absolute path to the working tree location"
 msgstr ""
 "El fitxer «%s» no conté el camí absolut a la ubicació de l'arbre de treball"
 
-#: worktree.c:326
+#: worktree.c:328
 #, c-format
 msgid "'%s' does not exist"
 msgstr "«%s» no existeix"
 
-#: worktree.c:332
+#: worktree.c:334
 #, c-format
 msgid "'%s' is not a .git file, error code %d"
 msgstr "«%s» no és un fitxer .git, codi d'error %d"
 
-#: worktree.c:341
+#: worktree.c:343
 #, c-format
 msgid "'%s' does not point back to '%s'"
 msgstr "«%s» no assenyala de tornada a «%s»"
 
-#: worktree.c:603
+#: worktree.c:604
 msgid "not a directory"
 msgstr "no és en un directori"
 
-#: worktree.c:612
+#: worktree.c:613
 msgid ".git is not a file"
 msgstr ".git no és un fitxer"
 
-#: worktree.c:614
+#: worktree.c:615
 msgid ".git file broken"
 msgstr "fitxer .git malmès"
 
-#: worktree.c:616
+#: worktree.c:617
 msgid ".git file incorrect"
 msgstr "fitxer .git malmès"
 
-#: worktree.c:722
+#: worktree.c:723
 msgid "not a valid path"
 msgstr "no és un camí vàlid"
 
-#: worktree.c:728
+#: worktree.c:729
 msgid "unable to locate repository; .git is not a file"
 msgstr "no s'ha pogut trobar el repositori; .git no és un fitxer"
 
-#: worktree.c:732
+#: worktree.c:733
 msgid "unable to locate repository; .git file does not reference a repository"
 msgstr ""
 "no s'ha pogut trobar el repositori; el fitxer .git no fa referència a un "
 "repositori"
 
-#: worktree.c:736
+#: worktree.c:737
 msgid "unable to locate repository; .git file broken"
 msgstr "no s'ha pogut trobar el repositori; el fitxer .git està malmès"
 
-#: worktree.c:742
+#: worktree.c:743
 msgid "gitdir unreadable"
 msgstr "gitdir illegible"
 
-#: worktree.c:746
+#: worktree.c:747
 msgid "gitdir incorrect"
 msgstr "gitdir incorrecte"
 
-#: worktree.c:771
+#: worktree.c:772
 msgid "not a valid directory"
 msgstr "no és en un directori vàlid"
 
-#: worktree.c:777
+#: worktree.c:778
 msgid "gitdir file does not exist"
 msgstr "el fitxer gitdir no existeix"
 
-#: worktree.c:782 worktree.c:791
+#: worktree.c:783 worktree.c:792
 #, c-format
 msgid "unable to read gitdir file (%s)"
 msgstr "no s'ha pogut llegir el fitxer gitdir (%s)"
 
-#: worktree.c:801
+#: worktree.c:802
 #, c-format
 msgid "short read (expected %<PRIuMAX> bytes, read %<PRIuMAX>)"
 msgstr "lectura curta (s'esperaven %<PRIuMAX> bytes, llegits %<PRIuMAX>)"
 
-#: worktree.c:809
+#: worktree.c:810
 msgid "invalid gitdir file"
 msgstr "fitxer gitdir no vàlid"
 
-#: worktree.c:817
+#: worktree.c:818
 msgid "gitdir file points to non-existent location"
 msgstr "el fitxer gitdir indica una ubicació no existent"
 
 #: wrapper.c:151
-#, fuzzy, c-format
+#, c-format
 msgid "could not setenv '%s'"
-msgstr "no s'ha pogut establir «%s»"
+msgstr "no s'ha pogut fer setenv «%s»"
 
 #: wrapper.c:203
 #, c-format
@@ -10014,11 +9952,11 @@ msgstr ""
 msgid "  (use \"git rm <file>...\" to mark resolution)"
 msgstr "  (useu «git rm <fitxer>...» per a senyalar resolució)"
 
-#: wt-status.c:211 wt-status.c:1125
+#: wt-status.c:211 wt-status.c:1131
 msgid "Changes to be committed:"
 msgstr "Canvis a cometre:"
 
-#: wt-status.c:234 wt-status.c:1134
+#: wt-status.c:234 wt-status.c:1140
 msgid "Changes not staged for commit:"
 msgstr "Canvis no «staged» per a cometre:"
 
@@ -10033,8 +9971,8 @@ msgstr "  (useu «git add/rm <fitxer>...» per a actualitzar què es cometrà)"
 #: wt-status.c:241
 msgid "  (use \"git restore <file>...\" to discard changes in working directory)"
 msgstr ""
-"  (useu «git restore <file>...» per a descartar canvis en el directori "
-"de treball)"
+"  (useu «git restore <file>...» per a descartar canvis en el directori de "
+"treball)"
 
 #: wt-status.c:243
 msgid "  (commit or discard the untracked or modified content in submodules)"
@@ -10118,22 +10056,22 @@ msgstr "contingut modificat, "
 msgid "untracked content, "
 msgstr "contingut no seguit, "
 
-#: wt-status.c:958
+#: wt-status.c:964
 #, c-format
 msgid "Your stash currently has %d entry"
 msgid_plural "Your stash currently has %d entries"
 msgstr[0] "L'«stash» té actualment %d entrada"
 msgstr[1] "L'«stash» té actualment %d entrades"
 
-#: wt-status.c:989
+#: wt-status.c:995
 msgid "Submodules changed but not updated:"
 msgstr "Submòduls canviats però no actualitzats:"
 
-#: wt-status.c:991
+#: wt-status.c:997
 msgid "Submodule changes to be committed:"
 msgstr "Canvis de submòdul a cometre:"
 
-#: wt-status.c:1073
+#: wt-status.c:1079
 msgid ""
 "Do not modify or remove the line above.\n"
 "Everything below it will be ignored."
@@ -10141,7 +10079,7 @@ msgstr ""
 "No modifiqueu ni elimineu la línia de dalt.\n"
 "Tot el que hi ha a sota s'ignorarà."
 
-#: wt-status.c:1165
+#: wt-status.c:1171
 #, c-format
 msgid ""
 "\n"
@@ -10152,109 +10090,113 @@ msgstr ""
 "S'ha trigat un %.2f segons a calcular els valors de la branca d'endavant i darrere.\n"
 "Podeu utilitzar «--no-ahead-behind» per a evitar-ho.\n"
 
-#: wt-status.c:1195
+#: wt-status.c:1201
 msgid "You have unmerged paths."
 msgstr "Teniu camins sense fusionar."
 
-#: wt-status.c:1198
+#: wt-status.c:1204
 msgid "  (fix conflicts and run \"git commit\")"
 msgstr "  (arregleu els conflictes i executeu «git commit»)"
 
-#: wt-status.c:1200
+#: wt-status.c:1206
 msgid "  (use \"git merge --abort\" to abort the merge)"
 msgstr "  (useu «git merge --abort» per a avortar la fusió)"
 
-#: wt-status.c:1204
+#: wt-status.c:1210
 msgid "All conflicts fixed but you are still merging."
 msgstr "Tots els conflictes estan arreglats però encara esteu fusionant."
 
-#: wt-status.c:1207
+#: wt-status.c:1213
 msgid "  (use \"git commit\" to conclude merge)"
 msgstr "  (useu «git commit» per a concloure la fusió)"
 
-#: wt-status.c:1216
+#: wt-status.c:1224
 msgid "You are in the middle of an am session."
 msgstr "Esteu enmig d'una sessió am."
 
-#: wt-status.c:1219
+#: wt-status.c:1227
 msgid "The current patch is empty."
 msgstr "El pedaç actual està buit."
 
-#: wt-status.c:1223
+#: wt-status.c:1232
 msgid "  (fix conflicts and then run \"git am --continue\")"
 msgstr "  (arregleu els conflictes i després executeu «git am --continue»)"
 
-#: wt-status.c:1225
+#: wt-status.c:1234
 msgid "  (use \"git am --skip\" to skip this patch)"
 msgstr "  (useu «git am --skip» per a ometre aquest pedaç)"
 
-#: wt-status.c:1227
+#: wt-status.c:1237
+msgid "  (use \"git am --allow-empty\" to record this patch as an empty commit)"
+msgstr "  (useu «git am --allow-empty» per a enregistrar aquest pedaç com una comissió buida)"
+
+#: wt-status.c:1239
 msgid "  (use \"git am --abort\" to restore the original branch)"
 msgstr "  (useu «git am --abort» per a restaurar la branca original)"
 
-#: wt-status.c:1360
+#: wt-status.c:1372
 msgid "git-rebase-todo is missing."
 msgstr "Manca git-rebase-todo."
 
-#: wt-status.c:1362
+#: wt-status.c:1374
 msgid "No commands done."
 msgstr "No s'ha fet cap ordre."
 
-#: wt-status.c:1365
+#: wt-status.c:1377
 #, c-format
 msgid "Last command done (%d command done):"
 msgid_plural "Last commands done (%d commands done):"
 msgstr[0] "Última ordre feta (%d ordre feta):"
 msgstr[1] "Últimes ordres fetes (%d ordres fetes):"
 
-#: wt-status.c:1376
+#: wt-status.c:1388
 #, c-format
 msgid "  (see more in file %s)"
 msgstr "  (vegeu més en el fitxer %s)"
 
-#: wt-status.c:1381
+#: wt-status.c:1393
 msgid "No commands remaining."
 msgstr "No manca cap ordre."
 
-#: wt-status.c:1384
+#: wt-status.c:1396
 #, c-format
 msgid "Next command to do (%d remaining command):"
 msgid_plural "Next commands to do (%d remaining commands):"
 msgstr[0] "Ordre següent a fer (manca %d ordre):"
 msgstr[1] "Ordres següents a fer (manquen %d ordres):"
 
-#: wt-status.c:1392
+#: wt-status.c:1404
 msgid "  (use \"git rebase --edit-todo\" to view and edit)"
 msgstr "  (useu «git rebase --edit-todo» per a veure i editar)"
 
-#: wt-status.c:1404
+#: wt-status.c:1416
 #, c-format
 msgid "You are currently rebasing branch '%s' on '%s'."
 msgstr "Actualment esteu fent «rebase» de la branca «%s» en «%s»."
 
-#: wt-status.c:1409
+#: wt-status.c:1421
 msgid "You are currently rebasing."
 msgstr "Actualment esteu fent «rebase»."
 
-#: wt-status.c:1422
+#: wt-status.c:1434
 msgid "  (fix conflicts and then run \"git rebase --continue\")"
 msgstr ""
 "  (arregleu els conflictes i després executeu «git rebase --continue»)"
 
-#: wt-status.c:1424
+#: wt-status.c:1436
 msgid "  (use \"git rebase --skip\" to skip this patch)"
 msgstr "  (useu «git rebase --skip» per a ometre aquest pedaç)"
 
-#: wt-status.c:1426
+#: wt-status.c:1438
 msgid "  (use \"git rebase --abort\" to check out the original branch)"
 msgstr "  (useu «git rebase --abort» per a agafar la branca original)"
 
-#: wt-status.c:1433
+#: wt-status.c:1445
 msgid "  (all conflicts fixed: run \"git rebase --continue\")"
 msgstr ""
 "  (tots els conflictes estan arreglats: executeu «git rebase --continue»)"
 
-#: wt-status.c:1437
+#: wt-status.c:1449
 #, c-format
 msgid ""
 "You are currently splitting a commit while rebasing branch '%s' on '%s'."
@@ -10262,165 +10204,164 @@ msgstr ""
 "Actualment esteu dividint una comissió mentre es fa «rebase» de la branca "
 "«%s» en «%s»."
 
-#: wt-status.c:1442
+#: wt-status.c:1454
 msgid "You are currently splitting a commit during a rebase."
 msgstr "Actualment esteu dividint una comissió durant un «rebase»."
 
-#: wt-status.c:1445
+#: wt-status.c:1457
 msgid "  (Once your working directory is clean, run \"git rebase --continue\")"
 msgstr ""
 "  (Una vegada que el vostre directori de treball sigui net, executeu «git "
 "rebase --continue»)"
 
-#: wt-status.c:1449
+#: wt-status.c:1461
 #, c-format
 msgid "You are currently editing a commit while rebasing branch '%s' on '%s'."
 msgstr ""
 "Actualment esteu editant una comissió mentre es fa «rebase» de la branca "
 "«%s» en «%s»."
 
-#: wt-status.c:1454
+#: wt-status.c:1466
 msgid "You are currently editing a commit during a rebase."
 msgstr "Actualment esteu editant una comissió durant un «rebase»."
 
-#: wt-status.c:1457
+#: wt-status.c:1469
 msgid "  (use \"git commit --amend\" to amend the current commit)"
 msgstr "  (useu «git commit --amend» per a esmenar la comissió actual)"
 
-#: wt-status.c:1459
+#: wt-status.c:1471
 msgid "  (use \"git rebase --continue\" once you are satisfied with your changes)"
 msgstr ""
 "  (useu «git rebase --continue» una vegada que estigueu satisfet amb els "
 "vostres canvis)"
 
-#: wt-status.c:1470
+#: wt-status.c:1482
 msgid "Cherry-pick currently in progress."
 msgstr "Hi ha «cherry pick» actualment en curs."
 
-#: wt-status.c:1473
+#: wt-status.c:1485
 #, c-format
 msgid "You are currently cherry-picking commit %s."
 msgstr "Actualment esteu fent «cherry pick» a la comissió %s."
 
-#: wt-status.c:1480
+#: wt-status.c:1492
 msgid "  (fix conflicts and run \"git cherry-pick --continue\")"
 msgstr "  (arregleu els conflictes i executeu «git cherry-pick --continue»)"
 
-#: wt-status.c:1483
+#: wt-status.c:1495
 msgid "  (run \"git cherry-pick --continue\" to continue)"
 msgstr "  (executeu «git cherry-pick --continue» per a continuar)"
 
-#: wt-status.c:1486
+#: wt-status.c:1498
 msgid "  (all conflicts fixed: run \"git cherry-pick --continue\")"
 msgstr ""
 "  (tots els conflictes estan arreglats: executeu «git cherry-pick "
 "--continue»)"
 
-#: wt-status.c:1488
+#: wt-status.c:1500
 msgid "  (use \"git cherry-pick --skip\" to skip this patch)"
 msgstr "  (useu «git cherry-pick --skip» per a ometre aquest pedaç)"
 
-#: wt-status.c:1490
+#: wt-status.c:1502
 msgid "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)"
 msgstr ""
 "  (useu «git cherry-pick --abort» per a cancel·lar l'operació de «cherry "
 "pick»)"
 
-#: wt-status.c:1500
+#: wt-status.c:1512
 msgid "Revert currently in progress."
 msgstr "Una reversió està actualment en curs."
 
-#: wt-status.c:1503
+#: wt-status.c:1515
 #, c-format
 msgid "You are currently reverting commit %s."
 msgstr "Actualment esteu revertint la comissió %s."
 
-#: wt-status.c:1509
+#: wt-status.c:1521
 msgid "  (fix conflicts and run \"git revert --continue\")"
 msgstr "  (arregleu els conflictes i executeu «git revert --continue»)"
 
-#: wt-status.c:1512
+#: wt-status.c:1524
 msgid "  (run \"git revert --continue\" to continue)"
 msgstr "  (executeu «git revert --continue» per a continuar)"
 
-#: wt-status.c:1515
+#: wt-status.c:1527
 msgid "  (all conflicts fixed: run \"git revert --continue\")"
 msgstr ""
 "  (tots els conflictes estan arreglats: executeu «git revert --continue»)"
 
-#: wt-status.c:1517
+#: wt-status.c:1529
 msgid "  (use \"git revert --skip\" to skip this patch)"
 msgstr "  (useu «git revert --skip» per a ometre aquest pedaç)"
 
-#: wt-status.c:1519
+#: wt-status.c:1531
 msgid "  (use \"git revert --abort\" to cancel the revert operation)"
 msgstr "  (useu «git revert --abort» per a cancel·lar l'operació de reversió)"
 
-#: wt-status.c:1529
+#: wt-status.c:1541
 #, c-format
 msgid "You are currently bisecting, started from branch '%s'."
 msgstr "Actualment esteu bisecant, heu començat des de la branca «%s»."
 
-#: wt-status.c:1533
+#: wt-status.c:1545
 msgid "You are currently bisecting."
 msgstr "Actualment esteu bisecant."
 
-#: wt-status.c:1536
+#: wt-status.c:1548
 msgid "  (use \"git bisect reset\" to get back to the original branch)"
 msgstr "  (useu «git bisect reset» per a tornar a la branca original)"
 
-#: wt-status.c:1547
-#, fuzzy
+#: wt-status.c:1559
 msgid "You are in a sparse checkout."
-msgstr "no s'ha pogut inicialitzar «sparse-checkout»"
+msgstr "Esteu en un «sparse-checkout»."
 
-#: wt-status.c:1550
-#, fuzzy, c-format
+#: wt-status.c:1562
+#, c-format
 msgid "You are in a sparse checkout with %d%% of tracked files present."
 msgstr ""
-"Esteu en una baixada del pagament amb un 1% d'arxius seguits presents."
+"Esteu en un «sparse-checkout» amb un %d%% de fitxers seguits presents."
 
-#: wt-status.c:1794
+#: wt-status.c:1806
 msgid "On branch "
 msgstr "En la branca "
 
-#: wt-status.c:1801
+#: wt-status.c:1813
 msgid "interactive rebase in progress; onto "
 msgstr "«rebase» interactiu en curs; sobre "
 
-#: wt-status.c:1803
+#: wt-status.c:1815
 msgid "rebase in progress; onto "
 msgstr "«rebase» en curs; sobre "
 
-#: wt-status.c:1808
+#: wt-status.c:1820
 msgid "HEAD detached at "
 msgstr "HEAD separat a "
 
-#: wt-status.c:1810
+#: wt-status.c:1822
 msgid "HEAD detached from "
 msgstr "HEAD separat des de "
 
-#: wt-status.c:1813
+#: wt-status.c:1825
 msgid "Not currently on any branch."
 msgstr "Actualment no s'és en cap branca."
 
-#: wt-status.c:1830
+#: wt-status.c:1842
 msgid "Initial commit"
 msgstr "Comissió inicial"
 
-#: wt-status.c:1831
+#: wt-status.c:1843
 msgid "No commits yet"
 msgstr "No s'ha fet cap comissió encara"
 
-#: wt-status.c:1845
+#: wt-status.c:1857
 msgid "Untracked files"
 msgstr "Fitxers no seguits"
 
-#: wt-status.c:1847
+#: wt-status.c:1859
 msgid "Ignored files"
 msgstr "Fitxers ignorats"
 
-#: wt-status.c:1851
+#: wt-status.c:1863
 #, c-format
 msgid ""
 "It took %.2f seconds to enumerate untracked files. 'status -uno'\n"
@@ -10432,30 +10373,30 @@ msgstr ""
 "oblidar-vos d'afegir fitxers nous vosaltres mateixos (vegeu\n"
 "«git help status»)."
 
-#: wt-status.c:1857
+#: wt-status.c:1869
 #, c-format
 msgid "Untracked files not listed%s"
 msgstr "Els fitxers no seguits no estan llistats%s"
 
-#: wt-status.c:1859
+#: wt-status.c:1871
 msgid " (use -u option to show untracked files)"
 msgstr " (useu l'opció -u per a mostrar els fitxers no seguits)"
 
-#: wt-status.c:1865
+#: wt-status.c:1877
 msgid "No changes"
 msgstr "Sense canvis"
 
-#: wt-status.c:1870
+#: wt-status.c:1882
 #, c-format
 msgid "no changes added to commit (use \"git add\" and/or \"git commit -a\")\n"
 msgstr "no hi ha canvis afegits a cometre (useu «git add» o «git commit -a»)\n"
 
-#: wt-status.c:1874
+#: wt-status.c:1886
 #, c-format
 msgid "no changes added to commit\n"
 msgstr "no hi ha canvis afegits a cometre\n"
 
-#: wt-status.c:1878
+#: wt-status.c:1890
 #, c-format
 msgid ""
 "nothing added to commit but untracked files present (use \"git add\" to "
@@ -10464,85 +10405,85 @@ msgstr ""
 "no hi ha res afegit a cometre però hi ha fitxers no seguits (useu «git add» "
 "per a seguir-los)\n"
 
-#: wt-status.c:1882
+#: wt-status.c:1894
 #, c-format
 msgid "nothing added to commit but untracked files present\n"
 msgstr "no hi ha res afegit a cometre però hi ha fitxers no seguits\n"
 
-#: wt-status.c:1886
+#: wt-status.c:1898
 #, c-format
 msgid "nothing to commit (create/copy files and use \"git add\" to track)\n"
 msgstr ""
 "no hi ha res a cometre (creeu/copieu fitxers i useu «git add» per a seguir-"
 "los)\n"
 
-#: wt-status.c:1890 wt-status.c:1896
+#: wt-status.c:1902 wt-status.c:1908
 #, c-format
 msgid "nothing to commit\n"
 msgstr "no hi ha res a cometre\n"
 
-#: wt-status.c:1893
+#: wt-status.c:1905
 #, c-format
 msgid "nothing to commit (use -u to show untracked files)\n"
 msgstr "no hi ha res a cometre (useu -u per a mostrar els fitxers no seguits)\n"
 
-#: wt-status.c:1898
+#: wt-status.c:1910
 #, c-format
 msgid "nothing to commit, working tree clean\n"
 msgstr "no hi ha res a cometre, l'arbre de treball està net\n"
 
-#: wt-status.c:2003
+#: wt-status.c:2015
 msgid "No commits yet on "
 msgstr "No s'ha fet cap comissió encara a "
 
-#: wt-status.c:2007
+#: wt-status.c:2019
 msgid "HEAD (no branch)"
 msgstr "HEAD (sense branca)"
 
-#: wt-status.c:2038
+#: wt-status.c:2050
 msgid "different"
 msgstr "diferent"
 
-#: wt-status.c:2040 wt-status.c:2048
+#: wt-status.c:2052 wt-status.c:2060
 msgid "behind "
 msgstr "darrere "
 
-#: wt-status.c:2043 wt-status.c:2046
+#: wt-status.c:2055 wt-status.c:2058
 msgid "ahead "
 msgstr "davant per "
 
 #. TRANSLATORS: the action is e.g. "pull with rebase"
-#: wt-status.c:2569
+#: wt-status.c:2596
 #, c-format
 msgid "cannot %s: You have unstaged changes."
 msgstr "no es pot %s: Teniu canvis «unstaged»."
 
-#: wt-status.c:2575
+#: wt-status.c:2602
 msgid "additionally, your index contains uncommitted changes."
 msgstr "addicionalment, el vostre índex conté canvis sense cometre."
 
-#: wt-status.c:2577
+#: wt-status.c:2604
 #, c-format
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr "no es pot %s: El vostre índex conté canvis sense cometre."
 
-#: compat/simple-ipc/ipc-unix-socket.c:183
+#: compat/simple-ipc/ipc-unix-socket.c:205
 msgid "could not send IPC command"
 msgstr "no s'ha pogut enviar l'ordre IPC"
 
-#: compat/simple-ipc/ipc-unix-socket.c:190
+#: compat/simple-ipc/ipc-unix-socket.c:212
 msgid "could not read IPC response"
 msgstr "no s'ha pogut llegir la resposta IPC"
 
-#: compat/simple-ipc/ipc-unix-socket.c:870
+#: compat/simple-ipc/ipc-unix-socket.c:892
 #, c-format
 msgid "could not start accept_thread '%s'"
 msgstr "no s'ha pogut començar un fil «accept_thread» «%s»"
 
-#: compat/simple-ipc/ipc-unix-socket.c:882
-#, fuzzy, c-format
+#: compat/simple-ipc/ipc-unix-socket.c:904
+#, c-format
 msgid "could not start worker[0] for '%s'"
-msgstr "no s'ha pogut llegir el fitxer de registre per a «%s»"
+msgstr "no s'ha pogut iniciar el fil[0] per a «%s»"
 
 #: compat/precompose_utf8.c:58 builtin/clone.c:347
 #, c-format
@@ -10576,110 +10517,115 @@ msgstr "elimina «%s»\n"
 msgid "Unstaged changes after refreshing the index:"
 msgstr "Canvis «unstaged» després d'actualitzar l'índex:"
 
-#: builtin/add.c:317 builtin/rev-parse.c:993
+#: builtin/add.c:313 builtin/rev-parse.c:993
 msgid "Could not read the index"
 msgstr "No s'ha pogut llegir l'índex"
 
-#: builtin/add.c:330
+#: builtin/add.c:326
 msgid "Could not write patch"
 msgstr "No s'ha pogut escriure el pedaç"
 
-#: builtin/add.c:333
+#: builtin/add.c:329
 msgid "editing patch failed"
 msgstr "l'edició del pedaç ha fallat"
 
-#: builtin/add.c:336
+#: builtin/add.c:332
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "No s'ha pogut fer stat a «%s»"
 
-#: builtin/add.c:338
+#: builtin/add.c:334
 msgid "Empty patch. Aborted."
 msgstr "El pedaç és buit. S'ha avortat."
 
-#: builtin/add.c:343
+#: builtin/add.c:340
 #, c-format
 msgid "Could not apply '%s'"
 msgstr "No s'ha pogut aplicar «%s»"
 
-#: builtin/add.c:351
+#: builtin/add.c:348
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr "Els camins següents s'ignoren per un dels vostres fitxers .gitignore:\n"
 
-#: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
-#: builtin/prune-packed.c:14 builtin/pull.c:204 builtin/push.c:550
+#: builtin/add.c:368 builtin/clean.c:927 builtin/fetch.c:174 builtin/mv.c:124
+#: builtin/prune-packed.c:14 builtin/pull.c:208 builtin/push.c:550
 #: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
-msgstr "fer una prova"
+msgstr "fes una prova"
 
-#: builtin/add.c:374
+#: builtin/add.c:369 builtin/check-ignore.c:22 builtin/commit.c:1484
+#: builtin/count-objects.c:98 builtin/fsck.c:789 builtin/log.c:2313
+#: builtin/mv.c:123 builtin/read-tree.c:120
+msgid "be verbose"
+msgstr "sigues detallat"
+
+#: builtin/add.c:371
 msgid "interactive picking"
-msgstr "recull interactiu"
+msgstr "selecció interactiva"
 
-#: builtin/add.c:375 builtin/checkout.c:1560 builtin/reset.c:314
+#: builtin/add.c:372 builtin/checkout.c:1581 builtin/reset.c:409
 msgid "select hunks interactively"
 msgstr "selecciona els trossos interactivament"
 
-#: builtin/add.c:376
+#: builtin/add.c:373
 msgid "edit current diff and apply"
 msgstr "edita la diferència actual i aplica-la"
 
-#: builtin/add.c:377
+#: builtin/add.c:374
 msgid "allow adding otherwise ignored files"
 msgstr "permet afegir fitxers que d'altra manera s'ignoren"
 
-#: builtin/add.c:378
+#: builtin/add.c:375
 msgid "update tracked files"
 msgstr "actualitza els fitxers seguits"
 
-#: builtin/add.c:379
+#: builtin/add.c:376
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr "torna a normalitzar EOL dels fitxers seguits (implica -u)"
 
-#: builtin/add.c:380
+#: builtin/add.c:377
 msgid "record only the fact that the path will be added later"
 msgstr "registra només el fet que el camí s'afegirà més tard"
 
-#: builtin/add.c:381
+#: builtin/add.c:378
 msgid "add changes from all tracked and untracked files"
 msgstr "afegeix els canvis de tots els fitxers seguits i no seguits"
 
-#: builtin/add.c:384
+#: builtin/add.c:381
 msgid "ignore paths removed in the working tree (same as --no-all)"
 msgstr ""
 "ignora els camins eliminats en l'arbre de treball (el mateix que --no-all)"
 
-#: builtin/add.c:386
+#: builtin/add.c:383
 msgid "don't add, only refresh the index"
 msgstr "no afegeixis, només actualitza l'índex"
 
-#: builtin/add.c:387
+#: builtin/add.c:384
 msgid "just skip files which cannot be added because of errors"
 msgstr "només omet els fitxers que no es poden afegir a causa d'errors"
 
-#: builtin/add.c:388
+#: builtin/add.c:385
 msgid "check if - even missing - files are ignored in dry run"
 msgstr ""
-"comproveu si els fitxers, fins i tot els absents, s'ignoren en fer una prova"
+"comprova si els fitxers, fins i tot els absents, s'ignoren en fer una prova"
 
-#: builtin/add.c:389 builtin/mv.c:128 builtin/rm.c:251
-#, fuzzy
+#: builtin/add.c:386 builtin/mv.c:128 builtin/rm.c:251
 msgid "allow updating entries outside of the sparse-checkout cone"
-msgstr "inicialitza el «sparse-checkout» en mode con"
+msgstr "permet actualitzar entrada fora del con del «sparse-checkout»"
 
-#: builtin/add.c:391 builtin/update-index.c:1004
+#: builtin/add.c:388 builtin/update-index.c:1004
 msgid "override the executable bit of the listed files"
-msgstr "passa per alt el bit executable dels fitxers llistats"
+msgstr "sobreescriu el bit executable dels fitxers llistats"
 
-#: builtin/add.c:393
+#: builtin/add.c:390
 msgid "warn when adding an embedded repository"
 msgstr "avisa'm quan s'afegeixi un repositori incrustat"
 
-#: builtin/add.c:395
+#: builtin/add.c:392
 msgid "backend for `git stash -p`"
 msgstr "rerefons per a «git stash -p»"
 
-#: builtin/add.c:413
+#: builtin/add.c:410
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -10710,12 +10656,12 @@ msgstr ""
 "\n"
 "Vegeu «git help submodule» per a més informació."
 
-#: builtin/add.c:442
+#: builtin/add.c:439
 #, c-format
 msgid "adding embedded git repository: %s"
 msgstr "s'està afegint un repositori incrustat: %s"
 
-#: builtin/add.c:462
+#: builtin/add.c:459
 msgid ""
 "Use -f if you really want to add them.\n"
 "Turn this message off by running\n"
@@ -10725,51 +10671,27 @@ msgstr ""
 "Desactiveu aquest missatge executant\n"
 "«git config advice.addIgnoredFile false»"
 
-#: builtin/add.c:477
+#: builtin/add.c:474
 msgid "adding files failed"
 msgstr "l'afegiment de fitxers ha fallat"
 
-#: builtin/add.c:513
-msgid "--dry-run is incompatible with --interactive/--patch"
-msgstr "--dry-run és incompatible amb --interactive/--patch"
-
-#: builtin/add.c:515 builtin/commit.c:358
-msgid "--pathspec-from-file is incompatible with --interactive/--patch"
-msgstr "--pathspec-from-file és incompatible amb --interactive/--patch"
-
-#: builtin/add.c:532
-msgid "--pathspec-from-file is incompatible with --edit"
-msgstr "--pathspec-from-file és incompatible amb --edit"
-
-#: builtin/add.c:544
-msgid "-A and -u are mutually incompatible"
-msgstr "-A i -u són mútuament incompatibles"
-
-#: builtin/add.c:547
-msgid "Option --ignore-missing can only be used together with --dry-run"
-msgstr "L'opció --ignore-missing només es pot usar juntament amb --dry-run"
-
-#: builtin/add.c:551
+#: builtin/add.c:548
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "el paràmetre --chmod «%s» ha de ser o -x o +x"
 
-#: builtin/add.c:572 builtin/checkout.c:1731 builtin/commit.c:364
-#: builtin/reset.c:334 builtin/rm.c:275 builtin/stash.c:1650
-msgid "--pathspec-from-file is incompatible with pathspec arguments"
-msgstr "--pathspec-from-file és incompatible amb els arguments de «pathspec»"
+#: builtin/add.c:569 builtin/checkout.c:1751 builtin/commit.c:364
+#: builtin/reset.c:429 builtin/rm.c:275 builtin/stash.c:1713
+#, c-format
+msgid "'%s' and pathspec arguments cannot be used together"
+msgstr "«%s» i l'especificació de camí no es poden usar juntes"
 
-#: builtin/add.c:579 builtin/checkout.c:1743 builtin/commit.c:370
-#: builtin/reset.c:340 builtin/rm.c:281 builtin/stash.c:1656
-msgid "--pathspec-file-nul requires --pathspec-from-file"
-msgstr "--pathspec-file-nul requereix --pathspec-from-file"
-
-#: builtin/add.c:583
+#: builtin/add.c:580
 #, c-format
 msgid "Nothing specified, nothing added.\n"
 msgstr "No s'ha especificat res, no s'ha afegit res.\n"
 
-#: builtin/add.c:585
+#: builtin/add.c:582
 msgid ""
 "Maybe you wanted to say 'git add .'?\n"
 "Turn this message off by running\n"
@@ -10779,111 +10701,119 @@ msgstr ""
 "Desactiveu aquest missatge executant\n"
 "«git config advice.addEmptyPathspec false»"
 
-#: builtin/am.c:366
+#: builtin/am.c:202
+#, c-format
+msgid "Invalid value for --empty: %s"
+msgstr "Valor no vàlid per a --empty: %s"
+
+#: builtin/am.c:392
 msgid "could not parse author script"
 msgstr "no s'ha pogut analitzar l'script d'autor"
 
-#: builtin/am.c:456
+#: builtin/am.c:482
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
 msgstr "s'ha suprimit «%s» pel lligam applypatch-msg"
 
-#: builtin/am.c:498
+#: builtin/am.c:524
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr "Línia d'entrada mal formada: «%s»."
 
-#: builtin/am.c:536
+#: builtin/am.c:562
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
 msgstr "S'ha produït un error en copiar les notes de «%s» a «%s»"
 
-#: builtin/am.c:562
+#: builtin/am.c:588
 msgid "fseek failed"
 msgstr "fseek ha fallat"
 
-#: builtin/am.c:750
+#: builtin/am.c:776
 #, c-format
 msgid "could not parse patch '%s'"
 msgstr "no s'ha pogut analitzar el pedaç «%s»"
 
-#: builtin/am.c:815
+#: builtin/am.c:841
 msgid "Only one StGIT patch series can be applied at once"
 msgstr "Només una sèrie de pedaços StGIT es pot aplicar a la vegada"
 
-#: builtin/am.c:863
+#: builtin/am.c:889
 msgid "invalid timestamp"
 msgstr "marca de temps no vàlida"
 
-#: builtin/am.c:868 builtin/am.c:880
+#: builtin/am.c:894 builtin/am.c:906
 msgid "invalid Date line"
 msgstr "línia Date no vàlida"
 
-#: builtin/am.c:875
+#: builtin/am.c:901
 msgid "invalid timezone offset"
 msgstr "desplaçament del fus horari no vàlid"
 
-#: builtin/am.c:968
+#: builtin/am.c:994
 msgid "Patch format detection failed."
 msgstr "La detecció de format de pedaç ha fallat."
 
-#: builtin/am.c:973 builtin/clone.c:300
+#: builtin/am.c:999 builtin/clone.c:300
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "s'ha produït un error en crear el directori «%s»"
 
-#: builtin/am.c:978
+#: builtin/am.c:1004
 msgid "Failed to split patches."
 msgstr "S'ha produït un error en dividir els pedaços."
 
-#: builtin/am.c:1127
+#: builtin/am.c:1153
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\"."
 msgstr "Quan hàgiu resolt aquest problema, executeu «%s --continue»."
 
-#: builtin/am.c:1128
+#: builtin/am.c:1154
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
 msgstr "Si preferiu ometre aquest pedaç, executeu «%s --skip» en lloc d'això."
 
-#: builtin/am.c:1129
+#: builtin/am.c:1159
+#, c-format
+msgid "To record the empty patch as an empty commit, run \"%s --allow-empty\"."
+msgstr ""
+"Per a enregistrar un pedaç buit com a comissió buida, executeu «%s --allow-empty»."
+
+#: builtin/am.c:1161
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr ""
 "Per a restaurar la branca original i deixar d'apedaçar, executeu «%s "
 "--abort»."
 
-#: builtin/am.c:1224
+#: builtin/am.c:1256
 msgid ""
 "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
-"Pedaç enviat amb format=flowed; es pot perdre l'espai al final de les línies."
+"Pedaç enviat amb format=flowed; es pot perdre l'espai al final de les "
+"línies."
 
-#: builtin/am.c:1252
-msgid "Patch is empty."
-msgstr "El pedaç està buit."
-
-#: builtin/am.c:1317
+#: builtin/am.c:1344
 #, c-format
 msgid "missing author line in commit %s"
 msgstr "manca la línia d'autor en la comissió %s"
 
-#: builtin/am.c:1320
+#: builtin/am.c:1347
 #, c-format
 msgid "invalid ident line: %.*s"
 msgstr "línia d'identitat no vàlida: %.*s"
 
-#: builtin/am.c:1539
+#: builtin/am.c:1566
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr ""
 "Al repositori li manquen els blobs necessaris per a retrocedir a una fusió "
 "de 3 vies."
 
-#: builtin/am.c:1541
+#: builtin/am.c:1568
 msgid "Using index info to reconstruct a base tree..."
 msgstr "S'està usant la informació d'índex per a reconstruir un arbre base..."
 
-#: builtin/am.c:1560
+#: builtin/am.c:1587
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
@@ -10891,65 +10821,84 @@ msgstr ""
 "Heu editat el vostre pedaç a mà?\n"
 "No s'aplica als blobs recordats en el seu índex."
 
-#: builtin/am.c:1566
+#: builtin/am.c:1593
 msgid "Falling back to patching base and 3-way merge..."
 msgstr "S'està retrocedint a apedaçar la base i una fusió de 3 vies..."
 
-#: builtin/am.c:1592
+#: builtin/am.c:1619
 msgid "Failed to merge in the changes."
 msgstr "S'ha produït un error en fusionar els canvis."
 
-#: builtin/am.c:1624
+#: builtin/am.c:1651
 msgid "applying to an empty history"
 msgstr "s'està aplicant a una història buida"
 
-#: builtin/am.c:1676 builtin/am.c:1680
+#: builtin/am.c:1703 builtin/am.c:1707
 #, c-format
 msgid "cannot resume: %s does not exist."
 msgstr "no es pot reprendre: %s no existeix."
 
-#: builtin/am.c:1698
+#: builtin/am.c:1725
 msgid "Commit Body is:"
 msgstr "El cos de la comissió és:"
 
 #. TRANSLATORS: Make sure to include [y], [n], [e], [v] and [a]
 #. in your translation. The program will only accept English
 #. input at this point.
-#: builtin/am.c:1708
+#: builtin/am.c:1735
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr ""
 "Voleu aplicar-lo? [y]es/[n]o/[e]dita/[v]isualitza el pedaç/[a]ccepta'ls "
 "tots: "
 
-#: builtin/am.c:1754 builtin/commit.c:409
+#: builtin/am.c:1781 builtin/commit.c:409
 msgid "unable to write index file"
 msgstr "no s'ha pogut escriure el fitxer d'índex"
 
-#: builtin/am.c:1758
+#: builtin/am.c:1785
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
 msgstr "Índex brut: no es poden aplicar pedaços (bruts: %s)"
 
-#: builtin/am.c:1798 builtin/am.c:1865
+#: builtin/am.c:1827
+#, c-format
+msgid "Skipping: %.*s"
+msgstr "S'està ometent: %.*s"
+
+#: builtin/am.c:1832
+#, c-format
+msgid "Creating an empty commit: %.*s"
+msgstr "S'està creant una comissió buida: %.*s"
+
+#: builtin/am.c:1836
+msgid "Patch is empty."
+msgstr "El pedaç està buit."
+
+#: builtin/am.c:1847 builtin/am.c:1916
 #, c-format
 msgid "Applying: %.*s"
 msgstr "S'està aplicant: %.*s"
 
-#: builtin/am.c:1815
+#: builtin/am.c:1864
 msgid "No changes -- Patch already applied."
 msgstr "Sense canvis -- El pedaç ja s'ha aplicat."
 
-#: builtin/am.c:1821
+#: builtin/am.c:1870
 #, c-format
 msgid "Patch failed at %s %.*s"
 msgstr "El pedaç ha fallat a %s %.*s"
 
-#: builtin/am.c:1825
+#: builtin/am.c:1874
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
-msgstr "Useu «git am --show-current-patch=diff» per veure el pedaç que ha fallat"
+msgstr ""
+"Useu «git am --show-current-patch=diff» per veure el pedaç que ha fallat"
 
-#: builtin/am.c:1868
+#: builtin/am.c:1920
+msgid "No changes - recorded it as an empty commit."
+msgstr "No hi ha canvis - enregistrat com una comissió buida"
+
+#: builtin/am.c:1922
 msgid ""
 "No changes - did you forget to use 'git add'?\n"
 "If there is nothing left to stage, chances are that something else\n"
@@ -10959,7 +10908,7 @@ msgstr ""
 "Si no hi ha res per fer «stage», probablement alguna altra cosa ja ha\n"
 "introduït els mateixos canvis; potser voleu ometre aquest pedaç."
 
-#: builtin/am.c:1875
+#: builtin/am.c:1930
 msgid ""
 "You still have unmerged paths in your index.\n"
 "You should 'git add' each file with resolved conflicts to mark them as such.\n"
@@ -10969,17 +10918,17 @@ msgstr ""
 "Heu de fer «git add» a cada fitxer amb conflictes resolts per a marcar-los com a tal.\n"
 "Podeu executar «git rm» en un fitxer per a acceptar «suprimit per ells» pel fitxer."
 
-#: builtin/am.c:1983 builtin/am.c:1987 builtin/am.c:1999 builtin/reset.c:353
-#: builtin/reset.c:361
+#: builtin/am.c:2038 builtin/am.c:2042 builtin/am.c:2054 builtin/reset.c:448
+#: builtin/reset.c:456
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "No s'ha pogut analitzar l'objecte «%s»."
 
-#: builtin/am.c:2035 builtin/am.c:2111
+#: builtin/am.c:2090 builtin/am.c:2166
 msgid "failed to clean index"
 msgstr "s'ha produït un error en netejar l'índex"
 
-#: builtin/am.c:2079
+#: builtin/am.c:2134
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
@@ -10987,179 +10936,187 @@ msgstr ""
 "Sembla que heu mogut HEAD després de l'última fallada de «am».\n"
 "No s'està rebobinant a ORIG_HEAD"
 
-#: builtin/am.c:2187
+#: builtin/am.c:2242
 #, c-format
 msgid "Invalid value for --patch-format: %s"
 msgstr "Valor no vàlid per a --patch-format: %s"
 
-#: builtin/am.c:2229
+#: builtin/am.c:2285
 #, c-format
 msgid "Invalid value for --show-current-patch: %s"
 msgstr "Valor no vàlid per --show-current-patch: %s"
 
-#: builtin/am.c:2233
+#: builtin/am.c:2289
 #, c-format
-msgid "--show-current-patch=%s is incompatible with --show-current-patch=%s"
-msgstr "--show-current-patch=%s és incompatible amb --show-current-patch=%s"
+msgid "options '%s=%s' and '%s=%s' cannot be used together"
+msgstr "Les opcions «%s=%s» i «%s=%s» no es poden usar juntes"
 
-#: builtin/am.c:2264
+#: builtin/am.c:2320
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
 msgstr "git am [<opcions>] [(<bústia> | <directori-de-correu>)...]"
 
-#: builtin/am.c:2265
+#: builtin/am.c:2321
 msgid "git am [<options>] (--continue | --skip | --abort)"
 msgstr "git am [<opcions>] (--continue | --skip | --abort)"
 
-#: builtin/am.c:2271
+#: builtin/am.c:2327
 msgid "run interactively"
 msgstr "executa interactivament"
 
-#: builtin/am.c:2273
+#: builtin/am.c:2329
 msgid "historical option -- no-op"
 msgstr "opció històrica -- no-op"
 
-#: builtin/am.c:2275
+#: builtin/am.c:2331
 msgid "allow fall back on 3way merging if needed"
 msgstr "permet retrocedir a una fusió de 3 vies si és necessari"
 
-#: builtin/am.c:2276 builtin/init-db.c:547 builtin/prune-packed.c:16
-#: builtin/repack.c:640 builtin/stash.c:961
+#: builtin/am.c:2332 builtin/init-db.c:547 builtin/prune-packed.c:16
+#: builtin/repack.c:642 builtin/stash.c:962
 msgid "be quiet"
 msgstr "silenciós"
 
-#: builtin/am.c:2278
+#: builtin/am.c:2334
 msgid "add a Signed-off-by trailer to the commit message"
-msgstr "afegeix una línia «Signed-off-by» al missatge de comissió"
+msgstr "afegeix un «trailer» tipus «Signed-off-by» al missatge de comissió"
 
-#: builtin/am.c:2281
+#: builtin/am.c:2337
 msgid "recode into utf8 (default)"
 msgstr "recodifica en utf8 (per defecte)"
 
-#: builtin/am.c:2283
+#: builtin/am.c:2339
 msgid "pass -k flag to git-mailinfo"
 msgstr "passa l'indicador -k a git-mailinfo"
 
-#: builtin/am.c:2285
+#: builtin/am.c:2341
 msgid "pass -b flag to git-mailinfo"
 msgstr "passa l'indicador -b a git-mailinfo"
 
-#: builtin/am.c:2287
+#: builtin/am.c:2343
 msgid "pass -m flag to git-mailinfo"
 msgstr "passa l'indicador -m a git-mailinfo"
 
-#: builtin/am.c:2289
+#: builtin/am.c:2345
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
 msgstr "passa l'indicador --keep-cr a git-mailsplit per al format mbox"
 
-#: builtin/am.c:2292
+#: builtin/am.c:2348
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr ""
 "no passis l'indicador --keep-cr a git-mailsplit independent d'am.keepcr"
 
-#: builtin/am.c:2295
+#: builtin/am.c:2351
 msgid "strip everything before a scissors line"
 msgstr "elimina tot abans d'una línia de tisores"
 
-#: builtin/am.c:2297
+#: builtin/am.c:2353
 msgid "pass it through git-mailinfo"
 msgstr "passa-ho a través del git-mailinfo"
 
-#: builtin/am.c:2300 builtin/am.c:2303 builtin/am.c:2306 builtin/am.c:2309
-#: builtin/am.c:2312 builtin/am.c:2315 builtin/am.c:2318 builtin/am.c:2321
-#: builtin/am.c:2327
+#: builtin/am.c:2356 builtin/am.c:2359 builtin/am.c:2362 builtin/am.c:2365
+#: builtin/am.c:2368 builtin/am.c:2371 builtin/am.c:2374 builtin/am.c:2377
+#: builtin/am.c:2383
 msgid "pass it through git-apply"
 msgstr "passa-ho a través de git-apply"
 
-#: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
-#: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
-#: builtin/pull.c:141 builtin/pull.c:200 builtin/pull.c:217
-#: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
-#: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
+#: builtin/am.c:2373 builtin/commit.c:1515 builtin/fmt-merge-msg.c:18
+#: builtin/fmt-merge-msg.c:21 builtin/grep.c:919 builtin/merge.c:263
+#: builtin/pull.c:142 builtin/pull.c:204 builtin/pull.c:221
+#: builtin/rebase.c:1046 builtin/repack.c:653 builtin/repack.c:657
+#: builtin/repack.c:659 builtin/show-branch.c:649 builtin/show-ref.c:172
 #: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
-#: parse-options.h:316
+#: parse-options.h:317
 msgid "n"
 msgstr "n"
 
-#: builtin/am.c:2323 builtin/branch.c:673 builtin/bugreport.c:109
-#: builtin/for-each-ref.c:40 builtin/replace.c:556 builtin/tag.c:479
+#: builtin/am.c:2379 builtin/branch.c:680 builtin/bugreport.c:109
+#: builtin/for-each-ref.c:41 builtin/replace.c:555 builtin/tag.c:479
 #: builtin/verify-tag.c:38
 msgid "format"
 msgstr "format"
 
-#: builtin/am.c:2324
+#: builtin/am.c:2380
 msgid "format the patch(es) are in"
 msgstr "el format en el qual estan els pedaços"
 
-#: builtin/am.c:2330
+#: builtin/am.c:2386
 msgid "override error message when patch failure occurs"
-msgstr "passa per alt el missatge d'error si falla l'aplicació del pedaç"
+msgstr "sobreescriu el missatge d'error si falla l'aplicació del pedaç"
 
-#: builtin/am.c:2332
+#: builtin/am.c:2388
 msgid "continue applying patches after resolving a conflict"
 msgstr "segueix aplicant pedaços després de resoldre un conflicte"
 
-#: builtin/am.c:2335
+#: builtin/am.c:2391
 msgid "synonyms for --continue"
 msgstr "sinònims de --continue"
 
-#: builtin/am.c:2338
+#: builtin/am.c:2394
 msgid "skip the current patch"
 msgstr "omet el pedaç actual"
 
-#: builtin/am.c:2341
+#: builtin/am.c:2397
 msgid "restore the original branch and abort the patching operation"
 msgstr "restaura la branca original i interromp l'operació d'apedaçament"
 
-#: builtin/am.c:2344
+#: builtin/am.c:2400
 msgid "abort the patching operation but keep HEAD where it is"
 msgstr "interromp l'operació d'apedaçament però manté HEAD on és"
 
-#: builtin/am.c:2348
+#: builtin/am.c:2404
 msgid "show the patch being applied"
 msgstr "mostra el pedaç que s'està aplicant"
 
-#: builtin/am.c:2353
+#: builtin/am.c:2408
+msgid "record the empty patch as an empty commit"
+msgstr "registra el pedaç buit com una comissió buida"
+
+#: builtin/am.c:2412
 msgid "lie about committer date"
 msgstr "menteix sobre la data del comitent"
 
-#: builtin/am.c:2355
+#: builtin/am.c:2414
 msgid "use current timestamp for author date"
 msgstr "usa el marc de temps actual per la data d'autor"
 
-#: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
-#: builtin/merge.c:299 builtin/pull.c:175 builtin/rebase.c:1099
+#: builtin/am.c:2416 builtin/commit-tree.c:118 builtin/commit.c:1643
+#: builtin/merge.c:302 builtin/pull.c:179 builtin/rebase.c:1099
 #: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
 msgstr "ID de clau"
 
-#: builtin/am.c:2358 builtin/rebase.c:1100
+#: builtin/am.c:2417 builtin/rebase.c:1100
 msgid "GPG-sign commits"
 msgstr "signa les comissions amb GPG"
 
-#: builtin/am.c:2361
+#: builtin/am.c:2420
+msgid "how to handle empty patches"
+msgstr "com gestionar les comissions buides"
+
+#: builtin/am.c:2423
 msgid "(internal use for git-rebase)"
 msgstr "(ús intern per a git-rebase)"
 
-#: builtin/am.c:2379
+#: builtin/am.c:2441
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
 msgstr ""
-"Fa molt que l'opció -b/--binary no ha fet res, i\n"
+"Fa molt que l'opció -b/--binary no fa res, i\n"
 "s'eliminarà. No l'useu més."
 
-#: builtin/am.c:2386
+#: builtin/am.c:2448
 msgid "failed to read the index"
 msgstr "S'ha produït un error en llegir l'índex"
 
-#: builtin/am.c:2401
+#: builtin/am.c:2463
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr ""
 "un directori de «rebase» anterior %s encara existeix però s'ha donat una "
 "bústia."
 
-#: builtin/am.c:2425
+#: builtin/am.c:2487
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
@@ -11168,11 +11125,11 @@ msgstr ""
 "S'ha trobat un directori %s extraviat.\n"
 "Useu «git am --abort» per a eliminar-lo."
 
-#: builtin/am.c:2431
+#: builtin/am.c:2493
 msgid "Resolve operation not in progress, we are not resuming."
 msgstr "Una operació de resolució no està en curs; no reprenem."
 
-#: builtin/am.c:2441
+#: builtin/am.c:2503
 msgid "interactive mode requires patches on the command line"
 msgstr "el mode interactiu requereix pedaços a la línia d'ordres"
 
@@ -11290,9 +11247,9 @@ msgid "please use two different terms"
 msgstr "useu dos termes diferents"
 
 #: builtin/bisect--helper.c:210
-#, fuzzy, c-format
+#, c-format
 msgid "We are not bisecting.\n"
-msgstr "No estem bisecant."
+msgstr "No estem bisecant.\n"
 
 #: builtin/bisect--helper.c:218
 #, c-format
@@ -11300,17 +11257,17 @@ msgid "'%s' is not a valid commit"
 msgstr "«%s» no és una comissió vàlida"
 
 #: builtin/bisect--helper.c:227
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "could not check out original HEAD '%s'. Try 'git bisect reset <commit>'."
 msgstr ""
-"no s'ha pogut comprovar l'original HEAD «%s». Proveu «git bisect reset "
+"no s'ha pogut agafar la HEAD original «%s». Proveu «git bisect reset "
 "<commit>»."
 
 #: builtin/bisect--helper.c:271
-#, fuzzy, c-format
+#, c-format
 msgid "Bad bisect_write argument: %s"
-msgstr "Arguments de bisectriu incorrectes"
+msgstr "Argument «bisect_write» incorrecte: %s"
 
 #: builtin/bisect--helper.c:276
 #, c-format
@@ -11323,28 +11280,29 @@ msgid "couldn't open the file '%s'"
 msgstr "no s'ha pogut obrir el fitxer «%s»"
 
 #: builtin/bisect--helper.c:314
-#, fuzzy, c-format
+#, c-format
 msgid "Invalid command: you're currently in a %s/%s bisect"
-msgstr "Ordre no vàlida esteu actualment en un percentatge/%s bisect"
+msgstr "Ordre no vàlida: esteu actualment en una bisecció %s/%s"
 
 #: builtin/bisect--helper.c:341
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "You need to give me at least one %s and %s revision.\n"
 "You can use \"git bisect %s\" and \"git bisect %s\" for that."
 msgstr ""
-"Heu de donar-me com a mínim un per cents i un per cents de revisió. Podeu "
-"utilitzar «git bisectrius» i «git bisectris» per a això."
+"Heu de donar com a mínim un %s i una revisió %s.\n"
+"Podeu usar «git bisect %s» i «git bisect %s» per a això."
 
 #: builtin/bisect--helper.c:345
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "You need to start by \"git bisect start\".\n"
 "You then need to give me at least one %s and %s revision.\n"
 "You can use \"git bisect %s\" and \"git bisect %s\" for that."
 msgstr ""
-"Heu de començar per «git bisect start». \n"
-"Després heu de donar-me com a mínim un per cents i per cents revisió. Podeu utilitzar «git bisect %s» i «git bisect %s» per a això."
+"Heu de començar amb «git bisect start».\n"
+"Heu de donar com a mínim un %s i una revisió %s.\n"
+"Podeu usar «git bisect %s» i «git bisect %s» per a això."
 
 #: builtin/bisect--helper.c:365
 #, c-format
@@ -11363,13 +11321,13 @@ msgid "no terms defined"
 msgstr "cap terme definit"
 
 #: builtin/bisect--helper.c:437
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Your current terms are %s for the old state\n"
 "and %s for the new state.\n"
 msgstr ""
-"Els seus actuals termes són percentatges per al vell Estat i percentatges "
-"per al nou Estat."
+"Els termes actuals són %s per a l'estat antic\n"
+"i %s per al nou estat.\n"
 
 #: builtin/bisect--helper.c:447
 #, c-format
@@ -11381,9 +11339,8 @@ msgstr ""
 "Les opcions admeses són: --term-good|--term-old i --term-bad|--term-new."
 
 #: builtin/bisect--helper.c:514 builtin/bisect--helper.c:1038
-#, fuzzy
 msgid "revision walk setup failed\n"
-msgstr "la configuració del passeig per revisions ha fallat"
+msgstr "la configuració del recorregut de revisions ha fallat\n"
 
 #: builtin/bisect--helper.c:536
 #, c-format
@@ -11453,9 +11410,9 @@ msgid "Bad rev input: %s"
 msgstr "Entrada amb revisió errònia: %s"
 
 #: builtin/bisect--helper.c:904
-#, fuzzy, c-format
+#, c-format
 msgid "Bad rev input (not a commit): %s"
-msgstr "Introducció de revisió errònia: $arg"
+msgstr "Entrada de revisió errònia (no és una comissió): %s"
 
 #: builtin/bisect--helper.c:936
 msgid "We are not bisecting."
@@ -11481,11 +11438,11 @@ msgid "running %s\n"
 msgstr "s'està executant %s\n"
 
 #: builtin/bisect--helper.c:1120
-#, fuzzy, c-format
+#, c-format
 msgid "bisect run failed: exit code %d from '%s' is < 0 or >= 128"
 msgstr ""
-"el pas de bisecció ha fallat:\n"
-"el codi de sortida $res de «$command» és < 0 o bé >= 128"
+"l'execució de la de bisecció ha fallat: codi de sortida %d de '%s' és < 0 o "
+">= 128"
 
 #: builtin/bisect--helper.c:1136
 #, c-format
@@ -11494,90 +11451,78 @@ msgstr "no es pot obrir «%s» per a escriptura"
 
 #: builtin/bisect--helper.c:1152
 msgid "bisect run cannot continue any more"
-msgstr "el pas de bisecció no pot continuar més"
+msgstr "l'execució de la bisecció no pot continuar més"
 
 #: builtin/bisect--helper.c:1154
 #, c-format
 msgid "bisect run success"
-msgstr "pas de bisecció reeixit"
+msgstr "execució de bisecció amb èxit"
 
 #: builtin/bisect--helper.c:1157
-#, fuzzy, c-format
+#, c-format
 msgid "bisect found first bad commit"
-msgstr "bisecant amb només una comissió %s"
+msgstr "la bisecció ha trobat una primera comissió errònia"
 
 #: builtin/bisect--helper.c:1160
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "bisect run failed: 'git bisect--helper --bisect-state %s' exited with error "
 "code %d"
 msgstr ""
-"el pas de bisecció ha fallat:\n"
-"«bisect_state $state» ha sortit amb el codi d'error $res"
+"l'execució de la bisecció ha fallat: «git bisect--helper --bisect-state %s» "
+"ha sortit amb el codi d'error %d"
 
 #: builtin/bisect--helper.c:1192
-#, fuzzy
 msgid "reset the bisection state"
 msgstr "restableix l'estat de la bisecció"
 
 #: builtin/bisect--helper.c:1194
-#, fuzzy
 msgid "check whether bad or good terms exist"
-msgstr "comprova si existeixen termes incorrectes o bons"
+msgstr "comprova si existeixen termes correctes o incorrectes"
 
 #: builtin/bisect--helper.c:1196
-#, fuzzy
 msgid "print out the bisect terms"
-msgstr "imprimeix els termes de la bisectriu"
+msgstr "imprimeix els termes de la bisecció"
 
 #: builtin/bisect--helper.c:1198
-#, fuzzy
 msgid "start the bisect session"
-msgstr "inicia la sessió bisect"
+msgstr "inicia la sessió bisecció"
 
 #: builtin/bisect--helper.c:1200
-#, fuzzy
 msgid "find the next bisection commit"
-msgstr "no es pot esmenar una comissió no existent"
+msgstr "troba la comissió de bisecció següent"
 
 #: builtin/bisect--helper.c:1202
-#, fuzzy
 msgid "mark the state of ref (or refs)"
-msgstr "marca l'estat de ref (o refs)"
+msgstr "marca l'estat de la referència o referències"
 
 #: builtin/bisect--helper.c:1204
-#, fuzzy
 msgid "list the bisection steps so far"
-msgstr "restableix l'estat de la bisecció"
+msgstr "mostra les passes de la la bisecció fins ara"
 
 #: builtin/bisect--helper.c:1206
-#, fuzzy
 msgid "replay the bisection process from the given file"
 msgstr "torna a reproduir el procés de bisecció des del fitxer donat"
 
 #: builtin/bisect--helper.c:1208
-#, fuzzy
 msgid "skip some commits for checkout"
-msgstr "la branca o entrega a agafar"
+msgstr "omet algunes comissions en agafar"
 
 #: builtin/bisect--helper.c:1210
-#, fuzzy
 msgid "visualize the bisection"
-msgstr "inicia la sessió bisect"
+msgstr "visualitza la bisecció"
 
 #: builtin/bisect--helper.c:1212
-#, fuzzy
 msgid "use <cmd>... to automatically bisect."
-msgstr "no cometis automàticament"
+msgstr "useu <cmd>... per a fer una bisecció automàticament."
 
 #: builtin/bisect--helper.c:1214
 msgid "no log for BISECT_WRITE"
 msgstr "no hi ha registre per a BISECT_WRITE"
 
 #: builtin/bisect--helper.c:1229
-#, fuzzy
 msgid "--bisect-reset requires either no argument or a commit"
-msgstr "--bisect-reset no requereix cap argument ni una comissió"
+msgstr "--bisect-reset no requereix cap argument ni comissió"
 
 #: builtin/bisect--helper.c:1234
 msgid "--bisect-terms requires 0 or 1 argument"
@@ -11588,14 +11533,12 @@ msgid "--bisect-next requires 0 arguments"
 msgstr "--bisect-next no requereix cap argument"
 
 #: builtin/bisect--helper.c:1254
-#, fuzzy
 msgid "--bisect-log requires 0 arguments"
-msgstr "--bisect-next no requereix cap argument"
+msgstr "--bisect-log no requereix cap argument"
 
 #: builtin/bisect--helper.c:1259
-#, fuzzy
 msgid "no logfile given"
-msgstr "Cap fitxer de registre donat"
+msgstr "no s'ha donat cap fitxer de registre"
 
 #: builtin/blame.c:32
 msgid "git blame [<options>] [<rev-opts>] [<rev>] [--] <file>"
@@ -11629,111 +11572,96 @@ msgid "cannot find revision %s to ignore"
 msgstr "no s'ha pogut trobar la revisió %s per ignorar"
 
 #: builtin/blame.c:863
-#, fuzzy
 msgid "show blame entries as we find them, incrementally"
-msgstr "Mostra les entrades «blame» mentre les trobem, incrementalment"
+msgstr "mostra les entrades «blame» mentre les trobem, incrementalment"
 
 #: builtin/blame.c:864
-#, fuzzy
 msgid "do not show object names of boundary commits (Default: off)"
 msgstr ""
-"Mostra un SHA-1 en blanc per les comissions de frontera (Per defecte: "
+"no mostris els noms d'objectes de les comissions de frontera (per defecte: "
 "desactivat)"
 
 #: builtin/blame.c:865
-#, fuzzy
 msgid "do not treat root commits as boundaries (Default: off)"
 msgstr ""
-"No tractis les comissions d'arrel com a límits (Per defecte: desactivat)"
+"no tractis les comissions arrel com de frontera (per defecte: desactivat)"
 
 #: builtin/blame.c:866
 msgid "show work cost statistics"
 msgstr "mostra les estadístiques de preu de treball"
 
-#: builtin/blame.c:867 builtin/checkout.c:1517 builtin/clone.c:94
-#: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
-#: builtin/merge.c:298 builtin/multi-pack-index.c:103
-#: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
-#: builtin/multi-pack-index.c:204 builtin/pull.c:119 builtin/push.c:566
+#: builtin/blame.c:867 builtin/checkout.c:1536 builtin/clone.c:94
+#: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:180
+#: builtin/merge.c:301 builtin/multi-pack-index.c:103
+#: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:180
+#: builtin/multi-pack-index.c:208 builtin/pull.c:120 builtin/push.c:566
 #: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "força l'informe de progrés"
 
 #: builtin/blame.c:868
-#, fuzzy
 msgid "show output score for blame entries"
-msgstr "Mostra la puntuació de sortida de les entrades «blame»"
+msgstr "mostra la puntuació de sortida de les entrades «blame»"
 
 #: builtin/blame.c:869
-#, fuzzy
 msgid "show original filename (Default: auto)"
-msgstr "Mostra el nom de fitxer original (Per defecte: automàtic)"
+msgstr "mostra el nom de fitxer original (per defecte: automàtic)"
 
 #: builtin/blame.c:870
-#, fuzzy
 msgid "show original linenumber (Default: off)"
-msgstr "Mostra el número de línia original (Per defecte: desactivat)"
+msgstr "mostra el número de línia original (per defecte: desactivat)"
 
 #: builtin/blame.c:871
-#, fuzzy
 msgid "show in a format designed for machine consumption"
-msgstr "Presenta en un format dissenyat per consumpció per màquina"
+msgstr "presenta en un format dissenyat per a ser consumit per una màquina"
 
 #: builtin/blame.c:872
-#, fuzzy
 msgid "show porcelain format with per-line commit information"
-msgstr "Mostra el format de porcellana amb informació de comissió per línia"
+msgstr "mostra en format de porcellana amb informació de comissió per línia"
 
 #: builtin/blame.c:873
-#, fuzzy
 msgid "use the same output mode as git-annotate (Default: off)"
 msgstr ""
-"Usa el mateix mode de sortida que git-annotate (Per defecte: desactivat)"
+"usa el mateix mode de sortida que git-annotate (per defecte: desactivat)"
 
 #: builtin/blame.c:874
-#, fuzzy
 msgid "show raw timestamp (Default: off)"
-msgstr "Mostra la marca de temps crua (Per defecte: desactivat)"
+msgstr "mostra la marca de temps en cru (per defecte: desactivat)"
 
 #: builtin/blame.c:875
-#, fuzzy
 msgid "show long commit SHA1 (Default: off)"
-msgstr "Mostra l'SHA1 de comissió llarg (Per defecte: desactivat)"
+msgstr "mostra l'SHA1 de comissió llarg (per defecte: desactivat)"
 
 #: builtin/blame.c:876
-#, fuzzy
 msgid "suppress author name and timestamp (Default: off)"
-msgstr "Omet el nom d'autor i la marca de temps (Per defecte: desactivat)"
+msgstr "omet el nom d'autor i la marca de temps (per defecte: desactivat)"
 
 #: builtin/blame.c:877
-#, fuzzy
 msgid "show author email instead of name (Default: off)"
 msgstr ""
-"Mostra l'adreça electrònica de l'autor en lloc del nom (Per defecte: "
+"mostra el correu electrònic de l'autor en comptes del nom (per defecte: "
 "desactivat)"
 
 #: builtin/blame.c:878
 msgid "ignore whitespace differences"
 msgstr "Ignora les diferències d'espai en blanc"
 
-#: builtin/blame.c:879 builtin/log.c:1823
+#: builtin/blame.c:879 builtin/log.c:1838
 msgid "rev"
 msgstr "rev"
 
 #: builtin/blame.c:879
-#, fuzzy
 msgid "ignore <rev> when blaming"
-msgstr "Ignora <rev> en culpar"
+msgstr "Ignora <rev> en fer «blame»"
 
 #: builtin/blame.c:880
 msgid "ignore revisions from <file>"
 msgstr "Ignora les revisions de <fitxer>"
 
 #: builtin/blame.c:881
-#, fuzzy
 msgid "color redundant metadata from previous line differently"
 msgstr ""
-"color les metadades redundants de la línia anterior de manera diferent"
+"acoloreix les metadades redundants de la línia anterior de manera diferent"
 
 #: builtin/blame.c:882
 msgid "color lines by age"
@@ -11768,11 +11696,10 @@ msgid "range"
 msgstr "rang"
 
 #: builtin/blame.c:889
-#, fuzzy
 msgid "process only line range <start>,<end> or function :<funcname>"
-msgstr "Processa només el rang de línies n,m, comptant des d'1"
+msgstr "processa només el rang <start>,<end> o la funció :<funcname>"
 
-#: builtin/blame.c:944
+#: builtin/blame.c:947
 msgid "--progress can't be used with --incremental or porcelain formats"
 msgstr ""
 "no es pot usar --progress amb els formats --incremental o de porcellana"
@@ -11784,18 +11711,18 @@ msgstr ""
 #. among various forms of relative timestamps, but
 #. your language may need more or fewer display
 #. columns.
-#: builtin/blame.c:995
+#: builtin/blame.c:998
 msgid "4 years, 11 months ago"
 msgstr "fa 4 anys i 11 mesos"
 
-#: builtin/blame.c:1111
+#: builtin/blame.c:1114
 #, c-format
 msgid "file %s has only %lu line"
 msgid_plural "file %s has only %lu lines"
 msgstr[0] "el fitxer %s té només %lu línia"
 msgstr[1] "el fitxer %s té només %lu línies"
 
-#: builtin/blame.c:1156
+#: builtin/blame.c:1159
 msgid "Blaming lines"
 msgstr "S'està fent un «blame»"
 
@@ -11827,7 +11754,7 @@ msgstr "git branch [<opcions>] [-r | -a] [--points-at]"
 msgid "git branch [<options>] [-r | -a] [--format]"
 msgstr "git branch [<opcions>] [-r | -a] [--format]"
 
-#: builtin/branch.c:154
+#: builtin/branch.c:153
 #, c-format
 msgid ""
 "deleting branch '%s' that has been merged to\n"
@@ -11837,7 +11764,7 @@ msgstr ""
 "         fusionat a «%s», però encara no\n"
 "         s'ha fusionat a HEAD."
 
-#: builtin/branch.c:158
+#: builtin/branch.c:157
 #, c-format
 msgid ""
 "not deleting branch '%s' that is not yet merged to\n"
@@ -11847,12 +11774,12 @@ msgstr ""
 "         s'ha fusionat a «%s», encara que està\n"
 "         fusionada a HEAD."
 
-#: builtin/branch.c:172
+#: builtin/branch.c:171
 #, c-format
 msgid "Couldn't look up commit object for '%s'"
 msgstr "No s'ha pogut trobar l'objecte de comissió de «%s»"
 
-#: builtin/branch.c:176
+#: builtin/branch.c:175
 #, c-format
 msgid ""
 "The branch '%s' is not fully merged.\n"
@@ -11861,7 +11788,7 @@ msgstr ""
 "La branca «%s» no està totalment fusionada.\n"
 "Si esteu segur que la voleu suprimir, executeu «git branch -D %s»."
 
-#: builtin/branch.c:189
+#: builtin/branch.c:188
 msgid "Update of config-file failed"
 msgstr "L'actualització del fitxer de configuració ha fallat"
 
@@ -11873,103 +11800,103 @@ msgstr "no es pot usar -a amb -d"
 msgid "Couldn't look up commit object for HEAD"
 msgstr "No s'ha pogut trobar l'objecte de comissió de HEAD"
 
-#: builtin/branch.c:244
+#: builtin/branch.c:247
 #, c-format
 msgid "Cannot delete branch '%s' checked out at '%s'"
 msgstr "No es pot suprimir la branca «%s» agafada a «%s»"
 
-#: builtin/branch.c:259
+#: builtin/branch.c:262
 #, c-format
 msgid "remote-tracking branch '%s' not found."
 msgstr "no s'ha trobat la branca amb seguiment remot «%s»."
 
-#: builtin/branch.c:260
+#: builtin/branch.c:263
 #, c-format
 msgid "branch '%s' not found."
 msgstr "no s'ha trobat la branca «%s»."
 
-#: builtin/branch.c:291
+#: builtin/branch.c:294
 #, c-format
 msgid "Deleted remote-tracking branch %s (was %s).\n"
 msgstr "S'ha suprimit la branca amb seguiment remot %s (era %s).\n"
 
-#: builtin/branch.c:292
+#: builtin/branch.c:295
 #, c-format
 msgid "Deleted branch %s (was %s).\n"
 msgstr "S'ha suprimit la branca %s (era %s).\n"
 
-#: builtin/branch.c:441 builtin/tag.c:63
+#: builtin/branch.c:445 builtin/tag.c:63
 msgid "unable to parse format string"
 msgstr "no s'ha pogut analitzar la cadena de format"
 
-#: builtin/branch.c:472
+#: builtin/branch.c:476
 msgid "could not resolve HEAD"
 msgstr "no s'ha pogut resoldre HEAD"
 
-#: builtin/branch.c:478
+#: builtin/branch.c:482
 #, c-format
 msgid "HEAD (%s) points outside of refs/heads/"
 msgstr "HEAD (%s) apunta fora de refs/heads/"
 
-#: builtin/branch.c:493
+#: builtin/branch.c:497
 #, c-format
 msgid "Branch %s is being rebased at %s"
 msgstr "S'està fent «rebase» en la branca %s a %s"
 
-#: builtin/branch.c:497
+#: builtin/branch.c:501
 #, c-format
 msgid "Branch %s is being bisected at %s"
 msgstr "La branca %s s'està bisecant a %s"
 
-#: builtin/branch.c:514
+#: builtin/branch.c:518
 msgid "cannot copy the current branch while not on any."
 msgstr "no es pot copiar branca actual mentre no s'és a cap."
 
-#: builtin/branch.c:516
+#: builtin/branch.c:520
 msgid "cannot rename the current branch while not on any."
 msgstr "no es pot canviar el nom de la branca actual mentre no s'és a cap."
 
-#: builtin/branch.c:527
+#: builtin/branch.c:531
 #, c-format
 msgid "Invalid branch name: '%s'"
 msgstr "Nom de branca no vàlid: «%s»"
 
-#: builtin/branch.c:556
+#: builtin/branch.c:560
 msgid "Branch rename failed"
 msgstr "El canvi de nom de branca ha fallat"
 
-#: builtin/branch.c:558
+#: builtin/branch.c:562
 msgid "Branch copy failed"
 msgstr "La còpia de la branca ha fallat"
 
-#: builtin/branch.c:562
+#: builtin/branch.c:566
 #, c-format
 msgid "Created a copy of a misnamed branch '%s'"
 msgstr "S'ha creat una còpia d'una branca mal anomenada «%s»"
 
-#: builtin/branch.c:565
+#: builtin/branch.c:569
 #, c-format
 msgid "Renamed a misnamed branch '%s' away"
 msgstr "S'ha canviat el nom de la branca mal anomenada «%s»"
 
-#: builtin/branch.c:571
+#: builtin/branch.c:575
 #, c-format
 msgid "Branch renamed to %s, but HEAD is not updated!"
 msgstr "S'ha canviat el nom de la branca a %s, però HEAD no està actualitzat!"
 
-#: builtin/branch.c:580
+#: builtin/branch.c:584
 msgid "Branch is renamed, but update of config-file failed"
 msgstr ""
 "La branca està canviada de nom, però l'actualització del fitxer de "
 "configuració ha fallat"
 
-#: builtin/branch.c:582
+#: builtin/branch.c:586
 msgid "Branch is copied, but update of config-file failed"
 msgstr ""
 "La branca està copiada, però l'actualització del fitxer de configuració ha "
 "fallat"
 
-#: builtin/branch.c:598
+#: builtin/branch.c:602
 #, c-format
 msgid ""
 "Please edit the description for the branch\n"
@@ -11980,180 +11907,176 @@ msgstr ""
 "  %s\n"
 "S'eliminaran les línies que comencin amb «%c».\n"
 
-#: builtin/branch.c:632
+#: builtin/branch.c:637
 msgid "Generic options"
 msgstr "Opcions genèriques"
 
-#: builtin/branch.c:634
+#: builtin/branch.c:639
 msgid "show hash and subject, give twice for upstream branch"
 msgstr "mostra el hash i l'assumpte, doneu dues vegades per a la branca font"
 
-#: builtin/branch.c:635
+#: builtin/branch.c:640
 msgid "suppress informational messages"
 msgstr "omet els missatges informatius"
 
-#: builtin/branch.c:636
-msgid "set up tracking mode (see git-pull(1))"
-msgstr "configura el mode de seguiment (vegeu git-pull(1))"
+#: builtin/branch.c:642
+msgid "set branch tracking configuration"
+msgstr "estableix la configuració del seguiment de la branca"
 
-#: builtin/branch.c:638
+#: builtin/branch.c:645
 msgid "do not use"
 msgstr "no usar"
 
-#: builtin/branch.c:640
+#: builtin/branch.c:647
 msgid "upstream"
 msgstr "font"
 
-#: builtin/branch.c:640
+#: builtin/branch.c:647
 msgid "change the upstream info"
 msgstr "canvia la informació de font"
 
-#: builtin/branch.c:641
+#: builtin/branch.c:648
 msgid "unset the upstream info"
 msgstr "treu la informació de la font"
 
-#: builtin/branch.c:642
+#: builtin/branch.c:649
 msgid "use colored output"
 msgstr "usa sortida amb colors"
 
-#: builtin/branch.c:643
+#: builtin/branch.c:650
 msgid "act on remote-tracking branches"
 msgstr "actua en branques amb seguiment remot"
 
-#: builtin/branch.c:645 builtin/branch.c:647
+#: builtin/branch.c:652 builtin/branch.c:654
 msgid "print only branches that contain the commit"
 msgstr "imprimeix només les branques que continguin la comissió"
 
-#: builtin/branch.c:646 builtin/branch.c:648
+#: builtin/branch.c:653 builtin/branch.c:655
 msgid "print only branches that don't contain the commit"
 msgstr "imprimeix només les branques que no continguin la comissió"
 
-#: builtin/branch.c:651
+#: builtin/branch.c:658
 msgid "Specific git-branch actions:"
 msgstr "Accions de git-branch específiques:"
 
-#: builtin/branch.c:652
+#: builtin/branch.c:659
 msgid "list both remote-tracking and local branches"
 msgstr "llista les branques amb seguiment remot i les locals"
 
-#: builtin/branch.c:654
+#: builtin/branch.c:661
 msgid "delete fully merged branch"
 msgstr "suprimeix la branca si està completament fusionada"
 
-#: builtin/branch.c:655
+#: builtin/branch.c:662
 msgid "delete branch (even if not merged)"
 msgstr "suprimeix la branca (encara que no estigui fusionada)"
 
-#: builtin/branch.c:656
+#: builtin/branch.c:663
 msgid "move/rename a branch and its reflog"
 msgstr "mou/canvia de nom una branca i el seu registre de referència"
 
-#: builtin/branch.c:657
+#: builtin/branch.c:664
 msgid "move/rename a branch, even if target exists"
 msgstr "mou/canvia de nom una branca, encara que el destí existeixi"
 
-#: builtin/branch.c:658
+#: builtin/branch.c:665
 msgid "copy a branch and its reflog"
 msgstr "copia una branca i el seu registre de referència"
 
-#: builtin/branch.c:659
+#: builtin/branch.c:666
 msgid "copy a branch, even if target exists"
 msgstr "copia una branca, encara que el destí existeixi"
 
-#: builtin/branch.c:660
+#: builtin/branch.c:667
 msgid "list branch names"
 msgstr "llista els noms de branca"
 
-#: builtin/branch.c:661
+#: builtin/branch.c:668
 msgid "show current branch name"
 msgstr "mostra el nom de la branca actual"
 
-#: builtin/branch.c:662
+#: builtin/branch.c:669
 msgid "create the branch's reflog"
 msgstr "crea el registre de referència de la branca"
 
-#: builtin/branch.c:664
+#: builtin/branch.c:671
 msgid "edit the description for the branch"
 msgstr "edita la descripció de la branca"
 
-#: builtin/branch.c:665
+#: builtin/branch.c:672
 msgid "force creation, move/rename, deletion"
 msgstr "força creació, moviment/canvi de nom, supressió"
 
-#: builtin/branch.c:666
+#: builtin/branch.c:673
 msgid "print only branches that are merged"
 msgstr "imprimeix només les branques que s'han fusionat"
 
-#: builtin/branch.c:667
+#: builtin/branch.c:674
 msgid "print only branches that are not merged"
 msgstr "imprimeix només les branques que no s'han fusionat"
 
-#: builtin/branch.c:668
+#: builtin/branch.c:675
 msgid "list branches in columns"
 msgstr "llista les branques en columnes"
 
-#: builtin/branch.c:670 builtin/for-each-ref.c:44 builtin/notes.c:413
+#: builtin/branch.c:677 builtin/for-each-ref.c:45 builtin/notes.c:413
 #: builtin/notes.c:416 builtin/notes.c:579 builtin/notes.c:582
 #: builtin/tag.c:475
 msgid "object"
 msgstr "objecte"
 
-#: builtin/branch.c:671
+#: builtin/branch.c:678
 msgid "print only branches of the object"
 msgstr "imprimeix només les branques de l'objecte"
 
-#: builtin/branch.c:672 builtin/for-each-ref.c:50 builtin/tag.c:482
+#: builtin/branch.c:679 builtin/for-each-ref.c:51 builtin/tag.c:482
 msgid "sorting and filtering are case insensitive"
 msgstr "l'ordenació i el filtratge distingeixen entre majúscules i minúscules"
 
-#: builtin/branch.c:673 builtin/for-each-ref.c:40 builtin/tag.c:480
+#: builtin/branch.c:680 builtin/for-each-ref.c:41 builtin/tag.c:480
 #: builtin/verify-tag.c:38
 msgid "format to use for the output"
 msgstr "format a usar en la sortida"
 
-#: builtin/branch.c:696 builtin/clone.c:678
+#: builtin/branch.c:703 builtin/clone.c:678
 msgid "HEAD not found below refs/heads!"
 msgstr "HEAD no trobat sota refs/heads!"
 
-#: builtin/branch.c:720
-msgid "--column and --verbose are incompatible"
-msgstr "--column i --verbose són incompatibles"
-
-#: builtin/branch.c:735 builtin/branch.c:792 builtin/branch.c:801
+#: builtin/branch.c:742 builtin/branch.c:798 builtin/branch.c:807
 msgid "branch name required"
 msgstr "cal el nom de branca"
 
-#: builtin/branch.c:768
+#: builtin/branch.c:774
 msgid "Cannot give description to detached HEAD"
 msgstr "No es pot donar descripció a un HEAD separat"
 
-#: builtin/branch.c:773
+#: builtin/branch.c:779
 msgid "cannot edit description of more than one branch"
 msgstr "no es pot editar la descripció de més d'una branca"
 
-#: builtin/branch.c:780
+#: builtin/branch.c:786
 #, c-format
 msgid "No commit on branch '%s' yet."
 msgstr "Encara no hi ha cap comissió en la branca «%s»."
 
-#: builtin/branch.c:783
+#: builtin/branch.c:789
 #, c-format
 msgid "No branch named '%s'."
 msgstr "No hi ha cap branca amb nom «%s»."
 
-#: builtin/branch.c:798
+#: builtin/branch.c:804
 msgid "too many branches for a copy operation"
 msgstr "hi ha massa branques per a una operació de còpia"
 
-#: builtin/branch.c:807
+#: builtin/branch.c:813
 msgid "too many arguments for a rename operation"
 msgstr "hi ha massa arguments per a una operació de canvi de nom"
 
-#: builtin/branch.c:812
+#: builtin/branch.c:818
 msgid "too many arguments to set new upstream"
 msgstr "hi ha massa arguments per a establir una nova font"
 
-#: builtin/branch.c:816
+#: builtin/branch.c:822
 #, c-format
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch."
@@ -12161,40 +12084,39 @@ msgstr ""
 "no s'ha pogut establir la font de HEAD com a %s quan no assenyala cap "
 "branca."
 
-#: builtin/branch.c:819 builtin/branch.c:842
+#: builtin/branch.c:825 builtin/branch.c:848
 #, c-format
 msgid "no such branch '%s'"
 msgstr "no existeix la branca «%s»"
 
-#: builtin/branch.c:823
+#: builtin/branch.c:829
 #, c-format
 msgid "branch '%s' does not exist"
 msgstr "la branca «%s» no existeix"
 
-#: builtin/branch.c:836
+#: builtin/branch.c:842
 msgid "too many arguments to unset upstream"
 msgstr "hi ha massa arguments per a desassignar la font"
 
-#: builtin/branch.c:840
+#: builtin/branch.c:846
 msgid "could not unset upstream of HEAD when it does not point to any branch."
 msgstr ""
 "no s'ha pogut desassignar la font de HEAD perquè no assenyala cap branca."
 
-#: builtin/branch.c:846
+#: builtin/branch.c:852
 #, c-format
 msgid "Branch '%s' has no upstream information"
 msgstr "La branca «%s» no té informació de font"
 
-#: builtin/branch.c:856
-#, fuzzy
+#: builtin/branch.c:862
 msgid ""
 "The -a, and -r, options to 'git branch' do not take a branch name.\n"
 "Did you mean to use: -a|-r --list <pattern>?"
 msgstr ""
-"Les opcions -a i -r a «git branch» no prenen un nom de branca. Voleu usar "
-"-a|-r --list <pattern>?"
+"Les opcions -a i -r a «git branch» no prenen un nom de branca.\n"
+"Volíeu usar -a|-r --list <pattern>?"
 
-#: builtin/branch.c:860
+#: builtin/branch.c:866
 msgid ""
 "the '--set-upstream' option is no longer supported. Please use '--track' or "
 "'--set-upstream-to' instead."
@@ -12220,9 +12142,9 @@ msgid "libc info: "
 msgstr "Informació de la libc: "
 
 #: builtin/bugreport.c:49
-#, fuzzy
 msgid "not run from a git repository - no hooks to show\n"
-msgstr "no és un repositori de git: %s"
+msgstr ""
+"no s'està executant en un repositori de git - no hi ha lligams a mostrar\n"
 
 #: builtin/bugreport.c:62
 msgid "git bugreport [-o|--output-directory <file>] [-s|--suffix <format>]"
@@ -12260,23 +12182,21 @@ msgid "specify a destination for the bugreport file"
 msgstr "especifiqueu una destinació per al fitxer d'informe d'error"
 
 #: builtin/bugreport.c:110
-#, fuzzy
 msgid "specify a strftime format suffix for the filename"
-msgstr "especifiqueu un sufix de format strftime per al nom de fitxer"
+msgstr "especifiqueu un sufix en format strftime per al nom de fitxer"
 
 #: builtin/bugreport.c:132
-#, fuzzy, c-format
+#, c-format
 msgid "could not create leading directories for '%s'"
-msgstr "no s'han pogut crear els directoris inicials de «%s»"
+msgstr "no s'han pogut crear els directoris principals de «%s»"
 
 #: builtin/bugreport.c:139
 msgid "System Info"
 msgstr "Informació del sistema"
 
 #: builtin/bugreport.c:142
-#, fuzzy
 msgid "Enabled Hooks"
-msgstr "no s'ha pogut bifurcar"
+msgstr "Habilita els lligams"
 
 #: builtin/bugreport.c:149
 #, c-format
@@ -12342,9 +12262,8 @@ msgid "Need a repository to unbundle."
 msgstr "Cal un repositori per a desfer un farcell."
 
 #: builtin/bundle.c:185
-#, fuzzy
 msgid "Unbundling objects"
-msgstr "S'estan indexant objectes"
+msgstr "S'estan desagrupant objectes"
 
 #: builtin/bundle.c:219 builtin/remote.c:1733
 #, c-format
@@ -12464,8 +12383,8 @@ msgstr "llegeix els noms de fitxer de stdin"
 msgid "terminate input and output records by a NUL character"
 msgstr "acaba els registres d'entrada i de sortida amb un caràcter NUL"
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1513 builtin/gc.c:549
-#: builtin/worktree.c:494
+#: builtin/check-ignore.c:21 builtin/checkout.c:1532 builtin/gc.c:550
+#: builtin/worktree.c:493
 msgid "suppress progress reporting"
 msgstr "omet els informes de progrés"
 
@@ -12523,10 +12442,10 @@ msgid "git checkout--worker [<options>]"
 msgstr "git checkout--worker [<opcions>]"
 
 #: builtin/checkout--worker.c:118 builtin/checkout-index.c:201
-#: builtin/column.c:31 builtin/column.c:32 builtin/submodule--helper.c:1863
-#: builtin/submodule--helper.c:1866 builtin/submodule--helper.c:1874
-#: builtin/submodule--helper.c:2510 builtin/submodule--helper.c:2576
-#: builtin/worktree.c:492 builtin/worktree.c:729
+#: builtin/column.c:31 builtin/column.c:32 builtin/submodule--helper.c:1864
+#: builtin/submodule--helper.c:1867 builtin/submodule--helper.c:1875
+#: builtin/submodule--helper.c:2511 builtin/submodule--helper.c:2577
+#: builtin/worktree.c:491 builtin/worktree.c:728
 msgid "string"
 msgstr "cadena"
 
@@ -12591,99 +12510,94 @@ msgstr "git switch [<options>] [<branch>]"
 msgid "git restore [<options>] [--source=<branch>] <file>..."
 msgstr "git restore [<opcions>] [--source=<branca>] <fitxer>..."
 
-#: builtin/checkout.c:190 builtin/checkout.c:229
+#: builtin/checkout.c:198 builtin/checkout.c:237
 #, c-format
 msgid "path '%s' does not have our version"
 msgstr "el camí «%s» no té la nostra versió"
 
-#: builtin/checkout.c:192 builtin/checkout.c:231
+#: builtin/checkout.c:200 builtin/checkout.c:239
 #, c-format
 msgid "path '%s' does not have their version"
 msgstr "el camí «%s» no té la seva versió"
 
-#: builtin/checkout.c:208
+#: builtin/checkout.c:216
 #, c-format
 msgid "path '%s' does not have all necessary versions"
 msgstr "el camí «%s» no té totes les versions necessàries"
 
-#: builtin/checkout.c:261
+#: builtin/checkout.c:269
 #, c-format
 msgid "path '%s' does not have necessary versions"
 msgstr "el camí «%s» no té les versions necessàries"
 
-#: builtin/checkout.c:278
+#: builtin/checkout.c:286
 #, c-format
 msgid "path '%s': cannot merge"
 msgstr "camí «%s»: no es pot fusionar"
 
-#: builtin/checkout.c:294
+#: builtin/checkout.c:302
 #, c-format
 msgid "Unable to add merge result for '%s'"
 msgstr "No s'ha pogut afegir el resultat de fusió per a «%s»"
 
-#: builtin/checkout.c:411
+#: builtin/checkout.c:419
 #, c-format
 msgid "Recreated %d merge conflict"
 msgid_plural "Recreated %d merge conflicts"
 msgstr[0] "Recreat un conflicte de fusió"
 msgstr[1] "Recreats %d conflictes de fusió"
 
-#: builtin/checkout.c:416
+#: builtin/checkout.c:424
 #, c-format
 msgid "Updated %d path from %s"
 msgid_plural "Updated %d paths from %s"
 msgstr[0] "S'ha actualitzat %d camí des de %s"
 msgstr[1] "S'han actualitzat %d camins des de %s"
 
-#: builtin/checkout.c:423
+#: builtin/checkout.c:431
 #, c-format
 msgid "Updated %d path from the index"
 msgid_plural "Updated %d paths from the index"
 msgstr[0] "S'ha actualitzat un camí des de l'índex"
 msgstr[1] "S'ha actualitzat %d camins des de l'índex"
 
-#: builtin/checkout.c:446 builtin/checkout.c:449 builtin/checkout.c:452
-#: builtin/checkout.c:456
+#: builtin/checkout.c:454 builtin/checkout.c:457 builtin/checkout.c:460
+#: builtin/checkout.c:464
 #, c-format
 msgid "'%s' cannot be used with updating paths"
 msgstr "«%s» no es pot usar amb actualització de camins"
 
-#: builtin/checkout.c:459 builtin/checkout.c:462
-#, c-format
-msgid "'%s' cannot be used with %s"
-msgstr "«%s» no es pot usar amb %s"
-
-#: builtin/checkout.c:466
+#: builtin/checkout.c:474
 #, c-format
 msgid "Cannot update paths and switch to branch '%s' at the same time."
 msgstr ""
 "No es poden actualitzar els camins i canviar a la branca «%s» a la vegada."
 
-#: builtin/checkout.c:470
+#: builtin/checkout.c:478
 #, c-format
 msgid "neither '%s' or '%s' is specified"
 msgstr "no s'ha especificat ni «%s» ni «%s»"
 
-#: builtin/checkout.c:474
+#: builtin/checkout.c:482
 #, c-format
 msgid "'%s' must be used when '%s' is not specified"
 msgstr "«%s» s'ha d'utilitzar quan no s'especifica «%s»"
 
-#: builtin/checkout.c:479 builtin/checkout.c:484
+#: builtin/checkout.c:487 builtin/checkout.c:492
 #, c-format
 msgid "'%s' or '%s' cannot be used with %s"
 msgstr "«%s» o «%s» no poden utilitzar-se amb %s"
 
-#: builtin/checkout.c:558 builtin/checkout.c:565
+#: builtin/checkout.c:566 builtin/checkout.c:573
 #, c-format
 msgid "path '%s' is unmerged"
 msgstr "el camí «%s» està sense fusionar"
 
-#: builtin/checkout.c:736
+#: builtin/checkout.c:747
 msgid "you need to resolve your current index first"
 msgstr "heu de primer resoldre el vostre índex actual"
 
-#: builtin/checkout.c:786
+#: builtin/checkout.c:797
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -12692,50 +12606,50 @@ msgstr ""
 "no es pot continuar amb els canvis «staged» als fitxers següents:\n"
 "%s"
 
-#: builtin/checkout.c:879
+#: builtin/checkout.c:890
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "No es pot fer reflog per a «%s»: %s\n"
 
-#: builtin/checkout.c:921
+#: builtin/checkout.c:934
 msgid "HEAD is now at"
 msgstr "HEAD ara és a"
 
-#: builtin/checkout.c:925 builtin/clone.c:609 t/helper/test-fast-rebase.c:203
+#: builtin/checkout.c:938 builtin/clone.c:609 t/helper/test-fast-rebase.c:203
 msgid "unable to update HEAD"
 msgstr "no s'ha pogut actualitzar HEAD"
 
-#: builtin/checkout.c:929
+#: builtin/checkout.c:942
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Restableix la branca «%s»\n"
 
-#: builtin/checkout.c:932
+#: builtin/checkout.c:945
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Ja esteu en «%s»\n"
 
-#: builtin/checkout.c:936
+#: builtin/checkout.c:949
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "S'ha canviat i restablert a la branca «%s»\n"
 
-#: builtin/checkout.c:938 builtin/checkout.c:1369
+#: builtin/checkout.c:951 builtin/checkout.c:1388
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "S'ha canviat a la branca nova «%s»\n"
 
-#: builtin/checkout.c:940
+#: builtin/checkout.c:953
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "S'ha canviat a la branca «%s»\n"
 
-#: builtin/checkout.c:991
+#: builtin/checkout.c:1004
 #, c-format
 msgid " ... and %d more.\n"
 msgstr " ... i %d més.\n"
 
-#: builtin/checkout.c:997
+#: builtin/checkout.c:1010
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -12758,7 +12672,7 @@ msgstr[1] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:1016
+#: builtin/checkout.c:1029
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -12785,29 +12699,28 @@ msgstr[1] ""
 " git branch <nom-de-branca-nova> %s\n"
 "\n"
 
-#: builtin/checkout.c:1051
+#: builtin/checkout.c:1064
 msgid "internal error in revision walk"
 msgstr "error intern en el passeig per revisions"
 
-#: builtin/checkout.c:1055
+#: builtin/checkout.c:1068
 msgid "Previous HEAD position was"
 msgstr "La posició de HEAD anterior era"
 
-#: builtin/checkout.c:1095 builtin/checkout.c:1364
+#: builtin/checkout.c:1114 builtin/checkout.c:1383
 msgid "You are on a branch yet to be born"
 msgstr "Sou en una branca que encara ha de néixer"
 
-#: builtin/checkout.c:1177
-#, fuzzy, c-format
+#: builtin/checkout.c:1196
+#, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
 "Please use -- (and optionally --no-guess) to disambiguate"
 msgstr ""
-"\"%s\" podria ser tant un fitxer local com una branca de seguiment. Si us "
-"plau useu -- (i opcionalment --no-gues) per a desambiguar"
+"«%s» podria ser tant un fitxer local com una branca de seguiment.\n"
+"Useu -- (i opcionalment --no-guess) per a desambiguar-ho"
 
-#: builtin/checkout.c:1184
-#, fuzzy
+#: builtin/checkout.c:1203
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -12818,57 +12731,60 @@ msgid ""
 "one remote, e.g. the 'origin' remote, consider setting\n"
 "checkout.defaultRemote=origin in your config."
 msgstr ""
-"Si voleu comprovar una branca de seguiment remota p. ex. «origen» podeu fer-"
-"ho classificant completament el nom amb l'opció --track git checkout --track"
-" origin/<name> Si voleu tenir sempre agafades d'un ambigu <name> preferiu un"
-" remot p. ex. el paràmetre remot 'origin' considereu "
-"agafar.defaultRemote=origin a la vostra configuració."
+"Si voleu agafar una branca de seguiment remota, p. ex. «origin», podeu\n"
+"fer-ho especificant el nom complet amb l'opció --track:\n"
+"\n"
+"    git checkout --track origin/<nom>\n"
+"\n"
+"Si voleu que en agafar un branca amb un <nom> ambigu s'usi una branca\n"
+"remota, p. ex. «origin» al remot, considereu configurar l'opció\n"
+"checkout.defaultRemote=origin en la vostra configuració."
 
-#: builtin/checkout.c:1194
+#: builtin/checkout.c:1213
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "«%s» coincideixen múltiples (%d) branques de seguiment remotes"
 
-#: builtin/checkout.c:1260
+#: builtin/checkout.c:1279
 msgid "only one reference expected"
 msgstr "només s'esperava una referència"
 
-#: builtin/checkout.c:1277
+#: builtin/checkout.c:1296
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "s'esperava només una referència, s'han donat %d."
 
-#: builtin/checkout.c:1323 builtin/worktree.c:269 builtin/worktree.c:437
+#: builtin/checkout.c:1342 builtin/worktree.c:269 builtin/worktree.c:436
 #, c-format
 msgid "invalid reference: %s"
 msgstr "referència no vàlida: %s"
 
-#: builtin/checkout.c:1336 builtin/checkout.c:1705
+#: builtin/checkout.c:1355 builtin/checkout.c:1725
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "la referència no és un arbre: %s"
 
-#: builtin/checkout.c:1383
+#: builtin/checkout.c:1402
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "s'espera una branca, s'ha obtingut l'etiqueta «%s»"
 
-#: builtin/checkout.c:1385
+#: builtin/checkout.c:1404
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "s'espera una branca, s'ha obtingut la branca remota «%s»"
 
-#: builtin/checkout.c:1386 builtin/checkout.c:1394
+#: builtin/checkout.c:1405 builtin/checkout.c:1413
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "s'espera una branca, s'ha obtingut «%s»"
 
-#: builtin/checkout.c:1389
+#: builtin/checkout.c:1408
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "s'espera una branca, s'ha obtingut la comissió «%s»"
 
-#: builtin/checkout.c:1405
+#: builtin/checkout.c:1424
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -12876,34 +12792,31 @@ msgstr ""
 "no es pot canviar de branca mentre es fusiona\n"
 "Considereu usar «git merge --quit» o «git worktree add»."
 
-#: builtin/checkout.c:1409
-#, fuzzy
+#: builtin/checkout.c:1428
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
 msgstr ""
-"no es pot canviar de branca al mig d'una sessió am Considereu \"git am "
-"--quit\" o \"git worktree add\"."
+"no es pot canviar de branca en mig d'una sessió «am»\n"
+"Considereu usar «git am --quit» o «git worktree add»."
 
-#: builtin/checkout.c:1413
-#, fuzzy
+#: builtin/checkout.c:1432
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
 msgstr ""
-"no es pot canviar de branca mentre es rebase considera «git rebase --quit» o"
-" «git worktree add»."
+"no es pot canviar de branca mentre es fa «rebase»\n"
+"Considereu usar «git rebase --quit» o «git worktree add»."
 
-#: builtin/checkout.c:1417
-#, fuzzy
+#: builtin/checkout.c:1436
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
 msgstr ""
-"no es pot canviar de branca mentre «cherry pick» considera «git cherry-pick "
-"--quit» o «git worktree add»."
+"no es pot canviar de branca mentre es fa «cherry-pick»\n"
+"Considereu usar «git cherry-pick --quit» o «git worktree add»."
 
-#: builtin/checkout.c:1421
+#: builtin/checkout.c:1440
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -12911,140 +12824,127 @@ msgstr ""
 "no es pot canviar de branca mentre s'està revertint\n"
 "Considereu «git revert --quit» o «git worktree add»."
 
-#: builtin/checkout.c:1425
-#, fuzzy
+#: builtin/checkout.c:1444
 msgid "you are switching branch while bisecting"
-msgstr "s'està canviant la branca mentre es bisect"
+msgstr "s'està canviant la branca mentre es fa una bisecció"
 
-#: builtin/checkout.c:1432
+#: builtin/checkout.c:1451
 msgid "paths cannot be used with switching branches"
 msgstr "els camins no es poden usar amb canvi de branca"
 
-#: builtin/checkout.c:1435 builtin/checkout.c:1439 builtin/checkout.c:1443
+#: builtin/checkout.c:1454 builtin/checkout.c:1458 builtin/checkout.c:1462
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "«%s» no es pot usar amb canvi de branca"
 
-#: builtin/checkout.c:1447 builtin/checkout.c:1450 builtin/checkout.c:1453
-#: builtin/checkout.c:1458 builtin/checkout.c:1463
+#: builtin/checkout.c:1466 builtin/checkout.c:1469 builtin/checkout.c:1472
+#: builtin/checkout.c:1477 builtin/checkout.c:1482
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "«%s» no es pot usar amb «%s»"
 
-#: builtin/checkout.c:1460
+#: builtin/checkout.c:1479
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "«%s» no pot prendre <start-point>"
 
-#: builtin/checkout.c:1468
+#: builtin/checkout.c:1487
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "No es pot canviar la branca a la no comissió «%s»"
 
-#: builtin/checkout.c:1475
+#: builtin/checkout.c:1494
 msgid "missing branch or commit argument"
 msgstr "manca branca o argument de comissió"
 
-#: builtin/checkout.c:1518
+#: builtin/checkout.c:1537
 msgid "perform a 3-way merge with the new branch"
 msgstr "realitza una fusió de 3 vies amb la branca nova"
 
-#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:322
+#: builtin/checkout.c:1538 builtin/log.c:1825 parse-options.h:323
 msgid "style"
 msgstr "estil"
 
-#: builtin/checkout.c:1520
-msgid "conflict style (merge or diff3)"
-msgstr "estil de conflicte (fusió o diff3)"
+#: builtin/checkout.c:1539
+msgid "conflict style (merge, diff3, or zdiff3)"
+msgstr "estil de conflicte (merge, diff3, o zdiff3)"
 
-#: builtin/checkout.c:1532 builtin/worktree.c:489
+#: builtin/checkout.c:1551 builtin/worktree.c:488
 msgid "detach HEAD at named commit"
 msgstr "separa HEAD a la comissió anomenada"
 
-#: builtin/checkout.c:1533
-msgid "set upstream info for new branch"
-msgstr "estableix la informació de font de la branca nova"
+#: builtin/checkout.c:1553
+msgid "set up tracking mode (see git-pull(1))"
+msgstr "configura el mode de seguiment (vegeu git-pull(1))"
 
-#: builtin/checkout.c:1535
+#: builtin/checkout.c:1556
 msgid "force checkout (throw away local modifications)"
 msgstr "agafa a la força (descarta qualsevol modificació local)"
 
-#: builtin/checkout.c:1537
+#: builtin/checkout.c:1558
 msgid "new-branch"
 msgstr "branca-nova"
 
-#: builtin/checkout.c:1537
+#: builtin/checkout.c:1558
 msgid "new unparented branch"
 msgstr "branca òrfena nova"
 
-#: builtin/checkout.c:1539 builtin/merge.c:302
+#: builtin/checkout.c:1560 builtin/merge.c:305
 msgid "update ignored files (default)"
 msgstr "actualitza els fitxers ignorats (per defecte)"
 
-#: builtin/checkout.c:1542
+#: builtin/checkout.c:1563
 msgid "do not check if another worktree is holding the given ref"
 msgstr "no comprovis si altre arbre de treball té la referència donada"
 
-#: builtin/checkout.c:1555
+#: builtin/checkout.c:1576
 msgid "checkout our version for unmerged files"
 msgstr "agafa la versió nostra dels fitxers sense fusionar"
 
-#: builtin/checkout.c:1558
+#: builtin/checkout.c:1579
 msgid "checkout their version for unmerged files"
 msgstr "agafa la versió seva dels fitxers sense fusionar"
 
-#: builtin/checkout.c:1562
+#: builtin/checkout.c:1583
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "no limitis les especificacions de camí només a entrades disperses"
 
-#: builtin/checkout.c:1620
+#: builtin/checkout.c:1640
 #, c-format
-msgid "-%c, -%c and --orphan are mutually exclusive"
-msgstr "-%c, -%c i --orphan són mútuament excloents"
+msgid "options '-%c', '-%c', and '%s' cannot be used together"
+msgstr "les opcions «-%c», «-%c», i «%s» no es poden usar juntes"
 
-#: builtin/checkout.c:1624
-msgid "-p and --overlay are mutually exclusive"
-msgstr "-p i --overlay són mútuament excloents"
-
-#: builtin/checkout.c:1661
+#: builtin/checkout.c:1681
 msgid "--track needs a branch name"
 msgstr "--track necessita un nom de branca"
 
-#: builtin/checkout.c:1666
+#: builtin/checkout.c:1686
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "falta el nom de la branca; proveu -%c"
 
-#: builtin/checkout.c:1698
+#: builtin/checkout.c:1718
 #, c-format
 msgid "could not resolve %s"
 msgstr "no es pot resoldre %s"
 
-#: builtin/checkout.c:1714
+#: builtin/checkout.c:1734
 msgid "invalid path specification"
 msgstr "especificació de camí no vàlida"
 
-#: builtin/checkout.c:1721
+#: builtin/checkout.c:1741
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr ""
 "«%s» no és una comissió i la branca «%s» no es pot crear a partir d'aquesta "
 "comissió"
 
-#: builtin/checkout.c:1725
+#: builtin/checkout.c:1745
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach no accepta un argument de camí «%s»"
 
-#: builtin/checkout.c:1734
-msgid "--pathspec-from-file is incompatible with --detach"
-msgstr "--pathspec-from-file és incompatible amb --detach"
-
-#: builtin/checkout.c:1737 builtin/reset.c:331 builtin/stash.c:1647
-msgid "--pathspec-from-file is incompatible with --patch"
-msgstr "--pathspec-from-file és incompatible amb --patch"
-
-#: builtin/checkout.c:1750
+#: builtin/checkout.c:1770
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -13052,74 +12952,71 @@ msgstr ""
 "git checkout: --ours/--theirs, --force i --merge són incompatibles en\n"
 "agafar de l'índex."
 
-#: builtin/checkout.c:1755
+#: builtin/checkout.c:1775
 msgid "you must specify path(s) to restore"
 msgstr "heu d'especificar el camí o camins a restaurar"
 
-#: builtin/checkout.c:1781 builtin/checkout.c:1783 builtin/checkout.c:1832
-#: builtin/checkout.c:1834 builtin/clone.c:126 builtin/remote.c:170
-#: builtin/remote.c:172 builtin/submodule--helper.c:2958
-#: builtin/submodule--helper.c:3252 builtin/worktree.c:485
-#: builtin/worktree.c:487
+#: builtin/checkout.c:1800 builtin/checkout.c:1802 builtin/checkout.c:1854
+#: builtin/checkout.c:1856 builtin/clone.c:126 builtin/remote.c:170
+#: builtin/remote.c:172 builtin/submodule--helper.c:2959
+#: builtin/submodule--helper.c:3253 builtin/worktree.c:484
+#: builtin/worktree.c:486
 msgid "branch"
 msgstr "branca"
 
-#: builtin/checkout.c:1782
+#: builtin/checkout.c:1801
 msgid "create and checkout a new branch"
 msgstr "crea i agafa una branca nova"
 
-#: builtin/checkout.c:1784
+#: builtin/checkout.c:1803
 msgid "create/reset and checkout a branch"
 msgstr "crea/restableix i agafa una branca"
 
-#: builtin/checkout.c:1785
+#: builtin/checkout.c:1804
 msgid "create reflog for new branch"
 msgstr "crea un registre de referència per a la branca nova"
 
-#: builtin/checkout.c:1787
-#, fuzzy
+#: builtin/checkout.c:1806
 msgid "second guess 'git checkout <no-such-branch>' (default)"
-msgstr "segon conjectura «git checkout <no-such-branch>» (per defecte)"
+msgstr "segona suposició «git checkout <no-such-branch>» (per defecte)"
 
-#: builtin/checkout.c:1788
+#: builtin/checkout.c:1807
 msgid "use overlay mode (default)"
 msgstr "utilitza el mode de superposició (per defecte)"
 
-#: builtin/checkout.c:1833
+#: builtin/checkout.c:1855
 msgid "create and switch to a new branch"
 msgstr "crea i canvia a una branca nova"
 
-#: builtin/checkout.c:1835
+#: builtin/checkout.c:1857
 msgid "create/reset and switch to a branch"
 msgstr "crea/restableix i canvia a una branca"
 
-#: builtin/checkout.c:1837
-#, fuzzy
+#: builtin/checkout.c:1859
 msgid "second guess 'git switch <no-such-branch>'"
-msgstr "segon conjectura «git switch <no-such-branch>»"
+msgstr "segona suposició «git switch <no-such-branch>»"
 
-#: builtin/checkout.c:1839
+#: builtin/checkout.c:1861
 msgid "throw away local modifications"
 msgstr "descarta les modificacions locals"
 
-#: builtin/checkout.c:1873
-#, fuzzy
+#: builtin/checkout.c:1897
 msgid "which tree-ish to checkout from"
-msgstr "de quin arbre agafar"
+msgstr "des de quin arbre agafar"
 
-#: builtin/checkout.c:1875
+#: builtin/checkout.c:1899
 msgid "restore the index"
 msgstr "restaura l'índex"
 
-#: builtin/checkout.c:1877
+#: builtin/checkout.c:1901
 msgid "restore the working tree (default)"
 msgstr "restaura l'arbre de treball (per defecte)"
 
-#: builtin/checkout.c:1879
+#: builtin/checkout.c:1903
 msgid "ignore unmerged entries"
 msgstr "ignora les entrades sense fusionar"
 
-#: builtin/checkout.c:1880
+#: builtin/checkout.c:1904
 msgid "use overlay mode"
 msgstr "utilitza el mode de superposició"
 
@@ -13154,7 +13051,15 @@ msgstr "Ometria el repositori %s\n"
 msgid "could not lstat %s\n"
 msgstr "no s'ha pogut fer lstat %s\n"
 
-#: builtin/clean.c:300 git-add--interactive.perl:593
+#: builtin/clean.c:39
+msgid "Refusing to remove current working directory\n"
+msgstr "S'ha rebutjat suprimir el directori de treball actual\n"
+
+#: builtin/clean.c:40
+msgid "Would refuse to remove current working directory\n"
+msgstr "Es rebutjarà eliminar el directori de treball actual\n"
+
+#: builtin/clean.c:326 git-add--interactive.perl:593
 #, c-format
 msgid ""
 "Prompt help:\n"
@@ -13167,7 +13072,7 @@ msgstr ""
 "foo        - selecciona un ítem basat en un prefix únic\n"
 "           - (buit) no seleccionis res\n"
 
-#: builtin/clean.c:304 git-add--interactive.perl:602
+#: builtin/clean.c:330 git-add--interactive.perl:602
 #, c-format
 msgid ""
 "Prompt help:\n"
@@ -13188,33 +13093,33 @@ msgstr ""
 "*          - tria tots els ítems\n"
 "           - (buit) finalitza la selecció\n"
 
-#: builtin/clean.c:519 git-add--interactive.perl:568
+#: builtin/clean.c:545 git-add--interactive.perl:568
 #: git-add--interactive.perl:573
 #, c-format, perl-format
 msgid "Huh (%s)?\n"
 msgstr "Perdó (%s)?\n"
 
-#: builtin/clean.c:659
+#: builtin/clean.c:685
 #, c-format
 msgid "Input ignore patterns>> "
 msgstr "Introduïu els patrons a ignorar>> "
 
-#: builtin/clean.c:693
+#: builtin/clean.c:719
 #, c-format
 msgid "WARNING: Cannot find items matched by: %s"
 msgstr "ADVERTÈNCIA: No es poden trobar ítems que coincideixin amb: %s"
 
-#: builtin/clean.c:714
+#: builtin/clean.c:740
 msgid "Select items to delete"
 msgstr "Selecciona els ítems a suprimir"
 
 #. TRANSLATORS: Make sure to keep [y/N] as is
-#: builtin/clean.c:755
+#: builtin/clean.c:781
 #, c-format
 msgid "Remove %s [y/N]? "
 msgstr "Voleu eliminar %s [y/N]? "
 
-#: builtin/clean.c:786
+#: builtin/clean.c:812
 msgid ""
 "clean               - start cleaning\n"
 "filter by pattern   - exclude items from deletion\n"
@@ -13232,52 +13137,52 @@ msgstr ""
 "help                - aquesta pantalla\n"
 "?                   - ajuda de selecció de l'avís"
 
-#: builtin/clean.c:822
+#: builtin/clean.c:848
 msgid "Would remove the following item:"
 msgid_plural "Would remove the following items:"
 msgstr[0] "Eliminaria l'ítem següent:"
 msgstr[1] "Eliminaria els ítems següents:"
 
-#: builtin/clean.c:838
+#: builtin/clean.c:864
 msgid "No more files to clean, exiting."
 msgstr "No hi ha més fitxers a netejar; s'està sortint."
 
-#: builtin/clean.c:900
+#: builtin/clean.c:926
 msgid "do not print names of files removed"
 msgstr "no imprimeixis els noms dels fitxers eliminats"
 
-#: builtin/clean.c:902
+#: builtin/clean.c:928
 msgid "force"
 msgstr "força"
 
-#: builtin/clean.c:903
+#: builtin/clean.c:929
 msgid "interactive cleaning"
 msgstr "neteja interactiva"
 
-#: builtin/clean.c:905
+#: builtin/clean.c:931
 msgid "remove whole directories"
 msgstr "elimina directoris sencers"
 
-#: builtin/clean.c:906 builtin/describe.c:565 builtin/describe.c:567
+#: builtin/clean.c:932 builtin/describe.c:565 builtin/describe.c:567
 #: builtin/grep.c:937 builtin/log.c:184 builtin/log.c:186
-#: builtin/ls-files.c:648 builtin/name-rev.c:526 builtin/name-rev.c:528
+#: builtin/ls-files.c:651 builtin/name-rev.c:535 builtin/name-rev.c:537
 #: builtin/show-ref.c:179
 msgid "pattern"
 msgstr "patró"
 
-#: builtin/clean.c:907
+#: builtin/clean.c:933
 msgid "add <pattern> to ignore rules"
 msgstr "afegiu <patró> per a ignorar les regles"
 
-#: builtin/clean.c:908
+#: builtin/clean.c:934
 msgid "remove ignored files, too"
 msgstr "elimina els fitxers ignorats, també"
 
-#: builtin/clean.c:910
+#: builtin/clean.c:936
 msgid "remove only ignored files"
 msgstr "elimina només els fitxers ignorats"
 
-#: builtin/clean.c:925
+#: builtin/clean.c:951
 msgid ""
 "clean.requireForce set to true and neither -i, -n, nor -f given; refusing to"
 " clean"
@@ -13285,7 +13190,7 @@ msgstr ""
 "clean.requireForce està establerta en cert i ni -i, -n ni -f s'han indicat; "
 "refusant netejar"
 
-#: builtin/clean.c:928
+#: builtin/clean.c:954
 msgid ""
 "clean.requireForce defaults to true and neither -i, -n, nor -f given; "
 "refusing to clean"
@@ -13293,7 +13198,7 @@ msgstr ""
 "clean.requireForce és per defecte cert i ni -i, -n ni -f s'han indicat; "
 "refusant netejar"
 
-#: builtin/clean.c:940
+#: builtin/clean.c:966
 msgid "-x and -X cannot be used together"
 msgstr "-x i -X no es poden usar junts"
 
@@ -13302,9 +13207,8 @@ msgid "git clone [<options>] [--] <repo> [<dir>]"
 msgstr "git clone [<opcions>] [--] <repositori> [<directori>]"
 
 #: builtin/clone.c:96
-#, fuzzy
 msgid "don't clone shallow repository"
-msgstr "per a clonar des d'un repositori local"
+msgstr "no clonis un repositori superficial"
 
 #: builtin/clone.c:98
 msgid "don't create a checkout"
@@ -13350,19 +13254,20 @@ msgstr "directori-de-plantilla"
 msgid "directory from which templates will be used"
 msgstr "directori des del qual s'usaran les plantilles"
 
-#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1870
-#: builtin/submodule--helper.c:2513 builtin/submodule--helper.c:3259
+#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1871
+#: builtin/submodule--helper.c:2514 builtin/submodule--helper.c:3260
 msgid "reference repository"
 msgstr "repositori de referència"
 
-#: builtin/clone.c:123 builtin/submodule--helper.c:1872
-#: builtin/submodule--helper.c:2515
+#: builtin/clone.c:123 builtin/submodule--helper.c:1873
+#: builtin/submodule--helper.c:2516
 msgid "use --reference only while cloning"
 msgstr "usa --reference només en clonar"
 
-#: builtin/clone.c:124 builtin/column.c:27 builtin/init-db.c:550
-#: builtin/merge-file.c:46 builtin/pack-objects.c:3944 builtin/repack.c:663
-#: builtin/submodule--helper.c:3261 t/helper/test-simple-ipc.c:595
+#: builtin/clone.c:124 builtin/column.c:27 builtin/fmt-merge-msg.c:27
+#: builtin/init-db.c:550 builtin/merge-file.c:48 builtin/merge.c:290
+#: builtin/pack-objects.c:3944 builtin/repack.c:665
+#: builtin/submodule--helper.c:3262 t/helper/test-simple-ipc.c:595
 #: t/helper/test-simple-ipc.c:597
 msgid "name"
 msgstr "nom"
@@ -13379,8 +13284,8 @@ msgstr "agafa <branca> en lloc de la HEAD del remot"
 msgid "path to git-upload-pack on the remote"
 msgstr "camí a git-upload-pack en el remot"
 
-#: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
-#: builtin/pull.c:208
+#: builtin/clone.c:130 builtin/fetch.c:181 builtin/grep.c:876
+#: builtin/pull.c:212
 msgid "depth"
 msgstr "profunditat"
 
@@ -13388,8 +13293,8 @@ msgstr "profunditat"
 msgid "create a shallow clone of that depth"
 msgstr "crea un clon superficial de tal profunditat"
 
-#: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
-#: builtin/pull.c:211
+#: builtin/clone.c:132 builtin/fetch.c:183 builtin/pack-objects.c:3933
+#: builtin/pull.c:215
 msgid "time"
 msgstr "data"
 
@@ -13397,17 +13302,17 @@ msgstr "data"
 msgid "create a shallow clone since a specific time"
 msgstr "crea un clon superficial des d'una data específica"
 
-#: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
-#: builtin/pull.c:214 builtin/pull.c:239 builtin/rebase.c:1022
+#: builtin/clone.c:134 builtin/fetch.c:185 builtin/fetch.c:208
+#: builtin/pull.c:218 builtin/pull.c:243 builtin/rebase.c:1022
 msgid "revision"
 msgstr "revisió"
 
-#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:215
+#: builtin/clone.c:135 builtin/fetch.c:186 builtin/pull.c:219
 msgid "deepen history of shallow clone, excluding rev"
 msgstr "aprofundeix la història d'un clon superficial, excloent una revisió"
 
-#: builtin/clone.c:137 builtin/submodule--helper.c:1882
-#: builtin/submodule--helper.c:2529
+#: builtin/clone.c:137 builtin/submodule--helper.c:1883
+#: builtin/submodule--helper.c:2530
 msgid "clone only one branch, HEAD or --branch"
 msgstr "clona només una branca, HEAD o --branch"
 
@@ -13436,22 +13341,22 @@ msgstr "clau=valor"
 msgid "set config inside the new repository"
 msgstr "estableix la configuració dins del repositori nou"
 
-#: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:230 builtin/push.c:575 builtin/send-pack.c:200
+#: builtin/clone.c:147 builtin/fetch.c:203 builtin/ls-remote.c:77
+#: builtin/pull.c:234 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "específic al servidor"
 
-#: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
-#: builtin/pull.c:231 builtin/push.c:575 builtin/send-pack.c:201
+#: builtin/clone.c:147 builtin/fetch.c:203 builtin/ls-remote.c:77
+#: builtin/pull.c:235 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr "opció a transmetre"
 
-#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:234
+#: builtin/clone.c:148 builtin/fetch.c:204 builtin/pull.c:238
 #: builtin/push.c:576
 msgid "use IPv4 addresses only"
 msgstr "usa només adreces IPv4"
 
-#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:237
+#: builtin/clone.c:150 builtin/fetch.c:206 builtin/pull.c:241
 #: builtin/push.c:578
 msgid "use IPv6 addresses only"
 msgstr "usa només adreces IPv6"
@@ -13478,9 +13383,9 @@ msgid "%s exists and is not a directory"
 msgstr "%s existeix i no és directori"
 
 #: builtin/clone.c:322
-#, fuzzy, c-format
+#, c-format
 msgid "failed to start iterator over '%s'"
-msgstr "no s'ha pogut iniciar l'iterador per sobre de «%s»"
+msgstr "no s'ha pogut iniciar l'iterador sobre «%s»"
 
 #: builtin/clone.c:353
 #, c-format
@@ -13503,15 +13408,14 @@ msgid "done.\n"
 msgstr "fet.\n"
 
 #: builtin/clone.c:403
-#, fuzzy
 msgid ""
 "Clone succeeded, but checkout failed.\n"
 "You can inspect what was checked out with 'git status'\n"
 "and retry with 'git restore --source=HEAD :/'\n"
 msgstr ""
-"El clonatge ha tingut èxit però ha fallat. Podeu inspeccionar el que s'ha "
-"comprovat amb «git status» i tornar-ho a provar amb «git restore "
-"--source=HEAD /»"
+"El clonatge ha tingut èxit, però no s'ha pogut agafar.\n"
+"Podeu inspeccionar el que s'ha agafat amb «git status»\n"
+"i tornar-ho a provar amb «git restore --source=HEAD :/»\n"
 
 #: builtin/clone.c:480
 #, c-format
@@ -13549,29 +13453,25 @@ msgstr "no es pot reempaquetar per a netejar"
 msgid "cannot unlink temporary alternates file"
 msgstr "no es pot desenllaçar el fitxer d'alternatives temporal"
 
-#: builtin/clone.c:886 builtin/receive-pack.c:2493
+#: builtin/clone.c:886
 msgid "Too many arguments."
 msgstr "Hi ha massa arguments."
 
-#: builtin/clone.c:890
+#: builtin/clone.c:890 contrib/scalar/scalar.c:414
 msgid "You must specify a repository to clone."
 msgstr "Heu d'especificar un repositori per a clonar."
 
 #: builtin/clone.c:903
 #, c-format
-msgid "--bare and --origin %s options are incompatible."
-msgstr "les opcions --bare i --origin %s són incompatibles."
-
-#: builtin/clone.c:906
-msgid "--bare and --separate-git-dir are incompatible."
-msgstr "--bare i --separate-git-dir són incompatibles."
+msgid "options '%s' and '%s %s' cannot be used together"
+msgstr "les opcions «%s» i «%s %s» no es poden usar juntes"
 
 #: builtin/clone.c:920
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "el repositori «%s» no existeix"
 
-#: builtin/clone.c:924 builtin/fetch.c:2029
+#: builtin/clone.c:924 builtin/fetch.c:2052
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "la profunditat %s no és un nombre positiu"
@@ -13591,8 +13491,8 @@ msgstr "el camí destí «%s» ja existeix i no és un directori buit."
 msgid "working tree '%s' already exists."
 msgstr "l'arbre de treball «%s» ja existeix."
 
-#: builtin/clone.c:969 builtin/clone.c:990 builtin/difftool.c:262
-#: builtin/log.c:1997 builtin/worktree.c:281 builtin/worktree.c:313
+#: builtin/clone.c:969 builtin/clone.c:990 builtin/difftool.c:256
+#: builtin/log.c:2012 builtin/worktree.c:281 builtin/worktree.c:313
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "no s'han pogut crear els directoris inicials de «%s»"
@@ -13716,7 +13616,7 @@ msgstr ""
 "[--changed-paths] [--[no-]max-new-filters <n>] [--[no-]progress] <split "
 "options>"
 
-#: builtin/commit-graph.c:51 builtin/fetch.c:191 builtin/log.c:1779
+#: builtin/commit-graph.c:51 builtin/fetch.c:192 builtin/log.c:1794
 msgid "dir"
 msgstr "directori"
 
@@ -13740,11 +13640,9 @@ msgid "unrecognized --split argument, %s"
 msgstr "argument --split no reconegut, %s"
 
 #: builtin/commit-graph.c:150
-#, fuzzy, c-format
+#, c-format
 msgid "unexpected non-hex object ID: %s"
-msgstr ""
-"s'esperava un identificador d'objecte de vora amb brossa s'han obtingut "
-"percentatges d'escombraries"
+msgstr "ID de l'objecte no hexadecimal inesperat: %s"
 
 #: builtin/commit-graph.c:155
 #, c-format
@@ -13753,16 +13651,15 @@ msgstr "no és un objecte vàlid: %s"
 
 #: builtin/commit-graph.c:205
 msgid "start walk at all refs"
-msgstr "comença a caminar en totes les referències"
+msgstr "comença el recorregut en totes les referències"
 
 #: builtin/commit-graph.c:207
 msgid "scan pack-indexes listed by stdin for commits"
 msgstr "explora els índexs del paquet llistats per a stdin per a comissions"
 
 #: builtin/commit-graph.c:209
-#, fuzzy
 msgid "start walk at commits listed by stdin"
-msgstr "comença a caminar a les comissions llistades per a stdin"
+msgstr "comença el recorregut per les comissions llistades per stdin"
 
 #: builtin/commit-graph.c:211
 msgid "include all commits already in the commit-graph file"
@@ -13777,9 +13674,9 @@ msgid "allow writing an incremental commit-graph file"
 msgstr "permet escriure un fitxer de graf de comissions incrementals"
 
 #: builtin/commit-graph.c:219
-#, fuzzy
 msgid "maximum number of commits in a non-base split commit-graph"
-msgstr "nombre màxim de comissions en un graf de comissions no basat"
+msgstr ""
+"nombre màxim de comissions en un graf de comissions separades sense base"
 
 #: builtin/commit-graph.c:221
 msgid "maximum ratio between two levels of a split commit-graph"
@@ -13787,27 +13684,24 @@ msgstr "ràtio màxima entre dos nivells d'un graf de comissions dividit"
 
 #: builtin/commit-graph.c:223
 msgid "only expire files older than a given date-time"
-msgstr "fes caducar els objectes més antics que l'hora i data donades"
+msgstr "fes caducar només els objectes més antics que l'hora i data donades"
 
 #: builtin/commit-graph.c:225
-#, fuzzy
 msgid "maximum number of changed-path Bloom filters to compute"
-msgstr ""
-"S'estan calculant els canvis les rutes de la comissió en els filtres Bloom"
+msgstr "nombre màxim de canvis de camí en filtres Bloom a calcular"
 
 #: builtin/commit-graph.c:251
-#, fuzzy
 msgid "use at most one of --reachable, --stdin-commits, or --stdin-packs"
-msgstr "usa com a màxim un dels --reachable --stdin-commits o --stdin-packs"
+msgstr "usa com a màxim un --reachable, --stdin-commits, o --stdin-packs"
 
-#: builtin/commit-graph.c:283
+#: builtin/commit-graph.c:282
 msgid "Collecting commits from input"
 msgstr "S'estan recollint les comissions de l'entrada"
 
-#: builtin/commit-graph.c:328 builtin/multi-pack-index.c:255
-#, fuzzy, c-format
+#: builtin/commit-graph.c:328 builtin/multi-pack-index.c:259
+#, c-format
 msgid "unrecognized subcommand: %s"
-msgstr "subcomandes no reconeguts"
+msgstr "subordre no reconeguda: %s"
 
 #: builtin/commit-tree.c:18
 msgid ""
@@ -13822,7 +13716,7 @@ msgstr ""
 msgid "duplicate parent %s ignored"
 msgstr "s'han ignorat el pare %s duplicat"
 
-#: builtin/commit-tree.c:56 builtin/commit-tree.c:134 builtin/log.c:562
+#: builtin/commit-tree.c:56 builtin/commit-tree.c:134 builtin/log.c:577
 #, c-format
 msgid "not a valid object name %s"
 msgstr "no és un nom d'objecte vàlid %s"
@@ -13845,13 +13739,13 @@ msgstr "pare"
 msgid "id of a parent commit object"
 msgstr "id d'un objecte de comissió pare"
 
-#: builtin/commit-tree.c:112 builtin/commit.c:1626 builtin/merge.c:283
-#: builtin/notes.c:407 builtin/notes.c:573 builtin/stash.c:1618
+#: builtin/commit-tree.c:112 builtin/commit.c:1627 builtin/merge.c:284
+#: builtin/notes.c:407 builtin/notes.c:573 builtin/stash.c:1677
 #: builtin/tag.c:454
 msgid "message"
 msgstr "missatge"
 
-#: builtin/commit-tree.c:113 builtin/commit.c:1626
+#: builtin/commit-tree.c:113 builtin/commit.c:1627
 msgid "commit message"
 msgstr "missatge de comissió"
 
@@ -13859,8 +13753,8 @@ msgstr "missatge de comissió"
 msgid "read commit log message from file"
 msgstr "llegeix el missatge de registre de comissió des d'un fitxer"
 
-#: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
-#: builtin/pull.c:176 builtin/revert.c:118
+#: builtin/commit-tree.c:119 builtin/commit.c:1644 builtin/merge.c:303
+#: builtin/pull.c:180 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "signa la comissió amb GPG"
 
@@ -13937,10 +13831,6 @@ msgstr ""
 #: builtin/commit.c:325
 msgid "failed to unpack HEAD tree object"
 msgstr "s'ha produït un error en desempaquetar l'objecte d'arbre HEAD"
-
-#: builtin/commit.c:361
-msgid "--pathspec-from-file with -a does not make sense"
-msgstr "--pathspec-from-file amb -a no té sentit"
 
 #: builtin/commit.c:375
 msgid "No paths with --include/--only does not make sense."
@@ -14029,8 +13919,8 @@ msgstr "no s'ha pogut llegir el fitxer de registre «%s»"
 
 #: builtin/commit.c:802
 #, c-format
-msgid "cannot combine -m with --fixup:%s"
-msgstr "no es pot combinar -m amb --fixup:%s"
+msgid "options '%s' and '%s:%s' cannot be used together"
+msgstr "les opcions «%s» i «%s:%s» no es poden usar juntes"
 
 #: builtin/commit.c:814 builtin/commit.c:830
 msgid "could not read SQUASH_MSG"
@@ -14045,14 +13935,13 @@ msgid "could not write commit template"
 msgstr "no s'ha pogut escriure la plantilla de comissió"
 
 #: builtin/commit.c:894
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "Please enter the commit message for your changes. Lines starting\n"
 "with '%c' will be ignored.\n"
 msgstr ""
-"Introduïu el missatge de comissió dels vostres canvis.\n"
-"S'ignoraran les línies que comencin amb «%c». Un missatge de\n"
-"comissió buit avorta la comissió.\n"
+"Introduïu el missatge de comissió per als vostres canvis.\n"
+"S'ignoraran les línies que comencin amb «%c».\n"
 
 #: builtin/commit.c:896
 #, c-format
@@ -14132,15 +14021,14 @@ msgid "Cannot read index"
 msgstr "No es pot llegir l'índex"
 
 #: builtin/commit.c:1026
-#, fuzzy
 msgid "unable to pass trailers to --trailers"
-msgstr "no s'ha pogut analitzar la capçalera de %s"
+msgstr "no s'han pogut passar els «trailers» a --trailers"
 
 #: builtin/commit.c:1066
 msgid "Error building trees"
-msgstr "Error en construir arbres"
+msgstr "Error en construir els arbres"
 
-#: builtin/commit.c:1080 builtin/tag.c:317
+#: builtin/commit.c:1080 builtin/tag.c:316
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr "Especifiqueu el missatge usant l'opció -m o l'opció -F.\n"
@@ -14157,136 +14045,125 @@ msgstr ""
 msgid "Invalid ignored mode '%s'"
 msgstr "Mode d'ignorància no vàlid «%s»"
 
-#: builtin/commit.c:1156 builtin/commit.c:1450
+#: builtin/commit.c:1156 builtin/commit.c:1451
 #, c-format
 msgid "Invalid untracked files mode '%s'"
 msgstr "Mode de fitxers no seguits no vàlid «%s»"
 
-#: builtin/commit.c:1196
-msgid "--long and -z are incompatible"
-msgstr "--long i -z són incompatibles"
-
 #: builtin/commit.c:1227
-#, fuzzy
 msgid "You are in the middle of a merge -- cannot reword."
-msgstr "Esteu enmig d'una fusió -- no es pot esmenar."
+msgstr "Esteu enmig d'una fusió -- no es pot fer «reword»."
 
 #: builtin/commit.c:1229
-#, fuzzy
 msgid "You are in the middle of a cherry-pick -- cannot reword."
-msgstr "Esteu enmig d'un «cherry pick» -- no es pot esmenar."
+msgstr "Esteu enmig d'un «cherry pick» -- no es pot fer «reword»."
 
 #: builtin/commit.c:1232
-#, fuzzy, c-format
-msgid "cannot combine reword option of --fixup with path '%s'"
-msgstr "no es poden combinar les opcions d'aplicació amb les opcions de fusió"
+#, c-format
+msgid "reword option of '%s' and path '%s' cannot be used together"
+msgstr "les opcions de «reword» «%s» i camí «%s» no es poden usar juntes"
 
 #: builtin/commit.c:1234
-#, fuzzy
-msgid ""
-"reword option of --fixup is mutually exclusive with "
-"--patch/--interactive/--all/--include/--only"
-msgstr ""
-"l'opció de reparaula de --fixup és mútuament excloent amb "
-"--patch/--interactive/--all/--include/--only"
+#, c-format
+msgid "reword option of '%s' and '%s' cannot be used together"
+msgstr "les opcions de «reword» «%s» i «%s» no es poden usar juntes"
 
-#: builtin/commit.c:1253
+#: builtin/commit.c:1254
 msgid "Using both --reset-author and --author does not make sense"
 msgstr "Usar ambdós --reset-author i --author no té sentit"
 
-#: builtin/commit.c:1260
+#: builtin/commit.c:1261
 msgid "You have nothing to amend."
 msgstr "No teniu res a esmenar."
 
-#: builtin/commit.c:1263
+#: builtin/commit.c:1264
 msgid "You are in the middle of a merge -- cannot amend."
 msgstr "Esteu enmig d'una fusió -- no es pot esmenar."
 
-#: builtin/commit.c:1265
+#: builtin/commit.c:1266
 msgid "You are in the middle of a cherry-pick -- cannot amend."
 msgstr "Esteu enmig d'un «cherry pick» -- no es pot esmenar."
 
-#: builtin/commit.c:1267
+#: builtin/commit.c:1268
 msgid "You are in the middle of a rebase -- cannot amend."
 msgstr "Esteu enmig d'un «rebase» -- no es pot esmenar."
 
-#: builtin/commit.c:1270
+#: builtin/commit.c:1271
 msgid "Options --squash and --fixup cannot be used together"
 msgstr "Les opcions --squash i --fixup no es poden usar juntes"
 
-#: builtin/commit.c:1280
+#: builtin/commit.c:1281
 msgid "Only one of -c/-C/-F/--fixup can be used."
 msgstr "Només un de -c/-C/-F/--fixup es pot usar."
 
-#: builtin/commit.c:1282
+#: builtin/commit.c:1283
 msgid "Option -m cannot be combined with -c/-C/-F."
 msgstr "L'opció -m no es pot combinar amb -c/-C/-F/."
 
-#: builtin/commit.c:1291
+#: builtin/commit.c:1292
 msgid "--reset-author can be used only with -C, -c or --amend."
 msgstr "--reset-author només es pot usar amb -C, -c o --amend."
 
-#: builtin/commit.c:1309
+#: builtin/commit.c:1310
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
 msgstr "Només un de --include/--only/--all/--interactive/--patch es pot usar."
 
-#: builtin/commit.c:1337
+#: builtin/commit.c:1338
 #, c-format
 msgid "unknown option: --fixup=%s:%s"
 msgstr "opció desconeguda: --fixup=%s:%s"
 
-#: builtin/commit.c:1354
+#: builtin/commit.c:1355
 #, c-format
 msgid "paths '%s ...' with -a does not make sense"
 msgstr "els camins «%s ...» amb -a no tenen sentit"
 
-#: builtin/commit.c:1485 builtin/commit.c:1654
+#: builtin/commit.c:1486 builtin/commit.c:1655
 msgid "show status concisely"
 msgstr "mostra l'estat concisament"
 
-#: builtin/commit.c:1487 builtin/commit.c:1656
+#: builtin/commit.c:1488 builtin/commit.c:1657
 msgid "show branch information"
 msgstr "mostra la informació de branca"
 
-#: builtin/commit.c:1489
+#: builtin/commit.c:1490
 msgid "show stash information"
 msgstr "mostra la informació de «stash»"
 
-#: builtin/commit.c:1491 builtin/commit.c:1658
-#, fuzzy
+#: builtin/commit.c:1492 builtin/commit.c:1659
 msgid "compute full ahead/behind values"
 msgstr "calcula els valors complets endavant/darrere"
 
-#: builtin/commit.c:1493
+#: builtin/commit.c:1494
 msgid "version"
 msgstr "versió"
 
-#: builtin/commit.c:1493 builtin/commit.c:1660 builtin/push.c:551
-#: builtin/worktree.c:691
+#: builtin/commit.c:1494 builtin/commit.c:1661 builtin/push.c:551
+#: builtin/worktree.c:690
 msgid "machine-readable output"
 msgstr "sortida llegible per una màquina"
 
-#: builtin/commit.c:1496 builtin/commit.c:1662
+#: builtin/commit.c:1497 builtin/commit.c:1663
 msgid "show status in long format (default)"
 msgstr "mostra l'estat en format llarg (per defecte)"
 
-#: builtin/commit.c:1499 builtin/commit.c:1665
+#: builtin/commit.c:1500 builtin/commit.c:1666
 msgid "terminate entries with NUL"
 msgstr "acaba les entrades amb NUL"
 
-#: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
-#: builtin/fast-export.c:1199 builtin/fast-export.c:1202
-#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:336
+#: builtin/commit.c:1502 builtin/commit.c:1506 builtin/commit.c:1669
+#: builtin/fast-export.c:1172 builtin/fast-export.c:1175
+#: builtin/fast-export.c:1178 builtin/rebase.c:1111 parse-options.h:337
 msgid "mode"
 msgstr "mode"
 
-#: builtin/commit.c:1502 builtin/commit.c:1668
+#: builtin/commit.c:1503 builtin/commit.c:1669
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
 "mostra els fitxers no seguits, modes opcionals: all, normal, no. (Per "
 "defecte: all)"
 
-#: builtin/commit.c:1506
+#: builtin/commit.c:1507
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
@@ -14294,11 +14171,11 @@ msgstr ""
 "mostra els fitxers ignorats, modes opcionals: traditional, matching, no. "
 "(Per defecte: traditional, matching, no.)"
 
-#: builtin/commit.c:1508 parse-options.h:192
+#: builtin/commit.c:1509 parse-options.h:192
 msgid "when"
 msgstr "quan"
 
-#: builtin/commit.c:1509
+#: builtin/commit.c:1510
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
@@ -14306,208 +14183,205 @@ msgstr ""
 "ignora els canvis als submòduls, opcional quan: all, dirty, untracked. (Per "
 "defecte: all)"
 
-#: builtin/commit.c:1511
+#: builtin/commit.c:1512
 msgid "list untracked files in columns"
 msgstr "mostra els fitxers no seguits en columnes"
 
-#: builtin/commit.c:1512
+#: builtin/commit.c:1513
 msgid "do not detect renames"
 msgstr "no detectis canvis de noms"
 
-#: builtin/commit.c:1514
+#: builtin/commit.c:1515
 msgid "detect renames, optionally set similarity index"
 msgstr ""
 "detecta canvis de noms, i opcionalment estableix un índex de semblança"
 
-#: builtin/commit.c:1537
+#: builtin/commit.c:1538
 msgid "Unsupported combination of ignored and untracked-files arguments"
 msgstr ""
 "No s'admet la combinació d'arguments d'ignorància i de fitxers no seguits"
 
-#: builtin/commit.c:1619
+#: builtin/commit.c:1620
 msgid "suppress summary after successful commit"
 msgstr "omet el resum després d'una comissió reeixida"
 
-#: builtin/commit.c:1620
+#: builtin/commit.c:1621
 msgid "show diff in commit message template"
 msgstr "mostra la diferència en la plantilla de missatge de comissió"
 
-#: builtin/commit.c:1622
+#: builtin/commit.c:1623
 msgid "Commit message options"
 msgstr "Opcions de missatge de comissió"
 
-#: builtin/commit.c:1623 builtin/merge.c:287 builtin/tag.c:456
+#: builtin/commit.c:1624 builtin/merge.c:288 builtin/tag.c:456
 msgid "read message from file"
 msgstr "llegiu el missatge des d'un fitxer"
 
-#: builtin/commit.c:1624
+#: builtin/commit.c:1625
 msgid "author"
 msgstr "autor"
 
-#: builtin/commit.c:1624
+#: builtin/commit.c:1625
 msgid "override author for commit"
-msgstr "autor corregit de la comissió"
+msgstr "sobreescriu l'autor de la comissió"
 
-#: builtin/commit.c:1625 builtin/gc.c:550
+#: builtin/commit.c:1626 builtin/gc.c:551
 msgid "date"
 msgstr "data"
 
-#: builtin/commit.c:1625
+#: builtin/commit.c:1626
 msgid "override date for commit"
-msgstr "data corregida de la comissió"
+msgstr "sobreescriu la data de la comissió"
 
-#: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
-#: parse-options.h:328 ref-filter.h:92
+#: builtin/commit.c:1628 builtin/commit.c:1629 builtin/commit.c:1635
+#: parse-options.h:329 ref-filter.h:89
 msgid "commit"
 msgstr "comissió"
 
-#: builtin/commit.c:1627
+#: builtin/commit.c:1628
 msgid "reuse and edit message from specified commit"
 msgstr "reusa i edita el missatge de la comissió especificada"
 
-#: builtin/commit.c:1628
+#: builtin/commit.c:1629
 msgid "reuse message from specified commit"
 msgstr "reusa el missatge de la comissió especificada"
 
 #. TRANSLATORS: Leave "[(amend|reword):]" as-is,
 #. and only translate <commit>.
-#: builtin/commit.c:1633
-#, fuzzy
+#: builtin/commit.c:1634
 msgid "[(amend|reword):]commit"
-msgstr "esmena la comissió anterior"
+msgstr "[(amend|reword):]commit"
 
-#: builtin/commit.c:1633
-#, fuzzy
+#: builtin/commit.c:1634
 msgid ""
 "use autosquash formatted message to fixup or amend/reword specified commit"
 msgstr ""
-"usa el missatge formatat de «squash» automàtic per a corregir la comissió "
-"especificada"
-
-#: builtin/commit.c:1634
-msgid "use autosquash formatted message to squash specified commit"
-msgstr ""
-"usa el missatge formatat de «squash» automàtic per a «squash» a la comissió "
+"usa un missatge amb format de «squash» automàtic per a esmenar la comissió "
 "especificada"
 
 #: builtin/commit.c:1635
+msgid "use autosquash formatted message to squash specified commit"
+msgstr ""
+"usa un missatge amb format de «squash» automàtic per a fer «squash» de la "
+"comissió especificada"
+
+#: builtin/commit.c:1636
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr "l'autor de la comissió soc jo ara (s'usa amb -C/-c/--amend)"
 
-#: builtin/commit.c:1636 builtin/interpret-trailers.c:111
+#: builtin/commit.c:1637 builtin/interpret-trailers.c:111
 msgid "trailer"
 msgstr "remolc"
 
-#: builtin/commit.c:1636
-#, fuzzy
+#: builtin/commit.c:1637
 msgid "add custom trailer(s)"
-msgstr "afegeix un(s) tràiler(s) personalitzat(s)"
+msgstr "afegeix un «trailer» personalitzat"
 
-#: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
-#: builtin/pull.c:145 builtin/revert.c:110
-#, fuzzy
+#: builtin/commit.c:1638 builtin/log.c:1769 builtin/merge.c:306
+#: builtin/pull.c:146 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
-msgstr "afegeix Signed-off-by:"
+msgstr "afegeix un «trailer» tipus «Signed-off-by»"
 
-#: builtin/commit.c:1638
+#: builtin/commit.c:1639
 msgid "use specified template file"
 msgstr "usa el fitxer de plantilla especificat"
 
-#: builtin/commit.c:1639
+#: builtin/commit.c:1640
 msgid "force edit of commit"
 msgstr "força l'edició de la comissió"
 
-#: builtin/commit.c:1641
+#: builtin/commit.c:1642
 msgid "include status in commit message template"
 msgstr "inclou l'estat en la plantilla de missatge de comissió"
 
-#: builtin/commit.c:1646
-msgid "Commit contents options"
-msgstr "Opcions dels continguts de les comissions"
-
 #: builtin/commit.c:1647
+msgid "Commit contents options"
+msgstr "Opcions per al contingut de les comissions"
+
+#: builtin/commit.c:1648
 msgid "commit all changed files"
 msgstr "comet tots els fitxers canviats"
 
-#: builtin/commit.c:1648
+#: builtin/commit.c:1649
 msgid "add specified files to index for commit"
 msgstr "afegeix els fitxers especificats a l'índex per a cometre"
 
-#: builtin/commit.c:1649
+#: builtin/commit.c:1650
 msgid "interactively add files"
 msgstr "afegeix els fitxers interactivament"
 
-#: builtin/commit.c:1650
+#: builtin/commit.c:1651
 msgid "interactively add changes"
 msgstr "afegeix els canvis interactivament"
 
-#: builtin/commit.c:1651
+#: builtin/commit.c:1652
 msgid "commit only specified files"
 msgstr "comet només els fitxers especificats"
 
-#: builtin/commit.c:1652
+#: builtin/commit.c:1653
 msgid "bypass pre-commit and commit-msg hooks"
 msgstr "evita els lligams de precomissió i missatge de comissió"
 
-#: builtin/commit.c:1653
+#: builtin/commit.c:1654
 msgid "show what would be committed"
 msgstr "mostra què es cometria"
 
-#: builtin/commit.c:1666
+#: builtin/commit.c:1667
 msgid "amend previous commit"
 msgstr "esmena la comissió anterior"
 
-#: builtin/commit.c:1667
+#: builtin/commit.c:1668
 msgid "bypass post-rewrite hook"
 msgstr "evita el lligam de post escriptura"
 
-#: builtin/commit.c:1674
+#: builtin/commit.c:1675
 msgid "ok to record an empty change"
 msgstr "està bé registrar un canvi buit"
 
-#: builtin/commit.c:1676
+#: builtin/commit.c:1677
 msgid "ok to record a change with an empty message"
 msgstr "està bé registrar un canvi amb missatge buit"
 
-#: builtin/commit.c:1752
+#: builtin/commit.c:1753
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
 msgstr "Fitxer MERGE_HEAD malmès (%s)"
 
-#: builtin/commit.c:1759
+#: builtin/commit.c:1760
 msgid "could not read MERGE_MODE"
 msgstr "no s'ha pogut llegir MERGE_MODE"
 
-#: builtin/commit.c:1780
+#: builtin/commit.c:1781
 #, c-format
 msgid "could not read commit message: %s"
 msgstr "no s'ha pogut llegir el missatge de comissió: %s"
 
-#: builtin/commit.c:1787
+#: builtin/commit.c:1788
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
 msgstr "S'està avortant la comissió a causa d'un missatge de comissió buit.\n"
 
-#: builtin/commit.c:1792
+#: builtin/commit.c:1793
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
 msgstr "S'està avortant la comissió; no heu editat el missatge.\n"
 
-#: builtin/commit.c:1803
-#, fuzzy, c-format
+#: builtin/commit.c:1804
+#, c-format
 msgid "Aborting commit due to empty commit message body.\n"
-msgstr "S'està avortant la comissió a causa d'un missatge de comissió buit.\n"
+msgstr ""
+"S'està interrompent la comissió a causa d'un missatge de comissió buit.\n"
 
-#: builtin/commit.c:1839
-#, fuzzy
+#: builtin/commit.c:1840
 msgid ""
 "repository has been updated, but unable to write\n"
 "new_index file. Check that disk is not full and quota is\n"
 "not exceeded, and then \"git restore --staged :/\" to recover."
 msgstr ""
-"s'ha actualitzat el repositori però no s'ha pogut escriure el fitxer "
-"newindex. Comproveu que el disc no està ple i que la quota no s'ha excedit i"
-" després «git restitueix --staged /» per recuperar-se."
+"s'ha actualitzat el repositori, però no s'ha pogut escriure\n"
+" el fitxer «new_index». Comproveu que el disc no està ple i\n"
+"que la quota no s'ha excedit, i després, feu\n"
+"«git restore --staged :/» per recuperar-lo."
 
 #: builtin/config.c:11
 msgid "git config [<options>]"
@@ -14676,11 +14550,10 @@ msgstr ""
 "d'ordres)"
 
 #: builtin/config.c:166
-#, fuzzy
 msgid "show scope of config (worktree, local, global, system, command)"
 msgstr ""
-"mostra l'abast de la configuració (arbre de treball ordre local global del "
-"sistema)"
+"mostra l'abast de la configuració («worktree», «local», «global», «system», "
+"«command»)"
 
 #: builtin/config.c:167 builtin/env--helper.c:45
 msgid "value"
@@ -14730,9 +14603,8 @@ msgid "writing to stdin is not supported"
 msgstr "no s'admet escriure a stdin"
 
 #: builtin/config.c:542
-#, fuzzy
 msgid "writing config blobs is not supported"
-msgstr "no es poden escriure els blobs de configuració"
+msgstr "no s'ha admet l'escriptura de blobs de configuració"
 
 #: builtin/config.c:627
 #, c-format
@@ -14770,15 +14642,13 @@ msgid "$HOME not set"
 msgstr "$HOME no està establerta"
 
 #: builtin/config.c:708
-#, fuzzy
 msgid ""
 "--worktree cannot be used with multiple working trees unless the config\n"
 "extension worktreeConfig is enabled. Please read \"CONFIGURATION FILE\"\n"
 "section in \"git help worktree\" for details"
 msgstr ""
-"--worktree no es pot utilitzar amb múltiples arbres de treball tret que "
-"l'extensió de configuració worktreeConfig estigui habilitada. Llegiu la "
-"secció «CONFIGURATION FITXER» a «git help worktree» per als detalls"
+"--worktree no es pot utilitzar amb múltiples arbres de treball tret que\n"
+"l'extensió de configuració worktreeConfig estigui habilitada. Llegiu la secció «CONFIGURATION FILE» a «git help worktree» per a més detalls"
 
 #: builtin/config.c:743
 msgid "--get-color and variable type are incoherent"
@@ -14882,9 +14752,11 @@ msgstr ""
 "d'unix"
 
 #: builtin/credential-store.c:66
-#, fuzzy, c-format
+#, c-format
 msgid "unable to get credential storage lock in %d ms"
-msgstr "no s'ha pogut obtenir el directori de treball actual"
+msgstr ""
+"no s'ha pogut obtenir el bloqueig de l'emmagatzematge de credencials en %d "
+"ms"
 
 #: builtin/describe.c:26
 msgid "git describe [<options>] [<commit-ish>...]"
@@ -15002,7 +14874,7 @@ msgstr "sempre usa el format llarg"
 
 #: builtin/describe.c:559
 msgid "only follow first parent"
-msgstr "només segueix la primera mare"
+msgstr "només segueix el primer pare"
 
 #: builtin/describe.c:562
 msgid "only output exact matches"
@@ -15020,7 +14892,7 @@ msgstr "només considera les etiquetes que coincideixen amb <patró>"
 msgid "do not consider tags matching <pattern>"
 msgstr "no consideris les etiquetes que no coincideixen amb <patró>"
 
-#: builtin/describe.c:570 builtin/name-rev.c:535
+#: builtin/describe.c:570 builtin/name-rev.c:544
 msgid "show abbreviated commit object as fallback"
 msgstr "mostra l'objecte de comissió abreviat com a sistema alternatiu"
 
@@ -15036,25 +14908,14 @@ msgstr "annexa <marca> en l'arbre de treball brut (per defecte: «-dirty»)"
 msgid "append <mark> on broken working tree (default: \"-broken\")"
 msgstr "annexa <marca> en l'arbre de treball brut (per defecte: «-broken»)"
 
-#: builtin/describe.c:593
-msgid "--long is incompatible with --abbrev=0"
-msgstr "--long és incompatible amb --abbrev=0"
-
 #: builtin/describe.c:622
 msgid "No names found, cannot describe anything."
 msgstr "No s'ha trobat cap nom, no es pot descriure res."
 
-#: builtin/describe.c:673
-msgid "--dirty is incompatible with commit-ishes"
-msgstr "--dirty és incompatible amb les comissions"
-
-#: builtin/describe.c:675
-msgid "--broken is incompatible with commit-ishes"
-msgstr "--broken és incompatible amb les comissions"
-
-#: builtin/diff-tree.c:155
-msgid "--stdin and --merge-base are mutually exclusive"
-msgstr "--stdin i --merge-base són mútuament excloents"
+#: builtin/describe.c:673 builtin/describe.c:675
+#, c-format
+msgid "option '%s' and commit-ishes cannot be used together"
+msgstr "les opcions «%s» i de comissió no es poden usar juntes"
 
 #: builtin/diff-tree.c:157
 msgid "--merge-base only works with two commits"
@@ -15075,26 +14936,26 @@ msgstr "opció no vàlida: %s"
 msgid "%s...%s: no merge base"
 msgstr "%s...%s: sense una base de fusió"
 
-#: builtin/diff.c:486
+#: builtin/diff.c:491
 msgid "Not a git repository"
 msgstr "No és un repositori de git"
 
-#: builtin/diff.c:532 builtin/grep.c:698
+#: builtin/diff.c:537 builtin/grep.c:698
 #, c-format
 msgid "invalid object '%s' given."
 msgstr "s'ha donat un objecte no vàlid «%s»."
 
-#: builtin/diff.c:543
+#: builtin/diff.c:548
 #, c-format
 msgid "more than two blobs given: '%s'"
 msgstr "s'ha donat més de dos blobs: «%s»"
 
-#: builtin/diff.c:548
+#: builtin/diff.c:553
 #, c-format
 msgid "unhandled object '%s' given."
 msgstr "s'ha donat l'objecte no gestionat «%s»."
 
-#: builtin/diff.c:582
+#: builtin/diff.c:587
 #, c-format
 msgid "%s...%s: multiple merge bases, using %s"
 msgstr "%s...%s: múltiples bases de fusió, utilitzant %s"
@@ -15103,84 +14964,82 @@ msgstr "%s...%s: múltiples bases de fusió, utilitzant %s"
 msgid "git difftool [<options>] [<commit> [<commit>]] [--] [<path>...]"
 msgstr "git difftool [<opcions>] [<commit> [<commit>]] [--] [<camí>...]"
 
-#: builtin/difftool.c:293
+#: builtin/difftool.c:287
 #, c-format
 msgid "could not read symlink %s"
 msgstr "no s'ha pogut llegir l'enllaç simbòlic %s"
 
-#: builtin/difftool.c:295
+#: builtin/difftool.c:289
 #, c-format
 msgid "could not read symlink file %s"
 msgstr "no s'ha pogut llegir el fitxer d'enllaç simbòlic %s"
 
-#: builtin/difftool.c:303
+#: builtin/difftool.c:297
 #, c-format
 msgid "could not read object %s for symlink %s"
 msgstr "no es pot llegir l'objecte %s per l'enllaç simbòlic %s"
 
-#: builtin/difftool.c:427
-#, fuzzy
+#: builtin/difftool.c:421
 msgid ""
 "combined diff formats ('-c' and '--cc') are not supported in\n"
 "directory diff mode ('-d' and '--dir-diff')."
 msgstr ""
 "els formats de diff combinats («-c» i «--cc») no s'admeten\n"
-"en el mode diff per directoris («-d» i «--dir-diff»)."
+"en el mode diff de directoris («-d» i «--dir-diff»)."
 
-#: builtin/difftool.c:632
+#: builtin/difftool.c:626
 #, c-format
 msgid "both files modified: '%s' and '%s'."
 msgstr "s'han modificat ambdós fitxers: «%s» i «%s»."
 
-#: builtin/difftool.c:634
+#: builtin/difftool.c:628
 msgid "working tree file has been left."
 msgstr "s'ha deixat un fitxer de l'arbre de treball."
 
-#: builtin/difftool.c:645
+#: builtin/difftool.c:639
 #, c-format
 msgid "temporary files exist in '%s'."
 msgstr "existeix un fitxer temporal a «%s»."
 
-#: builtin/difftool.c:646
+#: builtin/difftool.c:640
 msgid "you may want to cleanup or recover these."
 msgstr "podeu netejar o recuperar-los."
 
-#: builtin/difftool.c:651
+#: builtin/difftool.c:645
 #, c-format
 msgid "failed: %d"
 msgstr "ha fallat: %d"
 
-#: builtin/difftool.c:696
+#: builtin/difftool.c:690
 msgid "use `diff.guitool` instead of `diff.tool`"
 msgstr "usa «diff.guitool» en lloc de «diff.tool»"
 
-#: builtin/difftool.c:698
+#: builtin/difftool.c:692
 msgid "perform a full-directory diff"
 msgstr "fes un diff de tot el directori"
 
-#: builtin/difftool.c:700
+#: builtin/difftool.c:694
 msgid "do not prompt before launching a diff tool"
 msgstr "no preguntis abans d'executar l'eina diff"
 
-#: builtin/difftool.c:705
+#: builtin/difftool.c:699
 msgid "use symlinks in dir-diff mode"
 msgstr "utilitza enllaços simbòlics en mode dir-diff"
 
-#: builtin/difftool.c:706
+#: builtin/difftool.c:700
 msgid "tool"
 msgstr "eina"
 
-#: builtin/difftool.c:707
+#: builtin/difftool.c:701
 msgid "use the specified diff tool"
 msgstr "utilitza l'eina de diff especificada"
 
-#: builtin/difftool.c:709
+#: builtin/difftool.c:703
 msgid "print a list of diff tools that may be used with `--tool`"
 msgstr ""
 "imprimeix una llista de totes les eines diff que podeu usar amb «--tool»"
 
-#: builtin/difftool.c:712
-#, fuzzy
+#: builtin/difftool.c:706
 msgid ""
 "make 'git-difftool' exit when an invoked diff tool returns a non-zero exit "
 "code"
@@ -15188,31 +15047,23 @@ msgstr ""
 "fes que «git-difftool» surti quan l'eina de diff invocada torna un codi de "
 "sortida diferent de zero"
 
-#: builtin/difftool.c:715
+#: builtin/difftool.c:709
 msgid "specify a custom command for viewing diffs"
 msgstr "especifiqueu una ordre personalitzada per veure diffs"
 
-#: builtin/difftool.c:716
+#: builtin/difftool.c:710
 msgid "passed to `diff`"
 msgstr "passa-ho a «diff»"
 
-#: builtin/difftool.c:732
+#: builtin/difftool.c:726
 msgid "difftool requires worktree or --no-index"
 msgstr "difftool requereix worktree o --no-index"
 
-#: builtin/difftool.c:739
-msgid "--dir-diff is incompatible with --no-index"
-msgstr "--dir-diff és incompatible amb --no-index"
-
-#: builtin/difftool.c:742
-msgid "--gui, --tool and --extcmd are mutually exclusive"
-msgstr "--gui, --tool and --extcmd són mútuament excloents"
-
-#: builtin/difftool.c:750
+#: builtin/difftool.c:744
 msgid "no <tool> given for --tool=<tool>"
 msgstr "no s'ha proporcionat l'<eina> per a --tool=<eina>"
 
-#: builtin/difftool.c:757
+#: builtin/difftool.c:751
 msgid "no <cmd> given for --extcmd=<cmd>"
 msgstr "no s'ha proporcionat l'<ordre> per a --extcmd=<ordre>"
 
@@ -15225,295 +15076,274 @@ msgid "type"
 msgstr "tipus"
 
 #: builtin/env--helper.c:46
-#, fuzzy
 msgid "default for git_env_*(...) to fall back on"
-msgstr "per defecte per a gitenv*() per tornar-hi"
+msgstr "valor per defecte per a git_env_*(...) en cas d'absència"
 
 #: builtin/env--helper.c:48
-#, fuzzy
 msgid "be quiet only use git_env_*() value as exit code"
-msgstr "silenciós només utilitza el valor gitenv*() com a codi de sortida"
+msgstr "silenciós només utilitza el valor git_env_*() com a codi de sortida"
 
 #: builtin/env--helper.c:67
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "option `--default' expects a boolean value with `--type=bool`, not `%s`"
-msgstr "`--default' espera un valor booleà amb `-type=bool` no `%s`"
+msgstr "l'opció «--default» espera un valor booleà amb «--type=bool», no «%s»"
 
 #: builtin/env--helper.c:82
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "option `--default' expects an unsigned long value with `--type=ulong`, not "
 "`%s`"
 msgstr ""
-"`--default' espera un valor llarg sense signe amb `-type=ulong` no `%s`"
+"l'opció «--default» espera un valor llarg sense signe amb «--type=ulong», no"
+" `%s`"
 
 #: builtin/fast-export.c:29
 msgid "git fast-export [rev-list-opts]"
 msgstr "git fast-export [opcions-de-llista-de-revisions]"
 
-#: builtin/fast-export.c:869
+#: builtin/fast-export.c:843
 msgid "Error: Cannot export nested tags unless --mark-tags is specified."
 msgstr ""
 "Error: no es poden exportar les etiquetes imbricades a menys que "
 "s'especifiqui --mark-tags."
 
-#: builtin/fast-export.c:1178
+#: builtin/fast-export.c:1152
 msgid "--anonymize-map token cannot be empty"
 msgstr "el testimoni de --anonymize-map no pot estar buit"
 
-#: builtin/fast-export.c:1198
+#: builtin/fast-export.c:1171
 msgid "show progress after <n> objects"
 msgstr "mostra el progrés després de <n> objectes"
 
-#: builtin/fast-export.c:1200
+#: builtin/fast-export.c:1173
 msgid "select handling of signed tags"
 msgstr "selecciona la gestió de les etiquetes signades"
 
-#: builtin/fast-export.c:1203
+#: builtin/fast-export.c:1176
 msgid "select handling of tags that tag filtered objects"
 msgstr "selecciona la gestió de les etiquetes que etiquetin objectes filtrats"
 
-#: builtin/fast-export.c:1206
+#: builtin/fast-export.c:1179
 msgid "select handling of commit messages in an alternate encoding"
 msgstr ""
 "selecciona la gestió dels missatges de publicació en una codificació "
 "alternativa"
 
-#: builtin/fast-export.c:1209
+#: builtin/fast-export.c:1182
 msgid "dump marks to this file"
 msgstr "bolca les marques a aquest fitxer"
 
-#: builtin/fast-export.c:1211
+#: builtin/fast-export.c:1184
 msgid "import marks from this file"
 msgstr "importa les marques d'aquest fitxer"
 
-#: builtin/fast-export.c:1215
+#: builtin/fast-export.c:1188
 msgid "import marks from this file if it exists"
 msgstr "importa marques d'aquest fitxer si existeix"
 
-#: builtin/fast-export.c:1217
-#, fuzzy
+#: builtin/fast-export.c:1190
 msgid "fake a tagger when tags lack one"
-msgstr "Fingeix un etiquetador quan els en manca un a les etiquetes"
+msgstr "fingeix un etiquetador quan en falti un a les etiquetes"
 
-#: builtin/fast-export.c:1219
+#: builtin/fast-export.c:1192
 msgid "output full tree for each commit"
 msgstr "imprimeix l'arbre complet de per a cada comissió"
 
-#: builtin/fast-export.c:1221
-#, fuzzy
+#: builtin/fast-export.c:1194
 msgid "use the done feature to terminate the stream"
-msgstr "Usa la característica done per a acabar el corrent"
+msgstr "usa la característica fet per a acabar el flux"
 
-#: builtin/fast-export.c:1222
-#, fuzzy
+#: builtin/fast-export.c:1195
 msgid "skip output of blob data"
-msgstr "Omet l'emissió de dades de blob"
+msgstr "omet la sortida de dades de blob"
 
-#: builtin/fast-export.c:1223 builtin/log.c:1826
+#: builtin/fast-export.c:1196 builtin/log.c:1841
 msgid "refspec"
 msgstr "especificació de referència"
 
-#: builtin/fast-export.c:1224
+#: builtin/fast-export.c:1197
 msgid "apply refspec to exported refs"
 msgstr "aplica l'especificació de referència a les referències exportades"
 
-#: builtin/fast-export.c:1225
+#: builtin/fast-export.c:1198
 msgid "anonymize output"
 msgstr "anonimitza la sortida"
 
-#: builtin/fast-export.c:1226
-#, fuzzy
+#: builtin/fast-export.c:1199
 msgid "from:to"
-msgstr "des de"
+msgstr "des de:a"
 
-#: builtin/fast-export.c:1227
+#: builtin/fast-export.c:1200
 msgid "convert <from> to <to> in anonymized output"
 msgstr "converteix <from> a <to> en una sortida anònima"
 
-#: builtin/fast-export.c:1230
-#, fuzzy
+#: builtin/fast-export.c:1203
 msgid "reference parents which are not in fast-export stream by object id"
 msgstr ""
-"Referència pares que no estan en flux d'exportació ràpida per identificador "
-"d'objecte"
+"referència els pares que no estan en flux d'exportació ràpida per "
+"identificador d'objecte"
 
-#: builtin/fast-export.c:1232
-#, fuzzy
+#: builtin/fast-export.c:1205
 msgid "show original object ids of blobs/commits"
-msgstr "Mostra els ID dels objectes originals dels blobs/commits"
+msgstr "mostra els ID dels objectes originals dels blobs i comissions"
 
-#: builtin/fast-export.c:1234
-#, fuzzy
+#: builtin/fast-export.c:1207
 msgid "label tags with mark ids"
-msgstr "etiquetes amb els identificadors de marca"
+msgstr "marca les etiquetes amb els identificadors de marca"
 
-#: builtin/fast-export.c:1257
-msgid "--anonymize-map without --anonymize does not make sense"
-msgstr "--anonymize-map sense --anonymize no té sentit"
-
-#: builtin/fast-export.c:1272
-msgid "Cannot pass both --import-marks and --import-marks-if-exists"
-msgstr "No es poden passar alhora --import-marks i --import-marks-if-exists"
-
-#: builtin/fast-import.c:3088
+#: builtin/fast-import.c:3090
 #, c-format
 msgid "Missing from marks for submodule '%s'"
 msgstr "Falten les marques «from» per al submòdul «%s»"
 
-#: builtin/fast-import.c:3090
+#: builtin/fast-import.c:3092
 #, c-format
 msgid "Missing to marks for submodule '%s'"
 msgstr "Falten les marques per al submòdul «%s»"
 
-#: builtin/fast-import.c:3225
+#: builtin/fast-import.c:3227
 #, c-format
 msgid "Expected 'mark' command, got %s"
 msgstr "S'esperava l'ordre «mark», s'ha rebut %s"
 
-#: builtin/fast-import.c:3230
+#: builtin/fast-import.c:3232
 #, c-format
 msgid "Expected 'to' command, got %s"
 msgstr "S'esperava l'ordre «to», s'ha rebut «%s»"
 
-#: builtin/fast-import.c:3322
-#, fuzzy
+#: builtin/fast-import.c:3324
 msgid "Expected format name:filename for submodule rewrite option"
 msgstr ""
-"S'esperava un nom de fitxer de format per a l'opció de reescriptura de "
+"S'esperava el format «nom:nom de fitxer» per a l'opció de reescriptura de "
 "submòdul"
 
-#: builtin/fast-import.c:3377
-#, fuzzy, c-format
+#: builtin/fast-import.c:3379
+#, c-format
 msgid "feature '%s' forbidden in input without --allow-unsafe-features"
 msgstr ""
 "característica «%s» prohibida a l'entrada sense --allow-unsafe-features"
 
 #: builtin/fetch-pack.c:242
-#, fuzzy, c-format
+#, c-format
 msgid "Lockfile created but not reported: %s"
-msgstr "Submòduls canviats però no actualitzats:"
+msgstr "S'ha creat el fitxer de bloqueig però no s'ha informat: %s"
 
-#: builtin/fetch.c:35
+#: builtin/fetch.c:36
 msgid "git fetch [<options>] [<repository> [<refspec>...]]"
 msgstr ""
 "git fetch [<opcions>] [<repositori> [<especificació-de-referència>...]]"
 
-#: builtin/fetch.c:36
+#: builtin/fetch.c:37
 msgid "git fetch [<options>] <group>"
 msgstr "git fetch [<opcions>] <grup>"
 
-#: builtin/fetch.c:37
+#: builtin/fetch.c:38
 msgid "git fetch --multiple [<options>] [(<repository> | <group>)...]"
 msgstr "git fetch --multiple [<opcions>] [(<repositori> | <grup>)...]"
 
-#: builtin/fetch.c:38
+#: builtin/fetch.c:39
 msgid "git fetch --all [<options>]"
 msgstr "git fetch --all [<opcions>]"
 
-#: builtin/fetch.c:122
+#: builtin/fetch.c:123
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel no pot ser negatiu"
 
-#: builtin/fetch.c:145 builtin/pull.c:185
+#: builtin/fetch.c:146 builtin/pull.c:189
 msgid "fetch from all remotes"
 msgstr "obtén de tots els remots"
 
-#: builtin/fetch.c:147 builtin/pull.c:245
+#: builtin/fetch.c:148 builtin/pull.c:249
 msgid "set upstream for git pull/fetch"
 msgstr "estableix la font per a git pull/fetch"
 
-#: builtin/fetch.c:149 builtin/pull.c:188
+#: builtin/fetch.c:150 builtin/pull.c:192
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "annexa a .git/FETCH_HEAD en lloc de sobreescriure"
 
-#: builtin/fetch.c:151
-#, fuzzy
+#: builtin/fetch.c:152
 msgid "use atomic transaction to update references"
-msgstr "demana una transacció atòmica al costat remot"
+msgstr "usa una transacció atòmica per actualitzar les referències"
 
-#: builtin/fetch.c:153 builtin/pull.c:191
+#: builtin/fetch.c:154 builtin/pull.c:195
 msgid "path to upload pack on remote end"
 msgstr "camí al qual pujar el paquet al costat remot"
 
-#: builtin/fetch.c:154
+#: builtin/fetch.c:155
 msgid "force overwrite of local reference"
 msgstr "força la sobreescriptura de la referència local"
 
-#: builtin/fetch.c:156
+#: builtin/fetch.c:157
 msgid "fetch from multiple remotes"
 msgstr "obtén de múltiples remots"
 
-#: builtin/fetch.c:158 builtin/pull.c:195
+#: builtin/fetch.c:159 builtin/pull.c:199
 msgid "fetch all tags and associated objects"
 msgstr "obtén totes les etiquetes i tots els objectes associats"
 
-#: builtin/fetch.c:160
+#: builtin/fetch.c:161
 msgid "do not fetch all tags (--no-tags)"
 msgstr "no obtinguis les etiquetes (--no-tags)"
 
-#: builtin/fetch.c:162
+#: builtin/fetch.c:163
 msgid "number of submodules fetched in parallel"
 msgstr "nombre de submòduls obtinguts en paral·lel"
 
-#: builtin/fetch.c:164
-#, fuzzy
+#: builtin/fetch.c:165
 msgid "modify the refspec to place all refs within refs/prefetch/"
 msgstr ""
 "modifica l'especificació de referència per col·locar totes les referències "
 "dins de refs/prefetch/"
 
-#: builtin/fetch.c:166 builtin/pull.c:198
+#: builtin/fetch.c:167 builtin/pull.c:202
 msgid "prune remote-tracking branches no longer on remote"
 msgstr "poda les branques amb seguiment remot que ja no estiguin en el remot"
 
-#: builtin/fetch.c:168
-#, fuzzy
+#: builtin/fetch.c:169
 msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr ""
-"poda les etiquetes locals ja no a les remotes i el «clobber» ha canviat les "
-"etiquetes"
+"poda les etiquetes locals que ja no existeixen al remot i adjunta les "
+"etiquetes que han canviat"
 
-#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:122
+#: builtin/fetch.c:170 builtin/fetch.c:195 builtin/pull.c:123
 msgid "on-demand"
 msgstr "sota demanda"
 
-#: builtin/fetch.c:170
+#: builtin/fetch.c:171
 msgid "control recursive fetching of submodules"
 msgstr "controla l'obtenció recursiva de submòduls"
 
-#: builtin/fetch.c:175
-#, fuzzy
+#: builtin/fetch.c:176
 msgid "write fetched references to the FETCH_HEAD file"
-msgstr "escriu l'arxiu a aquest fitxer"
+msgstr "escriu les referències obtingudes al fitxer FETCH_HEAD"
 
-#: builtin/fetch.c:176 builtin/pull.c:206
+#: builtin/fetch.c:177 builtin/pull.c:210
 msgid "keep downloaded pack"
 msgstr "retén el paquet baixat"
 
-#: builtin/fetch.c:178
+#: builtin/fetch.c:179
 msgid "allow updating of HEAD ref"
 msgstr "permet l'actualització de la referència HEAD"
 
-#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:209
-#: builtin/pull.c:218
+#: builtin/fetch.c:182 builtin/fetch.c:188 builtin/pull.c:213
+#: builtin/pull.c:222
 msgid "deepen history of shallow clone"
 msgstr "aprofundeix la història d'un clon superficial"
 
-#: builtin/fetch.c:183 builtin/pull.c:212
+#: builtin/fetch.c:184 builtin/pull.c:216
 msgid "deepen history of shallow repository based on time"
 msgstr "aprofundeix la història d'un clon superficial basat en una data"
 
-#: builtin/fetch.c:189 builtin/pull.c:221
+#: builtin/fetch.c:190 builtin/pull.c:225
 msgid "convert to a complete repository"
 msgstr "converteix en un repositori complet"
 
-#: builtin/fetch.c:192
+#: builtin/fetch.c:193
 msgid "prepend this to submodule path output"
 msgstr "anteposa això a la sortida de camí del submòdul"
 
-#: builtin/fetch.c:195
+#: builtin/fetch.c:196
 msgid ""
 "default for recursive fetching of submodules (lower priority than config "
 "files)"
@@ -15521,146 +15351,147 @@ msgstr ""
 "per defecte per a l'obtenció recursiva de submòduls (prioritat més baixa que"
 " els fitxers de configuració)"
 
-#: builtin/fetch.c:199 builtin/pull.c:224
+#: builtin/fetch.c:200 builtin/pull.c:228
 msgid "accept refs that update .git/shallow"
 msgstr "accepta les referències que actualitzin .git/shallow"
 
-#: builtin/fetch.c:200 builtin/pull.c:226
+#: builtin/fetch.c:201 builtin/pull.c:230
 msgid "refmap"
 msgstr "mapa de referències"
 
-#: builtin/fetch.c:201 builtin/pull.c:227
+#: builtin/fetch.c:202 builtin/pull.c:231
 msgid "specify fetch refmap"
 msgstr "específica l'obtenció del mapa de referències"
 
-#: builtin/fetch.c:208 builtin/pull.c:240
+#: builtin/fetch.c:209 builtin/pull.c:244
 msgid "report that we have only objects reachable from this object"
 msgstr "informa que només hi ha objectes abastables des d'aquest objecte"
 
-#: builtin/fetch.c:210
-#, fuzzy
+#: builtin/fetch.c:211
 msgid "do not fetch a packfile; instead, print ancestors of negotiation tips"
 msgstr ""
-"no obtinguis un fitxer de paquet; en canvi, imprimeix els avantpassats dels "
+"no obtinguis un fitxer de paquet; en canvi, mostra els avantpassats dels "
 "consells de negociació"
 
-#: builtin/fetch.c:213 builtin/fetch.c:215
+#: builtin/fetch.c:214 builtin/fetch.c:216
 msgid "run 'maintenance --auto' after fetching"
 msgstr "executa «maintenance --auto» després d'obtenir"
 
-#: builtin/fetch.c:217 builtin/pull.c:243
+#: builtin/fetch.c:218 builtin/pull.c:247
 msgid "check for forced-updates on all updated branches"
 msgstr ""
 "comprova si hi ha actualitzacions forçades a totes les branques "
 "actualitzades"
 
-#: builtin/fetch.c:219
+#: builtin/fetch.c:220
 msgid "write the commit-graph after fetching"
 msgstr "escriu el graf de comissions després de recollir"
 
-#: builtin/fetch.c:221
-#, fuzzy
+#: builtin/fetch.c:222
 msgid "accept refspecs from stdin"
-msgstr "llegeix les referències des de stdin"
+msgstr "llegeix les especificacions de referència des de stdin"
 
-#: builtin/fetch.c:586
-msgid "Couldn't find remote ref HEAD"
-msgstr "No s'ha pogut trobar la referència HEAD remota"
+#: builtin/fetch.c:592
+msgid "couldn't find remote ref HEAD"
+msgstr "no s'ha pogut trobar la referència HEAD remota"
 
-#: builtin/fetch.c:760
+#: builtin/fetch.c:766
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "la configuració fetch.output conté un valor no vàlid %s"
 
-#: builtin/fetch.c:862
+#: builtin/fetch.c:867
 #, c-format
 msgid "object %s not found"
 msgstr "objecte %s no trobat"
 
-#: builtin/fetch.c:866
+#: builtin/fetch.c:871
 msgid "[up to date]"
 msgstr "[al dia]"
 
-#: builtin/fetch.c:879 builtin/fetch.c:895 builtin/fetch.c:967
+#: builtin/fetch.c:883 builtin/fetch.c:901 builtin/fetch.c:973
 msgid "[rejected]"
 msgstr "[rebutjat]"
 
-#: builtin/fetch.c:880
+#: builtin/fetch.c:885
 msgid "can't fetch in current branch"
 msgstr "no es pot obtenir en la branca actual"
 
-#: builtin/fetch.c:890
+#: builtin/fetch.c:886
+msgid "checked out in another worktree"
+msgstr "s'ha agafat en un altre arbre de treball"
+
+#: builtin/fetch.c:896
 msgid "[tag update]"
 msgstr "[actualització d'etiqueta]"
 
-#: builtin/fetch.c:891 builtin/fetch.c:928 builtin/fetch.c:950
-#: builtin/fetch.c:962
+#: builtin/fetch.c:897 builtin/fetch.c:934 builtin/fetch.c:956
+#: builtin/fetch.c:968
 msgid "unable to update local ref"
 msgstr "no s'ha pogut actualitzar la referència local"
 
-#: builtin/fetch.c:895
-#, fuzzy
+#: builtin/fetch.c:901
 msgid "would clobber existing tag"
-msgstr "es tancaria l'etiqueta existent"
+msgstr "s'adjuntaria l'etiqueta existent"
 
-#: builtin/fetch.c:917
+#: builtin/fetch.c:923
 msgid "[new tag]"
 msgstr "[etiqueta nova]"
 
-#: builtin/fetch.c:920
+#: builtin/fetch.c:926
 msgid "[new branch]"
 msgstr "[branca nova]"
 
-#: builtin/fetch.c:923
+#: builtin/fetch.c:929
 msgid "[new ref]"
 msgstr "[referència nova]"
 
-#: builtin/fetch.c:962
+#: builtin/fetch.c:968
 msgid "forced update"
 msgstr "actualització forçada"
 
-#: builtin/fetch.c:967
+#: builtin/fetch.c:973
 msgid "non-fast-forward"
 msgstr "sense avanç ràpid"
 
-#: builtin/fetch.c:1070
+#: builtin/fetch.c:1076
 msgid ""
-"Fetch normally indicates which branches had a forced update,\n"
-"but that check has been disabled. To re-enable, use '--show-forced-updates'\n"
-"flag or run 'git config fetch.showForcedUpdates true'."
+"fetch normally indicates which branches had a forced update,\n"
+"but that check has been disabled; to re-enable, use '--show-forced-updates'\n"
+"flag or run 'git config fetch.showForcedUpdates true'"
 msgstr ""
-"L'obtenció normalment indica quines branques tenien una actualització forçada,\n"
+"en obtenir normalment indica quines branques tenien una actualització forçada,\n"
 "però aquesta comprovació s'ha desactivat. Per tornar a habilitar-la, utilitzeu\n"
 "«--show-forced-updates» o executeu «git config fetch.showForcedUpdates true»."
 
-#: builtin/fetch.c:1074
+#: builtin/fetch.c:1080
 #, c-format
 msgid ""
-"It took %.2f seconds to check forced updates. You can use\n"
+"it took %.2f seconds to check forced updates; you can use\n"
 "'--no-show-forced-updates' or run 'git config fetch.showForcedUpdates false'\n"
-" to avoid this check.\n"
+"to avoid this check\n"
 msgstr ""
-"S'ha trigat %.2f segons a comprovar les actualitzacions forçades. Podeu\n"
+"s'ha trigat %.2f segons a comprovar les actualitzacions forçades. Podeu\n"
 "utilitzar «--no-show-forced-updates» o executar «git config \n"
 "fetch.showForcedUpdates false» per evitar aquesta comprovació.\n"
 
-#: builtin/fetch.c:1105
+#: builtin/fetch.c:1112
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s no ha enviat tots els objectes necessaris\n"
 
-#: builtin/fetch.c:1134
-#, fuzzy, c-format
+#: builtin/fetch.c:1141
+#, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr ""
-"rebutja %s perquè no es permet que les arrels superficials s'actualitzin"
+"s'ha rebutjat %s perquè no es permeten actualitzar les arrels superficials"
 
-#: builtin/fetch.c:1223 builtin/fetch.c:1371
+#: builtin/fetch.c:1231 builtin/fetch.c:1379
 #, c-format
 msgid "From %.*s\n"
 msgstr "De %.*s\n"
 
-#: builtin/fetch.c:1244
+#: builtin/fetch.c:1252
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -15670,142 +15501,143 @@ msgstr ""
 " intenteu executar «git remote prune %s» per a eliminar\n"
 " qualsevol branca antiga o conflictiva"
 
-#: builtin/fetch.c:1341
+#: builtin/fetch.c:1349
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s es tornarà penjant)"
 
-#: builtin/fetch.c:1342
+#: builtin/fetch.c:1350
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s s'ha tornat penjant)"
 
-#: builtin/fetch.c:1374
+#: builtin/fetch.c:1382
 msgid "[deleted]"
 msgstr "[suprimit]"
 
-#: builtin/fetch.c:1375 builtin/remote.c:1128
+#: builtin/fetch.c:1383 builtin/remote.c:1128
 msgid "(none)"
 msgstr "(cap)"
 
-#: builtin/fetch.c:1398
+#: builtin/fetch.c:1405
 #, c-format
-msgid "Refusing to fetch into current branch %s of non-bare repository"
-msgstr "S'està refusant obtenir en la branca actual %s d'un repositori no nu"
+msgid "refusing to fetch into branch '%s' checked out at '%s'"
+msgstr "s'ha rebutjat l'obtenció en la branca «%s» agafada a «%s»"
 
-#: builtin/fetch.c:1417
+#: builtin/fetch.c:1425
 #, c-format
-msgid "Option \"%s\" value \"%s\" is not valid for %s"
-msgstr "L'opció «%s» amb valor «%s» no és vàlida per a %s"
+msgid "option \"%s\" value \"%s\" is not valid for %s"
+msgstr "l'opció «%s» amb valor «%s» no és vàlida per a %s"
 
-#: builtin/fetch.c:1420
+#: builtin/fetch.c:1428
 #, c-format
-msgid "Option \"%s\" is ignored for %s\n"
-msgstr "S'ignora l'opció «%s» per a %s\n"
+msgid "option \"%s\" is ignored for %s\n"
+msgstr "s'ignora l'opció «%s» per a %s\n"
 
-#: builtin/fetch.c:1447
-#, fuzzy, c-format
+#: builtin/fetch.c:1455
+#, c-format
 msgid "the object %s does not exist"
-msgstr "el camí «%s» no existeix"
+msgstr "l'objecte %s no existeix"
 
-#: builtin/fetch.c:1633
+#: builtin/fetch.c:1643
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "s'han detectat múltiples branques, incompatible amb --set-upstream"
 
-#: builtin/fetch.c:1648
+#: builtin/fetch.c:1655
+#, c-format
+msgid ""
+"could not set upstream of HEAD to '%s' from '%s' when it does not point to "
+"any branch."
+msgstr ""
+"no s'ha pogut establir la font de HEAD a «%s» des de «%s» quan no assenyala cap "
+"branca."
+
+#: builtin/fetch.c:1668
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr ""
 "no s'està configurant la font per a una branca remota amb seguiment remot"
 
-#: builtin/fetch.c:1650
+#: builtin/fetch.c:1670
 msgid "not setting upstream for a remote tag"
 msgstr "no s'està configurant la font d'una etiqueta remota"
 
-#: builtin/fetch.c:1652
+#: builtin/fetch.c:1672
 msgid "unknown branch type"
 msgstr "tipus de branca desconegut"
 
-#: builtin/fetch.c:1654
+#: builtin/fetch.c:1674
 msgid ""
-"no source branch found.\n"
-"you need to specify exactly one branch with the --set-upstream option."
+"no source branch found;\n"
+"you need to specify exactly one branch with the --set-upstream option"
 msgstr ""
 "no s'ha trobat cap branca d'origen.\n"
-"Heu d'especificar exactament una branca amb l'opció --set-upstream."
+"heu d'especificar exactament una branca amb l'opció --set-upstream."
 
-#: builtin/fetch.c:1783 builtin/fetch.c:1846
+#: builtin/fetch.c:1804 builtin/fetch.c:1867
 #, c-format
 msgid "Fetching %s\n"
 msgstr "S'està obtenint %s\n"
 
-#: builtin/fetch.c:1793 builtin/fetch.c:1848 builtin/remote.c:101
+#: builtin/fetch.c:1814 builtin/fetch.c:1869
 #, c-format
-msgid "Could not fetch %s"
-msgstr "No s'ha pogut obtenir %s"
+msgid "could not fetch %s"
+msgstr "no s'ha pogut obtenir %s"
 
-#: builtin/fetch.c:1805
+#: builtin/fetch.c:1826
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "no s'ha pogut obtenir «%s» (codi de sortida: %d)\n"
 
-#: builtin/fetch.c:1909
+#: builtin/fetch.c:1930
 msgid ""
-"No remote repository specified.  Please, specify either a URL or a\n"
-"remote name from which new revisions should be fetched."
+"no remote repository specified; please specify either a URL or a\n"
+"remote name from which new revisions should be fetched"
 msgstr ""
-"Cap repositori remot especificat. Especifiqueu un URL o\n"
-"un nom remot del qual es deuen obtenir les revisions noves."
+"no s'ha especificat cap repositori remot. Especifiqueu un URL o\n"
+"un nom remot del qual s'han d'obtenir les revisions noves."
 
-#: builtin/fetch.c:1945
-msgid "You need to specify a tag name."
-msgstr "Necessiteu especificar un nom d'etiqueta."
+#: builtin/fetch.c:1966
+msgid "you need to specify a tag name"
+msgstr "necessiteu especificar un nom d'etiqueta"
 
-#: builtin/fetch.c:2009
+#: builtin/fetch.c:2032
 msgid "--negotiate-only needs one or more --negotiate-tip=*"
 msgstr "--negotiate-only necessita un o més --negotiate-tip=*"
 
-#: builtin/fetch.c:2013
-msgid "Negative depth in --deepen is not supported"
-msgstr "No s'admet una profunditat negativa en --deepen"
+#: builtin/fetch.c:2036
+msgid "negative depth in --deepen is not supported"
+msgstr "no s'admet una profunditat negativa en --deepen"
 
-#: builtin/fetch.c:2015
-msgid "--deepen and --depth are mutually exclusive"
-msgstr "--deepen i --depth són mútuament excloents"
-
-#: builtin/fetch.c:2020
-msgid "--depth and --unshallow cannot be used together"
-msgstr "--depth i --unshallow no es poden usar junts"
-
-#: builtin/fetch.c:2022
+#: builtin/fetch.c:2045
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "--unshallow en un repositori complet no té sentit"
 
-#: builtin/fetch.c:2039
+#: builtin/fetch.c:2062
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all no accepta un argument de repositori"
 
-#: builtin/fetch.c:2041
+#: builtin/fetch.c:2064
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all no té sentit amb especificacions de referència"
 
-#: builtin/fetch.c:2050
-#, c-format
-msgid "No such remote or remote group: %s"
-msgstr "No existeix un remot ni un grup remot: %s"
-
-#: builtin/fetch.c:2057
-msgid "Fetching a group and specifying refspecs does not make sense"
-msgstr "Obtenir un grup i especificar referències no té sentit"
-
 #: builtin/fetch.c:2073
+#, c-format
+msgid "no such remote or remote group: %s"
+msgstr "no existeix un remot ni un grup remot: %s"
+
+#: builtin/fetch.c:2081
+msgid "fetching a group and specifying refspecs does not make sense"
+msgstr "obtenir un grup i especificar referències no té sentit"
+
+#: builtin/fetch.c:2097
 msgid "must supply remote when using --negotiate-only"
 msgstr "s'ha de subministrar el remot en usar --negotiate-only"
 
-#: builtin/fetch.c:2078
-msgid "Protocol does not support --negotiate-only, exiting."
-msgstr "El protocol no admet --negotiate-only, se surt."
+#: builtin/fetch.c:2102
+msgid "protocol does not support --negotiate-only, exiting"
+msgstr "el protocol no admet --negotiate-only, se surt."
 
-#: builtin/fetch.c:2097
+#: builtin/fetch.c:2121
 msgid ""
 "--filter can only be used with the remote configured in "
 "extensions.partialclone"
@@ -15813,15 +15645,13 @@ msgstr ""
 "--filter només es pot utilitzar amb el remot configurat en "
 "extensions.partialclone"
 
-#: builtin/fetch.c:2101
-#, fuzzy
+#: builtin/fetch.c:2125
 msgid "--atomic can only be used when fetching from one remote"
-msgstr "L'opció --exec només es pot usar juntament amb --remote"
+msgstr "L'opció --atomic només es pot usar quan s'obté des d'un remot"
 
-#: builtin/fetch.c:2105
-#, fuzzy
+#: builtin/fetch.c:2129
 msgid "--stdin can only be used when fetching from one remote"
-msgstr "L'opció --exec només es pot usar juntament amb --remote"
+msgstr "L'opció --stdin només es pot usar quan s'obté des d'un remot"
 
 #: builtin/fmt-merge-msg.c:7
 msgid ""
@@ -15829,23 +15659,27 @@ msgid ""
 msgstr ""
 "git fmt-merge-msg [-m <missatge>] [--log[=<n>] | --no-log] [--file <fitxer>]"
 
-#: builtin/fmt-merge-msg.c:18
+#: builtin/fmt-merge-msg.c:19
 msgid "populate log with at most <n> entries from shortlog"
 msgstr "emplena el registre amb <n> entrades del registre curt com a màxim"
 
-#: builtin/fmt-merge-msg.c:21
+#: builtin/fmt-merge-msg.c:22
 msgid "alias for --log (deprecated)"
 msgstr "àlies per --log (en desús)"
 
-#: builtin/fmt-merge-msg.c:24
+#: builtin/fmt-merge-msg.c:25
 msgid "text"
 msgstr "text"
 
-#: builtin/fmt-merge-msg.c:25
+#: builtin/fmt-merge-msg.c:26
 msgid "use <text> as start of message"
 msgstr "usa <text> com a inici de missatge"
 
-#: builtin/fmt-merge-msg.c:26
+#: builtin/fmt-merge-msg.c:28
+msgid "use <name> instead of the real target branch"
+msgstr "usa <nom> en lloc de la branca de destí real"
+
+#: builtin/fmt-merge-msg.c:29
 msgid "file to read from"
 msgstr "fitxer del qual llegir"
 
@@ -15858,57 +15692,56 @@ msgid "git for-each-ref [--points-at <object>]"
 msgstr "git for-each-ref [--points-at <objecte>]"
 
 #: builtin/for-each-ref.c:12
-#, fuzzy
 msgid "git for-each-ref [--merged [<commit>]] [--no-merged [<commit>]]"
-msgstr "git for-each-ref [(--merged | --no-merged) [<comissió>]]"
+msgstr "git for-each-ref [--merged [<commit>]] [--no-merged [<commit>]]"
 
 #: builtin/for-each-ref.c:13
 msgid "git for-each-ref [--contains [<commit>]] [--no-contains [<commit>]]"
 msgstr ""
 "git for-each-ref [--contains [<comissió>]] [--no-contains [<comissió>]]"
 
-#: builtin/for-each-ref.c:30
+#: builtin/for-each-ref.c:31
 msgid "quote placeholders suitably for shells"
 msgstr ""
 "posa els marcadors de posició de forma adequada per a intèrprets d'ordres"
 
-#: builtin/for-each-ref.c:32
+#: builtin/for-each-ref.c:33
 msgid "quote placeholders suitably for perl"
 msgstr "posa els marcadors de posició entre cometes adequades per al perl"
 
-#: builtin/for-each-ref.c:34
+#: builtin/for-each-ref.c:35
 msgid "quote placeholders suitably for python"
 msgstr "posa els marcadors de posició entre cometes adequades per al python"
 
-#: builtin/for-each-ref.c:36
+#: builtin/for-each-ref.c:37
 msgid "quote placeholders suitably for Tcl"
 msgstr "posa els marcadors de posició entre cometes adequades per al Tcl"
 
-#: builtin/for-each-ref.c:39
+#: builtin/for-each-ref.c:40
 msgid "show only <n> matched refs"
 msgstr "mostra només <n> referències coincidents"
 
-#: builtin/for-each-ref.c:41 builtin/tag.c:481
+#: builtin/for-each-ref.c:42 builtin/tag.c:481
 msgid "respect format colors"
 msgstr "respecta els colors del format"
 
-#: builtin/for-each-ref.c:44
+#: builtin/for-each-ref.c:45
 msgid "print only refs which points at the given object"
 msgstr "imprimeix només les referències que assenyalin l'objecte donat"
 
-#: builtin/for-each-ref.c:46
+#: builtin/for-each-ref.c:47
 msgid "print only refs that are merged"
 msgstr "imprimeix només les referències que s'han fusionat"
 
-#: builtin/for-each-ref.c:47
+#: builtin/for-each-ref.c:48
 msgid "print only refs that are not merged"
 msgstr "imprimeix només les referències que no s'han fusionat"
 
-#: builtin/for-each-ref.c:48
+#: builtin/for-each-ref.c:49
 msgid "print only refs which contain the commit"
 msgstr "imprimeix només les referències que continguin la comissió"
 
-#: builtin/for-each-ref.c:49
+#: builtin/for-each-ref.c:50
 msgid "print only refs which don't contain the commit"
 msgstr "imprimeix només les referències que no continguin la comissió"
 
@@ -15921,7 +15754,6 @@ msgid "config"
 msgstr "config"
 
 #: builtin/for-each-repo.c:35
-#, fuzzy
 msgid "config key storing a list of repository paths"
 msgstr "clau de configuració emmagatzemant una llista de camins de repositori"
 
@@ -15955,11 +15787,13 @@ msgid "wrong object type in link"
 msgstr "tipus d'objecte incorrecte en l'enllaç"
 
 #: builtin/fsck.c:152
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "broken link from %7s %s\n"
 "              to %7s %s"
-msgstr "enllaç trencat del 7% al 7%"
+msgstr ""
+"enllaç trencat des de %7s %s\n"
+"               fins a %7s %s"
 
 #: builtin/fsck.c:264
 #, c-format
@@ -15972,14 +15806,13 @@ msgid "unreachable %s %s"
 msgstr "inabastable %s %s"
 
 #: builtin/fsck.c:311
-#, fuzzy, c-format
+#, c-format
 msgid "dangling %s %s"
-msgstr "per cent"
+msgstr "sense assignació %s %s"
 
 #: builtin/fsck.c:321
-#, fuzzy
 msgid "could not create lost-found"
-msgstr "no s'ha pogut crear el trobat perdut"
+msgstr "no s'ha pogut crear el trobat-perdut"
 
 #: builtin/fsck.c:332
 #, c-format
@@ -16011,9 +15844,9 @@ msgid "root %s"
 msgstr "arrel %s"
 
 #: builtin/fsck.c:428
-#, fuzzy, c-format
+#, c-format
 msgid "tagged %s %s (%s) in %s"
-msgstr "percentatges marcats"
+msgstr "marcat %s %s (%s) a %s"
 
 #: builtin/fsck.c:457
 #, c-format
@@ -16045,9 +15878,9 @@ msgid "notice: No default references"
 msgstr "avís: no hi ha referències per defecte"
 
 #: builtin/fsck.c:621
-#, fuzzy, c-format
+#, c-format
 msgid "%s: hash-path mismatch, found at: %s"
-msgstr "el resum no coincideix %s"
+msgstr "%s: el resum del camí no coincideix, trobat a: %s"
 
 #: builtin/fsck.c:624
 #, c-format
@@ -16055,130 +15888,129 @@ msgid "%s: object corrupt or missing: %s"
 msgstr "%s: objecte corrupte o no trobat: %s"
 
 #: builtin/fsck.c:628
-#, fuzzy, c-format
+#, c-format
 msgid "%s: object is of unknown type '%s': %s"
-msgstr "l'objecte %s té un identificador de tipus %d desconegut"
+msgstr "%s: l'objecte és de tipus desconegut «%s»: %s"
 
-#: builtin/fsck.c:644
+#: builtin/fsck.c:645
 #, c-format
 msgid "%s: object could not be parsed: %s"
 msgstr "%s: no s'ha pogut analitzar l'objecte: %s"
 
-#: builtin/fsck.c:664
+#: builtin/fsck.c:665
 #, c-format
 msgid "bad sha1 file: %s"
 msgstr "fitxer sha1 malmès: %s"
 
-#: builtin/fsck.c:685
+#: builtin/fsck.c:686
 msgid "Checking object directory"
 msgstr "S'està comprovant el directori d'objecte"
 
-#: builtin/fsck.c:688
+#: builtin/fsck.c:689
 msgid "Checking object directories"
 msgstr "S'estan comprovant els directoris d'objecte"
 
-#: builtin/fsck.c:704
+#: builtin/fsck.c:705
 #, c-format
 msgid "Checking %s link"
 msgstr "S'està comprovant l'enllaç %s"
 
-#: builtin/fsck.c:709 builtin/index-pack.c:859
+#: builtin/fsck.c:710 builtin/index-pack.c:859
 #, c-format
 msgid "invalid %s"
 msgstr "%s no vàlid"
 
-#: builtin/fsck.c:716
+#: builtin/fsck.c:717
 #, c-format
 msgid "%s points to something strange (%s)"
 msgstr "%s apunta a una cosa estranya (%s)"
 
-#: builtin/fsck.c:722
+#: builtin/fsck.c:723
 #, c-format
 msgid "%s: detached HEAD points at nothing"
 msgstr "%s: el HEAD separat no apunta a res"
 
-#: builtin/fsck.c:726
+#: builtin/fsck.c:727
 #, c-format
 msgid "notice: %s points to an unborn branch (%s)"
 msgstr "avís: %s apunta a una branca no nascuda (%s)"
 
-#: builtin/fsck.c:738
+#: builtin/fsck.c:739
 msgid "Checking cache tree"
 msgstr "S'està comprovant l'arbre de la memòria cau"
 
-#: builtin/fsck.c:743
-#, fuzzy, c-format
+#: builtin/fsck.c:744
+#, c-format
 msgid "%s: invalid sha1 pointer in cache-tree"
-msgstr "percentatges d'apuntador sha1 no vàlid a l'arbre de la memòria cau"
+msgstr "%s: apuntador sha1 no vàlid a l'arbre de la memòria cau"
 
-#: builtin/fsck.c:752
-#, fuzzy
+#: builtin/fsck.c:753
 msgid "non-tree in cache-tree"
-msgstr "no arbre en l'arbre de la memòria cau"
+msgstr "un no arbre en l'arbre de la memòria cau"
 
-#: builtin/fsck.c:783
+#: builtin/fsck.c:784
 msgid "git fsck [<options>] [<object>...]"
 msgstr "git fsck [<opcions>] [<objecte>...]"
 
-#: builtin/fsck.c:789
+#: builtin/fsck.c:790
 msgid "show unreachable objects"
 msgstr "mostra els objectes inabastables"
 
-#: builtin/fsck.c:790
+#: builtin/fsck.c:791
 msgid "show dangling objects"
 msgstr "mostra els objectes penjants"
 
-#: builtin/fsck.c:791
+#: builtin/fsck.c:792
 msgid "report tags"
 msgstr "informa de les etiquetes"
 
-#: builtin/fsck.c:792
+#: builtin/fsck.c:793
 msgid "report root nodes"
 msgstr "informa dels nodes d'arrel"
 
-#: builtin/fsck.c:793
+#: builtin/fsck.c:794
 msgid "make index objects head nodes"
 msgstr "fes els objectes d'índex nodes de cap"
 
-#: builtin/fsck.c:794
+#: builtin/fsck.c:795
 msgid "make reflogs head nodes (default)"
 msgstr ""
 "fes que els registres de referències siguin nodes de cap (per defecte)"
 
-#: builtin/fsck.c:795
+#: builtin/fsck.c:796
 msgid "also consider packs and alternate objects"
 msgstr "també considera els paquets i els objectes alternatius"
 
-#: builtin/fsck.c:796
+#: builtin/fsck.c:797
 msgid "check only connectivity"
 msgstr "comprova només la connectivitat"
 
-#: builtin/fsck.c:797 builtin/mktag.c:76
+#: builtin/fsck.c:798 builtin/mktag.c:76
 msgid "enable more strict checking"
 msgstr "habilita la comprovació més estricta"
 
-#: builtin/fsck.c:799
+#: builtin/fsck.c:800
 msgid "write dangling objects in .git/lost-found"
 msgstr "escriu objectes penjants a .git/lost-found"
 
-#: builtin/fsck.c:800 builtin/prune.c:134
+#: builtin/fsck.c:801 builtin/prune.c:146
 msgid "show progress"
 msgstr "mostra el progrés"
 
-#: builtin/fsck.c:801
+#: builtin/fsck.c:802
 msgid "show verbose names for reachable objects"
 msgstr "mostra els noms detallats dels objectes abastables"
 
-#: builtin/fsck.c:860 builtin/index-pack.c:261
+#: builtin/fsck.c:862 builtin/index-pack.c:261
 msgid "Checking objects"
 msgstr "S'estan comprovant els objectes"
 
-#: builtin/fsck.c:888
+#: builtin/fsck.c:890
 #, c-format
 msgid "%s: object missing"
 msgstr "%s: falta l'objecte"
 
-#: builtin/fsck.c:899
+#: builtin/fsck.c:901
 #, c-format
 msgid "invalid parameter: expected sha1, got '%s'"
 msgstr "paràmetre no vàlid: s'esperava sha1, s'ha obtingut «%s»"
@@ -16197,18 +16029,13 @@ msgstr "S'ha produït un error en fer fstat %s: %s"
 msgid "failed to parse '%s' value '%s'"
 msgstr "no s'ha pogut analitzar «%s» valor «%s»"
 
-#: builtin/gc.c:487 builtin/init-db.c:57
+#: builtin/gc.c:488 builtin/init-db.c:57
 #, c-format
 msgid "cannot stat '%s'"
 msgstr "no es pot fer stat en «%s»"
 
-#: builtin/gc.c:496 builtin/notes.c:238 builtin/tag.c:574
+#: builtin/gc.c:504
 #, c-format
-msgid "cannot read '%s'"
-msgstr "no es pot llegir «%s»"
-
-#: builtin/gc.c:503
-#, fuzzy, c-format
 msgid ""
 "The last gc run reported the following. Please correct the root cause\n"
 "and remove %s\n"
@@ -16216,62 +16043,62 @@ msgid ""
 "\n"
 "%s"
 msgstr ""
-"L'última execució de gc ha informat el següent. Corregiu\n"
-"la causa primordial i elimineu %s.\n"
+"L'última execució de gc ha informat el següent. Corregiu la causa\n"
+" principal i elimineu %s\n"
 "No es realitzarà la neteja automàtica fins que s'elimini el fitxer.\n"
 "\n"
 "%s"
 
-#: builtin/gc.c:551
+#: builtin/gc.c:552
 msgid "prune unreferenced objects"
 msgstr "poda objectes sense referència"
 
-#: builtin/gc.c:553
+#: builtin/gc.c:554
 msgid "be more thorough (increased runtime)"
 msgstr "sigues més exhaustiu (el temps d'execució augmenta)"
 
-#: builtin/gc.c:554
+#: builtin/gc.c:555
 msgid "enable auto-gc mode"
 msgstr "habilita el mode de recollida d'escombraries automàtica"
 
-#: builtin/gc.c:557
+#: builtin/gc.c:558
 msgid "force running gc even if there may be another gc running"
 msgstr ""
-"força l'execució de gc encara que hi pugui haver un altre gc executant"
+"força l'execució de gc encara que hi pugui haver un altre gc executant-se"
 
-#: builtin/gc.c:560
+#: builtin/gc.c:561
 msgid "repack all other packs except the largest pack"
 msgstr "reempaqueta tots els altres paquets excepte el paquet més gran"
 
-#: builtin/gc.c:576
+#: builtin/gc.c:577
 #, c-format
 msgid "failed to parse gc.logexpiry value %s"
 msgstr "no s'ha pogut analitzar el valor %s de gc.logexpiry"
 
-#: builtin/gc.c:587
-#, fuzzy, c-format
+#: builtin/gc.c:588
+#, c-format
 msgid "failed to parse prune expiry value %s"
-msgstr "no s'ha pogut analitzar el valor de venciment de la poda per cent"
+msgstr "no s'ha pogut analitzar el valor de venciment de la poda %s"
 
-#: builtin/gc.c:607
+#: builtin/gc.c:608
 #, c-format
 msgid "Auto packing the repository in background for optimum performance.\n"
 msgstr ""
 "S'està empaquetant el repositori automàticament en el rerefons per a un "
 "rendiment òptim.\n"
 
-#: builtin/gc.c:609
+#: builtin/gc.c:610
 #, c-format
 msgid "Auto packing the repository for optimum performance.\n"
 msgstr ""
 "S'està empaquetant automàticament el repositori per a un rendiment òptim.\n"
 
-#: builtin/gc.c:610
+#: builtin/gc.c:611
 #, c-format
 msgid "See \"git help gc\" for manual housekeeping.\n"
 msgstr "Vegeu «git help gc» per a neteja manual.\n"
 
-#: builtin/gc.c:650
+#: builtin/gc.c:652
 #, c-format
 msgid ""
 "gc is already running on machine '%s' pid %<PRIuMAX> (use --force if not)"
@@ -16279,7 +16106,7 @@ msgstr ""
 "gc ja s'està executant en la màquina «%s» pid %<PRIuMAX> (useu --force si "
 "no)"
 
-#: builtin/gc.c:705
+#: builtin/gc.c:707
 msgid ""
 "There are too many unreachable loose objects; run 'git prune' to remove "
 "them."
@@ -16287,235 +16114,210 @@ msgstr ""
 "Hi ha massa objectes solts inabastables; executeu «git prune» per a "
 "eliminar-los."
 
-#: builtin/gc.c:715
+#: builtin/gc.c:717
 msgid ""
 "git maintenance run [--auto] [--[no-]quiet] [--task=<task>] [--schedule]"
 msgstr ""
 "git maintenance run [--auto] [--[no-]quiet] [--task=<task>] [--schedule]"
 
-#: builtin/gc.c:745
+#: builtin/gc.c:747
 msgid "--no-schedule is not allowed"
 msgstr "--no-schedule no està permès"
 
-#: builtin/gc.c:750
+#: builtin/gc.c:752
 #, c-format
 msgid "unrecognized --schedule argument '%s'"
 msgstr "argument --schedule no reconegut, «%s»"
 
-#: builtin/gc.c:868
+#: builtin/gc.c:870
 msgid "failed to write commit-graph"
 msgstr "s'ha produït un error en escriure el graf de comissions"
 
-#: builtin/gc.c:904
-#, fuzzy
+#: builtin/gc.c:906
 msgid "failed to prefetch remotes"
-msgstr "s'ha produït un error en omplir els remots"
+msgstr "s'ha produït un error en preobtenir els remots"
 
-#: builtin/gc.c:1020
-#, fuzzy
+#: builtin/gc.c:1022
 msgid "failed to start 'git pack-objects' process"
-msgstr "no s'ha pogut iniciar el pack-objects"
+msgstr "no s'ha pogut iniciar el procés «git pack-objects»"
 
-#: builtin/gc.c:1037
-#, fuzzy
+#: builtin/gc.c:1039
 msgid "failed to finish 'git pack-objects' process"
-msgstr "no s'ha pogut finalitzar el pack-objects"
+msgstr "no s'ha pogut finalitzar el procés «git pack-objects»"
 
-#: builtin/gc.c:1089
-#, fuzzy
+#: builtin/gc.c:1090
 msgid "failed to write multi-pack-index"
-msgstr "no s'han pogut netejar els percentatges multi-paquet"
+msgstr "no s'han pogut escriu l'índex del multi-paquet"
 
-#: builtin/gc.c:1105
-#, fuzzy
+#: builtin/gc.c:1106
 msgid "'git multi-pack-index expire' failed"
-msgstr "l'índex múltiple és massa petit"
+msgstr "ha fallat el venciment de «git multi-pack-index expire»"
 
-#: builtin/gc.c:1164
-#, fuzzy
+#: builtin/gc.c:1165
 msgid "'git multi-pack-index repack' failed"
-msgstr "no s'ha pogut carregar l'índex del paquet per al fitxer de paquet %s"
+msgstr "ha fallat l'execució de «git multi-pack-index repack»"
 
-#: builtin/gc.c:1173
-#, fuzzy
+#: builtin/gc.c:1174
 msgid ""
 "skipping incremental-repack task because core.multiPackIndex is disabled"
 msgstr ""
-"s'està ometent la tasca de reempaquetar incremental perquè "
-"core.multiPackIndex està desactivat"
+"s'està ometent la tasca incremental-repack perquè core.multiPackIndex està "
+"desactivat"
 
-#: builtin/gc.c:1277
-#, fuzzy, c-format
+#: builtin/gc.c:1278
+#, c-format
 msgid "lock file '%s' exists, skipping maintenance"
-msgstr "el fitxer de bloqueig «%s» existeix s'omet el manteniment"
+msgstr "el fitxer de bloqueig «%s» existeix, s'omet el manteniment"
 
-#: builtin/gc.c:1307
+#: builtin/gc.c:1308
 #, c-format
 msgid "task '%s' failed"
 msgstr "la tasca «%s» ha fallat"
 
-#: builtin/gc.c:1389
-#, fuzzy, c-format
+#: builtin/gc.c:1390
+#, c-format
 msgid "'%s' is not a valid task"
-msgstr "«%s» no és un terme vàlid"
+msgstr "«%s» no és una tasca vàlida"
 
-#: builtin/gc.c:1394
-#, fuzzy, c-format
+#: builtin/gc.c:1395
+#, c-format
 msgid "task '%s' cannot be selected multiple times"
-msgstr "«%s» no es pot usar amb %s"
+msgstr "la tasca «%s» no es pot seleccionar múltiples vegades"
 
-#: builtin/gc.c:1409
-#, fuzzy
+#: builtin/gc.c:1410
 msgid "run tasks based on the state of the repository"
 msgstr "executa les tasques basades en l'estat del repositori"
 
-#: builtin/gc.c:1410
+#: builtin/gc.c:1411
 msgid "frequency"
 msgstr "freqüència"
 
-#: builtin/gc.c:1411
+#: builtin/gc.c:1412
 msgid "run tasks based on frequency"
 msgstr "executa les tasques basant-se en freqüència"
 
-#: builtin/gc.c:1414
-#, fuzzy
-msgid "do not report progress or other information over stderr"
-msgstr "no informeu sobre el progrés o altra informació sobre stderr"
-
 #: builtin/gc.c:1415
+msgid "do not report progress or other information over stderr"
+msgstr "no informeu sobre el progrés o altra informació as stderr"
+
+#: builtin/gc.c:1416
 msgid "task"
 msgstr "tasca"
 
-#: builtin/gc.c:1416
+#: builtin/gc.c:1417
 msgid "run a specific task"
 msgstr "executa una tasca específica"
 
-#: builtin/gc.c:1433
-#, fuzzy
+#: builtin/gc.c:1434
 msgid "use at most one of --auto and --schedule=<frequency>"
-msgstr "usa com a màxim un de --auto i --schedule=<frequency>"
+msgstr "usa com a màxim un entre --auto i --schedule=<frequency>"
 
-#: builtin/gc.c:1476
-#, fuzzy
+#: builtin/gc.c:1477
 msgid "failed to run 'git config'"
-msgstr "no s'ha pogut executar «git status» a «%s»"
+msgstr "no s'ha pogut executar «git config»"
 
-#: builtin/gc.c:1628
-#, fuzzy, c-format
+#: builtin/gc.c:1629
+#, c-format
 msgid "failed to expand path '%s'"
-msgstr "s'ha produït un error en crear el camí «%s»%s"
+msgstr "s'ha produït un error en expandir el camí «%s»"
 
-#: builtin/gc.c:1655 builtin/gc.c:1693
-#, fuzzy
+#: builtin/gc.c:1656 builtin/gc.c:1694
 msgid "failed to start launchctl"
-msgstr "S'ha produït un error'ha produït un error en iniciar emacsclient."
+msgstr "S'ha produït un error en iniciar launchctl"
 
-#: builtin/gc.c:1768 builtin/gc.c:2221
-#, fuzzy, c-format
+#: builtin/gc.c:1769 builtin/gc.c:2237
+#, c-format
 msgid "failed to create directories for '%s'"
-msgstr "s'ha produït un error en crear el directori «%s»"
+msgstr "s'ha produït un error en crear els directoris per a «%s»"
 
-#: builtin/gc.c:1795
-#, fuzzy, c-format
+#: builtin/gc.c:1796
+#, c-format
 msgid "failed to bootstrap service %s"
-msgstr "s'ha produït un error en eliminar %s"
+msgstr "s'ha produït un error en arrencar el servei %s"
 
-#: builtin/gc.c:1888
-#, fuzzy
+#: builtin/gc.c:1889
 msgid "failed to create temp xml file"
-msgstr "no s'han pogut crear els fitxers de sortida"
+msgstr "no s'han pogut crear un fitxer xml temporal"
 
-#: builtin/gc.c:1978
-#, fuzzy
+#: builtin/gc.c:1979
 msgid "failed to start schtasks"
-msgstr "s'ha produït un error en fer stat a %s"
+msgstr "s'ha produït un error en iniciar schtasks"
 
-#: builtin/gc.c:2047
-#, fuzzy
+#: builtin/gc.c:2063
 msgid "failed to run 'crontab -l'; your system might not support 'cron'"
 msgstr ""
 "no s'ha pogut executar «crontab -l»; el vostre sistema podria no admetre "
 "«cron»"
 
-#: builtin/gc.c:2064
-#, fuzzy
+#: builtin/gc.c:2080
 msgid "failed to run 'crontab'; your system might not support 'cron'"
 msgstr ""
 "no s'ha pogut executar «crontab»; el vostre sistema podria no admetre «cron»"
 
-#: builtin/gc.c:2068
-#, fuzzy
+#: builtin/gc.c:2084
 msgid "failed to open stdin of 'crontab'"
-msgstr "s'ha produït un error en obrir «%s»"
+msgstr "s'ha produït un error en obrir stdin de «crontab»"
 
-#: builtin/gc.c:2110
+#: builtin/gc.c:2126
 msgid "'crontab' died"
 msgstr "«crontab» ha mort"
 
-#: builtin/gc.c:2175
-#, fuzzy
+#: builtin/gc.c:2191
 msgid "failed to start systemctl"
-msgstr "s'ha produït un error en fer stat a %s"
+msgstr "s'ha produït un error en iniciar systemctl"
 
-#: builtin/gc.c:2185
-#, fuzzy
+#: builtin/gc.c:2201
 msgid "failed to run systemctl"
-msgstr "no s'ha pogut executar «%s»"
+msgstr "s'ha produït un error en executar systemctl"
 
-#: builtin/gc.c:2194 builtin/gc.c:2199 builtin/worktree.c:62
-#: builtin/worktree.c:945
+#: builtin/gc.c:2210 builtin/gc.c:2215 builtin/worktree.c:62
+#: builtin/worktree.c:944
 #, c-format
 msgid "failed to delete '%s'"
 msgstr "s'ha produït un error en suprimir «%s»"
 
-#: builtin/gc.c:2379
-#, fuzzy, c-format
+#: builtin/gc.c:2395
+#, c-format
 msgid "unrecognized --scheduler argument '%s'"
-msgstr "argument --schedule no reconegut, «%s»"
+msgstr "l'argument --scheduler no reconegut «%s»"
 
-#: builtin/gc.c:2404
-#, fuzzy
+#: builtin/gc.c:2420
 msgid "neither systemd timers nor crontab are available"
-msgstr "ni els temporitzadors de systemd ni el crontab estan disponibles"
+msgstr "ni els temporitzadors de systemd ni de crontab estan disponibles"
 
-#: builtin/gc.c:2419
-#, fuzzy, c-format
+#: builtin/gc.c:2435
+#, c-format
 msgid "%s scheduler is not available"
-msgstr "%s no és disponible"
+msgstr "el planificador %s no està disponible"
 
-#: builtin/gc.c:2433
-#, fuzzy
+#: builtin/gc.c:2449
 msgid "another process is scheduling background maintenance"
-msgstr "un altre procés és planificar el manteniment en segon pla"
+msgstr "un altre procés està planificant un manteniment en segon pla"
 
-#: builtin/gc.c:2455
-#, fuzzy
+#: builtin/gc.c:2471
 msgid "git maintenance start [--scheduler=<scheduler>]"
-msgstr "git manteniment start ---scheduler=<scheduler>]"
+msgstr "git maintenance start [--scheduler=<scheduler>]"
 
-#: builtin/gc.c:2464
-#, fuzzy
+#: builtin/gc.c:2480
 msgid "scheduler"
 msgstr "planificador"
 
-#: builtin/gc.c:2465
-#, fuzzy
+#: builtin/gc.c:2481
 msgid "scheduler to trigger git maintenance run"
 msgstr "planificador per activar l'execució de manteniment del git"
 
-#: builtin/gc.c:2479
-#, fuzzy
+#: builtin/gc.c:2495
 msgid "failed to add repo to global config"
-msgstr "no s'ha pogut afegir el fitxer de paquet «%s»"
+msgstr "no s'ha pogut afegir un repositori a la configuració global"
 
-#: builtin/gc.c:2488
+#: builtin/gc.c:2504
 msgid "git maintenance <subcommand> [<options>]"
 msgstr "git maintenance <subcommand> [<options>]"
 
-#: builtin/gc.c:2507
-#, fuzzy, c-format
+#: builtin/gc.c:2523
+#, c-format
 msgid "invalid subcommand: %s"
-msgstr "comissió no vàlida %s"
+msgstr "subordre no vàlida: %s"
 
 #: builtin/grep.c:30
 msgid "git grep [<options>] [-e] <pattern> [<rev>...] [[--] <path>...]"
@@ -16699,7 +16501,7 @@ msgstr "usa <n> fils de treball"
 
 #: builtin/grep.c:928
 msgid "shortcut for -C NUM"
-msgstr "drecera per -C NUM"
+msgstr "drecera per a -C NUM"
 
 #: builtin/grep.c:931
 msgid "show a line with the function name before matches"
@@ -16791,9 +16593,8 @@ msgstr ""
 "--[no-]exclude-standard no es pot utilitzar per als continguts seguits"
 
 #: builtin/grep.c:1188
-#, fuzzy
 msgid "both --cached and trees are given"
-msgstr "es donen ambdós --cached i arbres"
+msgstr "ambdós --cached i arbres venen donats"
 
 #: builtin/hash-object.c:83
 msgid ""
@@ -16867,46 +16668,45 @@ msgid "print all configuration variable names"
 msgstr "imprimeix tots els noms de les variables de configuració"
 
 #: builtin/help.c:78
-#, fuzzy
 msgid ""
 "git help [-a|--all] [--[no-]verbose]]\n"
 "         [[-i|--info] [-m|--man] [-w|--web]] [<command>]"
-msgstr "git help [--all] [--guides] [--man | --web | --info] [<ordre>]"
+msgstr ""
+"git help [-a|--all] [--[no-]verbose]]\n"
+"         [[-i|--info] [-m|--man] [-w|--web]] [<command>]"
 
 #: builtin/help.c:80
-#, fuzzy
 msgid "git help [-g|--guides]"
-msgstr "git help --g|--guides]"
+msgstr "git help [-g|--guides]"
 
 #: builtin/help.c:81
-#, fuzzy
 msgid "git help [-c|--config]"
-msgstr "git help --c|--config]"
+msgstr "git help [-c|--config]"
 
 #: builtin/help.c:196
 #, c-format
 msgid "unrecognized help format '%s'"
 msgstr "format d'ajuda no reconegut «%s»"
 
-#: builtin/help.c:223
+#: builtin/help.c:222
 msgid "Failed to start emacsclient."
 msgstr "S'ha produït un error en iniciar emacsclient."
 
-#: builtin/help.c:236
+#: builtin/help.c:235
 msgid "Failed to parse emacsclient version."
 msgstr "S'ha produït un error en analitzar la versió d'emacsclient."
 
-#: builtin/help.c:244
+#: builtin/help.c:243
 #, c-format
 msgid "emacsclient version '%d' too old (< 22)."
 msgstr "la versió d'emacsclient «%d» és massa vella (< 22)."
 
-#: builtin/help.c:262 builtin/help.c:284 builtin/help.c:294 builtin/help.c:302
+#: builtin/help.c:261 builtin/help.c:283 builtin/help.c:293 builtin/help.c:301
 #, c-format
 msgid "failed to exec '%s'"
 msgstr "s'ha produït un error en executar «%s»"
 
-#: builtin/help.c:340
+#: builtin/help.c:339
 #, c-format
 msgid ""
 "'%s': path for unsupported man viewer.\n"
@@ -16915,7 +16715,7 @@ msgstr ""
 "«%s»: camí a un visualitzador de manuals no compatible.\n"
 "Considereu usar «man.<eina>.cmd» en lloc d'això."
 
-#: builtin/help.c:352
+#: builtin/help.c:351
 #, c-format
 msgid ""
 "'%s': cmd for supported man viewer.\n"
@@ -16924,43 +16724,41 @@ msgstr ""
 "«%s»: ordre per a un visualitzador de manuals compatible.\n"
 "Considereu usar «man.<eina>.path» en lloc d'això."
 
-#: builtin/help.c:467
+#: builtin/help.c:466
 #, c-format
 msgid "'%s': unknown man viewer."
 msgstr "«%s»: visualitzador de manuals desconegut."
 
-#: builtin/help.c:483
+#: builtin/help.c:482
 msgid "no man viewer handled the request"
 msgstr "cap visualitzador de manuals ha gestionat la sol·licitud"
 
-#: builtin/help.c:490
+#: builtin/help.c:489
 msgid "no info viewer handled the request"
 msgstr "cap visualitzador d'informació ha gestionat la sol·licitud"
 
-#: builtin/help.c:551 builtin/help.c:562 git.c:348
+#: builtin/help.c:550 builtin/help.c:561 git.c:348
 #, c-format
 msgid "'%s' is aliased to '%s'"
 msgstr "«%s» és un àlies de «%s»"
 
-#: builtin/help.c:565 git.c:380
-#, fuzzy, c-format
+#: builtin/help.c:564 git.c:380
+#, c-format
 msgid "bad alias.%s string: %s"
-msgstr "àlies incorrecte.%s string%s"
+msgstr "cadena «alias.%s» incorrecte: %s"
 
-#: builtin/help.c:581
-#, fuzzy
+#: builtin/help.c:580
 msgid "this option doesn't take any other arguments"
-msgstr "fetch --all no accepta un argument de repositori"
+msgstr "aquesta opció no accepta cap altre argument"
 
-#: builtin/help.c:602 builtin/help.c:629
+#: builtin/help.c:601 builtin/help.c:628
 #, c-format
 msgid "usage: %s%s"
 msgstr "ús: %s%s"
 
-#: builtin/help.c:624
-#, fuzzy
+#: builtin/help.c:623
 msgid "'git help config' for more information"
-msgstr "'git help config' per a més informació"
+msgstr "«git help config» per a més informació"
 
 #: builtin/index-pack.c:221
 #, c-format
@@ -17160,9 +16958,9 @@ msgid "local object %s is corrupt"
 msgstr "l'objecte local %s és malmès"
 
 #: builtin/index-pack.c:1440
-#, fuzzy, c-format
+#, c-format
 msgid "packfile name '%s' does not end with '.%s'"
-msgstr "el nom del fitxer de paquet «%s» no acaba amb «.pack»"
+msgstr "el nom del fitxer de paquet «%s» no acaba amb «.%s»"
 
 #: builtin/index-pack.c:1464
 #, c-format
@@ -17170,14 +16968,14 @@ msgid "cannot write %s file '%s'"
 msgstr "no es pot escriure «%s» al fitxer «%s»"
 
 #: builtin/index-pack.c:1472
-#, fuzzy, c-format
+#, c-format
 msgid "cannot close written %s file '%s'"
-msgstr "no s'ha pogut tancar l'arxiu «%s» per escrit"
+msgstr "no s'ha pogut tancar el fitxer %s escrit «%s»"
 
 #: builtin/index-pack.c:1489
-#, fuzzy, c-format
-msgid "unable to rename temporary '*.%s' file to '%s"
-msgstr "no s'ha pogut canviar el nom del fitxer temporal a %s"
+#, c-format
+msgid "unable to rename temporary '*.%s' file to '%s'"
+msgstr "no s'ha pogut canviar el nom del fitxer temporal «*.%s» a «%s»"
 
 #: builtin/index-pack.c:1514
 msgid "error while closing pack file"
@@ -17227,17 +17025,9 @@ msgstr "%s incorrecte"
 msgid "unknown hash algorithm '%s'"
 msgstr "algorisme hash desconegut «%s»"
 
-#: builtin/index-pack.c:1848
-msgid "--fix-thin cannot be used without --stdin"
-msgstr "--fix-thin no es pot usar sense --stdin"
-
 #: builtin/index-pack.c:1850
 msgid "--stdin requires a git repository"
 msgstr "--stdin requereix un repositori git"
-
-#: builtin/index-pack.c:1852
-msgid "--object-format cannot be used with --stdin"
-msgstr "--object-format no es pot usar sense --stdin"
 
 #: builtin/index-pack.c:1867
 msgid "--verify with no packfile name given"
@@ -17365,10 +17155,6 @@ msgstr "hash"
 msgid "specify the hash algorithm to use"
 msgstr "especifiqueu l'algorisme de resum a usar"
 
-#: builtin/init-db.c:560
-msgid "--separate-git-dir and --bare are mutually exclusive"
-msgstr "--separate-git-dir i --bare són mútuament excloents"
-
 #: builtin/init-db.c:591 builtin/init-db.c:596
 #, c-format
 msgid "cannot mkdir %s"
@@ -17491,404 +17277,381 @@ msgid "decorate options"
 msgstr "opcions de decoració"
 
 #: builtin/log.c:190
-#, fuzzy
 msgid ""
 "trace the evolution of line range <start>,<end> or function :<funcname> in "
 "<file>"
 msgstr ""
-"Traça l'evolució del rang de línia <start>,<end> or funcions :<funcname> in "
-"{8771193"
+"traça l'evolució del rang de línia <start>,<end> o funcions :<funcname> a "
+"<file>"
 
 #: builtin/log.c:213
-#, fuzzy
 msgid "-L<range>:<file> cannot be used with pathspec"
-msgstr "%s: %s no es pot usar amb %s"
+msgstr "-L<range>:<file> no es pot usar amb una especificació de camí"
 
-#: builtin/log.c:306
+#: builtin/log.c:321
 #, c-format
 msgid "Final output: %d %s\n"
 msgstr "Sortida final: %d %s\n"
 
-#: builtin/log.c:571
+#: builtin/log.c:586
 #, c-format
 msgid "git show %s: bad file"
 msgstr "git show %s: fitxer incorrecte"
 
-#: builtin/log.c:586 builtin/log.c:676
+#: builtin/log.c:601 builtin/log.c:691
 #, c-format
 msgid "could not read object %s"
 msgstr "no s'ha pogut llegir l'objecte %s"
 
-#: builtin/log.c:701
+#: builtin/log.c:716
 #, c-format
 msgid "unknown type: %d"
 msgstr "tipus desconegut: %d"
 
-#: builtin/log.c:846
+#: builtin/log.c:861
 #, c-format
 msgid "%s: invalid cover from description mode"
 msgstr "%s: cobertura no vàlida des del mode descripció"
 
-#: builtin/log.c:853
+#: builtin/log.c:868
 msgid "format.headers without value"
 msgstr "format.headers sense valor"
 
-#: builtin/log.c:982
+#: builtin/log.c:997
 #, c-format
 msgid "cannot open patch file %s"
 msgstr "no s'ha pogut obrir el fitxer de pedaç %s"
 
-#: builtin/log.c:999
+#: builtin/log.c:1014
 msgid "need exactly one range"
 msgstr "necessita exactament un interval"
 
-#: builtin/log.c:1009
+#: builtin/log.c:1024
 msgid "not a range"
 msgstr "no és un interval"
 
-#: builtin/log.c:1173
-#, fuzzy
+#: builtin/log.c:1188
 msgid "cover letter needs email format"
-msgstr "la lletra de la portada necessita un format de correu electrònic"
+msgstr "la carta de presentació necessita un format de correu electrònic"
 
-#: builtin/log.c:1179
-#, fuzzy
+#: builtin/log.c:1194
 msgid "failed to create cover-letter file"
-msgstr "no s'ha pogut crear el fitxer de portada"
+msgstr "s'ha produït un error en crear el fitxer de carta de presentació"
 
-#: builtin/log.c:1266
+#: builtin/log.c:1281
 #, c-format
 msgid "insane in-reply-to: %s"
 msgstr "in-reply-to boig: %s"
 
-#: builtin/log.c:1293
+#: builtin/log.c:1308
 msgid "git format-patch [<options>] [<since> | <revision-range>]"
 msgstr "git format-patch [<opcions>] [<des-de> | <rang-de-revisions>]"
 
-#: builtin/log.c:1351
+#: builtin/log.c:1366
 msgid "two output directories?"
 msgstr "dos directoris de sortida?"
 
-#: builtin/log.c:1502 builtin/log.c:2328 builtin/log.c:2330 builtin/log.c:2342
+#: builtin/log.c:1517 builtin/log.c:2344 builtin/log.c:2346 builtin/log.c:2358
 #, c-format
 msgid "unknown commit %s"
 msgstr "comissió desconeguda %s"
 
-#: builtin/log.c:1513 builtin/replace.c:58 builtin/replace.c:207
+#: builtin/log.c:1528 builtin/replace.c:58 builtin/replace.c:207
 #: builtin/replace.c:210
 #, c-format
 msgid "failed to resolve '%s' as a valid ref"
 msgstr "s'ha produït un error en resoldre «%s» com a referència vàlida"
 
-#: builtin/log.c:1522
+#: builtin/log.c:1537
 msgid "could not find exact merge base"
 msgstr "no s'ha pogut trobar la base exacta de la fusió"
 
-#: builtin/log.c:1532
-#, fuzzy
+#: builtin/log.c:1547
 msgid ""
 "failed to get upstream, if you want to record base commit automatically,\n"
 "please use git branch --set-upstream-to to track a remote branch.\n"
 "Or you could specify base commit by --base=<base-commit-id> manually"
 msgstr ""
-"no s'ha pogut obtenir la font si voleu registrar la comissió base "
-"automàticament si us plau useu la branca git --set-upstream-to per al "
-"seguiment d'una branca remota. O podeu especificar la comissió base per "
+"no s'ha pogut obtenir la font, si voleu registrar la comissió base\n"
+"automàticament, useu git branch --set-upstream-to per a seguir una\n"
+"una branca remota. També podeu especificar la comissió base amb "
 "--base=<base-commit-id> manualment"
 
-#: builtin/log.c:1555
+#: builtin/log.c:1570
 msgid "failed to find exact merge base"
 msgstr "no s'ha pogut trobar la base exacta de la fusió"
 
-#: builtin/log.c:1572
+#: builtin/log.c:1587
 msgid "base commit should be the ancestor of revision list"
 msgstr "la comissió base ha de ser l'avantpassat de la llista de revisions"
 
-#: builtin/log.c:1582
+#: builtin/log.c:1597
 msgid "base commit shouldn't be in revision list"
 msgstr "la comissió base no ha de ser en la llista de revisions"
 
-#: builtin/log.c:1640
+#: builtin/log.c:1655
 msgid "cannot get patch id"
 msgstr "no es pot obtenir l'id del pedaç"
 
-#: builtin/log.c:1703
-#, fuzzy
+#: builtin/log.c:1718
 msgid "failed to infer range-diff origin of current series"
-msgstr "no s'ha pogut inferir l'interval-diferències"
+msgstr ""
+"no s'ha pogut inferir el rang de diferències d'origen de les sèries actuals"
 
-#: builtin/log.c:1705
-#, fuzzy, c-format
+#: builtin/log.c:1720
+#, c-format
 msgid "using '%s' as range-diff origin of current series"
-msgstr "utilitzant «%s» com a origen de rang-diferencia de la sèrie actual"
+msgstr ""
+"utilitzant «%s» com a origen de rang de diferències de la sèrie actual"
 
-#: builtin/log.c:1749
+#: builtin/log.c:1764
 msgid "use [PATCH n/m] even with a single patch"
 msgstr "usa [PATCH n/m] fins i tot amb un sol pedaç"
 
-#: builtin/log.c:1752
+#: builtin/log.c:1767
 msgid "use [PATCH] even with multiple patches"
 msgstr "usa [PATCH] fins i tot amb múltiples pedaços"
 
-#: builtin/log.c:1756
+#: builtin/log.c:1771
 msgid "print patches to standard out"
 msgstr "imprimeix els pedaços a la sortida estàndard"
 
-#: builtin/log.c:1758
+#: builtin/log.c:1773
 msgid "generate a cover letter"
 msgstr "genera una carta de presentació"
 
-#: builtin/log.c:1760
+#: builtin/log.c:1775
 msgid "use simple number sequence for output file names"
 msgstr "usa una seqüència de números per als noms dels fitxers de sortida"
 
-#: builtin/log.c:1761
+#: builtin/log.c:1776
 msgid "sfx"
 msgstr "sufix"
 
-#: builtin/log.c:1762
+#: builtin/log.c:1777
 msgid "use <sfx> instead of '.patch'"
 msgstr "usa <sufix> en lloc de «.patch»"
 
-#: builtin/log.c:1764
+#: builtin/log.c:1779
 msgid "start numbering patches at <n> instead of 1"
 msgstr "comença numerant els pedaços a <n> en lloc d'1"
 
-#: builtin/log.c:1765
-#, fuzzy
+#: builtin/log.c:1780
 msgid "reroll-count"
 msgstr "reroll-count"
 
-#: builtin/log.c:1766
+#: builtin/log.c:1781
 msgid "mark the series as Nth re-roll"
 msgstr "marca la sèrie com a l'enèsima llançada"
 
-#: builtin/log.c:1768
+#: builtin/log.c:1783
 msgid "max length of output filename"
 msgstr "mida màxima del nom del fitxer de sortida"
 
-#: builtin/log.c:1770
+#: builtin/log.c:1785
 msgid "use [RFC PATCH] instead of [PATCH]"
 msgstr "useu [RFC PATCH] en comptes de [PATCH]"
 
-#: builtin/log.c:1773
+#: builtin/log.c:1788
 msgid "cover-from-description-mode"
 msgstr "cover-from-description-mode"
 
-#: builtin/log.c:1774
+#: builtin/log.c:1789
 msgid "generate parts of a cover letter based on a branch's description"
 msgstr ""
 "genera parts d'una carta de presentació basant-se en la descripció d'una "
 "branca"
 
-#: builtin/log.c:1776
+#: builtin/log.c:1791
 msgid "use [<prefix>] instead of [PATCH]"
 msgstr "useu [<prefix>] en comptes de [PATCH]"
 
-#: builtin/log.c:1779
+#: builtin/log.c:1794
 msgid "store resulting files in <dir>"
 msgstr "emmagatzema els fitxers resultants a <directori>"
 
-#: builtin/log.c:1782
+#: builtin/log.c:1797
 msgid "don't strip/add [PATCH]"
 msgstr "no despullis/afegeixis [PATCH]"
 
-#: builtin/log.c:1785
+#: builtin/log.c:1800
 msgid "don't output binary diffs"
 msgstr "no emetis diferències binàries"
 
-#: builtin/log.c:1787
+#: builtin/log.c:1802
 msgid "output all-zero hash in From header"
 msgstr "emet un hash de tots zeros en la capçalera From"
 
-#: builtin/log.c:1789
+#: builtin/log.c:1804
 msgid "don't include a patch matching a commit upstream"
 msgstr "no incloguis pedaços que coincideixin amb comissions a la font"
 
-#: builtin/log.c:1791
+#: builtin/log.c:1806
 msgid "show patch format instead of default (patch + stat)"
 msgstr ""
 "mostra el format de pedaç en lloc del per defecte (pedaç + estadístiques)"
 
-#: builtin/log.c:1793
+#: builtin/log.c:1808
 msgid "Messaging"
 msgstr "Missatgeria"
 
-#: builtin/log.c:1794
+#: builtin/log.c:1809
 msgid "header"
 msgstr "capçalera"
 
-#: builtin/log.c:1795
+#: builtin/log.c:1810
 msgid "add email header"
 msgstr "afegeix una capçalera de correu electrònic"
 
-#: builtin/log.c:1796 builtin/log.c:1797
+#: builtin/log.c:1811 builtin/log.c:1812
 msgid "email"
 msgstr "correu electrònic"
 
-#: builtin/log.c:1796
+#: builtin/log.c:1811
 msgid "add To: header"
 msgstr "afegeix la capçalera To:"
 
-#: builtin/log.c:1797
+#: builtin/log.c:1812
 msgid "add Cc: header"
 msgstr "afegeix la capçalera Cc:"
 
-#: builtin/log.c:1798
+#: builtin/log.c:1813
 msgid "ident"
 msgstr "identitat"
 
-#: builtin/log.c:1799
+#: builtin/log.c:1814
 msgid "set From address to <ident> (or committer ident if absent)"
 msgstr ""
 "estableix l'adreça From a <identitat> (o la identitat del comitent si manca)"
 
-#: builtin/log.c:1801
+#: builtin/log.c:1816
 msgid "message-id"
 msgstr "ID de missatge"
 
-#: builtin/log.c:1802
+#: builtin/log.c:1817
 msgid "make first mail a reply to <message-id>"
 msgstr "fes que el primer missatge sigui una resposta a <ID de missatge>"
 
-#: builtin/log.c:1803 builtin/log.c:1806
+#: builtin/log.c:1818 builtin/log.c:1821
 msgid "boundary"
 msgstr "límit"
 
-#: builtin/log.c:1804
+#: builtin/log.c:1819
 msgid "attach the patch"
 msgstr "adjunta el pedaç"
 
-#: builtin/log.c:1807
+#: builtin/log.c:1822
 msgid "inline the patch"
 msgstr "posa el pedaç en el cos"
 
-#: builtin/log.c:1811
+#: builtin/log.c:1826
 msgid "enable message threading, styles: shallow, deep"
 msgstr "habilita l'enfilada de missatges, estils: shallow, deep"
 
-#: builtin/log.c:1813
+#: builtin/log.c:1828
 msgid "signature"
 msgstr "signatura"
 
-#: builtin/log.c:1814
+#: builtin/log.c:1829
 msgid "add a signature"
 msgstr "afegeix una signatura"
 
-#: builtin/log.c:1815
+#: builtin/log.c:1830
 msgid "base-commit"
 msgstr "comissió base"
 
-#: builtin/log.c:1816
+#: builtin/log.c:1831
 msgid "add prerequisite tree info to the patch series"
 msgstr "afegeix la informació d'arbre requerida a la sèrie de pedaços"
 
-#: builtin/log.c:1819
+#: builtin/log.c:1834
 msgid "add a signature from a file"
 msgstr "afegeix una signatura des d'un fitxer"
 
-#: builtin/log.c:1820
+#: builtin/log.c:1835
 msgid "don't print the patch filenames"
 msgstr "no imprimeixis els noms de fitxer del pedaç"
 
-#: builtin/log.c:1822
+#: builtin/log.c:1837
 msgid "show progress while generating patches"
 msgstr "mostra el progrés durant la generació de pedaços"
 
-#: builtin/log.c:1824
+#: builtin/log.c:1839
 msgid "show changes against <rev> in cover letter or single patch"
 msgstr ""
 "mostra els canvis contra <rev> a la carta de presentació o a un sol pedaç"
 
-#: builtin/log.c:1827
-#, fuzzy
+#: builtin/log.c:1842
 msgid "show changes against <refspec> in cover letter or single patch"
 msgstr ""
-"mostra els canvis contra <refspec> a la lletra de la portada o a un sol "
+"mostra els canvis contra <refspec> a la carta de presentació o a un sol "
 "pedaç"
 
-#: builtin/log.c:1829 builtin/range-diff.c:28
+#: builtin/log.c:1844 builtin/range-diff.c:28
 msgid "percentage by which creation is weighted"
 msgstr "percentatge pel qual la creació és ponderada"
 
-#: builtin/log.c:1916
+#: builtin/log.c:1931
 #, c-format
 msgid "invalid ident line: %s"
 msgstr "línia d'identitat no vàlida: %s"
 
-#: builtin/log.c:1931
-msgid "-n and -k are mutually exclusive"
-msgstr "-n i -k són mútuament excloents"
-
-#: builtin/log.c:1933
-msgid "--subject-prefix/--rfc and -k are mutually exclusive"
-msgstr "--subject-prefix/--rfc i -k són mútuament excloents"
-
-#: builtin/log.c:1941
+#: builtin/log.c:1956
 msgid "--name-only does not make sense"
 msgstr "--name-only no té sentit"
 
-#: builtin/log.c:1943
+#: builtin/log.c:1958
 msgid "--name-status does not make sense"
 msgstr "--name-status no té sentit"
 
-#: builtin/log.c:1945
+#: builtin/log.c:1960
 msgid "--check does not make sense"
 msgstr "--check no té sentit"
 
-#: builtin/log.c:1967
-msgid "--stdout, --output, and --output-directory are mutually exclusive"
-msgstr "--stdout, --output, i --output-directory són mútuament excloents"
-
-#: builtin/log.c:2089
+#: builtin/log.c:2104
 msgid "--interdiff requires --cover-letter or single patch"
 msgstr "--interdiff requereix --cover-letter o un sol pedaç"
 
-#: builtin/log.c:2093
+#: builtin/log.c:2108
 msgid "Interdiff:"
 msgstr "Interdiff:"
 
-#: builtin/log.c:2094
+#: builtin/log.c:2109
 #, c-format
 msgid "Interdiff against v%d:"
 msgstr "Interdiff contra v%d:"
 
-#: builtin/log.c:2100
-msgid "--creation-factor requires --range-diff"
-msgstr "--creation-factor requereix --range-diff"
-
-#: builtin/log.c:2104
+#: builtin/log.c:2119
 msgid "--range-diff requires --cover-letter or single patch"
 msgstr "--range-diff requereix --cover-letter o un sol pedaç"
 
-#: builtin/log.c:2112
-#, fuzzy
+#: builtin/log.c:2127
 msgid "Range-diff:"
-msgstr "Diferència-interval"
+msgstr "Diferència de l'interval:"
 
-#: builtin/log.c:2113
-#, fuzzy, c-format
+#: builtin/log.c:2128
+#, c-format
 msgid "Range-diff against v%d:"
-msgstr "Diferència de l'interval contra el v%d"
+msgstr "Diferència de l'interval contra el v%d:"
 
-#: builtin/log.c:2124
+#: builtin/log.c:2139
 #, c-format
 msgid "unable to read signature file '%s'"
 msgstr "no s'ha pogut llegir el fitxer de signatura «%s»"
 
-#: builtin/log.c:2160
+#: builtin/log.c:2175
 msgid "Generating patches"
 msgstr "S'estan generant els pedaços"
 
-#: builtin/log.c:2204
+#: builtin/log.c:2219
 msgid "failed to create output files"
 msgstr "no s'han pogut crear els fitxers de sortida"
 
-#: builtin/log.c:2263
+#: builtin/log.c:2279
 msgid "git cherry [-v] [<upstream> [<head> [<limit>]]]"
 msgstr "git cherry [-v] [<font> [<cap> [<límit>]]]"
 
-#: builtin/log.c:2317
+#: builtin/log.c:2333
 #, c-format
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> "
@@ -17897,132 +17660,133 @@ msgstr ""
 "No s'ha pogut trobar una branca remota seguida. Especifiqueu <font> "
 "manualment.\n"
 
-#: builtin/ls-files.c:561
+#: builtin/ls-files.c:564
 msgid "git ls-files [<options>] [<file>...]"
 msgstr "git ls-files [<opcions>] [<fitxer>...]"
 
-#: builtin/ls-files.c:615
+#: builtin/ls-files.c:618
 msgid "separate paths with the NUL character"
 msgstr "separa els camins amb el caràcter NUL"
 
-#: builtin/ls-files.c:617
+#: builtin/ls-files.c:620
 msgid "identify the file status with tags"
 msgstr "identifica l'estat de fitxer amb etiquetes"
 
-#: builtin/ls-files.c:619
+#: builtin/ls-files.c:622
 msgid "use lowercase letters for 'assume unchanged' files"
 msgstr "usa lletres minúscules per als fitxers «assume unchanged»"
 
-#: builtin/ls-files.c:621
+#: builtin/ls-files.c:624
 msgid "use lowercase letters for 'fsmonitor clean' files"
 msgstr "usa lletres minúscules per als fitxers «fsmonitor clean»"
 
-#: builtin/ls-files.c:623
+#: builtin/ls-files.c:626
 msgid "show cached files in the output (default)"
 msgstr ""
 "mostra en la sortida els fitxers desats en la memòria cau (per defecte)"
 
-#: builtin/ls-files.c:625
+#: builtin/ls-files.c:628
 msgid "show deleted files in the output"
 msgstr "mostra en la sortida els fitxers suprimits"
 
-#: builtin/ls-files.c:627
+#: builtin/ls-files.c:630
 msgid "show modified files in the output"
 msgstr "mostra en la sortida els fitxers modificats"
 
-#: builtin/ls-files.c:629
+#: builtin/ls-files.c:632
 msgid "show other files in the output"
 msgstr "mostra en la sortida els altres fitxers"
 
-#: builtin/ls-files.c:631
+#: builtin/ls-files.c:634
 msgid "show ignored files in the output"
 msgstr "mostra en la sortida els fitxers ignorats"
 
-#: builtin/ls-files.c:634
+#: builtin/ls-files.c:637
 msgid "show staged contents' object name in the output"
 msgstr "mostra en la sortida el nom d'objecte dels continguts «stage»"
 
-#: builtin/ls-files.c:636
+#: builtin/ls-files.c:639
 msgid "show files on the filesystem that need to be removed"
 msgstr "mostra els fitxers en el sistema de fitxers que s'han d'eliminar"
 
-#: builtin/ls-files.c:638
+#: builtin/ls-files.c:641
 msgid "show 'other' directories' names only"
 msgstr "mostra només els noms dels directoris «other»"
 
-#: builtin/ls-files.c:640
+#: builtin/ls-files.c:643
 msgid "show line endings of files"
 msgstr "mostra els terminadors de línia dels fitxers"
 
-#: builtin/ls-files.c:642
+#: builtin/ls-files.c:645
 msgid "don't show empty directories"
 msgstr "no mostris els directoris buits"
 
-#: builtin/ls-files.c:645
+#: builtin/ls-files.c:648
 msgid "show unmerged files in the output"
 msgstr "mostra en la sortida els fitxers sense fusionar"
 
-#: builtin/ls-files.c:647
+#: builtin/ls-files.c:650
 msgid "show resolve-undo information"
 msgstr "mostra la informació de resolució de desfet"
 
-#: builtin/ls-files.c:649
+#: builtin/ls-files.c:652
 msgid "skip files matching pattern"
 msgstr "omet els fitxers coincidents amb el patró"
 
-#: builtin/ls-files.c:652
-
+#: builtin/ls-files.c:655
 msgid "read exclude patterns from <file>"
 msgstr "llegeix els patrons des de <file>"
 
-#: builtin/ls-files.c:655
+#: builtin/ls-files.c:658
 msgid "read additional per-directory exclude patterns in <file>"
 msgstr "llegeix els patrons addicionals d'exclusió per directori en <fitxer>"
 
-#: builtin/ls-files.c:657
+#: builtin/ls-files.c:660
 msgid "add the standard git exclusions"
 msgstr "afegeix les exclusions estàndards de git"
 
-#: builtin/ls-files.c:661
+#: builtin/ls-files.c:664
 msgid "make the output relative to the project top directory"
 msgstr "fes que la sortida sigui relativa al directori superior del projecte"
 
-#: builtin/ls-files.c:664
+#: builtin/ls-files.c:667
 msgid "recurse through submodules"
 msgstr "inclou recursivament als submòduls"
 
-#: builtin/ls-files.c:666
+#: builtin/ls-files.c:669
 msgid "if any <file> is not in the index, treat this as an error"
 msgstr "si qualsevol <fitxer> no és en l'índex, tracta-ho com a error"
 
-#: builtin/ls-files.c:667
+#: builtin/ls-files.c:670
 msgid "tree-ish"
 msgstr "arbre"
 
-#: builtin/ls-files.c:668
+#: builtin/ls-files.c:671
 msgid "pretend that paths removed since <tree-ish> are still present"
 msgstr ""
 "pretén que els camins eliminats després de <arbre> encara siguin presents"
 
-#: builtin/ls-files.c:670
+#: builtin/ls-files.c:673
 msgid "show debugging data"
 msgstr "mostra les dades de depuració"
 
-#: builtin/ls-files.c:672
+#: builtin/ls-files.c:675
 msgid "suppress duplicate entries"
 msgstr "suprimeix les entrades duplicades"
 
+#: builtin/ls-files.c:677
+msgid "show sparse directories in the presence of a sparse index"
+msgstr "mostra els directoris dispersos en presència d'un índex dispers"
+
 #: builtin/ls-remote.c:9
-#, fuzzy
 msgid ""
 "git ls-remote [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
 "              [-q | --quiet] [--exit-code] [--get-url]\n"
 "              [--symref] [<repository> [<refs>...]]"
 msgstr ""
-"git ls-remote [--heads] [--tags] [--refs]\n"
-"                     [--upload-pack=<executable>] [-q | --quiet]\n"
-"                     [--exit-code] [--get-url] [--symref]\n"
-"                     [<repositori> [<referències>...]]"
+"git ls-remote [--heads] [--tags] [--refs] [--upload-pack=<exec>]\n"
+"              [-q | --quiet] [--exit-code] [--get-url]\n"
+"              [--symref] [<repository> [<refs>...]]"
 
 #: builtin/ls-remote.c:60
 msgid "do not print remote URL"
@@ -18099,44 +17863,36 @@ msgstr ""
 
 #. TRANSLATORS: keep <> in "<" mail ">" info.
 #: builtin/mailinfo.c:14
-#, fuzzy
 msgid "git mailinfo [<options>] <msg> <patch> < mail >info"
-msgstr "git diff --no-index [<opcions>] <camí> <camí>"
+msgstr "git mailinfo [<options>] <msg> <patch> < mail >info"
 
 #: builtin/mailinfo.c:58
-#, fuzzy
 msgid "keep subject"
-msgstr "retén els objectes inabastables"
+msgstr "mantén l'assumpte"
 
 #: builtin/mailinfo.c:60
-#, fuzzy
 msgid "keep non patch brackets in subject"
-msgstr "mantén els parèntesis sense pedaços en el tema"
+msgstr "mantén els parèntesis que no són del pedaç en l'assumpte"
 
 #: builtin/mailinfo.c:62
-#, fuzzy
 msgid "copy Message-ID to the end of commit message"
-msgstr "edita el missatge de comissió"
+msgstr "copia el Message-ID al final del missatge de comissió"
 
 #: builtin/mailinfo.c:64
-#, fuzzy
 msgid "re-code metadata to i18n.commitEncoding"
 msgstr "torna a codificar les metadades a i18n.commitEncoding"
 
 #: builtin/mailinfo.c:67
-#, fuzzy
 msgid "disable charset re-coding of metadata"
-msgstr "inhabilita la codificació del joc de caràcters de les metadades"
+msgstr "inhabilita la recodificació del joc de caràcters de les metadades"
 
 #: builtin/mailinfo.c:69
-#, fuzzy
 msgid "encoding"
 msgstr "codificació"
 
 #: builtin/mailinfo.c:70
-#, fuzzy
 msgid "re-code metadata to this encoding"
-msgstr "torna a codificar les metadades a aquesta codificació"
+msgstr "recodifica les metadades en aquesta codificació"
 
 #: builtin/mailinfo.c:72
 msgid "use scissors"
@@ -18147,12 +17903,10 @@ msgid "<action>"
 msgstr "<acció>"
 
 #: builtin/mailinfo.c:74
-#, fuzzy
 msgid "action when quoted CR is found"
-msgstr "acció quan es troba la CR citada"
+msgstr "acció quan es troba un CR en una cita"
 
 #: builtin/mailinfo.c:77
-#, fuzzy
 msgid "use headers in message's body"
 msgstr "utilitza les capçaleres en el cos del missatge"
 
@@ -18220,26 +17974,30 @@ msgid "use a diff3 based merge"
 msgstr "usa una fusió basada en diff3"
 
 #: builtin/merge-file.c:37
+msgid "use a zealous diff3 based merge"
+msgstr "usa una fusió basada en zealous diff3"
+
+#: builtin/merge-file.c:39
 msgid "for conflicts, use our version"
 msgstr "en conflictes, usa la nostra versió"
 
-#: builtin/merge-file.c:39
+#: builtin/merge-file.c:41
 msgid "for conflicts, use their version"
 msgstr "en conflictes, usa la seva versió"
 
-#: builtin/merge-file.c:41
+#: builtin/merge-file.c:43
 msgid "for conflicts, use a union version"
 msgstr "en conflictes, usa una versió d'unió"
 
-#: builtin/merge-file.c:44
+#: builtin/merge-file.c:46
 msgid "for conflicts, use this marker size"
 msgstr "en conflictes, usa aquesta mida de marcador"
 
-#: builtin/merge-file.c:45
+#: builtin/merge-file.c:47
 msgid "do not warn about conflicts"
 msgstr "no avisis de conflictes"
 
-#: builtin/merge-file.c:47
+#: builtin/merge-file.c:49
 msgid "set labels for file1/orig-file/file2"
 msgstr "estableix les etiquetes per a fitxer1/fitxer-original/fitxer2"
 
@@ -18278,181 +18036,184 @@ msgstr "S'està fusionant %s amb %s\n"
 msgid "git merge [<options>] [<commit>...]"
 msgstr "git merge [<opcions>] [<comissió>...]"
 
-#: builtin/merge.c:124
+#: builtin/merge.c:125
 msgid "switch `m' requires a value"
 msgstr "l'opció «m» requereix un valor"
 
-#: builtin/merge.c:147
+#: builtin/merge.c:148
 #, c-format
 msgid "option `%s' requires a value"
 msgstr "l'opció «%s» requereix un valor"
 
-#: builtin/merge.c:200
+#: builtin/merge.c:201
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
 msgstr "No s'ha pogut trobar l'estratègia de fusió «%s».\n"
 
-#: builtin/merge.c:201
+#: builtin/merge.c:202
 #, c-format
 msgid "Available strategies are:"
 msgstr "Les estratègies disponibles són:"
 
-#: builtin/merge.c:206
+#: builtin/merge.c:207
 #, c-format
 msgid "Available custom strategies are:"
 msgstr "Les estratègies personalitzades disponibles són:"
 
-#: builtin/merge.c:257 builtin/pull.c:133
+#: builtin/merge.c:258 builtin/pull.c:134
 msgid "do not show a diffstat at the end of the merge"
 msgstr "no mostris les estadístiques de diferència al final de la fusió"
 
-#: builtin/merge.c:260 builtin/pull.c:136
+#: builtin/merge.c:261 builtin/pull.c:137
 msgid "show a diffstat at the end of the merge"
 msgstr "mostra les estadístiques de diferència al final de la fusió"
 
-#: builtin/merge.c:261 builtin/pull.c:139
+#: builtin/merge.c:262 builtin/pull.c:140
 msgid "(synonym to --stat)"
 msgstr "(sinònim de --stat)"
 
-#: builtin/merge.c:263 builtin/pull.c:142
+#: builtin/merge.c:264 builtin/pull.c:143
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr ""
 "afegeix (com a màxim <n>) entrades del registre curt al missatge de comissió"
 " de fusió"
 
-#: builtin/merge.c:266 builtin/pull.c:148
+#: builtin/merge.c:267 builtin/pull.c:149
 msgid "create a single commit instead of doing a merge"
 msgstr "crea una única comissió en lloc de fusionar"
 
-#: builtin/merge.c:268 builtin/pull.c:151
+#: builtin/merge.c:269 builtin/pull.c:152
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "realitza una comissió si la fusió té èxit (per defecte)"
 
-#: builtin/merge.c:270 builtin/pull.c:154
+#: builtin/merge.c:271 builtin/pull.c:155
 msgid "edit message before committing"
 msgstr "edita el missatge abans de cometre"
 
-#: builtin/merge.c:272
+#: builtin/merge.c:273
 msgid "allow fast-forward (default)"
 msgstr "permet l'avanç ràpid (per defecte)"
 
-#: builtin/merge.c:274 builtin/pull.c:161
+#: builtin/merge.c:275 builtin/pull.c:162
 msgid "abort if fast-forward is not possible"
 msgstr "avorta si l'avanç ràpid no és possible"
 
-#: builtin/merge.c:278 builtin/pull.c:164
+#: builtin/merge.c:279 builtin/pull.c:168
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "verifica que la comissió anomenada tingui una signatura GPG vàlida"
 
-#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:168
+#: builtin/merge.c:280 builtin/notes.c:785 builtin/pull.c:172
 #: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr "estratègia"
 
-#: builtin/merge.c:280 builtin/pull.c:169
+#: builtin/merge.c:281 builtin/pull.c:173
 msgid "merge strategy to use"
 msgstr "estratègia de fusió a usar"
 
-#: builtin/merge.c:281 builtin/pull.c:172
+#: builtin/merge.c:282 builtin/pull.c:176
 msgid "option=value"
 msgstr "opció=valor"
 
-#: builtin/merge.c:282 builtin/pull.c:173
+#: builtin/merge.c:283 builtin/pull.c:177
 msgid "option for selected merge strategy"
 msgstr "opció per a l'estratègia de fusió seleccionada"
 
-#: builtin/merge.c:284
+#: builtin/merge.c:285
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr "missatge de comissió de fusió (per a una fusió no d'avanç ràpid)"
 
 #: builtin/merge.c:291
+msgid "use <name> instead of the real target"
+msgstr "usa <nom> en lloc de destí real"
+
+#: builtin/merge.c:294
 msgid "abort the current in-progress merge"
 msgstr "avorta la fusió en curs actual"
 
-#: builtin/merge.c:293
+#: builtin/merge.c:296
 msgid "--abort but leave index and working tree alone"
 msgstr "--abort però deixa l'índex i l'arbre de treball intactes"
 
-#: builtin/merge.c:295
+#: builtin/merge.c:298
 msgid "continue the current in-progress merge"
 msgstr "continua la fusió en curs actual"
 
-#: builtin/merge.c:297 builtin/pull.c:180
+#: builtin/merge.c:300 builtin/pull.c:184
 msgid "allow merging unrelated histories"
 msgstr "permet fusionar històries no relacionades"
 
-#: builtin/merge.c:304
-#, fuzzy
+#: builtin/merge.c:307
 msgid "bypass pre-merge-commit and commit-msg hooks"
-msgstr "evita els ganxos pre-combinació i missatge de comissió"
+msgstr "evita els lligams pre-merge-commit i commit-msg"
 
-#: builtin/merge.c:321
+#: builtin/merge.c:323
 msgid "could not run stash."
 msgstr "no s'ha pogut executar «stash»."
 
-#: builtin/merge.c:326
+#: builtin/merge.c:328
 msgid "stash failed"
 msgstr "l'«stash» ha fallat"
 
-#: builtin/merge.c:331
+#: builtin/merge.c:333
 #, c-format
 msgid "not a valid object: %s"
 msgstr "no és un objecte vàlid: %s"
 
-#: builtin/merge.c:353 builtin/merge.c:370
+#: builtin/merge.c:355 builtin/merge.c:372
 msgid "read-tree failed"
 msgstr "read-tree ha fallat"
 
-#: builtin/merge.c:401
+#: builtin/merge.c:403
 msgid "Already up to date. (nothing to squash)"
 msgstr "Ja està actualitzat. (res a fer «squash»)"
 
-#: builtin/merge.c:415
+#: builtin/merge.c:417
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
 msgstr "Comissió «squash» -- no s'està actualitzant HEAD\n"
 
-#: builtin/merge.c:465
+#: builtin/merge.c:467
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
 msgstr "Cap missatge de fusió -- no s'està actualitzant HEAD\n"
 
-#: builtin/merge.c:515
+#: builtin/merge.c:517
 #, c-format
 msgid "'%s' does not point to a commit"
 msgstr "«%s» no assenyala una comissió"
 
-#: builtin/merge.c:603
+#: builtin/merge.c:605
 #, c-format
 msgid "Bad branch.%s.mergeoptions string: %s"
 msgstr "Cadena branch.%s.mergeoptions incorrecta: %s"
 
-#: builtin/merge.c:730
+#: builtin/merge.c:732
 msgid "Not handling anything other than two heads merge."
 msgstr "No s'està gestionant res a part de la fusió de dos caps."
 
-#: builtin/merge.c:743
-#, fuzzy, c-format
+#: builtin/merge.c:745
+#, c-format
 msgid "unknown strategy option: -X%s"
-msgstr "opció desconeguda: %s\n"
+msgstr "opció d'estratègia desconeguda: -X%s"
 
-#: builtin/merge.c:762 t/helper/test-fast-rebase.c:223
+#: builtin/merge.c:764 t/helper/test-fast-rebase.c:223
 #, c-format
 msgid "unable to write %s"
 msgstr "no s'ha pogut escriure %s"
 
-#: builtin/merge.c:814
+#: builtin/merge.c:816
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "No s'ha pogut llegir de «%s»"
 
-#: builtin/merge.c:823
+#: builtin/merge.c:825
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
 "No s'està cometent la fusió; useu «git commit» per a completar la fusió.\n"
 
-#: builtin/merge.c:829
+#: builtin/merge.c:831
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
@@ -18462,11 +18223,11 @@ msgstr ""
 "necessària, especialment si es fusiona una branca amb funcionalitat\n"
 "nova.\n"
 
-#: builtin/merge.c:834
+#: builtin/merge.c:836
 msgid "An empty message aborts the commit.\n"
 msgstr "Un missatge buit interromp la comissió.\n"
 
-#: builtin/merge.c:837
+#: builtin/merge.c:839
 #, c-format
 msgid ""
 "Lines starting with '%c' will be ignored, and an empty message aborts\n"
@@ -18475,74 +18236,74 @@ msgstr ""
 "Les línies que comencen amb «%c» seran ignorades i un missatge buit "
 "interromp la comissió.\n"
 
-#: builtin/merge.c:892
+#: builtin/merge.c:894
 msgid "Empty commit message."
 msgstr "El missatge de comissió és buit."
 
-#: builtin/merge.c:907
+#: builtin/merge.c:909
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Meravellós.\n"
 
-#: builtin/merge.c:968
+#: builtin/merge.c:970
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
 "La fusió automàtica ha fallat; arregleu els conflictes i després cometeu el "
 "resultat.\n"
 
-#: builtin/merge.c:1007
+#: builtin/merge.c:1009
 msgid "No current branch."
 msgstr "No hi ha cap branca actual."
 
-#: builtin/merge.c:1009
+#: builtin/merge.c:1011
 msgid "No remote for the current branch."
 msgstr "No hi ha cap remot per a la branca actual."
 
-#: builtin/merge.c:1011
+#: builtin/merge.c:1013
 msgid "No default upstream defined for the current branch."
 msgstr "No hi ha cap font per defecte definida per a la branca actual."
 
-#: builtin/merge.c:1016
+#: builtin/merge.c:1018
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "No hi ha cap branca amb seguiment remot per a %s de %s"
 
-#: builtin/merge.c:1073
+#: builtin/merge.c:1075
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Valor incorrecte «%s» en l'entorn «%s»"
 
-#: builtin/merge.c:1174
+#: builtin/merge.c:1177
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "no és quelcom que puguem fusionar en %s: %s"
 
-#: builtin/merge.c:1208
+#: builtin/merge.c:1211
 msgid "not something we can merge"
 msgstr "no és quelcom que puguem fusionar"
 
-#: builtin/merge.c:1321
+#: builtin/merge.c:1324
 msgid "--abort expects no arguments"
 msgstr "--abort no espera cap argument"
 
-#: builtin/merge.c:1325
+#: builtin/merge.c:1328
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr "No hi ha fusió a avortar (manca MERGE_HEAD)."
 
-#: builtin/merge.c:1343
+#: builtin/merge.c:1346
 msgid "--quit expects no arguments"
 msgstr "--quit no espera cap argument"
 
-#: builtin/merge.c:1356
+#: builtin/merge.c:1359
 msgid "--continue expects no arguments"
 msgstr "--continue no espera cap argument"
 
-#: builtin/merge.c:1360
+#: builtin/merge.c:1363
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "No hi ha cap fusió en curs (manca MERGE_HEAD)."
 
-#: builtin/merge.c:1376
+#: builtin/merge.c:1379
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -18550,7 +18311,7 @@ msgstr ""
 "No heu conclòs la vostra fusió (MERGE_HEAD existeix).\n"
 "Cometeu els vostres canvis abans de fusionar."
 
-#: builtin/merge.c:1383
+#: builtin/merge.c:1386
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -18558,86 +18319,78 @@ msgstr ""
 "No heu conclòs el vostre «cherry pick» (CHERRY_PICK_HEAD existeix).\n"
 "Cometeu els vostres canvis abans de fusionar."
 
-#: builtin/merge.c:1386
+#: builtin/merge.c:1389
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr "No heu conclòs el vostre «cherry pick» (CHERRY_PICK_HEAD existeix)."
 
-#: builtin/merge.c:1400
-msgid "You cannot combine --squash with --no-ff."
-msgstr "No podeu combinar --squash amb --no-ff."
-
-#: builtin/merge.c:1402
-msgid "You cannot combine --squash with --commit."
-msgstr "No podeu combinar --squash amb --commit."
-
-#: builtin/merge.c:1418
+#: builtin/merge.c:1421
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr ""
 "No hi ha una comissió especificada i merge.defaultToUpstream no està "
 "establert."
 
-#: builtin/merge.c:1435
+#: builtin/merge.c:1438
 msgid "Squash commit into empty head not supported yet"
 msgstr "Una comissió «squash» a un HEAD buit encara no es permet"
 
-#: builtin/merge.c:1437
+#: builtin/merge.c:1440
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr "Una comissió no d'avanç ràpid no té sentit a un HEAD buit"
 
-#: builtin/merge.c:1442
+#: builtin/merge.c:1445
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "%s - no és una cosa que puguem fusionar"
 
-#: builtin/merge.c:1444
+#: builtin/merge.c:1447
 msgid "Can merge only exactly one commit into empty head"
 msgstr "Es pot fusionar només una comissió a un HEAD buit"
 
-#: builtin/merge.c:1531
+#: builtin/merge.c:1534
 msgid "refusing to merge unrelated histories"
 msgstr "s'està refusant fusionar històries no relacionades"
 
-#: builtin/merge.c:1550
+#: builtin/merge.c:1553
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "S'estan actualitzant %s..%s\n"
 
-#: builtin/merge.c:1598
+#: builtin/merge.c:1601
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "S'està intentant una fusió molt trivial en l'índex...\n"
 
-#: builtin/merge.c:1605
+#: builtin/merge.c:1608
 #, c-format
 msgid "Nope.\n"
 msgstr "No.\n"
 
-#: builtin/merge.c:1664 builtin/merge.c:1730
+#: builtin/merge.c:1667 builtin/merge.c:1733
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "S'està rebobinant l'arbre a la pristina...\n"
 
-#: builtin/merge.c:1668
+#: builtin/merge.c:1671
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "S'està intentant l'estratègia de fusió %s...\n"
 
-#: builtin/merge.c:1720
+#: builtin/merge.c:1723
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Cap estratègia de fusió ha gestionat la fusió.\n"
 
-#: builtin/merge.c:1722
+#: builtin/merge.c:1725
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "L'estratègia de fusió %s ha fallat.\n"
 
-#: builtin/merge.c:1732
+#: builtin/merge.c:1735
 #, c-format
 msgid "Using the %s strategy to prepare resolving by hand.\n"
 msgstr "S'està usant l'estratègia %s per a preparar la resolució a mà.\n"
 
-#: builtin/merge.c:1746
+#: builtin/merge.c:1749
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
@@ -18645,48 +18398,43 @@ msgstr ""
 "demanat\n"
 
 #: builtin/mktag.c:10
-#, fuzzy
 msgid "git mktag"
-msgstr "tag mktag"
+msgstr "git mktag"
 
 #: builtin/mktag.c:27
-#, fuzzy, c-format
+#, c-format
 msgid "warning: tag input does not pass fsck: %s"
-msgstr "avís: «:include:» no s'admet: %s\n"
+msgstr "avís: l'entrada d'etiqueta no passa fsck: %s"
 
 #: builtin/mktag.c:38
-#, fuzzy, c-format
+#, c-format
 msgid "error: tag input does not pass fsck: %s"
 msgstr "error: l'entrada d'etiqueta no passa fsck: %s"
 
 #: builtin/mktag.c:41
-#, fuzzy, c-format
+#, c-format
 msgid "%d (FSCK_IGNORE?) should never trigger this callback"
-msgstr "%d (FSCKIGNORE?) no hauria d'activar aquesta crida de retorn"
+msgstr "%d (FSCK_IGNORE?) no hauria d'activar mai aquesta crida de retorn"
 
 #: builtin/mktag.c:56
-#, fuzzy, c-format
+#, c-format
 msgid "could not read tagged object '%s'"
-msgstr "no s'ha pogut llegir l'objecte %s"
+msgstr "no s'ha pogut llegir l'objecte etiquetat «%s»"
 
 #: builtin/mktag.c:59
-#, fuzzy, c-format
+#, c-format
 msgid "object '%s' tagged as '%s', but is a '%s' type"
-msgstr "l'objecte %s és %s, no pas %s"
+msgstr "l'objecte «%s» s'ha etiquetat com a «%s», però és del tipus «%s»"
 
 #: builtin/mktag.c:98
-#, fuzzy
 msgid "tag on stdin did not pass our strict fsck check"
-msgstr ""
-"l'etiqueta a l'entrada estàndard no ha passat la comprovació estricta del "
-"fsck"
+msgstr "l'etiqueta a stdin no ha passat la comprovació estricta del fsck"
 
 #: builtin/mktag.c:101
-#, fuzzy
 msgid "tag on stdin did not refer to a valid object"
-msgstr "%s no apunta a un objecte vàlid"
+msgstr "l'etiqueta a stdin no apunta a un objecte vàlid"
 
-#: builtin/mktag.c:104 builtin/tag.c:243
+#: builtin/mktag.c:104 builtin/tag.c:242
 msgid "unable to write tag file"
 msgstr "no s'ha pogut escriure el fitxer d'etiqueta"
 
@@ -18707,13 +18455,12 @@ msgid "allow creation of more than one tree"
 msgstr "permet la creació de més d'un arbre"
 
 #: builtin/multi-pack-index.c:10
-#, fuzzy
 msgid ""
 "git multi-pack-index [<options>] write [--preferred-pack=<pack>][--refs-"
 "snapshot=<path>]"
 msgstr ""
-"git multi-pack-index [<options>] (write|verify|expire|repack --batch-"
-"size=<size>)"
+"git multi-pack-index [<options>] write [--preferred-pack=<pack>][--refs-"
+"snapshot=<path>]"
 
 #: builtin/multi-pack-index.c:14
 msgid "git multi-pack-index [<options>] verify"
@@ -18728,44 +18475,40 @@ msgid "git multi-pack-index [<options>] repack [--batch-size=<size>]"
 msgstr "git multi-pack-index [<opcions>] repack [--batch-size=<mida>]"
 
 #: builtin/multi-pack-index.c:57
-#, fuzzy
 msgid "object directory containing set of packfile and pack-index pairs"
 msgstr ""
-"directori de l'objecte que conté el conjunt de parells packfile i pack-index"
+"directori de l'objecte que conté el conjunt de parells de fitxers i índexs "
+"de paquets"
 
 #: builtin/multi-pack-index.c:98
-#, fuzzy
 msgid "preferred-pack"
 msgstr "paquet preferit"
 
 #: builtin/multi-pack-index.c:99
-#, fuzzy
 msgid "pack for reuse when computing a multi-pack bitmap"
 msgstr ""
 "empaqueta per a reutilitzar quan es calcula un mapa de bits multi-paquet"
 
 #: builtin/multi-pack-index.c:100
-#, fuzzy
 msgid "write multi-pack bitmap"
-msgstr "no s'han pogut netejar els percentatges multi-paquet"
+msgstr "escriu un map de bits multi-paquet"
 
 #: builtin/multi-pack-index.c:105
-#, fuzzy
 msgid "write multi-pack index containing only given indexes"
-msgstr "git multi-pack-index [<opcions>] verify"
+msgstr ""
+"escriu un map de bits multi-paquet que contingui només els índexs donats"
 
 #: builtin/multi-pack-index.c:107
-#, fuzzy
 msgid "refs snapshot for selecting bitmap commits"
-msgstr "instantània de refs per seleccionar entregues de mapa de bits"
+msgstr "instantània de referències per seleccionar les comissions de mapa de bits"
 
-#: builtin/multi-pack-index.c:202
+#: builtin/multi-pack-index.c:206
 #, fuzzy
 msgid ""
 "during repack, collect pack-files of smaller size into a batch that is "
 "larger than this size"
 msgstr ""
-"durant el reempaquetament dels fitxers de recollida de paquets de mida més "
+"durant el reempaquetament, dels fitxers de recollida de paquets de mida més "
 "petita en un lot que és més gran que aquesta mida"
 
 #: builtin/mv.c:18
@@ -18861,53 +18604,53 @@ msgstr "%s, origen=%s, destí=%s"
 msgid "Renaming %s to %s\n"
 msgstr "S'està canviant el nom de %s a %s\n"
 
-#: builtin/mv.c:314 builtin/remote.c:790 builtin/repack.c:853
+#: builtin/mv.c:314 builtin/remote.c:790 builtin/repack.c:857
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "el canvi del nom de «%s» ha fallat"
 
-#: builtin/name-rev.c:465
+#: builtin/name-rev.c:474
 msgid "git name-rev [<options>] <commit>..."
 msgstr "git name-rev [<opcions>] <comissió>..."
 
-#: builtin/name-rev.c:466
+#: builtin/name-rev.c:475
 msgid "git name-rev [<options>] --all"
 msgstr "git name-rev [<opcions>] --all"
 
-#: builtin/name-rev.c:467
+#: builtin/name-rev.c:476
 msgid "git name-rev [<options>] --stdin"
 msgstr "git name-rev [<opcions>] --stdin"
 
-#: builtin/name-rev.c:524
-#, fuzzy
+#: builtin/name-rev.c:533
 msgid "print only ref-based names (no object names)"
-msgstr "imprimeix només les branques de l'objecte"
+msgstr ""
+"imprimeix només els noms basats en referències (no els noms d'objecte)"
 
-#: builtin/name-rev.c:525
+#: builtin/name-rev.c:534
 msgid "only use tags to name the commits"
 msgstr "només usa les etiquetes per a anomenar les comissions"
 
-#: builtin/name-rev.c:527
+#: builtin/name-rev.c:536
 msgid "only use refs matching <pattern>"
 msgstr "només usa les referències que coincideixin amb <patró>"
 
-#: builtin/name-rev.c:529
+#: builtin/name-rev.c:538
 msgid "ignore refs matching <pattern>"
 msgstr "ignora les referències que coincideixin amb <patró>"
 
-#: builtin/name-rev.c:531
+#: builtin/name-rev.c:540
 msgid "list all commits reachable from all refs"
 msgstr "llista totes les comissions abastables de totes les referències"
 
-#: builtin/name-rev.c:532
+#: builtin/name-rev.c:541
 msgid "read from stdin"
 msgstr "llegeix de stdin"
 
-#: builtin/name-rev.c:533
+#: builtin/name-rev.c:542
 msgid "allow to print `undefined` names (default)"
 msgstr "permet imprimir els noms «undefined» (per defecte)"
 
-#: builtin/name-rev.c:539
+#: builtin/name-rev.c:548
 msgid "dereference tags in the input (internal use)"
 msgstr "desreferencia les etiquetes en l'entrada (ús intern)"
 
@@ -19028,26 +18771,26 @@ msgstr "git notes get-ref"
 msgid "Write/edit the notes for the following object:"
 msgstr "Escriviu/editeu les notes per l'objecte següent:"
 
-#: builtin/notes.c:150
+#: builtin/notes.c:149
 #, c-format
 msgid "unable to start 'show' for object '%s'"
 msgstr "no s'ha pogut iniciar «show» per a l'objecte «%s»"
 
-#: builtin/notes.c:154
+#: builtin/notes.c:153
 msgid "could not read 'show' output"
 msgstr "no s'ha pogut llegir la sortida de «show»"
 
-#: builtin/notes.c:162
+#: builtin/notes.c:161
 #, c-format
 msgid "failed to finish 'show' for object '%s'"
 msgstr "S'ha produït un error en finalitzar «show» per a l'objecte «%s»"
 
-#: builtin/notes.c:195
+#: builtin/notes.c:194
 msgid "please supply the note contents using either -m or -F option"
 msgstr ""
 "especifiqueu el contingut de la nota fent servir l'opció -m o l'opció -F"
 
-#: builtin/notes.c:204
+#: builtin/notes.c:203
 msgid "unable to write note object"
 msgstr "no s'ha pogut escriure l'objecte de nota"
 
@@ -19056,7 +18799,7 @@ msgstr "no s'ha pogut escriure l'objecte de nota"
 msgid "the note contents have been left in %s"
 msgstr "s'han deixat els continguts de la nota en %s"
 
-#: builtin/notes.c:240 builtin/tag.c:577
+#: builtin/notes.c:240 builtin/tag.c:581
 #, c-format
 msgid "could not open or read '%s'"
 msgstr "no s'ha pogut obrir o llegir «%s»"
@@ -19097,8 +18840,8 @@ msgstr "s'està refusant %s les notes en %s (fora de refs/notes/)"
 
 #: builtin/notes.c:374 builtin/notes.c:429 builtin/notes.c:507
 #: builtin/notes.c:519 builtin/notes.c:596 builtin/notes.c:663
-#: builtin/notes.c:813 builtin/notes.c:961 builtin/notes.c:983
-#: builtin/prune-packed.c:25 builtin/tag.c:587
+#: builtin/notes.c:813 builtin/notes.c:965 builtin/notes.c:987
+#: builtin/prune-packed.c:25 builtin/receive-pack.c:2487 builtin/tag.c:591
 msgid "too many arguments"
 msgstr "hi ha massa arguments"
 
@@ -19145,7 +18888,7 @@ msgstr ""
 msgid "Overwriting existing notes for object %s\n"
 msgstr "S'estan sobreescrivint les notes existents de l'objecte %s\n"
 
-#: builtin/notes.c:473 builtin/notes.c:635 builtin/notes.c:900
+#: builtin/notes.c:473 builtin/notes.c:635 builtin/notes.c:904
 #, c-format
 msgid "Removing note for object %s\n"
 msgstr "S'està eliminant la nota de l'objecte %s\n"
@@ -19269,19 +19012,19 @@ msgstr "cal especificar una referència de notes a fusionar"
 msgid "unknown -s/--strategy: %s"
 msgstr "-s/--strategy desconeguda: %s"
 
-#: builtin/notes.c:871
+#: builtin/notes.c:874
 #, c-format
 msgid "a notes merge into %s is already in-progress at %s"
 msgstr "una fusió de notes a %s ja està en curs a %s"
 
-#: builtin/notes.c:874
+#: builtin/notes.c:878
 #, c-format
 msgid "failed to store link to current notes ref (%s)"
 msgstr ""
 "s'ha produït un error en emmagatzemar l'enllaç a la referència de notes "
 "actual (%s)"
 
-#: builtin/notes.c:876
+#: builtin/notes.c:880
 #, c-format
 msgid ""
 "Automatic notes merge failed. Fix conflicts in %s and commit the result with"
@@ -19292,41 +19035,41 @@ msgstr ""
 "cometeu el resultat amb «git notes merge --commit», o avorteu la fusió amb "
 "«git notes merge --abort».\n"
 
-#: builtin/notes.c:895 builtin/tag.c:590
+#: builtin/notes.c:899 builtin/tag.c:594
 #, c-format
 msgid "Failed to resolve '%s' as a valid ref."
 msgstr "S'ha produït un error en resoldre «%s» com a referència vàlida."
 
-#: builtin/notes.c:898
+#: builtin/notes.c:902
 #, c-format
 msgid "Object %s has no note\n"
 msgstr "L'objecte %s no té cap nota\n"
 
-#: builtin/notes.c:910
+#: builtin/notes.c:914
 msgid "attempt to remove non-existent note is not an error"
 msgstr "l'intent d'eliminar una nota no existent no és un error"
 
-#: builtin/notes.c:913
+#: builtin/notes.c:917
 msgid "read object names from the standard input"
 msgstr "llegeix els noms d'objecte des de l'entrada estàndard"
 
-#: builtin/notes.c:952 builtin/prune.c:132 builtin/worktree.c:147
+#: builtin/notes.c:956 builtin/prune.c:144 builtin/worktree.c:147
 msgid "do not remove, show only"
 msgstr "no eliminis, només mostra"
 
-#: builtin/notes.c:953
+#: builtin/notes.c:957
 msgid "report pruned notes"
 msgstr "informa de notes podades"
 
-#: builtin/notes.c:996
+#: builtin/notes.c:1000
 msgid "notes-ref"
 msgstr "referència de notes"
 
-#: builtin/notes.c:997
+#: builtin/notes.c:1001
 msgid "use notes from <notes-ref>"
 msgstr "usa les notes de <referència-de-notes>"
 
-#: builtin/notes.c:1032 builtin/stash.c:1752
+#: builtin/notes.c:1036 builtin/stash.c:1818
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr "subordre desconeguda: %s"
@@ -19355,9 +19098,9 @@ msgstr ""
 "%<PRIuMAX> al paquet %s"
 
 #: builtin/pack-objects.c:580
-#, fuzzy, c-format
+#, c-format
 msgid "bad packed object CRC for %s"
-msgstr "objecte CRC mal empaquetat per a percentatges"
+msgstr "CRC de l'objecte empaquetat malmès per a %s"
 
 #: builtin/pack-objects.c:591
 #, c-format
@@ -19375,9 +19118,9 @@ msgid "ordered %u objects, expected %<PRIu32>"
 msgstr "ordenats %u objectes, s'esperaven %<PRIu32>"
 
 #: builtin/pack-objects.c:1036
-#, fuzzy, c-format
+#, c-format
 msgid "expected object at offset %<PRIuMAX> in pack %s"
-msgstr "el paquet té un objecte incorrecte a la posició %<PRIuMAX>: %s"
+msgstr "objecte esperat a la posició %<PRIuMAX> al paquet %s"
 
 #: builtin/pack-objects.c:1160
 msgid "disabling bitmap writing, packs are split due to pack.packSizeLimit"
@@ -19395,9 +19138,8 @@ msgid "failed to stat %s"
 msgstr "s'ha produït un error en fer stat a %s"
 
 #: builtin/pack-objects.c:1268
-#, fuzzy
 msgid "failed to write bitmap index"
-msgstr "escriu índex de mapa de bits"
+msgstr "s'ha produït un error en escriure l'índex de mapa de bits"
 
 #: builtin/pack-objects.c:1294
 #, c-format
@@ -19425,23 +19167,24 @@ msgid "Counting objects"
 msgstr "S'estan comptant els objectes"
 
 #: builtin/pack-objects.c:2439
-#, fuzzy, c-format
+#, c-format
 msgid "unable to parse object header of %s"
-msgstr "no s'ha pogut analitzar la capçalera de l'objecte dels percentatges"
+msgstr "no s'ha pogut analitzar la capçalera de l'objecte de %s"
 
 #: builtin/pack-objects.c:2509 builtin/pack-objects.c:2525
 #: builtin/pack-objects.c:2535
-#, fuzzy, c-format
+#, c-format
 msgid "object %s cannot be read"
-msgstr "no es poden llegir els objectes percentuals"
+msgstr "no es pot llegir l'objecte %s"
 
 #: builtin/pack-objects.c:2512 builtin/pack-objects.c:2539
-#, fuzzy, c-format
+#, c-format
 msgid "object %s inconsistent object length (%<PRIuMAX> vs %<PRIuMAX>)"
-msgstr "objecte%s longitud d'objecte inconsistent (%<PRIuMAX> vs%<PRIuMAX>)"
+msgstr ""
+"l'objecte %s té una longitud d'objecte inconsistent (%<PRIuMAX> vs "
+"%<PRIuMAX>)"
 
 #: builtin/pack-objects.c:2549
-#, fuzzy
 msgid "suboptimal pack - out of memory"
 msgstr "paquet subòptim - sense memòria"
 
@@ -19482,24 +19225,24 @@ msgstr ""
 "'%')"
 
 #: builtin/pack-objects.c:3212
-#, fuzzy, c-format
+#, c-format
 msgid "could not get type of object %s in pack %s"
-msgstr "no s'ha pogut obtenir el tipus de l'objecte: %s"
+msgstr "no s'ha pogut obtenir el tipus de l'objecte %s al paquet %s"
 
 #: builtin/pack-objects.c:3340 builtin/pack-objects.c:3351
 #: builtin/pack-objects.c:3365
-#, fuzzy, c-format
+#, c-format
 msgid "could not find pack '%s'"
-msgstr "no s'ha pogut finalitzar «%s»"
+msgstr "no s'ha pogut trobar el paquet «%s»"
 
 #: builtin/pack-objects.c:3408
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "expected edge object ID, got garbage:\n"
 " %s"
 msgstr ""
-"s'esperava un identificador d'objecte de vora amb brossa s'han obtingut "
-"percentatges d'escombraries"
+"s'esperava un identificador vora de l'objecte, s'ha rebut brossa:\n"
+" %s"
 
 #: builtin/pack-objects.c:3414
 #, c-format
@@ -19507,7 +19250,7 @@ msgid ""
 "expected object ID, got garbage:\n"
 " %s"
 msgstr ""
-"s'esperava un ID d'objecte, s'ha rebut brossa:\n"
+"s'esperava un identificador d'objecte, s'ha rebut brossa:\n"
 " %s"
 
 #: builtin/pack-objects.c:3507
@@ -19515,24 +19258,22 @@ msgid "invalid value for --missing"
 msgstr "valor no vàlid per a --missing"
 
 #: builtin/pack-objects.c:3532 builtin/pack-objects.c:3619
-#, fuzzy
 msgid "cannot open pack index"
 msgstr "no s'ha pogut obrir l'índex del paquet"
 
 #: builtin/pack-objects.c:3541
-#, fuzzy, c-format
+#, c-format
 msgid "loose object at %s could not be examined"
-msgstr "no s'han pogut examinar els objectes solts"
+msgstr "no s'ha pogut examinar l'objecte solt a %s"
 
 #: builtin/pack-objects.c:3627
-#, fuzzy
 msgid "unable to force loose object"
 msgstr "no s'ha pogut forçar l'objecte solt"
 
 #: builtin/pack-objects.c:3757
-#, fuzzy, c-format
+#, c-format
 msgid "not a rev '%s'"
-msgstr "no és una revisió \"%s\""
+msgstr "«%s» no és una revisió"
 
 #: builtin/pack-objects.c:3760 builtin/rev-parse.c:1061
 #, c-format
@@ -19633,9 +19374,8 @@ msgid "include objects referred to by the index"
 msgstr "inclou els objectes als quals faci referència l'índex"
 
 #: builtin/pack-objects.c:3924
-#, fuzzy
 msgid "read packs from stdin"
-msgstr "llegeix les actualitzacions des de stdin"
+msgstr "llegeix els paquets des de stdin"
 
 #: builtin/pack-objects.c:3926
 msgid "output pack to stdout"
@@ -19657,10 +19397,9 @@ msgstr "empaqueta els objectes inabastables solts"
 
 #: builtin/pack-objects.c:3934
 msgid "unpack unreachable objects newer than <time>"
-msgstr "desempaqueta els objectes inabastables més nous que <hora>"
+msgstr "desempaqueta els objectes inabastables més nous que <data>"
 
 #: builtin/pack-objects.c:3937
-#, fuzzy
 msgid "use the sparse reachability algorithm"
 msgstr "utilitza l'algorisme d'accessibilitat dispers"
 
@@ -19677,7 +19416,6 @@ msgid "ignore packs that have companion .keep file"
 msgstr "ignora els paquets que tinguin un fitxer .keep corresponent"
 
 #: builtin/pack-objects.c:3945
-#, fuzzy
 msgid "ignore this pack"
 msgstr "ignora aquest paquet"
 
@@ -19700,7 +19438,6 @@ msgid "write a bitmap index together with the pack index"
 msgstr "escriu un índex de mapa de bits juntament amb l'índex de paquet"
 
 #: builtin/pack-objects.c:3957
-#, fuzzy
 msgid "write a bitmap index if possible"
 msgstr "escriu un índex de mapa de bits si és possible"
 
@@ -19714,74 +19451,59 @@ msgid "do not pack objects in promisor packfiles"
 msgstr "no empaqueta els objectes als fitxers del paquet promisor"
 
 #: builtin/pack-objects.c:3966
-#, fuzzy
 msgid "respect islands during delta compression"
 msgstr "respecta les illes durant la compressió delta"
 
 #: builtin/pack-objects.c:3968
-#, fuzzy
 msgid "protocol"
 msgstr "protocol"
 
 #: builtin/pack-objects.c:3969
-#, fuzzy
 msgid "exclude any configured uploadpack.blobpackfileuri with this protocol"
 msgstr ""
-"exclou qualsevol uppack.blobpackfileuri configurat amb aquest protocol"
+"exclou qualsevol uploadpack.blobpackfileuri configurat amb aquest protocol"
 
 #: builtin/pack-objects.c:4002
-#, fuzzy, c-format
+#, c-format
 msgid "delta chain depth %d is too deep, forcing %d"
-msgstr ""
-"la profunditat de la cadena delta és massa profunda forçant un percentatge"
+msgstr "la profunditat de la cadena delta %d és massa profunda, forçant %d"
 
 #: builtin/pack-objects.c:4007
-#, fuzzy, c-format
+#, c-format
 msgid "pack.deltaCacheLimit is too high, forcing %d"
-msgstr "pack.deltaCacheLimit és massa alt forçant un percentatge"
+msgstr "pack.deltaCacheLimit és massa alt, forçant %d"
 
 #: builtin/pack-objects.c:4063
-#, fuzzy
 msgid "--max-pack-size cannot be used to build a pack for transfer"
 msgstr ""
 "--max-pack-size no es pot utilitzar per construir un paquet per a la "
 "transferència"
 
 #: builtin/pack-objects.c:4065
-#, fuzzy
 msgid "minimum pack size limit is 1 MiB"
 msgstr "el límit mínim de mida del paquet és 1 MiB"
 
 #: builtin/pack-objects.c:4070
-#, fuzzy
 msgid "--thin cannot be used to build an indexable pack"
 msgstr "--thin no es pot utilitzar per construir un paquet indexable"
 
-#: builtin/pack-objects.c:4073
-#, fuzzy
-msgid "--keep-unreachable and --unpack-unreachable are incompatible"
-msgstr "--keep-unreachable i --unpack-unreachable són incompatibles"
-
 #: builtin/pack-objects.c:4079
-#, fuzzy
 msgid "cannot use --filter without --stdout"
 msgstr "no es pot utilitzar --filter sense --stdout"
 
 #: builtin/pack-objects.c:4081
-#, fuzzy
 msgid "cannot use --filter with --stdin-packs"
-msgstr "no es pot utilitzar --filter sense --stdout"
+msgstr "no es pot utilitzar --filter sense --stdin-packs"
 
 #: builtin/pack-objects.c:4085
-#, fuzzy
 msgid "cannot use internal rev list with --stdin-packs"
-msgstr "no es poden especificar noms de camí amb --stdin"
+msgstr "no es pot utilitzar la llista de revisió interna amb --stdin-packs"
 
 #: builtin/pack-objects.c:4144
 msgid "Enumerating objects"
 msgstr "S'estan enumerant els objectes"
 
-#: builtin/pack-objects.c:4181
+#: builtin/pack-objects.c:4180
 #, c-format
 msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
@@ -19823,22 +19545,22 @@ msgstr "git prune-packed [-n | --dry-run] [-q | --quiet]"
 
 #: builtin/prune.c:14
 msgid "git prune [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]"
-msgstr "git prune [-n] [-v] [--progress] [--expire <hora>] [--] [<head>...]"
+msgstr "git prune [-n] [-v] [--progress] [--expire <data>] [--] [<head>...]"
 
-#: builtin/prune.c:133
+#: builtin/prune.c:145
 msgid "report pruned objects"
 msgstr "informa d'objectes podats"
 
-#: builtin/prune.c:136
+#: builtin/prune.c:148
 msgid "expire objects older than <time>"
-msgstr "fes caducar els objectes més vells que <hora>"
+msgstr "fes caducar els objectes més antics que <data>"
 
-#: builtin/prune.c:138
+#: builtin/prune.c:150
 #, fuzzy
 msgid "limit traversal to objects outside promisor packfiles"
-msgstr "limita el trànsit d'objectes fora dels fitxers del paquet promisor"
+msgstr "limita la transició als objectes fora dels fitxers de paquet de promisors"
 
-#: builtin/prune.c:151
+#: builtin/prune.c:163
 msgid "cannot prune in a precious-objects repo"
 msgstr "no es pot podar en un repositori d'objectes preciosos"
 
@@ -19852,44 +19574,48 @@ msgid "git pull [<options>] [<repository> [<refspec>...]]"
 msgstr ""
 "git pull [<opcions>] [<repositori> [<especificació-de-referència>...]]"
 
-#: builtin/pull.c:123
+#: builtin/pull.c:124
 msgid "control for recursive fetching of submodules"
 msgstr "controla l'obtenció recursiva de submòduls"
 
-#: builtin/pull.c:127
+#: builtin/pull.c:128
 msgid "Options related to merging"
 msgstr "Opcions relacionades amb fusionar"
 
-#: builtin/pull.c:130
+#: builtin/pull.c:131
 msgid "incorporate changes by rebasing rather than merging"
 msgstr "incorpora els canvis fent «rebase» en lloc de fusionar"
 
-#: builtin/pull.c:158 builtin/revert.c:126
+#: builtin/pull.c:159 builtin/revert.c:126
 msgid "allow fast-forward"
 msgstr "permet l'avanç ràpid"
 
-#: builtin/pull.c:167 parse-options.h:339
+#: builtin/pull.c:165
+msgid "control use of pre-merge-commit and commit-msg hooks"
+msgstr "controla l'ús dels lligams pre-merge-commit i commit-msg"
+
+#: builtin/pull.c:171 parse-options.h:340
 msgid "automatically stash/stash pop before and after"
 msgstr "fes «stash» i «stash pop» automàticament abans i després"
 
-#: builtin/pull.c:183
+#: builtin/pull.c:187
 msgid "Options related to fetching"
 msgstr "Opcions relacionades amb obtenir"
 
-#: builtin/pull.c:193
+#: builtin/pull.c:197
 msgid "force overwrite of local branch"
 msgstr "força la sobreescriptura de la branca local"
 
-#: builtin/pull.c:201
+#: builtin/pull.c:205
 msgid "number of submodules pulled in parallel"
 msgstr "nombre de submòduls baixats en paral·lel"
 
-#: builtin/pull.c:317
+#: builtin/pull.c:321
 #, c-format
 msgid "Invalid value for pull.ff: %s"
 msgstr "Valor no vàlid per a pull.ff: %s"
 
-#: builtin/pull.c:445
+#: builtin/pull.c:449
 msgid ""
 "There is no candidate for rebasing against among the refs that you just "
 "fetched."
@@ -19897,14 +19623,14 @@ msgstr ""
 "No hi ha cap candidat sobre el qual fer «rebase» entre les referències que "
 "acabeu d'obtenir."
 
-#: builtin/pull.c:447
+#: builtin/pull.c:451
 msgid ""
 "There are no candidates for merging among the refs that you just fetched."
 msgstr ""
 "No hi ha candidats per a fusionar entre les referències que acabeu "
 "d'obtenir."
 
-#: builtin/pull.c:448
+#: builtin/pull.c:452
 msgid ""
 "Generally this means that you provided a wildcard refspec which had no\n"
 "matches on the remote end."
@@ -19912,7 +19638,7 @@ msgstr ""
 "Generalment això vol dir que heu proveït una especificació de\n"
 "referència de comodí que no tenia cap coincidència en el costat remot."
 
-#: builtin/pull.c:451
+#: builtin/pull.c:455
 #, c-format
 msgid ""
 "You asked to pull from the remote '%s', but did not specify\n"
@@ -19923,43 +19649,44 @@ msgstr ""
 "Perquè aquest no és el remot configurat per defecte per a la vostra\n"
 "branca actual, heu d'especificar una branca en la línia d'ordres."
 
-#: builtin/pull.c:456 builtin/rebase.c:951
+#: builtin/pull.c:460 builtin/rebase.c:951
 msgid "You are not currently on a branch."
 msgstr "Actualment no sou en cap branca."
 
-#: builtin/pull.c:458 builtin/pull.c:473
+#: builtin/pull.c:462 builtin/pull.c:477
 msgid "Please specify which branch you want to rebase against."
 msgstr "Especifiqueu sobre quina branca voleu fer «rebase»."
 
-#: builtin/pull.c:460 builtin/pull.c:475
+#: builtin/pull.c:464 builtin/pull.c:479
 msgid "Please specify which branch you want to merge with."
 msgstr "Especifiqueu amb quina branca voleu fusionar."
 
-#: builtin/pull.c:461 builtin/pull.c:476
+#: builtin/pull.c:465 builtin/pull.c:480
 msgid "See git-pull(1) for details."
 msgstr "Vegeu git-pull(1) per a més informació."
 
-#: builtin/pull.c:463 builtin/pull.c:469 builtin/pull.c:478
+#: builtin/pull.c:467 builtin/pull.c:473 builtin/pull.c:482
 #: builtin/rebase.c:957
 msgid "<remote>"
 msgstr "<remot>"
 
-#: builtin/pull.c:463 builtin/pull.c:478 builtin/pull.c:483
+#: builtin/pull.c:467 builtin/pull.c:482 builtin/pull.c:487
+#: contrib/scalar/scalar.c:375
 msgid "<branch>"
 msgstr "<branca>"
 
-#: builtin/pull.c:471 builtin/rebase.c:949
+#: builtin/pull.c:475 builtin/rebase.c:949
 msgid "There is no tracking information for the current branch."
 msgstr "No hi ha cap informació de seguiment per a la branca actual."
 
-#: builtin/pull.c:480
+#: builtin/pull.c:484
 msgid ""
 "If you wish to set tracking information for this branch you can do so with:"
 msgstr ""
 "Si voleu establir informació de seguiment per a aquesta branca, podeu fer-ho"
 " amb:"
 
-#: builtin/pull.c:485
+#: builtin/pull.c:489
 #, c-format
 msgid ""
 "Your configuration specifies to merge with the ref '%s'\n"
@@ -19968,23 +19695,23 @@ msgstr ""
 "La vostra configuració especifica fusionar amb la referència «%s»\n"
 "del remot, però no s'ha obtingut tal referència."
 
-#: builtin/pull.c:596
+#: builtin/pull.c:600
 #, c-format
 msgid "unable to access commit %s"
 msgstr "no s'ha pogut accedir a la comissió %s"
 
-#: builtin/pull.c:902
+#: builtin/pull.c:908
 msgid "ignoring --verify-signatures for rebase"
 msgstr "s'està ignorant --verify-signatures en fer «rebase»"
 
-#: builtin/pull.c:936
+#: builtin/pull.c:969
 #, fuzzy
 msgid ""
 "You have divergent branches and need to specify how to reconcile them.\n"
 "You can do so by running one of the following commands sometime before\n"
 "your next pull:\n"
 "\n"
-"  git config pull.rebase false  # merge (the default strategy)\n"
+"  git config pull.rebase false  # merge\n"
 "  git config pull.rebase true   # rebase\n"
 "  git config pull.ff only       # fast-forward only\n"
 "\n"
@@ -19993,33 +19720,33 @@ msgid ""
 "or --ff-only on the command line to override the configured default per\n"
 "invocation.\n"
 msgstr ""
-"Baixar sense especificar com conciliar branques divergents està\n"
-"desaconsellat. Podeu desactivar aquest missatge executant una de les\n"
-"següents ordres abans de la propera baixada:\n"
+"Teniu branques divergents i necessiteu especificar com reconciliar-les.\n"
+"Podeu fer-ho executant una de les ordres següents en abans de que torneu\n"
+"a fer una baxiada:\n"
 "\n"
 "  git config pull.rebase false  # merge (estratègia per defecte)\n"
 "  git config pull.rebase true   # rebase\n"
-"  git config pull.ff only       # només fast-forward\n"
+"  git config pull.ff only       # fast-forward only\n"
 "\n"
 "Podeu reemplaçar «git config» per «git config --global» per a establir una\n"
 "preferència per defecte per a tots els repositoris. Podeu també usar --rebase,\n"
 "--no-rebase o --ff-only en la línia d'ordres per sobreescriure el valor\n"
 "per defecte configuració en aquesta execució.\n"
 
-#: builtin/pull.c:1010
+#: builtin/pull.c:1046
 msgid "Updating an unborn branch with changes added to the index."
 msgstr ""
 "S'està actualitzant una branca no nascuda amb canvis afegits a l'índex."
 
-#: builtin/pull.c:1014
+#: builtin/pull.c:1050
 msgid "pull with rebase"
 msgstr "baixar fent «rebase»"
 
-#: builtin/pull.c:1015
+#: builtin/pull.c:1051
 msgid "please commit or stash them."
 msgstr "cometeu-los o emmagatzemeu-los."
 
-#: builtin/pull.c:1040
+#: builtin/pull.c:1076
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -20030,7 +19757,7 @@ msgstr ""
 "s'està avançant ràpidament el vostre arbre de treball des de\n"
 "la comissió %s."
 
-#: builtin/pull.c:1046
+#: builtin/pull.c:1082
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -20047,25 +19774,23 @@ msgstr ""
 "$ git reset --hard\n"
 "per a recuperar."
 
-#: builtin/pull.c:1061
+#: builtin/pull.c:1097
 msgid "Cannot merge multiple branches into empty head."
 msgstr "No es poden fusionar múltiples branques a un HEAD buit."
 
-#: builtin/pull.c:1066
+#: builtin/pull.c:1102
 msgid "Cannot rebase onto multiple branches."
 msgstr "No es pot fer «rebase» sobre múltiples branques."
 
-#: builtin/pull.c:1068
-#, fuzzy
+#: builtin/pull.c:1104
 msgid "Cannot fast-forward to multiple branches."
-msgstr "No es pot fer «rebase» sobre múltiples branques."
+msgstr "No es pot fer un avançament ràpid a branques múltiples."
 
-#: builtin/pull.c:1082
-#, fuzzy
+#: builtin/pull.c:1119
 msgid "Need to specify how to reconcile divergent branches."
-msgstr "Cal especificar com conciliar les branques divergents."
+msgstr "Cal especificar com reconciliar les branques divergents."
 
-#: builtin/pull.c:1096
+#: builtin/pull.c:1133
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "no es pot fer «rebase» amb modificacions als submòduls enregistrades "
@@ -20249,7 +19974,7 @@ msgstr "S'està pujant a %s\n"
 msgid "failed to push some refs to '%s'"
 msgstr "s'ha produït un error en pujar algunes referències a «%s»"
 
-#: builtin/push.c:544 builtin/submodule--helper.c:3258
+#: builtin/push.c:544 builtin/submodule--helper.c:3259
 msgid "repository"
 msgstr "repositori"
 
@@ -20322,10 +20047,6 @@ msgstr "signa la pujada amb GPG"
 msgid "request atomic transaction on remote side"
 msgstr "demana una transacció atòmica al costat remot"
 
-#: builtin/push.c:592
-msgid "--delete is incompatible with --all, --mirror and --tags"
-msgstr "--delete és incompatible amb --all, --mirror i --tags"
-
 #: builtin/push.c:594
 msgid "--delete doesn't make sense without any refs"
 msgstr "--delete no té sentit sense referències"
@@ -20355,25 +20076,13 @@ msgstr ""
 "\n"
 "    git push <nom>\n"
 
-#: builtin/push.c:630
-msgid "--all and --tags are incompatible"
-msgstr "--all i --tags són incompatibles"
-
 #: builtin/push.c:632
 msgid "--all can't be combined with refspecs"
 msgstr "--all no es pot combinar amb especificacions de referència"
 
-#: builtin/push.c:636
-msgid "--mirror and --tags are incompatible"
-msgstr "--mirror i --tags són incompatibles"
-
 #: builtin/push.c:638
 msgid "--mirror can't be combined with refspecs"
 msgstr "--mirror no es pot combinar amb especificacions de referència"
-
-#: builtin/push.c:641
-msgid "--all and --mirror are incompatible"
-msgstr "--all i --mirror són incompatibles"
 
 #: builtin/push.c:648
 msgid "push options must not have new line characters"
@@ -20405,19 +20114,17 @@ msgid "passed to 'git log'"
 msgstr "passa-ho a «git log»"
 
 #: builtin/range-diff.c:35
-#, fuzzy
 msgid "only emit output related to the first range"
-msgstr "mostra només les comissions que no siguin en la primera branca"
+msgstr "emet només la sortida relacionada amb el primer interval"
 
 #: builtin/range-diff.c:37
-#, fuzzy
 msgid "only emit output related to the second range"
-msgstr "fes que la sortida sigui relativa al directori superior del projecte"
+msgstr "emet només la sortida relacionada amb el segon interval"
 
 #: builtin/range-diff.c:60 builtin/range-diff.c:64
-#, fuzzy, c-format
+#, c-format
 msgid "not a commit range: '%s'"
-msgstr "cap .. en rang: «%s»"
+msgstr "no és un rang de comissions: «%s»"
 
 #: builtin/range-diff.c:74
 msgid "single arg format must be symmetric range"
@@ -20428,15 +20135,14 @@ msgid "need two commit ranges"
 msgstr "calen dos rangs de comissió"
 
 #: builtin/read-tree.c:41
-#, fuzzy
 msgid ""
 "git read-tree [(-m [--trivial] [--aggressive] | --reset | --prefix=<prefix>)"
 " [-u | -i]] [--no-sparse-checkout] [--index-output=<file>] (--empty | <tree-"
 "ish1> [<tree-ish2> [<tree-ish3>]])"
 msgstr ""
 "git read-tree [(-m [--trivial] [--aggressive] | --reset | --prefix=<prefix>)"
-" [-u [--exclude-per-directory=<gitignore>] | -i]] [--no-sparse-checkout] "
-"[--index-output=<fitxer>] (--empty | <arbre1> [<arbre2> [<arbre3>]])"
+" [-u | -i]] [--no-sparse-checkout] [--index-output=<file>] (--empty | <tree-"
+"ish1> [<tree-ish2> [<tree-ish3>]])"
 
 #: builtin/read-tree.c:116
 msgid "write resulting index to <file>"
@@ -20503,30 +20209,27 @@ msgid "debug unpack-trees"
 msgstr "depura unpack-trees"
 
 #: builtin/read-tree.c:149
-#, fuzzy
 msgid "suppress feedback messages"
 msgstr "suprimeix els missatges de retroacció"
 
 #: builtin/read-tree.c:183
 msgid "You need to resolve your current index first"
-msgstr "Primer heu de resoldre l'índex actual"
+msgstr "Primer heu de resoldre el vostre índex actual"
 
 #: builtin/rebase.c:35
-#, fuzzy
 msgid ""
 "git rebase [-i] [options] [--exec <cmd>] [--onto <newbase> | --keep-base] "
 "[<upstream> [<branch>]]"
 msgstr ""
-"git rebase [-i] [opcions] [--exec <cmd>] [--onto <newbase> | --keep-base] "
+"git rebase [-i] [options] [--exec <cmd>] [--onto <newbase> | --keep-base] "
 "[<upstream> [<branch>]]"
 
 #: builtin/rebase.c:37
-#, fuzzy
 msgid ""
 "git rebase [-i] [options] [--exec <cmd>] [--onto <newbase>] --root "
 "[<branch>]"
 msgstr ""
-"git rebase [-i] [opcions] [--exec <cmd>] [--onto <newbase>] --root "
+"git rebase [-i] [options] [--exec <cmd>] [--onto <newbase>] --root "
 "[<branch>]"
 
 #: builtin/rebase.c:39
@@ -20547,29 +20250,28 @@ msgid "could not generate todo list"
 msgstr "no s'ha pogut generar la llista per a fer"
 
 #: builtin/rebase.c:331
-#, fuzzy
 msgid "a base commit must be provided with --upstream or --onto"
 msgstr "s'ha de proporcionar una comissió base amb --upstream o --onto"
 
 #: builtin/rebase.c:390
-#, fuzzy, c-format
+#, c-format
 msgid "%s requires the merge backend"
-msgstr "%s requereix un «rebase» interactiu"
+msgstr "%s requereix un rerefons de fusió"
 
 #: builtin/rebase.c:432
-#, fuzzy, c-format
+#, c-format
 msgid "could not get 'onto': '%s'"
-msgstr "no s'ha pogut obtenir «onto» «%s»"
+msgstr "no s'ha pogut obtenir «onto»: «%s»"
 
 #: builtin/rebase.c:449
-#, fuzzy, c-format
+#, c-format
 msgid "invalid orig-head: '%s'"
-msgstr "orig-head '%s' no és vàlid"
+msgstr "orig-head no és vàlid: «%s»"
 
 #: builtin/rebase.c:474
-#, fuzzy, c-format
+#, c-format
 msgid "ignoring invalid allow_rerere_autoupdate: '%s'"
-msgstr "s'ignorarà allowrerereautoupdate «%s» no vàlid"
+msgstr "s'ignora allow_rerere_autoupdate no vàlid: «%s»"
 
 #: builtin/rebase.c:597
 msgid ""
@@ -20584,7 +20286,7 @@ msgstr ""
 "Per a avortar i tornar a l'estat anterior abans de l'ordre «git rebase», executeu «git rebase --abort»."
 
 #: builtin/rebase.c:680
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "\n"
 "git encountered an error while preparing the patches to replay\n"
@@ -20594,15 +20296,19 @@ msgid ""
 "\n"
 "As a result, git cannot rebase them."
 msgstr ""
-"git va trobar un error en preparar els pedaços per a tornar a reproduir "
-"aquests revisions per cent. Com a resultat git no pot refer-los."
+"\n"
+"git ha trobat un error en preparar els pedaços per a tornar a reproduir\n"
+"aquestes revisions:\n"
+"\n"
+"    %s\n"
+"\n"
+"Com a resultat, git no pot fer un «rebase» d'elles."
 
 #: builtin/rebase.c:925
-#, fuzzy, c-format
+#, c-format
 msgid "unrecognized empty type '%s'; valid values are \"drop\", \"keep\", and \"ask\"."
 msgstr ""
-"no es reconeix el tipus buit «%s»; els valors vàlids són «drop» «keep» i "
-"«ask»."
+"tipus buit no reconegut «%s»; els valors vàlids són «drop», «keep» i «ask»."
 
 #: builtin/rebase.c:943
 #, c-format
@@ -20635,7 +20341,6 @@ msgstr ""
 "\n"
 
 #: builtin/rebase.c:989
-#, fuzzy
 msgid "exec commands cannot contain newlines"
 msgstr "les ordres exec no poden contenir línies noves"
 
@@ -20648,7 +20353,6 @@ msgid "rebase onto given branch instead of upstream"
 msgstr "fes un «rebase» en la branca donada en comptes de la font"
 
 #: builtin/rebase.c:1025
-#, fuzzy
 msgid "use the merge-base of upstream and branch as the current base"
 msgstr "utilitza la base de fusió de la font i la branca com a base actual"
 
@@ -20665,19 +20369,16 @@ msgid "display a diffstat of what changed upstream"
 msgstr "mostra un «diffstat» del que ha canviat a la font"
 
 #: builtin/rebase.c:1035
-#, fuzzy
 msgid "do not show diffstat of what changed upstream"
-msgstr "no mostris «diffstat» de quina font ha canviat"
+msgstr "no mostris «diffstat» del que ha canviat a la font"
 
 #: builtin/rebase.c:1038
-#, fuzzy
 msgid "add a Signed-off-by trailer to each commit"
-msgstr "afegeix una línia signada per cada entrega"
+msgstr "afegeix un «trailer» tipus «Signed-off-by» a cada comissió"
 
 #: builtin/rebase.c:1041
-#, fuzzy
 msgid "make committer date match author date"
-msgstr "Agrupa per «comitter» en comptes de per autor"
+msgstr "fes que la data del «comitter» coincideixi amb la data de l'autor"
 
 #: builtin/rebase.c:1043
 msgid "ignore author date and use current date"
@@ -20744,7 +20445,6 @@ msgid "how to handle commits that become empty"
 msgstr "com gestionar les comissions que queden buides"
 
 #: builtin/rebase.c:1093
-#, fuzzy
 msgid "keep commits which start empty"
 msgstr "manté les comissions que comencen en blanc"
 
@@ -20753,10 +20453,8 @@ msgid "move commits that begin with squash!/fixup! under -i"
 msgstr "mou les comissions que comencen amb squash!/fixup! sota -i"
 
 #: builtin/rebase.c:1104
-#, fuzzy
 msgid "add exec lines after each commit of the editable list"
-msgstr ""
-"afegeix línies d'exec després de cada publicació de la llista editable"
+msgstr "afegeix línies d'exec després de cada comissió de la llista editable"
 
 #: builtin/rebase.c:1108
 msgid "allow rebasing commits with empty messages"
@@ -20764,7 +20462,7 @@ msgstr "permet fer «rebase» de les comissions amb missatges buits"
 
 #: builtin/rebase.c:1112
 msgid "try to rebase merges instead of skipping them"
-msgstr "intenta fer «rebase» de les fusions en comptes de ometre-les"
+msgstr "intenta fer «rebase» de les fusions en comptes d'ometre-les"
 
 #: builtin/rebase.c:1115
 msgid "use 'merge-base --fork-point' to refine upstream"
@@ -20787,9 +20485,8 @@ msgid "rebase all reachable commits up to the root(s)"
 msgstr "fes «rebase» de totes les comissions accessibles fins a l'arrel"
 
 #: builtin/rebase.c:1126
-#, fuzzy
 msgid "automatically re-schedule any `exec` that fails"
-msgstr "torna a planificar automàticament qualsevol `exec` que falli"
+msgstr "torna a planificar automàticament qualsevol «exec» que falli"
 
 #: builtin/rebase.c:1128
 msgid "apply all changes, even those already present upstream"
@@ -20800,23 +20497,8 @@ msgid "It looks like 'git am' is in progress. Cannot rebase."
 msgstr "Sembla que «git am» està en curs. No es pot fer «rebase»."
 
 #: builtin/rebase.c:1180
-#, fuzzy
 msgid "--preserve-merges was replaced by --rebase-merges"
-msgstr ""
-"git rebase --preserve-merges està en desús. Utilitzeu --rebase-merges en "
-"lloc seu."
-
-#: builtin/rebase.c:1193
-msgid "cannot combine '--keep-base' with '--onto'"
-msgstr "no es pot combinar «--keep-base» amb «--onto»"
-
-#: builtin/rebase.c:1195
-msgid "cannot combine '--keep-base' with '--root'"
-msgstr "no es pot combinar «--keep-base» amb «--root»"
-
-#: builtin/rebase.c:1199
-msgid "cannot combine '--root' with '--fork-point'"
-msgstr "no es pot combinar «--root» amb «--fork-point»"
+msgstr "--preserve-merges ha estat substituït per --rebase-merges"
 
 #: builtin/rebase.c:1202
 msgid "No rebase in progress?"
@@ -20848,7 +20530,7 @@ msgid "could not move back to %s"
 msgstr "no s'ha pogut tornar a %s"
 
 #: builtin/rebase.c:1325
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "It seems that there is already a %s directory, and\n"
 "I wonder if you are in the middle of another rebase.  If that is the\n"
@@ -20859,9 +20541,13 @@ msgid ""
 "and run me again.  I am stopping in case you still have something\n"
 "valuable there.\n"
 msgstr ""
-"Sembla que ja hi ha un directori per cent i em pregunto si està vostè enmig "
-"d'un altre rebase. Si és així, si us plau, provi-ho si no és així, si us "
-"plau inciti-me."
+"Sembla que ja exigeix un directori %s, i em pregunto\n"
+"si esteu enmig d'un altre «rebase». Si aquest és el cas, proveu\n"
+"\t%s\n"
+"Si no és cas\n"
+"\t%s\n"
+"i executeu aquesta ordre de nou. S'atura l'operació en cas que\n"
+"tingueu quelcom valuós.\n"
 
 #: builtin/rebase.c:1353
 msgid "switch `C' expects a numerical value"
@@ -20877,8 +20563,8 @@ msgid "--strategy requires --merge or --interactive"
 msgstr "--strategy requereix --merge o --interactive"
 
 #: builtin/rebase.c:1463
-msgid "cannot combine apply options with merge options"
-msgstr "no es poden combinar les opcions d'aplicació amb les opcions de fusió"
+msgid "apply options and merge options cannot be used together"
+msgstr "les opcions apply i merge no es poden usar juntes"
 
 #: builtin/rebase.c:1476
 #, fuzzy, c-format
@@ -20899,12 +20585,12 @@ msgid "Could not create new root commit"
 msgstr "No s'ha pogut crear una comissió arrel nova"
 
 #: builtin/rebase.c:1568
-#, fuzzy, c-format
+#, c-format
 msgid "'%s': need exactly one merge base with branch"
 msgstr "'%s' necessita exactament una base de fusió amb branca"
 
 #: builtin/rebase.c:1571
-#, fuzzy, c-format
+#, c-format
 msgid "'%s': need exactly one merge base"
 msgstr "'%s' necessita exactament una base de fusió"
 
@@ -20914,18 +20600,17 @@ msgid "Does not point to a valid commit '%s'"
 msgstr "No apunta a una comissió vàlida «%s»"
 
 #: builtin/rebase.c:1607
-#, fuzzy, c-format
+#, c-format
 msgid "no such branch/commit '%s'"
-msgstr "fatal no existeix aquesta branca/commit «%s»"
+msgstr "no existeix aquesta branca o comissió «%s»"
 
 #: builtin/rebase.c:1618 builtin/submodule--helper.c:39
-#: builtin/submodule--helper.c:2658
+#: builtin/submodule--helper.c:2659
 #, c-format
 msgid "No such ref: %s"
 msgstr "No hi ha tal referència: %s"
 
 #: builtin/rebase.c:1629
-#, fuzzy
 msgid "Could not resolve HEAD to a revision"
 msgstr "No s'ha pogut resoldre HEAD a una revisió"
 
@@ -20990,7 +20675,7 @@ msgstr "Avanç ràpid %s a %s.\n"
 msgid "git receive-pack <git-dir>"
 msgstr "git receive-pack <git-dir>"
 
-#: builtin/receive-pack.c:1280
+#: builtin/receive-pack.c:1275
 msgid ""
 "By default, updating the current branch in a non-bare repository\n"
 "is denied, because it will make the index and work tree inconsistent\n"
@@ -21021,7 +20706,7 @@ msgstr ""
 "per defecte, establiu la variable de configuració\n"
 "«receive.denyCurrentBranch» a «refuse»."
 
-#: builtin/receive-pack.c:1300
+#: builtin/receive-pack.c:1295
 msgid ""
 "By default, deleting the current branch is denied, because the next\n"
 "'git clone' won't result in any file checked out, causing confusion.\n"
@@ -21043,13 +20728,13 @@ msgstr ""
 "\n"
 "Per a silenciar aquest missatge, podeu establir-la a «refuse»."
 
-#: builtin/receive-pack.c:2480
+#: builtin/receive-pack.c:2474
 msgid "quiet"
 msgstr "silenciós"
 
-#: builtin/receive-pack.c:2495
-msgid "You must specify a directory."
-msgstr "Heu d'especificar un directori."
+#: builtin/receive-pack.c:2489
+msgid "you must specify a directory"
+msgstr "heu d'especificar un directori."
 
 #: builtin/reflog.c:17
 msgid ""
@@ -21057,7 +20742,7 @@ msgid ""
 "[--rewrite] [--updateref] [--stale-fix] [--dry-run | -n] [--verbose] [--all]"
 " <refs>..."
 msgstr ""
-"git reflog expire [--expire=<hora>] [--expire-unreachable=<hora>] "
+"git reflog expire [--expire=<data>] [--expire-unreachable=<data>] "
 "[--rewrite] [--updateref] [--stale-fix] [--dry-run | -n] [--verbose] [--all]"
 " <referències>..."
 
@@ -21073,41 +20758,41 @@ msgstr ""
 msgid "git reflog exists <ref>"
 msgstr "git reflog exists <referència>"
 
-#: builtin/reflog.c:568 builtin/reflog.c:573
+#: builtin/reflog.c:585 builtin/reflog.c:590
 #, c-format
 msgid "'%s' is not a valid timestamp"
 msgstr "«%s» no és una marca de temps vàlida"
 
-#: builtin/reflog.c:609
+#: builtin/reflog.c:631
 #, c-format
 msgid "Marking reachable objects..."
 msgstr "S'estan marcant els objectes abastables..."
 
-#: builtin/reflog.c:647
+#: builtin/reflog.c:675
 #, c-format
 msgid "%s points nowhere!"
 msgstr "%s no apunta a enlloc"
 
-#: builtin/reflog.c:700
+#: builtin/reflog.c:731
 msgid "no reflog specified to delete"
 msgstr "no s'ha especificat cap registre de referència per a suprimir"
 
-#: builtin/reflog.c:708
+#: builtin/reflog.c:742
 #, c-format
 msgid "not a reflog: %s"
 msgstr "no és un registre de referència: %s"
 
-#: builtin/reflog.c:713
+#: builtin/reflog.c:747
 #, c-format
 msgid "no reflog for '%s'"
 msgstr "cap registre de referència per a «%s»"
 
-#: builtin/reflog.c:759
+#: builtin/reflog.c:794
 #, c-format
 msgid "invalid ref format: %s"
 msgstr "format de referència no vàlid: %s"
 
-#: builtin/reflog.c:768
+#: builtin/reflog.c:803
 msgid "git reflog [ show | expire | delete | exists ]"
 msgstr "git reflog [ show | expire | delete | exists ]"
 
@@ -21198,6 +20883,11 @@ msgstr "git remote update [<opcions>] [<grup> | <remot>]..."
 msgid "Updating %s"
 msgstr "S'està actualitzant %s"
 
+#: builtin/remote.c:101
+#, c-format
+msgid "Could not fetch %s"
+msgstr "No s'ha pogut obtenir %s"
+
 #: builtin/remote.c:131
 msgid ""
 "--mirror is dangerous and deprecated; please\n"
@@ -21256,9 +20946,9 @@ msgid "Could not setup master '%s'"
 msgstr "No s'ha pogut configurar la mestra «%s»"
 
 #: builtin/remote.c:322
-#, c-format, fuzzy
+#, c-format
 msgid "unhandled branch.%s.rebase=%s; assuming 'true'"
-msgstr "branca no gestionada.%s.rebase=%s; assumint 'true'"
+msgstr "no s'ha gestionat branch.%s.rebase=%s; assumint «true»"
 
 #: builtin/remote.c:366
 #, c-format
@@ -21280,14 +20970,15 @@ msgid "could not set '%s'"
 msgstr "no s'ha pogut establir «%s»"
 
 #: builtin/remote.c:665
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "The %s configuration remote.pushDefault in:\n"
 "\t%s:%d\n"
 "now names the non-existent remote '%s'"
 msgstr ""
-"La configuració dels percentatges és remota.pushDefault ins%d ara anomena "
-"els \"%s\" remots inexistents"
+"La configuració %s remote.pushDefault a:\n"
+"\t%s:%d\n"
+"ara anomena un remot no existent «%s»"
 
 #: builtin/remote.c:696 builtin/remote.c:841 builtin/remote.c:948
 #, c-format
@@ -21367,9 +21058,9 @@ msgid "rebases interactively onto remote %s"
 msgstr "es fa «rebase» interactivament sobre el remot %s"
 
 #: builtin/remote.c:1068
-#, fuzzy, c-format
+#, c-format
 msgid "rebases interactively (with merges) onto remote %s"
-msgstr "rebases interactivament (amb fusions) en percentatges remots"
+msgstr "es fa «rebase» interactivament (amb fusions) sobre el remot %s"
 
 #: builtin/remote.c:1071
 #, c-format
@@ -21648,166 +21339,153 @@ msgstr ""
 "no s'han pogut iniciar pack-objects per tornar a empaquetar els objectes "
 "«promissor»"
 
-#: builtin/repack.c:273 builtin/repack.c:816
+#: builtin/repack.c:275 builtin/repack.c:820
 #, fuzzy
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
 msgstr ""
 "reempaqueta S'esperen línies d'id. de l'objecte hexadecimal complet només "
 "des de pack-objects."
 
-#: builtin/repack.c:297
+#: builtin/repack.c:299
 #, fuzzy
 msgid "could not finish pack-objects to repack promisor objects"
 msgstr ""
 "no s'ha pogut finalitzar el paquet d'objectes per tornar a empaquetar "
 "objectes promisor"
 
-#: builtin/repack.c:312
-#, fuzzy, c-format
+#: builtin/repack.c:314
+#, c-format
 msgid "cannot open index for %s"
-msgstr "s'ha produït un error en obrir l'índex per «%s»"
+msgstr "no s'ha pogut obrir l'índex per a %s"
 
-#: builtin/repack.c:371
-#, fuzzy, c-format
+#: builtin/repack.c:373
+#, c-format
 msgid "pack %s too large to consider in geometric progression"
-msgstr "el paquet %s és massa gran per considerar en la progressió geomètrica"
+msgstr "el paquet %s és massa gran per considerar-ho en progressió geomètrica"
 
-#: builtin/repack.c:404 builtin/repack.c:411 builtin/repack.c:416
-#, fuzzy, c-format
+#: builtin/repack.c:406 builtin/repack.c:413 builtin/repack.c:418
+#, c-format
 msgid "pack %s too large to roll up"
 msgstr "el paquet %s és massa gran per enrotllar-lo"
 
-#: builtin/repack.c:496
-#, fuzzy, c-format
+#: builtin/repack.c:498
+#, c-format
 msgid "could not open tempfile %s for writing"
-msgstr "no s'ha pogut obrir «%s» per a escriptura"
+msgstr "no s'ha pogut obrir el fitxer temporal «%s» per a escriptura"
 
-#: builtin/repack.c:514
+#: builtin/repack.c:516
 #, fuzzy
 msgid "could not close refs snapshot tempfile"
 msgstr "no s'ha pogut crear el fitxer temporal"
 
-#: builtin/repack.c:628
+#: builtin/repack.c:630
 msgid "pack everything in a single pack"
 msgstr "empaqueta-ho tot en un únic paquet"
 
-#: builtin/repack.c:630
+#: builtin/repack.c:632
 msgid "same as -a, and turn unreachable objects loose"
 msgstr "el mateix que -a, i solta els objectes inabastables"
 
-#: builtin/repack.c:633
+#: builtin/repack.c:635
 msgid "remove redundant packs, and run git-prune-packed"
 msgstr "elimina els paquets redundants, i executeu git-prune-packed"
 
-#: builtin/repack.c:635
+#: builtin/repack.c:637
 msgid "pass --no-reuse-delta to git-pack-objects"
 msgstr "passa --no-reuse-delta a git-pack-objects"
 
-#: builtin/repack.c:637
+#: builtin/repack.c:639
 msgid "pass --no-reuse-object to git-pack-objects"
 msgstr "passa --no-reuse-object a git-pack-objects"
 
-#: builtin/repack.c:639
+#: builtin/repack.c:641
 msgid "do not run git-update-server-info"
 msgstr "no executis git-update-server-info"
 
-#: builtin/repack.c:642
+#: builtin/repack.c:644
 msgid "pass --local to git-pack-objects"
 msgstr "passa --local a git-pack-objects"
 
-#: builtin/repack.c:644
+#: builtin/repack.c:646
 msgid "write bitmap index"
 msgstr "escriu índex de mapa de bits"
 
-#: builtin/repack.c:646
-#, fuzzy
+#: builtin/repack.c:648
 msgid "pass --delta-islands to git-pack-objects"
-msgstr "passa --delta-illes a git-pack-objects"
+msgstr "passa --delta-islands a git-pack-objects"
 
-#: builtin/repack.c:647
+#: builtin/repack.c:649
 msgid "approxidate"
 msgstr "data aproximada"
 
-#: builtin/repack.c:648
-msgid "with -A, do not loosen objects older than this"
-msgstr "amb -A, no soltis els objectes més vells que aquest"
-
 #: builtin/repack.c:650
+msgid "with -A, do not loosen objects older than this"
+msgstr "amb -A, no soltis els objectes més antics que aquest"
+
+#: builtin/repack.c:652
 msgid "with -a, repack unreachable objects"
 msgstr "amb -a, reempaqueta els objectes inabastables"
 
-#: builtin/repack.c:652
+#: builtin/repack.c:654
 msgid "size of the window used for delta compression"
 msgstr "mida de la finestra que s'usa per a compressió de diferències"
 
-#: builtin/repack.c:653 builtin/repack.c:659
+#: builtin/repack.c:655 builtin/repack.c:661
 msgid "bytes"
 msgstr "octets"
 
-#: builtin/repack.c:654
+#: builtin/repack.c:656
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr ""
 "el mateix que l'anterior, però limita la mida de memòria en lloc del nombre "
 "d'entrades"
 
-#: builtin/repack.c:656
+#: builtin/repack.c:658
 msgid "limits the maximum delta depth"
 msgstr "limita la profunditat màxima de les diferències"
 
-#: builtin/repack.c:658
+#: builtin/repack.c:660
 msgid "limits the maximum number of threads"
 msgstr "limita el nombre màxim de fils"
 
-#: builtin/repack.c:660
+#: builtin/repack.c:662
 msgid "maximum size of each packfile"
 msgstr "mida màxima de cada fitxer de paquet"
 
-#: builtin/repack.c:662
+#: builtin/repack.c:664
 msgid "repack objects in packs marked with .keep"
 msgstr "reempaqueta els objectes en paquets marcats amb .keep"
 
-#: builtin/repack.c:664
-#, fuzzy
-msgid "do not repack this pack"
-msgstr "no reempaqueta aquest paquet"
-
 #: builtin/repack.c:666
-#, fuzzy
+msgid "do not repack this pack"
+msgstr "no reempaquetis aquest paquet"
+
+#: builtin/repack.c:668
 msgid "find a geometric progression with factor <N>"
 msgstr "troba una progressió geomètrica amb el factor <N>"
 
-#: builtin/repack.c:668
+#: builtin/repack.c:670
 #, fuzzy
 msgid "write a multi-pack index of the resulting packs"
 msgstr "no s'ha pogut carregar l'índex del paquet per al fitxer de paquet %s"
 
-#: builtin/repack.c:678
+#: builtin/repack.c:680
 msgid "cannot delete packs in a precious-objects repo"
 msgstr "no es poden suprimir paquets en un repositori d'objectes preciosos"
 
-#: builtin/repack.c:682
-msgid "--keep-unreachable and -A are incompatible"
-msgstr "--keep-unreachable i -A són incompatibles"
-
-#: builtin/repack.c:713
-#, fuzzy
-msgid "--geometric is incompatible with -A, -a"
-msgstr "--long és incompatible amb --abbrev=0"
-
-#: builtin/repack.c:825
-#, fuzzy
+#: builtin/repack.c:829
 msgid "Nothing new to pack."
-msgstr "Res nou per empaquetar."
+msgstr "Res nou a empaquetar."
 
-#: builtin/repack.c:855
-#, fuzzy, c-format
+#: builtin/repack.c:859
+#, c-format
 msgid "missing required file: %s"
-msgstr "falten els arguments per a %s"
+msgstr "falta el fitxer requerit: %s"
 
-#: builtin/repack.c:857
-#, fuzzy, c-format
+#: builtin/repack.c:861
+#, c-format
 msgid "could not unlink: %s"
-msgstr "no s'ha pogut bloquejar «%s»"
+msgstr "no s'ha pogut desenllaçar: «%s»"
 
 #: builtin/replace.c:22
 msgid "git replace [-f] <object> <replacement>"
@@ -21819,7 +21497,7 @@ msgstr "git replace [-f] --edit <objecte>"
 
 #: builtin/replace.c:24
 msgid "git replace [-f] --graft <commit> [<parent>...]"
-msgstr "git replace [-f] --graft <comissió> [<mare>...]"
+msgstr "git replace [-f] --graft <comissió> [<parent>...]"
 
 #: builtin/replace.c:25
 msgid "git replace [-f] --convert-graft-file"
@@ -21834,33 +21512,33 @@ msgid "git replace [--format=<format>] [-l [<pattern>]]"
 msgstr "git replace [--format=<format>] [-l [<patró>]]"
 
 #: builtin/replace.c:90
-#, fuzzy, c-format
+#, c-format
 msgid ""
 "invalid replace format '%s'\n"
 "valid formats are 'short', 'medium' and 'long'"
 msgstr ""
-"format de substitució no vàlid «%s» els formats vàlids són «short» «medium» "
-"i «long»"
+"format de reemplaçament no vàlid «%s»\n"
+"els formats vàlids són «short» «medium» i «long»"
 
 #: builtin/replace.c:125
-#, fuzzy, c-format
+#, c-format
 msgid "replace ref '%s' not found"
-msgstr "no s'ha trobat la ref '%s'"
+msgstr "no s'ha trobat la referència de reemplaç '«%s»"
 
 #: builtin/replace.c:141
-#, fuzzy, c-format
+#, c-format
 msgid "Deleted replace ref '%s'"
 msgstr "S'ha suprimit la referència «%s»"
 
 #: builtin/replace.c:153
-#, fuzzy, c-format
+#, c-format
 msgid "'%s' is not a valid ref name"
-msgstr "'%s' no és un nom de referència vàlid"
+msgstr "«%s» no és un nom de referència vàlid"
 
 #: builtin/replace.c:158
-#, fuzzy, c-format
+#, c-format
 msgid "replace ref '%s' already exists"
-msgstr "reemplaça la referència «%s» ja existeix"
+msgstr "la referència de reemplaçament «%s» ja existeix"
 
 #: builtin/replace.c:178
 #, fuzzy, c-format
@@ -21874,9 +21552,9 @@ msgstr ""
 " del tipus «%s»."
 
 #: builtin/replace.c:229
-#, fuzzy, c-format
+#, c-format
 msgid "unable to open %s for writing"
-msgstr "no s'han pogut obrir els percentatges per escriure"
+msgstr "no s'ha pogut obrir %s per a escriptura"
 
 #: builtin/replace.c:242
 #, fuzzy
@@ -21884,77 +21562,66 @@ msgid "cat-file reported failure"
 msgstr "error en el fitxer de gat"
 
 #: builtin/replace.c:258
-#, fuzzy, c-format
+#, c-format
 msgid "unable to open %s for reading"
-msgstr "no s'han pogut obrir els percentatges de lectura"
+msgstr "no s'ha pogut obrir %s per a lectura"
 
-#: builtin/replace.c:272
+#: builtin/replace.c:271
 #, fuzzy
 msgid "unable to spawn mktree"
 msgstr "no s'ha pogut engendrar el mktree"
 
-#: builtin/replace.c:276
-#, fuzzy
+#: builtin/replace.c:275
 msgid "unable to read from mktree"
 msgstr "no s'ha pogut llegir des de mktree"
 
-#: builtin/replace.c:285
-#, fuzzy
+#: builtin/replace.c:284
 msgid "mktree reported failure"
-msgstr "mktree ha fallat"
+msgstr "mktree ha informat d'una fallada"
 
-#: builtin/replace.c:289
-#, fuzzy
+#: builtin/replace.c:288
 msgid "mktree did not return an object name"
 msgstr "mktree no ha retornat un nom d'objecte"
 
-#: builtin/replace.c:298
-#, fuzzy, c-format
+#: builtin/replace.c:297
+#, c-format
 msgid "unable to fstat %s"
-msgstr "no s'han pogut fer fstat%s"
+msgstr "no s'ha pogut fer fstat %s"
 
-#: builtin/replace.c:303
-#, fuzzy
+#: builtin/replace.c:302
 msgid "unable to write object to database"
 msgstr "no s'ha pogut escriure l'objecte a la base de dades"
 
-#: builtin/replace.c:322 builtin/replace.c:378 builtin/replace.c:424
-#: builtin/replace.c:454
-#, fuzzy, c-format
-msgid "not a valid object name: '%s'"
-msgstr "no és un nom d'objecte vàlid «%s»"
-
-#: builtin/replace.c:326
-#, fuzzy, c-format
+#: builtin/replace.c:325
+#, c-format
 msgid "unable to get object type for %s"
-msgstr "no s'ha pogut obtenir el tipus d'objecte per un percentatge"
+msgstr "no s'ha pogut obtenir el tipus d'objecte per a %s"
 
-#: builtin/replace.c:342
-#, fuzzy
+#: builtin/replace.c:341
 msgid "editing object file failed"
 msgstr "l'edició del fitxer d'objecte ha fallat"
 
-#: builtin/replace.c:351
-#, fuzzy, c-format
+#: builtin/replace.c:350
+#, c-format
 msgid "new object is the same as the old one: '%s'"
-msgstr "l'objecte nou és el mateix que l'antic «%s»"
+msgstr "l'objecte nou és el mateix que l'antic: «%s»"
 
-#: builtin/replace.c:384
-#, fuzzy, c-format
+#: builtin/replace.c:383
+#, c-format
 msgid "could not parse %s as a commit"
-msgstr "no s'han pogut analitzar els percentatges com a comissió"
+msgstr "no s'ha pogut analitzar %s com a comissió"
 
-#: builtin/replace.c:416
+#: builtin/replace.c:415
 #, c-format
 msgid "bad mergetag in commit '%s'"
 msgstr "etiqueta de fusió incorrecta en la comissió «%s»"
 
-#: builtin/replace.c:418
+#: builtin/replace.c:417
 #, c-format
 msgid "malformed mergetag in commit '%s'"
 msgstr "etiqueta de fusió mal formada en la comissió «%s»"
 
-#: builtin/replace.c:430
+#: builtin/replace.c:429
 #, c-format
 msgid ""
 "original commit '%s' contains mergetag '%s' that is discarded; use --edit "
@@ -21963,106 +21630,105 @@ msgstr ""
 "la comissió original «%s» conté l'etiqueta de fusió «%s» que es descarta; "
 "useu --edit en lloc de --graft"
 
-#: builtin/replace.c:469
+#: builtin/replace.c:468
 #, c-format
 msgid "the original commit '%s' has a gpg signature"
 msgstr "la comissió original «%s» té una signatura gpg"
 
-#: builtin/replace.c:470
+#: builtin/replace.c:469
 msgid "the signature will be removed in the replacement commit!"
 msgstr "s'eliminarà la signatura en la comissió de reemplaçament!"
 
-#: builtin/replace.c:480
+#: builtin/replace.c:479
 #, c-format
 msgid "could not write replacement commit for: '%s'"
 msgstr "no s'ha pogut escriure la comissió de reemplaçament per a: «%s»"
 
-#: builtin/replace.c:488
+#: builtin/replace.c:487
 #, fuzzy, c-format
 msgid "graft for '%s' unnecessary"
 msgstr "empelt per '%s' innecessari"
 
-#: builtin/replace.c:492
+#: builtin/replace.c:491
 #, c-format
 msgid "new commit is the same as the old one: '%s'"
 msgstr "la comissió nova és la mateixa que l'antiga: «%s»"
 
-#: builtin/replace.c:527
+#: builtin/replace.c:526
 #, fuzzy, c-format
 msgid ""
 "could not convert the following graft(s):\n"
 "%s"
 msgstr "no s'han pogut convertir els següents percentatges d'empelt"
 
-#: builtin/replace.c:548
+#: builtin/replace.c:547
 msgid "list replace refs"
-msgstr "llista les referències reemplaçades"
+msgstr "llista les referències de reemplaçament"
+
+#: builtin/replace.c:548
+msgid "delete replace refs"
+msgstr "suprimeix les referències de reemplaçament"
 
 #: builtin/replace.c:549
-msgid "delete replace refs"
-msgstr "suprimeix les referències reemplaçades"
-
-#: builtin/replace.c:550
 msgid "edit existing object"
 msgstr "edita un objecte existent"
 
-#: builtin/replace.c:551
+#: builtin/replace.c:550
 msgid "change a commit's parents"
-msgstr "canvia les mares d'una comissió"
+msgstr "canvia els pares d'una comissió"
 
-#: builtin/replace.c:552
+#: builtin/replace.c:551
 #, fuzzy
 msgid "convert existing graft file"
 msgstr "converteix el fitxer d'empelt existent"
 
-#: builtin/replace.c:553
+#: builtin/replace.c:552
 msgid "replace the ref if it exists"
 msgstr "reemplaça la referència si existeix"
 
-#: builtin/replace.c:555
+#: builtin/replace.c:554
 msgid "do not pretty-print contents for --edit"
 msgstr "no imprimeixis bellament els continguts per a --edit"
 
-#: builtin/replace.c:556
+#: builtin/replace.c:555
 msgid "use this format"
 msgstr "usa aquest format"
 
-#: builtin/replace.c:569
+#: builtin/replace.c:568
 #, fuzzy
 msgid "--format cannot be used when not listing"
 msgstr "no es pot utilitzar «--format» en no llistar"
 
-#: builtin/replace.c:577
+#: builtin/replace.c:576
 #, fuzzy
 msgid "-f only makes sense when writing a replacement"
 msgstr "-f només té sentit quan s'escriu un reemplaçament"
 
-#: builtin/replace.c:581
+#: builtin/replace.c:580
 msgid "--raw only makes sense with --edit"
 msgstr "--raw només té sentit amb --edit"
 
-#: builtin/replace.c:587
-#, fuzzy
+#: builtin/replace.c:586
 msgid "-d needs at least one argument"
 msgstr "-d necessita almenys un argument"
 
-#: builtin/replace.c:593
+#: builtin/replace.c:592
 msgid "bad number of arguments"
 msgstr "nombre incorrecte d'arguments"
 
-#: builtin/replace.c:599
+#: builtin/replace.c:598
 msgid "-e needs exactly one argument"
 msgstr "-e necessita exactament un argument"
 
-#: builtin/replace.c:605
+#: builtin/replace.c:604
 msgid "-g needs at least one argument"
 msgstr "-g necessita almenys un argument"
 
-#: builtin/replace.c:611
+#: builtin/replace.c:610
 msgid "--convert-graft-file takes no argument"
 msgstr "--convert-graft-file arguments"
 
-#: builtin/replace.c:617
+#: builtin/replace.c:616
 msgid "only one pattern can be given with -l"
 msgstr "només es pot especificar un patró amb -l"
 
@@ -22085,136 +21751,125 @@ msgstr "'git rererere oblid' sense camins està en desús"
 msgid "unable to generate diff for '%s'"
 msgstr "s'ha pogut generar el diff per a «%s»"
 
-#: builtin/reset.c:32
+#: builtin/reset.c:33
 msgid ""
 "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<commit>]"
 msgstr ""
 "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<comissió>]"
 
-#: builtin/reset.c:33
-#, fuzzy
-msgid "git reset [-q] [<tree-ish>] [--] <pathspec>..."
-msgstr "git reset [-q] [<tree-ish>] [--] <pathspec>"
-
 #: builtin/reset.c:34
-#, fuzzy
+msgid "git reset [-q] [<tree-ish>] [--] <pathspec>..."
+msgstr "git reset [-q] [<tree-ish>] [--] <pathspec>..."
+
+#: builtin/reset.c:35
 msgid ""
 "git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<tree-ish>]"
 msgstr ""
 "git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<tree-ish>]"
 
-#: builtin/reset.c:35
-#, fuzzy
+#: builtin/reset.c:36
 msgid "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
-msgstr "git reset --patch [<tree-ish>] [--] [<pathspec>]"
+msgstr "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "mixed"
 msgstr "mixt"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "soft"
 msgstr "suau"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "hard"
 msgstr "dur"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "merge"
 msgstr "fusió"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "keep"
 msgstr "reteniment"
 
-#: builtin/reset.c:89
+#: builtin/reset.c:90
 msgid "You do not have a valid HEAD."
 msgstr "No teniu un HEAD vàlid."
 
-#: builtin/reset.c:91
+#: builtin/reset.c:92
 msgid "Failed to find tree of HEAD."
 msgstr "S'ha produït un error en trobar l'arbre de HEAD."
 
-#: builtin/reset.c:97
+#: builtin/reset.c:98
 #, c-format
 msgid "Failed to find tree of %s."
 msgstr "S'ha produït un error en cercar l'arbre de %s."
 
-#: builtin/reset.c:122
+#: builtin/reset.c:123
 #, c-format
 msgid "HEAD is now at %s"
 msgstr "HEAD ara és a %s"
 
-#: builtin/reset.c:201
+#: builtin/reset.c:299
 #, c-format
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "No es pot fer un restabliment de %s enmig d'una fusió."
 
-#: builtin/reset.c:301 builtin/stash.c:605 builtin/stash.c:679
-#: builtin/stash.c:703
+#: builtin/reset.c:396 builtin/stash.c:606 builtin/stash.c:680
+#: builtin/stash.c:704
 msgid "be quiet, only report errors"
 msgstr "sigues silenciós, només informa d'errors"
 
-#: builtin/reset.c:303
+#: builtin/reset.c:398
 msgid "reset HEAD and index"
 msgstr "restableix HEAD i l'índex"
 
-#: builtin/reset.c:304
+#: builtin/reset.c:399
 msgid "reset only HEAD"
 msgstr "restableix només HEAD"
 
-#: builtin/reset.c:306 builtin/reset.c:308
+#: builtin/reset.c:401 builtin/reset.c:403
 msgid "reset HEAD, index and working tree"
 msgstr "restableix HEAD, l'índex i l'arbre de treball"
 
-#: builtin/reset.c:310
+#: builtin/reset.c:405
 msgid "reset HEAD but keep local changes"
 msgstr "restableix HEAD però retén els canvis locals"
 
-#: builtin/reset.c:316
+#: builtin/reset.c:411
 msgid "record only the fact that removed paths will be added later"
 msgstr "registra només el fet que els camins eliminats s'afegiran després"
 
-#: builtin/reset.c:350
+#: builtin/reset.c:445
 #, c-format
 msgid "Failed to resolve '%s' as a valid revision."
 msgstr "S'ha produït un error en resoldre «%s» com a revisió vàlida."
 
-#: builtin/reset.c:358
+#: builtin/reset.c:453
 #, c-format
 msgid "Failed to resolve '%s' as a valid tree."
 msgstr "S'ha produït un error en resoldre «%s» com a arbre vàlid."
 
-#: builtin/reset.c:367
-msgid "--patch is incompatible with --{hard,mixed,soft}"
-msgstr "--patch és incompatible amb --{hard,mixed,soft}"
-
-#: builtin/reset.c:377
+#: builtin/reset.c:472
 msgid "--mixed with paths is deprecated; use 'git reset -- <paths>' instead."
 msgstr ""
 "--mixed amb camins està en desús; useu «git reset -- <camins>» en lloc "
 "d'això."
 
-#: builtin/reset.c:379
+#: builtin/reset.c:474
 #, c-format
 msgid "Cannot do %s reset with paths."
 msgstr "No es pot restablir de %s amb camins."
 
-#: builtin/reset.c:394
+#: builtin/reset.c:489
 #, c-format
 msgid "%s reset is not allowed in a bare repository"
 msgstr "el restabliment de %s no es permet en un repositori nu"
 
-#: builtin/reset.c:398
-msgid "-N can only be used with --mixed"
-msgstr "-N només es pot usar amb --mixed"
-
-#: builtin/reset.c:419
+#: builtin/reset.c:520
 msgid "Unstaged changes after reset:"
 msgstr "Canvis «unstaged» després del restabliment:"
 
-#: builtin/reset.c:422
+#: builtin/reset.c:523
 #, fuzzy, c-format
 msgid ""
 "\n"
@@ -22226,18 +21881,14 @@ msgstr ""
 " reinici. Podeu utilitzar «--quiet» per evitar-ho. Establiu el paràmetre de "
 "configuració reset.quiet a cert per fer que això sigui el predeterminat."
 
-#: builtin/reset.c:440
+#: builtin/reset.c:541
 #, c-format
 msgid "Could not reset index file to revision '%s'."
 msgstr "No s'ha pogut restablir el fitxer d'índex a la revisió «%s»."
 
-#: builtin/reset.c:445
+#: builtin/reset.c:546
 msgid "Could not write new index file."
 msgstr "No s'ha pogut escriure el fitxer d'índex nou."
-
-#: builtin/rev-list.c:541
-msgid "cannot combine --exclude-promisor-objects and --missing"
-msgstr "no es pot combinar --exclude-promisor-objects i --missing"
 
 #: builtin/rev-list.c:602
 msgid "object filtering requires --objects"
@@ -22248,9 +21899,9 @@ msgid "rev-list does not support display of notes"
 msgstr "el rev-list no permet mostrar notes"
 
 #: builtin/rev-list.c:679
-#, fuzzy
-msgid "marked counting is incompatible with --objects"
-msgstr "el recompte marcat és incompatible amb --objects"
+#, fuzzy, c-format
+msgid "marked counting and '%s' cannot be used together"
+msgstr "--reject i --3way no es poden usar junts."
 
 #: builtin/rev-parse.c:409
 msgid "git rev-parse --parseopt [<options>] -- [<args>...]"
@@ -22269,19 +21920,16 @@ msgid "output in stuck long form"
 msgstr "emet en forma llarga enganxada"
 
 #: builtin/rev-parse.c:438
-#, fuzzy
 msgid "premature end of input"
-msgstr "error de lectura d'entrada"
+msgstr "final prematur de l'entrada"
 
 #: builtin/rev-parse.c:442
-#, fuzzy
 msgid "no usage string given before the `--' separator"
 msgstr "no s'ha indicat cap cadena d'ús abans del separador «--»"
 
 #: builtin/rev-parse.c:548
-#, fuzzy
 msgid "Needed a single revision"
-msgstr "make_script: s'ha produït un error en preparar les revisions"
+msgstr "Cal una sola revisió"
 
 #: builtin/rev-parse.c:552
 msgid ""
@@ -22291,36 +21939,32 @@ msgid ""
 "\n"
 "Run \"git rev-parse --parseopt -h\" for more information on the first usage."
 msgstr ""
-"git rev-parse --parseopt [<opcions>] -- [<arguments>...]\n"
-"   o bé: git rev-parse --sq-quote [<argument>...]\n"
-"   o bé: git rev-parse [<opcions>] [<argument>...]\n"
+"git rev-parse --parseopt [<options>] -- [<args>...]\n"
+"   o bé: git rev-parse --sq-quote [<arg>...]\n"
+"   o bé: git rev-parse [<options>] [<arg>...]\n"
 "\n"
 "Executeu «git rev-parse --parseopt -h» per a més informació sobre el primer ús."
 
 #: builtin/rev-parse.c:712
-#, fuzzy
 msgid "--resolve-git-dir requires an argument"
-msgstr "--bisect-next no requereix cap argument"
+msgstr "--resolve-git-dir requereix un argument"
 
 #: builtin/rev-parse.c:715
-#, fuzzy, c-format
+#, c-format
 msgid "not a gitdir '%s'"
-msgstr "no és una revisió \"%s\""
+msgstr "no és un directori git «%s»"
 
 #: builtin/rev-parse.c:739
-#, fuzzy
 msgid "--git-path requires an argument"
-msgstr "--bisect-next no requereix cap argument"
+msgstr "--git-path requereix un argument"
 
 #: builtin/rev-parse.c:749
-#, fuzzy
 msgid "-n requires an argument"
-msgstr "--bisect-next no requereix cap argument"
+msgstr "-n requereix un argument"
 
 #: builtin/rev-parse.c:763
-#, fuzzy
 msgid "--path-format requires an argument"
-msgstr "--bisect-next no requereix cap argument"
+msgstr "--path-format requereix un argument"
 
 #: builtin/rev-parse.c:769
 #, fuzzy, c-format
@@ -22328,14 +21972,12 @@ msgid "unknown argument to --path-format: %s"
 msgstr "Valor no vàlid per a --patch-format: %s"
 
 #: builtin/rev-parse.c:776
-#, fuzzy
 msgid "--default requires an argument"
-msgstr "--bisect-next no requereix cap argument"
+msgstr "--default requereix un argument"
 
 #: builtin/rev-parse.c:782
-#, fuzzy
 msgid "--prefix requires an argument"
-msgstr "--bisect-next no requereix cap argument"
+msgstr "--prefix requereix un argument"
 
 #: builtin/rev-parse.c:851
 #, fuzzy, c-format
@@ -22449,11 +22091,11 @@ msgid_plural ""
 "the following files have staged content different from both the\n"
 "file and the HEAD:"
 msgstr[0] ""
-"el fitxer següent té contingut «stage» diferent d'ambdós el\n"
-"fitxer i la HEAD:"
+"el fitxer següent té contingut «staged» diferent al fitxer\n"
+"i a HEAD:"
 msgstr[1] ""
-"els fitxers següents tenen contingut «stage» diferent d'ambdós\n"
-"el fitxer i la HEAD:"
+"els fitxers següents tenen contingut «staged» diferent al fitxer\n"
+"i a HEAD:"
 
 #: builtin/rm.c:213
 msgid ""
@@ -22526,15 +22168,16 @@ msgid "git rm: unable to remove %s"
 msgstr "git rm: no s'ha pogut eliminar %s"
 
 #: builtin/send-pack.c:20
-#, fuzzy
 msgid ""
 "git send-pack [--mirror] [--dry-run] [--force]\n"
 "              [--receive-pack=<git-receive-pack>]\n"
 "              [--verbose] [--thin] [--atomic]\n"
 "              [<host>:]<directory> (--all | <ref>...)"
 msgstr ""
-"git send-pack [--all | --mirror] [--dry-run] [--force] [--receive-pack=<paquet-del-git-receive>] [--verbose] [--thin] [--atomic] [<màquina>:]<directori> [<referència>...]\n"
-"  --all i especificació <referència> explícita són mútuament excloents."
+"git send-pack [--mirror] [--dry-run] [--force]\n"
+"              [--receive-pack=<git-receive-pack>]\n"
+"              [--verbose] [--thin] [--atomic]\n"
+"              [<host>:]<directory> (--all | <ref>...)"
 
 #: builtin/send-pack.c:192
 msgid "remote name"
@@ -22600,26 +22243,22 @@ msgid "<w>[,<i1>[,<i2>]]"
 msgstr "<w>[,<i1>[,<i2>]]"
 
 #: builtin/shortlog.c:360
-#, fuzzy
 msgid "linewrap output"
-msgstr "Ajusta les línies de la sortida"
+msgstr "ajusta les línies de la sortida"
 
 #: builtin/shortlog.c:362
-#, fuzzy
 msgid "field"
 msgstr "camp"
 
 #: builtin/shortlog.c:363
-#, fuzzy
 msgid "group by field"
-msgstr "Agrupa per camp"
+msgstr "agrupa per camp"
 
 #: builtin/shortlog.c:394
 msgid "too many arguments given outside repository"
 msgstr "hi ha massa arguments donats fora del repositori"
 
 #: builtin/show-branch.c:13
-#, fuzzy
 msgid ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
 "                [--current] [--color[=<when>] | --no-color] [--sparse]\n"
@@ -22627,9 +22266,9 @@ msgid ""
 "                [--no-name | --sha1-name] [--topics] [(<rev> | <glob>)...]"
 msgstr ""
 "git show-branch [-a | --all] [-r | --remotes] [--topo-order | --date-order]\n"
-"\t\t[--current] [--color[=<quan>] | --no-color] [--sparse]\n"
-"\t\t[--more=<n> | --list | --independent | --merge-base]\n"
-"\t\t[--no-name | --sha1-name] [--topics] [(<revisió> | <glob>)...]"
+"                [--current] [--color[=<when>] | --no-color] [--sparse]\n"
+"                [--more=<n> | --list | --independent | --merge-base]\n"
+"                [--no-name | --sha1-name] [--topics] [(<rev> | <glob>)...]"
 
 #: builtin/show-branch.c:17
 msgid "git show-branch (-g | --reflog)[=<n>[,<base>]] [--list] [<ref>]"
@@ -22712,13 +22351,6 @@ msgstr "<n>[,<base>]"
 msgid "show <n> most recent ref-log entries starting at base"
 msgstr "mostra les <n> entrades més recents començant a la base"
 
-#: builtin/show-branch.c:710
-msgid ""
-"--reflog is incompatible with --all, --remotes, --independent or --merge-"
-"base"
-msgstr ""
-"--reflog és incompatible amb --all, --remotes, --independent o --merge-base"
-
 #: builtin/show-branch.c:734
 msgid "no branches given, and HEAD is not valid"
 msgstr "no s'ha donat cap branca, i HEAD no és vàlid"
@@ -22739,19 +22371,19 @@ msgstr[1] "es poden mostrar només %d entrades a la vegada."
 msgid "no such ref %s"
 msgstr "no hi ha tal referència %s"
 
-#: builtin/show-branch.c:828
+#: builtin/show-branch.c:830
 #, c-format
 msgid "cannot handle more than %d rev."
 msgid_plural "cannot handle more than %d revs."
 msgstr[0] "no es pot gestionar més d'%d revisió."
 msgstr[1] "no es poden gestionar més de %d revisions."
 
-#: builtin/show-branch.c:832
+#: builtin/show-branch.c:834
 #, c-format
 msgid "'%s' is not a valid ref."
 msgstr "«%s» no és una referència vàlida."
 
-#: builtin/show-branch.c:835
+#: builtin/show-branch.c:837
 #, c-format
 msgid "cannot find commit %s (%s)"
 msgstr "no es pot trobar la comissió %s (%s)"
@@ -22813,24 +22445,27 @@ msgid "show refs from stdin that aren't in local repository"
 msgstr "mostra les referències de stdin que no siguin en el repositori local"
 
 #: builtin/sparse-checkout.c:22
-#, fuzzy
 msgid "git sparse-checkout (init|list|set|add|reapply|disable) <options>"
-msgstr "git sparse-checkout (init|list|set|add|disable) <opcions>"
+msgstr "git sparse-checkout (init|list|set|add|reapply|disable) <opcions>"
 
 #: builtin/sparse-checkout.c:46
-#, fuzzy
 msgid "git sparse-checkout list"
-msgstr "git sparse-checkout init [--cone]"
+msgstr "git sparse-checkout list"
 
-#: builtin/sparse-checkout.c:72
+#: builtin/sparse-checkout.c:60
+#, fuzzy
+msgid "this worktree is not sparse"
+msgstr "HEAD de l'arbre de treball %s no està actualitzat"
+
+#: builtin/sparse-checkout.c:75
 #, fuzzy
 msgid "this worktree is not sparse (sparse-checkout file may not exist)"
 msgstr ""
 "aquest arbre de treball no és dispers (pot ser que el fitxer sparse-checkout"
 " no existeixi)"
 
-#: builtin/sparse-checkout.c:173
-#, c-format, fuzzy
+#: builtin/sparse-checkout.c:176
+#, fuzzy, c-format
 msgid ""
 "directory '%s' contains untracked files, but is not in the sparse-checkout "
 "cone"
@@ -22838,88 +22473,110 @@ msgstr ""
 "el directori '%s' conté fitxers no seguits, però no està en el con de la "
 "verificació dispersa"
 
-#: builtin/sparse-checkout.c:181
+#: builtin/sparse-checkout.c:184
 #, fuzzy, c-format
 msgid "failed to remove directory '%s'"
 msgstr "s'ha produït un error en crear el directori «%s»"
 
-#: builtin/sparse-checkout.c:321
+#: builtin/sparse-checkout.c:324
 #, fuzzy
 msgid "failed to create directory for sparse-checkout file"
 msgstr "no s'ha pogut crear el directori per al fitxer sparse-checkout"
 
-#: builtin/sparse-checkout.c:362
+#: builtin/sparse-checkout.c:365
 #, fuzzy
 msgid "unable to upgrade repository format to enable worktreeConfig"
 msgstr ""
 "no s'ha pogut actualitzar el format del repositori per habilitar "
 "worktreeConfig"
 
-#: builtin/sparse-checkout.c:364
+#: builtin/sparse-checkout.c:367
 #, fuzzy
 msgid "failed to set extensions.worktreeConfig setting"
 msgstr "no s'ha pogut establir el paràmetre extensions.worktreeConfig"
 
-#: builtin/sparse-checkout.c:384
-#, fuzzy
-msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
-msgstr "git sparse-checkout init [--cone]"
-
-#: builtin/sparse-checkout.c:404
-#, fuzzy
-msgid "initialize the sparse-checkout in cone mode"
-msgstr "inicialitza el «sparse-checkout» en mode con"
-
-#: builtin/sparse-checkout.c:406
-#, fuzzy
-msgid "toggle the use of a sparse index"
-msgstr "commuta l'ús d'un índex dispers"
-
-#: builtin/sparse-checkout.c:434
+#: builtin/sparse-checkout.c:411
 #, fuzzy
 msgid "failed to modify sparse-index config"
 msgstr "no s'ha pogut carregar l'índex del paquet per al fitxer de paquet %s"
 
-#: builtin/sparse-checkout.c:455
+#: builtin/sparse-checkout.c:422
+msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
+msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
+
+#: builtin/sparse-checkout.c:441 builtin/sparse-checkout.c:729
+#: builtin/sparse-checkout.c:778
+msgid "initialize the sparse-checkout in cone mode"
+msgstr "inicialitza el «sparse-checkout» en mode con"
+
+#: builtin/sparse-checkout.c:443 builtin/sparse-checkout.c:731
+#: builtin/sparse-checkout.c:780
+msgid "toggle the use of a sparse index"
+msgstr "commuta l'ús d'un índex dispers"
+
+#: builtin/sparse-checkout.c:476
 #, c-format
 msgid "failed to open '%s'"
 msgstr "s'ha produït un error en obrir «%s»"
 
-#: builtin/sparse-checkout.c:507
-#, fuzzy, c-format
+#: builtin/sparse-checkout.c:528
+#, c-format
 msgid "could not normalize path %s"
-msgstr "no s'ha pogut normalitzar el camí"
+msgstr "no s'ha pogut normalitzar el camí %s"
 
-#: builtin/sparse-checkout.c:519
-#, fuzzy
-msgid "git sparse-checkout (set|add) (--stdin | <patterns>)"
-msgstr "git sparse-checkout (set|add) (--stdin | <patrons>)"
-
-#: builtin/sparse-checkout.c:544
+#: builtin/sparse-checkout.c:557
 #, fuzzy, c-format
 msgid "unable to unquote C-style string '%s'"
 msgstr "no s'ha pogut treure la cadena de l'estil C «%s»"
 
-#: builtin/sparse-checkout.c:598 builtin/sparse-checkout.c:622
+#: builtin/sparse-checkout.c:612 builtin/sparse-checkout.c:640
 #, fuzzy
 msgid "unable to load existing sparse-checkout patterns"
 msgstr "no s'han pogut carregar els patrons de «sparse-checkout» existents"
 
-#: builtin/sparse-checkout.c:667
-msgid "read patterns from standard in"
-msgstr "llegeix els patrons de l'entrada estàndard"
+#: builtin/sparse-checkout.c:616
+#, fuzzy
+msgid "existing sparse-checkout patterns do not use cone mode"
+msgstr "no s'han pogut carregar els patrons de «sparse-checkout» existents"
 
 #: builtin/sparse-checkout.c:682
 #, fuzzy
-msgid "git sparse-checkout reapply"
-msgstr "git sparse-checkout init [--cone]"
+msgid "git sparse-checkout add (--stdin | <patterns>)"
+msgstr "git sparse-checkout (set|add) (--stdin | <patrons>)"
 
-#: builtin/sparse-checkout.c:701
+#: builtin/sparse-checkout.c:694 builtin/sparse-checkout.c:733
+msgid "read patterns from standard in"
+msgstr "llegeix els patrons de l'entrada estàndard"
+
+#: builtin/sparse-checkout.c:699
 #, fuzzy
-msgid "git sparse-checkout disable"
-msgstr "git sparse-checkout init [--cone]"
+msgid "no sparse-checkout to add to"
+msgstr "git sparse-checkout list"
 
-#: builtin/sparse-checkout.c:732
+#: builtin/sparse-checkout.c:712
+#, fuzzy
+msgid ""
+"git sparse-checkout set [--[no-]cone] [--[no-]sparse-index] (--stdin | "
+"<patterns>)"
+msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
+
+#: builtin/sparse-checkout.c:765
+#, fuzzy
+msgid "git sparse-checkout reapply [--[no-]cone] [--[no-]sparse-index]"
+msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
+
+#: builtin/sparse-checkout.c:785
+#, fuzzy
+msgid "must be in a sparse-checkout to reapply sparsity patterns"
+msgstr ""
+"ha d'estar en una eliminació de verificació per tornar a aplicar patrons "
+"d'escassetat"
+
+#: builtin/sparse-checkout.c:803
+msgid "git sparse-checkout disable"
+msgstr "git sparse-checkout disable"
+
+#: builtin/sparse-checkout.c:845
 msgid "error while refreshing working directory"
 msgstr "s'ha produït un error en actualitzar el directori de treball"
 
@@ -22932,12 +22589,10 @@ msgid "git stash show [<options>] [<stash>]"
 msgstr "git stash show [<opcions>] [<stash>]"
 
 #: builtin/stash.c:26 builtin/stash.c:50
-#, fuzzy
 msgid "git stash drop [-q|--quiet] [<stash>]"
 msgstr "git stash drop [-q|--quiet] [<stash>]"
 
 #: builtin/stash.c:27
-#, fuzzy
 msgid "git stash ( pop | apply ) [--index] [-q|--quiet] [<stash>]"
 msgstr "git stash ( pop | apply ) [--index] [-q|--quiet] [<stash>]"
 
@@ -22948,18 +22603,20 @@ msgstr "git stash branch <nom-de-branca> [<stash>]"
 #: builtin/stash.c:30
 #, fuzzy
 msgid ""
-"git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"git stash [push [-p|--patch] [-S|--staged] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [-m|--message <message>]\n"
 "          [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
 "          [--] [<pathspec>...]]"
 msgstr ""
-"git stash [push [-p|-patch] [-k|-[no-]keep-index] [-q|--quiet] "
-"[-u|--include-untracked] [-a|-all] [-m|-message <message>] [--pathspec-from-"
-"file=<file> [--path-spec-file-nul]]"
+"git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"          [-u|--include-untracked] [-a|--all] [-m|--message <message>]\n"
+"          [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
+"          [--] [<pathspec>...]]"
 
 #: builtin/stash.c:34
+#, fuzzy
 msgid ""
-"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"git stash save [-p|--patch] [-S|--staged] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [<message>]"
 msgstr ""
 "git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
@@ -22988,13 +22645,12 @@ msgstr ""
 "          [--] [<pathspec>...]]"
 
 #: builtin/stash.c:87
-#, fuzzy
 msgid ""
 "git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
 "               [-u|--include-untracked] [-a|--all] [<message>]"
 msgstr ""
 "git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
-"          [-u|--include-untracked] [-a|--all] [<missatge>]"
+"               [-u|--include-untracked] [-a|--all] [<missatge>]"
 
 #: builtin/stash.c:130
 #, c-format
@@ -23016,7 +22672,6 @@ msgid "%s is not a valid reference"
 msgstr "«%s» no és una referència vàlida"
 
 #: builtin/stash.c:227
-#, fuzzy
 msgid "git stash clear with arguments is unimplemented"
 msgstr "git stash clear amb paràmetres no està implementat"
 
@@ -23041,7 +22696,6 @@ msgid "could not generate diff %s^!."
 msgstr "no s'ha pogut generar diff %s^!."
 
 #: builtin/stash.c:526
-#, fuzzy
 msgid "conflicts in index. Try without --index."
 msgstr "hi ha conflictes en l'índex. Proveu-ho sense --index."
 
@@ -23058,145 +22712,162 @@ msgstr "S'està fusionant %s amb %s"
 msgid "Index was not unstashed."
 msgstr "L'índex no estava «unstashed»."
 
-#: builtin/stash.c:575
+#: builtin/stash.c:576
 msgid "could not restore untracked files from stash"
 msgstr "no s'han pogut restaurar els fitxers no seguits des del «stash»"
 
-#: builtin/stash.c:607 builtin/stash.c:705
+#: builtin/stash.c:608 builtin/stash.c:706
 msgid "attempt to recreate the index"
 msgstr "intenta tornar a crear l'índex"
 
-#: builtin/stash.c:651
+#: builtin/stash.c:652
 #, c-format
 msgid "Dropped %s (%s)"
 msgstr "Descartada %s (%s)"
 
-#: builtin/stash.c:654
+#: builtin/stash.c:655
 #, c-format
 msgid "%s: Could not drop stash entry"
 msgstr "%s: no s'ha pogut descartar l'entrada «stash»"
 
-#: builtin/stash.c:667
+#: builtin/stash.c:668
 #, c-format
 msgid "'%s' is not a stash reference"
 msgstr "«%s» no és una referència «stash»"
 
-#: builtin/stash.c:717
+#: builtin/stash.c:718
 msgid "The stash entry is kept in case you need it again."
 msgstr "Es conserva l'entrada «stash» en cas que la necessiteu altra vegada."
 
-#: builtin/stash.c:740
+#: builtin/stash.c:741
 msgid "No branch name specified"
 msgstr "Cap nom de branca especificat"
 
-#: builtin/stash.c:824
-#, fuzzy
+#: builtin/stash.c:825
 msgid "failed to parse tree"
-msgstr "s'ha produït un error en analitzar %s"
+msgstr "s'ha produït un error en analitzar l'arbre"
 
-#: builtin/stash.c:835
+#: builtin/stash.c:836
 #, fuzzy
 msgid "failed to unpack trees"
 msgstr "s'ha produït un error en desempaquetar l'objecte d'arbre HEAD"
 
-#: builtin/stash.c:855
-#, fuzzy
+#: builtin/stash.c:856
 msgid "include untracked files in the stash"
 msgstr "inclou els fitxers no seguits a «stash»"
 
-#: builtin/stash.c:858
-#, fuzzy
+#: builtin/stash.c:859
 msgid "only show untracked files in the stash"
-msgstr "inclou els fitxers no seguits a «stash»"
+msgstr "mostra només els fitxers no seguits a «stash»"
 
-#: builtin/stash.c:945 builtin/stash.c:982
+#: builtin/stash.c:946 builtin/stash.c:983
 #, c-format
 msgid "Cannot update %s with %s"
 msgstr "No es pot actualitzar %s amb %s"
 
-#: builtin/stash.c:963 builtin/stash.c:1619 builtin/stash.c:1684
+#: builtin/stash.c:964 builtin/stash.c:1678 builtin/stash.c:1750
 msgid "stash message"
 msgstr "missatge «stash»"
 
-#: builtin/stash.c:973
+#: builtin/stash.c:974
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "«git stash store» requereix un argument <comissió>"
 
-#: builtin/stash.c:1187
+#: builtin/stash.c:1159
+#, fuzzy
+msgid "No staged changes"
+msgstr "Sense canvis"
+
+#: builtin/stash.c:1220
 msgid "No changes selected"
 msgstr "No hi ha canvis seleccionats"
 
-#: builtin/stash.c:1287
+#: builtin/stash.c:1320
 msgid "You do not have the initial commit yet"
 msgstr "Encara no teniu la comissió inicial"
 
-#: builtin/stash.c:1314
+#: builtin/stash.c:1347
 msgid "Cannot save the current index state"
 msgstr "No es pot desar l'estat d'índex actual"
 
-#: builtin/stash.c:1323
+#: builtin/stash.c:1356
 msgid "Cannot save the untracked files"
 msgstr "No es poden desar els fitxers no seguits"
 
-#: builtin/stash.c:1334 builtin/stash.c:1343
+#: builtin/stash.c:1367 builtin/stash.c:1386
 msgid "Cannot save the current worktree state"
 msgstr "No es pot desar l'estat d'arbre de treball actual"
 
-#: builtin/stash.c:1371
+#: builtin/stash.c:1377
+#, fuzzy
+msgid "Cannot save the current staged state"
+msgstr "No es pot desar l'estat d'índex actual"
+
+#: builtin/stash.c:1414
 msgid "Cannot record working tree state"
 msgstr "No es pot registrar l'estat de l'arbre de treball"
 
-#: builtin/stash.c:1420
+#: builtin/stash.c:1463
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr "No es poden usar --patch i --include-untracked o --all a la vegada"
 
-#: builtin/stash.c:1438
+#: builtin/stash.c:1474
+#, fuzzy
+msgid "Can't use --staged and --include-untracked or --all at the same time"
+msgstr "No es poden usar --patch i --include-untracked o --all a la vegada"
+
+#: builtin/stash.c:1492
 msgid "Did you forget to 'git add'?"
 msgstr "Heu oblidat de fer «git add»?"
 
-#: builtin/stash.c:1453
+#: builtin/stash.c:1507
 msgid "No local changes to save"
 msgstr "No hi ha canvis locals a desar"
 
-#: builtin/stash.c:1460
+#: builtin/stash.c:1514
 msgid "Cannot initialize stash"
 msgstr "No es pot inicialitzar el magatzem"
 
-#: builtin/stash.c:1475
+#: builtin/stash.c:1529
 msgid "Cannot save the current status"
 msgstr "No es pot desar l'estat actual"
 
-#: builtin/stash.c:1480
+#: builtin/stash.c:1534
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "S'han desat el directori de treball i l'estat d'índex %s"
 
-#: builtin/stash.c:1571
+#: builtin/stash.c:1627
 msgid "Cannot remove worktree changes"
 msgstr "No es poden eliminar els canvis de l'arbre de treball"
 
-#: builtin/stash.c:1610 builtin/stash.c:1675
+#: builtin/stash.c:1667 builtin/stash.c:1739
 msgid "keep index"
 msgstr "mantén l'índex"
 
-#: builtin/stash.c:1612 builtin/stash.c:1677
+#: builtin/stash.c:1669 builtin/stash.c:1741
+#, fuzzy
+msgid "stash staged changes only"
+msgstr "només els canvis esglaonats"
+
+#: builtin/stash.c:1671 builtin/stash.c:1743
 #, fuzzy
 msgid "stash in patch mode"
 msgstr "stash en mode pedaç"
 
-#: builtin/stash.c:1613 builtin/stash.c:1678
+#: builtin/stash.c:1672 builtin/stash.c:1744
 msgid "quiet mode"
 msgstr "mode silenciós"
 
-#: builtin/stash.c:1615 builtin/stash.c:1680
+#: builtin/stash.c:1674 builtin/stash.c:1746
 msgid "include untracked files in stash"
 msgstr "inclou els fitxers no seguits a «stash»"
 
-#: builtin/stash.c:1617 builtin/stash.c:1682
+#: builtin/stash.c:1676 builtin/stash.c:1748
 msgid "include ignore files"
 msgstr "inclou els fitxers ignorats"
 
-#: builtin/stash.c:1717
+#: builtin/stash.c:1783
 #, fuzzy
 msgid ""
 "the stash.useBuiltin support has been removed!\n"
@@ -23222,7 +22893,7 @@ msgstr ""
 msgid "prepend comment character and space to each line"
 msgstr "anteposa el caràcter de comentari i un espai a cada línia"
 
-#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2667
+#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2668
 #, c-format
 msgid "Expecting a full ref name, got %s"
 msgstr "S'espera un nom de referència ple, s'ha rebut %s"
@@ -23245,7 +22916,7 @@ msgstr ""
 "no s'ha pogut trobar la configuració «%s». S'assumeix que aquest repositori "
 "és el seu repositori font autoritzat."
 
-#: builtin/submodule--helper.c:405 builtin/submodule--helper.c:1858
+#: builtin/submodule--helper.c:405 builtin/submodule--helper.c:1859
 msgid "alternative anchor for relative paths"
 msgstr "àncora alternativa per als camins relatius"
 
@@ -23320,9 +22991,8 @@ msgstr ""
 "submòdul «%s»"
 
 #: builtin/submodule--helper.c:685
-#, fuzzy
 msgid "suppress output for initializing a submodule"
-msgstr "Omet la sortida d'inicialitzar un submòdul"
+msgstr "omet la sortida en inicialitzar un submòdul"
 
 #: builtin/submodule--helper.c:690
 msgid "git submodule--helper init [<options>] [<path>]"
@@ -23343,19 +23013,17 @@ msgstr "no s'ha pogut resoldre la referència a HEAD dins del submòdul «%s»"
 msgid "failed to recurse into submodule '%s'"
 msgstr "s'ha produït un error en cercar recursivament al submòdul «%s»"
 
-#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1589
-#, fuzzy
+#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1590
 msgid "suppress submodule status output"
-msgstr "Suprimeix la sortida de l'estat del submòdul"
+msgstr "suprimeix la sortida de l'estat del submòdul"
 
 #: builtin/submodule--helper.c:863
-#, fuzzy
 msgid ""
 "use commit stored in the index instead of the one stored in the submodule "
 "HEAD"
 msgstr ""
-"Utilitza la comissió emmagatzemada a l'índex en lloc de la emmagatzemada al "
-"submòdul HEAD"
+"utilitza la comissió emmagatzemada a l'índex en lloc de la emmagatzemada al "
+"HEADdel submòdul"
 
 #: builtin/submodule--helper.c:869
 msgid "git submodule status [--quiet] [--cached] [--recursive] [<path>...]"
@@ -23366,68 +23034,57 @@ msgid "git submodule--helper name <path>"
 msgstr "git submodule--helper name <camí>"
 
 #: builtin/submodule--helper.c:965
-#, fuzzy, c-format
+#, c-format
 msgid "* %s %s(blob)->%s(submodule)"
-msgstr "* el %s(blob)->%s(submòdul)"
+msgstr "* %s %s(blob)->%s(submòdul)"
 
 #: builtin/submodule--helper.c:968
-#, fuzzy, c-format
+#, c-format
 msgid "* %s %s(submodule)->%s(blob)"
-msgstr "* un %s per cents(submòdul)->%s(blob)"
+msgstr "* %s %s(submòdul)->%s(blob)"
 
 #: builtin/submodule--helper.c:981
-#, fuzzy, c-format
+#, c-format
 msgid "%s"
-msgstr "percentatges"
+msgstr "%s"
 
 #: builtin/submodule--helper.c:1031
-#, fuzzy, c-format
+#, c-format
 msgid "couldn't hash object from '%s'"
-msgstr "no s'ha pogut analitzar l'objecte «%s»"
+msgstr "no s'ha pogut fer el resum de l'objecte de «%s»"
 
 #: builtin/submodule--helper.c:1035
-#, fuzzy, c-format
+#, c-format
 msgid "unexpected mode %o\n"
-msgstr "mode inesperat $mod_dst"
+msgstr "mode inesperat %o\n"
 
 #: builtin/submodule--helper.c:1276
-#, fuzzy
 msgid "use the commit stored in the index instead of the submodule HEAD"
 msgstr ""
-"Utilitza la comissió emmagatzemada a l'índex en lloc de la emmagatzemada al "
-"submòdul HEAD"
+"utilitza la comissió emmagatzemada a l'índex en lloc de la emmagatzemada al "
+"HEADdel submòdul"
 
 #: builtin/submodule--helper.c:1278
-#, fuzzy
 msgid "compare the commit in the index with that in the submodule HEAD"
 msgstr ""
-"Utilitza la comissió emmagatzemada a l'índex en lloc de la emmagatzemada al "
-"submòdul HEAD"
+"compara la comissió emmagatzemada a l'índex en lloc de la emmagatzemada al "
+"HEADdel submòdul"
 
 #: builtin/submodule--helper.c:1280
-#, fuzzy
 msgid "skip submodules with 'ignore_config' value set to 'all'"
-msgstr "omet els submòduls amb el valor «ignoreconfig» establert a «all»"
+msgstr "omet els submòduls amb el valor «ignore_config» establert a «all»"
 
 #: builtin/submodule--helper.c:1282
-#, fuzzy
 msgid "limit the summary size"
-msgstr "limita a caps"
+msgstr "limita la mida del resum"
 
 #: builtin/submodule--helper.c:1287
-#, fuzzy
 msgid "git submodule--helper summary [<options>] [<commit>] [--] [<path>]"
-msgstr "git submodule--helper init [<opcions>] [<camí>]"
+msgstr "git submodule--helper summary [<options>] [<commit>] [--] [<path>]"
 
 #: builtin/submodule--helper.c:1311
-#, fuzzy
 msgid "could not fetch a revision for HEAD"
-msgstr "no s'ha pogut separar HEAD"
-
-#: builtin/submodule--helper.c:1316
-#, fuzzy
-msgid "--cached and --files are mutually exclusive"
-msgstr "-n i -k són mútuament excloents"
+msgstr "no s'ha pogut obtenir una revisió per a HEAD"
 
 #: builtin/submodule--helper.c:1373
 #, c-format
@@ -23452,24 +23109,23 @@ msgid "failed to update remote for submodule '%s'"
 msgstr "s'ha produït un error en actualitzar el remot pel submòdul «%s»"
 
 #: builtin/submodule--helper.c:1451
-#, fuzzy
 msgid "suppress output of synchronizing submodule url"
-msgstr "Omet la sortida de la sincronització de l'url del submòdul"
+msgstr "omet la sortida de la sincronització de l'URL del submòdul"
 
 #: builtin/submodule--helper.c:1458
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
 msgstr "git submodule--helper sync [--quiet] [--recursive] [<camí>]"
 
-#: builtin/submodule--helper.c:1512
-#, c-format
+#: builtin/submodule--helper.c:1508
+#, fuzzy, c-format
 msgid ""
-"Submodule work tree '%s' contains a .git directory (use 'rm -rf' if you "
-"really want to remove it including all of its history)"
+"Submodule work tree '%s' contains a .git directory. This will be replaced "
+"with a .git file by using absorbgitdirs."
 msgstr ""
 "L'arbre de treball de submòdul «%s» conté un directori .git\n"
 "(useu «rm -rf» si realment voleu eliminar-lo, incloent tota la seva història)"
 
-#: builtin/submodule--helper.c:1524
+#: builtin/submodule--helper.c:1525
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
@@ -23478,49 +23134,47 @@ msgstr ""
 "L'arbre de treball del submòdul «%s» conté modificacions locals; useu «-f» "
 "per a descartar-les"
 
-#: builtin/submodule--helper.c:1532
+#: builtin/submodule--helper.c:1533
 #, c-format
 msgid "Cleared directory '%s'\n"
 msgstr "S'ha esborrat el directori «%s»\n"
 
-#: builtin/submodule--helper.c:1534
+#: builtin/submodule--helper.c:1535
 #, c-format
 msgid "Could not remove submodule work tree '%s'\n"
 msgstr "No s'ha pogut eliminar l'arbre de treball de submòdul «%s»\n"
 
-#: builtin/submodule--helper.c:1545
+#: builtin/submodule--helper.c:1546
 #, c-format
 msgid "could not create empty submodule directory %s"
 msgstr "no s'ha pogut crear el directori de submòdul buit %s"
 
-#: builtin/submodule--helper.c:1561
+#: builtin/submodule--helper.c:1562
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "S'ha desregistrat el submòdul «%s» (%s) per al camí «%s»\n"
 
-#: builtin/submodule--helper.c:1590
-#, fuzzy
+#: builtin/submodule--helper.c:1591
 msgid "remove submodule working trees even if they contain local changes"
 msgstr ""
-"Elimina els arbres de treball dels submòduls fins i tot si contenen canvis "
+"elimina els arbres de treball dels submòduls fins i tot si contenen canvis "
 "locals"
 
-#: builtin/submodule--helper.c:1591
-#, fuzzy
+#: builtin/submodule--helper.c:1592
 msgid "unregister all submodules"
-msgstr "Desregistra recursivament tots els submòduls"
+msgstr "desregistra tots els submòduls"
 
-#: builtin/submodule--helper.c:1596
+#: builtin/submodule--helper.c:1597
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<camí>...]]"
 
-#: builtin/submodule--helper.c:1610
+#: builtin/submodule--helper.c:1611
 msgid "Use '--all' if you really want to deinitialize all submodules"
 msgstr "Useu «--all» si realment voleu desinicialitzar tots els submòduls"
 
-#: builtin/submodule--helper.c:1655
+#: builtin/submodule--helper.c:1656
 #, fuzzy
 msgid ""
 "An alternate computed from a superproject's alternate is invalid.\n"
@@ -23533,168 +23187,164 @@ msgstr ""
 "submòdul.alternateErrorStrategy a 'info' o clona equivalentment amb "
 "«--reference-if-able' en lloc de «--reference»."
 
-#: builtin/submodule--helper.c:1700 builtin/submodule--helper.c:1703
+#: builtin/submodule--helper.c:1701 builtin/submodule--helper.c:1704
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
 msgstr "el submòdul «%s» no pot afegir un alternatiu: %s"
 
-#: builtin/submodule--helper.c:1739
+#: builtin/submodule--helper.c:1740
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
 msgstr "No es reconeix el valor «%s» per a submodule.alternateErrorStrategy"
 
-#: builtin/submodule--helper.c:1746
+#: builtin/submodule--helper.c:1747
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
 msgstr "No es reconeix el valor «%s» per a submodule.alternateLocation"
 
-#: builtin/submodule--helper.c:1771
-#, fuzzy, c-format
+#: builtin/submodule--helper.c:1772
+#, c-format
 msgid "refusing to create/use '%s' in another submodule's git dir"
-msgstr "refusant crear/usar '%s' en el directori git d'un altre submòdul"
+msgstr "s'ha rebutjat crear/usar «%s» en el directori git d'un altre submòdul"
 
-#: builtin/submodule--helper.c:1812
+#: builtin/submodule--helper.c:1813
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
 msgstr "el clonatge de «%s» al camí de submòdul «%s» ha fallat"
 
-#: builtin/submodule--helper.c:1817
+#: builtin/submodule--helper.c:1818
 #, c-format
 msgid "directory not empty: '%s'"
 msgstr "directori no buit: «%s»"
 
-#: builtin/submodule--helper.c:1829
+#: builtin/submodule--helper.c:1830
 #, c-format
 msgid "could not get submodule directory for '%s'"
 msgstr "no s'ha pogut obtenir el directori de submòdul per a «%s»"
 
-#: builtin/submodule--helper.c:1861
+#: builtin/submodule--helper.c:1862
 msgid "where the new submodule will be cloned to"
 msgstr "a on es clonarà el submòdul nou"
 
-#: builtin/submodule--helper.c:1864
+#: builtin/submodule--helper.c:1865
 msgid "name of the new submodule"
 msgstr "nom del submòdul nou"
 
-#: builtin/submodule--helper.c:1867
+#: builtin/submodule--helper.c:1868
 msgid "url where to clone the submodule from"
 msgstr "url del qual clonar el submòdul"
 
-#: builtin/submodule--helper.c:1875 builtin/submodule--helper.c:3264
+#: builtin/submodule--helper.c:1876 builtin/submodule--helper.c:3265
 msgid "depth for shallow clones"
 msgstr "profunditat dels clons superficials"
 
-#: builtin/submodule--helper.c:1878 builtin/submodule--helper.c:2525
-#: builtin/submodule--helper.c:3257
+#: builtin/submodule--helper.c:1879 builtin/submodule--helper.c:2526
+#: builtin/submodule--helper.c:3258
 msgid "force cloning progress"
 msgstr "força el progrés del clonatge"
 
-#: builtin/submodule--helper.c:1880 builtin/submodule--helper.c:2527
+#: builtin/submodule--helper.c:1881 builtin/submodule--helper.c:2528
 msgid "disallow cloning into non-empty directory"
 msgstr "no permetis clonar en un directori no buit"
 
-#: builtin/submodule--helper.c:1887
-#, fuzzy
+#: builtin/submodule--helper.c:1888
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
 "<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
 "<url> --path <path>"
 msgstr ""
-"git submodule--helper clone [--prefix=<path>] [--quiet] [---reference "
-"<repository>] [--name <name>] [--depth <] [---single-branch] --url <url> "
-"--path <path>"
+"git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
+"<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
+"<url> --path <path>"
 
-#: builtin/submodule--helper.c:1924
+#: builtin/submodule--helper.c:1925
 #, c-format
 msgid "Invalid update mode '%s' for submodule path '%s'"
 msgstr "Mode d'actualització «%s» no vàlid per al camí de submòdul «%s»"
 
-#: builtin/submodule--helper.c:1928
+#: builtin/submodule--helper.c:1929
 #, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
 msgstr ""
 "Mode d'actualització «%s» configurat no vàlid per al camí de submòdul «%s»"
 
-#: builtin/submodule--helper.c:2043
+#: builtin/submodule--helper.c:2044
 #, c-format
 msgid "Submodule path '%s' not initialized"
 msgstr "El camí de submòdul «%s» no està inicialitzat"
 
-#: builtin/submodule--helper.c:2047
+#: builtin/submodule--helper.c:2048
 msgid "Maybe you want to use 'update --init'?"
 msgstr "Potser voleu usar «update --init»?"
 
-#: builtin/submodule--helper.c:2077
+#: builtin/submodule--helper.c:2078
 #, c-format
 msgid "Skipping unmerged submodule %s"
 msgstr "S'està ometent el submòdul no fusionat %s"
 
-#: builtin/submodule--helper.c:2106
+#: builtin/submodule--helper.c:2107
 #, c-format
 msgid "Skipping submodule '%s'"
 msgstr "S'està ometent el submòdul «%s»"
 
-#: builtin/submodule--helper.c:2256
+#: builtin/submodule--helper.c:2257
 #, c-format
 msgid "Failed to clone '%s'. Retry scheduled"
 msgstr "S'ha produït un error en clonar «%s». S'ha programat un reintent"
 
-#: builtin/submodule--helper.c:2267
+#: builtin/submodule--helper.c:2268
 #, c-format
 msgid "Failed to clone '%s' a second time, aborting"
 msgstr "S'ha produït un error per segon cop en clonar «%s», s'està avortant"
 
-#: builtin/submodule--helper.c:2372
-#, fuzzy, c-format
+#: builtin/submodule--helper.c:2373
+#, c-format
 msgid "Unable to checkout '%s' in submodule path '%s'"
-msgstr "No s'ha pogut agafar «$sha1» en el camí de submòdul «$displaypath»"
+msgstr "No s'ha pogut agafar «%s» en el camí de submòdul «%s»"
 
-#: builtin/submodule--helper.c:2376
-#, fuzzy, c-format
+#: builtin/submodule--helper.c:2377
+#, c-format
 msgid "Unable to rebase '%s' in submodule path '%s'"
-msgstr ""
-"No s'ha pogut fer «rebase» «$sha1» en el camí de submòdul «$displaypath»"
+msgstr "No s'ha pogut fer «rebase» «%s» en el camí de submòdul «%s»"
 
-#: builtin/submodule--helper.c:2380
-#, fuzzy, c-format
+#: builtin/submodule--helper.c:2381
+#, c-format
 msgid "Unable to merge '%s' in submodule path '%s'"
-msgstr "No s'ha pogut fusionar «$sha1» en el camí de submòdul «$displaypath»"
+msgstr "No s'ha pogut fusionar «%s» en el camí de submòdul «%s»"
 
-#: builtin/submodule--helper.c:2384
-#, fuzzy, c-format
+#: builtin/submodule--helper.c:2385
+#, c-format
 msgid "Execution of '%s %s' failed in submodule path '%s'"
-msgstr ""
-"L'execució de «$command $sha1» ha fallat en el camí de submòdul "
-"«$displaypath»"
+msgstr "L'execució de «%s %s» ha fallat en el camí de submòdul «%s»"
 
-#: builtin/submodule--helper.c:2408
-#, fuzzy, c-format
+#: builtin/submodule--helper.c:2409
+#, c-format
 msgid "Submodule path '%s': checked out '%s'\n"
-msgstr "Camí de submòdul «$displaypath»: s'ha agafat «$sha1»"
+msgstr "Camí de submòdul «%s»: s'ha agafat «%s»\n"
 
-#: builtin/submodule--helper.c:2412
-#, fuzzy, c-format
+#: builtin/submodule--helper.c:2413
+#, c-format
 msgid "Submodule path '%s': rebased into '%s'\n"
-msgstr "Camí de submòdul «$displaypath»: s'ha fet «rebase» en «$sha1»"
+msgstr "Camí de submòdul «%s»: s'ha fet «rebase» en «%s»\n"
 
-#: builtin/submodule--helper.c:2416
-#, fuzzy, c-format
+#: builtin/submodule--helper.c:2417
+#, c-format
 msgid "Submodule path '%s': merged in '%s'\n"
-msgstr "Camí de submòdul «$displaypath»: s'ha fusionat en «$sha1»"
+msgstr "Camí de submòdul «%s»: s'ha fusionat en «%s»\n"
 
-#: builtin/submodule--helper.c:2420
-#, fuzzy, c-format
+#: builtin/submodule--helper.c:2421
+#, c-format
 msgid "Submodule path '%s': '%s %s'\n"
-msgstr "El camí de submòdul «%s» no està inicialitzat"
+msgstr "El camí de submòdul «%s»: '%s %s'\n"
 
-#: builtin/submodule--helper.c:2444
-#, fuzzy, c-format
+#: builtin/submodule--helper.c:2445
+#, c-format
 msgid "Unable to fetch in submodule path '%s'; trying to directly fetch %s:"
 msgstr ""
-"No s'ha pogut obtenir en el camí de submòdul «$displaypath»; s'està "
-"intentant obtenir directament $sha1:"
+"No s'ha pogut obtenir en el camí de submòdul «$%s»; s'està intentant obtenir"
+" directament %s:"
 
-#: builtin/submodule--helper.c:2453
+#: builtin/submodule--helper.c:2454
 #, fuzzy, c-format
 msgid ""
 "Fetched in submodule path '%s', but it did not contain %s. Direct fetching "
@@ -23703,97 +23353,87 @@ msgstr ""
 "S'ha obtingut en el camí de submòdul «$displaypath», però no contenia $sha1."
 " L'obtenció directa d'aquella comissió ha fallat."
 
-#: builtin/submodule--helper.c:2504 builtin/submodule--helper.c:2574
-#: builtin/submodule--helper.c:2812
+#: builtin/submodule--helper.c:2505 builtin/submodule--helper.c:2575
+#: builtin/submodule--helper.c:2813
 msgid "path into the working tree"
 msgstr "camí a l'arbre de treball"
 
-#: builtin/submodule--helper.c:2507 builtin/submodule--helper.c:2579
+#: builtin/submodule--helper.c:2508 builtin/submodule--helper.c:2580
 msgid "path into the working tree, across nested submodule boundaries"
 msgstr "camí a l'arbre de treball, a través de fronteres de submòduls niats"
 
-#: builtin/submodule--helper.c:2511 builtin/submodule--helper.c:2577
+#: builtin/submodule--helper.c:2512 builtin/submodule--helper.c:2578
 msgid "rebase, merge, checkout or none"
 msgstr "rebase, merge, checkout o none"
 
-#: builtin/submodule--helper.c:2517
+#: builtin/submodule--helper.c:2518
 #, fuzzy
 msgid "create a shallow clone truncated to the specified number of revisions"
 msgstr "Crea un clon superficial truncat al nombre de revisions especificat"
 
-#: builtin/submodule--helper.c:2520
+#: builtin/submodule--helper.c:2521
 msgid "parallel jobs"
 msgstr "tasques paral·leles"
 
-#: builtin/submodule--helper.c:2522
+#: builtin/submodule--helper.c:2523
 msgid "whether the initial clone should follow the shallow recommendation"
 msgstr "si el clonatge inicial ha de seguir la recomanació de superficialitat"
 
-#: builtin/submodule--helper.c:2523
+#: builtin/submodule--helper.c:2524
 msgid "don't print cloning progress"
 msgstr "no imprimeixis el progrés del clonatge"
 
-#: builtin/submodule--helper.c:2534
+#: builtin/submodule--helper.c:2535
 msgid "git submodule--helper update-clone [--prefix=<path>] [<path>...]"
 msgstr "git submodule--helper update-clone [--prefix=<camí>] [<camí>...]"
 
-#: builtin/submodule--helper.c:2547
+#: builtin/submodule--helper.c:2548
 msgid "bad value for update parameter"
 msgstr "valor incorrecte per al paràmetre update"
 
-#: builtin/submodule--helper.c:2565
-#, fuzzy
-msgid "suppress output for update by rebase or merge"
-msgstr "Omet la sortida d'inicialitzar un submòdul"
-
 #: builtin/submodule--helper.c:2566
-#, fuzzy
+msgid "suppress output for update by rebase or merge"
+msgstr "omet la sortida per les actualitzacions per «rebase» o fusió"
+
+#: builtin/submodule--helper.c:2567
 msgid "force checkout updates"
 msgstr "força les actualitzacions"
 
-#: builtin/submodule--helper.c:2568
-#, fuzzy
+#: builtin/submodule--helper.c:2569
 msgid "don't fetch new objects from the remote site"
-msgstr "Crea un objecte arbre des de l'índex actual"
-
-#: builtin/submodule--helper.c:2570
-#, fuzzy
-msgid "overrides update mode in case the repository is a fresh clone"
-msgstr ""
-"substitueix el mode d'actualització en cas que el repositori sigui un clon "
-"nou"
+msgstr "no obtinguis els objectes nous del lloc remot"
 
 #: builtin/submodule--helper.c:2571
-#, fuzzy
+msgid "overrides update mode in case the repository is a fresh clone"
+msgstr ""
+"sobreescriu el mode d'actualització en cas que el repositori sigui un clon "
+"nou"
+
+#: builtin/submodule--helper.c:2572
 msgid "depth for shallow fetch"
 msgstr "profunditat dels clons superficials"
 
-#: builtin/submodule--helper.c:2581
-#, fuzzy
+#: builtin/submodule--helper.c:2582
 msgid "sha1"
 msgstr "sha1"
 
-#: builtin/submodule--helper.c:2582
-#, fuzzy
+#: builtin/submodule--helper.c:2583
 msgid "SHA1 expected by superproject"
 msgstr "SHA1 esperat per superproject"
 
-#: builtin/submodule--helper.c:2584
-#, fuzzy
+#: builtin/submodule--helper.c:2585
 msgid "subsha1"
 msgstr "subsha1"
 
-#: builtin/submodule--helper.c:2585
-#, fuzzy
+#: builtin/submodule--helper.c:2586
 msgid "SHA1 of submodule's HEAD"
-msgstr "SHA1 del CAP del submòdul"
+msgstr "SHA1 del HEAD del submòdul"
 
-#: builtin/submodule--helper.c:2591
-#, fuzzy
+#: builtin/submodule--helper.c:2592
 msgid "git submodule--helper run-update-procedure [<options>] <path>"
-msgstr "git submodule--helper init [<opcions>] [<camí>]"
+msgstr "git submodule--helper run-update-procedure [<options>] <path>"
 
-#: builtin/submodule--helper.c:2662
+#: builtin/submodule--helper.c:2663
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
@@ -23802,106 +23442,91 @@ msgstr ""
 "La branca de submòdul (%s) està configurada per a heretar la branca del "
 "superprojecte, però el superprojecte no és en cap branca"
 
-#: builtin/submodule--helper.c:2780
+#: builtin/submodule--helper.c:2781
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
 msgstr "no s'ha pogut obtenir el gestor del repositori pel submòdul «%s»"
 
-#: builtin/submodule--helper.c:2813
+#: builtin/submodule--helper.c:2814
 msgid "recurse into submodules"
 msgstr "inclou recursivament als submòduls"
 
-#: builtin/submodule--helper.c:2819
+#: builtin/submodule--helper.c:2820
 msgid "git submodule--helper absorb-git-dirs [<options>] [<path>...]"
 msgstr "git submodule--helper absorb-git-dirs [<opcions>] [<camí>...]"
 
-#: builtin/submodule--helper.c:2875
+#: builtin/submodule--helper.c:2876
 msgid "check if it is safe to write to the .gitmodules file"
 msgstr "comprova si és segur escriure al fitxer .gitmodules"
 
-#: builtin/submodule--helper.c:2878
+#: builtin/submodule--helper.c:2879
 #, fuzzy
 msgid "unset the config in the .gitmodules file"
 msgstr "no s'ha definit la configuració al fitxer .gitmodules"
 
-#: builtin/submodule--helper.c:2883
-#, fuzzy
-msgid "git submodule--helper config <name> [<value>]"
-msgstr "git submodule--helper config <name> [<value>]"
-
 #: builtin/submodule--helper.c:2884
-#, fuzzy
-msgid "git submodule--helper config --unset <name>"
-msgstr "git submodule--helper config --unset <name>"
+msgid "git submodule--helper config <name> [<value>]"
+msgstr "git submodule--helper config <nom> [<valor>]"
 
 #: builtin/submodule--helper.c:2885
+msgid "git submodule--helper config --unset <name>"
+msgstr "git submodule--helper config --unset <nom>"
+
+#: builtin/submodule--helper.c:2886
 msgid "git submodule--helper config --check-writeable"
 msgstr "git submodule--helper config --check-writeable"
 
-#: builtin/submodule--helper.c:2904 builtin/submodule--helper.c:3120
-#: builtin/submodule--helper.c:3276
-#, fuzzy
+#: builtin/submodule--helper.c:2905 builtin/submodule--helper.c:3121
+#: builtin/submodule--helper.c:3277
 msgid "please make sure that the .gitmodules file is in the working tree"
-msgstr "Assegureu-vos que el fitxer .gitmodules és a l'arbre de treball"
+msgstr "assegureu-vos que el fitxer .gitmodules és a l'arbre de treball"
 
-#: builtin/submodule--helper.c:2920
-#, fuzzy
+#: builtin/submodule--helper.c:2921
 msgid "suppress output for setting url of a submodule"
-msgstr "Omet la sortida d'inicialitzar un submòdul"
+msgstr "omet la sortida en configurar una URL d'un submòdul"
 
-#: builtin/submodule--helper.c:2924
-#, fuzzy
+#: builtin/submodule--helper.c:2925
 msgid "git submodule--helper set-url [--quiet] <path> <newurl>"
-msgstr "git submodule--helper sync [--quiet] [--recursive] [<camí>]"
+msgstr "git submodule--helper set-url [--quiet] <path> <newurl>"
 
-#: builtin/submodule--helper.c:2957
-#, fuzzy
+#: builtin/submodule--helper.c:2958
 msgid "set the default tracking branch to master"
-msgstr "mostra les branques amb seguiment remot"
+msgstr "estableix la branca de seguiment per defecte a «master»"
 
-#: builtin/submodule--helper.c:2959
-#, fuzzy
+#: builtin/submodule--helper.c:2960
 msgid "set the default tracking branch"
-msgstr "mostra les branques amb seguiment remot"
-
-#: builtin/submodule--helper.c:2963
-#, fuzzy
-msgid "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
-msgstr "git submodule--helper sync [--quiet] [--recursive] [<camí>]"
+msgstr "estableix la branca de seguiment per defecte"
 
 #: builtin/submodule--helper.c:2964
-#, fuzzy
+msgid "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
+msgstr "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
+
+#: builtin/submodule--helper.c:2965
 msgid ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
-msgstr "git submodule--helper sync [--quiet] [--recursive] [<camí>]"
-
-#: builtin/submodule--helper.c:2971
-#, fuzzy
-msgid "--branch or --default required"
-msgstr "cal el nom de branca"
-
-#: builtin/submodule--helper.c:2974
-#, fuzzy
-msgid "--branch and --default are mutually exclusive"
-msgstr "--deepen i --depth són mútuament excloents"
-
-#: builtin/submodule--helper.c:3037
-#, fuzzy, c-format
-msgid "Adding existing repo at '%s' to the index\n"
-msgstr "S'està afegint el repositori existent a «$sm_path» a l'índex"
-
-#: builtin/submodule--helper.c:3040
-#, fuzzy, c-format
-msgid "'%s' already exists and is not a valid git repo"
-msgstr "«$sm_path» ja existeix i no és un repositori de git vàlid"
-
-#: builtin/submodule--helper.c:3053
-#, fuzzy, c-format
-msgid "A git directory for '%s' is found locally with remote(s):\n"
 msgstr ""
-"S'ha trobat un directori de git per a «$sm_name» localment amb els remots:"
+"git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
 
-#: builtin/submodule--helper.c:3060
+#: builtin/submodule--helper.c:2972
+msgid "--branch or --default required"
+msgstr "cal --branch o --default "
+
+#: builtin/submodule--helper.c:3038
+#, c-format
+msgid "Adding existing repo at '%s' to the index\n"
+msgstr "S'està afegint el repositori existent a «%s» a l'índex\n"
+
+#: builtin/submodule--helper.c:3041
+#, c-format
+msgid "'%s' already exists and is not a valid git repo"
+msgstr "«%s» ja existeix i no és un repositori de git vàlid"
+
+#: builtin/submodule--helper.c:3054
+#, c-format
+msgid "A git directory for '%s' is found locally with remote(s):\n"
+msgstr "S'ha trobat un directori de git per a «%s» localment amb els remots:\n"
+
+#: builtin/submodule--helper.c:3061
 #, fuzzy, c-format
 msgid ""
 "If you want to reuse this local git directory instead of cloning again from\n"
@@ -23914,60 +23539,59 @@ msgstr ""
 "useu l'opció «--force». Si el directori de git local no és el repositori correcte\n"
 "o no esteu segur de què vol dir això, trieu un altre nom amb l'opció «--name»."
 
-#: builtin/submodule--helper.c:3072
+#: builtin/submodule--helper.c:3073
 #, fuzzy, c-format
 msgid "Reactivating local git directory for submodule '%s'\n"
 msgstr ""
 "S'està reactivant el directori de git local per al submòdul «$sm_name»."
 
-#: builtin/submodule--helper.c:3109
-#, fuzzy, c-format
+#: builtin/submodule--helper.c:3110
+#, c-format
 msgid "unable to checkout submodule '%s'"
-msgstr "No s'ha pogut agafar el submòdul «$sm_path»"
+msgstr "no s'ha pogut agafar el submòdul «%s»"
 
-#: builtin/submodule--helper.c:3148
-#, fuzzy, c-format
+#: builtin/submodule--helper.c:3149
+#, c-format
 msgid "Failed to add submodule '%s'"
-msgstr "S'ha produït un error en afegir el submòdul «$sm_path»"
+msgstr "s'ha produït un error en afegir el submòdul «%s»"
 
-#: builtin/submodule--helper.c:3152 builtin/submodule--helper.c:3157
-#: builtin/submodule--helper.c:3165
-#, fuzzy, c-format
+#: builtin/submodule--helper.c:3153 builtin/submodule--helper.c:3158
+#: builtin/submodule--helper.c:3166
+#, c-format
 msgid "Failed to register submodule '%s'"
-msgstr "S'ha produït un error en registrar el submòdul «$sm_path»"
+msgstr "S'ha produït un error en registrar el submòdul «%s»"
 
-#: builtin/submodule--helper.c:3221
-#, fuzzy, c-format
+#: builtin/submodule--helper.c:3222
+#, c-format
 msgid "'%s' already exists in the index"
-msgstr "«$sm_path» ja existeix en l'índex"
+msgstr "«%s» ja existeix en l'índex"
 
-#: builtin/submodule--helper.c:3224
-#, fuzzy, c-format
+#: builtin/submodule--helper.c:3225
+#, c-format
 msgid "'%s' already exists in the index and is not a submodule"
-msgstr "«$sm_path» ja existeix en l'índex i no és submòdul"
+msgstr "«%s» ja existeix en l'índex i no és submòdul"
 
-#: builtin/submodule--helper.c:3253
+#: builtin/submodule--helper.c:3254
 #, fuzzy
 msgid "branch of repository to add as submodule"
 msgstr "la branca o entrega a agafar"
 
-#: builtin/submodule--helper.c:3254
+#: builtin/submodule--helper.c:3255
 #, fuzzy
 msgid "allow adding an otherwise ignored submodule path"
 msgstr "permet afegir fitxers que d'altra manera s'ignoren"
 
-#: builtin/submodule--helper.c:3256
-#, fuzzy
+#: builtin/submodule--helper.c:3257
 msgid "print only error messages"
-msgstr "imprimeix només les referències que s'han fusionat"
+msgstr "mostra només els missatges d'error"
 
-#: builtin/submodule--helper.c:3260
+#: builtin/submodule--helper.c:3261
 #, fuzzy
 msgid "borrow the objects from reference repositories"
 msgstr ""
 "ignora els objectes prestats d'un emmagatzematge d'objectes alternatiu"
 
-#: builtin/submodule--helper.c:3262
+#: builtin/submodule--helper.c:3263
 #, fuzzy
 msgid ""
 "sets the submodule’s name to the given string instead of defaulting to its "
@@ -23976,33 +23600,33 @@ msgstr ""
 "estableix el nom del submòdul a la cadena donada en lloc de per defecte al "
 "seu camí"
 
-#: builtin/submodule--helper.c:3269
+#: builtin/submodule--helper.c:3270
 #, fuzzy
 msgid "git submodule--helper add [<options>] [--] <repository> [<path>]"
 msgstr "git submodule--helper init [<opcions>] [<camí>]"
 
-#: builtin/submodule--helper.c:3297
+#: builtin/submodule--helper.c:3298
 msgid "Relative path can only be used from the toplevel of the working tree"
 msgstr ""
 "El camí relatiu només es pot usar des del nivell superior de l'arbre de "
 "treball"
 
-#: builtin/submodule--helper.c:3305
+#: builtin/submodule--helper.c:3306
 #, fuzzy, c-format
 msgid "repo URL: '%s' must be absolute or begin with ./|../"
 msgstr "URL de repositori: «$repo» ha de ser absolut o començar amb ./|../"
 
-#: builtin/submodule--helper.c:3340
+#: builtin/submodule--helper.c:3341
 #, fuzzy, c-format
 msgid "'%s' is not a valid submodule name"
 msgstr "«%s» no és un nom de remot vàlid"
 
-#: builtin/submodule--helper.c:3404 git.c:449 git.c:723
+#: builtin/submodule--helper.c:3405 git.c:452 git.c:726
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s no admet --super-prefix"
 
-#: builtin/submodule--helper.c:3410
+#: builtin/submodule--helper.c:3411
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
 msgstr "«%s» no és una subordre vàlida de submodule--helper"
@@ -24097,11 +23721,11 @@ msgstr ""
 "  %s\n"
 "Les línies que comencin amb «%c» es retindran; podeu eliminar-les per vós mateix si voleu.\n"
 
-#: builtin/tag.c:241
+#: builtin/tag.c:240
 msgid "unable to sign the tag"
 msgstr "no s'ha pogut signar l'etiqueta"
 
-#: builtin/tag.c:259
+#: builtin/tag.c:258
 #, fuzzy, c-format
 msgid ""
 "You have created a nested tag. The object referred to by your new tag is\n"
@@ -24113,15 +23737,15 @@ msgstr ""
 " etiqueta ja és una etiqueta. Si voleu etiquetar l'objecte que apunta per "
 "utilitzar l'etiqueta git -f%s%s perds^{}"
 
-#: builtin/tag.c:275
+#: builtin/tag.c:274
 msgid "bad object type."
 msgstr "el tipus d'objecte és incorrecte."
 
-#: builtin/tag.c:326
+#: builtin/tag.c:325
 msgid "no tag message?"
 msgstr "no hi ha cap missatge d'etiqueta?"
 
-#: builtin/tag.c:333
+#: builtin/tag.c:332
 #, c-format
 msgid "The tag message has been left in %s\n"
 msgstr "S'ha deixat el missatge de l'etiqueta en %s\n"
@@ -24202,45 +23826,22 @@ msgstr "imprimeix només les etiquetes que no s'han fusionat"
 msgid "print only tags of the object"
 msgstr "imprimeix només les etiquetes de l'objecte"
 
-#: builtin/tag.c:525
-msgid "--column and -n are incompatible"
-msgstr "--column i -n són incompatibles"
-
-#: builtin/tag.c:546
-msgid "-n option is only allowed in list mode"
+#: builtin/tag.c:558
+#, fuzzy, c-format
+msgid "the '%s' option is only allowed in list mode"
 msgstr "es permet l'opció -n només amb mode llista"
 
-#: builtin/tag.c:548
-msgid "--contains option is only allowed in list mode"
-msgstr "es permet l'opció --contains només amb mode llista"
-
-#: builtin/tag.c:550
-msgid "--no-contains option is only allowed in list mode"
-msgstr "es permet l'opció --no-contains només amb mode llista"
-
-#: builtin/tag.c:552
-msgid "--points-at option is only allowed in list mode"
-msgstr "es permet --points-at option només amb mode llista"
-
-#: builtin/tag.c:554
-msgid "--merged and --no-merged options are only allowed in list mode"
-msgstr "es permeten les opcions --merged i --no-merged només amb mode llista"
-
-#: builtin/tag.c:568
-msgid "only one -F or -m option is allowed."
-msgstr "només es permet una opció -F o -m."
-
-#: builtin/tag.c:593
+#: builtin/tag.c:597
 #, c-format
 msgid "'%s' is not a valid tag name."
 msgstr "«%s» no és un nom d'etiqueta vàlid."
 
-#: builtin/tag.c:598
+#: builtin/tag.c:602
 #, c-format
 msgid "tag '%s' already exists"
 msgstr "l'etiqueta «%s» ja existeix"
 
-#: builtin/tag.c:629
+#: builtin/tag.c:633
 #, c-format
 msgid "Updated tag '%s' (was %s)\n"
 msgstr "Etiqueta «%s» actualitzada (era %s)\n"
@@ -24646,7 +24247,7 @@ msgstr "informa dels arbres de treball podats"
 
 #: builtin/worktree.c:150
 msgid "expire working trees older than <time>"
-msgstr "fes caducar els arbres de treball més vells que <hora>"
+msgstr "fes caducar els arbres de treball més antics que <data>"
 
 #: builtin/worktree.c:220
 #, c-format
@@ -24686,141 +24287,126 @@ msgstr "no s'ha pogut crear directori de «%s»"
 msgid "initializing"
 msgstr "inicialitzant"
 
-#: builtin/worktree.c:421 builtin/worktree.c:427
+#: builtin/worktree.c:420 builtin/worktree.c:426
 #, c-format
 msgid "Preparing worktree (new branch '%s')"
 msgstr "S'està preparant l'arbre de treball (branca nova «%s»)"
 
-#: builtin/worktree.c:423
+#: builtin/worktree.c:422
 #, fuzzy, c-format
 msgid "Preparing worktree (resetting branch '%s'; was at %s)"
 msgstr ""
 "Preparant l'arbre de treball (la branca de reestructuració \"%s\"; estava en"
 " percentatges)"
 
-#: builtin/worktree.c:432
+#: builtin/worktree.c:431
 #, c-format
 msgid "Preparing worktree (checking out '%s')"
 msgstr "S'està preparant l'arbre de treball (s'està agafant «%s»)"
 
-#: builtin/worktree.c:438
+#: builtin/worktree.c:437
 #, c-format
 msgid "Preparing worktree (detached HEAD %s)"
 msgstr "S'està preparant l'arbre de treball (HEAD %s separat)"
 
-#: builtin/worktree.c:483
+#: builtin/worktree.c:482
 msgid "checkout <branch> even if already checked out in other worktree"
 msgstr "agafa <branca> encara que sigui agafada en altre arbre de treball"
 
-#: builtin/worktree.c:486
+#: builtin/worktree.c:485
 msgid "create a new branch"
 msgstr "crea una branca nova"
 
-#: builtin/worktree.c:488
+#: builtin/worktree.c:487
 msgid "create or reset a branch"
 msgstr "crea o restableix una branca"
 
-#: builtin/worktree.c:490
+#: builtin/worktree.c:489
 msgid "populate the new working tree"
 msgstr "emplena l'arbre de treball nou"
 
-#: builtin/worktree.c:491
+#: builtin/worktree.c:490
 msgid "keep the new working tree locked"
 msgstr "mantén l'arbre de treball nou bloquejat"
 
-#: builtin/worktree.c:493 builtin/worktree.c:730
+#: builtin/worktree.c:492 builtin/worktree.c:729
 msgid "reason for locking"
 msgstr "raó per bloquejar"
 
-#: builtin/worktree.c:496
+#: builtin/worktree.c:495
 msgid "set up tracking mode (see git-branch(1))"
 msgstr "configura el mode de seguiment (vegeu git-branch(1))"
 
-#: builtin/worktree.c:499
+#: builtin/worktree.c:498
 msgid "try to match the new branch name with a remote-tracking branch"
 msgstr ""
 "prova de fer coincidir el nom de la branca nova amb una branca amb seguiment"
 " remot"
 
-#: builtin/worktree.c:507
-msgid "-b, -B, and --detach are mutually exclusive"
-msgstr "-b, -B i --detach són mútuament excloents"
-
-#: builtin/worktree.c:509
-#, fuzzy
-msgid "--reason requires --lock"
-msgstr "raó per bloquejar"
-
-#: builtin/worktree.c:513
-#, fuzzy
+#: builtin/worktree.c:512
 msgid "added with --lock"
 msgstr "afegit amb --lock"
 
-#: builtin/worktree.c:575
+#: builtin/worktree.c:574
 msgid "--[no-]track can only be used if a new branch is created"
 msgstr "--[no-]track només es pot usar si es crea una branca nova"
 
-#: builtin/worktree.c:692
+#: builtin/worktree.c:691
 #, fuzzy
 msgid "show extended annotations and reasons, if available"
 msgstr "mostra les anotacions i raons esteses, si està disponible"
 
-#: builtin/worktree.c:694
+#: builtin/worktree.c:693
 #, fuzzy
 msgid "add 'prunable' annotation to worktrees older than <time>"
-msgstr "fes caducar els arbres de treball més vells que <hora>"
+msgstr "fes caducar els arbres de treball més antics que <data>"
 
-#: builtin/worktree.c:703
-#, fuzzy
-msgid "--verbose and --porcelain are mutually exclusive"
-msgstr "-p i --overlay són mútuament excloents"
-
-#: builtin/worktree.c:742 builtin/worktree.c:775 builtin/worktree.c:849
-#: builtin/worktree.c:973
+#: builtin/worktree.c:741 builtin/worktree.c:774 builtin/worktree.c:848
+#: builtin/worktree.c:972
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr "«%s» no és un arbre de treball"
 
-#: builtin/worktree.c:744 builtin/worktree.c:777
+#: builtin/worktree.c:743 builtin/worktree.c:776
 msgid "The main working tree cannot be locked or unlocked"
 msgstr "No es pot bloquejar ni desbloquejar l'arbre de treball principal"
 
-#: builtin/worktree.c:749
+#: builtin/worktree.c:748
 #, c-format
 msgid "'%s' is already locked, reason: %s"
 msgstr "«%s» ja està bloquejat, raó: «%s»"
 
-#: builtin/worktree.c:751
+#: builtin/worktree.c:750
 #, c-format
 msgid "'%s' is already locked"
 msgstr "«%s» ja està bloquejat"
 
-#: builtin/worktree.c:779
+#: builtin/worktree.c:778
 #, c-format
 msgid "'%s' is not locked"
 msgstr "«%s» no està bloquejat"
 
-#: builtin/worktree.c:820
+#: builtin/worktree.c:819
 msgid "working trees containing submodules cannot be moved or removed"
 msgstr ""
 "els arbres de treball que contenen submòduls no es poden moure ni eliminar"
 
-#: builtin/worktree.c:828
+#: builtin/worktree.c:827
 msgid "force move even if worktree is dirty or locked"
 msgstr ""
 "força el moviment encara que l'arbre de treball estigui brut o bloquejat"
 
-#: builtin/worktree.c:851 builtin/worktree.c:975
+#: builtin/worktree.c:850 builtin/worktree.c:974
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr "«%s» és un arbre de treball principal"
 
-#: builtin/worktree.c:856
+#: builtin/worktree.c:855
 #, c-format
 msgid "could not figure out destination name from '%s'"
 msgstr "no s'ha pogut deduir el nom de destí des de «%s»"
 
-#: builtin/worktree.c:869
+#: builtin/worktree.c:868
 #, fuzzy, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
@@ -24829,7 +24415,7 @@ msgstr ""
 "no es pot moure un bloqueig de l'arbre de treball bloquejat el raon per cent"
 " utilitza «move -f -f» per substituir o desbloquejar primer"
 
-#: builtin/worktree.c:871
+#: builtin/worktree.c:870
 #, fuzzy
 msgid ""
 "cannot move a locked working tree;\n"
@@ -24838,38 +24424,38 @@ msgstr ""
 "no es pot moure un arbre de treball bloquejat; useu primer «move -f -f» per "
 "sobreescriure o desbloquejar"
 
-#: builtin/worktree.c:874
+#: builtin/worktree.c:873
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
 msgstr "la validació ha fallat, no es pot moure l'arbre de treball: %s"
 
-#: builtin/worktree.c:879
+#: builtin/worktree.c:878
 #, c-format
 msgid "failed to move '%s' to '%s'"
 msgstr "s'ha produït un error en moure «%s» a «%s»"
 
-#: builtin/worktree.c:925
+#: builtin/worktree.c:924
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr "no s'ha pogut executar «git status» a «%s»"
 
-#: builtin/worktree.c:929
+#: builtin/worktree.c:928
 #, fuzzy, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
 "'%s' conté fitxers modificats o no seguits useu --force per suprimir-los"
 
-#: builtin/worktree.c:934
+#: builtin/worktree.c:933
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr "no s'ha pogut executar «git status» a «%s», codi %d"
 
-#: builtin/worktree.c:957
+#: builtin/worktree.c:956
 msgid "force removal even if worktree is dirty or locked"
 msgstr ""
 "força l'eliminació encara que l'arbre de treball estigui brut o bloquejat"
 
-#: builtin/worktree.c:980
+#: builtin/worktree.c:979
 #, fuzzy, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
@@ -24878,7 +24464,7 @@ msgstr ""
 "no s'ha pogut eliminar un bloqueig de l'arbre de treball bloquejat perquè "
 "els raonadors utilitzen «remove -f -f» per substituir o desbloquejar primer"
 
-#: builtin/worktree.c:982
+#: builtin/worktree.c:981
 #, fuzzy
 msgid ""
 "cannot remove a locked working tree;\n"
@@ -24887,19 +24473,19 @@ msgstr ""
 "no es pot eliminar un arbre de treball bloquejat; useu primer «remove -f -f»"
 " per sobreescriure o desbloquejar"
 
-#: builtin/worktree.c:985
+#: builtin/worktree.c:984
 #, fuzzy, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr ""
 "la validació ha fallat no es poden eliminar els percentatges dels arbres de "
 "treball"
 
-#: builtin/worktree.c:1009
+#: builtin/worktree.c:1008
 #, fuzzy, c-format
 msgid "repair: %s: %s"
 msgstr "%s no vàlid: «%s»"
 
-#: builtin/worktree.c:1012
+#: builtin/worktree.c:1011
 #, fuzzy, c-format
 msgid "error: %s: %s"
 msgstr "error en %s %s: %s"
@@ -24921,7 +24507,6 @@ msgid "only useful for debugging"
 msgstr "només útil per a la depuració"
 
 #: git.c:28
-#, fuzzy
 msgid ""
 "git [--version] [--help] [-C <path>] [-c <name>=<value>]\n"
 "           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]\n"
@@ -24930,9 +24515,12 @@ msgid ""
 "           [--super-prefix=<path>] [--config-env=<name>=<envvar>]\n"
 "           <command> [<args>]"
 msgstr ""
-"git [--version] [--help] [-C <path>] [-c <name>=<value>] [--exec-"
-"path[=<path>]] [---html-path] [---info-path] [--paginate | -P | --no-pager] "
-"[-git-dir=<-name]"
+"git [--version] [--help] [-C <path>] [-c <name>=<value>]\n"
+"           [--exec-path[=<path>]] [--html-path] [--man-path] [--info-path]\n"
+"           [-p | --paginate | -P | --no-pager] [--no-replace-objects] [--bare]\n"
+"           [--git-dir=<path>] [--work-tree=<path>] [--namespace=<name>]\n"
+"           [--super-prefix=<path>] [--config-env=<name>=<envvar>]\n"
+"           <command> [<args>]"
 
 #: git.c:36
 msgid ""
@@ -24946,20 +24534,15 @@ msgstr ""
 "«git help <concepte>» per a llegir sobre una subordre o concepte\n"
 "específic. Vegeu «git help git» per a una visió general del sistema."
 
-#: git.c:188
-#, c-format
-msgid "no directory given for --git-dir\n"
-msgstr "no s'ha especificat un directori per --git-dir\n"
+#: git.c:188 git.c:216 git.c:300
+#, fuzzy, c-format
+msgid "no directory given for '%s' option\n"
+msgstr "no s'ha especificat un directori per -C\n"
 
 #: git.c:202
 #, c-format
 msgid "no namespace given for --namespace\n"
 msgstr "no s'ha especificat un nom d'espai per --namespace\n"
-
-#: git.c:216
-#, c-format
-msgid "no directory given for --work-tree\n"
-msgstr "no s'ha especificat un directori per --work-tree\n"
 
 #: git.c:230
 #, c-format
@@ -24975,11 +24558,6 @@ msgstr "-c espera una cadena de configuració\n"
 #, fuzzy, c-format
 msgid "no config key given for --config-env\n"
 msgstr "no s'ha especificat un directori per --work-tree\n"
-
-#: git.c:300
-#, c-format
-msgid "no directory given for -C\n"
-msgstr "no s'ha especificat un directori per -C\n"
 
 #: git.c:326
 #, c-format
@@ -25001,38 +24579,38 @@ msgstr ""
 " fer-ho"
 
 #: git.c:391
-#, fuzzy, c-format
+#, c-format
 msgid "empty alias for %s"
-msgstr "àlies buit per a percentatges"
+msgstr "àlies buit per a %s"
 
 #: git.c:394
 #, c-format
 msgid "recursive alias: %s"
 msgstr "àlies recursiu: %s"
 
-#: git.c:476
+#: git.c:479
 msgid "write failure on standard output"
 msgstr "fallada d'escriptura en la sortida estàndard"
 
-#: git.c:478
+#: git.c:481
 msgid "unknown write failure on standard output"
 msgstr "fallada d'escriptura desconeguda en la sortida estàndard"
 
-#: git.c:480
+#: git.c:483
 msgid "close failed on standard output"
 msgstr "ha fallat el tancament en la sortida estàndard"
 
-#: git.c:832
+#: git.c:835
 #, fuzzy, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr "bucle d'àlies detectat expansió de «%s» no acaba%"
 
-#: git.c:882
+#: git.c:885
 #, fuzzy, c-format
 msgid "cannot handle %s as a builtin"
 msgstr "no es poden gestionar els percentatges com a integrat"
 
-#: git.c:895
+#: git.c:898
 #, c-format
 msgid ""
 "usage: %s\n"
@@ -25041,35 +24619,25 @@ msgstr ""
 "ús: %s\n"
 "\n"
 
-#: git.c:915
+#: git.c:918
 #, fuzzy, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr "ha fallat l'expansió de l'àlies '%s'; '%s' no és una ordre git"
 
-#: git.c:927
+#: git.c:930
 #, c-format
 msgid "failed to run command '%s': %s\n"
 msgstr "s'ha produït un error en executar l'ordre «%s»: %s\n"
 
-#: http-fetch.c:118
+#: http-fetch.c:128
 #, fuzzy, c-format
 msgid "argument to --packfile must be a valid hash (got '%s')"
 msgstr "l'argument a --packfile ha de ser un hash vàlid (té '%')"
 
-#: http-fetch.c:128
+#: http-fetch.c:138
 #, fuzzy
 msgid "not a git repository"
 msgstr "No és un repositori de git"
-
-#: http-fetch.c:134
-#, fuzzy
-msgid "--packfile requires --index-pack-args"
-msgstr "--pathspec-file-nul requereix --pathspec-from-file"
-
-#: http-fetch.c:143
-#, fuzzy
-msgid "--index-pack-args can only be used with --packfile"
-msgstr "-N només es pot usar amb --mixed"
 
 #: t/helper/test-fast-rebase.c:141
 #, fuzzy
@@ -25153,24 +24721,20 @@ msgid "number of threads in server thread pool"
 msgstr "nombre de fils en la reserva de fils del servidor"
 
 #: t/helper/test-simple-ipc.c:600
-#, fuzzy
 msgid "seconds to wait for daemon to start or stop"
-msgstr "segons a esperar que el dimoni comenci o atura"
+msgstr "segons a esperar que el dimoni comenci o s'aturi"
 
 #: t/helper/test-simple-ipc.c:602
-#, fuzzy
 msgid "number of bytes"
-msgstr "nombre incorrecte d'arguments"
+msgstr "nombre d'octets"
 
 #: t/helper/test-simple-ipc.c:603
-#, fuzzy
 msgid "number of requests per thread"
-msgstr "no s'ha pogut crear fil: %s"
+msgstr "nombre de peticions per fil"
 
 #: t/helper/test-simple-ipc.c:605
-#, fuzzy
 msgid "byte"
-msgstr "octets"
+msgstr "octet"
 
 #: t/helper/test-simple-ipc.c:605
 #, fuzzy
@@ -25178,7 +24742,6 @@ msgid "ballast character"
 msgstr "caràcter de llast"
 
 #: t/helper/test-simple-ipc.c:606
-#, fuzzy
 msgid "token"
 msgstr "testimoni"
 
@@ -25267,7 +24830,7 @@ msgid "Authentication failed for '%s'"
 msgstr "S'ha produït un error en autenticar per «%s»"
 
 #: remote-curl.c:504
-#, c-format, fuzzy
+#, fuzzy, c-format
 msgid "unable to access '%s' with http.pinnedPubkey configuration: %s"
 msgstr "no es pot accedir a '%s' amb la configuració de http.pinnedPubkey:%s"
 
@@ -25337,64 +24900,253 @@ msgid "%d bytes of body are still expected"
 msgstr "encara s'esperen bytes de cos per cent"
 
 #: remote-curl.c:1131
-#, fuzzy
 msgid "dumb http transport does not support shallow capabilities"
 msgstr "el transport ximple http no admet capacitats superficials"
 
 #: remote-curl.c:1146
-#, fuzzy
 msgid "fetch failed."
-msgstr "el fetch ha fallat."
+msgstr "l'obtenció ha fallat."
 
 #: remote-curl.c:1192
-#, fuzzy
 msgid "cannot fetch by sha1 over smart http"
-msgstr "no s’ha pogut obtenir per la sha1 a través de l’intel·ligent http"
+msgstr "no s'ha pogut obtenir per sha1 a través de l'http intel·ligent"
 
 #: remote-curl.c:1236 remote-curl.c:1242
-#, fuzzy, c-format
+#, c-format
 msgid "protocol error: expected sha/ref, got '%s'"
-msgstr "error de protocol esperat sha/ref s'ha obtingut «%s»"
+msgstr "error de protocol: s'esperva sha/ref, s'ha obtingut «%s»"
 
 #: remote-curl.c:1254 remote-curl.c:1372
-#, fuzzy, c-format
+#, c-format
 msgid "http transport does not support %s"
-msgstr "El transport http no dóna suport als percentatges"
+msgstr "El transport http no admet %s"
 
 #: remote-curl.c:1290
-#, fuzzy
 msgid "git-http-push failed"
 msgstr "git-http-push ha fallat"
 
 #: remote-curl.c:1478
-#, fuzzy
 msgid "remote-curl: usage: git remote-curl <remote> [<url>]"
-msgstr "ús remot de curl git remote-curl <remote> [<url>]"
+msgstr "remote-curl: ús: git remote-curl <remote> [<url>]"
 
 #: remote-curl.c:1510
-#, fuzzy
 msgid "remote-curl: error reading command stream from git"
-msgstr "error remot en llegir el flux d'ordres des de git"
+msgstr "remote-curl: error en llegir el flux d'ordres del git"
 
 #: remote-curl.c:1517
-#, fuzzy
 msgid "remote-curl: fetch attempted without a local repo"
-msgstr "s'ha intentat recuperar el valor remot sense un repositori local"
+msgstr "remote-curl: s'ha intentat la obtenció sense un dipòsit local"
 
 #: remote-curl.c:1558
-#, fuzzy, c-format
+#, c-format
 msgid "remote-curl: unknown command '%s' from git"
-msgstr "comandament desconegut «%s» del git"
+msgstr "remote-curl: ordre «%s» desconeguda del git"
+
+#: contrib/scalar/scalar.c:49
+#, fuzzy
+msgid "need a working directory"
+msgstr "No s'ha pogut llegir el directori de treball actual"
+
+#: contrib/scalar/scalar.c:86
+#, fuzzy
+msgid "could not find enlistment root"
+msgstr "no s'ha pogut trobar la comissió %s"
+
+#: contrib/scalar/scalar.c:89 contrib/scalar/scalar.c:351
+#: contrib/scalar/scalar.c:436 contrib/scalar/scalar.c:579
+#, fuzzy, c-format
+msgid "could not switch to '%s'"
+msgstr "no s'ha pogut commutar a %s"
+
+#: contrib/scalar/scalar.c:180
+#, fuzzy, c-format
+msgid "could not configure %s=%s"
+msgstr "no s'ha pogut blocar el fitxer de configuració %s"
+
+#: contrib/scalar/scalar.c:198
+#, fuzzy
+msgid "could not configure log.excludeDecoration"
+msgstr "no s'ha pogut configurar log.excludeDecoration"
+
+#: contrib/scalar/scalar.c:219
+#, fuzzy
+msgid "Scalar enlistments require a worktree"
+msgstr "Els allistaments escalars requereixen un arbre de treball"
+
+#: contrib/scalar/scalar.c:311
+#, fuzzy, c-format
+msgid "remote HEAD is not a branch: '%.*s'"
+msgstr "  Branca de HEAD: %s"
+
+#: contrib/scalar/scalar.c:317
+#, fuzzy
+msgid "failed to get default branch name from remote; using local default"
+msgstr ""
+"no s'ha pogut obtenir el nom de la branca per defecte des del remot; s'usa "
+"el predeterminat local"
+
+#: contrib/scalar/scalar.c:330
+#, fuzzy
+msgid "failed to get default branch name"
+msgstr ""
+"s'ha produït un error en formatar el valor per defecte de la configuració: "
+"%s"
+
+#: contrib/scalar/scalar.c:341
+#, fuzzy
+msgid "failed to unregister repository"
+msgstr "s'ha produït un error en crear el directori %s"
+
+#: contrib/scalar/scalar.c:356
+#, fuzzy
+msgid "failed to delete enlistment directory"
+msgstr "s'ha produït un error en suprimir el directori %s"
+
+#: contrib/scalar/scalar.c:376
+#, fuzzy
+msgid "branch to checkout after clone"
+msgstr "branca a cercar després de clonar"
+
+#: contrib/scalar/scalar.c:378
+#, fuzzy
+msgid "when cloning, create full working directory"
+msgstr "no s'ha pogut obtenir el directori de treball actual"
+
+#: contrib/scalar/scalar.c:380
+#, fuzzy
+msgid "only download metadata for the branch that will be checked out"
+msgstr "només baixa les metadades per a la branca que es comprovarà"
+
+#: contrib/scalar/scalar.c:385
+#, fuzzy
+msgid "scalar clone [<options>] [--] <repo> [<dir>]"
+msgstr "git clone [<opcions>] [--] <repositori> [<directori>]"
+
+#: contrib/scalar/scalar.c:410
+#, fuzzy, c-format
+msgid "cannot deduce worktree name from '%s'"
+msgstr "No es pot accedir a l'arbre de treball «%s»"
+
+#: contrib/scalar/scalar.c:419
+#, c-format, fuzzy
+msgid "directory '%s' exists already"
+msgstr "el directori '%s' ja existeix"
+
+#: contrib/scalar/scalar.c:446
+#, fuzzy, c-format
+msgid "failed to get default branch for '%s'"
+msgstr ""
+"s'ha produït un error en obtenir el remot per defecte pel submòdul «%s»"
+
+#: contrib/scalar/scalar.c:457
+#, fuzzy, c-format
+msgid "could not configure remote in '%s'"
+msgstr "no s'ha pogut crear el fitxer «%s»"
+
+#: contrib/scalar/scalar.c:466
+#, fuzzy, c-format
+msgid "could not configure '%s'"
+msgstr "no s'ha pogut tancar «%s»"
+
+#: contrib/scalar/scalar.c:469
+#, fuzzy
+msgid "partial clone failed; attempting full clone"
+msgstr "ha fallat la clonació parcial; s'està intentant la clonació completa"
+
+#: contrib/scalar/scalar.c:473
+#, fuzzy
+msgid "could not configure for full clone"
+msgstr "no s'ha pogut blocar el fitxer de configuració %s"
+
+#: contrib/scalar/scalar.c:505
+#, fuzzy
+msgid "`scalar list` does not take arguments"
+msgstr "%%(rest) no accepta arguments"
+
+#: contrib/scalar/scalar.c:518
+#, fuzzy
+msgid "scalar register [<enlistment>]"
+msgstr "registre escalar  ]<enlistment>]"
+
+#: contrib/scalar/scalar.c:545
+#, fuzzy
+msgid "reconfigure all registered enlistments"
+msgstr "reconfigura totes les llistes registrades"
+
+#: contrib/scalar/scalar.c:549
+#, fuzzy
+msgid "scalar reconfigure [--all | <enlistment>]"
+msgstr "reconfiguració escalar  |--all | <enlistment>]"
+
+#: contrib/scalar/scalar.c:567
+#, fuzzy
+msgid "--all or <enlistment>, but not both"
+msgstr "--all o <enlistment>, però no ambdós"
+
+#: contrib/scalar/scalar.c:582
+#, fuzzy, c-format
+msgid "git repository gone in '%s'"
+msgstr "no és un repositori de git: «%s»"
+
+#: contrib/scalar/scalar.c:622
+#, fuzzy
+msgid ""
+"scalar run <task> [<enlistment>]\n"
+"Tasks:\n"
+msgstr ""
+"scalar run <task>  {<enlistment>]\n"
+"Tasques:"
+
+#: contrib/scalar/scalar.c:640
+#, fuzzy, c-format
+msgid "no such task: '%s'"
+msgstr "no existeix la branca: «%s»"
+
+#: contrib/scalar/scalar.c:690
+#, fuzzy
+msgid "scalar unregister [<enlistment>]"
+msgstr "scalar unregister  <enlistment>]"
+
+#: contrib/scalar/scalar.c:737
+#, fuzzy
+msgid "scalar delete <enlistment>"
+msgstr "supressió de l'escalar <enlistment>"
+
+#: contrib/scalar/scalar.c:752
+#, fuzzy
+msgid "refusing to delete current working directory"
+msgstr "no s'ha pogut obtenir el directori de treball actual"
+
+#: contrib/scalar/scalar.c:767
+#, fuzzy
+msgid "include Git version"
+msgstr "especificació de hash no vàlida"
+
+#: contrib/scalar/scalar.c:769
+#, fuzzy
+msgid "include Git's build options"
+msgstr "inclou les opcions de construcció del Git"
+
+#: contrib/scalar/scalar.c:773
+#, fuzzy
+msgid "scalar verbose [-v | --verbose] [--build-options]"
+msgstr "scalar verbose  |-v | --verbose   --build-options]"
+
+#: contrib/scalar/scalar.c:821
+#, fuzzy
+msgid ""
+"scalar <command> [<options>]\n"
+"\n"
+"Commands:\n"
+msgstr "git maintenance <subcommand> [<options>]"
 
 #: compat/compiler.h:26
-#, fuzzy
 msgid "no compiler information available\n"
-msgstr "no hi ha informació disponible del compilador"
+msgstr "no hi ha informació disponible del compilador\n"
 
 #: compat/compiler.h:38
-#, fuzzy
 msgid "no libc information available\n"
-msgstr "mostra la informació de branca"
+msgstr "no hi ha informació disponible de libc\n"
 
 #: list-objects-filter-options.h:94
 msgid "args"
@@ -25412,42 +25164,39 @@ msgstr "data-de-caducitat"
 msgid "no-op (backward compatibility)"
 msgstr "operació nul·la (per a compatibilitat amb versions anteriors)"
 
-#: parse-options.h:309
+#: parse-options.h:310
 msgid "be more verbose"
 msgstr "sigues més detallat"
 
-#: parse-options.h:311
+#: parse-options.h:312
 msgid "be more quiet"
 msgstr "sigues més discret"
 
-#: parse-options.h:317
-#, fuzzy
+#: parse-options.h:318
 msgid "use <n> digits to display object names"
-msgstr "usa <n> xifres per presentar els SHA-1"
+msgstr "usa <n> xifres per mostrar els noms d'objecte"
 
-#: parse-options.h:336
+#: parse-options.h:337
 msgid "how to strip spaces and #comments from message"
 msgstr "com suprimir els espais i #comentaris del missatge"
 
-#: parse-options.h:337
-#, fuzzy
+#: parse-options.h:338
 msgid "read pathspec from file"
 msgstr "llegeix l'especificació del camí del fitxer"
 
-#: parse-options.h:338
-#, fuzzy
+#: parse-options.h:339
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL "
 "character"
 msgstr ""
 "amb --pathspec-from-file els elements d'especificació del camí estan "
-"separats amb caràcter NUL"
+"separats amb el caràcter NUL"
 
-#: ref-filter.h:101
+#: ref-filter.h:98
 msgid "key"
 msgstr "clau"
 
-#: ref-filter.h:101
+#: ref-filter.h:98
 msgid "field name to sort on"
 msgstr "nom del camp en el qual ordenar"
 
@@ -25495,12 +25244,10 @@ msgid "List, create, or delete branches"
 msgstr "Llista, crea o suprimeix branques"
 
 #: command-list.h:59
-#, fuzzy
 msgid "Collect information for user to file a bug report"
 msgstr "Recopila la informació per a l'usuari per enviar un informe d'error"
 
 #: command-list.h:60
-#, fuzzy
 msgid "Move objects and refs by archive"
 msgstr "Mou els objectes i les referències per arxiu"
 
@@ -25519,21 +25266,20 @@ msgid "Debug gitignore / exclude files"
 msgstr "Depura gitignore / fitxers d'exclusió"
 
 #: command-list.h:64
-#, fuzzy
 msgid "Show canonical names and email addresses of contacts"
 msgstr "Mostra els noms canònics i les adreces electròniques dels contactes"
 
 #: command-list.h:65
+msgid "Ensures that a reference name is well formed"
+msgstr "Assegura que un nom de referència està ben format"
+
+#: command-list.h:66
 msgid "Switch branches or restore working tree files"
 msgstr "Canvia de branca o restaura els fitxers de l'arbre de treball"
 
-#: command-list.h:66
+#: command-list.h:67
 msgid "Copy files from the index to the working tree"
 msgstr "Copia fitxers des de l'índex a l'arbre de treball"
-
-#: command-list.h:67
-msgid "Ensures that a reference name is well formed"
-msgstr "Assegura que un nom de referència està ben format"
 
 #: command-list.h:68
 msgid "Find commits yet to be applied to upstream"
@@ -25576,33 +25322,29 @@ msgid "Get and set repository or global options"
 msgstr "Obté o estableix opcions de repositori o globals"
 
 #: command-list.h:78
-#, fuzzy
 msgid "Count unpacked number of objects and their disk consumption"
 msgstr "Compta el nombre d'objectes desempaquetats i el seu consum de disc"
 
 #: command-list.h:79
-#, fuzzy
 msgid "Retrieve and store user credentials"
 msgstr "Recupera i desa les credencials d'usuari"
 
 #: command-list.h:80
-#, fuzzy
 msgid "Helper to temporarily store passwords in memory"
-msgstr "Ajudant per emmagatzemar temporalment les contrasenyes a la memòria"
+msgstr "Ajudant per emmagatzemar temporalment les contrasenyes en memòria"
 
 #: command-list.h:81
 msgid "Helper to store credentials on disk"
 msgstr "Ajudant per a emmagatzemar credencials a disc"
 
 #: command-list.h:82
-#, fuzzy
 msgid "Export a single commit to a CVS checkout"
-msgstr "Exporta una sola entrega a una versió de CVS"
+msgstr "Exporta en una sola comissió a CVS checkout"
 
 #: command-list.h:83
-#, fuzzy
 msgid "Salvage your data out of another SCM people love to hate"
-msgstr "Estalvia les teves dades d'una altra gent de SCM que li agrada odiar"
+msgstr ""
+"Salveu les vostres dades d'un altre SMC al que la gent li agrada odiar"
 
 #: command-list.h:84
 msgid "A CVS server emulator for Git"
@@ -25615,7 +25357,7 @@ msgstr "Un servidor realment senzill per a repositoris Git"
 #: command-list.h:86
 msgid "Give an object a human readable name based on an available ref"
 msgstr ""
-"Dona un nom llegible per humans basant-se en les referències disponibles"
+"Dona un nom llegible per a humans basant-se en les referències disponibles"
 
 #: command-list.h:87
 msgid "Show changes between commits, commit and working tree, etc"
@@ -25631,7 +25373,6 @@ msgid "Compare a tree to the working tree or index"
 msgstr "Compara un arbre amb l'arbre de treball o l'índex"
 
 #: command-list.h:90
-#, fuzzy
 msgid "Compares the content and mode of blobs found via two tree objects"
 msgstr ""
 "Compara el contingut i el mode dels blobs trobats a través de dos objectes "
@@ -25670,9 +25411,8 @@ msgid "Output information on each ref"
 msgstr "Mostra la informació en cada referència"
 
 #: command-list.h:99
-#, fuzzy
 msgid "Run a Git command on a list of repositories"
-msgstr "executa les tasques basades en l'estat del repositori"
+msgstr "Executa una ordre Git en una llista de repositoris"
 
 #: command-list.h:100
 msgid "Prepare patches for e-mail submission"
@@ -25687,7 +25427,6 @@ msgid "Cleanup unnecessary files and optimize the local repository"
 msgstr "Neteja els fitxers innecessaris i optimitza el repositori local"
 
 #: command-list.h:103
-#, fuzzy
 msgid "Extract commit ID from an archive created using git-archive"
 msgstr "Extreu l'ID de la comissió d'un arxiu creat amb el git-archive"
 
@@ -25721,14 +25460,12 @@ msgid "Push objects over HTTP/DAV to another repository"
 msgstr "Empeny objectes sobre HTTP/DAV a un altre repositori"
 
 #: command-list.h:111
-#, fuzzy
 msgid "Send a collection of patches from stdin to an IMAP folder"
 msgstr ""
 "Envia una col·lecció de pedaços des de l'entrada estàndard a una carpeta "
 "IMAP"
 
 #: command-list.h:112
-#, fuzzy
 msgid "Build pack index file for an existing packed archive"
 msgstr ""
 "Construeix el fitxer d'índex del paquet per a un arxiu empaquetat existent"
@@ -25738,73 +25475,65 @@ msgid "Create an empty Git repository or reinitialize an existing one"
 msgstr "Crea un repositori de Git buit o reinicialitza un existent"
 
 #: command-list.h:114
-#, fuzzy
 msgid "Instantly browse your working repository in gitweb"
 msgstr "Navegueu instantàniament pel vostre repositori de treball a gitweb"
 
 #: command-list.h:115
-#, fuzzy
 msgid "Add or parse structured information in commit messages"
-msgstr "Afegir o analitzar informació estructurada en missatges de publicació"
+msgstr ""
+"Afegeix o analitza la informació estructurada en els missatges de comissió"
 
 #: command-list.h:116
-msgid "The Git repository browser"
-msgstr "El navegador de repositoris Git"
-
-#: command-list.h:117
 msgid "Show commit logs"
 msgstr "Mostra els registres de comissió"
 
-#: command-list.h:118
+#: command-list.h:117
 msgid "Show information about files in the index and the working tree"
 msgstr "Mostra informació sobre els fitxers a l'índex i a l'arbre de treball"
 
-#: command-list.h:119
+#: command-list.h:118
 msgid "List references in a remote repository"
 msgstr "Mostra les referències d'un repositori remot"
 
-#: command-list.h:120
+#: command-list.h:119
 msgid "List the contents of a tree object"
 msgstr "Mostra els continguts d'un objecte de l'arbre"
 
-#: command-list.h:121
-#, fuzzy
+#: command-list.h:120
 msgid "Extracts patch and authorship from a single e-mail message"
-msgstr "Extreu pedaç i autoria d'un sol missatge de correu electrònic"
+msgstr "Extreu el pedaç i l'autoria d'un sol missatge de correu electrònic"
+
+#: command-list.h:121
+msgid "Simple UNIX mbox splitter program"
+msgstr "Programa de divisió mbox simple per a UNIX"
 
 #: command-list.h:122
-#, fuzzy
-msgid "Simple UNIX mbox splitter program"
-msgstr "Programa de divisor mbox simple per a UNIX"
+msgid "Run tasks to optimize Git repository data"
+msgstr "Executa tasques per a optimitzar les dades del repositori Git"
 
 #: command-list.h:123
-#, fuzzy
-msgid "Run tasks to optimize Git repository data"
-msgstr "Executa les tasques per optimitzar les dades del repositori Git"
-
-#: command-list.h:124
 msgid "Join two or more development histories together"
 msgstr "Uneix dues o més històries de desenvolupament"
 
-#: command-list.h:125
-#, fuzzy
+#: command-list.h:124
 msgid "Find as good common ancestors as possible for a merge"
 msgstr "Troba els millors avantpassats comuns possibles per a una fusió"
 
-#: command-list.h:126
-#, fuzzy
+#: command-list.h:125
 msgid "Run a three-way file merge"
 msgstr "Executa una fusió de fitxers de tres vies"
 
-#: command-list.h:127
-#, fuzzy
+#: command-list.h:126
 msgid "Run a merge for files needing merging"
 msgstr "Executa una fusió per als fitxers que cal fusionar"
 
-#: command-list.h:128
-#, fuzzy
+#: command-list.h:127
 msgid "The standard helper program to use with git-merge-index"
 msgstr "El programa d'ajuda estàndard a utilitzar amb git-merge-index"
+
+#: command-list.h:128
+msgid "Show three-way merge without touching index"
+msgstr "Mostra la fusió de tres vies sense tocar l'índex"
 
 #: command-list.h:129
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
@@ -25812,373 +25541,369 @@ msgstr ""
 "Executa eines de resolució de conflictes per a resoldre conflictes de fusió"
 
 #: command-list.h:130
-#, fuzzy
-msgid "Show three-way merge without touching index"
-msgstr "Mostra la fusió de tres vies sense l'índex tàctil"
+msgid "Creates a tag object with extra validation"
+msgstr "Crea un objecte etiqueta amb validació addicional"
 
 #: command-list.h:131
-#, fuzzy
-msgid "Write and verify multi-pack-indexes"
-msgstr "Escriu i verifica els multi-índexs"
-
-#: command-list.h:132
-#, fuzzy
-msgid "Creates a tag object with extra validation"
-msgstr "Crea un objecte etiqueta"
-
-#: command-list.h:133
 #, fuzzy
 msgid "Build a tree-object from ls-tree formatted text"
 msgstr "Construeix un objecte en arbre a partir de text formatat amb ls-tree"
 
-#: command-list.h:134
+#: command-list.h:132
+msgid "Write and verify multi-pack-indexes"
+msgstr "Escriu i verifica els índexs dels paquets multipaquet"
+
+#: command-list.h:133
 msgid "Move or rename a file, a directory, or a symlink"
 msgstr "Mou o canvia de nom a un fitxer, directori o enllaç simbòlic"
 
-#: command-list.h:135
+#: command-list.h:134
 #, fuzzy
 msgid "Find symbolic names for given revs"
 msgstr "Cerca noms simbòlics per a les revisions donades"
 
-#: command-list.h:136
+#: command-list.h:135
 msgid "Add or inspect object notes"
 msgstr "Afegeix o inspecciona notes de l'objecte"
 
-#: command-list.h:137
+#: command-list.h:136
 msgid "Import from and submit to Perforce repositories"
 msgstr "Importa des de i envia a repositoris Perforce"
 
-#: command-list.h:138
+#: command-list.h:137
 msgid "Create a packed archive of objects"
 msgstr "Crea un arxiu empaquetat d'objectes"
 
-#: command-list.h:139
+#: command-list.h:138
 msgid "Find redundant pack files"
 msgstr "Troba fitxers empaquetats redundants"
 
-#: command-list.h:140
+#: command-list.h:139
 #, fuzzy
 msgid "Pack heads and tags for efficient repository access"
 msgstr ""
 "Empaqueta els caps i les etiquetes per a un accés eficient al repositori"
 
-#: command-list.h:141
+#: command-list.h:140
 msgid "Compute unique ID for a patch"
 msgstr "Calcula un identificador únic per a cada pedaç"
 
-#: command-list.h:142
+#: command-list.h:141
 msgid "Prune all unreachable objects from the object database"
 msgstr "Poda tots els objectes no accessibles de la base de dades d'objectes"
 
-#: command-list.h:143
+#: command-list.h:142
 msgid "Remove extra objects that are already in pack files"
 msgstr "Elimina els objectes extres que ja estan en fitxers empaquetats"
 
-#: command-list.h:144
+#: command-list.h:143
 msgid "Fetch from and integrate with another repository or a local branch"
 msgstr "Obtén i integra amb un altre repositori o una branca local"
 
-#: command-list.h:145
+#: command-list.h:144
 msgid "Update remote refs along with associated objects"
 msgstr ""
 "Actualitza les referències remotes juntament amb els objectes associats"
 
-#: command-list.h:146
+#: command-list.h:145
 #, fuzzy
 msgid "Applies a quilt patchset onto the current branch"
 msgstr "Aplica un conjunt de pedaços cobert a la branca actual"
 
-#: command-list.h:147
+#: command-list.h:146
 msgid "Compare two commit ranges (e.g. two versions of a branch)"
 msgstr "Compara dos rangs de comissions (p. ex. dues versions d'una branca)"
 
-#: command-list.h:148
+#: command-list.h:147
 msgid "Reads tree information into the index"
 msgstr "Llegeix la informació de l'arbre a l'índex"
 
-#: command-list.h:149
+#: command-list.h:148
 msgid "Reapply commits on top of another base tip"
 msgstr "Torna a aplicar les comissions sobre un altre punt de basament"
 
-#: command-list.h:150
+#: command-list.h:149
 msgid "Receive what is pushed into the repository"
 msgstr "Rep el que s'envia al repositori"
 
-#: command-list.h:151
+#: command-list.h:150
 msgid "Manage reflog information"
 msgstr "Gestiona la informació del registre de referències"
 
-#: command-list.h:152
+#: command-list.h:151
 msgid "Manage set of tracked repositories"
 msgstr "Gestiona el conjunt de repositoris seguits"
 
-#: command-list.h:153
+#: command-list.h:152
 msgid "Pack unpacked objects in a repository"
 msgstr "Empaqueta els objectes desempaquetats en un repositori"
 
-#: command-list.h:154
-#, fuzzy
+#: command-list.h:153
 msgid "Create, list, delete refs to replace objects"
-msgstr "Crea una llista suprimeix les referències per substituir els objectes"
+msgstr "Crea, llista i esborra referències per substituir objectes"
 
-#: command-list.h:155
+#: command-list.h:154
 msgid "Generates a summary of pending changes"
 msgstr "Genera un resum dels canvis pendents"
 
-#: command-list.h:156
+#: command-list.h:155
 msgid "Reuse recorded resolution of conflicted merges"
 msgstr "Reutilitza la resolució registrada dels conflictes de fusió"
 
-#: command-list.h:157
+#: command-list.h:156
 msgid "Reset current HEAD to the specified state"
 msgstr "Restableix la HEAD actual a l'estat especificat"
 
-#: command-list.h:158
+#: command-list.h:157
 msgid "Restore working tree files"
 msgstr "Restaura els fitxers de l'arbre de treball"
 
-#: command-list.h:159
-msgid "Revert some existing commits"
-msgstr "Reverteix comissions existents"
-
-#: command-list.h:160
+#: command-list.h:158
 msgid "Lists commit objects in reverse chronological order"
 msgstr "Mostra les comissions en ordre topològic invers"
 
-#: command-list.h:161
+#: command-list.h:159
 msgid "Pick out and massage parameters"
 msgstr "Trieu i personalitzeu els paràmetres"
 
-#: command-list.h:162
+#: command-list.h:160
+msgid "Revert some existing commits"
+msgstr "Reverteix comissions existents"
+
+#: command-list.h:161
 msgid "Remove files from the working tree and from the index"
 msgstr "Elimina fitxers de l'arbre de treball i de l'índex"
 
-#: command-list.h:163
+#: command-list.h:162
 msgid "Send a collection of patches as emails"
 msgstr "Envia una col·lecció de pedaços com a correus electrònics"
 
-#: command-list.h:164
+#: command-list.h:163
 msgid "Push objects over Git protocol to another repository"
 msgstr "Puja objectes sobre el protocol Git a un altre repositori"
 
-#: command-list.h:165
-msgid "Restricted login shell for Git-only SSH access"
-msgstr "Intèrpret d'ordres d'entrada restringit només per a accés SSH al Git"
-
-#: command-list.h:166
-msgid "Summarize 'git log' output"
-msgstr "Resumeix la sortida «git log»"
-
-#: command-list.h:167
-msgid "Show various types of objects"
-msgstr "Mostra diversos tipus d'objectes"
-
-#: command-list.h:168
-msgid "Show branches and their commits"
-msgstr "Mostra les branques i les seves comissions"
-
-#: command-list.h:169
-msgid "Show packed archive index"
-msgstr "Mostra l'índex d'arxius empaquetat"
-
-#: command-list.h:170
-msgid "List references in a local repository"
-msgstr "Llista les referències en un repositori local"
-
-#: command-list.h:171
+#: command-list.h:164
 msgid "Git's i18n setup code for shell scripts"
 msgstr ""
 "Codi de configuració i18n del Git per als scripts de l'intèrpret d'ordres"
 
-#: command-list.h:172
+#: command-list.h:165
 msgid "Common Git shell script setup code"
 msgstr "Codi de scripts de configuració comuns pel Git shell"
 
-#: command-list.h:173
+#: command-list.h:166
+msgid "Restricted login shell for Git-only SSH access"
+msgstr "Intèrpret d'ordres d'entrada restringit només per a accés SSH al Git"
+
+#: command-list.h:167
+msgid "Summarize 'git log' output"
+msgstr "Resumeix la sortida «git log»"
+
+#: command-list.h:168
+msgid "Show various types of objects"
+msgstr "Mostra diversos tipus d'objectes"
+
+#: command-list.h:169
+msgid "Show branches and their commits"
+msgstr "Mostra les branques i les seves comissions"
+
+#: command-list.h:170
+msgid "Show packed archive index"
+msgstr "Mostra l'índex d'arxius empaquetat"
+
+#: command-list.h:171
+msgid "List references in a local repository"
+msgstr "Llista les referències en un repositori local"
+
+#: command-list.h:172
 msgid "Initialize and modify the sparse-checkout"
 msgstr "Inicialitza i modifica el «sparse-checkout»"
+
+#: command-list.h:173
+msgid "Add file contents to the staging area"
+msgstr "Afegeix el contingut del fitxer a l'àrea de «staging»"
 
 #: command-list.h:174
 msgid "Stash the changes in a dirty working directory away"
 msgstr "Fes «stash» dels canvis en un directori de treball brut"
 
 #: command-list.h:175
-msgid "Add file contents to the staging area"
-msgstr "Afegeix el contingut del fitxer a l'àrea de «staging»"
-
-#: command-list.h:176
 msgid "Show the working tree status"
 msgstr "Mostra l'estat de l'arbre de treball"
 
-#: command-list.h:177
+#: command-list.h:176
 msgid "Remove unnecessary whitespace"
 msgstr "Elimina l'espai en blanc innecessari"
 
-#: command-list.h:178
+#: command-list.h:177
 msgid "Initialize, update or inspect submodules"
 msgstr "Inicialitza, actualitza o inspecciona submòduls"
 
-#: command-list.h:179
+#: command-list.h:178
 msgid "Bidirectional operation between a Subversion repository and Git"
 msgstr "Operació bidireccional entre un repositori a Subversion i Git"
 
-#: command-list.h:180
+#: command-list.h:179
 msgid "Switch branches"
 msgstr "Commuta entre branques"
 
-#: command-list.h:181
+#: command-list.h:180
 msgid "Read, modify and delete symbolic refs"
 msgstr "Llegeix, modifica i suprimeix referències simbòliques"
 
-#: command-list.h:182
+#: command-list.h:181
 msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr ""
 "Crea, llista, suprimeix o verifica un objecte d'etiqueta signat amb GPG"
 
-#: command-list.h:183
+#: command-list.h:182
 msgid "Creates a temporary file with a blob's contents"
 msgstr "Crea un fitxer temporal amb els continguts dels blobs"
 
-#: command-list.h:184
+#: command-list.h:183
 msgid "Unpack objects from a packed archive"
 msgstr "Desempaqueta objectes d'un arxiu empaquetat"
 
-#: command-list.h:185
+#: command-list.h:184
 msgid "Register file contents in the working tree to the index"
 msgstr "Registra els continguts del fitxer en l'arbre de treball a l'índex"
 
-#: command-list.h:186
+#: command-list.h:185
 msgid "Update the object name stored in a ref safely"
 msgstr ""
 "Actualitza el nom de l'objecte emmagatzemat en una referència de forma "
 "segura"
 
-#: command-list.h:187
+#: command-list.h:186
 msgid "Update auxiliary info file to help dumb servers"
 msgstr ""
 "Actualitza el fitxer d'informació auxiliar per a ajudar als servidors "
 "ximples"
 
-#: command-list.h:188
+#: command-list.h:187
 msgid "Send archive back to git-archive"
 msgstr "Envia l'arxiu de tornada al git-archive"
 
-#: command-list.h:189
+#: command-list.h:188
 msgid "Send objects packed back to git-fetch-pack"
 msgstr "Envia els objectes empaquetats de tornada al git-fetch-pack"
 
-#: command-list.h:190
+#: command-list.h:189
 msgid "Show a Git logical variable"
 msgstr "Mostra una variable lògica del Git"
 
-#: command-list.h:191
+#: command-list.h:190
 msgid "Check the GPG signature of commits"
 msgstr "Verifica la signatura GPG de les comissions"
 
-#: command-list.h:192
+#: command-list.h:191
 msgid "Validate packed Git archive files"
 msgstr "Valida els fitxers d'arxius Git empaquetats"
 
-#: command-list.h:193
+#: command-list.h:192
 msgid "Check the GPG signature of tags"
 msgstr "Verifica la signatura GPG de les etiquetes"
 
-#: command-list.h:194
-msgid "Git web interface (web frontend to Git repositories)"
-msgstr "Interfície web del Git (interfície web pels repositoris Git)"
-
-#: command-list.h:195
+#: command-list.h:193
 msgid "Show logs with difference each commit introduces"
 msgstr "Mostra registres amb la diferència introduïda per cada comissió"
 
-#: command-list.h:196
+#: command-list.h:194
 msgid "Manage multiple working trees"
 msgstr "Gestiona múltiples arbres de treball"
 
-#: command-list.h:197
+#: command-list.h:195
 msgid "Create a tree object from the current index"
 msgstr "Crea un objecte arbre des de l'índex actual"
 
-#: command-list.h:198
+#: command-list.h:196
 msgid "Defining attributes per path"
 msgstr "La definició d'atributs per camí"
 
-#: command-list.h:199
+#: command-list.h:197
 msgid "Git command-line interface and conventions"
 msgstr "Interfície i convencions de la línia d'ordres del Git"
 
-#: command-list.h:200
+#: command-list.h:198
 msgid "A Git core tutorial for developers"
 msgstr "Un tutorial bàsic del Git per a desenvolupadors"
 
-#: command-list.h:201
+#: command-list.h:199
 msgid "Providing usernames and passwords to Git"
 msgstr "Proporcionar noms d'usuari i contrasenyes a Git"
 
-#: command-list.h:202
+#: command-list.h:200
 msgid "Git for CVS users"
 msgstr "Git per a usuaris del CVS"
 
-#: command-list.h:203
+#: command-list.h:201
 msgid "Tweaking diff output"
 msgstr "Ajustament de la sortida de diferències"
 
-#: command-list.h:204
+#: command-list.h:202
 msgid "A useful minimum set of commands for Everyday Git"
 msgstr "Un conjunt mínim útil d'ordres diàries del Git"
 
-#: command-list.h:205
+#: command-list.h:203
 msgid "Frequently asked questions about using Git"
 msgstr "Preguntes freqüents sobre l'ús del Git"
 
-#: command-list.h:206
+#: command-list.h:204
 msgid "A Git Glossary"
 msgstr "Un glossari de Git"
 
-#: command-list.h:207
+#: command-list.h:205
 msgid "Hooks used by Git"
 msgstr "Lligams utilitzats pel Git"
 
-#: command-list.h:208
+#: command-list.h:206
 msgid "Specifies intentionally untracked files to ignore"
 msgstr "Especifica els fitxers intencionalment no seguits a ignorar"
 
-#: command-list.h:209
+#: command-list.h:207
+msgid "The Git repository browser"
+msgstr "El navegador de repositoris Git"
+
+#: command-list.h:208
 #, fuzzy
 msgid "Map author/committer names and/or E-Mail addresses"
 msgstr "Assigna noms d'autor/comitè i/o adreces de correu electrònic"
 
-#: command-list.h:210
+#: command-list.h:209
 msgid "Defining submodule properties"
 msgstr "La definició de les propietats de submòduls"
 
-#: command-list.h:211
+#: command-list.h:210
 msgid "Git namespaces"
 msgstr "Espais de noms del Git"
 
-#: command-list.h:212
+#: command-list.h:211
 msgid "Helper programs to interact with remote repositories"
 msgstr "Programes d'ajuda per a interactuar amb repositoris remots"
 
-#: command-list.h:213
+#: command-list.h:212
 msgid "Git Repository Layout"
 msgstr "Disposició del repositori del Git"
 
-#: command-list.h:214
+#: command-list.h:213
 msgid "Specifying revisions and ranges for Git"
 msgstr "L'especificació de revisions i rangs per al Git"
 
-#: command-list.h:215
+#: command-list.h:214
 msgid "Mounting one repository inside another"
 msgstr "Muntant un repositori dins un altre"
+
+#: command-list.h:215
+msgid "A tutorial introduction to Git"
+msgstr "Un tutorial d'introducció al Git"
 
 #: command-list.h:216
 msgid "A tutorial introduction to Git: part two"
 msgstr "Un tutorial d'introducció al Git: segona part"
 
 #: command-list.h:217
-msgid "A tutorial introduction to Git"
-msgstr "Un tutorial d'introducció al Git"
+msgid "Git web interface (web frontend to Git repositories)"
+msgstr "Interfície web del Git (interfície web pels repositoris Git)"
 
 #: command-list.h:218
 msgid "An overview of recommended workflows with Git"
@@ -26198,7 +25923,7 @@ msgstr "La fusió automàtica no ha funcionat."
 
 #: git-merge-octopus.sh:62
 msgid "Should not be doing an octopus."
-msgstr "No s'ha de fer un pop."
+msgstr "No s'ha de fer un «octopus»."
 
 #: git-merge-octopus.sh:73
 #, sh-format
@@ -26257,42 +25982,42 @@ msgstr ""
 msgid "usage: $dashless $USAGE"
 msgstr "ús: $dashless $USAGE"
 
-#: git-sh-setup.sh:191
+#: git-sh-setup.sh:183
 #, sh-format
 msgid "Cannot chdir to $cdup, the toplevel of the working tree"
 msgstr ""
 "No es pot canviar de directori a $cdup, el nivell superior de l'arbre de "
 "treball"
 
-#: git-sh-setup.sh:200 git-sh-setup.sh:207
+#: git-sh-setup.sh:192 git-sh-setup.sh:199
 #, sh-format
 msgid "fatal: $program_name cannot be used without a working tree."
 msgstr "fatal: no es pot usar $program_name sense un arbre de treball."
 
-#: git-sh-setup.sh:221
+#: git-sh-setup.sh:213
 msgid "Cannot rewrite branches: You have unstaged changes."
 msgstr "No es poden reescriure branques: Teniu canvis «unstaged»."
 
-#: git-sh-setup.sh:224
+#: git-sh-setup.sh:216
 #, sh-format
 msgid "Cannot $action: You have unstaged changes."
 msgstr "No es pot $action: Teniu canvis «unstaged»."
 
-#: git-sh-setup.sh:235
+#: git-sh-setup.sh:227
 #, sh-format
 msgid "Cannot $action: Your index contains uncommitted changes."
 msgstr "No es pot $action: El vostre índex conté canvis sense cometre."
 
-#: git-sh-setup.sh:237
+#: git-sh-setup.sh:229
 msgid "Additionally, your index contains uncommitted changes."
 msgstr "Addicionalment, el vostre índex conté canvis sense cometre."
 
-#: git-sh-setup.sh:357
+#: git-sh-setup.sh:349
 msgid "You need to run this command from the toplevel of the working tree."
 msgstr ""
 "Heu d'executar aquesta ordre des del nivell superior de l'arbre de treball."
 
-#: git-sh-setup.sh:362
+#: git-sh-setup.sh:354
 msgid "Unable to determine absolute path of git directory"
 msgstr "No s'ha pogut determinar el camí absolut del directori de git"
 
@@ -26374,7 +26099,7 @@ msgstr ""
 msgid "failed to open hunk edit file for reading: %s"
 msgstr "s'ha produït un error en llegir al fitxer d'edició del tros: %s"
 
-#: git-add--interactive.perl:1251
+#: git-add--interactive.perl:1253
 msgid ""
 "y - stage this hunk\n"
 "n - do not stage this hunk\n"
@@ -26388,7 +26113,7 @@ msgstr ""
 "a - fes «stage» d'aquest tros i tota la resta de trossos del fitxer\n"
 "d - no facis «stage» d'aquest tros o de cap altre restant del fitxer"
 
-#: git-add--interactive.perl:1257
+#: git-add--interactive.perl:1259
 msgid ""
 "y - stash this hunk\n"
 "n - do not stash this hunk\n"
@@ -26402,7 +26127,7 @@ msgstr ""
 "a - fes «stash» d'aquest tros i tota la resta de trossos del fitxer\n"
 "d - no facis «stash» d'aquest tros o de cap altre restant del fitxer"
 
-#: git-add--interactive.perl:1263
+#: git-add--interactive.perl:1265
 msgid ""
 "y - unstage this hunk\n"
 "n - do not unstage this hunk\n"
@@ -26416,7 +26141,7 @@ msgstr ""
 "a - fes «unstage» d'aquest tros i tota la resta de trossos del fitxer\n"
 "d - no facis «unstage» d'aquest tros o de cap altre restant del fitxer"
 
-#: git-add--interactive.perl:1269
+#: git-add--interactive.perl:1271
 msgid ""
 "y - apply this hunk to index\n"
 "n - do not apply this hunk to index\n"
@@ -26430,7 +26155,7 @@ msgstr ""
 "a - aplica aquest tros i tots els trossos posteriors en el fitxer\n"
 "d - no apliquis aquest tros ni cap dels trossos posteriors en el fitxer"
 
-#: git-add--interactive.perl:1275 git-add--interactive.perl:1293
+#: git-add--interactive.perl:1277 git-add--interactive.perl:1295
 msgid ""
 "y - discard this hunk from worktree\n"
 "n - do not discard this hunk from worktree\n"
@@ -26444,7 +26169,7 @@ msgstr ""
 "a - descarta aquest tros i tots els trossos posteriors en el fitxer\n"
 "d - no descartis aquest tros ni cap dels trossos posteriors en el fitxer"
 
-#: git-add--interactive.perl:1281
+#: git-add--interactive.perl:1283
 msgid ""
 "y - discard this hunk from index and worktree\n"
 "n - do not discard this hunk from index and worktree\n"
@@ -26458,7 +26183,7 @@ msgstr ""
 "a - descarta aquest tros i tots els trossos posteriors en el fitxer\n"
 "d - no descartis aquest tros ni cap dels trossos posteriors en el fitxer"
 
-#: git-add--interactive.perl:1287
+#: git-add--interactive.perl:1289
 msgid ""
 "y - apply this hunk to index and worktree\n"
 "n - do not apply this hunk to index and worktree\n"
@@ -26472,7 +26197,7 @@ msgstr ""
 "a - aplica aquest tros i tots els trossos posteriors en el fitxer\n"
 "d - no apliquis aquest tros ni cap dels trossos posteriors en el fitxer"
 
-#: git-add--interactive.perl:1299
+#: git-add--interactive.perl:1301
 msgid ""
 "y - apply this hunk to worktree\n"
 "n - do not apply this hunk to worktree\n"
@@ -26486,7 +26211,7 @@ msgstr ""
 "a - aplica aquest tros i tots els trossos posteriors en el fitxer\n"
 "d - no apliquis aquest tros ni cap dels trossos posteriors en el fitxer"
 
-#: git-add--interactive.perl:1314
+#: git-add--interactive.perl:1316
 msgid ""
 "g - select a hunk to go to\n"
 "/ - search for a hunk matching the given regex\n"
@@ -26508,90 +26233,90 @@ msgstr ""
 "e - edita manualment el tros actual\n"
 "? - mostra l'ajuda\n"
 
-#: git-add--interactive.perl:1345
+#: git-add--interactive.perl:1347
 msgid "The selected hunks do not apply to the index!\n"
 msgstr "Els trossos seleccionats no apliquen a l'índex\n"
 
-#: git-add--interactive.perl:1360
+#: git-add--interactive.perl:1362
 #, perl-format
 msgid "ignoring unmerged: %s\n"
 msgstr "s'està ignorant %s no fusionat\n"
 
-#: git-add--interactive.perl:1479
+#: git-add--interactive.perl:1481
 #, perl-format
 msgid "Apply mode change to worktree [y,n,q,a,d%s,?]? "
 msgstr "Aplica el canvi de mode a l'arbre de treball [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1480
+#: git-add--interactive.perl:1482
 #, perl-format
 msgid "Apply deletion to worktree [y,n,q,a,d%s,?]? "
 msgstr "Aplica la supressió a l'arbre de treball [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1481
+#: git-add--interactive.perl:1483
 #, perl-format
 msgid "Apply addition to worktree [y,n,q,a,d%s,?]? "
 msgstr "Aplica l'addició a l'arbre de treball [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1482
+#: git-add--interactive.perl:1484
 #, perl-format
 msgid "Apply this hunk to worktree [y,n,q,a,d%s,?]? "
 msgstr "Aplica aquest tros a l'arbre de treball [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1599
+#: git-add--interactive.perl:1601
 msgid "No other hunks to goto\n"
 msgstr "No hi ha altres trossos on anar-hi\n"
 
-#: git-add--interactive.perl:1617
+#: git-add--interactive.perl:1619
 #, perl-format
 msgid "Invalid number: '%s'\n"
 msgstr "Número no vàlid: «%s»\n"
 
-#: git-add--interactive.perl:1622
+#: git-add--interactive.perl:1624
 #, perl-format
 msgid "Sorry, only %d hunk available.\n"
 msgid_plural "Sorry, only %d hunks available.\n"
 msgstr[0] "Només %d tros disponible.\n"
 msgstr[1] "Només %d trossos disponibles.\n"
 
-#: git-add--interactive.perl:1657
+#: git-add--interactive.perl:1659
 msgid "No other hunks to search\n"
 msgstr "No hi ha cap altre tros a cercar\n"
 
-#: git-add--interactive.perl:1674
+#: git-add--interactive.perl:1676
 #, perl-format
 msgid "Malformed search regexp %s: %s\n"
 msgstr "Expressió regular de cerca mal formada %s: %s\n"
 
-#: git-add--interactive.perl:1684
+#: git-add--interactive.perl:1686
 msgid "No hunk matches the given pattern\n"
 msgstr "No hi ha trossos que coincideixin amb el patró donat\n"
 
-#: git-add--interactive.perl:1696 git-add--interactive.perl:1718
+#: git-add--interactive.perl:1698 git-add--interactive.perl:1720
 msgid "No previous hunk\n"
 msgstr "Sense tros previ\n"
 
-#: git-add--interactive.perl:1705 git-add--interactive.perl:1724
+#: git-add--interactive.perl:1707 git-add--interactive.perl:1726
 msgid "No next hunk\n"
 msgstr "No hi ha tros següent\n"
 
-#: git-add--interactive.perl:1730
+#: git-add--interactive.perl:1732
 msgid "Sorry, cannot split this hunk\n"
 msgstr "No es pot dividir aquest tros\n"
 
-#: git-add--interactive.perl:1736
+#: git-add--interactive.perl:1738
 #, perl-format
 msgid "Split into %d hunk.\n"
 msgid_plural "Split into %d hunks.\n"
 msgstr[0] "Divideix en %d tros.\n"
 msgstr[1] "Divideix en %d trossos.\n"
 
-#: git-add--interactive.perl:1746
+#: git-add--interactive.perl:1748
 msgid "Sorry, cannot edit this hunk\n"
 msgstr "No es pot editar aquest tros\n"
 
 #. TRANSLATORS: please do not translate the command names
 #. 'status', 'update', 'revert', etc.
-#: git-add--interactive.perl:1811
+#: git-add--interactive.perl:1813
 msgid ""
 "status        - show paths with changes\n"
 "update        - add working tree state to the staged set of changes\n"
@@ -26607,55 +26332,55 @@ msgstr ""
 "diff          - mostra la diferència entre HEAD i l'índex\n"
 "add untracked - afegeix el contingut dels fitxers no seguits al conjunt de canvis «staged»\n"
 
-#: git-add--interactive.perl:1828 git-add--interactive.perl:1840
-#: git-add--interactive.perl:1843 git-add--interactive.perl:1850
-#: git-add--interactive.perl:1853 git-add--interactive.perl:1860
-#: git-add--interactive.perl:1864 git-add--interactive.perl:1870
+#: git-add--interactive.perl:1830 git-add--interactive.perl:1842
+#: git-add--interactive.perl:1845 git-add--interactive.perl:1852
+#: git-add--interactive.perl:1855 git-add--interactive.perl:1862
+#: git-add--interactive.perl:1866 git-add--interactive.perl:1872
 msgid "missing --"
 msgstr "manca --"
 
-#: git-add--interactive.perl:1866
+#: git-add--interactive.perl:1868
 #, perl-format
 msgid "unknown --patch mode: %s"
 msgstr "desconegut --patch mode: %s"
 
-#: git-add--interactive.perl:1872 git-add--interactive.perl:1878
+#: git-add--interactive.perl:1874 git-add--interactive.perl:1880
 #, perl-format
 msgid "invalid argument %s, expecting --"
 msgstr "argument %s no vàlid, s'esperava --"
 
-#: git-send-email.perl:129
+#: git-send-email.perl:159
 msgid "local zone differs from GMT by a non-minute interval\n"
 msgstr "la zona local difereix de GMT per un interval que no és de minuts\n"
 
-#: git-send-email.perl:136 git-send-email.perl:142
+#: git-send-email.perl:166 git-send-email.perl:172
 msgid "local time offset greater than or equal to 24 hours\n"
 msgstr "el desplaçament de la zona local és més gran o igual a 24 hores\n"
 
-#: git-send-email.perl:214
+#: git-send-email.perl:244
 #, fuzzy, perl-format
 msgid "fatal: command '%s' died with exit code %d"
 msgstr "fatal: l'ordre «%s» ha mort amb el codi de sortida %d"
 
-#: git-send-email.perl:227
+#: git-send-email.perl:257
 msgid "the editor exited uncleanly, aborting everything"
 msgstr "l'editor no ha sortit correctament, avortant-ho tot"
 
-#: git-send-email.perl:316
+#: git-send-email.perl:346
 #, perl-format
 msgid "'%s' contains an intermediate version of the email you were composing.\n"
 msgstr "«%s» conté una versió intermèdia del correu que estàveu redactant.\n"
 
-#: git-send-email.perl:321
+#: git-send-email.perl:351
 #, perl-format
 msgid "'%s.final' contains the composed email.\n"
 msgstr "«%s.final» conté el correu redactat.\n"
 
-#: git-send-email.perl:450
+#: git-send-email.perl:484
 msgid "--dump-aliases incompatible with other options\n"
 msgstr "--dump-aliases és incompatible amb altres opcions\n"
 
-#: git-send-email.perl:525
+#: git-send-email.perl:561
 #, fuzzy
 msgid ""
 "fatal: found configuration options for 'sendmail'\n"
@@ -26667,11 +26392,11 @@ msgstr ""
 "sendemail.forbidSendmailVariables a false per desactivar aquesta "
 "comprovació."
 
-#: git-send-email.perl:530 git-send-email.perl:746
+#: git-send-email.perl:566 git-send-email.perl:782
 msgid "Cannot run git format-patch from outside a repository\n"
 msgstr "No es pot executar git format-patch des de fora del repositori\n"
 
-#: git-send-email.perl:533
+#: git-send-email.perl:569
 #, fuzzy
 msgid ""
 "`batch-size` and `relogin` must be specified together (via command-line or "
@@ -26680,37 +26405,37 @@ msgstr ""
 "`batch-size` i `relogin` s'han d'especificar junts (a través de la línia "
 "d'ordres o l'opció de configuració)"
 
-#: git-send-email.perl:546
+#: git-send-email.perl:582
 #, perl-format
 msgid "Unknown --suppress-cc field: '%s'\n"
 msgstr "Camp --suppress-cc desconegut: «%s»\n"
 
-#: git-send-email.perl:577
+#: git-send-email.perl:613
 #, perl-format
 msgid "Unknown --confirm setting: '%s'\n"
 msgstr "Paràmetre --confirm desconegut: «%s»\n"
 
-#: git-send-email.perl:617
+#: git-send-email.perl:653
 #, perl-format
 msgid "warning: sendmail alias with quotes is not supported: %s\n"
 msgstr "avís: no s'admet l'àlies de sendmail amb cometes: %s\n"
 
-#: git-send-email.perl:619
+#: git-send-email.perl:655
 #, perl-format
 msgid "warning: `:include:` not supported: %s\n"
 msgstr "avís: «:include:» no s'admet: %s\n"
 
-#: git-send-email.perl:621
+#: git-send-email.perl:657
 #, perl-format
 msgid "warning: `/file` or `|pipe` redirection not supported: %s\n"
 msgstr "avís: les redireccions «/file» ni «|pipe» no s'admeten: %s\n"
 
-#: git-send-email.perl:626
+#: git-send-email.perl:662
 #, perl-format
 msgid "warning: sendmail line is not recognized: %s\n"
 msgstr "avís: no es pot reconèixer la línia sendmail: %s\n"
 
-#: git-send-email.perl:711
+#: git-send-email.perl:747
 #, perl-format
 msgid ""
 "File '%s' exists but it could also be the range of commits\n"
@@ -26725,12 +26450,12 @@ msgstr ""
 "    * Dient «./%s» si volíeu especificar un fitxer; o\n"
 "    * Proporcionant l'opció «--format-patch» si volíeu especificar un rang.\n"
 
-#: git-send-email.perl:732
+#: git-send-email.perl:768
 #, perl-format
 msgid "Failed to opendir %s: %s"
 msgstr "S'ha produït un error en obrir el directori %s: %s"
 
-#: git-send-email.perl:767
+#: git-send-email.perl:803
 msgid ""
 "\n"
 "No patch files specified!\n"
@@ -26740,17 +26465,17 @@ msgstr ""
 "No s'han especificat fitxers de pedaç\n"
 "\n"
 
-#: git-send-email.perl:780
+#: git-send-email.perl:816
 #, perl-format
 msgid "No subject line in %s?"
 msgstr "Sense assumpte a %s?"
 
-#: git-send-email.perl:791
+#: git-send-email.perl:827
 #, perl-format
 msgid "Failed to open for writing %s: %s"
 msgstr "S'ha produït un error en obrir per escriptura %s: %s"
 
-#: git-send-email.perl:802
+#: git-send-email.perl:838
 msgid ""
 "Lines beginning in \"GIT:\" will be removed.\n"
 "Consider including an overall diffstat or table of contents\n"
@@ -26764,27 +26489,27 @@ msgstr ""
 "\n"
 "Esborreu el contingut del cos si no voleu enviar cap resum.\n"
 
-#: git-send-email.perl:826
+#: git-send-email.perl:862
 #, perl-format
 msgid "Failed to open %s: %s"
 msgstr "S'ha produït un error en obrir %s: %s"
 
-#: git-send-email.perl:843
+#: git-send-email.perl:879
 #, perl-format
 msgid "Failed to open %s.final: %s"
 msgstr "S'ha produït un error en obrir %s.final: %s"
 
-#: git-send-email.perl:886
+#: git-send-email.perl:922
 msgid "Summary email is empty, skipping it\n"
 msgstr "El correu electrònic de resum està buit, s'omet\n"
 
 #. TRANSLATORS: please keep [y/N] as is.
-#: git-send-email.perl:935
+#: git-send-email.perl:971
 #, perl-format
 msgid "Are you sure you want to use <%s> [y/N]? "
 msgstr "Esteu segur que voleu usar <%s> [y/N]? "
 
-#: git-send-email.perl:990
+#: git-send-email.perl:1026
 msgid ""
 "The following files are 8bit, but do not declare a Content-Transfer-"
 "Encoding.\n"
@@ -26792,11 +26517,11 @@ msgstr ""
 "Els fitxers següents són 8bit, però no declaren un Content-Transfer-"
 "Encoding.\n"
 
-#: git-send-email.perl:995
+#: git-send-email.perl:1031
 msgid "Which 8bit encoding should I declare [UTF-8]? "
 msgstr "Quina codificació de 8 bits hauria de declarar [UTF-8]? "
 
-#: git-send-email.perl:1003
+#: git-send-email.perl:1039
 #, perl-format
 msgid ""
 "Refusing to send because the patch\n"
@@ -26807,23 +26532,23 @@ msgstr ""
 "\t%s\n"
 "perquè la plantilla té l'assumpte «*** SUBJECT HERE ***». Passeu --force si realment voleu enviar-ho.\n"
 
-#: git-send-email.perl:1022
+#: git-send-email.perl:1058
 msgid "To whom should the emails be sent (if anyone)?"
 msgstr ""
 "A qui s'haurien d'enviar els correus electrònics (si s'han d'enviar a algú)?"
 
-#: git-send-email.perl:1040
+#: git-send-email.perl:1076
 #, perl-format
 msgid "fatal: alias '%s' expands to itself\n"
 msgstr "fatal: l'àlies «%s» s'expandeix a si mateix\n"
 
-#: git-send-email.perl:1052
+#: git-send-email.perl:1088
 msgid "Message-ID to be used as In-Reply-To for the first email (if any)? "
 msgstr ""
 "S'ha d'usar el Message-ID com a In-Reply-To pel primer correu (si n'hi ha "
 "cap)? "
 
-#: git-send-email.perl:1114 git-send-email.perl:1122
+#: git-send-email.perl:1150 git-send-email.perl:1158
 #, perl-format
 msgid "error: unable to extract a valid address from: %s\n"
 msgstr "error: no s'ha pogut extreure una adreça vàlida de: %s\n"
@@ -26831,16 +26556,16 @@ msgstr "error: no s'ha pogut extreure una adreça vàlida de: %s\n"
 #. TRANSLATORS: Make sure to include [q] [d] [e] in your
 #. translation. The program will only accept English input
 #. at this point.
-#: git-send-email.perl:1126
+#: git-send-email.perl:1162
 msgid "What to do with this address? ([q]uit|[d]rop|[e]dit): "
 msgstr "Què cal fer amb aquesta adreça? ([q]surt|[d]escarta|[e]dita): "
 
-#: git-send-email.perl:1446
+#: git-send-email.perl:1482
 #, perl-format
 msgid "CA path \"%s\" does not exist"
 msgstr "el camí CA «%s» no existeix"
 
-#: git-send-email.perl:1529
+#: git-send-email.perl:1565
 msgid ""
 "    The Cc list above has been expanded by additional\n"
 "    addresses found in the patch commit message. By default\n"
@@ -26867,730 +26592,146 @@ msgstr ""
 #. TRANSLATORS: Make sure to include [y] [n] [e] [q] [a] in your
 #. translation. The program will only accept English input
 #. at this point.
-#: git-send-email.perl:1544
+#: git-send-email.perl:1580
 msgid "Send this email? ([y]es|[n]o|[e]dit|[q]uit|[a]ll): "
 msgstr ""
 "Voleu enviar aquest correu electrònic? ([y]sí|[n]o|[e]dita|[q]surt|[a]tot): "
 
-#: git-send-email.perl:1547
+#: git-send-email.perl:1583
 msgid "Send this email reply required"
 msgstr "Requereix resposta en enviar el correu"
 
-#: git-send-email.perl:1581
+#: git-send-email.perl:1617
 msgid "The required SMTP server is not properly defined."
 msgstr "El servidor SMTP requerit no està correctament definit."
 
-#: git-send-email.perl:1628
+#: git-send-email.perl:1664
 #, perl-format
 msgid "Server does not support STARTTLS! %s"
 msgstr "El servidor no admet STARTTLS! %s"
 
-#: git-send-email.perl:1633 git-send-email.perl:1637
+#: git-send-email.perl:1669 git-send-email.perl:1673
 #, perl-format
 msgid "STARTTLS failed! %s"
 msgstr "STARTTLS ha fallat! %s"
 
-#: git-send-email.perl:1646
+#: git-send-email.perl:1682
 msgid "Unable to initialize SMTP properly. Check config and use --smtp-debug."
 msgstr ""
 "No s'ha pogut inicialitzar SMTP correctament. Comproveu-ho la configuració i"
 " useu --smtp-debug."
 
-#: git-send-email.perl:1664
+#: git-send-email.perl:1700
 #, perl-format
 msgid "Failed to send %s\n"
 msgstr "S'ha produït un error en enviar %s\n"
 
-#: git-send-email.perl:1667
+#: git-send-email.perl:1703
 #, perl-format
 msgid "Dry-Sent %s\n"
 msgstr "Simulació d'enviament %s\n"
 
-#: git-send-email.perl:1667
+#: git-send-email.perl:1703
 #, perl-format
 msgid "Sent %s\n"
 msgstr "Enviat %s\n"
 
-#: git-send-email.perl:1669
+#: git-send-email.perl:1705
 msgid "Dry-OK. Log says:\n"
 msgstr "Simulació de correcte. El registre diu:\n"
 
-#: git-send-email.perl:1669
+#: git-send-email.perl:1705
 msgid "OK. Log says:\n"
 msgstr "Correcte. El registre diu: \n"
 
-#: git-send-email.perl:1688
+#: git-send-email.perl:1724
 msgid "Result: "
 msgstr "Resultat: "
 
-#: git-send-email.perl:1691
+#: git-send-email.perl:1727
 msgid "Result: OK\n"
 msgstr "Resultat: correcte\n"
 
-#: git-send-email.perl:1708
+#: git-send-email.perl:1744
 #, perl-format
 msgid "can't open file %s"
 msgstr "no es pot obrir el fitxer %s"
 
-#: git-send-email.perl:1756 git-send-email.perl:1776
+#: git-send-email.perl:1792 git-send-email.perl:1812
 #, perl-format
 msgid "(mbox) Adding cc: %s from line '%s'\n"
 msgstr "(mbox) S'està afegint cc: %s des de la línia «%s»\n"
 
-#: git-send-email.perl:1762
+#: git-send-email.perl:1798
 #, perl-format
 msgid "(mbox) Adding to: %s from line '%s'\n"
 msgstr "(mbox) S'està afegint a: %s des de la línia «%s»\n"
 
-#: git-send-email.perl:1819
+#: git-send-email.perl:1855
 #, perl-format
 msgid "(non-mbox) Adding cc: %s from line '%s'\n"
 msgstr "(no mbox) S'està afegint cc: %s des de la línia «%s»\n"
 
-#: git-send-email.perl:1854
+#: git-send-email.perl:1890
 #, perl-format
 msgid "(body) Adding cc: %s from line '%s'\n"
 msgstr "(cos) S'està afegint cc: %s des de la línia «%s»\n"
 
-#: git-send-email.perl:1973
+#: git-send-email.perl:2009
 #, perl-format
 msgid "(%s) Could not execute '%s'"
 msgstr "(%s) no s'ha pogut executar «%s»"
 
-#: git-send-email.perl:1980
+#: git-send-email.perl:2016
 #, perl-format
 msgid "(%s) Adding %s: %s from: '%s'\n"
 msgstr "(%s) S'està afegint %s: %s des de: «%s»\n"
 
-#: git-send-email.perl:1984
+#: git-send-email.perl:2020
 #, perl-format
 msgid "(%s) failed to close pipe to '%s'"
 msgstr "(%s) s'ha produït un error en tancar el conducte «%s»"
 
-#: git-send-email.perl:2014
+#: git-send-email.perl:2050
 msgid "cannot send message as 7bit"
 msgstr "no es pot enviar el missatge en 7 bits"
 
-#: git-send-email.perl:2022
+#: git-send-email.perl:2058
 msgid "invalid transfer encoding"
 msgstr "codificació de transferència no vàlida"
 
-#: git-send-email.perl:2059
-#, fuzzy, perl-format
+#: git-send-email.perl:2095
+#, perl-format
 msgid ""
 "fatal: %s: rejected by sendemail-validate hook\n"
 "%s\n"
 "warning: no patches were sent\n"
 msgstr ""
-"fatal: %s: %s\n"
-"avís: no s'han enviat pedaços\n"
+"fatal: %s: rebutjat pel lligam sendemail-validate\n"
+"%s\n"
+"avís: no s'ha enviat cap pedaç\n"
 
-#: git-send-email.perl:2069 git-send-email.perl:2122 git-send-email.perl:2132
+#: git-send-email.perl:2105 git-send-email.perl:2158 git-send-email.perl:2168
 #, perl-format
 msgid "unable to open %s: %s\n"
 msgstr "no s'ha pogut obrir %s: %s\n"
 
-#: git-send-email.perl:2072
-#, fuzzy, perl-format
+#: git-send-email.perl:2108
+#, perl-format
 msgid ""
 "fatal: %s:%d is longer than 998 characters\n"
 "warning: no patches were sent\n"
 msgstr ""
-"fatal: %s: %s\n"
-"avís: no s'han enviat pedaços\n"
+"fatal: %s:%d té més de 998 caràcters\n"
+"avís: no s'ha enviat cap pedaç\n"
 
-#: git-send-email.perl:2090
+#: git-send-email.perl:2126
 #, perl-format
 msgid "Skipping %s with backup suffix '%s'.\n"
 msgstr "S'està ometent %s amb el sufix de còpia de seguretat «%s».\n"
 
 #. TRANSLATORS: please keep "[y|N]" as is.
-#: git-send-email.perl:2094
+#: git-send-email.perl:2130
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Esteu segur que voleu enviar %s? [y|N]: "
-
-#, fuzzy, c-format
-#~ msgid ""
-#~ "The following pathspecs didn't match any eligible path, but they do match index\n"
-#~ "entries outside the current sparse checkout:\n"
-#~ msgstr ""
-#~ "Les següents especificacions de camí no coincideixen amb cap camí elegible, però sí que tenen índex de coincidències\n"
-#~ "entrades fora de l'actual pagament dispers:"
-
-#, fuzzy
-#~ msgid ""
-#~ "Disable or modify the sparsity rules if you intend to update such entries."
-#~ msgstr ""
-#~ "Desactiva o modifica les regles d'esparsitat si teniu la intenció "
-#~ "d'actualitzar aquestes entrades."
-
-#, c-format
-#~ msgid "could not set GIT_DIR to '%s'"
-#~ msgstr "no s'ha pogut establir GIT_DIR a «%s»"
-
-#, c-format
-#~ msgid "unable to unpack %s header with --allow-unknown-type"
-#~ msgstr "no s'ha pogut desempaquetar la capçalera %s amb --allow-unknown-type"
-
-#, c-format
-#~ msgid "unable to parse %s header with --allow-unknown-type"
-#~ msgstr "no s'ha pogut analitzar la capçalera %s amb --allow-unknown-type"
-
-#~ msgid "open /dev/null failed"
-#~ msgstr "s'ha produït un error en obrir /dev/null"
-
-#~ msgid ""
-#~ "after resolving the conflicts, mark the corrected paths\n"
-#~ "with 'git add <paths>' or 'git rm <paths>'\n"
-#~ "and commit the result with 'git commit'"
-#~ msgstr ""
-#~ "després de resoldre els conflictes, marqueu els camins\n"
-#~ "corregits amb «git add <camins>» o «git rm <camins>»\n"
-#~ "i cometeu el resultat amb «git commit»"
-
-#~ msgid "open /dev/null or dup failed"
-#~ msgstr "s'ha produït un error en obrir /dev/null o dup"
-
-#, fuzzy
-#~ msgid "attempting to use sparse-index without cone mode"
-#~ msgstr "s'està intentant utilitzar l'índex de dispersió sense el mode de con"
-
-#, fuzzy
-#~ msgid "unable to update cache-tree, staying full"
-#~ msgstr "no s'ha pogut actualitzar l'arbre cau"
-
-#, c-format
-#~ msgid "Could not open '%s' for writing."
-#~ msgstr "No s'ha pogut obrir «%s» per a escriptura."
-
-#, c-format
-#~ msgid "could not create archive file '%s'"
-#~ msgstr "no s'ha pogut crear el fitxer d'arxiu «%s»"
-
-#~ msgid "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
-#~ msgstr ""
-#~ "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
-
-#, fuzzy
-#~ msgid "--bisect-next-check requires 2 or 3 arguments"
-#~ msgstr "--bisect-next-check requereix 2 o 3 arguments"
-
-#, c-format
-#~ msgid "couldn't create a new file at '%s'"
-#~ msgstr "no s'ha pogut crear el fitxer nou a «%s»"
-
-#, c-format
-#~ msgid "git commit-tree: failed to open '%s'"
-#~ msgstr "git commit-tree: ha fallat en obrir «%s»"
-
-#, c-format
-#~ msgid "cannot open packfile '%s'"
-#~ msgstr "no es pot obrir el fitxer de paquet «%s»"
-
-#~ msgid "cannot store pack file"
-#~ msgstr "no es pot emmagatzemar el fitxer empaquetat"
-
-#~ msgid "cannot store index file"
-#~ msgstr "no es pot emmagatzemar el fitxer d'índex"
-
-#~ msgid "exclude patterns are read from <file>"
-#~ msgstr "els patrons d'exclusió es llegeixen de <fitxer>"
-
-#, c-format
-#~ msgid "Unknown option for merge-recursive: -X%s"
-#~ msgstr "Opció desconeguda de merge-recursive: -X%s"
-
-#, c-format
-#~ msgid "unusable todo list: '%s'"
-#~ msgstr "llista per a fer inestable: «%s»"
-
-#~ msgid "git rebase--interactive [<options>]"
-#~ msgstr "git rebase--interactive [<opcions>]"
-
-#~ msgid "rebase merge commits"
-#~ msgstr "fes «rebase» de les comissions de fusió"
-
-#, fuzzy
-#~ msgid "keep original branch points of cousins"
-#~ msgstr "mantén els punts de branca originals dels cosins"
-
-#, fuzzy
-#~ msgid "move commits that begin with squash!/fixup!"
-#~ msgstr "mou les comissions que comencen amb squash!/fixup!"
-
-#~ msgid "sign commits"
-#~ msgstr "signa les comissions"
-
-#~ msgid "continue rebase"
-#~ msgstr "continua el «rebase»"
-
-#~ msgid "skip commit"
-#~ msgstr "omet la comissió"
-
-#~ msgid "edit the todo list"
-#~ msgstr "edita la llista a fer"
-
-#~ msgid "show the current patch"
-#~ msgstr "mostra el pedaç actual"
-
-#~ msgid "shorten commit ids in the todo list"
-#~ msgstr "escurça els ids de les comissions en la llista per a fer"
-
-#~ msgid "expand commit ids in the todo list"
-#~ msgstr "expandeix els ids de les comissions en la llista per a fer"
-
-#~ msgid "check the todo list"
-#~ msgstr "comprova la llista a fer"
-
-#~ msgid "rearrange fixup/squash lines"
-#~ msgstr "reorganitza les línies «fixup/pick»"
-
-#~ msgid "insert exec commands in todo list"
-#~ msgstr "expandeix les ordres exec en la llista per a fer"
-
-#, fuzzy
-#~ msgid "onto"
-#~ msgstr "sobre"
-
-#, fuzzy
-#~ msgid "restrict-revision"
-#~ msgstr "revisió restringida"
-
-#, fuzzy
-#~ msgid "restrict revision"
-#~ msgstr "restringeix la revisió"
-
-#, fuzzy
-#~ msgid "squash-onto"
-#~ msgstr "squash-onto"
-
-#, fuzzy
-#~ msgid "squash onto"
-#~ msgstr "carabassa a"
-
-#, fuzzy
-#~ msgid "the upstream commit"
-#~ msgstr "la comissió principal"
-
-#, fuzzy
-#~ msgid "head-name"
-#~ msgstr "nom-cap"
-
-#, fuzzy
-#~ msgid "head name"
-#~ msgstr "nom del cap"
-
-#, fuzzy
-#~ msgid "rebase strategy"
-#~ msgstr "estratègia de rebase"
-
-#, fuzzy
-#~ msgid "strategy-opts"
-#~ msgstr "opcions estratègiques"
-
-#, fuzzy
-#~ msgid "strategy options"
-#~ msgstr "opcions d'estratègia"
-
-#, fuzzy
-#~ msgid "switch-to"
-#~ msgstr "canvia a"
-
-#, fuzzy
-#~ msgid "the branch or commit to checkout"
-#~ msgstr "la branca o entrega a agafar"
-
-#, fuzzy
-#~ msgid "onto-name"
-#~ msgstr "ont-name"
-
-#, fuzzy
-#~ msgid "onto name"
-#~ msgstr "al nom"
-
-#, fuzzy
-#~ msgid "cmd"
-#~ msgstr "cmd"
-
-#~ msgid "the command to run"
-#~ msgstr "l'ordre a executar"
-
-#, fuzzy
-#~ msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
-#~ msgstr "--[no-]rebase-cosins no té cap efecte sense --rebase-merges"
-
-#~ msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
-#~ msgstr "no es pot combinar «--preserve-merges» amb «--rebase-merges»"
-
-#~ msgid ""
-#~ "error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
-#~ msgstr ""
-#~ "error: no es pot combinar «--preserve-merges» amb «--reschedule-failed-exec»"
-
-#, fuzzy
-#~ msgid ""
-#~ "git submodule--helper add-clone [<options>...] --url <url> --path <path> "
-#~ "--name <name>"
-#~ msgstr "git submodule--helper init [<opcions>] [<camí>]"
-
-#, c-format
-#~ msgid "failed to create file %s"
-#~ msgstr "s'ha produït un error en crear el fitxer %s"
-
-#~ msgid "exit immediately after initial ref advertisement"
-#~ msgstr "surt immediatament després de l'anunci inicial de referència"
-
-#, fuzzy, c-format
-#~ msgid "socket/pipe already in use: '%s'"
-#~ msgstr "el sòcol/pipe ja s'està utilitzant: «%s»"
-
-#, fuzzy, c-format
-#~ msgid "could not start server on: '%s'"
-#~ msgstr "no s'ha pogut fer «stat» sobre el fitxer «%s»"
-
-#, fuzzy
-#~ msgid "could not spawn daemon in the background"
-#~ msgstr "no s'ha pogut crear el dimoni en segon pla"
-
-#, fuzzy
-#~ msgid "waitpid failed"
-#~ msgstr "«setsid» ha fallat"
-
-#, fuzzy
-#~ msgid "daemon not online yet"
-#~ msgstr "El dimoni encara no està en línia"
-
-#, fuzzy
-#~ msgid "daemon failed to start"
-#~ msgstr "s'ha produït un error en fer stat a %s"
-
-#, fuzzy
-#~ msgid "waitpid is confused"
-#~ msgstr "waitpid està confós"
-
-#, fuzzy
-#~ msgid "daemon has not shutdown yet"
-#~ msgstr "El dimoni encara no s'ha apagat"
-
-#, fuzzy
-#~ msgid "Protocol restrictions not supported with cURL < 7.19.4"
-#~ msgstr "Restriccions de protocol no compatibles amb cURL < 7.19.4"
-
-#, sh-format
-#~ msgid "running $command"
-#~ msgstr "s'està executant $command"
-
-#, sh-format
-#~ msgid "'$sm_path' does not have a commit checked out"
-#~ msgstr "«$sm_path» no té una comissió agafada"
-
-#, sh-format
-#~ msgid "Submodule path '$displaypath': '$command $sha1'"
-#~ msgstr "Camí de submòdul «$displaypath»: «$command $sha1»"
-
-#~ msgid "Applied autostash."
-#~ msgstr "S'ha aplicat l'«autostash»."
-
-#, sh-format
-#~ msgid "Cannot store $stash_sha1"
-#~ msgstr "No es pot emmagatzemar $stash_sha1"
-
-#~ msgid ""
-#~ "Applying autostash resulted in conflicts.\n"
-#~ "Your changes are safe in the stash.\n"
-#~ "You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
-#~ msgstr ""
-#~ "L'aplicació del «stash» automàtic ha resultat en conflictes.\n"
-#~ "Els vostres canvis estan segurs en el «stash».\n"
-#~ "Podeu executar «git stash pop» o «git stash drop» en qualsevol moment.\n"
-
-#, sh-format
-#~ msgid "Rebasing ($new_count/$total)"
-#~ msgstr "S'està fent «rebase» ($new_count/$total)"
-
-#~ msgid ""
-#~ "\n"
-#~ "Commands:\n"
-#~ "p, pick <commit> = use commit\n"
-#~ "r, reword <commit> = use commit, but edit the commit message\n"
-#~ "e, edit <commit> = use commit, but stop for amending\n"
-#~ "s, squash <commit> = use commit, but meld into previous commit\n"
-#~ "f, fixup <commit> = like \"squash\", but discard this commit's log message\n"
-#~ "x, exec <commit> = run command (the rest of the line) using shell\n"
-#~ "d, drop <commit> = remove commit\n"
-#~ "l, label <label> = label current HEAD with a name\n"
-#~ "t, reset <label> = reset HEAD to a label\n"
-#~ "m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
-#~ ".       create a merge commit using the original merge commit's\n"
-#~ ".       message (or the oneline, if no original merge commit was\n"
-#~ ".       specified). Use -c <commit> to reword the commit message.\n"
-#~ "\n"
-#~ "These lines can be re-ordered; they are executed from top to bottom.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Ordres:\n"
-#~ " p, pick <comissió> = usa la comissió\n"
-#~ " r, reword <comissió> = usa la comissió, però edita el missatge de comissió\n"
-#~ " e, edit <comissió> = usa la comissió, però atura't per a esmenar\n"
-#~ " s, squash <comissió> = usa la comissió, però fusiona-la a la comissió prèvia\n"
-#~ " f, fixup <comissió> = com a «squash», però descarta el missatge de registre d'aquesta comissió\n"
-#~ "x, exec <comissió> = executa l'ordre (la resta de la línia) usant l'intèrpret d'ordres\n"
-#~ "d, drop <comissió> = elimina la comissió\n"
-#~ "l, label <etiqueta> = etiqueta la HEAD actual amb un nom\n"
-#~ "t, reset <etiqueta> = reinicia HEAD a una etiqueta    \n"
-#~ "m, merge [-C <comissió> | -c <comissió>] <etiqueta> [# <oneline>]\n"
-#~ ".       crea una comissió de fusió usant el missatge de la comissió\n"
-#~ ".       de fusió original (o línia única, si no hi ha cap comissió de fusió original\n"
-#~ ".       especificada). Useu -c <comissió> per a reescriure el missatge de publicació.\n"
-#~ "\n"
-#~ "Es pot canviar l'ordre d'aquestes línies; s'executen de dalt a baix.\n"
-
-#, sh-format
-#~ msgid ""
-#~ "You can amend the commit now, with\n"
-#~ "\n"
-#~ "\tgit commit --amend $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "Once you are satisfied with your changes, run\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-#~ msgstr ""
-#~ "Podeu esmenar la comissió ara, amb\n"
-#~ "\n"
-#~ "\tgit commit --amend $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "Una vegada que estigueu satisfet amb els vostres canvis, executeu\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-
-#, sh-format
-#~ msgid "$sha1: not a commit that can be picked"
-#~ msgstr "$sha1: no és una comissió que es pugui triar"
-
-#, sh-format
-#~ msgid "Invalid commit name: $sha1"
-#~ msgstr "Nom de comissió no vàlid: $sha1"
-
-#~ msgid "Cannot write current commit's replacement sha1"
-#~ msgstr "No es pot escriure el sha1 reemplaçant de la comissió actual"
-
-#, sh-format
-#~ msgid "Fast-forward to $sha1"
-#~ msgstr "Avanç ràpid a $sha1"
-
-#, sh-format
-#~ msgid "Cannot fast-forward to $sha1"
-#~ msgstr "No es pot avançar ràpidament a $sha1"
-
-#, sh-format
-#~ msgid "Cannot move HEAD to $first_parent"
-#~ msgstr "No es pot moure HEAD a $first_parent"
-
-#, sh-format
-#~ msgid "Refusing to squash a merge: $sha1"
-#~ msgstr "S'està refusant fer «squash» a una fusió: $sha1"
-
-#, sh-format
-#~ msgid "Error redoing merge $sha1"
-#~ msgstr "Error en refer la fusió $sha1"
-
-#, sh-format
-#~ msgid "Could not pick $sha1"
-#~ msgstr "No s'ha pogut triar $sha1"
-
-#, sh-format
-#~ msgid "This is the commit message #${n}:"
-#~ msgstr "Aquest és el missatge de comissió núm. ${n}:"
-
-#, sh-format
-#~ msgid "The commit message #${n} will be skipped:"
-#~ msgstr "El missatge de comissió núm. ${n} s'ometrà:"
-
-#, sh-format
-#~ msgid "This is a combination of $count commit."
-#~ msgid_plural "This is a combination of $count commits."
-#~ msgstr[0] "Això és una combinació d'$count comissió."
-#~ msgstr[1] "Això és una combinació de $count comissions."
-
-#, sh-format
-#~ msgid "Cannot write $fixup_msg"
-#~ msgstr "No es pot escriure $fixup_msg"
-
-#~ msgid "This is a combination of 2 commits."
-#~ msgstr "Això és una combinació de 2 comissions."
-
-#, sh-format
-#~ msgid "Could not apply $sha1... $rest"
-#~ msgstr "No s'ha pogut aplicar $sha1... $rest"
-
-#, sh-format
-#~ msgid ""
-#~ "Could not amend commit after successfully picking $sha1... $rest\n"
-#~ "This is most likely due to an empty commit message, or the pre-commit hook\n"
-#~ "failed. If the pre-commit hook failed, you may need to resolve the issue before\n"
-#~ "you are able to reword the commit."
-#~ msgstr ""
-#~ "No s'ha pogut esmenar la comissió després de triar correctament $sha1... $rest\n"
-#~ "Això és probablement a causa d'un missatge de comissió buit, o el lligam de\n"
-#~ "precomissió ha fallat. Si el lligam de precomissió ha fallat, pot ser que\n"
-#~ "necessiteu resoldre el problema abans que pugueu canviar el missatge de\n"
-#~ "comissió."
-
-#, sh-format
-#~ msgid "Stopped at $sha1_abbrev... $rest"
-#~ msgstr "S'ha aturat a $sha1_abbrev... $rest"
-
-#, sh-format
-#~ msgid "Cannot '$squash_style' without a previous commit"
-#~ msgstr "No es pot fer «$squash_style» sense una comissió prèvia"
-
-#, sh-format
-#~ msgid "Executing: $rest"
-#~ msgstr "S'està executant: $rest"
-
-#, sh-format
-#~ msgid "Execution failed: $rest"
-#~ msgstr "L'execució ha fallat: $rest"
-
-#~ msgid "and made changes to the index and/or the working tree"
-#~ msgstr "i ha fet canvis a l'índex o l'arbre de treball"
-
-#~ msgid ""
-#~ "You can fix the problem, and then run\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-#~ msgstr ""
-#~ "Podeu arreglar el problema, i llavors executeu\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-
-#, sh-format
-#~ msgid ""
-#~ "Execution succeeded: $rest\n"
-#~ "but left changes to the index and/or the working tree\n"
-#~ "Commit or stash your changes, and then run\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-#~ msgstr ""
-#~ "L'execució ha tingut èxit: $rest\n"
-#~ "però ha deixat canvis a l'índex o l'arbre de treball\n"
-#~ "Cometeu o emmagatzemeu els vostres canvis, i llavors executeu\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-
-#, sh-format
-#~ msgid "Unknown command: $command $sha1 $rest"
-#~ msgstr "Ordre desconeguda: $command $sha1 $rest"
-
-#~ msgid "Please fix this using 'git rebase --edit-todo'."
-#~ msgstr "Corregiu-ho usant «git rebase --edit-todo»."
-
-#, sh-format
-#~ msgid "Successfully rebased and updated $head_name."
-#~ msgstr "S'ha fet «rebase» i actualitzat $head_name amb èxit."
-
-#~ msgid "Could not remove CHERRY_PICK_HEAD"
-#~ msgstr "No s'ha pogut eliminar CHERRY_PICK_HEAD"
-
-#, sh-format
-#~ msgid ""
-#~ "You have staged changes in your working tree.\n"
-#~ "If these changes are meant to be\n"
-#~ "squashed into the previous commit, run:\n"
-#~ "\n"
-#~ "  git commit --amend $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "If they are meant to go into a new commit, run:\n"
-#~ "\n"
-#~ "  git commit $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "In both cases, once you're done, continue with:\n"
-#~ "\n"
-#~ "  git rebase --continue\n"
-#~ msgstr ""
-#~ "Teniu canvis «stage» en el vostre arbre de treball.\n"
-#~ "Si aquests canvis són per fer «squash»\n"
-#~ "a la comissió prèvia, executeu:\n"
-#~ "\n"
-#~ "  git commit --amend $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "Si són per a formar una comissió nova, executeu:\n"
-#~ "\n"
-#~ "  git commit $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "En ambdós casos, quan hàgiu terminat, continueu amb:\n"
-#~ "\n"
-#~ "  git rebase --continue\n"
-
-#~ msgid "Error trying to find the author identity to amend commit"
-#~ msgstr ""
-#~ "Hi ha hagut un error en intentar trobar la identitat d'autor per a esmenar "
-#~ "la comissió"
-
-#~ msgid ""
-#~ "You have uncommitted changes in your working tree. Please commit them\n"
-#~ "first and then run 'git rebase --continue' again."
-#~ msgstr ""
-#~ "Teniu canvis no comesos en el vostre arbre de treball. \n"
-#~ "Primer cometeu-los i després executeu «git rebase --continue» de nou."
-
-#~ msgid "Could not commit staged changes."
-#~ msgstr "No s'han pogut cometre els canvis «staged»."
-
-#~ msgid "Could not execute editor"
-#~ msgstr "No s'ha pogut executar l'editor"
-
-#, sh-format
-#~ msgid "Could not checkout $switch_to"
-#~ msgstr "No s'ha pogut agafar $switch_to"
-
-#~ msgid "No HEAD?"
-#~ msgstr "No hi ha cap HEAD?"
-
-#, sh-format
-#~ msgid "Could not create temporary $state_dir"
-#~ msgstr "No s'ha pogut crear el $state_dir temporal"
-
-#~ msgid "Could not mark as interactive"
-#~ msgstr "No s'ha pogut marcar com a interactiu"
-
-#, sh-format
-#~ msgid "Rebase $shortrevisions onto $shortonto ($todocount command)"
-#~ msgid_plural "Rebase $shortrevisions onto $shortonto ($todocount commands)"
-#~ msgstr[0] "Fes «rebase» $shortrevisions sobre $shortonto ($todocount ordre)"
-#~ msgstr[1] "Fes «rebase» $shortrevisions sobre $shortonto ($todocount ordres)"
-
-#~ msgid "Note that empty commits are commented out"
-#~ msgstr "Tingueu en compte que les comissions buides estan comentades"
-
-#~ msgid "Could not init rewritten commits"
-#~ msgstr "No s'han pogut iniciar les comissions reescrites"
-
-#~ msgid "Cannot rebase: You have unstaged changes."
-#~ msgstr "No es pot fer «rebase»: teniu canvis «unstaged»."
-
-#~ msgid "Cannot pull with rebase: You have unstaged changes."
-#~ msgstr "No es pot baixar fent «rebase»: Teniu canvis «unstaged»."
-
-#~ msgid "Cannot rebase: Your index contains uncommitted changes."
-#~ msgstr "No es pot fer «rebase»: El vostre índex conté canvis sense cometre."
-
-#~ msgid "Cannot pull with rebase: Your index contains uncommitted changes."
-#~ msgstr ""
-#~ "No es pot baixar fent «rebase»: El vostre índex conté canvis sense cometre."
-
-#~ msgid "unable to write stateless separator packet"
-#~ msgstr "no s'ha pogut escriure el paquet de separació sense estat"
-
-#~ msgid "git merge --abort"
-#~ msgstr "git merge --abort"
-
-#~ msgid "git merge --continue"
-#~ msgstr "git merge --continue"
-
-#~ msgid "git stash clear"
-#~ msgstr "git stash clear"
-
-#~ msgid "remote server sent stateless separator"
-#~ msgstr "el servidor remot ha enviat un separador sense estat"

--- a/po/de.po
+++ b/po/de.po
@@ -16983,7 +16983,7 @@ msgstr "kein Informations-Betrachter konnte mit dieser Anfrage umgehen"
 #: builtin/help.c:551 builtin/help.c:562 git.c:348
 #, c-format
 msgid "'%s' is aliased to '%s'"
-msgstr "Für '%s' wurde der Alias '%s' angelegt."
+msgstr "'%s' ist ein Alias für '%s'"
 
 #: builtin/help.c:565 git.c:380
 #, c-format

--- a/po/fr.po
+++ b/po/fr.po
@@ -77,7 +77,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2022-01-11 09:38+0800\n"
+"POT-Creation-Date: 2022-01-17 08:34+0800\n"
 "PO-Revision-Date: 2022-01-12 21:11+0100\n"
 "Last-Translator: Cédric Malard <c.malard-git@valdun.net>\n"
 "Language-Team: Jean-Noël Avila <jn.avila@free.fr>\n"
@@ -979,8 +979,8 @@ msgstr "option d'ignorance d'espace non reconnue '%s'"
 #: builtin/checkout.c:1644 builtin/checkout.c:1754 builtin/checkout.c:1757
 #: builtin/clone.c:906 builtin/commit.c:358 builtin/commit.c:361
 #: builtin/commit.c:1196 builtin/describe.c:593 builtin/diff-tree.c:155
-#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2033
-#: builtin/fetch.c:2038 builtin/index-pack.c:1852 builtin/init-db.c:560
+#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2038
+#: builtin/fetch.c:2043 builtin/index-pack.c:1852 builtin/init-db.c:560
 #: builtin/log.c:1946 builtin/log.c:1948 builtin/ls-files.c:778
 #: builtin/merge.c:1403 builtin/merge.c:1405 builtin/pack-objects.c:4073
 #: builtin/push.c:592 builtin/push.c:630 builtin/push.c:636 builtin/push.c:641
@@ -2060,7 +2060,7 @@ msgstr "Une branche nommée '%s' existe déjà"
 
 #: branch.c:313
 #, c-format
-msgid "cannot force update the branch '%s'checked out at '%s'"
+msgid "cannot force update the branch '%s' checked out at '%s'"
 msgstr ""
 "impossible de forcer la mise à jour de la branche '%s' extraite dans '%s'"
 
@@ -5981,7 +5981,7 @@ msgstr "%s : échec de l'insertion dans la base de données"
 msgid "%s: unsupported file type"
 msgstr "%s : type de fichier non supporté"
 
-#: object-file.c:2329 builtin/fetch.c:1448
+#: object-file.c:2329 builtin/fetch.c:1453
 #, c-format
 msgid "%s is not a valid object"
 msgstr "%s n'est pas un objet valide"
@@ -7266,41 +7266,41 @@ msgstr "refus de mettre à jour une réf avec un nom cassé '%s'"
 msgid "update_ref failed for ref '%s': %s"
 msgstr "échec de update_ref pour la réf '%s' : %s"
 
-#: refs.c:2069
+#: refs.c:2067
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "mises à jour multiples pour la réf '%s' non permises"
 
-#: refs.c:2152
+#: refs.c:2150
 msgid "ref updates forbidden inside quarantine environment"
 msgstr "mises à jour des références interdites en environnement de quarantaine"
 
-#: refs.c:2163
+#: refs.c:2161
 msgid "ref updates aborted by hook"
 msgstr "mises à jour des références annulées par le crochet"
 
-#: refs.c:2271 refs.c:2301
+#: refs.c:2269 refs.c:2299
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "'%s' existe ; impossible de créer '%s'"
 
-#: refs.c:2277 refs.c:2312
+#: refs.c:2275 refs.c:2310
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "impossible de traiter '%s' et '%s' en même temps"
 
-#: refs/files-backend.c:1268
+#: refs/files-backend.c:1267
 #, c-format
 msgid "could not remove reference %s"
 msgstr "impossible de supprimer la référence %s"
 
-#: refs/files-backend.c:1282 refs/packed-backend.c:1549
+#: refs/files-backend.c:1281 refs/packed-backend.c:1549
 #: refs/packed-backend.c:1559
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr "impossible de supprimer la référence %s : %s"
 
-#: refs/files-backend.c:1285 refs/packed-backend.c:1562
+#: refs/files-backend.c:1284 refs/packed-backend.c:1562
 #, c-format
 msgid "could not delete references: %s"
 msgstr "impossible de supprimer les références : %s"
@@ -8349,7 +8349,8 @@ msgstr "impossible de résoudre HEAD"
 msgid "cannot abort from a branch yet to be born"
 msgstr "impossible d'abandonner depuis une branche non encore créée"
 
-#: sequencer.c:3180 builtin/fetch.c:999 builtin/fetch.c:1411 builtin/grep.c:772
+#: sequencer.c:3180 builtin/fetch.c:1004 builtin/fetch.c:1416
+#: builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr "impossible d'ouvrir '%s'"
@@ -9318,7 +9319,7 @@ msgstr ""
 msgid "invalid remote service path"
 msgstr "chemin de service distant invalide"
 
-#: transport-helper.c:661 transport.c:1474
+#: transport-helper.c:661 transport.c:1479
 msgid "operation not supported by protocol"
 msgstr "option non supportée par le protocole"
 
@@ -13599,7 +13600,7 @@ msgstr "les options '%s' et '%s %s' ne peuvent pas être utilisées ensemble"
 msgid "repository '%s' does not exist"
 msgstr "le dépôt '%s' n'existe pas"
 
-#: builtin/clone.c:924 builtin/fetch.c:2047
+#: builtin/clone.c:924 builtin/fetch.c:2052
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "la profondeur %s n'est pas un entier positif"
@@ -15532,71 +15533,71 @@ msgstr "écrire le graphe de commits après le rapatriement"
 msgid "accept refspecs from stdin"
 msgstr "lire les spécificateurs de référence depuis l'entrée standard"
 
-#: builtin/fetch.c:587
+#: builtin/fetch.c:592
 msgid "couldn't find remote ref HEAD"
 msgstr "impossible de trouver la référence HEAD distante"
 
-#: builtin/fetch.c:761
+#: builtin/fetch.c:766
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr ""
 "le paramètre de configuration fetch.output contient une valeur invalide %s"
 
-#: builtin/fetch.c:862
+#: builtin/fetch.c:867
 #, c-format
 msgid "object %s not found"
 msgstr "objet %s non trouvé"
 
-#: builtin/fetch.c:866
+#: builtin/fetch.c:871
 msgid "[up to date]"
 msgstr "[à jour]"
 
-#: builtin/fetch.c:878 builtin/fetch.c:896 builtin/fetch.c:968
+#: builtin/fetch.c:883 builtin/fetch.c:901 builtin/fetch.c:973
 msgid "[rejected]"
 msgstr "[rejeté]"
 
-#: builtin/fetch.c:880
+#: builtin/fetch.c:885
 msgid "can't fetch in current branch"
 msgstr "impossible de récupérer dans la branche actuelle"
 
-#: builtin/fetch.c:881
+#: builtin/fetch.c:886
 msgid "checked out in another worktree"
 msgstr "extrait dans un autre arbre de travail"
 
-#: builtin/fetch.c:891
+#: builtin/fetch.c:896
 msgid "[tag update]"
 msgstr "[mise à jour de l'étiquette]"
 
-#: builtin/fetch.c:892 builtin/fetch.c:929 builtin/fetch.c:951
-#: builtin/fetch.c:963
+#: builtin/fetch.c:897 builtin/fetch.c:934 builtin/fetch.c:956
+#: builtin/fetch.c:968
 msgid "unable to update local ref"
 msgstr "impossible de mettre à jour la référence locale"
 
-#: builtin/fetch.c:896
+#: builtin/fetch.c:901
 msgid "would clobber existing tag"
 msgstr "écraserait l'étiquette existante"
 
-#: builtin/fetch.c:918
+#: builtin/fetch.c:923
 msgid "[new tag]"
 msgstr "[nouvelle étiquette]"
 
-#: builtin/fetch.c:921
+#: builtin/fetch.c:926
 msgid "[new branch]"
 msgstr "[nouvelle branche]"
 
-#: builtin/fetch.c:924
+#: builtin/fetch.c:929
 msgid "[new ref]"
 msgstr "[nouvelle référence]"
 
-#: builtin/fetch.c:963
+#: builtin/fetch.c:968
 msgid "forced update"
 msgstr "mise à jour forcée"
 
-#: builtin/fetch.c:968
+#: builtin/fetch.c:973
 msgid "non-fast-forward"
 msgstr "pas en avance rapide"
 
-#: builtin/fetch.c:1071
+#: builtin/fetch.c:1076
 msgid ""
 "fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled; to re-enable, use '--show-forced-updates'\n"
@@ -15606,7 +15607,7 @@ msgstr ""
 "mais ceci a été désactivé. Pour ré-activer, utilisez le drapeau\n"
 "'--show-forced-updates' ou lancez 'git config fetch.showForcedUpdates true'"
 
-#: builtin/fetch.c:1075
+#: builtin/fetch.c:1080
 #, c-format
 msgid ""
 "it took %.2f seconds to check forced updates; you can use\n"
@@ -15618,24 +15619,24 @@ msgstr ""
 "Vous pouvez utiliser '--no-show-forced-updates' ou lancer\n"
 "'git config fetch.showForcedUpdates false' pour éviter cette vérification\n"
 
-#: builtin/fetch.c:1107
+#: builtin/fetch.c:1112
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s n'a pas envoyé tous les objets nécessaires\n"
 
-#: builtin/fetch.c:1136
+#: builtin/fetch.c:1141
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr ""
 "%s rejeté parce que les  mises à jour de racines superficielles ne sont pas "
 "permises"
 
-#: builtin/fetch.c:1226 builtin/fetch.c:1374
+#: builtin/fetch.c:1231 builtin/fetch.c:1379
 #, c-format
 msgid "From %.*s\n"
 msgstr "Depuis %.*s\n"
 
-#: builtin/fetch.c:1247
+#: builtin/fetch.c:1252
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -15644,49 +15645,49 @@ msgstr ""
 "des références locales n'ont pas pu être mises à jour ; essayez de lancer\n"
 " 'git remote prune %s' pour supprimer des branches anciennes en conflit"
 
-#: builtin/fetch.c:1344
+#: builtin/fetch.c:1349
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s sera en suspens)"
 
-#: builtin/fetch.c:1345
+#: builtin/fetch.c:1350
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s est devenu en suspens)"
 
-#: builtin/fetch.c:1377
+#: builtin/fetch.c:1382
 msgid "[deleted]"
 msgstr "[supprimé]"
 
-#: builtin/fetch.c:1378 builtin/remote.c:1128
+#: builtin/fetch.c:1383 builtin/remote.c:1128
 msgid "(none)"
 msgstr "(aucun(e))"
 
-#: builtin/fetch.c:1400
+#: builtin/fetch.c:1405
 #, c-format
 msgid "refusing to fetch into branch '%s' checked out at '%s'"
 msgstr "refus de récupérer dans la branche '%s' extraite dans '%s'"
 
-#: builtin/fetch.c:1420
+#: builtin/fetch.c:1425
 #, c-format
 msgid "option \"%s\" value \"%s\" is not valid for %s"
 msgstr "la valeur \"%2$s\" de l'option \"%1$s\" est invalide pour %3$s"
 
-#: builtin/fetch.c:1423
+#: builtin/fetch.c:1428
 #, c-format
 msgid "option \"%s\" is ignored for %s\n"
 msgstr "l'option \"%s\" est ignorée pour %s\n"
 
-#: builtin/fetch.c:1450
+#: builtin/fetch.c:1455
 #, c-format
 msgid "the object %s does not exist"
 msgstr "l'objet %s n'existe pas"
 
-#: builtin/fetch.c:1638
+#: builtin/fetch.c:1643
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "branches multiples détectées, imcompatible avec --set-upstream"
 
-#: builtin/fetch.c:1650
+#: builtin/fetch.c:1655
 #, c-format
 msgid ""
 "could not set upstream of HEAD to '%s' from '%s' when it does not point to "
@@ -15695,19 +15696,19 @@ msgstr ""
 "impossible de régler la branche amont de HEAD à '%s' depuis '%s' qui ne "
 "pointe sur aucune branche."
 
-#: builtin/fetch.c:1663
+#: builtin/fetch.c:1668
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "dépôt amont non défini pour la branche de suivi à distance"
 
-#: builtin/fetch.c:1665
+#: builtin/fetch.c:1670
 msgid "not setting upstream for a remote tag"
 msgstr "dépôt amont non défini pour l'étiquette distante"
 
-#: builtin/fetch.c:1667
+#: builtin/fetch.c:1672
 msgid "unknown branch type"
 msgstr "type de branche inconnu"
 
-#: builtin/fetch.c:1669
+#: builtin/fetch.c:1674
 msgid ""
 "no source branch found;\n"
 "you need to specify exactly one branch with the --set-upstream option"
@@ -15715,22 +15716,22 @@ msgstr ""
 "aucune branche source trouvée.\n"
 "Vous devez spécifier exactement une branche avec l'option --set-upstream"
 
-#: builtin/fetch.c:1799 builtin/fetch.c:1862
+#: builtin/fetch.c:1804 builtin/fetch.c:1867
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Récupération de %s\n"
 
-#: builtin/fetch.c:1809 builtin/fetch.c:1864
+#: builtin/fetch.c:1814 builtin/fetch.c:1869
 #, c-format
 msgid "could not fetch %s"
 msgstr "impossible de récupérer %s"
 
-#: builtin/fetch.c:1821
+#: builtin/fetch.c:1826
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "impossible de récupérer '%s' (code de sortie : %d)\n"
 
-#: builtin/fetch.c:1925
+#: builtin/fetch.c:1930
 msgid ""
 "no remote repository specified; please specify either a URL or a\n"
 "remote name from which new revisions should be fetched"
@@ -15738,50 +15739,50 @@ msgstr ""
 "Aucun dépôt distant spécifié. Veuillez spécifier une URL ou un nom\n"
 "distant depuis lesquels les nouvelles révisions devraient être récupérées"
 
-#: builtin/fetch.c:1961
+#: builtin/fetch.c:1966
 msgid "you need to specify a tag name"
 msgstr "Vous devez spécifier un nom d'étiquette"
 
-#: builtin/fetch.c:2027
+#: builtin/fetch.c:2032
 msgid "--negotiate-only needs one or more --negotiate-tip=*"
 msgstr "--negotiate-only nécessite au moins un --negotiate-tip=*"
 
-#: builtin/fetch.c:2031
+#: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"
 msgstr "une profondeur négative dans --deepen n'est pas supportée"
 
-#: builtin/fetch.c:2040
+#: builtin/fetch.c:2045
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "--unshallow sur un dépôt complet n'a pas de sens"
 
-#: builtin/fetch.c:2057
+#: builtin/fetch.c:2062
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all n'accepte pas d'argument de dépôt"
 
-#: builtin/fetch.c:2059
+#: builtin/fetch.c:2064
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all n'a pas de sens avec des spécifications de référence"
 
-#: builtin/fetch.c:2068
+#: builtin/fetch.c:2073
 #, c-format
 msgid "no such remote or remote group: %s"
 msgstr "distant ou groupe distant inexistant : %s"
 
-#: builtin/fetch.c:2076
+#: builtin/fetch.c:2081
 msgid "fetching a group and specifying refspecs does not make sense"
 msgstr ""
 "la récupération d'un groupe avec des spécifications de référence n'a pas de "
 "sens"
 
-#: builtin/fetch.c:2092
+#: builtin/fetch.c:2097
 msgid "must supply remote when using --negotiate-only"
 msgstr "le distant doit être fourni lors de l'utilisation de --negotiate-only"
 
-#: builtin/fetch.c:2097
+#: builtin/fetch.c:2102
 msgid "protocol does not support --negotiate-only, exiting"
 msgstr "Le protocole ne prend pas en charge --negotiate-only, abandon"
 
-#: builtin/fetch.c:2116
+#: builtin/fetch.c:2121
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -15789,11 +15790,11 @@ msgstr ""
 "--filter ne peut être utilisé qu'avec le dépôt distant configuré dans "
 "extensions.partialclone"
 
-#: builtin/fetch.c:2120
+#: builtin/fetch.c:2125
 msgid "--atomic can only be used when fetching from one remote"
 msgstr "--atomic ne peut être utilisée qu'en récupérant depuis un seul distant"
 
-#: builtin/fetch.c:2124
+#: builtin/fetch.c:2129
 msgid "--stdin can only be used when fetching from one remote"
 msgstr "--stdin ne peut être utilisée qu'en récupérant depuis un seul distant"
 

--- a/po/git.pot
+++ b/po/git.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2022-01-11 09:38+0800\n"
+"POT-Creation-Date: 2022-01-17 08:31+0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -788,8 +788,8 @@ msgstr ""
 #: builtin/checkout.c:1644 builtin/checkout.c:1754 builtin/checkout.c:1757
 #: builtin/clone.c:906 builtin/commit.c:358 builtin/commit.c:361
 #: builtin/commit.c:1196 builtin/describe.c:593 builtin/diff-tree.c:155
-#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2033
-#: builtin/fetch.c:2038 builtin/index-pack.c:1852 builtin/init-db.c:560
+#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2038
+#: builtin/fetch.c:2043 builtin/index-pack.c:1852 builtin/init-db.c:560
 #: builtin/log.c:1946 builtin/log.c:1948 builtin/ls-files.c:778
 #: builtin/merge.c:1403 builtin/merge.c:1405 builtin/pack-objects.c:4073
 #: builtin/push.c:592 builtin/push.c:630 builtin/push.c:636 builtin/push.c:641
@@ -1807,7 +1807,7 @@ msgstr ""
 
 #: branch.c:313
 #, c-format
-msgid "cannot force update the branch '%s'checked out at '%s'"
+msgid "cannot force update the branch '%s' checked out at '%s'"
 msgstr ""
 
 #: branch.c:336
@@ -5409,7 +5409,7 @@ msgstr ""
 msgid "%s: unsupported file type"
 msgstr ""
 
-#: object-file.c:2329 builtin/fetch.c:1448
+#: object-file.c:2329 builtin/fetch.c:1453
 #, c-format
 msgid "%s is not a valid object"
 msgstr ""
@@ -6587,41 +6587,41 @@ msgstr ""
 msgid "update_ref failed for ref '%s': %s"
 msgstr ""
 
-#: refs.c:2069
+#: refs.c:2067
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr ""
 
-#: refs.c:2152
+#: refs.c:2150
 msgid "ref updates forbidden inside quarantine environment"
 msgstr ""
 
-#: refs.c:2163
+#: refs.c:2161
 msgid "ref updates aborted by hook"
 msgstr ""
 
-#: refs.c:2271 refs.c:2301
+#: refs.c:2269 refs.c:2299
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr ""
 
-#: refs.c:2277 refs.c:2312
+#: refs.c:2275 refs.c:2310
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr ""
 
-#: refs/files-backend.c:1268
+#: refs/files-backend.c:1267
 #, c-format
 msgid "could not remove reference %s"
 msgstr ""
 
-#: refs/files-backend.c:1282 refs/packed-backend.c:1549
+#: refs/files-backend.c:1281 refs/packed-backend.c:1549
 #: refs/packed-backend.c:1559
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr ""
 
-#: refs/files-backend.c:1285 refs/packed-backend.c:1562
+#: refs/files-backend.c:1284 refs/packed-backend.c:1562
 #, c-format
 msgid "could not delete references: %s"
 msgstr ""
@@ -7574,7 +7574,8 @@ msgstr ""
 msgid "cannot abort from a branch yet to be born"
 msgstr ""
 
-#: sequencer.c:3180 builtin/fetch.c:999 builtin/fetch.c:1411 builtin/grep.c:772
+#: sequencer.c:3180 builtin/fetch.c:1004 builtin/fetch.c:1416
+#: builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr ""
@@ -8461,7 +8462,7 @@ msgstr ""
 msgid "invalid remote service path"
 msgstr ""
 
-#: transport-helper.c:661 transport.c:1474
+#: transport-helper.c:661 transport.c:1479
 msgid "operation not supported by protocol"
 msgstr ""
 
@@ -12380,7 +12381,7 @@ msgstr ""
 msgid "repository '%s' does not exist"
 msgstr ""
 
-#: builtin/clone.c:924 builtin/fetch.c:2047
+#: builtin/clone.c:924 builtin/fetch.c:2052
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr ""
@@ -14161,77 +14162,77 @@ msgstr ""
 msgid "accept refspecs from stdin"
 msgstr ""
 
-#: builtin/fetch.c:587
+#: builtin/fetch.c:592
 msgid "couldn't find remote ref HEAD"
 msgstr ""
 
-#: builtin/fetch.c:761
+#: builtin/fetch.c:766
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr ""
 
-#: builtin/fetch.c:862
+#: builtin/fetch.c:867
 #, c-format
 msgid "object %s not found"
 msgstr ""
 
-#: builtin/fetch.c:866
+#: builtin/fetch.c:871
 msgid "[up to date]"
 msgstr ""
 
-#: builtin/fetch.c:878 builtin/fetch.c:896 builtin/fetch.c:968
+#: builtin/fetch.c:883 builtin/fetch.c:901 builtin/fetch.c:973
 msgid "[rejected]"
 msgstr ""
 
-#: builtin/fetch.c:880
+#: builtin/fetch.c:885
 msgid "can't fetch in current branch"
 msgstr ""
 
-#: builtin/fetch.c:881
+#: builtin/fetch.c:886
 msgid "checked out in another worktree"
 msgstr ""
 
-#: builtin/fetch.c:891
+#: builtin/fetch.c:896
 msgid "[tag update]"
 msgstr ""
 
-#: builtin/fetch.c:892 builtin/fetch.c:929 builtin/fetch.c:951
-#: builtin/fetch.c:963
+#: builtin/fetch.c:897 builtin/fetch.c:934 builtin/fetch.c:956
+#: builtin/fetch.c:968
 msgid "unable to update local ref"
 msgstr ""
 
-#: builtin/fetch.c:896
+#: builtin/fetch.c:901
 msgid "would clobber existing tag"
 msgstr ""
 
-#: builtin/fetch.c:918
+#: builtin/fetch.c:923
 msgid "[new tag]"
 msgstr ""
 
-#: builtin/fetch.c:921
+#: builtin/fetch.c:926
 msgid "[new branch]"
 msgstr ""
 
-#: builtin/fetch.c:924
+#: builtin/fetch.c:929
 msgid "[new ref]"
 msgstr ""
 
-#: builtin/fetch.c:963
+#: builtin/fetch.c:968
 msgid "forced update"
 msgstr ""
 
-#: builtin/fetch.c:968
+#: builtin/fetch.c:973
 msgid "non-fast-forward"
 msgstr ""
 
-#: builtin/fetch.c:1071
+#: builtin/fetch.c:1076
 msgid ""
 "fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled; to re-enable, use '--show-forced-updates'\n"
 "flag or run 'git config fetch.showForcedUpdates true'"
 msgstr ""
 
-#: builtin/fetch.c:1075
+#: builtin/fetch.c:1080
 #, c-format
 msgid ""
 "it took %.2f seconds to check forced updates; you can use\n"
@@ -14240,168 +14241,168 @@ msgid ""
 "to avoid this check\n"
 msgstr ""
 
-#: builtin/fetch.c:1107
+#: builtin/fetch.c:1112
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr ""
 
-#: builtin/fetch.c:1136
+#: builtin/fetch.c:1141
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr ""
 
-#: builtin/fetch.c:1226 builtin/fetch.c:1374
+#: builtin/fetch.c:1231 builtin/fetch.c:1379
 #, c-format
 msgid "From %.*s\n"
 msgstr ""
 
-#: builtin/fetch.c:1247
+#: builtin/fetch.c:1252
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
 " 'git remote prune %s' to remove any old, conflicting branches"
 msgstr ""
 
-#: builtin/fetch.c:1344
+#: builtin/fetch.c:1349
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr ""
 
-#: builtin/fetch.c:1345
+#: builtin/fetch.c:1350
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr ""
 
-#: builtin/fetch.c:1377
+#: builtin/fetch.c:1382
 msgid "[deleted]"
 msgstr ""
 
-#: builtin/fetch.c:1378 builtin/remote.c:1128
+#: builtin/fetch.c:1383 builtin/remote.c:1128
 msgid "(none)"
 msgstr ""
 
-#: builtin/fetch.c:1400
+#: builtin/fetch.c:1405
 #, c-format
 msgid "refusing to fetch into branch '%s' checked out at '%s'"
 msgstr ""
 
-#: builtin/fetch.c:1420
+#: builtin/fetch.c:1425
 #, c-format
 msgid "option \"%s\" value \"%s\" is not valid for %s"
 msgstr ""
 
-#: builtin/fetch.c:1423
+#: builtin/fetch.c:1428
 #, c-format
 msgid "option \"%s\" is ignored for %s\n"
 msgstr ""
 
-#: builtin/fetch.c:1450
+#: builtin/fetch.c:1455
 #, c-format
 msgid "the object %s does not exist"
 msgstr ""
 
-#: builtin/fetch.c:1638
+#: builtin/fetch.c:1643
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr ""
 
-#: builtin/fetch.c:1650
+#: builtin/fetch.c:1655
 #, c-format
 msgid ""
 "could not set upstream of HEAD to '%s' from '%s' when it does not point to "
 "any branch."
 msgstr ""
 
-#: builtin/fetch.c:1663
+#: builtin/fetch.c:1668
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr ""
 
-#: builtin/fetch.c:1665
+#: builtin/fetch.c:1670
 msgid "not setting upstream for a remote tag"
 msgstr ""
 
-#: builtin/fetch.c:1667
+#: builtin/fetch.c:1672
 msgid "unknown branch type"
 msgstr ""
 
-#: builtin/fetch.c:1669
+#: builtin/fetch.c:1674
 msgid ""
 "no source branch found;\n"
 "you need to specify exactly one branch with the --set-upstream option"
 msgstr ""
 
-#: builtin/fetch.c:1799 builtin/fetch.c:1862
+#: builtin/fetch.c:1804 builtin/fetch.c:1867
 #, c-format
 msgid "Fetching %s\n"
 msgstr ""
 
-#: builtin/fetch.c:1809 builtin/fetch.c:1864
+#: builtin/fetch.c:1814 builtin/fetch.c:1869
 #, c-format
 msgid "could not fetch %s"
 msgstr ""
 
-#: builtin/fetch.c:1821
+#: builtin/fetch.c:1826
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr ""
 
-#: builtin/fetch.c:1925
+#: builtin/fetch.c:1930
 msgid ""
 "no remote repository specified; please specify either a URL or a\n"
 "remote name from which new revisions should be fetched"
 msgstr ""
 
-#: builtin/fetch.c:1961
+#: builtin/fetch.c:1966
 msgid "you need to specify a tag name"
 msgstr ""
 
-#: builtin/fetch.c:2027
+#: builtin/fetch.c:2032
 msgid "--negotiate-only needs one or more --negotiate-tip=*"
 msgstr ""
 
-#: builtin/fetch.c:2031
+#: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"
 msgstr ""
 
-#: builtin/fetch.c:2040
+#: builtin/fetch.c:2045
 msgid "--unshallow on a complete repository does not make sense"
 msgstr ""
 
-#: builtin/fetch.c:2057
+#: builtin/fetch.c:2062
 msgid "fetch --all does not take a repository argument"
 msgstr ""
 
-#: builtin/fetch.c:2059
+#: builtin/fetch.c:2064
 msgid "fetch --all does not make sense with refspecs"
 msgstr ""
 
-#: builtin/fetch.c:2068
+#: builtin/fetch.c:2073
 #, c-format
 msgid "no such remote or remote group: %s"
 msgstr ""
 
-#: builtin/fetch.c:2076
+#: builtin/fetch.c:2081
 msgid "fetching a group and specifying refspecs does not make sense"
 msgstr ""
 
-#: builtin/fetch.c:2092
+#: builtin/fetch.c:2097
 msgid "must supply remote when using --negotiate-only"
 msgstr ""
 
-#: builtin/fetch.c:2097
+#: builtin/fetch.c:2102
 msgid "protocol does not support --negotiate-only, exiting"
 msgstr ""
 
-#: builtin/fetch.c:2116
+#: builtin/fetch.c:2121
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
 msgstr ""
 
-#: builtin/fetch.c:2120
+#: builtin/fetch.c:2125
 msgid "--atomic can only be used when fetching from one remote"
 msgstr ""
 
-#: builtin/fetch.c:2124
+#: builtin/fetch.c:2129
 msgid "--stdin can only be used when fetching from one remote"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2022-01-11 09:38+0800\n"
+"POT-Creation-Date: 2022-01-17 08:34+0800\n"
 "PO-Revision-Date: 2021-08-14 09:35+0700\n"
 "Last-Translator: Bagas Sanjaya <bagasdotme@gmail.com>\n"
 "Language-Team: Indonesian\n"
@@ -863,8 +863,8 @@ msgstr "opsi abai spasi putih tidak dikenal '%s'"
 #: builtin/checkout.c:1644 builtin/checkout.c:1754 builtin/checkout.c:1757
 #: builtin/clone.c:906 builtin/commit.c:358 builtin/commit.c:361
 #: builtin/commit.c:1196 builtin/describe.c:593 builtin/diff-tree.c:155
-#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2033
-#: builtin/fetch.c:2038 builtin/index-pack.c:1852 builtin/init-db.c:560
+#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2038
+#: builtin/fetch.c:2043 builtin/index-pack.c:1852 builtin/init-db.c:560
 #: builtin/log.c:1946 builtin/log.c:1948 builtin/ls-files.c:778
 #: builtin/merge.c:1403 builtin/merge.c:1405 builtin/pack-objects.c:4073
 #: builtin/push.c:592 builtin/push.c:630 builtin/push.c:636 builtin/push.c:641
@@ -1897,12 +1897,15 @@ msgstr ""
 #: branch.c:203
 #, c-format
 msgid "asked to inherit tracking from '%s', but no remote is set"
-msgstr "diminta mewariskan pelacakan dari '%s', tetapi tidak ada remote yang disetel"
+msgstr ""
+"diminta mewariskan pelacakan dari '%s', tetapi tidak ada remote yang disetel"
 
 #: branch.c:209
 #, c-format
 msgid "asked to inherit tracking from '%s', but no merge configuration is set"
-msgstr "diminta mewariskan pelacakan dari '%s', tetapi tidak ada konfigurasi penggabungan yang disetel"
+msgstr ""
+"diminta mewariskan pelacakan dari '%s', tetapi tidak ada konfigurasi "
+"penggabungan yang disetel"
 
 #: branch.c:252
 #, c-format
@@ -1921,13 +1924,15 @@ msgstr "sebuah cabang bernama '%s' sudah ada"
 
 #: branch.c:313
 #, c-format
-msgid "cannot force update the branch '%s'checked out at '%s'"
+msgid "cannot force update the branch '%s' checked out at '%s'"
 msgstr "tidak dapat memperbarui paksa cabang '%s' yang ter-check out pada '%s'"
 
 #: branch.c:336
 #, c-format
 msgid "cannot set up tracking information; starting point '%s' is not a branch"
-msgstr "tidak dapat menyiapkan informasi pelacakan; titik awal '%s' bukan sebuah cabang"
+msgstr ""
+"tidak dapat menyiapkan informasi pelacakan; titik awal '%s' bukan sebuah "
+"cabang"
 
 #: branch.c:338
 #, c-format
@@ -3260,14 +3265,16 @@ msgstr "Opsi '%s', '%s', dan '%s' tidak dapat digunakan bersamaan"
 #: diff.c:4597
 #, c-format
 msgid "options '%s' and '%s' cannot be used together, use '%s' with '%s'"
-msgstr "opsi '%s' dan '%s' tidak dapat digunakan bersamaan, gunakan '%s' dengan '%s'"
+msgstr ""
+"opsi '%s' dan '%s' tidak dapat digunakan bersamaan, gunakan '%s' dengan '%s'"
 
 #: diff.c:4601
 #, c-format
 msgid ""
 "options '%s' and '%s' cannot be used together, use '%s' with '%s' and '%s'"
 msgstr ""
-"opsi '%s' dan '%s' tidak dapat digunakan bersamaan, gunakan '%s' dengan '%s' dan '%s'"
+"opsi '%s' dan '%s' tidak dapat digunakan bersamaan, gunakan '%s' dengan '%s' "
+"dan '%s'"
 
 #: diff.c:4681
 msgid "--follow requires exactly one pathspec"
@@ -5592,7 +5599,7 @@ msgstr ""
 msgid "%s: unsupported file type"
 msgstr ""
 
-#: object-file.c:2329 builtin/fetch.c:1448
+#: object-file.c:2329 builtin/fetch.c:1453
 #, c-format
 msgid "%s is not a valid object"
 msgstr ""
@@ -6820,41 +6827,41 @@ msgstr ""
 msgid "update_ref failed for ref '%s': %s"
 msgstr ""
 
-#: refs.c:2069
+#: refs.c:2067
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr ""
 
-#: refs.c:2152
+#: refs.c:2150
 msgid "ref updates forbidden inside quarantine environment"
 msgstr ""
 
-#: refs.c:2163
+#: refs.c:2161
 msgid "ref updates aborted by hook"
 msgstr ""
 
-#: refs.c:2271 refs.c:2301
+#: refs.c:2269 refs.c:2299
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr ""
 
-#: refs.c:2277 refs.c:2312
+#: refs.c:2275 refs.c:2310
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr ""
 
-#: refs/files-backend.c:1268
+#: refs/files-backend.c:1267
 #, c-format
 msgid "could not remove reference %s"
 msgstr ""
 
-#: refs/files-backend.c:1282 refs/packed-backend.c:1549
+#: refs/files-backend.c:1281 refs/packed-backend.c:1549
 #: refs/packed-backend.c:1559
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr ""
 
-#: refs/files-backend.c:1285 refs/packed-backend.c:1562
+#: refs/files-backend.c:1284 refs/packed-backend.c:1562
 #, c-format
 msgid "could not delete references: %s"
 msgstr ""
@@ -7831,7 +7838,8 @@ msgstr ""
 msgid "cannot abort from a branch yet to be born"
 msgstr ""
 
-#: sequencer.c:3180 builtin/fetch.c:999 builtin/fetch.c:1411 builtin/grep.c:772
+#: sequencer.c:3180 builtin/fetch.c:1004 builtin/fetch.c:1416
+#: builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr ""
@@ -8731,7 +8739,7 @@ msgstr ""
 msgid "invalid remote service path"
 msgstr ""
 
-#: transport-helper.c:661 transport.c:1474
+#: transport-helper.c:661 transport.c:1479
 msgid "operation not supported by protocol"
 msgstr ""
 
@@ -9539,7 +9547,8 @@ msgstr "  (gunakan \"git am --skip\" untuk lewati tambalan ini)"
 msgid ""
 "  (use \"git am --allow-empty\" to record this patch as an empty commit)"
 msgstr ""
-"  (gunakan \"git am --allow-empty\" untuk merekam tambalan ini sebagai komit kosong)"
+"  (gunakan \"git am --allow-empty\" untuk merekam tambalan ini sebagai komit "
+"kosong)"
 
 #: wt-status.c:1239
 msgid "  (use \"git am --abort\" to restore the original branch)"
@@ -10180,7 +10189,9 @@ msgstr ""
 #: builtin/am.c:1159
 #, c-format
 msgid "To record the empty patch as an empty commit, run \"%s --allow-empty\"."
-msgstr "Untuk merekam tambalan kosong sebagai komit kosong, jalankan \"%s --allow-empty\"."
+msgstr ""
+"Untuk merekam tambalan kosong sebagai komit kosong, jalankan \"%s --allow-"
+"empty\"."
 
 #: builtin/am.c:1161
 #, c-format
@@ -12846,7 +12857,7 @@ msgstr "opsi '%s' dan '%s %s' tidak dapat digunakan bersamaan"
 msgid "repository '%s' does not exist"
 msgstr "repositori '%s' tidak ada"
 
-#: builtin/clone.c:924 builtin/fetch.c:2047
+#: builtin/clone.c:924 builtin/fetch.c:2052
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "kedalaman %s bukan bilangan positif"
@@ -14625,7 +14636,9 @@ msgstr "jumlah submodul yang diambil secara bersamaan"
 
 #: builtin/fetch.c:165
 msgid "modify the refspec to place all refs within refs/prefetch/"
-msgstr "modifikasi spek referensi untuk tempatkan semua referensi di dalam refs/prefetch/"
+msgstr ""
+"modifikasi spek referensi untuk tempatkan semua referensi di dalam refs/"
+"prefetch/"
 
 #: builtin/fetch.c:167 builtin/pull.c:202
 msgid "prune remote-tracking branches no longer on remote"
@@ -14718,81 +14731,82 @@ msgstr "tulis grafik komit setelah pengambilan"
 msgid "accept refspecs from stdin"
 msgstr "terima spek referensi dari masukan standar"
 
-#: builtin/fetch.c:587
+#: builtin/fetch.c:592
 msgid "couldn't find remote ref HEAD"
 msgstr "tidak dapat menemukan referensi remote HEAD"
 
-#: builtin/fetch.c:761
+#: builtin/fetch.c:766
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "konfigurasi fetch.output berisi nilai tidak valid %s"
 
-#: builtin/fetch.c:862
+#: builtin/fetch.c:867
 #, c-format
 msgid "object %s not found"
 msgstr "objek %s tidak ditemukan"
 
-#: builtin/fetch.c:866
+#: builtin/fetch.c:871
 msgid "[up to date]"
 msgstr "[terkini]"
 
-#: builtin/fetch.c:878 builtin/fetch.c:896 builtin/fetch.c:968
+#: builtin/fetch.c:883 builtin/fetch.c:901 builtin/fetch.c:973
 msgid "[rejected]"
 msgstr "[tertolak]"
 
-#: builtin/fetch.c:880
+#: builtin/fetch.c:885
 msgid "can't fetch in current branch"
 msgstr "tidak dapat mengambil di cabang saat ini"
 
-#: builtin/fetch.c:881
+#: builtin/fetch.c:886
 msgid "checked out in another worktree"
 msgstr "ter-check out di dalam pohon kerja lainnya"
 
-#: builtin/fetch.c:891
+#: builtin/fetch.c:896
 msgid "[tag update]"
 msgstr "[pembaruan tag]"
 
-#: builtin/fetch.c:892 builtin/fetch.c:929 builtin/fetch.c:951
-#: builtin/fetch.c:963
+#: builtin/fetch.c:897 builtin/fetch.c:934 builtin/fetch.c:956
+#: builtin/fetch.c:968
 msgid "unable to update local ref"
 msgstr "tidak dapat memperbarui referensi lokal"
 
-#: builtin/fetch.c:896
+#: builtin/fetch.c:901
 msgid "would clobber existing tag"
 msgstr "akan klob tag yang ada"
 
-#: builtin/fetch.c:918
+#: builtin/fetch.c:923
 msgid "[new tag]"
 msgstr "[tag baru]"
 
-#: builtin/fetch.c:921
+#: builtin/fetch.c:926
 msgid "[new branch]"
 msgstr "[cabang baru]"
 
-#: builtin/fetch.c:924
+#: builtin/fetch.c:929
 msgid "[new ref]"
 msgstr "[referensi baru]"
 
-#: builtin/fetch.c:963
+#: builtin/fetch.c:968
 msgid "forced update"
 msgstr "pembaruan terpaksa"
 
-#: builtin/fetch.c:968
+#: builtin/fetch.c:973
 msgid "non-fast-forward"
 msgstr "bukan-maju-cepat"
 
-#: builtin/fetch.c:1071
+#: builtin/fetch.c:1076
 msgid ""
 "fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled; to re-enable, use '--show-forced-updates'\n"
 "flag or run 'git config fetch.showForcedUpdates true'"
 msgstr ""
 "fetch secara normal mengindikasikan cabang mana ada pembaruan terpaksa,\n"
-"tapi pemeriksaan tersebut sudah dinonaktifkan. Untuk aktifkan kembali, gunakan\n"
-"bendera '--show-forced-updates' atau jalankan 'git config fetch.showForcedUpdates "
-"true'."
+"tapi pemeriksaan tersebut sudah dinonaktifkan. Untuk aktifkan kembali, "
+"gunakan\n"
+"bendera '--show-forced-updates' atau jalankan 'git config fetch."
+"showForcedUpdates true'."
 
-#: builtin/fetch.c:1075
+#: builtin/fetch.c:1080
 #, c-format
 msgid ""
 "it took %.2f seconds to check forced updates; you can use\n"
@@ -14805,22 +14819,22 @@ msgstr ""
 "'git config fetch.showForcedUpdates false'\n"
 "untuk menghindari pemeriksaan ini.\n"
 
-#: builtin/fetch.c:1107
+#: builtin/fetch.c:1112
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s tidak mengirim semua objek yang diperlukan\n"
 
-#: builtin/fetch.c:1136
+#: builtin/fetch.c:1141
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr "tolak %s karena akar dangkal tidak diperkenankan untuk diperbarui"
 
-#: builtin/fetch.c:1226 builtin/fetch.c:1374
+#: builtin/fetch.c:1231 builtin/fetch.c:1379
 #, c-format
 msgid "From %.*s\n"
 msgstr "Dari %.*s\n"
 
-#: builtin/fetch.c:1247
+#: builtin/fetch.c:1252
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -14829,70 +14843,70 @@ msgstr ""
 "beberapa referensi lokal tidak dapat diperbarui; coba jalankan\n"
 " 'git remote prune %s' untuk hapus cabang yang lama dan berkonflik"
 
-#: builtin/fetch.c:1344
+#: builtin/fetch.c:1349
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s akan menjadi terjuntai)"
 
-#: builtin/fetch.c:1345
+#: builtin/fetch.c:1350
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s telah menjadi terjuntai)"
 
-#: builtin/fetch.c:1377
+#: builtin/fetch.c:1382
 msgid "[deleted]"
 msgstr "[dihapus]"
 
-#: builtin/fetch.c:1378 builtin/remote.c:1128
+#: builtin/fetch.c:1383 builtin/remote.c:1128
 msgid "(none)"
 msgstr "(tidak ada)"
 
-#: builtin/fetch.c:1400
+#: builtin/fetch.c:1405
 #, c-format
 msgid "refusing to fetch into branch '%s' checked out at '%s'"
 msgstr "menolak mengambil ke dalam cabang '%s' yang ter-checkout pada '%s'"
 
-#: builtin/fetch.c:1420
+#: builtin/fetch.c:1425
 #, c-format
 msgid "option \"%s\" value \"%s\" is not valid for %s"
 msgstr "opsi \"%s\" nilai \"%s\" tidak valid untuk %s"
 
-#: builtin/fetch.c:1423
+#: builtin/fetch.c:1428
 #, c-format
 msgid "option \"%s\" is ignored for %s\n"
 msgstr "opsi \"%s\" diabaikan untuk %s\n"
 
-#: builtin/fetch.c:1450
+#: builtin/fetch.c:1455
 #, c-format
 msgid "the object %s does not exist"
 msgstr "objek '%s' tidak ada"
 
-#: builtin/fetch.c:1638
+#: builtin/fetch.c:1643
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "banyak cabang terdeteksi, tidak kompatibel dengan --set-upstream"
 
-#: builtin/fetch.c:1650
+#: builtin/fetch.c:1655
 #, c-format
 msgid ""
 "could not set upstream of HEAD to '%s' from '%s' when it does not point to "
 "any branch."
 msgstr ""
-"tidak dapat menyetel hulu HEAD ke %s dari '%s' ketika itu tak menunjuk pada cabang "
-"apapun."
+"tidak dapat menyetel hulu HEAD ke %s dari '%s' ketika itu tak menunjuk pada "
+"cabang apapun."
 
-#: builtin/fetch.c:1663
+#: builtin/fetch.c:1668
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "tidak setel hulu untuk cabang remote pelacak remote"
 
-#: builtin/fetch.c:1665
+#: builtin/fetch.c:1670
 msgid "not setting upstream for a remote tag"
 msgstr "tidak setel hulu untuk tag remote"
 
-#: builtin/fetch.c:1667
+#: builtin/fetch.c:1672
 msgid "unknown branch type"
 msgstr "tipe cabang tidak diketahui"
 
-#: builtin/fetch.c:1669
+#: builtin/fetch.c:1674
 msgid ""
 "no source branch found;\n"
 "you need to specify exactly one branch with the --set-upstream option"
@@ -14900,22 +14914,22 @@ msgstr ""
 "cabang sumber tidak ditemukan;\n"
 "Anda harus sebutkan tepat satu cabang dengan opsi --set-upstream."
 
-#: builtin/fetch.c:1799 builtin/fetch.c:1862
+#: builtin/fetch.c:1804 builtin/fetch.c:1867
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Mengambil %s\n"
 
-#: builtin/fetch.c:1809 builtin/fetch.c:1864
+#: builtin/fetch.c:1814 builtin/fetch.c:1869
 #, c-format
 msgid "could not fetch %s"
 msgstr "tidak dapat mengambil %s"
 
-#: builtin/fetch.c:1821
+#: builtin/fetch.c:1826
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "tidak dapat mengambil '%s' (kode keluar: %d)\n"
 
-#: builtin/fetch.c:1925
+#: builtin/fetch.c:1930
 msgid ""
 "no remote repository specified; please specify either a URL or a\n"
 "remote name from which new revisions should be fetched"
@@ -14923,48 +14937,48 @@ msgstr ""
 "repositori remote tidak disebutkan; mohon sebutkan baik URL atau nama\n"
 "remote yang mana revisi baru sebaiknya diambil"
 
-#: builtin/fetch.c:1961
+#: builtin/fetch.c:1966
 msgid "you need to specify a tag name"
 msgstr "Anda perlu sebutkan sebuah nama tag"
 
-#: builtin/fetch.c:2027
+#: builtin/fetch.c:2032
 msgid "--negotiate-only needs one or more --negotiate-tip=*"
 msgstr "--negotiate-only perlu satu atau lebih --negotiate-tip=*"
 
-#: builtin/fetch.c:2031
+#: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"
 msgstr "kedalaman negatif pada --deepen tidak didukung"
 
-#: builtin/fetch.c:2040
+#: builtin/fetch.c:2045
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "--unshallow pada repositori penuh tidak masuk akal"
 
-#: builtin/fetch.c:2057
+#: builtin/fetch.c:2062
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all tidak mengambil argumen repositori"
 
-#: builtin/fetch.c:2059
+#: builtin/fetch.c:2064
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all tidak masuk akal dengan spek referensi"
 
-#: builtin/fetch.c:2068
+#: builtin/fetch.c:2073
 #, c-format
 msgid "no such remote or remote group: %s"
 msgstr "tidak ada remote atau grup remote seperti: %s"
 
-#: builtin/fetch.c:2076
+#: builtin/fetch.c:2081
 msgid "fetching a group and specifying refspecs does not make sense"
 msgstr "mengambil sebuah grup dan menyebutkan spek referensi tidak masuk akal"
 
-#: builtin/fetch.c:2092
+#: builtin/fetch.c:2097
 msgid "must supply remote when using --negotiate-only"
 msgstr "harus suplai remote ketika menggunakan --negotiate-only"
 
-#: builtin/fetch.c:2097
+#: builtin/fetch.c:2102
 msgid "protocol does not support --negotiate-only, exiting"
 msgstr "protokol tidak mendukung --negotiate-only, keluar."
 
-#: builtin/fetch.c:2116
+#: builtin/fetch.c:2121
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -14972,11 +14986,11 @@ msgstr ""
 "--filter hanya dapat digunakan dengan remote yang terkonfigurasi di "
 "extensions.partialclone"
 
-#: builtin/fetch.c:2120
+#: builtin/fetch.c:2125
 msgid "--atomic can only be used when fetching from one remote"
 msgstr "--atomic hanya dapat digunakan saat mengambil dari satu remote"
 
-#: builtin/fetch.c:2124
+#: builtin/fetch.c:2129
 msgid "--stdin can only be used when fetching from one remote"
 msgstr "--stdin hanya dapat digunakan saat mengambil dari satu remote"
 
@@ -18947,7 +18961,8 @@ msgstr ""
 "  git config pull.ff only       # hanya maju cepat\n"
 "\n"
 "Anda dapat mengganti \"git config\" dengan \"git config --global\" untuk\n"
-"menyetel preferensi asali untuk semua repositori. Anda juga dapat melewatkan\n"
+"menyetel preferensi asali untuk semua repositori. Anda juga dapat "
+"melewatkan\n"
 "--rebase, --no-rebase, atau --ff-only pada baris perintah untuk menimpa\n"
 "asali terkonfigurasi untuk setiap invokasi.\n"
 
@@ -21976,7 +21991,9 @@ msgstr ""
 
 #: builtin/stash.c:1474
 msgid "Can't use --staged and --include-untracked or --all at the same time"
-msgstr "Tidak dapat menggunakan --staged dan --include-untracked atau --all pada waktu yang bersamaan"
+msgstr ""
+"Tidak dapat menggunakan --staged dan --include-untracked atau --all pada "
+"waktu yang bersamaan"
 
 #: builtin/stash.c:1492
 msgid "Did you forget to 'git add'?"

--- a/po/id.po
+++ b/po/id.po
@@ -742,58 +742,62 @@ msgid ""
 "\n"
 "Disable this message with \"git config advice.%s false\""
 msgstr ""
+"\n"
+"Nonaktifkan pesan ini dengan \"git config advice.%s false\""
 
 #: advice.c:94
 #, c-format
 msgid "%shint: %.*s%s\n"
-msgstr ""
+msgstr "%shint: %.*s%s\n"
 
 #: advice.c:178
 msgid "Cherry-picking is not possible because you have unmerged files."
-msgstr ""
+msgstr "Pemetikan ceri tidak mungkin sebab Anda punya berkas tak tergabung."
 
 #: advice.c:180
 msgid "Committing is not possible because you have unmerged files."
-msgstr ""
+msgstr "Pengkomitan tidak mungkin sebab Anda punya berkas tak tergabung."
 
 #: advice.c:182
 msgid "Merging is not possible because you have unmerged files."
-msgstr ""
+msgstr "Penggabungan tidak mungkin sebab Anda punya berkas tak tergabung."
 
 #: advice.c:184
 msgid "Pulling is not possible because you have unmerged files."
-msgstr ""
+msgstr "Penarikan tidak mungkin sebab Anda punya berkas tak tergabung."
 
 #: advice.c:186
 msgid "Reverting is not possible because you have unmerged files."
-msgstr ""
+msgstr "Pembalikkan tidak mungkin sebab Anda punya berkas tak tergabung."
 
 #: advice.c:188
 #, c-format
 msgid "It is not possible to %s because you have unmerged files."
-msgstr ""
+msgstr "Tidak mungkin untuk %s sebab Anda punya berkas tak tergabung."
 
 #: advice.c:196
 msgid ""
 "Fix them up in the work tree, and then use 'git add/rm <file>'\n"
 "as appropriate to mark resolution and make a commit."
 msgstr ""
+"Perbaiki di dalam pohon kerja, lalu gunakan 'git add/rm <berkas>'\n"
+"sebagaimana mestinya untuk menandai resolusi dan membuat sebuah komit."
 
 #: advice.c:204
 msgid "Exiting because of an unresolved conflict."
-msgstr ""
+msgstr "Keluar karena sebuah konflik tak terselesaikan."
 
 #: advice.c:209 builtin/merge.c:1382
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
-msgstr ""
+msgstr "Anda belum mengakhiri penggabungan Anda (MERGE_HEAD ada)."
 
 #: advice.c:211
 msgid "Please, commit your changes before merging."
-msgstr ""
+msgstr "Mohon komit perubahan Anda sebelum menggabungkan."
 
 #: advice.c:212
 msgid "Exiting because of unfinished merge."
-msgstr ""
+msgstr "Keluar karena penggabungan belum selesai."
 
 #: advice.c:217
 msgid "Not possible to fast-forward, aborting."
@@ -806,6 +810,9 @@ msgid ""
 "outside of your sparse-checkout definition, so will not be\n"
 "updated in the index:\n"
 msgstr ""
+"Jalur dan/atau spek jalur berikut cocok dengan jalur yang ada\n"
+"di luar definisi checkout tipis Anda, jadi tidak akan diperbarui\n"
+"di dalam indeks:\n"
 
 #: advice.c:234
 msgid ""
@@ -813,6 +820,9 @@ msgid ""
 "* Use the --sparse option.\n"
 "* Disable or modify the sparsity rules."
 msgstr ""
+"Jika Anda berniat memperbarui entri tersebut, coba salah satu dari:\n"
+"* Gunakan opsi --sparse\n"
+"* Nonaktifkan atau modifikasi aturan kejarangan."
 
 #: advice.c:242
 #, c-format
@@ -836,14 +846,33 @@ msgid ""
 "false\n"
 "\n"
 msgstr ""
+"Catatan: berganti ke '%s'.\n"
+"\n"
+"Anda berada dalam keadaan 'HEAD terpisah'. Anda dapat melihat-lihat, membuat\n"
+"perubahan eksperimental and komit, dan Anda dapat membuang komit apa saja yang\n"
+"Anda buat di dalam keadaan ini tanpa mempengaruhi cabang apapun dengan bergantin"
+"kembali ke sebuah cabang.\n"
+"\n"
+"Jika Anda ingin membuat cabang baru untuk menyimpan komit yang Anda buat, Anda\n"
+"dapat melakukannya (sekarang atau nanti) dengan:\n"
+"\n"
+"  git switch -c <nama cabang baru>\n"
+"\n"
+"Atau batalkan operasi ini dengan:\n"
+"\n"
+"  git switch -\n"
+"\n"
+"Matikan saran ini dengan menyetel variabel konfigurasi advice.detachedHead ke "
+"false\n"
+"\n"
 
 #: alias.c:50
 msgid "cmdline ends with \\"
-msgstr ""
+msgstr "baris perintah diakhiri dengan \\"
 
 #: alias.c:51
 msgid "unclosed quote"
-msgstr ""
+msgstr "tanda kutip tak ditutup"
 
 #: apply.c:70
 #, c-format
@@ -7322,41 +7351,43 @@ msgstr "ujung penerima tidak mendukung opsi dorong"
 #: sequencer.c:197
 #, c-format
 msgid "invalid commit message cleanup mode '%s'"
-msgstr ""
+msgstr "mode pembersihan pesan komit tidak valid '%s'"
 
 #: sequencer.c:325
 #, c-format
 msgid "could not delete '%s'"
-msgstr ""
+msgstr "tidak dapat menghapus '%s'"
 
 #: sequencer.c:345 sequencer.c:4751 builtin/rebase.c:563 builtin/rebase.c:1297
 #: builtin/rm.c:409
 #, c-format
 msgid "could not remove '%s'"
-msgstr ""
+msgstr "tidak dapat menghapus '%s'"
 
 #: sequencer.c:355
 msgid "revert"
-msgstr ""
+msgstr "balik"
 
 #: sequencer.c:357
 msgid "cherry-pick"
-msgstr ""
+msgstr "petik ceri"
 
 #: sequencer.c:359
 msgid "rebase"
-msgstr ""
+msgstr "dasar ulang"
 
 #: sequencer.c:361
 #, c-format
 msgid "unknown action: %d"
-msgstr ""
+msgstr "aksi tidak dikenal: %d"
 
 #: sequencer.c:420
 msgid ""
 "after resolving the conflicts, mark the corrected paths\n"
 "with 'git add <paths>' or 'git rm <paths>'"
 msgstr ""
+"setelah menyelesaikan konflik, tandai jalur yang terkoreksi\n"
+"dengan 'git add <jalur>' atau 'git rm <jalur>'"
 
 #: sequencer.c:423
 msgid ""
@@ -7367,6 +7398,12 @@ msgid ""
 "To abort and get back to the state before \"git cherry-pick\",\n"
 "run \"git cherry-pick --abort\"."
 msgstr ""
+"Setelah menyelesaikan konflik, tandai dengan\n"
+"\"git add/rm <spek jalur\", lalu jalankan\n"
+"\"git cherry-pick --continue\".\n"
+"Atau Anda dapat melewati komit ini dengan \"git cherry-pick --skip\".\n"
+"Untuk membatalkan dan kembali ke keadaan sebelum \"git cherry-pick\",\n"
+"jalankan \"git cherry-pick --abort\"."
 
 #: sequencer.c:430
 msgid ""
@@ -7377,28 +7414,34 @@ msgid ""
 "To abort and get back to the state before \"git revert\",\n"
 "run \"git revert --abort\"."
 msgstr ""
+"Setelah menyelesaikan konflik, tandai dengan\n"
+"\"git add/rm <spek jalur>\", lalu jalankan\n"
+"\"git revert --continue\".\n"
+"Atau Anda dapat melewati komit ini dengan \"git revert --skip\".\n"
+"Untuk membatalkan dan kembali ke keadaan sebelum \"git revert\",\n"
+"jalankan \"git revert --abort\"."
 
 #: sequencer.c:448 sequencer.c:3292
 #, c-format
 msgid "could not lock '%s'"
-msgstr ""
+msgstr "tidak dapat mengunci '%s'"
 
 #: sequencer.c:450 sequencer.c:3091 sequencer.c:3296 sequencer.c:3310
 #: sequencer.c:3561 sequencer.c:5618 strbuf.c:1188 wrapper.c:639
 #, c-format
 msgid "could not write to '%s'"
-msgstr ""
+msgstr "tidak dapat menulis ke '%s'"
 
 #: sequencer.c:455
 #, c-format
 msgid "could not write eol to '%s'"
-msgstr ""
+msgstr "tidak dapat menulis akhir baris ke '%s'"
 
 #: sequencer.c:460 sequencer.c:3096 sequencer.c:3298 sequencer.c:3312
 #: sequencer.c:3569
 #, c-format
 msgid "failed to finalize '%s'"
-msgstr ""
+msgstr "gagal mengakhiri '%s'"
 
 #: sequencer.c:473 sequencer.c:1934 sequencer.c:3116 sequencer.c:3551
 #: sequencer.c:3679 builtin/am.c:289 builtin/commit.c:834 builtin/merge.c:1148
@@ -7409,21 +7452,21 @@ msgstr "tidak dapat membaca '%s'"
 #: sequencer.c:499
 #, c-format
 msgid "your local changes would be overwritten by %s."
-msgstr ""
+msgstr "perubahan lokal Anda akan ditimpa oleh %s."
 
 #: sequencer.c:503
 msgid "commit your changes or stash them to proceed."
-msgstr ""
+msgstr "komit perubahan Anda atau stase untuk melanjutkan."
 
 #: sequencer.c:535
 #, c-format
 msgid "%s: fast-forward"
-msgstr ""
+msgstr "%s: maju-cepat"
 
 #: sequencer.c:574 builtin/tag.c:614
 #, c-format
 msgid "Invalid cleanup mode %s"
-msgstr ""
+msgstr "Mode pembersihan tidak valid %s"
 
 #. TRANSLATORS: %s will be "revert", "cherry-pick" or
 #. "rebase".
@@ -7431,60 +7474,60 @@ msgstr ""
 #: sequencer.c:685
 #, c-format
 msgid "%s: Unable to write new index file"
-msgstr ""
+msgstr "%s: Tidak dapat menulis berkas indeks baru"
 
 #: sequencer.c:699
 msgid "unable to update cache tree"
-msgstr ""
+msgstr "tidak dapat memperbarui pohon tembolok"
 
 #: sequencer.c:713
 msgid "could not resolve HEAD commit"
-msgstr ""
+msgstr "tidak dapat menguraikan komit HEAD"
 
 #: sequencer.c:793
 #, c-format
 msgid "no key present in '%.*s'"
-msgstr ""
+msgstr "tidak ada kunci yang ada di pada '%.*s'"
 
 #: sequencer.c:804
 #, c-format
 msgid "unable to dequote value of '%s'"
-msgstr ""
+msgstr "tidak dapat membatal-kutip nilai dari '%s'"
 
 #: sequencer.c:841 wrapper.c:209 wrapper.c:379 builtin/am.c:756
 #: builtin/am.c:848 builtin/rebase.c:694
 #, c-format
 msgid "could not open '%s' for reading"
-msgstr ""
+msgstr "tidak dapat membuka '%s' untuk dibaca"
 
 #: sequencer.c:851
 msgid "'GIT_AUTHOR_NAME' already given"
-msgstr ""
+msgstr "'GIT_AUTHOR_NAME' sudah diberikan"
 
 #: sequencer.c:856
 msgid "'GIT_AUTHOR_EMAIL' already given"
-msgstr ""
+msgstr "'GIT_AUTHOR_EMAIL' sudah diberikan"
 
 #: sequencer.c:861
 msgid "'GIT_AUTHOR_DATE' already given"
-msgstr ""
+msgstr "'GIT_AUTHOR_DATE' sudah diberikan"
 
 #: sequencer.c:865
 #, c-format
 msgid "unknown variable '%s'"
-msgstr ""
+msgstr "variabel tidak dikenal '%s'"
 
 #: sequencer.c:870
 msgid "missing 'GIT_AUTHOR_NAME'"
-msgstr ""
+msgstr "'GIT_AUTHOR_NAME' hilang"
 
 #: sequencer.c:872
 msgid "missing 'GIT_AUTHOR_EMAIL'"
-msgstr ""
+msgstr "'GIT_AUTHOR_EMAIL' hilang"
 
 #: sequencer.c:874
 msgid "missing 'GIT_AUTHOR_DATE'"
-msgstr ""
+msgstr "'GIT_AUTHOR_DATE' hilang"
 
 #: sequencer.c:939
 #, c-format
@@ -7502,10 +7545,21 @@ msgid ""
 "\n"
 "  git rebase --continue\n"
 msgstr ""
+"Anda punya perubahan tergelar di dalam pohon kerja Anda.\n"
+"Apabila perubahan tersebut dimaksudkan untuk dilumat ke komit sebelumnya, jalankan:\n"
+"\n"
+"  git commit --amend %s\n"
+"\n"
+"Apabila dimaksudkan untuk masuk ke komit baru, jalankan:\n"
+"\n"
+"  git commit %s\n"
+"Pada kedua kasus tersebut, setelah selesai, lanjutkan dengan:\n"
+"\n"
+"  git rebase --continue\n"
 
 #: sequencer.c:1225
 msgid "'prepare-commit-msg' hook failed"
-msgstr ""
+msgstr "kait 'prepare-commit-msg' gagal"
 
 #: sequencer.c:1231
 msgid ""
@@ -7521,6 +7575,17 @@ msgid ""
 "\n"
 "    git commit --amend --reset-author\n"
 msgstr ""
+"Nama dan email Anda dikonfigurasikan otomatis berdasarkan nama pengguna\n"
+"dan nama host Anda. Periksa jika itu benar. Anda dapat mematikan pesan\n"
+"ini dengan menyetel secara eksplisit. Jalankan perintah berikut dan ikuti\n"
+"petunjuk di dalam penyunting untuk menyunting berkas konfigurasi Anda:\n"
+"\n"
+"    git config --global --edit\n"
+"\n"
+"Setelah itu, Anda dapat memperbaiki identitas yang digunakan untuk komit\n"
+"ini dengan:\n"
+"\n"
+"    git commit --amend --reset-author\n"
 
 #: sequencer.c:1244
 msgid ""
@@ -7535,348 +7600,359 @@ msgid ""
 "\n"
 "    git commit --amend --reset-author\n"
 msgstr ""
+"Nama dan email Anda dikonfigurasikan otomatis berdasarkan nama pengguna\n"
+"dan nama host Anda. Periksa jika itu benar. Anda dapat mematikan pesan\n"
+"ini dengan menyetel secara eksplisit:\n"
+"\n"
+"    git config --global user.name \"Nama Anda\"\n"
+"    git config --global user.email anda@example.com\n"
+"\n"
+"Setelah itu, Anda dapat memperbaiki identitas yang digunakan untuk komit\n"
+"ini dengan:\n"
+"\n"
+"    git commit --amend --reset-author\n"
 
 #: sequencer.c:1288
 msgid "couldn't look up newly created commit"
-msgstr ""
+msgstr "tidak dapat mencari komit yang baru saja dibuat"
 
 #: sequencer.c:1290
 msgid "could not parse newly created commit"
-msgstr ""
+msgstr "tidak dapat menguraikan komit yang baru saja dibuat"
 
 #: sequencer.c:1339
 msgid "unable to resolve HEAD after creating commit"
-msgstr ""
+msgstr "tidak dapat menguraikan HEAD setelah membuat komit"
 
 #: sequencer.c:1342
 msgid "detached HEAD"
-msgstr ""
+msgstr "HEAD terpisah"
 
 #: sequencer.c:1346
 msgid " (root-commit)"
-msgstr ""
+msgstr " (komit-akar)"
 
 #: sequencer.c:1367
 msgid "could not parse HEAD"
-msgstr ""
+msgstr "tidak dapat menguraikan HEAD"
 
 #: sequencer.c:1369
 #, c-format
 msgid "HEAD %s is not a commit!"
-msgstr ""
+msgstr "HEAD %s bukan sebuah komit!"
 
 #: sequencer.c:1373 sequencer.c:1451 builtin/commit.c:1708
 msgid "could not parse HEAD commit"
-msgstr ""
+msgstr "tidak dapat menguraikan komit HEAD"
 
 #: sequencer.c:1429 sequencer.c:2314
 msgid "unable to parse commit author"
-msgstr ""
+msgstr "tidak dapat menguraikan pengarang komit"
 
 #: sequencer.c:1440 builtin/am.c:1643 builtin/merge.c:710
 msgid "git write-tree failed to write a tree"
-msgstr ""
+msgstr "git write-tree gagal menulis sebuah pohon"
 
 #: sequencer.c:1473 sequencer.c:1593
 #, c-format
 msgid "unable to read commit message from '%s'"
-msgstr ""
+msgstr "tidak dapat membaca pesan komit dari '%s'"
 
 #: sequencer.c:1504 sequencer.c:1536
 #, c-format
 msgid "invalid author identity '%s'"
-msgstr ""
+msgstr "identitas pengarang tidak valid '%s'"
 
 #: sequencer.c:1510
 msgid "corrupt author: missing date information"
-msgstr ""
+msgstr "pengarang rusak: informasi tanggal hilang"
 
 #: sequencer.c:1549 builtin/am.c:1670 builtin/commit.c:1822 builtin/merge.c:915
 #: builtin/merge.c:940 t/helper/test-fast-rebase.c:78
 msgid "failed to write commit object"
-msgstr ""
+msgstr "gagal menulis objek komit"
 
 #: sequencer.c:1576 sequencer.c:4523 t/helper/test-fast-rebase.c:199
 #: t/helper/test-fast-rebase.c:217
 #, c-format
 msgid "could not update %s"
-msgstr ""
+msgstr "tidak dapat memperbarui %s"
 
 #: sequencer.c:1625
 #, c-format
 msgid "could not parse commit %s"
-msgstr ""
+msgstr "tidak dapat menguraikan komit %s"
 
 #: sequencer.c:1630
 #, c-format
 msgid "could not parse parent commit %s"
-msgstr ""
+msgstr "tidak dapat menguraikan komit induk %s"
 
 #: sequencer.c:1713 sequencer.c:1994
 #, c-format
 msgid "unknown command: %d"
-msgstr ""
+msgstr "perintah tidak dikenal: %d"
 
 #: sequencer.c:1755
 msgid "This is the 1st commit message:"
-msgstr ""
+msgstr "Ini komit pertama:"
 
 #: sequencer.c:1756
 #, c-format
 msgid "This is the commit message #%d:"
-msgstr ""
+msgstr "Ini komit ke-%d:"
 
 #: sequencer.c:1757
 msgid "The 1st commit message will be skipped:"
-msgstr ""
+msgstr "Pesan komit pertama akan dilewati:"
 
 #: sequencer.c:1758
 #, c-format
 msgid "The commit message #%d will be skipped:"
-msgstr ""
+msgstr "Pesan komit ke-%d akan dilewati"
 
 #: sequencer.c:1759
 #, c-format
 msgid "This is a combination of %d commits."
-msgstr ""
+msgstr "Ini kombinasi dari %d komit."
 
 #: sequencer.c:1906 sequencer.c:1963
 #, c-format
 msgid "cannot write '%s'"
-msgstr ""
+msgstr "tidak dapat menulis '%s'"
 
 #: sequencer.c:1953
 msgid "need a HEAD to fixup"
-msgstr ""
+msgstr "butuh sebuah HEAD untuk memperbaiki"
 
 #: sequencer.c:1955 sequencer.c:3596
 msgid "could not read HEAD"
-msgstr ""
+msgstr "tidak dapat membaca HEAD"
 
 #: sequencer.c:1957
 msgid "could not read HEAD's commit message"
-msgstr ""
+msgstr "tidak dapat membaca pesan komit HEAD"
 
 #: sequencer.c:1981
 #, c-format
 msgid "could not read commit message of %s"
-msgstr ""
+msgstr "tidak dapat membaca pesan komit %s"
 
 #: sequencer.c:2091
 msgid "your index file is unmerged."
-msgstr ""
+msgstr "berkas indeks Anda tak tergabung."
 
 #: sequencer.c:2098
 msgid "cannot fixup root commit"
-msgstr ""
+msgstr "tidak dapat memperbaiki komit akar"
 
 #: sequencer.c:2117
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
-msgstr ""
+msgstr "komit %s adalah penggabungan tetapi opsi -m tidak diberikan."
 
 #: sequencer.c:2125 sequencer.c:2133
 #, c-format
 msgid "commit %s does not have parent %d"
-msgstr ""
+msgstr "komit %s tidak punya induk %d"
 
 #: sequencer.c:2139
 #, c-format
 msgid "cannot get commit message for %s"
-msgstr ""
+msgstr "tidak dapat mendapatkan pesan komit untuk %s"
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
 #: sequencer.c:2158
 #, c-format
 msgid "%s: cannot parse parent commit %s"
-msgstr ""
+msgstr "%s: tidak dapat menguraikan komit induk %s"
 
 #: sequencer.c:2224
 #, c-format
 msgid "could not rename '%s' to '%s'"
-msgstr ""
+msgstr "tidak dapat menamai ulang '%s' ke '%s'"
 
 #: sequencer.c:2284
 #, c-format
 msgid "could not revert %s... %s"
-msgstr ""
+msgstr "tidak dapat membalikkan %s... %s"
 
 #: sequencer.c:2285
 #, c-format
 msgid "could not apply %s... %s"
-msgstr ""
+msgstr "tidak dapat menerapkan %s... %s"
 
 #: sequencer.c:2306
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
-msgstr ""
+msgstr "menjatuhkan %s %s -- isi tambalan sudah di hulu\n"
 
 #: sequencer.c:2364
 #, c-format
 msgid "git %s: failed to read the index"
-msgstr ""
+msgstr "git %s: gagal membaca indeks"
 
 #: sequencer.c:2372
 #, c-format
 msgid "git %s: failed to refresh the index"
-msgstr ""
+msgstr "git %s: gagal menyegarkan indeks"
 
 #: sequencer.c:2452
 #, c-format
 msgid "%s does not accept arguments: '%s'"
-msgstr ""
+msgstr "%s tidak menerima argumen: '%s'"
 
 #: sequencer.c:2461
 #, c-format
 msgid "missing arguments for %s"
-msgstr ""
+msgstr "argumen hilang untuk %s"
 
 #: sequencer.c:2504
 #, c-format
 msgid "could not parse '%s'"
-msgstr ""
+msgstr "tidak dapat menguraikan '%s'"
 
 #: sequencer.c:2565
 #, c-format
 msgid "invalid line %d: %.*s"
-msgstr ""
+msgstr "baris %d tidak valid: %.*s"
 
 #: sequencer.c:2576
 #, c-format
 msgid "cannot '%s' without a previous commit"
-msgstr ""
+msgstr "tidak dapat '%s' tanpa komit sebelumnya"
 
 #: sequencer.c:2624 builtin/rebase.c:184
 #, c-format
 msgid "could not read '%s'."
-msgstr ""
+msgstr "tidak dapat membaca '%s'."
 
 #: sequencer.c:2662
 msgid "cancelling a cherry picking in progress"
-msgstr ""
+msgstr "membatalkan pemetikan ceri yang sedang berlangsung"
 
 #: sequencer.c:2671
 msgid "cancelling a revert in progress"
-msgstr ""
+msgstr "membatalkan pembalikkan yang sedang berlangsung"
 
 #: sequencer.c:2711
 msgid "please fix this using 'git rebase --edit-todo'."
-msgstr ""
+msgstr "mohon perbaiki menggunakan 'git rebase --edit-todo'."
 
 #: sequencer.c:2713
 #, c-format
 msgid "unusable instruction sheet: '%s'"
-msgstr ""
+msgstr "lembar perintah tidak dapat digunakan: '%s'"
 
 #: sequencer.c:2718
 msgid "no commits parsed."
-msgstr ""
+msgstr "tidak ada komit yang diuraikan."
 
 #: sequencer.c:2729
 msgid "cannot cherry-pick during a revert."
-msgstr ""
+msgstr "tidak dapat memetik ceri selama pembalikkan."
 
 #: sequencer.c:2731
 msgid "cannot revert during a cherry-pick."
-msgstr ""
+msgstr "tidak dapat membalikkan selama petik ceri."
 
 #: sequencer.c:2809
 #, c-format
 msgid "invalid value for %s: %s"
-msgstr ""
+msgstr "nilai tidak valid untuk %s: %s"
 
 #: sequencer.c:2918
 msgid "unusable squash-onto"
-msgstr ""
+msgstr "squash-onto tidak dapat digunakan"
 
 #: sequencer.c:2938
 #, c-format
 msgid "malformed options sheet: '%s'"
-msgstr ""
+msgstr "lembar opsi jelek: '%s'"
 
 #: sequencer.c:3033 sequencer.c:4902
 msgid "empty commit set passed"
-msgstr ""
+msgstr "himpunan komit kosong dilewatkan"
 
 #: sequencer.c:3050
 msgid "revert is already in progress"
-msgstr ""
+msgstr "pembalikkan sudah berjalan"
 
 #: sequencer.c:3052
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
-msgstr ""
+msgstr "coba \"git revert (--continue | %s--abort | --quit)\""
 
 #: sequencer.c:3055
 msgid "cherry-pick is already in progress"
-msgstr ""
+msgstr "pemetikan ceri sudah berjalan"
 
 #: sequencer.c:3057
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
-msgstr ""
+msgstr "coba \"git cherry-pick (--continue | %s--abort | --quit)\""
 
 #: sequencer.c:3071
 #, c-format
 msgid "could not create sequencer directory '%s'"
-msgstr ""
+msgstr "tidak dapat membuat direktori pembaris '%s'"
 
 #: sequencer.c:3086
 msgid "could not lock HEAD"
-msgstr ""
+msgstr "tidak dapat mengunci HEAD"
 
 #: sequencer.c:3146 sequencer.c:4612
 msgid "no cherry-pick or revert in progress"
-msgstr ""
+msgstr "tidak ada pemetikan ceri atau pembalikkan yang sedang berjalan"
 
 #: sequencer.c:3148 sequencer.c:3159
 msgid "cannot resolve HEAD"
-msgstr ""
+msgstr "tidak dapat menguraikan HEAD"
 
 #: sequencer.c:3150 sequencer.c:3194
 msgid "cannot abort from a branch yet to be born"
-msgstr ""
+msgstr "tidak dapat membatalkan dari cabang yang belum lahir"
 
 #: sequencer.c:3180 builtin/fetch.c:1004 builtin/fetch.c:1416
 #: builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
-msgstr ""
+msgstr "tidak dapat membuka '%s'"
 
 #: sequencer.c:3182
 #, c-format
 msgid "cannot read '%s': %s"
-msgstr ""
+msgstr "tidak dapat membaca '%s': %s"
 
 #: sequencer.c:3183
 msgid "unexpected end of file"
-msgstr ""
+msgstr "akhir berkas tidak diharapkan"
 
 #: sequencer.c:3189
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
-msgstr ""
+msgstr "berkas HEAD pra-petik-ceri yang tersimpan '%s' rusak"
 
 #: sequencer.c:3200
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
-msgstr ""
+msgstr "Sepertinya Anda sudah memindahkan HEAD. Tidak memutar ulang, periksa HEAD Anda!"
 
 #: sequencer.c:3241
 msgid "no revert in progress"
-msgstr ""
+msgstr "tidak ada pembalikkan yang sedang berjalan"
 
 #: sequencer.c:3250
 msgid "no cherry-pick in progress"
-msgstr ""
+msgstr "tidak ada pemetikan ceri yang sedang berjalan"
 
 #: sequencer.c:3260
 msgid "failed to skip the commit"
-msgstr ""
+msgstr "gagal melewati komit"
 
 #: sequencer.c:3267
 msgid "there is nothing to skip"
-msgstr ""
+msgstr "tidak ada yang dilewati"
 
 #: sequencer.c:3270
 #, c-format
@@ -7884,15 +7960,17 @@ msgid ""
 "have you committed already?\n"
 "try \"git %s --continue\""
 msgstr ""
+"sudahkah Anda komit?\n"
+"coba \"git %s --continue\""
 
 #: sequencer.c:3432 sequencer.c:4503
 msgid "cannot read HEAD"
-msgstr ""
+msgstr "tidak dapat membaca HEAD"
 
 #: sequencer.c:3449
 #, c-format
 msgid "unable to copy '%s' to '%s'"
-msgstr ""
+msgstr "tidak dapat menyalin '%s' ke '%s'"
 
 #: sequencer.c:3457
 #, c-format
@@ -7905,26 +7983,33 @@ msgid ""
 "\n"
 "  git rebase --continue\n"
 msgstr ""
+"Anda dapat mengubah komit sekarang, dengan\n"
+"\n"
+"  git commit --amend %s\n"
+"\n"
+"Setelah Anda puas dengan perubahan Anda, jalankan\n"
+"\n"
+"  git rebase --continue\n"
 
 #: sequencer.c:3467
 #, c-format
 msgid "Could not apply %s... %.*s"
-msgstr ""
+msgstr "Tidak dapat menerapkan %s... %.*s"
 
 #: sequencer.c:3474
 #, c-format
 msgid "Could not merge %.*s"
-msgstr ""
+msgstr "Tidak dapat menggabungkan %.*s"
 
 #: sequencer.c:3488 sequencer.c:3492 builtin/difftool.c:633
 #, c-format
 msgid "could not copy '%s' to '%s'"
-msgstr ""
+msgstr "tidak dapat menyalin '%s' ke '%s'"
 
 #: sequencer.c:3503
 #, c-format
 msgid "Executing: %s\n"
-msgstr ""
+msgstr "Mengeksekusi: %s\n"
 
 #: sequencer.c:3514
 #, c-format
@@ -7935,10 +8020,15 @@ msgid ""
 "  git rebase --continue\n"
 "\n"
 msgstr ""
+"eksekusi gagal: %s\n"
+"%sAnda dapat memperbaiki masalah, lalu jalankan\n"
+"\n"
+"  git rebase --continue\n"
+"\n"
 
 #: sequencer.c:3520
 msgid "and made changes to the index and/or the working tree\n"
-msgstr ""
+msgstr "dan buat perubahan ke indeks dan/atau pohon kerja\n"
 
 #: sequencer.c:3526
 #, c-format
@@ -7950,89 +8040,95 @@ msgid ""
 "  git rebase --continue\n"
 "\n"
 msgstr ""
+"eksekusi berhasil: %s\n"
+"tapi meninggalkan perubahan ke indeks dan/atau pohon kerja\n"
+"Komit atau stase perubahan Anda, lalu jalankan\n"
+"\n"
+"  git rebase --continue\n"
+"\n"
 
 #: sequencer.c:3586
 #, c-format
 msgid "illegal label name: '%.*s'"
-msgstr ""
+msgstr "nama label ilegal: '%.*s'"
 
 #: sequencer.c:3659
 msgid "writing fake root commit"
-msgstr ""
+msgstr "menulis komit akar palsu"
 
 #: sequencer.c:3664
 msgid "writing squash-onto"
-msgstr ""
+msgstr "menulis squash-onto"
 
 #: sequencer.c:3743
 #, c-format
 msgid "could not resolve '%s'"
-msgstr ""
+msgstr "tidak dapat menguraikan '%s'"
 
 #: sequencer.c:3775
 msgid "cannot merge without a current revision"
-msgstr ""
+msgstr "tidak dapat menggabungkan tanpa revisi saat ini"
 
 #: sequencer.c:3797
 #, c-format
 msgid "unable to parse '%.*s'"
-msgstr ""
+msgstr "tidak dapat menguraikan '%.*s'"
 
 #: sequencer.c:3806
 #, c-format
 msgid "nothing to merge: '%.*s'"
-msgstr ""
+msgstr "tidak ada yang digabungkan: '%.*s'"
 
 #: sequencer.c:3818
 msgid "octopus merge cannot be executed on top of a [new root]"
-msgstr ""
+msgstr "penggabungan gurita tidak dapat dieksekusi di atas sebuah [akar baru]"
 
 #: sequencer.c:3873
 #, c-format
 msgid "could not get commit message of '%s'"
-msgstr ""
+msgstr "tidak dapat mendapatkan pesan komit dari '%s'"
 
 #: sequencer.c:4019
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
-msgstr ""
+msgstr "bahkan tidak dapat mencoba menggabungkan '%.*s'"
 
 #: sequencer.c:4035
 msgid "merge: Unable to write new index file"
-msgstr ""
+msgstr "merge: Tidak dapat menulis berkas indeks baru"
 
 #: sequencer.c:4116
 msgid "Cannot autostash"
-msgstr ""
+msgstr "Tidak dapat menstase otomatis"
 
 #: sequencer.c:4119
 #, c-format
 msgid "Unexpected stash response: '%s'"
-msgstr ""
+msgstr "Respons stase tidak diharapkan: '%s'"
 
 #: sequencer.c:4125
 #, c-format
 msgid "Could not create directory for '%s'"
-msgstr ""
+msgstr "Tidak dapat membuat direktori untuk '%s'"
 
 #: sequencer.c:4128
 #, c-format
 msgid "Created autostash: %s\n"
-msgstr ""
+msgstr "Stase otomatis dibuat: %s\n"
 
 #: sequencer.c:4132
 msgid "could not reset --hard"
-msgstr ""
+msgstr "tidak dapat reset --hard"
 
 #: sequencer.c:4157
 #, c-format
 msgid "Applied autostash.\n"
-msgstr ""
+msgstr "Stase otomatis diterapkan.\n"
 
 #: sequencer.c:4169
 #, c-format
 msgid "cannot store %s"
-msgstr ""
+msgstr "tidak dapat menyimpan %s"
 
 #: sequencer.c:4172
 #, c-format
@@ -8041,28 +8137,31 @@ msgid ""
 "Your changes are safe in the stash.\n"
 "You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
 msgstr ""
+"%s\n"
+"Perubahan Anda aman di dalam stase.\n"
+"Anda dapat menjalankan \"git stash pop\" atau \"git stash drop\" kapanpun.\n"
 
 #: sequencer.c:4177
 msgid "Applying autostash resulted in conflicts."
-msgstr ""
+msgstr "Menerapkan stase otomatis menghasilkan konflik."
 
 #: sequencer.c:4178
 msgid "Autostash exists; creating a new stash entry."
-msgstr ""
+msgstr "Stase otomatis sudah ada; membuat entri stase baru."
 
 #: sequencer.c:4252
 msgid "could not detach HEAD"
-msgstr ""
+msgstr "tidak dapat melepas HEAD"
 
 #: sequencer.c:4267
 #, c-format
 msgid "Stopped at HEAD\n"
-msgstr ""
+msgstr "Berhenti pada HEAD\n"
 
 #: sequencer.c:4269
 #, c-format
 msgid "Stopped at %s\n"
-msgstr ""
+msgstr "Berhenti pada %s\n"
 
 #: sequencer.c:4301
 #, c-format
@@ -8076,57 +8175,65 @@ msgid ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 msgstr ""
+"Tidak dapat mengeksekusi perintah todo\n"
+"\n"
+"    %.*s\n"
+"Itu sudah dijadwalkan ulang; Untuk menyunting perintah sebelum melanjutkan,\n"
+"mohon sunting daftar todo terlebih dahulu:\n"
+"\n"
+"    git rebase --edit-todo\n"
+"    git rebase --continue\n"
 
 #: sequencer.c:4347
 #, c-format
 msgid "Rebasing (%d/%d)%s"
-msgstr ""
+msgstr "Mendasarkan ulang (%d/%d)%s"
 
 #: sequencer.c:4393
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
-msgstr ""
+msgstr "Berhenti pada %s... %.*s\n"
 
 #: sequencer.c:4463
 #, c-format
 msgid "unknown command %d"
-msgstr ""
+msgstr "perintah tidak dikenal %d"
 
 #: sequencer.c:4511
 msgid "could not read orig-head"
-msgstr ""
+msgstr "tidak dapat membaca orig-head"
 
 #: sequencer.c:4516
 msgid "could not read 'onto'"
-msgstr ""
+msgstr "tidak dapat membaca 'onto'"
 
 #: sequencer.c:4530
 #, c-format
 msgid "could not update HEAD to %s"
-msgstr ""
+msgstr "tidak dapat memperbarui HEAD ke %s"
 
 #: sequencer.c:4590
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
-msgstr ""
+msgstr "%s didasarkan ulang dan diperbarui dengan sukses.\n"
 
 #: sequencer.c:4642
 msgid "cannot rebase: You have unstaged changes."
-msgstr ""
+msgstr "tidak dapat mendasarkan ulang: Anda punya perubahan tak tergelar."
 
 #: sequencer.c:4651
 msgid "cannot amend non-existing commit"
-msgstr ""
+msgstr "tidak dapat mengubah komit yang tidak ada"
 
 #: sequencer.c:4653
 #, c-format
 msgid "invalid file: '%s'"
-msgstr ""
+msgstr "berkas tidak valid: '%s'"
 
 #: sequencer.c:4655
 #, c-format
 msgid "invalid contents: '%s'"
-msgstr ""
+msgstr "konten tidak valid: '%s'"
 
 #: sequencer.c:4658
 msgid ""
@@ -8134,62 +8241,65 @@ msgid ""
 "You have uncommitted changes in your working tree. Please, commit them\n"
 "first and then run 'git rebase --continue' again."
 msgstr ""
+"\n"
+"Anda punya perubahan tak tergelar di dalam pohon kerja Anda. Mohon komit\n"
+"terlebih dahulu dan jalankan 'git rebase --continue' lagi."
 
 #: sequencer.c:4694 sequencer.c:4733
 #, c-format
 msgid "could not write file: '%s'"
-msgstr ""
+msgstr "tidak dapat menulis berkas: '%s'"
 
 #: sequencer.c:4749
 msgid "could not remove CHERRY_PICK_HEAD"
-msgstr ""
+msgstr "tidak dapat menghapus CHERRY_PICK_HEAD"
 
 #: sequencer.c:4759
 msgid "could not commit staged changes."
-msgstr ""
+msgstr "tidak dapat mengkomit perubahan tergelar."
 
 #: sequencer.c:4879
 #, c-format
 msgid "%s: can't cherry-pick a %s"
-msgstr ""
+msgstr "%s: tidak dapat memetik ceri sebuah %s"
 
 #: sequencer.c:4883
 #, c-format
 msgid "%s: bad revision"
-msgstr ""
+msgstr "%s: revisi jelek"
 
 #: sequencer.c:4918
 msgid "can't revert as initial commit"
-msgstr ""
+msgstr "tidak dapat membalikkan sebagai komit awal"
 
 #: sequencer.c:5189 sequencer.c:5418
 #, c-format
 msgid "skipped previously applied commit %s"
-msgstr ""
+msgstr "melewatkan komit yang sudah diterapkan sebelumnya %s"
 
 #: sequencer.c:5259 sequencer.c:5434
 msgid "use --reapply-cherry-picks to include skipped commits"
-msgstr ""
+msgstr "gunakan --reapply-cherry-picks untuk memasukkan komit yang terlewat"
 
 #: sequencer.c:5405
 msgid "make_script: unhandled options"
-msgstr ""
+msgstr "make_script: opsi tak ditangani"
 
 #: sequencer.c:5408
 msgid "make_script: error preparing revisions"
-msgstr ""
+msgstr "make_script: kesalahan membuat revisi"
 
 #: sequencer.c:5666 sequencer.c:5683
 msgid "nothing to do"
-msgstr ""
+msgstr "tidak ada yang dilakukan"
 
 #: sequencer.c:5702
 msgid "could not skip unnecessary pick commands"
-msgstr ""
+msgstr "tidak dapat melewatkan perintah pick yang tidak perlu"
 
 #: sequencer.c:5802
 msgid "the script was already rearranged."
-msgstr ""
+msgstr "skrip sudah ditata ulang."
 
 #: setup.c:134
 #, c-format
@@ -8342,7 +8452,7 @@ msgstr ""
 #: sparse-index.c:289
 #, c-format
 msgid "index entry is a directory, but not sparse (%08x)"
-msgstr ""
+msgstr "entri indeks adalah direktori, tapi bukan tipis (%08x)"
 
 #. TRANSLATORS: IEC 80000-13:2008 gibibyte
 #: strbuf.c:850
@@ -21645,19 +21755,19 @@ msgstr ""
 
 #: builtin/sparse-checkout.c:22
 msgid "git sparse-checkout (init|list|set|add|reapply|disable) <options>"
-msgstr ""
+msgstr "git sparse-checkout (init|list|set|add|reapply|disable) <opsi>"
 
 #: builtin/sparse-checkout.c:46
 msgid "git sparse-checkout list"
-msgstr ""
+msgstr "git sparse-checkout list"
 
 #: builtin/sparse-checkout.c:60
 msgid "this worktree is not sparse"
-msgstr ""
+msgstr "pohon kerja ini bukan tipis"
 
 #: builtin/sparse-checkout.c:75
 msgid "this worktree is not sparse (sparse-checkout file may not exist)"
-msgstr ""
+msgstr "pohon kerja ini bukan tipis (berkas sparse-checkout mungkin tidak ada)"
 
 #: builtin/sparse-checkout.c:176
 #, c-format
@@ -21665,98 +21775,102 @@ msgid ""
 "directory '%s' contains untracked files, but is not in the sparse-checkout "
 "cone"
 msgstr ""
+"directori '%s' berisi berkas tak teracak, tapi tidak di dalam kerucut "
+"sparse-checkout"
 
 #: builtin/sparse-checkout.c:184
 #, c-format
 msgid "failed to remove directory '%s'"
-msgstr ""
+msgstr "gagal menghapus direktori '%s'"
 
 #: builtin/sparse-checkout.c:324
 msgid "failed to create directory for sparse-checkout file"
-msgstr ""
+msgstr "gagal membuat direktori untuk berkas sparse-checkout"
 
 #: builtin/sparse-checkout.c:365
 msgid "unable to upgrade repository format to enable worktreeConfig"
-msgstr ""
+msgstr "gagal mengupgrade format repositori untuk mengaktifkan worktreeConfig"
 
 #: builtin/sparse-checkout.c:367
 msgid "failed to set extensions.worktreeConfig setting"
-msgstr ""
+msgstr "gagal menyetel setelan extensions.worktreeConfig"
 
 #: builtin/sparse-checkout.c:411
 msgid "failed to modify sparse-index config"
-msgstr ""
+msgstr "gagal memodifikasi konfigurasi sparse-index"
 
 #: builtin/sparse-checkout.c:422
 msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
-msgstr ""
+msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
 
 #: builtin/sparse-checkout.c:441 builtin/sparse-checkout.c:729
 #: builtin/sparse-checkout.c:778
 msgid "initialize the sparse-checkout in cone mode"
-msgstr ""
+msgstr "inisialisasi checkout tipis dalam mode kerucut"
 
 #: builtin/sparse-checkout.c:443 builtin/sparse-checkout.c:731
 #: builtin/sparse-checkout.c:780
 msgid "toggle the use of a sparse index"
-msgstr ""
+msgstr "gunakan indeks tipis"
 
 #: builtin/sparse-checkout.c:476
 #, c-format
 msgid "failed to open '%s'"
-msgstr ""
+msgstr "gagal membuka '%s'"
 
 #: builtin/sparse-checkout.c:528
 #, c-format
 msgid "could not normalize path %s"
-msgstr ""
+msgstr "tidak dapat menormalkan jalur %s"
 
 #: builtin/sparse-checkout.c:557
 #, c-format
 msgid "unable to unquote C-style string '%s'"
-msgstr ""
+msgstr "tidak dapat membatal-kutip untai gaya C '%s'"
 
 #: builtin/sparse-checkout.c:612 builtin/sparse-checkout.c:640
 msgid "unable to load existing sparse-checkout patterns"
-msgstr ""
+msgstr "tidak dapat memuat pola checkout tipis yang sudah ada"
 
 #: builtin/sparse-checkout.c:616
 msgid "existing sparse-checkout patterns do not use cone mode"
-msgstr ""
+msgstr "pola checkout tipis yang sudah ada tidak menggunakan mode kerucut"
 
 #: builtin/sparse-checkout.c:682
 msgid "git sparse-checkout add (--stdin | <patterns>)"
-msgstr ""
+msgstr "git sparse-checkout add (--stdin | <pola>)"
 
 #: builtin/sparse-checkout.c:694 builtin/sparse-checkout.c:733
 msgid "read patterns from standard in"
-msgstr ""
+msgstr "baca pola dari masukan standar"
 
 #: builtin/sparse-checkout.c:699
 msgid "no sparse-checkout to add to"
-msgstr ""
+msgstr "tidak ada checkout tipis untuk ditambahkan"
 
 #: builtin/sparse-checkout.c:712
 msgid ""
 "git sparse-checkout set [--[no-]cone] [--[no-]sparse-index] (--stdin | "
 "<patterns>)"
 msgstr ""
+"git sparse-checkout set [--[no-]cone] [--[no-]sparse-index] (--stdin | "
+"<pola>)"
 
 #: builtin/sparse-checkout.c:765
 msgid "git sparse-checkout reapply [--[no-]cone] [--[no-]sparse-index]"
-msgstr ""
+msgstr "git sparse-checkout reapply [--[no-]cone] [--[no-]sparse-index]"
 
 #: builtin/sparse-checkout.c:785
 msgid "must be in a sparse-checkout to reapply sparsity patterns"
-msgstr ""
+msgstr "harus berada di dalam checkout tipis untuk menerapkan ulang pola kejarangan"
 
 #: builtin/sparse-checkout.c:803
 msgid "git sparse-checkout disable"
-msgstr ""
+msgstr "git sparse-checkout disable"
 
 #: builtin/sparse-checkout.c:845
 msgid "error while refreshing working directory"
-msgstr ""
+msgstr "kesalahan saat menyegarkan direktori kerja"
 
 #: builtin/stash.c:24 builtin/stash.c:40
 msgid "git stash list [<options>]"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: git 2.34.0\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2022-01-11 09:38+0800\n"
+"POT-Creation-Date: 2022-01-17 08:34+0800\n"
 "PO-Revision-Date: 2022-01-11 16:34+0100\n"
 "Last-Translator: Peter Krefting <peter@softwolves.pp.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
@@ -904,8 +904,8 @@ msgstr "okänt alternativ för ignore-whitespace: \"%s\""
 #: builtin/checkout.c:1644 builtin/checkout.c:1754 builtin/checkout.c:1757
 #: builtin/clone.c:906 builtin/commit.c:358 builtin/commit.c:361
 #: builtin/commit.c:1196 builtin/describe.c:593 builtin/diff-tree.c:155
-#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2033
-#: builtin/fetch.c:2038 builtin/index-pack.c:1852 builtin/init-db.c:560
+#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2038
+#: builtin/fetch.c:2043 builtin/index-pack.c:1852 builtin/init-db.c:560
 #: builtin/log.c:1946 builtin/log.c:1948 builtin/ls-files.c:778
 #: builtin/merge.c:1403 builtin/merge.c:1405 builtin/pack-objects.c:4073
 #: builtin/push.c:592 builtin/push.c:630 builtin/push.c:636 builtin/push.c:641
@@ -1964,12 +1964,6 @@ msgstr "\"%s\" är inte ett giltigt grennamn"
 #, c-format
 msgid "a branch named '%s' already exists"
 msgstr "det finns redan en gren som heter \"%s\""
-
-#: branch.c:313
-#, c-format
-msgid "cannot force update the branch '%s'checked out at '%s'"
-msgstr ""
-"kan inte tvinga uppdatering av grenen \"%s\" som är utcheckad på \"%s\""
 
 #: branch.c:313
 #, c-format
@@ -5803,7 +5797,7 @@ msgstr "%s: misslyckades lägga in i databasen"
 msgid "%s: unsupported file type"
 msgstr "%s: filtypen stöds ej"
 
-#: object-file.c:2329 builtin/fetch.c:1448
+#: object-file.c:2329 builtin/fetch.c:1453
 #, c-format
 msgid "%s is not a valid object"
 msgstr "%s är inte ett giltigt objekt"
@@ -7076,41 +7070,41 @@ msgstr "vägrar uppdatera referens med trasigt namn \"%s\""
 msgid "update_ref failed for ref '%s': %s"
 msgstr "update_ref misslyckades för referensen \"%s\": %s"
 
-#: refs.c:2069
+#: refs.c:2067
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "flera uppdateringar för referensen \"%s\" tillåts inte"
 
-#: refs.c:2152
+#: refs.c:2150
 msgid "ref updates forbidden inside quarantine environment"
 msgstr "referensuppdateringar förbjudna i karantänmiljö"
 
-#: refs.c:2163
+#: refs.c:2161
 msgid "ref updates aborted by hook"
 msgstr "referensuppdateringar avbrutna av krok"
 
-#: refs.c:2271 refs.c:2301
+#: refs.c:2269 refs.c:2299
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "\"%s\" finns; kan inte skapa \"%s\""
 
-#: refs.c:2277 refs.c:2312
+#: refs.c:2275 refs.c:2310
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "kan inte hantera \"%s\" och \"%s\" samtidigt"
 
-#: refs/files-backend.c:1268
+#: refs/files-backend.c:1267
 #, c-format
 msgid "could not remove reference %s"
 msgstr "kunde inte ta bort referensen %s"
 
-#: refs/files-backend.c:1282 refs/packed-backend.c:1549
+#: refs/files-backend.c:1281 refs/packed-backend.c:1549
 #: refs/packed-backend.c:1559
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr "kunde inte ta bort referensen %s: %s"
 
-#: refs/files-backend.c:1285 refs/packed-backend.c:1562
+#: refs/files-backend.c:1284 refs/packed-backend.c:1562
 #, c-format
 msgid "could not delete references: %s"
 msgstr "kunde inte ta bort referenser: %s"
@@ -8141,7 +8135,8 @@ msgstr "kan inte bestämma HEAD"
 msgid "cannot abort from a branch yet to be born"
 msgstr "kan inte avbryta från en gren som ännu inte är född"
 
-#: sequencer.c:3180 builtin/fetch.c:999 builtin/fetch.c:1411 builtin/grep.c:772
+#: sequencer.c:3180 builtin/fetch.c:1004 builtin/fetch.c:1416
+#: builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr "kan inte öppna \"%s\""
@@ -9096,7 +9091,7 @@ msgstr "protkollet stöder inte att sätta sökväg till fjärrtjänst"
 msgid "invalid remote service path"
 msgstr "felaktig sökväg till fjärrtjänst"
 
-#: transport-helper.c:661 transport.c:1474
+#: transport-helper.c:661 transport.c:1479
 msgid "operation not supported by protocol"
 msgstr "funktionen stöds inte av protokollet"
 
@@ -13300,7 +13295,7 @@ msgstr "flaggorna \"%s\" och \"%s %s\" kan inte användas samtidigt"
 msgid "repository '%s' does not exist"
 msgstr "arkivet \"%s\" finns inte"
 
-#: builtin/clone.c:924 builtin/fetch.c:2047
+#: builtin/clone.c:924 builtin/fetch.c:2052
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "djupet %s är inte ett positivt tal"
@@ -15183,70 +15178,70 @@ msgstr "skriv incheckingsgrafen efter hämtning"
 msgid "accept refspecs from stdin"
 msgstr "ta emot referenser från standard in"
 
-#: builtin/fetch.c:587
+#: builtin/fetch.c:592
 msgid "couldn't find remote ref HEAD"
 msgstr "kunde inte hitta fjärr-referensen HEAD"
 
-#: builtin/fetch.c:761
+#: builtin/fetch.c:766
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "konfigurationen för fetch.output innehåller ogiltigt värde %s"
 
-#: builtin/fetch.c:862
+#: builtin/fetch.c:867
 #, c-format
 msgid "object %s not found"
 msgstr "objektet %s hittades inte"
 
-#: builtin/fetch.c:866
+#: builtin/fetch.c:871
 msgid "[up to date]"
 msgstr "[àjour]"
 
-#: builtin/fetch.c:878 builtin/fetch.c:896 builtin/fetch.c:968
+#: builtin/fetch.c:883 builtin/fetch.c:901 builtin/fetch.c:973
 msgid "[rejected]"
 msgstr "[refuserad]"
 
-#: builtin/fetch.c:880
+#: builtin/fetch.c:885
 msgid "can't fetch in current branch"
 msgstr "kan inte hämta i aktuell gren"
 
-#: builtin/fetch.c:881
+#: builtin/fetch.c:886
 msgid "checked out in another worktree"
 msgstr "utcheckat i en annan arbetskatalog"
 
-#: builtin/fetch.c:891
+#: builtin/fetch.c:896
 msgid "[tag update]"
 msgstr "[uppdaterad tagg]"
 
-#: builtin/fetch.c:892 builtin/fetch.c:929 builtin/fetch.c:951
-#: builtin/fetch.c:963
+#: builtin/fetch.c:897 builtin/fetch.c:934 builtin/fetch.c:956
+#: builtin/fetch.c:968
 msgid "unable to update local ref"
 msgstr "kunde inte uppdatera lokal ref"
 
-#: builtin/fetch.c:896
+#: builtin/fetch.c:901
 msgid "would clobber existing tag"
 msgstr "skulle skriva över befintlig tagg"
 
-#: builtin/fetch.c:918
+#: builtin/fetch.c:923
 msgid "[new tag]"
 msgstr "[ny tagg]"
 
-#: builtin/fetch.c:921
+#: builtin/fetch.c:926
 msgid "[new branch]"
 msgstr "[ny gren]"
 
-#: builtin/fetch.c:924
+#: builtin/fetch.c:929
 msgid "[new ref]"
 msgstr "[ny ref]"
 
-#: builtin/fetch.c:963
+#: builtin/fetch.c:968
 msgid "forced update"
 msgstr "tvingad uppdatering"
 
-#: builtin/fetch.c:968
+#: builtin/fetch.c:973
 msgid "non-fast-forward"
 msgstr "ej snabbspolad"
 
-#: builtin/fetch.c:1071
+#: builtin/fetch.c:1076
 msgid ""
 "fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled; to re-enable, use '--show-forced-updates'\n"
@@ -15257,7 +15252,7 @@ msgstr ""
 "av; för att slå på igen, använd flaggan \"--show-forced-updates\" eller kör\n"
 "\"git config fetch.showForcedUpdates true\""
 
-#: builtin/fetch.c:1075
+#: builtin/fetch.c:1080
 #, c-format
 msgid ""
 "it took %.2f seconds to check forced updates; you can use\n"
@@ -15270,22 +15265,22 @@ msgstr ""
 "showForcedUpdates\n"
 "false\" för att undvika testet\n"
 
-#: builtin/fetch.c:1107
+#: builtin/fetch.c:1112
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s sände inte alla nödvändiga objekt\n"
 
-#: builtin/fetch.c:1136
+#: builtin/fetch.c:1141
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr "avvisade %s då grunda rötter inte tillåts uppdateras"
 
-#: builtin/fetch.c:1226 builtin/fetch.c:1374
+#: builtin/fetch.c:1231 builtin/fetch.c:1379
 #, c-format
 msgid "From %.*s\n"
 msgstr "Från %.*s\n"
 
-#: builtin/fetch.c:1247
+#: builtin/fetch.c:1252
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -15294,49 +15289,49 @@ msgstr ""
 "vissa lokala referenser kunde inte uppdateras; testa att köra\n"
 " \"git remote prune %s\" för att ta bort gamla grenar som står i konflikt"
 
-#: builtin/fetch.c:1344
+#: builtin/fetch.c:1349
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s kommer bli dinglande)"
 
-#: builtin/fetch.c:1345
+#: builtin/fetch.c:1350
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s har blivit dinglande)"
 
-#: builtin/fetch.c:1377
+#: builtin/fetch.c:1382
 msgid "[deleted]"
 msgstr "[borttagen]"
 
-#: builtin/fetch.c:1378 builtin/remote.c:1128
+#: builtin/fetch.c:1383 builtin/remote.c:1128
 msgid "(none)"
 msgstr "(ingen)"
 
-#: builtin/fetch.c:1400
+#: builtin/fetch.c:1405
 #, c-format
 msgid "refusing to fetch into branch '%s' checked out at '%s'"
 msgstr "vägrar hämta till grenen \"%s\" som är utcheckad på \"%s\""
 
-#: builtin/fetch.c:1420
+#: builtin/fetch.c:1425
 #, c-format
 msgid "option \"%s\" value \"%s\" is not valid for %s"
 msgstr "flaggan \"%s\" med värdet \"%s\" är inte giltigt för %s"
 
-#: builtin/fetch.c:1423
+#: builtin/fetch.c:1428
 #, c-format
 msgid "option \"%s\" is ignored for %s\n"
 msgstr "flaggan \"%s\" ignoreras för %s\n"
 
-#: builtin/fetch.c:1450
+#: builtin/fetch.c:1455
 #, c-format
 msgid "the object %s does not exist"
 msgstr "objektet %s finns inte"
 
-#: builtin/fetch.c:1638
+#: builtin/fetch.c:1643
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "flera grenar upptäcktes, inkompatibelt med --set-upstream"
 
-#: builtin/fetch.c:1650
+#: builtin/fetch.c:1655
 #, c-format
 msgid ""
 "could not set upstream of HEAD to '%s' from '%s' when it does not point to "
@@ -15345,19 +15340,19 @@ msgstr ""
 "kunde inte sätta uppström för HEAD till \"%s\" från \"%s\" när det inte "
 "pekar mot någon gren."
 
-#: builtin/fetch.c:1663
+#: builtin/fetch.c:1668
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "ställer inte in uppströmsgren för en fjärrspårande gren på fjärren"
 
-#: builtin/fetch.c:1665
+#: builtin/fetch.c:1670
 msgid "not setting upstream for a remote tag"
 msgstr "ställer inte in uppström för en fjärrtag"
 
-#: builtin/fetch.c:1667
+#: builtin/fetch.c:1672
 msgid "unknown branch type"
 msgstr "okänd grentyp"
 
-#: builtin/fetch.c:1669
+#: builtin/fetch.c:1674
 msgid ""
 "no source branch found;\n"
 "you need to specify exactly one branch with the --set-upstream option"
@@ -15365,22 +15360,22 @@ msgstr ""
 "hittade ingen källgren;\n"
 "du måste ange exakt en gren med flaggan --set-upstream"
 
-#: builtin/fetch.c:1799 builtin/fetch.c:1862
+#: builtin/fetch.c:1804 builtin/fetch.c:1867
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Hämtar %s\n"
 
-#: builtin/fetch.c:1809 builtin/fetch.c:1864
+#: builtin/fetch.c:1814 builtin/fetch.c:1869
 #, c-format
 msgid "could not fetch %s"
 msgstr "kunde inte hämta %s"
 
-#: builtin/fetch.c:1821
+#: builtin/fetch.c:1826
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "kunde inte hämta \"%s\" (felkod: %d)\n"
 
-#: builtin/fetch.c:1925
+#: builtin/fetch.c:1930
 msgid ""
 "no remote repository specified; please specify either a URL or a\n"
 "remote name from which new revisions should be fetched"
@@ -15388,48 +15383,48 @@ msgstr ""
 "inget fjärrarkiv angavs; ange antingen en URL eller namnet på ett\n"
 "fjärrarkiv som nya incheckningar ska hämtas från"
 
-#: builtin/fetch.c:1961
+#: builtin/fetch.c:1966
 msgid "you need to specify a tag name"
 msgstr "du måste ange namnet på en tagg"
 
-#: builtin/fetch.c:2027
+#: builtin/fetch.c:2032
 msgid "--negotiate-only needs one or more --negotiate-tip=*"
 msgstr "--negotiate-only behöver en eller flera --negotiate-tip=*"
 
-#: builtin/fetch.c:2031
+#: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"
 msgstr "negativa djup stöds inte i --deepen"
 
-#: builtin/fetch.c:2040
+#: builtin/fetch.c:2045
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "--unshallow kan inte användas på ett komplett arkiv"
 
-#: builtin/fetch.c:2057
+#: builtin/fetch.c:2062
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all tar inte namnet på ett arkiv som argument"
 
-#: builtin/fetch.c:2059
+#: builtin/fetch.c:2064
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all kan inte anges med referensspecifikationer"
 
-#: builtin/fetch.c:2068
+#: builtin/fetch.c:2073
 #, c-format
 msgid "no such remote or remote group: %s"
 msgstr "fjärren eller fjärrgruppen finns inte: %s"
 
-#: builtin/fetch.c:2076
+#: builtin/fetch.c:2081
 msgid "fetching a group and specifying refspecs does not make sense"
 msgstr "kan inte hämta från grupp och ange referensspecifikationer"
 
-#: builtin/fetch.c:2092
+#: builtin/fetch.c:2097
 msgid "must supply remote when using --negotiate-only"
 msgstr "måste ange fjärr när --negotiate-only anges"
 
-#: builtin/fetch.c:2097
+#: builtin/fetch.c:2102
 msgid "protocol does not support --negotiate-only, exiting"
 msgstr "protokollet stöder inte --negotiate-only, avslutar"
 
-#: builtin/fetch.c:2116
+#: builtin/fetch.c:2121
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -15437,11 +15432,11 @@ msgstr ""
 "--filter kan endast användas med fjärren konfigurerad i extensions."
 "partialclone"
 
-#: builtin/fetch.c:2120
+#: builtin/fetch.c:2125
 msgid "--atomic can only be used when fetching from one remote"
 msgstr "--atomic kan bara användas vid hämtning från en fjärr"
 
-#: builtin/fetch.c:2124
+#: builtin/fetch.c:2129
 msgid "--stdin can only be used when fetching from one remote"
 msgstr "--stdin kan bara användas vid hämtning fårn en fjärr"
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -90,7 +90,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git Turkish Localization Project\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2022-01-11 09:38+0800\n"
+"POT-Creation-Date: 2022-01-17 08:34+0800\n"
 "PO-Revision-Date: 2022-01-11 18:00+0300\n"
 "Last-Translator: Emir SARI <emir_sari@icloud.com>\n"
 "Language-Team: Turkish (https://github.com/bitigchi/git-po/)\n"
@@ -977,8 +977,8 @@ msgstr "tanımlanamayan boşluk yok sayma seçeneği '%s'"
 #: builtin/checkout.c:1644 builtin/checkout.c:1754 builtin/checkout.c:1757
 #: builtin/clone.c:906 builtin/commit.c:358 builtin/commit.c:361
 #: builtin/commit.c:1196 builtin/describe.c:593 builtin/diff-tree.c:155
-#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2033
-#: builtin/fetch.c:2038 builtin/index-pack.c:1852 builtin/init-db.c:560
+#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2038
+#: builtin/fetch.c:2043 builtin/index-pack.c:1852 builtin/init-db.c:560
 #: builtin/log.c:1946 builtin/log.c:1948 builtin/ls-files.c:778
 #: builtin/merge.c:1403 builtin/merge.c:1405 builtin/pack-objects.c:4073
 #: builtin/push.c:592 builtin/push.c:630 builtin/push.c:636 builtin/push.c:641
@@ -1966,8 +1966,9 @@ msgstr "%s ikili nesnesi %s yolunda okunamıyor"
 msgid ""
 "cannot inherit upstream tracking configuration of multiple refs when "
 "rebasing is requested"
-msgstr "yeniden temellendirme istendiğinde birden çok başvurunun üst kaynak "
-"izleme yapılandırması miras alınamıyor"
+msgstr ""
+"yeniden temellendirme istendiğinde birden çok başvurunun üst kaynak izleme "
+"yapılandırması miras alınamıyor"
 
 #: branch.c:88
 #, c-format
@@ -2007,13 +2008,15 @@ msgstr ""
 #: branch.c:203
 #, c-format
 msgid "asked to inherit tracking from '%s', but no remote is set"
-msgstr "'%s' konumundan izleme miras istendi; ancak bir uzak konum ayarlanmamış"
+msgstr ""
+"'%s' konumundan izleme miras istendi; ancak bir uzak konum ayarlanmamış"
 
 #: branch.c:209
 #, c-format
 msgid "asked to inherit tracking from '%s', but no merge configuration is set"
-msgstr "'%s' konumundan izleme miras istendi; ancak bir birleştirme "
-"yapılandırması ayarlanmamış"
+msgstr ""
+"'%s' konumundan izleme miras istendi; ancak bir birleştirme yapılandırması "
+"ayarlanmamış"
 
 #: branch.c:252
 #, c-format
@@ -2032,7 +2035,7 @@ msgstr "'%s' adında bir dal halihazırda var"
 
 #: branch.c:313
 #, c-format
-msgid "cannot force update the branch '%s'checked out at '%s'"
+msgid "cannot force update the branch '%s' checked out at '%s'"
 msgstr "'%s' dalı zorla güncellenemiyor, '%s' konumunda çıkış yapılmış"
 
 #: branch.c:336
@@ -3429,15 +3432,17 @@ msgstr "'%s', '%s' ve '%s' seçenekleri birlikte kullanılamaz"
 #: diff.c:4597
 #, c-format
 msgid "options '%s' and '%s' cannot be used together, use '%s' with '%s'"
-msgstr "'%s' ve '%s' seçenekleri birlikte kullanılamaz, '%s' seçeneğini '%s' "
-"ile kullanın"
+msgstr ""
+"'%s' ve '%s' seçenekleri birlikte kullanılamaz, '%s' seçeneğini '%s' ile "
+"kullanın"
 
 #: diff.c:4601
 #, c-format
 msgid ""
 "options '%s' and '%s' cannot be used together, use '%s' with '%s' and '%s'"
-msgstr "'%s' ve '%s' seçenekleri birlikte kullanılamaz, '%s' seçeneğini '%s' "
-"ve '%s' ile kullanın"
+msgstr ""
+"'%s' ve '%s' seçenekleri birlikte kullanılamaz, '%s' seçeneğini '%s' ve '%s' "
+"ile kullanın"
 
 #: diff.c:4681
 msgid "--follow requires exactly one pathspec"
@@ -5867,7 +5872,7 @@ msgstr "%s: veritabanına ekleme başarısız"
 msgid "%s: unsupported file type"
 msgstr "%s: desteklenmeyen dosya türü"
 
-#: object-file.c:2329 builtin/fetch.c:1448
+#: object-file.c:2329 builtin/fetch.c:1453
 #, c-format
 msgid "%s is not a valid object"
 msgstr "%s geçerli bir nesne değil"
@@ -7130,41 +7135,41 @@ msgstr "hatalı ada iye '%s' başvurusunu güncelleme reddediliyor"
 msgid "update_ref failed for ref '%s': %s"
 msgstr "'%s' başvurusu için update_ref başarısız oldu: %s"
 
-#: refs.c:2069
+#: refs.c:2067
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "'%s' başvurusu için birden çok güncellemeye izin verilmiyor"
 
-#: refs.c:2152
+#: refs.c:2150
 msgid "ref updates forbidden inside quarantine environment"
 msgstr "başvuru güncellemeleri karantina ortamı içinde yasak"
 
-#: refs.c:2163
+#: refs.c:2161
 msgid "ref updates aborted by hook"
 msgstr "başvuru güncellemeleri kanca tarafından iptal edildi"
 
-#: refs.c:2271 refs.c:2301
+#: refs.c:2269 refs.c:2299
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "'%s' mevcut; '%s' oluşturulamıyor"
 
-#: refs.c:2277 refs.c:2312
+#: refs.c:2275 refs.c:2310
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "'%s' ve '%s' aynı anda işlenemiyor"
 
-#: refs/files-backend.c:1268
+#: refs/files-backend.c:1267
 #, c-format
 msgid "could not remove reference %s"
 msgstr "%s başvurusu kaldırılamadı"
 
-#: refs/files-backend.c:1282 refs/packed-backend.c:1549
+#: refs/files-backend.c:1281 refs/packed-backend.c:1549
 #: refs/packed-backend.c:1559
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr "%s başvurusu silinemedi: %s"
 
-#: refs/files-backend.c:1285 refs/packed-backend.c:1562
+#: refs/files-backend.c:1284 refs/packed-backend.c:1562
 #, c-format
 msgid "could not delete references: %s"
 msgstr "başvurular silinemedi: %s"
@@ -8193,7 +8198,8 @@ msgstr "HEAD çözülemiyor"
 msgid "cannot abort from a branch yet to be born"
 msgstr "daha doğmamış bir daldan iptal edilemiyor"
 
-#: sequencer.c:3180 builtin/fetch.c:999 builtin/fetch.c:1411 builtin/grep.c:772
+#: sequencer.c:3180 builtin/fetch.c:1004 builtin/fetch.c:1416
+#: builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr "'%s' açılamıyor"
@@ -9143,7 +9149,7 @@ msgstr "uzak servis yolu ayarlama protokol tarafından desteklenmiyor"
 msgid "invalid remote service path"
 msgstr "geçersiz uzak konum servis yolu"
 
-#: transport-helper.c:661 transport.c:1474
+#: transport-helper.c:661 transport.c:1479
 msgid "operation not supported by protocol"
 msgstr "işlem protokol tarafından desteklenmiyor"
 
@@ -10667,7 +10673,8 @@ msgstr "Eğer bu yamayı atlamayı yeğliyorsanız \"%s --skip\" çalıştırın
 #: builtin/am.c:1159
 #, c-format
 msgid "To record the empty patch as an empty commit, run \"%s --allow-empty\"."
-msgstr "Boş yamayı boş işleme kaydı olarak yazmak için \"%s --allow-empty\" "
+msgstr ""
+"Boş yamayı boş işleme kaydı olarak yazmak için \"%s --allow-empty\" "
 "çalıştırın."
 
 #: builtin/am.c:1161
@@ -13347,7 +13354,7 @@ msgstr "'%s' ve '%s %s' seçenekleri birlikte kullanılamaz"
 msgid "repository '%s' does not exist"
 msgstr "'%s' deposu mevcut değil"
 
-#: builtin/clone.c:924 builtin/fetch.c:2047
+#: builtin/clone.c:924 builtin/fetch.c:2052
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "%s derinliği pozitif bir sayı değil"
@@ -13932,7 +13939,8 @@ msgstr "Bir seç-al'ın tam ortasındasınız -- ileti değiştirilemiyor."
 #: builtin/commit.c:1232
 #, c-format
 msgid "reword option of '%s' and path '%s' cannot be used together"
-msgstr "'%s' ögesinin yeniden yazım seçeneği ve '%s' yolu birlikte kullanılamaz"
+msgstr ""
+"'%s' ögesinin yeniden yazım seçeneği ve '%s' yolu birlikte kullanılamaz"
 
 #: builtin/commit.c:1234
 #, c-format
@@ -15248,70 +15256,70 @@ msgstr "getirdikten sonra işleme grafiğini yaz"
 msgid "accept refspecs from stdin"
 msgstr "başvuru belirteçlerini stdin'den oku"
 
-#: builtin/fetch.c:587
+#: builtin/fetch.c:592
 msgid "couldn't find remote ref HEAD"
 msgstr "uzak HEAD başvurusu bulunamadı"
 
-#: builtin/fetch.c:761
+#: builtin/fetch.c:766
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "fetch.output yapılandırması geçersiz değer içeriyor: %s"
 
-#: builtin/fetch.c:862
+#: builtin/fetch.c:867
 #, c-format
 msgid "object %s not found"
 msgstr "%s nesnesi bulunamadı"
 
-#: builtin/fetch.c:866
+#: builtin/fetch.c:871
 msgid "[up to date]"
 msgstr "[güncel]"
 
-#: builtin/fetch.c:878 builtin/fetch.c:896 builtin/fetch.c:968
+#: builtin/fetch.c:883 builtin/fetch.c:901 builtin/fetch.c:973
 msgid "[rejected]"
 msgstr "[reddedildi]"
 
-#: builtin/fetch.c:880
+#: builtin/fetch.c:885
 msgid "can't fetch in current branch"
 msgstr "geçerli dalda getirme yapılamıyor"
 
-#: builtin/fetch.c:881
+#: builtin/fetch.c:886
 msgid "checked out in another worktree"
 msgstr "başka bir çalışma ağacında çıkış yapıldı"
 
-#: builtin/fetch.c:891
+#: builtin/fetch.c:896
 msgid "[tag update]"
 msgstr "[etiket güncellemesi]"
 
-#: builtin/fetch.c:892 builtin/fetch.c:929 builtin/fetch.c:951
-#: builtin/fetch.c:963
+#: builtin/fetch.c:897 builtin/fetch.c:934 builtin/fetch.c:956
+#: builtin/fetch.c:968
 msgid "unable to update local ref"
 msgstr "yerel başvuru güncellenemiyor"
 
-#: builtin/fetch.c:896
+#: builtin/fetch.c:901
 msgid "would clobber existing tag"
 msgstr "var olan etiketi değiştirecektir"
 
-#: builtin/fetch.c:918
+#: builtin/fetch.c:923
 msgid "[new tag]"
 msgstr "[yeni etiket]"
 
-#: builtin/fetch.c:921
+#: builtin/fetch.c:926
 msgid "[new branch]"
 msgstr "[yeni dal]"
 
-#: builtin/fetch.c:924
+#: builtin/fetch.c:929
 msgid "[new ref]"
 msgstr "[yeni başvuru]"
 
-#: builtin/fetch.c:963
+#: builtin/fetch.c:968
 msgid "forced update"
 msgstr "zorlanmış güncelleme"
 
-#: builtin/fetch.c:968
+#: builtin/fetch.c:973
 msgid "non-fast-forward"
 msgstr "ileri sarım değil"
 
-#: builtin/fetch.c:1071
+#: builtin/fetch.c:1076
 msgid ""
 "fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled; to re-enable, use '--show-forced-updates'\n"
@@ -15321,7 +15329,7 @@ msgstr ""
 "ancak bu denetleme kapatılmış. Yeniden açmak için '--show-forced-updates'\n"
 "bayrağını kullanın veya 'git config fetch.showForcedUpdates true' çalıştırın."
 
-#: builtin/fetch.c:1075
+#: builtin/fetch.c:1080
 #, c-format
 msgid ""
 "it took %.2f seconds to check forced updates; you can use\n"
@@ -15329,26 +15337,27 @@ msgid ""
 "false'\n"
 "to avoid this check\n"
 msgstr ""
-"Zorla güncellemeleri denetleme %.2f saniye sürdü. '--no-show-forced-updates'\n"
+"Zorla güncellemeleri denetleme %.2f saniye sürdü. '--no-show-forced-"
+"updates'\n"
 "kullanarak veya 'git config fetch.showForcedUpdates false' çalıştırarak\n"
 "bu denetlemeden kaçınabilirsiniz.\n"
 
-#: builtin/fetch.c:1107
+#: builtin/fetch.c:1112
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s tüm gerekli nesneleri göndermedi\n"
 
-#: builtin/fetch.c:1136
+#: builtin/fetch.c:1141
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr "%s reddedildi; çünkü sığ köklerin güncellenmesine izin verilmiyor"
 
-#: builtin/fetch.c:1226 builtin/fetch.c:1374
+#: builtin/fetch.c:1231 builtin/fetch.c:1379
 #, c-format
 msgid "From %.*s\n"
 msgstr "Şu konumdan: %.*s\n"
 
-#: builtin/fetch.c:1247
+#: builtin/fetch.c:1252
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -15357,49 +15366,49 @@ msgstr ""
 "bazı yerel başvurular güncellenemedi; 'git remote prune %s'\n"
 "kullanarak eski ve çakışan dalları kaldırmayı deneyin"
 
-#: builtin/fetch.c:1344
+#: builtin/fetch.c:1349
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s sarkacak)"
 
-#: builtin/fetch.c:1345
+#: builtin/fetch.c:1350
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s sarkmaya başladı)"
 
-#: builtin/fetch.c:1377
+#: builtin/fetch.c:1382
 msgid "[deleted]"
 msgstr "[silindi]"
 
-#: builtin/fetch.c:1378 builtin/remote.c:1128
+#: builtin/fetch.c:1383 builtin/remote.c:1128
 msgid "(none)"
 msgstr "(hiçbiri)"
 
-#: builtin/fetch.c:1400
+#: builtin/fetch.c:1405
 #, c-format
 msgid "refusing to fetch into branch '%s' checked out at '%s'"
 msgstr "'%s' dalına getirme reddediliyor, '%s' konumunda çıkış yapıldı"
 
-#: builtin/fetch.c:1420
+#: builtin/fetch.c:1425
 #, c-format
 msgid "option \"%s\" value \"%s\" is not valid for %s"
 msgstr "\"%s\" seçeneği \"%s\" değeri %s için geçerli değil"
 
-#: builtin/fetch.c:1423
+#: builtin/fetch.c:1428
 #, c-format
 msgid "option \"%s\" is ignored for %s\n"
 msgstr "\"%s\" seçeneği %s için yok sayılıyor\n"
 
-#: builtin/fetch.c:1450
+#: builtin/fetch.c:1455
 #, c-format
 msgid "the object %s does not exist"
 msgstr "%s diye bir nesne yok"
 
-#: builtin/fetch.c:1638
+#: builtin/fetch.c:1643
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "birden çok dal algılandı, --set-upstream ile uyumsuz"
 
-#: builtin/fetch.c:1650
+#: builtin/fetch.c:1655
 #, c-format
 msgid ""
 "could not set upstream of HEAD to '%s' from '%s' when it does not point to "
@@ -15408,19 +15417,19 @@ msgstr ""
 "HEAD'in üst kaynağı '%s' olarak '%s' konumundan ayarlanamadı; çünkü herhangi "
 "bir dala işaret etmiyor."
 
-#: builtin/fetch.c:1663
+#: builtin/fetch.c:1668
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "bir uzak konum uzak izleme dalı için üstkaynak ayarlanmıyor"
 
-#: builtin/fetch.c:1665
+#: builtin/fetch.c:1670
 msgid "not setting upstream for a remote tag"
 msgstr "bir uzak konum etiketi için üstkaynak ayarlanmıyor"
 
-#: builtin/fetch.c:1667
+#: builtin/fetch.c:1672
 msgid "unknown branch type"
 msgstr "bilinmeyen dal türü"
 
-#: builtin/fetch.c:1669
+#: builtin/fetch.c:1674
 msgid ""
 "no source branch found;\n"
 "you need to specify exactly one branch with the --set-upstream option"
@@ -15428,22 +15437,22 @@ msgstr ""
 "Kaynak dal bulunamadı.\n"
 "--set-upstream seçeneği ile tam olarak bir dal belirtmeniz gerekiyor."
 
-#: builtin/fetch.c:1799 builtin/fetch.c:1862
+#: builtin/fetch.c:1804 builtin/fetch.c:1867
 #, c-format
 msgid "Fetching %s\n"
 msgstr "%s getiriliyor\n"
 
-#: builtin/fetch.c:1809 builtin/fetch.c:1864
+#: builtin/fetch.c:1814 builtin/fetch.c:1869
 #, c-format
 msgid "could not fetch %s"
 msgstr "%s getirilemedi"
 
-#: builtin/fetch.c:1821
+#: builtin/fetch.c:1826
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "'%s' getirilemedi (çıkış kodu: %d)\n"
 
-#: builtin/fetch.c:1925
+#: builtin/fetch.c:1930
 msgid ""
 "no remote repository specified; please specify either a URL or a\n"
 "remote name from which new revisions should be fetched"
@@ -15451,50 +15460,50 @@ msgstr ""
 "Bir uzak dal belirtilmedi. Lütfen yeni revizyonların\n"
 "getirileceği bir URL veya uzak konum adı belirtin."
 
-#: builtin/fetch.c:1961
+#: builtin/fetch.c:1966
 msgid "you need to specify a tag name"
 msgstr "bir etiket adı belirtmeniz gerekiyor"
 
-#: builtin/fetch.c:2027
+#: builtin/fetch.c:2032
 msgid "--negotiate-only needs one or more --negotiate-tip=*"
 msgstr ""
 "--negotiate-only'nin bir veya daha çok --negotiate-tip=* gereksinimi var"
 
-#: builtin/fetch.c:2031
+#: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"
 msgstr "--deepen içinde negatif derinlik desteklenmiyor"
 
-#: builtin/fetch.c:2040
+#: builtin/fetch.c:2045
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "tam bir depo üzerinde --unshallow bir anlam ifade etmiyor"
 
-#: builtin/fetch.c:2057
+#: builtin/fetch.c:2062
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all bir depo argümanı almıyor"
 
-#: builtin/fetch.c:2059
+#: builtin/fetch.c:2064
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all başvuru belirteçleri ile birlikte bir anlam ifade etmiyor"
 
-#: builtin/fetch.c:2068
+#: builtin/fetch.c:2073
 #, c-format
 msgid "no such remote or remote group: %s"
 msgstr "böyle bir uzak konum veya uzak konum grubu yok: %s"
 
-#: builtin/fetch.c:2076
+#: builtin/fetch.c:2081
 msgid "fetching a group and specifying refspecs does not make sense"
 msgstr ""
 "bir grubu getirme ve başvuru belirteçleri tanımlama bir anlam ifade etmiyor"
 
-#: builtin/fetch.c:2092
+#: builtin/fetch.c:2097
 msgid "must supply remote when using --negotiate-only"
 msgstr "--negotiate-only kullanırken uzak konum sağlanmalıdır"
 
-#: builtin/fetch.c:2097
+#: builtin/fetch.c:2102
 msgid "protocol does not support --negotiate-only, exiting"
 msgstr "protokol, --negotiate-only desteklemediğinden çıkılıyor"
 
-#: builtin/fetch.c:2116
+#: builtin/fetch.c:2121
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -15502,11 +15511,11 @@ msgstr ""
 "--filter yalnızca extensions.partialclone içinde yapılandırılmış uzak konum "
 "ile kullanılabilir."
 
-#: builtin/fetch.c:2120
+#: builtin/fetch.c:2125
 msgid "--atomic can only be used when fetching from one remote"
 msgstr "--atomic yalnızca bir uzak konumdan getirirken kullanılabilir"
 
-#: builtin/fetch.c:2124
+#: builtin/fetch.c:2129
 msgid "--stdin can only be used when fetching from one remote"
 msgstr ""
 "--stdin seçeneği yalnızca bir uzak konumdan getirilirken kullanılabilir"
@@ -22317,8 +22326,9 @@ msgstr "git sparse-checkout reapply [--[no-]cone] [--[no-]sparse-index]"
 
 #: builtin/sparse-checkout.c:785
 msgid "must be in a sparse-checkout to reapply sparsity patterns"
-msgstr "aralıklılık dizgilerinin yeniden uygulanması için bir aralıklı çıkış "
-"içinde olmalı"
+msgstr ""
+"aralıklılık dizgilerinin yeniden uygulanması için bir aralıklı çıkış içinde "
+"olmalı"
 
 #: builtin/sparse-checkout.c:803
 msgid "git sparse-checkout disable"
@@ -22695,8 +22705,7 @@ msgid ""
 "."
 msgstr ""
 "run_command, %s ögesinin iç içe geçmiş altmodülleri içinde özyinelerken "
-"sıfır olmayan durum döndürdü"
-"."
+"sıfır olmayan durum döndürdü."
 
 #: builtin/submodule--helper.c:561
 msgid "suppress output of entering each submodule command"
@@ -24653,7 +24662,8 @@ msgstr "uzak konum HEAD'i bir dal değil: '%.*s'"
 
 #: contrib/scalar/scalar.c:317
 msgid "failed to get default branch name from remote; using local default"
-msgstr "uzak konumdan öntanımlı dal adı alınamadı; yerel öntanımlı kullanılıyor"
+msgstr ""
+"uzak konumdan öntanımlı dal adı alınamadı; yerel öntanımlı kullanılıyor"
 
 #: contrib/scalar/scalar.c:330
 msgid "failed to get default branch name"

--- a/po/vi.po
+++ b/po/vi.po
@@ -2,15 +2,15 @@
 # Bản dịch tiếng Việt dành cho GIT-CORE.
 # This file is distributed under the same license as the git-core package.
 # Nguyễn Thái Ngọc Duy <pclouds@gmail.com>, 2012.
-# Trần Ngọc Quân <vnwildman@gmail.com>, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021.
+# Trần Ngọc Quân <vnwildman@gmail.com>, 2012-2022.
 # Đoàn Trần Công Danh <congdanhqx@gmail.com>, 2020.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: git v2.34.0 round 3\n"
+"Project-Id-Version: git v2.35.0 round 2\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2021-11-10 08:55+0800\n"
-"PO-Revision-Date: 2021-11-11 13:18+0700\n"
+"POT-Creation-Date: 2022-01-17 08:31+0800\n"
+"PO-Revision-Date: 2022-01-17 14:14+0700\n"
 "Last-Translator: Trần Ngọc Quân <vnwildman@gmail.com>\n"
 "Language-Team: Vietnamese <translation-team-vi@lists.sourceforge.net>\n"
 "Language: vi\n"
@@ -19,15 +19,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Language-Team-Website: <http://translationproject.org/team/vi.html>\n"
-"X-Generator: Poedit 3.0\n"
+"X-Generator: Poedit 3.0.1\n"
 
 #: add-interactive.c:380
 #, c-format
 msgid "Huh (%s)?"
 msgstr "Hả (%s)?"
 
-#: add-interactive.c:533 add-interactive.c:834 reset.c:65 sequencer.c:3512
-#: sequencer.c:3979 sequencer.c:4141 builtin/rebase.c:1233
+#: add-interactive.c:533 add-interactive.c:834 reset.c:65 sequencer.c:3509
+#: sequencer.c:3974 sequencer.c:4136 builtin/rebase.c:1233
 #: builtin/rebase.c:1642
 msgid "could not read index"
 msgstr "không thể đọc bảng mục lục"
@@ -56,7 +56,7 @@ msgstr "Cập nhật"
 msgid "could not stage '%s'"
 msgstr "không thể đưa “%s” lên bệ phóng"
 
-#: add-interactive.c:707 add-interactive.c:896 reset.c:89 sequencer.c:3718
+#: add-interactive.c:707 add-interactive.c:896 reset.c:89 sequencer.c:3713
 msgid "could not write index"
 msgstr "không thể ghi bảng mục lục"
 
@@ -71,8 +71,8 @@ msgstr[0] "đã cập nhật %d đường dẫn\n"
 msgid "note: %s is untracked now.\n"
 msgstr "chú ý: %s giờ đã bỏ theo dõi.\n"
 
-#: add-interactive.c:733 apply.c:4149 builtin/checkout.c:298
-#: builtin/reset.c:151
+#: add-interactive.c:733 apply.c:4151 builtin/checkout.c:306
+#: builtin/reset.c:167
 #, c-format
 msgid "make_cache_entry failed for path '%s'"
 msgstr "make_cache_entry gặp lỗi đối với đường dẫn “%s”"
@@ -111,21 +111,21 @@ msgstr[0] "đã thêm %d đường dẫn\n"
 msgid "ignoring unmerged: %s"
 msgstr "bỏ qua những thứ chưa hòa trộn: %s"
 
-#: add-interactive.c:941 add-patch.c:1752 git-add--interactive.perl:1369
+#: add-interactive.c:941 add-patch.c:1752 git-add--interactive.perl:1371
 #, c-format
 msgid "Only binary files changed.\n"
 msgstr "Chỉ có các tập tin nhị phân là thay đổi.\n"
 
-#: add-interactive.c:943 add-patch.c:1750 git-add--interactive.perl:1371
+#: add-interactive.c:943 add-patch.c:1750 git-add--interactive.perl:1373
 #, c-format
 msgid "No changes.\n"
 msgstr "Không có thay đổi nào.\n"
 
-#: add-interactive.c:947 git-add--interactive.perl:1379
+#: add-interactive.c:947 git-add--interactive.perl:1381
 msgid "Patch update"
 msgstr "Cập nhật miếng vá"
 
-#: add-interactive.c:986 git-add--interactive.perl:1792
+#: add-interactive.c:986 git-add--interactive.perl:1794
 msgid "Review diff"
 msgstr "Xem xét lại diff"
 
@@ -199,11 +199,11 @@ msgstr "tùy chọn mục bằng số"
 msgid "(empty) select nothing"
 msgstr "(để trống) không chọn gì"
 
-#: add-interactive.c:1095 builtin/clean.c:813 git-add--interactive.perl:1896
+#: add-interactive.c:1095 builtin/clean.c:839 git-add--interactive.perl:1898
 msgid "*** Commands ***"
 msgstr "*** Lệnh ***"
 
-#: add-interactive.c:1096 builtin/clean.c:814 git-add--interactive.perl:1893
+#: add-interactive.c:1096 builtin/clean.c:840 git-add--interactive.perl:1895
 msgid "What now"
 msgstr "Giờ thì sao"
 
@@ -215,13 +215,13 @@ msgstr "đã đưa lên bệ phóng"
 msgid "unstaged"
 msgstr "chưa đưa lên bệ phóng"
 
-#: add-interactive.c:1148 apply.c:5016 apply.c:5019 builtin/am.c:2311
-#: builtin/am.c:2314 builtin/bugreport.c:107 builtin/clone.c:128
-#: builtin/fetch.c:152 builtin/merge.c:286 builtin/pull.c:194
-#: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1857
-#: builtin/submodule--helper.c:1860 builtin/submodule--helper.c:2503
-#: builtin/submodule--helper.c:2506 builtin/submodule--helper.c:2573
-#: builtin/submodule--helper.c:2578 builtin/submodule--helper.c:2811
+#: add-interactive.c:1148 apply.c:5020 apply.c:5023 builtin/am.c:2367
+#: builtin/am.c:2370 builtin/bugreport.c:107 builtin/clone.c:128
+#: builtin/fetch.c:153 builtin/merge.c:287 builtin/pull.c:194
+#: builtin/submodule--helper.c:404 builtin/submodule--helper.c:1858
+#: builtin/submodule--helper.c:1861 builtin/submodule--helper.c:2504
+#: builtin/submodule--helper.c:2507 builtin/submodule--helper.c:2574
+#: builtin/submodule--helper.c:2579 builtin/submodule--helper.c:2812
 #: git-add--interactive.perl:213
 msgid "path"
 msgstr "đường-dẫn"
@@ -230,27 +230,27 @@ msgstr "đường-dẫn"
 msgid "could not refresh index"
 msgstr "không thể đọc lại bảng mục lục"
 
-#: add-interactive.c:1169 builtin/clean.c:778 git-add--interactive.perl:1803
+#: add-interactive.c:1169 builtin/clean.c:804 git-add--interactive.perl:1805
 #, c-format
 msgid "Bye.\n"
 msgstr "Tạm biệt.\n"
 
-#: add-patch.c:34 git-add--interactive.perl:1431
+#: add-patch.c:34 git-add--interactive.perl:1433
 #, c-format, perl-format
 msgid "Stage mode change [y,n,q,a,d%s,?]? "
 msgstr "Thay đổi chế độ bệ phóng [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:35 git-add--interactive.perl:1432
+#: add-patch.c:35 git-add--interactive.perl:1434
 #, c-format, perl-format
 msgid "Stage deletion [y,n,q,a,d%s,?]? "
 msgstr "Xóa khỏi bệ phóng [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:36 git-add--interactive.perl:1433
+#: add-patch.c:36 git-add--interactive.perl:1435
 #, c-format, perl-format
 msgid "Stage addition [y,n,q,a,d%s,?]? "
 msgstr "Thêm vào bệ phóng [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:37 git-add--interactive.perl:1434
+#: add-patch.c:37 git-add--interactive.perl:1436
 #, c-format, perl-format
 msgid "Stage this hunk [y,n,q,a,d%s,?]? "
 msgstr "Đưa lên bệ phóng khúc này [y,n,q,a,d%s,?]? "
@@ -278,22 +278,22 @@ msgstr ""
 "d - đừng đưa lên bệ phóng khúc này cũng như bất kỳ cái nào còn lại trong tập "
 "tin\n"
 
-#: add-patch.c:56 git-add--interactive.perl:1437
+#: add-patch.c:56 git-add--interactive.perl:1439
 #, c-format, perl-format
 msgid "Stash mode change [y,n,q,a,d%s,?]? "
 msgstr "Thay đổi chế độ tạm cất đi [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:57 git-add--interactive.perl:1438
+#: add-patch.c:57 git-add--interactive.perl:1440
 #, c-format, perl-format
 msgid "Stash deletion [y,n,q,a,d%s,?]? "
 msgstr "Xóa tạm cất [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:58 git-add--interactive.perl:1439
+#: add-patch.c:58 git-add--interactive.perl:1441
 #, c-format, perl-format
 msgid "Stash addition [y,n,q,a,d%s,?]? "
 msgstr "Thêm vào tạm cất [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:59 git-add--interactive.perl:1440
+#: add-patch.c:59 git-add--interactive.perl:1442
 #, c-format, perl-format
 msgid "Stash this hunk [y,n,q,a,d%s,?]? "
 msgstr "Tạm cất khúc này [y,n,q,a,d%s,?]? "
@@ -320,22 +320,22 @@ msgstr ""
 "a - tạm cất khúc này và tất cả các khúc sau này trong tập tin\n"
 "d - đừng tạm cất khúc này cũng như bất kỳ cái nào còn lại trong tập tin\n"
 
-#: add-patch.c:80 git-add--interactive.perl:1443
+#: add-patch.c:80 git-add--interactive.perl:1445
 #, c-format, perl-format
 msgid "Unstage mode change [y,n,q,a,d%s,?]? "
 msgstr "Thay đổi chế độ bỏ ra khỏi bệ phóng [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:81 git-add--interactive.perl:1444
+#: add-patch.c:81 git-add--interactive.perl:1446
 #, c-format, perl-format
 msgid "Unstage deletion [y,n,q,a,d%s,?]? "
 msgstr "Xóa bỏ việc bỏ ra khỏi bệ phóng [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:82 git-add--interactive.perl:1445
+#: add-patch.c:82 git-add--interactive.perl:1447
 #, c-format, perl-format
 msgid "Unstage addition [y,n,q,a,d%s,?]? "
 msgstr "Thêm vào việc bỏ ra khỏi bệ phóng [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:83 git-add--interactive.perl:1446
+#: add-patch.c:83 git-add--interactive.perl:1448
 #, c-format, perl-format
 msgid "Unstage this hunk [y,n,q,a,d%s,?]? "
 msgstr "Bỏ ra khỏi bệ phóng khúc này [y,n,q,a,d%s,?]? "
@@ -364,22 +364,22 @@ msgstr ""
 "d - đừng đưa ra khỏi bệ phóng khúc này cũng như bất kỳ cái nào còn lại trong "
 "tập tin\n"
 
-#: add-patch.c:103 git-add--interactive.perl:1449
+#: add-patch.c:103 git-add--interactive.perl:1451
 #, c-format, perl-format
 msgid "Apply mode change to index [y,n,q,a,d%s,?]? "
 msgstr "Áp dụng thay đổi chế độ cho mục lục [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:104 git-add--interactive.perl:1450
+#: add-patch.c:104 git-add--interactive.perl:1452
 #, c-format, perl-format
 msgid "Apply deletion to index [y,n,q,a,d%s,?]? "
 msgstr "Áp dụng việc xóa vào mục lục [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:105 git-add--interactive.perl:1451
+#: add-patch.c:105 git-add--interactive.perl:1453
 #, c-format, perl-format
 msgid "Apply addition to index [y,n,q,a,d%s,?]? "
 msgstr "Áp dụng các thêm vào mục lục [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:106 git-add--interactive.perl:1452
+#: add-patch.c:106 git-add--interactive.perl:1454
 #, c-format, perl-format
 msgid "Apply this hunk to index [y,n,q,a,d%s,?]? "
 msgstr "Áo dụng khúc này vào mục lục [y,n,q,a,d%s,?]? "
@@ -406,26 +406,26 @@ msgstr ""
 "a - áp dụng khúc này và tất cả các khúc sau này trong tập tin\n"
 "d - đừng áp dụng khúc này cũng như bất kỳ cái nào sau này trong tập tin\n"
 
-#: add-patch.c:126 git-add--interactive.perl:1455
-#: git-add--interactive.perl:1473
+#: add-patch.c:126 git-add--interactive.perl:1457
+#: git-add--interactive.perl:1475
 #, c-format, perl-format
 msgid "Discard mode change from worktree [y,n,q,a,d%s,?]? "
 msgstr "Loại bỏ các thay đổi chế độ từ cây làm việc [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:127 git-add--interactive.perl:1456
-#: git-add--interactive.perl:1474
+#: add-patch.c:127 git-add--interactive.perl:1458
+#: git-add--interactive.perl:1476
 #, c-format, perl-format
 msgid "Discard deletion from worktree [y,n,q,a,d%s,?]? "
 msgstr "Loại bỏ việc xóa khỏi cây làm việc [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:128 git-add--interactive.perl:1457
-#: git-add--interactive.perl:1475
+#: add-patch.c:128 git-add--interactive.perl:1459
+#: git-add--interactive.perl:1477
 #, c-format, perl-format
 msgid "Discard addition from worktree [y,n,q,a,d%s,?]? "
 msgstr "Thêm các loại bỏ khỏi cây làm việc [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:129 git-add--interactive.perl:1458
-#: git-add--interactive.perl:1476
+#: add-patch.c:129 git-add--interactive.perl:1460
+#: git-add--interactive.perl:1478
 #, c-format, perl-format
 msgid "Discard this hunk from worktree [y,n,q,a,d%s,?]? "
 msgstr "Loại bỏ khúc này khỏi cây làm việc [y,n,q,a,d%s,?]? "
@@ -452,22 +452,22 @@ msgstr ""
 "a - loại bỏ khúc này và tất cả các khúc sau này trong tập tin\n"
 "d - đừng loại bỏ khúc này cũng như bất kỳ cái nào sau này trong tập tin\n"
 
-#: add-patch.c:149 add-patch.c:194 git-add--interactive.perl:1461
+#: add-patch.c:149 add-patch.c:194 git-add--interactive.perl:1463
 #, c-format, perl-format
 msgid "Discard mode change from index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Loại bỏ thay đổi chế độ từ mục lục và cây làm việc [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:150 add-patch.c:195 git-add--interactive.perl:1462
+#: add-patch.c:150 add-patch.c:195 git-add--interactive.perl:1464
 #, c-format, perl-format
 msgid "Discard deletion from index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Loại bỏ việc xóa khỏi mục lục và cây làm việc [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:151 add-patch.c:196 git-add--interactive.perl:1463
+#: add-patch.c:151 add-patch.c:196 git-add--interactive.perl:1465
 #, c-format, perl-format
 msgid "Discard addition from index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Thêm các loại bỏ từ mục lục và cây làm việc [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:152 add-patch.c:197 git-add--interactive.perl:1464
+#: add-patch.c:152 add-patch.c:197 git-add--interactive.perl:1466
 #, c-format, perl-format
 msgid "Discard this hunk from index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Loại bỏ khúc này khỏi mục lục và cây làm việc [y,n,q,a,d%s,?]? "
@@ -486,22 +486,22 @@ msgstr ""
 "a - loại bỏ khúc này và tất cả các khúc sau này trong tập tin\n"
 "d - đừng loại bỏ khúc này cũng như bất kỳ cái nào sau này trong tập tin\n"
 
-#: add-patch.c:171 add-patch.c:216 git-add--interactive.perl:1467
+#: add-patch.c:171 add-patch.c:216 git-add--interactive.perl:1469
 #, c-format, perl-format
 msgid "Apply mode change to index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Áp dụng thay đổi chế độ cho mục lục và cây làm việc [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:172 add-patch.c:217 git-add--interactive.perl:1468
+#: add-patch.c:172 add-patch.c:217 git-add--interactive.perl:1470
 #, c-format, perl-format
 msgid "Apply deletion to index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Áp dụng việc xóa vào mục lục và cây làm việc [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:173 add-patch.c:218 git-add--interactive.perl:1469
+#: add-patch.c:173 add-patch.c:218 git-add--interactive.perl:1471
 #, c-format, perl-format
 msgid "Apply addition to index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Áp dụng thêm vào mục lục và cây làm việc [y,n,q,a,d%s,?]? "
 
-#: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1470
+#: add-patch.c:174 add-patch.c:219 git-add--interactive.perl:1472
 #, c-format, perl-format
 msgid "Apply this hunk to index and worktree [y,n,q,a,d%s,?]? "
 msgstr "Áp dụng khúc này vào mục lục và cây làm việc [y,n,q,a,d%s,?]? "
@@ -639,7 +639,7 @@ msgstr "“git apply --cached” gặp lỗi"
 #. Consider translating (saying "no" discards!) as
 #. (saying "n" for "no" discards!) if the translation
 #. of the word "no" does not start with n.
-#: add-patch.c:1247 git-add--interactive.perl:1242
+#: add-patch.c:1247 git-add--interactive.perl:1244
 msgid ""
 "Your edited hunk does not apply. Edit again (saying \"no\" discards!) [y/n]? "
 msgstr ""
@@ -650,11 +650,11 @@ msgstr ""
 msgid "The selected hunks do not apply to the index!"
 msgstr "Các khúc đã chọn không được áp dụng vào bảng mục lục!"
 
-#: add-patch.c:1291 git-add--interactive.perl:1346
+#: add-patch.c:1291 git-add--interactive.perl:1348
 msgid "Apply them to the worktree anyway? "
 msgstr "Vẫn áp dụng chúng cho cây làm việc? "
 
-#: add-patch.c:1298 git-add--interactive.perl:1349
+#: add-patch.c:1298 git-add--interactive.perl:1351
 msgid "Nothing was applied.\n"
 msgstr "Đã không áp dụng gì cả.\n"
 
@@ -692,11 +692,11 @@ msgstr "Không có khúc kế tiếp"
 msgid "No other hunks to goto"
 msgstr "Không còn khúc nào để mà nhảy đến"
 
-#: add-patch.c:1549 git-add--interactive.perl:1606
+#: add-patch.c:1549 git-add--interactive.perl:1608
 msgid "go to which hunk (<ret> to see more)? "
 msgstr "nhảy đến khúc nào (<ret> để xem thêm)? "
 
-#: add-patch.c:1550 git-add--interactive.perl:1608
+#: add-patch.c:1550 git-add--interactive.perl:1610
 msgid "go to which hunk? "
 msgstr "nhảy đến khúc nào? "
 
@@ -715,7 +715,7 @@ msgstr[0] "Rất tiếc, chỉ có sẵn %d khúc."
 msgid "No other hunks to search"
 msgstr "Không còn khúc nào để mà tìm kiếm"
 
-#: add-patch.c:1581 git-add--interactive.perl:1661
+#: add-patch.c:1581 git-add--interactive.perl:1663
 msgid "search for regex? "
 msgstr "tìm kiếm cho biểu thức chính quy? "
 
@@ -806,7 +806,7 @@ msgstr ""
 msgid "Exiting because of an unresolved conflict."
 msgstr "Thoát ra bởi vì xung đột không thể giải quyết."
 
-#: advice.c:209 builtin/merge.c:1379
+#: advice.c:209 builtin/merge.c:1382
 msgid "You have not concluded your merge (MERGE_HEAD exists)."
 msgstr "Bạn chưa kết thúc việc hòa trộn (MERGE_HEAD vẫn tồn tại)."
 
@@ -904,21 +904,33 @@ msgstr "không nhận ra tùy chọn về khoảng trắng “%s”"
 msgid "unrecognized whitespace ignore option '%s'"
 msgstr "không nhận ra tùy chọn bỏ qua khoảng trắng “%s”"
 
-#: apply.c:136
-msgid "--reject and --3way cannot be used together."
-msgstr "--reject và --3way không thể dùng cùng nhau."
+#: apply.c:136 archive.c:584 range-diff.c:559 revision.c:2303 revision.c:2307
+#: revision.c:2316 revision.c:2321 revision.c:2527 revision.c:2870
+#: revision.c:2874 revision.c:2880 revision.c:2883 revision.c:2885
+#: builtin/add.c:510 builtin/add.c:512 builtin/add.c:529 builtin/add.c:541
+#: builtin/branch.c:727 builtin/checkout.c:467 builtin/checkout.c:470
+#: builtin/checkout.c:1644 builtin/checkout.c:1754 builtin/checkout.c:1757
+#: builtin/clone.c:906 builtin/commit.c:358 builtin/commit.c:361
+#: builtin/commit.c:1196 builtin/describe.c:593 builtin/diff-tree.c:155
+#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2038
+#: builtin/fetch.c:2043 builtin/index-pack.c:1852 builtin/init-db.c:560
+#: builtin/log.c:1946 builtin/log.c:1948 builtin/ls-files.c:778
+#: builtin/merge.c:1403 builtin/merge.c:1405 builtin/pack-objects.c:4073
+#: builtin/push.c:592 builtin/push.c:630 builtin/push.c:636 builtin/push.c:641
+#: builtin/rebase.c:1193 builtin/rebase.c:1195 builtin/rebase.c:1199
+#: builtin/repack.c:684 builtin/repack.c:715 builtin/reset.c:426
+#: builtin/reset.c:462 builtin/rev-list.c:541 builtin/show-branch.c:710
+#: builtin/stash.c:1707 builtin/stash.c:1710 builtin/submodule--helper.c:1316
+#: builtin/submodule--helper.c:2975 builtin/tag.c:526 builtin/tag.c:572
+#: builtin/worktree.c:702
+#, c-format
+msgid "options '%s' and '%s' cannot be used together"
+msgstr "tùy chọn '%s' và '%s' không thể dùng cùng nhau"
 
-#: apply.c:139
-msgid "--3way outside a repository"
-msgstr "--3way ở ngoài một kho chứa"
-
-#: apply.c:150
-msgid "--index outside a repository"
-msgstr "--index ở ngoài một kho chứa"
-
-#: apply.c:153
-msgid "--cached outside a repository"
-msgstr "--cached ở ngoài một kho chứa"
+#: apply.c:139 apply.c:150 apply.c:153
+#, c-format
+msgid "'%s' outside a repository"
+msgstr "'%s' ở ngoài một kho chứa"
 
 #: apply.c:800
 #, c-format
@@ -1131,8 +1143,8 @@ msgstr "gặp lỗi khi vá: %s:%ld"
 msgid "cannot checkout %s"
 msgstr "không thể lấy ra %s"
 
-#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:102 pack-revindex.c:214
-#: setup.c:308
+#: apply.c:3405 apply.c:3416 apply.c:3462 midx.c:104 pack-revindex.c:214
+#: setup.c:309
 #, c-format
 msgid "failed to read %s"
 msgstr "gặp lỗi khi đọc %s"
@@ -1142,382 +1154,381 @@ msgstr "gặp lỗi khi đọc %s"
 msgid "reading from '%s' beyond a symbolic link"
 msgstr "đọc từ “%s” vượt ra ngoài liên kết mềm"
 
-#: apply.c:3442 apply.c:3709
+#: apply.c:3442 apply.c:3711
 #, c-format
 msgid "path %s has been renamed/deleted"
 msgstr "đường dẫn %s đã bị xóa hoặc đổi tên"
 
-#: apply.c:3549 apply.c:3724
+#: apply.c:3549 apply.c:3726
 #, c-format
 msgid "%s: does not exist in index"
 msgstr "%s: không tồn tại trong bảng mục lục"
 
-#: apply.c:3558 apply.c:3732 apply.c:3976
+#: apply.c:3558 apply.c:3734 apply.c:3978
 #, c-format
 msgid "%s: does not match index"
 msgstr "%s: không khớp trong mục lục"
 
-#: apply.c:3593
+#: apply.c:3595
 msgid "repository lacks the necessary blob to perform 3-way merge."
 msgstr "kho thiếu đối tượng blob cần thiết để thực hiện hòa trộn “3-way”."
 
-#: apply.c:3596
+#: apply.c:3598
 #, c-format
 msgid "Performing three-way merge...\n"
 msgstr "Đang thực hiện hòa trộn “3-đường”…\n"
 
-#: apply.c:3612 apply.c:3616
+#: apply.c:3614 apply.c:3618
 #, c-format
 msgid "cannot read the current contents of '%s'"
 msgstr "không thể đọc nội dung hiện hành của “%s”"
 
-#: apply.c:3628
+#: apply.c:3630
 #, c-format
 msgid "Failed to perform three-way merge...\n"
 msgstr "Gặp lỗi khi thực hiện hòa trộn kiểu “three-way”…\n"
 
-#: apply.c:3642
+#: apply.c:3644
 #, c-format
 msgid "Applied patch to '%s' with conflicts.\n"
 msgstr "Đã áp dụng miếng vá %s với các xung đột.\n"
 
-#: apply.c:3647
+#: apply.c:3649
 #, c-format
 msgid "Applied patch to '%s' cleanly.\n"
 msgstr "Đã áp dụng miếng vá %s một cách sạch sẽ.\n"
 
-#: apply.c:3664
+#: apply.c:3666
 #, c-format
 msgid "Falling back to direct application...\n"
 msgstr "Đang trở lại ứng dụng chi phối…\n"
 
-#: apply.c:3676
+#: apply.c:3678
 msgid "removal patch leaves file contents"
 msgstr "loại bỏ miếng vá để lại nội dung tập tin"
 
-#: apply.c:3749
+#: apply.c:3751
 #, c-format
 msgid "%s: wrong type"
 msgstr "%s: sai kiểu"
 
-#: apply.c:3751
+#: apply.c:3753
 #, c-format
 msgid "%s has type %o, expected %o"
 msgstr "%s có kiểu %o, cần %o"
 
-#: apply.c:3916 apply.c:3918 read-cache.c:876 read-cache.c:905
-#: read-cache.c:1368
+#: apply.c:3918 apply.c:3920 read-cache.c:889 read-cache.c:918
+#: read-cache.c:1381
 #, c-format
 msgid "invalid path '%s'"
 msgstr "đường dẫn không hợp lệ “%s”"
 
-#: apply.c:3974
+#: apply.c:3976
 #, c-format
 msgid "%s: already exists in index"
 msgstr "%s: đã có từ trước trong bảng mục lục"
 
-#: apply.c:3978
+#: apply.c:3980
 #, c-format
 msgid "%s: already exists in working directory"
 msgstr "%s: đã sẵn có trong thư mục đang làm việc"
 
-#: apply.c:3998
+#: apply.c:4000
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o)"
 msgstr "chế độ mới (%o) của %s không khớp với chế độ cũ (%o)"
 
-#: apply.c:4003
+#: apply.c:4005
 #, c-format
 msgid "new mode (%o) of %s does not match old mode (%o) of %s"
 msgstr "chế độ mới (%o) của %s không khớp với chế độ cũ (%o) của %s"
 
-#: apply.c:4023
+#: apply.c:4025
 #, c-format
 msgid "affected file '%s' is beyond a symbolic link"
 msgstr "tập tin chịu tác động “%s” vượt ra ngoài liên kết mềm"
 
-#: apply.c:4027
+#: apply.c:4029
 #, c-format
 msgid "%s: patch does not apply"
 msgstr "%s: miếng vá không được áp dụng"
 
-#: apply.c:4042
+#: apply.c:4044
 #, c-format
 msgid "Checking patch %s..."
 msgstr "Đang kiểm tra miếng vá %s…"
 
-#: apply.c:4134
+#: apply.c:4136
 #, c-format
 msgid "sha1 information is lacking or useless for submodule %s"
 msgstr "thông tin sha1 thiếu hoặc không dùng được cho mô-đun %s"
 
-#: apply.c:4141
+#: apply.c:4143
 #, c-format
 msgid "mode change for %s, which is not in current HEAD"
 msgstr "thay đổi chế độ cho %s, cái mà không phải là HEAD hiện tại"
 
-#: apply.c:4144
+#: apply.c:4146
 #, c-format
 msgid "sha1 information is lacking or useless (%s)."
 msgstr "thông tin sha1 còn thiếu hay không dùng được(%s)."
 
-#: apply.c:4153
+#: apply.c:4155
 #, c-format
 msgid "could not add %s to temporary index"
 msgstr "không thể thêm %s vào chỉ mục tạm thời"
 
-#: apply.c:4163
+#: apply.c:4165
 #, c-format
 msgid "could not write temporary index to %s"
 msgstr "không thể ghi mục lục tạm vào %s"
 
-#: apply.c:4301
+#: apply.c:4303
 #, c-format
 msgid "unable to remove %s from index"
 msgstr "không thể gỡ bỏ %s từ mục lục"
 
-#: apply.c:4335
+#: apply.c:4337
 #, c-format
 msgid "corrupt patch for submodule %s"
 msgstr "miếng vá sai hỏng cho mô-đun-con %s"
 
-#: apply.c:4341
+#: apply.c:4343
 #, c-format
 msgid "unable to stat newly created file '%s'"
 msgstr "không thể lấy thống kê về tập tin %s mới hơn đã được tạo"
 
-#: apply.c:4349
+#: apply.c:4351
 #, c-format
 msgid "unable to create backing store for newly created file %s"
 msgstr "không thể tạo “kho lưu đằng sau” cho tập tin được tạo mới hơn %s"
 
-#: apply.c:4355 apply.c:4500
+#: apply.c:4357 apply.c:4502
 #, c-format
 msgid "unable to add cache entry for %s"
 msgstr "không thể thêm mục nhớ đệm cho %s"
 
-#: apply.c:4398 builtin/bisect--helper.c:540 builtin/gc.c:2241
-#: builtin/gc.c:2276
+#: apply.c:4400 builtin/bisect--helper.c:540 builtin/gc.c:2258
+#: builtin/gc.c:2293
 #, c-format
 msgid "failed to write to '%s'"
 msgstr "gặp lỗi khi ghi vào “%s”"
 
-#: apply.c:4402
+#: apply.c:4404
 #, c-format
 msgid "closing file '%s'"
 msgstr "đang đóng tập tin “%s”"
 
-#: apply.c:4472
+#: apply.c:4474
 #, c-format
 msgid "unable to write file '%s' mode %o"
 msgstr "không thể ghi vào tập tin “%s” chế độ %o"
 
-#: apply.c:4570
+#: apply.c:4572
 #, c-format
 msgid "Applied patch %s cleanly."
 msgstr "Đã áp dụng miếng vá %s một cách sạch sẽ."
 
-#: apply.c:4578
+#: apply.c:4580
 msgid "internal error"
 msgstr "lỗi nội bộ"
 
-#: apply.c:4581
+#: apply.c:4583
 #, c-format
 msgid "Applying patch %%s with %d reject..."
 msgid_plural "Applying patch %%s with %d rejects..."
 msgstr[0] "Đang áp dụng miếng vá %%s với %d lần từ chối…"
 
-#: apply.c:4592
+#: apply.c:4594
 #, c-format
 msgid "truncating .rej filename to %.*s.rej"
 msgstr "đang cắt ngắn tên tập tin .rej thành %.*s.rej"
 
-#: apply.c:4600 builtin/fetch.c:998 builtin/fetch.c:1408
+#: apply.c:4602
 #, c-format
 msgid "cannot open %s"
 msgstr "không mở được “%s”"
 
-#: apply.c:4614
+#: apply.c:4616
 #, c-format
 msgid "Hunk #%d applied cleanly."
 msgstr "Khối nhớ #%d được áp dụng gọn gàng."
 
-#: apply.c:4618
+#: apply.c:4620
 #, c-format
 msgid "Rejected hunk #%d."
 msgstr "Đoạn dữ liệu #%d bị từ chối."
 
-#: apply.c:4747
+#: apply.c:4749
 #, c-format
 msgid "Skipped patch '%s'."
 msgstr "Bỏ qua đường dẫn “%s”."
 
-#: apply.c:4755
-msgid "unrecognized input"
-msgstr "không thừa nhận đầu vào"
+#: apply.c:4758
+msgid "No valid patches in input (allow with \"--allow-empty\")"
+msgstr ""
+"Không có miếng vá hợp lệ nào trong đầu vào (cho phép với \"--allow-empty\")"
 
-#: apply.c:4775
+#: apply.c:4779
 msgid "unable to read index file"
 msgstr "không thể đọc tập tin lưu bảng mục lục"
 
-#: apply.c:4932
+#: apply.c:4936
 #, c-format
 msgid "can't open patch '%s': %s"
 msgstr "không thể mở miếng vá “%s”: %s"
 
-#: apply.c:4959
+#: apply.c:4963
 #, c-format
 msgid "squelched %d whitespace error"
 msgid_plural "squelched %d whitespace errors"
 msgstr[0] "đã chấm dứt %d lỗi khoảng trắng"
 
-#: apply.c:4965 apply.c:4980
+#: apply.c:4969 apply.c:4984
 #, c-format
 msgid "%d line adds whitespace errors."
 msgid_plural "%d lines add whitespace errors."
 msgstr[0] "%d dòng thêm khoảng trắng lỗi."
 
-#: apply.c:4973
+#: apply.c:4977
 #, c-format
 msgid "%d line applied after fixing whitespace errors."
 msgid_plural "%d lines applied after fixing whitespace errors."
 msgstr[0] "%d dòng được áp dụng sau khi sửa các lỗi khoảng trắng."
 
-#: apply.c:4989 builtin/add.c:707 builtin/mv.c:338 builtin/rm.c:429
+#: apply.c:4993 builtin/add.c:704 builtin/mv.c:338 builtin/rm.c:430
 msgid "Unable to write new index file"
 msgstr "Không thể ghi tập tin lưu bảng mục lục mới"
 
-#: apply.c:5017
+#: apply.c:5021
 msgid "don't apply changes matching the given path"
 msgstr "không áp dụng các thay đổi khớp với đường dẫn đã cho"
 
-#: apply.c:5020
+#: apply.c:5024
 msgid "apply changes matching the given path"
 msgstr "áp dụng các thay đổi khớp với đường dẫn đã cho"
 
-#: apply.c:5022 builtin/am.c:2320
+#: apply.c:5026 builtin/am.c:2376
 msgid "num"
 msgstr "số"
 
-#: apply.c:5023
+#: apply.c:5027
 msgid "remove <num> leading slashes from traditional diff paths"
 msgstr "gỡ bỏ <số> dấu gạch chéo dẫn đầu từ đường dẫn diff cổ điển"
 
-#: apply.c:5026
+#: apply.c:5030
 msgid "ignore additions made by the patch"
 msgstr "lờ đi phần bổ xung được tạo ra bởi miếng vá"
 
-#: apply.c:5028
+#: apply.c:5032
 msgid "instead of applying the patch, output diffstat for the input"
 msgstr ""
 "thay vì áp dụng một miếng vá, kết xuất kết quả từ lệnh diffstat cho đầu ra"
 
-#: apply.c:5032
+#: apply.c:5036
 msgid "show number of added and deleted lines in decimal notation"
 msgstr ""
 "hiển thị số lượng các dòng được thêm vào và xóa đi theo ký hiệu thập phân"
 
-#: apply.c:5034
+#: apply.c:5038
 msgid "instead of applying the patch, output a summary for the input"
 msgstr "thay vì áp dụng một miếng vá, kết xuất kết quả cho đầu vào"
 
-#: apply.c:5036
+#: apply.c:5040
 msgid "instead of applying the patch, see if the patch is applicable"
 msgstr "thay vì áp dụng miếng vá, hãy xem xem miếng vá có thích hợp không"
 
-#: apply.c:5038
+#: apply.c:5042
 msgid "make sure the patch is applicable to the current index"
 msgstr "hãy chắc chắn là miếng vá thích hợp với bảng mục lục hiện hành"
 
-#: apply.c:5040
+#: apply.c:5044
 msgid "mark new files with `git add --intent-to-add`"
 msgstr "đánh dấu các tập tin mới với “git add --intent-to-add”"
 
-#: apply.c:5042
+#: apply.c:5046
 msgid "apply a patch without touching the working tree"
 msgstr "áp dụng một miếng vá mà không động chạm đến cây làm việc"
 
-#: apply.c:5044
+#: apply.c:5048
 msgid "accept a patch that touches outside the working area"
 msgstr "chấp nhận một miếng vá mà không động chạm đến cây làm việc"
 
-#: apply.c:5047
+#: apply.c:5051
 msgid "also apply the patch (use with --stat/--summary/--check)"
 msgstr ""
 "đồng thời áp dụng miếng vá (dùng với tùy chọn --stat/--summary/--check)"
 
-#: apply.c:5049
+#: apply.c:5053
 msgid "attempt three-way merge, fall back on normal patch if that fails"
 msgstr ""
 "thử hòa trộn kiểu three-way, quay lại dán bình thường nếu không thể thực "
 "hiện được"
 
-#: apply.c:5051
+#: apply.c:5055
 msgid "build a temporary index based on embedded index information"
 msgstr ""
 "xây dựng bảng mục lục tạm thời trên cơ sở thông tin bảng mục lục được nhúng"
 
-#: apply.c:5054 builtin/checkout-index.c:196
+#: apply.c:5058 builtin/checkout-index.c:196
 msgid "paths are separated with NUL character"
 msgstr "các đường dẫn bị ngăn cách bởi ký tự NULL"
 
-#: apply.c:5056
+#: apply.c:5060
 msgid "ensure at least <n> lines of context match"
 msgstr "đảm bảo rằng có ít nhất <n> dòng ngữ cảnh khớp"
 
-#: apply.c:5057 builtin/am.c:2296 builtin/am.c:2299
+#: apply.c:5061 builtin/am.c:2352 builtin/am.c:2355
 #: builtin/interpret-trailers.c:98 builtin/interpret-trailers.c:100
 #: builtin/interpret-trailers.c:102 builtin/pack-objects.c:3960
 #: builtin/rebase.c:1051
 msgid "action"
 msgstr "hành động"
 
-#: apply.c:5058
+#: apply.c:5062
 msgid "detect new or modified lines that have whitespace errors"
 msgstr "tìm thấy một dòng mới hoặc bị sửa đổi mà nó có lỗi do khoảng trắng"
 
-#: apply.c:5061 apply.c:5064
+#: apply.c:5065 apply.c:5068
 msgid "ignore changes in whitespace when finding context"
 msgstr "lờ đi sự thay đổi do khoảng trắng gây ra khi tìm ngữ cảnh"
 
-#: apply.c:5067
+#: apply.c:5071
 msgid "apply the patch in reverse"
 msgstr "áp dụng miếng vá theo chiều ngược"
 
-#: apply.c:5069
+#: apply.c:5073
 msgid "don't expect at least one line of context"
 msgstr "đừng hy vọng có ít nhất một dòng ngữ cảnh"
 
-#: apply.c:5071
+#: apply.c:5075
 msgid "leave the rejected hunks in corresponding *.rej files"
 msgstr "để lại khối dữ liệu bị từ chối trong các tập tin *.rej tương ứng"
 
-#: apply.c:5073
+#: apply.c:5077
 msgid "allow overlapping hunks"
 msgstr "cho phép chồng khối nhớ"
 
-#: apply.c:5074 builtin/add.c:372 builtin/check-ignore.c:22
-#: builtin/commit.c:1483 builtin/count-objects.c:98 builtin/fsck.c:788
-#: builtin/log.c:2297 builtin/mv.c:123 builtin/read-tree.c:120
-msgid "be verbose"
-msgstr "chi tiết"
-
-#: apply.c:5076
+#: apply.c:5080
 msgid "tolerate incorrectly detected missing new-line at the end of file"
 msgstr ""
 "đã dò tìm thấy dung sai không chính xác thiếu dòng mới tại cuối tập tin"
 
-#: apply.c:5079
+#: apply.c:5083
 msgid "do not trust the line counts in the hunk headers"
 msgstr "không tin số lượng dòng trong phần đầu khối dữ liệu"
 
-#: apply.c:5081 builtin/am.c:2308
+#: apply.c:5085 builtin/am.c:2364
 msgid "root"
 msgstr "gốc"
 
-#: apply.c:5082
+#: apply.c:5086
 msgid "prepend <root> to all filenames"
 msgstr "treo thêm <root> vào tất cả các tên tập tin"
+
+#: apply.c:5089
+msgid "don't return error for empty patches"
+msgstr "đừng trả về lỗi khi các miếng vá trống rỗng"
 
 #: archive-tar.c:125 archive-zip.c:345
 #, c-format
@@ -1529,16 +1540,16 @@ msgstr "không thể stream blob “%s”"
 msgid "unsupported file mode: 0%o (SHA1: %s)"
 msgstr "chế độ tập tin không được hỗ trợ: 0%o (SHA1: %s)"
 
-#: archive-tar.c:450
+#: archive-tar.c:447
 #, c-format
 msgid "unable to start '%s' filter"
 msgstr "không thể bắt đầu bộ lọc “%s”"
 
-#: archive-tar.c:453
+#: archive-tar.c:450
 msgid "unable to redirect descriptor"
 msgstr "không thể chuyển hướng mô tả"
 
-#: archive-tar.c:460
+#: archive-tar.c:457
 #, c-format
 msgid "'%s' filter reported error"
 msgstr "bộ lọc “%s” đã báo cáo lỗi"
@@ -1582,19 +1593,13 @@ msgstr ""
 msgid "git archive --remote <repo> [--exec <cmd>] --list"
 msgstr "git archive --remote <kho> [--exec <lệnh>] --list"
 
-#: archive.c:188
+#: archive.c:188 archive.c:341 builtin/gc.c:497 builtin/notes.c:238
+#: builtin/tag.c:578
 #, c-format
-msgid "cannot read %s"
-msgstr "không thể đọc %s"
-
-#: archive.c:341 sequencer.c:473 sequencer.c:1932 sequencer.c:3114
-#: sequencer.c:3556 sequencer.c:3684 builtin/am.c:263 builtin/commit.c:834
-#: builtin/merge.c:1145
-#, c-format
-msgid "could not read '%s'"
+msgid "cannot read '%s'"
 msgstr "không thể đọc “%s”"
 
-#: archive.c:426 builtin/add.c:215 builtin/add.c:674 builtin/rm.c:334
+#: archive.c:426 builtin/add.c:215 builtin/add.c:671 builtin/rm.c:334
 #, c-format
 msgid "pathspec '%s' did not match any files"
 msgstr "đặc tả đường dẫn “%s” không khớp với bất kỳ tập tin nào"
@@ -1636,7 +1641,7 @@ msgstr "định_dạng"
 msgid "archive format"
 msgstr "định dạng lưu trữ"
 
-#: archive.c:552 builtin/log.c:1775
+#: archive.c:552 builtin/log.c:1790
 msgid "prefix"
 msgstr "tiền_tố"
 
@@ -1646,9 +1651,9 @@ msgstr "nối thêm tiền tố vào từng đường dẫn tập tin trong kho 
 
 #: archive.c:554 archive.c:557 builtin/blame.c:880 builtin/blame.c:884
 #: builtin/blame.c:885 builtin/commit-tree.c:115 builtin/config.c:135
-#: builtin/fast-export.c:1208 builtin/fast-export.c:1210
-#: builtin/fast-export.c:1214 builtin/grep.c:935 builtin/hash-object.c:103
-#: builtin/ls-files.c:651 builtin/ls-files.c:654 builtin/notes.c:410
+#: builtin/fast-export.c:1181 builtin/fast-export.c:1183
+#: builtin/fast-export.c:1187 builtin/grep.c:935 builtin/hash-object.c:103
+#: builtin/ls-files.c:654 builtin/ls-files.c:657 builtin/notes.c:410
 #: builtin/notes.c:576 builtin/read-tree.c:115 parse-options.h:190
 msgid "file"
 msgstr "tập_tin"
@@ -1678,7 +1683,7 @@ msgid "list supported archive formats"
 msgstr "liệt kê các kiểu nén được hỗ trợ"
 
 #: archive.c:568 builtin/archive.c:89 builtin/clone.c:118 builtin/clone.c:121
-#: builtin/submodule--helper.c:1869 builtin/submodule--helper.c:2512
+#: builtin/submodule--helper.c:1870 builtin/submodule--helper.c:2513
 msgid "repo"
 msgstr "kho"
 
@@ -1686,7 +1691,7 @@ msgstr "kho"
 msgid "retrieve the archive from remote repository <repo>"
 msgstr "nhận kho nén từ kho chứa <kho> trên máy chủ"
 
-#: archive.c:570 builtin/archive.c:91 builtin/difftool.c:714
+#: archive.c:570 builtin/archive.c:91 builtin/difftool.c:708
 #: builtin/notes.c:496
 msgid "command"
 msgstr "lệnh"
@@ -1699,17 +1704,19 @@ msgstr "đường dẫn đến lệnh git-upload-archive trên máy chủ"
 msgid "Unexpected option --remote"
 msgstr "Gặp tùy chọn không cần --remote"
 
-#: archive.c:580
-msgid "Option --exec can only be used together with --remote"
-msgstr "Tùy chọn --exec chỉ có thể được dùng cùng với --remote"
+#: archive.c:580 fetch-pack.c:300 revision.c:2887 builtin/add.c:544
+#: builtin/add.c:576 builtin/checkout.c:1763 builtin/commit.c:370
+#: builtin/fast-export.c:1230 builtin/index-pack.c:1848 builtin/log.c:2115
+#: builtin/reset.c:435 builtin/reset.c:493 builtin/rm.c:281
+#: builtin/stash.c:1719 builtin/worktree.c:508 http-fetch.c:144
+#: http-fetch.c:153
+#, c-format
+msgid "the option '%s' requires '%s'"
+msgstr "tùy chọn “%s” yêu cầu “%s”"
 
 #: archive.c:582
 msgid "Unexpected option --output"
 msgstr "Gặp tùy chọn không cần --output"
-
-#: archive.c:584
-msgid "Options --add-file and --remote cannot be used together"
-msgstr "Các tùy chọn --add-file và --remote không thể sử dụng cùng với nhau"
 
 #: archive.c:606
 #, c-format
@@ -1819,7 +1826,7 @@ msgstr "cần một điểm xét duyệt %s"
 msgid "could not create file '%s'"
 msgstr "không thể tạo tập tin “%s”"
 
-#: bisect.c:985 builtin/merge.c:154
+#: bisect.c:985 builtin/merge.c:155
 #, c-format
 msgid "could not read file '%s'"
 msgstr "không thể đọc tập tin “%s”"
@@ -1870,10 +1877,10 @@ msgid "--reverse and --first-parent together require specified latest commit"
 msgstr ""
 "cùng sử dụng --reverse và --first-parent cần chỉ định lần chuyển giao cuối"
 
-#: blame.c:2820 bundle.c:224 midx.c:1039 ref-filter.c:2370 remote.c:2041
-#: sequencer.c:2350 sequencer.c:4902 submodule.c:883 builtin/commit.c:1114
-#: builtin/log.c:414 builtin/log.c:1021 builtin/log.c:1629 builtin/log.c:2056
-#: builtin/log.c:2346 builtin/merge.c:429 builtin/pack-objects.c:3373
+#: blame.c:2820 bundle.c:224 midx.c:1042 ref-filter.c:2370 remote.c:2158
+#: sequencer.c:2352 sequencer.c:4899 submodule.c:883 builtin/commit.c:1114
+#: builtin/log.c:429 builtin/log.c:1036 builtin/log.c:1644 builtin/log.c:2071
+#: builtin/log.c:2362 builtin/merge.c:431 builtin/pack-objects.c:3373
 #: builtin/pack-objects.c:3775 builtin/pack-objects.c:3790
 #: builtin/shortlog.c:255
 msgid "revision walk setup failed"
@@ -1896,103 +1903,94 @@ msgstr "không có đường dẫn %s trong “%s”"
 msgid "cannot read blob %s for path %s"
 msgstr "không thể đọc blob %s cho đường dẫn “%s”"
 
-#: branch.c:53
+#: branch.c:77
+msgid ""
+"cannot inherit upstream tracking configuration of multiple refs when "
+"rebasing is requested"
+msgstr ""
+"không thể kế thừa cấu hình theo dõi thượng nguồn của nhiều tham chiếu khi mà "
+"lệnh cải tổ được yêu cầu"
+
+#: branch.c:88
 #, c-format
+msgid "not setting branch '%s' as its own upstream"
+msgstr "không cài đặt nhánh '%s' như là thượng nguồn của nó"
+
+#: branch.c:144
+#, c-format
+msgid "branch '%s' set up to track '%s' by rebasing."
+msgstr "nhánh “%s” cài đặt để theo dõi “%s” bằng cách rebase."
+
+#: branch.c:145
+#, c-format
+msgid "branch '%s' set up to track '%s'."
+msgstr "nhánh “%s” cài đặt để theo dõi “%s”."
+
+#: branch.c:148
+#, c-format
+msgid "branch '%s' set up to track:"
+msgstr "nhánh “%s” cài đặt để theo dõi:"
+
+#: branch.c:160
+msgid "unable to write upstream branch configuration"
+msgstr "không thể ghi cấu hình nhánh thượng nguồn"
+
+#: branch.c:162
 msgid ""
 "\n"
 "After fixing the error cause you may try to fix up\n"
-"the remote tracking information by invoking\n"
-"\"git branch --set-upstream-to=%s%s%s\"."
+"the remote tracking information by invoking:"
 msgstr ""
 "\n"
-"Sau khi sửa nguyên nhân lỗi bạn có lẻ cần thử sửa\n"
-"thông tin theo dõi máy chủ bằng cách gọi lệnh\n"
-"\"git branch --set-upstream-to=%s%s%s\"."
+"Sau khi sửa nguyên nhân gây lỗi bạn có lẻ cần thử sửa\n"
+"thông tin theo dõi máy chủ bằng cách gọi lệnh:"
 
-#: branch.c:67
+#: branch.c:203
 #, c-format
-msgid "Not setting branch %s as its own upstream."
-msgstr "Chưa cài đặt nhánh %s như là thượng nguồn của nó."
-
-#: branch.c:93
-#, c-format
-msgid "Branch '%s' set up to track remote branch '%s' from '%s' by rebasing."
+msgid "asked to inherit tracking from '%s', but no remote is set"
 msgstr ""
-"Nhánh “%s” cài đặt để theo dõi nhánh máy chủ “%s” từ “%s” bằng cách rebase."
+"đã hỏi để kế thừa theo dõi từ '%s', nhưng không có máy chủ nào được đặt"
 
-#: branch.c:94
+#: branch.c:209
 #, c-format
-msgid "Branch '%s' set up to track remote branch '%s' from '%s'."
-msgstr "Nhánh “%s” cài đặt để theo dõi nhánh máy chủ “%s” từ “%s”."
-
-#: branch.c:98
-#, c-format
-msgid "Branch '%s' set up to track local branch '%s' by rebasing."
-msgstr "Nhánh “%s” cài đặt để theo dõi nhánh nội bộ “%s” bằng cách rebase."
-
-#: branch.c:99
-#, c-format
-msgid "Branch '%s' set up to track local branch '%s'."
-msgstr "Nhánh “%s” cài đặt để theo dõi nhánh nội bộ “%s”."
-
-#: branch.c:104
-#, c-format
-msgid "Branch '%s' set up to track remote ref '%s' by rebasing."
+msgid "asked to inherit tracking from '%s', but no merge configuration is set"
 msgstr ""
-"Nhánh “%s” cài đặt để theo dõi tham chiếu máy chủ “%s” bằng cách rebase."
+"đã hỏi để kế thừa theo dõi từ '%s', nhưng không có cấu hình hòa trộn nào "
+"được đặt"
 
-#: branch.c:105
+#: branch.c:252
 #, c-format
-msgid "Branch '%s' set up to track remote ref '%s'."
-msgstr "Nhánh “%s” cài đặt để theo dõi tham chiếu máy chủ “%s”."
+msgid "not tracking: ambiguous information for ref %s"
+msgstr "không theo dõi: thông tin chưa rõ ràng cho tham chiếu %s"
 
-#: branch.c:109
+#: branch.c:287
 #, c-format
-msgid "Branch '%s' set up to track local ref '%s' by rebasing."
+msgid "'%s' is not a valid branch name"
+msgstr "“%s” không phải là một tên nhánh hợp lệ"
+
+#: branch.c:307
+#, c-format
+msgid "a branch named '%s' already exists"
+msgstr "đã có nhánh mang tên “%s”"
+
+#: branch.c:313
+#, c-format
+msgid "cannot force update the branch '%s' checked out at '%s'"
+msgstr "không thể ép buộc cập nhật nhánh “%s” đã được lấy ra tại “%s”"
+
+#: branch.c:336
+#, c-format
+msgid "cannot set up tracking information; starting point '%s' is not a branch"
 msgstr ""
-"Nhánh “%s” cài đặt để theo dõi tham chiếu nội bộ “%s” bằng cách rebase."
+"không thể cài đặt thông tin theo dõi; điểm bắt đầu “%s” không phải là một "
+"nhánh"
 
-#: branch.c:110
-#, c-format
-msgid "Branch '%s' set up to track local ref '%s'."
-msgstr "Nhánh “%s” cài đặt để theo dõi tham chiếu nội bộ “%s”."
-
-#: branch.c:119
-msgid "Unable to write upstream branch configuration"
-msgstr "Không thể ghi cấu hình nhánh thượng nguồn"
-
-#: branch.c:156
-#, c-format
-msgid "Not tracking: ambiguous information for ref %s"
-msgstr "Không theo dõi: thông tin chưa rõ ràng cho tham chiếu %s"
-
-#: branch.c:189
-#, c-format
-msgid "'%s' is not a valid branch name."
-msgstr "“%s” không phải là một tên nhánh hợp lệ."
-
-#: branch.c:208
-#, c-format
-msgid "A branch named '%s' already exists."
-msgstr "Đã có nhánh mang tên “%s”."
-
-#: branch.c:213
-msgid "Cannot force update the current branch."
-msgstr "Không thể ép buộc cập nhật nhánh hiện hành."
-
-#: branch.c:233
-#, c-format
-msgid "Cannot setup tracking information; starting point '%s' is not a branch."
-msgstr ""
-"Không thể cài đặt thông tin theo dõi; điểm bắt đầu “%s” không phải là một "
-"nhánh."
-
-#: branch.c:235
+#: branch.c:338
 #, c-format
 msgid "the requested upstream branch '%s' does not exist"
 msgstr "nhánh thượng nguồn đã yêu cầu “%s” không tồn tại"
 
-#: branch.c:237
+#: branch.c:340
 msgid ""
 "\n"
 "If you are planning on basing your work on an upstream\n"
@@ -2012,27 +2010,28 @@ msgstr ""
 "sẽ theo dõi bản đối chiếu máy chủ của nó, bạn cần dùng lệnh\n"
 "\"git push -u\" để đặt cấu hình thượng nguồn bạn muốn push."
 
-#: branch.c:281
+#: branch.c:384 builtin/replace.c:321 builtin/replace.c:377
+#: builtin/replace.c:423 builtin/replace.c:453
 #, c-format
-msgid "Not a valid object name: '%s'."
-msgstr "Không phải tên đối tượng hợp lệ: “%s”."
+msgid "not a valid object name: '%s'"
+msgstr "không phải là tên đối tượng hợp lệ: “%s”"
 
-#: branch.c:301
+#: branch.c:404
 #, c-format
-msgid "Ambiguous object name: '%s'."
-msgstr "Tên đối tượng chưa rõ ràng: “%s”."
+msgid "ambiguous object name: '%s'"
+msgstr "tên đối tượng chưa rõ ràng: “%s”."
 
-#: branch.c:306
+#: branch.c:409
 #, c-format
-msgid "Not a valid branch point: '%s'."
-msgstr "Nhánh không hợp lệ: “%s”."
+msgid "not a valid branch point: '%s'"
+msgstr "không phải là một điểm nhánh hợp lệ: “%s”"
 
-#: branch.c:366
+#: branch.c:469
 #, c-format
 msgid "'%s' is already checked out at '%s'"
 msgstr "“%s” đã được lấy ra tại “%s” rồi"
 
-#: branch.c:389
+#: branch.c:494
 #, c-format
 msgid "HEAD of working tree %s is not updated"
 msgstr "HEAD của cây làm việc %s chưa được cập nhật"
@@ -2057,7 +2056,7 @@ msgstr "“%s” không giống như tập tin v2 hay v3 bundle (định dạng 
 msgid "unrecognized header: %s%s (%d)"
 msgstr "phần đầu không được thừa nhận: %s%s (%d)"
 
-#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2618 sequencer.c:3404
+#: bundle.c:140 rerere.c:464 rerere.c:674 sequencer.c:2620 sequencer.c:3406
 #: builtin/commit.c:862
 #, c-format
 msgid "could not open '%s'"
@@ -2114,7 +2113,7 @@ msgstr "phiên bản bundle %d không được hỗ trợ"
 msgid "cannot write bundle version %d with algorithm %s"
 msgstr "không thể ghi phiên bản bundle %d với thuật toán %s"
 
-#: bundle.c:524 builtin/log.c:210 builtin/log.c:1938 builtin/shortlog.c:399
+#: bundle.c:524 builtin/log.c:210 builtin/log.c:1953 builtin/shortlog.c:399
 #, c-format
 msgid "unrecognized argument: %s"
 msgstr "đối số không được thừa nhận: %s"
@@ -2151,7 +2150,7 @@ msgstr "tìm thấy ID của mảnh bị trùng lặp %<PRIx32>"
 msgid "final chunk has non-zero id %<PRIx32>"
 msgstr "mảnh cuối cùng có id không bằng không %<PRIx32>"
 
-#: color.c:329
+#: color.c:354
 #, c-format
 msgid "invalid color value: %.*s"
 msgstr "giá trị màu không hợp lệ: %.*s"
@@ -2203,202 +2202,202 @@ msgstr ""
 msgid "unable to find all commit-graph files"
 msgstr "không thể tìm thấy tất cả các tập tin đồ-thị-các-lần-chuyển-giao"
 
-#: commit-graph.c:746 commit-graph.c:783
+#: commit-graph.c:749 commit-graph.c:786
 msgid "invalid commit position. commit-graph is likely corrupt"
 msgstr ""
 "vị trí lần chuyển giao không hợp lệ. đồ-thị-các-lần-chuyển-giao có vẻ như đã "
 "bị hỏng"
 
-#: commit-graph.c:767
+#: commit-graph.c:770
 #, c-format
 msgid "could not find commit %s"
 msgstr "không thể tìm thấy lần chuyển giao %s"
 
-#: commit-graph.c:800
+#: commit-graph.c:803
 msgid "commit-graph requires overflow generation data but has none"
 msgstr "commit-graph yêu cầu dữ liệu tạo tràn nhưng không có"
 
-#: commit-graph.c:1105 builtin/am.c:1342
+#: commit-graph.c:1108 builtin/am.c:1369
 #, c-format
 msgid "unable to parse commit %s"
 msgstr "không thể phân tích lần chuyển giao “%s”"
 
-#: commit-graph.c:1367 builtin/pack-objects.c:3070
+#: commit-graph.c:1370 builtin/pack-objects.c:3070
 #, c-format
 msgid "unable to get type of object %s"
 msgstr "không thể lấy kiểu của đối tượng “%s”"
 
-#: commit-graph.c:1398
+#: commit-graph.c:1401
 msgid "Loading known commits in commit graph"
 msgstr "Đang tải các lần chuyển giao chưa biết trong đồ thị lần chuyển giao"
 
-#: commit-graph.c:1415
+#: commit-graph.c:1418
 msgid "Expanding reachable commits in commit graph"
 msgstr ""
 "Mở rộng các lần chuyển giao có thể tiếp cận được trong trong đồ thị lần "
 "chuyển giao"
 
-#: commit-graph.c:1435
+#: commit-graph.c:1438
 msgid "Clearing commit marks in commit graph"
 msgstr "Đang dọn dẹp các đánh dấu lần chuyển giao trong đồ thị lần chuyển giao"
 
-#: commit-graph.c:1454
+#: commit-graph.c:1457
 msgid "Computing commit graph topological levels"
 msgstr "Đang tính mức hình học tô-pô tạo đồ thị các lần chuyển giao"
 
-#: commit-graph.c:1507
+#: commit-graph.c:1510
 msgid "Computing commit graph generation numbers"
 msgstr "Đang tính toán số tạo đồ thị các lần chuyển giao"
 
-#: commit-graph.c:1588
+#: commit-graph.c:1591
 msgid "Computing commit changed paths Bloom filters"
 msgstr "Đang tính toán chuyển giao các bộ lọc Bloom đường dẫn bị thay đổi"
 
-#: commit-graph.c:1665
+#: commit-graph.c:1668
 msgid "Collecting referenced commits"
 msgstr "Đang sưu tập các lần chuyển giao được tham chiếu"
 
-#: commit-graph.c:1690
+#: commit-graph.c:1693
 #, c-format
 msgid "Finding commits for commit graph in %d pack"
 msgid_plural "Finding commits for commit graph in %d packs"
 msgstr[0] ""
 "Đang tìm các lần chuyển giao cho đồ thị lần chuyển giao trong %d gói"
 
-#: commit-graph.c:1703
+#: commit-graph.c:1706
 #, c-format
 msgid "error adding pack %s"
 msgstr "gặp lỗi thêm gói %s"
 
-#: commit-graph.c:1707
+#: commit-graph.c:1710
 #, c-format
 msgid "error opening index for %s"
 msgstr "gặp lỗi khi mở mục lục cho “%s”"
 
-#: commit-graph.c:1744
+#: commit-graph.c:1747
 msgid "Finding commits for commit graph among packed objects"
 msgstr ""
 "Đang tìm các lần chuyển giao cho đồ thị lần chuyển giao trong số các đối "
 "tượng đã đóng gói"
 
-#: commit-graph.c:1762
+#: commit-graph.c:1765
 msgid "Finding extra edges in commit graph"
 msgstr "Đang tìm các cạnh mở tộng trong đồ thị lần chuyển giao"
 
-#: commit-graph.c:1811
+#: commit-graph.c:1814
 msgid "failed to write correct number of base graph ids"
 msgstr "gặp lỗi khi ghi số đúng của mã đồ họa cơ sở"
 
-#: commit-graph.c:1842 midx.c:1146
+#: commit-graph.c:1845 midx.c:1149
 #, c-format
 msgid "unable to create leading directories of %s"
 msgstr "không thể tạo các thư mục dẫn đầu của “%s”"
 
-#: commit-graph.c:1855
+#: commit-graph.c:1858
 msgid "unable to create temporary graph layer"
 msgstr "không thể tạo lớp sơ đồ tạm thời"
 
-#: commit-graph.c:1860
+#: commit-graph.c:1863
 #, c-format
 msgid "unable to adjust shared permissions for '%s'"
 msgstr "không thể chỉnh sửa quyền chia sẻ thành “%s”"
 
-#: commit-graph.c:1917
+#: commit-graph.c:1920
 #, c-format
 msgid "Writing out commit graph in %d pass"
 msgid_plural "Writing out commit graph in %d passes"
 msgstr[0] "Đang ghi ra đồ thị các lần chuyển giao trong lần %d"
 
-#: commit-graph.c:1953
+#: commit-graph.c:1956
 msgid "unable to open commit-graph chain file"
 msgstr "không thể mở tập tin mắt xích đồ thị chuyển giao"
 
-#: commit-graph.c:1969
+#: commit-graph.c:1972
 msgid "failed to rename base commit-graph file"
 msgstr "gặp lỗi khi đổi tên tập tin đồ-thị-các-lần-chuyển-giao"
 
-#: commit-graph.c:1989
+#: commit-graph.c:1992
 msgid "failed to rename temporary commit-graph file"
 msgstr "gặp lỗi khi đổi tên tập tin đồ-thị-các-lần-chuyển-giao tạm thời"
 
-#: commit-graph.c:2122
+#: commit-graph.c:2125
 msgid "Scanning merged commits"
 msgstr "Đang quét các lần chuyển giao đã hòa trộn"
 
-#: commit-graph.c:2166
+#: commit-graph.c:2169
 msgid "Merging commit-graph"
 msgstr "Đang hòa trộn đồ-thị-các-lần-chuyển-giao"
 
-#: commit-graph.c:2274
+#: commit-graph.c:2277
 msgid "attempting to write a commit-graph, but 'core.commitGraph' is disabled"
 msgstr ""
 "cố gắng để ghi một đồ thị các lần chuyển giao, nhưng “core.commitGraph” bị "
 "vô hiệu hóa"
 
-#: commit-graph.c:2381
+#: commit-graph.c:2384
 msgid "too many commits to write graph"
 msgstr "có quá nhiều lần chuyển giao để ghi đồ thị"
 
-#: commit-graph.c:2479
+#: commit-graph.c:2482
 msgid "the commit-graph file has incorrect checksum and is likely corrupt"
 msgstr ""
 "tập tin đồ-thị-các-lần-chuyển-giao có tổng kiểm không đúng và có vẻ như là "
 "đã hỏng"
 
-#: commit-graph.c:2489
+#: commit-graph.c:2492
 #, c-format
 msgid "commit-graph has incorrect OID order: %s then %s"
 msgstr "đồ-thị-các-lần-chuyển-giao có thứ tự OID không đúng: %s sau %s"
 
-#: commit-graph.c:2499 commit-graph.c:2514
+#: commit-graph.c:2502 commit-graph.c:2517
 #, c-format
 msgid "commit-graph has incorrect fanout value: fanout[%d] = %u != %u"
 msgstr ""
 "đồ-thị-các-lần-chuyển-giao có giá trị fanout không đúng: fanout[%d] = %u != "
 "%u"
 
-#: commit-graph.c:2506
+#: commit-graph.c:2509
 #, c-format
 msgid "failed to parse commit %s from commit-graph"
 msgstr "gặp lỗi khi phân tích lần chuyển giao từ %s đồ-thị-các-lần-chuyển-giao"
 
-#: commit-graph.c:2524
+#: commit-graph.c:2527
 msgid "Verifying commits in commit graph"
 msgstr "Đang thẩm tra các lần chuyển giao trong đồ thị lần chuyển giao"
 
-#: commit-graph.c:2539
+#: commit-graph.c:2542
 #, c-format
 msgid "failed to parse commit %s from object database for commit-graph"
 msgstr ""
 "gặp lỗi khi phân tích lần chuyển giao %s từ cơ sở dữ liệu đối tượng cho đồ "
 "thị lần chuyển giao"
 
-#: commit-graph.c:2546
+#: commit-graph.c:2549
 #, c-format
 msgid "root tree OID for commit %s in commit-graph is %s != %s"
 msgstr ""
 "OID cây gốc cho lần chuyển giao %s trong đồ-thị-các-lần-chuyển-giao là %s != "
 "%s"
 
-#: commit-graph.c:2556
+#: commit-graph.c:2559
 #, c-format
 msgid "commit-graph parent list for commit %s is too long"
 msgstr ""
 "danh sách cha mẹ đồ-thị-các-lần-chuyển-giao cho lần chuyển giao %s là quá dài"
 
-#: commit-graph.c:2565
+#: commit-graph.c:2568
 #, c-format
 msgid "commit-graph parent for %s is %s != %s"
 msgstr "cha mẹ đồ-thị-các-lần-chuyển-giao cho %s là %s != %s"
 
-#: commit-graph.c:2579
+#: commit-graph.c:2582
 #, c-format
 msgid "commit-graph parent list for commit %s terminates early"
 msgstr ""
 "danh sách cha mẹ đồ-thị-các-lần-chuyển-giao cho lần chuyển giao %s bị chấm "
 "dứt quá sớm"
 
-#: commit-graph.c:2584
+#: commit-graph.c:2587
 #, c-format
 msgid ""
 "commit-graph has generation number zero for commit %s, but non-zero elsewhere"
@@ -2406,7 +2405,7 @@ msgstr ""
 "đồ-thị-các-lần-chuyển-giao có con số không lần tạo cho lần chuyển giao %s, "
 "nhưng không phải số không ở chỗ khác"
 
-#: commit-graph.c:2588
+#: commit-graph.c:2591
 #, c-format
 msgid ""
 "commit-graph has non-zero generation number for commit %s, but zero elsewhere"
@@ -2414,22 +2413,22 @@ msgstr ""
 "đồ-thị-các-lần-chuyển-giao có con số không phải không lần tạo cho lần chuyển "
 "giao %s, nhưng số không ở chỗ khác"
 
-#: commit-graph.c:2605
+#: commit-graph.c:2608
 #, c-format
 msgid "commit-graph generation for commit %s is %<PRIuMAX> < %<PRIuMAX>"
 msgstr ""
 "tạo đồ-thị-các-lần-chuyển-giao cho lần chuyển giao %s là %<PRIuMAX> < "
 "%<PRIuMAX>"
 
-#: commit-graph.c:2611
+#: commit-graph.c:2614
 #, c-format
 msgid "commit date for commit %s in commit-graph is %<PRIuMAX> != %<PRIuMAX>"
 msgstr ""
 "ngày chuyển giao cho lần chuyển giao %s trong đồ-thị-các-lần-chuyển-giao là "
 "%<PRIuMAX> != %<PRIuMAX>"
 
-#: commit.c:53 sequencer.c:3107 builtin/am.c:373 builtin/am.c:418
-#: builtin/am.c:423 builtin/am.c:1421 builtin/am.c:2068 builtin/replace.c:457
+#: commit.c:53 sequencer.c:3109 builtin/am.c:399 builtin/am.c:444
+#: builtin/am.c:449 builtin/am.c:1448 builtin/am.c:2123 builtin/replace.c:456
 #, c-format
 msgid "could not parse %s"
 msgstr "không thể phân tích cú pháp %s"
@@ -2459,28 +2458,28 @@ msgstr ""
 "Tắt lời nhắn này bằng cách chạy\n"
 "\"git config advice.graftFileDeprecated false\""
 
-#: commit.c:1239
+#: commit.c:1241
 #, c-format
 msgid "Commit %s has an untrusted GPG signature, allegedly by %s."
 msgstr ""
 "Lần chuyển giao %s có một chữ ký GPG không đáng tin, được cho là bởi %s."
 
-#: commit.c:1243
+#: commit.c:1245
 #, c-format
 msgid "Commit %s has a bad GPG signature allegedly by %s."
 msgstr "Lần chuyển giao %s có một chữ ký GPG sai, được cho là bởi %s."
 
-#: commit.c:1246
+#: commit.c:1248
 #, c-format
 msgid "Commit %s does not have a GPG signature."
 msgstr "Lần chuyển giao %s không có chữ ký GPG."
 
-#: commit.c:1249
+#: commit.c:1251
 #, c-format
 msgid "Commit %s has a good GPG signature by %s\n"
 msgstr "Lần chuyển giao %s có một chữ ký GPG tốt bởi %s\n"
 
-#: commit.c:1503
+#: commit.c:1505
 msgid ""
 "Warning: commit message did not conform to UTF-8.\n"
 "You may want to amend it after fixing the message, or set the config\n"
@@ -2547,7 +2546,7 @@ msgstr "khóa không chứa một phần: %s"
 msgid "key does not contain variable name: %s"
 msgstr "khóa không chứa bất kỳ một tên biến nào: %s"
 
-#: config.c:470 sequencer.c:2804
+#: config.c:470 sequencer.c:2806
 #, c-format
 msgid "invalid key: %s"
 msgstr "khóa không đúng: %s"
@@ -2700,144 +2699,144 @@ msgstr "core.commentChar chỉ được có một ký tự"
 msgid "invalid mode for object creation: %s"
 msgstr "chế độ không hợp lệ đối với việc tạo đối tượng: %s"
 
-#: config.c:1581
+#: config.c:1584
 #, c-format
 msgid "malformed value for %s"
 msgstr "giá trị cho %s sai dạng"
 
-#: config.c:1607
+#: config.c:1610
 #, c-format
 msgid "malformed value for %s: %s"
 msgstr "giá trị cho %s sai dạng: %s"
 
-#: config.c:1608
+#: config.c:1611
 msgid "must be one of nothing, matching, simple, upstream or current"
 msgstr "phải là một trong số nothing, matching, simple, upstream hay current"
 
-#: config.c:1669 builtin/pack-objects.c:4053
+#: config.c:1672 builtin/pack-objects.c:4053
 #, c-format
 msgid "bad pack compression level %d"
 msgstr "mức nén gói %d không hợp lệ"
 
-#: config.c:1792
+#: config.c:1795
 #, c-format
 msgid "unable to load config blob object '%s'"
 msgstr "không thể tải đối tượng blob cấu hình “%s”"
 
-#: config.c:1795
+#: config.c:1798
 #, c-format
 msgid "reference '%s' does not point to a blob"
 msgstr "tham chiếu “%s” không chỉ đến một blob nào cả"
 
-#: config.c:1813
+#: config.c:1816
 #, c-format
 msgid "unable to resolve config blob '%s'"
 msgstr "không thể phân giải điểm xét duyệt “%s”"
 
-#: config.c:1858
+#: config.c:1861
 #, c-format
 msgid "failed to parse %s"
 msgstr "gặp lỗi khi phân tích cú pháp %s"
 
-#: config.c:1914
+#: config.c:1917
 msgid "unable to parse command-line config"
 msgstr "không thể phân tích cấu hình dòng lệnh"
 
-#: config.c:2282
+#: config.c:2285
 msgid "unknown error occurred while reading the configuration files"
 msgstr "đã có lỗi chưa biết xảy ra trong khi đọc các tập tin cấu hình"
 
-#: config.c:2456
+#: config.c:2459
 #, c-format
 msgid "Invalid %s: '%s'"
 msgstr "%s không hợp lệ: “%s”"
 
-#: config.c:2501
+#: config.c:2504
 #, c-format
 msgid "splitIndex.maxPercentChange value '%d' should be between 0 and 100"
 msgstr "giá trị splitIndex.maxPercentChange “%d” phải nằm giữa 0 và 100"
 
-#: config.c:2547
+#: config.c:2550
 #, c-format
 msgid "unable to parse '%s' from command-line config"
 msgstr "không thể phân tích “%s” từ cấu hình dòng lệnh"
 
-#: config.c:2549
+#: config.c:2552
 #, c-format
 msgid "bad config variable '%s' in file '%s' at line %d"
 msgstr "sai biến cấu hình “%s” trong tập tin “%s” tại dòng %d"
 
-#: config.c:2633
+#: config.c:2637
 #, c-format
 msgid "invalid section name '%s'"
 msgstr "tên của phần không hợp lệ “%s”"
 
-#: config.c:2665
+#: config.c:2669
 #, c-format
 msgid "%s has multiple values"
 msgstr "%s có đa giá trị"
 
-#: config.c:2694
+#: config.c:2698
 #, c-format
 msgid "failed to write new configuration file %s"
 msgstr "gặp lỗi khi ghi tập tin cấu hình “%s”"
 
-#: config.c:2946 config.c:3273
+#: config.c:2950 config.c:3277
 #, c-format
 msgid "could not lock config file %s"
 msgstr "không thể khóa tập tin cấu hình %s"
 
-#: config.c:2957
+#: config.c:2961
 #, c-format
 msgid "opening %s"
 msgstr "đang mở “%s”"
 
-#: config.c:2994 builtin/config.c:361
+#: config.c:2998 builtin/config.c:361
 #, c-format
 msgid "invalid pattern: %s"
 msgstr "mẫu không hợp lệ: %s"
 
-#: config.c:3019
+#: config.c:3023
 #, c-format
 msgid "invalid config file %s"
 msgstr "tập tin cấu hình “%s” không hợp lệ"
 
-#: config.c:3032 config.c:3286
+#: config.c:3036 config.c:3290
 #, c-format
 msgid "fstat on %s failed"
 msgstr "fstat trên %s gặp lỗi"
 
-#: config.c:3043
+#: config.c:3047
 #, c-format
 msgid "unable to mmap '%s'%s"
 msgstr "không thể mmap “%s”%s"
 
-#: config.c:3053 config.c:3291
+#: config.c:3057 config.c:3295
 #, c-format
 msgid "chmod on %s failed"
 msgstr "chmod trên %s gặp lỗi"
 
-#: config.c:3138 config.c:3388
+#: config.c:3142 config.c:3392
 #, c-format
 msgid "could not write config file %s"
 msgstr "không thể ghi tập tin cấu hình “%s”"
 
-#: config.c:3172
+#: config.c:3176
 #, c-format
 msgid "could not set '%s' to '%s'"
 msgstr "không thể đặt “%s” thành “%s”"
 
-#: config.c:3174 builtin/remote.c:662 builtin/remote.c:860 builtin/remote.c:868
+#: config.c:3178 builtin/remote.c:662 builtin/remote.c:860 builtin/remote.c:868
 #, c-format
 msgid "could not unset '%s'"
 msgstr "không thể thôi đặt “%s”"
 
-#: config.c:3264
+#: config.c:3268
 #, c-format
 msgid "invalid section name: %s"
 msgstr "tên của phần không hợp lệ: %s"
 
-#: config.c:3431
+#: config.c:3435
 #, c-format
 msgid "missing value for '%s'"
 msgstr "thiếu giá trị cho cho “%s”"
@@ -3014,7 +3013,7 @@ msgstr "đã khóa tên đường dẫn lạ “%s”"
 msgid "unable to fork"
 msgstr "không thể rẽ nhánh tiến trình con"
 
-#: connected.c:109 builtin/fsck.c:189 builtin/prune.c:45
+#: connected.c:109 builtin/fsck.c:189 builtin/prune.c:57
 msgid "Checking connectivity"
 msgstr "Đang kiểm tra kết nối"
 
@@ -3306,17 +3305,17 @@ msgstr ""
 "Không phải là một thư mục git. Dùng --no-index để so sánh hai đường dẫn bên "
 "ngoài một cây làm việc"
 
-#: diff.c:157
+#: diff.c:158
 #, c-format
 msgid "  Failed to parse dirstat cut-off percentage '%s'\n"
 msgstr "  Gặp lỗi khi phân tích dirstat cắt bỏ phần trăm “%s”\n"
 
-#: diff.c:162
+#: diff.c:163
 #, c-format
 msgid "  Unknown dirstat parameter '%s'\n"
 msgstr "  Không hiểu đối số dirstat “%s”\n"
 
-#: diff.c:298
+#: diff.c:299
 msgid ""
 "color moved setting must be one of 'no', 'default', 'blocks', 'zebra', "
 "'dimmed-zebra', 'plain'"
@@ -3324,7 +3323,7 @@ msgstr ""
 "cài đặt màu đã di chuyển phải là một trong “no”, “default”, “blocks”, "
 "“zebra”, “dimmed-zebra”, “plain”"
 
-#: diff.c:326
+#: diff.c:327
 #, c-format
 msgid ""
 "unknown color-moved-ws mode '%s', possible values are 'ignore-space-change', "
@@ -3334,7 +3333,7 @@ msgstr ""
 "change”, “ignore-space-at-eol”, “ignore-all-space”, “allow-indentation-"
 "change”"
 
-#: diff.c:334
+#: diff.c:335
 msgid ""
 "color-moved-ws: allow-indentation-change cannot be combined with other "
 "whitespace modes"
@@ -3342,12 +3341,12 @@ msgstr ""
 "color-moved-ws: allow-indentation-change không thể tổ hợp cùng với các chế "
 "độ khoảng trắng khác"
 
-#: diff.c:411
+#: diff.c:412
 #, c-format
 msgid "Unknown value for 'diff.submodule' config variable: '%s'"
 msgstr "Không hiểu giá trị cho biến cấu hình “diff.submodule”: “%s”"
 
-#: diff.c:471
+#: diff.c:472
 #, c-format
 msgid ""
 "Found errors in 'diff.dirstat' config variable:\n"
@@ -3356,49 +3355,49 @@ msgstr ""
 "Tìm thấy các lỗi trong biến cấu hình “diff.dirstat”:\n"
 "%s"
 
-#: diff.c:4290
+#: diff.c:4237
 #, c-format
 msgid "external diff died, stopping at %s"
 msgstr "phần mềm diff ở bên ngoài đã chết, dừng tại %s"
 
-#: diff.c:4642
-msgid "--name-only, --name-status, --check and -s are mutually exclusive"
-msgstr "--name-only, --name-status, --check và -s loại từ lẫn nhau"
+#: diff.c:4589
+#, c-format
+msgid "options '%s', '%s', '%s', and '%s' cannot be used together"
+msgstr "tùy chọn '%s', '%s', '%s' và '%s' không thể dùng cùng nhau"
 
-#: diff.c:4645
-msgid "-G, -S and --find-object are mutually exclusive"
-msgstr "Các tùy chọn -G, -S, và --find-object loại từ lẫn nhau"
+#: diff.c:4593 builtin/difftool.c:736 builtin/log.c:1982 builtin/worktree.c:506
+#, c-format
+msgid "options '%s', '%s', and '%s' cannot be used together"
+msgstr "tùy chọn '%s', '%s' và '%s' không thể dùng cùng nhau"
 
-#: diff.c:4648
+#: diff.c:4597
+#, c-format
+msgid "options '%s' and '%s' cannot be used together, use '%s' with '%s'"
+msgstr "tùy chọn '%s' và '%s' không thể dùng cùng nhau, dùng '%s' với '%s'"
+
+#: diff.c:4601
+#, c-format
 msgid ""
-"-G and --pickaxe-regex are mutually exclusive, use --pickaxe-regex with -S"
+"options '%s' and '%s' cannot be used together, use '%s' with '%s' and '%s'"
 msgstr ""
-"-G và --pickaxe-regex là loại trừ lẫn nhau, dùng --pickaxe-regex với -S"
+"tùy chọn '%s' và '%s' không thể dùng cùng nhau, dùng '%s' với '%s' và '%s'"
 
-#: diff.c:4651
-msgid ""
-"--pickaxe-all and --find-object are mutually exclusive, use --pickaxe-all "
-"with -G and -S"
-msgstr ""
-"tùy chọn --pickaxe-all và --find-object loại từ lẫn nhau, hãy dùng --pickaxe-"
-"all với -G và -S"
-
-#: diff.c:4730
+#: diff.c:4681
 msgid "--follow requires exactly one pathspec"
 msgstr "--follow cần chính xác một đặc tả đường dẫn"
 
-#: diff.c:4778
+#: diff.c:4729
 #, c-format
 msgid "invalid --stat value: %s"
 msgstr "giá trị --stat không hợp lệ: “%s”"
 
-#: diff.c:4783 diff.c:4788 diff.c:4793 diff.c:4798 diff.c:5326
+#: diff.c:4734 diff.c:4739 diff.c:4744 diff.c:4749 diff.c:5277
 #: parse-options.c:217 parse-options.c:221
 #, c-format
 msgid "%s expects a numerical value"
 msgstr "tùy chọn “%s” cần một giá trị bằng số"
 
-#: diff.c:4815
+#: diff.c:4766
 #, c-format
 msgid ""
 "Failed to parse --dirstat/-X option parameter:\n"
@@ -3407,42 +3406,42 @@ msgstr ""
 "Gặp lỗi khi phân tích đối số tùy chọn --dirstat/-X:\n"
 "%s"
 
-#: diff.c:4900
+#: diff.c:4851
 #, c-format
 msgid "unknown change class '%c' in --diff-filter=%s"
 msgstr "không hiểu lớp thay đổi “%c” trong --diff-filter=%s"
 
-#: diff.c:4924
+#: diff.c:4875
 #, c-format
 msgid "unknown value after ws-error-highlight=%.*s"
 msgstr "không hiểu giá trị sau ws-error-highlight=%.*s"
 
-#: diff.c:4938
+#: diff.c:4889
 #, c-format
 msgid "unable to resolve '%s'"
 msgstr "không thể phân giải “%s”"
 
-#: diff.c:4988 diff.c:4994
+#: diff.c:4939 diff.c:4945
 #, c-format
 msgid "%s expects <n>/<m> form"
 msgstr "%s cần dạng <n>/<m>"
 
-#: diff.c:5006
+#: diff.c:4957
 #, c-format
 msgid "%s expects a character, got '%s'"
 msgstr "%s cần một ký tự, nhưng lại nhận được “%s”"
 
-#: diff.c:5027
+#: diff.c:4978
 #, c-format
 msgid "bad --color-moved argument: %s"
 msgstr "đối số --color-moved sai: %s"
 
-#: diff.c:5046
+#: diff.c:4997
 #, c-format
 msgid "invalid mode '%s' in --color-moved-ws"
 msgstr "chế độ “%s” không hợp lệ trong --color-moved-ws"
 
-#: diff.c:5086
+#: diff.c:5037
 msgid ""
 "option diff-algorithm accepts \"myers\", \"minimal\", \"patience\" and "
 "\"histogram\""
@@ -3450,155 +3449,155 @@ msgstr ""
 "tùy chọn  diff-algorithm chấp nhận \"myers\", \"minimal\", \"patience\" và "
 "\"histogram\""
 
-#: diff.c:5122 diff.c:5142
+#: diff.c:5073 diff.c:5093
 #, c-format
 msgid "invalid argument to %s"
 msgstr "tham số cho %s không hợp lệ"
 
-#: diff.c:5246
+#: diff.c:5197
 #, c-format
 msgid "invalid regex given to -I: '%s'"
 msgstr "đưa cho -I biểu thức chính quy không hợp lệ: “%s”"
 
-#: diff.c:5295
+#: diff.c:5246
 #, c-format
 msgid "failed to parse --submodule option parameter: '%s'"
 msgstr "gặp lỗi khi phân tích đối số tùy chọn --submodule: “%s”"
 
-#: diff.c:5351
+#: diff.c:5302
 #, c-format
 msgid "bad --word-diff argument: %s"
 msgstr "đối số --word-diff sai: %s"
 
-#: diff.c:5387
+#: diff.c:5338
 msgid "Diff output format options"
 msgstr "Các tùy chọn định dạng khi xuất các khác biệt"
 
-#: diff.c:5389 diff.c:5395
+#: diff.c:5340 diff.c:5346
 msgid "generate patch"
 msgstr "tạo miếng vá"
 
-#: diff.c:5392 builtin/log.c:179
+#: diff.c:5343 builtin/log.c:179
 msgid "suppress diff output"
 msgstr "chặn mọi kết xuất từ diff"
 
-#: diff.c:5397 diff.c:5511 diff.c:5518
+#: diff.c:5348 diff.c:5462 diff.c:5469
 msgid "<n>"
 msgstr "<n>"
 
-#: diff.c:5398 diff.c:5401
+#: diff.c:5349 diff.c:5352
 msgid "generate diffs with <n> lines context"
 msgstr "tạo khác biệt với <n> dòng ngữ cảnh"
 
-#: diff.c:5403
+#: diff.c:5354
 msgid "generate the diff in raw format"
 msgstr "tạo khác biệt ở định dạng thô"
 
-#: diff.c:5406
+#: diff.c:5357
 msgid "synonym for '-p --raw'"
 msgstr "đồng nghĩa với “-p --raw”"
 
-#: diff.c:5410
+#: diff.c:5361
 msgid "synonym for '-p --stat'"
 msgstr "đồng nghĩa với “-p --stat”"
 
-#: diff.c:5414
+#: diff.c:5365
 msgid "machine friendly --stat"
 msgstr "--stat thuận tiện cho máy đọc"
 
-#: diff.c:5417
+#: diff.c:5368
 msgid "output only the last line of --stat"
 msgstr "chỉ xuất những dòng cuối của --stat"
 
-#: diff.c:5419 diff.c:5427
+#: diff.c:5370 diff.c:5378
 msgid "<param1,param2>..."
 msgstr "<tham_số_1,tham_số_2>…"
 
-#: diff.c:5420
+#: diff.c:5371
 msgid ""
 "output the distribution of relative amount of changes for each sub-directory"
 msgstr "đầu ra phân phối của số lượng thay đổi tương đối cho mỗi thư mục con"
 
-#: diff.c:5424
+#: diff.c:5375
 msgid "synonym for --dirstat=cumulative"
 msgstr "đồng nghĩa với --dirstat=cumulative"
 
-#: diff.c:5428
+#: diff.c:5379
 msgid "synonym for --dirstat=files,param1,param2..."
 msgstr "đồng nghĩa với --dirstat=files,param1,param2…"
 
-#: diff.c:5432
+#: diff.c:5383
 msgid "warn if changes introduce conflict markers or whitespace errors"
 msgstr ""
 "cảnh báo nếu các thay đổi đưa ra các bộ tạo xung đột hay lỗi khoảng trắng"
 
-#: diff.c:5435
+#: diff.c:5386
 msgid "condensed summary such as creations, renames and mode changes"
 msgstr "tổng hợp dạng xúc tích như là tạo, đổi tên và các thay đổi chế độ"
 
-#: diff.c:5438
+#: diff.c:5389
 msgid "show only names of changed files"
 msgstr "chỉ hiển thị tên của các tập tin đổi"
 
-#: diff.c:5441
+#: diff.c:5392
 msgid "show only names and status of changed files"
 msgstr "chỉ hiển thị tên tập tin và tình trạng của các tập tin bị thay đổi"
 
-#: diff.c:5443
+#: diff.c:5394
 msgid "<width>[,<name-width>[,<count>]]"
 msgstr "<rộng>[,<name-width>[,<số-lượng>]]"
 
-#: diff.c:5444
+#: diff.c:5395
 msgid "generate diffstat"
 msgstr "tạo diffstat"
 
-#: diff.c:5446 diff.c:5449 diff.c:5452
+#: diff.c:5397 diff.c:5400 diff.c:5403
 msgid "<width>"
 msgstr "<rộng>"
 
-#: diff.c:5447
+#: diff.c:5398
 msgid "generate diffstat with a given width"
 msgstr "tạo diffstat với độ rộng đã cho"
 
-#: diff.c:5450
+#: diff.c:5401
 msgid "generate diffstat with a given name width"
 msgstr "tạo diffstat với tên độ rộng đã cho"
 
-#: diff.c:5453
+#: diff.c:5404
 msgid "generate diffstat with a given graph width"
 msgstr "tạo diffstat với độ rộng đồ thị đã cho"
 
-#: diff.c:5455
+#: diff.c:5406
 msgid "<count>"
 msgstr "<số_lượng>"
 
-#: diff.c:5456
+#: diff.c:5407
 msgid "generate diffstat with limited lines"
 msgstr "tạo diffstat với các dòng bị giới hạn"
 
-#: diff.c:5459
+#: diff.c:5410
 msgid "generate compact summary in diffstat"
 msgstr "tạo tổng hợp xúc tích trong diffstat"
 
-#: diff.c:5462
+#: diff.c:5413
 msgid "output a binary diff that can be applied"
 msgstr "xuất ra một khác biệt dạng nhị phân cái mà có thể được áp dụng"
 
-#: diff.c:5465
+#: diff.c:5416
 msgid "show full pre- and post-image object names on the \"index\" lines"
 msgstr ""
 "hiển thị đầy đủ các tên đối tượng pre- và post-image trên các dòng \"mục lục"
 "\""
 
-#: diff.c:5467
+#: diff.c:5418
 msgid "show colored diff"
 msgstr "hiển thị thay đổi được tô màu"
 
-#: diff.c:5468
+#: diff.c:5419
 msgid "<kind>"
 msgstr "<kiểu>"
 
-#: diff.c:5469
+#: diff.c:5420
 msgid ""
 "highlight whitespace errors in the 'context', 'old' or 'new' lines in the "
 "diff"
@@ -3606,7 +3605,7 @@ msgstr ""
 "tô sáng các lỗi về khoảng trắng trong các dòng “context”, “old” và “new” "
 "trong khác biệt"
 
-#: diff.c:5472
+#: diff.c:5423
 msgid ""
 "do not munge pathnames and use NULs as output field terminators in --raw or "
 "--numstat"
@@ -3614,89 +3613,89 @@ msgstr ""
 "không munge tên đường dẫn và sử dụng NUL làm bộ phân tách trường đầu ra "
 "trong --raw hay --numstat"
 
-#: diff.c:5475 diff.c:5478 diff.c:5481 diff.c:5590
+#: diff.c:5426 diff.c:5429 diff.c:5432 diff.c:5541
 msgid "<prefix>"
 msgstr "<tiền_tố>"
 
-#: diff.c:5476
+#: diff.c:5427
 msgid "show the given source prefix instead of \"a/\""
 msgstr "hiển thị tiền tố nguồn đã cho thay cho \"a/\""
 
-#: diff.c:5479
+#: diff.c:5430
 msgid "show the given destination prefix instead of \"b/\""
 msgstr "hiển thị tiền tố đích đã cho thay cho \"b/\""
 
-#: diff.c:5482
+#: diff.c:5433
 msgid "prepend an additional prefix to every line of output"
 msgstr "treo vào trước một tiền tố bổ sung cho mỗi dòng kết xuất"
 
-#: diff.c:5485
+#: diff.c:5436
 msgid "do not show any source or destination prefix"
 msgstr "đừng hiển thị bất kỳ tiền tố nguồn hay đích"
 
-#: diff.c:5488
+#: diff.c:5439
 msgid "show context between diff hunks up to the specified number of lines"
 msgstr ""
 "hiển thị ngữ cảnh giữa các khúc khác biệt khi đạt đến số lượng dòng đã chỉ "
 "định"
 
-#: diff.c:5492 diff.c:5497 diff.c:5502
+#: diff.c:5443 diff.c:5448 diff.c:5453
 msgid "<char>"
 msgstr "<ký_tự>"
 
-#: diff.c:5493
+#: diff.c:5444
 msgid "specify the character to indicate a new line instead of '+'"
 msgstr "chỉ định một ký tự để biểu thị một dòng được thêm mới thay cho “+”"
 
-#: diff.c:5498
+#: diff.c:5449
 msgid "specify the character to indicate an old line instead of '-'"
 msgstr "chỉ định một ký tự để biểu thị một dòng đã cũ thay cho “-”"
 
-#: diff.c:5503
+#: diff.c:5454
 msgid "specify the character to indicate a context instead of ' '"
 msgstr "chỉ định một ký tự để biểu thị một ngữ cảnh thay cho “”"
 
-#: diff.c:5506
+#: diff.c:5457
 msgid "Diff rename options"
 msgstr "Tùy chọn khác biệt đổi tên"
 
-#: diff.c:5507
+#: diff.c:5458
 msgid "<n>[/<m>]"
 msgstr "<n>[/<m>]"
 
-#: diff.c:5508
+#: diff.c:5459
 msgid "break complete rewrite changes into pairs of delete and create"
 msgstr "ngắt các thay đổi ghi lại hoàn thiện thành cặp của xóa và tạo"
 
-#: diff.c:5512
+#: diff.c:5463
 msgid "detect renames"
 msgstr "dò tìm các tên thay đổi"
 
-#: diff.c:5516
+#: diff.c:5467
 msgid "omit the preimage for deletes"
 msgstr "bỏ qua preimage (tiền ảnh??) cho các việc xóa"
 
-#: diff.c:5519
+#: diff.c:5470
 msgid "detect copies"
 msgstr "dò bản sao"
 
-#: diff.c:5523
+#: diff.c:5474
 msgid "use unmodified files as source to find copies"
 msgstr "dùng các tập tin không bị chỉnh sửa như là nguồn để tìm các bản sao"
 
-#: diff.c:5525
+#: diff.c:5476
 msgid "disable rename detection"
 msgstr "tắt dò tìm đổi tên"
 
-#: diff.c:5528
+#: diff.c:5479
 msgid "use empty blobs as rename source"
 msgstr "dùng các blob trống rống như là nguồn đổi tên"
 
-#: diff.c:5530
+#: diff.c:5481
 msgid "continue listing the history of a file beyond renames"
 msgstr "tiếp tục liệt kê lịch sử của một tập tin ngoài đổi tên"
 
-#: diff.c:5533
+#: diff.c:5484
 msgid ""
 "prevent rename/copy detection if the number of rename/copy targets exceeds "
 "given limit"
@@ -3704,160 +3703,160 @@ msgstr ""
 "ngăn cản dò tìm đổi tên/bản sao nếu số lượng của đích đổi tên/bản sao vượt "
 "quá giới hạn đưa ra"
 
-#: diff.c:5535
+#: diff.c:5486
 msgid "Diff algorithm options"
 msgstr "Tùy chọn thuật toán khác biệt"
 
-#: diff.c:5537
+#: diff.c:5488
 msgid "produce the smallest possible diff"
 msgstr "sản sinh khác biệt ít nhất có thể"
 
-#: diff.c:5540
+#: diff.c:5491
 msgid "ignore whitespace when comparing lines"
 msgstr "lờ đi sự thay đổi do khoảng trắng gây ra khi so sánh các dòng"
 
-#: diff.c:5543
+#: diff.c:5494
 msgid "ignore changes in amount of whitespace"
 msgstr "lờ đi sự thay đổi do số lượng khoảng trắng gây ra"
 
-#: diff.c:5546
+#: diff.c:5497
 msgid "ignore changes in whitespace at EOL"
 msgstr "lờ đi sự thay đổi do khoảng trắng gây ra khi ở cuối dòng EOL"
 
-#: diff.c:5549
+#: diff.c:5500
 msgid "ignore carrier-return at the end of line"
 msgstr "bỏ qua ký tự về đầu dòng tại cuối dòng"
 
-#: diff.c:5552
+#: diff.c:5503
 msgid "ignore changes whose lines are all blank"
 msgstr "bỏ qua các thay đổi cho toàn bộ các dòng là trống"
 
-#: diff.c:5554 diff.c:5576 diff.c:5579 diff.c:5624
+#: diff.c:5505 diff.c:5527 diff.c:5530 diff.c:5575
 msgid "<regex>"
 msgstr "<regex>"
 
-#: diff.c:5555
+#: diff.c:5506
 msgid "ignore changes whose all lines match <regex>"
 msgstr "bỏ qua các thay đổi có tất cả các dòng khớp <regex>"
 
-#: diff.c:5558
+#: diff.c:5509
 msgid "heuristic to shift diff hunk boundaries for easy reading"
 msgstr "heuristic để dịch hạn biên của khối khác biệt cho dễ đọc"
 
-#: diff.c:5561
+#: diff.c:5512
 msgid "generate diff using the \"patience diff\" algorithm"
 msgstr "tạo khác biệt sử dung thuật toán \"patience diff\""
 
-#: diff.c:5565
+#: diff.c:5516
 msgid "generate diff using the \"histogram diff\" algorithm"
 msgstr "tạo khác biệt sử dung thuật toán \"histogram diff\""
 
-#: diff.c:5567
+#: diff.c:5518
 msgid "<algorithm>"
 msgstr "<thuật toán>"
 
-#: diff.c:5568
+#: diff.c:5519
 msgid "choose a diff algorithm"
 msgstr "chọn một thuật toán khác biệt"
 
-#: diff.c:5570
+#: diff.c:5521
 msgid "<text>"
 msgstr "<văn bản>"
 
-#: diff.c:5571
+#: diff.c:5522
 msgid "generate diff using the \"anchored diff\" algorithm"
 msgstr "tạo khác biệt sử dung thuật toán \"anchored diff\""
 
-#: diff.c:5573 diff.c:5582 diff.c:5585
+#: diff.c:5524 diff.c:5533 diff.c:5536
 msgid "<mode>"
 msgstr "<chế độ>"
 
-#: diff.c:5574
+#: diff.c:5525
 msgid "show word diff, using <mode> to delimit changed words"
 msgstr ""
 "hiển thị khác biệt từ, sử dụng <chế độ> để bỏ giới hạn các từ bị thay đổi"
 
-#: diff.c:5577
+#: diff.c:5528
 msgid "use <regex> to decide what a word is"
 msgstr "dùng <regex> để quyết định từ là cái gì"
 
-#: diff.c:5580
+#: diff.c:5531
 msgid "equivalent to --word-diff=color --word-diff-regex=<regex>"
 msgstr "tương đương với --word-diff=color --word-diff-regex=<regex>"
 
-#: diff.c:5583
+#: diff.c:5534
 msgid "moved lines of code are colored differently"
 msgstr "các dòng di chuyển của mã mà được tô màu khác nhau"
 
-#: diff.c:5586
+#: diff.c:5537
 msgid "how white spaces are ignored in --color-moved"
 msgstr "cách bỏ qua khoảng trắng trong --color-moved"
 
-#: diff.c:5589
+#: diff.c:5540
 msgid "Other diff options"
 msgstr "Các tùy chọn khác biệt khác"
 
-#: diff.c:5591
+#: diff.c:5542
 msgid "when run from subdir, exclude changes outside and show relative paths"
 msgstr ""
 "khi chạy từ thư mục con, thực thi các thay đổi bên ngoài và hiển thị các "
 "đường dẫn liên quan"
 
-#: diff.c:5595
+#: diff.c:5546
 msgid "treat all files as text"
 msgstr "coi mọi tập tin là dạng văn bản thường"
 
-#: diff.c:5597
+#: diff.c:5548
 msgid "swap two inputs, reverse the diff"
 msgstr "tráo đổi hai đầu vào, đảo ngược khác biệt"
 
-#: diff.c:5599
+#: diff.c:5550
 msgid "exit with 1 if there were differences, 0 otherwise"
 msgstr "thoát với mã 1 nếu không có khác biệt gì, 0 nếu ngược lại"
 
-#: diff.c:5601
+#: diff.c:5552
 msgid "disable all output of the program"
 msgstr "tắt mọi kết xuất của chương trình"
 
-#: diff.c:5603
+#: diff.c:5554
 msgid "allow an external diff helper to be executed"
 msgstr "cho phép mộ bộ hỗ trợ xuất khác biệt ở bên ngoài được phép thực thi"
 
-#: diff.c:5605
+#: diff.c:5556
 msgid "run external text conversion filters when comparing binary files"
 msgstr ""
 "chạy các bộ lọc văn bản thông thường bên ngoài khi so sánh các tập tin nhị "
 "phân"
 
-#: diff.c:5607
+#: diff.c:5558
 msgid "<when>"
 msgstr "<khi>"
 
-#: diff.c:5608
+#: diff.c:5559
 msgid "ignore changes to submodules in the diff generation"
 msgstr "bỏ qua các thay đổi trong mô-đun-con trong khi tạo khác biệt"
 
-#: diff.c:5611
+#: diff.c:5562
 msgid "<format>"
 msgstr "<định dạng>"
 
-#: diff.c:5612
+#: diff.c:5563
 msgid "specify how differences in submodules are shown"
 msgstr "chi định khác biệt bao nhiêu trong các mô đun con được hiển thị"
 
-#: diff.c:5616
+#: diff.c:5567
 msgid "hide 'git add -N' entries from the index"
 msgstr "ẩn các mục “git add -N” từ bảng mục lục"
 
-#: diff.c:5619
+#: diff.c:5570
 msgid "treat 'git add -N' entries as real in the index"
 msgstr "coi các mục “git add -N” như là có thật trong bảng mục lục"
 
-#: diff.c:5621
+#: diff.c:5572
 msgid "<string>"
 msgstr "<chuỗi>"
 
-#: diff.c:5622
+#: diff.c:5573
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "string"
@@ -3865,7 +3864,7 @@ msgstr ""
 "tìm các khác biệt cái mà thay đổi số lượng xảy ra của các phát sinh của "
 "chuỗi được chỉ ra"
 
-#: diff.c:5625
+#: diff.c:5576
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "regex"
@@ -3873,35 +3872,35 @@ msgstr ""
 "tìm các khác biệt cái mà thay đổi số lượng xảy ra của các phát sinh của biểu "
 "thức chính quy được chỉ ra"
 
-#: diff.c:5628
+#: diff.c:5579
 msgid "show all changes in the changeset with -S or -G"
 msgstr "hiển thị tất cả các thay đổi trong một bộ các thay đổi với -S hay -G"
 
-#: diff.c:5631
+#: diff.c:5582
 msgid "treat <string> in -S as extended POSIX regular expression"
 msgstr "coi <chuỗi> trong -S như là biểu thức chính qui POSIX có mở rộng"
 
-#: diff.c:5634
+#: diff.c:5585
 msgid "control the order in which files appear in the output"
 msgstr "điều khiển thứ tự xuát hiện các tập tin trong kết xuất"
 
-#: diff.c:5635 diff.c:5638
+#: diff.c:5586 diff.c:5589
 msgid "<path>"
 msgstr "<đường-dẫn>"
 
-#: diff.c:5636
+#: diff.c:5587
 msgid "show the change in the specified path first"
 msgstr "hiển thị các thay đổi trong đường dẫn đã cho đầu tiên"
 
-#: diff.c:5639
+#: diff.c:5590
 msgid "skip the output to the specified path"
 msgstr "bỏ qua đầu ra đến đường dẫn đã cho"
 
-#: diff.c:5641
+#: diff.c:5592
 msgid "<object-id>"
 msgstr "<mã-số-đối-tượng>"
 
-#: diff.c:5642
+#: diff.c:5593
 msgid ""
 "look for differences that change the number of occurrences of the specified "
 "object"
@@ -3909,32 +3908,32 @@ msgstr ""
 "tìm các khác biệt cái mà thay đổi số lượng xảy ra của các phát sinh của đối "
 "tượng được chỉ ra"
 
-#: diff.c:5644
+#: diff.c:5595
 msgid "[(A|C|D|M|R|T|U|X|B)...[*]]"
 msgstr "[(A|C|D|M|R|T|U|X|B)…[*]]"
 
-#: diff.c:5645
+#: diff.c:5596
 msgid "select files by diff type"
 msgstr "chọn các tập tin theo kiểu khác biệt"
 
-#: diff.c:5647
+#: diff.c:5598
 msgid "<file>"
 msgstr "<tập_tin>"
 
-#: diff.c:5648
+#: diff.c:5599
 msgid "Output to a specific file"
 msgstr "Xuất ra một tập tin cụ thể"
 
-#: diff.c:6306
+#: diff.c:6257
 msgid "exhaustive rename detection was skipped due to too many files."
 msgstr "nhận thấy đổi tên toàn diện đã bị bỏ qua bởi có quá nhiều tập tin."
 
-#: diff.c:6309
+#: diff.c:6260
 msgid "only found copies from modified paths due to too many files."
 msgstr ""
 "chỉ tìm thấy các bản sao từ đường dẫn đã sửa đổi bởi vì có quá nhiều tập tin."
 
-#: diff.c:6312
+#: diff.c:6263
 #, c-format
 msgid ""
 "you may want to set your %s variable to at least %d and retry the command."
@@ -3976,29 +3975,29 @@ msgstr "mẫu âm không được thừa nhận: “%s”"
 msgid "your sparse-checkout file may have issues: pattern '%s' is repeated"
 msgstr "tập tin sparse-checkout của bạn có lẽ gặp lỗi: mẫu “%s” đã bị lặp lại"
 
-#: dir.c:830
+#: dir.c:828
 msgid "disabling cone pattern matching"
 msgstr "vô hiệu khớp mẫu nón"
 
-#: dir.c:1214
+#: dir.c:1212
 #, c-format
 msgid "cannot use %s as an exclude file"
 msgstr "không thể dùng %s như là một tập tin loại trừ"
 
-#: dir.c:2464
+#: dir.c:2418
 #, c-format
 msgid "could not open directory '%s'"
 msgstr "không thể mở thư mục “%s”"
 
-#: dir.c:2766
+#: dir.c:2720
 msgid "failed to get kernel name and information"
 msgstr "gặp lỗi khi lấy tên và thông tin của nhân"
 
-#: dir.c:2890
+#: dir.c:2844
 msgid "untracked cache is disabled on this system or location"
 msgstr "bộ nhớ tạm không theo vết bị tắt trên hệ thống hay vị trí này"
 
-#: dir.c:3158
+#: dir.c:3112
 msgid ""
 "No directory name could be guessed.\n"
 "Please specify a directory on the command line"
@@ -4006,36 +4005,36 @@ msgstr ""
 "Không đoán được thư mục tên là gì.\n"
 "Vui lòng chỉ định tên một thư mục trên dòng lệnh"
 
-#: dir.c:3837
+#: dir.c:3800
 #, c-format
 msgid "index file corrupt in repo %s"
 msgstr "tập tin ghi bảng mục lục bị hỏng trong kho %s"
 
-#: dir.c:3884 dir.c:3889
+#: dir.c:3847 dir.c:3852
 #, c-format
 msgid "could not create directories for %s"
 msgstr "không thể tạo thư mục cho %s"
 
-#: dir.c:3918
+#: dir.c:3881
 #, c-format
 msgid "could not migrate git directory from '%s' to '%s'"
 msgstr "không thể di dời thư mục git từ “%s” sang “%s”"
 
-#: editor.c:77
+#: editor.c:74
 #, c-format
 msgid "hint: Waiting for your editor to close the file...%c"
 msgstr "gợi ý: Chờ trình biên soạn của bạn đóng tập tin…%c"
 
-#: entry.c:177
+#: entry.c:179
 msgid "Filtering content"
 msgstr "Nội dung lọc"
 
-#: entry.c:498
+#: entry.c:500
 #, c-format
 msgid "could not stat file '%s'"
 msgstr "không thể lấy thống kê tập tin “%s”"
 
-#: environment.c:143
+#: environment.c:145
 #, c-format
 msgid "bad git namespace path \"%s\""
 msgstr "đường dẫn không gian tên git \"%s\" sai"
@@ -4045,273 +4044,269 @@ msgstr "đường dẫn không gian tên git \"%s\" sai"
 msgid "too many args to run %s"
 msgstr "quá nhiều tham số để chạy %s"
 
-#: fetch-pack.c:193
+#: fetch-pack.c:194
 msgid "git fetch-pack: expected shallow list"
 msgstr "git fetch-pack: cần danh sách shallow"
 
-#: fetch-pack.c:196
+#: fetch-pack.c:197
 msgid "git fetch-pack: expected a flush packet after shallow list"
 msgstr "git fetch-pack: cần một gói đẩy sau danh sách shallow"
 
-#: fetch-pack.c:207
+#: fetch-pack.c:208
 msgid "git fetch-pack: expected ACK/NAK, got a flush packet"
 msgstr "git fetch-pack: cần ACK/NAK, nhưng lại nhận được một gói flush"
 
-#: fetch-pack.c:227
+#: fetch-pack.c:228
 #, c-format
 msgid "git fetch-pack: expected ACK/NAK, got '%s'"
 msgstr "git fetch-pack: cần ACK/NAK, nhưng lại nhận được “%s”"
 
-#: fetch-pack.c:238
+#: fetch-pack.c:239
 msgid "unable to write to remote"
 msgstr "không thể ghi lên máy phục vụ"
 
-#: fetch-pack.c:299
-msgid "--stateless-rpc requires multi_ack_detailed"
-msgstr "--stateless-rpc cần multi_ack_detailed"
-
-#: fetch-pack.c:394 fetch-pack.c:1434
+#: fetch-pack.c:395 fetch-pack.c:1439
 #, c-format
 msgid "invalid shallow line: %s"
 msgstr "dòng shallow không hợp lệ: %s"
 
-#: fetch-pack.c:400 fetch-pack.c:1440
+#: fetch-pack.c:401 fetch-pack.c:1445
 #, c-format
 msgid "invalid unshallow line: %s"
 msgstr "dòng unshallow không hợp lệ: %s"
 
-#: fetch-pack.c:402 fetch-pack.c:1442
+#: fetch-pack.c:403 fetch-pack.c:1447
 #, c-format
 msgid "object not found: %s"
 msgstr "không tìm thấy đối tượng: %s"
 
-#: fetch-pack.c:405 fetch-pack.c:1445
+#: fetch-pack.c:406 fetch-pack.c:1450
 #, c-format
 msgid "error in object: %s"
 msgstr "lỗi trong đối tượng: %s"
 
-#: fetch-pack.c:407 fetch-pack.c:1447
+#: fetch-pack.c:408 fetch-pack.c:1452
 #, c-format
 msgid "no shallow found: %s"
 msgstr "không tìm shallow nào: %s"
 
-#: fetch-pack.c:410 fetch-pack.c:1451
+#: fetch-pack.c:411 fetch-pack.c:1456
 #, c-format
 msgid "expected shallow/unshallow, got %s"
 msgstr "cần shallow/unshallow, nhưng lại nhận được %s"
 
-#: fetch-pack.c:450
+#: fetch-pack.c:451
 #, c-format
 msgid "got %s %d %s"
 msgstr "nhận %s %d - %s"
 
-#: fetch-pack.c:467
+#: fetch-pack.c:468
 #, c-format
 msgid "invalid commit %s"
 msgstr "lần chuyển giao %s không hợp lệ"
 
-#: fetch-pack.c:498
+#: fetch-pack.c:499
 msgid "giving up"
 msgstr "chịu thua"
 
-#: fetch-pack.c:511 progress.c:339
+#: fetch-pack.c:512 progress.c:339
 msgid "done"
 msgstr "xong"
 
-#: fetch-pack.c:523
+#: fetch-pack.c:524
 #, c-format
 msgid "got %s (%d) %s"
 msgstr "nhận %s (%d) %s"
 
-#: fetch-pack.c:559
+#: fetch-pack.c:560
 #, c-format
 msgid "Marking %s as complete"
 msgstr "Đánh dấu %s là đã hoàn thành"
 
-#: fetch-pack.c:774
+#: fetch-pack.c:775
 #, c-format
 msgid "already have %s (%s)"
 msgstr "đã sẵn có %s (%s)"
 
-#: fetch-pack.c:860
+#: fetch-pack.c:861
 msgid "fetch-pack: unable to fork off sideband demultiplexer"
 msgstr "fetch-pack: không thể rẽ nhánh sideband demultiplexer"
 
-#: fetch-pack.c:868
+#: fetch-pack.c:869
 msgid "protocol error: bad pack header"
 msgstr "lỗi giao thức: phần đầu gói bị sai"
 
-#: fetch-pack.c:962
+#: fetch-pack.c:965
 #, c-format
 msgid "fetch-pack: unable to fork off %s"
 msgstr "fetch-pack: không thể rẽ nhánh %s"
 
-#: fetch-pack.c:968
+#: fetch-pack.c:971
 msgid "fetch-pack: invalid index-pack output"
 msgstr "fetch-pack: kết xuất index-pack không hợp lệ"
 
-#: fetch-pack.c:985
+#: fetch-pack.c:988
 #, c-format
 msgid "%s failed"
 msgstr "%s gặp lỗi"
 
-#: fetch-pack.c:987
+#: fetch-pack.c:990
 msgid "error in sideband demultiplexer"
 msgstr "có lỗi trong sideband demultiplexer"
 
-#: fetch-pack.c:1030
+#: fetch-pack.c:1035
 #, c-format
 msgid "Server version is %.*s"
 msgstr "Phiên bản máy chủ là %.*s"
 
-#: fetch-pack.c:1038 fetch-pack.c:1044 fetch-pack.c:1047 fetch-pack.c:1053
-#: fetch-pack.c:1057 fetch-pack.c:1061 fetch-pack.c:1065 fetch-pack.c:1069
-#: fetch-pack.c:1073 fetch-pack.c:1077 fetch-pack.c:1081 fetch-pack.c:1085
-#: fetch-pack.c:1091 fetch-pack.c:1097 fetch-pack.c:1102 fetch-pack.c:1107
+#: fetch-pack.c:1043 fetch-pack.c:1049 fetch-pack.c:1052 fetch-pack.c:1058
+#: fetch-pack.c:1062 fetch-pack.c:1066 fetch-pack.c:1070 fetch-pack.c:1074
+#: fetch-pack.c:1078 fetch-pack.c:1082 fetch-pack.c:1086 fetch-pack.c:1090
+#: fetch-pack.c:1096 fetch-pack.c:1102 fetch-pack.c:1107 fetch-pack.c:1112
 #, c-format
 msgid "Server supports %s"
 msgstr "Máy chủ hỗ trợ %s"
 
-#: fetch-pack.c:1040
+#: fetch-pack.c:1045
 msgid "Server does not support shallow clients"
 msgstr "Máy chủ không hỗ trợ máy khách shallow"
 
-#: fetch-pack.c:1100
+#: fetch-pack.c:1105
 msgid "Server does not support --shallow-since"
 msgstr "Máy chủ không hỗ trợ --shallow-since"
 
-#: fetch-pack.c:1105
+#: fetch-pack.c:1110
 msgid "Server does not support --shallow-exclude"
 msgstr "Máy chủ không hỗ trợ --shallow-exclude"
 
-#: fetch-pack.c:1109
+#: fetch-pack.c:1114
 msgid "Server does not support --deepen"
 msgstr "Máy chủ không hỗ trợ --deepen"
 
-#: fetch-pack.c:1111
+#: fetch-pack.c:1116
 msgid "Server does not support this repository's object format"
 msgstr "Máy chủ không hỗ trợ định dạng đối tượng của kho này"
 
-#: fetch-pack.c:1124
+#: fetch-pack.c:1129
 msgid "no common commits"
 msgstr "không có lần chuyển giao chung nào"
 
-#: fetch-pack.c:1133 fetch-pack.c:1480 builtin/clone.c:1130
+#: fetch-pack.c:1138 fetch-pack.c:1485 builtin/clone.c:1130
 msgid "source repository is shallow, reject to clone."
 msgstr "kho nguồn là nông, nên bỏ từ chối nhân bản."
 
-#: fetch-pack.c:1139 fetch-pack.c:1671
+#: fetch-pack.c:1144 fetch-pack.c:1681
 msgid "git fetch-pack: fetch failed."
 msgstr "git fetch-pack: fetch gặp lỗi."
 
-#: fetch-pack.c:1253
+#: fetch-pack.c:1258
 #, c-format
 msgid "mismatched algorithms: client %s; server %s"
 msgstr "các thuật toán không khớp nhau: máy khách %s; máy chủ %s"
 
-#: fetch-pack.c:1257
+#: fetch-pack.c:1262
 #, c-format
 msgid "the server does not support algorithm '%s'"
 msgstr "máy chủ không hỗ trợ thuật toán “%s”"
 
-#: fetch-pack.c:1290
+#: fetch-pack.c:1295
 msgid "Server does not support shallow requests"
 msgstr "Máy chủ không hỗ trợ yêu cầu shallow"
 
-#: fetch-pack.c:1297
+#: fetch-pack.c:1302
 msgid "Server supports filter"
 msgstr "Máy chủ hỗ trợ bộ lọc"
 
-#: fetch-pack.c:1340 fetch-pack.c:2053
+#: fetch-pack.c:1345 fetch-pack.c:2063
 msgid "unable to write request to remote"
 msgstr "không thể ghi các yêu cầu lên máy phục vụ"
 
-#: fetch-pack.c:1358
+#: fetch-pack.c:1363
 #, c-format
 msgid "error reading section header '%s'"
 msgstr "gặp lỗi khi đọc phần đầu của đoạn %s"
 
-#: fetch-pack.c:1364
+#: fetch-pack.c:1369
 #, c-format
 msgid "expected '%s', received '%s'"
 msgstr "cần “%s”, nhưng lại nhận “%s”"
 
-#: fetch-pack.c:1398
+#: fetch-pack.c:1403
 #, c-format
 msgid "unexpected acknowledgment line: '%s'"
 msgstr "gặp dòng không được thừa nhận: “%s”"
 
-#: fetch-pack.c:1403
+#: fetch-pack.c:1408
 #, c-format
 msgid "error processing acks: %d"
 msgstr "gặp lỗi khi xử lý tín hiệu trả lời: %d"
 
-#: fetch-pack.c:1413
+#: fetch-pack.c:1418
 msgid "expected packfile to be sent after 'ready'"
 msgstr "cần tập tin gói để gửi sau “ready”"
 
-#: fetch-pack.c:1415
+#: fetch-pack.c:1420
 msgid "expected no other sections to be sent after no 'ready'"
 msgstr "không cần thêm phần nào để gửi sau “ready”"
 
-#: fetch-pack.c:1456
+#: fetch-pack.c:1461
 #, c-format
 msgid "error processing shallow info: %d"
 msgstr "lỗi xử lý thông tin shallow: %d"
 
-#: fetch-pack.c:1505
+#: fetch-pack.c:1510
 #, c-format
 msgid "expected wanted-ref, got '%s'"
 msgstr "cần wanted-ref, nhưng lại nhận được “%s”"
 
-#: fetch-pack.c:1510
+#: fetch-pack.c:1515
 #, c-format
 msgid "unexpected wanted-ref: '%s'"
 msgstr "wanted-ref không được mong đợi: “%s”"
 
-#: fetch-pack.c:1515
+#: fetch-pack.c:1520
 #, c-format
 msgid "error processing wanted refs: %d"
 msgstr "lỗi khi xử lý wanted refs: %d"
 
-#: fetch-pack.c:1545
+#: fetch-pack.c:1550
 msgid "git fetch-pack: expected response end packet"
 msgstr "git fetch-pack: cần nhận được trả lời là kết thúc gói"
 
-#: fetch-pack.c:1949
+#: fetch-pack.c:1959
 msgid "no matching remote head"
 msgstr "không khớp phần đầu máy chủ"
 
-#: fetch-pack.c:1972 builtin/clone.c:581
+#: fetch-pack.c:1982 builtin/clone.c:581
 msgid "remote did not send all necessary objects"
 msgstr "máy chủ đã không gửi tất cả các đối tượng cần thiết"
 
-#: fetch-pack.c:2075
+#: fetch-pack.c:2085
 msgid "unexpected 'ready' from remote"
 msgstr "gặp “ready” đột xuất từ máy chủ"
 
-#: fetch-pack.c:2098
+#: fetch-pack.c:2108
 #, c-format
 msgid "no such remote ref %s"
 msgstr "không có máy chủ tham chiếu nào như %s"
 
-#: fetch-pack.c:2101
+#: fetch-pack.c:2111
 #, c-format
 msgid "Server does not allow request for unadvertised object %s"
 msgstr ""
 "Máy phục vụ không cho phép yêu cầu cho đối tượng không được báo trước %s"
 
-#: gpg-interface.c:329 gpg-interface.c:451 gpg-interface.c:902
-#: gpg-interface.c:918
+#: gpg-interface.c:329 gpg-interface.c:457 gpg-interface.c:974
+#: gpg-interface.c:990
 msgid "could not create temporary file"
 msgstr "không thể tạo tập tin tạm thời"
 
-#: gpg-interface.c:332 gpg-interface.c:454
+#: gpg-interface.c:332 gpg-interface.c:460
 #, c-format
 msgid "failed writing detached signature to '%s'"
 msgstr "gặp lỗi khi ghi chữ ký đính kèm vào “%s”"
 
-#: gpg-interface.c:445
+#: gpg-interface.c:451
 msgid ""
 "gpg.ssh.allowedSignersFile needs to be configured and exist for ssh "
 "signature verification"
@@ -4319,7 +4314,7 @@ msgstr ""
 "gpg.ssh.allowedSignersFile cần được cấu hình và tồn tại để xác minh chữ ký "
 "ssh"
 
-#: gpg-interface.c:469
+#: gpg-interface.c:480
 msgid ""
 "ssh-keygen -Y find-principals/verify is needed for ssh signature "
 "verification (available in openssh version 8.2p1+)"
@@ -4327,57 +4322,57 @@ msgstr ""
 "ssh-keygen -Y find-principals/verify là cần thiết để xác minh chữ ký ssh (có "
 "sẵn trong phiên bản openssh 8.2p1+)"
 
-#: gpg-interface.c:523
+#: gpg-interface.c:536
 #, c-format
 msgid "ssh signing revocation file configured but not found: %s"
 msgstr "tập tin thu hồi chữ ký ssh đã được cấu hình nhưng không tìm thấy: %s"
 
-#: gpg-interface.c:576
+#: gpg-interface.c:624
 #, c-format
 msgid "bad/incompatible signature '%s'"
 msgstr "chữ sai / không tương thích “%s”"
 
-#: gpg-interface.c:735 gpg-interface.c:740
+#: gpg-interface.c:801 gpg-interface.c:806
 #, c-format
 msgid "failed to get the ssh fingerprint for key '%s'"
 msgstr "gặp lỗi khi lấy dấu vân tay ssh cho khóa “%s”"
 
-#: gpg-interface.c:762
+#: gpg-interface.c:829
 msgid ""
 "either user.signingkey or gpg.ssh.defaultKeyCommand needs to be configured"
 msgstr ""
 "hoặc là user.signingkey hoặc gpg.ssh.defaultKeyCommand cần được cấu hình"
 
-#: gpg-interface.c:780
+#: gpg-interface.c:851
 #, c-format
 msgid "gpg.ssh.defaultKeyCommand succeeded but returned no keys: %s %s"
 msgstr ""
 "gpg.ssh.defaultKeyCommand thành công nhưng lại không trả về khóa nào: %s %s"
 
-#: gpg-interface.c:786
+#: gpg-interface.c:857
 #, c-format
 msgid "gpg.ssh.defaultKeyCommand failed: %s %s"
 msgstr "gpg.ssh.defaultKeyCommand gặp lỗi: %s %s"
 
-#: gpg-interface.c:874
+#: gpg-interface.c:945
 msgid "gpg failed to sign the data"
 msgstr "gpg gặp lỗi khi ký dữ liệu"
 
-#: gpg-interface.c:895
+#: gpg-interface.c:967
 msgid "user.signingkey needs to be set for ssh signing"
 msgstr "user.signingkey cần được đặt cho ký ssh"
 
-#: gpg-interface.c:906
+#: gpg-interface.c:978
 #, c-format
 msgid "failed writing ssh signing key to '%s'"
 msgstr "gặp lỗi khi ghi chìa khóa ký ssh vào “%s”"
 
-#: gpg-interface.c:924
+#: gpg-interface.c:996
 #, c-format
 msgid "failed writing ssh signing key buffer to '%s'"
 msgstr "gặp lỗi khi ghi bộ đệm chìa khóa ký ssh vào “%s”"
 
-#: gpg-interface.c:942
+#: gpg-interface.c:1014
 msgid ""
 "ssh-keygen -Y sign is needed for ssh signing (available in openssh version "
 "8.2p1+)"
@@ -4385,7 +4380,7 @@ msgstr ""
 "ssh-keygen -Y sign là cần thiết cho ký ssh (sẵn có trong openssh phiên bản "
 "8.2p1+)"
 
-#: gpg-interface.c:954
+#: gpg-interface.c:1026
 #, c-format
 msgid "failed reading ssh signing data buffer from '%s'"
 msgstr "gặp lỗi khi đọc bộ đệm dữ liệu chữ ký ssh từ “%s”"
@@ -4395,7 +4390,7 @@ msgstr "gặp lỗi khi đọc bộ đệm dữ liệu chữ ký ssh từ “%s�
 msgid "ignored invalid color '%.*s' in log.graphColors"
 msgstr "bỏ qua màu không hợp lệ “%.*s” trong log.graphColors"
 
-#: grep.c:533
+#: grep.c:531
 msgid ""
 "given pattern contains NULL byte (via -f <file>). This is only supported "
 "with -P under PCRE v2"
@@ -4403,18 +4398,18 @@ msgstr ""
 "mẫu đã cho có chứa NULL byte (qua -f <file>). Điều này chỉ được hỗ trợ với -"
 "P dưới PCRE v2"
 
-#: grep.c:1928
+#: grep.c:1942
 #, c-format
 msgid "'%s': unable to read %s"
 msgstr "“%s”: không thể đọc %s"
 
-#: grep.c:1945 setup.c:176 builtin/clone.c:302 builtin/diff.c:90
+#: grep.c:1959 setup.c:177 builtin/clone.c:302 builtin/diff.c:90
 #: builtin/rm.c:136
 #, c-format
 msgid "failed to stat '%s'"
 msgstr "gặp lỗi khi lấy thống kê về “%s”"
 
-#: grep.c:1956
+#: grep.c:1970
 #, c-format
 msgid "'%s': short read"
 msgstr "“%s”: đọc ngắn"
@@ -4535,8 +4530,8 @@ msgstr "Tiếp tục và coi rằng ý bạn là “%s”."
 
 #: help.c:646
 #, c-format
-msgid "Run '%s' instead? (y/N)"
-msgstr "Chạy “%s” để thay thế? (y/N)"
+msgid "Run '%s' instead [y/N]? "
+msgstr "Chạy “%s” để thay thế? (y/N)? "
 
 #: help.c:654
 #, c-format
@@ -4752,7 +4747,7 @@ msgstr "cần đẩy dữ liệu lên đĩa sau tham số ls-refs (liệt kê th
 msgid "quoted CRLF detected"
 msgstr "phát hiện CRLF được trích dẫn"
 
-#: mailinfo.c:1254 builtin/am.c:177 builtin/mailinfo.c:46
+#: mailinfo.c:1254 builtin/am.c:184 builtin/mailinfo.c:46
 #, c-format
 msgid "bad action '%s' for '%s'"
 msgstr "thao tác sai “%s” cho “%s”"
@@ -4984,7 +4979,7 @@ msgstr "mô-đun-con"
 msgid "CONFLICT (%s): Merge conflict in %s"
 msgstr "XUNG ĐỘT (%s): Xung đột hòa trộn trong %s"
 
-#: merge-ort.c:3856
+#: merge-ort.c:3869
 #, c-format
 msgid ""
 "CONFLICT (modify/delete): %s deleted in %s and modified in %s.  Version %s "
@@ -4993,7 +4988,7 @@ msgstr ""
 "XUNG ĐỘT (sửa/xóa): %s bị xóa trong %s và sửa trong %s. Phiên bản %s của %s "
 "còn lại trong cây (tree)."
 
-#: merge-ort.c:4152
+#: merge-ort.c:4165
 #, c-format
 msgid ""
 "Note: %s not up to date and in way of checking out conflicted version; old "
@@ -5005,7 +5000,7 @@ msgstr ""
 #. TRANSLATORS: The %s arguments are: 1) tree hash of a merge
 #. base, and 2-3) the trees for the two trees we're merging.
 #.
-#: merge-ort.c:4521
+#: merge-ort.c:4534
 #, c-format
 msgid "collecting merge info failed for trees %s, %s, %s"
 msgstr "thu thập thông tin hòa trộn gặp lỗi cho cây %s, %s, %s"
@@ -5020,7 +5015,7 @@ msgstr ""
 "hòa trộn:\n"
 "  %s"
 
-#: merge-ort-wrappers.c:33 merge-recursive.c:3482 builtin/merge.c:403
+#: merge-ort-wrappers.c:33 merge-recursive.c:3482 builtin/merge.c:405
 msgid "Already up to date."
 msgstr "Đã cập nhật rồi."
 
@@ -5307,7 +5302,7 @@ msgstr "hòa trộn không trả về lần chuyển giao nào"
 msgid "Could not parse object '%s'"
 msgstr "Không thể phân tích đối tượng “%s”"
 
-#: merge-recursive.c:3834 builtin/merge.c:718 builtin/merge.c:904
+#: merge-recursive.c:3834 builtin/merge.c:720 builtin/merge.c:906
 #: builtin/stash.c:489
 msgid "Unable to write index."
 msgstr "Không thể ghi bảng mục lục."
@@ -5316,8 +5311,8 @@ msgstr "Không thể ghi bảng mục lục."
 msgid "failed to read the cache"
 msgstr "gặp lỗi khi đọc bộ nhớ đệm"
 
-#: merge.c:102 rerere.c:704 builtin/am.c:1933 builtin/am.c:1967
-#: builtin/checkout.c:590 builtin/checkout.c:842 builtin/clone.c:706
+#: merge.c:102 rerere.c:704 builtin/am.c:1988 builtin/am.c:2022
+#: builtin/checkout.c:598 builtin/checkout.c:853 builtin/clone.c:706
 #: builtin/stash.c:269
 msgid "unable to write new index file"
 msgstr "không thể ghi tập tin lưu bảng mục lục mới"
@@ -5326,212 +5321,212 @@ msgstr "không thể ghi tập tin lưu bảng mục lục mới"
 msgid "multi-pack-index OID fanout is of the wrong size"
 msgstr "fanout OID nhiều gói chỉ mục có kích thước sai"
 
-#: midx.c:109
+#: midx.c:111
 #, c-format
 msgid "multi-pack-index file %s is too small"
 msgstr "tập tin đồ thị multi-pack-index %s quá nhỏ"
 
-#: midx.c:125
+#: midx.c:127
 #, c-format
 msgid "multi-pack-index signature 0x%08x does not match signature 0x%08x"
 msgstr "chữ ký multi-pack-index 0x%08x không khớp chữ ký 0x%08x"
 
-#: midx.c:130
+#: midx.c:132
 #, c-format
 msgid "multi-pack-index version %d not recognized"
 msgstr "không nhận ra phiên bản %d của multi-pack-index"
 
-#: midx.c:135
+#: midx.c:137
 #, c-format
 msgid "multi-pack-index hash version %u does not match version %u"
 msgstr "phiên bản băm multi-pack-index %u không khớp phiên bản %u"
 
-#: midx.c:152
+#: midx.c:154
 msgid "multi-pack-index missing required pack-name chunk"
 msgstr "multi-pack-index thiếu mảnh pack-name cần thiết"
 
-#: midx.c:154
+#: midx.c:156
 msgid "multi-pack-index missing required OID fanout chunk"
 msgstr "multi-pack-index thiếu mảnh OID fanout cần thiết"
 
-#: midx.c:156
+#: midx.c:158
 msgid "multi-pack-index missing required OID lookup chunk"
 msgstr "multi-pack-index thiếu mảnh OID lookup cần thiết"
 
-#: midx.c:158
+#: midx.c:160
 msgid "multi-pack-index missing required object offsets chunk"
 msgstr "multi-pack-index thiếu mảnh các khoảng bù đối tượng cần thiết"
 
-#: midx.c:174
+#: midx.c:176
 #, c-format
 msgid "multi-pack-index pack names out of order: '%s' before '%s'"
 msgstr "các tên gói multi-pack-index không đúng thứ tự: “%s” trước “%s”"
 
-#: midx.c:221
+#: midx.c:224
 #, c-format
 msgid "bad pack-int-id: %u (%u total packs)"
 msgstr "pack-int-id sai: %u (%u các gói tổng)"
 
-#: midx.c:271
+#: midx.c:274
 msgid "multi-pack-index stores a 64-bit offset, but off_t is too small"
 msgstr "multi-pack-index lưu trữ một khoảng bù 64-bít, nhưng off_t là quá nhỏ"
 
-#: midx.c:502
+#: midx.c:505
 #, c-format
 msgid "failed to add packfile '%s'"
 msgstr "gặp lỗi khi thêm tập tin gói “%s”"
 
-#: midx.c:508
+#: midx.c:511
 #, c-format
 msgid "failed to open pack-index '%s'"
 msgstr "gặp lỗi khi mở pack-index “%s”"
 
-#: midx.c:576
+#: midx.c:579
 #, c-format
 msgid "failed to locate object %d in packfile"
 msgstr "gặp lỗi khi phân bổ đối tượng “%d” trong tập tin gói"
 
-#: midx.c:892
+#: midx.c:895
 msgid "cannot store reverse index file"
 msgstr "không thể lưu trữ tập tin ghi mục lục đảo ngược"
 
-#: midx.c:990
+#: midx.c:993
 #, c-format
 msgid "could not parse line: %s"
 msgstr "không thể phân tích cú pháp dòng: %s"
 
-#: midx.c:992
+#: midx.c:995
 #, c-format
 msgid "malformed line: %s"
 msgstr "dòng dị hình: %s"
 
-#: midx.c:1159
+#: midx.c:1162
 msgid "ignoring existing multi-pack-index; checksum mismatch"
 msgstr "bỏ qua multi-pack-index sẵn có; tổng kiểm không khớp"
 
-#: midx.c:1184
+#: midx.c:1187
 msgid "could not load pack"
 msgstr "không thể tải gói"
 
-#: midx.c:1190
+#: midx.c:1193
 #, c-format
 msgid "could not open index for %s"
 msgstr "không thể mở mục lục cho %s"
 
-#: midx.c:1201
+#: midx.c:1204
 msgid "Adding packfiles to multi-pack-index"
 msgstr "Đang thêm tập tin gói từ multi-pack-index"
 
-#: midx.c:1244
+#: midx.c:1247
 #, c-format
 msgid "unknown preferred pack: '%s'"
 msgstr "không hiểu \"preferred pack\": %s"
 
-#: midx.c:1289
+#: midx.c:1292
 #, c-format
 msgid "cannot select preferred pack %s with no objects"
 msgstr "không thể chọn gói ưa dùng %s với không đối tượng nào"
 
-#: midx.c:1321
+#: midx.c:1324
 #, c-format
 msgid "did not see pack-file %s to drop"
 msgstr "đã không thấy tập tin gói %s để mà xóa"
 
-#: midx.c:1367
+#: midx.c:1370
 #, c-format
 msgid "preferred pack '%s' is expired"
 msgstr "\"preferred pack\" “%s” đã hết hạn"
 
-#: midx.c:1380
+#: midx.c:1383
 msgid "no pack files to index."
 msgstr "không có tập tin gói để đánh mục lục."
 
-#: midx.c:1417
+#: midx.c:1420
 msgid "could not write multi-pack bitmap"
 msgstr "không thể ghi “multi-pack bitmap”"
 
-#: midx.c:1427
+#: midx.c:1430
 msgid "could not write multi-pack-index"
 msgstr "không thể ghi “multi-pack-index”"
 
-#: midx.c:1486 builtin/clean.c:37
+#: midx.c:1489 builtin/clean.c:37
 #, c-format
 msgid "failed to remove %s"
 msgstr "gặp lỗi khi gỡ bỏ %s"
 
-#: midx.c:1517
+#: midx.c:1522
 #, c-format
 msgid "failed to clear multi-pack-index at %s"
 msgstr "gặp lỗi khi xóa multi-pack-index tại %s"
 
-#: midx.c:1577
+#: midx.c:1585
 msgid "multi-pack-index file exists, but failed to parse"
 msgstr "đã có tập tin multi-pack-index, nhưng gặp lỗi khi phân tích cú pháp"
 
-#: midx.c:1585
+#: midx.c:1593
 msgid "incorrect checksum"
 msgstr "tổng kiểm không đúng"
 
-#: midx.c:1588
+#: midx.c:1596
 msgid "Looking for referenced packfiles"
 msgstr "Đang khóa cho các gói bị tham chiếu"
 
-#: midx.c:1603
+#: midx.c:1611
 #, c-format
 msgid ""
 "oid fanout out of order: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 msgstr "fanout cũ sai thứ tự: fanout[%d] = %<PRIx32> > %<PRIx32> = fanout[%d]"
 
-#: midx.c:1608
+#: midx.c:1616
 msgid "the midx contains no oid"
 msgstr "midx chẳng chứa oid nào"
 
-#: midx.c:1617
+#: midx.c:1625
 msgid "Verifying OID order in multi-pack-index"
 msgstr "Thẩm tra thứ tự OID trong multi-pack-index"
 
-#: midx.c:1626
+#: midx.c:1634
 #, c-format
 msgid "oid lookup out of order: oid[%d] = %s >= %s = oid[%d]"
 msgstr "lookup cũ sai thứ tự: oid[%d] = %s >= %s = oid[%d]"
 
-#: midx.c:1646
+#: midx.c:1654
 msgid "Sorting objects by packfile"
 msgstr "Đang sắp xếp các đối tượng theo tập tin gói"
 
-#: midx.c:1653
+#: midx.c:1661
 msgid "Verifying object offsets"
 msgstr "Đang thẩm tra các khoảng bù đối tượng"
 
-#: midx.c:1669
+#: midx.c:1677
 #, c-format
 msgid "failed to load pack entry for oid[%d] = %s"
 msgstr "gặp lỗi khi tải mục gói cho oid[%d] = %s"
 
-#: midx.c:1675
+#: midx.c:1683
 #, c-format
 msgid "failed to load pack-index for packfile %s"
 msgstr "gặp lỗi khi tải pack-index cho tập tin gói %s"
 
-#: midx.c:1684
+#: midx.c:1692
 #, c-format
 msgid "incorrect object offset for oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 msgstr ""
 "khoảng bù đối tượng không đúng cho oid[%d] = %s: %<PRIx64> != %<PRIx64>"
 
-#: midx.c:1709
+#: midx.c:1719
 msgid "Counting referenced objects"
 msgstr "Đang đếm các đối tượng được tham chiếu"
 
-#: midx.c:1719
+#: midx.c:1729
 msgid "Finding and deleting unreferenced packfiles"
 msgstr "Đang tìm và xóa các gói không được tham chiếu"
 
-#: midx.c:1911
+#: midx.c:1921
 msgid "could not start pack-objects"
 msgstr "không thể lấy thông tin thống kê về các đối tượng gói"
 
-#: midx.c:1931
+#: midx.c:1941
 msgid "could not finish pack-objects"
 msgstr "không thể hoàn thiện các đối tượng gói"
 
@@ -5592,259 +5587,259 @@ msgstr "Từ chối ghi đè ghi chú trong %s (nằm ngoài refs/notes/)"
 msgid "Bad %s value: '%s'"
 msgstr "Giá trị %s sai: “%s”"
 
-#: object-file.c:459
+#: object-file.c:456
 #, c-format
 msgid "object directory %s does not exist; check .git/objects/info/alternates"
 msgstr ""
 "thư mục đối tượng %s không tồn tại; kiểm tra .git/objects/info/alternates"
 
-#: object-file.c:517
+#: object-file.c:514
 #, c-format
 msgid "unable to normalize alternate object path: %s"
 msgstr "không thể thường hóa đường dẫn đối tượng thay thế: “%s”"
 
-#: object-file.c:591
+#: object-file.c:588
 #, c-format
 msgid "%s: ignoring alternate object stores, nesting too deep"
 msgstr "%s: đang bỏ qua kho đối tượng thay thế, lồng nhau quá sâu"
 
-#: object-file.c:598
+#: object-file.c:595
 #, c-format
 msgid "unable to normalize object directory: %s"
 msgstr "không thể chuẩn hóa thư mục đối tượng: “%s”"
 
-#: object-file.c:641
+#: object-file.c:638
 msgid "unable to fdopen alternates lockfile"
 msgstr "không thể fdopen tập tin khóa thay thế"
 
-#: object-file.c:659
+#: object-file.c:656
 msgid "unable to read alternates file"
 msgstr "không thể đọc tập tin thay thế"
 
-#: object-file.c:666
+#: object-file.c:663
 msgid "unable to move new alternates file into place"
 msgstr "không thể di chuyển tập tin thay thế vào chỗ"
 
-#: object-file.c:701
+#: object-file.c:741
 #, c-format
 msgid "path '%s' does not exist"
 msgstr "đường dẫn “%s” không tồn tại"
 
-#: object-file.c:722
+#: object-file.c:762
 #, c-format
 msgid "reference repository '%s' as a linked checkout is not supported yet."
 msgstr "kho tham chiếu “%s” như là lấy ra liên kết vẫn chưa được hỗ trợ."
 
-#: object-file.c:728
+#: object-file.c:768
 #, c-format
 msgid "reference repository '%s' is not a local repository."
 msgstr "kho tham chiếu “%s” không phải là một kho nội bộ."
 
-#: object-file.c:734
+#: object-file.c:774
 #, c-format
 msgid "reference repository '%s' is shallow"
 msgstr "kho tham chiếu “%s” là nông"
 
-#: object-file.c:742
+#: object-file.c:782
 #, c-format
 msgid "reference repository '%s' is grafted"
 msgstr "kho tham chiếu “%s” bị cấy ghép"
 
-#: object-file.c:773
+#: object-file.c:813
 #, c-format
 msgid "could not find object directory matching %s"
 msgstr "không thể tìm thấy thư mục đối tượng khớp với “%s”"
 
-#: object-file.c:823
+#: object-file.c:863
 #, c-format
 msgid "invalid line while parsing alternate refs: %s"
 msgstr "dòng không hợp lệ trong khi phân tích các tham chiếu thay thế: %s"
 
-#: object-file.c:973
+#: object-file.c:1013
 #, c-format
 msgid "attempting to mmap %<PRIuMAX> over limit %<PRIuMAX>"
 msgstr "đang cố để mmap %<PRIuMAX> vượt quá giới hạn %<PRIuMAX>"
 
-#: object-file.c:1008
+#: object-file.c:1048
 #, c-format
 msgid "mmap failed%s"
 msgstr "mmap gặp lỗi%s"
 
-#: object-file.c:1174
+#: object-file.c:1214
 #, c-format
 msgid "object file %s is empty"
 msgstr "tập tin đối tượng %s trống rỗng"
 
-#: object-file.c:1293 object-file.c:2499
+#: object-file.c:1333 object-file.c:2542
 #, c-format
 msgid "corrupt loose object '%s'"
 msgstr "đối tượng mất hỏng “%s”"
 
-#: object-file.c:1295 object-file.c:2503
+#: object-file.c:1335 object-file.c:2546
 #, c-format
 msgid "garbage at end of loose object '%s'"
 msgstr "gặp rác tại cuối của đối tượng bị mất “%s”"
 
-#: object-file.c:1417
+#: object-file.c:1457
 #, c-format
 msgid "unable to parse %s header"
 msgstr "không thể phân tích phần đầu của “%s”"
 
-#: object-file.c:1419
+#: object-file.c:1459
 msgid "invalid object type"
 msgstr "kiểu đối tượng không hợp lệ"
 
-#: object-file.c:1430
+#: object-file.c:1470
 #, c-format
 msgid "unable to unpack %s header"
 msgstr "không thể giải gói phần đầu %s"
 
-#: object-file.c:1434
+#: object-file.c:1474
 #, c-format
 msgid "header for %s too long, exceeds %d bytes"
 msgstr "phần đầu cho %s quá dài, vượt quá %d byte"
 
-#: object-file.c:1664
+#: object-file.c:1704
 #, c-format
 msgid "failed to read object %s"
 msgstr "gặp lỗi khi đọc đối tượng “%s”"
 
-#: object-file.c:1668
+#: object-file.c:1708
 #, c-format
 msgid "replacement %s not found for %s"
 msgstr "c%s thay thế không được tìm thấy cho %s"
 
-#: object-file.c:1672
+#: object-file.c:1712
 #, c-format
 msgid "loose object %s (stored in %s) is corrupt"
 msgstr "đối tượng mất %s (được lưu trong %s) bị hỏng"
 
-#: object-file.c:1676
+#: object-file.c:1716
 #, c-format
 msgid "packed object %s (stored in %s) is corrupt"
 msgstr "đối tượng đã đóng gói %s (được lưu trong %s) bị hỏng"
 
-#: object-file.c:1781
+#: object-file.c:1821
 #, c-format
 msgid "unable to write file %s"
 msgstr "không thể ghi tập tin %s"
 
-#: object-file.c:1788
+#: object-file.c:1828
 #, c-format
 msgid "unable to set permission to '%s'"
 msgstr "không thể đặt quyền thành “%s”"
 
-#: object-file.c:1795
+#: object-file.c:1835
 msgid "file write error"
 msgstr "lỗi ghi tập tin"
 
-#: object-file.c:1815
+#: object-file.c:1858
 msgid "error when closing loose object file"
 msgstr "gặp lỗi trong khi đóng tập tin đối tượng"
 
-#: object-file.c:1882
+#: object-file.c:1925
 #, c-format
 msgid "insufficient permission for adding an object to repository database %s"
 msgstr ""
 "không đủ thẩm quyền để thêm một đối tượng vào cơ sở dữ liệu kho chứa %s"
 
-#: object-file.c:1884
+#: object-file.c:1927
 msgid "unable to create temporary file"
 msgstr "không thể tạo tập tin tạm thời"
 
-#: object-file.c:1908
+#: object-file.c:1951
 msgid "unable to write loose object file"
 msgstr "không thể ghi tập tin đối tượng đã mất"
 
-#: object-file.c:1914
+#: object-file.c:1957
 #, c-format
 msgid "unable to deflate new object %s (%d)"
 msgstr "không thể xả nén đối tượng mới %s (%d)"
 
-#: object-file.c:1918
+#: object-file.c:1961
 #, c-format
 msgid "deflateEnd on object %s failed (%d)"
 msgstr "deflateEnd trên đối tượng %s gặp lỗi (%d)"
 
-#: object-file.c:1922
+#: object-file.c:1965
 #, c-format
 msgid "confused by unstable object source data for %s"
 msgstr "chưa rõ ràng baowir dữ liệu nguồn đối tượng không ổn định cho %s"
 
-#: object-file.c:1933 builtin/pack-objects.c:1243
+#: object-file.c:1976 builtin/pack-objects.c:1243
 #, c-format
 msgid "failed utime() on %s"
 msgstr "gặp lỗi utime() trên “%s”"
 
-#: object-file.c:2011
+#: object-file.c:2054
 #, c-format
 msgid "cannot read object for %s"
 msgstr "không thể đọc đối tượng cho %s"
 
-#: object-file.c:2062
+#: object-file.c:2105
 msgid "corrupt commit"
 msgstr "lần chuyển giao sai hỏng"
 
-#: object-file.c:2070
+#: object-file.c:2113
 msgid "corrupt tag"
 msgstr "thẻ sai hỏng"
 
-#: object-file.c:2170
+#: object-file.c:2213
 #, c-format
 msgid "read error while indexing %s"
 msgstr "gặp lỗi đọc khi đánh mục lục %s"
 
-#: object-file.c:2173
+#: object-file.c:2216
 #, c-format
 msgid "short read while indexing %s"
 msgstr "không đọc ngắn khi đánh mục lục %s"
 
-#: object-file.c:2246 object-file.c:2256
+#: object-file.c:2289 object-file.c:2299
 #, c-format
 msgid "%s: failed to insert into database"
 msgstr "%s: gặp lỗi khi thêm vào cơ sở dữ liệu"
 
-#: object-file.c:2262
+#: object-file.c:2305
 #, c-format
 msgid "%s: unsupported file type"
 msgstr "%s: kiểu tập tin không được hỗ trợ"
 
-#: object-file.c:2286 builtin/fetch.c:1445
+#: object-file.c:2329 builtin/fetch.c:1453
 #, c-format
 msgid "%s is not a valid object"
 msgstr "%s không phải là một đối tượng hợp lệ"
 
-#: object-file.c:2288
+#: object-file.c:2331
 #, c-format
 msgid "%s is not a valid '%s' object"
 msgstr "%s không phải là một đối tượng “%s” hợp lệ"
 
-#: object-file.c:2315
+#: object-file.c:2358
 #, c-format
 msgid "unable to open %s"
 msgstr "không thể mở %s"
 
-#: object-file.c:2510
+#: object-file.c:2553
 #, c-format
 msgid "hash mismatch for %s (expected %s)"
 msgstr "mã băm không khớp cho %s (cần %s)"
 
-#: object-file.c:2533
+#: object-file.c:2576
 #, c-format
 msgid "unable to mmap %s"
 msgstr "không thể mmap %s"
 
-#: object-file.c:2539
+#: object-file.c:2582
 #, c-format
 msgid "unable to unpack header of %s"
 msgstr "không thể giải gói phần đầu của “%s”"
 
-#: object-file.c:2544
+#: object-file.c:2587
 #, c-format
 msgid "unable to parse header of %s"
 msgstr "không thể phân tích phần đầu của “%s”"
 
-#: object-file.c:2555
+#: object-file.c:2598
 #, c-format
 msgid "unable to unpack contents of %s"
 msgstr "không thể giải gói nội dung của “%s”"
@@ -5973,25 +5968,25 @@ msgstr "không thể phân tích đối tượng: “%s”"
 msgid "hash mismatch %s"
 msgstr "mã băm không khớp %s"
 
-#: pack-bitmap.c:348
+#: pack-bitmap.c:353
 msgid "multi-pack bitmap is missing required reverse index"
 msgstr "ánh xạ multi-pack thiếu mục lục để dành cần thiết"
 
-#: pack-bitmap.c:424
+#: pack-bitmap.c:429
 msgid "load_reverse_index: could not open pack"
 msgstr "load_reverse_index: không thể mở gói"
 
-#: pack-bitmap.c:1064 pack-bitmap.c:1070 builtin/pack-objects.c:2424
+#: pack-bitmap.c:1069 pack-bitmap.c:1075 builtin/pack-objects.c:2424
 #, c-format
 msgid "unable to get size of %s"
 msgstr "không thể lấy kích cỡ của %s"
 
-#: pack-bitmap.c:1916
+#: pack-bitmap.c:1935
 #, c-format
 msgid "could not find %s in pack %s at offset %<PRIuMAX>"
 msgstr "không thể tìm thấy %s trong gói “%s” tại vị trí %<PRIuMAX>"
 
-#: pack-bitmap.c:1952 builtin/rev-list.c:92
+#: pack-bitmap.c:1971 builtin/rev-list.c:92
 #, c-format
 msgid "unable to get disk usage of %s"
 msgstr "không thể dung lượng đĩa đã dùng của %s"
@@ -6040,45 +6035,50 @@ msgstr "gặp lỗi làm cho %s đọc được"
 msgid "could not write '%s' promisor file"
 msgstr "không thể ghi tập tin promisor “%s”"
 
-#: packfile.c:626
+#: packfile.c:627
 msgid "offset before end of packfile (broken .idx?)"
 msgstr "vị trí tương đối trước điểm kết thúc của tập tin gói (.idx hỏng à?)"
 
-#: packfile.c:656
+#: packfile.c:657
 #, c-format
 msgid "packfile %s cannot be mapped%s"
 msgstr "tập tin gói %s không thể được ánh xạ %s"
 
-#: packfile.c:1923
+#: packfile.c:1924
 #, c-format
 msgid "offset before start of pack index for %s (corrupt index?)"
 msgstr "vị trí tương đối nằm trước chỉ mục gói cho %s (mục lục bị hỏng à?)"
 
-#: packfile.c:1927
+#: packfile.c:1928
 #, c-format
 msgid "offset beyond end of pack index for %s (truncated index?)"
 msgstr ""
 "vị trí tương đối vượt quá cuối của chỉ mục gói cho %s (mục lục bị cắt cụt à?)"
 
-#: parse-options-cb.c:20 parse-options-cb.c:24 builtin/commit-graph.c:175
+#: parse-options-cb.c:21 parse-options-cb.c:25 builtin/commit-graph.c:175
 #, c-format
 msgid "option `%s' expects a numerical value"
 msgstr "tùy chọn “%s” cần một giá trị bằng số"
 
-#: parse-options-cb.c:41
+#: parse-options-cb.c:42
 #, c-format
 msgid "malformed expiration date '%s'"
 msgstr "ngày tháng hết hạn dị hình “%s”"
 
-#: parse-options-cb.c:54
+#: parse-options-cb.c:55
 #, c-format
 msgid "option `%s' expects \"always\", \"auto\", or \"never\""
 msgstr "tùy chọn “%s” cần \"always\", \"auto\", hoặc \"never\""
 
-#: parse-options-cb.c:132 parse-options-cb.c:149
+#: parse-options-cb.c:133 parse-options-cb.c:150
 #, c-format
 msgid "malformed object name '%s'"
 msgstr "tên đối tượng dị hình “%s”"
+
+#: parse-options-cb.c:307
+#, c-format
+msgid "option `%s' expects \"%s\" or \"%s\""
+msgstr "tùy chọn “%s” cần \"%s\" hoặc \"%s\""
 
 #: parse-options.c:58
 #, c-format
@@ -6115,36 +6115,36 @@ msgstr "%s cần một giá trị dạng số không âm với một hậu tố 
 msgid "ambiguous option: %s (could be --%s%s or --%s%s)"
 msgstr "tùy chọn chưa rõ rang: %s (nên là --%s%s hay --%s%s)"
 
-#: parse-options.c:427 parse-options.c:435
+#: parse-options.c:428 parse-options.c:436
 #, c-format
 msgid "did you mean `--%s` (with two dashes)?"
 msgstr "có phải ý bạn là “--%s“ (với hai dấu gạch ngang)?"
 
-#: parse-options.c:677 parse-options.c:1053
+#: parse-options.c:678 parse-options.c:1054
 #, c-format
 msgid "alias of --%s"
 msgstr "bí danh của --%s"
 
-#: parse-options.c:891
+#: parse-options.c:892
 #, c-format
 msgid "unknown option `%s'"
 msgstr "không hiểu tùy chọn “%s”"
 
-#: parse-options.c:893
+#: parse-options.c:894
 #, c-format
 msgid "unknown switch `%c'"
 msgstr "không hiểu tùy chọn “%c”"
 
-#: parse-options.c:895
+#: parse-options.c:896
 #, c-format
 msgid "unknown non-ascii option in string: `%s'"
 msgstr "không hiểu tùy chọn non-ascii trong chuỗi: “%s”"
 
-#: parse-options.c:919
+#: parse-options.c:920
 msgid "..."
 msgstr "…"
 
-#: parse-options.c:933
+#: parse-options.c:934
 #, c-format
 msgid "usage: %s"
 msgstr "cách dùng: %s"
@@ -6152,7 +6152,7 @@ msgstr "cách dùng: %s"
 #. TRANSLATORS: the colon here should align with the
 #. one in "usage: %s" translation.
 #.
-#: parse-options.c:948
+#: parse-options.c:949
 #, c-format
 msgid "   or: %s"
 msgstr "     hoặc: %s"
@@ -6176,17 +6176,17 @@ msgstr "     hoặc: %s"
 #. translated) N_() usage string, which contained embedded
 #. newlines before we split it up.
 #.
-#: parse-options.c:969
+#: parse-options.c:970
 #, c-format
 msgid "%*s%s"
 msgstr "%*s%s"
 
-#: parse-options.c:992
+#: parse-options.c:993
 #, c-format
 msgid "    %s"
 msgstr "    %s"
 
-#: parse-options.c:1039
+#: parse-options.c:1040
 msgid "-NUM"
 msgstr "-SỐ"
 
@@ -6316,17 +6316,17 @@ msgstr "lỗi đọc"
 msgid "the remote end hung up unexpectedly"
 msgstr "máy chủ bị treo bất ngờ"
 
-#: pkt-line.c:390 pkt-line.c:392
+#: pkt-line.c:417 pkt-line.c:419
 #, c-format
 msgid "protocol error: bad line length character: %.4s"
 msgstr "lỗi giao thức: ký tự chiều dài dòng bị sai: %.4s"
 
-#: pkt-line.c:407 pkt-line.c:409 pkt-line.c:415 pkt-line.c:417
+#: pkt-line.c:434 pkt-line.c:436 pkt-line.c:442 pkt-line.c:444
 #, c-format
 msgid "protocol error: bad line length %d"
 msgstr "lỗi giao thức: chiều dài dòng bị sai %d"
 
-#: pkt-line.c:434 sideband.c:165
+#: pkt-line.c:472 sideband.c:165
 #, c-format
 msgid "remote error: %s"
 msgstr "lỗi máy chủ: %s"
@@ -6378,7 +6378,7 @@ msgstr "không thể lấy thông tin thống kê về “log“"
 msgid "could not read `log` output"
 msgstr "không thể đọc kết xuất “log”"
 
-#: range-diff.c:97 sequencer.c:5605
+#: range-diff.c:97 sequencer.c:5602
 #, c-format
 msgid "could not parse commit '%s'"
 msgstr "không thể phân tích lần chuyển giao “%s”"
@@ -6401,61 +6401,57 @@ msgstr "không thể phân tích cú pháp phần đầu git “%.*s”"
 msgid "failed to generate diff"
 msgstr "gặp lỗi khi tạo khác biệt"
 
-#: range-diff.c:559
-msgid "--left-only and --right-only are mutually exclusive"
-msgstr "--left-only và --right-only loại từ lẫn nhau"
-
 #: range-diff.c:562 range-diff.c:564
 #, c-format
 msgid "could not parse log for '%s'"
 msgstr "không thể phân tích nhật ký cho “%s”"
 
-#: read-cache.c:710
+#: read-cache.c:723
 #, c-format
 msgid "will not add file alias '%s' ('%s' already exists in index)"
 msgstr ""
 "sẽ không thêm các bí danh “%s” (“%s” đã có từ trước trong bảng mục lục)"
 
-#: read-cache.c:726
+#: read-cache.c:739
 msgid "cannot create an empty blob in the object database"
 msgstr "không thể tạo một blob rỗng trong cơ sở dữ liệu đối tượng"
 
-#: read-cache.c:748
+#: read-cache.c:761
 #, c-format
 msgid "%s: can only add regular files, symbolic links or git-directories"
 msgstr ""
 "%s: chỉ có thể thêm tập tin thông thường, liên kết mềm hoặc git-directories"
 
-#: read-cache.c:753 builtin/submodule--helper.c:3241
+#: read-cache.c:766 builtin/submodule--helper.c:3242
 #, c-format
 msgid "'%s' does not have a commit checked out"
 msgstr "“%s” không có một lần chuyển giao nào được lấy ra"
 
-#: read-cache.c:805
+#: read-cache.c:818
 #, c-format
 msgid "unable to index file '%s'"
 msgstr "không thể đánh mục lục tập tin “%s”"
 
-#: read-cache.c:824
+#: read-cache.c:837
 #, c-format
 msgid "unable to add '%s' to index"
 msgstr "không thể thêm %s vào bảng mục lục"
 
-#: read-cache.c:835
+#: read-cache.c:848
 #, c-format
 msgid "unable to stat '%s'"
 msgstr "không thể lấy thống kê “%s”"
 
-#: read-cache.c:1373
+#: read-cache.c:1386
 #, c-format
 msgid "'%s' appears as both a file and as a directory"
 msgstr "%s có vẻ không phải là tập tin và cũng chẳng phải là một thư mục"
 
-#: read-cache.c:1588
+#: read-cache.c:1601
 msgid "Refresh index"
 msgstr "Làm tươi mới bảng mục lục"
 
-#: read-cache.c:1720
+#: read-cache.c:1733
 #, c-format
 msgid ""
 "index.version set, but the value is invalid.\n"
@@ -6464,7 +6460,7 @@ msgstr ""
 "index.version được đặt, nhưng giá trị của nó lại không hợp lệ.\n"
 "Dùng phiên bản %i"
 
-#: read-cache.c:1730
+#: read-cache.c:1743
 #, c-format
 msgid ""
 "GIT_INDEX_VERSION set, but the value is invalid.\n"
@@ -6473,143 +6469,143 @@ msgstr ""
 "GIT_INDEX_VERSION được đặt, nhưng giá trị của nó lại không hợp lệ.\n"
 "Dùng phiên bản %i"
 
-#: read-cache.c:1786
+#: read-cache.c:1799
 #, c-format
 msgid "bad signature 0x%08x"
 msgstr "chữ ký sai 0x%08x"
 
-#: read-cache.c:1789
+#: read-cache.c:1802
 #, c-format
 msgid "bad index version %d"
 msgstr "phiên bản mục lục sai %d"
 
-#: read-cache.c:1798
+#: read-cache.c:1811
 msgid "bad index file sha1 signature"
 msgstr "chữ ký dạng sha1 cho tập tin mục lục không đúng"
 
-#: read-cache.c:1832
+#: read-cache.c:1845
 #, c-format
 msgid "index uses %.4s extension, which we do not understand"
 msgstr "mục lục dùng phần mở rộng %.4s, cái mà chúng tôi không hiểu được"
 
-#: read-cache.c:1834
+#: read-cache.c:1847
 #, c-format
 msgid "ignoring %.4s extension"
 msgstr "đang lờ đi phần mở rộng %.4s"
 
-#: read-cache.c:1871
+#: read-cache.c:1884
 #, c-format
 msgid "unknown index entry format 0x%08x"
 msgstr "không hiểu định dạng mục lục 0x%08x"
 
-#: read-cache.c:1887
+#: read-cache.c:1900
 #, c-format
 msgid "malformed name field in the index, near path '%s'"
 msgstr "trường tên sai sạng trong mục lục, gần đường dẫn “%s”"
 
-#: read-cache.c:1944
+#: read-cache.c:1957
 msgid "unordered stage entries in index"
 msgstr "các mục tin stage không đúng thứ tự trong mục lục"
 
-#: read-cache.c:1947
+#: read-cache.c:1960
 #, c-format
 msgid "multiple stage entries for merged file '%s'"
 msgstr "nhiều mục stage cho tập tin hòa trộn “%s”"
 
-#: read-cache.c:1950
+#: read-cache.c:1963
 #, c-format
 msgid "unordered stage entries for '%s'"
 msgstr "các mục tin stage không đúng thứ tự cho “%s”"
 
-#: read-cache.c:2065 read-cache.c:2363 rerere.c:549 rerere.c:583 rerere.c:1095
-#: submodule.c:1662 builtin/add.c:603 builtin/check-ignore.c:183
-#: builtin/checkout.c:519 builtin/checkout.c:708 builtin/clean.c:987
+#: read-cache.c:2078 read-cache.c:2384 rerere.c:549 rerere.c:583 rerere.c:1095
+#: submodule.c:1662 builtin/add.c:600 builtin/check-ignore.c:183
+#: builtin/checkout.c:527 builtin/checkout.c:719 builtin/clean.c:1013
 #: builtin/commit.c:378 builtin/diff-tree.c:122 builtin/grep.c:519
-#: builtin/mv.c:148 builtin/reset.c:253 builtin/rm.c:293
-#: builtin/submodule--helper.c:327 builtin/submodule--helper.c:3201
+#: builtin/mv.c:148 builtin/reset.c:499 builtin/rm.c:293
+#: builtin/submodule--helper.c:327 builtin/submodule--helper.c:3202
 msgid "index file corrupt"
 msgstr "tập tin ghi bảng mục lục bị hỏng"
 
-#: read-cache.c:2209
+#: read-cache.c:2222
 #, c-format
 msgid "unable to create load_cache_entries thread: %s"
 msgstr "không thể tạo tuyến load_cache_entries: %s"
 
-#: read-cache.c:2222
+#: read-cache.c:2235
 #, c-format
 msgid "unable to join load_cache_entries thread: %s"
 msgstr "không thể gia nhập tuyến load_cache_entries: %s"
 
-#: read-cache.c:2255
+#: read-cache.c:2268
 #, c-format
 msgid "%s: index file open failed"
 msgstr "%s: mở tập tin mục lục gặp lỗi"
 
-#: read-cache.c:2259
+#: read-cache.c:2272
 #, c-format
 msgid "%s: cannot stat the open index"
 msgstr "%s: không thể lấy thống kê bảng mục lục đã mở"
 
-#: read-cache.c:2263
+#: read-cache.c:2276
 #, c-format
 msgid "%s: index file smaller than expected"
 msgstr "%s: tập tin mục lục nhỏ hơn mong đợi"
 
-#: read-cache.c:2267
+#: read-cache.c:2280
 #, c-format
 msgid "%s: unable to map index file%s"
 msgstr "%s: không thể ánh xạ tập tin mục lục%s"
 
-#: read-cache.c:2310
+#: read-cache.c:2323
 #, c-format
 msgid "unable to create load_index_extensions thread: %s"
 msgstr "không thể tạo tuyến load_index_extensions: %s"
 
-#: read-cache.c:2337
+#: read-cache.c:2350
 #, c-format
 msgid "unable to join load_index_extensions thread: %s"
 msgstr "không thể gia nhập tuyến load_index_extensions: %s"
 
-#: read-cache.c:2375
+#: read-cache.c:2396
 #, c-format
 msgid "could not freshen shared index '%s'"
 msgstr "không thể làm tươi mới mục lục đã chia sẻ “%s”"
 
-#: read-cache.c:2434
+#: read-cache.c:2455
 #, c-format
 msgid "broken index, expect %s in %s, got %s"
 msgstr "mục lục bị hỏng, cần %s trong %s, nhưng lại nhận được %s"
 
-#: read-cache.c:3065 strbuf.c:1179 wrapper.c:641 builtin/merge.c:1147
+#: read-cache.c:3086 strbuf.c:1191 wrapper.c:641 builtin/merge.c:1150
 #, c-format
 msgid "could not close '%s'"
 msgstr "không thể đóng “%s”"
 
-#: read-cache.c:3108
+#: read-cache.c:3129
 msgid "failed to convert to a sparse-index"
 msgstr "gặp lỗi khi chuyển đổi sang \"sparse-index\""
 
-#: read-cache.c:3179
+#: read-cache.c:3200
 #, c-format
 msgid "could not stat '%s'"
 msgstr "không thể lấy thông tin thống kê về “%s”"
 
-#: read-cache.c:3192
+#: read-cache.c:3213
 #, c-format
 msgid "unable to open git dir: %s"
 msgstr "không thể mở thư mục git: %s"
 
-#: read-cache.c:3204
+#: read-cache.c:3225
 #, c-format
 msgid "unable to unlink: %s"
 msgstr "không thể bỏ liên kết (unlink): “%s”"
 
-#: read-cache.c:3233
+#: read-cache.c:3254
 #, c-format
 msgid "cannot fix permission bits on '%s'"
 msgstr "không thể sửa các bít phân quyền trên “%s”"
 
-#: read-cache.c:3390
+#: read-cache.c:3411
 #, c-format
 msgid "%s: cannot drop to stage #0"
 msgstr "%s: không thể xóa bỏ stage #0"
@@ -6732,8 +6728,8 @@ msgstr ""
 "Tuy nhiên, nếu bạn xóa bỏ mọi thứ, việc cải tổ sẽ bị bãi bỏ.\n"
 "\n"
 
-#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3888
-#: sequencer.c:3914 sequencer.c:5711 builtin/fsck.c:328 builtin/gc.c:1789
+#: rebase-interactive.c:113 rerere.c:469 rerere.c:676 sequencer.c:3883
+#: sequencer.c:3909 sequencer.c:5708 builtin/fsck.c:328 builtin/gc.c:1791
 #: builtin/rebase.c:190
 #, c-format
 msgid "could not write '%s'"
@@ -6776,7 +6772,7 @@ msgstr ""
 msgid "%s: 'preserve' superseded by 'merges'"
 msgstr "%s: “preserve” bị cấm bởi “merges”"
 
-#: ref-filter.c:42 wt-status.c:2036
+#: ref-filter.c:42 wt-status.c:2048
 msgid "gone"
 msgstr "đã ra đi"
 
@@ -6815,7 +6811,8 @@ msgstr "Giá trị nguyên cần tên tham chiếu:lstrip=%s"
 msgid "Integer value expected refname:rstrip=%s"
 msgstr "Giá trị nguyên cần tên tham chiếu:rstrip=%s"
 
-#: ref-filter.c:265
+#: ref-filter.c:265 ref-filter.c:344 ref-filter.c:377 ref-filter.c:431
+#: ref-filter.c:443 ref-filter.c:462 ref-filter.c:534 ref-filter.c:560
 #, c-format
 msgid "unrecognized %%(%s) argument: %s"
 msgstr "đối số không được thừa nhận %%(%s): %s"
@@ -6824,11 +6821,6 @@ msgstr "đối số không được thừa nhận %%(%s): %s"
 #, c-format
 msgid "%%(objecttype) does not take arguments"
 msgstr "%%(objecttype) không nhận các đối số"
-
-#: ref-filter.c:344
-#, c-format
-msgid "unrecognized %%(objectsize) argument: %s"
-msgstr "tham số không được thừa nhận %%(objectsize): %s"
 
 #: ref-filter.c:352
 #, c-format
@@ -6839,11 +6831,6 @@ msgstr "%%(deltabase) không nhận các đối số"
 #, c-format
 msgid "%%(body) does not take arguments"
 msgstr "%%(body) không nhận các đối số"
-
-#: ref-filter.c:377
-#, c-format
-msgid "unrecognized %%(subject) argument: %s"
-msgstr "tham số không được thừa nhận %%(subject): %s"
 
 #: ref-filter.c:396
 #, c-format
@@ -6860,25 +6847,10 @@ msgstr "không hiểu tham số %%(trailers): %s"
 msgid "positive value expected contents:lines=%s"
 msgstr "cần nội dung mang giá trị dương:lines=%s"
 
-#: ref-filter.c:431
-#, c-format
-msgid "unrecognized %%(contents) argument: %s"
-msgstr "đối số không được thừa nhận %%(contents): %s"
-
-#: ref-filter.c:443
-#, c-format
-msgid "unrecognized %%(raw) argument: %s"
-msgstr "đối số không được thừa nhận %%(raw): %s"
-
 #: ref-filter.c:458
 #, c-format
 msgid "positive value expected '%s' in %%(%s)"
 msgstr "cần giá trị dương “%s” trong %%(%s)"
-
-#: ref-filter.c:462
-#, c-format
-msgid "unrecognized argument '%s' in %%(%s)"
-msgstr "đối số “%s” không được thừa nhận trong %%(%s)"
 
 #: ref-filter.c:476
 #, c-format
@@ -6900,20 +6872,10 @@ msgstr "vị trí không được thừa nhận:%s"
 msgid "unrecognized width:%s"
 msgstr "chiều rộng không được thừa nhận:%s"
 
-#: ref-filter.c:534
-#, c-format
-msgid "unrecognized %%(align) argument: %s"
-msgstr "đối số không được thừa nhận %%(align): %s"
-
 #: ref-filter.c:542
 #, c-format
 msgid "positive width expected with the %%(align) atom"
 msgstr "cần giá trị độ rộng dương với nguyên tử %%(align)"
-
-#: ref-filter.c:560
-#, c-format
-msgid "unrecognized %%(if) argument: %s"
-msgstr "đối số không được thừa nhận %%(if): %s"
 
 #: ref-filter.c:568
 #, c-format
@@ -6938,15 +6900,10 @@ msgstr ""
 "không phải là một kho git, nhưng trường “%.*s” yêu cầu truy cập vào dữ liệu "
 "đối tượng"
 
-#: ref-filter.c:844
+#: ref-filter.c:844 ref-filter.c:910 ref-filter.c:946 ref-filter.c:948
 #, c-format
-msgid "format: %%(if) atom used without a %%(then) atom"
-msgstr "định dạng: nguyên tử %%(if) được dùng mà không có nguyên tử %%(then)"
-
-#: ref-filter.c:910
-#, c-format
-msgid "format: %%(then) atom used without an %%(if) atom"
-msgstr "định dạng: nguyên tử %%(then) được dùng mà không có nguyên tử %%(if)"
+msgid "format: %%(%s) atom used without a %%(%s) atom"
+msgstr "định dạng: nguyên tử %%(%s) được dùng mà không có nguyên tử %%(%s)"
 
 #: ref-filter.c:912
 #, c-format
@@ -6957,16 +6914,6 @@ msgstr "định dạng: nguyên tử %%(then) được dùng nhiều hơn một 
 #, c-format
 msgid "format: %%(then) atom used after %%(else)"
 msgstr "định dạng: nguyên tử %%(then) được dùng sau %%(else)"
-
-#: ref-filter.c:946
-#, c-format
-msgid "format: %%(else) atom used without an %%(if) atom"
-msgstr "định dạng: nguyên tử %%(else) được dùng mà không có nguyên tử %%(if)"
-
-#: ref-filter.c:948
-#, c-format
-msgid "format: %%(else) atom used without a %%(then) atom"
-msgstr "định dạng: nguyên tử %%(else) được dùng mà không có nguyên tử %%(then)"
 
 #: ref-filter.c:950
 #, c-format
@@ -7042,22 +6989,22 @@ msgstr "đối tượng dị hình tại “%s”"
 msgid "ignoring ref with broken name %s"
 msgstr "đang lờ đi tham chiếu với tên hỏng %s"
 
-#: ref-filter.c:2250 refs.c:673
+#: ref-filter.c:2250 refs.c:676
 #, c-format
 msgid "ignoring broken ref %s"
 msgstr "đang lờ đi tham chiếu hỏng %s"
 
-#: ref-filter.c:2623
+#: ref-filter.c:2629
 #, c-format
 msgid "format: %%(end) atom missing"
 msgstr "định dạng: thiếu nguyên tử %%(end)"
 
-#: ref-filter.c:2726
+#: ref-filter.c:2740
 #, c-format
 msgid "malformed object name %s"
 msgstr "tên đối tượng dị hình %s"
 
-#: ref-filter.c:2731
+#: ref-filter.c:2745
 #, c-format
 msgid "option `%s' must point to a commit"
 msgstr "tùy chọn “%s” phải chỉ đến một lần chuyển giao"
@@ -7102,71 +7049,71 @@ msgstr "không thể lấy về “%s”"
 msgid "invalid branch name: %s = %s"
 msgstr "tên nhánh không hợp lệ: %s = %s"
 
-#: refs.c:671
+#: refs.c:674
 #, c-format
 msgid "ignoring dangling symref %s"
 msgstr "đang lờ đi tham chiếu mềm thừa %s"
 
-#: refs.c:920
+#: refs.c:925
 #, c-format
 msgid "log for ref %s has gap after %s"
 msgstr "nhật ký cho tham chiếu %s có khoảng trống sau %s"
 
-#: refs.c:927
+#: refs.c:932
 #, c-format
 msgid "log for ref %s unexpectedly ended on %s"
 msgstr "nhật ký cho tham chiếu %s kết thúc bất ngờ trên %s"
 
-#: refs.c:992
+#: refs.c:997
 #, c-format
 msgid "log for %s is empty"
 msgstr "nhật ký cho %s trống rỗng"
 
-#: refs.c:1084
+#: refs.c:1090
 #, c-format
 msgid "refusing to update ref with bad name '%s'"
 msgstr "từ chối cập nhật tham chiếu với tên sai “%s”"
 
-#: refs.c:1155
+#: refs.c:1168
 #, c-format
 msgid "update_ref failed for ref '%s': %s"
 msgstr "update_ref bị lỗi cho ref “%s”: %s"
 
-#: refs.c:2062
+#: refs.c:2067
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "không cho phép đa cập nhật cho tham chiếu “%s”"
 
-#: refs.c:2142
+#: refs.c:2150
 msgid "ref updates forbidden inside quarantine environment"
 msgstr "cập nhật tham chiếu bị cấm trong môi trường kiểm tra"
 
-#: refs.c:2153
+#: refs.c:2161
 msgid "ref updates aborted by hook"
 msgstr "các cập nhật tham chiếu bị bãi bỏ bởi móc"
 
-#: refs.c:2253 refs.c:2283
+#: refs.c:2269 refs.c:2299
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "“%s” sẵn có; không thể tạo “%s”"
 
-#: refs.c:2259 refs.c:2294
+#: refs.c:2275 refs.c:2310
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "không thể xử lý “%s” và “%s” cùng một lúc"
 
-#: refs/files-backend.c:1271
+#: refs/files-backend.c:1267
 #, c-format
 msgid "could not remove reference %s"
 msgstr "không thể gỡ bỏ tham chiếu: %s"
 
-#: refs/files-backend.c:1285 refs/packed-backend.c:1549
+#: refs/files-backend.c:1281 refs/packed-backend.c:1549
 #: refs/packed-backend.c:1559
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr "không thể xóa bỏ tham chiếu %s: %s"
 
-#: refs/files-backend.c:1288 refs/packed-backend.c:1562
+#: refs/files-backend.c:1284 refs/packed-backend.c:1562
 #, c-format
 msgid "could not delete references: %s"
 msgstr "không thể xóa bỏ tham chiếu: %s"
@@ -7176,50 +7123,50 @@ msgstr "không thể xóa bỏ tham chiếu: %s"
 msgid "invalid refspec '%s'"
 msgstr "refspec không hợp lệ “%s”"
 
-#: remote.c:351
+#: remote.c:402
 #, c-format
 msgid "config remote shorthand cannot begin with '/': %s"
 msgstr "cấu hình viết tắt máy chủ không thể bắt đầu bằng “/”: %s"
 
-#: remote.c:399
+#: remote.c:450
 msgid "more than one receivepack given, using the first"
 msgstr "đã đưa ra nhiều hơn một gói nhận về, đang sử dụng cái đầu tiên"
 
-#: remote.c:407
+#: remote.c:458
 msgid "more than one uploadpack given, using the first"
 msgstr "đã đưa ra nhiều hơn một gói tải lên, đang sử dụng cái đầu tiên"
 
-#: remote.c:590
+#: remote.c:699
 #, c-format
 msgid "Cannot fetch both %s and %s to %s"
 msgstr "Không thể lấy về cả %s và %s cho %s"
 
-#: remote.c:594
+#: remote.c:703
 #, c-format
 msgid "%s usually tracks %s, not %s"
 msgstr "%s thường theo dõi %s, không phải %s"
 
-#: remote.c:598
+#: remote.c:707
 #, c-format
 msgid "%s tracks both %s and %s"
 msgstr "%s theo dõi cả %s và %s"
 
-#: remote.c:666
+#: remote.c:775
 #, c-format
 msgid "key '%s' of pattern had no '*'"
 msgstr "khóa “%s” của mẫu k có “*”"
 
-#: remote.c:676
+#: remote.c:785
 #, c-format
 msgid "value '%s' of pattern has no '*'"
 msgstr "giá trị “%s” của mẫu k có “*”"
 
-#: remote.c:1083
+#: remote.c:1192
 #, c-format
 msgid "src refspec %s does not match any"
 msgstr "refspec %s nguồn không khớp bất kỳ cái gì"
 
-#: remote.c:1088
+#: remote.c:1197
 #, c-format
 msgid "src refspec %s matches more than one"
 msgstr "refspec %s nguồn khớp nhiều hơn một"
@@ -7228,7 +7175,7 @@ msgstr "refspec %s nguồn khớp nhiều hơn một"
 #. <remote> <src>:<dst>" push, and "being pushed ('%s')" is
 #. the <src>.
 #.
-#: remote.c:1103
+#: remote.c:1212
 #, c-format
 msgid ""
 "The destination you provided is not a full refname (i.e.,\n"
@@ -7253,7 +7200,7 @@ msgstr ""
 "Nếu cả hai là không thể, thì chúng tôi cũng chịu thua. Bạn phải dùng tham "
 "chiếu dạng đầy đủ."
 
-#: remote.c:1123
+#: remote.c:1232
 #, c-format
 msgid ""
 "The <src> part of the refspec is a commit object.\n"
@@ -7264,7 +7211,7 @@ msgstr ""
 "Có phải ý bạn là một tạo một nhánh mới bằng cách đẩy lên\n"
 "“%s:refs/heads/%s”?"
 
-#: remote.c:1128
+#: remote.c:1237
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tag object.\n"
@@ -7275,7 +7222,7 @@ msgstr ""
 "Có phải ý bạn là một tạo một thẻ mới bằng cách đẩy lên\n"
 "“%s:refs/tags/%s”?"
 
-#: remote.c:1133
+#: remote.c:1242
 #, c-format
 msgid ""
 "The <src> part of the refspec is a tree object.\n"
@@ -7286,7 +7233,7 @@ msgstr ""
 "Có phải ý bạn là một tạo một cây mới bằng cách đẩy lên\n"
 "“%s:refs/tags/%s”?"
 
-#: remote.c:1138
+#: remote.c:1247
 #, c-format
 msgid ""
 "The <src> part of the refspec is a blob object.\n"
@@ -7297,115 +7244,115 @@ msgstr ""
 "Có phải ý bạn là một tạo một blob mới bằng cách đẩy lên\n"
 "“%s:refs/tags/%s”?"
 
-#: remote.c:1174
+#: remote.c:1283
 #, c-format
 msgid "%s cannot be resolved to branch"
 msgstr "“%s” không thể được phân giải thành nhánh"
 
-#: remote.c:1185
+#: remote.c:1294
 #, c-format
 msgid "unable to delete '%s': remote ref does not exist"
 msgstr "không thể xóa “%s”: tham chiếu trên máy chủ không tồn tại"
 
-#: remote.c:1197
+#: remote.c:1306
 #, c-format
 msgid "dst refspec %s matches more than one"
 msgstr "dst refspec %s khớp nhiều hơn một"
 
-#: remote.c:1204
+#: remote.c:1313
 #, c-format
 msgid "dst ref %s receives from more than one src"
 msgstr "dst ref %s nhận từ hơn một nguồn"
 
-#: remote.c:1724 remote.c:1825
+#: remote.c:1834 remote.c:1941
 msgid "HEAD does not point to a branch"
 msgstr "HEAD không chỉ đến một nhánh nào cả"
 
-#: remote.c:1733
+#: remote.c:1843
 #, c-format
 msgid "no such branch: '%s'"
 msgstr "không có nhánh nào như thế: “%s”"
 
-#: remote.c:1736
+#: remote.c:1846
 #, c-format
 msgid "no upstream configured for branch '%s'"
 msgstr "không có thượng nguồn được cấu hình cho nhánh “%s”"
 
-#: remote.c:1742
+#: remote.c:1852
 #, c-format
 msgid "upstream branch '%s' not stored as a remote-tracking branch"
 msgstr ""
 "nhánh thượng nguồn “%s” không được lưu lại như là một nhánh theo dõi máy chủ"
 
-#: remote.c:1757
+#: remote.c:1867
 #, c-format
 msgid "push destination '%s' on remote '%s' has no local tracking branch"
 msgstr "đẩy lên đích “%s” trên máy chủ “%s” không có nhánh theo dõi nội bộ"
 
-#: remote.c:1769
+#: remote.c:1882
 #, c-format
 msgid "branch '%s' has no remote for pushing"
 msgstr "nhánh “%s” không có máy chủ để đẩy lên"
 
-#: remote.c:1779
+#: remote.c:1892
 #, c-format
 msgid "push refspecs for '%s' do not include '%s'"
 msgstr "đẩy refspecs cho “%s” không bao gồm “%s”"
 
-#: remote.c:1792
+#: remote.c:1905
 msgid "push has no destination (push.default is 'nothing')"
 msgstr "đẩy lên mà không có đích (push.default là “nothing”)"
 
-#: remote.c:1814
+#: remote.c:1927
 msgid "cannot resolve 'simple' push to a single destination"
 msgstr "không thể phân giải đẩy “đơn giản” đến một đích đơn"
 
-#: remote.c:1943
+#: remote.c:2060
 #, c-format
 msgid "couldn't find remote ref %s"
 msgstr "không thể tìm thấy tham chiếu máy chủ %s"
 
-#: remote.c:1956
+#: remote.c:2073
 #, c-format
 msgid "* Ignoring funny ref '%s' locally"
 msgstr "* Đang bỏ qua tham chiếu thú vị nội bộ “%s”"
 
-#: remote.c:2119
+#: remote.c:2236
 #, c-format
 msgid "Your branch is based on '%s', but the upstream is gone.\n"
 msgstr ""
 "Nhánh của bạn dựa trên cơ sở là “%s”, nhưng trên thượng nguồn không còn.\n"
 
-#: remote.c:2123
+#: remote.c:2240
 msgid "  (use \"git branch --unset-upstream\" to fixup)\n"
 msgstr "   (dùng \" git branch --unset-upstream\" để sửa)\n"
 
-#: remote.c:2126
+#: remote.c:2243
 #, c-format
 msgid "Your branch is up to date with '%s'.\n"
 msgstr "Nhánh của bạn đã cập nhật với “%s”.\n"
 
-#: remote.c:2130
+#: remote.c:2247
 #, c-format
 msgid "Your branch and '%s' refer to different commits.\n"
 msgstr "Nhánh của bạn và “%s” tham chiếu đến các lần chuyển giao khác nhau.\n"
 
-#: remote.c:2133
+#: remote.c:2250
 #, c-format
 msgid "  (use \"%s\" for details)\n"
 msgstr "  (dùng \"%s\" để biết thêm chi tiết)\n"
 
-#: remote.c:2137
+#: remote.c:2254
 #, c-format
 msgid "Your branch is ahead of '%s' by %d commit.\n"
 msgid_plural "Your branch is ahead of '%s' by %d commits.\n"
 msgstr[0] "Nhánh của bạn đứng trước “%s” %d lần chuyển giao.\n"
 
-#: remote.c:2143
+#: remote.c:2260
 msgid "  (use \"git push\" to publish your local commits)\n"
 msgstr "  (dùng \"git push\" để xuất bản các lần chuyển giao nội bộ của bạn)\n"
 
-#: remote.c:2146
+#: remote.c:2263
 #, c-format
 msgid "Your branch is behind '%s' by %d commit, and can be fast-forwarded.\n"
 msgid_plural ""
@@ -7414,11 +7361,11 @@ msgstr[0] ""
 "Nhánh của bạn đứng đằng sau “%s” %d lần chuyển giao, và có thể được chuyển-"
 "tiếp-nhanh.\n"
 
-#: remote.c:2154
+#: remote.c:2271
 msgid "  (use \"git pull\" to update your local branch)\n"
 msgstr "  (dùng \"git pull\" để cập nhật nhánh nội bộ của bạn)\n"
 
-#: remote.c:2157
+#: remote.c:2274
 #, c-format
 msgid ""
 "Your branch and '%s' have diverged,\n"
@@ -7431,13 +7378,13 @@ msgstr[0] ""
 "và có %d và %d lần chuyển giao khác nhau cho từng cái,\n"
 "tương ứng với mỗi lần.\n"
 
-#: remote.c:2167
+#: remote.c:2284
 msgid "  (use \"git pull\" to merge the remote branch into yours)\n"
 msgstr ""
 "  (dùng \"git pull\" để hòa trộn nhánh trên máy chủ vào trong nhánh của "
 "bạn)\n"
 
-#: remote.c:2359
+#: remote.c:2476
 #, c-format
 msgid "cannot parse expected object name '%s'"
 msgstr "không thể phân tích tên đối tượng mong muốn “%s”"
@@ -7470,7 +7417,7 @@ msgstr "không thể ghi bản ghi rerere"
 msgid "there were errors while writing '%s' (%s)"
 msgstr "gặp lỗi đọc khi đang ghi “%s” (%s)"
 
-#: rerere.c:482 builtin/gc.c:2246 builtin/gc.c:2281
+#: rerere.c:482 builtin/gc.c:2263 builtin/gc.c:2298
 #, c-format
 msgid "failed to flush '%s'"
 msgstr "gặp lỗi khi đẩy dữ liệu “%s” lên đĩa"
@@ -7515,8 +7462,8 @@ msgstr "không thể unlink stray “%s”"
 msgid "Recorded preimage for '%s'"
 msgstr "Preimage đã được ghi lại cho “%s”"
 
-#: rerere.c:865 submodule.c:2121 builtin/log.c:2002
-#: builtin/submodule--helper.c:1776 builtin/submodule--helper.c:1819
+#: rerere.c:865 submodule.c:2121 builtin/log.c:2017
+#: builtin/submodule--helper.c:1777 builtin/submodule--helper.c:1820
 #, c-format
 msgid "could not create directory '%s'"
 msgstr "không thể tạo thư mục “%s”"
@@ -7554,37 +7501,29 @@ msgstr "không thể mở thư mục rr-cache"
 msgid "could not determine HEAD revision"
 msgstr "không thể dò tìm điểm xét duyệt HEAD"
 
-#: reset.c:70 reset.c:76 sequencer.c:3705
+#: reset.c:70 reset.c:76 sequencer.c:3700
 #, c-format
 msgid "failed to find tree of %s"
 msgstr "gặp lỗi khi tìm cây của %s"
 
-#: revision.c:2259
-msgid "--unsorted-input is incompatible with --no-walk"
-msgstr "--unsorted-input xung khắc với --no-walk"
-
-#: revision.c:2346
+#: revision.c:2347
 msgid "--unpacked=<packfile> no longer supported"
 msgstr "--unpacked=<packfile> không còn được hỗ trợ nữa"
 
-#: revision.c:2655 revision.c:2659
-msgid "--no-walk is incompatible with --unsorted-input"
-msgstr "--no-walk xung khắc với --unsorted-input"
-
-#: revision.c:2690
+#: revision.c:2686
 msgid "your current branch appears to be broken"
 msgstr "nhánh hiện tại của bạn có vẻ như bị hỏng"
 
-#: revision.c:2693
+#: revision.c:2689
 #, c-format
 msgid "your current branch '%s' does not have any commits yet"
 msgstr "nhánh hiện tại của bạn “%s” không có một lần chuyển giao nào cả"
 
-#: revision.c:2895
+#: revision.c:2891
 msgid "-L does not yet support diff formats besides -p and -s"
 msgstr "-L vẫn chưa hỗ trợ định dạng khác biệt nào ngoài -p và -s"
 
-#: run-command.c:1278
+#: run-command.c:1262
 #, c-format
 msgid "cannot create async thread: %s"
 msgstr "không thể tạo tuyến trình async: %s"
@@ -7650,8 +7589,8 @@ msgstr "chế độ dọn dẹp ghi chú các lần chuyển giao không hợp l
 msgid "could not delete '%s'"
 msgstr "không thể xóa bỏ “%s”"
 
-#: sequencer.c:345 sequencer.c:4754 builtin/rebase.c:563 builtin/rebase.c:1297
-#: builtin/rm.c:408
+#: sequencer.c:345 sequencer.c:4751 builtin/rebase.c:563 builtin/rebase.c:1297
+#: builtin/rm.c:409
 #, c-format
 msgid "could not remove '%s'"
 msgstr "không thể gỡ bỏ “%s”"
@@ -7713,13 +7652,13 @@ msgstr ""
 "Để bãi bỏ và quay trở lại trạng thái trước \"git revert\",\n"
 "chạy \"git revert --abort\"."
 
-#: sequencer.c:448 sequencer.c:3290
+#: sequencer.c:448 sequencer.c:3292
 #, c-format
 msgid "could not lock '%s'"
 msgstr "không thể khóa “%s”"
 
-#: sequencer.c:450 sequencer.c:3089 sequencer.c:3294 sequencer.c:3308
-#: sequencer.c:3566 sequencer.c:5621 strbuf.c:1176 wrapper.c:639
+#: sequencer.c:450 sequencer.c:3091 sequencer.c:3296 sequencer.c:3310
+#: sequencer.c:3561 sequencer.c:5618 strbuf.c:1188 wrapper.c:639
 #, c-format
 msgid "could not write to '%s'"
 msgstr "không thể ghi vào “%s”"
@@ -7729,11 +7668,17 @@ msgstr "không thể ghi vào “%s”"
 msgid "could not write eol to '%s'"
 msgstr "không thể ghi eol vào “%s”"
 
-#: sequencer.c:460 sequencer.c:3094 sequencer.c:3296 sequencer.c:3310
-#: sequencer.c:3574
+#: sequencer.c:460 sequencer.c:3096 sequencer.c:3298 sequencer.c:3312
+#: sequencer.c:3569
 #, c-format
 msgid "failed to finalize '%s'"
 msgstr "gặp lỗi khi hoàn thành “%s”"
+
+#: sequencer.c:473 sequencer.c:1934 sequencer.c:3116 sequencer.c:3551
+#: sequencer.c:3679 builtin/am.c:289 builtin/commit.c:834 builtin/merge.c:1148
+#, c-format
+msgid "could not read '%s'"
+msgstr "không thể đọc “%s”"
 
 #: sequencer.c:499
 #, c-format
@@ -7749,7 +7694,7 @@ msgstr "chuyển giao các thay đổi của bạn hay tạm cất (stash) chún
 msgid "%s: fast-forward"
 msgstr "%s: chuyển-tiếp-nhanh"
 
-#: sequencer.c:574 builtin/tag.c:610
+#: sequencer.c:574 builtin/tag.c:614
 #, c-format
 msgid "Invalid cleanup mode %s"
 msgstr "Chế độ dọn dẹp không hợp lệ %s"
@@ -7780,8 +7725,8 @@ msgstr "không có khóa hiện diện trong “%.*s”"
 msgid "unable to dequote value of '%s'"
 msgstr "không thể giải trích dẫn giá trị của “%s”"
 
-#: sequencer.c:841 wrapper.c:209 wrapper.c:379 builtin/am.c:730
-#: builtin/am.c:822 builtin/rebase.c:694
+#: sequencer.c:841 wrapper.c:209 wrapper.c:379 builtin/am.c:756
+#: builtin/am.c:848 builtin/rebase.c:694
 #, c-format
 msgid "could not open '%s' for reading"
 msgstr "không thể mở “%s” để đọc"
@@ -7844,11 +7789,11 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:1229
+#: sequencer.c:1225
 msgid "'prepare-commit-msg' hook failed"
 msgstr "móc “prepare-commit-msg” bị lỗi"
 
-#: sequencer.c:1235
+#: sequencer.c:1231
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7879,7 +7824,7 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1248
+#: sequencer.c:1244
 msgid ""
 "Your name and email address were configured automatically based\n"
 "on your username and hostname. Please check that they are accurate.\n"
@@ -7907,351 +7852,352 @@ msgstr ""
 "\n"
 "    git commit --amend --reset-author\n"
 
-#: sequencer.c:1290
+#: sequencer.c:1288
 msgid "couldn't look up newly created commit"
 msgstr "không thể tìm thấy lần chuyển giao mới hơn đã được tạo"
 
-#: sequencer.c:1292
+#: sequencer.c:1290
 msgid "could not parse newly created commit"
 msgstr ""
 "không thể phân tích cú pháp của đối tượng chuyển giao mới hơn đã được tạo"
 
-#: sequencer.c:1338
+#: sequencer.c:1339
 msgid "unable to resolve HEAD after creating commit"
 msgstr "không thể phân giải HEAD sau khi tạo lần chuyển giao"
 
-#: sequencer.c:1340
+#: sequencer.c:1342
 msgid "detached HEAD"
 msgstr "đã rời khỏi HEAD"
 
-#: sequencer.c:1344
+#: sequencer.c:1346
 msgid " (root-commit)"
 msgstr " (root-commit)"
 
-#: sequencer.c:1365
+#: sequencer.c:1367
 msgid "could not parse HEAD"
 msgstr "không thể phân tích HEAD"
 
-#: sequencer.c:1367
+#: sequencer.c:1369
 #, c-format
 msgid "HEAD %s is not a commit!"
 msgstr "HEAD %s không phải là một lần chuyển giao!"
 
-#: sequencer.c:1371 sequencer.c:1449 builtin/commit.c:1707
+#: sequencer.c:1373 sequencer.c:1451 builtin/commit.c:1708
 msgid "could not parse HEAD commit"
 msgstr "không thể phân tích commit (lần chuyển giao) HEAD"
 
-#: sequencer.c:1427 sequencer.c:2312
+#: sequencer.c:1429 sequencer.c:2314
 msgid "unable to parse commit author"
 msgstr "không thể phân tích tác giả của lần chuyển giao"
 
-#: sequencer.c:1438 builtin/am.c:1616 builtin/merge.c:708
+#: sequencer.c:1440 builtin/am.c:1643 builtin/merge.c:710
 msgid "git write-tree failed to write a tree"
 msgstr "lệnh git write-tree gặp lỗi khi ghi một cây"
 
-#: sequencer.c:1471 sequencer.c:1591
+#: sequencer.c:1473 sequencer.c:1593
 #, c-format
 msgid "unable to read commit message from '%s'"
 msgstr "không thể đọc phần chú thích (message) từ “%s”"
 
-#: sequencer.c:1502 sequencer.c:1534
+#: sequencer.c:1504 sequencer.c:1536
 #, c-format
 msgid "invalid author identity '%s'"
 msgstr "định danh tác giả không hợp lệ “%s”"
 
-#: sequencer.c:1508
+#: sequencer.c:1510
 msgid "corrupt author: missing date information"
 msgstr "tác giả sai hỏng: thiếu thông tin ngày tháng"
 
-#: sequencer.c:1547 builtin/am.c:1643 builtin/commit.c:1821 builtin/merge.c:913
-#: builtin/merge.c:938 t/helper/test-fast-rebase.c:78
+#: sequencer.c:1549 builtin/am.c:1670 builtin/commit.c:1822 builtin/merge.c:915
+#: builtin/merge.c:940 t/helper/test-fast-rebase.c:78
 msgid "failed to write commit object"
 msgstr "gặp lỗi khi ghi đối tượng chuyển giao"
 
-#: sequencer.c:1574 sequencer.c:4526 t/helper/test-fast-rebase.c:199
+#: sequencer.c:1576 sequencer.c:4523 t/helper/test-fast-rebase.c:199
 #: t/helper/test-fast-rebase.c:217
 #, c-format
 msgid "could not update %s"
 msgstr "không thể cập nhật %s"
 
-#: sequencer.c:1623
+#: sequencer.c:1625
 #, c-format
 msgid "could not parse commit %s"
 msgstr "không thể phân tích lần chuyển giao %s"
 
-#: sequencer.c:1628
+#: sequencer.c:1630
 #, c-format
 msgid "could not parse parent commit %s"
 msgstr "không thể phân tích lần chuyển giao cha mẹ “%s”"
 
-#: sequencer.c:1711 sequencer.c:1992
+#: sequencer.c:1713 sequencer.c:1994
 #, c-format
 msgid "unknown command: %d"
 msgstr "không hiểu câu lệnh %d"
 
-#: sequencer.c:1753
+#: sequencer.c:1755
 msgid "This is the 1st commit message:"
 msgstr "Đây là chú thích cho lần chuyển giao thứ nhất:"
 
-#: sequencer.c:1754
+#: sequencer.c:1756
 #, c-format
 msgid "This is the commit message #%d:"
 msgstr "Đây là chú thích cho lần chuyển giao thứ #%d:"
 
-#: sequencer.c:1755
+#: sequencer.c:1757
 msgid "The 1st commit message will be skipped:"
 msgstr "Chú thích cho lần chuyển giao thứ nhất sẽ bị bỏ qua:"
 
-#: sequencer.c:1756
+#: sequencer.c:1758
 #, c-format
 msgid "The commit message #%d will be skipped:"
 msgstr "Chú thích cho lần chuyển giao thứ #%d sẽ bị bỏ qua:"
 
-#: sequencer.c:1757
+#: sequencer.c:1759
 #, c-format
 msgid "This is a combination of %d commits."
 msgstr "Đây là tổ hợp của %d lần chuyển giao."
 
-#: sequencer.c:1904 sequencer.c:1961
+#: sequencer.c:1906 sequencer.c:1963
 #, c-format
 msgid "cannot write '%s'"
 msgstr "không thể ghi “%s”"
 
-#: sequencer.c:1951
+#: sequencer.c:1953
 msgid "need a HEAD to fixup"
 msgstr "cần một HEAD để sửa"
 
-#: sequencer.c:1953 sequencer.c:3601
+#: sequencer.c:1955 sequencer.c:3596
 msgid "could not read HEAD"
 msgstr "không thể đọc HEAD"
 
-#: sequencer.c:1955
+#: sequencer.c:1957
 msgid "could not read HEAD's commit message"
 msgstr "không thể đọc phần chú thích (message) của HEAD"
 
-#: sequencer.c:1979
+#: sequencer.c:1981
 #, c-format
 msgid "could not read commit message of %s"
 msgstr "không thể đọc phần chú thích (message) của %s"
 
-#: sequencer.c:2089
+#: sequencer.c:2091
 msgid "your index file is unmerged."
 msgstr "tập tin lưu mục lục của bạn không được hòa trộn."
 
-#: sequencer.c:2096
+#: sequencer.c:2098
 msgid "cannot fixup root commit"
 msgstr "không thể sửa chữa lần chuyển giao gốc"
 
-#: sequencer.c:2115
+#: sequencer.c:2117
 #, c-format
 msgid "commit %s is a merge but no -m option was given."
 msgstr "lần chuyển giao %s là một lần hòa trộn nhưng không đưa ra tùy chọn -m."
 
-#: sequencer.c:2123 sequencer.c:2131
+#: sequencer.c:2125 sequencer.c:2133
 #, c-format
 msgid "commit %s does not have parent %d"
 msgstr "lần chuyển giao %s không có cha mẹ %d"
 
-#: sequencer.c:2137
+#: sequencer.c:2139
 #, c-format
 msgid "cannot get commit message for %s"
 msgstr "không thể lấy ghi chú lần chuyển giao cho %s"
 
 #. TRANSLATORS: The first %s will be a "todo" command like
 #. "revert" or "pick", the second %s a SHA1.
-#: sequencer.c:2156
+#: sequencer.c:2158
 #, c-format
 msgid "%s: cannot parse parent commit %s"
 msgstr "%s: không thể phân tích lần chuyển giao mẹ của %s"
 
-#: sequencer.c:2222
+#: sequencer.c:2224
 #, c-format
 msgid "could not rename '%s' to '%s'"
 msgstr "không thể đổi tên “%s” thành “%s”"
 
-#: sequencer.c:2282
+#: sequencer.c:2284
 #, c-format
 msgid "could not revert %s... %s"
 msgstr "không thể hoàn nguyên %s… %s"
 
-#: sequencer.c:2283
+#: sequencer.c:2285
 #, c-format
 msgid "could not apply %s... %s"
 msgstr "không thể áp dụng miếng vá %s… %s"
 
-#: sequencer.c:2304
+#: sequencer.c:2306
 #, c-format
 msgid "dropping %s %s -- patch contents already upstream\n"
 msgstr "xóa %s %s -- vá nội dung thượng nguồn đã có\n"
 
-#: sequencer.c:2362
+#: sequencer.c:2364
 #, c-format
 msgid "git %s: failed to read the index"
 msgstr "git %s: gặp lỗi đọc bảng mục lục"
 
-#: sequencer.c:2370
+#: sequencer.c:2372
 #, c-format
 msgid "git %s: failed to refresh the index"
 msgstr "git %s: gặp lỗi khi làm tươi mới bảng mục lục"
 
-#: sequencer.c:2450
+#: sequencer.c:2452
 #, c-format
 msgid "%s does not accept arguments: '%s'"
 msgstr "%s không nhận các đối số: “%s”"
 
-#: sequencer.c:2459
+#: sequencer.c:2461
 #, c-format
 msgid "missing arguments for %s"
 msgstr "thiếu đối số cho %s"
 
-#: sequencer.c:2502
+#: sequencer.c:2504
 #, c-format
 msgid "could not parse '%s'"
 msgstr "không thể phân tích cú pháp “%s”"
 
-#: sequencer.c:2563
+#: sequencer.c:2565
 #, c-format
 msgid "invalid line %d: %.*s"
 msgstr "dòng không hợp lệ %d: %.*s"
 
-#: sequencer.c:2574
+#: sequencer.c:2576
 #, c-format
 msgid "cannot '%s' without a previous commit"
 msgstr "không thể “%s” thể mà không có lần chuyển giao kế trước"
 
-#: sequencer.c:2622 builtin/rebase.c:184
+#: sequencer.c:2624 builtin/rebase.c:184
 #, c-format
 msgid "could not read '%s'."
 msgstr "không thể đọc “%s”."
 
-#: sequencer.c:2660
+#: sequencer.c:2662
 msgid "cancelling a cherry picking in progress"
 msgstr "đang hủy bỏ thao tác cherry pick đang thực hiện"
 
-#: sequencer.c:2669
+#: sequencer.c:2671
 msgid "cancelling a revert in progress"
 msgstr "đang hủy bỏ các thao tác hoàn nguyên đang thực hiện"
 
-#: sequencer.c:2709
+#: sequencer.c:2711
 msgid "please fix this using 'git rebase --edit-todo'."
 msgstr "vui lòng sửa lỗi này bằng cách dùng “git rebase --edit-todo”."
 
-#: sequencer.c:2711
+#: sequencer.c:2713
 #, c-format
 msgid "unusable instruction sheet: '%s'"
 msgstr "bảng chỉ thị không thể dùng được: %s"
 
-#: sequencer.c:2716
+#: sequencer.c:2718
 msgid "no commits parsed."
 msgstr "không có lần chuyển giao nào được phân tích."
 
-#: sequencer.c:2727
+#: sequencer.c:2729
 msgid "cannot cherry-pick during a revert."
 msgstr "không thể cherry-pick trong khi hoàn nguyên."
 
-#: sequencer.c:2729
+#: sequencer.c:2731
 msgid "cannot revert during a cherry-pick."
 msgstr "không thể thực hiện việc hoàn nguyên trong khi đang cherry-pick."
 
-#: sequencer.c:2807
+#: sequencer.c:2809
 #, c-format
 msgid "invalid value for %s: %s"
 msgstr "giá trị cho %s không hợp lệ: %s"
 
-#: sequencer.c:2916
+#: sequencer.c:2918
 msgid "unusable squash-onto"
 msgstr "squash-onto không dùng được"
 
-#: sequencer.c:2936
+#: sequencer.c:2938
 #, c-format
 msgid "malformed options sheet: '%s'"
 msgstr "bảng tùy chọn dị hình: “%s”"
 
-#: sequencer.c:3031 sequencer.c:4905
+#: sequencer.c:3033 sequencer.c:4902
 msgid "empty commit set passed"
 msgstr "lần chuyển giao trống rỗng đặt là hợp quy cách"
 
-#: sequencer.c:3048
+#: sequencer.c:3050
 msgid "revert is already in progress"
 msgstr "có thao tác hoàn nguyên đang được thực hiện"
 
-#: sequencer.c:3050
+#: sequencer.c:3052
 #, c-format
 msgid "try \"git revert (--continue | %s--abort | --quit)\""
 msgstr "hãy thử \"git revert (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:3053
+#: sequencer.c:3055
 msgid "cherry-pick is already in progress"
 msgstr "có thao tác “cherry-pick” đang được thực hiện"
 
-#: sequencer.c:3055
+#: sequencer.c:3057
 #, c-format
 msgid "try \"git cherry-pick (--continue | %s--abort | --quit)\""
 msgstr "hãy thử \"git cherry-pick (--continue | %s--abort | --quit)\""
 
-#: sequencer.c:3069
+#: sequencer.c:3071
 #, c-format
 msgid "could not create sequencer directory '%s'"
 msgstr "không thể tạo thư mục xếp dãy “%s”"
 
-#: sequencer.c:3084
+#: sequencer.c:3086
 msgid "could not lock HEAD"
 msgstr "không thể khóa HEAD"
 
-#: sequencer.c:3144 sequencer.c:4615
+#: sequencer.c:3146 sequencer.c:4612
 msgid "no cherry-pick or revert in progress"
 msgstr "không cherry-pick hay hoàn nguyên trong tiến trình"
 
-#: sequencer.c:3146 sequencer.c:3157
+#: sequencer.c:3148 sequencer.c:3159
 msgid "cannot resolve HEAD"
 msgstr "không thể phân giải HEAD"
 
-#: sequencer.c:3148 sequencer.c:3192
+#: sequencer.c:3150 sequencer.c:3194
 msgid "cannot abort from a branch yet to be born"
 msgstr "không thể hủy bỏ từ một nhánh mà nó còn chưa được tạo ra"
 
-#: sequencer.c:3178 builtin/grep.c:772
+#: sequencer.c:3180 builtin/fetch.c:1004 builtin/fetch.c:1416
+#: builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr "không mở được “%s”"
 
-#: sequencer.c:3180
+#: sequencer.c:3182
 #, c-format
 msgid "cannot read '%s': %s"
 msgstr "không thể đọc “%s”: %s"
 
-#: sequencer.c:3181
+#: sequencer.c:3183
 msgid "unexpected end of file"
 msgstr "gặp kết thúc tập tin đột xuất"
 
-#: sequencer.c:3187
+#: sequencer.c:3189
 #, c-format
 msgid "stored pre-cherry-pick HEAD file '%s' is corrupt"
 msgstr "tập tin HEAD “pre-cherry-pick” đã lưu “%s” bị hỏng"
 
-#: sequencer.c:3198
+#: sequencer.c:3200
 msgid "You seem to have moved HEAD. Not rewinding, check your HEAD!"
 msgstr ""
 "Bạn có lẽ đã có HEAD đã bị di chuyển đi, Không thể tua, kiểm tra HEAD của "
 "bạn!"
 
-#: sequencer.c:3239
+#: sequencer.c:3241
 msgid "no revert in progress"
 msgstr "không có tiến trình hoàn nguyên nào"
 
-#: sequencer.c:3248
+#: sequencer.c:3250
 msgid "no cherry-pick in progress"
 msgstr "không có cherry-pick đang được thực hiện"
 
-#: sequencer.c:3258
+#: sequencer.c:3260
 msgid "failed to skip the commit"
 msgstr "gặp lỗi khi bỏ qua đối tượng chuyển giao"
 
-#: sequencer.c:3265
+#: sequencer.c:3267
 msgid "there is nothing to skip"
 msgstr "ở đây không có gì để mà bỏ qua cả"
 
-#: sequencer.c:3268
+#: sequencer.c:3270
 #, c-format
 msgid ""
 "have you committed already?\n"
@@ -8260,16 +8206,16 @@ msgstr ""
 "bạn đã sẵn sàng chuyển giao chưa?\n"
 "thử \"git %s --continue\""
 
-#: sequencer.c:3430 sequencer.c:4506
+#: sequencer.c:3432 sequencer.c:4503
 msgid "cannot read HEAD"
 msgstr "không thể đọc HEAD"
 
-#: sequencer.c:3447
+#: sequencer.c:3449
 #, c-format
 msgid "unable to copy '%s' to '%s'"
 msgstr "không thể chép “%s” sang “%s”"
 
-#: sequencer.c:3455
+#: sequencer.c:3457
 #, c-format
 msgid ""
 "You can amend the commit now, with\n"
@@ -8288,27 +8234,27 @@ msgstr ""
 "\n"
 "  git rebase --continue\n"
 
-#: sequencer.c:3465
+#: sequencer.c:3467
 #, c-format
 msgid "Could not apply %s... %.*s"
 msgstr "Không thể áp dụng %s… %.*s"
 
-#: sequencer.c:3472
+#: sequencer.c:3474
 #, c-format
 msgid "Could not merge %.*s"
 msgstr "Không hòa trộn %.*s"
 
-#: sequencer.c:3486 sequencer.c:3490 builtin/difftool.c:639
+#: sequencer.c:3488 sequencer.c:3492 builtin/difftool.c:633
 #, c-format
 msgid "could not copy '%s' to '%s'"
 msgstr "không thể chép “%s” sang “%s”"
 
-#: sequencer.c:3502
+#: sequencer.c:3503
 #, c-format
 msgid "Executing: %s\n"
 msgstr "Đang thực thi: %s\n"
 
-#: sequencer.c:3517
+#: sequencer.c:3514
 #, c-format
 msgid ""
 "execution failed: %s\n"
@@ -8323,11 +8269,11 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3523
+#: sequencer.c:3520
 msgid "and made changes to the index and/or the working tree\n"
 msgstr "và tạo các thay đổi bảng mục lục và/hay cây làm việc\n"
 
-#: sequencer.c:3529
+#: sequencer.c:3526
 #, c-format
 msgid ""
 "execution succeeded: %s\n"
@@ -8344,90 +8290,90 @@ msgstr ""
 "  git rebase --continue\n"
 "\n"
 
-#: sequencer.c:3591
+#: sequencer.c:3586
 #, c-format
 msgid "illegal label name: '%.*s'"
 msgstr "tên nhãn dị hình: “%.*s”"
 
-#: sequencer.c:3664
+#: sequencer.c:3659
 msgid "writing fake root commit"
 msgstr "ghi lần chuyển giao gốc giả"
 
-#: sequencer.c:3669
+#: sequencer.c:3664
 msgid "writing squash-onto"
 msgstr "đang ghi squash-onto"
 
-#: sequencer.c:3748
+#: sequencer.c:3743
 #, c-format
 msgid "could not resolve '%s'"
 msgstr "không thể phân giải “%s”"
 
-#: sequencer.c:3780
+#: sequencer.c:3775
 msgid "cannot merge without a current revision"
 msgstr "không thể hòa trộn mà không có một điểm xét duyệt hiện tại"
 
-#: sequencer.c:3802
+#: sequencer.c:3797
 #, c-format
 msgid "unable to parse '%.*s'"
 msgstr "không thể phân tích “%.*s”"
 
-#: sequencer.c:3811
+#: sequencer.c:3806
 #, c-format
 msgid "nothing to merge: '%.*s'"
 msgstr "chẳng có gì để hòa trộn: “%.*s”"
 
-#: sequencer.c:3823
+#: sequencer.c:3818
 msgid "octopus merge cannot be executed on top of a [new root]"
 msgstr "hòa trộn octopus không thể được thực thi trên đỉnh của một [new root]"
 
-#: sequencer.c:3878
+#: sequencer.c:3873
 #, c-format
 msgid "could not get commit message of '%s'"
 msgstr "không thể lấy chú thích của lần chuyển giao của “%s”"
 
-#: sequencer.c:4024
+#: sequencer.c:4019
 #, c-format
 msgid "could not even attempt to merge '%.*s'"
 msgstr "không thể ngay cả khi thử hòa trộn “%.*s”"
 
-#: sequencer.c:4040
+#: sequencer.c:4035
 msgid "merge: Unable to write new index file"
 msgstr "merge: Không thể ghi tập tin lưu bảng mục lục mới"
 
-#: sequencer.c:4121
+#: sequencer.c:4116
 msgid "Cannot autostash"
 msgstr "Không thể autostash"
 
-#: sequencer.c:4124
+#: sequencer.c:4119
 #, c-format
 msgid "Unexpected stash response: '%s'"
 msgstr "Gặp đáp ứng stash không cần: “%s”"
 
-#: sequencer.c:4130
+#: sequencer.c:4125
 #, c-format
 msgid "Could not create directory for '%s'"
 msgstr "Không thể tạo thư mục cho “%s”"
 
-#: sequencer.c:4133
+#: sequencer.c:4128
 #, c-format
 msgid "Created autostash: %s\n"
 msgstr "Đã tạo autostash: %s\n"
 
-#: sequencer.c:4137
+#: sequencer.c:4132
 msgid "could not reset --hard"
 msgstr "không thể reset --hard"
 
-#: sequencer.c:4162
+#: sequencer.c:4157
 #, c-format
 msgid "Applied autostash.\n"
 msgstr "Đã áp dụng autostash.\n"
 
-#: sequencer.c:4174
+#: sequencer.c:4169
 #, c-format
 msgid "cannot store %s"
 msgstr "không thử lưu “%s”"
 
-#: sequencer.c:4177
+#: sequencer.c:4172
 #, c-format
 msgid ""
 "%s\n"
@@ -8439,29 +8385,29 @@ msgstr ""
 "Bạn có thể chạy lệnh \"git stash pop\" hay \"git stash drop\" bất kỳ lúc "
 "nào.\n"
 
-#: sequencer.c:4182
+#: sequencer.c:4177
 msgid "Applying autostash resulted in conflicts."
 msgstr "Áp dụng autostash có hiệu quả trong các xung đột."
 
-#: sequencer.c:4183
+#: sequencer.c:4178
 msgid "Autostash exists; creating a new stash entry."
 msgstr "Autostash đã sẵn có; nên tạo một mục stash mới."
 
-#: sequencer.c:4255
+#: sequencer.c:4252
 msgid "could not detach HEAD"
 msgstr "không thể tách rời HEAD"
 
-#: sequencer.c:4270
+#: sequencer.c:4267
 #, c-format
 msgid "Stopped at HEAD\n"
 msgstr "Dừng lại ở HEAD\n"
 
-#: sequencer.c:4272
+#: sequencer.c:4269
 #, c-format
 msgid "Stopped at %s\n"
 msgstr "Dừng lại ở %s\n"
 
-#: sequencer.c:4304
+#: sequencer.c:4301
 #, c-format
 msgid ""
 "Could not execute the todo command\n"
@@ -8482,58 +8428,58 @@ msgstr ""
 "    git rebase --edit-todo\n"
 "    git rebase --continue\n"
 
-#: sequencer.c:4350
+#: sequencer.c:4347
 #, c-format
 msgid "Rebasing (%d/%d)%s"
 msgstr "Đang cải tổ (%d/%d)%s"
 
-#: sequencer.c:4396
+#: sequencer.c:4393
 #, c-format
 msgid "Stopped at %s...  %.*s\n"
 msgstr "Dừng lại ở %s…  %.*s\n"
 
-#: sequencer.c:4466
+#: sequencer.c:4463
 #, c-format
 msgid "unknown command %d"
 msgstr "không hiểu câu lệnh %d"
 
-#: sequencer.c:4514
+#: sequencer.c:4511
 msgid "could not read orig-head"
 msgstr "không thể đọc orig-head"
 
-#: sequencer.c:4519
+#: sequencer.c:4516
 msgid "could not read 'onto'"
 msgstr "không thể đọc “onto”."
 
-#: sequencer.c:4533
+#: sequencer.c:4530
 #, c-format
 msgid "could not update HEAD to %s"
 msgstr "không thể cập nhật HEAD thành %s"
 
-#: sequencer.c:4593
+#: sequencer.c:4590
 #, c-format
 msgid "Successfully rebased and updated %s.\n"
 msgstr "Cài tổ và cập nhật %s một cách thành công.\n"
 
-#: sequencer.c:4645
+#: sequencer.c:4642
 msgid "cannot rebase: You have unstaged changes."
 msgstr "không thể cải tổ: Bạn có các thay đổi chưa được đưa lên bệ phóng."
 
-#: sequencer.c:4654
+#: sequencer.c:4651
 msgid "cannot amend non-existing commit"
 msgstr "không thể tu bỏ một lần chuyển giao không tồn tại"
 
-#: sequencer.c:4656
+#: sequencer.c:4653
 #, c-format
 msgid "invalid file: '%s'"
 msgstr "tập tin không hợp lệ: “%s”"
 
-#: sequencer.c:4658
+#: sequencer.c:4655
 #, c-format
 msgid "invalid contents: '%s'"
 msgstr "nội dung không hợp lệ: “%s”"
 
-#: sequencer.c:4661
+#: sequencer.c:4658
 msgid ""
 "\n"
 "You have uncommitted changes in your working tree. Please, commit them\n"
@@ -8543,69 +8489,69 @@ msgstr ""
 "Bạn có các thay đổi chưa chuyển giao trong thư mục làm việc. Vui lòng\n"
 "chuyển giao chúng trước và sau đó chạy lệnh “git rebase --continue” lần nữa."
 
-#: sequencer.c:4697 sequencer.c:4736
+#: sequencer.c:4694 sequencer.c:4733
 #, c-format
 msgid "could not write file: '%s'"
 msgstr "không thể ghi tập tin: “%s”"
 
-#: sequencer.c:4752
+#: sequencer.c:4749
 msgid "could not remove CHERRY_PICK_HEAD"
 msgstr "không thể xóa bỏ CHERRY_PICK_HEAD"
 
-#: sequencer.c:4762
+#: sequencer.c:4759
 msgid "could not commit staged changes."
 msgstr "không thể chuyển giao các thay đổi đã đưa lên bệ phóng."
 
-#: sequencer.c:4882
+#: sequencer.c:4879
 #, c-format
 msgid "%s: can't cherry-pick a %s"
 msgstr "%s: không thể cherry-pick một %s"
 
-#: sequencer.c:4886
+#: sequencer.c:4883
 #, c-format
 msgid "%s: bad revision"
 msgstr "%s: điểm xét duyệt sai"
 
-#: sequencer.c:4921
+#: sequencer.c:4918
 msgid "can't revert as initial commit"
 msgstr "không thể hoàn nguyên một lần chuyển giao khởi tạo"
 
-#: sequencer.c:5192 sequencer.c:5421
+#: sequencer.c:5189 sequencer.c:5418
 #, c-format
 msgid "skipped previously applied commit %s"
 msgstr "bỏ qua lần chuyển giao được áp dụng kế trước %s"
 
-#: sequencer.c:5262 sequencer.c:5437
+#: sequencer.c:5259 sequencer.c:5434
 msgid "use --reapply-cherry-picks to include skipped commits"
 msgstr ""
 "dùng --reapply-cherry-picks để bao gồm các lần chuyển giao đã bị bỏ qua"
 
-#: sequencer.c:5408
+#: sequencer.c:5405
 msgid "make_script: unhandled options"
 msgstr "make_script: các tùy chọn được không xử lý"
 
-#: sequencer.c:5411
+#: sequencer.c:5408
 msgid "make_script: error preparing revisions"
 msgstr "make_script: lỗi chuẩn bị điểm hiệu chỉnh"
 
-#: sequencer.c:5669 sequencer.c:5686
+#: sequencer.c:5666 sequencer.c:5683
 msgid "nothing to do"
 msgstr "không có gì để làm"
 
-#: sequencer.c:5705
+#: sequencer.c:5702
 msgid "could not skip unnecessary pick commands"
 msgstr "không thể bỏ qua các lệnh cậy (pick) không cần thiết"
 
-#: sequencer.c:5805
+#: sequencer.c:5802
 msgid "the script was already rearranged."
 msgstr "văn lệnh đã sẵn được sắp đặt rồi."
 
-#: setup.c:133
+#: setup.c:134
 #, c-format
 msgid "'%s' is outside repository at '%s'"
 msgstr "“%s” ngoài một kho chứa tại “%s”"
 
-#: setup.c:185
+#: setup.c:186
 #, c-format
 msgid ""
 "%s: no such path in the working tree.\n"
@@ -8615,7 +8561,7 @@ msgstr ""
 "Dùng “git <lệnh> -- <đường/dẫn>…” để chỉ định đường dẫn mà nó không tồn tại "
 "một cách nội bộ."
 
-#: setup.c:198
+#: setup.c:199
 #, c-format
 msgid ""
 "ambiguous argument '%s': unknown revision or path not in the working tree.\n"
@@ -8627,12 +8573,12 @@ msgstr ""
 "Dùng “--” để ngăn cách các đường dẫn khỏi điểm xem xét, như thế này:\n"
 "“git <lệnh> [<điểm xem xét>…] -- [<tập tin>…]”"
 
-#: setup.c:264
+#: setup.c:265
 #, c-format
 msgid "option '%s' must come before non-option arguments"
 msgstr "tùy chọn “%s” phải trước các đối số đầu tiên không có tùy chọn"
 
-#: setup.c:283
+#: setup.c:284
 #, c-format
 msgid ""
 "ambiguous argument '%s': both revision and filename\n"
@@ -8643,98 +8589,98 @@ msgstr ""
 "Dùng “--” để ngăn cách các đường dẫn khỏi điểm xem xét, như thế này:\n"
 "“git <lệnh> [<điểm xem xét>…] -- [<tập tin>…]”"
 
-#: setup.c:419
+#: setup.c:420
 msgid "unable to set up work tree using invalid config"
 msgstr "không thể cài đặt thư mục làm việc sử dụng cấu hình không hợp lệ"
 
-#: setup.c:423 builtin/rev-parse.c:895
+#: setup.c:424 builtin/rev-parse.c:895
 msgid "this operation must be run in a work tree"
 msgstr "thao tác này phải được thực hiện trong thư mục làm việc"
 
-#: setup.c:658
+#: setup.c:722
 #, c-format
 msgid "Expected git repo version <= %d, found %d"
 msgstr "Cần phiên bản kho git <= %d, nhưng lại nhận được %d"
 
-#: setup.c:666
+#: setup.c:730
 msgid "unknown repository extension found:"
 msgid_plural "unknown repository extensions found:"
 msgstr[0] "tìm thấy phần mở rộng kho chưa biết:"
 
-#: setup.c:680
+#: setup.c:744
 msgid "repo version is 0, but v1-only extension found:"
 msgid_plural "repo version is 0, but v1-only extensions found:"
 msgstr[0] "phiên bản kho là 0, nhưng lại tìm thấy phần mở rộng chỉ v1:"
 
-#: setup.c:701
+#: setup.c:765
 #, c-format
 msgid "error opening '%s'"
 msgstr "gặp lỗi khi mở “%s”"
 
-#: setup.c:703
+#: setup.c:767
 #, c-format
 msgid "too large to be a .git file: '%s'"
 msgstr "tập tin .git là quá lớn: “%s”"
 
-#: setup.c:705
+#: setup.c:769
 #, c-format
 msgid "error reading %s"
 msgstr "gặp lỗi khi đọc %s"
 
-#: setup.c:707
+#: setup.c:771
 #, c-format
 msgid "invalid gitfile format: %s"
 msgstr "định dạng tập tin git không hợp lệ: %s"
 
-#: setup.c:709
+#: setup.c:773
 #, c-format
 msgid "no path in gitfile: %s"
 msgstr "không có đường dẫn trong tập tin git: %s"
 
-#: setup.c:711
+#: setup.c:775
 #, c-format
 msgid "not a git repository: %s"
 msgstr "không phải là kho git: %s"
 
-#: setup.c:813
+#: setup.c:877
 #, c-format
 msgid "'$%s' too big"
 msgstr "“$%s” quá lớn"
 
-#: setup.c:827
+#: setup.c:891
 #, c-format
 msgid "not a git repository: '%s'"
 msgstr "không phải là kho git: “%s”"
 
-#: setup.c:856 setup.c:858 setup.c:889
+#: setup.c:920 setup.c:922 setup.c:953
 #, c-format
 msgid "cannot chdir to '%s'"
 msgstr "không thể chdir (chuyển đổi thư mục) sang “%s”"
 
-#: setup.c:861 setup.c:917 setup.c:927 setup.c:966 setup.c:974
+#: setup.c:925 setup.c:981 setup.c:991 setup.c:1030 setup.c:1038
 msgid "cannot come back to cwd"
 msgstr "không thể quay lại cwd"
 
-#: setup.c:988
+#: setup.c:1052
 #, c-format
 msgid "failed to stat '%*s%s%s'"
 msgstr "gặp lỗi khi lấy thống kê về “%*s%s%s”"
 
-#: setup.c:1231
+#: setup.c:1295
 msgid "Unable to read current working directory"
 msgstr "Không thể đọc thư mục làm việc hiện hành"
 
-#: setup.c:1240 setup.c:1246
+#: setup.c:1304 setup.c:1310
 #, c-format
 msgid "cannot change to '%s'"
 msgstr "không thể chuyển sang “%s”"
 
-#: setup.c:1251
+#: setup.c:1315
 #, c-format
 msgid "not a git repository (or any of the parent directories): %s"
 msgstr "không phải là kho git (hoặc bất kỳ thư mục cha mẹ nào): %s"
 
-#: setup.c:1257
+#: setup.c:1321
 #, c-format
 msgid ""
 "not a git repository (or any parent up to mount point %s)\n"
@@ -8744,7 +8690,7 @@ msgstr ""
 "Dừng tại biên của hệ thống tập tin (GIT_DISCOVERY_ACROSS_FILESYSTEM chưa "
 "đặt)."
 
-#: setup.c:1381
+#: setup.c:1446
 #, c-format
 msgid ""
 "problem with core.sharedRepository filemode value (0%.3o).\n"
@@ -8753,15 +8699,15 @@ msgstr ""
 "gặp vấn đề với giá trị chế độ tập tin core.sharedRepository (0%.3o).\n"
 "người sở hữu tập tin phải luôn có quyền đọc và ghi."
 
-#: setup.c:1443
+#: setup.c:1508
 msgid "fork failed"
 msgstr "gặp lỗi khi rẽ nhánh tiến trình"
 
-#: setup.c:1448
+#: setup.c:1513
 msgid "setsid failed"
 msgstr "setsid gặp lỗi"
 
-#: sparse-index.c:273
+#: sparse-index.c:289
 #, c-format
 msgid "index entry is a directory, but not sparse (%08x)"
 msgstr "mục tin mục lục là một thư mục, nhưng không \"sparse\" (%08x)"
@@ -8816,13 +8762,13 @@ msgid "%u byte/s"
 msgid_plural "%u bytes/s"
 msgstr[0] "%u byte/giây"
 
-#: strbuf.c:1174 wrapper.c:207 wrapper.c:377 builtin/am.c:739
+#: strbuf.c:1186 wrapper.c:207 wrapper.c:377 builtin/am.c:765
 #: builtin/rebase.c:650
 #, c-format
 msgid "could not open '%s' for writing"
 msgstr "không thể mở “%s” để ghi"
 
-#: strbuf.c:1183
+#: strbuf.c:1195
 #, c-format
 msgid "could not edit '%s'"
 msgstr "không thể sửa “%s”"
@@ -8917,7 +8863,7 @@ msgstr ""
 msgid "process for submodule '%s' failed"
 msgstr "xử lý cho mô-đun-con “%s” gặp lỗi"
 
-#: submodule.c:1194 builtin/branch.c:692 builtin/submodule--helper.c:2713
+#: submodule.c:1194 builtin/branch.c:699 builtin/submodule--helper.c:2714
 msgid "Failed to resolve HEAD as a valid ref."
 msgstr "Gặp lỗi khi phân giải HEAD như là một tham chiếu hợp lệ."
 
@@ -9164,7 +9110,7 @@ msgstr "giao thức này không hỗ trợ cài đặt đường dẫn dịch v�
 msgid "invalid remote service path"
 msgstr "đường dẫn dịch vụ máy chủ không hợp lệ"
 
-#: transport-helper.c:661 transport.c:1475
+#: transport-helper.c:661 transport.c:1479
 msgid "operation not supported by protocol"
 msgstr "thao tác không được gia thức hỗ trợ"
 
@@ -9386,7 +9332,7 @@ msgstr ""
 msgid "Aborting."
 msgstr "Bãi bỏ."
 
-#: transport.c:1344
+#: transport.c:1343
 msgid "failed to push all needed submodules"
 msgstr "gặp lỗi khi đẩy dữ liệu của tất cả các mô-đun-con cần thiết"
 
@@ -9406,7 +9352,7 @@ msgstr "tên tập tin trống rỗng trong mục tin cây"
 msgid "too-short tree file"
 msgstr "tập tin cây quá ngắn"
 
-#: unpack-trees.c:115
+#: unpack-trees.c:118
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by checkout:\n"
@@ -9417,7 +9363,7 @@ msgstr ""
 "%%sVui lòng chuyển giao các thay đổi hay tạm cất chúng đi trước khi bạn "
 "chuyển nhánh."
 
-#: unpack-trees.c:117
+#: unpack-trees.c:120
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by checkout:\n"
@@ -9427,7 +9373,7 @@ msgstr ""
 "checkout:\n"
 "%%s"
 
-#: unpack-trees.c:120
+#: unpack-trees.c:123
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -9438,7 +9384,7 @@ msgstr ""
 "%%sVui lòng chuyển giao các thay đổi hay tạm cất chúng đi trước khi bạn hòa "
 "trộn."
 
-#: unpack-trees.c:122
+#: unpack-trees.c:125
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by merge:\n"
@@ -9448,7 +9394,7 @@ msgstr ""
 "hòa trộn:\n"
 "%%s"
 
-#: unpack-trees.c:125
+#: unpack-trees.c:128
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by %s:\n"
@@ -9458,7 +9404,7 @@ msgstr ""
 "%s:\n"
 "%%sVui lòng chuyển giao các thay đổi hay tạm cất chúng đi trước khi bạn %s."
 
-#: unpack-trees.c:127
+#: unpack-trees.c:130
 #, c-format
 msgid ""
 "Your local changes to the following files would be overwritten by %s:\n"
@@ -9468,7 +9414,7 @@ msgstr ""
 "%s:\n"
 "%%s"
 
-#: unpack-trees.c:132
+#: unpack-trees.c:135
 #, c-format
 msgid ""
 "Updating the following directories would lose untracked files in them:\n"
@@ -9478,7 +9424,16 @@ msgstr ""
 "trong nó:\n"
 "%s"
 
-#: unpack-trees.c:136
+#: unpack-trees.c:138
+#, c-format
+msgid ""
+"Refusing to remove the current working directory:\n"
+"%s"
+msgstr ""
+"Từ chối gỡ bỏ thư mục làm việc hiện tại:\n"
+"%s"
+
+#: unpack-trees.c:142
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by checkout:\n"
@@ -9488,7 +9443,7 @@ msgstr ""
 "checkout:\n"
 "%%sVui lòng di chuyển hay gỡ bỏ chúng trước khi bạn chuyển nhánh."
 
-#: unpack-trees.c:138
+#: unpack-trees.c:144
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by checkout:\n"
@@ -9498,7 +9453,7 @@ msgstr ""
 "checkout:\n"
 "%%s"
 
-#: unpack-trees.c:141
+#: unpack-trees.c:147
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by merge:\n"
@@ -9508,7 +9463,7 @@ msgstr ""
 "trộn:\n"
 "%%sVui lòng di chuyển hay gỡ bỏ chúng trước khi bạn hòa trộn."
 
-#: unpack-trees.c:143
+#: unpack-trees.c:149
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by merge:\n"
@@ -9518,7 +9473,7 @@ msgstr ""
 "trộn:\n"
 "%%s"
 
-#: unpack-trees.c:146
+#: unpack-trees.c:152
 #, c-format
 msgid ""
 "The following untracked working tree files would be removed by %s:\n"
@@ -9526,19 +9481,19 @@ msgid ""
 msgstr ""
 "Các tập tin cây làm việc chưa được theo dõi sau đây sẽ bị gỡ bỏ bởi %s:\n"
 "%%sVui lòng di chuyển hay gỡ bỏ chúng trước khi bạn %s."
-
-#: unpack-trees.c:148
-#, c-format
-msgid ""
-"The following untracked working tree files would be removed by %s:\n"
-"%%s"
-msgstr ""
-"Các tập tin cây làm việc chưa được theo dõi sau đây sẽ bị gỡ bỏ bởi %s:\n"
-"%%s"
 
 #: unpack-trees.c:154
 #, c-format
 msgid ""
+"The following untracked working tree files would be removed by %s:\n"
+"%%s"
+msgstr ""
+"Các tập tin cây làm việc chưa được theo dõi sau đây sẽ bị gỡ bỏ bởi %s:\n"
+"%%s"
+
+#: unpack-trees.c:160
+#, c-format
+msgid ""
 "The following untracked working tree files would be overwritten by "
 "checkout:\n"
 "%%sPlease move or remove them before you switch branches."
@@ -9547,7 +9502,7 @@ msgstr ""
 "checkout:\n"
 "%%sVui lòng di chuyển hay gỡ bỏ chúng trước khi bạn chuyển nhánh."
 
-#: unpack-trees.c:156
+#: unpack-trees.c:162
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by "
@@ -9558,7 +9513,7 @@ msgstr ""
 "checkout:\n"
 "%%s"
 
-#: unpack-trees.c:159
+#: unpack-trees.c:165
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by merge:\n"
@@ -9568,7 +9523,7 @@ msgstr ""
 "hòa trộn:\n"
 "%%sVui lòng di chuyển hay gỡ bỏ chúng trước khi bạn hòa trộn."
 
-#: unpack-trees.c:161
+#: unpack-trees.c:167
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by merge:\n"
@@ -9578,7 +9533,7 @@ msgstr ""
 "hòa trộn:\n"
 "%%s"
 
-#: unpack-trees.c:164
+#: unpack-trees.c:170
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by %s:\n"
@@ -9588,7 +9543,7 @@ msgstr ""
 "%s:\n"
 "%%sVui lòng di chuyển hay gỡ bỏ chúng trước khi bạn %s."
 
-#: unpack-trees.c:166
+#: unpack-trees.c:172
 #, c-format
 msgid ""
 "The following untracked working tree files would be overwritten by %s:\n"
@@ -9598,12 +9553,12 @@ msgstr ""
 "%s:\n"
 "%%s"
 
-#: unpack-trees.c:174
+#: unpack-trees.c:180
 #, c-format
 msgid "Entry '%s' overlaps with '%s'.  Cannot bind."
 msgstr "Mục “%s” đè lên “%s”. Không thể buộc."
 
-#: unpack-trees.c:177
+#: unpack-trees.c:183
 #, c-format
 msgid ""
 "Cannot update submodule:\n"
@@ -9612,7 +9567,7 @@ msgstr ""
 "Không thể cập nhật mô-đun-con:\n"
 "%s"
 
-#: unpack-trees.c:180
+#: unpack-trees.c:186
 #, c-format
 msgid ""
 "The following paths are not up to date and were left despite sparse "
@@ -9623,7 +9578,7 @@ msgstr ""
 "mẫu sparse:\n"
 "%s"
 
-#: unpack-trees.c:182
+#: unpack-trees.c:188
 #, c-format
 msgid ""
 "The following paths are unmerged and were left despite sparse patterns:\n"
@@ -9633,7 +9588,7 @@ msgstr ""
 "sparse:\n"
 "%s"
 
-#: unpack-trees.c:184
+#: unpack-trees.c:190
 #, c-format
 msgid ""
 "The following paths were already present and thus not updated despite sparse "
@@ -9644,12 +9599,12 @@ msgstr ""
 "cấp các mẫu sparse:\n"
 "%s"
 
-#: unpack-trees.c:264
+#: unpack-trees.c:270
 #, c-format
 msgid "Aborting\n"
 msgstr "Bãi bỏ\n"
 
-#: unpack-trees.c:291
+#: unpack-trees.c:297
 #, c-format
 msgid ""
 "After fixing the above paths, you may want to run `git sparse-checkout "
@@ -9658,11 +9613,11 @@ msgstr ""
 "Sau khi sửa các đường dẫn phía trên, bạn có thể chạy “git sparse-checkout "
 "reapply“.\n"
 
-#: unpack-trees.c:352
+#: unpack-trees.c:358
 msgid "Updating files"
 msgstr "Đang cập nhật các tập tin"
 
-#: unpack-trees.c:384
+#: unpack-trees.c:390
 msgid ""
 "the following paths have collided (e.g. case-sensitive paths\n"
 "on a case-insensitive filesystem) and only one from the same\n"
@@ -9672,17 +9627,17 @@ msgstr ""
 "HOA/thường trên một hệ thống tập tin không phân biệt HOA/thường)\n"
 "và chỉ một từ cùng một nhóm xung đột là trong cây làm việc hiện tại:\n"
 
-#: unpack-trees.c:1620
+#: unpack-trees.c:1636
 msgid "Updating index flags"
 msgstr "Đang cập nhật các cờ mục lục"
 
-#: unpack-trees.c:2772
+#: unpack-trees.c:2803
 #, c-format
 msgid "worktree and untracked commit have duplicate entries: %s"
 msgstr ""
 "cây làm việc và lần chuyển giao không được theo dõi có các mục trùng lặp: %s"
 
-#: upload-pack.c:1561
+#: upload-pack.c:1565
 msgid "expected flush after fetch arguments"
 msgstr "cần đẩy dữ liệu lên đĩa sau các tham số của lệnh fetch"
 
@@ -9719,100 +9674,100 @@ msgstr "đoạn đường dẫn “..” không hợp lệ"
 msgid "Fetching objects"
 msgstr "Đang lấy về các đối tượng"
 
-#: worktree.c:236 builtin/am.c:2154 builtin/bisect--helper.c:156
+#: worktree.c:238 builtin/am.c:2209 builtin/bisect--helper.c:156
 #, c-format
 msgid "failed to read '%s'"
 msgstr "gặp lỗi khi đọc “%s”"
 
-#: worktree.c:303
+#: worktree.c:305
 #, c-format
 msgid "'%s' at main working tree is not the repository directory"
 msgstr "“%s” tại cây làm việc chình không phải là thư mục kho"
 
-#: worktree.c:314
+#: worktree.c:316
 #, c-format
 msgid "'%s' file does not contain absolute path to the working tree location"
 msgstr ""
 "tập tin “%s” không chứa đường dẫn tuyệt đối đến vị trí cây làm việc hiện"
 
-#: worktree.c:326
+#: worktree.c:328
 #, c-format
 msgid "'%s' does not exist"
 msgstr "\"%s\" không tồn tại"
 
-#: worktree.c:332
+#: worktree.c:334
 #, c-format
 msgid "'%s' is not a .git file, error code %d"
 msgstr "“%s” không phải là tập tin .git, mã lỗi %d"
 
-#: worktree.c:341
+#: worktree.c:343
 #, c-format
 msgid "'%s' does not point back to '%s'"
 msgstr "“%s” không chỉ ngược đến “%s”"
 
-#: worktree.c:603
+#: worktree.c:604
 msgid "not a directory"
 msgstr "không phải thư mục"
 
-#: worktree.c:612
+#: worktree.c:613
 msgid ".git is not a file"
 msgstr ".git không phải là một tập tin"
 
-#: worktree.c:614
+#: worktree.c:615
 msgid ".git file broken"
 msgstr "tệp .git bị hỏng"
 
-#: worktree.c:616
+#: worktree.c:617
 msgid ".git file incorrect"
 msgstr "tập tin .git không chính xác"
 
-#: worktree.c:722
+#: worktree.c:723
 msgid "not a valid path"
 msgstr "không phải là một đường dẫn hợp lệ"
 
-#: worktree.c:728
+#: worktree.c:729
 msgid "unable to locate repository; .git is not a file"
 msgstr "không thể phân bổ kho chứa; .git không phải là một tập tin"
 
-#: worktree.c:732
+#: worktree.c:733
 msgid "unable to locate repository; .git file does not reference a repository"
 msgstr "không thể phân bổ kho chứa; tập tin .git tham chiếu đến một kho"
 
-#: worktree.c:736
+#: worktree.c:737
 msgid "unable to locate repository; .git file broken"
 msgstr "không thể phân bổ kho chứa; tập tin .git bị hỏng"
 
-#: worktree.c:742
+#: worktree.c:743
 msgid "gitdir unreadable"
 msgstr "gitdir không thể đọc được"
 
-#: worktree.c:746
+#: worktree.c:747
 msgid "gitdir incorrect"
 msgstr "gitdir không chính xác"
 
-#: worktree.c:771
+#: worktree.c:772
 msgid "not a valid directory"
 msgstr "không phải thư mục hợp lệ"
 
-#: worktree.c:777
+#: worktree.c:778
 msgid "gitdir file does not exist"
 msgstr "tập tin gitdir không tồn tại"
 
-#: worktree.c:782 worktree.c:791
+#: worktree.c:783 worktree.c:792
 #, c-format
 msgid "unable to read gitdir file (%s)"
 msgstr "không thể đọc tập tin gitdir (%s)"
 
-#: worktree.c:801
+#: worktree.c:802
 #, c-format
 msgid "short read (expected %<PRIuMAX> bytes, read %<PRIuMAX>)"
 msgstr "đọc ngắn (cần %<PRIuMAX> byte, đọc %<PRIuMAX>)"
 
-#: worktree.c:809
+#: worktree.c:810
 msgid "invalid gitdir file"
 msgstr "tập tin gitdir (thư mục git) không hợp lệ"
 
-#: worktree.c:817
+#: worktree.c:818
 msgid "gitdir file points to non-existent location"
 msgstr "tập tin gitdir chỉ đến vị trí không tồn tại"
 
@@ -9873,11 +9828,11 @@ msgstr ""
 msgid "  (use \"git rm <file>...\" to mark resolution)"
 msgstr "  (dùng \"git rm <tập-tin>…\" để đánh dấu là cần giải quyết)"
 
-#: wt-status.c:211 wt-status.c:1125
+#: wt-status.c:211 wt-status.c:1131
 msgid "Changes to be committed:"
 msgstr "Những thay đổi sẽ được chuyển giao:"
 
-#: wt-status.c:234 wt-status.c:1134
+#: wt-status.c:234 wt-status.c:1140
 msgid "Changes not staged for commit:"
 msgstr "Các thay đổi chưa được đặt lên bệ phóng để chuyển giao:"
 
@@ -9981,21 +9936,21 @@ msgstr "nội dung bị sửa đổi, "
 msgid "untracked content, "
 msgstr "nội dung chưa được theo dõi, "
 
-#: wt-status.c:958
+#: wt-status.c:964
 #, c-format
 msgid "Your stash currently has %d entry"
 msgid_plural "Your stash currently has %d entries"
 msgstr[0] "Bạn hiện nay ở trong phần cất đi đang có %d mục"
 
-#: wt-status.c:989
+#: wt-status.c:995
 msgid "Submodules changed but not updated:"
 msgstr "Những mô-đun-con đã bị thay đổi nhưng chưa được cập nhật:"
 
-#: wt-status.c:991
+#: wt-status.c:997
 msgid "Submodule changes to be committed:"
 msgstr "Những mô-đun-con thay đổi đã được chuyển giao:"
 
-#: wt-status.c:1073
+#: wt-status.c:1079
 msgid ""
 "Do not modify or remove the line above.\n"
 "Everything below it will be ignored."
@@ -10003,7 +9958,7 @@ msgstr ""
 "Không sửa hay xóa bỏ đường ở trên.\n"
 "Mọi thứ phía dưới sẽ được xóa bỏ."
 
-#: wt-status.c:1165
+#: wt-status.c:1171
 #, c-format
 msgid ""
 "\n"
@@ -10014,109 +9969,116 @@ msgstr ""
 "Nó cần %.2f giây để tính toán giá trị của trước/sau của nhánh.\n"
 "Bạn có thể dùng “--no-ahead-behind” tránh phải điều này.\n"
 
-#: wt-status.c:1195
+#: wt-status.c:1201
 msgid "You have unmerged paths."
 msgstr "Bạn có những đường dẫn chưa được hòa trộn."
 
-#: wt-status.c:1198
+#: wt-status.c:1204
 msgid "  (fix conflicts and run \"git commit\")"
 msgstr "  (sửa các xung đột rồi chạy \"git commit\")"
 
-#: wt-status.c:1200
+#: wt-status.c:1206
 msgid "  (use \"git merge --abort\" to abort the merge)"
 msgstr "  (dùng \"git merge --abort\" để bãi bỏ việc hòa trộn)"
 
-#: wt-status.c:1204
+#: wt-status.c:1210
 msgid "All conflicts fixed but you are still merging."
 msgstr "Tất cả các xung đột đã được giải quyết nhưng bạn vẫn đang hòa trộn."
 
-#: wt-status.c:1207
+#: wt-status.c:1213
 msgid "  (use \"git commit\" to conclude merge)"
 msgstr "  (dùng \"git commit\" để hoàn tất việc hòa trộn)"
 
-#: wt-status.c:1216
+#: wt-status.c:1224
 msgid "You are in the middle of an am session."
 msgstr "Bạn đang ở giữa của một phiên “am”."
 
-#: wt-status.c:1219
+#: wt-status.c:1227
 msgid "The current patch is empty."
 msgstr "Miếng vá hiện tại bị trống rỗng."
 
-#: wt-status.c:1223
+#: wt-status.c:1232
 msgid "  (fix conflicts and then run \"git am --continue\")"
 msgstr "  (sửa các xung đột và sau đó chạy lệnh \"git am --continue\")"
 
-#: wt-status.c:1225
+#: wt-status.c:1234
 msgid "  (use \"git am --skip\" to skip this patch)"
 msgstr "  (dùng \"git am --skip\" để bỏ qua miếng vá này)"
 
-#: wt-status.c:1227
+#: wt-status.c:1237
+msgid ""
+"  (use \"git am --allow-empty\" to record this patch as an empty commit)"
+msgstr ""
+"  (dùng \"git am --allow-empty\" ghi miếng vá này như một lần chuyển giao "
+"rỗng)"
+
+#: wt-status.c:1239
 msgid "  (use \"git am --abort\" to restore the original branch)"
 msgstr "  (dùng \"git am --abort\" để phục hồi lại nhánh nguyên thủy)"
 
-#: wt-status.c:1360
+#: wt-status.c:1372
 msgid "git-rebase-todo is missing."
 msgstr "thiếu git-rebase-todo."
 
-#: wt-status.c:1362
+#: wt-status.c:1374
 msgid "No commands done."
 msgstr "Không thực hiện lệnh nào."
 
-#: wt-status.c:1365
+#: wt-status.c:1377
 #, c-format
 msgid "Last command done (%d command done):"
 msgid_plural "Last commands done (%d commands done):"
 msgstr[0] "Lệnh thực hiện cuối (%d lệnh được thực thi):"
 
-#: wt-status.c:1376
+#: wt-status.c:1388
 #, c-format
 msgid "  (see more in file %s)"
 msgstr "  (xem thêm trong %s)"
 
-#: wt-status.c:1381
+#: wt-status.c:1393
 msgid "No commands remaining."
 msgstr "Không có lệnh nào còn lại."
 
-#: wt-status.c:1384
+#: wt-status.c:1396
 #, c-format
 msgid "Next command to do (%d remaining command):"
 msgid_plural "Next commands to do (%d remaining commands):"
 msgstr[0] "Lệnh cần làm kế tiếp (%d lệnh còn lại):"
 
-#: wt-status.c:1392
+#: wt-status.c:1404
 msgid "  (use \"git rebase --edit-todo\" to view and edit)"
 msgstr "  (dùng lệnh \"git rebase --edit-todo\" để xem và sửa)"
 
-#: wt-status.c:1404
+#: wt-status.c:1416
 #, c-format
 msgid "You are currently rebasing branch '%s' on '%s'."
 msgstr "Bạn hiện nay đang thực hiện việc “rebase” nhánh “%s” trên “%s”."
 
-#: wt-status.c:1409
+#: wt-status.c:1421
 msgid "You are currently rebasing."
 msgstr "Bạn hiện nay đang thực hiện việc “rebase” (cải tổ)."
 
-#: wt-status.c:1422
+#: wt-status.c:1434
 msgid "  (fix conflicts and then run \"git rebase --continue\")"
 msgstr ""
 "  (sửa các xung đột và sau đó chạy lệnh “cải tổ” \"git rebase --continue\")"
 
-#: wt-status.c:1424
+#: wt-status.c:1436
 msgid "  (use \"git rebase --skip\" to skip this patch)"
 msgstr "  (dùng lệnh “cải tổ” \"git rebase --skip\" để bỏ qua lần vá này)"
 
-#: wt-status.c:1426
+#: wt-status.c:1438
 msgid "  (use \"git rebase --abort\" to check out the original branch)"
 msgstr ""
 "  (dùng lệnh “cải tổ” \"git rebase --abort\" để check-out nhánh nguyên thủy)"
 
-#: wt-status.c:1433
+#: wt-status.c:1445
 msgid "  (all conflicts fixed: run \"git rebase --continue\")"
 msgstr ""
 "  (khi tất cả các xung đột đã sửa xong: chạy lệnh “cải tổ” \"git rebase --"
 "continue\")"
 
-#: wt-status.c:1437
+#: wt-status.c:1449
 #, c-format
 msgid ""
 "You are currently splitting a commit while rebasing branch '%s' on '%s'."
@@ -10124,169 +10086,169 @@ msgstr ""
 "Bạn hiện nay đang thực hiện việc chia tách một lần chuyển giao trong khi "
 "đang “rebase” nhánh “%s” trên “%s”."
 
-#: wt-status.c:1442
+#: wt-status.c:1454
 msgid "You are currently splitting a commit during a rebase."
 msgstr ""
 "Bạn hiện tại đang cắt đôi một lần chuyển giao trong khi đang thực hiện việc "
 "rebase."
 
-#: wt-status.c:1445
+#: wt-status.c:1457
 msgid "  (Once your working directory is clean, run \"git rebase --continue\")"
 msgstr ""
 "  (Một khi thư mục làm việc của bạn đã gọn gàng, chạy lệnh “cải tổ” \"git "
 "rebase --continue\")"
 
-#: wt-status.c:1449
+#: wt-status.c:1461
 #, c-format
 msgid "You are currently editing a commit while rebasing branch '%s' on '%s'."
 msgstr ""
 "Bạn hiện nay đang thực hiện việc sửa chữa một lần chuyển giao trong khi đang "
 "rebase nhánh “%s” trên “%s”."
 
-#: wt-status.c:1454
+#: wt-status.c:1466
 msgid "You are currently editing a commit during a rebase."
 msgstr "Bạn hiện đang sửa một lần chuyển giao trong khi bạn thực hiện rebase."
 
-#: wt-status.c:1457
+#: wt-status.c:1469
 msgid "  (use \"git commit --amend\" to amend the current commit)"
 msgstr "  (dùng \"git commit --amend\" để “tu bổ” lần chuyển giao hiện tại)"
 
-#: wt-status.c:1459
+#: wt-status.c:1471
 msgid ""
 "  (use \"git rebase --continue\" once you are satisfied with your changes)"
 msgstr ""
 "  (chạy lệnh “cải tổ” \"git rebase --continue\" một khi bạn cảm thấy hài "
 "lòng về những thay đổi của mình)"
 
-#: wt-status.c:1470
+#: wt-status.c:1482
 msgid "Cherry-pick currently in progress."
 msgstr "Cherry-pick hiện tại đang được thực hiện."
 
-#: wt-status.c:1473
+#: wt-status.c:1485
 #, c-format
 msgid "You are currently cherry-picking commit %s."
 msgstr "Bạn hiện nay đang thực hiện việc cherry-pick lần chuyển giao %s."
 
-#: wt-status.c:1480
+#: wt-status.c:1492
 msgid "  (fix conflicts and run \"git cherry-pick --continue\")"
 msgstr ""
 "  (sửa các xung đột và sau đó chạy lệnh \"git cherry-pick --continue\")"
 
-#: wt-status.c:1483
+#: wt-status.c:1495
 msgid "  (run \"git cherry-pick --continue\" to continue)"
 msgstr "  (chạy lệnh \"git cherry-pick --continue\" để tiếp tục)"
 
-#: wt-status.c:1486
+#: wt-status.c:1498
 msgid "  (all conflicts fixed: run \"git cherry-pick --continue\")"
 msgstr ""
 "  (khi tất cả các xung đột đã sửa xong: chạy lệnh \"git cherry-pick --"
 "continue\")"
 
-#: wt-status.c:1488
+#: wt-status.c:1500
 msgid "  (use \"git cherry-pick --skip\" to skip this patch)"
 msgstr "  (dùng \"git cherry-pick --skip\" để bỏ qua miếng vá này)"
 
-#: wt-status.c:1490
+#: wt-status.c:1502
 msgid "  (use \"git cherry-pick --abort\" to cancel the cherry-pick operation)"
 msgstr "  (dùng \"git cherry-pick --abort\" để hủy bỏ thao tác cherry-pick)"
 
-#: wt-status.c:1500
+#: wt-status.c:1512
 msgid "Revert currently in progress."
 msgstr "Hoàn nguyên hiện tại đang thực hiện."
 
-#: wt-status.c:1503
+#: wt-status.c:1515
 #, c-format
 msgid "You are currently reverting commit %s."
 msgstr "Bạn hiện nay đang thực hiện thao tác hoàn nguyên lần chuyển giao “%s”."
 
-#: wt-status.c:1509
+#: wt-status.c:1521
 msgid "  (fix conflicts and run \"git revert --continue\")"
 msgstr "  (sửa các xung đột và sau đó chạy lệnh \"git revert --continue\")"
 
-#: wt-status.c:1512
+#: wt-status.c:1524
 msgid "  (run \"git revert --continue\" to continue)"
 msgstr "  (chạy lệnh \"git revert --continue\" để tiếp tục)"
 
-#: wt-status.c:1515
+#: wt-status.c:1527
 msgid "  (all conflicts fixed: run \"git revert --continue\")"
 msgstr ""
 "  (khi tất cả các xung đột đã sửa xong: chạy lệnh \"git revert --continue\")"
 
-#: wt-status.c:1517
+#: wt-status.c:1529
 msgid "  (use \"git revert --skip\" to skip this patch)"
 msgstr "  (dùng lệnh \"git revert --skip\" để bỏ qua lần vá này)"
 
-#: wt-status.c:1519
+#: wt-status.c:1531
 msgid "  (use \"git revert --abort\" to cancel the revert operation)"
 msgstr "  (dùng \"git revert --abort\" để hủy bỏ thao tác hoàn nguyên)"
 
-#: wt-status.c:1529
+#: wt-status.c:1541
 #, c-format
 msgid "You are currently bisecting, started from branch '%s'."
 msgstr ""
 "Bạn hiện nay đang thực hiện thao tác di chuyển nửa bước (bisect), bắt đầu từ "
 "nhánh “%s”."
 
-#: wt-status.c:1533
+#: wt-status.c:1545
 msgid "You are currently bisecting."
 msgstr "Bạn hiện tại đang thực hiện việc bisect (di chuyển nửa bước)."
 
-#: wt-status.c:1536
+#: wt-status.c:1548
 msgid "  (use \"git bisect reset\" to get back to the original branch)"
 msgstr "  (dùng \"git bisect reset\" để quay trở lại nhánh nguyên thủy)"
 
-#: wt-status.c:1547
+#: wt-status.c:1559
 msgid "You are in a sparse checkout."
 msgstr "Bạn đang trong lần lấy ra sparse."
 
-#: wt-status.c:1550
+#: wt-status.c:1562
 #, c-format
 msgid "You are in a sparse checkout with %d%% of tracked files present."
 msgstr ""
 "Bạn đang ở trong lần lấy ra sparser %d%% của các tập tin được theo dõi hiện "
 "tại."
 
-#: wt-status.c:1794
+#: wt-status.c:1806
 msgid "On branch "
 msgstr "Trên nhánh "
 
-#: wt-status.c:1801
+#: wt-status.c:1813
 msgid "interactive rebase in progress; onto "
 msgstr "rebase ở chế độ tương tác đang được thực hiện; lên trên "
 
-#: wt-status.c:1803
+#: wt-status.c:1815
 msgid "rebase in progress; onto "
 msgstr "rebase đang được thực hiện: lên trên "
 
-#: wt-status.c:1808
+#: wt-status.c:1820
 msgid "HEAD detached at "
 msgstr "HEAD được tách rời tại "
 
-#: wt-status.c:1810
+#: wt-status.c:1822
 msgid "HEAD detached from "
 msgstr "HEAD được tách rời từ "
 
-#: wt-status.c:1813
+#: wt-status.c:1825
 msgid "Not currently on any branch."
 msgstr "Hiện tại chẳng ở nhánh nào cả."
 
-#: wt-status.c:1830
+#: wt-status.c:1842
 msgid "Initial commit"
 msgstr "Lần chuyển giao khởi tạo"
 
-#: wt-status.c:1831
+#: wt-status.c:1843
 msgid "No commits yet"
 msgstr "Vẫn chưa chuyển giao"
 
-#: wt-status.c:1845
+#: wt-status.c:1857
 msgid "Untracked files"
 msgstr "Những tập tin chưa được theo dõi"
 
-#: wt-status.c:1847
+#: wt-status.c:1859
 msgid "Ignored files"
 msgstr "Những tập tin bị lờ đi"
 
-#: wt-status.c:1851
+#: wt-status.c:1863
 #, c-format
 msgid ""
 "It took %.2f seconds to enumerate untracked files. 'status -uno'\n"
@@ -10298,32 +10260,32 @@ msgstr ""
 "có lẽ làm nó nhanh hơn, nhưng bạn phải cẩn thận đừng quên mình phải\n"
 "tự thêm các tập tin mới (xem “git help status”.."
 
-#: wt-status.c:1857
+#: wt-status.c:1869
 #, c-format
 msgid "Untracked files not listed%s"
 msgstr "Những tập tin chưa được theo dõi không được liệt kê ra %s"
 
-#: wt-status.c:1859
+#: wt-status.c:1871
 msgid " (use -u option to show untracked files)"
 msgstr " (dùng tùy chọn -u để hiển thị các tập tin chưa được theo dõi)"
 
-#: wt-status.c:1865
+#: wt-status.c:1877
 msgid "No changes"
 msgstr "Không có thay đổi nào"
 
-#: wt-status.c:1870
+#: wt-status.c:1882
 #, c-format
 msgid "no changes added to commit (use \"git add\" and/or \"git commit -a\")\n"
 msgstr ""
 "không có thay đổi nào được thêm vào để chuyển giao (dùng \"git add\" và/hoặc "
 "\"git commit -a\")\n"
 
-#: wt-status.c:1874
+#: wt-status.c:1886
 #, c-format
 msgid "no changes added to commit\n"
 msgstr "không có thay đổi nào được thêm vào để chuyển giao\n"
 
-#: wt-status.c:1878
+#: wt-status.c:1890
 #, c-format
 msgid ""
 "nothing added to commit but untracked files present (use \"git add\" to "
@@ -10332,87 +10294,87 @@ msgstr ""
 "không có gì được thêm vào lần chuyển giao nhưng có những tập tin chưa được "
 "theo dõi hiện diện (dùng \"git add\" để đưa vào theo dõi)\n"
 
-#: wt-status.c:1882
+#: wt-status.c:1894
 #, c-format
 msgid "nothing added to commit but untracked files present\n"
 msgstr ""
 "không có gì được thêm vào lần chuyển giao nhưng có những tập tin chưa được "
 "theo dõi hiện diện\n"
 
-#: wt-status.c:1886
+#: wt-status.c:1898
 #, c-format
 msgid "nothing to commit (create/copy files and use \"git add\" to track)\n"
 msgstr ""
 "không có gì để chuyển giao (tạo/sao-chép các tập tin và dùng \"git add\" để "
 "đưa vào theo dõi)\n"
 
-#: wt-status.c:1890 wt-status.c:1896
+#: wt-status.c:1902 wt-status.c:1908
 #, c-format
 msgid "nothing to commit\n"
 msgstr "không có gì để chuyển giao\n"
 
-#: wt-status.c:1893
+#: wt-status.c:1905
 #, c-format
 msgid "nothing to commit (use -u to show untracked files)\n"
 msgstr ""
 "không có gì để chuyển giao (dùng -u xem các tập tin chưa được theo dõi)\n"
 
-#: wt-status.c:1898
+#: wt-status.c:1910
 #, c-format
 msgid "nothing to commit, working tree clean\n"
 msgstr "không có gì để chuyển giao, thư mục làm việc sạch sẽ\n"
 
-#: wt-status.c:2003
+#: wt-status.c:2015
 msgid "No commits yet on "
 msgstr "Vẫn không thực hiện lệnh chuyển giao nào "
 
-#: wt-status.c:2007
+#: wt-status.c:2019
 msgid "HEAD (no branch)"
 msgstr "HEAD (không nhánh)"
 
-#: wt-status.c:2038
+#: wt-status.c:2050
 msgid "different"
 msgstr "khác"
 
-#: wt-status.c:2040 wt-status.c:2048
+#: wt-status.c:2052 wt-status.c:2060
 msgid "behind "
 msgstr "đằng sau "
 
-#: wt-status.c:2043 wt-status.c:2046
+#: wt-status.c:2055 wt-status.c:2058
 msgid "ahead "
 msgstr "phía trước "
 
 #. TRANSLATORS: the action is e.g. "pull with rebase"
-#: wt-status.c:2569
+#: wt-status.c:2596
 #, c-format
 msgid "cannot %s: You have unstaged changes."
 msgstr "không thể %s: Bạn có các thay đổi chưa được đưa lên bệ phóng."
 
-#: wt-status.c:2575
+#: wt-status.c:2602
 msgid "additionally, your index contains uncommitted changes."
 msgstr ""
 "thêm vào đó, bảng mục lục của bạn có chứa các thay đổi chưa được chuyển giao."
 
-#: wt-status.c:2577
+#: wt-status.c:2604
 #, c-format
 msgid "cannot %s: Your index contains uncommitted changes."
 msgstr ""
 "không thể %s: Mục lục của bạn có chứa các thay đổi chưa được chuyển giao."
 
-#: compat/simple-ipc/ipc-unix-socket.c:183
+#: compat/simple-ipc/ipc-unix-socket.c:205
 msgid "could not send IPC command"
 msgstr "không thể gửi lệnh IPC"
 
-#: compat/simple-ipc/ipc-unix-socket.c:190
+#: compat/simple-ipc/ipc-unix-socket.c:212
 msgid "could not read IPC response"
 msgstr "không thể đọc đáp ứng IPC"
 
-#: compat/simple-ipc/ipc-unix-socket.c:870
+#: compat/simple-ipc/ipc-unix-socket.c:892
 #, c-format
 msgid "could not start accept_thread '%s'"
 msgstr "không thể khởi chạy accept_thread “%s”"
 
-#: compat/simple-ipc/ipc-unix-socket.c:882
+#: compat/simple-ipc/ipc-unix-socket.c:904
 #, c-format
 msgid "could not start worker[0] for '%s'"
 msgstr "không thể khởi chạy bộ làm việc worker[0] cho “%s”"
@@ -10450,113 +10412,119 @@ msgid "Unstaged changes after refreshing the index:"
 msgstr ""
 "Đưa ra khỏi bệ phóng các thay đổi sau khi làm tươi mới lại bảng mục lục:"
 
-#: builtin/add.c:317 builtin/rev-parse.c:993
+#: builtin/add.c:313 builtin/rev-parse.c:993
 msgid "Could not read the index"
 msgstr "Không thể đọc bảng mục lục"
 
-#: builtin/add.c:330
+#: builtin/add.c:326
 msgid "Could not write patch"
 msgstr "Không thể ghi ra miếng vá"
 
-#: builtin/add.c:333
+#: builtin/add.c:329
 msgid "editing patch failed"
 msgstr "gặp lỗi khi sửa miếng vá"
 
-#: builtin/add.c:336
+#: builtin/add.c:332
 #, c-format
 msgid "Could not stat '%s'"
 msgstr "Không thể lấy thông tin thống kê về “%s”"
 
-#: builtin/add.c:338
+#: builtin/add.c:334
 msgid "Empty patch. Aborted."
 msgstr "Miếng vá trống rỗng. Nên bỏ qua."
 
-#: builtin/add.c:343
+#: builtin/add.c:340
 #, c-format
 msgid "Could not apply '%s'"
 msgstr "Không thể áp dụng miếng vá “%s”"
 
-#: builtin/add.c:351
+#: builtin/add.c:348
 msgid "The following paths are ignored by one of your .gitignore files:\n"
 msgstr ""
 "Các đường dẫn theo sau đây sẽ bị lờ đi bởi một trong các tập tin .gitignore "
 "của bạn:\n"
 
-#: builtin/add.c:371 builtin/clean.c:901 builtin/fetch.c:173 builtin/mv.c:124
+#: builtin/add.c:368 builtin/clean.c:927 builtin/fetch.c:174 builtin/mv.c:124
 #: builtin/prune-packed.c:14 builtin/pull.c:208 builtin/push.c:550
 #: builtin/remote.c:1429 builtin/rm.c:244 builtin/send-pack.c:194
 msgid "dry run"
 msgstr "chạy thử"
 
-#: builtin/add.c:374
+#: builtin/add.c:369 builtin/check-ignore.c:22 builtin/commit.c:1484
+#: builtin/count-objects.c:98 builtin/fsck.c:789 builtin/log.c:2313
+#: builtin/mv.c:123 builtin/read-tree.c:120
+msgid "be verbose"
+msgstr "chi tiết"
+
+#: builtin/add.c:371
 msgid "interactive picking"
 msgstr "sửa bằng cách tương tác"
 
-#: builtin/add.c:375 builtin/checkout.c:1560 builtin/reset.c:314
+#: builtin/add.c:372 builtin/checkout.c:1581 builtin/reset.c:409
 msgid "select hunks interactively"
 msgstr "chọn “hunks” theo kiểu tương tác"
 
-#: builtin/add.c:376
+#: builtin/add.c:373
 msgid "edit current diff and apply"
 msgstr "sửa diff hiện nay và áp dụng nó"
 
-#: builtin/add.c:377
+#: builtin/add.c:374
 msgid "allow adding otherwise ignored files"
 msgstr "cho phép thêm các tập tin bị bỏ qua khác"
 
-#: builtin/add.c:378
+#: builtin/add.c:375
 msgid "update tracked files"
 msgstr "cập nhật các tập tin được theo dõi"
 
-#: builtin/add.c:379
+#: builtin/add.c:376
 msgid "renormalize EOL of tracked files (implies -u)"
 msgstr "thường hóa lại EOL của các tập tin được theo dõi (ý là -u)"
 
-#: builtin/add.c:380
+#: builtin/add.c:377
 msgid "record only the fact that the path will be added later"
 msgstr "chỉ ghi lại sự việc mà đường dẫn sẽ được thêm vào sau"
 
-#: builtin/add.c:381
+#: builtin/add.c:378
 msgid "add changes from all tracked and untracked files"
 msgstr ""
 "thêm các thay đổi từ tất cả các tập tin có cũng như không được theo dõi dấu "
 "vết"
 
-#: builtin/add.c:384
+#: builtin/add.c:381
 msgid "ignore paths removed in the working tree (same as --no-all)"
 msgstr ""
 "lờ đi các đường dẫn bị gỡ bỏ trong cây thư mục làm việc (giống với --no-all)"
 
-#: builtin/add.c:386
+#: builtin/add.c:383
 msgid "don't add, only refresh the index"
 msgstr "không thêm, chỉ làm tươi mới bảng mục lục"
 
-#: builtin/add.c:387
+#: builtin/add.c:384
 msgid "just skip files which cannot be added because of errors"
 msgstr "chie bỏ qua những tập tin mà nó không thể được thêm vào bởi vì gặp lỗi"
 
-#: builtin/add.c:388
+#: builtin/add.c:385
 msgid "check if - even missing - files are ignored in dry run"
 msgstr ""
 "kiểm tra xem - thậm chí thiếu - tập tin bị bỏ qua trong quá trình chạy thử"
 
-#: builtin/add.c:389 builtin/mv.c:128 builtin/rm.c:251
+#: builtin/add.c:386 builtin/mv.c:128 builtin/rm.c:251
 msgid "allow updating entries outside of the sparse-checkout cone"
 msgstr "cho phép cập nhật các mục ở ngoài “sparse-checkout cone”"
 
-#: builtin/add.c:391 builtin/update-index.c:1004
+#: builtin/add.c:388 builtin/update-index.c:1004
 msgid "override the executable bit of the listed files"
 msgstr "ghi đè lên bít thi hành của các tập tin được liệt kê"
 
-#: builtin/add.c:393
+#: builtin/add.c:390
 msgid "warn when adding an embedded repository"
 msgstr "cảnh báo khi thêm một kho nhúng"
 
-#: builtin/add.c:395
+#: builtin/add.c:392
 msgid "backend for `git stash -p`"
 msgstr "ứng dụng chạy phía sau cho “git stash -p”"
 
-#: builtin/add.c:413
+#: builtin/add.c:410
 #, c-format
 msgid ""
 "You've added another git repository inside your current repository.\n"
@@ -10587,12 +10555,12 @@ msgstr ""
 "\n"
 "Xem \"git help submodule\" để biết thêm chi tiết."
 
-#: builtin/add.c:442
+#: builtin/add.c:439
 #, c-format
 msgid "adding embedded git repository: %s"
 msgstr "thêm cần một kho git nhúng: %s"
 
-#: builtin/add.c:462
+#: builtin/add.c:459
 msgid ""
 "Use -f if you really want to add them.\n"
 "Turn this message off by running\n"
@@ -10602,51 +10570,27 @@ msgstr ""
 "Tắt thông báo này bằng cách chạy lệnh\n"
 "\"git config advice.addIgnoredFile false\""
 
-#: builtin/add.c:477
+#: builtin/add.c:474
 msgid "adding files failed"
 msgstr "thêm tập tin gặp lỗi"
 
-#: builtin/add.c:513
-msgid "--dry-run is incompatible with --interactive/--patch"
-msgstr "--dry-run xung khắc với --interactive/--patch"
-
-#: builtin/add.c:515 builtin/commit.c:358
-msgid "--pathspec-from-file is incompatible with --interactive/--patch"
-msgstr "--pathspec-from-file xung khắc với --interactive/--patch"
-
-#: builtin/add.c:532
-msgid "--pathspec-from-file is incompatible with --edit"
-msgstr "--pathspec-from-file xung khắc với --edit"
-
-#: builtin/add.c:544
-msgid "-A and -u are mutually incompatible"
-msgstr "-A và -u xung khắc nhau"
-
-#: builtin/add.c:547
-msgid "Option --ignore-missing can only be used together with --dry-run"
-msgstr "Tùy chọn --ignore-missing chỉ có thể được dùng cùng với --dry-run"
-
-#: builtin/add.c:551
+#: builtin/add.c:548
 #, c-format
 msgid "--chmod param '%s' must be either -x or +x"
 msgstr "--chmod tham số “%s” phải hoặc là -x hay +x"
 
-#: builtin/add.c:572 builtin/checkout.c:1731 builtin/commit.c:364
-#: builtin/reset.c:334 builtin/rm.c:275 builtin/stash.c:1650
-msgid "--pathspec-from-file is incompatible with pathspec arguments"
-msgstr "--pathspec-from-file xung khắc với các tham số đặc tả đường dẫn"
+#: builtin/add.c:569 builtin/checkout.c:1751 builtin/commit.c:364
+#: builtin/reset.c:429 builtin/rm.c:275 builtin/stash.c:1713
+#, c-format
+msgid "'%s' and pathspec arguments cannot be used together"
+msgstr "'%s' và các tham số đặc tả đường dẫn không thể dùng cùng nhau"
 
-#: builtin/add.c:579 builtin/checkout.c:1743 builtin/commit.c:370
-#: builtin/reset.c:340 builtin/rm.c:281 builtin/stash.c:1656
-msgid "--pathspec-file-nul requires --pathspec-from-file"
-msgstr "--pathspec-file-nul cần --pathspec-from-file"
-
-#: builtin/add.c:583
+#: builtin/add.c:580
 #, c-format
 msgid "Nothing specified, nothing added.\n"
 msgstr "Không có gì được chỉ ra, không có gì được thêm vào.\n"
 
-#: builtin/add.c:585
+#: builtin/add.c:582
 msgid ""
 "Maybe you wanted to say 'git add .'?\n"
 "Turn this message off by running\n"
@@ -10656,109 +10600,117 @@ msgstr ""
 "Tắt thông báo này bằng cách chạy lệnh\n"
 "\"git config advice.addEmptyPathspec false\""
 
-#: builtin/am.c:366
+#: builtin/am.c:202
+#, c-format
+msgid "Invalid value for --empty: %s"
+msgstr "Giá trị cho --empty không hợp lệ: %s"
+
+#: builtin/am.c:392
 msgid "could not parse author script"
 msgstr "không thể phân tích cú pháp văn lệnh tác giả"
 
-#: builtin/am.c:456
+#: builtin/am.c:482
 #, c-format
 msgid "'%s' was deleted by the applypatch-msg hook"
 msgstr "“%s” bị xóa bởi móc applypatch-msg"
 
-#: builtin/am.c:498
+#: builtin/am.c:524
 #, c-format
 msgid "Malformed input line: '%s'."
 msgstr "Dòng đầu vào dị hình: “%s”."
 
-#: builtin/am.c:536
+#: builtin/am.c:562
 #, c-format
 msgid "Failed to copy notes from '%s' to '%s'"
 msgstr "Gặp lỗi khi sao chép ghi chú (note) từ “%s” tới “%s”"
 
-#: builtin/am.c:562
+#: builtin/am.c:588
 msgid "fseek failed"
 msgstr "fseek gặp lỗi"
 
-#: builtin/am.c:750
+#: builtin/am.c:776
 #, c-format
 msgid "could not parse patch '%s'"
 msgstr "không thể phân tích cú pháp “%s”"
 
-#: builtin/am.c:815
+#: builtin/am.c:841
 msgid "Only one StGIT patch series can be applied at once"
 msgstr "Chỉ có một sê-ri miếng vá StGIT được áp dụng một lúc"
 
-#: builtin/am.c:863
+#: builtin/am.c:889
 msgid "invalid timestamp"
 msgstr "dấu thời gian không hợp lệ"
 
-#: builtin/am.c:868 builtin/am.c:880
+#: builtin/am.c:894 builtin/am.c:906
 msgid "invalid Date line"
 msgstr "dòng Ngày tháng không hợp lệ"
 
-#: builtin/am.c:875
+#: builtin/am.c:901
 msgid "invalid timezone offset"
 msgstr "độ lệch múi giờ không hợp lệ"
 
-#: builtin/am.c:968
+#: builtin/am.c:994
 msgid "Patch format detection failed."
 msgstr "Dò tìm định dạng miếng vá gặp lỗi."
 
-#: builtin/am.c:973 builtin/clone.c:300
+#: builtin/am.c:999 builtin/clone.c:300
 #, c-format
 msgid "failed to create directory '%s'"
 msgstr "tạo thư mục \"%s\" gặp lỗi"
 
-#: builtin/am.c:978
+#: builtin/am.c:1004
 msgid "Failed to split patches."
 msgstr "Gặp lỗi khi chia nhỏ các miếng vá."
 
-#: builtin/am.c:1127
+#: builtin/am.c:1153
 #, c-format
 msgid "When you have resolved this problem, run \"%s --continue\"."
 msgstr "Khi bạn đã giải quyết xong trục trặc này, hãy chạy \"%s --continue\"."
 
-#: builtin/am.c:1128
+#: builtin/am.c:1154
 #, c-format
 msgid "If you prefer to skip this patch, run \"%s --skip\" instead."
 msgstr ""
 "Nếu bạn muốn bỏ qua miếng vá này, hãy chạy lệnh \"%s --skip\" để thay thế."
 
-#: builtin/am.c:1129
+#: builtin/am.c:1159
+#, c-format
+msgid "To record the empty patch as an empty commit, run \"%s --allow-empty\"."
+msgstr ""
+"Để ghi một miếng vá trống rỗng như một lần chuyển giao rông, \"%s --allow-"
+"empty\"."
+
+#: builtin/am.c:1161
 #, c-format
 msgid "To restore the original branch and stop patching, run \"%s --abort\"."
 msgstr "Để phục hồi lại nhánh gốc và dừng vá, hãy chạy \"%s --abort\"."
 
-#: builtin/am.c:1224
+#: builtin/am.c:1256
 msgid "Patch sent with format=flowed; space at the end of lines might be lost."
 msgstr ""
 "Miếng vá được gửi với format=flowed; khoảng trống ở cuối của các dòng có thể "
 "bị mất."
 
-#: builtin/am.c:1252
-msgid "Patch is empty."
-msgstr "Miếng vá trống rỗng."
-
-#: builtin/am.c:1317
+#: builtin/am.c:1344
 #, c-format
 msgid "missing author line in commit %s"
 msgstr "thiếu dòng tác giả trong lần chuyển gia %s"
 
-#: builtin/am.c:1320
+#: builtin/am.c:1347
 #, c-format
 msgid "invalid ident line: %.*s"
 msgstr "dòng định danh không hợp lệ: %.*s"
 
-#: builtin/am.c:1539
+#: builtin/am.c:1566
 msgid "Repository lacks necessary blobs to fall back on 3-way merge."
 msgstr "Kho thiếu đối tượng blob cần thiết để thực hiện “3-way merge”."
 
-#: builtin/am.c:1541
+#: builtin/am.c:1568
 msgid "Using index info to reconstruct a base tree..."
 msgstr ""
 "Sử dụng thông tin trong bảng mục lục để cấu trúc lại một cây (tree) cơ sở…"
 
-#: builtin/am.c:1560
+#: builtin/am.c:1587
 msgid ""
 "Did you hand edit your patch?\n"
 "It does not apply to blobs recorded in its index."
@@ -10766,24 +10718,24 @@ msgstr ""
 "Bạn đã sửa miếng vá của mình bằng cách thủ công à?\n"
 "Nó không thể áp dụng các blob đã được ghi lại trong bảng mục lục của nó."
 
-#: builtin/am.c:1566
+#: builtin/am.c:1593
 msgid "Falling back to patching base and 3-way merge..."
 msgstr "Đang dùng phương án dự phòng: vá bản cơ sở và “hòa trộn 3-đường”…"
 
-#: builtin/am.c:1592
+#: builtin/am.c:1619
 msgid "Failed to merge in the changes."
 msgstr "Gặp lỗi khi trộn vào các thay đổi."
 
-#: builtin/am.c:1624
+#: builtin/am.c:1651
 msgid "applying to an empty history"
 msgstr "áp dụng vào một lịch sử trống rỗng"
 
-#: builtin/am.c:1676 builtin/am.c:1680
+#: builtin/am.c:1703 builtin/am.c:1707
 #, c-format
 msgid "cannot resume: %s does not exist."
 msgstr "không thể phục hồi: %s không tồn tại."
 
-#: builtin/am.c:1698
+#: builtin/am.c:1725
 msgid "Commit Body is:"
 msgstr "Thân của lần chuyển giao là:"
 
@@ -10791,41 +10743,59 @@ msgstr "Thân của lần chuyển giao là:"
 #. in your translation. The program will only accept English
 #. input at this point.
 #.
-#: builtin/am.c:1708
+#: builtin/am.c:1735
 #, c-format
 msgid "Apply? [y]es/[n]o/[e]dit/[v]iew patch/[a]ccept all: "
 msgstr ""
 "Áp dụng? đồng ý [y]/khô[n]g/chỉnh sửa [e]/hiển thị miếng [v]á/chấp nhận tất "
 "cả [a]: "
 
-#: builtin/am.c:1754 builtin/commit.c:409
+#: builtin/am.c:1781 builtin/commit.c:409
 msgid "unable to write index file"
 msgstr "không thể ghi tập tin lưu mục lục"
 
-#: builtin/am.c:1758
+#: builtin/am.c:1785
 #, c-format
 msgid "Dirty index: cannot apply patches (dirty: %s)"
 msgstr "Bảng mục lục bẩn: không thể áp dụng các miếng vá (bẩn: %s)"
 
-#: builtin/am.c:1798 builtin/am.c:1865
+#: builtin/am.c:1827
+#, c-format
+msgid "Skipping: %.*s"
+msgstr "Đang bỏ qua: %.*s"
+
+#: builtin/am.c:1832
+#, c-format
+msgid "Creating an empty commit: %.*s"
+msgstr "Đang tạo một lần chuyển giao trống rỗng: %.*s"
+
+#: builtin/am.c:1836
+msgid "Patch is empty."
+msgstr "Miếng vá trống rỗng."
+
+#: builtin/am.c:1847 builtin/am.c:1916
 #, c-format
 msgid "Applying: %.*s"
 msgstr "Áp dụng: %.*s"
 
-#: builtin/am.c:1815
+#: builtin/am.c:1864
 msgid "No changes -- Patch already applied."
 msgstr "Không thay đổi gì cả -- Miếng vá đã được áp dụng rồi."
 
-#: builtin/am.c:1821
+#: builtin/am.c:1870
 #, c-format
 msgid "Patch failed at %s %.*s"
 msgstr "Gặp lỗi khi vá tại %s %.*s"
 
-#: builtin/am.c:1825
+#: builtin/am.c:1874
 msgid "Use 'git am --show-current-patch=diff' to see the failed patch"
 msgstr "Dùng “git am --show-current-patch=diff” để xem miếng vá bị lỗi"
 
-#: builtin/am.c:1868
+#: builtin/am.c:1920
+msgid "No changes - recorded it as an empty commit."
+msgstr "Không có thay đổi nào - được ghi thành một lần chuyển giao rỗng."
+
+#: builtin/am.c:1922
 msgid ""
 "No changes - did you forget to use 'git add'?\n"
 "If there is nothing left to stage, chances are that something else\n"
@@ -10836,7 +10806,7 @@ msgstr ""
 "đã sẵn được đưa vào với cùng nội dung thay đổi; bạn có lẽ muốn bỏ qua miếng "
 "vá này."
 
-#: builtin/am.c:1875
+#: builtin/am.c:1930
 msgid ""
 "You still have unmerged paths in your index.\n"
 "You should 'git add' each file with resolved conflicts to mark them as "
@@ -10849,17 +10819,17 @@ msgstr ""
 "Bạn có lẽ muốn chạy “git rm“ trên một tập tin để chấp nhận \"được xóa bởi họ"
 "\" cho nó."
 
-#: builtin/am.c:1983 builtin/am.c:1987 builtin/am.c:1999 builtin/reset.c:353
-#: builtin/reset.c:361
+#: builtin/am.c:2038 builtin/am.c:2042 builtin/am.c:2054 builtin/reset.c:448
+#: builtin/reset.c:456
 #, c-format
 msgid "Could not parse object '%s'."
 msgstr "Không thể phân tích đối tượng “%s”."
 
-#: builtin/am.c:2035 builtin/am.c:2111
+#: builtin/am.c:2090 builtin/am.c:2166
 msgid "failed to clean index"
 msgstr "gặp lỗi khi dọn bảng mục lục"
 
-#: builtin/am.c:2079
+#: builtin/am.c:2134
 msgid ""
 "You seem to have moved HEAD since the last 'am' failure.\n"
 "Not rewinding to ORIG_HEAD"
@@ -10867,160 +10837,168 @@ msgstr ""
 "Bạn có lẽ đã có HEAD đã bị di chuyển đi kể từ lần “am” thất bại cuối cùng.\n"
 "Không thể chuyển tới ORIG_HEAD"
 
-#: builtin/am.c:2187
+#: builtin/am.c:2242
 #, c-format
 msgid "Invalid value for --patch-format: %s"
 msgstr "Giá trị không hợp lệ cho --patch-format: %s"
 
-#: builtin/am.c:2229
+#: builtin/am.c:2285
 #, c-format
 msgid "Invalid value for --show-current-patch: %s"
 msgstr "Giá trị không hợp lệ cho --show-current-patch: %s"
 
-#: builtin/am.c:2233
+#: builtin/am.c:2289
 #, c-format
-msgid "--show-current-patch=%s is incompatible with --show-current-patch=%s"
-msgstr "--show-current-patch=%s xung khắc với --show-current-patch=%s"
+msgid "options '%s=%s' and '%s=%s' cannot be used together"
+msgstr "tùy chọn '%s=%s' và '%s=%s' không thể dùng cùng nhau"
 
-#: builtin/am.c:2264
+#: builtin/am.c:2320
 msgid "git am [<options>] [(<mbox> | <Maildir>)...]"
 msgstr "git am [<các tùy chọn>] [(<mbox>|<Maildir>)…]"
 
-#: builtin/am.c:2265
+#: builtin/am.c:2321
 msgid "git am [<options>] (--continue | --skip | --abort)"
 msgstr "git am [<các tùy chọn>] (--continue | --skip | --abort)"
 
-#: builtin/am.c:2271
+#: builtin/am.c:2327
 msgid "run interactively"
 msgstr "chạy kiểu tương tác"
 
-#: builtin/am.c:2273
+#: builtin/am.c:2329
 msgid "historical option -- no-op"
 msgstr "tùy chọn lịch sử -- không-toán-tử"
 
-#: builtin/am.c:2275
+#: builtin/am.c:2331
 msgid "allow fall back on 3way merging if needed"
 msgstr "cho phép quay trở lại để hòa trộn kiểu “3way” nếu cần"
 
-#: builtin/am.c:2276 builtin/init-db.c:547 builtin/prune-packed.c:16
-#: builtin/repack.c:640 builtin/stash.c:961
+#: builtin/am.c:2332 builtin/init-db.c:547 builtin/prune-packed.c:16
+#: builtin/repack.c:642 builtin/stash.c:962
 msgid "be quiet"
 msgstr "im lặng"
 
-#: builtin/am.c:2278
+#: builtin/am.c:2334
 msgid "add a Signed-off-by trailer to the commit message"
 msgstr "thêm dòng Signed-off-by vào cuối ghi chú của lần chuyển giao"
 
-#: builtin/am.c:2281
+#: builtin/am.c:2337
 msgid "recode into utf8 (default)"
 msgstr "chuyển mã thành utf8 (mặc định)"
 
-#: builtin/am.c:2283
+#: builtin/am.c:2339
 msgid "pass -k flag to git-mailinfo"
 msgstr "chuyển cờ -k cho git-mailinfo"
 
-#: builtin/am.c:2285
+#: builtin/am.c:2341
 msgid "pass -b flag to git-mailinfo"
 msgstr "chuyển cờ -b cho git-mailinfo"
 
-#: builtin/am.c:2287
+#: builtin/am.c:2343
 msgid "pass -m flag to git-mailinfo"
 msgstr "chuyển cờ -m cho git-mailinfo"
 
-#: builtin/am.c:2289
+#: builtin/am.c:2345
 msgid "pass --keep-cr flag to git-mailsplit for mbox format"
 msgstr "chuyển cờ --keep-cr cho git-mailsplit với định dạng mbox"
 
-#: builtin/am.c:2292
+#: builtin/am.c:2348
 msgid "do not pass --keep-cr flag to git-mailsplit independent of am.keepcr"
 msgstr ""
 "đừng chuyển cờ --keep-cr cho git-mailsplit không phụ thuộc vào am.keepcr"
 
-#: builtin/am.c:2295
+#: builtin/am.c:2351
 msgid "strip everything before a scissors line"
 msgstr "cắt mọi thứ trước dòng scissors"
 
-#: builtin/am.c:2297
+#: builtin/am.c:2353
 msgid "pass it through git-mailinfo"
 msgstr "chuyển nó qua git-mailinfo"
 
-#: builtin/am.c:2300 builtin/am.c:2303 builtin/am.c:2306 builtin/am.c:2309
-#: builtin/am.c:2312 builtin/am.c:2315 builtin/am.c:2318 builtin/am.c:2321
-#: builtin/am.c:2327
+#: builtin/am.c:2356 builtin/am.c:2359 builtin/am.c:2362 builtin/am.c:2365
+#: builtin/am.c:2368 builtin/am.c:2371 builtin/am.c:2374 builtin/am.c:2377
+#: builtin/am.c:2383
 msgid "pass it through git-apply"
 msgstr "chuyển nó qua git-apply"
 
-#: builtin/am.c:2317 builtin/commit.c:1514 builtin/fmt-merge-msg.c:17
-#: builtin/fmt-merge-msg.c:20 builtin/grep.c:919 builtin/merge.c:262
+#: builtin/am.c:2373 builtin/commit.c:1515 builtin/fmt-merge-msg.c:18
+#: builtin/fmt-merge-msg.c:21 builtin/grep.c:919 builtin/merge.c:263
 #: builtin/pull.c:142 builtin/pull.c:204 builtin/pull.c:221
-#: builtin/rebase.c:1046 builtin/repack.c:651 builtin/repack.c:655
-#: builtin/repack.c:657 builtin/show-branch.c:649 builtin/show-ref.c:172
+#: builtin/rebase.c:1046 builtin/repack.c:653 builtin/repack.c:657
+#: builtin/repack.c:659 builtin/show-branch.c:649 builtin/show-ref.c:172
 #: builtin/tag.c:445 parse-options.h:154 parse-options.h:175
-#: parse-options.h:315
+#: parse-options.h:317
 msgid "n"
 msgstr "n"
 
-#: builtin/am.c:2323 builtin/branch.c:673 builtin/bugreport.c:109
-#: builtin/for-each-ref.c:40 builtin/replace.c:556 builtin/tag.c:479
+#: builtin/am.c:2379 builtin/branch.c:680 builtin/bugreport.c:109
+#: builtin/for-each-ref.c:41 builtin/replace.c:555 builtin/tag.c:479
 #: builtin/verify-tag.c:38
 msgid "format"
 msgstr "định dạng"
 
-#: builtin/am.c:2324
+#: builtin/am.c:2380
 msgid "format the patch(es) are in"
 msgstr "định dạng (các) miếng vá theo"
 
-#: builtin/am.c:2330
+#: builtin/am.c:2386
 msgid "override error message when patch failure occurs"
 msgstr "đè lên các lời nhắn lỗi khi xảy ra lỗi vá nghiêm trọng"
 
-#: builtin/am.c:2332
+#: builtin/am.c:2388
 msgid "continue applying patches after resolving a conflict"
 msgstr "tiếp tục áp dụng các miếng vá sau khi giải quyết xung đột"
 
-#: builtin/am.c:2335
+#: builtin/am.c:2391
 msgid "synonyms for --continue"
 msgstr "đồng nghĩa với --continue"
 
-#: builtin/am.c:2338
+#: builtin/am.c:2394
 msgid "skip the current patch"
 msgstr "bỏ qua miếng vá hiện hành"
 
-#: builtin/am.c:2341
+#: builtin/am.c:2397
 msgid "restore the original branch and abort the patching operation"
 msgstr "phục hồi lại nhánh gốc và loại bỏ thao tác vá"
 
-#: builtin/am.c:2344
+#: builtin/am.c:2400
 msgid "abort the patching operation but keep HEAD where it is"
 msgstr "bỏ qua thao tác vá nhưng vẫn giữ HEAD nơi nó chỉ đến"
 
-#: builtin/am.c:2348
+#: builtin/am.c:2404
 msgid "show the patch being applied"
 msgstr "hiển thị miếng vá đã được áp dụng rồi"
 
-#: builtin/am.c:2353
+#: builtin/am.c:2408
+msgid "record the empty patch as an empty commit"
+msgstr "ghi lại miếng vá trống rỗng như là một lần chuyển giao trống"
+
+#: builtin/am.c:2412
 msgid "lie about committer date"
 msgstr "nói dối về ngày chuyển giao"
 
-#: builtin/am.c:2355
+#: builtin/am.c:2414
 msgid "use current timestamp for author date"
 msgstr "dùng dấu thời gian hiện tại cho ngày tác giả"
 
-#: builtin/am.c:2357 builtin/commit-tree.c:118 builtin/commit.c:1642
-#: builtin/merge.c:299 builtin/pull.c:179 builtin/rebase.c:1099
+#: builtin/am.c:2416 builtin/commit-tree.c:118 builtin/commit.c:1643
+#: builtin/merge.c:302 builtin/pull.c:179 builtin/rebase.c:1099
 #: builtin/revert.c:117 builtin/tag.c:460
 msgid "key-id"
 msgstr "mã-số-khóa"
 
-#: builtin/am.c:2358 builtin/rebase.c:1100
+#: builtin/am.c:2417 builtin/rebase.c:1100
 msgid "GPG-sign commits"
 msgstr "Các lần chuyển giao ký-GPG"
 
-#: builtin/am.c:2361
+#: builtin/am.c:2420
+msgid "how to handle empty patches"
+msgstr "xử lý các miếng vá trống rỗng như thế nào"
+
+#: builtin/am.c:2423
 msgid "(internal use for git-rebase)"
 msgstr "(dùng nội bộ cho git-rebase)"
 
-#: builtin/am.c:2379
+#: builtin/am.c:2441
 msgid ""
 "The -b/--binary option has been a no-op for long time, and\n"
 "it will be removed. Please do not use it anymore."
@@ -11028,16 +11006,16 @@ msgstr ""
 "Tùy chọn -b/--binary đã không dùng từ lâu rồi, và\n"
 "nó sẽ được bỏ đi. Xin đừng sử dụng nó thêm nữa."
 
-#: builtin/am.c:2386
+#: builtin/am.c:2448
 msgid "failed to read the index"
 msgstr "gặp lỗi đọc bảng mục lục"
 
-#: builtin/am.c:2401
+#: builtin/am.c:2463
 #, c-format
 msgid "previous rebase directory %s still exists but mbox given."
 msgstr "thư mục rebase trước %s không sẵn có nhưng mbox lại đưa ra."
 
-#: builtin/am.c:2425
+#: builtin/am.c:2487
 #, c-format
 msgid ""
 "Stray %s directory found.\n"
@@ -11046,11 +11024,11 @@ msgstr ""
 "Tìm thấy thư mục lạc %s.\n"
 "Dùng \"git am --abort\" để loại bỏ nó đi."
 
-#: builtin/am.c:2431
+#: builtin/am.c:2493
 msgid "Resolve operation not in progress, we are not resuming."
 msgstr "Thao tác phân giải không được tiến hành, chúng ta không phục hồi lại."
 
-#: builtin/am.c:2441
+#: builtin/am.c:2503
 msgid "interactive mode requires patches on the command line"
 msgstr "chế độ tương tác yêu cầu có các miếng vá trên dòng lệnh"
 
@@ -11510,11 +11488,11 @@ msgstr "không coi các lần chuyển giao gốc là giới hạn (Mặc địn
 msgid "show work cost statistics"
 msgstr "hiển thị thống kê công sức làm việc"
 
-#: builtin/blame.c:867 builtin/checkout.c:1517 builtin/clone.c:94
-#: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:179
-#: builtin/merge.c:298 builtin/multi-pack-index.c:103
-#: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:178
-#: builtin/multi-pack-index.c:204 builtin/pull.c:120 builtin/push.c:566
+#: builtin/blame.c:867 builtin/checkout.c:1536 builtin/clone.c:94
+#: builtin/commit-graph.c:75 builtin/commit-graph.c:228 builtin/fetch.c:180
+#: builtin/merge.c:301 builtin/multi-pack-index.c:103
+#: builtin/multi-pack-index.c:154 builtin/multi-pack-index.c:180
+#: builtin/multi-pack-index.c:208 builtin/pull.c:120 builtin/push.c:566
 #: builtin/send-pack.c:202
 msgid "force progress reporting"
 msgstr "ép buộc báo cáo tiến triển công việc"
@@ -11563,7 +11541,7 @@ msgstr "hiển thị thư điện tử của tác giả thay cho tên (Mặc đ�
 msgid "ignore whitespace differences"
 msgstr "bỏ qua các khác biệt do khoảng trắng gây ra"
 
-#: builtin/blame.c:879 builtin/log.c:1823
+#: builtin/blame.c:879 builtin/log.c:1838
 msgid "rev"
 msgstr "rev"
 
@@ -11616,7 +11594,7 @@ msgstr "vùng"
 msgid "process only line range <start>,<end> or function :<funcname>"
 msgstr "xử lý chỉ dòng vùng <đầu>,<cuối> hoặc tính năng :<funcname>"
 
-#: builtin/blame.c:944
+#: builtin/blame.c:947
 msgid "--progress can't be used with --incremental or porcelain formats"
 msgstr ""
 "--progress không được dùng cùng với --incremental hay các định dạng porcelain"
@@ -11629,17 +11607,17 @@ msgstr ""
 #. your language may need more or fewer display
 #. columns.
 #.
-#: builtin/blame.c:995
+#: builtin/blame.c:998
 msgid "4 years, 11 months ago"
 msgstr "4 năm, 11 tháng trước"
 
-#: builtin/blame.c:1111
+#: builtin/blame.c:1114
 #, c-format
 msgid "file %s has only %lu line"
 msgid_plural "file %s has only %lu lines"
 msgstr[0] "tập tin %s chỉ có %lu dòng"
 
-#: builtin/blame.c:1156
+#: builtin/blame.c:1159
 msgid "Blaming lines"
 msgstr "Các dòng blame"
 
@@ -11671,7 +11649,7 @@ msgstr "git branch [<các tùy chọn>] [-r | -a] [--points-at]"
 msgid "git branch [<options>] [-r | -a] [--format]"
 msgstr "git branch [<các tùy chọn>] [-r | -a] [--format]"
 
-#: builtin/branch.c:154
+#: builtin/branch.c:153
 #, c-format
 msgid ""
 "deleting branch '%s' that has been merged to\n"
@@ -11680,7 +11658,7 @@ msgstr ""
 "đang xóa nhánh “%s” mà nó lại đã được hòa trộn vào\n"
 "         “%s”, nhưng vẫn chưa được hòa trộn vào HEAD."
 
-#: builtin/branch.c:158
+#: builtin/branch.c:157
 #, c-format
 msgid ""
 "not deleting branch '%s' that is not yet merged to\n"
@@ -11689,12 +11667,12 @@ msgstr ""
 "không xóa nhánh “%s” cái mà chưa được hòa trộn vào\n"
 "         “%s”, cho dù là nó đã được hòa trộn vào HEAD."
 
-#: builtin/branch.c:172
+#: builtin/branch.c:171
 #, c-format
 msgid "Couldn't look up commit object for '%s'"
 msgstr "Không thể tìm kiếm đối tượng chuyển giao cho “%s”"
 
-#: builtin/branch.c:176
+#: builtin/branch.c:175
 #, c-format
 msgid ""
 "The branch '%s' is not fully merged.\n"
@@ -11703,7 +11681,7 @@ msgstr ""
 "Nhánh “%s” không được trộn một cách đầy đủ.\n"
 "Nếu bạn thực sự muốn xóa nó, thì chạy lệnh “git branch -D %s”."
 
-#: builtin/branch.c:189
+#: builtin/branch.c:188
 msgid "Update of config-file failed"
 msgstr "Cập nhật tập tin cấu hình gặp lỗi"
 
@@ -11715,99 +11693,99 @@ msgstr "không thể dùng tùy chọn -a với -d"
 msgid "Couldn't look up commit object for HEAD"
 msgstr "Không thể tìm kiếm đối tượng chuyển giao cho HEAD"
 
-#: builtin/branch.c:244
+#: builtin/branch.c:247
 #, c-format
 msgid "Cannot delete branch '%s' checked out at '%s'"
 msgstr "Không thể xóa nhánh “%s” đã được lấy ra tại “%s”"
 
-#: builtin/branch.c:259
+#: builtin/branch.c:262
 #, c-format
 msgid "remote-tracking branch '%s' not found."
 msgstr "không tìm thấy nhánh theo dõi máy chủ “%s”."
 
-#: builtin/branch.c:260
+#: builtin/branch.c:263
 #, c-format
 msgid "branch '%s' not found."
 msgstr "không tìm thấy nhánh “%s”."
 
-#: builtin/branch.c:291
+#: builtin/branch.c:294
 #, c-format
 msgid "Deleted remote-tracking branch %s (was %s).\n"
 msgstr "Đã xóa nhánh theo dõi máy chủ \"%s\" (từng là %s).\n"
 
-#: builtin/branch.c:292
+#: builtin/branch.c:295
 #, c-format
 msgid "Deleted branch %s (was %s).\n"
 msgstr "Nhánh “%s” đã bị xóa (từng là %s)\n"
 
-#: builtin/branch.c:441 builtin/tag.c:63
+#: builtin/branch.c:445 builtin/tag.c:63
 msgid "unable to parse format string"
 msgstr "không thể phân tích chuỗi định dạng"
 
-#: builtin/branch.c:472
+#: builtin/branch.c:476
 msgid "could not resolve HEAD"
 msgstr "không thể phân giải HEAD"
 
-#: builtin/branch.c:478
+#: builtin/branch.c:482
 #, c-format
 msgid "HEAD (%s) points outside of refs/heads/"
 msgstr "HEAD (%s) chỉ bên ngoài của refs/heads/"
 
-#: builtin/branch.c:493
+#: builtin/branch.c:497
 #, c-format
 msgid "Branch %s is being rebased at %s"
 msgstr "Nhánh %s đang được cải tổ lại tại %s"
 
-#: builtin/branch.c:497
+#: builtin/branch.c:501
 #, c-format
 msgid "Branch %s is being bisected at %s"
 msgstr "Nhánh %s đang được di chuyển phân đôi (bisect) tại %s"
 
-#: builtin/branch.c:514
+#: builtin/branch.c:518
 msgid "cannot copy the current branch while not on any."
 msgstr "không thể sao chép nhánh hiện hành trong khi nó chẳng ở đâu cả."
 
-#: builtin/branch.c:516
+#: builtin/branch.c:520
 msgid "cannot rename the current branch while not on any."
 msgstr "không thể đổi tên nhánh hiện hành trong khi nó chẳng ở đâu cả."
 
-#: builtin/branch.c:527
+#: builtin/branch.c:531
 #, c-format
 msgid "Invalid branch name: '%s'"
 msgstr "Tên nhánh không hợp lệ: “%s”"
 
-#: builtin/branch.c:556
+#: builtin/branch.c:560
 msgid "Branch rename failed"
 msgstr "Gặp lỗi khi đổi tên nhánh"
 
-#: builtin/branch.c:558
+#: builtin/branch.c:562
 msgid "Branch copy failed"
 msgstr "Gặp lỗi khi sao chép nhánh"
 
-#: builtin/branch.c:562
+#: builtin/branch.c:566
 #, c-format
 msgid "Created a copy of a misnamed branch '%s'"
 msgstr "Đã tạo một bản sao của nhánh khuyết danh “%s”"
 
-#: builtin/branch.c:565
+#: builtin/branch.c:569
 #, c-format
 msgid "Renamed a misnamed branch '%s' away"
 msgstr "Đã đổi tên nhánh khuyết danh “%s” đi"
 
-#: builtin/branch.c:571
+#: builtin/branch.c:575
 #, c-format
 msgid "Branch renamed to %s, but HEAD is not updated!"
 msgstr "Nhánh bị đổi tên thành %s, nhưng HEAD lại không được cập nhật!"
 
-#: builtin/branch.c:580
+#: builtin/branch.c:584
 msgid "Branch is renamed, but update of config-file failed"
 msgstr "Nhánh bị đổi tên, nhưng cập nhật tập tin cấu hình gặp lỗi"
 
-#: builtin/branch.c:582
+#: builtin/branch.c:586
 msgid "Branch is copied, but update of config-file failed"
 msgstr "Nhánh đã được sao chép, nhưng cập nhật tập tin cấu hình gặp lỗi"
 
-#: builtin/branch.c:598
+#: builtin/branch.c:602
 #, c-format
 msgid ""
 "Please edit the description for the branch\n"
@@ -11818,180 +11796,176 @@ msgstr ""
 "  %s\n"
 "Những dòng được bắt đầu bằng “%c” sẽ được cắt bỏ.\n"
 
-#: builtin/branch.c:632
+#: builtin/branch.c:637
 msgid "Generic options"
 msgstr "Tùy chọn chung"
 
-#: builtin/branch.c:634
+#: builtin/branch.c:639
 msgid "show hash and subject, give twice for upstream branch"
 msgstr "hiển thị mã băm và chủ đề, đưa ra hai lần cho nhánh thượng nguồn"
 
-#: builtin/branch.c:635
+#: builtin/branch.c:640
 msgid "suppress informational messages"
 msgstr "không xuất các thông tin"
 
-#: builtin/branch.c:636
-msgid "set up tracking mode (see git-pull(1))"
-msgstr "cài đặt chế độ theo dõi (xem git-pull(1))"
+#: builtin/branch.c:642
+msgid "set branch tracking configuration"
+msgstr "đặt cấu hình thao dõi nhánh"
 
-#: builtin/branch.c:638
+#: builtin/branch.c:645
 msgid "do not use"
 msgstr "không dùng"
 
-#: builtin/branch.c:640
+#: builtin/branch.c:647
 msgid "upstream"
 msgstr "thượng nguồn"
 
-#: builtin/branch.c:640
+#: builtin/branch.c:647
 msgid "change the upstream info"
 msgstr "thay đổi thông tin thượng nguồn"
 
-#: builtin/branch.c:641
+#: builtin/branch.c:648
 msgid "unset the upstream info"
 msgstr "bỏ đặt thông tin thượng nguồn"
 
-#: builtin/branch.c:642
+#: builtin/branch.c:649
 msgid "use colored output"
 msgstr "tô màu kết xuất"
 
-#: builtin/branch.c:643
+#: builtin/branch.c:650
 msgid "act on remote-tracking branches"
 msgstr "thao tác trên nhánh “remote-tracking”"
 
-#: builtin/branch.c:645 builtin/branch.c:647
+#: builtin/branch.c:652 builtin/branch.c:654
 msgid "print only branches that contain the commit"
 msgstr "chỉ hiển thị những nhánh mà nó chứa lần chuyển giao"
 
-#: builtin/branch.c:646 builtin/branch.c:648
+#: builtin/branch.c:653 builtin/branch.c:655
 msgid "print only branches that don't contain the commit"
 msgstr "chỉ hiển thị những nhánh mà nó không chứa lần chuyển giao"
 
-#: builtin/branch.c:651
+#: builtin/branch.c:658
 msgid "Specific git-branch actions:"
 msgstr "Hành động git-branch:"
 
-#: builtin/branch.c:652
+#: builtin/branch.c:659
 msgid "list both remote-tracking and local branches"
 msgstr "liệt kê cả nhánh “remote-tracking” và nội bộ"
 
-#: builtin/branch.c:654
+#: builtin/branch.c:661
 msgid "delete fully merged branch"
 msgstr "xóa một toàn bộ nhánh đã hòa trộn"
 
-#: builtin/branch.c:655
+#: builtin/branch.c:662
 msgid "delete branch (even if not merged)"
 msgstr "xóa nhánh (cho dù là chưa được hòa trộn)"
 
-#: builtin/branch.c:656
+#: builtin/branch.c:663
 msgid "move/rename a branch and its reflog"
 msgstr "di chuyển hay đổi tên một nhánh và reflog của nó"
 
-#: builtin/branch.c:657
+#: builtin/branch.c:664
 msgid "move/rename a branch, even if target exists"
 msgstr "di chuyển hoặc đổi tên một nhánh ngay cả khi đích đã có sẵn"
 
-#: builtin/branch.c:658
+#: builtin/branch.c:665
 msgid "copy a branch and its reflog"
 msgstr "sao chép một nhánh và reflog của nó"
 
-#: builtin/branch.c:659
+#: builtin/branch.c:666
 msgid "copy a branch, even if target exists"
 msgstr "sao chép một nhánh ngay cả khi đích đã có sẵn"
 
-#: builtin/branch.c:660
+#: builtin/branch.c:667
 msgid "list branch names"
 msgstr "liệt kê các tên nhánh"
 
-#: builtin/branch.c:661
+#: builtin/branch.c:668
 msgid "show current branch name"
 msgstr "hiển thị nhánh hiện hành"
 
-#: builtin/branch.c:662
+#: builtin/branch.c:669
 msgid "create the branch's reflog"
 msgstr "tạo reflog của nhánh"
 
-#: builtin/branch.c:664
+#: builtin/branch.c:671
 msgid "edit the description for the branch"
 msgstr "sửa mô tả cho nhánh"
 
-#: builtin/branch.c:665
+#: builtin/branch.c:672
 msgid "force creation, move/rename, deletion"
 msgstr "buộc tạo, di chuyển/đổi tên, xóa"
 
-#: builtin/branch.c:666
+#: builtin/branch.c:673
 msgid "print only branches that are merged"
 msgstr "chỉ hiển thị những nhánh mà nó được hòa trộn"
 
-#: builtin/branch.c:667
+#: builtin/branch.c:674
 msgid "print only branches that are not merged"
 msgstr "chỉ hiển thị những nhánh mà nó không được hòa trộn"
 
-#: builtin/branch.c:668
+#: builtin/branch.c:675
 msgid "list branches in columns"
 msgstr "liệt kê các nhánh trong các cột"
 
-#: builtin/branch.c:670 builtin/for-each-ref.c:44 builtin/notes.c:413
+#: builtin/branch.c:677 builtin/for-each-ref.c:45 builtin/notes.c:413
 #: builtin/notes.c:416 builtin/notes.c:579 builtin/notes.c:582
 #: builtin/tag.c:475
 msgid "object"
 msgstr "đối tượng"
 
-#: builtin/branch.c:671
+#: builtin/branch.c:678
 msgid "print only branches of the object"
 msgstr "chỉ hiển thị các nhánh của đối tượng"
 
-#: builtin/branch.c:672 builtin/for-each-ref.c:50 builtin/tag.c:482
+#: builtin/branch.c:679 builtin/for-each-ref.c:51 builtin/tag.c:482
 msgid "sorting and filtering are case insensitive"
 msgstr "sắp xếp và lọc là phân biệt HOA thường"
 
-#: builtin/branch.c:673 builtin/for-each-ref.c:40 builtin/tag.c:480
+#: builtin/branch.c:680 builtin/for-each-ref.c:41 builtin/tag.c:480
 #: builtin/verify-tag.c:38
 msgid "format to use for the output"
 msgstr "định dạng sẽ dùng cho đầu ra"
 
-#: builtin/branch.c:696 builtin/clone.c:678
+#: builtin/branch.c:703 builtin/clone.c:678
 msgid "HEAD not found below refs/heads!"
 msgstr "Không tìm thấy HEAD ở dưới refs/heads!"
 
-#: builtin/branch.c:720
-msgid "--column and --verbose are incompatible"
-msgstr "tùy chọn --column và --verbose xung khắc nhau"
-
-#: builtin/branch.c:735 builtin/branch.c:792 builtin/branch.c:801
+#: builtin/branch.c:742 builtin/branch.c:798 builtin/branch.c:807
 msgid "branch name required"
 msgstr "cần chỉ ra tên nhánh"
 
-#: builtin/branch.c:768
+#: builtin/branch.c:774
 msgid "Cannot give description to detached HEAD"
 msgstr "Không thể đưa ra mô tả HEAD đã tách rời"
 
-#: builtin/branch.c:773
+#: builtin/branch.c:779
 msgid "cannot edit description of more than one branch"
 msgstr "không thể sửa mô tả cho nhiều hơn một nhánh"
 
-#: builtin/branch.c:780
+#: builtin/branch.c:786
 #, c-format
 msgid "No commit on branch '%s' yet."
 msgstr "Vẫn chưa chuyển giao trên nhánh “%s”."
 
-#: builtin/branch.c:783
+#: builtin/branch.c:789
 #, c-format
 msgid "No branch named '%s'."
 msgstr "Không có nhánh nào có tên “%s”."
 
-#: builtin/branch.c:798
+#: builtin/branch.c:804
 msgid "too many branches for a copy operation"
 msgstr "quá nhiều nhánh dành cho thao tác sao chép"
 
-#: builtin/branch.c:807
+#: builtin/branch.c:813
 msgid "too many arguments for a rename operation"
 msgstr "quá nhiều tham số cho thao tác đổi tên"
 
-#: builtin/branch.c:812
+#: builtin/branch.c:818
 msgid "too many arguments to set new upstream"
 msgstr "quá nhiều tham số để đặt thượng nguồn mới"
 
-#: builtin/branch.c:816
+#: builtin/branch.c:822
 #, c-format
 msgid ""
 "could not set upstream of HEAD to %s when it does not point to any branch."
@@ -11999,30 +11973,30 @@ msgstr ""
 "không thể đặt thượng nguồn của HEAD thành %s khi mà nó chẳng chỉ đến nhánh "
 "nào cả."
 
-#: builtin/branch.c:819 builtin/branch.c:842
+#: builtin/branch.c:825 builtin/branch.c:848
 #, c-format
 msgid "no such branch '%s'"
 msgstr "không có nhánh nào như thế “%s”"
 
-#: builtin/branch.c:823
+#: builtin/branch.c:829
 #, c-format
 msgid "branch '%s' does not exist"
 msgstr "chưa có nhánh “%s”"
 
-#: builtin/branch.c:836
+#: builtin/branch.c:842
 msgid "too many arguments to unset upstream"
 msgstr "quá nhiều tham số để bỏ đặt thượng nguồn"
 
-#: builtin/branch.c:840
+#: builtin/branch.c:846
 msgid "could not unset upstream of HEAD when it does not point to any branch."
 msgstr "không thể bỏ đặt thượng nguồn của HEAD không chỉ đến một nhánh nào cả."
 
-#: builtin/branch.c:846
+#: builtin/branch.c:852
 #, c-format
 msgid "Branch '%s' has no upstream information"
 msgstr "Nhánh “%s” không có thông tin thượng nguồn"
 
-#: builtin/branch.c:856
+#: builtin/branch.c:862
 msgid ""
 "The -a, and -r, options to 'git branch' do not take a branch name.\n"
 "Did you mean to use: -a|-r --list <pattern>?"
@@ -12031,7 +12005,7 @@ msgstr ""
 "nhánh.\n"
 "Có phải ý bạn là dùng: -a|-r --list <mẫu>?"
 
-#: builtin/branch.c:860
+#: builtin/branch.c:866
 msgid ""
 "the '--set-upstream' option is no longer supported. Please use '--track' or "
 "'--set-upstream-to' instead."
@@ -12302,8 +12276,8 @@ msgstr "đọc tên tập tin từ đầu vào tiêu chuẩn"
 msgid "terminate input and output records by a NUL character"
 msgstr "chấm dứt các bản ghi vào và ra bằng ký tự NULL"
 
-#: builtin/check-ignore.c:21 builtin/checkout.c:1513 builtin/gc.c:549
-#: builtin/worktree.c:494
+#: builtin/check-ignore.c:21 builtin/checkout.c:1532 builtin/gc.c:550
+#: builtin/worktree.c:493
 msgid "suppress progress reporting"
 msgstr "chặn các báo cáo tiến trình hoạt động"
 
@@ -12361,10 +12335,10 @@ msgid "git checkout--worker [<options>]"
 msgstr "git checkout--worker [<các tùy chọn>]"
 
 #: builtin/checkout--worker.c:118 builtin/checkout-index.c:201
-#: builtin/column.c:31 builtin/column.c:32 builtin/submodule--helper.c:1863
-#: builtin/submodule--helper.c:1866 builtin/submodule--helper.c:1874
-#: builtin/submodule--helper.c:2510 builtin/submodule--helper.c:2576
-#: builtin/worktree.c:492 builtin/worktree.c:729
+#: builtin/column.c:31 builtin/column.c:32 builtin/submodule--helper.c:1864
+#: builtin/submodule--helper.c:1867 builtin/submodule--helper.c:1875
+#: builtin/submodule--helper.c:2511 builtin/submodule--helper.c:2577
+#: builtin/worktree.c:491 builtin/worktree.c:728
 msgid "string"
 msgstr "chuỗi"
 
@@ -12429,96 +12403,91 @@ msgstr "git switch [<các tùy chọn>] [<nhánh>]"
 msgid "git restore [<options>] [--source=<branch>] <file>..."
 msgstr "git restore [<các tùy chọn>] [--source=<nhánh>] <tập tin>…"
 
-#: builtin/checkout.c:190 builtin/checkout.c:229
+#: builtin/checkout.c:198 builtin/checkout.c:237
 #, c-format
 msgid "path '%s' does not have our version"
 msgstr "đường dẫn “%s” không có các phiên bản của chúng ta"
 
-#: builtin/checkout.c:192 builtin/checkout.c:231
+#: builtin/checkout.c:200 builtin/checkout.c:239
 #, c-format
 msgid "path '%s' does not have their version"
 msgstr "đường dẫn “%s” không có các phiên bản của chúng"
 
-#: builtin/checkout.c:208
+#: builtin/checkout.c:216
 #, c-format
 msgid "path '%s' does not have all necessary versions"
 msgstr "đường dẫn “%s” không có tất cả các phiên bản cần thiết"
 
-#: builtin/checkout.c:261
+#: builtin/checkout.c:269
 #, c-format
 msgid "path '%s' does not have necessary versions"
 msgstr "đường dẫn “%s” không có các phiên bản cần thiết"
 
-#: builtin/checkout.c:278
+#: builtin/checkout.c:286
 #, c-format
 msgid "path '%s': cannot merge"
 msgstr "đường dẫn “%s”: không thể hòa trộn"
 
-#: builtin/checkout.c:294
+#: builtin/checkout.c:302
 #, c-format
 msgid "Unable to add merge result for '%s'"
 msgstr "Không thể thêm kết quả hòa trộn cho “%s”"
 
-#: builtin/checkout.c:411
+#: builtin/checkout.c:419
 #, c-format
 msgid "Recreated %d merge conflict"
 msgid_plural "Recreated %d merge conflicts"
 msgstr[0] "Đã tạo lại %d xung đột hòa trộn"
 
-#: builtin/checkout.c:416
+#: builtin/checkout.c:424
 #, c-format
 msgid "Updated %d path from %s"
 msgid_plural "Updated %d paths from %s"
 msgstr[0] "Đã cập nhật đường dẫn %d từ %s"
 
-#: builtin/checkout.c:423
+#: builtin/checkout.c:431
 #, c-format
 msgid "Updated %d path from the index"
 msgid_plural "Updated %d paths from the index"
 msgstr[0] "Đã cập nhật đường dẫn %d từ mục lục"
 
-#: builtin/checkout.c:446 builtin/checkout.c:449 builtin/checkout.c:452
-#: builtin/checkout.c:456
+#: builtin/checkout.c:454 builtin/checkout.c:457 builtin/checkout.c:460
+#: builtin/checkout.c:464
 #, c-format
 msgid "'%s' cannot be used with updating paths"
 msgstr "không được dùng “%s” với các đường dẫn cập nhật"
 
-#: builtin/checkout.c:459 builtin/checkout.c:462
-#, c-format
-msgid "'%s' cannot be used with %s"
-msgstr "không được dùng “%s” với %s"
-
-#: builtin/checkout.c:466
+#: builtin/checkout.c:474
 #, c-format
 msgid "Cannot update paths and switch to branch '%s' at the same time."
 msgstr ""
 "Không thể cập nhật các đường dẫn và chuyển đến nhánh “%s” cùng một lúc."
 
-#: builtin/checkout.c:470
+#: builtin/checkout.c:478
 #, c-format
 msgid "neither '%s' or '%s' is specified"
 msgstr "không chỉ định “%s” cũng không “%s”"
 
-#: builtin/checkout.c:474
+#: builtin/checkout.c:482
 #, c-format
 msgid "'%s' must be used when '%s' is not specified"
 msgstr "phải có “%s” khi không chỉ định “%s”"
 
-#: builtin/checkout.c:479 builtin/checkout.c:484
+#: builtin/checkout.c:487 builtin/checkout.c:492
 #, c-format
 msgid "'%s' or '%s' cannot be used with %s"
 msgstr "“%s” hay “%s” không thể được sử dụng với %s"
 
-#: builtin/checkout.c:558 builtin/checkout.c:565
+#: builtin/checkout.c:566 builtin/checkout.c:573
 #, c-format
 msgid "path '%s' is unmerged"
 msgstr "đường dẫn “%s” không được hòa trộn"
 
-#: builtin/checkout.c:736
+#: builtin/checkout.c:747
 msgid "you need to resolve your current index first"
 msgstr "bạn cần phải giải quyết bảng mục lục hiện tại của bạn trước đã"
 
-#: builtin/checkout.c:786
+#: builtin/checkout.c:797
 #, c-format
 msgid ""
 "cannot continue with staged changes in the following files:\n"
@@ -12528,50 +12497,50 @@ msgstr ""
 "sau:\n"
 "%s"
 
-#: builtin/checkout.c:879
+#: builtin/checkout.c:890
 #, c-format
 msgid "Can not do reflog for '%s': %s\n"
 msgstr "Không thể thực hiện reflog cho “%s”: %s\n"
 
-#: builtin/checkout.c:921
+#: builtin/checkout.c:934
 msgid "HEAD is now at"
 msgstr "HEAD hiện giờ tại"
 
-#: builtin/checkout.c:925 builtin/clone.c:609 t/helper/test-fast-rebase.c:203
+#: builtin/checkout.c:938 builtin/clone.c:609 t/helper/test-fast-rebase.c:203
 msgid "unable to update HEAD"
 msgstr "không thể cập nhật HEAD"
 
-#: builtin/checkout.c:929
+#: builtin/checkout.c:942
 #, c-format
 msgid "Reset branch '%s'\n"
 msgstr "Đặt lại nhánh “%s”\n"
 
-#: builtin/checkout.c:932
+#: builtin/checkout.c:945
 #, c-format
 msgid "Already on '%s'\n"
 msgstr "Đã sẵn sàng trên “%s”\n"
 
-#: builtin/checkout.c:936
+#: builtin/checkout.c:949
 #, c-format
 msgid "Switched to and reset branch '%s'\n"
 msgstr "Đã chuyển tới và đặt lại nhánh “%s”\n"
 
-#: builtin/checkout.c:938 builtin/checkout.c:1369
+#: builtin/checkout.c:951 builtin/checkout.c:1388
 #, c-format
 msgid "Switched to a new branch '%s'\n"
 msgstr "Đã chuyển đến nhánh mới “%s”\n"
 
-#: builtin/checkout.c:940
+#: builtin/checkout.c:953
 #, c-format
 msgid "Switched to branch '%s'\n"
 msgstr "Đã chuyển đến nhánh “%s”\n"
 
-#: builtin/checkout.c:991
+#: builtin/checkout.c:1004
 #, c-format
 msgid " ... and %d more.\n"
 msgstr " … và nhiều hơn %d.\n"
 
-#: builtin/checkout.c:997
+#: builtin/checkout.c:1010
 #, c-format
 msgid ""
 "Warning: you are leaving %d commit behind, not connected to\n"
@@ -12590,7 +12559,7 @@ msgstr[0] ""
 "\n"
 "%s\n"
 
-#: builtin/checkout.c:1016
+#: builtin/checkout.c:1029
 #, c-format
 msgid ""
 "If you want to keep it by creating a new branch, this may be a good time\n"
@@ -12611,19 +12580,19 @@ msgstr[0] ""
 " git branch <tên_nhánh_mới> %s\n"
 "\n"
 
-#: builtin/checkout.c:1051
+#: builtin/checkout.c:1064
 msgid "internal error in revision walk"
 msgstr "lỗi nội bộ trong khi di chuyển qua các điểm xét duyệt"
 
-#: builtin/checkout.c:1055
+#: builtin/checkout.c:1068
 msgid "Previous HEAD position was"
 msgstr "Vị trí trước kia của HEAD là"
 
-#: builtin/checkout.c:1095 builtin/checkout.c:1364
+#: builtin/checkout.c:1114 builtin/checkout.c:1383
 msgid "You are on a branch yet to be born"
 msgstr "Bạn tại nhánh mà nó chưa hề được sinh ra"
 
-#: builtin/checkout.c:1177
+#: builtin/checkout.c:1196
 #, c-format
 msgid ""
 "'%s' could be both a local file and a tracking branch.\n"
@@ -12632,7 +12601,7 @@ msgstr ""
 "“%s” không thể là cả tập tin nội bộ và một nhánh theo dõi.\n"
 "Vui long dùng -- (và tùy chọn thêm --no-guess) để tránh lẫn lộn"
 
-#: builtin/checkout.c:1184
+#: builtin/checkout.c:1203
 msgid ""
 "If you meant to check out a remote tracking branch on, e.g. 'origin',\n"
 "you can do so by fully qualifying the name with the --track option:\n"
@@ -12652,51 +12621,51 @@ msgstr ""
 "chưa rõ ràng, ví dụ máy chủ “origin”, cân nhắc cài đặt\n"
 "checkout.defaultRemote=origin trong cấu hình của bạn."
 
-#: builtin/checkout.c:1194
+#: builtin/checkout.c:1213
 #, c-format
 msgid "'%s' matched multiple (%d) remote tracking branches"
 msgstr "“%s” khớp với nhiều (%d) nhánh máy chủ được theo dõi"
 
-#: builtin/checkout.c:1260
+#: builtin/checkout.c:1279
 msgid "only one reference expected"
 msgstr "chỉ cần một tham chiếu"
 
-#: builtin/checkout.c:1277
+#: builtin/checkout.c:1296
 #, c-format
 msgid "only one reference expected, %d given."
 msgstr "chỉ cần một tham chiếu, nhưng lại đưa ra %d."
 
-#: builtin/checkout.c:1323 builtin/worktree.c:269 builtin/worktree.c:437
+#: builtin/checkout.c:1342 builtin/worktree.c:269 builtin/worktree.c:436
 #, c-format
 msgid "invalid reference: %s"
 msgstr "tham chiếu không hợp lệ: %s"
 
-#: builtin/checkout.c:1336 builtin/checkout.c:1705
+#: builtin/checkout.c:1355 builtin/checkout.c:1725
 #, c-format
 msgid "reference is not a tree: %s"
 msgstr "tham chiếu không phải là một cây:%s"
 
-#: builtin/checkout.c:1383
+#: builtin/checkout.c:1402
 #, c-format
 msgid "a branch is expected, got tag '%s'"
 msgstr "cần một nhánh, nhưng lại nhận được thẻ “%s”"
 
-#: builtin/checkout.c:1385
+#: builtin/checkout.c:1404
 #, c-format
 msgid "a branch is expected, got remote branch '%s'"
 msgstr "cần một nhánh, nhưng lại nhận được nhánh máy phục vụ “%s”"
 
-#: builtin/checkout.c:1386 builtin/checkout.c:1394
+#: builtin/checkout.c:1405 builtin/checkout.c:1413
 #, c-format
 msgid "a branch is expected, got '%s'"
 msgstr "cần một nhánh, nhưng lại nhận được “%s”"
 
-#: builtin/checkout.c:1389
+#: builtin/checkout.c:1408
 #, c-format
 msgid "a branch is expected, got commit '%s'"
 msgstr "cần một nhánh, nhưng lại nhận được “%s”"
 
-#: builtin/checkout.c:1405
+#: builtin/checkout.c:1424
 msgid ""
 "cannot switch branch while merging\n"
 "Consider \"git merge --quit\" or \"git worktree add\"."
@@ -12704,7 +12673,7 @@ msgstr ""
 "không thể chuyển nhánh trong khi đang hòa trộn\n"
 "Cân nhắc dung \"git merge --quit\" hoặc \"git worktree add\"."
 
-#: builtin/checkout.c:1409
+#: builtin/checkout.c:1428
 msgid ""
 "cannot switch branch in the middle of an am session\n"
 "Consider \"git am --quit\" or \"git worktree add\"."
@@ -12712,7 +12681,7 @@ msgstr ""
 "không thể chuyển nhanh ở giữa một phiên am\n"
 "Cân nhắc dùng \"git am --quit\" hoặc \"git worktree add\"."
 
-#: builtin/checkout.c:1413
+#: builtin/checkout.c:1432
 msgid ""
 "cannot switch branch while rebasing\n"
 "Consider \"git rebase --quit\" or \"git worktree add\"."
@@ -12720,7 +12689,7 @@ msgstr ""
 "không thể chuyển nhánh trong khi cải tổ\n"
 "Cân nhắc dùng \"git rebase --quit\" hay \"git worktree add\"."
 
-#: builtin/checkout.c:1417
+#: builtin/checkout.c:1436
 msgid ""
 "cannot switch branch while cherry-picking\n"
 "Consider \"git cherry-pick --quit\" or \"git worktree add\"."
@@ -12728,7 +12697,7 @@ msgstr ""
 "không thể chuyển nhánh trong khi  cherry-picking\n"
 "Cân nhắc dùng \"git cherry-pick --quit\" hay \"git worktree add\"."
 
-#: builtin/checkout.c:1421
+#: builtin/checkout.c:1440
 msgid ""
 "cannot switch branch while reverting\n"
 "Consider \"git revert --quit\" or \"git worktree add\"."
@@ -12736,143 +12705,131 @@ msgstr ""
 "không thể chuyển nhánh trong khi hoàn nguyên\n"
 "Cân nhắc dùng \"git revert --quit\" hoặc \"git worktree add\"."
 
-#: builtin/checkout.c:1425
+#: builtin/checkout.c:1444
 msgid "you are switching branch while bisecting"
 msgstr ""
 "bạn hiện tại đang thực hiện việc chuyển nhánh trong khi đang di chuyển nửa "
 "bước"
 
-#: builtin/checkout.c:1432
+#: builtin/checkout.c:1451
 msgid "paths cannot be used with switching branches"
 msgstr "các đường dẫn không thể dùng cùng với các nhánh chuyển"
 
-#: builtin/checkout.c:1435 builtin/checkout.c:1439 builtin/checkout.c:1443
+#: builtin/checkout.c:1454 builtin/checkout.c:1458 builtin/checkout.c:1462
 #, c-format
 msgid "'%s' cannot be used with switching branches"
 msgstr "“%s” không thể được sử dụng với các nhánh chuyển"
 
-#: builtin/checkout.c:1447 builtin/checkout.c:1450 builtin/checkout.c:1453
-#: builtin/checkout.c:1458 builtin/checkout.c:1463
+#: builtin/checkout.c:1466 builtin/checkout.c:1469 builtin/checkout.c:1472
+#: builtin/checkout.c:1477 builtin/checkout.c:1482
 #, c-format
 msgid "'%s' cannot be used with '%s'"
 msgstr "“%s” không thể được dùng với “%s”"
 
-#: builtin/checkout.c:1460
+#: builtin/checkout.c:1479
 #, c-format
 msgid "'%s' cannot take <start-point>"
 msgstr "“%s” không thể nhận <điểm-đầu>"
 
-#: builtin/checkout.c:1468
+#: builtin/checkout.c:1487
 #, c-format
 msgid "Cannot switch branch to a non-commit '%s'"
 msgstr "Không thể chuyển nhánh đến một thứ không phải là lần chuyển giao “%s”"
 
-#: builtin/checkout.c:1475
+#: builtin/checkout.c:1494
 msgid "missing branch or commit argument"
 msgstr "thiếu tham số là nhánh hoặc lần chuyển giao"
 
-#: builtin/checkout.c:1518
+#: builtin/checkout.c:1537
 msgid "perform a 3-way merge with the new branch"
 msgstr "thực hiện hòa trộn kiểu 3-way với nhánh mới"
 
-#: builtin/checkout.c:1519 builtin/log.c:1810 parse-options.h:321
+#: builtin/checkout.c:1538 builtin/log.c:1825 parse-options.h:323
 msgid "style"
 msgstr "kiểu"
 
-#: builtin/checkout.c:1520
-msgid "conflict style (merge or diff3)"
-msgstr "xung đột kiểu (hòa trộn hoặc diff3)"
+#: builtin/checkout.c:1539
+msgid "conflict style (merge, diff3, or zdiff3)"
+msgstr "xung đột kiểu (hòa trộn, diff3 hoặc zdiff3)"
 
-#: builtin/checkout.c:1532 builtin/worktree.c:489
+#: builtin/checkout.c:1551 builtin/worktree.c:488
 msgid "detach HEAD at named commit"
 msgstr "rời bỏ HEAD tại lần chuyển giao theo tên"
 
-#: builtin/checkout.c:1533
-msgid "set upstream info for new branch"
-msgstr "đặt thông tin thượng nguồn cho nhánh mới"
+#: builtin/checkout.c:1553
+msgid "set up tracking mode (see git-pull(1))"
+msgstr "cài đặt chế độ theo dõi (xem git-pull(1))"
 
-#: builtin/checkout.c:1535
+#: builtin/checkout.c:1556
 msgid "force checkout (throw away local modifications)"
 msgstr "ép buộc lấy ra (bỏ đi những thay đổi nội bộ)"
 
-#: builtin/checkout.c:1537
+#: builtin/checkout.c:1558
 msgid "new-branch"
 msgstr "nhánh-mới"
 
-#: builtin/checkout.c:1537
+#: builtin/checkout.c:1558
 msgid "new unparented branch"
 msgstr "nhánh không cha mới"
 
-#: builtin/checkout.c:1539 builtin/merge.c:302
+#: builtin/checkout.c:1560 builtin/merge.c:305
 msgid "update ignored files (default)"
 msgstr "cập nhật các tập tin bị bỏ qua (mặc định)"
 
-#: builtin/checkout.c:1542
+#: builtin/checkout.c:1563
 msgid "do not check if another worktree is holding the given ref"
 msgstr "không kiểm tra nếu cây làm việc khác đang giữ tham chiếu đã cho"
 
-#: builtin/checkout.c:1555
+#: builtin/checkout.c:1576
 msgid "checkout our version for unmerged files"
 msgstr ""
 "lấy ra (checkout) phiên bản của chúng ta cho các tập tin chưa được hòa trộn"
 
-#: builtin/checkout.c:1558
+#: builtin/checkout.c:1579
 msgid "checkout their version for unmerged files"
 msgstr ""
 "lấy ra (checkout) phiên bản của chúng họ cho các tập tin chưa được hòa trộn"
 
-#: builtin/checkout.c:1562
+#: builtin/checkout.c:1583
 msgid "do not limit pathspecs to sparse entries only"
 msgstr "không giới hạn đặc tả đường dẫn thành chỉ các mục rải rác"
 
-#: builtin/checkout.c:1620
+#: builtin/checkout.c:1640
 #, c-format
-msgid "-%c, -%c and --orphan are mutually exclusive"
-msgstr "-%c, -%c và --orphan loại từ lẫn nhau"
+msgid "options '-%c', '-%c', and '%s' cannot be used together"
+msgstr "tùy chọn '-%c', '-%c' và '%s' không thể dùng cùng nhau"
 
-#: builtin/checkout.c:1624
-msgid "-p and --overlay are mutually exclusive"
-msgstr "-p và --overlay loại từ lẫn nhau"
-
-#: builtin/checkout.c:1661
+#: builtin/checkout.c:1681
 msgid "--track needs a branch name"
 msgstr "--track cần tên một nhánh"
 
-#: builtin/checkout.c:1666
+#: builtin/checkout.c:1686
 #, c-format
 msgid "missing branch name; try -%c"
 msgstr "thiếu tên nhánh; hãy thử -%c"
 
-#: builtin/checkout.c:1698
+#: builtin/checkout.c:1718
 #, c-format
 msgid "could not resolve %s"
 msgstr "không thể phân giải “%s”"
 
-#: builtin/checkout.c:1714
+#: builtin/checkout.c:1734
 msgid "invalid path specification"
 msgstr "đường dẫn đã cho không hợp lệ"
 
-#: builtin/checkout.c:1721
+#: builtin/checkout.c:1741
 #, c-format
 msgid "'%s' is not a commit and a branch '%s' cannot be created from it"
 msgstr ""
 "“%s” không phải là một lần chuyển giao và một nhánh'%s” không thể được tạo "
 "từ đó"
 
-#: builtin/checkout.c:1725
+#: builtin/checkout.c:1745
 #, c-format
 msgid "git checkout: --detach does not take a path argument '%s'"
 msgstr "git checkout: --detach không nhận một đối số đường dẫn “%s”"
 
-#: builtin/checkout.c:1734
-msgid "--pathspec-from-file is incompatible with --detach"
-msgstr "--pathspec-from-file xung khắc với --detach"
-
-#: builtin/checkout.c:1737 builtin/reset.c:331 builtin/stash.c:1647
-msgid "--pathspec-from-file is incompatible with --patch"
-msgstr "--pathspec-from-file xung khắc với --patch"
-
-#: builtin/checkout.c:1750
+#: builtin/checkout.c:1770
 msgid ""
 "git checkout: --ours/--theirs, --force and --merge are incompatible when\n"
 "checking out of the index."
@@ -12880,71 +12837,71 @@ msgstr ""
 "git checkout: --ours/--theirs, --force và --merge là xung khắc với nhau khi\n"
 "checkout bảng mục lục (index)."
 
-#: builtin/checkout.c:1755
+#: builtin/checkout.c:1775
 msgid "you must specify path(s) to restore"
 msgstr "bạn phải chỉ định các thư mục muốn hồi phục"
 
-#: builtin/checkout.c:1781 builtin/checkout.c:1783 builtin/checkout.c:1832
-#: builtin/checkout.c:1834 builtin/clone.c:126 builtin/remote.c:170
-#: builtin/remote.c:172 builtin/submodule--helper.c:2958
-#: builtin/submodule--helper.c:3252 builtin/worktree.c:485
-#: builtin/worktree.c:487
+#: builtin/checkout.c:1800 builtin/checkout.c:1802 builtin/checkout.c:1854
+#: builtin/checkout.c:1856 builtin/clone.c:126 builtin/remote.c:170
+#: builtin/remote.c:172 builtin/submodule--helper.c:2959
+#: builtin/submodule--helper.c:3253 builtin/worktree.c:484
+#: builtin/worktree.c:486
 msgid "branch"
 msgstr "nhánh"
 
-#: builtin/checkout.c:1782
+#: builtin/checkout.c:1801
 msgid "create and checkout a new branch"
 msgstr "tạo và checkout một nhánh mới"
 
-#: builtin/checkout.c:1784
+#: builtin/checkout.c:1803
 msgid "create/reset and checkout a branch"
 msgstr "tạo/đặt_lại và checkout một nhánh"
 
-#: builtin/checkout.c:1785
+#: builtin/checkout.c:1804
 msgid "create reflog for new branch"
 msgstr "tạo reflog cho nhánh mới"
 
-#: builtin/checkout.c:1787
+#: builtin/checkout.c:1806
 msgid "second guess 'git checkout <no-such-branch>' (default)"
 msgstr "gợi ý thứ hai “git checkout <không-nhánh-nào-như-vậy>” (mặc định)"
 
-#: builtin/checkout.c:1788
+#: builtin/checkout.c:1807
 msgid "use overlay mode (default)"
 msgstr "dùng chế độ che phủ (mặc định)"
 
-#: builtin/checkout.c:1833
+#: builtin/checkout.c:1855
 msgid "create and switch to a new branch"
 msgstr "tạo và chuyển đến một nhánh mới"
 
-#: builtin/checkout.c:1835
+#: builtin/checkout.c:1857
 msgid "create/reset and switch to a branch"
 msgstr "tạo/đặt_lại và chuyển đến một nhánh"
 
-#: builtin/checkout.c:1837
+#: builtin/checkout.c:1859
 msgid "second guess 'git switch <no-such-branch>'"
 msgstr "gợi ý thứ hai \"git switch <không-nhánh-nào-như-vậy>\""
 
-#: builtin/checkout.c:1839
+#: builtin/checkout.c:1861
 msgid "throw away local modifications"
 msgstr "vứt bỏ các sửa đổi địa phương"
 
-#: builtin/checkout.c:1873
+#: builtin/checkout.c:1897
 msgid "which tree-ish to checkout from"
 msgstr "lấy ra từ tree-ish nào"
 
-#: builtin/checkout.c:1875
+#: builtin/checkout.c:1899
 msgid "restore the index"
 msgstr "phục hồi bảng mục lục"
 
-#: builtin/checkout.c:1877
+#: builtin/checkout.c:1901
 msgid "restore the working tree (default)"
 msgstr "phục hồi cây làm việc (mặc định)"
 
-#: builtin/checkout.c:1879
+#: builtin/checkout.c:1903
 msgid "ignore unmerged entries"
 msgstr "bỏ qua những thứ chưa hòa trộn: %s"
 
-#: builtin/checkout.c:1880
+#: builtin/checkout.c:1904
 msgid "use overlay mode"
 msgstr "dùng chế độ che phủ"
 
@@ -12980,7 +12937,15 @@ msgstr "Nên bỏ qua kho chứa %s\n"
 msgid "could not lstat %s\n"
 msgstr "không thể lấy thông tin thống kê đầy đủ của %s\n"
 
-#: builtin/clean.c:300 git-add--interactive.perl:593
+#: builtin/clean.c:39
+msgid "Refusing to remove current working directory\n"
+msgstr "Từ chối gỡ bỏ thư mục làm việc hiện tại\n"
+
+#: builtin/clean.c:40
+msgid "Would refuse to remove current working directory\n"
+msgstr "Nên từ chối gỡ bỏ thư mục làm việc hiện tại\n"
+
+#: builtin/clean.c:326 git-add--interactive.perl:593
 #, c-format
 msgid ""
 "Prompt help:\n"
@@ -12993,7 +12958,7 @@ msgstr ""
 "foo        - chọn mục trên cơ sở tiền tố duy nhất\n"
 "           - (để trống) không chọn gì cả\n"
 
-#: builtin/clean.c:304 git-add--interactive.perl:602
+#: builtin/clean.c:330 git-add--interactive.perl:602
 #, c-format
 msgid ""
 "Prompt help:\n"
@@ -13014,33 +12979,33 @@ msgstr ""
 "*          - chọn tất\n"
 "           - (để trống) kết thúc việc chọn\n"
 
-#: builtin/clean.c:519 git-add--interactive.perl:568
+#: builtin/clean.c:545 git-add--interactive.perl:568
 #: git-add--interactive.perl:573
 #, c-format, perl-format
 msgid "Huh (%s)?\n"
 msgstr "Hả (%s)?\n"
 
-#: builtin/clean.c:659
+#: builtin/clean.c:685
 #, c-format
 msgid "Input ignore patterns>> "
 msgstr "Mẫu để lọc các tập tin đầu vào cần lờ đi>> "
 
-#: builtin/clean.c:693
+#: builtin/clean.c:719
 #, c-format
 msgid "WARNING: Cannot find items matched by: %s"
 msgstr "CẢNH BÁO: Không tìm thấy các mục được khớp bởi: %s"
 
-#: builtin/clean.c:714
+#: builtin/clean.c:740
 msgid "Select items to delete"
 msgstr "Chọn mục muốn xóa"
 
 #. TRANSLATORS: Make sure to keep [y/N] as is
-#: builtin/clean.c:755
+#: builtin/clean.c:781
 #, c-format
 msgid "Remove %s [y/N]? "
 msgstr "Xóa bỏ “%s” [y/N]? "
 
-#: builtin/clean.c:786
+#: builtin/clean.c:812
 msgid ""
 "clean               - start cleaning\n"
 "filter by pattern   - exclude items from deletion\n"
@@ -13058,51 +13023,51 @@ msgstr ""
 "help                - hiển thị chính trợ giúp này\n"
 "?                   - trợ giúp dành cho chọn bằng cách nhắc"
 
-#: builtin/clean.c:822
+#: builtin/clean.c:848
 msgid "Would remove the following item:"
 msgid_plural "Would remove the following items:"
 msgstr[0] "Có muốn gỡ bỏ (các) mục sau đây không:"
 
-#: builtin/clean.c:838
+#: builtin/clean.c:864
 msgid "No more files to clean, exiting."
 msgstr "Không còn tập-tin nào để dọn dẹp, đang thoát ra."
 
-#: builtin/clean.c:900
+#: builtin/clean.c:926
 msgid "do not print names of files removed"
 msgstr "không hiển thị tên của các tập tin đã gỡ bỏ"
 
-#: builtin/clean.c:902
+#: builtin/clean.c:928
 msgid "force"
 msgstr "ép buộc"
 
-#: builtin/clean.c:903
+#: builtin/clean.c:929
 msgid "interactive cleaning"
 msgstr "dọn bằng kiểu tương tác"
 
-#: builtin/clean.c:905
+#: builtin/clean.c:931
 msgid "remove whole directories"
 msgstr "gỡ bỏ toàn bộ thư mục"
 
-#: builtin/clean.c:906 builtin/describe.c:565 builtin/describe.c:567
+#: builtin/clean.c:932 builtin/describe.c:565 builtin/describe.c:567
 #: builtin/grep.c:937 builtin/log.c:184 builtin/log.c:186
-#: builtin/ls-files.c:648 builtin/name-rev.c:526 builtin/name-rev.c:528
+#: builtin/ls-files.c:651 builtin/name-rev.c:535 builtin/name-rev.c:537
 #: builtin/show-ref.c:179
 msgid "pattern"
 msgstr "mẫu"
 
-#: builtin/clean.c:907
+#: builtin/clean.c:933
 msgid "add <pattern> to ignore rules"
 msgstr "thêm <mẫu> vào trong qui tắc bỏ qua"
 
-#: builtin/clean.c:908
+#: builtin/clean.c:934
 msgid "remove ignored files, too"
 msgstr "đồng thời gỡ bỏ cả các tập tin bị bỏ qua"
 
-#: builtin/clean.c:910
+#: builtin/clean.c:936
 msgid "remove only ignored files"
 msgstr "chỉ gỡ bỏ những tập tin bị bỏ qua"
 
-#: builtin/clean.c:925
+#: builtin/clean.c:951
 msgid ""
 "clean.requireForce set to true and neither -i, -n, nor -f given; refusing to "
 "clean"
@@ -13110,7 +13075,7 @@ msgstr ""
 "clean.requireForce được đặt thành true và không đưa ra tùy chọn -i, -n mà "
 "cũng không -f; từ chối lệnh dọn dẹp (clean)"
 
-#: builtin/clean.c:928
+#: builtin/clean.c:954
 msgid ""
 "clean.requireForce defaults to true and neither -i, -n, nor -f given; "
 "refusing to clean"
@@ -13118,7 +13083,7 @@ msgstr ""
 "clean.requireForce mặc định được đặt là true và không đưa ra tùy chọn -i, -n "
 "mà cũng không -f; từ chối lệnh dọn dẹp (clean)"
 
-#: builtin/clean.c:940
+#: builtin/clean.c:966
 msgid "-x and -X cannot be used together"
 msgstr "-x và -X không thể dùng cùng nhau"
 
@@ -13174,19 +13139,20 @@ msgstr "thư-mục-mẫu"
 msgid "directory from which templates will be used"
 msgstr "thư mục mà tại đó các mẫu sẽ được dùng"
 
-#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1870
-#: builtin/submodule--helper.c:2513 builtin/submodule--helper.c:3259
+#: builtin/clone.c:119 builtin/clone.c:121 builtin/submodule--helper.c:1871
+#: builtin/submodule--helper.c:2514 builtin/submodule--helper.c:3260
 msgid "reference repository"
 msgstr "kho tham chiếu"
 
-#: builtin/clone.c:123 builtin/submodule--helper.c:1872
-#: builtin/submodule--helper.c:2515
+#: builtin/clone.c:123 builtin/submodule--helper.c:1873
+#: builtin/submodule--helper.c:2516
 msgid "use --reference only while cloning"
 msgstr "chỉ dùng --reference khi nhân bản"
 
-#: builtin/clone.c:124 builtin/column.c:27 builtin/init-db.c:550
-#: builtin/merge-file.c:46 builtin/pack-objects.c:3944 builtin/repack.c:663
-#: builtin/submodule--helper.c:3261 t/helper/test-simple-ipc.c:595
+#: builtin/clone.c:124 builtin/column.c:27 builtin/fmt-merge-msg.c:27
+#: builtin/init-db.c:550 builtin/merge-file.c:48 builtin/merge.c:290
+#: builtin/pack-objects.c:3944 builtin/repack.c:665
+#: builtin/submodule--helper.c:3262 t/helper/test-simple-ipc.c:595
 #: t/helper/test-simple-ipc.c:597
 msgid "name"
 msgstr "tên"
@@ -13203,7 +13169,7 @@ msgstr "lấy ra <nhánh> thay cho HEAD của máy chủ"
 msgid "path to git-upload-pack on the remote"
 msgstr "đường dẫn đến git-upload-pack trên máy chủ"
 
-#: builtin/clone.c:130 builtin/fetch.c:180 builtin/grep.c:876
+#: builtin/clone.c:130 builtin/fetch.c:181 builtin/grep.c:876
 #: builtin/pull.c:212
 msgid "depth"
 msgstr "độ-sâu"
@@ -13212,7 +13178,7 @@ msgstr "độ-sâu"
 msgid "create a shallow clone of that depth"
 msgstr "tạo bản sao không đầy đủ cho mức sâu đã cho"
 
-#: builtin/clone.c:132 builtin/fetch.c:182 builtin/pack-objects.c:3933
+#: builtin/clone.c:132 builtin/fetch.c:183 builtin/pack-objects.c:3933
 #: builtin/pull.c:215
 msgid "time"
 msgstr "thời-gian"
@@ -13221,17 +13187,17 @@ msgstr "thời-gian"
 msgid "create a shallow clone since a specific time"
 msgstr "tạo bản sao không đầy đủ từ thời điểm đã cho"
 
-#: builtin/clone.c:134 builtin/fetch.c:184 builtin/fetch.c:207
+#: builtin/clone.c:134 builtin/fetch.c:185 builtin/fetch.c:208
 #: builtin/pull.c:218 builtin/pull.c:243 builtin/rebase.c:1022
 msgid "revision"
 msgstr "điểm xét duyệt"
 
-#: builtin/clone.c:135 builtin/fetch.c:185 builtin/pull.c:219
+#: builtin/clone.c:135 builtin/fetch.c:186 builtin/pull.c:219
 msgid "deepen history of shallow clone, excluding rev"
 msgstr "làm sâu hơn lịch sử của bản sao shallow, bằng điểm xét duyệt loại trừ"
 
-#: builtin/clone.c:137 builtin/submodule--helper.c:1882
-#: builtin/submodule--helper.c:2529
+#: builtin/clone.c:137 builtin/submodule--helper.c:1883
+#: builtin/submodule--helper.c:2530
 msgid "clone only one branch, HEAD or --branch"
 msgstr "chỉ nhân bản một nhánh, HEAD hoặc --branch"
 
@@ -13261,22 +13227,22 @@ msgstr "khóa=giá_trị"
 msgid "set config inside the new repository"
 msgstr "đặt cấu hình bên trong một kho chứa mới"
 
-#: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
+#: builtin/clone.c:147 builtin/fetch.c:203 builtin/ls-remote.c:77
 #: builtin/pull.c:234 builtin/push.c:575 builtin/send-pack.c:200
 msgid "server-specific"
 msgstr "đặc-tả-máy-phục-vụ"
 
-#: builtin/clone.c:147 builtin/fetch.c:202 builtin/ls-remote.c:77
+#: builtin/clone.c:147 builtin/fetch.c:203 builtin/ls-remote.c:77
 #: builtin/pull.c:235 builtin/push.c:575 builtin/send-pack.c:201
 msgid "option to transmit"
 msgstr "tùy chọn để chuyển giao"
 
-#: builtin/clone.c:148 builtin/fetch.c:203 builtin/pull.c:238
+#: builtin/clone.c:148 builtin/fetch.c:204 builtin/pull.c:238
 #: builtin/push.c:576
 msgid "use IPv4 addresses only"
 msgstr "chỉ dùng địa chỉ IPv4"
 
-#: builtin/clone.c:150 builtin/fetch.c:205 builtin/pull.c:241
+#: builtin/clone.c:150 builtin/fetch.c:206 builtin/pull.c:241
 #: builtin/push.c:578
 msgid "use IPv6 addresses only"
 msgstr "chỉ dùng địa chỉ IPv6"
@@ -13368,29 +13334,25 @@ msgstr "không thể đóng gói để dọn dẹp"
 msgid "cannot unlink temporary alternates file"
 msgstr "không thể bỏ liên kết tập tin thay thế tạm thời"
 
-#: builtin/clone.c:886 builtin/receive-pack.c:2493
+#: builtin/clone.c:886
 msgid "Too many arguments."
 msgstr "Có quá nhiều đối số."
 
-#: builtin/clone.c:890
+#: builtin/clone.c:890 contrib/scalar/scalar.c:414
 msgid "You must specify a repository to clone."
 msgstr "Bạn phải chỉ định một kho để mà nhân bản (clone)."
 
 #: builtin/clone.c:903
 #, c-format
-msgid "--bare and --origin %s options are incompatible."
-msgstr "tùy chọn --bare và --origin %s xung khắc nhau."
-
-#: builtin/clone.c:906
-msgid "--bare and --separate-git-dir are incompatible."
-msgstr "tùy chọn --bare và --separate-git-dir xung khắc nhau."
+msgid "options '%s' and '%s %s' cannot be used together"
+msgstr "tùy chọn '%s', và '%s %s' không thể dùng cùng nhau"
 
 #: builtin/clone.c:920
 #, c-format
 msgid "repository '%s' does not exist"
 msgstr "kho chứa “%s” chưa tồn tại"
 
-#: builtin/clone.c:924 builtin/fetch.c:2029
+#: builtin/clone.c:924 builtin/fetch.c:2052
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "độ sâu %s không phải là một số nguyên dương"
@@ -13411,8 +13373,8 @@ msgstr ""
 msgid "working tree '%s' already exists."
 msgstr "cây làm việc “%s” đã sẵn tồn tại rồi."
 
-#: builtin/clone.c:969 builtin/clone.c:990 builtin/difftool.c:262
-#: builtin/log.c:1997 builtin/worktree.c:281 builtin/worktree.c:313
+#: builtin/clone.c:969 builtin/clone.c:990 builtin/difftool.c:256
+#: builtin/log.c:2012 builtin/worktree.c:281 builtin/worktree.c:313
 #, c-format
 msgid "could not create leading directories of '%s'"
 msgstr "không thể tạo các thư mục dẫn đầu của “%s”"
@@ -13537,7 +13499,7 @@ msgstr ""
 "paths] [--[no-]max-new-filters <n>] [--[no-]progress] <các tùy chọn chia "
 "tách>"
 
-#: builtin/commit-graph.c:51 builtin/fetch.c:191 builtin/log.c:1779
+#: builtin/commit-graph.c:51 builtin/fetch.c:192 builtin/log.c:1794
 msgid "dir"
 msgstr "tmục"
 
@@ -13626,7 +13588,7 @@ msgstr ""
 msgid "Collecting commits from input"
 msgstr "Sưu tập các lần chuyển giao từ đầu vào"
 
-#: builtin/commit-graph.c:328 builtin/multi-pack-index.c:255
+#: builtin/commit-graph.c:328 builtin/multi-pack-index.c:259
 #, c-format
 msgid "unrecognized subcommand: %s"
 msgstr "không hiểu câu lệnh con: %s"
@@ -13644,7 +13606,7 @@ msgstr ""
 msgid "duplicate parent %s ignored"
 msgstr "cha mẹ bị trùng lặp %s đã bị bỏ qua"
 
-#: builtin/commit-tree.c:56 builtin/commit-tree.c:134 builtin/log.c:562
+#: builtin/commit-tree.c:56 builtin/commit-tree.c:134 builtin/log.c:577
 #, c-format
 msgid "not a valid object name %s"
 msgstr "không phải là tên đối tượng hợp lệ “%s”"
@@ -13667,13 +13629,13 @@ msgstr "cha-mẹ"
 msgid "id of a parent commit object"
 msgstr "mã số của đối tượng chuyển giao cha mẹ"
 
-#: builtin/commit-tree.c:112 builtin/commit.c:1626 builtin/merge.c:283
-#: builtin/notes.c:407 builtin/notes.c:573 builtin/stash.c:1618
+#: builtin/commit-tree.c:112 builtin/commit.c:1627 builtin/merge.c:284
+#: builtin/notes.c:407 builtin/notes.c:573 builtin/stash.c:1677
 #: builtin/tag.c:454
 msgid "message"
 msgstr "chú thích"
 
-#: builtin/commit-tree.c:113 builtin/commit.c:1626
+#: builtin/commit-tree.c:113 builtin/commit.c:1627
 msgid "commit message"
 msgstr "chú thích của lần chuyển giao"
 
@@ -13681,7 +13643,7 @@ msgstr "chú thích của lần chuyển giao"
 msgid "read commit log message from file"
 msgstr "đọc chú thích nhật ký lần chuyển giao từ tập tin"
 
-#: builtin/commit-tree.c:119 builtin/commit.c:1643 builtin/merge.c:300
+#: builtin/commit-tree.c:119 builtin/commit.c:1644 builtin/merge.c:303
 #: builtin/pull.c:180 builtin/revert.c:118
 msgid "GPG sign commit"
 msgstr "Ký lần chuyển giao dùng GPG"
@@ -13763,10 +13725,6 @@ msgstr ""
 #: builtin/commit.c:325
 msgid "failed to unpack HEAD tree object"
 msgstr "gặp lỗi khi tháo dỡ HEAD đối tượng cây"
-
-#: builtin/commit.c:361
-msgid "--pathspec-from-file with -a does not make sense"
-msgstr "--pathspec-from-file với -a là không có ý nghĩa gì"
 
 #: builtin/commit.c:375
 msgid "No paths with --include/--only does not make sense."
@@ -13858,8 +13816,8 @@ msgstr "không đọc được tệp nhật ký “%s”"
 
 #: builtin/commit.c:802
 #, c-format
-msgid "cannot combine -m with --fixup:%s"
-msgstr "không thể kết hợp “-m” với “--fixup”:%s"
+msgid "options '%s' and '%s:%s' cannot be used together"
+msgstr "tùy chọn '%s', và '%s:%s' không thể dùng cùng nhau"
 
 #: builtin/commit.c:814 builtin/commit.c:830
 msgid "could not read SQUASH_MSG"
@@ -13970,7 +13928,7 @@ msgstr "không thể chuyển phần đuôi cho “--trailers”"
 msgid "Error building trees"
 msgstr "Gặp lỗi khi xây dựng cây"
 
-#: builtin/commit.c:1080 builtin/tag.c:317
+#: builtin/commit.c:1080 builtin/tag.c:316
 #, c-format
 msgid "Please supply the message using either -m or -F option.\n"
 msgstr "Xin hãy cung cấp lời chú giải hoặc là dùng tùy chọn -m hoặc là -F.\n"
@@ -13987,14 +13945,10 @@ msgstr ""
 msgid "Invalid ignored mode '%s'"
 msgstr "Chế độ bỏ qua không hợp lệ “%s”"
 
-#: builtin/commit.c:1156 builtin/commit.c:1450
+#: builtin/commit.c:1156 builtin/commit.c:1451
 #, c-format
 msgid "Invalid untracked files mode '%s'"
 msgstr "Chế độ cho các tập tin chưa được theo dõi không hợp lệ “%s”"
-
-#: builtin/commit.c:1196
-msgid "--long and -z are incompatible"
-msgstr "hai tùy chọn --long và -z không tương thích với nhau"
 
 #: builtin/commit.c:1227
 msgid "You are in the middle of a merge -- cannot reword."
@@ -14009,120 +13963,118 @@ msgstr ""
 
 #: builtin/commit.c:1232
 #, c-format
-msgid "cannot combine reword option of --fixup with path '%s'"
-msgstr "không thể tổ hợp tùy chọn \"reword\" của --fixup với đường dẫn “%s”"
+msgid "reword option of '%s' and path '%s' cannot be used together"
+msgstr ""
+"không thể tổ hợp tùy chọn \"reword\" của '%s' với đường dẫn '%s' cùng nhau"
 
 #: builtin/commit.c:1234
-msgid ""
-"reword option of --fixup is mutually exclusive with --patch/--interactive/--"
-"all/--include/--only"
-msgstr ""
-"tùy chọn \"reword\" của --fixup là loại trừ qua lại với --patch/--"
-"interactive/--all/--include/--only"
+#, c-format
+msgid "reword option of '%s' and '%s' cannot be used together"
+msgstr "không thể tổ hợp tùy chọn \"reword\" của '%s' với '%s' cùng nhau"
 
-#: builtin/commit.c:1253
+#: builtin/commit.c:1254
 msgid "Using both --reset-author and --author does not make sense"
 msgstr "Sử dụng cả hai tùy chọn --reset-author và --author không hợp lý"
 
-#: builtin/commit.c:1260
+#: builtin/commit.c:1261
 msgid "You have nothing to amend."
 msgstr "Không có gì để mà “tu bổ” cả."
 
-#: builtin/commit.c:1263
+#: builtin/commit.c:1264
 msgid "You are in the middle of a merge -- cannot amend."
 msgstr ""
 "Bạn đang ở giữa của quá trình hòa trộn -- không thể thực hiện việc “tu bổ”."
 
-#: builtin/commit.c:1265
+#: builtin/commit.c:1266
 msgid "You are in the middle of a cherry-pick -- cannot amend."
 msgstr ""
 "Bạn đang ở giữa của quá trình cherry-pick -- không thể thực hiện việc “tu "
 "bổ”."
 
-#: builtin/commit.c:1267
+#: builtin/commit.c:1268
 msgid "You are in the middle of a rebase -- cannot amend."
 msgstr ""
 "Bạn đang ở giữa của quá trình cải tổ -- nên không thể thực hiện việc “tu bổ”."
 
-#: builtin/commit.c:1270
+#: builtin/commit.c:1271
 msgid "Options --squash and --fixup cannot be used together"
 msgstr "Các tùy chọn --squash và --fixup không thể sử dụng cùng với nhau"
 
-#: builtin/commit.c:1280
+#: builtin/commit.c:1281
 msgid "Only one of -c/-C/-F/--fixup can be used."
 msgstr "Chỉ được dùng một trong số tùy chọn trong số -c/-C/-F/--fixup."
 
-#: builtin/commit.c:1282
+#: builtin/commit.c:1283
 msgid "Option -m cannot be combined with -c/-C/-F."
 msgstr "Tùy chọn -m không thể được tổ hợp cùng với -c/-C/-F."
 
-#: builtin/commit.c:1291
+#: builtin/commit.c:1292
 msgid "--reset-author can be used only with -C, -c or --amend."
 msgstr ""
 "--reset-author chỉ có thể được sử dụng với tùy chọn -C, -c hay --amend."
 
-#: builtin/commit.c:1309
+#: builtin/commit.c:1310
 msgid "Only one of --include/--only/--all/--interactive/--patch can be used."
 msgstr ""
 "Chỉ một trong các tùy chọn --include/--only/--all/--interactive/--patch được "
 "sử dụng."
 
-#: builtin/commit.c:1337
+#: builtin/commit.c:1338
 #, c-format
 msgid "unknown option: --fixup=%s:%s"
 msgstr "không hiểu tùy chọn: --fixup=%s:%s"
 
-#: builtin/commit.c:1354
+#: builtin/commit.c:1355
 #, c-format
 msgid "paths '%s ...' with -a does not make sense"
 msgstr "các đường dẫn “%s …” với tùy chọn -a không hợp lý"
 
-#: builtin/commit.c:1485 builtin/commit.c:1654
+#: builtin/commit.c:1486 builtin/commit.c:1655
 msgid "show status concisely"
 msgstr "hiển thị trạng thái ở dạng súc tích"
 
-#: builtin/commit.c:1487 builtin/commit.c:1656
+#: builtin/commit.c:1488 builtin/commit.c:1657
 msgid "show branch information"
 msgstr "hiển thị thông tin nhánh"
 
-#: builtin/commit.c:1489
+#: builtin/commit.c:1490
 msgid "show stash information"
 msgstr "hiển thị thông tin về tạm cất"
 
-#: builtin/commit.c:1491 builtin/commit.c:1658
+#: builtin/commit.c:1492 builtin/commit.c:1659
 msgid "compute full ahead/behind values"
 msgstr "tính đầy đủ giá trị trước/sau"
 
-#: builtin/commit.c:1493
+#: builtin/commit.c:1494
 msgid "version"
 msgstr "phiên bản"
 
-#: builtin/commit.c:1493 builtin/commit.c:1660 builtin/push.c:551
-#: builtin/worktree.c:691
+#: builtin/commit.c:1494 builtin/commit.c:1661 builtin/push.c:551
+#: builtin/worktree.c:690
 msgid "machine-readable output"
 msgstr "kết xuất dạng máy-có-thể-đọc"
 
-#: builtin/commit.c:1496 builtin/commit.c:1662
+#: builtin/commit.c:1497 builtin/commit.c:1663
 msgid "show status in long format (default)"
 msgstr "hiển thị trạng thái ở định dạng dài (mặc định)"
 
-#: builtin/commit.c:1499 builtin/commit.c:1665
+#: builtin/commit.c:1500 builtin/commit.c:1666
 msgid "terminate entries with NUL"
 msgstr "chấm dứt các mục bằng NUL"
 
-#: builtin/commit.c:1501 builtin/commit.c:1505 builtin/commit.c:1668
-#: builtin/fast-export.c:1199 builtin/fast-export.c:1202
-#: builtin/fast-export.c:1205 builtin/rebase.c:1111 parse-options.h:335
+#: builtin/commit.c:1502 builtin/commit.c:1506 builtin/commit.c:1669
+#: builtin/fast-export.c:1172 builtin/fast-export.c:1175
+#: builtin/fast-export.c:1178 builtin/rebase.c:1111 parse-options.h:337
 msgid "mode"
 msgstr "chế độ"
 
-#: builtin/commit.c:1502 builtin/commit.c:1668
+#: builtin/commit.c:1503 builtin/commit.c:1669
 msgid "show untracked files, optional modes: all, normal, no. (Default: all)"
 msgstr ""
 "hiển thị các tập tin chưa được theo dõi  dấu vết, các chế độ tùy chọn:  all, "
 "normal, no. (Mặc định: all)"
 
-#: builtin/commit.c:1506
+#: builtin/commit.c:1507
 msgid ""
 "show ignored files, optional modes: traditional, matching, no. (Default: "
 "traditional)"
@@ -14130,11 +14082,11 @@ msgstr ""
 "hiển thị các tập tin bị bỏ qua, các chế độ tùy chọn: traditional, matching, "
 "no. (Mặc định: traditional)"
 
-#: builtin/commit.c:1508 parse-options.h:192
+#: builtin/commit.c:1509 parse-options.h:192
 msgid "when"
 msgstr "khi"
 
-#: builtin/commit.c:1509
+#: builtin/commit.c:1510
 msgid ""
 "ignore changes to submodules, optional when: all, dirty, untracked. "
 "(Default: all)"
@@ -14142,199 +14094,199 @@ msgstr ""
 "bỏ qua các thay đổi trong mô-đun-con, tùy chọn khi: all, dirty, untracked. "
 "(Mặc định: all)"
 
-#: builtin/commit.c:1511
+#: builtin/commit.c:1512
 msgid "list untracked files in columns"
 msgstr "hiển thị danh sách các tập-tin chưa được theo dõi trong các cột"
 
-#: builtin/commit.c:1512
+#: builtin/commit.c:1513
 msgid "do not detect renames"
 msgstr "không dò tìm các tên thay đổi"
 
-#: builtin/commit.c:1514
+#: builtin/commit.c:1515
 msgid "detect renames, optionally set similarity index"
 msgstr "dò các tên thay đổi, tùy ý đặt mục lục tương tự"
 
-#: builtin/commit.c:1537
+#: builtin/commit.c:1538
 msgid "Unsupported combination of ignored and untracked-files arguments"
 msgstr ""
 "Không hỗ trỡ tổ hợp các tham số các tập tin bị bỏ qua và không được theo dõi"
 
-#: builtin/commit.c:1619
+#: builtin/commit.c:1620
 msgid "suppress summary after successful commit"
 msgstr "không hiển thị tổng kết sau khi chuyển giao thành công"
 
-#: builtin/commit.c:1620
+#: builtin/commit.c:1621
 msgid "show diff in commit message template"
 msgstr "hiển thị sự khác biệt trong mẫu tin nhắn chuyển giao"
 
-#: builtin/commit.c:1622
+#: builtin/commit.c:1623
 msgid "Commit message options"
 msgstr "Các tùy chọn ghi chú commit"
 
-#: builtin/commit.c:1623 builtin/merge.c:287 builtin/tag.c:456
+#: builtin/commit.c:1624 builtin/merge.c:288 builtin/tag.c:456
 msgid "read message from file"
 msgstr "đọc chú thích từ tập tin"
 
-#: builtin/commit.c:1624
+#: builtin/commit.c:1625
 msgid "author"
 msgstr "tác giả"
 
-#: builtin/commit.c:1624
+#: builtin/commit.c:1625
 msgid "override author for commit"
 msgstr "ghi đè tác giả cho commit"
 
-#: builtin/commit.c:1625 builtin/gc.c:550
+#: builtin/commit.c:1626 builtin/gc.c:551
 msgid "date"
 msgstr "ngày tháng"
 
-#: builtin/commit.c:1625
+#: builtin/commit.c:1626
 msgid "override date for commit"
 msgstr "ghi đè ngày tháng cho lần chuyển giao"
 
-#: builtin/commit.c:1627 builtin/commit.c:1628 builtin/commit.c:1634
-#: parse-options.h:327 ref-filter.h:92
+#: builtin/commit.c:1628 builtin/commit.c:1629 builtin/commit.c:1635
+#: parse-options.h:329 ref-filter.h:89
 msgid "commit"
 msgstr "lần_chuyển_giao"
 
-#: builtin/commit.c:1627
+#: builtin/commit.c:1628
 msgid "reuse and edit message from specified commit"
 msgstr "dùng lại các ghi chú từ lần chuyển giao đã cho nhưng có cho sửa chữa"
 
-#: builtin/commit.c:1628
+#: builtin/commit.c:1629
 msgid "reuse message from specified commit"
 msgstr "dùng lại các ghi chú từ lần chuyển giao đã cho"
 
 #. TRANSLATORS: Leave "[(amend|reword):]" as-is,
 #. and only translate <commit>.
 #.
-#: builtin/commit.c:1633
+#: builtin/commit.c:1634
 msgid "[(amend|reword):]commit"
 msgstr "[(amend|reword):]commit"
 
-#: builtin/commit.c:1633
+#: builtin/commit.c:1634
 msgid ""
 "use autosquash formatted message to fixup or amend/reword specified commit"
 msgstr ""
 "dùng ghi chú có định dạng autosquash để sửa chữa hoặc tu bổ/reword lần "
 "chuyển giao đã chỉ ra"
 
-#: builtin/commit.c:1634
+#: builtin/commit.c:1635
 msgid "use autosquash formatted message to squash specified commit"
 msgstr ""
 "dùng lời nhắn có định dạng tự động nén để nén lại các lần chuyển giao đã chỉ "
 "ra"
 
-#: builtin/commit.c:1635
+#: builtin/commit.c:1636
 msgid "the commit is authored by me now (used with -C/-c/--amend)"
 msgstr ""
 "lần chuyển giao nhận tôi là tác giả (được dùng với tùy chọn -C/-c/--amend)"
 
-#: builtin/commit.c:1636 builtin/interpret-trailers.c:111
+#: builtin/commit.c:1637 builtin/interpret-trailers.c:111
 msgid "trailer"
 msgstr "bộ dò vết"
 
-#: builtin/commit.c:1636
+#: builtin/commit.c:1637
 msgid "add custom trailer(s)"
 msgstr "thêm đuôi tự chọn"
 
-#: builtin/commit.c:1637 builtin/log.c:1754 builtin/merge.c:303
+#: builtin/commit.c:1638 builtin/log.c:1769 builtin/merge.c:306
 #: builtin/pull.c:146 builtin/revert.c:110
 msgid "add a Signed-off-by trailer"
 msgstr "thêm dòng Signed-off-by vào cuối"
 
-#: builtin/commit.c:1638
+#: builtin/commit.c:1639
 msgid "use specified template file"
 msgstr "sử dụng tập tin mẫu đã cho"
 
-#: builtin/commit.c:1639
+#: builtin/commit.c:1640
 msgid "force edit of commit"
 msgstr "ép buộc sửa lần commit"
 
-#: builtin/commit.c:1641
+#: builtin/commit.c:1642
 msgid "include status in commit message template"
 msgstr "bao gồm các trạng thái trong mẫu ghi chú chuyển giao"
 
-#: builtin/commit.c:1646
+#: builtin/commit.c:1647
 msgid "Commit contents options"
 msgstr "Các tùy nội dung ghi chú commit"
 
-#: builtin/commit.c:1647
+#: builtin/commit.c:1648
 msgid "commit all changed files"
 msgstr "chuyển giao tất cả các tập tin có thay đổi"
 
-#: builtin/commit.c:1648
+#: builtin/commit.c:1649
 msgid "add specified files to index for commit"
 msgstr "thêm các tập tin đã chỉ ra vào bảng mục lục để chuyển giao"
 
-#: builtin/commit.c:1649
+#: builtin/commit.c:1650
 msgid "interactively add files"
 msgstr "thêm các tập-tin bằng tương tác"
 
-#: builtin/commit.c:1650
+#: builtin/commit.c:1651
 msgid "interactively add changes"
 msgstr "thêm các thay đổi bằng tương tác"
 
-#: builtin/commit.c:1651
+#: builtin/commit.c:1652
 msgid "commit only specified files"
 msgstr "chỉ chuyển giao các tập tin đã chỉ ra"
 
-#: builtin/commit.c:1652
+#: builtin/commit.c:1653
 msgid "bypass pre-commit and commit-msg hooks"
 msgstr "vòng qua móc (hook) pre-commit và commit-msg"
 
-#: builtin/commit.c:1653
+#: builtin/commit.c:1654
 msgid "show what would be committed"
 msgstr "hiển thị xem cái gì có thể được chuyển giao"
 
-#: builtin/commit.c:1666
+#: builtin/commit.c:1667
 msgid "amend previous commit"
 msgstr "“tu bổ” (amend) lần commit trước"
 
-#: builtin/commit.c:1667
+#: builtin/commit.c:1668
 msgid "bypass post-rewrite hook"
 msgstr "vòng qua móc (hook) post-rewrite"
 
-#: builtin/commit.c:1674
+#: builtin/commit.c:1675
 msgid "ok to record an empty change"
 msgstr "ok để ghi lại một thay đổi trống rỗng"
 
-#: builtin/commit.c:1676
+#: builtin/commit.c:1677
 msgid "ok to record a change with an empty message"
 msgstr "ok để ghi các thay đổi với lời nhắn trống rỗng"
 
-#: builtin/commit.c:1752
+#: builtin/commit.c:1753
 #, c-format
 msgid "Corrupt MERGE_HEAD file (%s)"
 msgstr "Tập tin MERGE_HEAD sai hỏng (%s)"
 
-#: builtin/commit.c:1759
+#: builtin/commit.c:1760
 msgid "could not read MERGE_MODE"
 msgstr "không thể đọc MERGE_MODE"
 
-#: builtin/commit.c:1780
+#: builtin/commit.c:1781
 #, c-format
 msgid "could not read commit message: %s"
 msgstr "không thể đọc phần chú thích (message) của lần chuyển giao: %s"
 
-#: builtin/commit.c:1787
+#: builtin/commit.c:1788
 #, c-format
 msgid "Aborting commit due to empty commit message.\n"
 msgstr "Bãi bỏ việc chuyển giao bởi vì phần chú thích của nó trống rỗng.\n"
 
-#: builtin/commit.c:1792
+#: builtin/commit.c:1793
 #, c-format
 msgid "Aborting commit; you did not edit the message.\n"
 msgstr ""
 "Đang bỏ qua việc chuyển giao; bạn đã không biên soạn phần chú thích "
 "(message).\n"
 
-#: builtin/commit.c:1803
+#: builtin/commit.c:1804
 #, c-format
 msgid "Aborting commit due to empty commit message body.\n"
 msgstr ""
 "Bãi bỏ việc chuyển giao bởi vì phần thân chú thích của nó trống rỗng.\n"
 
-#: builtin/commit.c:1839
+#: builtin/commit.c:1840
 msgid ""
 "repository has been updated, but unable to write\n"
 "new_index file. Check that disk is not full and quota is\n"
@@ -14842,7 +14794,7 @@ msgstr "chỉ cân nhắc đến những thẻ khớp với <mẫu>"
 msgid "do not consider tags matching <pattern>"
 msgstr "không coi rằng các thẻ khớp với <mẫu>"
 
-#: builtin/describe.c:570 builtin/name-rev.c:535
+#: builtin/describe.c:570 builtin/name-rev.c:544
 msgid "show abbreviated commit object as fallback"
 msgstr "hiển thị đối tượng chuyển giao vắn tắt như là fallback"
 
@@ -14858,25 +14810,14 @@ msgstr "thêm <dấu> trên cây thư mục làm việc bẩn (mặc định \"-
 msgid "append <mark> on broken working tree (default: \"-broken\")"
 msgstr "thêm <dấu> trên cây thư mục làm việc bị hỏng (mặc định \"-broken\")"
 
-#: builtin/describe.c:593
-msgid "--long is incompatible with --abbrev=0"
-msgstr "--long là xung khắc với tùy chọn --abbrev=0"
-
 #: builtin/describe.c:622
 msgid "No names found, cannot describe anything."
 msgstr "Không tìm thấy các tên, không thể mô tả gì cả."
 
-#: builtin/describe.c:673
-msgid "--dirty is incompatible with commit-ishes"
-msgstr "--dirty là xung khắc với các tùy chọn commit-ish"
-
-#: builtin/describe.c:675
-msgid "--broken is incompatible with commit-ishes"
-msgstr "--broken là xung khắc với commit-ishes"
-
-#: builtin/diff-tree.c:155
-msgid "--stdin and --merge-base are mutually exclusive"
-msgstr "--stdin và --merge-base loại từ lẫn nhau"
+#: builtin/describe.c:673 builtin/describe.c:675
+#, c-format
+msgid "option '%s' and commit-ishes cannot be used together"
+msgstr "tùy chọn '%s' và commit-ishes không thể dùng cùng nhau"
 
 #: builtin/diff-tree.c:157
 msgid "--merge-base only works with two commits"
@@ -14897,26 +14838,26 @@ msgstr "tùy chọn không hợp lệ: %s"
 msgid "%s...%s: no merge base"
 msgstr "%s…%s: không có cơ sở hòa trộn"
 
-#: builtin/diff.c:486
+#: builtin/diff.c:491
 msgid "Not a git repository"
 msgstr "Không phải là kho git"
 
-#: builtin/diff.c:532 builtin/grep.c:698
+#: builtin/diff.c:537 builtin/grep.c:698
 #, c-format
 msgid "invalid object '%s' given."
 msgstr "đối tượng đã cho “%s” không hợp lệ."
 
-#: builtin/diff.c:543
+#: builtin/diff.c:548
 #, c-format
 msgid "more than two blobs given: '%s'"
 msgstr "đã cho nhiều hơn hai đối tượng blob: “%s”"
 
-#: builtin/diff.c:548
+#: builtin/diff.c:553
 #, c-format
 msgid "unhandled object '%s' given."
 msgstr "đã cho đối tượng không thể nắm giữ “%s”."
 
-#: builtin/diff.c:582
+#: builtin/diff.c:587
 #, c-format
 msgid "%s...%s: multiple merge bases, using %s"
 msgstr "%s…%s: có nhiều cơ sở để hòa trộn, nên dùng %s"
@@ -14927,22 +14868,22 @@ msgstr ""
 "git difftool [<các tùy chọn>] [<lần_chuyển_giao> [<lần_chuyển_giao>]] [--] </"
 "đường/dẫn>…]"
 
-#: builtin/difftool.c:293
+#: builtin/difftool.c:287
 #, c-format
 msgid "could not read symlink %s"
 msgstr "không thể đọc liên kết mềm %s"
 
-#: builtin/difftool.c:295
+#: builtin/difftool.c:289
 #, c-format
 msgid "could not read symlink file %s"
 msgstr "không đọc được tập tin liên kết mềm %s"
 
-#: builtin/difftool.c:303
+#: builtin/difftool.c:297
 #, c-format
 msgid "could not read object %s for symlink %s"
 msgstr "không thể đọc đối tượng %s cho liên kết mềm %s"
 
-#: builtin/difftool.c:427
+#: builtin/difftool.c:421
 msgid ""
 "combined diff formats ('-c' and '--cc') are not supported in\n"
 "directory diff mode ('-d' and '--dir-diff')."
@@ -14950,88 +14891,80 @@ msgstr ""
 "các định dạng diff tổ hợp(“-c” và “--cc”) chưa được hỗ trợ trong\n"
 "chế độ diff thư mục(“-d” và “--dir-diff”)."
 
-#: builtin/difftool.c:632
+#: builtin/difftool.c:626
 #, c-format
 msgid "both files modified: '%s' and '%s'."
 msgstr "cả hai tập tin đã bị sửa: “%s” và “%s”."
 
-#: builtin/difftool.c:634
+#: builtin/difftool.c:628
 msgid "working tree file has been left."
 msgstr "cây làm việc ở bên trái."
 
-#: builtin/difftool.c:645
+#: builtin/difftool.c:639
 #, c-format
 msgid "temporary files exist in '%s'."
 msgstr "các tập tin tạm đã sẵn có trong “%s”."
 
-#: builtin/difftool.c:646
+#: builtin/difftool.c:640
 msgid "you may want to cleanup or recover these."
 msgstr "bạn có lẽ muốn dọn dẹp hay phục hồi ở đây."
 
-#: builtin/difftool.c:651
+#: builtin/difftool.c:645
 #, c-format
 msgid "failed: %d"
 msgstr "gặp lỗi: %d"
 
-#: builtin/difftool.c:696
+#: builtin/difftool.c:690
 msgid "use `diff.guitool` instead of `diff.tool`"
 msgstr "dùng “diff.guitool“ thay vì dùng “diff.tool“"
 
-#: builtin/difftool.c:698
+#: builtin/difftool.c:692
 msgid "perform a full-directory diff"
 msgstr "thực hiện một diff toàn thư mục"
 
-#: builtin/difftool.c:700
+#: builtin/difftool.c:694
 msgid "do not prompt before launching a diff tool"
 msgstr "đừng nhắc khi khởi chạy công cụ diff"
 
-#: builtin/difftool.c:705
+#: builtin/difftool.c:699
 msgid "use symlinks in dir-diff mode"
 msgstr "dùng liên kết mềm trong diff-thư-mục"
 
-#: builtin/difftool.c:706
+#: builtin/difftool.c:700
 msgid "tool"
 msgstr "công cụ"
 
-#: builtin/difftool.c:707
+#: builtin/difftool.c:701
 msgid "use the specified diff tool"
 msgstr "dùng công cụ diff đã cho"
 
-#: builtin/difftool.c:709
+#: builtin/difftool.c:703
 msgid "print a list of diff tools that may be used with `--tool`"
 msgstr "in ra danh sách các công cụ dif cái mà có thẻ dùng với “--tool“"
 
-#: builtin/difftool.c:712
+#: builtin/difftool.c:706
 msgid ""
 "make 'git-difftool' exit when an invoked diff tool returns a non-zero exit "
 "code"
 msgstr "làm cho “git-difftool” thoát khi gọi công cụ diff trả về mã khác không"
 
-#: builtin/difftool.c:715
+#: builtin/difftool.c:709
 msgid "specify a custom command for viewing diffs"
 msgstr "chỉ định một lệnh tùy ý để xem diff"
 
-#: builtin/difftool.c:716
+#: builtin/difftool.c:710
 msgid "passed to `diff`"
 msgstr "chuyển cho “diff”"
 
-#: builtin/difftool.c:732
+#: builtin/difftool.c:726
 msgid "difftool requires worktree or --no-index"
 msgstr "difftool cần cây làm việc hoặc --no-index"
 
-#: builtin/difftool.c:739
-msgid "--dir-diff is incompatible with --no-index"
-msgstr "--dir-diff xung khắc với --no-index"
-
-#: builtin/difftool.c:742
-msgid "--gui, --tool and --extcmd are mutually exclusive"
-msgstr "--gui, --tool và --extcmd loại từ lẫn nhau"
-
-#: builtin/difftool.c:750
+#: builtin/difftool.c:744
 msgid "no <tool> given for --tool=<tool>"
 msgstr "chưa đưa ra <công_cụ> cho --tool=<công_cụ>"
 
-#: builtin/difftool.c:757
+#: builtin/difftool.c:751
 msgid "no <cmd> given for --extcmd=<cmd>"
 msgstr "chưa đưa ra <lệnh> cho --extcmd=<lệnh>"
 
@@ -15070,126 +15003,118 @@ msgstr ""
 msgid "git fast-export [rev-list-opts]"
 msgstr "git fast-export [rev-list-opts]"
 
-#: builtin/fast-export.c:869
+#: builtin/fast-export.c:843
 msgid "Error: Cannot export nested tags unless --mark-tags is specified."
 msgstr "Lỗi: không thể xuất thẻ lồng nhau trừ khi --mark-tags được chỉ định."
 
-#: builtin/fast-export.c:1178
+#: builtin/fast-export.c:1152
 msgid "--anonymize-map token cannot be empty"
 msgstr "--anonymize-map thẻ không thể là rỗng"
 
-#: builtin/fast-export.c:1198
+#: builtin/fast-export.c:1171
 msgid "show progress after <n> objects"
 msgstr "hiển thị tiến triển sau <n> đối tượng"
 
-#: builtin/fast-export.c:1200
+#: builtin/fast-export.c:1173
 msgid "select handling of signed tags"
 msgstr "chọn điều khiển của thẻ đã ký"
 
-#: builtin/fast-export.c:1203
+#: builtin/fast-export.c:1176
 msgid "select handling of tags that tag filtered objects"
 msgstr "chọn sự xử lý của các thẻ, cái mà đánh thẻ các đối tượng được lọc ra"
 
-#: builtin/fast-export.c:1206
+#: builtin/fast-export.c:1179
 msgid "select handling of commit messages in an alternate encoding"
 msgstr ""
 "chọn bộ xử lý cho các ghi chú của lần chuyển giao theo một bộ mã thay thế"
 
-#: builtin/fast-export.c:1209
+#: builtin/fast-export.c:1182
 msgid "dump marks to this file"
 msgstr "đổ các đánh dấu này vào tập-tin"
 
-#: builtin/fast-export.c:1211
+#: builtin/fast-export.c:1184
 msgid "import marks from this file"
 msgstr "nhập vào đánh dấu từ tập tin này"
 
-#: builtin/fast-export.c:1215
+#: builtin/fast-export.c:1188
 msgid "import marks from this file if it exists"
 msgstr "nhập vào đánh dấu từ tập tin sẵn có"
 
-#: builtin/fast-export.c:1217
+#: builtin/fast-export.c:1190
 msgid "fake a tagger when tags lack one"
 msgstr "làm giả một cái thẻ khi thẻ bị thiếu một cái"
 
-#: builtin/fast-export.c:1219
+#: builtin/fast-export.c:1192
 msgid "output full tree for each commit"
 msgstr "xuất ra toàn bộ cây cho mỗi lần chuyển giao"
 
-#: builtin/fast-export.c:1221
+#: builtin/fast-export.c:1194
 msgid "use the done feature to terminate the stream"
 msgstr "sử dụng tính năng done để chấm dứt luồng dữ liệu"
 
-#: builtin/fast-export.c:1222
+#: builtin/fast-export.c:1195
 msgid "skip output of blob data"
 msgstr "bỏ qua kết xuất của dữ liệu blob"
 
-#: builtin/fast-export.c:1223 builtin/log.c:1826
+#: builtin/fast-export.c:1196 builtin/log.c:1841
 msgid "refspec"
 msgstr "refspec"
 
-#: builtin/fast-export.c:1224
+#: builtin/fast-export.c:1197
 msgid "apply refspec to exported refs"
 msgstr "áp dụng refspec cho refs đã xuất"
 
-#: builtin/fast-export.c:1225
+#: builtin/fast-export.c:1198
 msgid "anonymize output"
 msgstr "kết xuất anonymize"
 
-#: builtin/fast-export.c:1226
+#: builtin/fast-export.c:1199
 msgid "from:to"
 msgstr "từ:đến"
 
-#: builtin/fast-export.c:1227
+#: builtin/fast-export.c:1200
 msgid "convert <from> to <to> in anonymized output"
 msgstr "chuyển đổi <from> sang <to> đầu ra ẩn danh"
 
-#: builtin/fast-export.c:1230
+#: builtin/fast-export.c:1203
 msgid "reference parents which are not in fast-export stream by object id"
 msgstr ""
 "các cha mẹ tham chiếu cái mà không trong luồng dữ liệu fast-export bởi mã id "
 "đối tượng"
 
-#: builtin/fast-export.c:1232
+#: builtin/fast-export.c:1205
 msgid "show original object ids of blobs/commits"
 msgstr "hiển thị các mã id nguyên gốc của blobs/commits"
 
-#: builtin/fast-export.c:1234
+#: builtin/fast-export.c:1207
 msgid "label tags with mark ids"
 msgstr "gắn thẻ với các mã ID đánh dấu"
 
-#: builtin/fast-export.c:1257
-msgid "--anonymize-map without --anonymize does not make sense"
-msgstr "--anonymize-map mà không có --anonymize là không hợp lý"
-
-#: builtin/fast-export.c:1272
-msgid "Cannot pass both --import-marks and --import-marks-if-exists"
-msgstr "Không thể chuyển qua cả hai --import-marks và --import-marks-if-exists"
-
-#: builtin/fast-import.c:3088
+#: builtin/fast-import.c:3090
 #, c-format
 msgid "Missing from marks for submodule '%s'"
 msgstr "Thiếu các đánh dấu cho mô-đun-con “%s”"
 
-#: builtin/fast-import.c:3090
+#: builtin/fast-import.c:3092
 #, c-format
 msgid "Missing to marks for submodule '%s'"
 msgstr "Thiếu đánh dấu cho mô-đun-con “%s”"
 
-#: builtin/fast-import.c:3225
+#: builtin/fast-import.c:3227
 #, c-format
 msgid "Expected 'mark' command, got %s"
 msgstr "Cần lệnh “mark”, nhưng lại nhận được %s"
 
-#: builtin/fast-import.c:3230
+#: builtin/fast-import.c:3232
 #, c-format
 msgid "Expected 'to' command, got %s"
 msgstr "Cần lệnh “to”, nhưng lại nhận được %s"
 
-#: builtin/fast-import.c:3322
+#: builtin/fast-import.c:3324
 msgid "Expected format name:filename for submodule rewrite option"
 msgstr "Cần định dạng tên:tên_tập_tin cho tùy chọn ghi lại mô-đun-con"
 
-#: builtin/fast-import.c:3377
+#: builtin/fast-import.c:3379
 #, c-format
 msgid "feature '%s' forbidden in input without --allow-unsafe-features"
 msgstr ""
@@ -15200,119 +15125,119 @@ msgstr ""
 msgid "Lockfile created but not reported: %s"
 msgstr "Tập tin khóa đã được tạo nhưng chưa được báo cáo: %s"
 
-#: builtin/fetch.c:35
+#: builtin/fetch.c:36
 msgid "git fetch [<options>] [<repository> [<refspec>...]]"
 msgstr "git fetch [<các tùy chọn>] [<kho-chứa> [<refspec>…]]"
 
-#: builtin/fetch.c:36
+#: builtin/fetch.c:37
 msgid "git fetch [<options>] <group>"
 msgstr "git fetch [<các tùy chọn>] [<nhóm>"
 
-#: builtin/fetch.c:37
+#: builtin/fetch.c:38
 msgid "git fetch --multiple [<options>] [(<repository> | <group>)...]"
 msgstr "git fetch --multiple [<các tùy chọn>] [(<kho> | <nhóm>)…]"
 
-#: builtin/fetch.c:38
+#: builtin/fetch.c:39
 msgid "git fetch --all [<options>]"
 msgstr "git fetch --all [<các tùy chọn>]"
 
-#: builtin/fetch.c:122
+#: builtin/fetch.c:123
 msgid "fetch.parallel cannot be negative"
 msgstr "fetch.parallel không thể âm"
 
-#: builtin/fetch.c:145 builtin/pull.c:189
+#: builtin/fetch.c:146 builtin/pull.c:189
 msgid "fetch from all remotes"
 msgstr "lấy về từ tất cả các máy chủ"
 
-#: builtin/fetch.c:147 builtin/pull.c:249
+#: builtin/fetch.c:148 builtin/pull.c:249
 msgid "set upstream for git pull/fetch"
 msgstr "đặt thượng nguồn cho git pull/fetch"
 
-#: builtin/fetch.c:149 builtin/pull.c:192
+#: builtin/fetch.c:150 builtin/pull.c:192
 msgid "append to .git/FETCH_HEAD instead of overwriting"
 msgstr "nối thêm vào .git/FETCH_HEAD thay vì ghi đè lên nó"
 
-#: builtin/fetch.c:151
+#: builtin/fetch.c:152
 msgid "use atomic transaction to update references"
 msgstr "sử dụng giao dịch hạt nhân bên phía máy chủ"
 
-#: builtin/fetch.c:153 builtin/pull.c:195
+#: builtin/fetch.c:154 builtin/pull.c:195
 msgid "path to upload pack on remote end"
 msgstr "đường dẫn đến gói tải lên trên máy chủ cuối"
 
-#: builtin/fetch.c:154
+#: builtin/fetch.c:155
 msgid "force overwrite of local reference"
 msgstr "ép buộc ghi đè lên tham chiếu nội bộ"
 
-#: builtin/fetch.c:156
+#: builtin/fetch.c:157
 msgid "fetch from multiple remotes"
 msgstr "lấy từ nhiều máy chủ cùng lúc"
 
-#: builtin/fetch.c:158 builtin/pull.c:199
+#: builtin/fetch.c:159 builtin/pull.c:199
 msgid "fetch all tags and associated objects"
 msgstr "lấy tất cả các thẻ cùng với các đối tượng liên quan đến nó"
 
-#: builtin/fetch.c:160
+#: builtin/fetch.c:161
 msgid "do not fetch all tags (--no-tags)"
 msgstr "không lấy tất cả các thẻ (--no-tags)"
 
-#: builtin/fetch.c:162
+#: builtin/fetch.c:163
 msgid "number of submodules fetched in parallel"
 msgstr "số lượng mô-đun-con được lấy đồng thời"
 
-#: builtin/fetch.c:164
+#: builtin/fetch.c:165
 msgid "modify the refspec to place all refs within refs/prefetch/"
 msgstr ""
 "sửa đặc tả đường dẫn cho các tham chiếu mọi chỗ có trong refs/prefetch/"
 
-#: builtin/fetch.c:166 builtin/pull.c:202
+#: builtin/fetch.c:167 builtin/pull.c:202
 msgid "prune remote-tracking branches no longer on remote"
 msgstr ""
 "cắt cụt (prune) các nhánh “remote-tracking” không còn tồn tại trên máy chủ "
 "nữa"
 
-#: builtin/fetch.c:168
+#: builtin/fetch.c:169
 msgid "prune local tags no longer on remote and clobber changed tags"
 msgstr "cắt xém các thẻ nội bộ không còn ở máy chủ và xóa các thẻ đã thay đổi"
 
-#: builtin/fetch.c:169 builtin/fetch.c:194 builtin/pull.c:123
+#: builtin/fetch.c:170 builtin/fetch.c:195 builtin/pull.c:123
 msgid "on-demand"
 msgstr "khi-cần"
 
-#: builtin/fetch.c:170
+#: builtin/fetch.c:171
 msgid "control recursive fetching of submodules"
 msgstr "điều khiển việc lấy về đệ quy trong các mô-đun-con"
 
-#: builtin/fetch.c:175
+#: builtin/fetch.c:176
 msgid "write fetched references to the FETCH_HEAD file"
 msgstr "ghi các tham chiếu lấy về vào tập tin FETCH_HEAD"
 
-#: builtin/fetch.c:176 builtin/pull.c:210
+#: builtin/fetch.c:177 builtin/pull.c:210
 msgid "keep downloaded pack"
 msgstr "giữ lại gói đã tải về"
 
-#: builtin/fetch.c:178
+#: builtin/fetch.c:179
 msgid "allow updating of HEAD ref"
 msgstr "cho phép cập nhật th.chiếu HEAD"
 
-#: builtin/fetch.c:181 builtin/fetch.c:187 builtin/pull.c:213
+#: builtin/fetch.c:182 builtin/fetch.c:188 builtin/pull.c:213
 #: builtin/pull.c:222
 msgid "deepen history of shallow clone"
 msgstr "làm sâu hơn lịch sử của bản sao"
 
-#: builtin/fetch.c:183 builtin/pull.c:216
+#: builtin/fetch.c:184 builtin/pull.c:216
 msgid "deepen history of shallow repository based on time"
 msgstr "làm sâu hơn lịch sử của kho bản sao shallow dựa trên thời gian"
 
-#: builtin/fetch.c:189 builtin/pull.c:225
+#: builtin/fetch.c:190 builtin/pull.c:225
 msgid "convert to a complete repository"
 msgstr "chuyển đổi hoàn toàn sang kho git"
 
-#: builtin/fetch.c:192
+#: builtin/fetch.c:193
 msgid "prepend this to submodule path output"
 msgstr "soạn sẵn cái này cho kết xuất đường dẫn mô-đun-con"
 
-#: builtin/fetch.c:195
+#: builtin/fetch.c:196
 msgid ""
 "default for recursive fetching of submodules (lower priority than config "
 "files)"
@@ -15320,142 +15245,146 @@ msgstr ""
 "mặc định cho việc lấy đệ quy các mô-đun-con (có mức ưu tiên thấp hơn các tập "
 "tin cấu hình config)"
 
-#: builtin/fetch.c:199 builtin/pull.c:228
+#: builtin/fetch.c:200 builtin/pull.c:228
 msgid "accept refs that update .git/shallow"
 msgstr "chấp nhận tham chiếu cập nhật .git/shallow"
 
-#: builtin/fetch.c:200 builtin/pull.c:230
+#: builtin/fetch.c:201 builtin/pull.c:230
 msgid "refmap"
 msgstr "refmap"
 
-#: builtin/fetch.c:201 builtin/pull.c:231
+#: builtin/fetch.c:202 builtin/pull.c:231
 msgid "specify fetch refmap"
 msgstr "chỉ ra refmap cần lấy về"
 
-#: builtin/fetch.c:208 builtin/pull.c:244
+#: builtin/fetch.c:209 builtin/pull.c:244
 msgid "report that we have only objects reachable from this object"
 msgstr ""
 "báo cáo rằng chúng ta chỉ có các đối tượng tiếp cận được từ đối tượng này"
 
-#: builtin/fetch.c:210
+#: builtin/fetch.c:211
 msgid "do not fetch a packfile; instead, print ancestors of negotiation tips"
 msgstr ""
 "không lấy về một packfile; thay vào đó, hãy in tổ tiên của đỉnh đàm phán"
 
-#: builtin/fetch.c:213 builtin/fetch.c:215
+#: builtin/fetch.c:214 builtin/fetch.c:216
 msgid "run 'maintenance --auto' after fetching"
 msgstr "chạy “maintenance --auto” sau khi lấy về"
 
-#: builtin/fetch.c:217 builtin/pull.c:247
+#: builtin/fetch.c:218 builtin/pull.c:247
 msgid "check for forced-updates on all updated branches"
 msgstr "kiểm cho các-cập-nhật-bắt-buộc trên mọi nhánh đã cập nhật"
 
-#: builtin/fetch.c:219
+#: builtin/fetch.c:220
 msgid "write the commit-graph after fetching"
 msgstr "ghi ra đồ thị các lần chuyển giao sau khi lấy về"
 
-#: builtin/fetch.c:221
+#: builtin/fetch.c:222
 msgid "accept refspecs from stdin"
 msgstr "chấp nhận tham chiếu từ đầu vào tiêu chuẩn"
 
-#: builtin/fetch.c:586
-msgid "Couldn't find remote ref HEAD"
-msgstr "Không thể tìm thấy máy chủ cho tham chiếu HEAD"
+#: builtin/fetch.c:592
+msgid "couldn't find remote ref HEAD"
+msgstr "không thể tìm thấy HEAD tham chiếu máy chủ"
 
-#: builtin/fetch.c:760
+#: builtin/fetch.c:766
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "phần cấu hình fetch.output có chứa giá-trị không hợp lệ %s"
 
-#: builtin/fetch.c:862
+#: builtin/fetch.c:867
 #, c-format
 msgid "object %s not found"
 msgstr "không tìm thấy đối tượng %s"
 
-#: builtin/fetch.c:866
+#: builtin/fetch.c:871
 msgid "[up to date]"
 msgstr "[đã cập nhật]"
 
-#: builtin/fetch.c:879 builtin/fetch.c:895 builtin/fetch.c:967
+#: builtin/fetch.c:883 builtin/fetch.c:901 builtin/fetch.c:973
 msgid "[rejected]"
 msgstr "[Bị từ chối]"
 
-#: builtin/fetch.c:880
+#: builtin/fetch.c:885
 msgid "can't fetch in current branch"
 msgstr "không thể fetch (lấy) về nhánh hiện hành"
 
-#: builtin/fetch.c:890
+#: builtin/fetch.c:886
+msgid "checked out in another worktree"
+msgstr "lấy ra trong cây làm việc khác"
+
+#: builtin/fetch.c:896
 msgid "[tag update]"
 msgstr "[cập nhật thẻ]"
 
-#: builtin/fetch.c:891 builtin/fetch.c:928 builtin/fetch.c:950
-#: builtin/fetch.c:962
+#: builtin/fetch.c:897 builtin/fetch.c:934 builtin/fetch.c:956
+#: builtin/fetch.c:968
 msgid "unable to update local ref"
 msgstr "không thể cập nhật tham chiếu nội bộ"
 
-#: builtin/fetch.c:895
+#: builtin/fetch.c:901
 msgid "would clobber existing tag"
 msgstr "nên xóa chồng các thẻ có sẵn"
 
-#: builtin/fetch.c:917
+#: builtin/fetch.c:923
 msgid "[new tag]"
 msgstr "[thẻ mới]"
 
-#: builtin/fetch.c:920
+#: builtin/fetch.c:926
 msgid "[new branch]"
 msgstr "[nhánh mới]"
 
-#: builtin/fetch.c:923
+#: builtin/fetch.c:929
 msgid "[new ref]"
 msgstr "[ref (tham chiếu) mới]"
 
-#: builtin/fetch.c:962
+#: builtin/fetch.c:968
 msgid "forced update"
 msgstr "cưỡng bức cập nhật"
 
-#: builtin/fetch.c:967
+#: builtin/fetch.c:973
 msgid "non-fast-forward"
 msgstr "không-phải-chuyển-tiếp-nhanh"
 
-#: builtin/fetch.c:1070
+#: builtin/fetch.c:1076
 msgid ""
-"Fetch normally indicates which branches had a forced update,\n"
-"but that check has been disabled. To re-enable, use '--show-forced-updates'\n"
-"flag or run 'git config fetch.showForcedUpdates true'."
+"fetch normally indicates which branches had a forced update,\n"
+"but that check has been disabled; to re-enable, use '--show-forced-updates'\n"
+"flag or run 'git config fetch.showForcedUpdates true'"
 msgstr ""
-"Việc lấy về thường chỉ ra các nhánh buộc phải cập nhật,\n"
-"nhưng lựa chọn bị tắt. Để kích hoạt lại, sử dụng cờ\n"
+"việc lấy về thường chỉ ra các nhánh buộc phải cập nhật,\n"
+"nhưng lựa chọn bị tắt; để kích hoạt lại, sử dụng cờ\n"
 "“--show-forced-updates” hoặc chạy “git config fetch.showForcedUpdates true”."
 
-#: builtin/fetch.c:1074
+#: builtin/fetch.c:1080
 #, c-format
 msgid ""
-"It took %.2f seconds to check forced updates. You can use\n"
+"it took %.2f seconds to check forced updates; you can use\n"
 "'--no-show-forced-updates' or run 'git config fetch.showForcedUpdates "
 "false'\n"
-" to avoid this check.\n"
+"to avoid this check\n"
 msgstr ""
-"Việc này cần %.2f giây để kiểm tra các cập nhật ép buộc. Bạn có thể dùng\n"
+"việc này cần %.2f giây để kiểm tra các cập nhật ép buộc; bạn có thể dùng\n"
 "“--no-show-forced-updates” hoặc chạy “git config fetch.showForcedUpdates "
 "false”\n"
-"để tránh kiểm tra này.\n"
+"để tránh kiểm tra này\n"
 
-#: builtin/fetch.c:1105
+#: builtin/fetch.c:1112
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s đã không gửi tất cả các đối tượng cần thiết\n"
 
-#: builtin/fetch.c:1134
+#: builtin/fetch.c:1141
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr "từ chối %s bởi vì các gốc nông thì không được phép cập nhật"
 
-#: builtin/fetch.c:1223 builtin/fetch.c:1371
+#: builtin/fetch.c:1231 builtin/fetch.c:1379
 #, c-format
 msgid "From %.*s\n"
 msgstr "Từ %.*s\n"
 
-#: builtin/fetch.c:1244
+#: builtin/fetch.c:1252
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -15464,143 +15393,142 @@ msgstr ""
 "một số tham chiếu nội bộ không thể được cập nhật; hãy thử chạy\n"
 " “git remote prune %s” để bỏ đi những nhánh cũ, hay bị xung đột"
 
-#: builtin/fetch.c:1341
+#: builtin/fetch.c:1349
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   (%s sẽ trở thành không đầu (không được quản lý))"
 
-#: builtin/fetch.c:1342
+#: builtin/fetch.c:1350
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   (%s đã trở thành không đầu (không được quản lý))"
 
-#: builtin/fetch.c:1374
+#: builtin/fetch.c:1382
 msgid "[deleted]"
 msgstr "[đã xóa]"
 
-#: builtin/fetch.c:1375 builtin/remote.c:1128
+#: builtin/fetch.c:1383 builtin/remote.c:1128
 msgid "(none)"
 msgstr "(không)"
 
-#: builtin/fetch.c:1398
+#: builtin/fetch.c:1405
 #, c-format
-msgid "Refusing to fetch into current branch %s of non-bare repository"
-msgstr ""
-"Từ chối việc lấy vào trong nhánh hiện tại %s của một kho chứa không phải kho "
-"trần (bare)"
+msgid "refusing to fetch into branch '%s' checked out at '%s'"
+msgstr "từ chối lấy về vào nhánh “%s” đã được lấy ra tại “%s”"
 
-#: builtin/fetch.c:1417
+#: builtin/fetch.c:1425
 #, c-format
-msgid "Option \"%s\" value \"%s\" is not valid for %s"
-msgstr "Tùy chọn \"%s\" có giá trị \"%s\" là không hợp lệ cho %s"
+msgid "option \"%s\" value \"%s\" is not valid for %s"
+msgstr "tùy chọn \"%s\" có giá trị \"%s\" là không hợp lệ cho %s"
 
-#: builtin/fetch.c:1420
+#: builtin/fetch.c:1428
 #, c-format
-msgid "Option \"%s\" is ignored for %s\n"
-msgstr "Tùy chọn \"%s\" bị bỏ qua với %s\n"
+msgid "option \"%s\" is ignored for %s\n"
+msgstr "tùy chọn \"%s\" bị bỏ qua với %s\n"
 
-#: builtin/fetch.c:1447
+#: builtin/fetch.c:1455
 #, c-format
 msgid "the object %s does not exist"
 msgstr "đối tượng “%s” không tồn tại"
 
-#: builtin/fetch.c:1633
+#: builtin/fetch.c:1643
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "phát hiện nhiều nhánh, không tương thích với --set-upstream"
 
-#: builtin/fetch.c:1648
+#: builtin/fetch.c:1655
+#, c-format
+msgid ""
+"could not set upstream of HEAD to '%s' from '%s' when it does not point to "
+"any branch."
+msgstr ""
+"không thể đặt thượng nguồn của HEAD thành '%s' từ '%s' khi mà nó chẳng chỉ "
+"đến nhánh nào cả."
+
+#: builtin/fetch.c:1668
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "không cài đặt thượng nguồn cho một nhánh được theo dõi trên máy chủ"
 
-#: builtin/fetch.c:1650
+#: builtin/fetch.c:1670
 msgid "not setting upstream for a remote tag"
 msgstr "không cài đặt thượng nguồn cho một thẻ nhánh trên máy chủ"
 
-#: builtin/fetch.c:1652
+#: builtin/fetch.c:1672
 msgid "unknown branch type"
 msgstr "không hiểu kiểu nhánh"
 
-#: builtin/fetch.c:1654
+#: builtin/fetch.c:1674
 msgid ""
-"no source branch found.\n"
-"you need to specify exactly one branch with the --set-upstream option."
+"no source branch found;\n"
+"you need to specify exactly one branch with the --set-upstream option"
 msgstr ""
 "không tìm thấy nhánh nguồn.\n"
-"bạn cần phải chỉ định chính xác một nhánh với tùy chọn --set-upstream."
+"bạn cần phải chỉ định chính xác một nhánh với tùy chọn --set-upstream"
 
-#: builtin/fetch.c:1783 builtin/fetch.c:1846
+#: builtin/fetch.c:1804 builtin/fetch.c:1867
 #, c-format
 msgid "Fetching %s\n"
 msgstr "Đang lấy “%s” về\n"
 
-#: builtin/fetch.c:1793 builtin/fetch.c:1848 builtin/remote.c:101
+#: builtin/fetch.c:1814 builtin/fetch.c:1869
 #, c-format
-msgid "Could not fetch %s"
-msgstr "Không thể lấy“%s” về"
+msgid "could not fetch %s"
+msgstr "không thể lấy “%s” về"
 
-#: builtin/fetch.c:1805
+#: builtin/fetch.c:1826
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "không thể lấy “%s” (mã thoát: %d)\n"
 
-#: builtin/fetch.c:1909
+#: builtin/fetch.c:1930
 msgid ""
-"No remote repository specified.  Please, specify either a URL or a\n"
-"remote name from which new revisions should be fetched."
+"no remote repository specified; please specify either a URL or a\n"
+"remote name from which new revisions should be fetched"
 msgstr ""
-"Chưa chỉ ra kho chứa máy chủ.  Xin hãy chỉ định hoặc là URL hoặc\n"
-"tên máy chủ từ cái mà những điểm xét duyệt mới có thể được fetch (lấy về)."
+"chưa chỉ ra kho chứa máy chủ; xin hãy chỉ định hoặc là URL hoặc\n"
+"tên máy chủ từ cái mà những điểm xét duyệt mới có thể được fetch (lấy về)"
 
-#: builtin/fetch.c:1945
-msgid "You need to specify a tag name."
-msgstr "Bạn phải định rõ tên thẻ."
+#: builtin/fetch.c:1966
+msgid "you need to specify a tag name"
+msgstr "bạn cần chỉ định một tên thẻ"
 
-#: builtin/fetch.c:2009
+#: builtin/fetch.c:2032
 msgid "--negotiate-only needs one or more --negotiate-tip=*"
 msgstr "--negotiate-only cần một tham số hay nhiều --negotiate-tip=* hơn"
 
-#: builtin/fetch.c:2013
-msgid "Negative depth in --deepen is not supported"
-msgstr "Mức sâu là số âm trong --deepen là không được hỗ trợ"
+#: builtin/fetch.c:2036
+msgid "negative depth in --deepen is not supported"
+msgstr "mức sâu là số âm trong --deepen là không được hỗ trợ"
 
-#: builtin/fetch.c:2015
-msgid "--deepen and --depth are mutually exclusive"
-msgstr "Các tùy chọn --deepen và --depth loại từ lẫn nhau"
-
-#: builtin/fetch.c:2020
-msgid "--depth and --unshallow cannot be used together"
-msgstr "tùy chọn --depth và --unshallow không thể sử dụng cùng với nhau"
-
-#: builtin/fetch.c:2022
+#: builtin/fetch.c:2045
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "--unshallow trên kho hoàn chỉnh là không hợp lý"
 
-#: builtin/fetch.c:2039
+#: builtin/fetch.c:2062
 msgid "fetch --all does not take a repository argument"
 msgstr "lệnh lấy về \"fetch --all\" không lấy đối số kho chứa"
 
-#: builtin/fetch.c:2041
+#: builtin/fetch.c:2064
 msgid "fetch --all does not make sense with refspecs"
 msgstr "lệnh lấy về \"fetch --all\" không hợp lý với refspecs"
 
-#: builtin/fetch.c:2050
-#, c-format
-msgid "No such remote or remote group: %s"
-msgstr "Không có nhóm máy chủ hay máy chủ như thế: %s"
-
-#: builtin/fetch.c:2057
-msgid "Fetching a group and specifying refspecs does not make sense"
-msgstr "Việc lấy về cả một nhóm và chỉ định refspecs không hợp lý"
-
 #: builtin/fetch.c:2073
+#, c-format
+msgid "no such remote or remote group: %s"
+msgstr "không có nhóm máy chủ hay máy chủ như thế: %s"
+
+#: builtin/fetch.c:2081
+msgid "fetching a group and specifying refspecs does not make sense"
+msgstr "việc lấy về một nhóm và chỉ định refspecs là không hợp lý"
+
+#: builtin/fetch.c:2097
 msgid "must supply remote when using --negotiate-only"
 msgstr "phải cung cấp máy chủ khi sử dụng --negotiate-only"
 
-#: builtin/fetch.c:2078
-msgid "Protocol does not support --negotiate-only, exiting."
-msgstr "Giao thức không hỗ trợ --negotiate-only, nên thoát."
+#: builtin/fetch.c:2102
+msgid "protocol does not support --negotiate-only, exiting"
+msgstr "giao thức không hỗ trợ --negotiate-only, nên thoát"
 
-#: builtin/fetch.c:2097
+#: builtin/fetch.c:2121
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
@@ -15608,11 +15536,11 @@ msgstr ""
 "--filter chỉ có thể được dùng với máy chủ được cấu hình bằng extensions."
 "partialclone"
 
-#: builtin/fetch.c:2101
+#: builtin/fetch.c:2125
 msgid "--atomic can only be used when fetching from one remote"
 msgstr "--atomic chỉ có thể dùng khi lấy về từ một máy chủ"
 
-#: builtin/fetch.c:2105
+#: builtin/fetch.c:2129
 msgid "--stdin can only be used when fetching from one remote"
 msgstr "--stdin chỉ có thể dùng khi lấy về từ một máy chủ"
 
@@ -15623,23 +15551,27 @@ msgstr ""
 "git fmt-merge-msg [-m <chú_thích>] [--log[=<n>] | --no-log] [--file <tập-"
 "tin>]"
 
-#: builtin/fmt-merge-msg.c:18
+#: builtin/fmt-merge-msg.c:19
 msgid "populate log with at most <n> entries from shortlog"
 msgstr "gắn nhật ký với ít nhất <n> mục từ lệnh “shortlog”"
 
-#: builtin/fmt-merge-msg.c:21
+#: builtin/fmt-merge-msg.c:22
 msgid "alias for --log (deprecated)"
 msgstr "bí danh cho --log (không được dùng)"
 
-#: builtin/fmt-merge-msg.c:24
+#: builtin/fmt-merge-msg.c:25
 msgid "text"
 msgstr "văn bản"
 
-#: builtin/fmt-merge-msg.c:25
+#: builtin/fmt-merge-msg.c:26
 msgid "use <text> as start of message"
 msgstr "dùng <văn bản thường> để bắt đầu ghi chú"
 
-#: builtin/fmt-merge-msg.c:26
+#: builtin/fmt-merge-msg.c:28
+msgid "use <name> instead of the real target branch"
+msgstr "dùng <tên> thay cho nhánh đích thật"
+
+#: builtin/fmt-merge-msg.c:29
 msgid "file to read from"
 msgstr "tập tin để đọc dữ liệu từ đó"
 
@@ -15663,47 +15595,47 @@ msgstr ""
 "git for-each-ref [--contains [<lần-chuyển-giao>]] [--no-contains [<lần-"
 "chuyển-giao>]]"
 
-#: builtin/for-each-ref.c:30
+#: builtin/for-each-ref.c:31
 msgid "quote placeholders suitably for shells"
 msgstr "trích dẫn để phù hợp cho hệ vỏ (shell)"
 
-#: builtin/for-each-ref.c:32
+#: builtin/for-each-ref.c:33
 msgid "quote placeholders suitably for perl"
 msgstr "trích dẫn để phù hợp cho perl"
 
-#: builtin/for-each-ref.c:34
+#: builtin/for-each-ref.c:35
 msgid "quote placeholders suitably for python"
 msgstr "trích dẫn để phù hợp cho python"
 
-#: builtin/for-each-ref.c:36
+#: builtin/for-each-ref.c:37
 msgid "quote placeholders suitably for Tcl"
 msgstr "trích dẫn để phù hợp cho Tcl"
 
-#: builtin/for-each-ref.c:39
+#: builtin/for-each-ref.c:40
 msgid "show only <n> matched refs"
 msgstr "hiển thị chỉ <n> tham chiếu khớp"
 
-#: builtin/for-each-ref.c:41 builtin/tag.c:481
+#: builtin/for-each-ref.c:42 builtin/tag.c:481
 msgid "respect format colors"
 msgstr "các màu định dạng lưu tâm"
 
-#: builtin/for-each-ref.c:44
+#: builtin/for-each-ref.c:45
 msgid "print only refs which points at the given object"
 msgstr "chỉ hiển thị các tham chiếu mà nó chỉ đến đối tượng đã cho"
 
-#: builtin/for-each-ref.c:46
+#: builtin/for-each-ref.c:47
 msgid "print only refs that are merged"
 msgstr "chỉ hiển thị những tham chiếu mà nó được hòa trộn"
 
-#: builtin/for-each-ref.c:47
+#: builtin/for-each-ref.c:48
 msgid "print only refs that are not merged"
 msgstr "chỉ hiển thị những tham chiếu mà nó không được hòa trộn"
 
-#: builtin/for-each-ref.c:48
+#: builtin/for-each-ref.c:49
 msgid "print only refs which contain the commit"
 msgstr "chỉ hiển thị những tham chiếu mà nó chứa lần chuyển giao"
 
-#: builtin/for-each-ref.c:49
+#: builtin/for-each-ref.c:50
 msgid "print only refs which don't contain the commit"
 msgstr "chỉ hiển thị những tham chiếu mà nó không chứa lần chuyển giao"
 
@@ -15854,124 +15786,124 @@ msgstr "%s: thiếu đối tượng hoặc hỏng: %s"
 msgid "%s: object is of unknown type '%s': %s"
 msgstr "%s: đối tượng có kiểu chưa biết “%s”: %s"
 
-#: builtin/fsck.c:644
+#: builtin/fsck.c:645
 #, c-format
 msgid "%s: object could not be parsed: %s"
 msgstr "%s: không thể phân tích cú đối tượng: %s"
 
-#: builtin/fsck.c:664
+#: builtin/fsck.c:665
 #, c-format
 msgid "bad sha1 file: %s"
 msgstr "tập tin sha1 sai: %s"
 
-#: builtin/fsck.c:685
+#: builtin/fsck.c:686
 msgid "Checking object directory"
 msgstr "Đang kiểm tra thư mục đối tượng"
 
-#: builtin/fsck.c:688
+#: builtin/fsck.c:689
 msgid "Checking object directories"
 msgstr "Đang kiểm tra các thư mục đối tượng"
 
-#: builtin/fsck.c:704
+#: builtin/fsck.c:705
 #, c-format
 msgid "Checking %s link"
 msgstr "Đang lấy liên kết %s"
 
-#: builtin/fsck.c:709 builtin/index-pack.c:859
+#: builtin/fsck.c:710 builtin/index-pack.c:859
 #, c-format
 msgid "invalid %s"
 msgstr "%s không hợp lệ"
 
-#: builtin/fsck.c:716
+#: builtin/fsck.c:717
 #, c-format
 msgid "%s points to something strange (%s)"
 msgstr "%s chỉ đến thứ gì đó xa lạ (%s)"
 
-#: builtin/fsck.c:722
+#: builtin/fsck.c:723
 #, c-format
 msgid "%s: detached HEAD points at nothing"
 msgstr "%s: HEAD đã tách rời không chỉ vào đâu cả"
 
-#: builtin/fsck.c:726
+#: builtin/fsck.c:727
 #, c-format
 msgid "notice: %s points to an unborn branch (%s)"
 msgstr "chú ý: %s chỉ đến một nhánh chưa sinh (%s)"
 
-#: builtin/fsck.c:738
+#: builtin/fsck.c:739
 msgid "Checking cache tree"
 msgstr "Đang kiểm tra cây nhớ tạm"
 
-#: builtin/fsck.c:743
+#: builtin/fsck.c:744
 #, c-format
 msgid "%s: invalid sha1 pointer in cache-tree"
 msgstr "%s: con trỏ sha1 không hợp lệ trong cache-tree"
 
-#: builtin/fsck.c:752
+#: builtin/fsck.c:753
 msgid "non-tree in cache-tree"
 msgstr "non-tree trong cache-tree"
 
-#: builtin/fsck.c:783
+#: builtin/fsck.c:784
 msgid "git fsck [<options>] [<object>...]"
 msgstr "git fsck [<các tùy chọn>] [<đối-tượng>…]"
 
-#: builtin/fsck.c:789
+#: builtin/fsck.c:790
 msgid "show unreachable objects"
 msgstr "hiển thị các đối tượng không thể đọc được"
 
-#: builtin/fsck.c:790
+#: builtin/fsck.c:791
 msgid "show dangling objects"
 msgstr "hiển thị các đối tượng không được quản lý"
 
-#: builtin/fsck.c:791
+#: builtin/fsck.c:792
 msgid "report tags"
 msgstr "báo cáo các thẻ"
 
-#: builtin/fsck.c:792
+#: builtin/fsck.c:793
 msgid "report root nodes"
 msgstr "báo cáo node gốc"
 
-#: builtin/fsck.c:793
+#: builtin/fsck.c:794
 msgid "make index objects head nodes"
 msgstr "tạo “index objects head nodes”"
 
-#: builtin/fsck.c:794
+#: builtin/fsck.c:795
 msgid "make reflogs head nodes (default)"
 msgstr "tạo “reflogs head nodes” (mặc định)"
 
-#: builtin/fsck.c:795
+#: builtin/fsck.c:796
 msgid "also consider packs and alternate objects"
 msgstr "cũng cân nhắc đến các đối tượng gói và thay thế"
 
-#: builtin/fsck.c:796
+#: builtin/fsck.c:797
 msgid "check only connectivity"
 msgstr "chỉ kiểm tra kết nối"
 
-#: builtin/fsck.c:797 builtin/mktag.c:76
+#: builtin/fsck.c:798 builtin/mktag.c:76
 msgid "enable more strict checking"
 msgstr "cho phép kiểm tra hạn chế hơn"
 
-#: builtin/fsck.c:799
+#: builtin/fsck.c:800
 msgid "write dangling objects in .git/lost-found"
 msgstr "ghi các đối tượng không được quản lý trong .git/lost-found"
 
-#: builtin/fsck.c:800 builtin/prune.c:134
+#: builtin/fsck.c:801 builtin/prune.c:146
 msgid "show progress"
 msgstr "hiển thị quá trình"
 
-#: builtin/fsck.c:801
+#: builtin/fsck.c:802
 msgid "show verbose names for reachable objects"
 msgstr "hiển thị tên chi tiết cho các đối tượng đọc được"
 
-#: builtin/fsck.c:861 builtin/index-pack.c:261
+#: builtin/fsck.c:862 builtin/index-pack.c:261
 msgid "Checking objects"
 msgstr "Đang kiểm tra các đối tượng"
 
-#: builtin/fsck.c:889
+#: builtin/fsck.c:890
 #, c-format
 msgid "%s: object missing"
 msgstr "%s: thiếu đối tượng"
 
-#: builtin/fsck.c:900
+#: builtin/fsck.c:901
 #, c-format
 msgid "invalid parameter: expected sha1, got '%s'"
 msgstr "tham số không hợp lệ: cần sha1, nhưng lại nhận được “%s”"
@@ -15990,17 +15922,12 @@ msgstr "Gặp lỗi khi lấy thông tin thống kê về tập tin %s: %s"
 msgid "failed to parse '%s' value '%s'"
 msgstr "gặp lỗi khi phân tích “%s” giá trị “%s”"
 
-#: builtin/gc.c:487 builtin/init-db.c:57
+#: builtin/gc.c:488 builtin/init-db.c:57
 #, c-format
 msgid "cannot stat '%s'"
 msgstr "không thể lấy thông tin thống kê về “%s”"
 
-#: builtin/gc.c:496 builtin/notes.c:238 builtin/tag.c:574
-#, c-format
-msgid "cannot read '%s'"
-msgstr "không thể đọc “%s”"
-
-#: builtin/gc.c:503
+#: builtin/gc.c:504
 #, c-format
 msgid ""
 "The last gc run reported the following. Please correct the root cause\n"
@@ -16015,54 +15942,54 @@ msgstr ""
 "\n"
 "%s"
 
-#: builtin/gc.c:551
+#: builtin/gc.c:552
 msgid "prune unreferenced objects"
 msgstr "xóa bỏ các đối tượng không được tham chiếu"
 
-#: builtin/gc.c:553
+#: builtin/gc.c:554
 msgid "be more thorough (increased runtime)"
 msgstr "cẩn thận hơn nữa (tăng thời gian chạy)"
 
-#: builtin/gc.c:554
+#: builtin/gc.c:555
 msgid "enable auto-gc mode"
 msgstr "bật chế độ auto-gc"
 
-#: builtin/gc.c:557
+#: builtin/gc.c:558
 msgid "force running gc even if there may be another gc running"
 msgstr "buộc gc chạy ngay cả khi có tiến trình gc khác đang chạy"
 
-#: builtin/gc.c:560
+#: builtin/gc.c:561
 msgid "repack all other packs except the largest pack"
 msgstr "đóng gói lại tất cả các gói khác ngoại trừ gói lớn nhất"
 
-#: builtin/gc.c:576
+#: builtin/gc.c:577
 #, c-format
 msgid "failed to parse gc.logexpiry value %s"
 msgstr "gặp lỗi khi phân tích giá trị gc.logexpiry %s"
 
-#: builtin/gc.c:587
+#: builtin/gc.c:588
 #, c-format
 msgid "failed to parse prune expiry value %s"
 msgstr "gặp lỗi khi phân tích giá trị prune %s"
 
-#: builtin/gc.c:607
+#: builtin/gc.c:608
 #, c-format
 msgid "Auto packing the repository in background for optimum performance.\n"
 msgstr ""
 "Tự động đóng gói kho chứa trên nền hệ thống để tối ưu hóa hiệu suất làm "
 "việc.\n"
 
-#: builtin/gc.c:609
+#: builtin/gc.c:610
 #, c-format
 msgid "Auto packing the repository for optimum performance.\n"
 msgstr "Tự động đóng gói kho chứa để tối ưu hóa hiệu suất làm việc.\n"
 
-#: builtin/gc.c:610
+#: builtin/gc.c:611
 #, c-format
 msgid "See \"git help gc\" for manual housekeeping.\n"
 msgstr "Xem \"git help gc\" để có hướng dẫn cụ thể về cách dọn dẹp kho git.\n"
 
-#: builtin/gc.c:650
+#: builtin/gc.c:652
 #, c-format
 msgid ""
 "gc is already running on machine '%s' pid %<PRIuMAX> (use --force if not)"
@@ -16070,210 +15997,210 @@ msgstr ""
 "gc đang được thực hiện trên máy “%s” pid %<PRIuMAX> (dùng --force nếu không "
 "phải thế)"
 
-#: builtin/gc.c:705
+#: builtin/gc.c:707
 msgid ""
 "There are too many unreachable loose objects; run 'git prune' to remove them."
 msgstr ""
 "Có quá nhiều đối tượng tự do không được dùng đến; hãy chạy lệnh “git prune” "
 "để xóa bỏ chúng đi."
 
-#: builtin/gc.c:715
+#: builtin/gc.c:717
 msgid ""
 "git maintenance run [--auto] [--[no-]quiet] [--task=<task>] [--schedule]"
 msgstr ""
 "git maintenance run [--auto] [--[no-]quiet] [--task=<nhiệm vụ>] [--schedule]"
 
-#: builtin/gc.c:745
+#: builtin/gc.c:747
 msgid "--no-schedule is not allowed"
 msgstr "--no-schedule không được phép"
 
-#: builtin/gc.c:750
+#: builtin/gc.c:752
 #, c-format
 msgid "unrecognized --schedule argument '%s'"
 msgstr "đối số --schedule không được thừa nhận %s"
 
-#: builtin/gc.c:868
+#: builtin/gc.c:870
 msgid "failed to write commit-graph"
 msgstr "gặp lỗi khi ghi đồ thị các lần chuyển giao"
 
-#: builtin/gc.c:904
+#: builtin/gc.c:906
 msgid "failed to prefetch remotes"
 msgstr "gặp lỗi khi tải trước các máy chủ"
 
-#: builtin/gc.c:1020
+#: builtin/gc.c:1022
 msgid "failed to start 'git pack-objects' process"
 msgstr "gặp lỗi khi lấy thông tin thống kê về tiến trình “git pack-objects”"
 
-#: builtin/gc.c:1037
+#: builtin/gc.c:1039
 msgid "failed to finish 'git pack-objects' process"
 msgstr "gặp lỗi khi hoàn tất tiến trình “git pack-objects”"
 
-#: builtin/gc.c:1088
+#: builtin/gc.c:1090
 msgid "failed to write multi-pack-index"
 msgstr "gặp lỗi khi ghi multi-pack-index"
 
-#: builtin/gc.c:1104
+#: builtin/gc.c:1106
 msgid "'git multi-pack-index expire' failed"
 msgstr "gặp lỗi khi chạy “git multi-pack-index expire”"
 
-#: builtin/gc.c:1163
+#: builtin/gc.c:1165
 msgid "'git multi-pack-index repack' failed"
 msgstr "gặp lỗi khi chạy “git multi-pack-index repack”"
 
-#: builtin/gc.c:1172
+#: builtin/gc.c:1174
 msgid ""
 "skipping incremental-repack task because core.multiPackIndex is disabled"
 msgstr "bỏ qua tác vụ incremental-repack vì core.multiPackIndex bị vô hiệu hóa"
 
-#: builtin/gc.c:1276
+#: builtin/gc.c:1278
 #, c-format
 msgid "lock file '%s' exists, skipping maintenance"
 msgstr "đã có khóa của tập tin “%s”, bỏ qua bảo trì"
 
-#: builtin/gc.c:1306
+#: builtin/gc.c:1308
 #, c-format
 msgid "task '%s' failed"
 msgstr "gặp lỗi khi thực hiện nhiệm vụ “%s”"
 
-#: builtin/gc.c:1388
+#: builtin/gc.c:1390
 #, c-format
 msgid "'%s' is not a valid task"
 msgstr "“%s” không phải một nhiệm vụ hợp lệ"
 
-#: builtin/gc.c:1393
+#: builtin/gc.c:1395
 #, c-format
 msgid "task '%s' cannot be selected multiple times"
 msgstr "nhiệm vụ “%s” không được chọn nhiều lần"
 
-#: builtin/gc.c:1408
+#: builtin/gc.c:1410
 msgid "run tasks based on the state of the repository"
 msgstr "chạy nhiệm vụ dựa trên trạng thái của kho chứa"
 
-#: builtin/gc.c:1409
+#: builtin/gc.c:1411
 msgid "frequency"
 msgstr "tần số"
 
-#: builtin/gc.c:1410
+#: builtin/gc.c:1412
 msgid "run tasks based on frequency"
 msgstr "chạy nhiệm vụ dựa trên tần suất"
 
-#: builtin/gc.c:1413
+#: builtin/gc.c:1415
 msgid "do not report progress or other information over stderr"
 msgstr "đừng báo cáo diễn tiến hay các thông tin khác ra đầu lỗi tiêu chuẩn"
 
-#: builtin/gc.c:1414
+#: builtin/gc.c:1416
 msgid "task"
 msgstr "tác vụ"
 
-#: builtin/gc.c:1415
+#: builtin/gc.c:1417
 msgid "run a specific task"
 msgstr "chạy một nhiệm vụ cụ thể"
 
-#: builtin/gc.c:1432
+#: builtin/gc.c:1434
 msgid "use at most one of --auto and --schedule=<frequency>"
 msgstr "dùng nhiều nhất là một trong --auto và --schedule=<frequency>"
 
-#: builtin/gc.c:1475
+#: builtin/gc.c:1477
 msgid "failed to run 'git config'"
 msgstr "gặp lỗi khi chạy “git config”"
 
-#: builtin/gc.c:1627
+#: builtin/gc.c:1629
 #, c-format
 msgid "failed to expand path '%s'"
 msgstr "gặp lỗi khi khai triển đường dẫn “%s”"
 
-#: builtin/gc.c:1654 builtin/gc.c:1692
+#: builtin/gc.c:1656 builtin/gc.c:1694
 msgid "failed to start launchctl"
 msgstr "gặp lỗi khi khởi chạy launchctl"
 
-#: builtin/gc.c:1767 builtin/gc.c:2220
+#: builtin/gc.c:1769 builtin/gc.c:2237
 #, c-format
 msgid "failed to create directories for '%s'"
 msgstr "gặp lỗi khi tạo thư mục cho \"%s\""
 
-#: builtin/gc.c:1794
+#: builtin/gc.c:1796
 #, c-format
 msgid "failed to bootstrap service %s"
 msgstr "gặp lỗi khi mồi dịch vụ %s"
 
-#: builtin/gc.c:1887
+#: builtin/gc.c:1889
 msgid "failed to create temp xml file"
 msgstr "gặp lỗi khi tạo tập tin xml tạm thời"
 
-#: builtin/gc.c:1977
+#: builtin/gc.c:1979
 msgid "failed to start schtasks"
 msgstr "gặp lỗi khi lấy thông tin thống kê về schtasks"
 
-#: builtin/gc.c:2046
+#: builtin/gc.c:2063
 msgid "failed to run 'crontab -l'; your system might not support 'cron'"
 msgstr ""
 "gặp lỗi khi chạy “crontab -l”; hệ thống của bạn có thể không hỗ trợ “cron”"
 
-#: builtin/gc.c:2063
+#: builtin/gc.c:2080
 msgid "failed to run 'crontab'; your system might not support 'cron'"
 msgstr "gặp lỗi khi chạy “crontab”; hiển thị của bạn có lẽ không hỗ trợ “cron”"
 
-#: builtin/gc.c:2067
+#: builtin/gc.c:2084
 msgid "failed to open stdin of 'crontab'"
 msgstr "gặp lỗi khi mở đầu vào tiêu chuẩn của “crontab”"
 
-#: builtin/gc.c:2109
+#: builtin/gc.c:2126
 msgid "'crontab' died"
 msgstr "“crontab” đã chết"
 
-#: builtin/gc.c:2174
+#: builtin/gc.c:2191
 msgid "failed to start systemctl"
 msgstr "gặp lỗi khi khởi chạy systemctl"
 
-#: builtin/gc.c:2184
+#: builtin/gc.c:2201
 msgid "failed to run systemctl"
 msgstr "gặp lỗi khi chạy systemctl"
 
-#: builtin/gc.c:2193 builtin/gc.c:2198 builtin/worktree.c:62
-#: builtin/worktree.c:945
+#: builtin/gc.c:2210 builtin/gc.c:2215 builtin/worktree.c:62
+#: builtin/worktree.c:944
 #, c-format
 msgid "failed to delete '%s'"
 msgstr "gặp lỗi khi xóa “%s”"
 
-#: builtin/gc.c:2378
+#: builtin/gc.c:2395
 #, c-format
 msgid "unrecognized --scheduler argument '%s'"
 msgstr "đối số --scheduler không được thừa nhận “%s”"
 
-#: builtin/gc.c:2403
+#: builtin/gc.c:2420
 msgid "neither systemd timers nor crontab are available"
 msgstr "hoặc là bộ lập lịch systemd hoặc là crontab không sẵn có"
 
-#: builtin/gc.c:2418
+#: builtin/gc.c:2435
 #, c-format
 msgid "%s scheduler is not available"
 msgstr "bộ lên lịch %s không sẵn có"
 
-#: builtin/gc.c:2432
+#: builtin/gc.c:2449
 msgid "another process is scheduling background maintenance"
 msgstr "một tiến trình khác được lập kế hoạch chạy nền để bảo trì"
 
-#: builtin/gc.c:2454
+#: builtin/gc.c:2471
 msgid "git maintenance start [--scheduler=<scheduler>]"
 msgstr "git maintenance start [--scheduler=<bộ lên lịch>]"
 
-#: builtin/gc.c:2463
+#: builtin/gc.c:2480
 msgid "scheduler"
 msgstr "bộ lên lịch"
 
-#: builtin/gc.c:2464
+#: builtin/gc.c:2481
 msgid "scheduler to trigger git maintenance run"
 msgstr "bộ lên lịch để kích hoạt chạy chương trình bảo trì git"
 
-#: builtin/gc.c:2478
+#: builtin/gc.c:2495
 msgid "failed to add repo to global config"
 msgstr "gặp lỗi khi thêm cấu hình toàn cục"
 
-#: builtin/gc.c:2487
+#: builtin/gc.c:2504
 msgid "git maintenance <subcommand> [<options>]"
 msgstr "git maintenance run <lệnh_con> [<các tùy chọn>]"
 
-#: builtin/gc.c:2506
+#: builtin/gc.c:2523
 #, c-format
 msgid "invalid subcommand: %s"
 msgstr "lện con không hợp lệ: %s"
@@ -16642,25 +16569,25 @@ msgstr "git help [-c|--config]"
 msgid "unrecognized help format '%s'"
 msgstr "không nhận ra định dạng trợ giúp “%s”"
 
-#: builtin/help.c:223
+#: builtin/help.c:222
 msgid "Failed to start emacsclient."
 msgstr "Gặp lỗi khi khởi chạy emacsclient."
 
-#: builtin/help.c:236
+#: builtin/help.c:235
 msgid "Failed to parse emacsclient version."
 msgstr "Gặp lỗi khi phân tích phiên bản emacsclient."
 
-#: builtin/help.c:244
+#: builtin/help.c:243
 #, c-format
 msgid "emacsclient version '%d' too old (< 22)."
 msgstr "phiên bản của emacsclient “%d” quá cũ (< 22)."
 
-#: builtin/help.c:262 builtin/help.c:284 builtin/help.c:294 builtin/help.c:302
+#: builtin/help.c:261 builtin/help.c:283 builtin/help.c:293 builtin/help.c:301
 #, c-format
 msgid "failed to exec '%s'"
 msgstr "gặp lỗi khi thực thi “%s”"
 
-#: builtin/help.c:340
+#: builtin/help.c:339
 #, c-format
 msgid ""
 "'%s': path for unsupported man viewer.\n"
@@ -16669,7 +16596,7 @@ msgstr ""
 "“%s”: đường dẫn không hỗ trợ bộ trình chiếu man.\n"
 "Hãy cân nhắc đến việc sử dụng “man.<tool>.cmd” để thay thế."
 
-#: builtin/help.c:352
+#: builtin/help.c:351
 #, c-format
 msgid ""
 "'%s': cmd for supported man viewer.\n"
@@ -16678,39 +16605,39 @@ msgstr ""
 "“%s”: cmd (lệnh) hỗ trợ bộ trình chiếu man.\n"
 "Hãy cân nhắc đến việc sử dụng “man.<tool>.path” để thay thế."
 
-#: builtin/help.c:467
+#: builtin/help.c:466
 #, c-format
 msgid "'%s': unknown man viewer."
 msgstr "“%s”: không rõ chương trình xem man."
 
-#: builtin/help.c:483
+#: builtin/help.c:482
 msgid "no man viewer handled the request"
 msgstr "không có trình xem trợ giúp dạng manpage tiếp hợp với yêu cầu"
 
-#: builtin/help.c:490
+#: builtin/help.c:489
 msgid "no info viewer handled the request"
 msgstr "không có trình xem trợ giúp dạng info tiếp hợp với yêu cầu"
 
-#: builtin/help.c:551 builtin/help.c:562 git.c:348
+#: builtin/help.c:550 builtin/help.c:561 git.c:348
 #, c-format
 msgid "'%s' is aliased to '%s'"
 msgstr "“%s” được đặt bí danh thành “%s”"
 
-#: builtin/help.c:565 git.c:380
+#: builtin/help.c:564 git.c:380
 #, c-format
 msgid "bad alias.%s string: %s"
 msgstr "chuỗi alias.%s sai: %s"
 
-#: builtin/help.c:581
+#: builtin/help.c:580
 msgid "this option doesn't take any other arguments"
 msgstr "tùy chọn này không nhận tham số nào khác"
 
-#: builtin/help.c:602 builtin/help.c:629
+#: builtin/help.c:601 builtin/help.c:628
 #, c-format
 msgid "usage: %s%s"
 msgstr "cách dùng: %s%s"
 
-#: builtin/help.c:624
+#: builtin/help.c:623
 msgid "'git help config' for more information"
 msgstr "Chạy lệnh “git help config” để có thêm thông tin"
 
@@ -16971,17 +16898,9 @@ msgstr "%s sai"
 msgid "unknown hash algorithm '%s'"
 msgstr "không hiểu thuật toán băm dữ liệu “%s”"
 
-#: builtin/index-pack.c:1848
-msgid "--fix-thin cannot be used without --stdin"
-msgstr "--fix-thin không thể được dùng mà không có --stdin"
-
 #: builtin/index-pack.c:1850
 msgid "--stdin requires a git repository"
 msgstr "--stdin cần một kho git"
-
-#: builtin/index-pack.c:1852
-msgid "--object-format cannot be used with --stdin"
-msgstr "--object-format không thể được dùng với --stdin"
 
 #: builtin/index-pack.c:1867
 msgid "--verify with no packfile name given"
@@ -17107,10 +17026,6 @@ msgstr "băm"
 #: builtin/init-db.c:553 builtin/show-index.c:22 builtin/verify-pack.c:75
 msgid "specify the hash algorithm to use"
 msgstr "chỉ định thuật toán băm dữ liệu muốn dùng"
-
-#: builtin/init-db.c:560
-msgid "--separate-git-dir and --bare are mutually exclusive"
-msgstr "Các tùy chọn --separate-git-dir và --bare loại từ lẫn nhau"
 
 #: builtin/init-db.c:591 builtin/init-db.c:596
 #, c-format
@@ -17245,85 +17160,85 @@ msgstr ""
 msgid "-L<range>:<file> cannot be used with pathspec"
 msgstr "-L<vùng>:<tập_tin> không thể được sử dụng với đặc tả đường dẫn"
 
-#: builtin/log.c:306
+#: builtin/log.c:321
 #, c-format
 msgid "Final output: %d %s\n"
 msgstr "Kết xuất cuối cùng: %d %s\n"
 
-#: builtin/log.c:571
+#: builtin/log.c:586
 #, c-format
 msgid "git show %s: bad file"
 msgstr "git show %s: sai tập tin"
 
-#: builtin/log.c:586 builtin/log.c:676
+#: builtin/log.c:601 builtin/log.c:691
 #, c-format
 msgid "could not read object %s"
 msgstr "không thể đọc đối tượng %s"
 
-#: builtin/log.c:701
+#: builtin/log.c:716
 #, c-format
 msgid "unknown type: %d"
 msgstr "không nhận ra kiểu: %d"
 
-#: builtin/log.c:846
+#: builtin/log.c:861
 #, c-format
 msgid "%s: invalid cover from description mode"
 msgstr "%s: bao bọc không hợp lệ từ chế độ mô tả"
 
-#: builtin/log.c:853
+#: builtin/log.c:868
 msgid "format.headers without value"
 msgstr "format.headers không có giá trị cụ thể"
 
-#: builtin/log.c:982
+#: builtin/log.c:997
 #, c-format
 msgid "cannot open patch file %s"
 msgstr "không thể mở tập tin miếng vá: %s"
 
-#: builtin/log.c:999
+#: builtin/log.c:1014
 msgid "need exactly one range"
 msgstr "cần chính xác một vùng"
 
-#: builtin/log.c:1009
+#: builtin/log.c:1024
 msgid "not a range"
 msgstr "không phải là một vùng"
 
-#: builtin/log.c:1173
+#: builtin/log.c:1188
 msgid "cover letter needs email format"
 msgstr "“cover letter” cần cho định dạng thư"
 
-#: builtin/log.c:1179
+#: builtin/log.c:1194
 msgid "failed to create cover-letter file"
 msgstr "gặp lỗi khi tạo các tập tin cover-letter"
 
-#: builtin/log.c:1266
+#: builtin/log.c:1281
 #, c-format
 msgid "insane in-reply-to: %s"
 msgstr "in-reply-to điên rồ: %s"
 
-#: builtin/log.c:1293
+#: builtin/log.c:1308
 msgid "git format-patch [<options>] [<since> | <revision-range>]"
 msgstr "git format-patch [<các tùy chọn>] [<kể-từ> | <vùng-xem-xét>]"
 
-#: builtin/log.c:1351
+#: builtin/log.c:1366
 msgid "two output directories?"
 msgstr "hai thư mục kết xuất?"
 
-#: builtin/log.c:1502 builtin/log.c:2328 builtin/log.c:2330 builtin/log.c:2342
+#: builtin/log.c:1517 builtin/log.c:2344 builtin/log.c:2346 builtin/log.c:2358
 #, c-format
 msgid "unknown commit %s"
 msgstr "không hiểu lần chuyển giao %s"
 
-#: builtin/log.c:1513 builtin/replace.c:58 builtin/replace.c:207
+#: builtin/log.c:1528 builtin/replace.c:58 builtin/replace.c:207
 #: builtin/replace.c:210
 #, c-format
 msgid "failed to resolve '%s' as a valid ref"
 msgstr "gặp lỗi khi phân giải “%s” như là một tham chiếu hợp lệ"
 
-#: builtin/log.c:1522
+#: builtin/log.c:1537
 msgid "could not find exact merge base"
 msgstr "không tìm thấy nền hòa trộn chính xác"
 
-#: builtin/log.c:1532
+#: builtin/log.c:1547
 msgid ""
 "failed to get upstream, if you want to record base commit automatically,\n"
 "please use git branch --set-upstream-to to track a remote branch.\n"
@@ -17334,294 +17249,277 @@ msgstr ""
 "nhánh máy chủ. Hoặc là bạn có thể chỉ định lần chuyển giao nền bằng\n"
 "\"--base=<base-commit-id>\" một cách thủ công"
 
-#: builtin/log.c:1555
+#: builtin/log.c:1570
 msgid "failed to find exact merge base"
 msgstr "gặp lỗi khi tìm nền hòa trộn chính xác"
 
-#: builtin/log.c:1572
+#: builtin/log.c:1587
 msgid "base commit should be the ancestor of revision list"
 msgstr "lần chuyển giao nền không là tổ tiên của danh sách điểm xét duyệt"
 
-#: builtin/log.c:1582
+#: builtin/log.c:1597
 msgid "base commit shouldn't be in revision list"
 msgstr "lần chuyển giao nền không được trong danh sách điểm xét duyệt"
 
-#: builtin/log.c:1640
+#: builtin/log.c:1655
 msgid "cannot get patch id"
 msgstr "không thể lấy mã miếng vá"
 
-#: builtin/log.c:1703
+#: builtin/log.c:1718
 msgid "failed to infer range-diff origin of current series"
 msgstr ""
 "gặp lỗi khi suy luận range-diff (vùng khác biệt) gốc của sê-ri hiện tại"
 
-#: builtin/log.c:1705
+#: builtin/log.c:1720
 #, c-format
 msgid "using '%s' as range-diff origin of current series"
 msgstr "dùng “%s” như là gốc range-diff của sê-ri hiện tại"
 
-#: builtin/log.c:1749
+#: builtin/log.c:1764
 msgid "use [PATCH n/m] even with a single patch"
 msgstr "dùng [PATCH n/m] ngay cả với miếng vá đơn"
 
-#: builtin/log.c:1752
+#: builtin/log.c:1767
 msgid "use [PATCH] even with multiple patches"
 msgstr "dùng [VÁ] ngay cả với các miếng vá phức tạp"
 
-#: builtin/log.c:1756
+#: builtin/log.c:1771
 msgid "print patches to standard out"
 msgstr "hiển thị miếng vá ra đầu ra chuẩn"
 
-#: builtin/log.c:1758
+#: builtin/log.c:1773
 msgid "generate a cover letter"
 msgstr "tạo bì thư"
 
-#: builtin/log.c:1760
+#: builtin/log.c:1775
 msgid "use simple number sequence for output file names"
 msgstr "sử dụng chỗi dãy số dạng đơn giản cho tên tập-tin xuất ra"
 
-#: builtin/log.c:1761
+#: builtin/log.c:1776
 msgid "sfx"
 msgstr "sfx"
 
-#: builtin/log.c:1762
+#: builtin/log.c:1777
 msgid "use <sfx> instead of '.patch'"
 msgstr "sử dụng <sfx> thay cho “.patch”"
 
-#: builtin/log.c:1764
+#: builtin/log.c:1779
 msgid "start numbering patches at <n> instead of 1"
 msgstr "bắt đầu đánh số miếng vá từ <n> thay vì 1"
 
-#: builtin/log.c:1765
+#: builtin/log.c:1780
 msgid "reroll-count"
 msgstr "đếm reroll"
 
-#: builtin/log.c:1766
+#: builtin/log.c:1781
 msgid "mark the series as Nth re-roll"
 msgstr "đánh dấu chuỗi nối tiếp dạng thứ-N re-roll"
 
-#: builtin/log.c:1768
+#: builtin/log.c:1783
 msgid "max length of output filename"
 msgstr "chiều dài tên tập tin đầu ra tối đa"
 
-#: builtin/log.c:1770
+#: builtin/log.c:1785
 msgid "use [RFC PATCH] instead of [PATCH]"
 msgstr "dùng [VÁ RFC] thay cho [VÁ]"
 
-#: builtin/log.c:1773
+#: builtin/log.c:1788
 msgid "cover-from-description-mode"
 msgstr "cover-from-description-mode"
 
-#: builtin/log.c:1774
+#: builtin/log.c:1789
 msgid "generate parts of a cover letter based on a branch's description"
 msgstr "tạo ra các phần của một lá thư bao gồm dựa trên mô tả của nhánh"
 
-#: builtin/log.c:1776
+#: builtin/log.c:1791
 msgid "use [<prefix>] instead of [PATCH]"
 msgstr "dùng [<tiền-tố>] thay cho [VÁ]"
 
-#: builtin/log.c:1779
+#: builtin/log.c:1794
 msgid "store resulting files in <dir>"
 msgstr "lưu các tập tin kết quả trong <t.mục>"
 
-#: builtin/log.c:1782
+#: builtin/log.c:1797
 msgid "don't strip/add [PATCH]"
 msgstr "không strip/add [VÁ]"
 
-#: builtin/log.c:1785
+#: builtin/log.c:1800
 msgid "don't output binary diffs"
 msgstr "không kết xuất diff (những khác biệt) nhị phân"
 
-#: builtin/log.c:1787
+#: builtin/log.c:1802
 msgid "output all-zero hash in From header"
 msgstr "xuất mọi mã băm all-zero trong phần đầu From"
 
-#: builtin/log.c:1789
+#: builtin/log.c:1804
 msgid "don't include a patch matching a commit upstream"
 msgstr "không bao gồm miếng vá khớp với một lần chuyển giao thượng nguồn"
 
-#: builtin/log.c:1791
+#: builtin/log.c:1806
 msgid "show patch format instead of default (patch + stat)"
 msgstr "hiển thị định dạng miếng vá thay vì mặc định (miếng vá + thống kê)"
 
-#: builtin/log.c:1793
+#: builtin/log.c:1808
 msgid "Messaging"
 msgstr "Lời nhắn"
 
-#: builtin/log.c:1794
+#: builtin/log.c:1809
 msgid "header"
 msgstr "đầu đề thư"
 
-#: builtin/log.c:1795
+#: builtin/log.c:1810
 msgid "add email header"
 msgstr "thêm đầu đề thư"
 
-#: builtin/log.c:1796 builtin/log.c:1797
+#: builtin/log.c:1811 builtin/log.c:1812
 msgid "email"
 msgstr "thư điện tử"
 
-#: builtin/log.c:1796
+#: builtin/log.c:1811
 msgid "add To: header"
 msgstr "thêm To: đầu đề thư"
 
-#: builtin/log.c:1797
+#: builtin/log.c:1812
 msgid "add Cc: header"
 msgstr "thêm Cc: đầu đề thư"
 
-#: builtin/log.c:1798
+#: builtin/log.c:1813
 msgid "ident"
 msgstr "thụt lề"
 
-#: builtin/log.c:1799
+#: builtin/log.c:1814
 msgid "set From address to <ident> (or committer ident if absent)"
 msgstr ""
 "đặt “Địa chỉ gửi” thành <thụ lề> (hoặc thụt lề người commit nếu bỏ quên)"
 
-#: builtin/log.c:1801
+#: builtin/log.c:1816
 msgid "message-id"
 msgstr "message-id"
 
-#: builtin/log.c:1802
+#: builtin/log.c:1817
 msgid "make first mail a reply to <message-id>"
 msgstr "dùng thư đầu tiên để trả lời <message-id>"
 
-#: builtin/log.c:1803 builtin/log.c:1806
+#: builtin/log.c:1818 builtin/log.c:1821
 msgid "boundary"
 msgstr "ranh giới"
 
-#: builtin/log.c:1804
+#: builtin/log.c:1819
 msgid "attach the patch"
 msgstr "đính kèm miếng vá"
 
-#: builtin/log.c:1807
+#: builtin/log.c:1822
 msgid "inline the patch"
 msgstr "dùng miếng vá làm nội dung"
 
-#: builtin/log.c:1811
+#: builtin/log.c:1826
 msgid "enable message threading, styles: shallow, deep"
 msgstr "cho phép luồng lời nhắn, kiểu: “shallow”, “deep”"
 
-#: builtin/log.c:1813
+#: builtin/log.c:1828
 msgid "signature"
 msgstr "chữ ký"
 
-#: builtin/log.c:1814
+#: builtin/log.c:1829
 msgid "add a signature"
 msgstr "thêm chữ ký"
 
-#: builtin/log.c:1815
+#: builtin/log.c:1830
 msgid "base-commit"
 msgstr "lần_chuyển_giao_nền"
 
-#: builtin/log.c:1816
+#: builtin/log.c:1831
 msgid "add prerequisite tree info to the patch series"
 msgstr "add trước hết đòi hỏi thông tin cây tới sê-ri miếng vá"
 
-#: builtin/log.c:1819
+#: builtin/log.c:1834
 msgid "add a signature from a file"
 msgstr "thêm chữ ký từ một tập tin"
 
-#: builtin/log.c:1820
+#: builtin/log.c:1835
 msgid "don't print the patch filenames"
 msgstr "không hiển thị các tên tập tin của miếng vá"
 
-#: builtin/log.c:1822
+#: builtin/log.c:1837
 msgid "show progress while generating patches"
 msgstr "hiển thị bộ đo tiến triển trong khi tạo các miếng vá"
 
-#: builtin/log.c:1824
+#: builtin/log.c:1839
 msgid "show changes against <rev> in cover letter or single patch"
 msgstr ""
 "hiển thị các thay đổi dựa trên <rev> trong các chữ bao bọc hoặc miếng vá đơn"
 
-#: builtin/log.c:1827
+#: builtin/log.c:1842
 msgid "show changes against <refspec> in cover letter or single patch"
 msgstr ""
 "hiển thị các thay đổi dựa trên <refspec> trong các chữ bao bọc hoặc miếng vá "
 "đơn"
 
-#: builtin/log.c:1829 builtin/range-diff.c:28
+#: builtin/log.c:1844 builtin/range-diff.c:28
 msgid "percentage by which creation is weighted"
 msgstr "tỷ lệ phần trăm theo cái tạo là weighted"
 
-#: builtin/log.c:1916
+#: builtin/log.c:1931
 #, c-format
 msgid "invalid ident line: %s"
 msgstr "dòng định danh không hợp lệ: %s"
 
-#: builtin/log.c:1931
-msgid "-n and -k are mutually exclusive"
-msgstr "-n và -k loại trừ lẫn nhau"
-
-#: builtin/log.c:1933
-msgid "--subject-prefix/--rfc and -k are mutually exclusive"
-msgstr "--subject-prefix/--rfc và -k xung khắc nhau"
-
-#: builtin/log.c:1941
+#: builtin/log.c:1956
 msgid "--name-only does not make sense"
 msgstr "--name-only không hợp lý"
 
-#: builtin/log.c:1943
+#: builtin/log.c:1958
 msgid "--name-status does not make sense"
 msgstr "--name-status không hợp lý"
 
-#: builtin/log.c:1945
+#: builtin/log.c:1960
 msgid "--check does not make sense"
 msgstr "--check không hợp lý"
 
-#: builtin/log.c:1967
-msgid "--stdout, --output, and --output-directory are mutually exclusive"
-msgstr ""
-"Các tùy chọn --stdout, --output, và --output-directory loại từ lẫn nhau"
-
-#: builtin/log.c:2089
+#: builtin/log.c:2104
 msgid "--interdiff requires --cover-letter or single patch"
 msgstr "--interdiff cần --cover-letter hoặc vá đơn"
 
-#: builtin/log.c:2093
+#: builtin/log.c:2108
 msgid "Interdiff:"
 msgstr "Interdiff:"
 
-#: builtin/log.c:2094
+#: builtin/log.c:2109
 #, c-format
 msgid "Interdiff against v%d:"
 msgstr "Interdiff dựa trên v%d:"
 
-#: builtin/log.c:2100
-msgid "--creation-factor requires --range-diff"
-msgstr "--creation-factor yêu cầu --range-diff"
-
-#: builtin/log.c:2104
+#: builtin/log.c:2119
 msgid "--range-diff requires --cover-letter or single patch"
 msgstr "--range-diff yêu cầu --cover-letter hoặc miếng vá đơn"
 
-#: builtin/log.c:2112
+#: builtin/log.c:2127
 msgid "Range-diff:"
 msgstr "Range-diff:"
 
-#: builtin/log.c:2113
+#: builtin/log.c:2128
 #, c-format
 msgid "Range-diff against v%d:"
 msgstr "Range-diff dựa trên v%d:"
 
-#: builtin/log.c:2124
+#: builtin/log.c:2139
 #, c-format
 msgid "unable to read signature file '%s'"
 msgstr "không thể đọc tập tin chữ ký “%s”"
 
-#: builtin/log.c:2160
+#: builtin/log.c:2175
 msgid "Generating patches"
 msgstr "Đang tạo các miếng vá"
 
-#: builtin/log.c:2204
+#: builtin/log.c:2219
 msgid "failed to create output files"
 msgstr "gặp lỗi khi tạo các tập tin kết xuất"
 
-#: builtin/log.c:2263
+#: builtin/log.c:2279
 msgid "git cherry [-v] [<upstream> [<head> [<limit>]]]"
 msgstr "git cherry [-v] [<thượng-nguồn> [<đầu> [<giới-hạn>]]]"
 
-#: builtin/log.c:2317
+#: builtin/log.c:2333
 #, c-format
 msgid ""
 "Could not find a tracked remote branch, please specify <upstream> manually.\n"
@@ -17629,120 +17527,124 @@ msgstr ""
 "Không tìm thấy nhánh mạng được theo dõi, hãy chỉ định <thượng-nguồn> một "
 "cách thủ công.\n"
 
-#: builtin/ls-files.c:561
+#: builtin/ls-files.c:564
 msgid "git ls-files [<options>] [<file>...]"
 msgstr "git ls-files [<các tùy chọn>] [<tập-tin>…]"
 
-#: builtin/ls-files.c:615
+#: builtin/ls-files.c:618
 msgid "separate paths with the NUL character"
 msgstr "các đường dẫn được ngăn cách bởi ký tự NULL"
 
-#: builtin/ls-files.c:617
+#: builtin/ls-files.c:620
 msgid "identify the file status with tags"
 msgstr "nhận dạng các trạng thái tập tin với thẻ"
 
-#: builtin/ls-files.c:619
+#: builtin/ls-files.c:622
 msgid "use lowercase letters for 'assume unchanged' files"
 msgstr ""
 "dùng chữ cái viết thường cho các tập tin “assume unchanged” (giả định không "
 "thay đổi)"
 
-#: builtin/ls-files.c:621
+#: builtin/ls-files.c:624
 msgid "use lowercase letters for 'fsmonitor clean' files"
 msgstr "dùng chữ cái viết thường cho các tập tin “fsmonitor clean”"
 
-#: builtin/ls-files.c:623
+#: builtin/ls-files.c:626
 msgid "show cached files in the output (default)"
 msgstr "hiển thị các tập tin được nhớ tạm vào đầu ra (mặc định)"
 
-#: builtin/ls-files.c:625
+#: builtin/ls-files.c:628
 msgid "show deleted files in the output"
 msgstr "hiển thị các tập tin đã xóa trong kết xuất"
 
-#: builtin/ls-files.c:627
+#: builtin/ls-files.c:630
 msgid "show modified files in the output"
 msgstr "hiển thị các tập tin đã bị sửa đổi ra kết xuất"
 
-#: builtin/ls-files.c:629
+#: builtin/ls-files.c:632
 msgid "show other files in the output"
 msgstr "hiển thị các tập tin khác trong kết xuất"
 
-#: builtin/ls-files.c:631
+#: builtin/ls-files.c:634
 msgid "show ignored files in the output"
 msgstr "hiển thị các tập tin bị bỏ qua trong kết xuất"
 
-#: builtin/ls-files.c:634
+#: builtin/ls-files.c:637
 msgid "show staged contents' object name in the output"
 msgstr "hiển thị tên đối tượng của nội dung được đặt lên bệ phóng ra kết xuất"
 
-#: builtin/ls-files.c:636
+#: builtin/ls-files.c:639
 msgid "show files on the filesystem that need to be removed"
 msgstr "hiển thị các tập tin trên hệ thống tập tin mà nó cần được gỡ bỏ"
 
-#: builtin/ls-files.c:638
+#: builtin/ls-files.c:641
 msgid "show 'other' directories' names only"
 msgstr "chỉ hiển thị tên của các thư mục “khác”"
 
-#: builtin/ls-files.c:640
+#: builtin/ls-files.c:643
 msgid "show line endings of files"
 msgstr "hiển thị kết thúc dòng của các tập tin"
 
-#: builtin/ls-files.c:642
+#: builtin/ls-files.c:645
 msgid "don't show empty directories"
 msgstr "không hiển thị thư mục rỗng"
 
-#: builtin/ls-files.c:645
+#: builtin/ls-files.c:648
 msgid "show unmerged files in the output"
 msgstr "hiển thị các tập tin chưa hòa trộn trong kết xuất"
 
-#: builtin/ls-files.c:647
+#: builtin/ls-files.c:650
 msgid "show resolve-undo information"
 msgstr "hiển thị thông tin resolve-undo"
 
-#: builtin/ls-files.c:649
+#: builtin/ls-files.c:652
 msgid "skip files matching pattern"
 msgstr "bỏ qua những tập tin khớp với một mẫu"
 
-#: builtin/ls-files.c:652
+#: builtin/ls-files.c:655
 msgid "read exclude patterns from <file>"
 msgstr "đọc mẫu cần loại trừ từ <tập-tin>"
 
-#: builtin/ls-files.c:655
+#: builtin/ls-files.c:658
 msgid "read additional per-directory exclude patterns in <file>"
 msgstr "đọc thêm các mẫu ngoại trừ mỗi thư mục trong <tập tin>"
 
-#: builtin/ls-files.c:657
+#: builtin/ls-files.c:660
 msgid "add the standard git exclusions"
 msgstr "thêm loại trừ tiêu chuẩn kiểu git"
 
-#: builtin/ls-files.c:661
+#: builtin/ls-files.c:664
 msgid "make the output relative to the project top directory"
 msgstr "làm cho kết xuất liên quan đến thư mục ở mức cao nhất (gốc) của dự án"
 
-#: builtin/ls-files.c:664
+#: builtin/ls-files.c:667
 msgid "recurse through submodules"
 msgstr "đệ quy xuyên qua mô-đun con"
 
-#: builtin/ls-files.c:666
+#: builtin/ls-files.c:669
 msgid "if any <file> is not in the index, treat this as an error"
 msgstr "nếu <tập tin> bất kỳ không ở trong bảng mục lục, xử lý nó như một lỗi"
 
-#: builtin/ls-files.c:667
+#: builtin/ls-files.c:670
 msgid "tree-ish"
 msgstr "tree-ish"
 
-#: builtin/ls-files.c:668
+#: builtin/ls-files.c:671
 msgid "pretend that paths removed since <tree-ish> are still present"
 msgstr ""
 "giả định rằng các đường dẫn đã bị gỡ bỏ kể từ <tree-ish> nay vẫn hiện diện"
 
-#: builtin/ls-files.c:670
+#: builtin/ls-files.c:673
 msgid "show debugging data"
 msgstr "hiển thị dữ liệu gỡ lỗi"
 
-#: builtin/ls-files.c:672
+#: builtin/ls-files.c:675
 msgid "suppress duplicate entries"
 msgstr "chặn các mục tin trùng lặp"
+
+#: builtin/ls-files.c:677
+msgid "show sparse directories in the presence of a sparse index"
+msgstr "hiển thị thư mục \"sparse\" trong sự có mặt của mục lục \"sparse\""
 
 #: builtin/ls-remote.c:9
 msgid ""
@@ -17937,26 +17839,30 @@ msgid "use a diff3 based merge"
 msgstr "dùng kiểu hòa dựa trên diff3"
 
 #: builtin/merge-file.c:37
+msgid "use a zealous diff3 based merge"
+msgstr "dùng kiểu hòa trộn dựa trên 'zealous diff3'"
+
+#: builtin/merge-file.c:39
 msgid "for conflicts, use our version"
 msgstr "để tránh xung đột, sử dụng phiên bản của chúng ta"
 
-#: builtin/merge-file.c:39
+#: builtin/merge-file.c:41
 msgid "for conflicts, use their version"
 msgstr "để tránh xung đột, sử dụng phiên bản của họ"
 
-#: builtin/merge-file.c:41
+#: builtin/merge-file.c:43
 msgid "for conflicts, use a union version"
 msgstr "để tránh xung đột, sử dụng phiên bản kết hợp"
 
-#: builtin/merge-file.c:44
+#: builtin/merge-file.c:46
 msgid "for conflicts, use this marker size"
 msgstr "để tránh xung đột, hãy sử dụng kích thước bộ tạo này"
 
-#: builtin/merge-file.c:45
+#: builtin/merge-file.c:47
 msgid "do not warn about conflicts"
 msgstr "không cảnh báo về các xung đột xảy ra"
 
-#: builtin/merge-file.c:47
+#: builtin/merge-file.c:49
 msgid "set labels for file1/orig-file/file2"
 msgstr "đặt nhãn cho tập-tin-1/tập-tin-gốc/tập-tin-2"
 
@@ -17994,181 +17900,185 @@ msgstr "Đang hòa trộn %s với %s\n"
 msgid "git merge [<options>] [<commit>...]"
 msgstr "git merge [<các tùy chọn>] [<commit>…]"
 
-#: builtin/merge.c:124
+#: builtin/merge.c:125
 msgid "switch `m' requires a value"
 msgstr "switch “m” yêu cầu một giá trị"
 
-#: builtin/merge.c:147
+#: builtin/merge.c:148
 #, c-format
 msgid "option `%s' requires a value"
 msgstr "tùy chọn “%s” yêu cầu một giá trị"
 
-#: builtin/merge.c:200
+#: builtin/merge.c:201
 #, c-format
 msgid "Could not find merge strategy '%s'.\n"
 msgstr "Không tìm thấy chiến lược hòa trộn “%s”.\n"
 
-#: builtin/merge.c:201
+#: builtin/merge.c:202
 #, c-format
 msgid "Available strategies are:"
 msgstr "Các chiến lược sẵn sàng là:"
 
-#: builtin/merge.c:206
+#: builtin/merge.c:207
 #, c-format
 msgid "Available custom strategies are:"
 msgstr "Các chiến lược tùy chỉnh sẵn sàng là:"
 
-#: builtin/merge.c:257 builtin/pull.c:134
+#: builtin/merge.c:258 builtin/pull.c:134
 msgid "do not show a diffstat at the end of the merge"
 msgstr "không hiển thị thống kê khác biệt tại cuối của lần hòa trộn"
 
-#: builtin/merge.c:260 builtin/pull.c:137
+#: builtin/merge.c:261 builtin/pull.c:137
 msgid "show a diffstat at the end of the merge"
 msgstr "hiển thị thống kê khác biệt tại cuối của hòa trộn"
 
-#: builtin/merge.c:261 builtin/pull.c:140
+#: builtin/merge.c:262 builtin/pull.c:140
 msgid "(synonym to --stat)"
 msgstr "(đồng nghĩa với --stat)"
 
-#: builtin/merge.c:263 builtin/pull.c:143
+#: builtin/merge.c:264 builtin/pull.c:143
 msgid "add (at most <n>) entries from shortlog to merge commit message"
 msgstr "thêm (ít nhất <n>) mục từ shortlog cho ghi chú chuyển giao hòa trộn"
 
-#: builtin/merge.c:266 builtin/pull.c:149
+#: builtin/merge.c:267 builtin/pull.c:149
 msgid "create a single commit instead of doing a merge"
 msgstr "tạo một lần chuyển giao đưon thay vì thực hiện việc hòa trộn"
 
-#: builtin/merge.c:268 builtin/pull.c:152
+#: builtin/merge.c:269 builtin/pull.c:152
 msgid "perform a commit if the merge succeeds (default)"
 msgstr "thực hiện chuyển giao nếu hòa trộn thành công (mặc định)"
 
-#: builtin/merge.c:270 builtin/pull.c:155
+#: builtin/merge.c:271 builtin/pull.c:155
 msgid "edit message before committing"
 msgstr "sửa chú thích trước khi chuyển giao"
 
-#: builtin/merge.c:272
+#: builtin/merge.c:273
 msgid "allow fast-forward (default)"
 msgstr "cho phép chuyển-tiếp-nhanh (mặc định)"
 
-#: builtin/merge.c:274 builtin/pull.c:162
+#: builtin/merge.c:275 builtin/pull.c:162
 msgid "abort if fast-forward is not possible"
 msgstr "bỏ qua nếu chuyển-tiếp-nhanh không thể được"
 
-#: builtin/merge.c:278 builtin/pull.c:168
+#: builtin/merge.c:279 builtin/pull.c:168
 msgid "verify that the named commit has a valid GPG signature"
 msgstr "thẩm tra xem lần chuyển giao có tên đó có chữ ký GPG hợp lệ hay không"
 
-#: builtin/merge.c:279 builtin/notes.c:785 builtin/pull.c:172
+#: builtin/merge.c:280 builtin/notes.c:785 builtin/pull.c:172
 #: builtin/rebase.c:1117 builtin/revert.c:114
 msgid "strategy"
 msgstr "chiến lược"
 
-#: builtin/merge.c:280 builtin/pull.c:173
+#: builtin/merge.c:281 builtin/pull.c:173
 msgid "merge strategy to use"
 msgstr "chiến lược hòa trộn sẽ dùng"
 
-#: builtin/merge.c:281 builtin/pull.c:176
+#: builtin/merge.c:282 builtin/pull.c:176
 msgid "option=value"
 msgstr "tùy_chọn=giá_trị"
 
-#: builtin/merge.c:282 builtin/pull.c:177
+#: builtin/merge.c:283 builtin/pull.c:177
 msgid "option for selected merge strategy"
 msgstr "tùy chọn cho chiến lược hòa trộn đã chọn"
 
-#: builtin/merge.c:284
+#: builtin/merge.c:285
 msgid "merge commit message (for a non-fast-forward merge)"
 msgstr ""
 "hòa trộn ghi chú của lần chuyển giao (dành cho hòa trộn không-chuyển-tiếp-"
 "nhanh)"
 
 #: builtin/merge.c:291
+msgid "use <name> instead of the real target"
+msgstr "dùng <tên> thay cho đích thật"
+
+#: builtin/merge.c:294
 msgid "abort the current in-progress merge"
 msgstr "bãi bỏ quá trình hòa trộn hiện tại đang thực hiện"
 
-#: builtin/merge.c:293
+#: builtin/merge.c:296
 msgid "--abort but leave index and working tree alone"
 msgstr "--abort nhưng để lại bảng mục lục và cây làm việc"
 
-#: builtin/merge.c:295
+#: builtin/merge.c:298
 msgid "continue the current in-progress merge"
 msgstr "tiếp tục quá trình hòa trộn hiện tại đang thực hiện"
 
-#: builtin/merge.c:297 builtin/pull.c:184
+#: builtin/merge.c:300 builtin/pull.c:184
 msgid "allow merging unrelated histories"
 msgstr "cho phép hòa trộn lịch sử không liên quan"
 
-#: builtin/merge.c:304
+#: builtin/merge.c:307
 msgid "bypass pre-merge-commit and commit-msg hooks"
 msgstr "vòng qua móc (hook) pre-merge-commit và commit-msg"
 
-#: builtin/merge.c:321
+#: builtin/merge.c:323
 msgid "could not run stash."
 msgstr "không thể chạy stash."
 
-#: builtin/merge.c:326
+#: builtin/merge.c:328
 msgid "stash failed"
 msgstr "lệnh tạm cất gặp lỗi"
 
-#: builtin/merge.c:331
+#: builtin/merge.c:333
 #, c-format
 msgid "not a valid object: %s"
 msgstr "không phải là một đối tượng hợp lệ: %s"
 
-#: builtin/merge.c:353 builtin/merge.c:370
+#: builtin/merge.c:355 builtin/merge.c:372
 msgid "read-tree failed"
 msgstr "read-tree gặp lỗi"
 
-#: builtin/merge.c:401
+#: builtin/merge.c:403
 msgid "Already up to date. (nothing to squash)"
 msgstr "Đã cập nhật rồi. (không có gì để squash)"
 
-#: builtin/merge.c:415
+#: builtin/merge.c:417
 #, c-format
 msgid "Squash commit -- not updating HEAD\n"
 msgstr "Squash commit -- không cập nhật HEAD\n"
 
-#: builtin/merge.c:465
+#: builtin/merge.c:467
 #, c-format
 msgid "No merge message -- not updating HEAD\n"
 msgstr "Không có lời chú thích hòa trộn -- nên không cập nhật HEAD\n"
 
-#: builtin/merge.c:515
+#: builtin/merge.c:517
 #, c-format
 msgid "'%s' does not point to a commit"
 msgstr "“%s” không chỉ đến một lần chuyển giao nào cả"
 
-#: builtin/merge.c:603
+#: builtin/merge.c:605
 #, c-format
 msgid "Bad branch.%s.mergeoptions string: %s"
 msgstr "Chuỗi branch.%s.mergeoptions sai: %s"
 
-#: builtin/merge.c:730
+#: builtin/merge.c:732
 msgid "Not handling anything other than two heads merge."
 msgstr "Không cầm nắm gì ngoài hai head hòa trộn."
 
-#: builtin/merge.c:743
+#: builtin/merge.c:745
 #, c-format
 msgid "unknown strategy option: -X%s"
 msgstr "không hiểu chiến lược: -X%s"
 
-#: builtin/merge.c:762 t/helper/test-fast-rebase.c:223
+#: builtin/merge.c:764 t/helper/test-fast-rebase.c:223
 #, c-format
 msgid "unable to write %s"
 msgstr "không thể ghi %s"
 
-#: builtin/merge.c:814
+#: builtin/merge.c:816
 #, c-format
 msgid "Could not read from '%s'"
 msgstr "Không thể đọc từ “%s”"
 
-#: builtin/merge.c:823
+#: builtin/merge.c:825
 #, c-format
 msgid "Not committing merge; use 'git commit' to complete the merge.\n"
 msgstr ""
 "Vẫn chưa hòa trộn các lần chuyển giao; sử dụng lệnh “git commit” để hoàn tất "
 "việc hòa trộn.\n"
 
-#: builtin/merge.c:829
+#: builtin/merge.c:831
 msgid ""
 "Please enter a commit message to explain why this merge is necessary,\n"
 "especially if it merges an updated upstream into a topic branch.\n"
@@ -18180,11 +18090,11 @@ msgstr ""
 "topic.\n"
 "\n"
 
-#: builtin/merge.c:834
+#: builtin/merge.c:836
 msgid "An empty message aborts the commit.\n"
 msgstr "Nếu phần chú thích rỗng sẽ hủy bỏ lần chuyển giao.\n"
 
-#: builtin/merge.c:837
+#: builtin/merge.c:839
 #, c-format
 msgid ""
 "Lines starting with '%c' will be ignored, and an empty message aborts\n"
@@ -18193,75 +18103,75 @@ msgstr ""
 "Những dòng được bắt đầu bằng “%c” sẽ được bỏ qua, và nếu phần chú\n"
 "thích rỗng sẽ hủy bỏ lần chuyển giao.\n"
 
-#: builtin/merge.c:892
+#: builtin/merge.c:894
 msgid "Empty commit message."
 msgstr "Chú thích của lần commit (chuyển giao) bị trống rỗng."
 
-#: builtin/merge.c:907
+#: builtin/merge.c:909
 #, c-format
 msgid "Wonderful.\n"
 msgstr "Tuyệt vời.\n"
 
-#: builtin/merge.c:968
+#: builtin/merge.c:970
 #, c-format
 msgid "Automatic merge failed; fix conflicts and then commit the result.\n"
 msgstr ""
 "Việc tự động hòa trộn gặp lỗi; hãy sửa các xung đột sau đó chuyển giao kết "
 "quả.\n"
 
-#: builtin/merge.c:1007
+#: builtin/merge.c:1009
 msgid "No current branch."
 msgstr "Không phải nhánh hiện hành."
 
-#: builtin/merge.c:1009
+#: builtin/merge.c:1011
 msgid "No remote for the current branch."
 msgstr "Không có máy chủ cho nhánh hiện hành."
 
-#: builtin/merge.c:1011
+#: builtin/merge.c:1013
 msgid "No default upstream defined for the current branch."
 msgstr "Không có thượng nguồn mặc định được định nghĩa cho nhánh hiện hành."
 
-#: builtin/merge.c:1016
+#: builtin/merge.c:1018
 #, c-format
 msgid "No remote-tracking branch for %s from %s"
 msgstr "Không nhánh mạng theo dõi cho %s từ %s"
 
-#: builtin/merge.c:1073
+#: builtin/merge.c:1075
 #, c-format
 msgid "Bad value '%s' in environment '%s'"
 msgstr "Giá trị sai “%s” trong biến môi trường “%s”"
 
-#: builtin/merge.c:1174
+#: builtin/merge.c:1177
 #, c-format
 msgid "not something we can merge in %s: %s"
 msgstr "không phải là một thứ gì đó mà chúng tôi có thể hòa trộn trong %s: %s"
 
-#: builtin/merge.c:1208
+#: builtin/merge.c:1211
 msgid "not something we can merge"
 msgstr "không phải là thứ gì đó mà chúng tôi có thể hòa trộn"
 
-#: builtin/merge.c:1321
+#: builtin/merge.c:1324
 msgid "--abort expects no arguments"
 msgstr "--abort không nhận các đối số"
 
-#: builtin/merge.c:1325
+#: builtin/merge.c:1328
 msgid "There is no merge to abort (MERGE_HEAD missing)."
 msgstr ""
 "Ở đây không có lần hòa trộn nào được hủy bỏ giữa chừng cả (thiếu MERGE_HEAD)."
 
-#: builtin/merge.c:1343
+#: builtin/merge.c:1346
 msgid "--quit expects no arguments"
 msgstr "--quit không nhận các đối số"
 
-#: builtin/merge.c:1356
+#: builtin/merge.c:1359
 msgid "--continue expects no arguments"
 msgstr "--continue không nhận đối số"
 
-#: builtin/merge.c:1360
+#: builtin/merge.c:1363
 msgid "There is no merge in progress (MERGE_HEAD missing)."
 msgstr "Ở đây không có lần hòa trộn nào đang được xử lý cả (thiếu MERGE_HEAD)."
 
-#: builtin/merge.c:1376
+#: builtin/merge.c:1379
 msgid ""
 "You have not concluded your merge (MERGE_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -18269,7 +18179,7 @@ msgstr ""
 "Bạn chưa kết thúc việc hòa trộn (MERGE_HEAD vẫn tồn tại).\n"
 "Hãy chuyển giao các thay đổi trước khi bạn có thể hòa trộn."
 
-#: builtin/merge.c:1383
+#: builtin/merge.c:1386
 msgid ""
 "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists).\n"
 "Please, commit your changes before you merge."
@@ -18277,86 +18187,78 @@ msgstr ""
 "Bạn chưa kết thúc việc cherry-pick (CHERRY_PICK_HEAD vẫn tồn tại).\n"
 "Hãy chuyển giao các thay đổi trước khi bạn có thể hòa trộn."
 
-#: builtin/merge.c:1386
+#: builtin/merge.c:1389
 msgid "You have not concluded your cherry-pick (CHERRY_PICK_HEAD exists)."
 msgstr "Bạn chưa kết thúc việc cherry-pick (CHERRY_PICK_HEAD vẫn tồn tại)."
 
-#: builtin/merge.c:1400
-msgid "You cannot combine --squash with --no-ff."
-msgstr "Bạn không thể kết hợp --squash với --no-ff."
-
-#: builtin/merge.c:1402
-msgid "You cannot combine --squash with --commit."
-msgstr "Bạn không thể kết hợp --squash với --commit."
-
-#: builtin/merge.c:1418
+#: builtin/merge.c:1421
 msgid "No commit specified and merge.defaultToUpstream not set."
 msgstr "Không chỉ ra lần chuyển giao và merge.defaultToUpstream chưa được đặt."
 
-#: builtin/merge.c:1435
+#: builtin/merge.c:1438
 msgid "Squash commit into empty head not supported yet"
 msgstr "Squash commit vào một head trống rỗng vẫn chưa được hỗ trợ"
 
-#: builtin/merge.c:1437
+#: builtin/merge.c:1440
 msgid "Non-fast-forward commit does not make sense into an empty head"
 msgstr ""
 "Chuyển giao không-chuyển-tiếp-nhanh không hợp lý ở trong một head trống rỗng"
 
-#: builtin/merge.c:1442
+#: builtin/merge.c:1445
 #, c-format
 msgid "%s - not something we can merge"
 msgstr "%s - không phải là thứ gì đó mà chúng tôi có thể hòa trộn"
 
-#: builtin/merge.c:1444
+#: builtin/merge.c:1447
 msgid "Can merge only exactly one commit into empty head"
 msgstr ""
 "Không thể hòa trộn một cách đúng đắn một lần chuyển giao vào một head rỗng"
 
-#: builtin/merge.c:1531
+#: builtin/merge.c:1534
 msgid "refusing to merge unrelated histories"
 msgstr "từ chối hòa trộn lịch sử không liên quan"
 
-#: builtin/merge.c:1550
+#: builtin/merge.c:1553
 #, c-format
 msgid "Updating %s..%s\n"
 msgstr "Đang cập nhật %s..%s\n"
 
-#: builtin/merge.c:1598
+#: builtin/merge.c:1601
 #, c-format
 msgid "Trying really trivial in-index merge...\n"
 msgstr "Đang thử hòa trộn kiểu “trivial in-index”…\n"
 
-#: builtin/merge.c:1605
+#: builtin/merge.c:1608
 #, c-format
 msgid "Nope.\n"
 msgstr "Không.\n"
 
-#: builtin/merge.c:1664 builtin/merge.c:1730
+#: builtin/merge.c:1667 builtin/merge.c:1733
 #, c-format
 msgid "Rewinding the tree to pristine...\n"
 msgstr "Đang tua lại cây thành thời xa xưa…\n"
 
-#: builtin/merge.c:1668
+#: builtin/merge.c:1671
 #, c-format
 msgid "Trying merge strategy %s...\n"
 msgstr "Đang thử chiến lược hòa trộn %s…\n"
 
-#: builtin/merge.c:1720
+#: builtin/merge.c:1723
 #, c-format
 msgid "No merge strategy handled the merge.\n"
 msgstr "Không có chiến lược hòa trộn nào được nắm giữ (handle) sự hòa trộn.\n"
 
-#: builtin/merge.c:1722
+#: builtin/merge.c:1725
 #, c-format
 msgid "Merge with strategy %s failed.\n"
 msgstr "Hòa trộn với chiến lược %s gặp lỗi.\n"
 
-#: builtin/merge.c:1732
+#: builtin/merge.c:1735
 #, c-format
 msgid "Using the %s strategy to prepare resolving by hand.\n"
 msgstr "Sử dụng chiến lược %s để chuẩn bị giải quyết bằng tay.\n"
 
-#: builtin/merge.c:1746
+#: builtin/merge.c:1749
 #, c-format
 msgid "Automatic merge went well; stopped before committing as requested\n"
 msgstr ""
@@ -18402,7 +18304,7 @@ msgid "tag on stdin did not refer to a valid object"
 msgstr ""
 "thẻ trên đầu vào tiêu chuẩn không chỉ đến một lần chuyển giao hợp lệ nào cả"
 
-#: builtin/mktag.c:104 builtin/tag.c:243
+#: builtin/mktag.c:104 builtin/tag.c:242
 msgid "unable to write tag file"
 msgstr "không thể ghi vào tập tin lưu thẻ"
 
@@ -18466,7 +18368,7 @@ msgstr "ghi mục lục multi-pack chỉ chứa các mục lục đã cho"
 msgid "refs snapshot for selecting bitmap commits"
 msgstr "ảnh chụp nhanh refs để chọn các lần chuyển giao ánh xạ"
 
-#: builtin/multi-pack-index.c:202
+#: builtin/multi-pack-index.c:206
 msgid ""
 "during repack, collect pack-files of smaller size into a batch that is "
 "larger than this size"
@@ -18566,53 +18468,53 @@ msgstr "%s, nguồn=%s, đích=%s"
 msgid "Renaming %s to %s\n"
 msgstr "Đổi tên %s thành %s\n"
 
-#: builtin/mv.c:314 builtin/remote.c:790 builtin/repack.c:853
+#: builtin/mv.c:314 builtin/remote.c:790 builtin/repack.c:857
 #, c-format
 msgid "renaming '%s' failed"
 msgstr "gặp lỗi khi đổi tên “%s”"
 
-#: builtin/name-rev.c:465
+#: builtin/name-rev.c:474
 msgid "git name-rev [<options>] <commit>..."
 msgstr "git name-rev [<các tùy chọn>] <commit>…"
 
-#: builtin/name-rev.c:466
+#: builtin/name-rev.c:475
 msgid "git name-rev [<options>] --all"
 msgstr "git name-rev [<các tùy chọn>] --all"
 
-#: builtin/name-rev.c:467
+#: builtin/name-rev.c:476
 msgid "git name-rev [<options>] --stdin"
 msgstr "git name-rev [<các tùy chọn>] --stdin"
 
-#: builtin/name-rev.c:524
+#: builtin/name-rev.c:533
 msgid "print only ref-based names (no object names)"
 msgstr "chỉ hiển thị các tham chiếu cơ sở (không phải các tên đối tượng)"
 
-#: builtin/name-rev.c:525
+#: builtin/name-rev.c:534
 msgid "only use tags to name the commits"
 msgstr "chỉ dùng các thẻ để đặt tên cho các lần chuyển giao"
 
-#: builtin/name-rev.c:527
+#: builtin/name-rev.c:536
 msgid "only use refs matching <pattern>"
 msgstr "chỉ sử dụng các tham chiếu khớp với <mẫu>"
 
-#: builtin/name-rev.c:529
+#: builtin/name-rev.c:538
 msgid "ignore refs matching <pattern>"
 msgstr "bỏ qua các tham chiếu khớp với <mẫu>"
 
-#: builtin/name-rev.c:531
+#: builtin/name-rev.c:540
 msgid "list all commits reachable from all refs"
 msgstr ""
 "liệt kê tất cả các lần chuyển giao có thể đọc được từ tất cả các tham chiếu"
 
-#: builtin/name-rev.c:532
+#: builtin/name-rev.c:541
 msgid "read from stdin"
 msgstr "đọc từ đầu vào tiêu chuẩn"
 
-#: builtin/name-rev.c:533
+#: builtin/name-rev.c:542
 msgid "allow to print `undefined` names (default)"
 msgstr "cho phép in các tên “chưa định nghĩa” (mặc định)"
 
-#: builtin/name-rev.c:539
+#: builtin/name-rev.c:548
 msgid "dereference tags in the input (internal use)"
 msgstr "bãi bỏ tham chiếu các thẻ trong đầu vào (dùng nội bộ)"
 
@@ -18730,26 +18632,26 @@ msgstr "git notes get-ref"
 msgid "Write/edit the notes for the following object:"
 msgstr "Ghi hay sửa ghi chú cho đối tượng sau đây:"
 
-#: builtin/notes.c:150
+#: builtin/notes.c:149
 #, c-format
 msgid "unable to start 'show' for object '%s'"
 msgstr "không thể khởi chạy “show” cho đối tượng “%s”"
 
-#: builtin/notes.c:154
+#: builtin/notes.c:153
 msgid "could not read 'show' output"
 msgstr "không thể đọc kết xuất “show”"
 
-#: builtin/notes.c:162
+#: builtin/notes.c:161
 #, c-format
 msgid "failed to finish 'show' for object '%s'"
 msgstr "gặp lỗi khi hoàn thành “show” cho đối tượng “%s”"
 
-#: builtin/notes.c:195
+#: builtin/notes.c:194
 msgid "please supply the note contents using either -m or -F option"
 msgstr ""
 "xin hãy áp dụng nội dung của ghi chú sử dụng hoặc là tùy chọn -m hoặc là -F"
 
-#: builtin/notes.c:204
+#: builtin/notes.c:203
 msgid "unable to write note object"
 msgstr "không thể ghi đối tượng ghi chú (note)"
 
@@ -18758,7 +18660,7 @@ msgstr "không thể ghi đối tượng ghi chú (note)"
 msgid "the note contents have been left in %s"
 msgstr "nội dung ghi chú còn lại %s"
 
-#: builtin/notes.c:240 builtin/tag.c:577
+#: builtin/notes.c:240 builtin/tag.c:581
 #, c-format
 msgid "could not open or read '%s'"
 msgstr "không thể mở hay đọc “%s”"
@@ -18800,8 +18702,8 @@ msgstr "từ chối %s ghi chú trong %s (nằm ngoài refs/notes/)"
 
 #: builtin/notes.c:374 builtin/notes.c:429 builtin/notes.c:507
 #: builtin/notes.c:519 builtin/notes.c:596 builtin/notes.c:663
-#: builtin/notes.c:813 builtin/notes.c:961 builtin/notes.c:983
-#: builtin/prune-packed.c:25 builtin/tag.c:587
+#: builtin/notes.c:813 builtin/notes.c:965 builtin/notes.c:987
+#: builtin/prune-packed.c:25 builtin/receive-pack.c:2487 builtin/tag.c:591
 msgid "too many arguments"
 msgstr "có quá nhiều đối số"
 
@@ -18848,7 +18750,7 @@ msgstr ""
 msgid "Overwriting existing notes for object %s\n"
 msgstr "Đang ghi đè lên ghi chú cũ cho đối tượng %s\n"
 
-#: builtin/notes.c:473 builtin/notes.c:635 builtin/notes.c:900
+#: builtin/notes.c:473 builtin/notes.c:635 builtin/notes.c:904
 #, c-format
 msgid "Removing note for object %s\n"
 msgstr "Đang gỡ bỏ ghi chú (note) cho đối tượng %s\n"
@@ -18972,17 +18874,17 @@ msgstr "bạn phải chỉ định tham chiếu ghi chú để hòa trộn"
 msgid "unknown -s/--strategy: %s"
 msgstr "không hiểu -s/--strategy: %s"
 
-#: builtin/notes.c:871
+#: builtin/notes.c:874
 #, c-format
 msgid "a notes merge into %s is already in-progress at %s"
 msgstr "một ghi chú hòa trộn vào %s đã sẵn trong quá trình xử lý tại %s"
 
-#: builtin/notes.c:874
+#: builtin/notes.c:878
 #, c-format
 msgid "failed to store link to current notes ref (%s)"
 msgstr "gặp lỗi khi lưu liên kết đến tham chiếu ghi chú hiện tại (%s)"
 
-#: builtin/notes.c:876
+#: builtin/notes.c:880
 #, c-format
 msgid ""
 "Automatic notes merge failed. Fix conflicts in %s and commit the result with "
@@ -18993,41 +18895,41 @@ msgstr ""
 "chuyển giao kết quả bằng “git notes merge --commit”, hoặc bãi bỏ việc hòa "
 "trộn bằng “git notes merge --abort”.\n"
 
-#: builtin/notes.c:895 builtin/tag.c:590
+#: builtin/notes.c:899 builtin/tag.c:594
 #, c-format
 msgid "Failed to resolve '%s' as a valid ref."
 msgstr "Gặp lỗi khi phân giải “%s” như là một tham chiếu hợp lệ."
 
-#: builtin/notes.c:898
+#: builtin/notes.c:902
 #, c-format
 msgid "Object %s has no note\n"
 msgstr "Đối tượng %s không có ghi chú (note)\n"
 
-#: builtin/notes.c:910
+#: builtin/notes.c:914
 msgid "attempt to remove non-existent note is not an error"
 msgstr "cố gắng gỡ bỏ một note chưa từng tồn tại không phải là một lỗi"
 
-#: builtin/notes.c:913
+#: builtin/notes.c:917
 msgid "read object names from the standard input"
 msgstr "đọc tên đối tượng từ thiết bị nhập chuẩn"
 
-#: builtin/notes.c:952 builtin/prune.c:132 builtin/worktree.c:147
+#: builtin/notes.c:956 builtin/prune.c:144 builtin/worktree.c:147
 msgid "do not remove, show only"
 msgstr "không gỡ bỏ, chỉ hiển thị"
 
-#: builtin/notes.c:953
+#: builtin/notes.c:957
 msgid "report pruned notes"
 msgstr "báo cáo các đối tượng đã prune"
 
-#: builtin/notes.c:996
+#: builtin/notes.c:1000
 msgid "notes-ref"
 msgstr "notes-ref"
 
-#: builtin/notes.c:997
+#: builtin/notes.c:1001
 msgid "use notes from <notes-ref>"
 msgstr "dùng “notes” từ <notes-ref>"
 
-#: builtin/notes.c:1032 builtin/stash.c:1752
+#: builtin/notes.c:1036 builtin/stash.c:1818
 #, c-format
 msgid "unknown subcommand: %s"
 msgstr "không hiểu câu lệnh con: %s"
@@ -19427,10 +19329,6 @@ msgstr "giới hạn kích thước tối thiểu của gói là 1 MiB"
 msgid "--thin cannot be used to build an indexable pack"
 msgstr "--thin không thể được dùng để xây dựng gói đánh mục lục được"
 
-#: builtin/pack-objects.c:4073
-msgid "--keep-unreachable and --unpack-unreachable are incompatible"
-msgstr "--keep-unreachable và --unpack-unreachable xung khắc nhau"
-
 #: builtin/pack-objects.c:4079
 msgid "cannot use --filter without --stdout"
 msgstr "không thể dùng tùy chọn --filter mà không có --stdout"
@@ -19447,7 +19345,7 @@ msgstr "không thể dùng danh sách rev bên trong với --stdin-packs"
 msgid "Enumerating objects"
 msgstr "Đánh số các đối tượng"
 
-#: builtin/pack-objects.c:4181
+#: builtin/pack-objects.c:4180
 #, c-format
 msgid ""
 "Total %<PRIu32> (delta %<PRIu32>), reused %<PRIu32> (delta %<PRIu32>), pack-"
@@ -19490,19 +19388,19 @@ msgstr "git prune-packed [-n | --dry-run] [-q | --quiet]"
 msgid "git prune [-n] [-v] [--progress] [--expire <time>] [--] [<head>...]"
 msgstr "git prune [-n] [-v] [--progress] [--expire <thời-gian>] [--] [<head>…]"
 
-#: builtin/prune.c:133
+#: builtin/prune.c:145
 msgid "report pruned objects"
 msgstr "báo cáo các đối tượng đã prune"
 
-#: builtin/prune.c:136
+#: builtin/prune.c:148
 msgid "expire objects older than <time>"
 msgstr "các đối tượng hết hạn cũ hơn khoảng <thời gian>"
 
-#: builtin/prune.c:138
+#: builtin/prune.c:150
 msgid "limit traversal to objects outside promisor packfiles"
 msgstr "giới hạn giao đến các đối tượng nằm ngoài các tập tin gói hứa hẹn"
 
-#: builtin/prune.c:151
+#: builtin/prune.c:163
 msgid "cannot prune in a precious-objects repo"
 msgstr "không thể tỉa bớt trong một kho đối_tượng_vĩ_đại"
 
@@ -19535,7 +19433,7 @@ msgstr "cho phép chuyển-tiếp-nhanh"
 msgid "control use of pre-merge-commit and commit-msg hooks"
 msgstr "điều khiển cách dùng các móc (hook) pre-merge-commit và commit-msg"
 
-#: builtin/pull.c:171 parse-options.h:338
+#: builtin/pull.c:171 parse-options.h:340
 msgid "automatically stash/stash pop before and after"
 msgstr "tự động stash/stash pop trước và sau"
 
@@ -19614,6 +19512,7 @@ msgid "<remote>"
 msgstr "<máy chủ>"
 
 #: builtin/pull.c:467 builtin/pull.c:482 builtin/pull.c:487
+#: contrib/scalar/scalar.c:375
 msgid "<branch>"
 msgstr "<nhánh>"
 
@@ -19645,13 +19544,13 @@ msgstr "không thể truy cập lần chuyển giao “%s”"
 msgid "ignoring --verify-signatures for rebase"
 msgstr "bỏ qua --verify-signatures khi rebase"
 
-#: builtin/pull.c:942
+#: builtin/pull.c:969
 msgid ""
 "You have divergent branches and need to specify how to reconcile them.\n"
 "You can do so by running one of the following commands sometime before\n"
 "your next pull:\n"
 "\n"
-"  git config pull.rebase false  # merge (the default strategy)\n"
+"  git config pull.rebase false  # merge\n"
 "  git config pull.rebase true   # rebase\n"
 "  git config pull.ff only       # fast-forward only\n"
 "\n"
@@ -19665,9 +19564,9 @@ msgstr ""
 "Bạn có thể làm như vậy bằng cách chạy một trong những lệnh sau đây\n"
 "thỉnh thoảng trước khi thực hiện lệnh pull tiếp theo của bạn:\n"
 "\n"
-"  git config pull.rebase false  # merge (chiến lược mặc định)\n"
+"  git config pull.rebase false  # merge\n"
 "  git config pull.rebase true   # rebase\n"
-"  git config pull.ff only       # fast-forward only\n"
+"  git config pull.ff only       # chỉ fast-forward\n"
 "\n"
 "Bạn có thể thay thế \"git config\" với \"git config --global\" để thiết lập "
 "mặc định\n"
@@ -19676,21 +19575,21 @@ msgstr ""
 "hoặc --ff-only trên dòng lệnh để ghi đè các mặc định đã cấu hình cho mỗi\n"
 "lần gọi.\n"
 
-#: builtin/pull.c:1016
+#: builtin/pull.c:1046
 msgid "Updating an unborn branch with changes added to the index."
 msgstr ""
 "Đang cập nhật một nhánh chưa được sinh ra với các thay đổi được thêm vào "
 "bảng mục lục."
 
-#: builtin/pull.c:1020
+#: builtin/pull.c:1050
 msgid "pull with rebase"
 msgstr "pull với rebase"
 
-#: builtin/pull.c:1021
+#: builtin/pull.c:1051
 msgid "please commit or stash them."
 msgstr "xin hãy chuyển giao hoặc tạm cất (stash) chúng."
 
-#: builtin/pull.c:1046
+#: builtin/pull.c:1076
 #, c-format
 msgid ""
 "fetch updated the current branch head.\n"
@@ -19701,7 +19600,7 @@ msgstr ""
 "đang chuyển-tiếp-nhanh cây làm việc của bạn từ\n"
 "lần chuyển giaot %s."
 
-#: builtin/pull.c:1052
+#: builtin/pull.c:1082
 #, c-format
 msgid ""
 "Cannot fast-forward your working tree.\n"
@@ -19719,23 +19618,23 @@ msgstr ""
 "$ git reset --hard\n"
 "để khôi phục lại."
 
-#: builtin/pull.c:1067
+#: builtin/pull.c:1097
 msgid "Cannot merge multiple branches into empty head."
 msgstr "Không thể hòa trộn nhiều nhánh vào trong một head trống rỗng."
 
-#: builtin/pull.c:1072
+#: builtin/pull.c:1102
 msgid "Cannot rebase onto multiple branches."
 msgstr "Không thể thực hiện lệnh rebase (cải tổ) trên nhiều nhánh."
 
-#: builtin/pull.c:1074
+#: builtin/pull.c:1104
 msgid "Cannot fast-forward to multiple branches."
 msgstr "Không thể thực hiện chuyển tiếp nhanh trên nhiều nhánh."
 
-#: builtin/pull.c:1088
+#: builtin/pull.c:1119
 msgid "Need to specify how to reconcile divergent branches."
 msgstr "Caanfchir định làm thế nào để giải quyết các nhánh phân kỳ."
 
-#: builtin/pull.c:1102
+#: builtin/pull.c:1133
 msgid "cannot rebase with locally recorded submodule modifications"
 msgstr ""
 "không thể cải tổ với các thay đổi mô-đun-con được ghi lại một cách cục bộ"
@@ -19919,7 +19818,7 @@ msgstr "Đang đẩy lên %s\n"
 msgid "failed to push some refs to '%s'"
 msgstr "gặp lỗi khi đẩy tới một số tham chiếu đến “%s”"
 
-#: builtin/push.c:544 builtin/submodule--helper.c:3258
+#: builtin/push.c:544 builtin/submodule--helper.c:3259
 msgid "repository"
 msgstr "kho"
 
@@ -19992,10 +19891,6 @@ msgstr "ký lần đẩy dùng GPG"
 msgid "request atomic transaction on remote side"
 msgstr "yêu cầu giao dịch hạt nhân bên phía máy chủ"
 
-#: builtin/push.c:592
-msgid "--delete is incompatible with --all, --mirror and --tags"
-msgstr "--delete là xung khắc với các tùy chọn --all, --mirror và --tags"
-
 #: builtin/push.c:594
 msgid "--delete doesn't make sense without any refs"
 msgstr "--delete không hợp lý nếu không có bất kỳ tham chiếu nào"
@@ -20026,25 +19921,13 @@ msgstr ""
 "\n"
 "    git push <tên>\n"
 
-#: builtin/push.c:630
-msgid "--all and --tags are incompatible"
-msgstr "--all và --tags xung khắc nhau"
-
 #: builtin/push.c:632
 msgid "--all can't be combined with refspecs"
 msgstr "--all không thể được tổ hợp cùng với đặc tả đường dẫn"
 
-#: builtin/push.c:636
-msgid "--mirror and --tags are incompatible"
-msgstr "--mirror và --tags xung khắc nhau"
-
 #: builtin/push.c:638
 msgid "--mirror can't be combined with refspecs"
 msgstr "--mirror không thể được tổ hợp cùng với đặc tả đường dẫn"
-
-#: builtin/push.c:641
-msgid "--all and --mirror are incompatible"
-msgstr "--all và --mirror xung khắc nhau"
 
 #: builtin/push.c:648
 msgid "push options must not have new line characters"
@@ -20473,18 +20356,6 @@ msgstr ""
 msgid "--preserve-merges was replaced by --rebase-merges"
 msgstr "--preserve-merges đã bị thay thế bằng --rebase-merges"
 
-#: builtin/rebase.c:1193
-msgid "cannot combine '--keep-base' with '--onto'"
-msgstr "không thể kết hợp “--keep-base” với “--onto”"
-
-#: builtin/rebase.c:1195
-msgid "cannot combine '--keep-base' with '--root'"
-msgstr "không thể kết hợp “--keep-base” với “--root”"
-
-#: builtin/rebase.c:1199
-msgid "cannot combine '--root' with '--fork-point'"
-msgstr "không thể kết hợp “--root” với “--fork-point”"
-
 #: builtin/rebase.c:1202
 msgid "No rebase in progress?"
 msgstr "Không có tiến trình rebase nào phải không?"
@@ -20551,8 +20422,9 @@ msgid "--strategy requires --merge or --interactive"
 msgstr "--strategy cần --merge hay --interactive"
 
 #: builtin/rebase.c:1463
-msgid "cannot combine apply options with merge options"
-msgstr "không thể tổ hợp các tùy chọn áp dụng với các tùy chọn hòa trộn"
+msgid "apply options and merge options cannot be used together"
+msgstr ""
+"không thể tổ hợp các tùy chọn áp dụng với các tùy chọn hòa trộn với nhau"
 
 #: builtin/rebase.c:1476
 #, c-format
@@ -20593,7 +20465,7 @@ msgid "no such branch/commit '%s'"
 msgstr "không có nhánh/lần chuyển giao “%s” như thế"
 
 #: builtin/rebase.c:1618 builtin/submodule--helper.c:39
-#: builtin/submodule--helper.c:2658
+#: builtin/submodule--helper.c:2659
 #, c-format
 msgid "No such ref: %s"
 msgstr "Không có tham chiếu nào như thế: %s"
@@ -20662,7 +20534,7 @@ msgstr "Chuyển-tiếp-nhanh %s đến %s.\n"
 msgid "git receive-pack <git-dir>"
 msgstr "git receive-pack <thư-mục-git>"
 
-#: builtin/receive-pack.c:1280
+#: builtin/receive-pack.c:1275
 msgid ""
 "By default, updating the current branch in a non-bare repository\n"
 "is denied, because it will make the index and work tree inconsistent\n"
@@ -20692,7 +20564,7 @@ msgstr ""
 "Để chấm dứt lời nhắn này và vẫn giữ cách ứng xử mặc định, hãy đặt\n"
 "biến cấu hình “receive.denyCurrentBranch” thành “refuse”."
 
-#: builtin/receive-pack.c:1300
+#: builtin/receive-pack.c:1295
 msgid ""
 "By default, deleting the current branch is denied, because the next\n"
 "'git clone' won't result in any file checked out, causing confusion.\n"
@@ -20713,13 +20585,13 @@ msgstr ""
 "\n"
 "Để chấm dứt lời nhắn này, bạn hãy đặt nó thành “refuse”."
 
-#: builtin/receive-pack.c:2480
+#: builtin/receive-pack.c:2474
 msgid "quiet"
 msgstr "im lặng"
 
-#: builtin/receive-pack.c:2495
-msgid "You must specify a directory."
-msgstr "Bạn phải chỉ định thư mục."
+#: builtin/receive-pack.c:2489
+msgid "you must specify a directory"
+msgstr "bạn phải chỉ định thư mục"
 
 #: builtin/reflog.c:17
 msgid ""
@@ -20743,41 +20615,41 @@ msgstr ""
 msgid "git reflog exists <ref>"
 msgstr "git reflog exists <tham_chiếu>"
 
-#: builtin/reflog.c:568 builtin/reflog.c:573
+#: builtin/reflog.c:585 builtin/reflog.c:590
 #, c-format
 msgid "'%s' is not a valid timestamp"
 msgstr "“%s” không phải là dấu thời gian hợp lệ"
 
-#: builtin/reflog.c:609
+#: builtin/reflog.c:631
 #, c-format
 msgid "Marking reachable objects..."
 msgstr "Đánh dấu các đối tượng tiếp cận được…"
 
-#: builtin/reflog.c:647
+#: builtin/reflog.c:675
 #, c-format
 msgid "%s points nowhere!"
 msgstr "%s chẳng chỉ đến đâu cả!"
 
-#: builtin/reflog.c:700
+#: builtin/reflog.c:731
 msgid "no reflog specified to delete"
 msgstr "chưa chỉ ra reflog để xóa"
 
-#: builtin/reflog.c:708
+#: builtin/reflog.c:742
 #, c-format
 msgid "not a reflog: %s"
 msgstr "không phải một reflog: %s"
 
-#: builtin/reflog.c:713
+#: builtin/reflog.c:747
 #, c-format
 msgid "no reflog for '%s'"
 msgstr "không reflog cho “%s”"
 
-#: builtin/reflog.c:759
+#: builtin/reflog.c:794
 #, c-format
 msgid "invalid ref format: %s"
 msgstr "định dạng tham chiếu không hợp lệ: %s"
 
-#: builtin/reflog.c:768
+#: builtin/reflog.c:803
 msgid "git reflog [ show | expire | delete | exists ]"
 msgstr "git reflog [ show | expire | delete | exists ]"
 
@@ -20867,6 +20739,11 @@ msgstr "git remote update [<các tùy chọn>] [<nhóm> | <máy-chủ>]…"
 #, c-format
 msgid "Updating %s"
 msgstr "Đang cập nhật %s"
+
+#: builtin/remote.c:101
+#, c-format
+msgid "Could not fetch %s"
+msgstr "Không thể lấy“%s” về"
 
 #: builtin/remote.c:131
 msgid ""
@@ -21312,150 +21189,142 @@ msgstr ""
 "không thể lấy thông tin thống kê pack-objects để mà đóng gói lại các đối "
 "tượng hứa hẹn"
 
-#: builtin/repack.c:273 builtin/repack.c:816
+#: builtin/repack.c:275 builtin/repack.c:820
 msgid "repack: Expecting full hex object ID lines only from pack-objects."
 msgstr ""
 "repack: Đang chỉ cần các dòng ID đối tượng dạng thập lục phân đầy dủ từ pack-"
 "objects."
 
-#: builtin/repack.c:297
+#: builtin/repack.c:299
 msgid "could not finish pack-objects to repack promisor objects"
 msgstr "không thể hoàn tất pack-objects để đóng gói các đối tượng hứa hẹn"
 
-#: builtin/repack.c:312
+#: builtin/repack.c:314
 #, c-format
 msgid "cannot open index for %s"
 msgstr "không thể mở mục lục cho “%s”"
 
-#: builtin/repack.c:371
+#: builtin/repack.c:373
 #, c-format
 msgid "pack %s too large to consider in geometric progression"
 msgstr "gói %s là quá lớn để được xem là trong tiến trình hình học"
 
-#: builtin/repack.c:404 builtin/repack.c:411 builtin/repack.c:416
+#: builtin/repack.c:406 builtin/repack.c:413 builtin/repack.c:418
 #, c-format
 msgid "pack %s too large to roll up"
 msgstr "gói %s là quá lớn để được cuộn lại"
 
-#: builtin/repack.c:496
+#: builtin/repack.c:498
 #, c-format
 msgid "could not open tempfile %s for writing"
 msgstr "không thể mở tập tin tạm %s để ghi"
 
-#: builtin/repack.c:514
+#: builtin/repack.c:516
 msgid "could not close refs snapshot tempfile"
 msgstr "không thể đóng tập tin tạm thời chụp nhanh các tham chiếu"
 
-#: builtin/repack.c:628
+#: builtin/repack.c:630
 msgid "pack everything in a single pack"
 msgstr "đóng gói mọi thứ trong một gói đơn"
 
-#: builtin/repack.c:630
+#: builtin/repack.c:632
 msgid "same as -a, and turn unreachable objects loose"
 msgstr "giống với -a, và chỉnh sửa các đối tượng không đọc được thiếu sót"
 
-#: builtin/repack.c:633
+#: builtin/repack.c:635
 msgid "remove redundant packs, and run git-prune-packed"
 msgstr "xóa bỏ các gói dư thừa, và chạy git-prune-packed"
 
-#: builtin/repack.c:635
+#: builtin/repack.c:637
 msgid "pass --no-reuse-delta to git-pack-objects"
 msgstr "chuyển --no-reuse-delta cho git-pack-objects"
 
-#: builtin/repack.c:637
+#: builtin/repack.c:639
 msgid "pass --no-reuse-object to git-pack-objects"
 msgstr "chuyển --no-reuse-object cho git-pack-objects"
 
-#: builtin/repack.c:639
+#: builtin/repack.c:641
 msgid "do not run git-update-server-info"
 msgstr "không chạy git-update-server-info"
 
-#: builtin/repack.c:642
+#: builtin/repack.c:644
 msgid "pass --local to git-pack-objects"
 msgstr "chuyển --local cho git-pack-objects"
 
-#: builtin/repack.c:644
+#: builtin/repack.c:646
 msgid "write bitmap index"
 msgstr "ghi mục lục ánh xạ"
 
-#: builtin/repack.c:646
+#: builtin/repack.c:648
 msgid "pass --delta-islands to git-pack-objects"
 msgstr "chuyển --delta-islands cho git-pack-objects"
 
-#: builtin/repack.c:647
+#: builtin/repack.c:649
 msgid "approxidate"
 msgstr "ngày ước tính"
 
-#: builtin/repack.c:648
+#: builtin/repack.c:650
 msgid "with -A, do not loosen objects older than this"
 msgstr "với -A, các đối tượng cũ hơn khoảng thời gian này thì không bị mất"
 
-#: builtin/repack.c:650
+#: builtin/repack.c:652
 msgid "with -a, repack unreachable objects"
 msgstr "với -a, đóng gói lại các đối tượng không thể đọc được"
 
-#: builtin/repack.c:652
+#: builtin/repack.c:654
 msgid "size of the window used for delta compression"
 msgstr "kích thước cửa sổ được dùng cho nén “delta”"
 
-#: builtin/repack.c:653 builtin/repack.c:659
+#: builtin/repack.c:655 builtin/repack.c:661
 msgid "bytes"
 msgstr "byte"
 
-#: builtin/repack.c:654
+#: builtin/repack.c:656
 msgid "same as the above, but limit memory size instead of entries count"
 msgstr "giống như trên, nhưng giới hạn kích thước bộ nhớ hay vì số lượng"
 
-#: builtin/repack.c:656
+#: builtin/repack.c:658
 msgid "limits the maximum delta depth"
 msgstr "giới hạn độ sâu tối đa của “delta”"
 
-#: builtin/repack.c:658
+#: builtin/repack.c:660
 msgid "limits the maximum number of threads"
 msgstr "giới hạn số lượng tối đa tuyến trình"
 
-#: builtin/repack.c:660
+#: builtin/repack.c:662
 msgid "maximum size of each packfile"
 msgstr "kích thước tối đa cho từng tập tin gói"
 
-#: builtin/repack.c:662
+#: builtin/repack.c:664
 msgid "repack objects in packs marked with .keep"
 msgstr "đóng gói lại các đối tượng trong các gói đã đánh dấu bằng .keep"
 
-#: builtin/repack.c:664
+#: builtin/repack.c:666
 msgid "do not repack this pack"
 msgstr "đừng đóng gói lại gói này"
 
-#: builtin/repack.c:666
+#: builtin/repack.c:668
 msgid "find a geometric progression with factor <N>"
 msgstr "tìm một tiến trình hình học với hệ số <N>"
 
-#: builtin/repack.c:668
+#: builtin/repack.c:670
 msgid "write a multi-pack index of the resulting packs"
 msgstr "ghi mục lục “multi-pack” của các gói kết quả"
 
-#: builtin/repack.c:678
+#: builtin/repack.c:680
 msgid "cannot delete packs in a precious-objects repo"
 msgstr "không thể xóa các gói trong một kho đối_tượng_vĩ_đại"
 
-#: builtin/repack.c:682
-msgid "--keep-unreachable and -A are incompatible"
-msgstr "--keep-unreachable và -A xung khắc nhau"
-
-#: builtin/repack.c:713
-msgid "--geometric is incompatible with -A, -a"
-msgstr "--geometric là xung khắc với tùy chọn -A, -a"
-
-#: builtin/repack.c:825
+#: builtin/repack.c:829
 msgid "Nothing new to pack."
 msgstr "Không có gì mới để mà đóng gói."
 
-#: builtin/repack.c:855
+#: builtin/repack.c:859
 #, c-format
 msgid "missing required file: %s"
 msgstr "thiếu tập tin cần thiết: %s"
 
-#: builtin/repack.c:857
+#: builtin/repack.c:861
 #, c-format
 msgid "could not unlink: %s"
 msgstr "không thể bỏ liên kết: %s"
@@ -21538,67 +21407,61 @@ msgstr "cat-file đã báo cáo gặp lỗi nghiêm trọng"
 msgid "unable to open %s for reading"
 msgstr "không thể mở “%s” để đọc"
 
-#: builtin/replace.c:272
+#: builtin/replace.c:271
 msgid "unable to spawn mktree"
 msgstr "không thể sinh tiến trình con mktree"
 
-#: builtin/replace.c:276
+#: builtin/replace.c:275
 msgid "unable to read from mktree"
 msgstr "không thể đọc từ mktree"
 
-#: builtin/replace.c:285
+#: builtin/replace.c:284
 msgid "mktree reported failure"
 msgstr "mktree đã báo cáo gặp lỗi nghiêm trọng"
 
-#: builtin/replace.c:289
+#: builtin/replace.c:288
 msgid "mktree did not return an object name"
 msgstr "mktree đã không trả về một tên đối tượng"
 
-#: builtin/replace.c:298
+#: builtin/replace.c:297
 #, c-format
 msgid "unable to fstat %s"
 msgstr "không thể fstat %s"
 
-#: builtin/replace.c:303
+#: builtin/replace.c:302
 msgid "unable to write object to database"
 msgstr "không thể ghi đối tượng vào cơ sở dữ liệu"
 
-#: builtin/replace.c:322 builtin/replace.c:378 builtin/replace.c:424
-#: builtin/replace.c:454
-#, c-format
-msgid "not a valid object name: '%s'"
-msgstr "không phải là tên đối tượng hợp lệ: “%s”"
-
-#: builtin/replace.c:326
+#: builtin/replace.c:325
 #, c-format
 msgid "unable to get object type for %s"
 msgstr "không thể lấy kiểu đối tượng cho %s"
 
-#: builtin/replace.c:342
+#: builtin/replace.c:341
 msgid "editing object file failed"
 msgstr "việc sửa tập tin đối tượng gặp lỗi"
 
-#: builtin/replace.c:351
+#: builtin/replace.c:350
 #, c-format
 msgid "new object is the same as the old one: '%s'"
 msgstr "đối tượng mới là giống với cái cũ: “%s”"
 
-#: builtin/replace.c:384
+#: builtin/replace.c:383
 #, c-format
 msgid "could not parse %s as a commit"
 msgstr "không thể phân tích %s như là một lần chuyển giao"
 
-#: builtin/replace.c:416
+#: builtin/replace.c:415
 #, c-format
 msgid "bad mergetag in commit '%s'"
 msgstr "thẻ hòa trộn sai trong lần chuyển giao “%s”"
 
-#: builtin/replace.c:418
+#: builtin/replace.c:417
 #, c-format
 msgid "malformed mergetag in commit '%s'"
 msgstr "thẻ hòa trộn không đúng dạng ở lần chuyển giao “%s”"
 
-#: builtin/replace.c:430
+#: builtin/replace.c:429
 #, c-format
 msgid ""
 "original commit '%s' contains mergetag '%s' that is discarded; use --edit "
@@ -21607,31 +21470,31 @@ msgstr ""
 "lần chuyển giao gốc “%s” có chứa thẻ hòa trộn “%s” cái mà bị loại bỏ; dùng "
 "tùy chọn --edit thay cho --graft"
 
-#: builtin/replace.c:469
+#: builtin/replace.c:468
 #, c-format
 msgid "the original commit '%s' has a gpg signature"
 msgstr "lần chuyển giao gốc “%s” có chữ ký GPG"
 
-#: builtin/replace.c:470
+#: builtin/replace.c:469
 msgid "the signature will be removed in the replacement commit!"
 msgstr "chữ ký sẽ được bỏ đi trong lần chuyển giao thay thế!"
 
-#: builtin/replace.c:480
+#: builtin/replace.c:479
 #, c-format
 msgid "could not write replacement commit for: '%s'"
 msgstr "không thể ghi lần chuyển giao thay thế cho: “%s”"
 
-#: builtin/replace.c:488
+#: builtin/replace.c:487
 #, c-format
 msgid "graft for '%s' unnecessary"
 msgstr "graft cho “%s” không cần thiết"
 
-#: builtin/replace.c:492
+#: builtin/replace.c:491
 #, c-format
 msgid "new commit is the same as the old one: '%s'"
 msgstr "lần chuyển giao mới là giống với cái cũ: “%s”"
 
-#: builtin/replace.c:527
+#: builtin/replace.c:526
 #, c-format
 msgid ""
 "could not convert the following graft(s):\n"
@@ -21640,71 +21503,71 @@ msgstr ""
 "không thể chuyển đổi các graft sau đây:\n"
 "%s"
 
-#: builtin/replace.c:548
+#: builtin/replace.c:547
 msgid "list replace refs"
 msgstr "liệt kê các refs thay thế"
 
-#: builtin/replace.c:549
+#: builtin/replace.c:548
 msgid "delete replace refs"
 msgstr "xóa tham chiếu thay thế"
 
-#: builtin/replace.c:550
+#: builtin/replace.c:549
 msgid "edit existing object"
 msgstr "sửa đối tượng sẵn có"
 
-#: builtin/replace.c:551
+#: builtin/replace.c:550
 msgid "change a commit's parents"
 msgstr "thay đổi cha mẹ của lần chuyển giao"
 
-#: builtin/replace.c:552
+#: builtin/replace.c:551
 msgid "convert existing graft file"
 msgstr "chuyển đổi các tập tin graft sẵn có"
 
-#: builtin/replace.c:553
+#: builtin/replace.c:552
 msgid "replace the ref if it exists"
 msgstr "thay thế tham chiếu nếu nó đã sẵn có"
 
-#: builtin/replace.c:555
+#: builtin/replace.c:554
 msgid "do not pretty-print contents for --edit"
 msgstr "đừng in đẹp các nội dung cho --edit"
 
-#: builtin/replace.c:556
+#: builtin/replace.c:555
 msgid "use this format"
 msgstr "dùng định dạng này"
 
-#: builtin/replace.c:569
+#: builtin/replace.c:568
 msgid "--format cannot be used when not listing"
 msgstr "--format không thể được dùng khi không liệt kê gì"
 
-#: builtin/replace.c:577
+#: builtin/replace.c:576
 msgid "-f only makes sense when writing a replacement"
 msgstr "-f chỉ hợp lý khi ghi một cái thay thế"
 
-#: builtin/replace.c:581
+#: builtin/replace.c:580
 msgid "--raw only makes sense with --edit"
 msgstr "--raw chỉ hợp lý với --edit"
 
-#: builtin/replace.c:587
+#: builtin/replace.c:586
 msgid "-d needs at least one argument"
 msgstr "-d cần ít nhất một tham số"
 
-#: builtin/replace.c:593
+#: builtin/replace.c:592
 msgid "bad number of arguments"
 msgstr "số lượng đối số không đúng"
 
-#: builtin/replace.c:599
+#: builtin/replace.c:598
 msgid "-e needs exactly one argument"
 msgstr "-e cần chính các là một đối số"
 
-#: builtin/replace.c:605
+#: builtin/replace.c:604
 msgid "-g needs at least one argument"
 msgstr "-q cần ít nhất một tham số"
 
-#: builtin/replace.c:611
+#: builtin/replace.c:610
 msgid "--convert-graft-file takes no argument"
 msgstr "--convert-graft-file không nhận đối số"
 
-#: builtin/replace.c:617
+#: builtin/replace.c:616
 msgid "only one pattern can be given with -l"
 msgstr "chỉ một mẫu được chỉ ra với tùy chọn -l"
 
@@ -21726,133 +21589,125 @@ msgstr "“git rerere forget” mà không có các đường dẫn là đã l�
 msgid "unable to generate diff for '%s'"
 msgstr "không thể tạo khác biệt cho “%s”"
 
-#: builtin/reset.c:32
+#: builtin/reset.c:33
 msgid ""
 "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<commit>]"
 msgstr ""
 "git reset [--mixed | --soft | --hard | --merge | --keep] [-q] [<commit>]"
 
-#: builtin/reset.c:33
+#: builtin/reset.c:34
 msgid "git reset [-q] [<tree-ish>] [--] <pathspec>..."
 msgstr "git reset [-q] [<tree-ish>] [--] <đặc/tả/đường/dẫn>…"
 
-#: builtin/reset.c:34
+#: builtin/reset.c:35
 msgid ""
 "git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<tree-ish>]"
 msgstr ""
 "git reset [-q] [--pathspec-from-file [--pathspec-file-nul]] [<tree-ish>]"
 
-#: builtin/reset.c:35
+#: builtin/reset.c:36
 msgid "git reset --patch [<tree-ish>] [--] [<pathspec>...]"
 msgstr "git reset --patch [<tree-ish>] [--] [<đặc/tả/đường/dẫn>…]"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "mixed"
 msgstr "pha trộn"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "soft"
 msgstr "mềm"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "hard"
 msgstr "cứng"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "merge"
 msgstr "hòa trộn"
 
-#: builtin/reset.c:41
+#: builtin/reset.c:42
 msgid "keep"
 msgstr "giữ lại"
 
-#: builtin/reset.c:89
+#: builtin/reset.c:90
 msgid "You do not have a valid HEAD."
 msgstr "Bạn không có HEAD nào hợp lệ."
 
-#: builtin/reset.c:91
+#: builtin/reset.c:92
 msgid "Failed to find tree of HEAD."
 msgstr "Gặp lỗi khi tìm cây của HEAD."
 
-#: builtin/reset.c:97
+#: builtin/reset.c:98
 #, c-format
 msgid "Failed to find tree of %s."
 msgstr "Gặp lỗi khi tìm cây của %s."
 
-#: builtin/reset.c:122
+#: builtin/reset.c:123
 #, c-format
 msgid "HEAD is now at %s"
 msgstr "HEAD hiện giờ tại %s"
 
-#: builtin/reset.c:201
+#: builtin/reset.c:299
 #, c-format
 msgid "Cannot do a %s reset in the middle of a merge."
 msgstr "Không thể thực hiện một %s reset ở giữa của quá trình hòa trộn."
 
-#: builtin/reset.c:301 builtin/stash.c:605 builtin/stash.c:679
-#: builtin/stash.c:703
+#: builtin/reset.c:396 builtin/stash.c:606 builtin/stash.c:680
+#: builtin/stash.c:704
 msgid "be quiet, only report errors"
 msgstr "làm việc ở chế độ im lặng, chỉ hiển thị khi có lỗi"
 
-#: builtin/reset.c:303
+#: builtin/reset.c:398
 msgid "reset HEAD and index"
 msgstr "đặt lại (reset) HEAD và bảng mục lục"
 
-#: builtin/reset.c:304
+#: builtin/reset.c:399
 msgid "reset only HEAD"
 msgstr "chỉ đặt lại (reset) HEAD"
 
-#: builtin/reset.c:306 builtin/reset.c:308
+#: builtin/reset.c:401 builtin/reset.c:403
 msgid "reset HEAD, index and working tree"
 msgstr "đặt lại HEAD, bảng mục lục và cây làm việc"
 
-#: builtin/reset.c:310
+#: builtin/reset.c:405
 msgid "reset HEAD but keep local changes"
 msgstr "đặt lại HEAD nhưng giữ lại các thay đổi nội bộ"
 
-#: builtin/reset.c:316
+#: builtin/reset.c:411
 msgid "record only the fact that removed paths will be added later"
 msgstr "chỉ ghi lại những đường dẫn thực sự sẽ được thêm vào sau này"
 
-#: builtin/reset.c:350
+#: builtin/reset.c:445
 #, c-format
 msgid "Failed to resolve '%s' as a valid revision."
 msgstr "Gặp lỗi khi phân giải “%s” như là điểm xét duyệt hợp lệ."
 
-#: builtin/reset.c:358
+#: builtin/reset.c:453
 #, c-format
 msgid "Failed to resolve '%s' as a valid tree."
 msgstr "Gặp lỗi khi phân giải “%s” như là một cây (tree) hợp lệ."
 
-#: builtin/reset.c:367
-msgid "--patch is incompatible with --{hard,mixed,soft}"
-msgstr "--patch xung khắc với --{hard,mixed,soft}"
-
-#: builtin/reset.c:377
+#: builtin/reset.c:472
 msgid "--mixed with paths is deprecated; use 'git reset -- <paths>' instead."
 msgstr ""
 "--mixed với các đường dẫn không còn dùng nữa; hãy thay thế bằng lệnh “git "
 "reset -- </các/đường/dẫn>”."
 
-#: builtin/reset.c:379
+#: builtin/reset.c:474
 #, c-format
 msgid "Cannot do %s reset with paths."
 msgstr "Không thể thực hiện lệnh %s reset với các đường dẫn."
 
-#: builtin/reset.c:394
+#: builtin/reset.c:489
 #, c-format
 msgid "%s reset is not allowed in a bare repository"
 msgstr "%s reset không được phép trên kho thuần"
 
-#: builtin/reset.c:398
-msgid "-N can only be used with --mixed"
-msgstr "-N chỉ được dùng khi có --mixed"
-
-#: builtin/reset.c:419
+#: builtin/reset.c:520
 msgid "Unstaged changes after reset:"
 msgstr "Những thay đổi được đưa ra khỏi bệ phóng sau khi reset:"
 
-#: builtin/reset.c:422
+#: builtin/reset.c:523
 #, c-format
 msgid ""
 "\n"
@@ -21867,18 +21722,14 @@ msgstr ""
 "trong\n"
 "cài đặt config nếu bạn muốn thực hiện nó như là mặc định.\n"
 
-#: builtin/reset.c:440
+#: builtin/reset.c:541
 #, c-format
 msgid "Could not reset index file to revision '%s'."
 msgstr "Không thể đặt lại (reset) bảng mục lục thành điểm xét duyệt “%s”."
 
-#: builtin/reset.c:445
+#: builtin/reset.c:546
 msgid "Could not write new index file."
 msgstr "Không thể ghi tập tin lưu bảng mục lục mới."
-
-#: builtin/rev-list.c:541
-msgid "cannot combine --exclude-promisor-objects and --missing"
-msgstr "không thể tổ hợp --exclude-promisor-objects và --missing"
 
 #: builtin/rev-list.c:602
 msgid "object filtering requires --objects"
@@ -21889,8 +21740,9 @@ msgid "rev-list does not support display of notes"
 msgstr "rev-list không hỗ trợ hiển thị các ghi chú"
 
 #: builtin/rev-list.c:679
-msgid "marked counting is incompatible with --objects"
-msgstr "được đánh dấu đếm là xung khắc với --objects"
+#, c-format
+msgid "marked counting and '%s' cannot be used together"
+msgstr "đánh dấu để đếm và '%s' không thể dùng cùng nhau"
 
 #: builtin/rev-parse.c:409
 msgid "git rev-parse --parseopt [<options>] -- [<args>...]"
@@ -22325,13 +22177,6 @@ msgstr "<n>[,<cơ_sở>]"
 msgid "show <n> most recent ref-log entries starting at base"
 msgstr "hiển thị <n> các mục “ref-log” gần nhất kể từ nền (base)"
 
-#: builtin/show-branch.c:710
-msgid ""
-"--reflog is incompatible with --all, --remotes, --independent or --merge-base"
-msgstr ""
-"--reflog là không tương thích với các tùy chọn --all, --remotes, --"
-"independent hay --merge-base"
-
 #: builtin/show-branch.c:734
 msgid "no branches given, and HEAD is not valid"
 msgstr "chưa đưa ra nhánh, và HEAD không hợp lệ"
@@ -22351,18 +22196,18 @@ msgstr[0] "chỉ có thể hiển thị cùng lúc %d hạng mục."
 msgid "no such ref %s"
 msgstr "không có tham chiếu nào như thế %s"
 
-#: builtin/show-branch.c:828
+#: builtin/show-branch.c:830
 #, c-format
 msgid "cannot handle more than %d rev."
 msgid_plural "cannot handle more than %d revs."
 msgstr[0] "không thể xử lý nhiều hơn %d điểm xét duyệt."
 
-#: builtin/show-branch.c:832
+#: builtin/show-branch.c:834
 #, c-format
 msgid "'%s' is not a valid ref."
 msgstr "“%s” không phải tham chiếu hợp lệ."
 
-#: builtin/show-branch.c:835
+#: builtin/show-branch.c:837
 #, c-format
 msgid "cannot find commit %s (%s)"
 msgstr "không thể tìm thấy lần chuyển giao %s (%s)"
@@ -22431,13 +22276,17 @@ msgstr "git sparse-checkout (init|list|set|add|reapply|disable) <các-tùy-chọ
 msgid "git sparse-checkout list"
 msgstr "git sparse-checkout list"
 
-#: builtin/sparse-checkout.c:72
+#: builtin/sparse-checkout.c:60
+msgid "this worktree is not sparse"
+msgstr "cây làm việc này không phải là sparse"
+
+#: builtin/sparse-checkout.c:75
 msgid "this worktree is not sparse (sparse-checkout file may not exist)"
 msgstr ""
 "không thể phân tích cú pháp cây làm việc này (tập tin sparse-checkout có lẽ "
 "không tồn tại)"
 
-#: builtin/sparse-checkout.c:173
+#: builtin/sparse-checkout.c:176
 #, c-format
 msgid ""
 "directory '%s' contains untracked files, but is not in the sparse-checkout "
@@ -22446,75 +22295,97 @@ msgstr ""
 "thư mục “%s” có chứa các tập tin chưa được theo dõi, nhưng lại không trong "
 "“sparse-checkout cone”"
 
-#: builtin/sparse-checkout.c:181
+#: builtin/sparse-checkout.c:184
 #, c-format
 msgid "failed to remove directory '%s'"
 msgstr "gặp lỗi khi gỡ bỏ thư mục \"%s\""
 
-#: builtin/sparse-checkout.c:321
+#: builtin/sparse-checkout.c:324
 msgid "failed to create directory for sparse-checkout file"
 msgstr "gặp lỗi khi tạo thư mục cho tập tin sparse-checkout"
 
-#: builtin/sparse-checkout.c:362
+#: builtin/sparse-checkout.c:365
 msgid "unable to upgrade repository format to enable worktreeConfig"
 msgstr "không thể nâng cấp định dạng kho lưu trữ để kích hoạt worktreeConfig"
 
-#: builtin/sparse-checkout.c:364
+#: builtin/sparse-checkout.c:367
 msgid "failed to set extensions.worktreeConfig setting"
 msgstr "gặp lỗi khi đặt cài đặt extensions.worktreeConfig"
 
-#: builtin/sparse-checkout.c:384
-msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
-msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
-
-#: builtin/sparse-checkout.c:404
-msgid "initialize the sparse-checkout in cone mode"
-msgstr "khởi tạo sparse-checkout trong chế độ nón"
-
-#: builtin/sparse-checkout.c:406
-msgid "toggle the use of a sparse index"
-msgstr "bật tắt việc sử dụng một \"sparse index\""
-
-#: builtin/sparse-checkout.c:434
+#: builtin/sparse-checkout.c:411
 msgid "failed to modify sparse-index config"
 msgstr "gặp lỗi khi sửa cấu hình \"sparse-index\""
 
-#: builtin/sparse-checkout.c:455
+#: builtin/sparse-checkout.c:422
+msgid "git sparse-checkout init [--cone] [--[no-]sparse-index]"
+msgstr "git sparse-checkout init [--cone] [--[no-]sparse-index]"
+
+#: builtin/sparse-checkout.c:441 builtin/sparse-checkout.c:729
+#: builtin/sparse-checkout.c:778
+msgid "initialize the sparse-checkout in cone mode"
+msgstr "khởi tạo sparse-checkout trong chế độ nón"
+
+#: builtin/sparse-checkout.c:443 builtin/sparse-checkout.c:731
+#: builtin/sparse-checkout.c:780
+msgid "toggle the use of a sparse index"
+msgstr "bật tắt việc sử dụng một \"sparse index\""
+
+#: builtin/sparse-checkout.c:476
 #, c-format
 msgid "failed to open '%s'"
 msgstr "gặp lỗi khi mở “%s”"
 
-#: builtin/sparse-checkout.c:507
+#: builtin/sparse-checkout.c:528
 #, c-format
 msgid "could not normalize path %s"
 msgstr "không thể thường hóa đường dẫn “%s”"
 
-#: builtin/sparse-checkout.c:519
-msgid "git sparse-checkout (set|add) (--stdin | <patterns>)"
-msgstr "git sparse-checkout (set|add) (--stdin | <các mẫu>)"
-
-#: builtin/sparse-checkout.c:544
+#: builtin/sparse-checkout.c:557
 #, c-format
 msgid "unable to unquote C-style string '%s'"
 msgstr "không thể bỏ trích dẫn chuỗi kiểu C “%s”"
 
-#: builtin/sparse-checkout.c:598 builtin/sparse-checkout.c:622
+#: builtin/sparse-checkout.c:612 builtin/sparse-checkout.c:640
 msgid "unable to load existing sparse-checkout patterns"
 msgstr "không thể tải các mẫu sparse-checkout"
 
-#: builtin/sparse-checkout.c:667
+#: builtin/sparse-checkout.c:616
+msgid "existing sparse-checkout patterns do not use cone mode"
+msgstr "đặt các mẫu sparse-checkout sẵn có không sử dụng chế độ cone"
+
+#: builtin/sparse-checkout.c:682
+msgid "git sparse-checkout add (--stdin | <patterns>)"
+msgstr "git sparse-checkout add (--stdin | <các mẫu>)"
+
+#: builtin/sparse-checkout.c:694 builtin/sparse-checkout.c:733
 msgid "read patterns from standard in"
 msgstr "đọc các mẫu từ đầu vào tiêu chuẩn"
 
-#: builtin/sparse-checkout.c:682
-msgid "git sparse-checkout reapply"
-msgstr "git sparse-checkout reapply"
+#: builtin/sparse-checkout.c:699
+msgid "no sparse-checkout to add to"
+msgstr "không có sparse-checkout để thêm vào"
 
-#: builtin/sparse-checkout.c:701
+#: builtin/sparse-checkout.c:712
+msgid ""
+"git sparse-checkout set [--[no-]cone] [--[no-]sparse-index] (--stdin | "
+"<patterns>)"
+msgstr ""
+"git sparse-checkout set [--[no-]cone] [--[no-]sparse-index] (--stdin | <các "
+"mẫu>)"
+
+#: builtin/sparse-checkout.c:765
+msgid "git sparse-checkout reapply [--[no-]cone] [--[no-]sparse-index]"
+msgstr "git sparse-checkout reapply [--[no-]cone] [--[no-]sparse-index]"
+
+#: builtin/sparse-checkout.c:785
+msgid "must be in a sparse-checkout to reapply sparsity patterns"
+msgstr "phải trong một sparse-checkout để áp dụng lại các mẫu sparse"
+
+#: builtin/sparse-checkout.c:803
 msgid "git sparse-checkout disable"
 msgstr "git sparse-checkout disable"
 
-#: builtin/sparse-checkout.c:732
+#: builtin/sparse-checkout.c:845
 msgid "error while refreshing working directory"
 msgstr "gặp lỗi khi đọc lại thư mục làm việc"
 
@@ -22540,22 +22411,26 @@ msgstr "git stash branch <tên-nhánh> [<stash>]"
 
 #: builtin/stash.c:30
 msgid ""
-"git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"git stash [push [-p|--patch] [-S|--staged] [-k|--[no-]keep-index] [-q|--"
+"quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [-m|--message <message>]\n"
 "          [--pathspec-from-file=<file> [--pathspec-file-nul]]\n"
 "          [--] [<pathspec>...]]"
 msgstr ""
-"git stash [push [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
-"          [-u|--include-untracked] [-a|--all] [-m|--message <lời nhắn>]\n"
+"git stash [push [-p|--patch] [-S|--staged] [-k|--[no-]keep-index] [-q|--"
+"quiet]\n"
+"          [-u|--include-untracked] [-a|--all] [-m|--message <ghi chú>]\n"
 "          [--pathspec-from-file=<tập_tin> [--pathspec-file-nul]]\n"
 "          [--] [<đặc/tả/đường/dẫn>…]]"
 
 #: builtin/stash.c:34
 msgid ""
-"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"git stash save [-p|--patch] [-S|--staged] [-k|--[no-]keep-index] [-q|--"
+"quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [<message>]"
 msgstr ""
-"git stash save [-p|--patch] [-k|--[no-]keep-index] [-q|--quiet]\n"
+"git stash save [-p|--patch] [-S|--staged] [-k|--[no-]keep-index] [-q|--"
+"quiet]\n"
 "          [-u|--include-untracked] [-a|--all] [<ghi chú>]"
 
 #: builtin/stash.c:55
@@ -22648,140 +22523,156 @@ msgstr "Đang hòa trộn %s với %s"
 msgid "Index was not unstashed."
 msgstr "Bảng mục lục đã không được bỏ stash."
 
-#: builtin/stash.c:575
+#: builtin/stash.c:576
 msgid "could not restore untracked files from stash"
 msgstr "không thể phục hồi các tập tin chưa theo dõi từ mục cất đi (stash)"
 
-#: builtin/stash.c:607 builtin/stash.c:705
+#: builtin/stash.c:608 builtin/stash.c:706
 msgid "attempt to recreate the index"
 msgstr "gặp lỗi đọc bảng mục lục"
 
-#: builtin/stash.c:651
+#: builtin/stash.c:652
 #, c-format
 msgid "Dropped %s (%s)"
 msgstr "Đã xóa %s (%s)"
 
-#: builtin/stash.c:654
+#: builtin/stash.c:655
 #, c-format
 msgid "%s: Could not drop stash entry"
 msgstr "%s: Không thể xóa bỏ mục stash"
 
-#: builtin/stash.c:667
+#: builtin/stash.c:668
 #, c-format
 msgid "'%s' is not a stash reference"
 msgstr "”%s” không phải tham chiếu đến stash"
 
-#: builtin/stash.c:717
+#: builtin/stash.c:718
 msgid "The stash entry is kept in case you need it again."
 msgstr "Các mục tạm cất (stash) được giữ trong trường hợp bạn lại cần nó."
 
-#: builtin/stash.c:740
+#: builtin/stash.c:741
 msgid "No branch name specified"
 msgstr "Chưa chỉ ra tên của nhánh"
 
-#: builtin/stash.c:824
+#: builtin/stash.c:825
 msgid "failed to parse tree"
 msgstr "gặp lỗi khi phân tích cây"
 
-#: builtin/stash.c:835
+#: builtin/stash.c:836
 msgid "failed to unpack trees"
 msgstr "gặp lỗi khi tháo dỡ cây"
 
-#: builtin/stash.c:855
+#: builtin/stash.c:856
 msgid "include untracked files in the stash"
 msgstr "bao gồm các tập tin không được theo dõi trong stash"
 
-#: builtin/stash.c:858
+#: builtin/stash.c:859
 msgid "only show untracked files in the stash"
 msgstr "chỉ hiển thị các tập tin không được theo dõi trong stash"
 
-#: builtin/stash.c:945 builtin/stash.c:982
+#: builtin/stash.c:946 builtin/stash.c:983
 #, c-format
 msgid "Cannot update %s with %s"
 msgstr "Không thể cập nhật %s với %s"
 
-#: builtin/stash.c:963 builtin/stash.c:1619 builtin/stash.c:1684
+#: builtin/stash.c:964 builtin/stash.c:1678 builtin/stash.c:1750
 msgid "stash message"
 msgstr "phần chú thích cho stash"
 
-#: builtin/stash.c:973
+#: builtin/stash.c:974
 msgid "\"git stash store\" requires one <commit> argument"
 msgstr "\"git stash store\" cần một đối số <lần chuyển giao>"
 
-#: builtin/stash.c:1187
+#: builtin/stash.c:1159
+msgid "No staged changes"
+msgstr "Không có thay đổi đã được đưa lên bệ phóng"
+
+#: builtin/stash.c:1220
 msgid "No changes selected"
 msgstr "Chưa có thay đổi nào được chọn"
 
-#: builtin/stash.c:1287
+#: builtin/stash.c:1320
 msgid "You do not have the initial commit yet"
 msgstr "Bạn chưa còn có lần chuyển giao khởi tạo"
 
-#: builtin/stash.c:1314
+#: builtin/stash.c:1347
 msgid "Cannot save the current index state"
 msgstr "Không thể ghi lại trạng thái bảng mục lục hiện hành"
 
-#: builtin/stash.c:1323
+#: builtin/stash.c:1356
 msgid "Cannot save the untracked files"
 msgstr "Không thể ghi lại các tập tin chưa theo dõi"
 
-#: builtin/stash.c:1334 builtin/stash.c:1343
+#: builtin/stash.c:1367 builtin/stash.c:1386
 msgid "Cannot save the current worktree state"
 msgstr "Không thể ghi lại trạng thái cây-làm-việc hiện hành"
 
-#: builtin/stash.c:1371
+#: builtin/stash.c:1377
+msgid "Cannot save the current staged state"
+msgstr "Không thể ghi lại trạng thái bệ phóng hiện hành"
+
+#: builtin/stash.c:1414
 msgid "Cannot record working tree state"
 msgstr "Không thể ghi lại trạng thái cây làm việc hiện hành"
 
-#: builtin/stash.c:1420
+#: builtin/stash.c:1463
 msgid "Can't use --patch and --include-untracked or --all at the same time"
 msgstr "Không thể dùng --patch và --include-untracked hay --all cùng một lúc"
 
-#: builtin/stash.c:1438
+#: builtin/stash.c:1474
+msgid "Can't use --staged and --include-untracked or --all at the same time"
+msgstr "Không thể dùng --staged và --include-untracked hay --all cùng một lúc"
+
+#: builtin/stash.c:1492
 msgid "Did you forget to 'git add'?"
 msgstr "Có lẽ bạn đã quên “git add ” phải không?"
 
-#: builtin/stash.c:1453
+#: builtin/stash.c:1507
 msgid "No local changes to save"
 msgstr "Không có thay đổi nội bộ nào được ghi lại"
 
-#: builtin/stash.c:1460
+#: builtin/stash.c:1514
 msgid "Cannot initialize stash"
 msgstr "Không thể khởi tạo stash"
 
-#: builtin/stash.c:1475
+#: builtin/stash.c:1529
 msgid "Cannot save the current status"
 msgstr "Không thể ghi lại trạng thái hiện hành"
 
-#: builtin/stash.c:1480
+#: builtin/stash.c:1534
 #, c-format
 msgid "Saved working directory and index state %s"
 msgstr "Đã ghi lại thư mục làm việc và trạng thái mục lục %s"
 
-#: builtin/stash.c:1571
+#: builtin/stash.c:1627
 msgid "Cannot remove worktree changes"
 msgstr "Không thể gỡ bỏ các thay đổi cây-làm-việc"
 
-#: builtin/stash.c:1610 builtin/stash.c:1675
+#: builtin/stash.c:1667 builtin/stash.c:1739
 msgid "keep index"
 msgstr "giữ nguyên bảng mục lục"
 
-#: builtin/stash.c:1612 builtin/stash.c:1677
+#: builtin/stash.c:1669 builtin/stash.c:1741
+msgid "stash staged changes only"
+msgstr "chỉ tạm cất đi các thay đổi đã đưa lên bệ phóng"
+
+#: builtin/stash.c:1671 builtin/stash.c:1743
 msgid "stash in patch mode"
 msgstr "cất đi ở chế độ miếng vá"
 
-#: builtin/stash.c:1613 builtin/stash.c:1678
+#: builtin/stash.c:1672 builtin/stash.c:1744
 msgid "quiet mode"
 msgstr "chế độ im lặng"
 
-#: builtin/stash.c:1615 builtin/stash.c:1680
+#: builtin/stash.c:1674 builtin/stash.c:1746
 msgid "include untracked files in stash"
 msgstr "bao gồm các tập tin không được theo dõi trong stash"
 
-#: builtin/stash.c:1617 builtin/stash.c:1682
+#: builtin/stash.c:1676 builtin/stash.c:1748
 msgid "include ignore files"
 msgstr "bao gồm các tập tin bị bỏ qua"
 
-#: builtin/stash.c:1717
+#: builtin/stash.c:1783
 msgid ""
 "the stash.useBuiltin support has been removed!\n"
 "See its entry in 'git help config' for details."
@@ -22805,7 +22696,7 @@ msgstr "giữ và xóa bỏ mọi dòng bắt đầu bằng ký tự ghi chú"
 msgid "prepend comment character and space to each line"
 msgstr "treo trước ký tự ghi chú và ký tự khoảng trắng cho từng dòng"
 
-#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2667
+#: builtin/submodule--helper.c:46 builtin/submodule--helper.c:2668
 #, c-format
 msgid "Expecting a full ref name, got %s"
 msgstr "Cần tên tham chiếu dạng đầy đủ, nhưng lại nhận được %s"
@@ -22828,7 +22719,7 @@ msgstr ""
 "không thể tìm thấy cấu hình “%s”. Coi rằng đây là kho thượng nguồn có quyền "
 "sở hữu chính nó."
 
-#: builtin/submodule--helper.c:405 builtin/submodule--helper.c:1858
+#: builtin/submodule--helper.c:405 builtin/submodule--helper.c:1859
 msgid "alternative anchor for relative paths"
 msgstr "điểm neo thay thế cho các đường dẫn tương đối"
 
@@ -22925,7 +22816,7 @@ msgstr "không thể phân giải tham chiếu HEAD bên trong mô-đun-con “%
 msgid "failed to recurse into submodule '%s'"
 msgstr "gặp lỗi khi đệ quy vào trong mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1589
+#: builtin/submodule--helper.c:862 builtin/submodule--helper.c:1590
 msgid "suppress submodule status output"
 msgstr "chặn kết xuất về tình trạng mô-đun-con"
 
@@ -23000,10 +22891,6 @@ msgstr ""
 msgid "could not fetch a revision for HEAD"
 msgstr "không thể lấy về một điểm xem xét cho HEAD"
 
-#: builtin/submodule--helper.c:1316
-msgid "--cached and --files are mutually exclusive"
-msgstr "Các tùy chọn --cached và --files loại từ lẫn nhau"
-
 #: builtin/submodule--helper.c:1373
 #, c-format
 msgid "Synchronizing submodule url for '%s'\n"
@@ -23032,16 +22919,16 @@ msgstr "chặn kết xuất của url mô-đun-con đồng bộ"
 msgid "git submodule--helper sync [--quiet] [--recursive] [<path>]"
 msgstr "git submodule--helper sync [--quiet] [--recursive] [</đường/dẫn>]"
 
-#: builtin/submodule--helper.c:1512
+#: builtin/submodule--helper.c:1508
 #, c-format
 msgid ""
-"Submodule work tree '%s' contains a .git directory (use 'rm -rf' if you "
-"really want to remove it including all of its history)"
+"Submodule work tree '%s' contains a .git directory. This will be replaced "
+"with a .git file by using absorbgitdirs."
 msgstr ""
-"Cây làm việc mô-đun-con “%s” có chứa thư mục .git (dùng “rm -rf” nếu bạn "
-"thực sự muốn gỡ bỏ nó cùng với toàn bộ lịch sử của chúng)"
+"Cây làm việc mô-đun-con “%s” có chứa thư mục .git. Việc này sẽ được thay thế "
+"với một tập tin .git bằng các sử dụng absorbgitdirs."
 
-#: builtin/submodule--helper.c:1524
+#: builtin/submodule--helper.c:1525
 #, c-format
 msgid ""
 "Submodule work tree '%s' contains local modifications; use '-f' to discard "
@@ -23050,45 +22937,45 @@ msgstr ""
 "Cây làm việc mô-đun-con “%s” chứa các thay đổi nội bộ; hãy dùng “-f” để loại "
 "bỏ chúng đi"
 
-#: builtin/submodule--helper.c:1532
+#: builtin/submodule--helper.c:1533
 #, c-format
 msgid "Cleared directory '%s'\n"
 msgstr "Đã xóa thư mục “%s”\n"
 
-#: builtin/submodule--helper.c:1534
+#: builtin/submodule--helper.c:1535
 #, c-format
 msgid "Could not remove submodule work tree '%s'\n"
 msgstr "Không thể gỡ bỏ cây làm việc mô-đun-con “%s”\n"
 
-#: builtin/submodule--helper.c:1545
+#: builtin/submodule--helper.c:1546
 #, c-format
 msgid "could not create empty submodule directory %s"
 msgstr "không thể tạo thư mục mô-đun-con rỗng “%s”"
 
-#: builtin/submodule--helper.c:1561
+#: builtin/submodule--helper.c:1562
 #, c-format
 msgid "Submodule '%s' (%s) unregistered for path '%s'\n"
 msgstr "Mô-đun-con “%s” (%s) được đăng ký cho đường dẫn “%s”\n"
 
-#: builtin/submodule--helper.c:1590
+#: builtin/submodule--helper.c:1591
 msgid "remove submodule working trees even if they contain local changes"
 msgstr "gỡ bỏ cây làm việc của mô-đun-con ngay cả khi nó có thay đổi nội bộ"
 
-#: builtin/submodule--helper.c:1591
+#: builtin/submodule--helper.c:1592
 msgid "unregister all submodules"
 msgstr "bỏ đăng ký tất cả các trong mô-đun-con"
 
-#: builtin/submodule--helper.c:1596
+#: builtin/submodule--helper.c:1597
 msgid ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--] [<path>...]]"
 msgstr ""
 "git submodule deinit [--quiet] [-f | --force] [--all | [--]  [</đường/dẫn>…]]"
 
-#: builtin/submodule--helper.c:1610
+#: builtin/submodule--helper.c:1611
 msgid "Use '--all' if you really want to deinitialize all submodules"
 msgstr "Dùng “--all” nếu bạn thực sự muốn hủy khởi tạo mọi mô-đun-con"
 
-#: builtin/submodule--helper.c:1655
+#: builtin/submodule--helper.c:1656
 msgid ""
 "An alternate computed from a superproject's alternate is invalid.\n"
 "To allow Git to clone without an alternate in such a case, set\n"
@@ -23103,67 +22990,67 @@ msgstr ""
 "bằng\n"
 "“--reference-if-able” thay vì dùng “--reference”."
 
-#: builtin/submodule--helper.c:1700 builtin/submodule--helper.c:1703
+#: builtin/submodule--helper.c:1701 builtin/submodule--helper.c:1704
 #, c-format
 msgid "submodule '%s' cannot add alternate: %s"
 msgstr "mô-đun-con “%s” không thể thêm thay thế: %s"
 
-#: builtin/submodule--helper.c:1739
+#: builtin/submodule--helper.c:1740
 #, c-format
 msgid "Value '%s' for submodule.alternateErrorStrategy is not recognized"
 msgstr "Giá trị “%s” cho submodule.alternateErrorStrategy không được thừa nhận"
 
-#: builtin/submodule--helper.c:1746
+#: builtin/submodule--helper.c:1747
 #, c-format
 msgid "Value '%s' for submodule.alternateLocation is not recognized"
 msgstr "Giá trị “%s” cho submodule.alternateLocation không được thừa nhận"
 
-#: builtin/submodule--helper.c:1771
+#: builtin/submodule--helper.c:1772
 #, c-format
 msgid "refusing to create/use '%s' in another submodule's git dir"
 msgstr "từ chối tạo/dùng “%s” trong một thư mục git của mô đun con"
 
-#: builtin/submodule--helper.c:1812
+#: builtin/submodule--helper.c:1813
 #, c-format
 msgid "clone of '%s' into submodule path '%s' failed"
 msgstr "việc sao “%s” vào đường dẫn mô-đun-con “%s” gặp lỗi"
 
-#: builtin/submodule--helper.c:1817
+#: builtin/submodule--helper.c:1818
 #, c-format
 msgid "directory not empty: '%s'"
 msgstr "thư mục không trống: “%s”"
 
-#: builtin/submodule--helper.c:1829
+#: builtin/submodule--helper.c:1830
 #, c-format
 msgid "could not get submodule directory for '%s'"
 msgstr "không thể lấy thư mục mô-đun-con cho “%s”"
 
-#: builtin/submodule--helper.c:1861
+#: builtin/submodule--helper.c:1862
 msgid "where the new submodule will be cloned to"
 msgstr "nhân bản mô-đun-con mới vào chỗ nào"
 
-#: builtin/submodule--helper.c:1864
+#: builtin/submodule--helper.c:1865
 msgid "name of the new submodule"
 msgstr "tên của mô-đun-con mới"
 
-#: builtin/submodule--helper.c:1867
+#: builtin/submodule--helper.c:1868
 msgid "url where to clone the submodule from"
 msgstr "url nơi mà nhân bản mô-đun-con từ đó"
 
-#: builtin/submodule--helper.c:1875 builtin/submodule--helper.c:3264
+#: builtin/submodule--helper.c:1876 builtin/submodule--helper.c:3265
 msgid "depth for shallow clones"
 msgstr "chiều sâu lịch sử khi tạo bản sao"
 
-#: builtin/submodule--helper.c:1878 builtin/submodule--helper.c:2525
-#: builtin/submodule--helper.c:3257
+#: builtin/submodule--helper.c:1879 builtin/submodule--helper.c:2526
+#: builtin/submodule--helper.c:3258
 msgid "force cloning progress"
 msgstr "ép buộc tiến trình nhân bản"
 
-#: builtin/submodule--helper.c:1880 builtin/submodule--helper.c:2527
+#: builtin/submodule--helper.c:1881 builtin/submodule--helper.c:2528
 msgid "disallow cloning into non-empty directory"
 msgstr "làm đầy đủ dữ liệu cho bản sao vào trong một thư mục trống rỗng"
 
-#: builtin/submodule--helper.c:1887
+#: builtin/submodule--helper.c:1888
 msgid ""
 "git submodule--helper clone [--prefix=<path>] [--quiet] [--reference "
 "<repository>] [--name <name>] [--depth <depth>] [--single-branch] --url "
@@ -23173,94 +23060,94 @@ msgstr ""
 "<kho>] [--name <tên>] [--depth <sâu>] [--single-branch] --url <url> --path </"
 "đường/dẫn>"
 
-#: builtin/submodule--helper.c:1924
+#: builtin/submodule--helper.c:1925
 #, c-format
 msgid "Invalid update mode '%s' for submodule path '%s'"
 msgstr "Chế độ cập nhật “%s” không hợp lệ cho đường dẫn mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:1928
+#: builtin/submodule--helper.c:1929
 #, c-format
 msgid "Invalid update mode '%s' configured for submodule path '%s'"
 msgstr ""
 "Chế độ cập nhật “%s” không hợp lệ được cấu hình cho đường dẫn mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:2043
+#: builtin/submodule--helper.c:2044
 #, c-format
 msgid "Submodule path '%s' not initialized"
 msgstr "Đường dẫn mô-đun-con “%s” chưa được khởi tạo"
 
-#: builtin/submodule--helper.c:2047
+#: builtin/submodule--helper.c:2048
 msgid "Maybe you want to use 'update --init'?"
 msgstr "Có lẽ bạn là bạn muốn dùng \"update --init\" phải không?"
 
-#: builtin/submodule--helper.c:2077
+#: builtin/submodule--helper.c:2078
 #, c-format
 msgid "Skipping unmerged submodule %s"
 msgstr "Bỏ qua các mô-đun-con chưa được hòa trộn %s"
 
-#: builtin/submodule--helper.c:2106
+#: builtin/submodule--helper.c:2107
 #, c-format
 msgid "Skipping submodule '%s'"
 msgstr "Bỏ qua mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:2256
+#: builtin/submodule--helper.c:2257
 #, c-format
 msgid "Failed to clone '%s'. Retry scheduled"
 msgstr "Gặp lỗi khi nhân bản “%s”. Thử lại lịch trình"
 
-#: builtin/submodule--helper.c:2267
+#: builtin/submodule--helper.c:2268
 #, c-format
 msgid "Failed to clone '%s' a second time, aborting"
 msgstr "Gặp lỗi khi nhân bản “%s” lần thứ hai nên bãi bỏ"
 
-#: builtin/submodule--helper.c:2372
+#: builtin/submodule--helper.c:2373
 #, c-format
 msgid "Unable to checkout '%s' in submodule path '%s'"
 msgstr "Không thể lấy ra “%s” trong đường dẫn mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:2376
+#: builtin/submodule--helper.c:2377
 #, c-format
 msgid "Unable to rebase '%s' in submodule path '%s'"
 msgstr "Không thể cải tổ “%s” trong đường dẫn mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:2380
+#: builtin/submodule--helper.c:2381
 #, c-format
 msgid "Unable to merge '%s' in submodule path '%s'"
 msgstr "Không thể hòa trộn (merge) “%s” trong đường dẫn mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:2384
+#: builtin/submodule--helper.c:2385
 #, c-format
 msgid "Execution of '%s %s' failed in submodule path '%s'"
 msgstr ""
 "Thực hiện không thành công lệnh “%s %s” trong đường dẫn mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:2408
+#: builtin/submodule--helper.c:2409
 #, c-format
 msgid "Submodule path '%s': checked out '%s'\n"
 msgstr "Đường dẫn mô-đun-con “%s”: đã checkout “%s”\n"
 
-#: builtin/submodule--helper.c:2412
+#: builtin/submodule--helper.c:2413
 #, c-format
 msgid "Submodule path '%s': rebased into '%s'\n"
 msgstr "Đường dẫn mô-đun-con “%s”: được rebase vào trong “%s”\n"
 
-#: builtin/submodule--helper.c:2416
+#: builtin/submodule--helper.c:2417
 #, c-format
 msgid "Submodule path '%s': merged in '%s'\n"
 msgstr "Đường dẫn mô-đun-con “%s”: được hòa trộn vào “%s”\n"
 
-#: builtin/submodule--helper.c:2420
+#: builtin/submodule--helper.c:2421
 #, c-format
 msgid "Submodule path '%s': '%s %s'\n"
 msgstr "Đường dẫn mô-đun-con “%s”: “%s %s”\n"
 
-#: builtin/submodule--helper.c:2444
+#: builtin/submodule--helper.c:2445
 #, c-format
 msgid "Unable to fetch in submodule path '%s'; trying to directly fetch %s:"
 msgstr ""
 "Không thể lấy về trong đường dẫn mô-đun-con “%s”; thử lấy về trực tiếp %s:"
 
-#: builtin/submodule--helper.c:2453
+#: builtin/submodule--helper.c:2454
 #, c-format
 msgid ""
 "Fetched in submodule path '%s', but it did not contain %s. Direct fetching "
@@ -23269,87 +23156,87 @@ msgstr ""
 "Đã lấy về từ đường dẫn mô-đun con “%s”, nhưng nó không chứa %s. Lấy về trực "
 "tiếp lần chuyển giao gặp lỗi đó."
 
-#: builtin/submodule--helper.c:2504 builtin/submodule--helper.c:2574
-#: builtin/submodule--helper.c:2812
+#: builtin/submodule--helper.c:2505 builtin/submodule--helper.c:2575
+#: builtin/submodule--helper.c:2813
 msgid "path into the working tree"
 msgstr "đường dẫn đến cây làm việc"
 
-#: builtin/submodule--helper.c:2507 builtin/submodule--helper.c:2579
+#: builtin/submodule--helper.c:2508 builtin/submodule--helper.c:2580
 msgid "path into the working tree, across nested submodule boundaries"
 msgstr "đường dẫn đến cây làm việc, chéo biên giới mô-đun-con lồng nhau"
 
-#: builtin/submodule--helper.c:2511 builtin/submodule--helper.c:2577
+#: builtin/submodule--helper.c:2512 builtin/submodule--helper.c:2578
 msgid "rebase, merge, checkout or none"
 msgstr "rebase, merge, checkout hoặc không làm gì cả"
 
-#: builtin/submodule--helper.c:2517
+#: builtin/submodule--helper.c:2518
 msgid "create a shallow clone truncated to the specified number of revisions"
 msgstr ""
 "tạo một bản sao nông được cắt ngắn thành số lượng điểm xét duyệt đã cho"
 
-#: builtin/submodule--helper.c:2520
+#: builtin/submodule--helper.c:2521
 msgid "parallel jobs"
 msgstr "công việc đồng thời"
 
-#: builtin/submodule--helper.c:2522
+#: builtin/submodule--helper.c:2523
 msgid "whether the initial clone should follow the shallow recommendation"
 msgstr "nhân bản lần đầu có nên theo khuyến nghị là nông hay không"
 
-#: builtin/submodule--helper.c:2523
+#: builtin/submodule--helper.c:2524
 msgid "don't print cloning progress"
 msgstr "đừng in tiến trình nhân bản"
 
-#: builtin/submodule--helper.c:2534
+#: builtin/submodule--helper.c:2535
 msgid "git submodule--helper update-clone [--prefix=<path>] [<path>...]"
 msgstr ""
 "git submodule--helper update-clone [--prefix=</đường/dẫn>] [</đường/dẫn>…]"
 
-#: builtin/submodule--helper.c:2547
+#: builtin/submodule--helper.c:2548
 msgid "bad value for update parameter"
 msgstr "giá trị cho  tham số cập nhật bị sai"
 
-#: builtin/submodule--helper.c:2565
+#: builtin/submodule--helper.c:2566
 msgid "suppress output for update by rebase or merge"
 msgstr "chặn kết xuất cho cập nhật bởi cải tổ hoặc hòa trộn"
 
-#: builtin/submodule--helper.c:2566
+#: builtin/submodule--helper.c:2567
 msgid "force checkout updates"
 msgstr "ép buộc lấy ra các cập nhật"
 
-#: builtin/submodule--helper.c:2568
+#: builtin/submodule--helper.c:2569
 msgid "don't fetch new objects from the remote site"
 msgstr "đừng lấy các đối tượng mới từ địa chỉ trên mạng"
 
-#: builtin/submodule--helper.c:2570
+#: builtin/submodule--helper.c:2571
 msgid "overrides update mode in case the repository is a fresh clone"
 msgstr "ghi đè chế độ cập nhật trong trường hợp kho lưu trữ là bản sao mới"
 
-#: builtin/submodule--helper.c:2571
+#: builtin/submodule--helper.c:2572
 msgid "depth for shallow fetch"
 msgstr "chiều sâu lịch sử muốn lấy về"
 
-#: builtin/submodule--helper.c:2581
+#: builtin/submodule--helper.c:2582
 msgid "sha1"
 msgstr "sha1"
 
-#: builtin/submodule--helper.c:2582
+#: builtin/submodule--helper.c:2583
 msgid "SHA1 expected by superproject"
 msgstr "SHA1 là cần thiết cho superproject"
 
-#: builtin/submodule--helper.c:2584
+#: builtin/submodule--helper.c:2585
 msgid "subsha1"
 msgstr "subsha1"
 
-#: builtin/submodule--helper.c:2585
+#: builtin/submodule--helper.c:2586
 msgid "SHA1 of submodule's HEAD"
 msgstr "SHA1 của HEAD của mô-đun-con"
 
-#: builtin/submodule--helper.c:2591
+#: builtin/submodule--helper.c:2592
 msgid "git submodule--helper run-update-procedure [<options>] <path>"
 msgstr ""
 "git submodule--helper run-update-procedure [<các tùy chọn>] </đường/dẫn>"
 
-#: builtin/submodule--helper.c:2662
+#: builtin/submodule--helper.c:2663
 #, c-format
 msgid ""
 "Submodule (%s) branch configured to inherit branch from superproject, but "
@@ -23358,96 +23245,92 @@ msgstr ""
 "Nhánh mô-đun-con (%s) được cấu hình kế thừa nhánh từ siêu dự án, nhưng siêu "
 "dự án lại không trên bất kỳ nhánh nào"
 
-#: builtin/submodule--helper.c:2780
+#: builtin/submodule--helper.c:2781
 #, c-format
 msgid "could not get a repository handle for submodule '%s'"
 msgstr "không thể lấy thẻ quản kho cho mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:2813
+#: builtin/submodule--helper.c:2814
 msgid "recurse into submodules"
 msgstr "đệ quy vào trong mô-đun-con"
 
-#: builtin/submodule--helper.c:2819
+#: builtin/submodule--helper.c:2820
 msgid "git submodule--helper absorb-git-dirs [<options>] [<path>...]"
 msgstr "git submodule--helper absorb-git-dirs [<các tùy chọn>] [</đường/dẫn>…]"
 
-#: builtin/submodule--helper.c:2875
+#: builtin/submodule--helper.c:2876
 msgid "check if it is safe to write to the .gitmodules file"
 msgstr "chọn nếu nó là an toàn để ghi vào tập tin .gitmodules"
 
-#: builtin/submodule--helper.c:2878
+#: builtin/submodule--helper.c:2879
 msgid "unset the config in the .gitmodules file"
 msgstr "bỏ đặt cấu hình trong tập tin .gitmodules"
 
-#: builtin/submodule--helper.c:2883
+#: builtin/submodule--helper.c:2884
 msgid "git submodule--helper config <name> [<value>]"
 msgstr "git submodule--helper config <tên> [<giá trị>]"
 
-#: builtin/submodule--helper.c:2884
+#: builtin/submodule--helper.c:2885
 msgid "git submodule--helper config --unset <name>"
 msgstr "git submodule--helper config --unset <tên>"
 
-#: builtin/submodule--helper.c:2885
+#: builtin/submodule--helper.c:2886
 msgid "git submodule--helper config --check-writeable"
 msgstr "git submodule--helper config --check-writeable"
 
-#: builtin/submodule--helper.c:2904 builtin/submodule--helper.c:3120
-#: builtin/submodule--helper.c:3276
+#: builtin/submodule--helper.c:2905 builtin/submodule--helper.c:3121
+#: builtin/submodule--helper.c:3277
 msgid "please make sure that the .gitmodules file is in the working tree"
 msgstr "hãy đảm bảo rằng tập tin .gitmodules có trong cây làm việc"
 
-#: builtin/submodule--helper.c:2920
+#: builtin/submodule--helper.c:2921
 msgid "suppress output for setting url of a submodule"
 msgstr "chặn kết xuất cho cài đặt url của một mô-đun-con"
 
-#: builtin/submodule--helper.c:2924
+#: builtin/submodule--helper.c:2925
 msgid "git submodule--helper set-url [--quiet] <path> <newurl>"
 msgstr "git submodule--helper set-url [--quiet] </đường/dẫn> <url_mới>"
 
-#: builtin/submodule--helper.c:2957
+#: builtin/submodule--helper.c:2958
 msgid "set the default tracking branch to master"
 msgstr "đặt nhánh theo dõi mặc định thành master"
 
-#: builtin/submodule--helper.c:2959
+#: builtin/submodule--helper.c:2960
 msgid "set the default tracking branch"
 msgstr "đặt nhánh theo dõi mặc định"
 
-#: builtin/submodule--helper.c:2963
+#: builtin/submodule--helper.c:2964
 msgid "git submodule--helper set-branch [-q|--quiet] (-d|--default) <path>"
 msgstr ""
 "git submodule--helper set-branch [-q|--quiet](-d|--default)</đường/dẫn>"
 
-#: builtin/submodule--helper.c:2964
+#: builtin/submodule--helper.c:2965
 msgid ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <branch> <path>"
 msgstr ""
 "git submodule--helper set-branch [-q|--quiet] (-b|--branch) <nhánh> </đường/"
 "dẫn>"
 
-#: builtin/submodule--helper.c:2971
+#: builtin/submodule--helper.c:2972
 msgid "--branch or --default required"
 msgstr "cần --branch hoặc --default"
 
-#: builtin/submodule--helper.c:2974
-msgid "--branch and --default are mutually exclusive"
-msgstr "Các tùy chọn --branch và --default loại từ lẫn nhau"
-
-#: builtin/submodule--helper.c:3037
+#: builtin/submodule--helper.c:3038
 #, c-format
 msgid "Adding existing repo at '%s' to the index\n"
 msgstr "Đang thêm repo có sẵn tại “%s” vào bảng mục lục\n"
 
-#: builtin/submodule--helper.c:3040
+#: builtin/submodule--helper.c:3041
 #, c-format
 msgid "'%s' already exists and is not a valid git repo"
 msgstr "“%s” đã tồn tại từ trước và không phải là một kho git hợp lệ"
 
-#: builtin/submodule--helper.c:3053
+#: builtin/submodule--helper.c:3054
 #, c-format
 msgid "A git directory for '%s' is found locally with remote(s):\n"
 msgstr "Thư mục git cho “%s” được tìm thấy một cách cục bộ với các máy chủ:\n"
 
-#: builtin/submodule--helper.c:3060
+#: builtin/submodule--helper.c:3061
 #, c-format
 msgid ""
 "If you want to reuse this local git directory instead of cloning again from\n"
@@ -23465,87 +23348,87 @@ msgstr ""
 "là bạn không chắc chắn điều đó nghĩa là gì thì chọn tên khác với tùy chọn “--"
 "name”."
 
-#: builtin/submodule--helper.c:3072
+#: builtin/submodule--helper.c:3073
 #, c-format
 msgid "Reactivating local git directory for submodule '%s'\n"
 msgstr "Phục hồi sự hoạt động của thư mục git nội bộ cho mô-đun-con “%s”.\n"
 
-#: builtin/submodule--helper.c:3109
+#: builtin/submodule--helper.c:3110
 #, c-format
 msgid "unable to checkout submodule '%s'"
 msgstr "không thể lấy ra mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:3148
+#: builtin/submodule--helper.c:3149
 #, c-format
 msgid "Failed to add submodule '%s'"
 msgstr "Gặp lỗi khi thêm mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:3152 builtin/submodule--helper.c:3157
-#: builtin/submodule--helper.c:3165
+#: builtin/submodule--helper.c:3153 builtin/submodule--helper.c:3158
+#: builtin/submodule--helper.c:3166
 #, c-format
 msgid "Failed to register submodule '%s'"
 msgstr "Gặp lỗi khi đăng ký mô-đun-con “%s”"
 
-#: builtin/submodule--helper.c:3221
+#: builtin/submodule--helper.c:3222
 #, c-format
 msgid "'%s' already exists in the index"
 msgstr "”%s” thực sự đã tồn tại ở bảng mục lục rồi"
 
-#: builtin/submodule--helper.c:3224
+#: builtin/submodule--helper.c:3225
 #, c-format
 msgid "'%s' already exists in the index and is not a submodule"
 msgstr ""
 "”%s” thực sự đã tồn tại ở bảng mục lục rồi và không phải là một mô-đun-con"
 
-#: builtin/submodule--helper.c:3253
+#: builtin/submodule--helper.c:3254
 msgid "branch of repository to add as submodule"
 msgstr "nhánh của kho để thêm như là mô-đun-con"
 
-#: builtin/submodule--helper.c:3254
+#: builtin/submodule--helper.c:3255
 msgid "allow adding an otherwise ignored submodule path"
 msgstr "cho phép thêm một đường dẫn mô-đun-con bị bỏ qua khác"
 
-#: builtin/submodule--helper.c:3256
+#: builtin/submodule--helper.c:3257
 msgid "print only error messages"
 msgstr "chỉ hiển thị các thông điệp báo lỗi"
 
-#: builtin/submodule--helper.c:3260
+#: builtin/submodule--helper.c:3261
 msgid "borrow the objects from reference repositories"
 msgstr "vay mượn các đối tượng từ kho thay thế"
 
-#: builtin/submodule--helper.c:3262
+#: builtin/submodule--helper.c:3263
 msgid ""
 "sets the submodule’s name to the given string instead of defaulting to its "
 "path"
 msgstr ""
 "đặt tên của submodule bằng chuỗi đã cho thay vì mặc định là đường dẫn của nó"
 
-#: builtin/submodule--helper.c:3269
+#: builtin/submodule--helper.c:3270
 msgid "git submodule--helper add [<options>] [--] <repository> [<path>]"
 msgstr "git submodule--helper add [<các tùy chọn>] [--] <kho> [</đường/dẫn>]"
 
-#: builtin/submodule--helper.c:3297
+#: builtin/submodule--helper.c:3298
 msgid "Relative path can only be used from the toplevel of the working tree"
 msgstr ""
 "Đường dẫn tương đối chỉ có thể dùng từ thư mục ở mức cao nhất của cây làm "
 "việc"
 
-#: builtin/submodule--helper.c:3305
+#: builtin/submodule--helper.c:3306
 #, c-format
 msgid "repo URL: '%s' must be absolute or begin with ./|../"
 msgstr "repo URL: “%s” phải là đường dẫn tuyệt đối hoặc là bắt đầu bằng ./|../"
 
-#: builtin/submodule--helper.c:3340
+#: builtin/submodule--helper.c:3341
 #, c-format
 msgid "'%s' is not a valid submodule name"
 msgstr "“%s” không phải là một tên mô-đun-con hợp lệ"
 
-#: builtin/submodule--helper.c:3404 git.c:449 git.c:723
+#: builtin/submodule--helper.c:3405 git.c:452 git.c:726
 #, c-format
 msgid "%s doesn't support --super-prefix"
 msgstr "%s không hỗ trợ --super-prefix"
 
-#: builtin/submodule--helper.c:3410
+#: builtin/submodule--helper.c:3411
 #, c-format
 msgid "'%s' is not a valid submodule--helper subcommand"
 msgstr "“%s” không phải là lệnh con submodule--helper hợp lệ"
@@ -23644,11 +23527,11 @@ msgstr ""
 "Những dòng được bắt đầu bằng “%c” sẽ được giữ lại; bạn có thể xóa chúng đi "
 "nếu muốn.\n"
 
-#: builtin/tag.c:241
+#: builtin/tag.c:240
 msgid "unable to sign the tag"
 msgstr "không thể ký thẻ"
 
-#: builtin/tag.c:259
+#: builtin/tag.c:258
 #, c-format
 msgid ""
 "You have created a nested tag. The object referred to by your new tag is\n"
@@ -23661,15 +23544,15 @@ msgstr ""
 "\n"
 "\tgit tag -f %s %s^{}"
 
-#: builtin/tag.c:275
+#: builtin/tag.c:274
 msgid "bad object type."
 msgstr "kiểu đối tượng sai."
 
-#: builtin/tag.c:326
+#: builtin/tag.c:325
 msgid "no tag message?"
 msgstr "không có chú thích gì cho cho thẻ à?"
 
-#: builtin/tag.c:333
+#: builtin/tag.c:332
 #, c-format
 msgid "The tag message has been left in %s\n"
 msgstr "Nội dung ghi chú còn lại %s\n"
@@ -23750,46 +23633,22 @@ msgstr "chỉ hiển thị những thẻ mà nó không được hòa trộn"
 msgid "print only tags of the object"
 msgstr "chỉ hiển thị các thẻ của đối tượng"
 
-#: builtin/tag.c:525
-msgid "--column and -n are incompatible"
-msgstr "--column và -n xung khắc nhau"
+#: builtin/tag.c:558
+#, c-format
+msgid "the '%s' option is only allowed in list mode"
+msgstr "tùy chọn '%s' chỉ cho phép dùng trong chế độ liệt kê"
 
-#: builtin/tag.c:546
-msgid "-n option is only allowed in list mode"
-msgstr "tùy chọn -n chỉ cho phép dùng trong chế độ liệt kê"
-
-#: builtin/tag.c:548
-msgid "--contains option is only allowed in list mode"
-msgstr "tùy chọn --contains chỉ cho phép dùng trong chế độ liệt kê"
-
-#: builtin/tag.c:550
-msgid "--no-contains option is only allowed in list mode"
-msgstr "tùy chọn --no-contains chỉ cho phép dùng trong chế độ liệt kê"
-
-#: builtin/tag.c:552
-msgid "--points-at option is only allowed in list mode"
-msgstr "tùy chọn --points-at chỉ cho phép dùng trong chế độ liệt kê"
-
-#: builtin/tag.c:554
-msgid "--merged and --no-merged options are only allowed in list mode"
-msgstr ""
-"tùy chọn --merged và --no-merged chỉ cho phép dùng trong chế độ liệt kê"
-
-#: builtin/tag.c:568
-msgid "only one -F or -m option is allowed."
-msgstr "chỉ có một tùy chọn -F hoặc -m là được phép."
-
-#: builtin/tag.c:593
+#: builtin/tag.c:597
 #, c-format
 msgid "'%s' is not a valid tag name."
 msgstr "“%s” không phải thẻ hợp lệ."
 
-#: builtin/tag.c:598
+#: builtin/tag.c:602
 #, c-format
 msgid "tag '%s' already exists"
 msgstr "thẻ “%s” đã tồn tại rồi"
 
-#: builtin/tag.c:629
+#: builtin/tag.c:633
 #, c-format
 msgid "Updated tag '%s' (was %s)\n"
 msgstr "Đã cập nhật thẻ “%s” (trước là %s)\n"
@@ -24220,132 +24079,120 @@ msgstr "không thể tạo thư mục của “%s”"
 msgid "initializing"
 msgstr "khởi tạo"
 
-#: builtin/worktree.c:421 builtin/worktree.c:427
+#: builtin/worktree.c:420 builtin/worktree.c:426
 #, c-format
 msgid "Preparing worktree (new branch '%s')"
 msgstr "Đang chuẩn bị cây làm việc (nhánh mới “%s”)"
 
-#: builtin/worktree.c:423
+#: builtin/worktree.c:422
 #, c-format
 msgid "Preparing worktree (resetting branch '%s'; was at %s)"
 msgstr "Đang chuẩn bị cây làm việc (đang cài đặt nhánh “%s”, trước đây tại %s)"
 
-#: builtin/worktree.c:432
+#: builtin/worktree.c:431
 #, c-format
 msgid "Preparing worktree (checking out '%s')"
 msgstr "Đang chuẩn bị cây làm việc (đang lấy ra “%s”)"
 
-#: builtin/worktree.c:438
+#: builtin/worktree.c:437
 #, c-format
 msgid "Preparing worktree (detached HEAD %s)"
 msgstr "Đang chuẩn bị cây làm việc (HEAD đã tách rời “%s”)"
 
-#: builtin/worktree.c:483
+#: builtin/worktree.c:482
 msgid "checkout <branch> even if already checked out in other worktree"
 msgstr "lấy ra <nhánh> ngay cả khi nó đã được lấy ra ở cây làm việc khác"
 
-#: builtin/worktree.c:486
+#: builtin/worktree.c:485
 msgid "create a new branch"
 msgstr "tạo nhánh mới"
 
-#: builtin/worktree.c:488
+#: builtin/worktree.c:487
 msgid "create or reset a branch"
 msgstr "tạo hay đặt lại một nhánh"
 
-#: builtin/worktree.c:490
+#: builtin/worktree.c:489
 msgid "populate the new working tree"
 msgstr "di chuyển cây làm việc mới"
 
-#: builtin/worktree.c:491
+#: builtin/worktree.c:490
 msgid "keep the new working tree locked"
 msgstr "giữ cây làm việc mới bị khóa"
 
-#: builtin/worktree.c:493 builtin/worktree.c:730
+#: builtin/worktree.c:492 builtin/worktree.c:729
 msgid "reason for locking"
 msgstr "lý do khóa"
 
-#: builtin/worktree.c:496
+#: builtin/worktree.c:495
 msgid "set up tracking mode (see git-branch(1))"
 msgstr "cài đặt chế độ theo dõi (xem git-branch(1))"
 
-#: builtin/worktree.c:499
+#: builtin/worktree.c:498
 msgid "try to match the new branch name with a remote-tracking branch"
 msgstr "có khớp tên tên nhánh mới với một nhánh theo dõi máy chủ"
 
-#: builtin/worktree.c:507
-msgid "-b, -B, and --detach are mutually exclusive"
-msgstr "Các tùy chọn -b, -B, và --detach loại từ lẫn nhau"
-
-#: builtin/worktree.c:509
-msgid "--reason requires --lock"
-msgstr "--reason cần --lock"
-
-#: builtin/worktree.c:513
+#: builtin/worktree.c:512
 msgid "added with --lock"
 msgstr "được thêm với --lock"
 
-#: builtin/worktree.c:575
+#: builtin/worktree.c:574
 msgid "--[no-]track can only be used if a new branch is created"
 msgstr "--[no-]track chỉ có thể được dùng nếu một nhánh mới được tạo"
 
-#: builtin/worktree.c:692
+#: builtin/worktree.c:691
 msgid "show extended annotations and reasons, if available"
 msgstr "hiển thị chú thích và lý do mở rộng, nếu có"
 
-#: builtin/worktree.c:694
+#: builtin/worktree.c:693
 msgid "add 'prunable' annotation to worktrees older than <time>"
 msgstr ""
 "thêm chú thích kiểu “prunable” cho các cây làm việc hết hạn cũ hơn khoảng "
 "<thời gian>"
 
-#: builtin/worktree.c:703
-msgid "--verbose and --porcelain are mutually exclusive"
-msgstr "--verbose và --porcelain loại từ lẫn nhau"
-
-#: builtin/worktree.c:742 builtin/worktree.c:775 builtin/worktree.c:849
-#: builtin/worktree.c:973
+#: builtin/worktree.c:741 builtin/worktree.c:774 builtin/worktree.c:848
+#: builtin/worktree.c:972
 #, c-format
 msgid "'%s' is not a working tree"
 msgstr "%s không phải là cây làm việc"
 
-#: builtin/worktree.c:744 builtin/worktree.c:777
+#: builtin/worktree.c:743 builtin/worktree.c:776
 msgid "The main working tree cannot be locked or unlocked"
 msgstr "Cây thư mục làm việc chính không thể khóa hay bỏ khóa được"
 
-#: builtin/worktree.c:749
+#: builtin/worktree.c:748
 #, c-format
 msgid "'%s' is already locked, reason: %s"
 msgstr "“%s” đã được khóa rồi, lý do: %s"
 
-#: builtin/worktree.c:751
+#: builtin/worktree.c:750
 #, c-format
 msgid "'%s' is already locked"
 msgstr "“%s” đã được khóa rồi"
 
-#: builtin/worktree.c:779
+#: builtin/worktree.c:778
 #, c-format
 msgid "'%s' is not locked"
 msgstr "“%s” chưa bị khóa"
 
-#: builtin/worktree.c:820
+#: builtin/worktree.c:819
 msgid "working trees containing submodules cannot be moved or removed"
 msgstr "cây làm việc có chứa mô-đun-con không thể di chuyển hay xóa bỏ"
 
-#: builtin/worktree.c:828
+#: builtin/worktree.c:827
 msgid "force move even if worktree is dirty or locked"
 msgstr "ép buộc ngay cả khi cây làm việc đang bẩn hay bị khóa"
 
-#: builtin/worktree.c:851 builtin/worktree.c:975
+#: builtin/worktree.c:850 builtin/worktree.c:974
 #, c-format
 msgid "'%s' is a main working tree"
 msgstr "“%s” là cây làm việc chính"
 
-#: builtin/worktree.c:856
+#: builtin/worktree.c:855
 #, c-format
 msgid "could not figure out destination name from '%s'"
 msgstr "không thể phác họa ra tên đích đến “%s”"
 
-#: builtin/worktree.c:869
+#: builtin/worktree.c:868
 #, c-format
 msgid ""
 "cannot move a locked working tree, lock reason: %s\n"
@@ -24354,7 +24201,7 @@ msgstr ""
 "không thể di chuyển một cây-làm-việc bị khóa, khóa vì: %s\n"
 "dùng “move -f -f” để ghi đè hoặc mở khóa trước đã"
 
-#: builtin/worktree.c:871
+#: builtin/worktree.c:870
 msgid ""
 "cannot move a locked working tree;\n"
 "use 'move -f -f' to override or unlock first"
@@ -24362,38 +24209,38 @@ msgstr ""
 "không thể di chuyển một cây-làm-việc bị khóa;\n"
 "dùng “move -f -f” để ghi đè hoặc mở khóa trước đã"
 
-#: builtin/worktree.c:874
+#: builtin/worktree.c:873
 #, c-format
 msgid "validation failed, cannot move working tree: %s"
 msgstr "thẩm tra gặp lỗi, không thể di chuyển một cây-làm-việc: %s"
 
-#: builtin/worktree.c:879
+#: builtin/worktree.c:878
 #, c-format
 msgid "failed to move '%s' to '%s'"
 msgstr "gặp lỗi khi chuyển “%s” sang “%s”"
 
-#: builtin/worktree.c:925
+#: builtin/worktree.c:924
 #, c-format
 msgid "failed to run 'git status' on '%s'"
 msgstr "gặp lỗi khi chạy “git status” vào “%s”"
 
-#: builtin/worktree.c:929
+#: builtin/worktree.c:928
 #, c-format
 msgid "'%s' contains modified or untracked files, use --force to delete it"
 msgstr ""
 "“%s” có chứa các tập tin đã bị sửa chữa hoặc chưa được theo dõi, hãy dùng --"
 "force để xóa nó"
 
-#: builtin/worktree.c:934
+#: builtin/worktree.c:933
 #, c-format
 msgid "failed to run 'git status' on '%s', code %d"
 msgstr "gặp lỗi khi chạy “git status” trong “%s”, mã %d"
 
-#: builtin/worktree.c:957
+#: builtin/worktree.c:956
 msgid "force removal even if worktree is dirty or locked"
 msgstr "ép buộc di chuyển thậm chí cả khi cây làm việc đang bẩn hay bị khóa"
 
-#: builtin/worktree.c:980
+#: builtin/worktree.c:979
 #, c-format
 msgid ""
 "cannot remove a locked working tree, lock reason: %s\n"
@@ -24402,7 +24249,7 @@ msgstr ""
 "không thể xóa bỏ một cây-làm-việc bị khóa, khóa vì: %s\n"
 "dùng “remove -f -f” để ghi đè hoặc mở khóa trước đã"
 
-#: builtin/worktree.c:982
+#: builtin/worktree.c:981
 msgid ""
 "cannot remove a locked working tree;\n"
 "use 'remove -f -f' to override or unlock first"
@@ -24410,17 +24257,17 @@ msgstr ""
 "không thể xóa bỏ một cây-làm-việc bị khóa;\n"
 "dùng “remove -f -f” để ghi đè hoặc mở khóa trước đã"
 
-#: builtin/worktree.c:985
+#: builtin/worktree.c:984
 #, c-format
 msgid "validation failed, cannot remove working tree: %s"
 msgstr "thẩm tra gặp lỗi, không thể gỡ bỏ một cây-làm-việc: %s"
 
-#: builtin/worktree.c:1009
+#: builtin/worktree.c:1008
 #, c-format
 msgid "repair: %s: %s"
 msgstr "sửa chữa: %s: %s"
 
-#: builtin/worktree.c:1012
+#: builtin/worktree.c:1011
 #, c-format
 msgid "error: %s: %s"
 msgstr "lỗi: %s: %s"
@@ -24473,20 +24320,15 @@ msgstr ""
 "để xem các đặc tả cho lệnh hay khái niệm cụ thể.\n"
 "Xem “git help git” để biết tổng quan của hệ thống."
 
-#: git.c:188
+#: git.c:188 git.c:216 git.c:300
 #, c-format
-msgid "no directory given for --git-dir\n"
-msgstr "chưa chỉ ra thư mục cho --git-dir\n"
+msgid "no directory given for '%s' option\n"
+msgstr "không đưa ra thư mục cho tùy chọn '%s'\n"
 
 #: git.c:202
 #, c-format
 msgid "no namespace given for --namespace\n"
 msgstr "chưa đưa ra không gian làm việc cho --namespace\n"
-
-#: git.c:216
-#, c-format
-msgid "no directory given for --work-tree\n"
-msgstr "chưa đưa ra cây làm việc cho --work-tree\n"
 
 #: git.c:230
 #, c-format
@@ -24502,11 +24344,6 @@ msgstr "-c cần một chuỗi cấu hình\n"
 #, c-format
 msgid "no config key given for --config-env\n"
 msgstr "không đưa ra khóa cấu hình cho --config-env\n"
-
-#: git.c:300
-#, c-format
-msgid "no directory given for -C\n"
-msgstr "chưa đưa ra thư mục cho -C\n"
 
 #: git.c:326
 #, c-format
@@ -24537,30 +24374,30 @@ msgstr "làm trống bí danh cho %s"
 msgid "recursive alias: %s"
 msgstr "đệ quy các bí danh: %s"
 
-#: git.c:476
+#: git.c:479
 msgid "write failure on standard output"
 msgstr "lỗi ghi nghiêm trong trên đầu ra tiêu chuẩn"
 
-#: git.c:478
+#: git.c:481
 msgid "unknown write failure on standard output"
 msgstr "lỗi nghiêm trọng chưa biết khi ghi ra đầu ra tiêu chuẩn"
 
-#: git.c:480
+#: git.c:483
 msgid "close failed on standard output"
 msgstr "gặp lỗi khi đóng đầu ra tiêu chuẩn"
 
-#: git.c:832
+#: git.c:835
 #, c-format
 msgid "alias loop detected: expansion of '%s' does not terminate:%s"
 msgstr ""
 "dò tìm thấy các bí danh quẩn tròn: biểu thức của “%s” không có điểm kết:%s"
 
-#: git.c:882
+#: git.c:885
 #, c-format
 msgid "cannot handle %s as a builtin"
 msgstr "không thể xử lý %s như là một phần bổ sung"
 
-#: git.c:895
+#: git.c:898
 #, c-format
 msgid ""
 "usage: %s\n"
@@ -24569,32 +24406,24 @@ msgstr ""
 "cách dùng: %s\n"
 "\n"
 
-#: git.c:915
+#: git.c:918
 #, c-format
 msgid "expansion of alias '%s' failed; '%s' is not a git command\n"
 msgstr "gặp lỗi khi khai triển bí danh “%s”; “%s” không phải là lệnh git\n"
 
-#: git.c:927
+#: git.c:930
 #, c-format
 msgid "failed to run command '%s': %s\n"
 msgstr "gặp lỗi khi chạy lệnh “%s”: %s\n"
 
-#: http-fetch.c:118
+#: http-fetch.c:128
 #, c-format
 msgid "argument to --packfile must be a valid hash (got '%s')"
 msgstr "tham số cho --packfile phải là một giá trị băm hợp lệ (nhận được “%s”)"
 
-#: http-fetch.c:128
+#: http-fetch.c:138
 msgid "not a git repository"
 msgstr "không phải là kho git"
-
-#: http-fetch.c:134
-msgid "--packfile requires --index-pack-args"
-msgstr "--packfile cần --index-pack-args"
-
-#: http-fetch.c:143
-msgid "--index-pack-args can only be used with --packfile"
-msgstr "--index-pack-args chỉ được dùng khi có --packfile"
 
 #: t/helper/test-fast-rebase.c:141
 msgid "unhandled options"
@@ -24880,6 +24709,175 @@ msgstr "remote-curl: đã cố gắng fetch mà không có kho nội bộ"
 msgid "remote-curl: unknown command '%s' from git"
 msgstr "remote-curl: không hiểu lệnh “%s” từ git"
 
+#: contrib/scalar/scalar.c:49
+msgid "need a working directory"
+msgstr "cần một thư mục làm việc"
+
+#: contrib/scalar/scalar.c:86
+msgid "could not find enlistment root"
+msgstr "không tìm thấy gốc enlistment"
+
+#: contrib/scalar/scalar.c:89 contrib/scalar/scalar.c:351
+#: contrib/scalar/scalar.c:436 contrib/scalar/scalar.c:579
+#, c-format
+msgid "could not switch to '%s'"
+msgstr "không thể chuyển đến '%s'"
+
+#: contrib/scalar/scalar.c:180
+#, c-format
+msgid "could not configure %s=%s"
+msgstr "không thể đóng cấu hình %s=%s"
+
+#: contrib/scalar/scalar.c:198
+msgid "could not configure log.excludeDecoration"
+msgstr "không thể cấu hình log.excludeDecoration"
+
+#: contrib/scalar/scalar.c:219
+msgid "Scalar enlistments require a worktree"
+msgstr "'Scalar enlistments' cần một cây làm việc"
+
+#: contrib/scalar/scalar.c:311
+#, c-format
+msgid "remote HEAD is not a branch: '%.*s'"
+msgstr "HEAD của máy chủ không phải một nhánh: '%.*s'"
+
+#: contrib/scalar/scalar.c:317
+msgid "failed to get default branch name from remote; using local default"
+msgstr "gặp lỗi khi lấy tên nhánh mặc định từ máy chủ; sử dụng mặc định nội bộ"
+
+#: contrib/scalar/scalar.c:330
+msgid "failed to get default branch name"
+msgstr "gặp lỗi khi lấy tên nhánh mặc định"
+
+#: contrib/scalar/scalar.c:341
+msgid "failed to unregister repository"
+msgstr "gặp lỗi khi hủy đăng ký kho chứa"
+
+#: contrib/scalar/scalar.c:356
+msgid "failed to delete enlistment directory"
+msgstr "gặp lỗi khi xóa thư mục dành được"
+
+#: contrib/scalar/scalar.c:376
+msgid "branch to checkout after clone"
+msgstr "nhánh để lấy ra sau khi nhân bản"
+
+#: contrib/scalar/scalar.c:378
+msgid "when cloning, create full working directory"
+msgstr "khi nhân bản, tạo đầy đủ thư mục làm việc"
+
+#: contrib/scalar/scalar.c:380
+msgid "only download metadata for the branch that will be checked out"
+msgstr "chỉ siêu dữ liệu tải về cho nhánh mà sẽ được lấy ra"
+
+#: contrib/scalar/scalar.c:385
+msgid "scalar clone [<options>] [--] <repo> [<dir>]"
+msgstr "scalar clone [<các tùy chọn>] [--] <kho> [<t.mục>]"
+
+#: contrib/scalar/scalar.c:410
+#, c-format
+msgid "cannot deduce worktree name from '%s'"
+msgstr "không thể suy diễn tên cây làm việc từ '%s'"
+
+#: contrib/scalar/scalar.c:419
+#, c-format
+msgid "directory '%s' exists already"
+msgstr "thư mục '%s' đã sẵn có"
+
+#: contrib/scalar/scalar.c:446
+#, c-format
+msgid "failed to get default branch for '%s'"
+msgstr "gặp lỗi khi lấy nhánh mặc định cho '%s'"
+
+#: contrib/scalar/scalar.c:457
+#, c-format
+msgid "could not configure remote in '%s'"
+msgstr "không thể cấu hình máy chủ trong '%s'"
+
+#: contrib/scalar/scalar.c:466
+#, c-format
+msgid "could not configure '%s'"
+msgstr "không thể cấu hình '%s'"
+
+#: contrib/scalar/scalar.c:469
+msgid "partial clone failed; attempting full clone"
+msgstr "nhân bản từng phần gặp lỗi; đang cố thử nhân bản đầy đủ"
+
+#: contrib/scalar/scalar.c:473
+msgid "could not configure for full clone"
+msgstr "không thể cấu hình cho nhân bản đầy đủ"
+
+#: contrib/scalar/scalar.c:505
+msgid "`scalar list` does not take arguments"
+msgstr "`scalar list` không nhận các tham số"
+
+#: contrib/scalar/scalar.c:518
+msgid "scalar register [<enlistment>]"
+msgstr "scalar register [<enlistment>]"
+
+#: contrib/scalar/scalar.c:545
+msgid "reconfigure all registered enlistments"
+msgstr "cấu hình mọi enlistments đã đăng ký"
+
+#: contrib/scalar/scalar.c:549
+msgid "scalar reconfigure [--all | <enlistment>]"
+msgstr "scalar reconfigure [--all | <enlistment>]"
+
+#: contrib/scalar/scalar.c:567
+msgid "--all or <enlistment>, but not both"
+msgstr "--all hoặc <enlistment>, không thể là cả hai"
+
+#: contrib/scalar/scalar.c:582
+#, c-format
+msgid "git repository gone in '%s'"
+msgstr "kho git ra đi trong '%s'"
+
+#: contrib/scalar/scalar.c:622
+msgid ""
+"scalar run <task> [<enlistment>]\n"
+"Tasks:\n"
+msgstr ""
+"scalar run <task> [<enlistment>]\n"
+"Nhiệm vụ:\n"
+
+#: contrib/scalar/scalar.c:640
+#, c-format
+msgid "no such task: '%s'"
+msgstr "không có nhiệm vụ nào như thế: “%s”"
+
+#: contrib/scalar/scalar.c:690
+msgid "scalar unregister [<enlistment>]"
+msgstr "scalar unregister [<enlistment>]"
+
+#: contrib/scalar/scalar.c:737
+msgid "scalar delete <enlistment>"
+msgstr "scalar delete <enlistment>"
+
+#: contrib/scalar/scalar.c:752
+msgid "refusing to delete current working directory"
+msgstr "từ chối gỡ bỏ thư mục làm việc hiện tại"
+
+#: contrib/scalar/scalar.c:767
+msgid "include Git version"
+msgstr "bao gồm phiên bản Git"
+
+#: contrib/scalar/scalar.c:769
+msgid "include Git's build options"
+msgstr "bao gồm các tùy chọn biên dịch của Git"
+
+#: contrib/scalar/scalar.c:773
+msgid "scalar verbose [-v | --verbose] [--build-options]"
+msgstr "scalar verbose [-v | --verbose] [--build-options]"
+
+#: contrib/scalar/scalar.c:821
+msgid ""
+"scalar <command> [<options>]\n"
+"\n"
+"Commands:\n"
+msgstr ""
+"scalar <lệnh> [<các tùy chọn>]\n"
+"\n"
+"Các lệnh:\n"
+
 #: compat/compiler.h:26
 msgid "no compiler information available\n"
 msgstr "hiện không có thông tin về trình biên dịch\n"
@@ -24904,38 +24902,38 @@ msgstr "ngày hết hạn"
 msgid "no-op (backward compatibility)"
 msgstr "no-op (tương thích ngược)"
 
-#: parse-options.h:308
+#: parse-options.h:310
 msgid "be more verbose"
 msgstr "chi tiết hơn nữa"
 
-#: parse-options.h:310
+#: parse-options.h:312
 msgid "be more quiet"
 msgstr "im lặng hơn nữa"
 
-#: parse-options.h:316
+#: parse-options.h:318
 msgid "use <n> digits to display object names"
 msgstr "sử dụng <n> chữ số để hiển thị tên đối tượng"
 
-#: parse-options.h:335
+#: parse-options.h:337
 msgid "how to strip spaces and #comments from message"
 msgstr "làm thế nào để cắt bỏ khoảng trắng và #ghichú từ mẩu tin nhắn"
 
-#: parse-options.h:336
+#: parse-options.h:338
 msgid "read pathspec from file"
 msgstr "đọc đặc tả đường dẫn từ tập tin"
 
-#: parse-options.h:337
+#: parse-options.h:339
 msgid ""
 "with --pathspec-from-file, pathspec elements are separated with NUL character"
 msgstr ""
 "với --pathspec-from-file, các phần tử đặc tả đường dẫn bị ngăn cách bởi ký "
 "tự NULL"
 
-#: ref-filter.h:101
+#: ref-filter.h:98
 msgid "key"
 msgstr "khóa"
 
-#: ref-filter.h:101
+#: ref-filter.h:98
 msgid "field name to sort on"
 msgstr "tên trường cần sắp xếp"
 
@@ -25007,16 +25005,16 @@ msgid "Show canonical names and email addresses of contacts"
 msgstr "Hiển thị tên và địa chỉ thư điện tử của các liên hệ dạng chuẩn hóa"
 
 #: command-list.h:65
+msgid "Ensures that a reference name is well formed"
+msgstr "Đảm bảo rằng một tên tham chiếu ở dạng thức tốt"
+
+#: command-list.h:66
 msgid "Switch branches or restore working tree files"
 msgstr "Chuyển các nhánh hoặc phục hồi lại các tập tin cây làm việc"
 
-#: command-list.h:66
+#: command-list.h:67
 msgid "Copy files from the index to the working tree"
 msgstr "Sao chép các tập tin từ mục lục ra cây làm việc"
-
-#: command-list.h:67
-msgid "Ensures that a reference name is well formed"
-msgstr "Đảm bảo rằng một tên tham chiếu ở dạng thức tốt"
 
 #: command-list.h:68
 msgid "Find commits yet to be applied to upstream"
@@ -25221,56 +25219,56 @@ msgid "Add or parse structured information in commit messages"
 msgstr "Thêm hay phân tích thông tin cấu trúc trong ghi chú lần chuyển giao"
 
 #: command-list.h:116
-msgid "The Git repository browser"
-msgstr "Bộ duyện kho Git"
-
-#: command-list.h:117
 msgid "Show commit logs"
 msgstr "Hiển thị nhật ký các lần chuyển giao"
 
-#: command-list.h:118
+#: command-list.h:117
 msgid "Show information about files in the index and the working tree"
 msgstr "Hiển thị thông tin về các tập tin trong bảng mục lục và cây làm việc"
 
-#: command-list.h:119
+#: command-list.h:118
 msgid "List references in a remote repository"
 msgstr "Liệt kê các tham chiếu trong một kho chứa trên mạng"
 
-#: command-list.h:120
+#: command-list.h:119
 msgid "List the contents of a tree object"
 msgstr "Liệt kê nội dung của đối tượng cây"
 
-#: command-list.h:121
+#: command-list.h:120
 msgid "Extracts patch and authorship from a single e-mail message"
 msgstr "Trích xuất miếng và và nguồn tác giả từ một thư điện tử đơn"
 
-#: command-list.h:122
+#: command-list.h:121
 msgid "Simple UNIX mbox splitter program"
 msgstr "Chương trình phân tách UNIX mbox đơn giản"
 
-#: command-list.h:123
+#: command-list.h:122
 msgid "Run tasks to optimize Git repository data"
 msgstr "Chạy các nhiệm vụ để tối ưu hóa dữ liệu kho Git"
 
-#: command-list.h:124
+#: command-list.h:123
 msgid "Join two or more development histories together"
 msgstr "Hợp nhất hai hay nhiều hơn lịch sử của các nhà phát triển"
 
-#: command-list.h:125
+#: command-list.h:124
 msgid "Find as good common ancestors as possible for a merge"
 msgstr "Tìm các tổ tiên chung tốt có thể được cho hòa trộn"
 
-#: command-list.h:126
+#: command-list.h:125
 msgid "Run a three-way file merge"
 msgstr "Chạy một hòa trộn tập tin “3-đường”"
 
-#: command-list.h:127
+#: command-list.h:126
 msgid "Run a merge for files needing merging"
 msgstr "Chạy một hòa trộn cho các tập tin cần hòa trộn"
 
-#: command-list.h:128
+#: command-list.h:127
 msgid "The standard helper program to use with git-merge-index"
 msgstr "Một chương trình hỗ trợ tiêu chuẩn dùng với git-merge-index"
+
+#: command-list.h:128
+msgid "Show three-way merge without touching index"
+msgstr "Hiển thị hòa trộn ba-đường mà không đụng chạm đến mục lục"
 
 #: command-list.h:129
 msgid "Run merge conflict resolution tools to resolve merge conflicts"
@@ -25279,357 +25277,357 @@ msgstr ""
 "trộn"
 
 #: command-list.h:130
-msgid "Show three-way merge without touching index"
-msgstr "Hiển thị hòa trộn ba-đường mà không đụng chạm đến mục lục"
-
-#: command-list.h:131
-msgid "Write and verify multi-pack-indexes"
-msgstr "Ghi và thẩm tra các multi-pack-indexes"
-
-#: command-list.h:132
 msgid "Creates a tag object with extra validation"
 msgstr "Tạo một đối tượng thẻ với kiểm tra mở rộng"
 
-#: command-list.h:133
+#: command-list.h:131
 msgid "Build a tree-object from ls-tree formatted text"
 msgstr "Xây dựng một tree-object từ văn bản định dạng ls-tree"
 
-#: command-list.h:134
+#: command-list.h:132
+msgid "Write and verify multi-pack-indexes"
+msgstr "Ghi và thẩm tra các multi-pack-indexes"
+
+#: command-list.h:133
 msgid "Move or rename a file, a directory, or a symlink"
 msgstr "Di chuyển hay đổi tên một tập tin, thư mục hoặc liên kết mềm"
 
-#: command-list.h:135
+#: command-list.h:134
 msgid "Find symbolic names for given revs"
 msgstr "Tìm các tên liên kết mềm cho điểm xét đã cho"
 
-#: command-list.h:136
+#: command-list.h:135
 msgid "Add or inspect object notes"
 msgstr "Thêm hoặc điều tra đối tượng ghi chú"
 
-#: command-list.h:137
+#: command-list.h:136
 msgid "Import from and submit to Perforce repositories"
 msgstr "Nhập vào từ và gửi đến các kho cần thiết"
 
-#: command-list.h:138
+#: command-list.h:137
 msgid "Create a packed archive of objects"
 msgstr "Tạo một kho lưu được đóng gói cho các đối"
 
-#: command-list.h:139
+#: command-list.h:138
 msgid "Find redundant pack files"
 msgstr "Tìm các tập tin gói dư thừa"
 
-#: command-list.h:140
+#: command-list.h:139
 msgid "Pack heads and tags for efficient repository access"
 msgstr "Đóng gói các phần đầu và thẻ để truy cập kho hiệu quả hơn"
 
-#: command-list.h:141
+#: command-list.h:140
 msgid "Compute unique ID for a patch"
 msgstr "Tính toán ID duy nhất cho một miếng vá"
 
-#: command-list.h:142
+#: command-list.h:141
 msgid "Prune all unreachable objects from the object database"
 msgstr ""
 "Xén bớt tất các các đối tượng không tiếp cận được từ cơ sở dữ liệu đối tượng"
 
-#: command-list.h:143
+#: command-list.h:142
 msgid "Remove extra objects that are already in pack files"
 msgstr "Xóa bỏ các đối tượng mở rộng cái mà đã sẵn có trong các tập tin gói"
 
-#: command-list.h:144
+#: command-list.h:143
 msgid "Fetch from and integrate with another repository or a local branch"
 msgstr "Lấy về và hợp nhất với kho khác hay một nhánh nội bộ"
 
-#: command-list.h:145
+#: command-list.h:144
 msgid "Update remote refs along with associated objects"
 msgstr "Cập nhật th.chiếu máy chủ cùng với các đối tượng liên quan đến nó"
 
-#: command-list.h:146
+#: command-list.h:145
 msgid "Applies a quilt patchset onto the current branch"
 msgstr "Ấp dụng một bộ miếng vá quilt vào trong nhánh hiện hành"
 
-#: command-list.h:147
+#: command-list.h:146
 msgid "Compare two commit ranges (e.g. two versions of a branch)"
 msgstr "So sánh hai vùng chuyển giao (vd: hai phiên bản của một nhánh)"
 
-#: command-list.h:148
+#: command-list.h:147
 msgid "Reads tree information into the index"
 msgstr "Đọc thông tin cây vào trong mục lục"
 
-#: command-list.h:149
+#: command-list.h:148
 msgid "Reapply commits on top of another base tip"
 msgstr "Thu hoạch các lần chuyển giao trên đỉnh của đầu mút cơ sở khác"
 
-#: command-list.h:150
+#: command-list.h:149
 msgid "Receive what is pushed into the repository"
 msgstr "Nhận cái mà được đẩy vào trong kho"
 
-#: command-list.h:151
+#: command-list.h:150
 msgid "Manage reflog information"
 msgstr "Quản lý thông tin reflog"
 
-#: command-list.h:152
+#: command-list.h:151
 msgid "Manage set of tracked repositories"
 msgstr "Quản lý tập hợp các kho chứa đã được theo dõi"
 
-#: command-list.h:153
+#: command-list.h:152
 msgid "Pack unpacked objects in a repository"
 msgstr "Đóng gói các đối tượng chưa đóng gói ở một kho chứa"
 
-#: command-list.h:154
+#: command-list.h:153
 msgid "Create, list, delete refs to replace objects"
 msgstr "Tạo, liệt kê, xóa các tham chiếu để thay thế các đối tượng"
 
-#: command-list.h:155
+#: command-list.h:154
 msgid "Generates a summary of pending changes"
 msgstr "Tạo ra một tóm tắt các thay đổi còn treo"
 
-#: command-list.h:156
+#: command-list.h:155
 msgid "Reuse recorded resolution of conflicted merges"
 msgstr "Dùng lại các giải pháp đã ghi lại của các hòa trộn bị xung đột"
 
-#: command-list.h:157
+#: command-list.h:156
 msgid "Reset current HEAD to the specified state"
 msgstr "Đặt lại HEAD hiện hành thành trạng thái đã cho"
 
-#: command-list.h:158
+#: command-list.h:157
 msgid "Restore working tree files"
 msgstr "Hoàn nguyên các tập tin cây làm việc"
 
-#: command-list.h:159
-msgid "Revert some existing commits"
-msgstr "Hoàn lại một số lần chuyển giao sẵn có"
-
-#: command-list.h:160
+#: command-list.h:158
 msgid "Lists commit objects in reverse chronological order"
 msgstr "Liệt kê các đối tượng chuyển giao theo thứ tự tôpô đảo ngược"
 
-#: command-list.h:161
+#: command-list.h:159
 msgid "Pick out and massage parameters"
 msgstr "Cậy ra và xử lý các tham số"
 
-#: command-list.h:162
+#: command-list.h:160
+msgid "Revert some existing commits"
+msgstr "Hoàn lại một số lần chuyển giao sẵn có"
+
+#: command-list.h:161
 msgid "Remove files from the working tree and from the index"
 msgstr "Gỡ bỏ các tập tin từ cây làm việc và từ bảng mục lục"
 
-#: command-list.h:163
+#: command-list.h:162
 msgid "Send a collection of patches as emails"
 msgstr "Gửi một tập hợp của các miếng vá ở dạng thư điện tử"
 
-#: command-list.h:164
+#: command-list.h:163
 msgid "Push objects over Git protocol to another repository"
 msgstr "Đẩy các đối tượng lên thông qua giao thức Git đến kho chứa khác"
 
-#: command-list.h:165
-msgid "Restricted login shell for Git-only SSH access"
-msgstr "Hệ vỏ đăng nhập có hạn chế cho truy cập SSH chỉ-Git"
-
-#: command-list.h:166
-msgid "Summarize 'git log' output"
-msgstr "Kết xuất “git log” dạng tóm tắt"
-
-#: command-list.h:167
-msgid "Show various types of objects"
-msgstr "Hiển thị các kiểu khác nhau của các đối tượng"
-
-#: command-list.h:168
-msgid "Show branches and their commits"
-msgstr "Hiển thị những nhánh và các lần chuyển giao của chúng"
-
-#: command-list.h:169
-msgid "Show packed archive index"
-msgstr "Hiển thị các muc lục kho nén đã đóng gói"
-
-#: command-list.h:170
-msgid "List references in a local repository"
-msgstr "Liệt kê các tham chiếu trong một kho nội bộ"
-
-#: command-list.h:171
+#: command-list.h:164
 msgid "Git's i18n setup code for shell scripts"
 msgstr "Nã cài đặt quốc tế hóa của Git cho văn lệnh hệ vỏ"
 
-#: command-list.h:172
+#: command-list.h:165
 msgid "Common Git shell script setup code"
 msgstr "Mã cài đặt văn lệnh hệ vỏ Git chung"
 
-#: command-list.h:173
+#: command-list.h:166
+msgid "Restricted login shell for Git-only SSH access"
+msgstr "Hệ vỏ đăng nhập có hạn chế cho truy cập SSH chỉ-Git"
+
+#: command-list.h:167
+msgid "Summarize 'git log' output"
+msgstr "Kết xuất “git log” dạng tóm tắt"
+
+#: command-list.h:168
+msgid "Show various types of objects"
+msgstr "Hiển thị các kiểu khác nhau của các đối tượng"
+
+#: command-list.h:169
+msgid "Show branches and their commits"
+msgstr "Hiển thị những nhánh và các lần chuyển giao của chúng"
+
+#: command-list.h:170
+msgid "Show packed archive index"
+msgstr "Hiển thị các muc lục kho nén đã đóng gói"
+
+#: command-list.h:171
+msgid "List references in a local repository"
+msgstr "Liệt kê các tham chiếu trong một kho nội bộ"
+
+#: command-list.h:172
 msgid "Initialize and modify the sparse-checkout"
 msgstr "Khởi tạo và sửa đổi sparse-checkout"
+
+#: command-list.h:173
+msgid "Add file contents to the staging area"
+msgstr "Thêm nội dung tập tin vào vùng bệ phóng"
 
 #: command-list.h:174
 msgid "Stash the changes in a dirty working directory away"
 msgstr "Tạm cất đi các thay đổi trong một thư mục làm việc bẩn"
 
 #: command-list.h:175
-msgid "Add file contents to the staging area"
-msgstr "Thêm nội dung tập tin vào vùng bệ phóng"
-
-#: command-list.h:176
 msgid "Show the working tree status"
 msgstr "Hiển thị trạng thái cây làm việc"
 
-#: command-list.h:177
+#: command-list.h:176
 msgid "Remove unnecessary whitespace"
 msgstr "Xóa bỏ các khoảng trắng không cần thiết"
 
-#: command-list.h:178
+#: command-list.h:177
 msgid "Initialize, update or inspect submodules"
 msgstr "Khởi tạo, cập nhật hay điều tra các mô-đun-con"
 
-#: command-list.h:179
+#: command-list.h:178
 msgid "Bidirectional operation between a Subversion repository and Git"
 msgstr "Thao tác hai hướng giữ hai kho Subversion và Git"
 
-#: command-list.h:180
+#: command-list.h:179
 msgid "Switch branches"
 msgstr "Các nhánh chuyển"
 
-#: command-list.h:181
+#: command-list.h:180
 msgid "Read, modify and delete symbolic refs"
 msgstr "Đọc, sửa và xóa tham chiếu mềm"
 
-#: command-list.h:182
+#: command-list.h:181
 msgid "Create, list, delete or verify a tag object signed with GPG"
 msgstr "Tạo, liệt kê, xóa hay xác thực một đối tượng thẻ được ký bằng GPG"
 
-#: command-list.h:183
+#: command-list.h:182
 msgid "Creates a temporary file with a blob's contents"
 msgstr "Tạo một tập tin tạm với nội dung của blob"
 
-#: command-list.h:184
+#: command-list.h:183
 msgid "Unpack objects from a packed archive"
 msgstr "Gỡ các đối tượng khỏi một kho lưu đã đóng gói"
 
-#: command-list.h:185
+#: command-list.h:184
 msgid "Register file contents in the working tree to the index"
 msgstr "Đăng ký nội dung tập tin từ cây làm việc đến bảng mục lục"
 
-#: command-list.h:186
+#: command-list.h:185
 msgid "Update the object name stored in a ref safely"
 msgstr "Cập nhật tên đối tượng được lưu trong một tham chiếu một cách an toàn"
 
-#: command-list.h:187
+#: command-list.h:186
 msgid "Update auxiliary info file to help dumb servers"
 msgstr "Cập nhật tập tin thông tin phụ trợ để giúp đỡ các dịch vụ dumb"
 
-#: command-list.h:188
+#: command-list.h:187
 msgid "Send archive back to git-archive"
 msgstr "Gửi kho lưu trở lại cho git-archive"
 
-#: command-list.h:189
+#: command-list.h:188
 msgid "Send objects packed back to git-fetch-pack"
 msgstr "Gửi các đối tượng đã đóng gói trở lại cho git-fetch-pack"
 
-#: command-list.h:190
+#: command-list.h:189
 msgid "Show a Git logical variable"
 msgstr "Hiển thị một biến Git luận lý"
 
-#: command-list.h:191
+#: command-list.h:190
 msgid "Check the GPG signature of commits"
 msgstr "Kiểm tra ký lần chuyển giao dùng GPG"
 
-#: command-list.h:192
+#: command-list.h:191
 msgid "Validate packed Git archive files"
 msgstr "Kiểm tra lại các tập tin kho (lưu trữ, nén) Git đã được đóng gói"
 
-#: command-list.h:193
+#: command-list.h:192
 msgid "Check the GPG signature of tags"
 msgstr "Kiểm tra chữ ký GPG của các thẻ"
 
-#: command-list.h:194
-msgid "Git web interface (web frontend to Git repositories)"
-msgstr "Giao diện Git trên nền web (ứng dụng web chạy trên kho Git)"
-
-#: command-list.h:195
+#: command-list.h:193
 msgid "Show logs with difference each commit introduces"
 msgstr "Hiển thị các nhật ký với từng lần chuyển giao khác nhau đưa ra"
 
-#: command-list.h:196
+#: command-list.h:194
 msgid "Manage multiple working trees"
 msgstr "Quản lý nhiều cây làm việc"
 
-#: command-list.h:197
+#: command-list.h:195
 msgid "Create a tree object from the current index"
 msgstr "Tạo một đối tượng cây từ đầu vào tiêu chuẩn stdin hiện tại"
 
-#: command-list.h:198
+#: command-list.h:196
 msgid "Defining attributes per path"
 msgstr "Định nghĩa các thuộc tính cho mỗi đường dẫn"
 
-#: command-list.h:199
+#: command-list.h:197
 msgid "Git command-line interface and conventions"
 msgstr "Giao diện dòng lệnh Git và quy ước"
 
-#: command-list.h:200
+#: command-list.h:198
 msgid "A Git core tutorial for developers"
 msgstr "Hướng dẫn Git cơ bản cho nhà phát triển"
 
-#: command-list.h:201
+#: command-list.h:199
 msgid "Providing usernames and passwords to Git"
 msgstr "Cung cấp tài khoản và mật khẩu cho Git"
 
-#: command-list.h:202
+#: command-list.h:200
 msgid "Git for CVS users"
 msgstr "Git dành cho những người dùng CVS"
 
-#: command-list.h:203
+#: command-list.h:201
 msgid "Tweaking diff output"
 msgstr "Chỉnh kết xuất diff"
 
-#: command-list.h:204
+#: command-list.h:202
 msgid "A useful minimum set of commands for Everyday Git"
 msgstr "Một tập hợp lệnh hữu dụng tối thiểu để dùng Git hàng ngày"
 
-#: command-list.h:205
+#: command-list.h:203
 msgid "Frequently asked questions about using Git"
 msgstr "Các câu hỏi thường gặp về cách sử dụng Git"
 
-#: command-list.h:206
+#: command-list.h:204
 msgid "A Git Glossary"
 msgstr "Thuật ngữ chuyên môn Git"
 
-#: command-list.h:207
+#: command-list.h:205
 msgid "Hooks used by Git"
 msgstr "Các móc được sử dụng bởi Git"
 
-#: command-list.h:208
+#: command-list.h:206
 msgid "Specifies intentionally untracked files to ignore"
 msgstr "Chỉ định các tập tin không cần theo dõi"
 
-#: command-list.h:209
+#: command-list.h:207
+msgid "The Git repository browser"
+msgstr "Bộ duyện kho Git"
+
+#: command-list.h:208
 msgid "Map author/committer names and/or E-Mail addresses"
 msgstr "Ánh xạ tên tác giả/người chuyển giao và/hoặc địa chỉ E-Mail"
 
-#: command-list.h:210
+#: command-list.h:209
 msgid "Defining submodule properties"
 msgstr "Định nghĩa thuộc tính mô-đun-con"
 
-#: command-list.h:211
+#: command-list.h:210
 msgid "Git namespaces"
 msgstr "Không gian tên Git"
 
-#: command-list.h:212
+#: command-list.h:211
 msgid "Helper programs to interact with remote repositories"
 msgstr "Các chương trình hỗ trợ để tương tác với các kho chứa trên máy chủ"
 
-#: command-list.h:213
+#: command-list.h:212
 msgid "Git Repository Layout"
 msgstr "Bố cục kho Git"
 
-#: command-list.h:214
+#: command-list.h:213
 msgid "Specifying revisions and ranges for Git"
 msgstr "Chỉ định điểm xét duyệt và vùng cho Git"
 
-#: command-list.h:215
+#: command-list.h:214
 msgid "Mounting one repository inside another"
 msgstr "Gắn một kho chứa vào trong một cái khác"
+
+#: command-list.h:215
+msgid "A tutorial introduction to Git"
+msgstr "Hướng dẫn cách dùng Git"
 
 #: command-list.h:216
 msgid "A tutorial introduction to Git: part two"
 msgstr "Hướng dẫn cách dùng Git: phần hai"
 
 #: command-list.h:217
-msgid "A tutorial introduction to Git"
-msgstr "Hướng dẫn cách dùng Git"
+msgid "Git web interface (web frontend to Git repositories)"
+msgstr "Giao diện Git trên nền web (ứng dụng web chạy trên kho Git)"
 
 #: command-list.h:218
 msgid "An overview of recommended workflows with Git"
@@ -25706,46 +25704,46 @@ msgstr "Gặp lỗi khi đệ quy vào trong đường dẫn mô-đun-con “$di
 msgid "usage: $dashless $USAGE"
 msgstr "cách dùng: $dashless $USAGE"
 
-#: git-sh-setup.sh:191
+#: git-sh-setup.sh:183
 #, sh-format
 msgid "Cannot chdir to $cdup, the toplevel of the working tree"
 msgstr ""
 "Không thể chuyển thư mục (chdir) sang $cdup, thư mục ở mức cao nhất của cây "
 "làm việc"
 
-#: git-sh-setup.sh:200 git-sh-setup.sh:207
+#: git-sh-setup.sh:192 git-sh-setup.sh:199
 #, sh-format
 msgid "fatal: $program_name cannot be used without a working tree."
 msgstr ""
 "lỗi nghiêm trọng: $program_name không thể được dùng ngoaoif thư mục làm việc."
 
-#: git-sh-setup.sh:221
+#: git-sh-setup.sh:213
 msgid "Cannot rewrite branches: You have unstaged changes."
 msgstr ""
 "Không thể ghi lại các nhánh: Bạn có các thay đổi chưa được đưa lên bệ phóng."
 
-#: git-sh-setup.sh:224
+#: git-sh-setup.sh:216
 #, sh-format
 msgid "Cannot $action: You have unstaged changes."
 msgstr "Không thể $action: Bạn có các thay đổi chưa được đưa lên bệ phóng."
 
-#: git-sh-setup.sh:235
+#: git-sh-setup.sh:227
 #, sh-format
 msgid "Cannot $action: Your index contains uncommitted changes."
 msgstr ""
 "Không thể $action: Mục lục của bạn có chứa các thay đổi chưa được chuyển "
 "giao."
 
-#: git-sh-setup.sh:237
+#: git-sh-setup.sh:229
 msgid "Additionally, your index contains uncommitted changes."
 msgstr ""
 "Thêm vào đó, bảng mục lục của bạn có chứa các thay đổi chưa được chuyển giao."
 
-#: git-sh-setup.sh:357
+#: git-sh-setup.sh:349
 msgid "You need to run this command from the toplevel of the working tree."
 msgstr "Bạn cần chạy lệnh này từ thư mục ở mức cao nhất của cây làm việc."
 
-#: git-sh-setup.sh:362
+#: git-sh-setup.sh:354
 msgid "Unable to determine absolute path of git directory"
 msgstr "Không thể dò tìm đường dẫn tuyệt đối của thư mục git"
 
@@ -25826,7 +25824,7 @@ msgstr ""
 msgid "failed to open hunk edit file for reading: %s"
 msgstr "gặp lỗi khi mở tập tin khúc để đọc: %s"
 
-#: git-add--interactive.perl:1251
+#: git-add--interactive.perl:1253
 msgid ""
 "y - stage this hunk\n"
 "n - do not stage this hunk\n"
@@ -25841,7 +25839,7 @@ msgstr ""
 "d - đừng đưa lên bệ phóng khúc này cũng như bất kỳ cái nào còn lại trong tập "
 "tin"
 
-#: git-add--interactive.perl:1257
+#: git-add--interactive.perl:1259
 msgid ""
 "y - stash this hunk\n"
 "n - do not stash this hunk\n"
@@ -25855,7 +25853,7 @@ msgstr ""
 "a - tạm cất khúc này và tất cả các khúc sau này trong tập tin\n"
 "d - đừng tạm cất khúc này cũng như bất kỳ cái nào còn lại trong tập tin"
 
-#: git-add--interactive.perl:1263
+#: git-add--interactive.perl:1265
 msgid ""
 "y - unstage this hunk\n"
 "n - do not unstage this hunk\n"
@@ -25871,7 +25869,7 @@ msgstr ""
 "d - đừng đưa ra khỏi bệ phóng khúc này cũng như bất kỳ cái nào còn lại trong "
 "tập tin"
 
-#: git-add--interactive.perl:1269
+#: git-add--interactive.perl:1271
 msgid ""
 "y - apply this hunk to index\n"
 "n - do not apply this hunk to index\n"
@@ -25885,7 +25883,7 @@ msgstr ""
 "a - áp dụng khúc này và tất cả các khúc sau này trong tập tin\n"
 "d - đừng áp dụng khúc này cũng như bất kỳ cái nào sau này trong tập tin"
 
-#: git-add--interactive.perl:1275 git-add--interactive.perl:1293
+#: git-add--interactive.perl:1277 git-add--interactive.perl:1295
 msgid ""
 "y - discard this hunk from worktree\n"
 "n - do not discard this hunk from worktree\n"
@@ -25899,7 +25897,7 @@ msgstr ""
 "a - loại bỏ khúc này và tất cả các khúc sau này trong tập tin\n"
 "d - đừng loại bỏ khúc này cũng như bất kỳ cái nào sau này trong tập tin"
 
-#: git-add--interactive.perl:1281
+#: git-add--interactive.perl:1283
 msgid ""
 "y - discard this hunk from index and worktree\n"
 "n - do not discard this hunk from index and worktree\n"
@@ -25913,7 +25911,7 @@ msgstr ""
 "a - loại bỏ khúc này và tất cả các khúc sau này trong tập tin\n"
 "d - đừng loại bỏ khúc này cũng như bất kỳ cái nào sau này trong tập tin"
 
-#: git-add--interactive.perl:1287
+#: git-add--interactive.perl:1289
 msgid ""
 "y - apply this hunk to index and worktree\n"
 "n - do not apply this hunk to index and worktree\n"
@@ -25927,7 +25925,7 @@ msgstr ""
 "a - áp dụng khúc này và tất cả các khúc sau này trong tập tin\n"
 "d - đừng áp dụng khúc này cũng như bất kỳ cái nào sau này trong tập tin"
 
-#: git-add--interactive.perl:1299
+#: git-add--interactive.perl:1301
 msgid ""
 "y - apply this hunk to worktree\n"
 "n - do not apply this hunk to worktree\n"
@@ -25941,7 +25939,7 @@ msgstr ""
 "a - áp dụng khúc này và tất cả các khúc sau này trong tập tin\n"
 "d - đừng áp dụng khúc này cũng như bất kỳ cái nào sau này trong tập tin"
 
-#: git-add--interactive.perl:1314
+#: git-add--interactive.perl:1316
 msgid ""
 "g - select a hunk to go to\n"
 "/ - search for a hunk matching the given regex\n"
@@ -25963,88 +25961,88 @@ msgstr ""
 "e - sửa bằng tay khúc hiện hành\n"
 "? - in trợ giúp\n"
 
-#: git-add--interactive.perl:1345
+#: git-add--interactive.perl:1347
 msgid "The selected hunks do not apply to the index!\n"
 msgstr "Các khúc đã chọn không được áp dụng vào bảng mục lục!\n"
 
-#: git-add--interactive.perl:1360
+#: git-add--interactive.perl:1362
 #, perl-format
 msgid "ignoring unmerged: %s\n"
 msgstr "bỏ qua những thứ chưa hòa trộn: %s\n"
 
-#: git-add--interactive.perl:1479
+#: git-add--interactive.perl:1481
 #, perl-format
 msgid "Apply mode change to worktree [y,n,q,a,d%s,?]? "
 msgstr "Áp dụng thay đổi chế độ cho cây làm việc [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1480
+#: git-add--interactive.perl:1482
 #, perl-format
 msgid "Apply deletion to worktree [y,n,q,a,d%s,?]? "
 msgstr "Áp dụng việc xóa cho cây làm việc [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1481
+#: git-add--interactive.perl:1483
 #, perl-format
 msgid "Apply addition to worktree [y,n,q,a,d%s,?]? "
 msgstr "Áp dụng việc thêm cho cây làm việc [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1482
+#: git-add--interactive.perl:1484
 #, perl-format
 msgid "Apply this hunk to worktree [y,n,q,a,d%s,?]? "
 msgstr "Áp dụng khúc này vào cây làm việc [y,n,q,a,d%s,?]? "
 
-#: git-add--interactive.perl:1599
+#: git-add--interactive.perl:1601
 msgid "No other hunks to goto\n"
 msgstr "Không còn khúc nào để mà nhảy đến\n"
 
-#: git-add--interactive.perl:1617
+#: git-add--interactive.perl:1619
 #, perl-format
 msgid "Invalid number: '%s'\n"
 msgstr "Số không hợp lệ: “%s”\n"
 
-#: git-add--interactive.perl:1622
+#: git-add--interactive.perl:1624
 #, perl-format
 msgid "Sorry, only %d hunk available.\n"
 msgid_plural "Sorry, only %d hunks available.\n"
 msgstr[0] "Rất tiếc, chỉ có sẵn %d khúc.\n"
 
-#: git-add--interactive.perl:1657
+#: git-add--interactive.perl:1659
 msgid "No other hunks to search\n"
 msgstr "Không còn khúc nào để mà tìm kiếm\n"
 
-#: git-add--interactive.perl:1674
+#: git-add--interactive.perl:1676
 #, perl-format
 msgid "Malformed search regexp %s: %s\n"
 msgstr "Định dạng tìm kiếm của biểu thức chính quy không đúng %s: %s\n"
 
-#: git-add--interactive.perl:1684
+#: git-add--interactive.perl:1686
 msgid "No hunk matches the given pattern\n"
 msgstr "Không thấy khúc nào khớp mẫu đã cho\n"
 
-#: git-add--interactive.perl:1696 git-add--interactive.perl:1718
+#: git-add--interactive.perl:1698 git-add--interactive.perl:1720
 msgid "No previous hunk\n"
 msgstr "Không có khúc kế trước\n"
 
-#: git-add--interactive.perl:1705 git-add--interactive.perl:1724
+#: git-add--interactive.perl:1707 git-add--interactive.perl:1726
 msgid "No next hunk\n"
 msgstr "Không có khúc kế tiếp\n"
 
-#: git-add--interactive.perl:1730
+#: git-add--interactive.perl:1732
 msgid "Sorry, cannot split this hunk\n"
 msgstr "Rất tiếc, không thể chia nhỏ khúc này\n"
 
-#: git-add--interactive.perl:1736
+#: git-add--interactive.perl:1738
 #, perl-format
 msgid "Split into %d hunk.\n"
 msgid_plural "Split into %d hunks.\n"
 msgstr[0] "Chi nhỏ thành %d khúc.\n"
 
-#: git-add--interactive.perl:1746
+#: git-add--interactive.perl:1748
 msgid "Sorry, cannot edit this hunk\n"
 msgstr "Rất tiếc, không thể sửa khúc này\n"
 
 #. TRANSLATORS: please do not translate the command names
 #. 'status', 'update', 'revert', etc.
-#: git-add--interactive.perl:1811
+#: git-add--interactive.perl:1813
 msgid ""
 "status        - show paths with changes\n"
 "update        - add working tree state to the staged set of changes\n"
@@ -26064,56 +26062,56 @@ msgstr ""
 "add untracked - thêm nội dung các các tập tin chưa theo dõi và tập hợp các "
 "thay đổi đã đặt lên bệ phóng\n"
 
-#: git-add--interactive.perl:1828 git-add--interactive.perl:1840
-#: git-add--interactive.perl:1843 git-add--interactive.perl:1850
-#: git-add--interactive.perl:1853 git-add--interactive.perl:1860
-#: git-add--interactive.perl:1864 git-add--interactive.perl:1870
+#: git-add--interactive.perl:1830 git-add--interactive.perl:1842
+#: git-add--interactive.perl:1845 git-add--interactive.perl:1852
+#: git-add--interactive.perl:1855 git-add--interactive.perl:1862
+#: git-add--interactive.perl:1866 git-add--interactive.perl:1872
 msgid "missing --"
 msgstr "thiếu --"
 
-#: git-add--interactive.perl:1866
+#: git-add--interactive.perl:1868
 #, perl-format
 msgid "unknown --patch mode: %s"
 msgstr "không hiểu chế độ --patch: %s"
 
-#: git-add--interactive.perl:1872 git-add--interactive.perl:1878
+#: git-add--interactive.perl:1874 git-add--interactive.perl:1880
 #, perl-format
 msgid "invalid argument %s, expecting --"
 msgstr "đối số không hợp lệ %s, cần --"
 
-#: git-send-email.perl:129
+#: git-send-email.perl:159
 msgid "local zone differs from GMT by a non-minute interval\n"
 msgstr "múi giờ nội bộ khác biệt với GMT bởi khoảng thời gian không-phút\n"
 
-#: git-send-email.perl:136 git-send-email.perl:142
+#: git-send-email.perl:166 git-send-email.perl:172
 msgid "local time offset greater than or equal to 24 hours\n"
 msgstr "khoảng bù thời gian nội bộ lớn hơn hoặc bằng 24 giờ\n"
 
-#: git-send-email.perl:214
+#: git-send-email.perl:244
 #, perl-format
 msgid "fatal: command '%s' died with exit code %d"
 msgstr "lỗi nghiêm trọng: lệnh “%s” chết với mã thoát %d"
 
-#: git-send-email.perl:227
+#: git-send-email.perl:257
 msgid "the editor exited uncleanly, aborting everything"
 msgstr "trình soạn thảo thoát không sạch sẽ, bãi bỏ mọi thứ"
 
-#: git-send-email.perl:316
+#: git-send-email.perl:346
 #, perl-format
 msgid ""
 "'%s' contains an intermediate version of the email you were composing.\n"
 msgstr "“%s” có chưa một phiên bản trung gian của thư bạn đã soạn.\n"
 
-#: git-send-email.perl:321
+#: git-send-email.perl:351
 #, perl-format
 msgid "'%s.final' contains the composed email.\n"
 msgstr "“%s.final” chứa thư điện tử đã soạn thảo.\n"
 
-#: git-send-email.perl:450
+#: git-send-email.perl:484
 msgid "--dump-aliases incompatible with other options\n"
 msgstr "--dump-aliases xung khắc với các tùy chọn khác\n"
 
-#: git-send-email.perl:525
+#: git-send-email.perl:561
 msgid ""
 "fatal: found configuration options for 'sendmail'\n"
 "git-send-email is configured with the sendemail.* options - note the 'e'.\n"
@@ -26123,11 +26121,11 @@ msgstr ""
 "git-send-email được cấu hình với các tùy chọn sendemail.* - chú ý “e”.\n"
 "Đặt sendemail.forbidSendmailVariables thành false để tắt kiểm tra này.\n"
 
-#: git-send-email.perl:530 git-send-email.perl:746
+#: git-send-email.perl:566 git-send-email.perl:782
 msgid "Cannot run git format-patch from outside a repository\n"
 msgstr "Không thể chạy git format-patch ở ngoài một kho chứa\n"
 
-#: git-send-email.perl:533
+#: git-send-email.perl:569
 msgid ""
 "`batch-size` and `relogin` must be specified together (via command-line or "
 "configuration option)\n"
@@ -26135,37 +26133,37 @@ msgstr ""
 "“batch-size” và “relogin” phải được chỉ định cùng với nhau (thông qua dòng "
 "lệnh hoặc tùy chọn cấu hình)\n"
 
-#: git-send-email.perl:546
+#: git-send-email.perl:582
 #, perl-format
 msgid "Unknown --suppress-cc field: '%s'\n"
 msgstr "Không hiểu trường --suppress-cc: “%s”\n"
 
-#: git-send-email.perl:577
+#: git-send-email.perl:613
 #, perl-format
 msgid "Unknown --confirm setting: '%s'\n"
 msgstr "Không hiểu cài đặt --confirm: “%s”\n"
 
-#: git-send-email.perl:617
+#: git-send-email.perl:653
 #, perl-format
 msgid "warning: sendmail alias with quotes is not supported: %s\n"
 msgstr "cảnh báo: bí danh sendmail với dấu trích dẫn không được hỗ trợ: %s\n"
 
-#: git-send-email.perl:619
+#: git-send-email.perl:655
 #, perl-format
 msgid "warning: `:include:` not supported: %s\n"
 msgstr "cảnh báo: “:include:“ không được hỗ trợ: %s\n"
 
-#: git-send-email.perl:621
+#: git-send-email.perl:657
 #, perl-format
 msgid "warning: `/file` or `|pipe` redirection not supported: %s\n"
 msgstr "cảnh báo: chuyển hướng “/file“ hay “|pipe“ không được hỗ trợ: %s\n"
 
-#: git-send-email.perl:626
+#: git-send-email.perl:662
 #, perl-format
 msgid "warning: sendmail line is not recognized: %s\n"
 msgstr "cảnh báo: dòng sendmail không nhận ra được: %s\n"
 
-#: git-send-email.perl:711
+#: git-send-email.perl:747
 #, perl-format
 msgid ""
 "File '%s' exists but it could also be the range of commits\n"
@@ -26180,12 +26178,12 @@ msgstr ""
 "    * Nói \"./%s\" nếu ý bạn là một tập tin; hoặc\n"
 "    * Đưa ra tùy chọn --format-patch nếu ý bạn là chuẩn bị.\n"
 
-#: git-send-email.perl:732
+#: git-send-email.perl:768
 #, perl-format
 msgid "Failed to opendir %s: %s"
 msgstr "Gặp lỗi khi mở thư mục “%s”: %s"
 
-#: git-send-email.perl:767
+#: git-send-email.perl:803
 msgid ""
 "\n"
 "No patch files specified!\n"
@@ -26195,17 +26193,17 @@ msgstr ""
 "Chưa chỉ định các tập tin miếng vá!\n"
 "\n"
 
-#: git-send-email.perl:780
+#: git-send-email.perl:816
 #, perl-format
 msgid "No subject line in %s?"
 msgstr "Không có dòng chủ đề trong %s?"
 
-#: git-send-email.perl:791
+#: git-send-email.perl:827
 #, perl-format
 msgid "Failed to open for writing %s: %s"
 msgstr "Gặp lỗi khi mở “%s” để ghi: %s"
 
-#: git-send-email.perl:802
+#: git-send-email.perl:838
 msgid ""
 "Lines beginning in \"GIT:\" will be removed.\n"
 "Consider including an overall diffstat or table of contents\n"
@@ -26219,27 +26217,27 @@ msgstr ""
 "\n"
 "Xóa nội dung phần thân nếu bạn không muốn gửi tóm tắt.\n"
 
-#: git-send-email.perl:826
+#: git-send-email.perl:862
 #, perl-format
 msgid "Failed to open %s: %s"
 msgstr "Gặp lỗi khi mở “%s”: %s"
 
-#: git-send-email.perl:843
+#: git-send-email.perl:879
 #, perl-format
 msgid "Failed to open %s.final: %s"
 msgstr "Gặp lỗi khi mở %s.final: %s"
 
-#: git-send-email.perl:886
+#: git-send-email.perl:922
 msgid "Summary email is empty, skipping it\n"
 msgstr "Thư tổng thể là trống rỗng, nên bỏ qua nó\n"
 
 #. TRANSLATORS: please keep [y/N] as is.
-#: git-send-email.perl:935
+#: git-send-email.perl:971
 #, perl-format
 msgid "Are you sure you want to use <%s> [y/N]? "
 msgstr "Bạn có chắc muốn dùng <%s> [y/N]? "
 
-#: git-send-email.perl:990
+#: git-send-email.perl:1026
 msgid ""
 "The following files are 8bit, but do not declare a Content-Transfer-"
 "Encoding.\n"
@@ -26247,11 +26245,11 @@ msgstr ""
 "Các trường sau đây là 8bit, nhưng không khai báo một Content-Transfer-"
 "Encoding.\n"
 
-#: git-send-email.perl:995
+#: git-send-email.perl:1031
 msgid "Which 8bit encoding should I declare [UTF-8]? "
 msgstr "Bảng mã 8bit nào tôi nên khai báo [UTF-8]? "
 
-#: git-send-email.perl:1003
+#: git-send-email.perl:1039
 #, perl-format
 msgid ""
 "Refusing to send because the patch\n"
@@ -26264,20 +26262,20 @@ msgstr ""
 "có chủ đề ở dạng mẫu “*** SUBJECT HERE ***”. Dùng --force nếu bạn thực sự "
 "muốn gửi.\n"
 
-#: git-send-email.perl:1022
+#: git-send-email.perl:1058
 msgid "To whom should the emails be sent (if anyone)?"
 msgstr "Tới người mà thư được gửi (nếu có)?"
 
-#: git-send-email.perl:1040
+#: git-send-email.perl:1076
 #, perl-format
 msgid "fatal: alias '%s' expands to itself\n"
 msgstr "nghiêm trọng: bí danh “%s” được khai triển thành chính nó\n"
 
-#: git-send-email.perl:1052
+#: git-send-email.perl:1088
 msgid "Message-ID to be used as In-Reply-To for the first email (if any)? "
 msgstr "Message-ID được dùng như là In-Reply-To cho thư đầu tiên (nếu có)? "
 
-#: git-send-email.perl:1114 git-send-email.perl:1122
+#: git-send-email.perl:1150 git-send-email.perl:1158
 #, perl-format
 msgid "error: unable to extract a valid address from: %s\n"
 msgstr "lỗi: không thể rút trích một địa chỉ hợp lệ từ: %s\n"
@@ -26285,16 +26283,16 @@ msgstr "lỗi: không thể rút trích một địa chỉ hợp lệ từ: %s\n
 #. TRANSLATORS: Make sure to include [q] [d] [e] in your
 #. translation. The program will only accept English input
 #. at this point.
-#: git-send-email.perl:1126
+#: git-send-email.perl:1162
 msgid "What to do with this address? ([q]uit|[d]rop|[e]dit): "
 msgstr "Làm gì với địa chỉ này? (thoát[q]|xóa[d]|sửa[e]): "
 
-#: git-send-email.perl:1446
+#: git-send-email.perl:1482
 #, perl-format
 msgid "CA path \"%s\" does not exist"
 msgstr "Đường dẫn CA “%s” không tồn tại"
 
-#: git-send-email.perl:1529
+#: git-send-email.perl:1565
 msgid ""
 "    The Cc list above has been expanded by additional\n"
 "    addresses found in the patch commit message. By default\n"
@@ -26321,114 +26319,114 @@ msgstr ""
 #. TRANSLATORS: Make sure to include [y] [n] [e] [q] [a] in your
 #. translation. The program will only accept English input
 #. at this point.
-#: git-send-email.perl:1544
+#: git-send-email.perl:1580
 msgid "Send this email? ([y]es|[n]o|[e]dit|[q]uit|[a]ll): "
 msgstr "Gửi thư này chứ? ([y]có|[n]không|[e]sửa|[q]thoát|[a]tất): "
 
-#: git-send-email.perl:1547
+#: git-send-email.perl:1583
 msgid "Send this email reply required"
 msgstr "Gửi thư này trả lời yêu cầu"
 
-#: git-send-email.perl:1581
+#: git-send-email.perl:1617
 msgid "The required SMTP server is not properly defined."
 msgstr "Máy phục vụ SMTP chưa được định nghĩa một cách thích hợp."
 
-#: git-send-email.perl:1628
+#: git-send-email.perl:1664
 #, perl-format
 msgid "Server does not support STARTTLS! %s"
 msgstr "Máy chủ không hỗ trợ STARTTLS! %s"
 
-#: git-send-email.perl:1633 git-send-email.perl:1637
+#: git-send-email.perl:1669 git-send-email.perl:1673
 #, perl-format
 msgid "STARTTLS failed! %s"
 msgstr "STARTTLS gặp lỗi! %s"
 
-#: git-send-email.perl:1646
+#: git-send-email.perl:1682
 msgid "Unable to initialize SMTP properly. Check config and use --smtp-debug."
 msgstr ""
 "Không thể khởi tạo SMTP một cách đúng đắn. Kiểm tra cấu hình và dùng --smtp-"
 "debug."
 
-#: git-send-email.perl:1664
+#: git-send-email.perl:1700
 #, perl-format
 msgid "Failed to send %s\n"
 msgstr "Gặp lỗi khi gửi %s\n"
 
-#: git-send-email.perl:1667
+#: git-send-email.perl:1703
 #, perl-format
 msgid "Dry-Sent %s\n"
 msgstr "Thử gửi %s\n"
 
-#: git-send-email.perl:1667
+#: git-send-email.perl:1703
 #, perl-format
 msgid "Sent %s\n"
 msgstr "Gửi %s\n"
 
-#: git-send-email.perl:1669
+#: git-send-email.perl:1705
 msgid "Dry-OK. Log says:\n"
 msgstr "Dry-OK. Nhật ký nói rằng:\n"
 
-#: git-send-email.perl:1669
+#: git-send-email.perl:1705
 msgid "OK. Log says:\n"
 msgstr "OK. Nhật ký nói rằng:\n"
 
-#: git-send-email.perl:1688
+#: git-send-email.perl:1724
 msgid "Result: "
 msgstr "Kết quả: "
 
-#: git-send-email.perl:1691
+#: git-send-email.perl:1727
 msgid "Result: OK\n"
 msgstr "Kết quả: Tốt\n"
 
-#: git-send-email.perl:1708
+#: git-send-email.perl:1744
 #, perl-format
 msgid "can't open file %s"
 msgstr "không thể mở tập tin “%s”"
 
-#: git-send-email.perl:1756 git-send-email.perl:1776
+#: git-send-email.perl:1792 git-send-email.perl:1812
 #, perl-format
 msgid "(mbox) Adding cc: %s from line '%s'\n"
 msgstr "(mbox) Thêm cc: %s từ dòng “%s”\n"
 
-#: git-send-email.perl:1762
+#: git-send-email.perl:1798
 #, perl-format
 msgid "(mbox) Adding to: %s from line '%s'\n"
 msgstr "(mbox) Đang thêm to: %s từ dòng “%s”\n"
 
-#: git-send-email.perl:1819
+#: git-send-email.perl:1855
 #, perl-format
 msgid "(non-mbox) Adding cc: %s from line '%s'\n"
 msgstr "(non-mbox) Thêm cc: %s từ dòng “%s”\n"
 
-#: git-send-email.perl:1854
+#: git-send-email.perl:1890
 #, perl-format
 msgid "(body) Adding cc: %s from line '%s'\n"
 msgstr "(body) Thêm cc: %s từ dòng “%s”\n"
 
-#: git-send-email.perl:1973
+#: git-send-email.perl:2009
 #, perl-format
 msgid "(%s) Could not execute '%s'"
 msgstr "(%s) Không thể thực thi “%s”"
 
-#: git-send-email.perl:1980
+#: git-send-email.perl:2016
 #, perl-format
 msgid "(%s) Adding %s: %s from: '%s'\n"
 msgstr "(%s) Đang thêm %s: %s từ: “%s”\n"
 
-#: git-send-email.perl:1984
+#: git-send-email.perl:2020
 #, perl-format
 msgid "(%s) failed to close pipe to '%s'"
 msgstr "(%s) gặp lỗi khi đóng đường ống đến “%s”"
 
-#: git-send-email.perl:2014
+#: git-send-email.perl:2050
 msgid "cannot send message as 7bit"
 msgstr "không thể lấy gửi thư dạng 7 bít"
 
-#: git-send-email.perl:2022
+#: git-send-email.perl:2058
 msgid "invalid transfer encoding"
 msgstr "bảng mã truyền không hợp lệ"
 
-#: git-send-email.perl:2059
+#: git-send-email.perl:2095
 #, perl-format
 msgid ""
 "fatal: %s: rejected by sendemail-validate hook\n"
@@ -26439,12 +26437,12 @@ msgstr ""
 "%s\n"
 "cảnh báo: không có miếng vá nào được gửi đi\n"
 
-#: git-send-email.perl:2069 git-send-email.perl:2122 git-send-email.perl:2132
+#: git-send-email.perl:2105 git-send-email.perl:2158 git-send-email.perl:2168
 #, perl-format
 msgid "unable to open %s: %s\n"
 msgstr "không thể mở %s: %s\n"
 
-#: git-send-email.perl:2072
+#: git-send-email.perl:2108
 #, perl-format
 msgid ""
 "fatal: %s:%d is longer than 998 characters\n"
@@ -26453,2382 +26451,13 @@ msgstr ""
 "nghiêm trọng: %s: %d là dài hơn 998 ký tự\n"
 "cảnh báo: không có miếng vá nào được gửi đi\n"
 
-#: git-send-email.perl:2090
+#: git-send-email.perl:2126
 #, perl-format
 msgid "Skipping %s with backup suffix '%s'.\n"
 msgstr "Bỏ qua %s với hậu tố sao lưu dự phòng “%s”.\n"
 
 #. TRANSLATORS: please keep "[y|N]" as is.
-#: git-send-email.perl:2094
+#: git-send-email.perl:2130
 #, perl-format
 msgid "Do you really want to send %s? [y|N]: "
 msgstr "Bạn có thực sự muốn gửi %s? [y|N](có/KHÔNG): "
-
-#~ msgid ""
-#~ "The following pathspecs didn't match any eligible path, but they do match "
-#~ "index\n"
-#~ "entries outside the current sparse checkout:\n"
-#~ msgstr ""
-#~ "Các đặc tả đường dẫn sau đây không khớp với bất kỳ đường dẫn thích hợp "
-#~ "nào,\n"
-#~ "nhưng chúng khớp với các mục mục lục bên ngoài \"sparse checkout\" hiện "
-#~ "tại:\n"
-
-#~ msgid ""
-#~ "Disable or modify the sparsity rules if you intend to update such entries."
-#~ msgstr ""
-#~ "Vô hiệu hóa hoặc sửa đổi các quy tắc sparsity nếu bạn có ý định cập nhật "
-#~ "các mục như vậy."
-
-#~ msgid "could not set GIT_DIR to '%s'"
-#~ msgstr "không thể đặt GIT_DIR thành “%s”"
-
-#~ msgid "unable to unpack %s header with --allow-unknown-type"
-#~ msgstr "không thể giải nén phần đầu gói %s với --allow-unknown-type"
-
-#~ msgid "unable to parse %s header with --allow-unknown-type"
-#~ msgstr "không thể phân tích phần đầu gói %s với --allow-unknown-type"
-
-#~ msgid "open /dev/null failed"
-#~ msgstr "gặp lỗi khi mở “/dev/null”"
-
-#~ msgid ""
-#~ "after resolving the conflicts, mark the corrected paths\n"
-#~ "with 'git add <paths>' or 'git rm <paths>'\n"
-#~ "and commit the result with 'git commit'"
-#~ msgstr ""
-#~ "sau khi giải quyết các xung đột, đánh dấu đường dẫn đã sửa\n"
-#~ "với lệnh “git add </các/đường/dẫn>” hoặc “git rm </các/đường/dẫn>”\n"
-#~ "và chuyển giao kết quả bằng lệnh “git commit”"
-
-#~ msgid "open /dev/null or dup failed"
-#~ msgstr "gặp lỗi khi mở “/dev/null” hay dup"
-
-#~ msgid "attempting to use sparse-index without cone mode"
-#~ msgstr "cố gắng sử dụng chỉ mục thưa thớt mà không có chế độ hình nón"
-
-#~ msgid "unable to update cache-tree, staying full"
-#~ msgstr "không thể cập nhật cây bộ nhớ đệm, chỗ chứa bị đầy"
-
-#~ msgid "Could not open '%s' for writing."
-#~ msgstr "Không thể mở “%s” để ghi."
-
-#~ msgid "could not create archive file '%s'"
-#~ msgstr "không thể tạo tập tin kho (lưu trữ, nén) “%s”"
-
-#~ msgid ""
-#~ "git bisect--helper --bisect-next-check <good_term> <bad_term> [<term>]"
-#~ msgstr ""
-#~ "git bisect--helper --bisect-next-check <lúc_sai> <lúc_đúng> [<term>]"
-
-#~ msgid "--bisect-next-check requires 2 or 3 arguments"
-#~ msgstr "--bisect-next-check cần 2 hoặc 3 tham số"
-
-#~ msgid "couldn't create a new file at '%s'"
-#~ msgstr "không thể tạo tập tin mới tại “%s”"
-
-#~ msgid "git commit-tree: failed to open '%s'"
-#~ msgstr "git commit-tree: gặp lỗi khi mở “%s”"
-
-#~ msgid "cannot open packfile '%s'"
-#~ msgstr "không thể mở packfile “%s”"
-
-#~ msgid "cannot store pack file"
-#~ msgstr "không thể lưu tập tin gói"
-
-#~ msgid "cannot store index file"
-#~ msgstr "không thể lưu trữ tập tin ghi mục lục"
-
-#~ msgid "exclude patterns are read from <file>"
-#~ msgstr "mẫu loại trừ được đọc từ <tập tin>"
-
-#~ msgid "Unknown option for merge-recursive: -X%s"
-#~ msgstr "Không hiểu tùy chọn cho merge-recursive: -X%s"
-
-#~ msgid "unusable todo list: '%s'"
-#~ msgstr "danh sách cần làm không dùng được: “%s”"
-
-#~ msgid "git rebase--interactive [<options>]"
-#~ msgstr "git rebase--interactive [<các tùy chọn>]"
-
-#~ msgid "rebase merge commits"
-#~ msgstr "cải tổ các lần chuyển giao hòa trộn"
-
-#~ msgid "keep original branch points of cousins"
-#~ msgstr "giữ các điểm nhánh nguyên bản của các anh em họ"
-
-#~ msgid "move commits that begin with squash!/fixup!"
-#~ msgstr "di chuyển các lần chuyển giao bắt đầu bằng squash!/fixup!"
-
-#~ msgid "sign commits"
-#~ msgstr "ký các lần chuyển giao"
-
-#~ msgid "continue rebase"
-#~ msgstr "tiếp tục cải tổ"
-
-#~ msgid "skip commit"
-#~ msgstr "bỏ qua lần chuyển giao"
-
-#~ msgid "edit the todo list"
-#~ msgstr "sửa danh sách cần làm"
-
-#~ msgid "show the current patch"
-#~ msgstr "hiển thị miếng vá hiện hành"
-
-#~ msgid "shorten commit ids in the todo list"
-#~ msgstr "rút ngắn mã chuyển giao trong danh sách cần làm"
-
-#~ msgid "expand commit ids in the todo list"
-#~ msgstr "khai triển mã chuyển giao trong danh sách cần làm"
-
-#~ msgid "check the todo list"
-#~ msgstr "kiểm tra danh sách cần làm"
-
-#~ msgid "rearrange fixup/squash lines"
-#~ msgstr "sắp xếp lại các dòng fixup/squash"
-
-#~ msgid "insert exec commands in todo list"
-#~ msgstr "chèn các lệnh thực thi trong danh sách cần làm"
-
-#~ msgid "onto"
-#~ msgstr "lên trên"
-
-#~ msgid "restrict-revision"
-#~ msgstr "điểm-xét-duyệt-hạn-chế"
-
-#~ msgid "restrict revision"
-#~ msgstr "điểm xét duyệt hạn chế"
-
-#~ msgid "squash-onto"
-#~ msgstr "squash-lên-trên"
-
-#~ msgid "squash onto"
-#~ msgstr "squash lên trên"
-
-#~ msgid "the upstream commit"
-#~ msgstr "lần chuyển giao thượng nguồn"
-
-#~ msgid "head-name"
-#~ msgstr "tên-đầu"
-
-#~ msgid "head name"
-#~ msgstr "tên đầu"
-
-#~ msgid "rebase strategy"
-#~ msgstr "chiến lược cải tổ"
-
-#~ msgid "strategy-opts"
-#~ msgstr "tùy-chọn-chiến-lược"
-
-#~ msgid "strategy options"
-#~ msgstr "các tùy chọn chiến lược"
-
-#~ msgid "switch-to"
-#~ msgstr "chuyển-đến"
-
-#~ msgid "the branch or commit to checkout"
-#~ msgstr "nhánh hay lần chuyển giao lần lấy ra"
-
-#~ msgid "onto-name"
-#~ msgstr "onto-name"
-
-#~ msgid "onto name"
-#~ msgstr "tên lên trên"
-
-#~ msgid "cmd"
-#~ msgstr "lệnh"
-
-#~ msgid "the command to run"
-#~ msgstr "lệnh muốn chạy"
-
-#~ msgid "--[no-]rebase-cousins has no effect without --rebase-merges"
-#~ msgstr ""
-#~ "--[no-]rebase-cousins không có tác dụng khi không có --rebase-merges"
-
-#~ msgid "cannot combine '--preserve-merges' with '--rebase-merges'"
-#~ msgstr "không thể kết hợp “--preserve-merges” với “--rebase-merges”"
-
-#~ msgid ""
-#~ "error: cannot combine '--preserve-merges' with '--reschedule-failed-exec'"
-#~ msgstr ""
-#~ "không thể kết hợp “--preserve-merges” với “--reschedule-failed-exec”"
-
-#~ msgid ""
-#~ "git submodule--helper add-clone [<options>...] --url <url> --path <path> "
-#~ "--name <name>"
-#~ msgstr ""
-#~ "git submodule--helper add-clone [<các tùy chọn>…] --url <url> --path </"
-#~ "đường/dẫn> --name <tên>"
-
-#~ msgid "failed to create file %s"
-#~ msgstr "gặp lỗi khi tạo tập tin %s"
-
-#~ msgid "exit immediately after initial ref advertisement"
-#~ msgstr "thoát ngay sau khi khởi tạo quảng cáo tham chiếu"
-
-#~ msgid "socket/pipe already in use: '%s'"
-#~ msgstr "socket/pipe đã đang được sử dụng rồi: “%s”"
-
-#~ msgid "could not start server on: '%s'"
-#~ msgstr "không thể khởi động máy phục vụ lên: “%s”"
-
-#~ msgid "could not spawn daemon in the background"
-#~ msgstr "không thể sinh ra daemon trong nền"
-
-#~ msgid "waitpid failed"
-#~ msgstr "waitpid gặp lỗi"
-
-#~ msgid "daemon not online yet"
-#~ msgstr "\"daemon\" vẫn chưa trực tuyến"
-
-#~ msgid "daemon failed to start"
-#~ msgstr "daemon gặp lỗi khi khởi động"
-
-#~ msgid "waitpid is confused"
-#~ msgstr "waitpid là chưa rõ ràng"
-
-#~ msgid "daemon has not shutdown yet"
-#~ msgstr "\"daemon\" vẫn chưa được tắt đi"
-
-#~ msgid "Protocol restrictions not supported with cURL < 7.19.4"
-#~ msgstr "Các hạn chế giao thức không được hỗ trợ với cURL < 7.19.4"
-
-#~ msgid "running $command"
-#~ msgstr "đang chạy lệnh $command"
-
-#~ msgid "'$sm_path' does not have a commit checked out"
-#~ msgstr "“$sm_path” không có lần chuyển giao nào được lấy ra"
-
-#~ msgid "Submodule path '$displaypath': '$command $sha1'"
-#~ msgstr "Đường dẫn mô-đun-con “$displaypath”: “$command $sha1”"
-
-#~ msgid "Applied autostash."
-#~ msgstr "Đã áp dụng autostash."
-
-#~ msgid "Cannot store $stash_sha1"
-#~ msgstr "Không thể lưu $stash_sha1"
-
-#~ msgid ""
-#~ "Applying autostash resulted in conflicts.\n"
-#~ "Your changes are safe in the stash.\n"
-#~ "You can run \"git stash pop\" or \"git stash drop\" at any time.\n"
-#~ msgstr ""
-#~ "Áp dụng autostash có hiệu quả trong các xung đột.\n"
-#~ "Các thay đổi của bạn an toàn trong stash (tạm cất đi).\n"
-#~ "Bạn có thể chạy lệnh \"git stash pop\" hay \"git stash drop\" bất kỳ lúc "
-#~ "nào.\n"
-
-#~ msgid "Rebasing ($new_count/$total)"
-#~ msgstr "Đang rebase ($new_count/$total)"
-
-#~ msgid ""
-#~ "\n"
-#~ "Commands:\n"
-#~ "p, pick <commit> = use commit\n"
-#~ "r, reword <commit> = use commit, but edit the commit message\n"
-#~ "e, edit <commit> = use commit, but stop for amending\n"
-#~ "s, squash <commit> = use commit, but meld into previous commit\n"
-#~ "f, fixup <commit> = like \"squash\", but discard this commit's log "
-#~ "message\n"
-#~ "x, exec <commit> = run command (the rest of the line) using shell\n"
-#~ "d, drop <commit> = remove commit\n"
-#~ "l, label <label> = label current HEAD with a name\n"
-#~ "t, reset <label> = reset HEAD to a label\n"
-#~ "m, merge [-C <commit> | -c <commit>] <label> [# <oneline>]\n"
-#~ ".       create a merge commit using the original merge commit's\n"
-#~ ".       message (or the oneline, if no original merge commit was\n"
-#~ ".       specified). Use -c <commit> to reword the commit message.\n"
-#~ "\n"
-#~ "These lines can be re-ordered; they are executed from top to bottom.\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Các lệnh:\n"
-#~ "p, pick <commit> = dùng lần chuyển giao\n"
-#~ "r, reword <commit> = dùng lần chuyển giao, nhưng sửa lại phần chú thích\n"
-#~ "e, edit <commit> = dùng lần chuyển giao, nhưng dừng lại để tu bổ (amend)\n"
-#~ "s, squash <commit> = dùng lần chuyển giao, nhưng meld vào lần chuyển giao "
-#~ "kế trước\n"
-#~ "f, fixup <commit> = giống như \"squash\", nhưng loại bỏ chú thích của lần "
-#~ "chuyển giao này\n"
-#~ "x, exec <commit> = chạy lệnh (phần còn lại của dòng) dùng hệ vỏ\n"
-#~ "d, drop <commit> = xóa lần chuyển giao\n"
-#~ "l, label <label> = đánh nhãn HEAD hiện tại bằng một tên\n"
-#~ "t, reset <label> = đặt lại HEAD thành một nhãn\n"
-#~ "m, merge [-C <commit> | -c <commit>] <nhãn> [# <một_dòng>]\n"
-#~ ".       tạo một lần chuyển giao hòa trộn sử dụng chú thích của lần "
-#~ "chuyển\n"
-#~ ".       giao hòa trộn gốc (hoặc một_dòng, nếu không chỉ định lần chuyển "
-#~ "giao hòa\n"
-#~ ".       trộn gốc). Dùng -c <commit> để reword chú thích của lần chuyển "
-#~ "giao.\n"
-#~ "\n"
-#~ "Những dòng này có thể đảo ngược thứ tự; chúng chạy từ trên đỉnh xuống "
-#~ "dưới đáy.\n"
-
-#~ msgid ""
-#~ "You can amend the commit now, with\n"
-#~ "\n"
-#~ "\tgit commit --amend $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "Once you are satisfied with your changes, run\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-#~ msgstr ""
-#~ "Bạn có thể tu bổ lần chuyển giao ngay bây giờ bằng:\n"
-#~ "\n"
-#~ "\tgit commit --amend $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "Một khi đã hài lòng với những thay đổi của mình, thì chạy:\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-
-#~ msgid "$sha1: not a commit that can be picked"
-#~ msgstr "$sha1: không phải là lần chuyển giao mà có thể lấy ra được"
-
-#~ msgid "Invalid commit name: $sha1"
-#~ msgstr "Tên lần chuyển giao không hợp lệ: $sha1"
-
-#~ msgid "Cannot write current commit's replacement sha1"
-#~ msgstr "Không thể ghi lại sha1 thay thế của lần chuyển giao"
-
-#~ msgid "Fast-forward to $sha1"
-#~ msgstr "Chuyển-tiếp-nhanh đến $sha1"
-
-#~ msgid "Cannot fast-forward to $sha1"
-#~ msgstr "Không thể chuyển-tiếp-nhanh đến $sha1"
-
-#~ msgid "Cannot move HEAD to $first_parent"
-#~ msgstr "Không thể di chuyển HEAD đến $first_parent"
-
-#~ msgid "Refusing to squash a merge: $sha1"
-#~ msgstr "Từ chối squash lần hòa trộn: $sha1"
-
-#~ msgid "Error redoing merge $sha1"
-#~ msgstr "Gặp lỗi khi hoàn lại bước hòa trộn $sha1"
-
-#~ msgid "Could not pick $sha1"
-#~ msgstr "Không thể lấy ra $sha1"
-
-#~ msgid "This is the commit message #${n}:"
-#~ msgstr "Đây là chú thích cho lần chuyển giao thứ #${n}:"
-
-#~ msgid "The commit message #${n} will be skipped:"
-#~ msgstr "Chú thích cho lần chuyển giao thứ #${n} sẽ bị bỏ qua:"
-
-#~ msgid "This is a combination of $count commit."
-#~ msgid_plural "This is a combination of $count commits."
-#~ msgstr[0] "Đây là tổ hợp của $count lần chuyển giao."
-
-#~ msgid "Cannot write $fixup_msg"
-#~ msgstr "Không thể $fixup_msg"
-
-#~ msgid "This is a combination of 2 commits."
-#~ msgstr "Đây là tổ hợp của 2 lần chuyển giao."
-
-#~ msgid "Could not apply $sha1... $rest"
-#~ msgstr "Không thể áp dụng $sha1… $rest"
-
-#~ msgid ""
-#~ "Could not amend commit after successfully picking $sha1... $rest\n"
-#~ "This is most likely due to an empty commit message, or the pre-commit "
-#~ "hook\n"
-#~ "failed. If the pre-commit hook failed, you may need to resolve the issue "
-#~ "before\n"
-#~ "you are able to reword the commit."
-#~ msgstr ""
-#~ "Không thể tu bổ lần chuyển giao sau khi lấy ra $sha1… $rest thành công\n"
-#~ "Việc này có thể là do một ghi chú cho lần chuyển giao là trống rỗng, hoặc "
-#~ "móc pre-commit\n"
-#~ "gặp lỗi. Nếu là móc pre-commit bị lỗi, Bạn có lẽ cần giải quyết trục trặc "
-#~ "này\n"
-#~ "trước khi bạn có thể làm việc lại với lần chuyển giao."
-
-#~ msgid "Stopped at $sha1_abbrev... $rest"
-#~ msgstr "Bị dừng tại $sha1_abbrev… $rest"
-
-#~ msgid "Cannot '$squash_style' without a previous commit"
-#~ msgstr "Không “$squash_style” thể mà không có lần chuyển giao kế trước"
-
-#~ msgid "Executing: $rest"
-#~ msgstr "Đang thực thi: $rest"
-
-#~ msgid "Execution failed: $rest"
-#~ msgstr "Thực thi gặp lỗi: $rest"
-
-#~ msgid "and made changes to the index and/or the working tree"
-#~ msgstr "và tạo các thay đổi bảng mục lục và/hay cây làm việc"
-
-#~ msgid ""
-#~ "You can fix the problem, and then run\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-#~ msgstr ""
-#~ "Bạn có thể sửa các trục trặc, và sau đó chạy lệnh “cải tổ”:\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-
-#~ msgid ""
-#~ "Execution succeeded: $rest\n"
-#~ "but left changes to the index and/or the working tree\n"
-#~ "Commit or stash your changes, and then run\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-#~ msgstr ""
-#~ "Thực thi thành công: $rest\n"
-#~ "nhưng còn các thay đổi trong mục lục và/hoặc cây làm việc\n"
-#~ "Chuyển giao hay tạm cất các thay đổi này đi, rồi chạy\n"
-#~ "\n"
-#~ "\tgit rebase --continue"
-
-#~ msgid "Unknown command: $command $sha1 $rest"
-#~ msgstr "Lệnh chưa biết: $command $sha1 $rest"
-
-#~ msgid "Please fix this using 'git rebase --edit-todo'."
-#~ msgstr "Vui lòng sửa lỗi này bằng cách dùng “git rebase --edit-todo”."
-
-#~ msgid "Successfully rebased and updated $head_name."
-#~ msgstr "Cài tổ và cập nhật $head_name một cách thành công."
-
-#~ msgid "Could not remove CHERRY_PICK_HEAD"
-#~ msgstr "Không thể xóa bỏ CHERRY_PICK_HEAD"
-
-#~ msgid ""
-#~ "You have staged changes in your working tree.\n"
-#~ "If these changes are meant to be\n"
-#~ "squashed into the previous commit, run:\n"
-#~ "\n"
-#~ "  git commit --amend $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "If they are meant to go into a new commit, run:\n"
-#~ "\n"
-#~ "  git commit $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "In both cases, once you're done, continue with:\n"
-#~ "\n"
-#~ "  git rebase --continue\n"
-#~ msgstr ""
-#~ "Bạn có các thay đổi so với trong bệ phóng trong\n"
-#~ "thư mục làm việc của bạn. Nếu các thay đổi này là muốn\n"
-#~ "squash vào lần chuyển giao kế trước, chạy:\n"
-#~ "\n"
-#~ "  git commit --amend $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "Nếu chúng có ý là đi đến lần chuyển giao mới, thì chạy:\n"
-#~ "\n"
-#~ "  git commit $gpg_sign_opt_quoted\n"
-#~ "\n"
-#~ "Trong cả hai trường hợp, một khi bạn làm xong, tiếp tục bằng:\n"
-#~ "\n"
-#~ "  git rebase --continue\n"
-
-#~ msgid "Error trying to find the author identity to amend commit"
-#~ msgstr "Lỗi khi cố tìm định danh của tác giả để tu bổ lần chuyển giao"
-
-#~ msgid ""
-#~ "You have uncommitted changes in your working tree. Please commit them\n"
-#~ "first and then run 'git rebase --continue' again."
-#~ msgstr ""
-#~ "Bạn có các thay đổi chưa chuyển giao trong thư mục làm việc.\n"
-#~ "Vui lòng chuyển giao chúng và sau đó chạy lệnh “git rebase --continue” "
-#~ "lần nữa."
-
-#~ msgid "Could not commit staged changes."
-#~ msgstr "Không thể chuyển giao các thay đổi đã đưa lên bệ phóng."
-
-#~ msgid "Could not execute editor"
-#~ msgstr "Không thể thực thi trình biên soạn"
-
-#~ msgid "Could not checkout $switch_to"
-#~ msgstr "Không thể lấy ra $switch_to"
-
-#~ msgid "No HEAD?"
-#~ msgstr "Không HEAD?"
-
-#~ msgid "Could not create temporary $state_dir"
-#~ msgstr "Không thể tạo thư mục tạm thời $state_dir"
-
-#~ msgid "Could not mark as interactive"
-#~ msgstr "Không thể đánh dấu là tương tác"
-
-#~ msgid "Rebase $shortrevisions onto $shortonto ($todocount command)"
-#~ msgid_plural "Rebase $shortrevisions onto $shortonto ($todocount commands)"
-#~ msgstr[0] "Cải tổ $shortrevisions vào $shortonto (các lệnh $todocount)"
-
-#~ msgid "Note that empty commits are commented out"
-#~ msgstr "Chú ý rằng lần chuyển giao trống rỗng là ghi chú"
-
-#~ msgid "Could not init rewritten commits"
-#~ msgstr "Không thể khởi tạo các lần chuyển giao ghi lại"
-
-#~ msgid "Cannot rebase: You have unstaged changes."
-#~ msgstr "Không thể cải tổ: Bạn có các thay đổi chưa được đưa lên bệ phóng."
-
-#~ msgid "Cannot pull with rebase: You have unstaged changes."
-#~ msgstr ""
-#~ "Không thể pull với cải tổ: Bạn có các thay đổi chưa được đưa lên bệ phóng."
-
-#~ msgid "Cannot rebase: Your index contains uncommitted changes."
-#~ msgstr ""
-#~ "Không thể cải tổ: Mục lục của bạn có chứa các thay đổi chưa được chuyển "
-#~ "giao."
-
-#~ msgid "Cannot pull with rebase: Your index contains uncommitted changes."
-#~ msgstr ""
-#~ "Không thể pull với cải tổ: Bạn có các thay đổi chưa được chuyển giao."
-
-#~ msgid "unable to write stateless separator packet"
-#~ msgstr "không thể ghi gói phân tách không trạng thái"
-
-#~ msgid "git merge --abort"
-#~ msgstr "git merge --abort"
-
-#~ msgid "git merge --continue"
-#~ msgstr "git merge --continue"
-
-#~ msgid "git stash clear"
-#~ msgstr "git stash clear"
-
-#~ msgid "remote server sent stateless separator"
-#~ msgstr "máy phục vụ từ xa gửi các bộ ngăn cách không tình trạng"
-
-#~ msgid "--cached and --3way cannot be used together."
-#~ msgstr "--cached và --3way không thể dùng cùng nhau."
-
-#~ msgid "both"
-#~ msgstr "cả hai"
-
-#~ msgid "one"
-#~ msgstr "một"
-
-#~ msgid "Already up to date!"
-#~ msgstr "Đã cập nhật rồi!"
-
-#~ msgid "Already up to date. Yeeah!"
-#~ msgstr "Đã cập nhật rồi. Yeeah!"
-
-#~ msgid "--batch-size option is only for 'repack' subcommand"
-#~ msgstr "tùy chọn --batch-size chỉ cho lệnh con “repack”"
-
-#~ msgid "Percentage by which creation is weighted"
-#~ msgstr "Tỷ lệ phần trăm cái tạo là weighted"
-
-#~ msgid ""
-#~ "the rebase.useBuiltin support has been removed!\n"
-#~ "See its entry in 'git help config' for details."
-#~ msgstr ""
-#~ "việc hỗ trợ rebase.useBuiltin đã bị xóa!\n"
-#~ "Xem mục tin của nó trong “ git help config” để biết chi tiết."
-
-#~ msgid "%s: patch contains a line longer than 998 characters"
-#~ msgstr "%s: miếng vá có chứa dòng dài hơn 998 ký tự"
-
-#~ msgid "repository contains replace objects; skipping commit-graph"
-#~ msgstr ""
-#~ "kho lưu trữ chứa các đối tượng thay thế; bỏ qua sơ đồ lần chuyển giao"
-
-#~ msgid "repository contains (deprecated) grafts; skipping commit-graph"
-#~ msgstr ""
-#~ "kho lưu trữ chứa các mối ghép (đã lạc hậu); bỏ qua sơ đồ các lần chuyển "
-#~ "giao"
-
-#~ msgid "repository is shallow; skipping commit-graph"
-#~ msgstr "kho nguồn là nông, nên bỏ qua commit-graph"
-
-#~ msgid "commit-graph improper chunk offset %08x%08x"
-#~ msgstr "bù mảnh đồ-thị-các-lần-chuyển-giao không đúng chỗ %08x%08x"
-
-#~ msgid "commit-graph chunk id %08x appears multiple times"
-#~ msgstr "mã mảnh đồ-thị-các-lần-chuyển-giao %08x xuất hiện nhiều lần"
-
-#~ msgid "invalid chunk offset (too large)"
-#~ msgstr "khoảng bù đoạn không hợp lệ (quá lớn)"
-
-#~ msgid "Writing chunks to multi-pack-index"
-#~ msgstr "Đang ghi các khúc vào multi-pack-index"
-
-#~ msgid "rev-list died"
-#~ msgstr "rev-list đã chết"
-
-#~ msgid ""
-#~ "git bisect--helper --bisect-write [--no-log] <state> <revision> "
-#~ "<good_term> <bad_term>"
-#~ msgstr ""
-#~ "git bisect--helper --bisect-write [--no-log] <state> <revision> <lúc_sai> "
-#~ "<lúc_đúng>"
-
-#~ msgid ""
-#~ "git bisect--helper --bisect-check-and-set-terms <command> <good_term> "
-#~ "<bad_term>"
-#~ msgstr ""
-#~ "git bisect--helper --bisect-check-and-set-terms <command> <lúc_sai> "
-#~ "<lúc_đúng>"
-
-#~ msgid "git bisect--helper --bisect-auto-next"
-#~ msgstr "git bisect--helper --bisect-auto-next"
-
-#~ msgid "write out the bisection state in BISECT_LOG"
-#~ msgstr "ghi ra tình trạng di chuyển nửa bước trong BISECT_LOG"
-
-#~ msgid "check and set terms in a bisection state"
-#~ msgstr "kiểm tra và đặt thời điểm trong di chuyển nửa bước"
-
-#~ msgid ""
-#~ "verify the next bisection state then checkout the next bisection commit"
-#~ msgstr ""
-#~ "xác nhận trạng thái phân đôi kế sau đó lấy ra lần chuyển giao phân đôi kế"
-
-#~ msgid "--bisect-write requires either 4 or 5 arguments"
-#~ msgstr "--bisect-write cần 4 hoặc 5 tham số"
-
-#~ msgid "--check-and-set-terms requires 3 arguments"
-#~ msgstr "--check-and-set-terms cần 3 tham số"
-
-#~ msgid "--bisect-auto-next requires 0 arguments"
-#~ msgstr "--bisect-auto-next cần 0 tham số"
-
-#~ msgid "Force progress reporting"
-#~ msgstr "Ép buộc báo cáo diễn biến công việc"
-
-#~ msgid "Error deleting remote-tracking branch '%s'"
-#~ msgstr "Gặp lỗi khi đang xóa nhánh theo dõi máy chủ “%s”"
-
-#~ msgid "Error deleting branch '%s'"
-#~ msgstr "Gặp lỗi khi xóa bỏ nhánh “%s”"
-
-#~ msgid "show parse tree for grep expression"
-#~ msgstr "hiển thị cây phân tích cú pháp cho biểu thức “grep” (tìm kiếm)"
-
-#~ msgid "too many parameters"
-#~ msgstr "quá nhiều đối số"
-
-#~ msgid "too few parameters"
-#~ msgstr "quá ít đối số"
-
-#~ msgid "Recurse into nested submodules"
-#~ msgstr "Đệ quy vào trong các mô-đun-con lồng nhau"
-
-#~ msgid "too many params"
-#~ msgstr "quá nhiều đối số"
-
-#~ msgid "Bad rev input: $arg"
-#~ msgstr "Đầu vào rev sai: $arg"
-
-#~ msgid "Counting distinct commits in commit graph"
-#~ msgstr "Đang đếm các lần chuyển giao khác nhau trong đồ thị lần chuyển giao"
-
-#~ msgid "the commit graph format cannot write %d commits"
-#~ msgstr ""
-#~ "định dạng đồ họa các lần chuyển giao không thể ghi %d lần chuyển giao"
-
-#~ msgid "store only"
-#~ msgstr "chỉ lưu (không nén)"
-
-#~ msgid "compress faster"
-#~ msgstr "nén nhanh hơn"
-
-#~ msgid "compress better"
-#~ msgstr "nén nhỏ hơn"
-
-#~ msgid "unexpected duplicate commit id %s"
-#~ msgstr "gặp mã số tích lần chuyển giao bị trùng lặp “%s”"
-
-#~ msgid "error preparing packfile from multi-pack-index"
-#~ msgstr "lỗi chuẩn bị tập tin gói từ multi-pack-index"
-
-#~ msgid "%s: not a valid OID"
-#~ msgstr "%s không phải là một OID hợp lệ"
-
-#~ msgid "invalid committer '%s'"
-#~ msgstr "chuyển giao không hợp lệ “%s”"
-
-#~ msgid "invalid committer: %s"
-#~ msgstr "chuyển giao không hợp lệ: %s"
-
-#~ msgid "git bisect--helper --next-all"
-#~ msgstr "git bisect--helper --next-all"
-
-#~ msgid "git bisect--helper --write-terms <bad_term> <good_term>"
-#~ msgstr "git bisect--helper --write-terms <bad_term> <good_term>"
-
-#~ msgid "git bisect--helper --bisect-autostart"
-#~ msgstr "git bisect--helper --bisect-autostart"
-
-#~ msgid "perform 'git bisect next'"
-#~ msgstr "thực hiện “git bisect next”"
-
-#~ msgid "write the terms to .git/BISECT_TERMS"
-#~ msgstr "ghi thời kỳ vào .git/BISECT_TERMS"
-
-#~ msgid "cleanup the bisection state"
-#~ msgstr "dọn dẹp tình trạng di chuyển nửa bước"
-
-#~ msgid "check for expected revs"
-#~ msgstr "kiểm tra cho điểm xem xét cần dùng"
-
-#~ msgid "start the bisection if it has not yet been started"
-#~ msgstr "chạy di chuyển phân đôi nếu nó vẫn chưa được khởi chạy"
-
-#~ msgid "--write-terms requires two arguments"
-#~ msgstr "--write-terms cần hai tham số"
-
-#~ msgid "--bisect-clean-state requires no arguments"
-#~ msgstr "--bisect-clean-state không nhận đối số"
-
-#~ msgid "--bisect-autostart does not accept arguments"
-#~ msgstr "--bisect-autostart không nhận đối số"
-
-#~ msgid "n,m"
-#~ msgstr "n,m"
-
-#~ msgid "Process line range n,m in file, counting from 1"
-#~ msgstr "Xử lý chỉ dòng vùng n,m trong tập tin, tính từ 1"
-
-#~ msgid "name of output directory is too long"
-#~ msgstr "tên của thư mục kết xuất quá dài"
-
-#~ msgid "standard output, or directory, which one?"
-#~ msgstr "đầu ra chuẩn, hay thư mục, chọn cái nào?"
-
-#~ msgid ""
-#~ "WARNING: Some packs in use have been renamed by\n"
-#~ "WARNING: prefixing old- to their name, in order to\n"
-#~ "WARNING: replace them with the new version of the\n"
-#~ "WARNING: file.  But the operation failed, and the\n"
-#~ "WARNING: attempt to rename them back to their\n"
-#~ "WARNING: original names also failed.\n"
-#~ "WARNING: Please rename them in %s manually:\n"
-#~ msgstr ""
-#~ "CẢNH BÁO: Một số gói đang dùng vừa được đổi tên bằng cách\n"
-#~ "CẢNH BÁO: đánh tiền tố old- vào tên của chúng, mục đích là\n"
-#~ "CẢNH BÁO: thay chúng bằng phiên bản mới của tập\n"
-#~ "CẢNH BÁO: tin. Nhưng thao tác lại gặp lỗi, và nỗ\n"
-#~ "CẢNH BÁO: lực để đổi ngược lại tên chúng cho đúng với tên\n"
-#~ "CẢNH BÁO: nguyên gốc của nó cũng gặp lỗi.\n"
-#~ "CẢNH BÁO: Vui lòng đổi tên chúng trong %s bằng tay:\n"
-
-#~ msgid "failed to remove '%s'"
-#~ msgstr "gặp lỗi khi gỡ bỏ “%s”"
-
-#~ msgid "Routines to help parsing remote repository access parameters"
-#~ msgstr ""
-#~ "Các thủ tục để giúp phân tích các tham số truy cập kho chứa trên mạng"
-
-#~ msgid "Bad rev input: $bisected_head"
-#~ msgstr "Đầu vào rev sai: $bisected_head"
-
-#~ msgid "Bad rev input: $rev"
-#~ msgstr "Đầu vào rev sai: $rev"
-
-#~ msgid "See git-${cmd}(1) for details."
-#~ msgstr "Xem git-${cmd}(1) để biết thêm chi tiết."
-
-#~ msgid "unknown hash algorithm length"
-#~ msgstr "không hiểu chiều dài thuật toán băm dữ liệu"
-
-#~ msgid ""
-#~ "commit-graph chunk lookup table entry missing; file may be incomplete"
-#~ msgstr ""
-#~ "bảng tìm kiếm mảnh đồ-thị-các-lần-chuyển-giao còn thiếu; tập tin có thể "
-#~ "sẽ không hoàn thiện"
-
-#~ msgid "Writing changed paths Bloom filters index"
-#~ msgstr "Ghi dữ liệu các mục lục Bloom đường dẫn đã bị thay đổi"
-
-#~ msgid "hash version %u does not match"
-#~ msgstr "phiên bản băm “%u” không khớp"
-
-#~ msgid "Remote with no URL"
-#~ msgstr "Máy chủ không có địa chỉ URL"
-
-#~ msgid "%%(subject) does not take arguments"
-#~ msgstr "%%(subject) không nhận các đối số"
-
-#~ msgid "positive value expected objectname:short=%s"
-#~ msgstr "cần nội dung mang giá trị dương:shot=%s"
-
-#~ msgid "unrecognized %%(objectname) argument: %s"
-#~ msgstr "đối số không được thừa nhận %%(objectname): %s"
-
-#~ msgid "option `%s' is incompatible with --merged"
-#~ msgstr "tùy chọn “%s” là xung khắc với tùy chọn --merged"
-
-#~ msgid "option `%s' is incompatible with --no-merged"
-#~ msgstr "tùy chọn “%s” là xung khắc với tùy chọn --no-merged"
-
-#~ msgid "could not open '%s' for writing: %s"
-#~ msgstr "không thể mở “%s” để ghi: %s"
-
-#~ msgid "could not read ref '%s'"
-#~ msgstr "không thể đọc tham chiếu “%s”"
-
-#~ msgid "ref '%s' already exists"
-#~ msgstr "tham chiếu “%s” đã có từ trước rồi"
-
-#~ msgid "unexpected object ID when writing '%s'"
-#~ msgstr "không cần ID đối tượng khi ghi “%s”"
-
-#~ msgid "unexpected object ID when deleting '%s'"
-#~ msgstr "gặp ID đối tượng không cần khi xóa “%s”"
-
-#~ msgid "The hash algorithm %s is not supported in this build."
-#~ msgstr "Thuật toán băm %s không được hỗ trợ trong bản biên dịch này."
-
-#~ msgid "could not open the file BISECT_TERMS"
-#~ msgstr "không thể mở tập tin BISECT_TERMS"
-
-#~ msgid "update BISECT_HEAD instead of checking out the current commit"
-#~ msgstr ""
-#~ "cập nhật BISECT_HEAD thay vì lấy ra (checking out) lần chuyển giao hiện "
-#~ "hành"
-
-#~ msgid "print only names (no SHA-1)"
-#~ msgstr "chỉ hiển thị tên (không SHA-1)"
-
-#~ msgid "passed to 'git am'"
-#~ msgstr "chuyển cho “git am”"
-
-#~ msgid "The --cached option cannot be used with the --files option"
-#~ msgstr "Tùy chọn --cached không thể dùng cùng với tùy chọn --files"
-
-#~ msgid "  Warn: $display_name doesn't contain commit $sha1_src"
-#~ msgstr "  Cảnh báo: $display_name không chứa lần chuyển giao $sha1_src"
-
-#~ msgid "  Warn: $display_name doesn't contain commit $sha1_dst"
-#~ msgstr "  Cảnh báo: $display_name không chứa lần chuyển giao $sha1_dst"
-
-#~ msgid ""
-#~ "  Warn: $display_name doesn't contain commits $sha1_src and $sha1_dst"
-#~ msgstr ""
-#~ "  Cảnh báo: $display_name không chứa những lần chuyển giao $sha1_src và "
-#~ "$sha1_dst"
-
-#~ msgid "Finding commits for commit graph from %d ref"
-#~ msgid_plural "Finding commits for commit graph from %d refs"
-#~ msgstr[0] ""
-#~ "Đang tìm các lần chuyển giao cho đồ thị lần chuyển giao từ %d tham chiếu"
-
-#~ msgid "invalid commit object id: %s"
-#~ msgstr "mã số đối tượng lần chuyển giao không hợp lệ: %s"
-
-#~ msgid "Removing worktrees/%s: not a valid directory"
-#~ msgstr "Gỡ bỏ cây làm việc/%s: không phải là thư mục hợp lệ"
-
-#~ msgid "Removing worktrees/%s: unable to read gitdir file (%s)"
-#~ msgstr "Gỡ bỏ cây làm việc/%s: không thể đọc tập tin gitdir (%s)"
-
-#~ msgid "Removing worktrees/%s: invalid gitdir file"
-#~ msgstr "Gỡ bỏ cây làm việc/%s: tập tin gitdir không hợp lệ"
-
-#~ msgid "unable to re-add worktree '%s'"
-#~ msgstr "không thể thêm-lại cây “%s”"
-
-#~ msgid "target '%s' already exists"
-#~ msgstr "đích “%s” đã tồn tại rồi"
-
-#~ msgid ""
-#~ "Cannot update sparse checkout: the following entries are not up to date:\n"
-#~ "%s"
-#~ msgstr ""
-#~ "Không thể cập nhật checkout rải rác: các mục tin sau đây chưa cập nhật:\n"
-#~ "%s"
-
-#~ msgid ""
-#~ "The following working tree files would be overwritten by sparse checkout "
-#~ "update:\n"
-#~ "%s"
-#~ msgstr ""
-#~ "Các tập tin cây làm việc chưa được theo dõi sau đây sẽ bị ghi đè bởi cập "
-#~ "nhật checkout rải rác:\n"
-#~ "%s"
-
-#~ msgid ""
-#~ "The following working tree files would be removed by sparse checkout "
-#~ "update:\n"
-#~ "%s"
-#~ msgstr ""
-#~ "Các tập tin cây làm việc chưa được theo dõi sau đây sẽ bị xóa bỏ bởi cập "
-#~ "nhật checkout rải rác:\n"
-#~ "%s"
-
-#~ msgid "annotated tag %s has no embedded name"
-#~ msgstr "thẻ được chú giải %s không có tên nhúng"
-
-#~ msgid "automatically stash/stash pop before and after rebase"
-#~ msgstr "tự động stash/stash pop tước và sau tu bổ (rebase)"
-
-#~ msgid "--[no-]autostash option is only valid with --rebase."
-#~ msgstr "tùy chọn --[no-]autostash chỉ hợp lệ khi dùng với --rebase."
-
-#~ msgid "(DEPRECATED) keep empty commits"
-#~ msgstr "(CŨ) giữ lại các lần chuyển giao rỗng"
-
-#~ msgid "Could not read '%s'"
-#~ msgstr "Không thể đọc “%s”"
-
-#~ msgid "Cannot store %s"
-#~ msgstr "Không thể lưu “%s”"
-
-#~ msgid "set sparse-checkout patterns"
-#~ msgstr "đặt các mẫu sparse-checkout"
-
-#~ msgid "disable sparse-checkout"
-#~ msgstr "tắt sparse-checkout"
-
-#~ msgid "could not exec %s"
-#~ msgstr "không thể thực thi %s"
-
-#~ msgid "Cannot remove temporary index (can't happen)"
-#~ msgstr "Không thể gỡ bỏ bảng mục lục tạm thời (không thể xảy ra)"
-
-#~ msgid "Cannot update $ref_stash with $w_commit"
-#~ msgstr "Không thể cập nhật $ref_stash với $w_commit"
-
-#~ msgid "error: unknown option for 'stash push': $option"
-#~ msgstr "lỗi: không hiểu tùy chọn cho “stash push”: $option"
-
-#~ msgid "Saved working directory and index state $stash_msg"
-#~ msgstr "Đã ghi lại thư mục làm việc và trạng thái mục lục $stash_msg"
-
-#~ msgid "unknown option: $opt"
-#~ msgstr "không hiểu tùy chọn: $opt"
-
-#~ msgid "Too many revisions specified: $REV"
-#~ msgstr "Chỉ ra quá nhiều điểm xét duyệt: $REV"
-
-#~ msgid "$reference is not a valid reference"
-#~ msgstr "$reference không phải là tham chiếu hợp lệ"
-
-#~ msgid "'$args' is not a stash-like commit"
-#~ msgstr "“$args” không phải là lần chuyển giao kiểu-stash (cất đi)"
-
-#~ msgid "'$args' is not a stash reference"
-#~ msgstr "”$args” không phải tham chiếu đến stash"
-
-#~ msgid "unable to refresh index"
-#~ msgstr "không thể làm tươi mới bảng mục lục"
-
-#~ msgid "Cannot apply a stash in the middle of a merge"
-#~ msgstr "Không thể áp dụng một stash ở giữa của quá trình hòa trộn"
-
-#~ msgid "Conflicts in index. Try without --index."
-#~ msgstr ""
-#~ "Xung đột trong bảng mục lục. Hãy thử mà không dùng tùy chọn --index."
-
-#~ msgid "Could not save index tree"
-#~ msgstr "Không thể ghi lại cây chỉ mục"
-
-#~ msgid "Could not restore untracked files from stash entry"
-#~ msgstr "Không thể phục hồi các tập tin chưa theo dõi từ mục cất đi (stash)"
-
-#~ msgid "Cannot unstage modified files"
-#~ msgstr "Không thể bỏ ra khỏi bệ phóng các tập tin đã được sửa chữa"
-
-#~ msgid "Dropped ${REV} ($s)"
-#~ msgstr "Đã xóa ${REV} ($s)"
-
-#~ msgid "${REV}: Could not drop stash entry"
-#~ msgstr "${REV}: Không thể xóa bỏ mục stash"
-
-#~ msgid "(To restore them type \"git stash apply\")"
-#~ msgstr "(Để phục hồi lại chúng hãy gõ \"git stash apply\")"
-
-#~ msgid "Stage mode change [y,n,a,q,d%s,?]? "
-#~ msgstr "Thay đổi chế độ bệ phóng [y,n,a,q,d%s,?]? "
-
-#~ msgid "Stage deletion [y,n,a,q,d%s,?]? "
-#~ msgstr "Xóa khỏi bệ phóng [y,n,a,q,d%s,?]? "
-
-#~ msgid "Stage this hunk [y,n,a,q,d%s,?]? "
-#~ msgstr "Đưa lên bệ phóng khúc này [y,n,a,q,d%s,?]? "
-
-#~ msgid ""
-#~ "If the patch applies cleanly, the edited hunk will immediately be\n"
-#~ "marked for staging.\n"
-#~ msgstr ""
-#~ "Nếu miếng vá được áp dụng sạch sẽ, khúc đã sửa sẽ ngay lập tức\n"
-#~ "được đánh dấu để chuyển lên bệ phóng.\n"
-
-#~ msgid ""
-#~ "y - stage this hunk\n"
-#~ "n - do not stage this hunk\n"
-#~ "q - quit; do not stage this hunk or any of the remaining ones\n"
-#~ "a - stage this and all the remaining hunks\n"
-#~ "d - do not stage this hunk nor any of the remaining hunks\n"
-#~ msgstr ""
-#~ "y - đưa lên bệ phóng khúc này\n"
-#~ "n - đừng đưa lên bệ phóng khúc này\n"
-#~ "q - thoát; đừng đưa lên bệ phóng khúc này cũng như bất kỳ cái nào còn "
-#~ "lại\n"
-#~ "a - đưa lên bệ phóng khúc này và tất cả các khúc còn lại sau này\n"
-#~ "d - đừng đưa lên bệ phóng khúc này cũng như bất kỳ cái nào còn lại\n"
-
-#~ msgid "could not copy '%s' to '%s'."
-#~ msgstr "không thể chép “%s” sang “%s”."
-
-#~ msgid "malformed ident line"
-#~ msgstr "dòng định danh không hợp lệ"
-
-#~ msgid "could not parse '%.*s'"
-#~ msgstr "không thể phân tích cú pháp “%.*s”"
-
-#~ msgid "could not checkout %s"
-#~ msgstr "không thể lấy ra %s"
-
-#~ msgid "filename in tree entry contains backslash: '%s'"
-#~ msgstr "tên tập tin trong mục tin cây có chứa ký tự gạch ngược: “%s”"
-
-#~ msgid "Use -f if you really want to add them.\n"
-#~ msgstr "Sử dụng tùy chọn -f nếu bạn thực sự muốn thêm chúng vào.\n"
-
-#~ msgid "Maybe you wanted to say 'git add .'?\n"
-#~ msgstr "Có lẽ ý bạn là “git add .” phải không?\n"
-
-#~ msgid "packfile is invalid: %s"
-#~ msgstr "tập tin gói không hợp lệ: %s"
-
-#~ msgid "unable to open packfile for reuse: %s"
-#~ msgstr "không thể mở tập tin gói để dùng lại: %s"
-
-#~ msgid "unable to seek in reused packfile"
-#~ msgstr "không thể di chuyển vị trí đọc trong tập tin gói dùng lại"
-
-#~ msgid "unable to read from reused packfile"
-#~ msgstr "không thể đọc từ tập tin gói dùng lại"
-
-#~ msgid "no HEAD?"
-#~ msgstr "không HEAD?"
-
-#~ msgid "preserve empty commits during rebase"
-#~ msgstr "ngăn cấm các lần chuyển giao trống rỗng trong suốt quá trình cải tổ"
-
-#~ msgid "cannot combine --use-bitmap-index with object filtering"
-#~ msgstr "không thể tổ hợp --use-bitmap-index với lọc đối tượng"
-
-#~ msgid ""
-#~ "The following path is ignored by one of your .gitignore files:\n"
-#~ "$sm_path\n"
-#~ "Use -f if you really want to add it."
-#~ msgstr ""
-#~ "Các đường dẫn theo sau đây sẽ bị lờ đi bởi một trong các tập tin ."
-#~ "gitignore của bạn:\n"
-#~ "$sm_path\n"
-#~ "Sử dụng -f nếu bạn thực sự muốn thêm nó vào."
-
-#~ msgid "Use an experimental heuristic to improve diffs"
-#~ msgstr "Dùng một phỏng đoán thử nghiệm để tăng cường các diff"
-
-#~ msgid "git commit-graph [--object-dir <objdir>]"
-#~ msgstr "git commit-graph [--object-dir <objdir>]"
-
-#~ msgid "git commit-graph read [--object-dir <objdir>]"
-#~ msgstr "git commit-graph read [--object-dir <objdir>]"
-
-#~ msgid "unknown core.untrackedCache value '%s'; using 'keep' default value"
-#~ msgstr ""
-#~ "không hiểu giá trị core.untrackedCache “%s”; dùng giá trị mặc định “keep”"
-
-#~ msgid "cannot change partial clone promisor remote"
-#~ msgstr "không thể thay đổi nhân bản từng phần máy chủ promisor"
-
-#~ msgid "error building trees"
-#~ msgstr "gặp lỗi khi xây dựng cây"
-
-#~ msgid "invalid date format '%s' in '%s'"
-#~ msgstr "định dạng ngày tháng không hợp lệ “%s” trong “%s”"
-
-#~ msgid "writing root commit"
-#~ msgstr "ghi chuyển giao gốc"
-
-#~ msgid "staged changes in the following files may be lost: %s"
-#~ msgstr ""
-#~ "các thay đổi đã đưa lên bệ phóng trong các tập tin sau đây có thể bị mất: "
-#~ "%s"
-
-#~ msgid ""
-#~ "--filter can only be used with the remote configured in extensions."
-#~ "partialClone"
-#~ msgstr ""
-#~ "--filter chỉ có thể được dùng với máy chủ được cấu hình bằng extensions."
-#~ "partialClone"
-
-#~ msgid "verify commit-msg hook"
-#~ msgstr "thẩm tra móc (hook) commit-msg"
-
-#~ msgid "cannot combine '--rebase-merges' with '--strategy-option'"
-#~ msgstr "không thể kết hợp “--rebase-merges” với “--strategy-option”"
-
-#~ msgid "invalid sparse value '%s'"
-#~ msgstr "giá trị sparse không hợp lệ “%s”"
-
-#~ msgid ""
-#~ "Fetch normally indicates which branches had a forced update, but that "
-#~ "check has been disabled."
-#~ msgstr ""
-#~ "Lấy về bình thường cho biết các các nhánh nào buộc phải cập nhật, nhưng "
-#~ "việc kiểm tra đã bị vô hiệu hóa."
-
-#~ msgid ""
-#~ "or run 'git config fetch.showForcedUpdates false' to avoid this check.\n"
-#~ msgstr ""
-#~ "hoặc chạy “git config fetch.showForcedUpdates false” để tránh kiểm tra "
-#~ "này.\n"
-
-#~ msgid ""
-#~ "log.mailmap is not set; its implicit value will change in an\n"
-#~ "upcoming release. To squelch this message and preserve current\n"
-#~ "behaviour, set the log.mailmap configuration value to false.\n"
-#~ "\n"
-#~ "To squelch this message and adopt the new behaviour now, set the\n"
-#~ "log.mailmap configuration value to true.\n"
-#~ "\n"
-#~ "See 'git help config' and search for 'log.mailmap' for further "
-#~ "information."
-#~ msgstr ""
-#~ "log.mailmap không được đặt; giá trị ngầm của nó sẽ thay đổi trong một\n"
-#~ "phát hành sắp tới. Để chấm dứt thông báo này và duy trì hành xử\n"
-#~ "hiện tại, đặt giá trị cấu hình log.mailmap thành false.\n"
-#~ "\n"
-#~ "Để làm chấm dứt thông báo này và áp cách hành xử mới, hãy đặt\n"
-#~ "giá trị cấu hình log.mailmap true.\n"
-#~ "\n"
-#~ "Xem “git help config “ và tìm kiếm “ log.mailmap “ để biết thêm thông tin."
-
-#~ msgid "Server supports multi_ack_detailed"
-#~ msgstr "Máy chủ hỗ trợ multi_ack_detailed"
-
-#~ msgid "Server supports no-done"
-#~ msgstr "Máy chủ hỗ trợ no-done"
-
-#~ msgid "Server supports multi_ack"
-#~ msgstr "Máy chủ hỗ trợ multi_ack"
-
-#~ msgid "Server supports side-band-64k"
-#~ msgstr "Máy chủ hỗ trợ side-band-64k"
-
-#~ msgid "Server supports side-band"
-#~ msgstr "Máy chủ hỗ trợ side-band"
-
-#~ msgid "Server supports allow-tip-sha1-in-want"
-#~ msgstr "Máy chủ hỗ trợ allow-tip-sha1-in-want"
-
-#~ msgid "Server supports allow-reachable-sha1-in-want"
-#~ msgstr "Máy chủ hỗ trợ allow-reachable-sha1-in-want"
-
-#~ msgid "Server supports ofs-delta"
-#~ msgstr "Máy chủ hỗ trợ ofs-delta"
-
-#~ msgid "Checking out files"
-#~ msgstr "Đang lấy ra các tập tin"
-
-#~ msgid "cannot be interactive without stdin connected to a terminal."
-#~ msgstr ""
-#~ "không thể được tương tác mà không có stdin kết nối với một thiết bị cuối."
-
-#~ msgid "failed to stat %s\n"
-#~ msgstr "gặp lỗi khi lấy thông tin thống kê về %s\n"
-
-#~ msgid ""
-#~ "If you wish to skip this commit, use:\n"
-#~ "\n"
-#~ "    git reset\n"
-#~ "\n"
-#~ "Then \"git cherry-pick --continue\" will resume cherry-picking\n"
-#~ "the remaining commits.\n"
-#~ msgstr ""
-#~ "Nếu bạn muốn bỏ qua lần chuyển giao này thì dùng:\n"
-#~ "\n"
-#~ "    git reset\n"
-#~ "\n"
-#~ "Thế thì \"git cherry-pick --continue\" sẽ phục hồi lại việc cherry-pick\n"
-#~ "những lần chuyển giao còn lại.\n"
-
-#~ msgid "unrecognized verb: %s"
-#~ msgstr "verb không được thừa nhận: %s"
-
-#~ msgid "option '%s' requires a value"
-#~ msgstr "tùy chọn “%s” yêu cầu một giá trị"
-
-#~ msgid "could not transform the todo list"
-#~ msgstr "không thể chuyển dạng danh sách cần làm"
-
-#~ msgid "default"
-#~ msgstr "mặc định"
-
-#~ msgid "Could not create directory '%s'"
-#~ msgstr "Không thể tạo thư mục “%s”"
-
-#~ msgid "allow rerere to update index with resolved conflict"
-#~ msgstr ""
-#~ "cho phép rerere cập nhật bảng mục lục với các xung đột đã được giải quyết"
-
-#~ msgid "could not open %s"
-#~ msgstr "không thể mở %s"
-
-#~ msgid "Could not move back to $head_name"
-#~ msgstr "Không thể quay trở lại $head_name"
-
-#~ msgid ""
-#~ "It seems that there is already a $state_dir_base directory, and\n"
-#~ "I wonder if you are in the middle of another rebase.  If that is the\n"
-#~ "case, please try\n"
-#~ "\t$cmd_live_rebase\n"
-#~ "If that is not the case, please\n"
-#~ "\t$cmd_clear_stale_rebase\n"
-#~ "and run me again.  I am stopping in case you still have something\n"
-#~ "valuable there."
-#~ msgstr ""
-#~ "Hình như là ở đây sẵn có một thư mục $state_dir_base, và\n"
-#~ "Tôi tự hỏi có phải bạn đang ở giữa một lệnh rebase khác. Nếu đúng là\n"
-#~ "như vậy, xin hãy thử\n"
-#~ "\t$cmd_live_rebase\n"
-#~ "Nếu không phải thế, hãy thử\n"
-#~ "\t$cmd_clear_stale_rebase\n"
-#~ "và chạy TÔI lần nữa. TÔI  dừng lại trong trường hợp bạn vẫn\n"
-#~ "có một số thứ quý giá ở đây."
-
-#~ msgid ""
-#~ "fatal: cannot combine am options with either interactive or merge options"
-#~ msgstr ""
-#~ "lỗi nghiêm trọng: không thể tổ hợp các tùy chọn am với các tùy chọn tương "
-#~ "tác hay hòa trộn"
-
-#~ msgid "fatal: cannot combine '--signoff' with '--preserve-merges'"
-#~ msgstr ""
-#~ "lỗi nghiêm trọng: không thể kết hợp “--signoff” với “--preserve-merges”"
-
-#~ msgid "fatal: cannot combine '--preserve-merges' with '--rebase-merges'"
-#~ msgstr ""
-#~ "lỗi nghiêm trọng: không thể kết hợp “--preserve-merges” với “--rebase-"
-#~ "merges”"
-
-#~ msgid "fatal: cannot combine '--rebase-merges' with '--strategy-option'"
-#~ msgstr ""
-#~ "lỗi nghiêm trọng: không thể kết hợp “--rebase-merges” với “--strategy-"
-#~ "option”"
-
-#~ msgid "fatal: cannot combine '--rebase-merges' with '--strategy'"
-#~ msgstr ""
-#~ "lỗi nghiêm trọng: không thể kết hợp “--rebase-merges” với “--strategy”"
-
-#~ msgid "invalid upstream '$upstream_name'"
-#~ msgstr "thượng nguồn không hợp lệ “$upstream_name”"
-
-#~ msgid "$onto_name: there are more than one merge bases"
-#~ msgstr "$onto_name: ở đây có nhiều hơn một nền móng hòa trộn"
-
-#~ msgid "$onto_name: there is no merge base"
-#~ msgstr "$onto_name: ở đây không có nền móng hòa trộn nào"
-
-#~ msgid "Does not point to a valid commit: $onto_name"
-#~ msgstr "Không chỉ đến một lần chuyển giao không hợp lệ: $onto_name"
-
-#~ msgid "fatal: no such branch/commit '$branch_name'"
-#~ msgstr "nghiêm trọng: không có nhánh như thế: “$branch_name”"
-
-#~ msgid "Created autostash: $stash_abbrev"
-#~ msgstr "Đã tạo autostash: $stash_abbrev"
-
-#~ msgid "Current branch $branch_name is up to date."
-#~ msgstr "Nhánh hiện tại $branch_name đã được cập nhật rồi."
-
-#~ msgid "Current branch $branch_name is up to date, rebase forced."
-#~ msgstr ""
-#~ "Nhánh hiện tại $branch_name đã được cập nhật rồi, lệnh rebase ép buộc."
-
-#~ msgid "Changes to $onto:"
-#~ msgstr "Thay đổi thành $onto:"
-
-#~ msgid "Changes from $mb to $onto:"
-#~ msgstr "Thay đổi từ $mb thành $onto:"
-
-#~ msgid "Fast-forwarded $branch_name to $onto_name."
-#~ msgstr "Chuyển-tiếp-nhanh $branch_name thành $onto_name."
-
-#~ msgid "First, rewinding head to replay your work on top of it..."
-#~ msgstr ""
-#~ "Trước tiên, di chuyển head để xem lại các công việc trên đỉnh của nó…"
-
-#~ msgid "ignoring unknown color-moved-ws mode '%s'"
-#~ msgstr "bỏ qua chế độ color-moved-ws chưa biết “%s”"
-
-#~ msgid "only 'tree:0' is supported"
-#~ msgstr "chỉ “tree:0” là được hỗ trợ"
-
-#~ msgid "Renaming %s to %s and %s to %s instead"
-#~ msgstr "Đang đổi tên %s thành %s thay vì %s thành %s"
-
-#~ msgid "Adding merged %s"
-#~ msgstr "Thêm hòa trộn %s"
-
-#~ msgid "Internal error"
-#~ msgstr "Lỗi nội bộ"
-
-#~ msgid "mainline was specified but commit %s is not a merge."
-#~ msgstr ""
-#~ "luồng chính đã được chỉ ra nhưng lần chuyển giao %s không phải là một lần "
-#~ "hòa trộn."
-
-#~ msgid "unable to write sha1 filename %s"
-#~ msgstr "không thể ghi vào tên tập tin sha1 %s"
-
-#~ msgid "cannot read sha1_file for %s"
-#~ msgstr "không thể đọc sha1_file cho %s"
-
-#~ msgid ""
-#~ "error: cannot combine interactive options (--interactive, --exec, --"
-#~ "rebase-merges, --preserve-merges, --keep-empty, --root + --onto) with am "
-#~ "options (%s)"
-#~ msgstr ""
-#~ "lỗi: không thể tổ hợp các tùy chọn tương tác (--interactive, --exec, --"
-#~ "rebase-merges, --preserve-merges, --keep-empty, --root + --onto) với các "
-#~ "tùy chọn am (%s)"
-
-#~ msgid ""
-#~ "error: cannot combine merge options (--merge, --strategy, --strategy-"
-#~ "option) with am options (%s)"
-#~ msgstr ""
-#~ "lỗi: không thể kết hợp các tùy chọn hòa trộn (--merge, --strategy, --"
-#~ "strategy-option) với một tùy chọn am (%s)"
-
-#~ msgid "unrecognised option: '$arg'"
-#~ msgstr "không công nhận tùy chọn: “$arg”"
-
-#~ msgid "'$invalid' is not a valid commit"
-#~ msgstr "”$invalid” không phải là lần chuyển giao hợp lệ"
-
-#~ msgid "could not parse '%s' (looking for '%s')"
-#~ msgstr "không thể phân tích “%s” (đang tìm kiếm cho “%s”)"
-
-#~ msgid "deprecated synonym for --create-reflog"
-#~ msgstr "đồng nghĩa đã lạc hậu cho --create-reflog"
-
-#~ msgid "Can't stat %s"
-#~ msgstr "không thể lấy thông tin thống kê về “%s”"
-
-#~ msgid "abort rebase"
-#~ msgstr "bãi bỏ việc cải tổ"
-
-#~ msgid "make rebase script"
-#~ msgstr "tạo văn lệnh rebase"
-
-#~ msgid "cannot move a locked working tree"
-#~ msgstr "không thể di chuyển một cây-làm-việc bị khóa"
-
-#~ msgid "cannot remove a locked working tree"
-#~ msgstr "không thể gỡ bỏ một cây-làm-việc bị khóa"
-
-#~ msgid ""
-#~ "\n"
-#~ "\tHowever, if you remove everything, the rebase will be aborted.\n"
-#~ "\n"
-#~ "\t"
-#~ msgstr ""
-#~ "\n"
-#~ "\tTuy nhiên, nếu bạn xóa bỏ mọi thứ, việc cải tổ sẽ bị bãi bỏ.\n"
-#~ "\n"
-#~ "\t"
-
-#~ msgid "could not parse '%s' (looking for '%s'"
-#~ msgstr "không thể phân tích “%s” (tìm kiếm cho “%s”"
-
-#~ msgid "push|fetch"
-#~ msgstr "push|fetch"
-
-#~ msgid "Dirty index: cannot merge (dirty: %s)"
-#~ msgstr "Bảng mục lục bẩn: không thể hòa trộn (bẩn: %s)"
-
-#~ msgid "(+/-)x"
-#~ msgstr "(+/-)x"
-
-#~ msgid "<command>"
-#~ msgstr "<lệnh>"
-
-#~ msgid "w[,i1[,i2]]"
-#~ msgstr "w[,i1[,i2]]"
-
-#~ msgid "Entering '$displaypath'"
-#~ msgstr "Đang vào “$displaypath”"
-
-#~ msgid "Stopping at '$displaypath'; script returned non-zero status."
-#~ msgstr "Dừng lại tại “$displaypath”; script trả về trạng thái khác không."
-
-#~ msgid "Everyday Git With 20 Commands Or So"
-#~ msgstr "Mỗi ngày học 20 lệnh Git hay hơn"
-
-#~ msgid "Could not open '%s' for writing"
-#~ msgstr "Không thể mở “%s” để ghi"
-
-#~ msgid ""
-#~ "unexpected 1st line of squash message:\n"
-#~ "\n"
-#~ "\t%.*s"
-#~ msgstr ""
-#~ "không cần dòng thứ nhất của ghi chú squash:\n"
-#~ "\n"
-#~ "\t%.*s"
-
-#~ msgid ""
-#~ "invalid 1st line of squash message:\n"
-#~ "\n"
-#~ "\t%.*s"
-#~ msgstr ""
-#~ "dòng thứ nhất của ghi chú squash không hợp lệ:\n"
-#~ "\n"
-#~ "\t%.*s"
-
-#~ msgid "BUG: returned path string doesn't match cwd?"
-#~ msgstr "LỖI: trả về chuỗi đường dẫn không khớp cwd?"
-
-#~ msgid "Error in object"
-#~ msgstr "Lỗi trong đối tượng"
-
-#~ msgid "git fetch-pack: expected ACK/NAK, got EOF"
-#~ msgstr "git fetch-pack: cần ACK/NAK, nhưng lại nhận được EOF"
-
-#~ msgid "invalid filter-spec expression '%s'"
-#~ msgstr "biểu thức đặc tả bộ lọc “%s” không hợp lệ"
-
-#~ msgid "The copy of the patch that failed is found in: %s"
-#~ msgstr "Bản sao chép của miếng vá mà nó gặp lỗi thì được tìm thấy trong: %s"
-
-#~ msgid "pathspec and --all are incompatible"
-#~ msgstr "đặc tả đường dẫn và --all xung khắc nhau"
-
-#~ msgid "Submodule '$name' ($url) unregistered for path '$displaypath'"
-#~ msgstr ""
-#~ "Mô-đun-con “$name” ($url) được bỏ đăng ký cho đường dẫn “$displaypath”"
-
-#~ msgid "To/Cc/Bcc fields are not interpreted yet, they have been ignored\n"
-#~ msgstr "Các trường To/Cc/Bcc không được phiên dịch, chúng bị bỏ qua\n"
-
-#~ msgid ""
-#~ "empty strings as pathspecs will be made invalid in upcoming releases. "
-#~ "please use . instead if you meant to match all paths"
-#~ msgstr ""
-#~ "chuỗi rỗng làm đặc tả đường dẫn không hợp lệ ở lần phát hành kế tiếp. Vui "
-#~ "lòng dùng . để thay thế nếu ý bạn là khớp mọi đường dẫn"
-
-#~ msgid "could not truncate '%s'"
-#~ msgstr "không thể cắt cụt “%s”"
-
-#~ msgid "could not close %s"
-#~ msgstr "không thể đóng %s"
-
-#~ msgid "Copied a misnamed branch '%s' away"
-#~ msgstr "Đã chép nhánh khuyết danh “%s” đi"
-
-#~ msgid "it does not make sense to create 'HEAD' manually"
-#~ msgstr "không hợp lý khi tạo “HEAD” thủ công"
-
-#~ msgid "Don't know how to clone %s"
-#~ msgstr "Không biết làm cách nào để nhân bản (clone) %s"
-
-#~ msgid "Don't know how to fetch from %s"
-#~ msgstr "Không biết làm cách nào để lấy về từ %s"
-
-#~ msgid "'$term' is not a valid term"
-#~ msgstr "“$term” không phải là thời kỳ hợp lệ"
-
-#~ msgid ""
-#~ "error: unknown option for 'stash save': $option\n"
-#~ "       To provide a message, use git stash save -- '$option'"
-#~ msgstr ""
-#~ "lỗi: không hiểu tùy chọn cho “stash save”: $option\n"
-#~ "     Để có thể dùng lời chú thích có chứa -- ở đầu,\n"
-#~ "     dùng git stash save -- \"$option\""
-
-#~ msgid "Failed to recurse into submodule path '$sm_path'"
-#~ msgstr "Gặp lỗi khi đệ quy vào trong đường dẫn mô-đun-con “$sm_path”"
-
-#~ msgid "submodule update strategy not supported for submodule '%s'"
-#~ msgstr ""
-#~ "chiến lược cập nhật mô-đun-con không được hỗ trợ cho mô-đun-con “%s”"
-
-#~ msgid "change upstream info"
-#~ msgstr "thay đổi thông tin thượng nguồn"
-
-#~ msgid ""
-#~ "\n"
-#~ "If you wanted to make '%s' track '%s', do this:\n"
-#~ "\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Nếu bạn muốn “%s” theo dõi “%s”, thực hiện lệnh sau:\n"
-#~ "\n"
-
-#~ msgid "basename"
-#~ msgstr "tên cơ sở"
-
-#~ msgid ""
-#~ "When you have resolved this problem, run \"git rebase --continue\".\n"
-#~ "If you prefer to skip this patch, run \"git rebase --skip\" instead.\n"
-#~ "To check out the original branch and stop rebasing, run \"git rebase --"
-#~ "abort\"."
-#~ msgstr ""
-#~ "Khi bạn cần giải quyết vấn đề này hãy chạy lệnh \"git rebase --continue"
-#~ "\".\n"
-#~ "Nếu bạn có ý định bỏ qua miếng vá, thay vào đó bạn chạy \"git rebase --"
-#~ "skip\".\n"
-#~ "Để phục hồi lại thành nhánh nguyên thủy và dừng việc vá lại thì chạy "
-#~ "\"git rebase --abort\"."
-
-#~ msgid ""
-#~ "Warning: the SHA-1 is missing or isn't a commit in the following line:\n"
-#~ " - $line"
-#~ msgstr ""
-#~ "Cảnh báo: SHA-1 bị thiếu hoặc không phải là một lần chuyển giao trong "
-#~ "dòng sau đây:\n"
-#~ " - $line"
-
-#~ msgid ""
-#~ "Warning: the command isn't recognized in the following line:\n"
-#~ " - $line"
-#~ msgstr ""
-#~ "Cảnh báo: lệnh không nhận ra trong dòng sau đây:\n"
-#~ " - $line"
-
-#~ msgid "Or you can abort the rebase with 'git rebase --abort'."
-#~ msgstr "Hoặc là bạn có thể bãi bỏ lần cải tổ với lệnh “git rebase --abort”."
-
-#~ msgid "%s, %"
-#~ msgid_plural "%s, %"
-#~ msgstr[0] "%s, %"
-
-#~ msgid "in %0.1f seconds automatically..."
-#~ msgstr "trong %0.1f giây một cách tự động…"
-
-#~ msgid "dup2(%d,%d) failed"
-#~ msgstr "dup2(%d,%d) gặp lỗi"
-
-#~ msgid "Initial commit on "
-#~ msgstr "Lần chuyển giao khởi tạo trên "
-
-#~ msgid "Patch is empty. Was it split wrong?"
-#~ msgstr "Miếng vá trống rỗng. Quá trình chia nhỏ miếng vá có lỗi?"
-
-#~ msgid ""
-#~ "You still have unmerged paths in your index.\n"
-#~ "Did you forget to use 'git add'?"
-#~ msgstr ""
-#~ "Bạn vẫn có những đường dẫn chưa được hòa trộn trong bảng mục lục của "
-#~ "mình.\n"
-#~ "Bạn đã quên sử dụng lệnh “git add” à?"
-
-#~ msgid ""
-#~ "Cannot update paths and switch to branch '%s' at the same time.\n"
-#~ "Did you intend to checkout '%s' which can not be resolved as commit?"
-#~ msgstr ""
-#~ "Không thể cập nhật và chuyển thành nhánh “%s” cùng lúc\n"
-#~ "Bạn đã có ý định checkout “%s” cái mà không thể được phân giải như là lần "
-#~ "chuyển giao?"
-
-#~ msgid "Explicit paths specified without -i or -o; assuming --only paths..."
-#~ msgstr ""
-#~ "Những đường dẫn rõ ràng được chỉ ra không có tùy chọn -i cũng không -o; "
-#~ "coi là --only những đường dẫn"
-
-#~ msgid "default mode for recursion"
-#~ msgstr "chế độ mặc định cho đệ qui"
-
-#~ msgid "submodule--helper subcommand must be called with a subcommand"
-#~ msgstr "lệnh con submodule--helper phải được gọi với một lệnh con"
-
-#~ msgid "tag: tagging "
-#~ msgstr "thẻ: đang đánh thẻ"
-
-#~ msgid "commit object"
-#~ msgstr "đối tượng lần chuyển giao"
-
-#~ msgid "blob object"
-#~ msgstr "đối tượng blob"
-
-#~ msgid ""
-#~ "There is nothing to exclude from by :(exclude) patterns.\n"
-#~ "Perhaps you forgot to add either ':/' or '.' ?"
-#~ msgstr ""
-#~ "Ở đây không có gì bị loại trừ bởi: các mẫu (loại trừ).\n"
-#~ "Có lẽ bạn đã quên thêm hoặc là “:/” hoặc là “.”?"
-
-#~ msgid "unrecognized format: %%(%s)"
-#~ msgstr "không nhận ra định dạng: %%(%s)"
-
-#~ msgid ":strip= requires a positive integer argument"
-#~ msgstr ":strip= cần một đối số nguyên dương"
-
-#~ msgid "ref '%s' does not have %ld components to :strip"
-#~ msgstr "tham chiếu “%s” không có %ld thành phần để mà :strip"
-
-#~ msgid "[%s: gone]"
-#~ msgstr "[%s: đã ra đi]"
-
-#~ msgid "[%s]"
-#~ msgstr "[%s]"
-
-#~ msgid "[%s: behind %d]"
-#~ msgstr "[%s: đứng sau %d]"
-
-#~ msgid "[%s: ahead %d]"
-#~ msgstr "[%s: phía trước %d]"
-
-#~ msgid "[%s: ahead %d, behind %d]"
-#~ msgstr "[%s: trước %d, sau %d]"
-
-#~ msgid " **** invalid ref ****"
-#~ msgstr " **** tham chiếu không hợp lệ ****"
-
-#~ msgid "insanely long object directory %.*s"
-#~ msgstr "thư mục đối tượng dài một cách điên rồ %.*s"
-
-#~ msgid "tag name too long: %.*s..."
-#~ msgstr "tên thẻ quá dài: %.*s…"
-
-#~ msgid "tag header too big."
-#~ msgstr "phần đầu thẻ quá lớn."
-
-#~ msgid ""
-#~ "If the patch applies cleanly, the edited hunk will immediately be\n"
-#~ "marked for discarding"
-#~ msgstr ""
-#~ "Nếu miếng vá được áp dụng sạch sẽ, hunk đã sửa sẽ ngay lập tức\n"
-#~ "được đánh dấu để loại bỏ"
-
-#~ msgid "Use an experimental blank-line-based heuristic to improve diffs"
-#~ msgstr ""
-#~ "Dùng một phỏng đoán dựa trên dòng trắng thử nghiệm để tăng cường các diff"
-
-#~ msgid "Clever... amending the last one with dirty index."
-#~ msgstr "Giỏi…  “tu bổ” cái cuối với bảng mục lục bẩn."
-
-#~ msgid ""
-#~ "the following submodule (or one of its nested submodules)\n"
-#~ "uses a .git directory:"
-#~ msgid_plural ""
-#~ "the following submodules (or one of their nested submodules)\n"
-#~ "use a .git directory:"
-#~ msgstr[0] ""
-#~ "các mô-đun-con sau đây (hay một trong số mô-đun-con bên trong của nó)\n"
-#~ "dùng một thư mục .git:"
-
-#~ msgid ""
-#~ "\n"
-#~ "(use 'rm -rf' if you really want to remove it including all of its "
-#~ "history)"
-#~ msgstr ""
-#~ "\n"
-#~ "(dùng /\"rm -rf/\" nếu bạn thực sự muốn gỡ bỏ nó cùng với tất cả lịch sử "
-#~ "của chúng)"
-
-#~ msgid "Error wrapping up %s."
-#~ msgstr "Lỗi bao bọc %s."
-
-#~ msgid "Your local changes would be overwritten by cherry-pick."
-#~ msgstr "Các thay đổi nội bộ của bạn có thể bị ghi đè bởi lệnh cherry-pick."
-
-#~ msgid "Cannot revert during another revert."
-#~ msgstr "Không thể hoàn nguyên trong khi có hoàn nguyên khác."
-
-#~ msgid "Cannot cherry-pick during another cherry-pick."
-#~ msgstr ""
-#~ "Không thể thực hiện việc cherry-pick trong khi khi đang cherry-pick khác."
-
-#~ msgid "Could not open %s"
-#~ msgstr "Không thể mở %s"
-
-#~ msgid "Could not format %s."
-#~ msgstr "Không thể định dạng “%s”."
-
-#~ msgid "You need to set your committer info first"
-#~ msgstr "Bạn cần đặt thông tin về người chuyển giao mã nguồn trước đã"
-
-#~ msgid "bad numeric config value '%s' for '%s': invalid unit"
-#~ msgstr "sai giá trị bằng số của cấu hình “%s” cho “%s”: đơn vị sai"
-
-#~ msgid "bad numeric config value '%s' for '%s' in blob %s: invalid unit"
-#~ msgstr ""
-#~ "sai giá trị bằng số của cấu hình “%s” cho “%s” trong blob %s: đơn vị sai"
-
-#~ msgid "bad numeric config value '%s' for '%s' in file %s: invalid unit"
-#~ msgstr ""
-#~ "sai giá trị bằng số của cấu hình “%s” cho “%s” trong tập tin %s: đơn vị "
-#~ "sai"
-
-#~ msgid ""
-#~ "bad numeric config value '%s' for '%s' in standard input: invalid unit"
-#~ msgstr ""
-#~ "sai giá trị bằng số của cấu hình “%s” cho “%s” trong đầu vào tiêu chuẩn: "
-#~ "đơn vị không hợp lệ"
-
-#~ msgid ""
-#~ "bad numeric config value '%s' for '%s' in submodule-blob %s: invalid unit"
-#~ msgstr ""
-#~ "sai giá trị bằng số của cấu hình “%s” cho “%s” trong submodule-blob %s: "
-#~ "đơn vị không hợp lệ"
-
-#~ msgid ""
-#~ "bad numeric config value '%s' for '%s' in command line %s: invalid unit"
-#~ msgstr ""
-#~ "sai giá trị bằng số của cấu hình “%s” cho “%s” trong dòng lệnh %s: đơn vị "
-#~ "không hợp lệ"
-
-#~ msgid "bad numeric config value '%s' for '%s' in %s: invalid unit"
-#~ msgstr ""
-#~ "sai giá trị bằng số của cấu hình “%s” cho “%s” trong %s: đơn vị không hợp "
-#~ "lệ"
-
-#~ msgid "This is the 3rd commit message:"
-#~ msgstr "Đây là chú thích cho lần chuyển giao thứ 3:"
-
-#~ msgid "This is the 4th commit message:"
-#~ msgstr "Đây là chú thích cho lần chuyển giao thứ 4:"
-
-#~ msgid "This is the 5th commit message:"
-#~ msgstr "Đây là chú thích cho lần chuyển giao thứ 5:"
-
-#~ msgid "This is the 6th commit message:"
-#~ msgstr "Đây là chú thích cho lần chuyển giao thứ 6:"
-
-#~ msgid "This is the 7th commit message:"
-#~ msgstr "Đây là chú thích cho lần chuyển giao thứ 7:"
-
-#~ msgid "This is the 8th commit message:"
-#~ msgstr "Đây là chú thích cho lần chuyển giao thứ 8:"
-
-#~ msgid "This is the 9th commit message:"
-#~ msgstr "Đây là chú thích cho lần chuyển giao thứ 9:"
-
-#~ msgid "This is the 10th commit message:"
-#~ msgstr "Đây là chú thích cho lần chuyển giao thứ 10:"
-
-#~ msgid "This is the ${n}th commit message:"
-#~ msgstr "Đây là chú thích cho lần chuyển giao thứ ${n}:"
-
-#~ msgid "This is the ${n}st commit message:"
-#~ msgstr "Đây là chú thích cho lần chuyển giao thứ ${n}:"
-
-#~ msgid "This is the ${n}nd commit message:"
-#~ msgstr "Đây là chú thích cho lần chuyển giao thứ ${n}:"
-
-#~ msgid "This is the ${n}rd commit message:"
-#~ msgstr "Đây là chú thích cho lần chuyển giao thứ ${n}:"
-
-#~ msgid "The 2nd commit message will be skipped:"
-#~ msgstr "Chú thích cho lần chuyển giao thứ 2 sẽ bị bỏ qua:"
-
-#~ msgid "The 3rd commit message will be skipped:"
-#~ msgstr "Chú thích cho lần chuyển giao thứ 3 sẽ bị bỏ qua:"
-
-#~ msgid "The 4th commit message will be skipped:"
-#~ msgstr "Chú thích cho lần chuyển giao thứ 4 sẽ bị bỏ qua:"
-
-#~ msgid "The 5th commit message will be skipped:"
-#~ msgstr "Chú thích cho lần chuyển giao thứ 5 sẽ bị bỏ qua:"
-
-#~ msgid "The 6th commit message will be skipped:"
-#~ msgstr "Chú thích cho lần chuyển giao thứ 6 sẽ bị bỏ qua:"
-
-#~ msgid "The 7th commit message will be skipped:"
-#~ msgstr "Chú thích cho lần chuyển giao thứ 7 sẽ bị bỏ qua:"
-
-#~ msgid "The 8th commit message will be skipped:"
-#~ msgstr "Chú thích cho lần chuyển giao thứ 8 sẽ bị bỏ qua:"
-
-#~ msgid "The 9th commit message will be skipped:"
-#~ msgstr "Chú thích cho lần chuyển giao thứ 9 sẽ bị bỏ qua:"
-
-#~ msgid "The 10th commit message will be skipped:"
-#~ msgstr "Chú thích cho lần chuyển giao thứ 10 sẽ bị bỏ qua:"
-
-#~ msgid "The ${n}th commit message will be skipped:"
-#~ msgstr "Chú thích cho lần chuyển giao thứ ${n} sẽ bị bỏ qua:"
-
-#~ msgid "The ${n}st commit message will be skipped:"
-#~ msgstr "Chú thích cho lần chuyển giao thứ ${n} sẽ bị bỏ qua:"
-
-#~ msgid "The ${n}nd commit message will be skipped:"
-#~ msgstr "Chú thích cho lần chuyển giao thứ ${n} sẽ bị bỏ qua:"
-
-#~ msgid "The ${n}rd commit message will be skipped:"
-#~ msgstr "Chú thích cho lần chuyển giao thứ ${n} sẽ bị bỏ qua:"
-
-#~ msgid "could not run gpg."
-#~ msgstr "không thể chạy gpg."
-
-#~ msgid "gpg did not accept the data"
-#~ msgstr "gpg đã không chấp nhận dữ liệu"
-
-#~ msgid "unsupported object type in the tree"
-#~ msgstr "kiểu đối tượng không được hỗ trợ trong cây (tree)"
-
-#~ msgid "Fatal merge failure, shouldn't happen."
-#~ msgstr "Việc hòa trộn hỏng nghiêm trọng, không nên để xảy ra."
-
-#~ msgid "Unprocessed path??? %s"
-#~ msgstr "Đường dẫn chưa được xử lý??? %s"
-
-#~ msgid "Cannot %s during a %s"
-#~ msgstr "Không thể %s trong khi %s"
-
-#~ msgid "Can't cherry-pick into empty head"
-#~ msgstr "Không thể cherry-pick vào một đầu (head) trống rỗng"
-
-#~ msgid "bug: unhandled unmerged status %x"
-#~ msgstr "lỗi: không thể tiếp nhận trạng thái chưa hòa trộn %x"
-
-#~ msgid "bug: unhandled diff status %c"
-#~ msgstr "lỗi: không thể tiếp nhận trạng thái lệnh diff %c"
-
-#~ msgid "could not write branch description template"
-#~ msgstr "không thể ghi mẫu mô tả nhánh"
-
-#~ msgid "corrupt index file"
-#~ msgstr "tập tin ghi bảng mục lục bị hỏng"
-
-#~ msgid "detach the HEAD at named commit"
-#~ msgstr "rời bỏ HEAD tại lần chuyển giao danh nghĩa"
-
-#~ msgid "Checking connectivity... "
-#~ msgstr "Đang kiểm tra kết nối… "
-
-#~ msgid "  (unable to update local ref)"
-#~ msgstr "  (không thể cập nhật tham chiếu nội bộ)"
-
-#~ msgid "Initialized empty"
-#~ msgstr "Khởi tạo trống rỗng"
-
-#~ msgid " shared"
-#~ msgstr " đã chia sẻ"
-
-#~ msgid "Verify that the named commit has a valid GPG signature"
-#~ msgstr ""
-#~ "Thẩm tra xem lần chuyển giao có tên đó có chữ ký GPG hợp lệ hay không"
-
-#~ msgid "Writing SQUASH_MSG"
-#~ msgstr "Đang ghi SQUASH_MSG"
-
-#~ msgid "Finishing SQUASH_MSG"
-#~ msgstr "Hoàn thành SQUASH_MSG"
-
-#~ msgid "   and with remote"
-#~ msgstr "   và với máy chủ"
-
-#~ msgid "removing '%s' failed"
-#~ msgstr "gặp lỗi khi xóa bỏ “%s”"
-
-#~ msgid ""
-#~ "If you want to reuse this local git directory instead of cloning again "
-#~ "from"
-#~ msgstr "Nếu bạn muốn dùng lại thư mục git nội bộ này thay vì nhân bản từ nó"
-
-#~ msgid ""
-#~ "use the '--force' option. If the local git directory is not the correct "
-#~ "repo"
-#~ msgstr ""
-#~ "dùng tùy chọn “--force”. Nếu thư mục git nội bộ không phải là repo (kho) "
-#~ "đúng"
-
-#~ msgid ""
-#~ "or you are unsure what this means choose another name with the '--name' "
-#~ "option."
-#~ msgstr ""
-#~ "hay bạn không chắc chắn điều đó có nghĩa gì chọn tên khác với tùy chọn “--"
-#~ "name”."
-
-#~ msgid "Submodule work tree '$displaypath' contains a .git directory"
-#~ msgstr "Cây làm việc mô-đun-con “$displaypath” có chứa thư mục .git"
-
-#~ msgid ""
-#~ "(use 'rm -rf' if you really want to remove it including all of its "
-#~ "history)"
-#~ msgstr ""
-#~ "(dùng “rm -rf” nếu bạn thực sự muốn gỡ bỏ nó cùng với tất cả lịch sử của "
-#~ "chúng)"
-
-#~ msgid "'%s': %s"
-#~ msgstr "“%s”: %s"
-
-#~ msgid "    git branch -d %s\n"
-#~ msgstr "    git branch -d %s\n"
-
-#~ msgid "    git branch --set-upstream-to %s\n"
-#~ msgstr "    git branch --set-upstream-to %s\n"
-
-#~ msgid "cannot open %s: %s\n"
-#~ msgstr "không thể mở %s: %s\n"
-
-#~ msgid "Please, stage your changes to .gitmodules or stash them to proceed"
-#~ msgstr ""
-#~ "Vui lòng đưa các thay đổi của bạn vào “.gitmodules” hay tạm cất chúng đi "
-#~ "để xử lý"
-
-#~ msgid "failed to remove: %s"
-#~ msgstr "gặp lỗi khi gỡ bỏ: %s"
-
-#~ msgid ""
-#~ "Submodule path '$displaypath' not initialized\n"
-#~ "Maybe you want to use 'update --init'?"
-#~ msgstr ""
-#~ "Đường dẫn mô-đun-con “$displaypath” chưa được khởi tạo.\n"
-#~ "Có lẽ bạn muốn sử dụng lệnh “update --init”?"
-
-#~ msgid "Forward-port local commits to the updated upstream head"
-#~ msgstr ""
-#~ "Chuyển tiếp những lần chuyển giao nội bộ tới head thượng nguồn đã cập nhật"
-
-#~ msgid "improper format entered align:%s"
-#~ msgstr "định dạng không đúng chỗ căn chỉnh:%s"
-
-#~ msgid ""
-#~ "push.default is unset; its implicit value has changed in\n"
-#~ "Git 2.0 from 'matching' to 'simple'. To squelch this message\n"
-#~ "and maintain the traditional behavior, use:\n"
-#~ "\n"
-#~ "  git config --global push.default matching\n"
-#~ "\n"
-#~ "To squelch this message and adopt the new behavior now, use:\n"
-#~ "\n"
-#~ "  git config --global push.default simple\n"
-#~ "\n"
-#~ "When push.default is set to 'matching', git will push local branches\n"
-#~ "to the remote branches that already exist with the same name.\n"
-#~ "\n"
-#~ "Since Git 2.0, Git defaults to the more conservative 'simple'\n"
-#~ "behavior, which only pushes the current branch to the corresponding\n"
-#~ "remote branch that 'git pull' uses to update the current branch.\n"
-#~ "\n"
-#~ "See 'git help config' and search for 'push.default' for further "
-#~ "information.\n"
-#~ "(the 'simple' mode was introduced in Git 1.7.11. Use the similar mode\n"
-#~ "'current' instead of 'simple' if you sometimes use older versions of Git)"
-#~ msgstr ""
-#~ "biến push.default chưa được đặt; giá trị ngầm định của nó\n"
-#~ "đã được thay đổi trong Git 2.0 từ “matching” thành “simple”.\n"
-#~ "Để không hiển thị nhắc nhở này và duy trì cách xử lý cũ, hãy chạy lệnh:\n"
-#~ "\n"
-#~ "  git config --global push.default matching\n"
-#~ "\n"
-#~ "Để không hiển thị nhắc nhở này và áp dụng cách ứng xử mới, hãy chạy "
-#~ "lệnh:\n"
-#~ "\n"
-#~ "  git config --global push.default simple\n"
-#~ "\n"
-#~ "Khi push.default được đặt thành “matching”, git sẽ đẩy các nhánh nội bộ\n"
-#~ "lên các nhánh trên máy chủ, cái mà đã sẵn có và cùng tên.\n"
-#~ "\n"
-#~ "Trong 2.0, Git sẽ mặc định duy trì các ứng xử “simple”,\n"
-#~ "cái này chỉ đẩy những nhánh hiện hành lên các nhánh tương ứng\n"
-#~ "trên máy chủ cái mà lệnh “git pull” dùng để cập nhật nhánh hiện tại.\n"
-#~ "\n"
-#~ "Xem “git help config” và tìm đến “push.default” để có thêm thông tin.\n"
-#~ "(chế độ “simple” được bắt đầu sử dụng từ Git 1.7.11. Sử dụng chế độ tương "
-#~ "tự\n"
-#~ "“current” thay vì “simple” nếu bạn thỉnh thoảng phải sử dụng bản Git cũ)"
-
-#~ msgid "Could not append '%s'"
-#~ msgstr "Không thể nối thêm “%s”"
-
-#~ msgid "unable to look up current user in the passwd file: %s"
-#~ msgstr "không tìm thấy người dùng hiện tại trong tập tin passwd: %s"
-
-#~ msgid "no such user"
-#~ msgstr "không có người dùng như vậy"
-
-#~ msgid "Testing "
-#~ msgstr "Đang thử"
-
-#~ msgid "branch '%s' does not point at a commit"
-#~ msgstr "nhánh “%s” không chỉ đến một lần chuyển giao nào cả"
-
-#~ msgid "--dissociate given, but there is no --reference"
-#~ msgstr "đã đưa ra --dissociate, nhưng ở đây lại không có --reference"
-
-#~ msgid "show usage"
-#~ msgstr "hiển thị cách dùng"
-
-#~ msgid "insanely long template name %s"
-#~ msgstr "tên mẫu dài một cách điên rồ %s"
-
-#~ msgid "insanely long symlink %s"
-#~ msgstr "liên kết mềm dài một cách điên rồ %s"
-
-#~ msgid "insanely long template path %s"
-#~ msgstr "đường dẫn mẫu “%s” dài một cách điên rồ"
-
-#~ msgid "unsupported sort specification '%s' in variable '%s'"
-#~ msgstr "không hỗ trợ đặc tả sắp xếp “%s” trong biến “%s”"
-
-#~ msgid "switch 'points-at' requires an object"
-#~ msgstr "chuyển đến “points-at” yêu cần một đối tượng"
-
-#~ msgid "--sort and -n are incompatible"
-#~ msgstr "--sort và -n xung khắc nhau"
-
-#~ msgid "Gitdir '$a' is part of the submodule path '$b' or vice versa"
-#~ msgstr ""
-#~ "Gitdir “$a” là bộ phận của đường dẫn mô-đun-con “$b” hoặc \"vice versa\""
-
-#~ msgid "false|true|preserve"
-#~ msgstr "false|true|preserve"
-
-#~ msgid "BUG: reopen a lockfile that is still open"
-#~ msgstr "LỖI: mở lại tập tin khóa mà nó lại đang được mở"
-
-#~ msgid "BUG: reopen a lockfile that has been committed"
-#~ msgstr "LỖI: mở lại tập tin khóa mà nó đã được chuyển giao"
-
-#~ msgid "option %s does not accept negative form"
-#~ msgstr "tùy chọn %s không chấp nhận dạng thức âm"
-
-#~ msgid "-b and -B are mutually exclusive"
-#~ msgstr "-b và -B loại từ lẫn nhau."
-
-#~ msgid "Patch format $patch_format is not supported."
-#~ msgstr "Định dạng miếng vá $patch_format không được hỗ trợ."
-
-#~ msgid "Please make up your mind. --skip or --abort?"
-#~ msgstr "Xin hãy rõ ràng. --skip hay --abort?"
-
-#~ msgid ""
-#~ "Patch is empty.  Was it split wrong?\n"
-#~ "If you would prefer to skip this patch, instead run \"$cmdline --skip\".\n"
-#~ "To restore the original branch and stop patching run \"$cmdline --abort\"."
-#~ msgstr ""
-#~ "Miếng vá trống rỗng.  Nó đã bị chia cắt sai phải không?\n"
-#~ "Nếu bạn thích bỏ qua miếng vá này, hãy chạy lệnh sau để thay thế "
-#~ "\"$cmdline --skip\".\n"
-#~ "Để phục hồi lại nhánh nguyên thủy và dừng vá lại hãy chạy lệnh \"$cmdline "
-#~ "--abort\"."
-
-#~ msgid "Patch does not have a valid e-mail address."
-#~ msgstr "Miếng vá không có địa chỉ thư điện tử hợp lệ."
-
-#~ msgid "Applying: $FIRSTLINE"
-#~ msgstr "Đang áp dụng (miếng vá): $FIRSTLINE"
-
-#~ msgid "Patch failed at $msgnum $FIRSTLINE"
-#~ msgstr "Gặp lỗi khi vá tại $msgnum $FIRSTLINE"
-
-#~ msgid ""
-#~ "Pull is not possible because you have unmerged files.\n"
-#~ "Please, fix them up in the work tree, and then use 'git add/rm <file>'\n"
-#~ "as appropriate to mark resolution and make a commit."
-#~ msgstr ""
-#~ "Pull là không thể được bởi vì bạn có những tập tin chưa được hòa trộn.\n"
-#~ "Xin hãy sửa chữa chúng trước, và sau đó sử dụng lệnh “git add/rm <tập-"
-#~ "tin>”\n"
-#~ "để phê chuẩn việc đánh dấu đây cần được giải quyết và tạo một lần chuyển "
-#~ "giao."
-
-#~ msgid "no branch specified"
-#~ msgstr "chưa chỉ ra tên của nhánh"
-
-#~ msgid "prune .git/worktrees"
-#~ msgstr "xén .git/worktrees"
-
-#~ msgid "The most commonly used git commands are:"
-#~ msgstr "Những lệnh git hay được dùng nhất là:"
-
-#~ msgid "No such branch: '%s'"
-#~ msgstr "Không có nhánh nào như thế: “%s”"
-
-#~ msgid "Could not create git link %s"
-#~ msgstr "Không thể tạo liên kết git “%s”"
-
-#~ msgid "Invalid gc.pruneexpire: '%s'"
-#~ msgstr "gc.pruneexpire không hợp lệ: “%s”"
-
-#~ msgid "(detached from %s)"
-#~ msgstr "(được tách rời từ %s)"
-
-#~ msgid "No existing author found with '%s'"
-#~ msgstr "Không tìm thấy tác giả có sẵn với “%s”"
-
-#~ msgid "search also in ignored files"
-#~ msgstr "tìm cả trong các tập tin đã bị lờ đi"
-
-#~ msgid "git remote set-head <name> (-a | --auto | -d | --delete |<branch>)"
-#~ msgstr "git remote set-head <tên> (-a | --auto | -d | --delete | <nhánh>)"
-
-#~ msgid "no files added"
-#~ msgstr "chưa có tập tin nào được thêm vào"
-
-#~ msgid "slot"
-#~ msgstr "khe"
-
-#~ msgid "check"
-#~ msgstr "kiểm tra"
-
-#~ msgid "Failed to lock ref for update"
-#~ msgstr "Gặp lỗi khi khóa tham chiếu để cập nhật"
-
-#~ msgid "Failed to write ref"
-#~ msgstr "Gặp lỗi khi ghi tham chiếu"
-
-#~ msgid "commit has empty message"
-#~ msgstr "lần chuyển giao có ghi chú trống rỗng"
-
-#~ msgid "cannot lock HEAD ref"
-#~ msgstr "không thể khóa HEAD ref (tham chiếu)"
-
-#~ msgid "cannot update HEAD ref"
-#~ msgstr "không thể cập nhật ref (tham chiếu) HEAD"
-
-#~ msgid "Failed to chdir: %s"
-#~ msgstr "Gặp lỗi với lệnh chdir: %s"
-
-#~ msgid "%s: cannot lock the ref"
-#~ msgstr "%s: không thể khóa ref (tham chiếu)"
-
-#~ msgid "Failed to lock HEAD during fast_forward_to"
-#~ msgstr "Gặp lỗi khi khóa HEAD trong quá trình fast_forward_to"
-
-#~ msgid "key id"
-#~ msgstr "id của khóa"
-
-#~ msgid "Tracking not set up: name too long: %s"
-#~ msgstr "Việc theo dõi chưa được cài đặt: tên quá dài: %s"
-
-#~ msgid "bug"
-#~ msgstr "lỗi"
-
-#~ msgid ", behind "
-#~ msgstr ", đằng sau "
-
-#~ msgid "could not find .gitmodules in index"
-#~ msgstr "không tìm thấy .gitmodules trong bảng mục lục"
-
-#~ msgid "reading updated .gitmodules failed"
-#~ msgstr "gặp lỗi khi đọc cập nhật .gitmodules"
-
-#~ msgid "unable to stat updated .gitmodules"
-#~ msgstr "không thể lấy thống kê .gitmodules đã cập nhật"
-
-#~ msgid "unable to remove .gitmodules from index"
-#~ msgstr "không thể gỡ bỏ .gitmodules từ mục lục"
-
-#~ msgid "adding updated .gitmodules failed"
-#~ msgstr "gặp lỗi khi thêm .gitmodules đã cập nhật"
-
-#~ msgid ""
-#~ "The behavior of 'git add %s (or %s)' with no path argument from a\n"
-#~ "subdirectory of the tree will change in Git 2.0 and should not be used "
-#~ "anymore.\n"
-#~ "To add content for the whole tree, run:\n"
-#~ "\n"
-#~ "  git add %s :/\n"
-#~ "  (or git add %s :/)\n"
-#~ "\n"
-#~ "To restrict the command to the current directory, run:\n"
-#~ "\n"
-#~ "  git add %s .\n"
-#~ "  (or git add %s .)\n"
-#~ "\n"
-#~ "With the current Git version, the command is restricted to the current "
-#~ "directory.\n"
-#~ msgstr ""
-#~ "Cách ứng xử của lệnh “git add %s (hay %s)” khi không có tham số đường dẫn "
-#~ "từ\n"
-#~ "thư-mục con của cây sẽ thay đổi kể từ Git 2.0 và không thể sử dụng như "
-#~ "thế nữa.\n"
-#~ "Để thêm nội dung cho toàn bộ cây, chạy:\n"
-#~ "\n"
-#~ "  git add %s :/\n"
-#~ "  (hoặc git add %s :/)\n"
-#~ "\n"
-#~ "Để hạn chế lệnh cho thư-mục hiện tại, chạy:\n"
-#~ "\n"
-#~ "  git add %s .\n"
-#~ "  (hoặc git add %s .)\n"
-#~ "\n"
-#~ "Với phiên bản hiện tại của Git, lệnh bị hạn chế cho thư-mục hiện tại.\n"
-
-#~ msgid ""
-#~ "You ran 'git add' with neither '-A (--all)' or '--ignore-removal',\n"
-#~ "whose behaviour will change in Git 2.0 with respect to paths you "
-#~ "removed.\n"
-#~ "Paths like '%s' that are\n"
-#~ "removed from your working tree are ignored with this version of Git.\n"
-#~ "\n"
-#~ "* 'git add --ignore-removal <pathspec>', which is the current default,\n"
-#~ "  ignores paths you removed from your working tree.\n"
-#~ "\n"
-#~ "* 'git add --all <pathspec>' will let you also record the removals.\n"
-#~ "\n"
-#~ "Run 'git status' to check the paths you removed from your working tree.\n"
-#~ msgstr ""
-#~ "Bạn chạy “git add” mà không có “-A (--all)” cũng không “--ignore-"
-#~ "removal”,\n"
-#~ "cách ứng xử của nó sẽ thay đổi kể từ Git 2.0: nó quan tâm đến các đường "
-#~ "dẫn mà\n"
-#~ "bạn đã gỡ bỏ. Các đường dẫn như là “%s” cái mà\n"
-#~ "bị gỡ bỏ từ cây làm việc của bạn thì bị bỏ qua với phiên bản này của "
-#~ "Git.\n"
-#~ "\n"
-#~ "* “git add --ignore-removal <pathspec>”, cái hiện tại là mặc định,\n"
-#~ "  bỏ qua các đường dẫn bạn đã gỡ bỏ từ cây làm việc của bạn.\n"
-#~ "\n"
-#~ "* “git add --all <pathspec>” sẽ đồng thời giúp bạn ghi lại việc dời đi.\n"
-#~ "\n"
-#~ "Chạy “git status” để kiểm tra các đường dẫn bạn đã gỡ bỏ từ cây làm việc "
-#~ "của bạn.\n"
-
-#~ msgid ""
-#~ "Auto packing the repository for optimum performance. You may also\n"
-#~ "run \"git gc\" manually. See \"git help gc\" for more information.\n"
-#~ msgstr ""
-#~ "Tự động đóng gói kho chứa để tối ưu hóa hiệu suất làm việc.\n"
-#~ "chạy lệnh \"git gc\" một cách thủ công. Hãy xem \"git help gc\" để biết "
-#~ "thêm chi tiết.\n"
-
-#~ msgid ""
-#~ "Updates were rejected because a pushed branch tip is behind its remote\n"
-#~ "counterpart. If you did not intend to push that branch, you may want to\n"
-#~ "specify branches to push or set the 'push.default' configuration "
-#~ "variable\n"
-#~ "to 'simple', 'current' or 'upstream' to push only the current branch."
-#~ msgstr ""
-#~ "Việc cập nhật bị từ chối bởi vì đầu mút của nhánh được push nằm đằng sau "
-#~ "bộ\n"
-#~ "phận tương ứng của máy chủ. Nếu bạn không có ý định push nhánh đó, bạn có "
-#~ "lẽ muốn\n"
-#~ "chỉ định các nhánh để push hoặt là đặt nội dung cho biến cấu hình “push."
-#~ "default”\n"
-#~ "thành “simple”, “current” hoặc “upstream” để chỉ push nhánh hiện hành mà "
-#~ "thôi."
-
-#~ msgid "copied:     %s -> %s"
-#~ msgstr "đã sao chép:   %s -> %s"
-
-#~ msgid "deleted:    %s"
-#~ msgstr "đã xóa:        %s"
-
-#~ msgid "modified:   %s"
-#~ msgstr "đã sửa đổi:    %s"
-
-#~ msgid "renamed:    %s -> %s"
-#~ msgstr "đã đổi tên:    %s -> %s"
-
-#~ msgid "unmerged:   %s"
-#~ msgstr "chưa hòa trộn: %s"
-
-#~ msgid "input paths are terminated by a null character"
-#~ msgstr "các đường dẫn được  ngăn cách bởi ký tự null"
-
-#~ msgid ""
-#~ "Aborting. Consider using either the --force or --include-untracked option."
-#~ msgstr ""
-#~ "Bãi bỏ. Cân nhắc dùng một trong hai tùy chọn --force và --include-"
-#~ "untracked."
-
-#~ msgid "  (fix conflicts and then run \"git am --resolved\")"
-#~ msgstr "  (sửa các xung đột và sau đó chạy lệnh \"git am --resolved\")"
-
-#~ msgid "  (all conflicts fixed: run \"git commit\")"
-#~ msgstr "  (khi tất cả các xung đột đã sửa xong: chạy lệnh \"git commit\")"
-
-#~ msgid "more than %d trees given: '%s'"
-#~ msgstr "đã chỉ ra nhiều hơn %d cây (tree): “%s”"
-
-#~ msgid ""
-#~ "'%s' has changes staged in the index\n"
-#~ "(use --cached to keep the file, or -f to force removal)"
-#~ msgstr ""
-#~ "“%s” có các thay đổi được lưu trạng thái trong bảng mục lục\n"
-#~ "(dùng tùy chọn --cached để giữ tập tin, hoặc -f để ép buộc gỡ bỏ)"
-
-#~ msgid "show commits where no parent comes before its children"
-#~ msgstr "hiển thị các lần chuyển giao nơi mà cha mẹ đến trước con của nó"
-
-#~ msgid "show the HEAD reference"
-#~ msgstr "hiển thị tham chiếu của HEAD"
-
-#~ msgid "Unable to fetch in submodule path '$prefix$sm_path'"
-#~ msgstr "Không thể lấy về trong đường dẫn mô-đun-con “$prefix$sm_path”"
-
-#~ msgid "Failed to recurse into submodule path '$prefix$sm_path'"
-#~ msgstr "Gặp lỗi khi đệ quy vào trong đường dẫn mô-đun-con “$prefix$sm_path”"
-
-#~ msgid "It took %.2f seconds to enumerate untracked files.  'status -uno'"
-#~ msgstr "Cần %.2f giây để đếm các tập tin chưa được theo dõi.  “status -uno”"
-
-#~ msgid "may speed it up, but you have to be careful not to forget to add"
-#~ msgstr ""
-#~ "có thể làm nó nhanh lên, nhưng bạn phải cẩn trọng đừng quên thêm nó vào"
-
-#~ msgid "new files yourself (see 'git help status')."
-#~ msgstr "tập tin mới của chính bạn (xem “git help status”.."
-
-#~ msgid "git shortlog [-n] [-s] [-e] [-w] [rev-opts] [--] [<commit-id>... ]"
-#~ msgstr "git shortlog [-n] [-s] [-e] [-w] [rev-opts] [--] [<commit-id>… ]"
-
-#~ msgid "use any ref in .git/refs"
-#~ msgstr "sử dụng bất kỳ ref nào trong .git/refs"
-
-#~ msgid "use any tag in .git/refs/tags"
-#~ msgstr "sử dụng bất kỳ thẻ nào trong .git/refs/tags"
-
-#~ msgid "failed to close pipe to 'show' for object '%s'"
-#~ msgstr "gặp lỗi khi đóng đường ống cho lệnh “show” cho đối tượng “%s”"
-
-#~ msgid "You do not have a valid HEAD"
-#~ msgstr "Bạn không có HEAD nào hợp lệ"
-
-#~ msgid "oops"
-#~ msgstr "ôi?"
-
-#~ msgid "Not removing %s\n"
-#~ msgstr "Không xóa %s\n"
-
-#~ msgid "git remote set-head <name> (-a | -d | <branch>])"
-#~ msgstr "git remote set-head <tên> (-a | -d | <nhánh>])"
-
-#~ msgid " %d file changed"
-#~ msgid_plural " %d files changed"
-#~ msgstr[0] " %d tập tin thay đổi"
-
-#~ msgid ", %d insertion(+)"
-#~ msgid_plural ", %d insertions(+)"
-#~ msgstr[0] ", %d thêm(+)"
-
-#~ msgid ", %d deletion(-)"
-#~ msgid_plural ", %d deletions(-)"
-#~ msgstr[0] ", %d xóa(-)"
-
-#~ msgid " (use \"git add\" to track)"
-#~ msgstr " (dùng \"git add\" để theo dõi dấu vết)"
-
-#~ msgid "--detach cannot be used with -b/-B/--orphan"
-#~ msgstr "--detach không thể được sử dụng với tùy chọn -b/-B/--orphan"
-
-#~ msgid "--orphan and -b|-B are mutually exclusive"
-#~ msgstr "Tùy chọn --orphan và -b|-B loại từ lẫn nhau"
-
-#~ msgid "git checkout: -f and -m are incompatible"
-#~ msgstr "git checkout: hai tùy chọn -f và -m xung khắc nhau"
-
-#~ msgid ""
-#~ "git checkout: updating paths is incompatible with switching branches."
-#~ msgstr ""
-#~ "git checkout: việc cập nhật các đường dẫn là xung khắc với việc chuyển "
-#~ "đổi các nhánh."
-
-#~ msgid "diff setup failed"
-#~ msgstr "cài đặt diff gặp lỗi"
-
-#~ msgid "merge-recursive: disk full?"
-#~ msgstr "merge-recursive: đĩa bị đầy?"
-
-#~ msgid "diff_setup_done failed"
-#~ msgstr "diff_setup_done gặp lỗi"
-
-#~ msgid "%s: has been deleted/renamed"
-#~ msgstr "%s: đã được xóa/thay-tên"
-
-#~ msgid "'%s': not a documentation directory."
-#~ msgstr "”%s”: không phải là một thư mục tài liệu."
-
-#~ msgid "--"
-#~ msgstr "--"
-
-#~ msgid "Could not extract email from committer identity."
-#~ msgstr ""
-#~ "Không thể rút trích địa chỉ thư điện tử từ định danh người chuyển giao"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -144,7 +144,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Git\n"
 "Report-Msgid-Bugs-To: Git Mailing List <git@vger.kernel.org>\n"
-"POT-Creation-Date: 2022-01-11 09:38+0800\n"
+"POT-Creation-Date: 2022-01-17 08:34+0800\n"
 "PO-Revision-Date: 2022-01-11 18:18+0000\n"
 "Last-Translator: Fangyi Zhou <me@fangyi.io>\n"
 "Language-Team: GitHub <https://github.com/jiangxin/git/>\n"
@@ -1011,8 +1011,8 @@ msgstr "未能识别的空白字符忽略选项 '%s'"
 #: builtin/checkout.c:1644 builtin/checkout.c:1754 builtin/checkout.c:1757
 #: builtin/clone.c:906 builtin/commit.c:358 builtin/commit.c:361
 #: builtin/commit.c:1196 builtin/describe.c:593 builtin/diff-tree.c:155
-#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2033
-#: builtin/fetch.c:2038 builtin/index-pack.c:1852 builtin/init-db.c:560
+#: builtin/difftool.c:733 builtin/fast-export.c:1245 builtin/fetch.c:2038
+#: builtin/fetch.c:2043 builtin/index-pack.c:1852 builtin/init-db.c:560
 #: builtin/log.c:1946 builtin/log.c:1948 builtin/ls-files.c:778
 #: builtin/merge.c:1403 builtin/merge.c:1405 builtin/pack-objects.c:4073
 #: builtin/push.c:592 builtin/push.c:630 builtin/push.c:636 builtin/push.c:641
@@ -2051,7 +2051,7 @@ msgstr "一个名为 '%s' 的分支已经存在"
 
 #: branch.c:313
 #, c-format
-msgid "cannot force update the branch '%s'checked out at '%s'"
+msgid "cannot force update the branch '%s' checked out at '%s'"
 msgstr "无法强制更新检出于 '%2$s' 的分支 '%1$s'"
 
 #: branch.c:336
@@ -5788,7 +5788,7 @@ msgstr "%s：无法插入数据库"
 msgid "%s: unsupported file type"
 msgstr "%s：不支持的文件类型"
 
-#: object-file.c:2329 builtin/fetch.c:1448
+#: object-file.c:2329 builtin/fetch.c:1453
 #, c-format
 msgid "%s is not a valid object"
 msgstr "%s 不是一个有效的对象"
@@ -7037,41 +7037,41 @@ msgstr "拒绝更新有错误名称 '%s' 的引用"
 msgid "update_ref failed for ref '%s': %s"
 msgstr "对引用 '%s' 执行 update_ref 失败：%s"
 
-#: refs.c:2069
+#: refs.c:2067
 #, c-format
 msgid "multiple updates for ref '%s' not allowed"
 msgstr "不允许对引用 '%s' 多次更新"
 
-#: refs.c:2152
+#: refs.c:2150
 msgid "ref updates forbidden inside quarantine environment"
 msgstr "在隔离环境中禁止更新引用"
 
-#: refs.c:2163
+#: refs.c:2161
 msgid "ref updates aborted by hook"
 msgstr "引用更新被钩子中止"
 
-#: refs.c:2271 refs.c:2301
+#: refs.c:2269 refs.c:2299
 #, c-format
 msgid "'%s' exists; cannot create '%s'"
 msgstr "'%s' 已存在，无法创建 '%s'"
 
-#: refs.c:2277 refs.c:2312
+#: refs.c:2275 refs.c:2310
 #, c-format
 msgid "cannot process '%s' and '%s' at the same time"
 msgstr "无法同时处理 '%s' 和 '%s'"
 
-#: refs/files-backend.c:1268
+#: refs/files-backend.c:1267
 #, c-format
 msgid "could not remove reference %s"
 msgstr "无法删除引用 %s"
 
-#: refs/files-backend.c:1282 refs/packed-backend.c:1549
+#: refs/files-backend.c:1281 refs/packed-backend.c:1549
 #: refs/packed-backend.c:1559
 #, c-format
 msgid "could not delete reference %s: %s"
 msgstr "无法删除引用 %s：%s"
 
-#: refs/files-backend.c:1285 refs/packed-backend.c:1562
+#: refs/files-backend.c:1284 refs/packed-backend.c:1562
 #, c-format
 msgid "could not delete references: %s"
 msgstr "无法删除引用：%s"
@@ -8087,7 +8087,8 @@ msgstr "不能解析 HEAD"
 msgid "cannot abort from a branch yet to be born"
 msgstr "不能从尚未建立的分支终止"
 
-#: sequencer.c:3180 builtin/fetch.c:999 builtin/fetch.c:1411 builtin/grep.c:772
+#: sequencer.c:3180 builtin/fetch.c:1004 builtin/fetch.c:1416
+#: builtin/grep.c:772
 #, c-format
 msgid "cannot open '%s'"
 msgstr "不能打开 '%s'"
@@ -9023,7 +9024,7 @@ msgstr "协议不支持设置远程服务路径"
 msgid "invalid remote service path"
 msgstr "无效的远程服务路径"
 
-#: transport-helper.c:661 transport.c:1474
+#: transport-helper.c:661 transport.c:1479
 msgid "operation not supported by protocol"
 msgstr "协议不支持该操作"
 
@@ -13190,7 +13191,7 @@ msgstr "选项 '%s' 和 '%s %s' 不能同时使用"
 msgid "repository '%s' does not exist"
 msgstr "仓库 '%s' 不存在"
 
-#: builtin/clone.c:924 builtin/fetch.c:2047
+#: builtin/clone.c:924 builtin/fetch.c:2052
 #, c-format
 msgid "depth %s is not a positive number"
 msgstr "深度 %s 不是一个正数"
@@ -15036,70 +15037,70 @@ msgstr "抓取后写提交图"
 msgid "accept refspecs from stdin"
 msgstr "从标准输入获取引用规格"
 
-#: builtin/fetch.c:587
+#: builtin/fetch.c:592
 msgid "couldn't find remote ref HEAD"
 msgstr "无法发现远程 HEAD 引用"
 
-#: builtin/fetch.c:761
+#: builtin/fetch.c:766
 #, c-format
 msgid "configuration fetch.output contains invalid value %s"
 msgstr "配置变量 fetch.output 包含无效值 %s"
 
-#: builtin/fetch.c:862
+#: builtin/fetch.c:867
 #, c-format
 msgid "object %s not found"
 msgstr "对象 %s 未发现"
 
-#: builtin/fetch.c:866
+#: builtin/fetch.c:871
 msgid "[up to date]"
 msgstr "[最新]"
 
-#: builtin/fetch.c:878 builtin/fetch.c:896 builtin/fetch.c:968
+#: builtin/fetch.c:883 builtin/fetch.c:901 builtin/fetch.c:973
 msgid "[rejected]"
 msgstr "[已拒绝]"
 
-#: builtin/fetch.c:880
+#: builtin/fetch.c:885
 msgid "can't fetch in current branch"
 msgstr "当前分支下不能执行获取操作"
 
-#: builtin/fetch.c:881
+#: builtin/fetch.c:886
 msgid "checked out in another worktree"
 msgstr "已在另一个工作树中检出"
 
-#: builtin/fetch.c:891
+#: builtin/fetch.c:896
 msgid "[tag update]"
 msgstr "[标签更新]"
 
-#: builtin/fetch.c:892 builtin/fetch.c:929 builtin/fetch.c:951
-#: builtin/fetch.c:963
+#: builtin/fetch.c:897 builtin/fetch.c:934 builtin/fetch.c:956
+#: builtin/fetch.c:968
 msgid "unable to update local ref"
 msgstr "不能更新本地引用"
 
-#: builtin/fetch.c:896
+#: builtin/fetch.c:901
 msgid "would clobber existing tag"
 msgstr "会破坏现有的标签"
 
-#: builtin/fetch.c:918
+#: builtin/fetch.c:923
 msgid "[new tag]"
 msgstr "[新标签]"
 
-#: builtin/fetch.c:921
+#: builtin/fetch.c:926
 msgid "[new branch]"
 msgstr "[新分支]"
 
-#: builtin/fetch.c:924
+#: builtin/fetch.c:929
 msgid "[new ref]"
 msgstr "[新引用]"
 
-#: builtin/fetch.c:963
+#: builtin/fetch.c:968
 msgid "forced update"
 msgstr "强制更新"
 
-#: builtin/fetch.c:968
+#: builtin/fetch.c:973
 msgid "non-fast-forward"
 msgstr "非快进"
 
-#: builtin/fetch.c:1071
+#: builtin/fetch.c:1076
 msgid ""
 "fetch normally indicates which branches had a forced update,\n"
 "but that check has been disabled; to re-enable, use '--show-forced-updates'\n"
@@ -15109,7 +15110,7 @@ msgstr ""
 "要重新启用，请使用 '--show-forced-updates' 选项或运行\n"
 "'git config fetch.showForcedUpdates true'"
 
-#: builtin/fetch.c:1075
+#: builtin/fetch.c:1080
 #, c-format
 msgid ""
 "it took %.2f seconds to check forced updates; you can use\n"
@@ -15120,22 +15121,22 @@ msgstr ""
 "花了 %.2f 秒来检查强制更新；您可以使用 '--no-show-forced-updates'\n"
 "或运行 'git config fetch.showForcedUpdates false' 以避免此项检查\n"
 
-#: builtin/fetch.c:1107
+#: builtin/fetch.c:1112
 #, c-format
 msgid "%s did not send all necessary objects\n"
 msgstr "%s 未发送所有必需的对象\n"
 
-#: builtin/fetch.c:1136
+#: builtin/fetch.c:1141
 #, c-format
 msgid "rejected %s because shallow roots are not allowed to be updated"
 msgstr "拒绝 %s 因为浅克隆的根不允许被更新"
 
-#: builtin/fetch.c:1226 builtin/fetch.c:1374
+#: builtin/fetch.c:1231 builtin/fetch.c:1379
 #, c-format
 msgid "From %.*s\n"
 msgstr "来自 %.*s\n"
 
-#: builtin/fetch.c:1247
+#: builtin/fetch.c:1252
 #, c-format
 msgid ""
 "some local refs could not be updated; try running\n"
@@ -15145,69 +15146,69 @@ msgstr ""
 " 'git remote prune %s' 来删除旧的、有冲突的分支"
 
 #  译者：注意保持前导空格
-#: builtin/fetch.c:1344
+#: builtin/fetch.c:1349
 #, c-format
 msgid "   (%s will become dangling)"
 msgstr "   （%s 将成为悬空状态）"
 
 #  译者：注意保持前导空格
-#: builtin/fetch.c:1345
+#: builtin/fetch.c:1350
 #, c-format
 msgid "   (%s has become dangling)"
 msgstr "   （%s 已成为悬空状态）"
 
-#: builtin/fetch.c:1377
+#: builtin/fetch.c:1382
 msgid "[deleted]"
 msgstr "[已删除]"
 
-#: builtin/fetch.c:1378 builtin/remote.c:1128
+#: builtin/fetch.c:1383 builtin/remote.c:1128
 msgid "(none)"
 msgstr "（无）"
 
-#: builtin/fetch.c:1400
+#: builtin/fetch.c:1405
 #, c-format
 msgid "refusing to fetch into branch '%s' checked out at '%s'"
 msgstr "拒绝获取于 '%2$s' 检出的分支 '%1$s'"
 
-#: builtin/fetch.c:1420
+#: builtin/fetch.c:1425
 #, c-format
 msgid "option \"%s\" value \"%s\" is not valid for %s"
 msgstr "选项 \"%s\" 的值 \"%s\" 对于 %s 是无效的"
 
-#: builtin/fetch.c:1423
+#: builtin/fetch.c:1428
 #, c-format
 msgid "option \"%s\" is ignored for %s\n"
 msgstr "选项 \"%s\" 为 %s 所忽略\n"
 
-#: builtin/fetch.c:1450
+#: builtin/fetch.c:1455
 #, c-format
 msgid "the object %s does not exist"
 msgstr "对象 '%s' 不存在"
 
-#: builtin/fetch.c:1638
+#: builtin/fetch.c:1643
 msgid "multiple branches detected, incompatible with --set-upstream"
 msgstr "检测到多分支，和 --set-upstream 不兼容"
 
-#: builtin/fetch.c:1650
+#: builtin/fetch.c:1655
 #, c-format
 msgid ""
 "could not set upstream of HEAD to '%s' from '%s' when it does not point to "
 "any branch."
 msgstr "无法在不指向任何分支时将 HEAD 的上游从 '%s' 设置为 '%s'。"
 
-#: builtin/fetch.c:1663
+#: builtin/fetch.c:1668
 msgid "not setting upstream for a remote remote-tracking branch"
 msgstr "没有为一个远程跟踪分支设置上游"
 
-#: builtin/fetch.c:1665
+#: builtin/fetch.c:1670
 msgid "not setting upstream for a remote tag"
 msgstr "没有为一个远程标签设置上游"
 
-#: builtin/fetch.c:1667
+#: builtin/fetch.c:1672
 msgid "unknown branch type"
 msgstr "未知的分支类型"
 
-#: builtin/fetch.c:1669
+#: builtin/fetch.c:1674
 msgid ""
 "no source branch found;\n"
 "you need to specify exactly one branch with the --set-upstream option"
@@ -15215,79 +15216,79 @@ msgstr ""
 "未发现源分支；\n"
 "您需要使用 --set-upstream 选项指定一个分支"
 
-#: builtin/fetch.c:1799 builtin/fetch.c:1862
+#: builtin/fetch.c:1804 builtin/fetch.c:1867
 #, c-format
 msgid "Fetching %s\n"
 msgstr "正在获取 %s\n"
 
-#: builtin/fetch.c:1809 builtin/fetch.c:1864
+#: builtin/fetch.c:1814 builtin/fetch.c:1869
 #, c-format
 msgid "could not fetch %s"
 msgstr "不能获取 %s"
 
-#: builtin/fetch.c:1821
+#: builtin/fetch.c:1826
 #, c-format
 msgid "could not fetch '%s' (exit code: %d)\n"
 msgstr "无法获取 '%s'（退出码：%d）\n"
 
-#: builtin/fetch.c:1925
+#: builtin/fetch.c:1930
 msgid ""
 "no remote repository specified; please specify either a URL or a\n"
 "remote name from which new revisions should be fetched"
 msgstr "未指定远程仓库；请指定一个用于获取新版本的 URL 或远程仓库名"
 
-#: builtin/fetch.c:1961
+#: builtin/fetch.c:1966
 msgid "you need to specify a tag name"
 msgstr "您需要指定一个标签名称"
 
-#: builtin/fetch.c:2027
+#: builtin/fetch.c:2032
 msgid "--negotiate-only needs one or more --negotiate-tip=*"
 msgstr "--negotiate-only 需要一个或多个 --negotiate-tip=*"
 
-#: builtin/fetch.c:2031
+#: builtin/fetch.c:2036
 msgid "negative depth in --deepen is not supported"
 msgstr "--deepen 不支持负数深度"
 
-#: builtin/fetch.c:2040
+#: builtin/fetch.c:2045
 msgid "--unshallow on a complete repository does not make sense"
 msgstr "对于一个完整的仓库，参数 --unshallow 没有意义"
 
-#: builtin/fetch.c:2057
+#: builtin/fetch.c:2062
 msgid "fetch --all does not take a repository argument"
 msgstr "fetch --all 不能带一个仓库参数"
 
-#: builtin/fetch.c:2059
+#: builtin/fetch.c:2064
 msgid "fetch --all does not make sense with refspecs"
 msgstr "fetch --all 带引用规格没有任何意义"
 
-#: builtin/fetch.c:2068
+#: builtin/fetch.c:2073
 #, c-format
 msgid "no such remote or remote group: %s"
 msgstr "没有这样的远程或远程组：%s"
 
-#: builtin/fetch.c:2076
+#: builtin/fetch.c:2081
 msgid "fetching a group and specifying refspecs does not make sense"
 msgstr "获取组并指定引用规格没有意义"
 
-#: builtin/fetch.c:2092
+#: builtin/fetch.c:2097
 msgid "must supply remote when using --negotiate-only"
 msgstr "在使用 --negotiate-only 时必须提供远程仓库"
 
-#: builtin/fetch.c:2097
+#: builtin/fetch.c:2102
 msgid "protocol does not support --negotiate-only, exiting"
 msgstr "协议不支持 --negotiate-only，退出"
 
-#: builtin/fetch.c:2116
+#: builtin/fetch.c:2121
 msgid ""
 "--filter can only be used with the remote configured in extensions."
 "partialclone"
 msgstr "只可以将 --filter 用于在 extensions.partialclone 中配置的远程仓库"
 
-#: builtin/fetch.c:2120
+#: builtin/fetch.c:2125
 msgid "--atomic can only be used when fetching from one remote"
 msgstr "--atomic 仅在从一个远程仓库获取的时候可用"
 
-#: builtin/fetch.c:2124
+#: builtin/fetch.c:2129
 msgid "--stdin can only be used when fetching from one remote"
 msgstr "--stdin 仅在从一个远程仓库获取的时候可用"
 

--- a/refs.c
+++ b/refs.c
@@ -1713,8 +1713,6 @@ const char *refs_resolve_ref_unsafe(struct ref_store *refs,
 		if (refs_read_raw_ref(refs, refname, oid, &sb_refname,
 				      &read_flags, failure_errno)) {
 			*flags |= read_flags;
-			if (errno)
-				*failure_errno = errno;
 
 			/* In reading mode, refs must eventually resolve */
 			if (resolve_flags & RESOLVE_REF_READING)

--- a/refs/files-backend.c
+++ b/refs/files-backend.c
@@ -385,7 +385,6 @@ stat_ref:
 	if (lstat(path, &st) < 0) {
 		int ignore_errno;
 		myerr = errno;
-		errno = 0;
 		if (myerr != ENOENT)
 			goto out;
 		if (refs_read_raw_ref(refs->packed_ref_store, refname, oid,
@@ -402,7 +401,6 @@ stat_ref:
 		strbuf_reset(&sb_contents);
 		if (strbuf_readlink(&sb_contents, path, st.st_size) < 0) {
 			myerr = errno;
-			errno = 0;
 			if (myerr == ENOENT || myerr == EINVAL)
 				/* inconsistent with lstat; retry */
 				goto stat_ref;
@@ -472,6 +470,7 @@ out:
 
 	strbuf_release(&sb_path);
 	strbuf_release(&sb_contents);
+	errno = 0;
 	return ret;
 }
 

--- a/reftable/merged_test.c
+++ b/reftable/merged_test.c
@@ -207,11 +207,11 @@ static void test_merged(void)
 		},
 	};
 
-	struct reftable_ref_record want[] = {
-		r2[0],
-		r1[1],
-		r3[0],
-		r3[1],
+	struct reftable_ref_record *want[] = {
+		&r2[0],
+		&r1[1],
+		&r3[0],
+		&r3[1],
 	};
 
 	struct reftable_ref_record *refs[] = { r1, r2, r3 };
@@ -250,7 +250,7 @@ static void test_merged(void)
 
 	EXPECT(ARRAY_SIZE(want) == len);
 	for (i = 0; i < len; i++) {
-		EXPECT(reftable_ref_record_equal(&want[i], &out[i],
+		EXPECT(reftable_ref_record_equal(want[i], &out[i],
 						 GIT_SHA1_RAWSZ));
 	}
 	for (i = 0; i < len; i++) {
@@ -345,10 +345,10 @@ static void test_merged_logs(void)
 			.value_type = REFTABLE_LOG_DELETION,
 		},
 	};
-	struct reftable_log_record want[] = {
-		r2[0],
-		r3[0],
-		r1[1],
+	struct reftable_log_record *want[] = {
+		&r2[0],
+		&r3[0],
+		&r1[1],
 	};
 
 	struct reftable_log_record *logs[] = { r1, r2, r3 };
@@ -387,7 +387,7 @@ static void test_merged_logs(void)
 
 	EXPECT(ARRAY_SIZE(want) == len);
 	for (i = 0; i < len; i++) {
-		EXPECT(reftable_log_record_equal(&want[i], &out[i],
+		EXPECT(reftable_log_record_equal(want[i], &out[i],
 						 GIT_SHA1_RAWSZ));
 	}
 

--- a/reftable/merged_test.c
+++ b/reftable/merged_test.c
@@ -24,8 +24,8 @@ https://developers.google.com/open-source/licenses/bsd
 static void write_test_table(struct strbuf *buf,
 			     struct reftable_ref_record refs[], int n)
 {
-	int min = 0xffffffff;
-	int max = 0;
+	uint64_t min = 0xffffffff;
+	uint64_t max = 0;
 	int i = 0;
 	int err;
 

--- a/t/helper/test-drop-caches.c
+++ b/t/helper/test-drop-caches.c
@@ -3,6 +3,7 @@
 
 #if defined(GIT_WINDOWS_NATIVE)
 #include "lazyload.h"
+#include <winnt.h>
 
 static int cmd_sync(void)
 {
@@ -86,7 +87,8 @@ static int cmd_dropcaches(void)
 {
 	HANDLE hProcess = GetCurrentProcess();
 	HANDLE hToken;
-	DECLARE_PROC_ADDR(ntdll.dll, DWORD, NtSetSystemInformation, INT, PVOID, ULONG);
+	DECLARE_PROC_ADDR(ntdll.dll, DWORD, NTAPI, NtSetSystemInformation, INT, PVOID,
+		ULONG);
 	SYSTEM_MEMORY_LIST_COMMAND command;
 	int status;
 

--- a/t/t1450-fsck.sh
+++ b/t/t1450-fsck.sh
@@ -94,13 +94,13 @@ test_expect_success 'object with hash and type mismatch' '
 	)
 '
 
-test_expect_success POSIXPERM 'zlib corrupt loose object output ' '
+test_expect_success 'zlib corrupt loose object output ' '
 	git init --bare corrupt-loose-output &&
 	(
 		cd corrupt-loose-output &&
 		oid=$(git hash-object -w --stdin --literally </dev/null) &&
 		oidf=objects/$(test_oid_to_path "$oid") &&
-		chmod 755 $oidf &&
+		chmod +w $oidf &&
 		echo extra garbage >>$oidf &&
 
 		cat >expect.error <<-EOF &&

--- a/t/t6200-fmt-merge-msg.sh
+++ b/t/t6200-fmt-merge-msg.sh
@@ -126,6 +126,7 @@ test_expect_success GPG 'message for merging local tag signed by good key' '
 	git fetch . signed-good-tag &&
 	git fmt-merge-msg <.git/FETCH_HEAD >actual &&
 	grep "^Merge tag ${apos}signed-good-tag${apos}" actual &&
+	grep "^signed-tag-msg" actual &&
 	grep "^# gpg: Signature made" actual &&
 	grep "^# gpg: Good signature from" actual
 '
@@ -135,6 +136,7 @@ test_expect_success GPG 'message for merging local tag signed by unknown key' '
 	git fetch . signed-good-tag &&
 	GNUPGHOME=. git fmt-merge-msg <.git/FETCH_HEAD >actual &&
 	grep "^Merge tag ${apos}signed-good-tag${apos}" actual &&
+	grep "^signed-tag-msg" actual &&
 	grep "^# gpg: Signature made" actual &&
 	grep -E "^# gpg: Can${apos}t check signature: (public key not found|No public key)" actual
 '
@@ -145,6 +147,7 @@ test_expect_success GPGSSH 'message for merging local tag signed by good ssh key
 	git fetch . signed-good-ssh-tag &&
 	git fmt-merge-msg <.git/FETCH_HEAD >actual &&
 	grep "^Merge tag ${apos}signed-good-ssh-tag${apos}" actual &&
+	grep "^signed-ssh-tag-msg" actual &&
 	grep "${GPGSSH_GOOD_SIGNATURE_TRUSTED}" actual &&
 	! grep "${GPGSSH_BAD_SIGNATURE}" actual
 '
@@ -155,6 +158,7 @@ test_expect_success GPGSSH 'message for merging local tag signed by unknown ssh 
 	git fetch . signed-untrusted-ssh-tag &&
 	git fmt-merge-msg <.git/FETCH_HEAD >actual &&
 	grep "^Merge tag ${apos}signed-untrusted-ssh-tag${apos}" actual &&
+	grep "^signed-ssh-tag-msg-untrusted" actual &&
 	grep "${GPGSSH_GOOD_SIGNATURE_UNTRUSTED}" actual &&
 	! grep "${GPGSSH_BAD_SIGNATURE}" actual &&
 	grep "${GPGSSH_KEY_NOT_TRUSTED}" actual
@@ -166,6 +170,7 @@ test_expect_success GPGSSH,GPGSSH_VERIFYTIME 'message for merging local tag sign
 	git fetch . expired-signed &&
 	git fmt-merge-msg <.git/FETCH_HEAD >actual &&
 	grep "^Merge tag ${apos}expired-signed${apos}" actual &&
+	grep "^expired-signed" actual &&
 	! grep "${GPGSSH_GOOD_SIGNATURE_TRUSTED}" actual
 '
 
@@ -175,6 +180,7 @@ test_expect_success GPGSSH,GPGSSH_VERIFYTIME 'message for merging local tag sign
 	git fetch . notyetvalid-signed &&
 	git fmt-merge-msg <.git/FETCH_HEAD >actual &&
 	grep "^Merge tag ${apos}notyetvalid-signed${apos}" actual &&
+	grep "^notyetvalid-signed" actual &&
 	! grep "${GPGSSH_GOOD_SIGNATURE_TRUSTED}" actual
 '
 
@@ -184,6 +190,7 @@ test_expect_success GPGSSH,GPGSSH_VERIFYTIME 'message for merging local tag sign
 	git fetch . timeboxedvalid-signed &&
 	git fmt-merge-msg <.git/FETCH_HEAD >actual &&
 	grep "^Merge tag ${apos}timeboxedvalid-signed${apos}" actual &&
+	grep "^timeboxedvalid-signed" actual &&
 	grep "${GPGSSH_GOOD_SIGNATURE_TRUSTED}" actual &&
 	! grep "${GPGSSH_BAD_SIGNATURE}" actual
 '
@@ -194,6 +201,7 @@ test_expect_success GPGSSH,GPGSSH_VERIFYTIME 'message for merging local tag sign
 	git fetch . timeboxedinvalid-signed &&
 	git fmt-merge-msg <.git/FETCH_HEAD >actual &&
 	grep "^Merge tag ${apos}timeboxedinvalid-signed${apos}" actual &&
+	grep "^timeboxedinvalid-signed" actual &&
 	! grep "${GPGSSH_GOOD_SIGNATURE_TRUSTED}" actual
 '
 

--- a/t/t7510-signed-commit.sh
+++ b/t/t7510-signed-commit.sh
@@ -71,25 +71,7 @@ test_expect_success GPG 'create signed commits' '
 	git tag eleventh-signed $(cat oid) &&
 	echo 12 | git commit-tree --gpg-sign=B7227189 HEAD^{tree} >oid &&
 	test_line_count = 1 oid &&
-	git tag twelfth-signed-alt $(cat oid) &&
-
-	cat >keydetails <<-\EOF &&
-	Key-Type: RSA
-	Key-Length: 2048
-	Subkey-Type: RSA
-	Subkey-Length: 2048
-	Name-Real: Unknown User
-	Name-Email: unknown@git.com
-	Expire-Date: 0
-	%no-ask-passphrase
-	%no-protection
-	EOF
-	gpg --batch --gen-key keydetails &&
-	echo 13 >file && git commit -a -S"unknown@git.com" -m thirteenth &&
-	git tag thirteenth-signed &&
-	DELETE_FINGERPRINT=$(gpg -K --with-colons --fingerprint --batch unknown@git.com | grep "^fpr" | head -n 1 | awk -F ":" "{print \$10;}") &&
-	gpg --batch --yes --delete-secret-keys $DELETE_FINGERPRINT &&
-	gpg --batch --yes --delete-keys unknown@git.com
+	git tag twelfth-signed-alt $(cat oid)
 '
 
 test_expect_success GPG 'verify and show signatures' '
@@ -129,7 +111,7 @@ test_expect_success GPG 'verify and show signatures' '
 '
 
 test_expect_success GPG 'verify-commit exits failure on unknown signature' '
-	test_must_fail git verify-commit thirteenth-signed 2>actual &&
+	test_must_fail env GNUPGHOME="$GNUPGHOME_NOT_USED" git verify-commit initial 2>actual &&
 	! grep "Good signature from" actual &&
 	! grep "BAD signature from" actual &&
 	grep -q -F -e "No public key" -e "public key not found" actual

--- a/transport.c
+++ b/transport.c
@@ -1457,13 +1457,18 @@ int transport_fetch_refs(struct transport *transport, struct ref *refs)
 	return rc;
 }
 
-void transport_unlock_pack(struct transport *transport)
+void transport_unlock_pack(struct transport *transport, unsigned int flags)
 {
+	int in_signal_handler = !!(flags & TRANSPORT_UNLOCK_PACK_IN_SIGNAL_HANDLER);
 	int i;
 
 	for (i = 0; i < transport->pack_lockfiles.nr; i++)
-		unlink_or_warn(transport->pack_lockfiles.items[i].string);
-	string_list_clear(&transport->pack_lockfiles, 0);
+		if (in_signal_handler)
+			unlink(transport->pack_lockfiles.items[i].string);
+		else
+			unlink_or_warn(transport->pack_lockfiles.items[i].string);
+	if (!in_signal_handler)
+		string_list_clear(&transport->pack_lockfiles, 0);
 }
 
 int transport_connect(struct transport *transport, const char *name,

--- a/transport.h
+++ b/transport.h
@@ -279,7 +279,19 @@ const struct ref *transport_get_remote_refs(struct transport *transport,
  */
 const struct git_hash_algo *transport_get_hash_algo(struct transport *transport);
 int transport_fetch_refs(struct transport *transport, struct ref *refs);
-void transport_unlock_pack(struct transport *transport);
+
+/*
+ * If this flag is set, unlocking will avoid to call non-async-signal-safe
+ * functions. This will necessarily leave behind some data structures which
+ * cannot be cleaned up.
+ */
+#define TRANSPORT_UNLOCK_PACK_IN_SIGNAL_HANDLER (1 << 0)
+
+/*
+ * Unlock all packfiles locked by the transport.
+ */
+void transport_unlock_pack(struct transport *transport, unsigned int flags);
+
 int transport_disconnect(struct transport *transport);
 char *transport_anonymize_url(const char *url);
 void transport_take_over(struct transport *transport,


### PR DESCRIPTION
@ralfth and @PhillipSz: Please have a look at my suggestions for the German translation of Git v2.35.0. Only the commits b63e8aaa6c (fix from @jottkaerr) and d99fa3c4fb needs to be reviewed, the commit 4ab1b1ff6a is the automatically generated one to update the po file.
As always I also updated some other translations that are not part of this Git update. For example omitting the full stop at the end of a sentence if the original string does not contain one or starting with a small letter after a semicolon...